### PR TITLE
feat(playground): widen initialMessages type

### DIFF
--- a/.changeset/unlucky-trees-doubt.md
+++ b/.changeset/unlucky-trees-doubt.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-playground": patch
+---
+
+feat: widen initialMessages type

--- a/packages/react-playground/src/lib/playground-runtime.ts
+++ b/packages/react-playground/src/lib/playground-runtime.ts
@@ -18,12 +18,12 @@ import {
   ChatModelAdapter,
   Unsubscribe,
   ChatModelRunResult,
-  CoreMessage,
   fromCoreMessage,
   INTERNAL,
   ThreadSuggestion,
   ThreadRuntime,
   AssistantRuntime,
+  ThreadMessageLike,
 } from "@assistant-ui/react";
 import { LanguageModelV1FunctionTool } from "@ai-sdk/provider";
 import { useMemo, useState } from "react";
@@ -37,6 +37,8 @@ const {
   DefaultThreadComposerRuntimeCore,
   AssistantRuntimeImpl,
   ThreadRuntimeImpl,
+  fromThreadMessageLike,
+  getAutoStatus,
 } = INTERNAL;
 
 const makeModelConfigStore = () =>
@@ -137,14 +139,22 @@ class PlaygroundRuntimeCore extends BaseAssistantRuntimeCore {
 
   constructor(
     adapter: ChatModelAdapter,
-    initialMessages: readonly CoreMessage[],
+    initialMessages: readonly ThreadMessageLike[],
   ) {
     super();
 
     this.threadList = new PlaygroundThreadListRuntimeCore(() => {
+      const messages = initialMessages.map((m, idx) => {
+        const isLast = idx === initialMessages.length - 1;
+        return fromThreadMessageLike(
+          m,
+          generateId(),
+          getAutoStatus(isLast, false),
+        );
+      });
       const thread = new PlaygroundThreadRuntimeCore(
         this._proxyConfigProvider,
-        fromCoreMessages(initialMessages),
+        messages,
         adapter,
       );
       initialMessages = [];

--- a/packages/react/src/internal.ts
+++ b/packages/react/src/internal.ts
@@ -12,5 +12,7 @@ export {
   type ThreadRuntimeCoreBinding,
   type ThreadListItemRuntimeBinding,
 } from "./api/ThreadRuntime";
+export { fromThreadMessageLike } from "./runtimes/external-store/ThreadMessageLike";
+export { getAutoStatus } from "./runtimes/external-store/auto-status";
 
 export * from "./utils/smooth";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced flexibility for initial messages in the React Playground package
  - Improved message handling with new `ThreadMessageLike` type support

- **Improvements**
  - Updated message processing logic to provide more robust type safety
  - Expanded public API with new utility functions for thread messaging

- **Technical Updates**
  - Refined message type handling across multiple components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->