### PR TITLE
fix: ThreadPrimitive.Suggestion no longer clears the composer

### DIFF
--- a/.changeset/fuzzy-vans-run.md
+++ b/.changeset/fuzzy-vans-run.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: make ThreadPrimitive.Suggestion method optional

--- a/.changeset/pretty-cheetahs-roll.md
+++ b/.changeset/pretty-cheetahs-roll.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: ThreadPrimitive.Suggestion no longer clears the composer

--- a/.changeset/shy-mayflies-wave.md
+++ b/.changeset/shy-mayflies-wave.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: expose the useThreadViewportAutoScroll in the API

--- a/packages/react/src/primitives/thread/ThreadSuggestion.tsx
+++ b/packages/react/src/primitives/thread/ThreadSuggestion.tsx
@@ -14,7 +14,7 @@ const useThreadSuggestion = ({
   autoSend,
 }: {
   prompt: string;
-  method: "replace";
+  method?: "replace";
   autoSend?: boolean | undefined;
 }) => {
   const threadRuntime = useThreadRuntime();
@@ -23,7 +23,6 @@ const useThreadSuggestion = ({
   const callback = useCallback(() => {
     if (autoSend && !threadRuntime.getState().isRunning) {
       threadRuntime.append(prompt);
-      threadRuntime.composer.setText("");
     } else {
       threadRuntime.composer.setText(prompt);
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `ThreadPrimitive.Suggestion` to not clear the composer and makes `method` optional, while exposing `useThreadViewportAutoScroll` in the API.
> 
>   - **Behavior**:
>     - `ThreadPrimitive.Suggestion` no longer clears the composer when a suggestion is made in `ThreadSuggestion.tsx`.
>     - `method` parameter in `useThreadSuggestion` is now optional in `ThreadSuggestion.tsx`.
>   - **Features**:
>     - Expose `useThreadViewportAutoScroll` in the API.
>   - **Changesets**:
>     - Documented changes in `.changeset/fuzzy-vans-run.md`, `.changeset/pretty-cheetahs-roll.md`, and `.changeset/shy-mayflies-wave.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for a45c4a9aae4630aa3eddb25b3b94315cf63a0b45. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->