### PR TITLE
fix: cli node 20 support

### DIFF
--- a/.changeset/three-badgers-perform.md
+++ b/.changeset/three-badgers-perform.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: node 20 support

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,8 +3,6 @@
   "version": "0.0.32",
   "license": "MIT",
   "source": "./src/index.ts",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "dependencies": {
     "chalk": "^5.4.1",
     "cli-progress": "^3.12.0",
@@ -30,7 +28,7 @@
     "dist",
     "README.md"
   ],
-  "bin": "./dist/index.mjs",
+  "bin": "./dist/index.js",
   "scripts": {
     "build": "tsx scripts/build.mts"
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `package.json` in `cli` package for Node 20 support by changing `bin` field and removing `main` and `module` fields.
> 
>   - **Node 20 Support**:
>     - Update `bin` field in `package.json` to `./dist/index.js` from `./dist/index.mjs`.
>     - Remove `main` and `module` fields from `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for e6331f88c9de51f1c6484d220ef238248ca8772d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->