### PR TITLE
fix: mark fields in local-runtime as readonly

### DIFF
--- a/.changeset/hip-bees-design.md
+++ b/.changeset/hip-bees-design.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: mark ChatAdapter types as readonly

--- a/examples/with-external-store/app/MyRuntimeProvider.tsx
+++ b/examples/with-external-store/app/MyRuntimeProvider.tsx
@@ -17,7 +17,7 @@ export function MyRuntimeProvider({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const [messages, setMessages] = useState<ThreadMessageLike[]>([]);
+  const [messages, setMessages] = useState<readonly ThreadMessageLike[]>([]);
 
   const onNew = async (message: AppendMessage) => {
     if (message.content.length !== 1 || message.content[0]?.type !== "text")

--- a/packages/react/src/runtimes/edge/createEdgeRuntimeAPI.ts
+++ b/packages/react/src/runtimes/edge/createEdgeRuntimeAPI.ts
@@ -28,7 +28,7 @@ import { z } from "zod";
 type FinishResult = {
   messages: CoreMessage[];
   metadata: {
-    steps: ThreadStep[];
+    steps: readonly ThreadStep[];
   };
 };
 

--- a/packages/react/src/runtimes/external-store/ExternalStoreAdapter.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreAdapter.tsx
@@ -51,7 +51,7 @@ type ExternalStoreMessageConverterAdapter<T> = {
 type ExternalStoreAdapterBase<T> = {
   isDisabled?: boolean | undefined;
   isRunning?: boolean | undefined;
-  messages: T[];
+  messages: readonly T[];
   suggestions?: readonly ThreadSuggestion[] | undefined;
   extras?: unknown;
 

--- a/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
@@ -25,7 +25,7 @@ const EMPTY_ARRAY = Object.freeze([]);
 
 export const hasUpcomingMessage = (
   isRunning: boolean,
-  messages: ThreadMessage[],
+  messages: readonly ThreadMessage[],
 ) => {
   return isRunning && messages[messages.length - 1]?.role !== "assistant";
 };
@@ -51,7 +51,7 @@ export class ExternalStoreThreadRuntimeCore
     return this._capabilities;
   }
 
-  private _messages!: ThreadMessage[];
+  private _messages!: readonly ThreadMessage[];
   public isDisabled!: boolean;
 
   public override get messages() {
@@ -248,14 +248,15 @@ export class ExternalStoreThreadRuntimeCore
     this._store.onAddToolResult(options);
   }
 
-  private updateMessages = (messages: ThreadMessage[]) => {
+  private updateMessages = (messages: readonly ThreadMessage[]) => {
     const hasConverter = this._store.convertMessage !== undefined;
     if (hasConverter) {
       this._store.setMessages?.(
         messages.flatMap(getExternalStoreMessage).filter((m) => m != null),
       );
     } else {
-      this._store.setMessages?.(messages);
+      // TODO mark this as readonly in v0.8.0
+      this._store.setMessages?.(messages as ThreadMessage[]);
     }
   };
 }

--- a/packages/react/src/runtimes/external-store/ThreadMessageConverter.ts
+++ b/packages/react/src/runtimes/external-store/ThreadMessageConverter.ts
@@ -10,7 +10,7 @@ export class ThreadMessageConverter {
   private readonly cache = new WeakMap<WeakKey, ThreadMessage>();
 
   convertMessages<TIn extends WeakKey>(
-    messages: TIn[],
+    messages: readonly TIn[],
     converter: ConverterCallback<TIn>,
   ): ThreadMessage[] {
     return messages.map((m, idx) => {

--- a/packages/react/src/runtimes/local/ChatModelAdapter.tsx
+++ b/packages/react/src/runtimes/local/ChatModelAdapter.tsx
@@ -10,41 +10,41 @@ import type {
 import type { ModelContext } from "../../model-context/ModelContextTypes";
 
 export type ChatModelRunUpdate = {
-  content: ThreadAssistantContentPart[];
-  metadata?: Record<string, unknown>;
+  readonly content: readonly ThreadAssistantContentPart[];
+  readonly metadata?: Record<string, unknown>;
 };
 
 export type ChatModelRunResult = {
-  content?: ThreadAssistantContentPart[] | undefined;
-  status?: MessageStatus | undefined;
-  metadata?: {
-    unstable_annotations?: unknown[] | undefined;
-    unstable_data?: unknown[] | undefined;
-    steps?: ThreadStep[] | undefined;
-    custom?: Record<string, unknown> | undefined;
+  readonly content?: readonly ThreadAssistantContentPart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_annotations?: readonly unknown[] | undefined;
+    readonly unstable_data?: readonly unknown[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
   };
 };
 
 export type CoreChatModelRunResult = Omit<ChatModelRunResult, "content"> & {
-  content: (TextContentPart | ToolCallContentPart)[];
+  readonly content: readonly (TextContentPart | ToolCallContentPart)[];
 };
 
 export type ChatModelRunOptions = {
-  messages: ThreadMessage[];
-  runConfig: RunConfig;
-  abortSignal: AbortSignal;
-  context: ModelContext;
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext;
 
   /**
    * @deprecated This field was renamed to `context`.
    */
-  config: ModelContext;
+  readonly config: ModelContext;
 
-  unstable_assistantMessageId?: string;
+  readonly unstable_assistantMessageId?: string;
 };
 
 export type ChatModelAdapter = {
-  run: (
+  run(
     options: ChatModelRunOptions,
-  ) => Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult, void>;
+  ): Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult, void>;
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Mark various types as readonly in `local-runtime` and `external-store` components to ensure immutability.
> 
>   - **Behavior**:
>     - Mark `messages` as `readonly` in `MyRuntimeProvider` in `app/MyRuntimeProvider.tsx`.
>     - Mark `steps` as `readonly` in `FinishResult` in `createEdgeRuntimeAPI.ts`.
>     - Mark `messages` as `readonly` in `ExternalStoreAdapter.tsx` and `ExternalStoreThreadRuntimeCore.tsx`.
>     - Mark `messages` as `readonly` in `convertMessages()` in `ThreadMessageConverter.ts`.
>     - Mark `content`, `metadata`, and `messages` as `readonly` in `ChatModelAdapter.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 2b7f549d8f2abd866ec7585c3f635825c038a0b6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->