### PR TITLE
feat: use message composer's runConfig as default value in reloadConfig

### DIFF
--- a/packages/react/src/api/MessageRuntime.ts
+++ b/packages/react/src/api/MessageRuntime.ts
@@ -150,10 +150,7 @@ export class MessageRuntimeImpl implements MessageRuntime {
           ref: this.path.ref + `${this.path.ref}.composer`,
           composerSource: "edit",
         },
-        getState: () =>
-          this._threadBinding
-            .getState()
-            .getEditComposer(this._core.getState().id),
+        getState: this._getEditComposerRuntimeCore,
         subscribe: (callback) => this._threadBinding.subscribe(callback),
       }),
       () => this._threadBinding.getState().beginEdit(this._core.getState().id),
@@ -177,11 +174,23 @@ export class MessageRuntimeImpl implements MessageRuntime {
 
   public readonly composer;
 
+  private _getEditComposerRuntimeCore = () => {
+    return this._threadBinding
+      .getState()
+      .getEditComposer(this._core.getState().id);
+  };
+
   public getState() {
     return this._core.getState();
   }
 
-  public reload({ runConfig = {} }: ReloadConfig = {}) {
+  public reload(reloadConfig: ReloadConfig = {}) {
+    const editComposerRuntimeCore = this._getEditComposerRuntimeCore();
+    const composerRuntimeCore =
+      editComposerRuntimeCore ?? this._threadBinding.getState().composer;
+    const composer = editComposerRuntimeCore ?? composerRuntimeCore;
+
+    const { runConfig = composer.runConfig } = reloadConfig;
     const state = this._core.getState();
     if (state.role !== "assistant")
       throw new Error("Can only reload assistant messages");

--- a/packages/react/src/runtimes/composer/DefaultEditComposerRuntimeCore.tsx
+++ b/packages/react/src/runtimes/composer/DefaultEditComposerRuntimeCore.tsx
@@ -18,7 +18,7 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
   private _parentId;
   private _sourceId;
   constructor(
-    private runtime: Omit<ThreadRuntimeCore, "composer"> & {
+    private runtime: ThreadRuntimeCore & {
       adapters?: { attachments?: AttachmentAdapter | undefined } | undefined;
     },
     private endEditCallback: () => void,
@@ -36,6 +36,9 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
     this._nonTextParts = message.content.filter(
       (part) => part.type !== "text" && part.type !== "ui",
     );
+
+    // Use the runConfig from the regular (non-edit) composer as the initial runConfig for the edit composer
+    this.setRunConfig({ ...runtime.composer.runConfig });
   }
 
   public async handleSend(


### PR DESCRIPTION
This fixes #1406.

I've encountered the same issue as the author, where the runConfig attributes applied in the composer weren't used during reloads or edits. 

An example use case for justification is as follows: 
The composer may be rendered with components for selecting model parameters, such as the type of model or context sources. When submitted, these parameters can be passed to the runtime by setting `messageRuntime.composer.setRunConfig({ ... })`. However, if the request fails and the user clicks on "reload", it makes sense that the same runConfig values would be used in the retry request. 

I've aimed at keeping the API changes minimal by only using the normal composer's runConfig values as a fallback if no other values are provided while improving the default behaviour.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `runConfig` from message composer is used as default during reloads in `MessageRuntimeImpl`.
> 
>   - **Behavior**:
>     - `reload()` in `MessageRuntimeImpl` now defaults to using `composer.runConfig` if no `runConfig` is provided.
>     - `DefaultEditComposerRuntimeCore` constructor sets initial `runConfig` from the regular composer.
>   - **Functions**:
>     - Refactor `getState` in `MessageRuntimeImpl` to use `_getEditComposerRuntimeCore`.
>     - Add `_getEditComposerRuntimeCore` method in `MessageRuntimeImpl` to retrieve edit composer state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 45298ca674cebd7388e6edb99162de1c5ab80e36. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->