### PR TITLE
feat(thread-list): forward model context to thread runtimes

### DIFF
--- a/.changeset/sour-beers-pretend.md
+++ b/.changeset/sour-beers-pretend.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat(thread-list): forward model context to thread runtimes

--- a/packages/react/src/runtimes/adapters/RuntimeAdapterProvider.tsx
+++ b/packages/react/src/runtimes/adapters/RuntimeAdapterProvider.tsx
@@ -1,8 +1,10 @@
 import { createContext, FC, useContext } from "react";
 import { ThreadHistoryAdapter } from "./thread-history/ThreadHistoryAdapter";
+import { ModelContextProvider } from "../../model-context";
 
 export type RuntimeAdapters = {
-  history: ThreadHistoryAdapter;
+  modelContext?: ModelContextProvider;
+  history?: ThreadHistoryAdapter;
 };
 
 const RuntimeAdaptersContext = createContext<RuntimeAdapters | null>(null);
@@ -18,8 +20,14 @@ export const RuntimeAdapterProvider: FC<RuntimeAdapterProvider.Props> = ({
   adapters,
   children,
 }) => {
+  const context = useContext(RuntimeAdaptersContext);
   return (
-    <RuntimeAdaptersContext.Provider value={adapters}>
+    <RuntimeAdaptersContext.Provider
+      value={{
+        ...context,
+        ...adapters,
+      }}
+    >
       {children}
     </RuntimeAdaptersContext.Provider>
   );

--- a/packages/react/src/runtimes/external-store/useExternalStoreRuntime.tsx
+++ b/packages/react/src/runtimes/external-store/useExternalStoreRuntime.tsx
@@ -5,6 +5,7 @@ import { ExternalStoreRuntimeCore } from "./ExternalStoreRuntimeCore";
 import { ExternalStoreAdapter } from "./ExternalStoreAdapter";
 import { AssistantRuntimeImpl } from "../../api/AssistantRuntime";
 import { ThreadRuntimeImpl } from "../../api/ThreadRuntime";
+import { useRuntimeAdapters } from "../adapters/RuntimeAdapterProvider";
 
 export const useExternalStoreRuntime = <T,>(store: ExternalStoreAdapter<T>) => {
   const [runtime] = useState(() => new ExternalStoreRuntimeCore(store));
@@ -12,6 +13,13 @@ export const useExternalStoreRuntime = <T,>(store: ExternalStoreAdapter<T>) => {
   useEffect(() => {
     runtime.setAdapter(store);
   });
+
+  const { modelContext } = useRuntimeAdapters() ?? {};
+
+  useEffect(() => {
+    if (!modelContext) return undefined;
+    return runtime.registerModelContextProvider(modelContext);
+  }, [modelContext, runtime]);
 
   return useMemo(
     () => AssistantRuntimeImpl.create(runtime, ThreadRuntimeImpl),

--- a/packages/react/src/runtimes/local/useLocalRuntime.tsx
+++ b/packages/react/src/runtimes/local/useLocalRuntime.tsx
@@ -38,7 +38,7 @@ export const useLocalRuntime = (
   adapter: ChatModelAdapter,
   { initialMessages, ...options }: LocalRuntimeOptions = {},
 ) => {
-  const threadListAdapters = useRuntimeAdapters();
+  const { modelContext, ...threadListAdapters } = useRuntimeAdapters() ?? {};
   const opt = useMemo(
     () => ({
       ...options,
@@ -57,6 +57,11 @@ export const useLocalRuntime = (
     runtime.threads.getMainThreadRuntimeCore().__internal_setOptions(opt);
     runtime.threads.getMainThreadRuntimeCore().__internal_load();
   }, [runtime, opt]);
+
+  useEffect(() => {
+    if (!modelContext) return undefined;
+    return runtime.registerModelContextProvider(modelContext);
+  }, [modelContext, runtime]);
 
   return useMemo(() => LocalRuntimeImpl.create(runtime), [runtime]);
 };

--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
@@ -13,6 +13,8 @@ import { OptimisticState } from "./OptimisticState";
 import { FC, Fragment, useEffect, useId } from "react";
 import { create } from "zustand";
 import { AssistantStream, AssistantMessageStream } from "assistant-stream";
+import { ModelContextProvider } from "../../model-context";
+import { RuntimeAdapterProvider } from "../adapters/RuntimeAdapterProvider";
 
 type RemoteThreadData =
   | {
@@ -225,7 +227,10 @@ export class RemoteThreadListThreadListRuntimeCore
     return this._loadThreadsPromise;
   }
 
-  constructor(adapter: RemoteThreadListAdapter) {
+  constructor(
+    adapter: RemoteThreadListAdapter,
+    private readonly contextProvider: ModelContextProvider,
+  ) {
     super();
 
     this._state.subscribe(() => this._notifySubscribers());
@@ -540,12 +545,18 @@ export class RemoteThreadListThreadListRuntimeCore
     const boundIds = this.useBoundIds();
     const { Provider } = this.useProvider();
 
+    const adapters = {
+      modelContext: this.contextProvider,
+    };
+
     return (
       (boundIds.length === 0 || boundIds[0] === id) && (
         // only render if the component is the first one mounted
-        <this._hookManager.__internal_RenderThreadRuntimes
-          provider={Provider}
-        />
+        <RuntimeAdapterProvider adapters={adapters}>
+          <this._hookManager.__internal_RenderThreadRuntimes
+            provider={Provider}
+          />
+        </RuntimeAdapterProvider>
       )
     );
   };

--- a/packages/react/src/runtimes/remote-thread-list/useRemoteThreadListRuntime.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/useRemoteThreadListRuntime.tsx
@@ -15,7 +15,10 @@ class RemoteThreadListRuntimeCore
 
   constructor(adapter: RemoteThreadListAdapter) {
     super();
-    this.threads = new RemoteThreadListThreadListRuntimeCore(adapter);
+    this.threads = new RemoteThreadListThreadListRuntimeCore(
+      adapter,
+      this._contextProvider,
+    );
   }
 
   public get RenderComponent() {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Forward `modelContext` to thread runtimes and integrate it into runtime logic across various components.
> 
>   - **Behavior**:
>     - Forward `modelContext` to thread runtimes in `RuntimeAdapterProvider`, `useExternalStoreRuntime`, `useLocalRuntime`, and `useRemoteThreadListRuntime`.
>     - Register `modelContext` with runtime cores in `useExternalStoreRuntime` and `useLocalRuntime`.
>   - **Components**:
>     - Add `modelContext` to `RuntimeAdapters` type in `RuntimeAdapterProvider.tsx`.
>     - Modify `RemoteThreadListThreadListRuntimeCore` constructor to accept `ModelContextProvider` and use it in rendering logic.
>   - **Misc**:
>     - Update `useRuntimeAdapters` to include `modelContext`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 12914e8a51e957c76ab698a9087f36777ca9ac4d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->