### PR TITLE
docs: publish v0-8 migration guide

### DIFF
--- a/apps/docs/content/docs/migrations/meta.json
+++ b/apps/docs/content/docs/migrations/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Migrations",
-  "pages": ["deprecation-policy", "v0-7"]
+  "pages": ["deprecation-policy", "v0-7", "v0-8"]
 }

--- a/apps/docs/content/docs/migrations/v0-8.mdx
+++ b/apps/docs/content/docs/migrations/v0-8.mdx
@@ -101,7 +101,7 @@ const ChartToolUI = makeAssistantToolUI({
 <Thread tools={[ChartToolUI]} />;
 ```
 
-(if you are using unstyled primitives, render the <ChartToolUI /> component anywhere inside your AssistantRuntimeProvider)
+(if you are using unstyled primitives, render the `<ChartToolUI />` component anywhere inside your AssistantRuntimeProvider)
 
 ### Fallback Approach: Override ContentPartText
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a migration guide for version 0.8, detailing new setup requirements and recommended UI practices.
> 
>   - **Documentation**:
>     - Adds `v0-8.mdx` migration guide for version 0.8.
>     - Updates `meta.json` to include `v0-8` in the pages list.
>   - **Migration Guide Details**:
>     - Describes additional setup for Vercel AI SDK RSC due to removal of built-in RSC support.
>     - Recommends using `ToolUI` instead of `UIContentPart` for better separation of data and UI layers.
>     - Provides examples for migrating `convertMessage` callback to use `ToolUI`.
>     - Suggests fallback approach using `UI_PLACEHOLDER` and custom `TextContentPartComponent`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 4871710e1f93ce07260a0e273440a9c6bbab31d7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added migration guide for version 0.8
	- Updated documentation for Vercel AI SDK RSC setup
	- Provided new guidelines for handling UI components and tool calls

- **New Features**
	- Expanded migration documentation to include version 0.8 changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->