### PR TITLE
fix(cli): fileURLToPath to get codemods

### DIFF
--- a/.changeset/chatty-phones-buy.md
+++ b/.changeset/chatty-phones-buy.md
@@ -1,5 +1,0 @@
----
-"assistant-ui": patch
----
-
-fix: fileURLToPath to get codemods

--- a/.changeset/chatty-phones-buy.md
+++ b/.changeset/chatty-phones-buy.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: fileURLToPath to get codemods

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # assistant-ui
 
+## 0.0.36
+
+### Patch Changes
+
+- 8190d09: fix: fileURLToPath to get codemods
+
 ## 0.0.35
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant-ui",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "license": "MIT",
   "source": "./src/index.ts",
   "dependencies": {

--- a/packages/cli/src/lib/transform.ts
+++ b/packages/cli/src/lib/transform.ts
@@ -2,9 +2,13 @@ import { execFileSync } from "child_process";
 import debug from "debug";
 import path from "path";
 import { TransformOptions } from "./transform-options";
+import { fileURLToPath } from "url";
 
 const log = debug("codemod:transform");
 const error = debug("codemod:transform:error");
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 function buildCommand(
   codemodPath: string,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Use `fileURLToPath` in `transform.ts` to correctly resolve file paths, update version to `0.0.36`.
> 
>   - **Behavior**:
>     - Use `fileURLToPath` in `transform.ts` to resolve `__filename` and `__dirname` for correct path handling.
>   - **Versioning**:
>     - Update version to `0.0.36` in `package.json`.
>     - Add changelog entry for version `0.0.36` in `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for da67f06f35af4be29f39682db4107b7aa6903ca7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->