### PR TITLE
fix: support AISDKInterop + sendMessageId for human+system messages

### DIFF
--- a/.changeset/fast-mails-press.md
+++ b/.changeset/fast-mails-press.md
@@ -1,5 +1,0 @@
----
-"@assistant-ui/react": patch
----
-
-fix: support AISDKInterop + sendMessageId for human+system messages

--- a/.changeset/fast-mails-press.md
+++ b/.changeset/fast-mails-press.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: support AISDKInterop + sendMessageId for human+system messages

--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -34,7 +34,7 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.57",
+    "@assistant-ui/react": "^0.7.58",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -30,7 +30,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.57",
+    "@assistant-ui/react": "^0.7.58",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -31,7 +31,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.57",
+    "@assistant-ui/react": "^0.7.58",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -41,7 +41,7 @@
     "react-markdown": "^9.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.57",
+    "@assistant-ui/react": "^0.7.58",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "tailwindcss": "^3.4.4"

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -27,7 +27,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap --clean"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.57",
+    "@assistant-ui/react": "^0.7.58",
     "@assistant-ui/react-markdown": "^0.7.11",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react-trieve/package.json
+++ b/packages/react-trieve/package.json
@@ -45,7 +45,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.57",
+    "@assistant-ui/react": "^0.7.58",
     "@assistant-ui/react-markdown": "^0.7.11",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.7.58
+
+### Patch Changes
+
+- 02996f9: fix: support AISDKInterop + sendMessageId for human+system messages
+
 ## 0.7.57
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.7.57",
+  "version": "0.7.58",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/react/src/runtimes/edge/EdgeChatAdapter.ts
+++ b/packages/react/src/runtimes/edge/EdgeChatAdapter.ts
@@ -68,9 +68,9 @@ export class EdgeChatAdapter implements ChatModelAdapter {
       body: JSON.stringify({
         system: context.system,
         messages: this.options.unstable_AISDKInterop
-          ? (toLanguageModelMessages(
-              messages,
-            ) as EdgeRuntimeRequestOptions["messages"]) // TODO figure out a better way to do this
+          ? (toLanguageModelMessages(messages, {
+              unstable_includeId: this.options.unstable_sendMessageIds,
+            }) as EdgeRuntimeRequestOptions["messages"]) // TODO figure out a better way to do this
           : toCoreMessages(messages, {
               unstable_includeId: this.options.unstable_sendMessageIds,
             }),

--- a/packages/react/src/runtimes/edge/converters/toLanguageModelMessages.ts
+++ b/packages/react/src/runtimes/edge/converters/toLanguageModelMessages.ts
@@ -74,12 +74,22 @@ const assistantMessageSplitter = () => {
 
 export function toLanguageModelMessages(
   message: readonly CoreMessage[] | readonly ThreadMessage[],
+  options: { unstable_includeId?: boolean | undefined } = {},
 ): LanguageModelV1Message[] {
+  const includeId = options.unstable_includeId ?? false;
   return message.flatMap((message) => {
     const role = message.role;
     switch (role) {
       case "system": {
-        return [{ role: "system", content: message.content[0].text }];
+        return [
+          {
+            ...(includeId
+              ? { unstable_id: (message as ThreadMessage).id }
+              : {}),
+            role: "system",
+            content: message.content[0].text,
+          },
+        ];
       }
 
       case "user": {
@@ -89,6 +99,7 @@ export function toLanguageModelMessages(
           ...attachments.map((a) => a.content).flat(),
         ];
         const msg: LanguageModelV1Message = {
+          ...(includeId ? { unstable_id: (message as ThreadMessage).id } : {}),
           role: "user",
           content: content.map(
             (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `EdgeChatAdapter` to support AISDKInterop and message ID options, and update peer dependencies to `@assistant-ui/react` version `0.7.58`.
> 
>   - **Behavior**:
>     - `EdgeChatAdapter` in `EdgeChatAdapter.ts` now supports `unstable_AISDKInterop` and `unstable_sendMessageIds` options for handling human and system messages.
>     - `toLanguageModelMessages` in `toLanguageModelMessages.ts` updated to include `unstable_id` when `unstable_includeId` is true.
>   - **Dependencies**:
>     - Update `@assistant-ui/react` peer dependency to `^0.7.58` in `package.json` files of `react-ai-sdk`, `react-hook-form`, `react-langgraph`, `react-markdown`, `react-syntax-highlighter`, and `react-trieve`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 3c6a6127dd09695ae27f65f383530fea7437a1c5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->