### PR TITLE
fix: useInputSync IME composition support

### DIFF
--- a/.changeset/cold-ladybugs-sniff.md
+++ b/.changeset/cold-ladybugs-sniff.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: useInputSync IME composition support

--- a/packages/react-ai-sdk/src/ui/utils/useInputSync.tsx
+++ b/packages/react-ai-sdk/src/ui/utils/useInputSync.tsx
@@ -1,31 +1,24 @@
 import { useEffect } from "react";
 import { useAssistant, useChat } from "@ai-sdk/react";
 import { AssistantRuntime } from "@assistant-ui/react";
-import { useCallbackRef } from "@radix-ui/react-use-callback-ref";
 
 type VercelHelpers =
   | ReturnType<typeof useChat>
   | ReturnType<typeof useAssistant>;
 
 export const useInputSync = (
-  helpers: VercelHelpers,
+  { setInput, input }: VercelHelpers,
   runtime: AssistantRuntime,
 ) => {
   // sync input from vercel to assistant-ui
   useEffect(() => {
-    if (runtime.thread.composer.getState().text !== helpers.input) {
-      runtime.thread.composer.setText(helpers.input);
-    }
-  }, [helpers, runtime]);
+    runtime.thread.composer.setText(input);
+  }, [runtime, input]);
 
   // sync input from assistant-ui to vercel
-  const handleThreadUpdate = useCallbackRef(() => {
-    if (runtime.thread.composer.getState().text !== helpers.input) {
-      helpers.setInput(runtime.thread.composer.getState().text);
-    }
-  });
-
   useEffect(() => {
-    return runtime.thread.subscribe(handleThreadUpdate);
-  }, [runtime, handleThreadUpdate]);
+    return runtime.thread.composer.subscribe(() => {
+      setInput(runtime.thread.composer.getState().text);
+    });
+  }, [runtime, setInput]);
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies `useInputSync` to improve IME composition support by streamlining input synchronization logic.
> 
>   - **Behavior**:
>     - Simplifies input synchronization in `useInputSync` by removing `useCallbackRef` and directly using `useEffect` for both directions.
>     - Ensures `runtime.thread.composer.setText(input)` is called directly in `useEffect` for Vercel to assistant-ui sync.
>     - Uses `runtime.thread.composer.subscribe` in `useEffect` for assistant-ui to Vercel sync, directly setting input with `setInput`.
>   - **Misc**:
>     - Updates changeset in `.changeset/cold-ladybugs-sniff.md` to reflect IME composition support fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 7f8c7c986a664bdbb4563a337790d1622f88e8fa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->