### PR TITLE
refactor(ai-sdk): deprecate getVercelRSCMessage

### DIFF
--- a/.changeset/witty-coats-hunt.md
+++ b/.changeset/witty-coats-hunt.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+refactor: deprecate getVercelRSCMessage

--- a/packages/react-ai-sdk/src/rsc/getVercelRSCMessage.tsx
+++ b/packages/react-ai-sdk/src/rsc/getVercelRSCMessage.tsx
@@ -4,7 +4,7 @@ import {
 } from "@assistant-ui/react";
 
 /**
- * @deprecated Use `getExternalStoreMessage` instead.
+ * @deprecated Use `getExternalStoreMessage` instead. This method was specific to Vercel RSC implementation and has been replaced by a more generic external store message handler that provides better compatibility and maintainability across different environments.
  */
 export const getVercelRSCMessage = (message: ThreadMessage) => {
   return getExternalStoreMessage(message);

--- a/packages/react-ai-sdk/src/rsc/getVercelRSCMessage.tsx
+++ b/packages/react-ai-sdk/src/rsc/getVercelRSCMessage.tsx
@@ -4,7 +4,8 @@ import {
 } from "@assistant-ui/react";
 
 /**
- * @deprecated Use `getExternalStoreMessage` instead. This method was specific to Vercel RSC implementation and has been replaced by a more generic external store message handler that provides better compatibility and maintainability across different environments.
+ * @deprecated Use `getExternalStoreMessage` instead. This method was specific to Vercel RSC
+ * implementation and has been replaced by a more generic external store message handler.
  */
 export const getVercelRSCMessage = (message: ThreadMessage) => {
   return getExternalStoreMessage(message);

--- a/packages/react-ai-sdk/src/rsc/getVercelRSCMessage.tsx
+++ b/packages/react-ai-sdk/src/rsc/getVercelRSCMessage.tsx
@@ -3,8 +3,9 @@ import {
   type ThreadMessage,
 } from "@assistant-ui/react";
 
-export const symbolInnerRSCMessage = Symbol("innerVercelRSCMessage");
-
+/**
+ * @deprecated Use `getExternalStoreMessage` instead.
+ */
 export const getVercelRSCMessage = (message: ThreadMessage) => {
   return getExternalStoreMessage(message);
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecation**
	- Deprecated `getVercelRSCMessage` function in `@assistant-ui/react-ai-sdk` package
	- Recommended using alternative method for message handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->