### PR TITLE
fix: useSmooth unnecessary re-renders

### DIFF
--- a/.changeset/shy-beans-argue.md
+++ b/.changeset/shy-beans-argue.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-ui": patch
+"@assistant-ui/react": patch
+---
+
+fix: useSmooth unnecessary re-renders

--- a/packages/react/src/utils/smooth/useSmooth.tsx
+++ b/packages/react/src/utils/smooth/useSmooth.tsx
@@ -83,20 +83,24 @@ export const useSmooth = (
   const setText = useCallbackRef((text: string) => {
     setDisplayedText(text);
     if (smoothStatusStore) {
-      writableStore(smoothStatusStore).setState(
-        text !== state.text ? SMOOTH_STATUS : state.status,
-      );
+      const target =
+        displayedText !== text || state.status.type === "running"
+          ? SMOOTH_STATUS
+          : state.status;
+      writableStore(smoothStatusStore).setState(target, true);
     }
   });
 
   // TODO this is hacky
   useEffect(() => {
     if (smoothStatusStore) {
-      writableStore(smoothStatusStore).setState(
-        text !== state.text ? SMOOTH_STATUS : state.status,
-      );
+      const target =
+        displayedText !== text || state.status.type === "running"
+          ? SMOOTH_STATUS
+          : state.status;
+      writableStore(smoothStatusStore).setState(target, true);
     }
-  }, [smoothStatusStore, text, displayedText, state.status, state.text]);
+  }, [smoothStatusStore, text, displayedText, state.status]);
 
   const [animatorRef] = useState<TextStreamAnimator>(
     new TextStreamAnimator(text, setText),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize `useSmooth` and `MarkdownTextPrimitive` to prevent unnecessary re-renders by refining smooth status management and component structure.
> 
>   - **Behavior**:
>     - Refactor `MarkdownTextPrimitive` in `MarkdownText.tsx` to use `MarkdownTextInner` for rendering, reducing unnecessary re-renders.
>     - Use `useSmoothStatus` in `MarkdownTextPrimitiveImpl` to manage smooth status.
>   - **Hooks**:
>     - Update `useSmooth` in `useSmooth.tsx` to optimize state updates and prevent unnecessary re-renders by adjusting smooth status logic.
>     - Use `writableStore` to set smooth status conditionally based on text changes and animation state.
>   - **Misc**:
>     - Add `withSmoothContextProvider` to `MarkdownTextPrimitive` to wrap `MarkdownTextPrimitiveImpl`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for dd1c9c38988b65ff570b47962bab080c8bd072ef. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->