### PR TITLE
feat(markdown): memoizeMarkdownComponents

### DIFF
--- a/.changeset/smart-steaks-jog.md
+++ b/.changeset/smart-steaks-jog.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-markdown": patch
+---
+
+feat: memoizeMarkdownComponents

--- a/apps/docs/components/docs-chat/DocsChat.tsx
+++ b/apps/docs/components/docs-chat/DocsChat.tsx
@@ -2,12 +2,10 @@
 
 import { FC } from "react";
 import {
-  AssistantModal,
   AssistantModalPrimitive,
   ChatModelAdapter,
   useLocalRuntime,
 } from "@assistant-ui/react";
-import { makeMarkdownText } from "@assistant-ui/react-markdown";
 import { makePrismAsyncSyntaxHighlighter } from "@assistant-ui/react-syntax-highlighter";
 import { coldarkDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import remarkGfm from "remark-gfm";
@@ -16,6 +14,8 @@ import {
   type ThreadConfig,
   Composer,
   ThreadWelcome,
+  AssistantModal,
+  makeMarkdownText,
 } from "@assistant-ui/react-ui";
 import entelligenceLogoLight from "./entelligence-light.png";
 import entelligenceLogoDark from "./entelligence-dark.png";

--- a/apps/docs/components/shadcn/Shadcn.tsx
+++ b/apps/docs/components/shadcn/Shadcn.tsx
@@ -1,6 +1,5 @@
 import { MenuIcon, ShareIcon } from "lucide-react";
-import { Thread, ThreadList } from "@assistant-ui/react-ui";
-import { makeMarkdownText } from "@assistant-ui/react-markdown";
+import { Thread, ThreadList, makeMarkdownText } from "@assistant-ui/react-ui";
 import remarkGfm from "remark-gfm";
 import { makePrismAsyncSyntaxHighlighter } from "@assistant-ui/react-syntax-highlighter";
 import { coldarkDark } from "react-syntax-highlighter/dist/cjs/styles/prism";

--- a/apps/docs/content/docs/components/content-part.mdx
+++ b/apps/docs/content/docs/components/content-part.mdx
@@ -24,7 +24,7 @@ Markdown text is usually used for assistant messages.
 ### Plain Text
 
 ```tsx
-import { ContentPart } from "@assistant/react";
+import { ContentPart } from "@assistant/react-ui";
 
 <ContentPart.Text />;
 ```
@@ -32,7 +32,7 @@ import { ContentPart } from "@assistant/react";
 ### Markdown Text
 
 ```tsx
-import { makeMarkdownText } from "@assistant-ui/react-markdown";
+import { makeMarkdownText } from "@assistant-ui/react-ui";
 
 const MarkdownText = makeMarkdownText();
 

--- a/apps/docs/content/docs/runtimes/langgraph/index.mdx
+++ b/apps/docs/content/docs/runtimes/langgraph/index.mdx
@@ -190,9 +190,8 @@ export const sendMessage = async (params: {
 "use client";
 
 import { useRef } from "react";
-import { Thread } from "@assistant-ui/react-ui";
+import { Thread, makeMarkdownText } from "@assistant-ui/react-ui";
 import { useLangGraphRuntime } from "@assistant-ui/react-langgraph";
-import { makeMarkdownText } from "@assistant-ui/react-markdown";
 
 import { createThread, getThreadState, sendMessage } from "@/lib/chatApi";
 

--- a/apps/docs/content/docs/runtimes/langgraph/tutorial/part-1.mdx
+++ b/apps/docs/content/docs/runtimes/langgraph/tutorial/part-1.mdx
@@ -77,8 +77,7 @@ Rich text rendering using Markdown is enabled by default. You can view `/app/pag
 ```tsx title="@/app/page.tsx" {4,6,11}
 "use client";
 
-import { makeMarkdownText } from "@assistant-ui/react-markdown";
-import { Thread } from "@assistant-ui/react-ui";
+import { Thread, makeMarkdownText } from "@assistant-ui/react-ui";
 
 const MarkdownText = makeMarkdownText();
 

--- a/apps/docs/content/docs/ui/styled/Markdown.mdx
+++ b/apps/docs/content/docs/ui/styled/Markdown.mdx
@@ -30,8 +30,7 @@ npm install @assistant-ui/react-markdown
 {
   plugins: [
     require("tailwindcss-animate"),
-    require("@assistant-ui/react-ui/tailwindcss"),
-    require("@assistant-ui/react-markdown/tailwindcss"),
+    require("@assistant-ui/react-ui/tailwindcss")
   ],
 }
 ```
@@ -40,15 +39,14 @@ npm install @assistant-ui/react-markdown
 {
   plugins: [
     require("tailwindcss-animate"),
-    require("@assistant-ui/react-ui/tailwindcss")({ shadcn: true }),
-    require("@assistant-ui/react-markdown/tailwindcss"),
+    require("@assistant-ui/react-ui/tailwindcss")({ shadcn: true })
   ],
 }
 ```
 
 ```ts title="/app/layout.tsx" tab="Not using Tailwind"
 import "@assistant-ui/react-ui/styles/index.css";
-import "@assistant-ui/react-markdown/styles/markdown.css";
+import "@assistant-ui/react-ui/styles/markdown.css";
 ```
 
 </Tabs>
@@ -60,7 +58,7 @@ import "@assistant-ui/react-markdown/styles/markdown.css";
 ### Define a `MarkdownText` component
 
 ```tsx {1} twoslash title="@/components/markdown-text.tsx"
-import { makeMarkdownText } from "@assistant-ui/react-markdown";
+import { makeMarkdownText } from "@assistant-ui/react-ui";
 
 export const MarkdownText = makeMarkdownText();
 ```

--- a/apps/registry/components/assistant-ui/markdown-text.tsx
+++ b/apps/registry/components/assistant-ui/markdown-text.tsx
@@ -7,7 +7,7 @@ import "@assistant-ui/react-markdown/styles/dot.css";
 import {
   CodeHeaderProps,
   MarkdownTextPrimitive,
-  MarkdownTextPrimitiveProps,
+  unstable_memoizeMarkdownComponents as memoizeMarkdownComponents,
   useIsMarkdownCodeBlock,
 } from "@assistant-ui/react-markdown";
 import remarkGfm from "remark-gfm";
@@ -65,62 +65,62 @@ const useCopyToClipboard = ({
   return { isCopied, copyToClipboard };
 };
 
-const defaultComponents: MarkdownTextPrimitiveProps["components"] = {
-  h1: ({ node, className, ...props }) => (
+const defaultComponents = memoizeMarkdownComponents({
+  h1: ({ className, ...props }) => (
     <h1 className={cn("aui-md-h1", className)} {...props} />
   ),
-  h2: ({ node, className, ...props }) => (
+  h2: ({ className, ...props }) => (
     <h2 className={cn("aui-md-h2", className)} {...props} />
   ),
-  h3: ({ node, className, ...props }) => (
+  h3: ({ className, ...props }) => (
     <h3 className={cn("aui-md-h3", className)} {...props} />
   ),
-  h4: ({ node, className, ...props }) => (
+  h4: ({ className, ...props }) => (
     <h4 className={cn("aui-md-h4", className)} {...props} />
   ),
-  h5: ({ node, className, ...props }) => (
+  h5: ({ className, ...props }) => (
     <h5 className={cn("aui-md-h5", className)} {...props} />
   ),
-  h6: ({ node, className, ...props }) => (
+  h6: ({ className, ...props }) => (
     <h6 className={cn("aui-md-h6", className)} {...props} />
   ),
-  p: ({ node, className, ...props }) => (
+  p: ({ className, ...props }) => (
     <p className={cn("aui-md-p", className)} {...props} />
   ),
-  a: ({ node, className, ...props }) => (
+  a: ({ className, ...props }) => (
     <a className={cn("aui-md-a", className)} {...props} />
   ),
-  blockquote: ({ node, className, ...props }) => (
+  blockquote: ({ className, ...props }) => (
     <blockquote className={cn("aui-md-blockquote", className)} {...props} />
   ),
-  ul: ({ node, className, ...props }) => (
+  ul: ({ className, ...props }) => (
     <ul className={cn("aui-md-ul", className)} {...props} />
   ),
-  ol: ({ node, className, ...props }) => (
+  ol: ({ className, ...props }) => (
     <ol className={cn("aui-md-ol", className)} {...props} />
   ),
-  hr: ({ node, className, ...props }) => (
+  hr: ({ className, ...props }) => (
     <hr className={cn("aui-md-hr", className)} {...props} />
   ),
-  table: ({ node, className, ...props }) => (
+  table: ({ className, ...props }) => (
     <table className={cn("aui-md-table", className)} {...props} />
   ),
-  th: ({ node, className, ...props }) => (
+  th: ({ className, ...props }) => (
     <th className={cn("aui-md-th", className)} {...props} />
   ),
-  td: ({ node, className, ...props }) => (
+  td: ({ className, ...props }) => (
     <td className={cn("aui-md-td", className)} {...props} />
   ),
-  tr: ({ node, className, ...props }) => (
+  tr: ({ className, ...props }) => (
     <tr className={cn("aui-md-tr", className)} {...props} />
   ),
-  sup: ({ node, className, ...props }) => (
+  sup: ({ className, ...props }) => (
     <sup className={cn("aui-md-sup", className)} {...props} />
   ),
-  pre: ({ node, className, ...props }) => (
+  pre: ({ className, ...props }) => (
     <pre className={cn("aui-md-pre", className)} {...props} />
   ),
-  code: function Code({ node, className, ...props }) {
+  code: function Code({ className, ...props }) {
     const isCodeBlock = useIsMarkdownCodeBlock();
     return (
       <code
@@ -130,4 +130,4 @@ const defaultComponents: MarkdownTextPrimitiveProps["components"] = {
     );
   },
   CodeHeader,
-};
+});

--- a/examples/local-ollama/components/MyAssistant.tsx
+++ b/examples/local-ollama/components/MyAssistant.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEdgeRuntime } from "@assistant-ui/react";
-import { Thread } from "@assistant-ui/react-ui";
-import { makeMarkdownText } from "@assistant-ui/react-markdown";
+import { Thread, makeMarkdownText } from "@assistant-ui/react-ui";
 
 const MarkdownText = makeMarkdownText();
 

--- a/examples/with-langgraph/app/page.tsx
+++ b/examples/with-langgraph/app/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Thread, ThreadList } from "@assistant-ui/react-ui";
+import { Thread, ThreadList, makeMarkdownText } from "@assistant-ui/react-ui";
 import { PriceSnapshotTool } from "@/components/tools/price-snapshot/PriceSnapshotTool";
 import { PurchaseStockTool } from "@/components/tools/purchase-stock/PurchaseStockTool";
 import { ToolFallback } from "@/components/tools/ToolFallback";
-import { makeMarkdownText } from "@assistant-ui/react-markdown";
 
 const MarkdownText = makeMarkdownText({});
 

--- a/packages/react-markdown/src/index.ts
+++ b/packages/react-markdown/src/index.ts
@@ -16,3 +16,5 @@ export {
 } from "./ui/markdown-text";
 
 export { CodeHeader } from "./ui/code-header";
+
+export { memoizeMarkdownComponents as unstable_memoizeMarkdownComponents } from "./memoization";

--- a/packages/react-markdown/src/memoization.tsx
+++ b/packages/react-markdown/src/memoization.tsx
@@ -1,0 +1,47 @@
+import { Element } from "hast";
+import { ComponentProps, ComponentType, ElementType, memo } from "react";
+import { CodeHeaderProps, SyntaxHighlighterProps } from "./overrides/types";
+
+type Components = {
+  [Key in Extract<ElementType, string>]?: ComponentType<ComponentProps<Key>>;
+} & {
+  SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps> | undefined;
+  CodeHeader?: ComponentType<CodeHeaderProps> | undefined;
+};
+
+const areChildrenEqual = (prev: string | unknown, next: string | unknown) => {
+  if (typeof prev === "string") return prev === next;
+  return JSON.stringify(prev) === JSON.stringify(next);
+};
+
+export const areNodesEqual = (
+  prev: Element | undefined,
+  next: Element | undefined,
+) => {
+  if (!prev || !next) return prev === next;
+  const isEqual =
+    JSON.stringify(prev?.properties) === JSON.stringify(next?.properties) &&
+    areChildrenEqual(prev?.children, next?.children);
+  return isEqual;
+};
+
+export const memoCompareNodes = (
+  prev: { node?: Element | undefined },
+  next: { node?: Element | undefined },
+) => {
+  return areNodesEqual(prev.node, next.node);
+};
+
+export const memoizeMarkdownComponents = (components: Components = {}) => {
+  return Object.fromEntries(
+    Object.entries(components ?? {}).map(([key, value]) => {
+      if (!value) return [key, value];
+
+      const Component = value as ComponentType;
+      const WithoutNode = ({ node, ...props }: { node?: Element }) => {
+        return <Component {...props} />;
+      };
+      return [key, memo(WithoutNode, memoCompareNodes)];
+    }),
+  );
+};

--- a/packages/react-markdown/src/overrides/CodeBlock.tsx
+++ b/packages/react-markdown/src/overrides/CodeBlock.tsx
@@ -18,14 +18,12 @@ export type CodeBlockProps = {
     CodeHeader: ComponentType<CodeHeaderProps>;
     SyntaxHighlighter: ComponentType<SyntaxHighlighterProps>;
   };
-  node: Element | undefined;
 };
 
 export const DefaultCodeBlock: FC<CodeBlockProps> = ({
   components: { Pre, Code, SyntaxHighlighter, CodeHeader },
   language,
   code,
-  node,
 }) => {
   const components = useMemo(() => ({ Pre, Code }), [Pre, Code]);
 
@@ -38,7 +36,6 @@ export const DefaultCodeBlock: FC<CodeBlockProps> = ({
         components={components}
         language={language ?? "unknown"}
         code={code}
-        node={node}
       />
     </>
   );

--- a/packages/react-markdown/src/overrides/PreOverride.tsx
+++ b/packages/react-markdown/src/overrides/PreOverride.tsx
@@ -1,5 +1,11 @@
-import { createContext, ComponentPropsWithoutRef, useContext } from "react";
+import {
+  createContext,
+  ComponentPropsWithoutRef,
+  useContext,
+  memo,
+} from "react";
 import { PreComponent } from "./types";
+import { memoCompareNodes } from "../memoization";
 
 export const PreContext = createContext<Omit<
   ComponentPropsWithoutRef<PreComponent>,
@@ -10,6 +16,8 @@ export const useIsMarkdownCodeBlock = () => {
   return useContext(PreContext) !== null;
 };
 
-export const PreOverride: PreComponent = ({ children, ...rest }) => {
+const PreOverrideImpl: PreComponent = ({ children, ...rest }) => {
   return <PreContext.Provider value={rest}>{children}</PreContext.Provider>;
 };
+
+export const PreOverride = memo(PreOverrideImpl, memoCompareNodes);

--- a/packages/react-markdown/src/overrides/defaultComponents.tsx
+++ b/packages/react-markdown/src/overrides/defaultComponents.tsx
@@ -1,5 +1,4 @@
 import type { ComponentType, ReactNode } from "react";
-import { Element } from "hast";
 import { PreComponent, CodeComponent, CodeHeaderProps } from "./types";
 
 export const DefaultPre: PreComponent = ({ node, ...rest }) => (
@@ -13,10 +12,9 @@ export const DefaultCode: CodeComponent = ({ node, ...rest }) => (
 export const DefaultCodeBlockContent: ComponentType<{
   components: { Pre: PreComponent; Code: CodeComponent };
   code: string | ReactNode | undefined;
-  node: Element | undefined;
-}> = ({ components: { Pre, Code }, code, node }) => (
-  <Pre node={node}>
-    <Code node={node}>{code}</Code>
+}> = ({ components: { Pre, Code }, code }) => (
+  <Pre>
+    <Code>{code}</Code>
   </Pre>
 );
 

--- a/packages/react-markdown/src/primitives/MarkdownText.tsx
+++ b/packages/react-markdown/src/primitives/MarkdownText.tsx
@@ -7,6 +7,7 @@ import {
   forwardRef,
   ForwardRefExoticComponent,
   RefAttributes,
+  useMemo,
   type ComponentPropsWithoutRef,
   type ComponentType,
 } from "react";
@@ -81,25 +82,38 @@ export const MarkdownTextPrimitive: ForwardRefExoticComponent<MarkdownTextPrimit
       code = DefaultCode,
       SyntaxHighlighter = DefaultCodeBlockContent,
       CodeHeader = DefaultCodeHeader,
-      by_language,
-      ...componentsRest
     } = userComponents ?? {};
-    const components: Options["components"] = {
-      ...componentsRest,
-      pre: PreOverride,
-      code: useCallbackRef((props) => (
-        <CodeOverride
-          components={{
-            Pre: pre,
-            Code: code,
-            SyntaxHighlighter,
-            CodeHeader,
-          }}
-          componentsByLanguage={componentsByLanguage}
-          {...props}
-        />
-      )),
-    };
+    const useCodeOverrideComponents = useMemo(() => {
+      return {
+        Pre: pre,
+        Code: code,
+        SyntaxHighlighter,
+        CodeHeader,
+      };
+    }, [pre, code, SyntaxHighlighter, CodeHeader]);
+    const CodeComponent = useCallbackRef((props) => (
+      <CodeOverride
+        components={useCodeOverrideComponents}
+        componentsByLanguage={componentsByLanguage}
+        {...props}
+      />
+    ));
+
+    const components: Options["components"] = useMemo(() => {
+      const {
+        pre = DefaultPre,
+        code = DefaultCode,
+        SyntaxHighlighter = DefaultCodeBlockContent,
+        CodeHeader = DefaultCodeHeader,
+        by_language,
+        ...componentsRest
+      } = userComponents ?? {};
+      return {
+        ...componentsRest,
+        pre: PreOverride,
+        code: CodeComponent,
+      };
+    }, [CodeComponent, userComponents, componentsByLanguage]);
 
     return (
       <Container

--- a/packages/react-ui/src/ui/markdown/markdown-text.tsx
+++ b/packages/react-ui/src/ui/markdown/markdown-text.tsx
@@ -4,6 +4,7 @@ import classNames from "classnames";
 import {
   MarkdownTextPrimitive,
   MarkdownTextPrimitiveProps,
+  unstable_memoizeMarkdownComponents,
   useIsMarkdownCodeBlock,
 } from "@assistant-ui/react-markdown";
 import { INTERNAL } from "@assistant-ui/react";
@@ -12,65 +13,65 @@ const { withSmoothContextProvider, useSmoothStatus } = INTERNAL;
 
 export type MakeMarkdownTextProps = MarkdownTextPrimitiveProps;
 
-const defaultComponents: MakeMarkdownTextProps["components"] = {
-  h1: ({ node, className, ...props }) => (
+const defaultComponents = unstable_memoizeMarkdownComponents({
+  h1: ({ className, ...props }) => (
     <h1 className={classNames("aui-md-h1", className)} {...props} />
   ),
-  h2: ({ node, className, ...props }) => (
+  h2: ({ className, ...props }) => (
     <h2 className={classNames("aui-md-h2", className)} {...props} />
   ),
-  h3: ({ node, className, ...props }) => (
+  h3: ({ className, ...props }) => (
     <h3 className={classNames("aui-md-h3", className)} {...props} />
   ),
-  h4: ({ node, className, ...props }) => (
+  h4: ({ className, ...props }) => (
     <h4 className={classNames("aui-md-h4", className)} {...props} />
   ),
-  h5: ({ node, className, ...props }) => (
+  h5: ({ className, ...props }) => (
     <h5 className={classNames("aui-md-h5", className)} {...props} />
   ),
-  h6: ({ node, className, ...props }) => (
+  h6: ({ className, ...props }) => (
     <h6 className={classNames("aui-md-h6", className)} {...props} />
   ),
-  p: ({ node, className, ...props }) => (
+  p: ({ className, ...props }) => (
     <p className={classNames("aui-md-p", className)} {...props} />
   ),
-  a: ({ node, className, ...props }) => (
+  a: ({ className, ...props }) => (
     <a className={classNames("aui-md-a", className)} {...props} />
   ),
-  blockquote: ({ node, className, ...props }) => (
+  blockquote: ({ className, ...props }) => (
     <blockquote
       className={classNames("aui-md-blockquote", className)}
       {...props}
     />
   ),
-  ul: ({ node, className, ...props }) => (
+  ul: ({ className, ...props }) => (
     <ul className={classNames("aui-md-ul", className)} {...props} />
   ),
-  ol: ({ node, className, ...props }) => (
+  ol: ({ className, ...props }) => (
     <ol className={classNames("aui-md-ol", className)} {...props} />
   ),
-  hr: ({ node, className, ...props }) => (
+  hr: ({ className, ...props }) => (
     <hr className={classNames("aui-md-hr", className)} {...props} />
   ),
-  table: ({ node, className, ...props }) => (
+  table: ({ className, ...props }) => (
     <table className={classNames("aui-md-table", className)} {...props} />
   ),
-  th: ({ node, className, ...props }) => (
+  th: ({ className, ...props }) => (
     <th className={classNames("aui-md-th", className)} {...props} />
   ),
-  td: ({ node, className, ...props }) => (
+  td: ({ className, ...props }) => (
     <td className={classNames("aui-md-td", className)} {...props} />
   ),
-  tr: ({ node, className, ...props }) => (
+  tr: ({ className, ...props }) => (
     <tr className={classNames("aui-md-tr", className)} {...props} />
   ),
-  sup: ({ node, className, ...props }) => (
+  sup: ({ className, ...props }) => (
     <sup className={classNames("aui-md-sup", className)} {...props} />
   ),
-  pre: ({ node, className, ...props }) => (
+  pre: ({ className, ...props }) => (
     <pre className={classNames("aui-md-pre", className)} {...props} />
   ),
-  code: ({ node, className, ...props }) => {
+  code: ({ className, ...props }) => {
     const isCodeBlock = useIsMarkdownCodeBlock();
     return (
       <code
@@ -80,7 +81,7 @@ const defaultComponents: MakeMarkdownTextProps["components"] = {
     );
   },
   CodeHeader,
-};
+});
 
 export const makeMarkdownText = ({
   className,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduced `memoizeMarkdownComponents` to optimize Markdown component rendering and updated imports and documentation accordingly.
> 
>   - **Memoization**:
>     - Introduced `memoizeMarkdownComponents` in `memoization.tsx` to optimize Markdown component rendering.
>     - Applied `memoizeMarkdownComponents` to default components in `markdown-text.tsx` and `markdown-text.tsx` in `react-ui`.
>   - **Imports and Refactoring**:
>     - Updated imports to use `makeMarkdownText` from `@assistant-ui/react-ui` instead of `@assistant-ui/react-markdown` in multiple files including `DocsChat.tsx`, `Shadcn.tsx`, and `content-part.mdx`.
>     - Removed `node` prop from components in `CodeBlock.tsx`, `CodeOverride.tsx`, and `defaultComponents.tsx`.
>   - **Documentation**:
>     - Updated documentation files to reflect changes in Markdown component usage and imports, such as in `Markdown.mdx` and `langgraph/index.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 51949542f4cc960784c70ea8e12ff89514aaedce. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->