### PR TITLE
fix: references to react-ui

### DIFF
--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -1,5 +1,5 @@
-@import "../../../packages/react/src/styles/index.css";
-@import "../../../packages/react/src/styles/modal.css";
+@import "../../../packages/react-ui/src/styles/index.css";
+@import "../../../packages/react-ui/src/styles/modal.css";
 
 @tailwind base;
 @tailwind components;

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -303,7 +303,7 @@ Add the following to your `tailwind.config.ts`:
 {
   plugins: [
     require("tailwindcss-animate"), // make sure to "npm install tailwindcss-animate"
-    require("@assistant-ui/react/tailwindcss")({ shadcn: true })
+    require("@assistant-ui/react-ui/tailwindcss")({ shadcn: true })
   ],
 }
 ```

--- a/apps/docs/content/docs/migrations/deprecation-policy.mdx
+++ b/apps/docs/content/docs/migrations/deprecation-policy.mdx
@@ -23,7 +23,7 @@ These features may be removed at any time without notice.
 
 A deprecation of these features will undergo a short (&lt;1) month deprecation notice period.
 
-- TailwindCSS Plugins (e.g. `@assistant-ui/react/tailwindcss`)
+- TailwindCSS Plugins (e.g. `@assistant-ui/react-ui/tailwindcss`)
 - Context API
 - Runtime API
 - Message types

--- a/apps/docs/content/docs/ui/styled/Thread.mdx
+++ b/apps/docs/content/docs/ui/styled/Thread.mdx
@@ -33,7 +33,7 @@ Add the following to your `tailwind.config.ts`:
 {
   plugins: [
     require("tailwindcss-animate"), // make sure to "npm install tailwindcss-animate"
-    require("@assistant-ui/react/tailwindcss")({
+    require("@assistant-ui/react-ui/tailwindcss")({
       components: ["thread"],
     })
   ],

--- a/apps/docs/tailwind.config.ts
+++ b/apps/docs/tailwind.config.ts
@@ -78,7 +78,7 @@ const config = {
   presets: [createPreset()],
   plugins: [
     require("tailwindcss-animate"),
-    require("@assistant-ui/react/tailwindcss")({
+    require("@assistant-ui/react-ui/tailwindcss")({
       components: [],
       shadcn: true,
     }),

--- a/apps/registry/registry/registry.ts
+++ b/apps/registry/registry/registry.ts
@@ -9,7 +9,7 @@ export const registry: RegistryItem[] = [
       config: {
         plugins: [
           `require("tailwindcss-animate")`,
-          `require("@assistant-ui/react/tailwindcss")({ shadcn: true })`,
+          `require("@assistant-ui/react-ui/tailwindcss")({ shadcn: true })`,
         ],
       },
     },

--- a/examples/local-ollama/tailwind.config.ts
+++ b/examples/local-ollama/tailwind.config.ts
@@ -9,7 +9,7 @@ const config = {
   ],
   plugins: [
     require("tailwindcss-animate"),
-    require("@assistant-ui/react/tailwindcss"),
+    require("@assistant-ui/react-ui/tailwindcss"),
     require("@assistant-ui/react-markdown/tailwindcss"),
   ],
 } satisfies Config;

--- a/examples/with-ai-sdk/tailwind.config.ts
+++ b/examples/with-ai-sdk/tailwind.config.ts
@@ -10,7 +10,7 @@ const config = {
   ],
   plugins: [
     require("tailwindcss-animate"),
-    require("@assistant-ui/react/tailwindcss"),
+    require("@assistant-ui/react-ui/tailwindcss"),
   ],
 } satisfies Config;
 

--- a/examples/with-cloud/tailwind.config.ts
+++ b/examples/with-cloud/tailwind.config.ts
@@ -10,7 +10,7 @@ const config = {
   ],
   plugins: [
     require("tailwindcss-animate"),
-    require("@assistant-ui/react/tailwindcss"),
+    require("@assistant-ui/react-ui/tailwindcss"),
   ],
 } satisfies Config;
 

--- a/examples/with-external-store/tailwind.config.ts
+++ b/examples/with-external-store/tailwind.config.ts
@@ -10,7 +10,7 @@ const config = {
   ],
   plugins: [
     require("tailwindcss-animate"),
-    require("@assistant-ui/react/tailwindcss"),
+    require("@assistant-ui/react-ui/tailwindcss"),
   ],
 } satisfies Config;
 

--- a/examples/with-ffmpeg/tailwind.config.ts
+++ b/examples/with-ffmpeg/tailwind.config.ts
@@ -78,7 +78,7 @@ const config = {
   },
   plugins: [
     require("tailwindcss-animate"),
-    require("@assistant-ui/react/tailwindcss")({ shadcn: true }),
+    require("@assistant-ui/react-ui/tailwindcss")({ shadcn: true }),
   ],
 } satisfies Config;
 

--- a/examples/with-langgraph/tailwind.config.ts
+++ b/examples/with-langgraph/tailwind.config.ts
@@ -78,7 +78,7 @@ const config = {
   },
   plugins: [
     require("tailwindcss-animate"),
-    require("@assistant-ui/react/tailwindcss")({ shadcn: true }),
+    require("@assistant-ui/react-ui/tailwindcss")({ shadcn: true }),
     require("@assistant-ui/react-markdown/tailwindcss"),
   ],
 } satisfies Config;

--- a/examples/with-react-hook-form/tailwind.config.ts
+++ b/examples/with-react-hook-form/tailwind.config.ts
@@ -78,7 +78,7 @@ const config = {
   },
   plugins: [
     require("tailwindcss-animate"),
-    require("@assistant-ui/react/tailwindcss")({ shadcn: true }),
+    require("@assistant-ui/react-ui/tailwindcss")({ shadcn: true }),
   ],
 } satisfies Config;
 

--- a/examples/with-trieve/tailwind.config.ts
+++ b/examples/with-trieve/tailwind.config.ts
@@ -78,7 +78,7 @@ const config = {
   },
   plugins: [
     require("tailwindcss-animate"),
-    require("@assistant-ui/react/tailwindcss")({ shadcn: true }),
+    require("@assistant-ui/react-ui/tailwindcss")({ shadcn: true }),
     require("@assistant-ui/react-markdown/tailwindcss"),
     require("@assistant-ui/react-trieve/tailwindcss"),
   ],

--- a/packages/react-markdown/tailwind.config.ts
+++ b/packages/react-markdown/tailwind.config.ts
@@ -51,7 +51,7 @@ const config = {
   },
   plugins: [
     animatePlugin,
-    require("@assistant-ui/react/tailwindcss")({ components: [] }),
+    require("@assistant-ui/react-ui/tailwindcss")({ components: [] }),
   ],
 } satisfies Config;
 

--- a/packages/react-trieve/tailwind.config.ts
+++ b/packages/react-trieve/tailwind.config.ts
@@ -51,7 +51,7 @@ const config = {
   },
   plugins: [
     animatePlugin,
-    require("@assistant-ui/react/tailwindcss")({ components: [] }),
+    require("@assistant-ui/react-ui/tailwindcss")({ components: [] }),
   ],
 } satisfies Config;
 

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -81,7 +81,7 @@
   "homepage": "https://www.assistant-ui.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/assistant-ui/assistant-ui/tree/main/packages/react"
+    "url": "https://github.com/assistant-ui/assistant-ui/tree/main/packages/react-ui"
   },
   "bugs": {
     "url": "https://github.com/assistant-ui/assistant-ui/issues"

--- a/packages/tool-ui-weather/tailwind.config.ts
+++ b/packages/tool-ui-weather/tailwind.config.ts
@@ -51,7 +51,7 @@ const config = {
   },
   plugins: [
     animatePlugin,
-    require("@assistant-ui/react/tailwindcss")({ components: [] }),
+    require("@assistant-ui/react-ui/tailwindcss")({ components: [] }),
   ],
 } satisfies Config;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename references from `react` to `react-ui` in imports, plugins, and documentation across the codebase.
> 
>   - **Imports and Plugins**:
>     - Update import paths in `global.css` to use `react-ui` instead of `react`.
>     - Change TailwindCSS plugin references from `@assistant-ui/react/tailwindcss` to `@assistant-ui/react-ui/tailwindcss` in `tailwind.config.ts` files across multiple examples and packages.
>   - **Documentation**:
>     - Update references in `getting-started.mdx`, `deprecation-policy.mdx`, and `Thread.mdx` to use `@assistant-ui/react-ui`.
>   - **Package Configuration**:
>     - Update `repository.url` in `package.json` to reflect `react-ui` path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 8402f1741b2b10cc25f4993ce4064568687013ef. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->