### PR TITLE
fix: event subscriptions triggering on threadList changes

### DIFF
--- a/.changeset/light-donkeys-rush.md
+++ b/.changeset/light-donkeys-rush.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: event subscriptions triggering on threadList changes

--- a/.changeset/light-donkeys-rush.md
+++ b/.changeset/light-donkeys-rush.md
@@ -1,5 +1,0 @@
----
-"@assistant-ui/react": patch
----
-
-fix: event subscriptions triggering on threadList changes

--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -34,7 +34,7 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.41",
+    "@assistant-ui/react": "^0.7.42",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -30,7 +30,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.41",
+    "@assistant-ui/react": "^0.7.42",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -31,7 +31,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.41",
+    "@assistant-ui/react": "^0.7.42",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -41,7 +41,7 @@
     "react-markdown": "^9.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.41",
+    "@assistant-ui/react": "^0.7.42",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "tailwindcss": "^3.4.4"

--- a/packages/react-playground/package.json
+++ b/packages/react-playground/package.json
@@ -47,7 +47,7 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.41",
+    "@assistant-ui/react": "^0.7.42",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "tailwindcss": "^3.4.4"

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -27,7 +27,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap --clean"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.41",
+    "@assistant-ui/react": "^0.7.42",
     "@assistant-ui/react-markdown": "^0.7.11",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react-trieve/package.json
+++ b/packages/react-trieve/package.json
@@ -45,7 +45,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.41",
+    "@assistant-ui/react": "^0.7.42",
     "@assistant-ui/react-markdown": "^0.7.11",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.7.42
+
+### Patch Changes
+
+- 9c3961d: fix: event subscriptions triggering on threadList changes
+
 ## 0.7.41
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.7.41",
+  "version": "0.7.42",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/react/src/api/subscribable/EventSubscriptionSubject.ts
+++ b/packages/react/src/api/subscribable/EventSubscriptionSubject.ts
@@ -1,0 +1,44 @@
+import { Unsubscribe } from "../../types";
+import { BaseSubject } from "./BaseSubject";
+import { EventSubscribable } from "./Subscribable";
+
+export class EventSubscriptionSubject<
+  TEvent extends string,
+> extends BaseSubject {
+  constructor(private config: EventSubscribable<TEvent>) {
+    super();
+  }
+
+  public getState() {
+    return this.config.binding.getState();
+  }
+
+  public outerSubscribe(callback: () => void) {
+    return this.config.binding.subscribe(callback);
+  }
+
+  protected _connect(): Unsubscribe {
+    const callback = () => {
+      this.notifySubscribers();
+    };
+
+    let lastState = this.config.binding.getState();
+    let innerUnsubscribe = lastState?.unstable_on(this.config.event, callback);
+    const onRuntimeUpdate = () => {
+      const newState = this.config.binding.getState();
+      if (newState === lastState) return;
+      lastState = newState;
+
+      innerUnsubscribe?.();
+      innerUnsubscribe = this.config.binding
+        .getState()
+        ?.unstable_on(this.config.event, callback);
+    };
+
+    const outerUnsubscribe = this.outerSubscribe(onRuntimeUpdate);
+    return () => {
+      outerUnsubscribe?.();
+      innerUnsubscribe?.();
+    };
+  }
+}

--- a/packages/react/src/api/subscribable/Subscribable.ts
+++ b/packages/react/src/api/subscribable/Subscribable.ts
@@ -13,3 +13,14 @@ export type NestedSubscribable<
   TState extends Subscribable | undefined,
   TPath,
 > = SubscribableWithState<TState, TPath>;
+
+export type EventSubscribable<TEvent extends string> = {
+  event: TEvent;
+  binding: SubscribableWithState<
+    | {
+        unstable_on: (event: TEvent, callback: () => void) => Unsubscribe;
+      }
+    | undefined,
+    unknown
+  >;
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes event subscriptions triggering on thread list changes by introducing `EventSubscriptionSubject` and updating `unstable_on()` methods in `ComposerRuntimeImpl` and `ThreadRuntimeImpl`.
> 
>   - **Behavior**:
>     - Fixes event subscriptions triggering on `threadList` changes by introducing `EventSubscriptionSubject` in `ComposerRuntime.ts` and `ThreadRuntime.ts`.
>     - Updates `unstable_on()` method in `ComposerRuntimeImpl` and `ThreadRuntimeImpl` to use `EventSubscriptionSubject`.
>   - **Dependencies**:
>     - Updates `@assistant-ui/react` peer dependency to `^0.7.42` in `package.json` files of `react-ai-sdk`, `react-hook-form`, `react-langgraph`, `react-markdown`, `react-playground`, `react-syntax-highlighter`, and `react-trieve`.
>   - **Misc**:
>     - Adds `EventSubscriptionSubject.ts` to handle event subscriptions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for ebd6f352d6f9124aa8f809d5c9a8b22c10a3b5f9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Updates**
	- Updated `@assistant-ui/react` peer dependency to version 0.7.42 across multiple packages

- **Bug Fixes**
	- Resolved an issue with event subscriptions incorrectly triggering on thread list changes

- **Internal Improvements**
	- Enhanced event subscription management in runtime components
	- Introduced new `EventSubscriptionSubject` for more structured event handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->