### PR TITLE
fix: memoize MessageRepository.getMessages()

### DIFF
--- a/.changeset/tricky-cups-sing.md
+++ b/.changeset/tricky-cups-sing.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: memoize MessageRepository.getMessages()


### PR DESCRIPTION
fixes #1452
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Memoizes `getMessages()` in `MessageRepository` using `CachedValue` to improve performance by caching results and invalidating cache on message updates.
> 
>   - **Memoization**:
>     - Introduces `CachedValue` class to memoize results of `getMessages()` in `MessageRepository`.
>     - Caches the result of `getMessages()` and invalidates cache on message updates.
>   - **Cache Invalidation**:
>     - Calls `_messages.dirty()` in `addOrUpdateMessage()`, `deleteMessage()`, `switchToBranch()`, and `resetHead()` to invalidate cache when messages change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 3a9df803eaca79542e6af01d08e65db981de58f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->