### PR TITLE
fix: properly forward unstable_shouldContinueIgnoreToolNames

### DIFF
--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -34,7 +34,7 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.49",
+    "@assistant-ui/react": "^0.7.50",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -30,7 +30,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.49",
+    "@assistant-ui/react": "^0.7.50",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -31,7 +31,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.49",
+    "@assistant-ui/react": "^0.7.50",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -41,7 +41,7 @@
     "react-markdown": "^9.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.49",
+    "@assistant-ui/react": "^0.7.50",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "tailwindcss": "^3.4.4"

--- a/packages/react-playground/package.json
+++ b/packages/react-playground/package.json
@@ -47,7 +47,7 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.49",
+    "@assistant-ui/react": "^0.7.50",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "tailwindcss": "^3.4.4"

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -27,7 +27,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap --clean"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.49",
+    "@assistant-ui/react": "^0.7.50",
     "@assistant-ui/react-markdown": "^0.7.11",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react-trieve/package.json
+++ b/packages/react-trieve/package.json
@@ -45,7 +45,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.49",
+    "@assistant-ui/react": "^0.7.50",
     "@assistant-ui/react-markdown": "^0.7.11",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.7.50
+
+### Patch Changes
+
+- fix: properly forward unstable_shouldContinueIgnoreToolNames
+
 ## 0.7.49
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.7.49",
+  "version": "0.7.50",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/react/src/runtimes/local/LocalRuntimeOptions.tsx
+++ b/packages/react/src/runtimes/local/LocalRuntimeOptions.tsx
@@ -31,13 +31,20 @@ export type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
 export const splitLocalRuntimeOptions = <T extends LocalRuntimeOptions>(
   options: T,
 ) => {
-  const { initialMessages, maxSteps, adapters, ...rest } = options;
+  const {
+    initialMessages,
+    maxSteps,
+    adapters,
+    unstable_shouldContinueIgnoreToolNames,
+    ...rest
+  } = options;
 
   return {
     localRuntimeOptions: {
       initialMessages,
       maxSteps,
       adapters,
+      unstable_shouldContinueIgnoreToolNames,
     },
     otherOptions: rest,
   };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes forwarding of `unstable_shouldContinueIgnoreToolNames` in `LocalRuntimeOptions` and updates `@assistant-ui/react` to version `0.7.50`.
> 
>   - **Behavior**:
>     - Fixes forwarding of `unstable_shouldContinueIgnoreToolNames` in `splitLocalRuntimeOptions` in `LocalRuntimeOptions.tsx`.
>   - **Dependencies**:
>     - Update `@assistant-ui/react` peer dependency to `^0.7.50` in `package.json` of `react-ai-sdk`, `react-hook-form`, `react-langgraph`, `react-markdown`, `react-playground`, `react-syntax-highlighter`, and `react-trieve`.
>   - **Versioning**:
>     - Bump version of `@assistant-ui/react` to `0.7.50` in `package.json`.
>     - Document changes in `CHANGELOG.md` for version `0.7.50`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 6877f35892c500cd8394772aa45079f41f9314dc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->