### PR TITLE
fix(react-ui): move aui to peer deps

### DIFF
--- a/.changeset/stale-timers-lick.md
+++ b/.changeset/stale-timers-lick.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ui": patch
+---
+
+fix: move aui to peer deps

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -33,8 +33,6 @@
     "build": "tsx scripts/build.mts"
   },
   "dependencies": {
-    "@assistant-ui/react": "workspace:^",
-    "@assistant-ui/react-markdown": "workspace:^",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-primitive": "^2.0.1",
@@ -45,6 +43,8 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
+    "@assistant-ui/react": "*",
+    "@assistant-ui/react-markdown": "*",
     "@types/react": "*",
     "@types/react-dom": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
@@ -63,6 +63,8 @@
     }
   },
   "devDependencies": {
+    "@assistant-ui/react": "workspace:^",
+    "@assistant-ui/react-markdown": "workspace:^",
     "@assistant-ui/tailwindcss-transformer": "workspace:*",
     "@assistant-ui/tsbuildutils": "workspace:^",
     "@assistant-ui/tsconfig": "workspace:*",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move `@assistant-ui/react` and `@assistant-ui/react-markdown` to peer dependencies in `react-ui` package.
> 
>   - **Dependencies**:
>     - Move `@assistant-ui/react` and `@assistant-ui/react-markdown` from `dependencies` to `peerDependencies` in `package.json` of `react-ui`.
>     - Add `@assistant-ui/react` and `@assistant-ui/react-markdown` to `devDependencies` in `package.json` of `react-ui`.
>   - **Changeset**:
>     - Add changeset `stale-timers-lick.md` to document the patch update for moving dependencies to peer dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 5fb55555096af79fd1632f64f9482e41f402bb78. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->