### PR TITLE
feat: ThreadMessageLike optional toolCallId + args

### DIFF
--- a/.changeset/shy-shoes-warn.md
+++ b/.changeset/shy-shoes-warn.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: ThreadMessageLike optional toolCallId + args

--- a/packages/react/src/cloud/auiV0.ts
+++ b/packages/react/src/cloud/auiV0.ts
@@ -4,7 +4,10 @@ import { MessageStatus } from "../types/AssistantTypes";
 import { fromThreadMessageLike } from "../runtimes/external-store/ThreadMessageLike";
 import { CloudMessage } from "./AssistantCloudThreadMessages";
 import { isJSONValue } from "../utils/json/is-json";
-import { ReadonlyJSONValue } from "../utils/json/json-value";
+import {
+  ReadonlyJSONObject,
+  ReadonlyJSONValue,
+} from "../utils/json/json-value";
 import { ExportedMessageRepositoryItem } from "../runtimes/utils/MessageRepository";
 
 type AuiV0MessageContentPart =
@@ -16,7 +19,7 @@ type AuiV0MessageContentPart =
       readonly type: "tool-call";
       readonly toolCallId: string;
       readonly toolName: string;
-      readonly args: ReadonlyJSONValue;
+      readonly args: ReadonlyJSONObject;
       readonly result?: ReadonlyJSONValue;
       readonly isError?: true;
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add optional `toolCallId` and `args` to `ThreadMessageLike`, updating encoding/decoding logic in `auiV0.ts` and `ThreadMessageLike.tsx`.
> 
>   - **Behavior**:
>     - `ThreadMessageLike` now supports optional `toolCallId` and `args` fields in `ThreadMessageLike.tsx`.
>     - Default `toolCallId` generated using `generateId()` if not provided.
>     - `args` field defaults to parsed `argsText` if not provided.
>   - **Encoding/Decoding**:
>     - Updated `auiV0Encode` and `auiV0Decode` in `auiV0.ts` to handle optional `toolCallId` and `args`.
>     - Ensures `args` and `argsText` consistency in `auiV0Encode`.
>   - **Imports**:
>     - Add `generateId` import in `ThreadMessageLike.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for fef9888f89bc5e414f2ae00bd2a4b05b0c195846. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->