### PR TITLE
fix: export getExternalStoreMessages

### DIFF
--- a/.changeset/hot-actors-relate.md
+++ b/.changeset/hot-actors-relate.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: export getExternalStoreMessages

--- a/packages/react/src/runtimes/external-store/index.ts
+++ b/packages/react/src/runtimes/external-store/index.ts
@@ -4,7 +4,10 @@ export type {
 } from "./ExternalStoreAdapter";
 export type { ThreadMessageLike } from "./ThreadMessageLike";
 export { useExternalStoreRuntime } from "./useExternalStoreRuntime";
-export { getExternalStoreMessage } from "./getExternalStoreMessage";
+export {
+  getExternalStoreMessage,
+  getExternalStoreMessages,
+} from "./getExternalStoreMessage";
 export {
   useExternalMessageConverter,
   convertExternalMessages as unstable_convertExternalMessages,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Export `getExternalStoreMessages` from `index.ts` in the `external-store` runtime.
> 
>   - **Exports**:
>     - Export `getExternalStoreMessages` from `getExternalStoreMessage` in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 9d76167140a8f87d31db766af8ae769d0e6a6569. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->