### PR TITLE
fix: shadcn thread composer style

### DIFF
--- a/apps/registry/registry/components/shadcn/thread.tsx
+++ b/apps/registry/registry/components/shadcn/thread.tsx
@@ -49,12 +49,12 @@ const MyThreadWelcome: FC = () => {
 
 const MyComposer: FC = () => {
   return (
-<ComposerPrimitive.Root className="flex w-full flex-wrap items-end rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in focus-within:border-ring/20">
+    <ComposerPrimitive.Root className="focus-within:border-ring/20 flex w-full flex-wrap items-end rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in">
       <ComposerPrimitive.Input
         autoFocus
         placeholder="Write a message..."
         rows={1}
-        className="placeholder:text-muted-foreground size-full max-h-40 resize-none border-none bg-transparent p-4 pr-12 text-sm outline-none focus:ring-0 disabled:cursor-not-allowed"
+        className="placeholder:text-muted-foreground max-h-40 flex-grow resize-none border-none bg-transparent px-2 py-4 text-sm outline-none focus:ring-0 disabled:cursor-not-allowed"
       />
       <ComposerPrimitive.Send asChild>
         <TooltipIconButton


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reorder CSS classes in `MyComposer` component in `thread.tsx` to improve styling behavior.
> 
>   - **Styling**:
>     - Reorder CSS classes in `MyComposer` component in `thread.tsx` to improve styling behavior.
>     - Adjust `className` for `ComposerPrimitive.Root` and `ComposerPrimitive.Input` to enhance layout and responsiveness.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 6851d83ae009234f2bf8a4a9811106ec01774cc8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated styling for the composer component
	- Adjusted padding and focus border classes for improved visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->