### PR TITLE
feat(local-runtime): New ThreadList items should appear at the top of the list

### DIFF
--- a/.changeset/gold-parrots-reply.md
+++ b/.changeset/gold-parrots-reply.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat(local-runtime): New ThreadList items should appear at the top of the list

--- a/packages/react/src/runtimes/local/LocalThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalThreadListRuntimeCore.tsx
@@ -132,11 +132,11 @@ export class LocalThreadListRuntimeCore implements ThreadListRuntimeCore {
     // newState
     switch (newState) {
       case "regular":
-        this._threadIds = [...this._threadIds, data.threadId];
+        this._threadIds = [data.threadId, ...this._threadIds];
         break;
 
       case "archived":
-        this._archivedThreadIds = [...this._archivedThreadIds, data.threadId];
+        this._archivedThreadIds = [data.threadId, ...this._archivedThreadIds];
         break;
 
       case "deleted":


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> New threads in `LocalThreadListRuntimeCore` now appear at the top of the list by modifying the `_stateOp` function.
> 
>   - **Behavior**:
>     - New threads now appear at the top of the list in `LocalThreadListRuntimeCore`.
>     - Modified `_stateOp` function to prepend `threadId` to `_threadIds` and `_archivedThreadIds` arrays.
>   - **Misc**:
>     - Added changeset file `gold-parrots-reply.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 21eae214e0d73760303dc9b8b727f5443e746369. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Modified thread list management to prepend new thread IDs to the beginning of thread lists instead of appending them to the end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->