### PR TITLE
fix(langgraph): always use uuid

### DIFF
--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -1,8 +1,5 @@
 import { useState, useCallback, useRef } from "react";
-import { INTERNAL } from "@assistant-ui/react";
 import { v4 as uuidv4 } from "uuid";
-
-const { generateId } = INTERNAL;
 
 export type LangGraphCommand = {
   resume: string;
@@ -41,7 +38,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
       const addMessages = (newMessages: TMessage[]) => {
         if (newMessages.length === 0) return;
         for (const message of newMessages) {
-          messagesMap.set(message.id ?? generateId(), message);
+          messagesMap.set(message.id ?? uuidv4(), message);
         }
         setMessages([...messagesMap.values()]);
       };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `generateId` with `uuidv4` for message IDs in `useLangGraphMessages.ts`, ensuring all messages have a UUID.
> 
>   - **Behavior**:
>     - Replaces `generateId` with `uuidv4` for generating message IDs in `useLangGraphMessages.ts`.
>     - Ensures all messages have a UUID in `sendMessage` and `addMessages` functions.
>   - **Imports**:
>     - Removes `INTERNAL` import, which included `generateId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d7a74c895079f71620d3adf70048950983fb3d44. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated message ID generation to use standard UUID library
	- Removed internal ID generation method

<!-- end of auto-generated comment: release notes by coderabbit.ai -->