### PR TITLE
docs: start migration guide for upcoming v0.8

### DIFF
--- a/.changeset/slimy-wasps-push.md
+++ b/.changeset/slimy-wasps-push.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+feat: RSCDisplay

--- a/apps/docs/content/docs/migrations/v0-8.mdx
+++ b/apps/docs/content/docs/migrations/v0-8.mdx
@@ -9,8 +9,6 @@ import { Callout } from "fumadocs-ui/components/callout";
   v0.8.0 is released.
 </Callout>
 
-This guide serves as a reference for users facing breaking changes during upgrade to v0.8. You do not need to read this guide to upgrade to v0.8.
-
 ## Vercel AI SDK RSC requires additional setup
 
 Built-in RSC support in assistant-ui has been removed, so an additional setup step is required.
@@ -40,7 +38,7 @@ First, reconsider your approach.
 Creating UI components in the `convertMessage` callback is considered an anti-pattern.
 The recommended alternative approach is to pass tool-call content parts, and use `makeAssistantToolUI` to map these tool calls to UI components.
 
-This ensures that the the data layer is separate and decoupled from the UI layer.
+This ensures that the data layer is separate and decoupled from the UI layer.
 
 #### Example
 
@@ -155,4 +153,4 @@ We pass this component to our Thread:
 
 (if you are using unstyled primitives, update MyThread.tsx, and pass the component to MessagePrimitive.Content)
 
-Now, the UI_PLACEHORDER content part is replaced with the UI component we defined earlier.
+Now, the `UI_PLACEHOLDER` content part is replaced with the UI component we defined earlier.

--- a/apps/docs/content/docs/migrations/v0-8.mdx
+++ b/apps/docs/content/docs/migrations/v0-8.mdx
@@ -100,7 +100,7 @@ const ChartToolUI = makeAssistantToolUI({
 });
 
 // use tool UI to display the chart
-<Thread tools=[ChartToolUI] />;
+<Thread tools={[ChartToolUI]} />;
 ```
 
 (if you are using unstyled primitives, render the <ChartToolUI /> component anywhere inside your AssistantRuntimeProvider)

--- a/apps/docs/content/docs/migrations/v0-8.mdx
+++ b/apps/docs/content/docs/migrations/v0-8.mdx
@@ -1,0 +1,158 @@
+---
+title: Migration to v0.8
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+<Callout>
+  This migration guide is for an upcoming release. More changes may land before
+  v0.8.0 is released.
+</Callout>
+
+This guide serves as a reference for users facing breaking changes during upgrade to v0.8. You do not need to read this guide to upgrade to v0.8.
+
+## Vercel AI SDK RSC requires additional setup
+
+Built-in RSC support in assistant-ui has been removed, so an additional setup step is required.
+The RSC runtime now requires additional setup to display React Server Components.
+
+```ts
+import { RSCDisplay } from "@assistant-ui/react-ai-sdk";
+
+// if you are using the default Thread component
+// add RSCDisplay to assistantMessage.components.Text
+<Thread assistantMessage={{ components: { Text: RSCDisplay } }} />
+
+
+// if you are using unstyled primitives, update MyThread.tsx
+<MessagePrimitive.Content components={{ Text: RSCDisplay }} />
+```
+
+## Migrate away from UIContentPart
+
+For instructions on migrating for Vercel AI SDK RSC, see section above.
+This migration guide is for users of `useExternalStoreRuntime`.
+
+### Recommended Approach: Use ToolUI
+
+First, reconsider your approach.
+
+Creating UI components in the `convertMessage` callback is considered an anti-pattern.
+The recommended alternative approach is to pass tool-call content parts, and use `makeAssistantToolUI` to map these tool calls to UI components.
+
+This ensures that the the data layer is separate and decoupled from the UI layer.
+
+#### Example
+
+Consider the following example, where you are using a UIContentPart to show a loading indicator.
+
+```ts title="bad.ts"
+// THIS IS BAD
+const convertMessage = (message: MyMessage): ThreadMessageLike => {
+  if (message.isLoading) {
+    return { content: [{ type: "ui", display:< MyLoader /> }] };
+  }
+  // ...
+};
+```
+
+```ts title="good.ts"
+const convertMessage = (message: MyMessage): ThreadMessageLike => {
+  if (message.isLoading) {
+    return { content: [] };
+  }
+  // ...
+};
+
+// use the empty content part to show the loading indicator
+<Thread assistantMessage={{ components: { Empty: MyLoader } }} />;
+```
+
+(if you are using unstyled primitives, update MyThread.tsx, and pass the component to MessagePrimitive.Content)
+
+#### Example 2
+
+Consider the following example, where you are displaying a custom chart based on data received from an external source.
+
+```ts title="bad.ts"
+// THIS IS BAD
+const convertMessage = (message: MyMessage): ThreadMessageLike => {
+  return { content: [{ type: "ui", display: <MyChart data={message.chartData} /> }] };
+};
+```
+
+```ts title="good.ts"
+const convertMessage = (message: MyMessage): ThreadMessageLike => {
+  return {
+    content: [
+      {
+        type: "tool-call",
+        toolName: "chart",
+        args: message.chartData,
+      },
+    ],
+  };
+};
+
+const ChartToolUI = makeAssistantToolUI({
+  toolName: "chart",
+  render: ({ args }) => <MyChart data={args} />,
+});
+
+// use tool UI to display the chart
+<Thread tools=[ChartToolUI] />;
+```
+
+(if you are using unstyled primitives, render the <ChartToolUI /> component anywhere inside your AssistantRuntimeProvider)
+
+### Fallback Approach: Override ContentPartText
+
+However, sometimes you receive UI components from an external source.
+
+The example below assumes that your custom `MyMessage` type has a `display` field.
+
+First, we define a dummy `UI_PLACEHOLDER` content part, which we will replace with the UI component later:
+
+```ts
+const UI_PLACEHOLDER = Object.freeze({
+  type: "text",
+  text: "UI content placeholder",
+});
+const convertMessage = (message: MyMessage): ThreadMessageLike => ({
+  content: [
+    // other content parts,
+    UI_PLACEHOLDER,
+  ],
+});
+```
+
+Then, we define a custom `TextContentPartComponent`:
+
+```tsx
+const MyText: TextContentPartComponent = () => {
+  const isUIPlaceholder = useContentPart((p) => p === UI_PLACEHOLDER);
+
+  // this assumes that you have a `display` field on your original message objects before conversion.
+  const ui = useMessage((m) =>
+    isUIPlaceholder ? getExternalStoreMessage(m).display : undefined,
+  );
+  if (ui) {
+    return ui;
+  }
+
+  return <MarkdownText />; // your default text component
+};
+```
+
+We pass this component to our Thread:
+
+```tsx
+<Thread
+  assistantMessage={{ components: { Text: MyText } }}
+  userMessage={{ components: { Text: MyText } }}
+/>
+```
+
+(if you are using unstyled primitives, update MyThread.tsx, and pass the component to MessagePrimitive.Content)
+
+Now, the UI_PLACEHORDER content part is replaced with the UI component we defined earlier.

--- a/packages/react-ai-sdk/src/rsc/RSCDisplay.tsx
+++ b/packages/react-ai-sdk/src/rsc/RSCDisplay.tsx
@@ -1,0 +1,23 @@
+"use client";
+import {
+  TextContentPartComponent,
+  useThread,
+  useMessage,
+  getExternalStoreMessage,
+} from "@assistant-ui/react";
+import {
+  RSCThreadExtras,
+  symbolInternalRSCExtras,
+} from "./utils/RSCThreadExtras";
+
+export const RSCDisplay: TextContentPartComponent = () => {
+  const convertFn = useThread((t) => {
+    const extras = (t.extras as RSCThreadExtras)?.[symbolInternalRSCExtras];
+    if (!extras)
+      throw new Error(
+        "This function can only be used inside a Vercel RSC runtime.",
+      );
+    return extras.convertFn;
+  });
+  return useMessage((m) => convertFn(getExternalStoreMessage(m)).display);
+};

--- a/packages/react-ai-sdk/src/rsc/index.ts
+++ b/packages/react-ai-sdk/src/rsc/index.ts
@@ -2,3 +2,4 @@ export { useVercelRSCRuntime } from "./useVercelRSCRuntime";
 export { getVercelRSCMessage } from "./getVercelRSCMessage";
 export type { VercelRSCAdapter } from "./VercelRSCAdapter";
 export type { VercelRSCMessage } from "./VercelRSCMessage";
+export { RSCDisplay } from "./RSCDisplay";

--- a/packages/react-ai-sdk/src/rsc/useVercelRSCRuntime.tsx
+++ b/packages/react-ai-sdk/src/rsc/useVercelRSCRuntime.tsx
@@ -3,38 +3,13 @@
 import type { VercelRSCAdapter } from "./VercelRSCAdapter";
 import {
   ExternalStoreAdapter,
-  getExternalStoreMessage,
-  TextContentPartComponent,
   ThreadMessageLike,
   useExternalMessageConverter,
   useExternalStoreRuntime,
-  useMessage,
-  useThread,
 } from "@assistant-ui/react";
 import { VercelRSCMessage } from "./VercelRSCMessage";
 import { useCallback, useMemo } from "react";
-
-const symbolInternalRSCExtras = Symbol("internal-rsc-extras");
-
-type RSCThreadExtras =
-  | {
-      [symbolInternalRSCExtras]?: {
-        convertFn: (message: any) => VercelRSCMessage;
-      };
-    }
-  | undefined;
-
-export const RSCDisplay: TextContentPartComponent = () => {
-  const convertFn = useThread((t) => {
-    const extras = (t.extras as RSCThreadExtras)?.[symbolInternalRSCExtras];
-    if (!extras)
-      throw new Error(
-        "This function can only be used inside a Vercel RSC runtime.",
-      );
-    return extras.convertFn;
-  });
-  return useMessage((m) => convertFn(getExternalStoreMessage(m)).display);
-};
+import { symbolInternalRSCExtras } from "./utils/RSCThreadExtras";
 
 const vercelToThreadMessage = <T,>(
   converter: (message: T) => VercelRSCMessage,

--- a/packages/react-ai-sdk/src/rsc/utils/RSCThreadExtras.tsx
+++ b/packages/react-ai-sdk/src/rsc/utils/RSCThreadExtras.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { VercelRSCMessage } from "../VercelRSCMessage";
+
+export const symbolInternalRSCExtras = Symbol("internal-rsc-extras");
+export type RSCThreadExtras =
+  | {
+      [symbolInternalRSCExtras]?: {
+        convertFn: (message: any) => VercelRSCMessage;
+      };
+    }
+  | undefined;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds migration guide for v0.8 and introduces `RSCDisplay` for handling React Server Components in `@assistant-ui/react-ai-sdk`.
> 
>   - **Migration Guide**:
>     - Adds `v0-8.mdx` for migration to v0.8, detailing breaking changes and new setup for RSC.
>     - Recommends using `ToolUI` instead of `UIContentPart` for better data/UI separation.
>   - **RSCDisplay Component**:
>     - Introduces `RSCDisplay` in `RSCDisplay.tsx` to handle React Server Components.
>     - Exports `RSCDisplay` in `index.ts`.
>   - **Runtime Updates**:
>     - Updates `useVercelRSCRuntime.tsx` to use `symbolInternalRSCExtras` for RSC logic.
>     - Moves `symbolInternalRSCExtras` to `RSCThreadExtras.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 076b5043bcb893244c19d532935b8e0ecfba2305. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->