### PR TITLE
feat: send toolCallId to the exeucte callback, Tool.experimental_onSchemaValidationError

### DIFF
--- a/.changeset/olive-dolls-jam.md
+++ b/.changeset/olive-dolls-jam.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: send toolCallId to the exeucte callback

--- a/.changeset/stupid-poems-dance.md
+++ b/.changeset/stupid-poems-dance.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: Tool.experimental_onSchemaValidationError

--- a/packages/react/src/model-context/ModelContextTypes.ts
+++ b/packages/react/src/model-context/ModelContextTypes.ts
@@ -27,9 +27,15 @@ export type LanguageModelConfig = z.infer<typeof LanguageModelConfigSchema>;
 type ToolExecuteFunction<TArgs, TResult> = (
   args: TArgs,
   context: {
+    toolCallId: string;
     abortSignal: AbortSignal;
   },
 ) => TResult | Promise<TResult>;
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<
+  unknown,
+  TResult
+>;
 
 export type Tool<
   TArgs extends Record<string, unknown> = Record<string | number, unknown>,
@@ -38,6 +44,7 @@ export type Tool<
   description?: string | undefined;
   parameters: z.ZodSchema<TArgs> | JSONSchema7;
   execute?: ToolExecuteFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
 };
 
 export type ModelContext = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Send `toolCallId` to `execute` callback and add `experimental_onSchemaValidationError` in `Tool` type for schema validation errors.
> 
>   - **Behavior**:
>     - Send `toolCallId` to `execute` callback in `ToolExecuteFunction` in `ModelContextTypes.ts` and `toolResultStream()` in `toolResultStream.ts`.
>     - Add `experimental_onSchemaValidationError` to `Tool` type in `ModelContextTypes.ts` to handle schema validation errors.
>   - **Misc**:
>     - Add changeset files `olive-dolls-jam.md` and `stupid-poems-dance.md` to document changes as patches.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 39ef2682807760b909f6de70c0857ff6787532b2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->