### PR TITLE
fix(ai-sdk): switchToNewThread

### DIFF
--- a/.changeset/stale-seals-impress.md
+++ b/.changeset/stale-seals-impress.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react": patch
+---
+
+fix(ai-sdk): onSwitchToThread

--- a/examples/with-ai-sdk/app/MyRuntimeProvider.tsx
+++ b/examples/with-ai-sdk/app/MyRuntimeProvider.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ThreadMessageLike } from "@assistant-ui/react";
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { useVercelUseChatRuntime } from "@assistant-ui/react-ai-sdk";
 import { useChat } from "ai/react";

--- a/packages/react-ai-sdk/src/ui/use-chat/useVercelUseChatRuntime.tsx
+++ b/packages/react-ai-sdk/src/ui/use-chat/useVercelUseChatRuntime.tsx
@@ -10,6 +10,8 @@ import { toCreateMessage } from "../utils/toCreateMessage";
 import { vercelAttachmentAdapter } from "../utils/vercelAttachmentAdapter";
 import { getVercelAIMessages } from "../getVercelAIMessages";
 import { ExternalStoreAdapter } from "@assistant-ui/react";
+import { useState } from "react";
+import { generateId } from "@ai-sdk/ui-utils";
 
 export type VercelUseChatAdapter = {
   adapters?:
@@ -26,6 +28,8 @@ export const useVercelUseChatRuntime = (
     isRunning: chatHelpers.isLoading,
     messages: chatHelpers.messages,
   });
+
+  const [threadId, setThreadId] = useState<string>(generateId());
 
   const runtime = useExternalStoreRuntime({
     isRunning: chatHelpers.isLoading,
@@ -59,12 +63,16 @@ export const useVercelUseChatRuntime = (
       ...adapter.adapters,
       threadList: new Proxy(adapter.adapters?.threadList ?? {}, {
         get(target, prop, receiver) {
+          if (prop === "threadId") {
+            return target.threadId ?? threadId;
+          }
           if (prop === "onSwitchToNewThread") {
             return () => {
               chatHelpers.messages = [];
               chatHelpers.input = "";
               chatHelpers.setMessages([]);
               chatHelpers.setInput("");
+              setThreadId(generateId());
 
               if (typeof target.onSwitchToNewThread === "function") {
                 return target.onSwitchToNewThread.call(target);

--- a/packages/react/src/runtimes/external-store/ExternalStoreRuntimeCore.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreRuntimeCore.tsx
@@ -4,9 +4,7 @@ import { ExternalStoreAdapter } from "./ExternalStoreAdapter";
 import { ExternalStoreThreadRuntimeCore } from "./ExternalStoreThreadRuntimeCore";
 
 const getThreadListAdapter = (store: ExternalStoreAdapter<any>) => {
-  return {
-    ...store.adapters?.threadList,
-  };
+  return store.adapters?.threadList ?? {};
 };
 
 export class ExternalStoreRuntimeCore extends BaseAssistantRuntimeCore {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes `onSwitchToNewThread` in `useVercelUseChatRuntime.tsx` to reset chat state and generate a new thread ID, with minor refactor in `ExternalStoreRuntimeCore.tsx`.
> 
>   - **Behavior**:
>     - Fixes `onSwitchToNewThread` in `useVercelUseChatRuntime.tsx` to reset chat state and generate a new thread ID.
>     - Uses `generateId()` to create a new thread ID when switching threads.
>   - **Refactor**:
>     - Simplifies `getThreadListAdapter` in `ExternalStoreRuntimeCore.tsx` by using nullish coalescing.
>   - **Examples**:
>     - Removes unused import `ThreadMessageLike` from `MyRuntimeProvider.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 7a45e5a149997b5251bf5f5d54fef7def043d1f7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->