### PR TITLE
fix: missing "use client" directives

### DIFF
--- a/.changeset/moody-tools-report.md
+++ b/.changeset/moody-tools-report.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-ui": patch
+---
+
+fix: missing "use client" directives

--- a/packages/react-markdown/src/overrides/PreOverride.tsx
+++ b/packages/react-markdown/src/overrides/PreOverride.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   createContext,
   ComponentPropsWithoutRef,

--- a/packages/react-markdown/src/ui/useCopyToClipboard.tsx
+++ b/packages/react-markdown/src/ui/useCopyToClipboard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 
 namespace useCopyToClipboard {

--- a/packages/react-ui/src/ui/markdown/useCopyToClipboard.tsx
+++ b/packages/react-ui/src/ui/markdown/useCopyToClipboard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 
 namespace useCopyToClipboard {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add missing "use client" directives to `PreOverride.tsx` and `useCopyToClipboard.tsx` in `react-markdown` and `react-ui`.
> 
>   - **Directives**:
>     - Add missing `"use client"` directive to `PreOverride.tsx` in `react-markdown`.
>     - Add missing `"use client"` directive to `useCopyToClipboard.tsx` in `react-markdown` and `react-ui`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 6d51c4206e863e776073889c8466307e181672ea. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->