### PR TITLE
docs: add walkthrough for AI SDK + cloud

### DIFF
--- a/apps/docs/content/docs/cloud/ai-sdk.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk.mdx
@@ -126,7 +126,7 @@ export function MyRuntimeProvider({
 ```
 
 <Callout emoji="💡">
-  Observe that the `useMyLangGraphRuntime` hook is extracted into a separate
+  Observe that the `useMyAISDKRuntime` hook is extracted into a separate
   function. This hook will be mounted multiple times, once per active thread.
 </Callout>
 

--- a/apps/docs/content/docs/cloud/ai-sdk.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk.mdx
@@ -124,7 +124,7 @@ export function MyRuntimeProvider({
 ```
 
 <Callout emoji="💡">
-  Observe that the `useMyLangGraphRuntime` hook is extracted into a separate
+  Observe that the `useMyAISDKRuntime` hook is extracted into a separate
   function. This hook will be mounted multiple times, once per active thread.
 </Callout>
 

--- a/apps/docs/content/docs/cloud/ai-sdk.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk.mdx
@@ -1,11 +1,11 @@
 ---
-title: Walkthrough - assistant-cloud with LangGraph Cloud
+title: Walkthrough - assistant-cloud with AI SDK by Vercel
 ---
 
 ## Overview
 
 With the help of assistant-cloud, you can add thread management and thread history capabilities to assistant-ui.  
-This guide will walk you through the process of integrating assistant-cloud with LangGraph Cloud.
+This guide will walk you through the process of integrating assistant-cloud with the AI SDK by Vercel.
 
 ### Prerequisites
 
@@ -51,42 +51,44 @@ Then, In the assistant-cloud dashboard, navigate to the "Auth Rules" tab and cre
 
 Now that we have everything set up, let's write the code for the runtime provider.
 
-The code below is a simple LangGraph runtime provider that uses the assistant-cloud API to create and manage threads.
+The code below is a simple AI SDK runtime provider that uses the assistant-cloud API to create and manage threads.
 
-```tsx twoslash {1-2,5-6,19,27,29-36,38-45}
-// @errors: 2307
+```tsx title="/app/api/chat/route.ts"
+import { openai } from "@ai-sdk/openai";
+import { streamText } from "ai";
 
+export const maxDuration = 30;
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = streamText({
+    model: openai("gpt-4o"),
+    messages,
+  });
+
+  return result.toDataStreamResponse();
+}
+```
+
+```tsx twoslash {1-2,5-6,19,27,29-36,38-45} title="/app/MyRuntimeProvider.tsx"
 "use client";
 
 import {
   AssistantCloud,
   AssistantRuntimeProvider,
   useCloudThreadListRuntime,
-  useThreadListItemRuntime,
+  useEdgeRuntime,
 } from "@assistant-ui/react";
-import { useLangGraphRuntime } from "@assistant-ui/react-langgraph";
 import { createThread, getThreadState, sendMessage } from "@/lib/chatApi";
-import { LangChainMessage } from "@assistant-ui/react-langgraph";
 import { useAuth } from "@clerk/nextjs";
 import { useMemo } from "react";
 
 // ---cut---
-const useMyLangGraphRuntime = () => {
-  const threadListItemRuntime = useThreadListItemRuntime();
-  const runtime = useLangGraphRuntime({
-    stream: async function* (messages) {
-      const { externalId } = await threadListItemRuntime.initialize();
-      if (!externalId) throw new Error("Thread not found");
-
-      return sendMessage({ threadId: externalId, messages });
-    },
-    onSwitchToThread: async (externalId) => {
-      const state = await getThreadState(externalId);
-      return {
-        messages:
-          (state.values as { messages?: LangChainMessage[] }).messages ?? [],
-      };
-    },
+const useMyAISDKRuntime = () => {
+  const runtime = useEdgeRuntime({
+    api: "/api/chat",
+    unstable_AISDKInterop: true,
   });
 
   return runtime;
@@ -110,11 +112,7 @@ export function MyRuntimeProvider({
 
   const runtime = useCloudThreadListRuntime({
     cloud,
-    runtimeHook: useMyLangGraphRuntime,
-    create: async () => {
-      const { thread_id } = await createThread();
-      return { externalId: thread_id };
-    },
+    runtimeHook: useMyAISDKRuntime,
   });
 
   return (

--- a/apps/docs/content/docs/cloud/ai-sdk.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk.mdx
@@ -72,6 +72,8 @@ export async function POST(req: Request) {
 ```
 
 ```tsx twoslash {1-2,5-6,19,27,29-36,38-45} title="/app/MyRuntimeProvider.tsx"
+// @errors: 2307
+
 "use client";
 
 import {
@@ -124,7 +126,7 @@ export function MyRuntimeProvider({
 ```
 
 <Callout emoji="💡">
-  Observe that the `useMyAISDKRuntime` hook is extracted into a separate
+  Observe that the `useMyLangGraphRuntime` hook is extracted into a separate
   function. This hook will be mounted multiple times, once per active thread.
 </Callout>
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds documentation for integrating assistant-cloud with AI SDK by Vercel and updates title in LangGraph Cloud walkthrough.
> 
>   - **New Documentation**:
>     - Adds `ai-sdk.mdx` for integrating `assistant-cloud` with AI SDK by Vercel.
>     - Includes setup instructions for project creation, authorization using Clerk, and runtime provider code.
>     - Provides example code for `MyRuntimeProvider` and `ThreadList` component.
>   - **Title Change**:
>     - Updates title in `langgraph.mdx` to "Walkthrough - assistant-cloud with LangGraph Cloud".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 88bd18afc244f45cf7d91d4103e850a0a1c8a058. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->