### PR TITLE
feat(cloud-threadlist): auto initialize threads

### DIFF
--- a/.changeset/nice-parrots-cheat.md
+++ b/.changeset/nice-parrots-cheat.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat(cloud-threadlist): auto initialize threads

--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
@@ -13,7 +13,10 @@ import {
 import { UseBoundStore, StoreApi, create } from "zustand";
 import { useAssistantRuntime } from "../../context";
 import { ThreadListItemRuntimeProvider } from "../../context/providers/ThreadListItemRuntimeProvider";
-import { useThreadListItem } from "../../context/react/ThreadListItemContext";
+import {
+  useThreadListItem,
+  useThreadListItemRuntime,
+} from "../../context/react/ThreadListItemContext";
 import { ThreadRuntimeCore, ThreadRuntimeImpl } from "../../internal";
 import { BaseSubscribable } from "./BaseSubscribable";
 import { AssistantRuntime } from "../../api";
@@ -112,6 +115,16 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
       return threadBinding.outerSubscribe(updateRuntime);
     }, [threadBinding]);
 
+    // auto initialize thread
+    const threadListItemRuntime = useThreadListItemRuntime();
+    useEffect(() => {
+      return runtime.threads.main.unstable_on("initialize", () => {
+        if (threadListItemRuntime.getState().status === "new") {
+          threadListItemRuntime.initialize();
+        }
+      });
+    }, [runtime, threadListItemRuntime]);
+
     return null;
   };
 
@@ -121,7 +134,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   }> = memo(({ threadId, provider: Provider }) => {
     const assistantRuntime = useAssistantRuntime();
     const threadListItemRuntime = useMemo(
-      () => assistantRuntime.threadList.getItemById(threadId),
+      () => assistantRuntime.threads.getItemById(threadId),
       [assistantRuntime, threadId],
     );
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Auto-initialize threads in `RemoteThreadListHookInstanceManager` when status is 'new'.
> 
>   - **Behavior**:
>     - Auto-initialize threads in `RemoteThreadListHookInstanceManager` when status is 'new'.
>     - Uses `useThreadListItemRuntime` to manage thread initialization.
>   - **Imports**:
>     - Add `useThreadListItemRuntime` to imports from `ThreadListItemContext`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d354efc9ea80eb7d5e025e8260833ffb4cb2eff1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced thread list runtime management
  - Added automatic thread initialization mechanism

- **Improvements**
  - Updated method for accessing thread list items in assistant runtime

<!-- end of auto-generated comment: release notes by coderabbit.ai -->