### PR TITLE
Fix(Docs): code snippet on ui/primitives/assistantmodal

### DIFF
--- a/apps/docs/content/docs/ui/primitives/AssistantModal.mdx
+++ b/apps/docs/content/docs/ui/primitives/AssistantModal.mdx
@@ -20,7 +20,7 @@ const Thread = () => (
     <AssistantModalPrimitive.Content>
       <Thread />
     </AssistantModalPrimitive.Content>
-  </ThreadPrimitive.Root>
+  </AssistantModalPrimitive.Root>
 );
 ```
 


### PR DESCRIPTION
## Description
The closing component tag seems wrong in the code sample on this [page](https://www.assistant-ui.com/docs/ui/primitives/AssistantModal#anatomy). it should be `</AssistantModalPrimitive.Root>` instead of `</ThreadPrimitive.Root>`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix incorrect closing tag in `AssistantModal.mdx` code snippet.
> 
>   - **Docs**:
>     - Fix incorrect closing tag in code snippet in `AssistantModal.mdx` from `</ThreadPrimitive.Root>` to `</AssistantModalPrimitive.Root>`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 01e6dee4b1d63027a0d3f3b9ded82940a9ba5ec6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for `AssistantModal` component
	- Corrected component reference from `ThreadPrimitive.Root` to `AssistantModalPrimitive.Root`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->