### PR TITLE
fix(shadcn): wrap in TooltipProvider

### DIFF
--- a/apps/registry/components/assistant-ui/attachment.tsx
+++ b/apps/registry/components/assistant-ui/attachment.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/dialog";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import { TooltipProvider } from "@radix-ui/react-tooltip";
 
 const useFileSrc = (file: File | undefined) => {
   const [src, setSrc] = useState<string | undefined>(undefined);
@@ -132,27 +133,29 @@ const AttachmentUI: FC = () => {
     }
   });
   return (
-    <Tooltip>
-      <AttachmentPrimitive.Root className="aui-attachment-root">
-        <AttachmentPreviewDialog>
-          <TooltipTrigger asChild>
-            <div className="aui-attachment-content">
-              <AttachmentThumb />
-              <div className="aui-attachment-text">
-                <p className="aui-attachment-name">
-                  <AttachmentPrimitive.Name />
-                </p>
-                <p className="aui-attachment-type">{typeLabel}</p>
+    <TooltipProvider>
+      <Tooltip>
+        <AttachmentPrimitive.Root className="aui-attachment-root">
+          <AttachmentPreviewDialog>
+            <TooltipTrigger asChild>
+              <div className="aui-attachment-content">
+                <AttachmentThumb />
+                <div className="aui-attachment-text">
+                  <p className="aui-attachment-name">
+                    <AttachmentPrimitive.Name />
+                  </p>
+                  <p className="aui-attachment-type">{typeLabel}</p>
+                </div>
               </div>
-            </div>
-          </TooltipTrigger>
-        </AttachmentPreviewDialog>
-        {canRemove && <AttachmentRemove />}
-      </AttachmentPrimitive.Root>
-      <TooltipContent side="top">
-        <AttachmentPrimitive.Name />
-      </TooltipContent>
-    </Tooltip>
+            </TooltipTrigger>
+          </AttachmentPreviewDialog>
+          {canRemove && <AttachmentRemove />}
+        </AttachmentPrimitive.Root>
+        <TooltipContent side="top">
+          <AttachmentPrimitive.Name />
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Wraps `AttachmentUI` component in `TooltipProvider` for proper tooltip management.
> 
>   - **Behavior**:
>     - Wraps `AttachmentUI` component in `TooltipProvider` to ensure proper tooltip management.
>   - **Components**:
>     - Affects `AttachmentUI` in `attachment.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 4206dda05187225be42ead0964c3e1081a707eaf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->