### PR TITLE
feat(cli): codemod to migrate to @assistant-ui/react-ui

### DIFF
--- a/.changeset/friendly-schools-return.md
+++ b/.changeset/friendly-schools-return.md
@@ -1,0 +1,7 @@
+---
+"assistant-ui": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-markdown": patch
+---
+
+feat: codemod to migrate to @assistant-ui/react-ui

--- a/apps/docs/content/docs/migrations/v0-8.mdx
+++ b/apps/docs/content/docs/migrations/v0-8.mdx
@@ -9,6 +9,17 @@ import { Callout } from "fumadocs-ui/components/callout";
   v0.8.0 is released.
 </Callout>
 
+## Styled Components moved to @assistant-ui/react-ui
+
+All styled components (Thread, ThreadList, AssistantModal, makeMarkdownText, etc.) have been moved to a new package, `@assistant-ui/react-ui`.
+
+To migrate, use the migration codemod:
+
+```sh
+# IMPORTANT: make sure to commit all changes to git / creating a backup before running the codemod
+npx assistant-ui upgrade
+```
+
 ## Vercel AI SDK RSC requires additional setup
 
 Built-in RSC support in assistant-ui has been removed, so an additional setup step is required.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,8 @@
     "commander": "^13.0.0",
     "cross-spawn": "^7.0.6",
     "debug": "^4.4.0",
+    "detect-package-manager": "^3.0.2",
+    "glob": "^11.0.1",
     "jscodeshift": "^17.1.2"
   },
   "devDependencies": {

--- a/packages/cli/src/codemods/v0-8/ui-package-split.ts
+++ b/packages/cli/src/codemods/v0-8/ui-package-split.ts
@@ -1,6 +1,6 @@
 import { createTransformer } from "../utils/createTransformer";
 
-const reactUIExports = [
+const reactUIExports: string[] = [
   "ThreadConfigProvider",
   "useThreadConfig",
   "ThreadConfig",
@@ -23,49 +23,181 @@ const reactUIExports = [
   "ThreadListItem",
   "ThreadWelcome",
   "UserMessage",
-  "UserActionBar",
+  "makeMarkdownText",
+  "MakeMarkdownTextProps",
+  "CodeHeader",
 ];
 
-const migrateUIComponents = createTransformer(({ j, root, markAsChanged }) => {
-  // Find the import declarations for `@assistant-ui/react`
-  const importDeclarations = root.find(j.ImportDeclaration, {
-    source: { value: "@assistant-ui/react" },
-  });
+const migrateAssistantUI = createTransformer(({ j, root, markAsChanged }) => {
+  const sourcesToMigrate: string[] = [
+    "@assistant-ui/react",
+    "@assistant-ui/react-markdown",
+  ];
+  const movedSpecifiers: any[] = [];
+  let lastMigratedImportPath: any = null;
 
-  importDeclarations.forEach((path: any) => {
-    const specifiersToReactUI: any[] = [];
-    const specifiersToKeep: any[] = [];
-
-    path.value.specifiers.forEach((specifier: any) => {
-      if (
-        j.ImportSpecifier.check(specifier) &&
-        reactUIExports.includes(specifier.imported.name)
-      ) {
-        specifiersToReactUI.push(specifier);
-      } else {
-        specifiersToKeep.push(specifier);
+  root
+    .find(j.ImportDeclaration)
+    .filter((path: any) => sourcesToMigrate.includes(path.value.source.value))
+    .forEach((path: any) => {
+      let hadMigratedSpecifiers = false;
+      const remainingSpecifiers: any[] = [];
+      path.value.specifiers.forEach((specifier: any) => {
+        if (
+          j.ImportSpecifier.check(specifier) &&
+          reactUIExports.includes(specifier.imported.name)
+        ) {
+          movedSpecifiers.push(specifier);
+          hadMigratedSpecifiers = true;
+        } else {
+          remainingSpecifiers.push(specifier);
+        }
+      });
+      if (hadMigratedSpecifiers) {
+        lastMigratedImportPath = path;
+      }
+      if (remainingSpecifiers.length === 0) {
+        j(path).remove();
+        markAsChanged();
+      } else if (remainingSpecifiers.length !== path.value.specifiers.length) {
+        path.value.specifiers = remainingSpecifiers;
+        markAsChanged();
       }
     });
 
-    if (specifiersToReactUI.length === 0) return;
-
-    // Add a new import for `@assistant-ui/react-ui`
-    const reactUIImport = j.importDeclaration(
-      specifiersToReactUI,
-      j.literal("@assistant-ui/react-ui"),
-    );
-    j(path).insertAfter(reactUIImport);
-
-    if (specifiersToKeep.length > 0) {
-      // Update the existing import declaration with the remaining specifiers
-      path.value.specifiers = specifiersToKeep;
+  if (movedSpecifiers.length > 0) {
+    const existingReactUIImport = root.find(j.ImportDeclaration, {
+      source: { value: "@assistant-ui/react-ui" },
+    });
+    if (existingReactUIImport.size() > 0) {
+      existingReactUIImport.forEach((path: any) => {
+        movedSpecifiers.forEach((specifier: any) => {
+          if (
+            !path.value.specifiers.some(
+              (s: any) => s.imported.name === specifier.imported.name,
+            )
+          ) {
+            path.value.specifiers.push(specifier);
+          }
+        });
+      });
     } else {
-      // Remove the import declaration if no specifiers are left
-      j(path).remove();
+      const newImport = j.importDeclaration(
+        movedSpecifiers,
+        j.literal("@assistant-ui/react-ui"),
+      );
+      if (lastMigratedImportPath) {
+        j(lastMigratedImportPath).insertAfter(newImport);
+      } else {
+        const firstImport = root.find(j.ImportDeclaration).at(0);
+        if (firstImport.size() > 0) {
+          firstImport.insertBefore(newImport);
+        } else {
+          root.get().node.program.body.unshift(newImport);
+        }
+      }
     }
-
     markAsChanged();
+  }
+
+  const cssReplacements: Record<string, string> = {
+    "@assistant-ui/react/styles/index.css":
+      "@assistant-ui/react-ui/styles/index.css",
+    "@assistant-ui/react/styles/modal.css":
+      "@assistant-ui/react-ui/styles/modal.css",
+    "@assistant-ui/react-markdown/styles/markdown.css":
+      "@assistant-ui/react-ui/styles/markdown.css",
+  };
+
+  root.find(j.ImportDeclaration).forEach((path: any) => {
+    const sourceValue: string = path.value.source.value;
+    if (cssReplacements[sourceValue]) {
+      path.value.source = j.literal(cssReplacements[sourceValue]);
+      markAsChanged();
+    }
   });
+
+  let removedMarkdownPlugin = false;
+  root
+    .find(j.CallExpression, { callee: { name: "require" } })
+    .filter((path: any) => {
+      const arg = path.value.arguments[0];
+      return (
+        arg &&
+        (arg.type === "Literal" || arg.type === "StringLiteral") &&
+        arg.value === "@assistant-ui/react-markdown/tailwindcss"
+      );
+    })
+    .forEach((path: any) => {
+      removedMarkdownPlugin = true;
+      const parent = path.parentPath;
+      if (
+        parent &&
+        parent.value &&
+        parent.value.type === "VariableDeclarator"
+      ) {
+        const varDecl = parent.parentPath;
+        if (
+          varDecl &&
+          varDecl.value.declarations &&
+          varDecl.value.declarations.length === 1
+        ) {
+          j(varDecl).remove();
+        } else {
+          varDecl.value.declarations = varDecl.value.declarations.filter(
+            (decl: any) => decl !== parent.value,
+          );
+        }
+        markAsChanged();
+      } else {
+        j(path).remove();
+        markAsChanged();
+      }
+    });
+
+  root
+    .find(j.CallExpression, { callee: { name: "require" } })
+    .filter((path: any) => {
+      const arg = path.value.arguments[0];
+      return (
+        arg &&
+        (arg.type === "Literal" || arg.type === "StringLiteral") &&
+        arg.value === "@assistant-ui/react/tailwindcss"
+      );
+    })
+    .forEach((path: any) => {
+      path.value.arguments[0].value = "@assistant-ui/react-ui/tailwindcss";
+      markAsChanged();
+      if (removedMarkdownPlugin) {
+        if (
+          path.parentPath &&
+          path.parentPath.value &&
+          path.parentPath.value.type === "CallExpression" &&
+          path.parentPath.value.arguments.length > 0
+        ) {
+          const configObj = path.parentPath.value.arguments[0];
+          if (configObj && configObj.type === "ObjectExpression") {
+            const componentsProp = configObj.properties.find((prop: any) => {
+              return (
+                (prop.key.name === "components" ||
+                  prop.key.value === "components") &&
+                prop.value.type === "ArrayExpression"
+              );
+            });
+            if (componentsProp) {
+              const componentsArray = componentsProp.value.elements;
+              const hasMarkdown = componentsArray.some(
+                (el: any) => el.type === "Literal" && el.value === "markdown",
+              );
+              if (!hasMarkdown) {
+                componentsArray.push(j.literal("markdown"));
+                markAsChanged();
+              }
+            }
+          }
+        }
+      }
+    });
 });
 
-export default migrateUIComponents;
+export default migrateAssistantUI;

--- a/packages/cli/src/lib/install-ui-lib.ts
+++ b/packages/cli/src/lib/install-ui-lib.ts
@@ -1,0 +1,92 @@
+import * as fs from "fs";
+import * as path from "path";
+import { execSync } from "child_process";
+import { sync as globSync } from "glob";
+import * as readline from "readline";
+import { detect } from "detect-package-manager";
+
+function askQuestion(query: string): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question(query, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+function isPackageInstalled(pkg: string): boolean {
+  const cwd = process.cwd();
+  try {
+    const pkgJsonPath = path.join(cwd, "package.json");
+    if (fs.existsSync(pkgJsonPath)) {
+      const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+      const deps = pkgJson.dependencies || {};
+      const devDeps = pkgJson.devDependencies || {};
+      if (deps[pkg] || devDeps[pkg]) {
+        return true;
+      }
+    }
+  } catch (e) {
+    // Fall back to node_modules check below.
+  }
+  const modulePath = path.join(cwd, "node_modules", ...pkg.split("/"));
+  return fs.existsSync(modulePath);
+}
+
+export default async function installReactUILib(): Promise<void> {
+  const cwd = process.cwd();
+  const pattern = "**/*.{js,jsx,ts,tsx}";
+  const files = globSync(pattern, {
+    cwd,
+    ignore: ["**/node_modules/**", "**/dist/**", "**/build/**"],
+  });
+
+  let found = false;
+  for (const file of files) {
+    const fullPath = path.join(cwd, file);
+    const content = fs.readFileSync(fullPath, "utf8");
+    if (content.includes("@assistant-ui/react-ui")) {
+      found = true;
+      break;
+    }
+  }
+
+  if (found) {
+    if (isPackageInstalled("@assistant-ui/react-ui")) {
+      console.log(
+        "@assistant-ui/react-ui is already installed. Skipping installation.",
+      );
+      return;
+    }
+
+    const answer = await askQuestion(
+      "React UI imports were added but @assistant-ui/react-ui is not installed. Do you want to install it? (Y/n) ",
+    );
+    if (answer === "" || answer.toLowerCase().startsWith("y")) {
+      const pm = await detect();
+      let cmd = "";
+      if (pm === "yarn") {
+        cmd = "yarn add @assistant-ui/react-ui";
+      } else if (pm === "pnpm") {
+        cmd = "pnpm add @assistant-ui/react-ui";
+      } else if (pm === "bun") {
+        cmd = "bun add @assistant-ui/react-ui";
+      } else {
+        cmd = "npm install @assistant-ui/react-ui";
+      }
+      try {
+        execSync(cmd, { stdio: "inherit" });
+      } catch (e) {
+        console.error("Installation failed:", e);
+      }
+    } else {
+      console.log("Skipping installation.");
+    }
+  } else {
+    console.log("No React UI imports found; skipping installation.");
+  }
+}

--- a/packages/cli/src/lib/upgrade.ts
+++ b/packages/cli/src/lib/upgrade.ts
@@ -2,13 +2,21 @@ import debug from "debug";
 import { transform, TransformErrors } from "./transform";
 import { TransformOptions } from "./transform-options";
 import { SingleBar, Presets } from "cli-progress";
+import installReactUILib from "./install-ui-lib";
 
 const bundle = ["v0-8/ui-package-split"];
 
 const log = debug("codemod:upgrade");
 const error = debug("codemod:upgrade:error");
 
-export function upgrade(options: TransformOptions) {
+/**
+ * Runs the upgrade cycle:
+ *   - Runs each codemod in the bundle.
+ *   - Displays progress using cli-progress.
+ *   - After codemods run, checks if any file now imports from "@assistant-ui/react-ui".
+ *     If so, prompts the user to install the package.
+ */
+export async function upgrade(options: TransformOptions) {
   const cwd = process.cwd();
   log("Starting upgrade...");
   const modCount = bundle.length;
@@ -34,6 +42,9 @@ export function upgrade(options: TransformOptions) {
       error(`codemod=${transform}, path=${filename}, summary=${summary}`);
     });
   }
+
+  // After codemods run, check if any file imports "@assistant-ui/react-ui" and prompt for install.
+  await installReactUILib();
 
   log("Upgrade complete.");
 }

--- a/packages/react-markdown/src/index.ts
+++ b/packages/react-markdown/src/index.ts
@@ -11,10 +11,14 @@ export type {
 export { useIsMarkdownCodeBlock } from "./overrides/PreOverride";
 
 export {
+  /** @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`. */
   makeMarkdownText,
+
+  /** @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`. */
   type MakeMarkdownTextProps,
 } from "./ui/markdown-text";
 
+/** @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`. */
 export { CodeHeader } from "./ui/code-header";
 
 export { memoizeMarkdownComponents as unstable_memoizeMarkdownComponents } from "./memoization";

--- a/packages/react-ui/src/ui/index.ts
+++ b/packages/react-ui/src/ui/index.ts
@@ -44,3 +44,5 @@ export {
   makeMarkdownText,
   type MakeMarkdownTextProps,
 } from "./markdown/markdown-text";
+
+export { CodeHeader } from "./markdown/code-header";

--- a/packages/react/src/ui/index.ts
+++ b/packages/react/src/ui/index.ts
@@ -1,41 +1,98 @@
-export {
-  ThreadConfigProvider,
-  useThreadConfig,
-  type ThreadConfig,
-  type ThreadWelcomeConfig,
-  type UserMessageConfig,
-  type AssistantMessageConfig,
-  type StringsConfig,
-  type SuggestionConfig,
-  type ThreadConfigProviderProps,
-} from "./thread-config";
+/** @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`. */
+export { ThreadConfigProvider } from "./thread-config";
 
+/** @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`. */
+export { useThreadConfig } from "./thread-config";
+
+/** @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`. */
+export type { ThreadConfig } from "./thread-config";
+
+/** @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`. */
+export type { ThreadWelcomeConfig } from "./thread-config";
+
+/** @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`. */
+export type { UserMessageConfig } from "./thread-config";
+
+/** @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`. */
+export type { AssistantMessageConfig } from "./thread-config";
+
+/** @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`. */
+export type { StringsConfig } from "./thread-config";
+
+/** @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`. */
+export type { SuggestionConfig } from "./thread-config";
+
+/** @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`. */
+export type { ThreadConfigProviderProps } from "./thread-config";
+
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export { default as AssistantActionBar } from "./assistant-action-bar";
 
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export { default as AssistantMessage } from "./assistant-message";
 
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export { default as AssistantModal } from "./assistant-modal";
 
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export { default as BranchPicker } from "./branch-picker";
 
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export { default as Composer } from "./composer";
 
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export { default as ContentPart } from "./content-part";
 
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export {
   default as AttachmentUI, // TODO name collision with Attachment
 } from "./attachment-ui";
 
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export { default as EditComposer } from "./edit-composer";
 
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export { default as Thread } from "./thread";
 
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export { default as ThreadList } from "./thread-list";
 
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export { default as ThreadListItem } from "./thread-list-item";
 
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export { default as ThreadWelcome } from "./thread-welcome";
 
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export { default as UserMessage } from "./user-message";
 
+/**
+ * @deprecated This export was moved to `@assistant-ui/react-ui`. Use the migration codemod to update your code, by running `npx assistant-ui upgrade`.
+ */
 export { default as UserActionBar } from "./user-action-bar";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1201,6 +1201,12 @@ importers:
       debug:
         specifier: ^4.4.0
         version: 4.4.0
+      detect-package-manager:
+        specifier: ^3.0.2
+        version: 3.0.2
+      glob:
+        specifier: ^11.0.1
+        version: 11.0.1
       jscodeshift:
         specifier: ^17.1.2
         version: 17.1.2
@@ -4506,6 +4512,10 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  detect-package-manager@3.0.2:
+    resolution: {integrity: sha512-8JFjJHutStYrfWwzfretQoyNGoZVW1Fsrp4JO9spa7h/fBfwgTMEIy4/LBzRDGsxwVPHU0q+T9YvwLDJoOApLQ==}
+    engines: {node: '>=12'}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -4826,6 +4836,10 @@ packages:
     resolution: {integrity: sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==}
     engines: {node: '>=18.0.0'}
 
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
@@ -5033,6 +5047,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -5190,6 +5208,10 @@ packages:
 
   human-id@1.0.2:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -5355,6 +5377,10 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -5824,6 +5850,10 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   minimatch@10.0.1:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
     engines: {node: 20 || >=22}
@@ -5938,6 +5968,10 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -5982,6 +6016,10 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
 
   oniguruma-to-es@2.1.0:
     resolution: {integrity: sha512-Iq/949c5IueVC5gQR7OYXs0uHsDIePcgZFlVRIVGfQcWwbKG+nsyWfthswdytShlRdkZADY+bWSi+BRyUL81gA==}
@@ -6676,6 +6714,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -6778,6 +6819,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -10278,6 +10323,10 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  detect-package-manager@3.0.2:
+    dependencies:
+      execa: 5.1.1
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -10782,6 +10831,18 @@ snapshots:
 
   eventsource-parser@3.0.0: {}
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   extend-shallow@2.0.1:
     dependencies:
       is-extendable: 0.1.1
@@ -11041,6 +11102,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@6.0.1: {}
+
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.3
@@ -11291,6 +11354,8 @@ snapshots:
 
   human-id@1.0.2: {}
 
+  human-signals@2.1.0: {}
+
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
@@ -11455,6 +11520,8 @@ snapshots:
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.3
+
+  is-stream@2.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -12211,6 +12278,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-fn@2.1.0: {}
+
   minimatch@10.0.1:
     dependencies:
       brace-expansion: 2.0.1
@@ -12300,6 +12369,10 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -12350,6 +12423,10 @@ snapshots:
       partial-json: 0.1.7
     optionalDependencies:
       zod: 3.24.1
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   oniguruma-to-es@2.1.0:
     dependencies:
@@ -13136,6 +13213,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   simple-swizzle@0.2.2:
@@ -13257,6 +13336,8 @@ snapshots:
   strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
+
+  strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces a codemod to migrate styled components to `@assistant-ui/react-ui`, updates CLI for package installation, and marks exports as deprecated.
> 
>   - **Codemod**:
>     - Adds `migrateAssistantUI` transformer in `ui-package-split.ts` to migrate imports from `@assistant-ui/react` and `@assistant-ui/react-markdown` to `@assistant-ui/react-ui`.
>     - Handles CSS import path replacements and removal of `@assistant-ui/react-markdown/tailwindcss` plugin.
>     - Updates `require` calls to use `@assistant-ui/react-ui/tailwindcss`.
>   - **CLI**:
>     - Adds `install-ui-lib.ts` to check and prompt installation of `@assistant-ui/react-ui` if imports are detected.
>     - Updates `upgrade.ts` to include `installReactUILib` after codemods run.
>     - Updates `package.json` to include `detect-package-manager` and `glob` dependencies.
>   - **Documentation**:
>     - Updates `v0-8.mdx` to include migration instructions using the codemod.
>   - **Exports**:
>     - Marks exports in `react/src/ui/index.ts` as deprecated and moved to `@assistant-ui/react-ui`.
>     - Updates `react-markdown/src/index.ts` with deprecation notices for moved exports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 218342b6cc312b06a7386bb9f232ecf8c6841e82. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->