### PR TITLE
feat: reverse order of threads in useRemoteThreadListRuntime

### DIFF
--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -34,7 +34,7 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.42",
+    "@assistant-ui/react": "^0.7.43",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -30,7 +30,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.42",
+    "@assistant-ui/react": "^0.7.43",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -31,7 +31,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.42",
+    "@assistant-ui/react": "^0.7.43",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -41,7 +41,7 @@
     "react-markdown": "^9.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.42",
+    "@assistant-ui/react": "^0.7.43",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "tailwindcss": "^3.4.4"

--- a/packages/react-playground/package.json
+++ b/packages/react-playground/package.json
@@ -47,7 +47,7 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.42",
+    "@assistant-ui/react": "^0.7.43",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "tailwindcss": "^3.4.4"

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -27,7 +27,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap --clean"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.42",
+    "@assistant-ui/react": "^0.7.43",
     "@assistant-ui/react-markdown": "^0.7.11",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react-trieve/package.json
+++ b/packages/react-trieve/package.json
@@ -45,7 +45,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.42",
+    "@assistant-ui/react": "^0.7.43",
     "@assistant-ui/react-markdown": "^0.7.11",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.7.43
+
+### Patch Changes
+
+- feat: reverse order of threads in useRemoteThreadListRuntime
+
 ## 0.7.42
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.7.42",
+  "version": "0.7.43",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
@@ -89,11 +89,11 @@ const updateStatusReducer = (
   // newStatus
   switch (newStatus) {
     case "regular":
-      newState.threadIds = [...newState.threadIds, threadId];
+      newState.threadIds = [threadId, ...newState.threadIds];
       break;
 
     case "archived":
-      newState.archivedThreadIds = [...newState.archivedThreadIds, threadId];
+      newState.archivedThreadIds = [threadId, ...newState.archivedThreadIds];
       break;
 
     case "deleted":


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverse thread order in `useRemoteThreadListRuntime` and update `@assistant-ui/react` to version `0.7.43`.
> 
>   - **Behavior**:
>     - Reverse order of threads in `updateStatusReducer` in `RemoteThreadListThreadListRuntimeCore.tsx` by prepending `threadId` to `threadIds` and `archivedThreadIds`.
>   - **Dependencies**:
>     - Update `@assistant-ui/react` peer dependency to `^0.7.43` in `package.json` files of `react-ai-sdk`, `react-hook-form`, `react-langgraph`, `react-markdown`, `react-playground`, `react-syntax-highlighter`, and `react-trieve`.
>   - **Versioning**:
>     - Bump version of `@assistant-ui/react` to `0.7.43` in `package.json` and update `CHANGELOG.md` to reflect the thread order change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 41d9a2f1607221e4059613cccdedc11077f66952. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->