### PR TITLE
docs: add two previous blog posts

### DIFF
--- a/apps/docs/content/blog/2024-09-11/index.mdx
+++ b/apps/docs/content/blog/2024-09-11/index.mdx
@@ -1,0 +1,10 @@
+---
+title: Build conversational AI agents with LangGraph and assistant-ui
+description: Announcing our collaboration with LangChain
+author: Harrison Chase
+date: 2024-09-11T12:00:00
+---
+
+import { Redirect } from "./redirect";
+
+<Redirect />

--- a/apps/docs/content/blog/2024-09-11/redirect.tsx
+++ b/apps/docs/content/blog/2024-09-11/redirect.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export const Redirect = () => {
+  redirect("https://medium.com/relta/github-assistant-49ae388ad758");
+};

--- a/apps/docs/content/blog/2024-12-15/index.mdx
+++ b/apps/docs/content/blog/2024-12-15/index.mdx
@@ -1,0 +1,10 @@
+---
+title: Announcing github-assistant
+description: github-assistant answers questions about your GitHub repositories.
+author: Amir Zohrenejad
+date: 2024-12-15T12:00:00
+---
+
+import { Redirect } from "./redirect";
+
+<Redirect />

--- a/apps/docs/content/blog/2024-12-15/redirect.tsx
+++ b/apps/docs/content/blog/2024-12-15/redirect.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export const Redirect = () => {
+  redirect("https://blog.langchain.dev/assistant-ui/");
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add two blog posts with redirects to external URLs in the documentation.
> 
>   - **Blog Posts**:
>     - Add `2024-09-11/index.mdx` for blog post titled "Build conversational AI agents with LangGraph and assistant-ui" by Harrison Chase.
>     - Add `2024-12-15/index.mdx` for blog post titled "Announcing github-assistant" by Amir Zohrenejad.
>   - **Redirects**:
>     - Add `2024-09-11/redirect.tsx` to redirect to "https://medium.com/relta/github-assistant-49ae388ad758".
>     - Add `2024-12-15/redirect.tsx` to redirect to "https://blog.langchain.dev/assistant-ui/".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 0104fbc05702452196e77b74e23503dd665fd695. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->