### PR TITLE
feat: useExternalMessageConverter megeConfig.joinStrategy

### DIFF
--- a/.changeset/wise-wombats-perform.md
+++ b/.changeset/wise-wombats-perform.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: useExternalMessageConverter megeConfig.joinStrategy


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `joinStrategy` option to `useExternalMessageConverter` for configurable message conversion strategies.
> 
>   - **Feature**:
>     - Add `joinStrategy` option to `useExternalMessageConverter.Message` for message conversion.
>     - Supports `joinStrategy` values: `"concat-content"` and `"none"`.
>   - **Functions**:
>     - Update `chunkExternalMessages` to handle `joinStrategy` logic, flushing messages based on strategy.
>     - Modify `useExternalMessageConverter` to accept `joinStrategy` and pass it to `chunkExternalMessages`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 55365fd1a6c295ce5bcdde65522b25e5a5b338d5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->