### PR TITLE
fix: sync thread.css

### DIFF
--- a/apps/registry/components/assistant-ui/thread.tsx
+++ b/apps/registry/components/assistant-ui/thread.tsx
@@ -23,6 +23,7 @@ import { Button } from "@/components/ui/button";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 
+
 export const Thread: FC = () => {
   return (
     <ThreadPrimitive.Root

--- a/packages/react-ui/src/styles/tailwindcss/thread.css
+++ b/packages/react-ui/src/styles/tailwindcss/thread.css
@@ -8,7 +8,7 @@
 }
 
 .aui-thread-viewport-footer {
-  @apply max-w-aui-thread sticky bottom-0 mt-3 flex w-full flex-col items-center justify-end rounded-t-lg bg-inherit pb-4;
+  @apply max-w-[var(--aui-thread-max-width)] sticky bottom-0 mt-3 flex w-full flex-col items-center justify-end rounded-t-lg bg-inherit pb-4;
 }
 
 .aui-thread-scroll-to-bottom {
@@ -26,7 +26,7 @@
 /* thread welcome */
 
 .aui-thread-welcome-root {
-  @apply max-w-aui-thread flex w-full flex-grow flex-col;
+  @apply max-w-[var(--aui-thread-max-width)] flex w-full flex-grow flex-col;
 }
 
 .aui-thread-welcome-center {
@@ -111,7 +111,7 @@
 
 .aui-user-message-root {
   @apply grid auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] gap-y-2 [&>*]:col-start-2;
-  @apply max-w-aui-thread w-full py-4;
+  @apply max-w-[var(--aui-thread-max-width)] w-full py-4;
 }
 
 :where(.aui-user-message-root) > .aui-branch-picker-root {
@@ -126,7 +126,7 @@
 
 .aui-user-message-content {
   @apply bg-aui-muted text-aui-foreground max-w-[calc(var(--aui-thread-max-width)*0.8)] break-words rounded-3xl px-5 py-2.5;
-
+  
   @apply col-start-2 row-start-2;
 }
 
@@ -148,7 +148,7 @@
 /* edit composer */
 
 .aui-edit-composer-root {
-  @apply bg-aui-muted max-w-aui-thread my-4 flex w-full flex-col gap-2 rounded-xl;
+  @apply bg-aui-muted max-w-[var(--aui-thread-max-width)] my-4 flex w-full flex-col gap-2 rounded-xl;
 }
 
 .aui-edit-composer-input {
@@ -163,7 +163,7 @@
 
 .aui-assistant-message-root {
   @apply grid grid-cols-[auto_auto_1fr] grid-rows-[auto_1fr];
-  @apply max-w-aui-thread relative w-full py-4;
+  @apply max-w-[var(--aui-thread-max-width)] relative w-full py-4;
 }
 
 :where(.aui-assistant-message-root) > .aui-avatar-root {

--- a/packages/react/src/styles/tailwindcss/thread.css
+++ b/packages/react/src/styles/tailwindcss/thread.css
@@ -1,11 +1,10 @@
 /* thread */
 .aui-thread-root {
   @apply bg-aui-background box-border h-full;
-  @apply [&>.aui-thread-viewport]:bg-inherit;
 }
 
 .aui-thread-viewport {
-  @apply bg-aui-background flex h-full flex-col items-center overflow-y-scroll scroll-smooth px-4 pt-8;
+  @apply flex h-full flex-col items-center overflow-y-scroll scroll-smooth bg-inherit px-4 pt-8;
 }
 
 .aui-thread-viewport-footer {
@@ -60,8 +59,12 @@
   @apply placeholder:text-aui-muted-foreground max-h-40 flex-grow resize-none border-none bg-transparent px-2 py-4 text-sm outline-none focus:ring-0 disabled:cursor-not-allowed;
 }
 
-.aui-composer-send,
-.aui-composer-cancel,
+.aui-composer-send {
+  @apply my-2.5 size-8 p-2 transition-opacity ease-in;
+}
+.aui-composer-cancel {
+  @apply my-2.5 size-8 p-2 transition-opacity ease-in;
+}
 .aui-composer-attach {
   @apply my-2.5 size-8 p-2 transition-opacity ease-in;
 }
@@ -111,36 +114,35 @@
   @apply max-w-[var(--aui-thread-max-width)] w-full py-4;
 }
 
-:where(.aui-user-message-root) > .aui-user-action-bar-root {
-  @apply col-start-1 row-start-2 mr-3 mt-2.5;
-}
-
-:where(.aui-user-message-root) > .aui-user-message-attachments {
-  @apply col-span-full col-start-1 row-start-1;
-  @apply justify-end;
-}
-
-:where(.aui-user-message-root) > .aui-user-message-content {
-  @apply col-start-2 row-start-2;
-}
-
 :where(.aui-user-message-root) > .aui-branch-picker-root {
+  @apply col-span-full col-start-1 row-start-3;
+  @apply -mr-1 justify-end;
+}
+
+.aui-user-branch-picker {
   @apply col-span-full col-start-1 row-start-3;
   @apply -mr-1 justify-end;
 }
 
 .aui-user-message-content {
   @apply bg-aui-muted text-aui-foreground max-w-[calc(var(--aui-thread-max-width)*0.8)] break-words rounded-3xl px-5 py-2.5;
+  
+  @apply col-start-2 row-start-2;
 }
 
 .aui-user-message-attachments {
   @apply flex w-full flex-row gap-3;
+
+  @apply col-span-full col-start-1 row-start-1;
+  @apply justify-end;
 }
 
 /* user action bar */
 
 .aui-user-action-bar-root {
   @apply flex flex-col items-end;
+
+  @apply col-start-1 row-start-2 mr-3 mt-2.5;
 }
 
 /* edit composer */
@@ -168,28 +170,33 @@
   @apply col-start-1 row-span-full row-start-1 mr-4;
 }
 
+.aui-assistant-avatar {
+  @apply col-start-1 row-span-full row-start-1 mr-4;
+}
+
 :where(.aui-assistant-message-root) > .aui-branch-picker-root {
   @apply col-start-2 row-start-2;
   @apply -ml-2 mr-2;
 }
 
-:where(.aui-assistant-message-root) > .aui-assistant-action-bar-root {
-  @apply col-start-3 row-start-2;
-  @apply -ml-1;
-}
-
-:where(.aui-assistant-message-root) > .aui-assistant-message-content {
-  @apply col-span-2 col-start-2 row-start-1 my-1.5;
+.aui-assistant-branch-picker {
+  @apply col-start-2 row-start-2;
+  @apply -ml-2 mr-2;
 }
 
 .aui-assistant-message-content {
   @apply text-aui-foreground max-w-[calc(var(--aui-thread-max-width)*0.8)] break-words leading-7;
+
+  @apply col-span-2 col-start-2 row-start-1 my-1.5;
 }
 
 /* assistant action bar */
 
 .aui-assistant-action-bar-root {
   @apply text-aui-muted-foreground flex gap-1;
+
+  @apply col-start-3 row-start-2;
+  @apply -ml-1;
 }
 
 :where(.aui-assistant-action-bar-root)[data-floating] {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated `thread.css` in `react-ui` and `react` packages to use a CSS variable for max-width, enhancing flexibility.
> 
>   - **CSS Changes**:
>     - Replaced `max-w-aui-thread` with `max-w-[var(--aui-thread-max-width)]` in `thread.css` in `react-ui` and `react` packages.
>     - Affected classes include `.aui-thread-viewport-footer`, `.aui-thread-welcome-root`, `.aui-user-message-root`, `.aui-edit-composer-root`, and `.aui-assistant-message-root`.
>   - **Misc**:
>     - Minor formatting changes in `thread.css` in `react` package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 359bde955cef3db98de3381d032fbeb5159060df. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->