### PR TITLE
feat: Edge Runtime onResponse/onError/onfinish, sendExtraMessageFields, unstable_AISDKInterop=v2 support

### DIFF
--- a/.changeset/purple-pets-flow.md
+++ b/.changeset/purple-pets-flow.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: Edge Runtime onResponse/onError/onfinish, sendExtraMessageFields, unstable_AISDKInterop=v2 support

--- a/packages/react/src/runtimes/edge/EdgeChatAdapter.ts
+++ b/packages/react/src/runtimes/edge/EdgeChatAdapter.ts
@@ -11,6 +11,11 @@ import { streamPartDecoderStream } from "./streams/utils/streamPartDecoderStream
 import { runResultStream } from "./streams/runResultStream";
 import { toolResultStream } from "./streams/toolResultStream";
 import { toLanguageModelMessages } from "./converters";
+import { ThreadMessage } from "../../types";
+import { Tool } from "../../model-context";
+import { z } from "zod";
+import zodToJsonSchema from "zod-to-json-schema";
+import { JSONSchema7 } from "json-schema";
 
 export function asAsyncIterable<T>(
   source: ReadableStream<T>,
@@ -29,23 +34,71 @@ export function asAsyncIterable<T>(
     },
   };
 }
+
 export type EdgeChatAdapterOptions = {
   api: string;
+
+  // experimental_prepareRequestBody?: (options: {
+  //   id: string;
+  //   messages: UIMessage[];
+  //   requestData?: JSONValue;
+  //   requestBody?: object;
+  // }) => unknown;
+
+  // onToolCall?: ({
+  //   toolCall,
+  // }: {
+  //   toolCall: UIMessageToolInvocation;
+  // }) => void | Promise<unknown> | unknown;
+
+  /**
+   * Callback function to be called when the API response is received.
+   */
+  onResponse?: (response: Response) => void | Promise<void>;
+  /**
+   * Optional callback function that is called when the assistant message is finished streaming.
+   */
+  onFinish?: (message: ThreadMessage) => void;
+  /**
+   * Callback function to be called when an error is encountered.
+   */
+  onError?: (error: Error) => void;
 
   credentials?: RequestCredentials;
   headers?: Record<string, string> | Headers;
   body?: object;
 
   /**
-   * When enabled, the adapter will not strip `id` from messages in the messages array.
+   * @deprecated Renamed to `sendExtraMessageFields`.
    */
   unstable_sendMessageIds?: boolean;
 
   /**
+   * When enabled, the adapter will not strip `id` from messages in the messages array.
+   */
+  sendExtraMessageFields?: boolean;
+
+  /**
    * When enabled, the adapter will send messages in the format expected by the Vercel AI SDK Core.
    * This feature will be removed in the future in favor of a better solution.
+   *
+   * `v2` sends frontend tools in a format that can be directly passed to `stremaText`
    */
-  unstable_AISDKInterop?: boolean | undefined;
+  unstable_AISDKInterop?: boolean | "v2" | undefined;
+};
+
+const toAISDKTools = (tools: Record<string, Tool<any, any>>) => {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, tool]) => [
+      name,
+      {
+        ...(tool.description ? { description: tool.description } : undefined),
+        parameters: (tool.parameters instanceof z.ZodType
+          ? zodToJsonSchema(tool.parameters)
+          : tool.parameters) as JSONSchema7,
+      },
+    ]),
+  );
 };
 
 export class EdgeChatAdapter implements ChatModelAdapter {
@@ -57,6 +110,7 @@ export class EdgeChatAdapter implements ChatModelAdapter {
     abortSignal,
     context,
     unstable_assistantMessageId,
+    unstable_getMessage,
   }: ChatModelRunOptions) {
     const headers = new Headers(this.options.headers);
     headers.set("Content-Type", "application/json");
@@ -69,12 +123,20 @@ export class EdgeChatAdapter implements ChatModelAdapter {
         system: context.system,
         messages: this.options.unstable_AISDKInterop
           ? (toLanguageModelMessages(messages, {
-              unstable_includeId: this.options.unstable_sendMessageIds,
+              unstable_includeId:
+                this.options.unstable_sendMessageIds ||
+                this.options.sendExtraMessageFields,
             }) as EdgeRuntimeRequestOptions["messages"]) // TODO figure out a better way to do this
           : toCoreMessages(messages, {
-              unstable_includeId: this.options.unstable_sendMessageIds,
+              unstable_includeId:
+                this.options.unstable_sendMessageIds ||
+                this.options.sendExtraMessageFields,
             }),
-        tools: context.tools ? toLanguageModelTools(context.tools) : [],
+        tools: context.tools
+          ? this.options.unstable_AISDKInterop === "v2"
+            ? (toAISDKTools(context.tools) as any)
+            : toLanguageModelTools(context.tools)
+          : [],
         unstable_assistantMessageId,
         runConfig,
         ...context.callSettings,
@@ -85,22 +147,31 @@ export class EdgeChatAdapter implements ChatModelAdapter {
       signal: abortSignal,
     });
 
-    if (!result.ok) {
-      throw new Error(`Status ${result.status}: ${await result.text()}`);
+    await this.options.onResponse?.(result);
+
+    try {
+      if (!result.ok) {
+        throw new Error(`Status ${result.status}: ${await result.text()}`);
+      }
+
+      const stream = result
+        .body!.pipeThrough(streamPartDecoderStream())
+        .pipeThrough(assistantDecoderStream())
+        .pipeThrough(toolResultStream(context.tools, abortSignal))
+        .pipeThrough(runResultStream());
+
+      let update: ChatModelRunResult | undefined;
+      for await (update of asAsyncIterable(stream)) {
+        yield update;
+      }
+
+      if (update === undefined)
+        throw new Error("No data received from Edge Runtime");
+
+      this.options.onFinish?.(unstable_getMessage());
+    } catch (error: unknown) {
+      this.options.onError?.(error as Error);
+      throw error;
     }
-
-    const stream = result
-      .body!.pipeThrough(streamPartDecoderStream())
-      .pipeThrough(assistantDecoderStream())
-      .pipeThrough(toolResultStream(context.tools, abortSignal))
-      .pipeThrough(runResultStream());
-
-    let update: ChatModelRunResult | undefined;
-    for await (update of asAsyncIterable(stream)) {
-      yield update;
-    }
-
-    if (update === undefined)
-      throw new Error("No data received from Edge Runtime");
   }
 }

--- a/packages/react/src/runtimes/local/ChatModelAdapter.tsx
+++ b/packages/react/src/runtimes/local/ChatModelAdapter.tsx
@@ -42,6 +42,7 @@ export type ChatModelRunOptions = {
   readonly config: ModelContext;
 
   readonly unstable_assistantMessageId?: string;
+  unstable_getMessage(): ThreadMessage;
 };
 
 export type ChatModelAdapter = {

--- a/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
@@ -249,6 +249,9 @@ export class LocalThreadRuntimeCore
         context,
         config: context,
         unstable_assistantMessageId: message.id,
+        unstable_getMessage() {
+          return message;
+        },
       });
 
       // handle async iterator for streaming results


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add callbacks for API response handling and support for `unstable_AISDKInterop=v2` in `EdgeChatAdapter`, with related updates in `ChatModelAdapter.tsx` and `LocalThreadRuntimeCore.tsx`.
> 
>   - **Behavior**:
>     - Add `onResponse`, `onFinish`, and `onError` callbacks to `EdgeChatAdapter` for handling API responses, message completion, and errors.
>     - Support `unstable_AISDKInterop` with `v2` option for tool format compatibility.
>   - **Options**:
>     - Rename `unstable_sendMessageIds` to `sendExtraMessageFields` in `EdgeChatAdapterOptions`.
>   - **Functions**:
>     - Add `unstable_getMessage` to `ChatModelRunOptions` in `ChatModelAdapter.tsx` and implement in `LocalThreadRuntimeCore.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 61152460d1950b0ddf45ea0aa71818c4e7efb523. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->