### PR TITLE
feat: export useRemoteThreadListRuntime

### DIFF
--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -34,7 +34,7 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.39",
+    "@assistant-ui/react": "^0.7.40",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -30,7 +30,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.39",
+    "@assistant-ui/react": "^0.7.40",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -31,7 +31,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.39",
+    "@assistant-ui/react": "^0.7.40",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -41,7 +41,7 @@
     "react-markdown": "^9.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.39",
+    "@assistant-ui/react": "^0.7.40",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "tailwindcss": "^3.4.4"

--- a/packages/react-playground/package.json
+++ b/packages/react-playground/package.json
@@ -47,7 +47,7 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.39",
+    "@assistant-ui/react": "^0.7.40",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "tailwindcss": "^3.4.4"

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -27,7 +27,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap --clean"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.39",
+    "@assistant-ui/react": "^0.7.40",
     "@assistant-ui/react-markdown": "^0.7.11",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react-trieve/package.json
+++ b/packages/react-trieve/package.json
@@ -45,7 +45,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.39",
+    "@assistant-ui/react": "^0.7.40",
     "@assistant-ui/react-markdown": "^0.7.11",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.7.40
+
+### Patch Changes
+
+- feat: export useRemoteThreadListRuntime
+
 ## 0.7.39
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.7.39",
+  "version": "0.7.40",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
@@ -16,7 +16,9 @@ import { ThreadListItemRuntimeProvider } from "../../context/providers/ThreadLis
 import { useThreadListItem } from "../../context/react/ThreadListItemContext";
 import { ThreadRuntimeCore, ThreadRuntimeImpl } from "../../internal";
 import { BaseSubscribable } from "./BaseSubscribable";
-import { RemoteThreadListHook } from "./types";
+import { AssistantRuntime } from "../../api";
+
+type RemoteThreadListHook = () => AssistantRuntime;
 
 type RemoteThreadListHookInstance = {
   runtime?: ThreadRuntimeCore;

--- a/packages/react/src/runtimes/remote-thread-list/index.ts
+++ b/packages/react/src/runtimes/remote-thread-list/index.ts
@@ -1,2 +1,3 @@
-// export { useRemoteThreadListRuntime } from "./useRemoteThreadListRuntime";
+export { useRemoteThreadListRuntime as unstable_useRemoteThreadListRuntime } from "./useRemoteThreadListRuntime";
+export type { RemoteThreadListAdapter as unstable_RemoteThreadListAdapter } from "./types";
 export * from "./cloud";

--- a/packages/react/src/runtimes/remote-thread-list/types.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/types.tsx
@@ -19,8 +19,6 @@ export type RemoteThreadListResponse = {
   threads: RemoteThreadMetadata[];
 };
 
-export type RemoteThreadListHook = () => AssistantRuntime;
-
 export type RemoteThreadListSubscriber = {
   onInitialize: (
     threadId: string,
@@ -33,7 +31,7 @@ export type RemoteThreadListSubscriber = {
 };
 
 export type RemoteThreadListAdapter = {
-  runtimeHook: RemoteThreadListHook;
+  runtimeHook: () => AssistantRuntime;
 
   list(): Promise<RemoteThreadListResponse>;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Export `useRemoteThreadListRuntime` as `unstable_useRemoteThreadListRuntime` and update `RemoteThreadListAdapter` type, along with peer dependency version updates.
> 
>   - **Exports**:
>     - Export `useRemoteThreadListRuntime` as `unstable_useRemoteThreadListRuntime` in `index.ts`.
>     - Export `RemoteThreadListAdapter` type as `unstable_RemoteThreadListAdapter` in `index.ts`.
>   - **Types**:
>     - Remove `RemoteThreadListHook` type from `types.tsx`.
>     - Update `runtimeHook` type in `RemoteThreadListAdapter` to `() => AssistantRuntime` in `types.tsx`.
>   - **Peer Dependencies**:
>     - Update `@assistant-ui/react` version to `^0.7.40` in `package.json` of `react-ai-sdk`, `react-hook-form`, `react-langgraph`, `react-markdown`, `react-playground`, `react-syntax-highlighter`, and `react-trieve`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 2af701a209985b4bf99aa0d529d1729e2ea36f70. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->