### PR TITLE
fix: ToolContentPart.args should never be null

### DIFF
--- a/.changeset/short-terms-agree.md
+++ b/.changeset/short-terms-agree.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: ToolContentPart.args should never be null

--- a/packages/react/src/runtimes/edge/streams/runResultStream.ts
+++ b/packages/react/src/runtimes/edge/streams/runResultStream.ts
@@ -168,7 +168,7 @@ const appendOrUpdateToolCall = (
       toolCallId,
       toolName,
       argsText: argsTextDelta,
-      args: parsePartialJson(argsTextDelta),
+      args: argsTextDelta ? parsePartialJson(argsTextDelta) : {}, 
     };
     contentParts = [...contentParts, contentPart];
   } else {
@@ -176,7 +176,7 @@ const appendOrUpdateToolCall = (
     contentPart = {
       ...contentPart,
       argsText,
-      args: parsePartialJson(argsText),
+      args: argsTextDelta ? parsePartialJson(argsTextDelta) : {}, 
     };
     contentParts = [
       ...contentParts.slice(0, contentPartIdx),

--- a/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
+++ b/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
@@ -112,7 +112,7 @@ export const fromThreadMessageLike = (
                 return {
                   ...part,
                   toolCallId: part.toolCallId ?? "tool-" + generateId(),
-                  args: part.args ?? parsePartialJson(part.argsText ?? ""),
+                  args: part.args ?? parsePartialJson(part.argsText ?? "{}"),
                   argsText: part.argsText ?? "",
                 };
               }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure `ToolContentPart.args` is never null by defaulting to an empty object in `runResultStream.ts` and `ThreadMessageLike.tsx`.
> 
>   - **Behavior**:
>     - Ensure `ToolContentPart.args` is never null by defaulting to an empty object in `runResultStream.ts` and `ThreadMessageLike.tsx`.
>   - **Functions**:
>     - Update `appendOrUpdateToolCall` in `runResultStream.ts` to use `{}` if `argsTextDelta` is null or empty.
>     - Update `fromThreadMessageLike` in `ThreadMessageLike.tsx` to parse `argsText` as `{}` if null or empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 2b4f4c72e8f5e045d0753daaaf42f3384a57e7b7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->