### PR TITLE
fix: always use npx for jscodeshift

### DIFF
--- a/.changeset/poor-cups-speak.md
+++ b/.changeset/poor-cups-speak.md
@@ -1,5 +1,0 @@
----
-"assistant-ui": patch
----
-
-fix: always use npx for jscodeshift

--- a/.changeset/poor-cups-speak.md
+++ b/.changeset/poor-cups-speak.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: always use npx for jscodeshift

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # assistant-ui
 
+## 0.0.35
+
+### Patch Changes
+
+- 1a42993: fix: always use npx for jscodeshift
+
 ## 0.0.34
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant-ui",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "license": "MIT",
   "source": "./src/index.ts",
   "dependencies": {

--- a/packages/cli/src/lib/transform.ts
+++ b/packages/cli/src/lib/transform.ts
@@ -1,32 +1,19 @@
 import { execFileSync } from "child_process";
 import debug from "debug";
-import fs from "fs";
 import path from "path";
 import { TransformOptions } from "./transform-options";
-import { fileURLToPath } from "url";
 
 const log = debug("codemod:transform");
 const error = debug("codemod:transform:error");
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-function getJscodeshift(): string {
-  const localJscodeshift = path.resolve(
-    __dirname,
-    "../../node_modules/.bin/jscodeshift",
-  );
-  return fs.existsSync(localJscodeshift) ? localJscodeshift : "npx jscodeshift";
-}
-
 function buildCommand(
   codemodPath: string,
   targetPath: string,
-  jscodeshift: string,
   options: TransformOptions,
 ): string[] {
   const command = [
-    jscodeshift,
+    "npx",
+    "jscodeshift",
     "-t",
     codemodPath,
     targetPath,
@@ -95,13 +82,7 @@ export function transform(
   const codemodPath = path.resolve(__dirname, `../codemods/${codemod}.js`);
 
   const targetPath = path.resolve(source);
-  const jscodeshift = getJscodeshift();
-  const command = buildCommand(
-    codemodPath,
-    targetPath,
-    jscodeshift,
-    transformOptions,
-  );
+  const command = buildCommand(codemodPath, targetPath, transformOptions);
   const stdout = execFileSync(command[0]!, command.slice(1), {
     encoding: "utf8",
     stdio: "pipe",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Always use `npx jscodeshift` in `transform.ts`, removing local binary check.
> 
>   - **Behavior**:
>     - Always use `npx jscodeshift` in `buildCommand()` in `transform.ts`.
>     - Removes `getJscodeshift()` function, which checked for local `jscodeshift` binary.
>   - **Misc**:
>     - Adds changeset `poor-cups-speak.md` for patch update to `assistant-ui`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1a42993a211692ee85d5fa96d50a95204e4d4506. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->