### PR TITLE
feat(local-runtime): add temporary shouldContinueIgnoreToolNames override

### DIFF
--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -34,7 +34,7 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.48",
+    "@assistant-ui/react": "^0.7.49",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -30,7 +30,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.48",
+    "@assistant-ui/react": "^0.7.49",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -31,7 +31,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.48",
+    "@assistant-ui/react": "^0.7.49",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -41,7 +41,7 @@
     "react-markdown": "^9.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.48",
+    "@assistant-ui/react": "^0.7.49",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "tailwindcss": "^3.4.4"

--- a/packages/react-playground/package.json
+++ b/packages/react-playground/package.json
@@ -47,7 +47,7 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.48",
+    "@assistant-ui/react": "^0.7.49",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "tailwindcss": "^3.4.4"

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -27,7 +27,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap --clean"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.48",
+    "@assistant-ui/react": "^0.7.49",
     "@assistant-ui/react-markdown": "^0.7.11",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react-trieve/package.json
+++ b/packages/react-trieve/package.json
@@ -45,7 +45,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.48",
+    "@assistant-ui/react": "^0.7.49",
     "@assistant-ui/react-markdown": "^0.7.11",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.7.49
+
+### Patch Changes
+
+- feat(local-runtime): add temporary shouldContinueIgnoreToolNames override
+
 ## 0.7.48
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.7.48",
+  "version": "0.7.49",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/react/src/runtimes/local/LocalRuntimeOptions.tsx
+++ b/packages/react/src/runtimes/local/LocalRuntimeOptions.tsx
@@ -14,6 +14,12 @@ export type LocalRuntimeOptionsBase = {
     speech?: SpeechSynthesisAdapter | undefined;
     feedback?: FeedbackAdapter | undefined;
   };
+
+  /**
+   * @deprecated This is a temporary workaround for subgraph frontend function calls.
+   * This feature will be removed in a future version without notice. DO NOT USE.
+   */
+  unstable_shouldContinueIgnoreToolNames?: string[] | undefined;
 };
 
 // TODO align LocalRuntimeOptions with LocalRuntimeOptionsBase

--- a/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
@@ -130,7 +130,12 @@ export class LocalThreadRuntimeCore
     try {
       do {
         message = await this.performRoundtrip(parentId, message, runConfig);
-      } while (shouldContinue(message));
+      } while (
+        shouldContinue(
+          message,
+          this._options.unstable_shouldContinueIgnoreToolNames ?? [],
+        )
+      );
     } finally {
       this._notifyEventSubscribers("run-end");
     }
@@ -289,7 +294,13 @@ export class LocalThreadRuntimeCore
     };
     this.repository.addOrUpdateMessage(parentId, message);
 
-    if (added && shouldContinue(message)) {
+    if (
+      added &&
+      shouldContinue(
+        message,
+        this._options.unstable_shouldContinueIgnoreToolNames ?? [],
+      )
+    ) {
       this.performRoundtrip(parentId, message, this._lastRunConfig);
     }
   }

--- a/packages/react/src/runtimes/local/shouldContinue.tsx
+++ b/packages/react/src/runtimes/local/shouldContinue.tsx
@@ -1,6 +1,14 @@
 import type { ThreadAssistantMessage } from "../../types";
 
-export const shouldContinue = (result: ThreadAssistantMessage) =>
+export const shouldContinue = (
+  result: ThreadAssistantMessage,
+  ignoreToolNames: string[],
+) =>
   result.status?.type === "requires-action" &&
   result.status.reason === "tool-calls" &&
-  result.content.every((c) => c.type !== "tool-call" || !!c.result);
+  result.content.every(
+    (c) =>
+      c.type !== "tool-call" ||
+      !!c.result ||
+      ignoreToolNames.includes(c.toolName),
+  );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a temporary override for ignoring tool names in local runtime, updating `shouldContinue` logic and `@assistant-ui/react` version.
> 
>   - **Behavior**:
>     - Adds `unstable_shouldContinueIgnoreToolNames` to `LocalRuntimeOptionsBase` in `LocalRuntimeOptions.tsx` as a temporary workaround for subgraph frontend function calls.
>     - Modifies `shouldContinue` in `shouldContinue.tsx` to accept `ignoreToolNames` and skip tool names in this list.
>     - Updates `LocalThreadRuntimeCore` in `LocalThreadRuntimeCore.tsx` to use `unstable_shouldContinueIgnoreToolNames` in `shouldContinue` calls.
>   - **Dependencies**:
>     - Updates `@assistant-ui/react` peer dependency to `^0.7.49` in multiple `package.json` files.
>   - **Changelog**:
>     - Adds entry for version `0.7.49` in `CHANGELOG.md` noting the new temporary override feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 091a112cbebe4626e0ee9a0f870d712a47d78b9e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a temporary override `shouldContinueIgnoreToolNames` for local runtime to provide more control over tool name handling.

- **Chores**
	- Updated package version to 0.7.49
	- Updated peer dependencies across multiple packages to match the new version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->