### PR TITLE
feat: convertExternalMessages

### DIFF
--- a/.changeset/ninety-stingrays-brake.md
+++ b/.changeset/ninety-stingrays-brake.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: convertExternalMessages

--- a/packages/react/src/runtimes/external-store/index.ts
+++ b/packages/react/src/runtimes/external-store/index.ts
@@ -5,4 +5,7 @@ export type {
 export type { ThreadMessageLike } from "./ThreadMessageLike";
 export { useExternalStoreRuntime } from "./useExternalStoreRuntime";
 export { getExternalStoreMessage } from "./getExternalStoreMessage";
-export { useExternalMessageConverter } from "./external-message-converter";
+export {
+  useExternalMessageConverter,
+  convertExternalMessages as unstable_convertExternalMessages,
+} from "./external-message-converter";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `convertExternalMessages` function to process and transform messages, exported as `unstable_convertExternalMessages`.
> 
>   - **New Functionality**:
>     - Add `convertExternalMessages` function in `external-message-converter.tsx` to process messages with a callback and return transformed messages.
>     - Export `convertExternalMessages` as `unstable_convertExternalMessages` in `index.ts`.
>   - **Changeset**:
>     - Add changeset `ninety-stingrays-brake.md` for patch update to `@assistant-ui/react`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for bc957384e7428da357b86f7e1be38b567679522c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->