### PR TITLE
docs: markdown in DocsChat

### DIFF
--- a/apps/docs/components/docs-chat/DocsChat.tsx
+++ b/apps/docs/components/docs-chat/DocsChat.tsx
@@ -131,7 +131,16 @@ const MyAssistantModalTrigger: FC = () => {
 
 const MyThread: FC = () => {
   return (
-    <Thread.Root className="flex flex-col">
+    <Thread.Root
+      className="flex flex-col"
+      config={{
+        assistantMessage: {
+          components: {
+            Text: MarkdownText,
+          },
+        },
+      }}
+    >
       <Thread.Viewport>
         <ThreadWelcome />
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds markdown support to `MyThread` in `DocsChat.tsx` for rendering assistant messages.
> 
>   - **Behavior**:
>     - Adds markdown support to `MyThread` in `DocsChat.tsx` by configuring `Thread.Root` to use `MarkdownText` for `assistantMessage` rendering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 28a792f41c6576616ba74ff1cc94d1ff479dd6d9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->