### PR TITLE
fix: tailwindcss plugin crashes without config

### DIFF
--- a/.changeset/strange-apples-tap.md
+++ b/.changeset/strange-apples-tap.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: tailwindcss plugin crashes without config

--- a/packages/react/src/tailwindcss/index.ts
+++ b/packages/react/src/tailwindcss/index.ts
@@ -81,7 +81,7 @@ const auiPlugin = plugin.withOptions<AssisstantTailwindPluginOptions>(
     components = ["assistant-modal", "thread"],
     colors = {},
     shadcn = false,
-  }) => {
+  } = {}) => {
     const prefix = !shadcn ? "--aui-" : "--";
     return {
       ...(components.length > 0


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes crash in `auiPlugin` by setting default configuration values in `index.ts`.
> 
>   - **Behavior**:
>     - Fixes crash in `auiPlugin` in `index.ts` when no configuration is provided by setting default values for `components`, `colors`, and `shadcn`.
>   - **Misc**:
>     - Adds changeset `strange-apples-tap.md` to document the patch update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 87f5b6ed72f6b7bd326cfa5a3f6532337d7c3dff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->