### PR TITLE
feat(langgraph): interrupt state support

### DIFF
--- a/.changeset/wicked-scissors-fry.md
+++ b/.changeset/wicked-scissors-fry.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+feat: interrupt state stream support

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-langgraph",
-  "version": "0.1.18",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/react-langgraph/src/index.ts
+++ b/packages/react-langgraph/src/index.ts
@@ -1,11 +1,19 @@
 export {
   useLangGraphRuntime,
-  useLangGraphRuntimeSend,
-  useLangGraphRuntimeSendCommand,
+  useLangGraphSend,
+  useLangGraphSendCommand,
+  useLangGraphInterruptState,
 } from "./useLangGraphRuntime";
 
-export { useLangGraphMessages } from "./useLangGraphMessages";
+export {
+  useLangGraphMessages,
+  type LangGraphInterruptState,
+  type LangGraphCommand,
+  type LangGraphSendMessageConfig,
+  type LangGraphStreamCallback,
+} from "./useLangGraphMessages";
 export { convertLangchainMessages } from "./convertLangchainMessages";
+
 export type {
   LangChainMessage,
   LangChainEvent,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds interrupt state support to `react-langgraph`, updating hooks and types to manage interrupt states.
> 
>   - **Behavior**:
>     - Adds interrupt state support in `useLangGraphMessages.ts` and `useLangGraphRuntime.ts`.
>     - Introduces `LangGraphInterruptState` type and `useLangGraphInterruptState` hook.
>     - Updates `useLangGraphMessages` to handle "updates" events and set interrupt state.
>   - **Exports**:
>     - Renames `useLangGraphRuntimeSend` to `useLangGraphSend`.
>     - Renames `useLangGraphRuntimeSendCommand` to `useLangGraphSendCommand`.
>   - **Version**:
>     - Updates version in `package.json` to 0.2.0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d680ad3c0c97f2cf248c85b1711071dd03d71d87. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for @assistant-ui/react-langgraph v0.2.0

- **New Features**
  - Added interrupt state management for enhanced runtime control
  - Introduced new type exports for more flexible configuration

- **Breaking Changes**
  - Renamed runtime-related methods:
    - `useLangGraphRuntimeSend` → `useLangGraphSend`
    - `useLangGraphRuntimeSendCommand` → `useLangGraphSendCommand`

- **Improvements**
  - Expanded event types and messaging capabilities
  - Enhanced type definitions for better developer experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->