### PR TITLE
fix: attachment filename should never overflow

### DIFF
--- a/.changeset/silver-peaches-change.md
+++ b/.changeset/silver-peaches-change.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: attachment filename should never overflow

--- a/packages/react/src/styles/tailwindcss/thread.css
+++ b/packages/react/src/styles/tailwindcss/thread.css
@@ -93,7 +93,7 @@
 }
 
 .aui-attachment-name {
-  @apply text-aui-muted-foreground line-clamp-1 text-ellipsis text-xs font-bold;
+  @apply text-aui-muted-foreground line-clamp-1 text-ellipsis break-all text-xs font-bold;
 }
 
 .aui-attachment-type {


### PR DESCRIPTION
fixes #1226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated `.aui-attachment-name` CSS class to improve text wrapping for long attachment names by adding `break-all` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->