### PR TITLE
registry: simply and avoid css or tailwind configs

### DIFF
--- a/apps/registry/components/assistant-ui/thread.tsx
+++ b/apps/registry/components/assistant-ui/thread.tsx
@@ -25,7 +25,12 @@ import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button
 
 export const Thread: FC = () => {
   return (
-    <ThreadPrimitive.Root className="aui-root aui-thread-root">
+    <ThreadPrimitive.Root
+      className="aui-root aui-thread-root"
+      style={{
+        ["--aui-thread-max-width" as string]: "42rem",
+      }}
+    >
       <ThreadPrimitive.Viewport className="aui-thread-viewport">
         <ThreadWelcome />
 

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -60,13 +60,13 @@ async function buildRegistry(registry: RegistryItem[]) {
       });
 
       return {
-        $schema: "https://ui.shadcn.com/schema/registry-item.json",
         content: transformedContent,
         ...file,
       };
     });
 
     const payload = {
+      $schema: "https://ui.shadcn.com/schema/registry-item.json",
       ...item,
       files,
     };

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -10,22 +10,6 @@ export const registry: RegistryItem[] = [
         path: "components/assistant-ui/thread.tsx",
       },
     ],
-    cssVars: {
-      light: {
-        "--aui-thread-max-width": "42rem",
-      },
-    },
-    tailwind: {
-      config: {
-        theme: {
-          extend: {
-            maxWidth: {
-              "aui-thread": "var(--aui-thread-max-width)",
-            },
-          },
-        },
-      },
-    },
     dependencies: ["@assistant-ui/react", "lucide-react"],
     registryDependencies: [
       "button",

--- a/packages/react/src/styles/tailwindcss/thread.css
+++ b/packages/react/src/styles/tailwindcss/thread.css
@@ -9,7 +9,7 @@
 }
 
 .aui-thread-viewport-footer {
-  @apply max-w-aui-thread sticky bottom-0 mt-3 flex w-full flex-col items-center justify-end rounded-t-lg bg-inherit pb-4;
+  @apply max-w-[var(--aui-thread-max-width)] sticky bottom-0 mt-3 flex w-full flex-col items-center justify-end rounded-t-lg bg-inherit pb-4;
 }
 
 .aui-thread-scroll-to-bottom {
@@ -27,7 +27,7 @@
 /* thread welcome */
 
 .aui-thread-welcome-root {
-  @apply max-w-aui-thread flex w-full flex-grow flex-col;
+  @apply max-w-[var(--aui-thread-max-width)] flex w-full flex-grow flex-col;
 }
 
 .aui-thread-welcome-center {
@@ -108,7 +108,7 @@
 
 .aui-user-message-root {
   @apply grid auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] gap-y-2 [&>*]:col-start-2;
-  @apply max-w-aui-thread w-full py-4;
+  @apply max-w-[var(--aui-thread-max-width)] w-full py-4;
 }
 
 :where(.aui-user-message-root) > .aui-user-action-bar-root {
@@ -146,7 +146,7 @@
 /* edit composer */
 
 .aui-edit-composer-root {
-  @apply bg-aui-muted max-w-aui-thread my-4 flex w-full flex-col gap-2 rounded-xl;
+  @apply bg-aui-muted max-w-[var(--aui-thread-max-width)] my-4 flex w-full flex-col gap-2 rounded-xl;
 }
 
 .aui-edit-composer-input {
@@ -161,7 +161,7 @@
 
 .aui-assistant-message-root {
   @apply grid grid-cols-[auto_auto_1fr] grid-rows-[auto_1fr];
-  @apply max-w-aui-thread relative w-full py-4;
+  @apply max-w-[var(--aui-thread-max-width)] relative w-full py-4;
 }
 
 :where(.aui-assistant-message-root) > .aui-avatar-root {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplified CSS configuration by removing Tailwind settings and using CSS variables directly in `thread.tsx` and `thread.css`.
> 
>   - **Behavior**:
>     - Removed `cssVars` and `tailwind` configurations from `registry.ts`.
>     - Applied `--aui-thread-max-width` directly in `thread.tsx` and `thread.css`.
>   - **Styles**:
>     - Updated `thread.css` to use `max-w-[var(--aui-thread-max-width)]` instead of `max-w-aui-thread`.
>   - **Scripts**:
>     - Moved `$schema` in `build-registry.ts` to the payload object.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for fc03b46e8f1fb27966fc77d80fd2ac8054802c48. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->