### PR TITLE
fix: update classes to use un-prefixed tailwind classes

### DIFF
--- a/apps/registry/registry/components/shadcn/full/thread.tsx
+++ b/apps/registry/registry/components/shadcn/full/thread.tsx
@@ -81,7 +81,7 @@ const MyThreadWelcome: FC = () => {
 
 const MyComposer: FC = () => {
   return (
-    <ComposerPrimitive.Root className="focus-within:border-ring/20 flex w-full flex-wrap items-end rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in">
+<ComposerPrimitive.Root className="flex w-full flex-wrap items-end rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in focus-within:border-ring/20">
       <ComposerPrimitive.Input
         autoFocus
         placeholder="Write a message..."

--- a/apps/registry/registry/components/shadcn/full/thread.tsx
+++ b/apps/registry/registry/components/shadcn/full/thread.tsx
@@ -81,7 +81,7 @@ const MyThreadWelcome: FC = () => {
 
 const MyComposer: FC = () => {
   return (
-    <ComposerPrimitive.Root className="focus-within:border-aui-ring/20 flex w-full flex-wrap items-end rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in">
+    <ComposerPrimitive.Root className="focus-within:border-ring/20 flex w-full flex-wrap items-end rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in">
       <ComposerPrimitive.Input
         autoFocus
         placeholder="Write a message..."

--- a/apps/registry/registry/components/shadcn/markdown-text.tsx
+++ b/apps/registry/registry/components/shadcn/markdown-text.tsx
@@ -170,7 +170,7 @@ const MarkdownTextImpl = () => {
           return (
             <code
               className={cn(
-                !isCodeBlock && "bg-aui-muted rounded border font-semibold",
+                !isCodeBlock && "bg-muted rounded border font-semibold",
                 className,
               )}
               {...props}

--- a/apps/registry/registry/components/shadcn/thread.tsx
+++ b/apps/registry/registry/components/shadcn/thread.tsx
@@ -49,7 +49,7 @@ const MyThreadWelcome: FC = () => {
 
 const MyComposer: FC = () => {
   return (
-    <ComposerPrimitive.Root className="focus-within:border-aui-ring/20 flex w-full flex-wrap items-end rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in">
+    <ComposerPrimitive.Root className="focus-within:border-ring/20 flex w-full flex-wrap items-end rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in">
       <ComposerPrimitive.Input
         autoFocus
         placeholder="Write a message..."

--- a/apps/registry/registry/components/shadcn/thread.tsx
+++ b/apps/registry/registry/components/shadcn/thread.tsx
@@ -49,7 +49,7 @@ const MyThreadWelcome: FC = () => {
 
 const MyComposer: FC = () => {
   return (
-    <ComposerPrimitive.Root className="focus-within:border-ring/20 flex w-full flex-wrap items-end rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in">
+<ComposerPrimitive.Root className="flex w-full flex-wrap items-end rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in focus-within:border-ring/20">
       <ComposerPrimitive.Input
         autoFocus
         placeholder="Write a message..."


### PR DESCRIPTION
Issue: default shadcn components had `aui-` prefix so when installed these classes didn't have any corresponding styles bundled

Fix: removed: `aui-` prefixes and used plain tailwind classes