### PR TITLE
feat(runtimes/local): widen initialMessages type to ThreadMessageLike

### DIFF
--- a/.changeset/many-deers-do.md
+++ b/.changeset/many-deers-do.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: widen initialMessages type to ThreadMessageLike

--- a/packages/react/src/runtimes/local/LocalRuntimeOptions.tsx
+++ b/packages/react/src/runtimes/local/LocalRuntimeOptions.tsx
@@ -1,5 +1,5 @@
-import type { CoreMessage } from "../../types";
 import { AttachmentAdapter } from "../attachment/AttachmentAdapter";
+import { ThreadMessageLike } from "../external-store";
 import { FeedbackAdapter } from "../feedback/FeedbackAdapter";
 import { SpeechSynthesisAdapter } from "../speech/SpeechAdapterTypes";
 import { ChatModelAdapter } from "./ChatModelAdapter";
@@ -16,7 +16,7 @@ export type LocalRuntimeOptionsBase = {
 
 // TODO align LocalRuntimeOptions with LocalRuntimeOptionsBase
 export type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
-  initialMessages?: readonly CoreMessage[] | undefined;
+  initialMessages?: readonly ThreadMessageLike[] | undefined;
   adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
 };
 


### PR DESCRIPTION
fixes #1233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type flexibility for `initialMessages` in the `@assistant-ui/react` package
	- Broadened message type support to improve compatibility

- **Refactor**
	- Updated message processing logic to work with `ThreadMessageLike` type
	- Modified type signatures across multiple components to support new message structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->