### PR TITLE
refactor: deprecate UI content part

### DIFF
--- a/.changeset/nasty-hounds-hunt.md
+++ b/.changeset/nasty-hounds-hunt.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+refactor: deprecate UIContentPart

--- a/packages/react-ai-sdk/src/rsc/useVercelRSCRuntime.tsx
+++ b/packages/react-ai-sdk/src/rsc/useVercelRSCRuntime.tsx
@@ -3,10 +3,38 @@
 import type { VercelRSCAdapter } from "./VercelRSCAdapter";
 import {
   ExternalStoreAdapter,
+  getExternalStoreMessage,
+  TextContentPartComponent,
   ThreadMessageLike,
+  useExternalMessageConverter,
   useExternalStoreRuntime,
+  useMessage,
+  useThread,
 } from "@assistant-ui/react";
 import { VercelRSCMessage } from "./VercelRSCMessage";
+import { useCallback, useMemo } from "react";
+
+const symbolInternalRSCExtras = Symbol("internal-rsc-extras");
+
+type RSCThreadExtras =
+  | {
+      [symbolInternalRSCExtras]?: {
+        convertFn: (message: any) => VercelRSCMessage;
+      };
+    }
+  | undefined;
+
+export const RSCDisplay: TextContentPartComponent = () => {
+  const convertFn = useThread((t) => {
+    const extras = (t.extras as RSCThreadExtras)?.[symbolInternalRSCExtras];
+    if (!extras)
+      throw new Error(
+        "This function can only be used inside a Vercel RSC runtime.",
+      );
+    return extras.convertFn;
+  });
+  return useMessage((m) => convertFn(getExternalStoreMessage(m)).display);
+};
 
 const vercelToThreadMessage = <T,>(
   converter: (message: T) => VercelRSCMessage,
@@ -28,20 +56,37 @@ export const useVercelRSCRuntime = <T extends WeakKey>(
   const onNew = adapter.onNew;
   if (!onNew)
     throw new Error("You must pass a onNew function to useVercelRSCRuntime");
-  const eAdapter: ExternalStoreAdapter<any> = {
-    isRunning: adapter.isRunning,
+
+  const convertFn = useMemo(() => {
+    return (
+      adapter.convertMessage?.bind(adapter) ?? ((m: T) => m as VercelRSCMessage)
+    );
+  }, [adapter.convertMessage]);
+  const callback = useCallback(
+    (m: T) => {
+      return vercelToThreadMessage(convertFn, m);
+    },
+    [convertFn],
+  );
+
+  const messages = useExternalMessageConverter({
+    callback,
+    isRunning: adapter.isRunning ?? false,
     messages: adapter.messages,
+  });
+
+  const eAdapter: ExternalStoreAdapter = {
+    isRunning: adapter.isRunning,
+    messages,
     onNew,
     onEdit: adapter.onEdit,
     onReload: adapter.onReload,
-    convertMessage: (m: T) =>
-      vercelToThreadMessage(
-        adapter.convertMessage ?? ((m) => m as VercelRSCMessage),
-        m,
-      ),
     adapters: adapter.adapters,
     unstable_capabilities: {
       copy: false,
+    },
+    extras: {
+      [symbolInternalRSCExtras]: { convertFn },
     },
   };
 

--- a/packages/react/src/primitive-hooks/contentPart/useContentPartDisplay.tsx
+++ b/packages/react/src/primitive-hooks/contentPart/useContentPartDisplay.tsx
@@ -4,6 +4,9 @@ import { ContentPartState } from "../../api/ContentPartRuntime";
 import { useContentPart } from "../../context/react/ContentPartContext";
 import { UIContentPart } from "../../types";
 
+/**
+ * @deprecated UI content parts are deprecated and will be removed in v0.8.0.
+ */
 export const useContentPartDisplay = () => {
   const display = useContentPart((c) => {
     if (c.type !== "ui")

--- a/packages/react/src/types/AssistantTypes.ts
+++ b/packages/react/src/types/AssistantTypes.ts
@@ -21,6 +21,43 @@ export type Unstable_AudioContentPart = {
   };
 };
 
+/**
+ * @deprecated UI content parts are deprecated and will be removed in v0.8.0.
+ * Migration guide for external-store users using UI content parts:
+ * If you must, store UI elements on your external store messages, update your
+ * external store converter:
+ * ```ts
+ * const UI_PLACEHOLDER = Object.freeze({ type: "text", text: "UI content placeholder" });
+ * const convertMessage = (message: TMessage): ThreadMessageLike => ({
+ *   content: [
+ *     // other content parts,
+ *     UI_PLACEHOLDER
+ *   ],
+ * });
+ * ```
+ *
+ * Then, define a custom `TextContentPartComponent`:
+ *
+ * ```tsx
+ * const MyText: FC = () => {
+ *   const isUIPlaceholder = useContentPart(p => p === UI_PLACEHOLDER);
+ *
+ *   // this assumes that you have a `display` field on your original message objects before conversion.
+ *   const ui = useMessage(m => isUIPlaceholder ? getExternalStoreMessage(m).display : undefined);
+ *   if (ui) {
+ *     return ui;
+ *   }
+ *
+ *   return <MarkdownText />; // your default text component
+ * }
+ * ```
+ *
+ *  Pass this component to your Thread:
+ *
+ * ```tsx
+ * <Thread assistantMessage={{ components: { Text: MyText } }} userMessage={{ components: { Text: MyText } }} />
+ * ```
+ */
 export type UIContentPart = {
   readonly type: "ui";
   readonly display: ReactNode;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Deprecation**
  - UI content parts will be removed in version 0.8.0
  - Developers using external stores with UI content parts should follow migration guide in documentation

- **New Features**
  - Added `RSCDisplay` component for enhanced message handling in Vercel RSC runtime

- **Performance Improvements**
  - Optimized message conversion logic with memoization and callback techniques

<!-- end of auto-generated comment: release notes by coderabbit.ai -->