### PR TITLE
refactor: expose the useThreadViewportAutoScroll in the API

### DIFF
--- a/packages/react/src/primitives/index.ts
+++ b/packages/react/src/primitives/index.ts
@@ -12,3 +12,4 @@ export * as ThreadListItemPrimitive from "./threadListItem";
 export { useContentPartDisplay } from "./contentPart/useContentPartDisplay";
 export { useContentPartImage } from "./contentPart/useContentPartImage";
 export { useContentPartText } from "./contentPart/useContentPartText";
+export { useThreadViewportAutoScroll } from "./thread/useThreadViewportAutoScroll";


### PR DESCRIPTION
First of all, thanks so much for this library! It has saved me a lot of time.

I have been trying to implement the Shadcn scrollbar in the ThreadViewport using [these docs](https://www.assistant-ui.com/docs/ui/shadcn-ui/Scrollbar), but this requires a very specific version of `@radix-ui/scroll-area` (BTW, this still hasn't been fixed as per https://github.com/radix-ui/primitives/pull/2945). In cases where this is not possible, it would be nice to create a custom viewport that passes the scrollRef to the Radix-ui viewport.
For example:
```tsx
const CustomScrollAreaViewport = forwardRef<
  HTMLDivElement,
  ScrollAreaPrimitive.ScrollAreaViewportProps & {
    autoScroll?: boolean | undefined;
  }
>(({ autoScroll, children, ...rest }, forwardedRef) => {
  const autoScrollRef = useThreadViewportAutoScroll({
    autoScroll,
  });

  const ref = useComposedRefs(forwardedRef);
  return (
    <ScrollAreaPrimitive.Viewport ref={ref} className="h-full w-full rounded-[inherit]" {...rest}>
      {children}
    </ScrollAreaPrimitive.Viewport>
  );
});

```

This pr exposes the auto scroll hook used by the `ThreadPrimitive.Viewport` component.

If you're okay with this change, I will update the docs as well to explain this alternative workaround. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expose `useThreadViewportAutoScroll` in `index.ts` for custom viewport creation with auto-scroll.
> 
>   - **API Changes**:
>     - Expose `useThreadViewportAutoScroll` in `index.ts` to allow custom viewport creation with auto-scroll functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for a9ebcf4b95455a3e30175c5b7e1fa192d98b7062. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->