### PR TITLE
docs(ai-sdk): add info about getExternalStoreMessages

### DIFF
--- a/apps/docs/content/docs/runtimes/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/external-store.mdx
@@ -75,3 +75,27 @@ export function MyRuntimeProvider({
   );
 }
 ```
+
+## Accessing External Store Messages
+
+You can use the `getExternalStoreMessages` utility to convert `ThreadMessage`s back to your own message type.
+
+```tsx
+const MyAssistantMessage = () => {
+  const myMessages = useMessage((m) => getExternalStoreMessages(m));
+  // ...
+};
+```
+
+Keep in mind that `getExternalStoreMessages` may return multiple messages. This is because assistant-ui merges adjacent assistant and tool messages into a single assistant message.
+
+You can do the same operation for individual content parts as well:
+
+```tsx
+const WeatherToolUI = makeAssistantToolUI({
+  render: () => {
+    const myMessages = useContentPart((p) => getExternalStoreMessages(p));
+    // ...
+  },
+});
+```

--- a/apps/docs/content/docs/runtimes/vercel-ai-sdk/rsc.mdx
+++ b/apps/docs/content/docs/runtimes/vercel-ai-sdk/rsc.mdx
@@ -203,3 +203,14 @@ export default function RootLayout({
 
   </Step>
 </Steps>
+
+## Accessing AI SDK Messages
+
+You can use `getExternalStoreMessages` utility to convert `ThreadMessage`s back to your message format.
+
+```tsx
+const MyAssistantMessage = () => {
+  const myMessage = useMessage((m) => getExternalStoreMessages(m)[0]);
+  // ...
+};
+```

--- a/apps/docs/content/docs/runtimes/vercel-ai-sdk/rsc.mdx
+++ b/apps/docs/content/docs/runtimes/vercel-ai-sdk/rsc.mdx
@@ -206,7 +206,7 @@ export default function RootLayout({
 
 ## Accessing AI SDK Messages
 
-You can use `getExternalStoreMessages` utility to convert `ThreadMessage`s back to your message format.
+You can use the `getExternalStoreMessages` utility to convert `ThreadMessage`s back to your message format.
 
 ```tsx
 const MyAssistantMessage = () => {

--- a/apps/docs/content/docs/runtimes/vercel-ai-sdk/use-assistant.mdx
+++ b/apps/docs/content/docs/runtimes/vercel-ai-sdk/use-assistant.mdx
@@ -39,7 +39,7 @@ npm install @assistant-ui/react @assistant-ui/react-ai-sdk ai openai
 ```tsx
 import { AssistantResponse } from "ai";
 import OpenAI from "openai";
-import type { Run } from 'openai/resources/beta/threads/runs/runs';
+import type { Run } from "openai/resources/beta/threads/runs/runs";
 
 const openai = new OpenAI();
 
@@ -175,3 +175,21 @@ export default function RootLayout({
 
   </Step>
 </Steps>
+
+## Accessing AI SDK Messages
+
+You can use `getExternalStoreMessages` utility to convert `ThreadMessage`s back to `Message`s from AI SDK.
+
+```tsx
+const MyAssistantMessage = () => {
+  const aiSDKMessages = useMessage((m) => getExternalStoreMessages(m));
+  // ...
+};
+
+const WeatherToolUI = makeAssistantToolUI({
+  render: () => {
+    const aiSDKMessage = useContentPart((p) => getExternalStoreMessages(p)[0]);
+    // ...
+  },
+});
+```

--- a/apps/docs/content/docs/runtimes/vercel-ai-sdk/use-chat.mdx
+++ b/apps/docs/content/docs/runtimes/vercel-ai-sdk/use-chat.mdx
@@ -118,3 +118,21 @@ export default function RootLayout({
 
   </Step>
 </Steps>
+
+## Accessing AI SDK Messages
+
+You can use `getExternalStoreMessages` utility to convert `ThreadMessage`s back to `Message`s from AI SDK.
+
+```tsx
+const MyAssistantMessage = () => {
+  const aiSDKMessages = useMessage((m) => getExternalStoreMessages(m));
+  // ...
+};
+
+const WeatherToolUI = makeAssistantToolUI({
+  render: () => {
+    const aiSDKMessage = useContentPart((p) => getExternalStoreMessages(p)[0]);
+    // ...
+  },
+});
+```

--- a/apps/docs/content/docs/runtimes/vercel-ai-sdk/use-chat.mdx
+++ b/apps/docs/content/docs/runtimes/vercel-ai-sdk/use-chat.mdx
@@ -121,7 +121,7 @@ export default function RootLayout({
 
 ## Accessing AI SDK Messages
 
-You can use `getExternalStoreMessages` utility to convert `ThreadMessage`s back to `Message`s from AI SDK.
+You can use the `getExternalStoreMessages` utility to convert `ThreadMessage`s back to `Message`s from AI SDK.
 
 ```tsx
 const MyAssistantMessage = () => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for `getExternalStoreMessages` utility in multiple files, explaining its usage and behavior.
> 
>   - **Documentation**:
>     - Adds section on `getExternalStoreMessages` in `external-store.mdx`, `rsc.mdx`, `use-assistant.mdx`, and `use-chat.mdx`.
>     - Provides examples of using `getExternalStoreMessages` with `useMessage` and `useContentPart` hooks.
>     - Explains that `getExternalStoreMessages` may return multiple messages due to message merging behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 11959ea61b3c2b08229d16899e1641e1b5c15e5a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->