### PR TITLE
fix: thread auto-scroll reliability

### DIFF
--- a/.changeset/seven-apples-itch.md
+++ b/.changeset/seven-apples-itch.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: thread auto-scroll reliability

--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.tsx
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.tsx
@@ -14,13 +14,11 @@ import { writableStore } from "../../context/ReadonlyStore";
 export namespace useThreadViewportAutoScroll {
   export type Options = {
     autoScroll?: boolean | undefined;
-    unstable_scrollToBottomOnRunStart?: boolean | undefined;
   };
 }
 
 export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
   autoScroll = true,
-  unstable_scrollToBottomOnRunStart = true,
 }: useThreadViewportAutoScroll.Options): RefCallback<TElement> => {
   const divRef = useRef<TElement>(null);
 
@@ -83,8 +81,6 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
     };
   });
 
-  const autoScrollRef = useComposedRefs<TElement>(resizeRef, scrollRef, divRef);
-
   useOnScrollToBottom(() => {
     scrollToBottom("auto");
   });
@@ -92,10 +88,9 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
   // autoscroll on run start
   const threadRuntime = useThreadRuntime();
   useEffect(() => {
-    if (!unstable_scrollToBottomOnRunStart) return undefined;
+    return threadRuntime.unstable_on("run-start", () => scrollToBottom("auto"));
+  }, []);
 
-    return threadRuntime.unstable_on("run-start", focus);
-  }, [unstable_scrollToBottomOnRunStart]);
-
+  const autoScrollRef = useComposedRefs<TElement>(resizeRef, scrollRef, divRef);
   return autoScrollRef;
 };

--- a/packages/react/src/utils/hooks/useOnResizeContent.tsx
+++ b/packages/react/src/utils/hooks/useOnResizeContent.tsx
@@ -11,31 +11,17 @@ export const useOnResizeContent = (callback: () => void) => {
         callbackRef();
       });
 
-      const mutationObserver = new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-          for (const node of mutation.addedNodes) {
-            if (node instanceof Element) {
-              resizeObserver.observe(node);
-            }
-          }
-
-          for (const node of mutation.removedNodes) {
-            if (node instanceof Element) {
-              resizeObserver.unobserve(node);
-            }
-          }
-        }
-
+      const mutationObserver = new MutationObserver(() => {
         callbackRef();
       });
 
       resizeObserver.observe(el);
-      mutationObserver.observe(el, { childList: true });
-
-      // Observe existing children
-      for (const child of el.children) {
-        resizeObserver.observe(child);
-      }
+      mutationObserver.observe(el, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        characterData: true,
+      });
 
       return () => {
         resizeObserver.disconnect();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves thread auto-scroll reliability by removing `unstable_scrollToBottomOnRunStart` and enhancing `MutationObserver` in `useOnResizeContent`.
> 
>   - **Behavior**:
>     - Removed `unstable_scrollToBottomOnRunStart` option from `useThreadViewportAutoScroll` in `useThreadViewportAutoScroll.tsx`.
>     - Adjusted `MutationObserver` in `useOnResizeContent` in `useOnResizeContent.tsx` to observe `subtree`, `attributes`, and `characterData` for more reliable content resize detection.
>   - **Refactoring**:
>     - Moved `autoScrollRef` initialization to the end of `useThreadViewportAutoScroll` function in `useThreadViewportAutoScroll.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for f5c1762f9349111fe852fac9088967979c7f0c1c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->