### PR TITLE
fix: markdown styles ignored when using tailwind plugin

### DIFF
--- a/packages/react-markdown/tailwind.config.ts
+++ b/packages/react-markdown/tailwind.config.ts
@@ -51,7 +51,8 @@ const config = {
   },
   plugins: [
     animatePlugin,
-    require("@assistant-ui/react-ui/tailwindcss")({ components: [] }),
+    // temp - move markdown styles to react-ui
+    require("@assistant-ui/react/tailwindcss")({ components: [] }),
   ],
 } satisfies Config;
 

--- a/packages/react-ui/src/tailwindcss/index.ts
+++ b/packages/react-ui/src/tailwindcss/index.ts
@@ -78,15 +78,16 @@ const auiPlugin = plugin.withOptions<AssisstantTailwindPluginOptions>(
       }
     },
   ({
-    components = ["assistant-modal", "thread"],
+    // components = ["assistant-modal", "thread"],
     colors = {},
     shadcn = false,
   } = {}) => {
     const prefix = !shadcn ? "--aui-" : "--";
     return {
-      ...(components.length > 0
-        ? { safelist: [{ pattern: /^aui-/ }] }
-        : undefined),
+      safelist: [{ pattern: /^aui-/ }],
+      // ...(components.length > 0
+      //   ? { safelist: [{ pattern: /^aui-/ }] }
+      //   : undefined),
       theme: {
         extend: {
           maxWidth: {

--- a/packages/react/src/tailwindcss/index.ts
+++ b/packages/react/src/tailwindcss/index.ts
@@ -78,15 +78,12 @@ const auiPlugin = plugin.withOptions<AssisstantTailwindPluginOptions>(
       }
     },
   ({
-    components = ["assistant-modal", "thread"],
     colors = {},
     shadcn = false,
   } = {}) => {
     const prefix = !shadcn ? "--aui-" : "--";
     return {
-      ...(components.length > 0
-        ? { safelist: [{ pattern: /^aui-/ }] }
-        : undefined),
+      safelist: [{ pattern: /^aui-/ }],
       theme: {
         extend: {
           maxWidth: {

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,8 @@
       "env": [
         "OPENAI_*",
         "ASSISTANT_UI_*",
-        "ENTELLIGENCE_API_*",
+        "ENTELLIGENCE_*",
+        "SENTRY_*",
         "NEXT_PUBLIC_*",
         "TRIEVE_*"
       ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes markdown styles handling in Tailwind configuration and updates environment variables in `turbo.json`.
> 
>   - **Tailwind Configuration**:
>     - In `tailwind.config.ts`, updated plugin path from `@assistant-ui/react-ui/tailwindcss` to `@assistant-ui/react/tailwindcss`.
>     - Removed `components` array handling in `safelist` logic in `index.ts` of `react-ui` and `react` packages.
>   - **Environment Variables**:
>     - In `turbo.json`, added `SENTRY_*` to the environment variables list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 479bbd57038d36be6e2d77ff1069f92f87a92db1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->