### PR TITLE
fix: use the correct chat history for generating titles

### DIFF
--- a/packages/react/src/runtimes/remote-thread-list/cloud/useCloudThreadListRuntime.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/cloud/useCloudThreadListRuntime.tsx
@@ -67,7 +67,9 @@ export const useCloudThreadListRuntime = (adapter: CloudThreadListAdapter) => {
         .unstable_on("run-end", () => {
           dispose();
 
-          const messages = runtime.thread.getState().messages;
+          const messages = runtime.threads
+            .getById(threadId)
+            .getState().messages;
           const begin = beginnable(() => {
             return adapterRef.current.cloud.runs.stream({
               thread_id: remoteId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes message retrieval in `useCloudThreadListRuntime` to use the correct thread ID for generating titles.
> 
>   - **Behavior**:
>     - Fixes message retrieval in `useCloudThreadListRuntime` by using `runtime.threads.getById(threadId).getState().messages` instead of `runtime.thread.getState().messages`.
>   - **Functions**:
>     - Corrects the `unstable_on("run-end")` event handler to use the correct thread ID for message retrieval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for efb7515a2e56b1028244c776f9c43eeed2618f88. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message retrieval mechanism to ensure messages are fetched from the correct thread context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->