### PR TITLE
fix: ES2022 compatibility, RemoteThreadList should not return an iterator

### DIFF
--- a/.changeset/sour-goats-worry.md
+++ b/.changeset/sour-goats-worry.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: RemoteThreadList should not return an iterator

--- a/packages/assistant-stream/src/core/modules/runs.ts
+++ b/packages/assistant-stream/src/core/modules/runs.ts
@@ -191,12 +191,17 @@ export function createAssistantRun(
   const controller = new RunControllerImpl();
   const promiseOrVoid = callback(controller);
   if (promiseOrVoid instanceof Promise) {
-    promiseOrVoid
-      .catch((e) => {
+    const runTask = async () => {
+      try {
+        await promiseOrVoid;
+      } catch (e) {
         controller.addError(e instanceof Error ? e.message : String(e));
         throw e;
-      })
-      .finally(() => controller.close());
+      } finally {
+        controller.close();
+      }
+    };
+    runTask();
   } else {
     controller.close();
   }

--- a/packages/react/src/runtimes/composer/BaseComposerRuntimeCore.tsx
+++ b/packages/react/src/runtimes/composer/BaseComposerRuntimeCore.tsx
@@ -175,7 +175,11 @@ export abstract class BaseComposerRuntimeCore
 
     await adapter.remove(attachment);
 
-    this._attachments = this._attachments.toSpliced(index, 1);
+    // this._attachments.toSpliced(index, 1); - not yet widely supported
+    this._attachments = [
+      ...this._attachments.slice(0, index),
+      ...this._attachments.slice(index + 1),
+    ];
     this._notifySubscribers();
   }
 

--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
@@ -139,14 +139,12 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   }> = ({ provider }) => {
     this.useAliveThreadsKeysChanged(); // trigger re-render on alive threads change
 
-    return this.instances
-      .keys()
-      .map((threadId) => (
-        <this._OuterActiveThreadProvider
-          key={threadId}
-          threadId={threadId}
-          provider={provider}
-        />
-      ));
+    return Array.from(this.instances.keys()).map((threadId) => (
+      <this._OuterActiveThreadProvider
+        key={threadId}
+        threadId={threadId}
+        provider={provider}
+      />
+    ));
   };
 }

--- a/packages/react/src/runtimes/remote-thread-list/index.ts
+++ b/packages/react/src/runtimes/remote-thread-list/index.ts
@@ -1,3 +1,6 @@
 export { useRemoteThreadListRuntime as unstable_useRemoteThreadListRuntime } from "./useRemoteThreadListRuntime";
-export type { RemoteThreadListAdapter as unstable_RemoteThreadListAdapter } from "./types";
+export type {
+  RemoteThreadListAdapter as unstable_RemoteThreadListAdapter,
+  RemoteThreadListSubscriber as unstable_RemoteThreadListSubscriber,
+} from "./types";
 export * from "./cloud";

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -8,7 +8,7 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "ES2022"],
     "paths": {
       "@assistant-ui/*": ["../../packages/*/src"],
       "assistant-stream": ["../../packages/assistant-stream/src"],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix ES2022 compatibility and ensure `RemoteThreadList` returns an array, not an iterator.
> 
>   - **Behavior**:
>     - Fix `RemoteThreadList` to return an array instead of an iterator in `RemoteThreadListHookInstanceManager.tsx`.
>     - Update async handling in `createAssistantRun()` in `runs.ts` to use an async function for better error handling.
>   - **Compatibility**:
>     - Replace `toSpliced()` with `slice()` in `BaseComposerRuntimeCore.tsx` for broader compatibility.
>     - Update `tsconfig/base.json` to use `ES2022`.
>   - **Types**:
>     - Export `RemoteThreadListSubscriber` type in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for bfd7221a7b9ff365bec7b30120b48e71b69438cc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for `RemoteThreadListSubscriber` type export
- **Bug Fixes**
	- Updated attachment removal method for better compatibility
	- Improved error handling in assistant run creation
- **Refactor**
	- Modified key retrieval method in thread list runtime
	- Updated TypeScript configuration to use ES2022 standard

<!-- end of auto-generated comment: release notes by coderabbit.ai -->