### PR TITLE
fix: __dirname in node 20

### DIFF
--- a/.changeset/neat-pigs-decide.md
+++ b/.changeset/neat-pigs-decide.md
@@ -1,0 +1,6 @@
+---
+"create-assistant-ui": patch
+"assistant-ui": patch
+---
+
+fix: node 20 support

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "dist",
     "README.md"
   ],
-  "bin": "./dist/index.js",
+  "bin": "./dist/index.mjs",
   "scripts": {
     "build": "tsx scripts/build.mts"
   },

--- a/packages/cli/src/lib/transform.ts
+++ b/packages/cli/src/lib/transform.ts
@@ -3,9 +3,13 @@ import debug from "debug";
 import fs from "fs";
 import path from "path";
 import { TransformOptions } from "./transform-options";
+import { fileURLToPath } from "url";
 
 const log = debug("codemod:transform");
 const error = debug("codemod:transform:error");
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 function getJscodeshift(): string {
   const localJscodeshift = path.resolve(

--- a/packages/create-assistant-ui/package.json
+++ b/packages/create-assistant-ui/package.json
@@ -12,6 +12,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@assistant-ui/tsbuildutils": "workspace:^",
     "@assistant-ui/tsconfig": "workspace:*",
     "@types/cross-spawn": "^6.0.6",
     "@types/node": "^22.10.7",
@@ -21,9 +22,9 @@
     "dist",
     "README.md"
   ],
-  "bin": "./dist/index.js",
+  "bin": "./dist/index.mjs",
   "scripts": {
-    "build": "tsup src/index.ts --format esm --sourcemap --clean"
+    "build": "tsx scripts/build.mts"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/create-assistant-ui/scripts/build.mts
+++ b/packages/create-assistant-ui/scripts/build.mts
@@ -1,0 +1,3 @@
+import { Build } from "@assistant-ui/tsbuildutils";
+
+await Build.start().transpileTypescript();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1269,6 +1269,9 @@ importers:
         specifier: ^3.24.1
         version: 3.24.1
     devDependencies:
+      '@assistant-ui/tsbuildutils':
+        specifier: workspace:^
+        version: link:../tsbuildutils
       '@assistant-ui/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix Node 20 compatibility by updating `__dirname` handling and switching to ESM format for binaries.
> 
>   - **Node 20 Compatibility**:
>     - Use `fileURLToPath` and `path.dirname` to define `__dirname` in `transform.ts`.
>   - **Package Updates**:
>     - Change `bin` entry from `.js` to `.mjs` in `package.json` for both `cli` and `create-assistant-ui`.
>     - Update `build` script in `create-assistant-ui/package.json` to use `tsx` instead of `tsup`.
>   - **Build Script**:
>     - Add `build.mts` script in `create-assistant-ui` to transpile TypeScript using `@assistant-ui/tsbuildutils`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 8578975906eafc0cd37119466cfaf56dc61c3cb5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->