### PR TITLE
feat: LangGraph interrupt persistence support

### DIFF
--- a/.changeset/curvy-planes-double.md
+++ b/.changeset/curvy-planes-double.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+feat: LangGraph interrupt persistence support

--- a/examples/with-langgraph/app/MyRuntimeProvider.tsx
+++ b/examples/with-langgraph/app/MyRuntimeProvider.tsx
@@ -31,6 +31,7 @@ const useMyLangGraphRuntime = () => {
       return {
         messages:
           (state.values as { messages?: LangChainMessage[] }).messages ?? [],
+        interrupts: state.tasks[0]?.interrupts ?? [],
       };
     },
   });

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -30,7 +30,7 @@ export type LangGraphInterruptState = {
   value: any;
   resumable: boolean;
   when: string;
-  ns: string[];
+  ns?: string[];
 };
 
 export const useLangGraphMessages = <TMessage extends { id?: string }>({
@@ -86,5 +86,12 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
     }
   }, [abortControllerRef]);
 
-  return { interrupt, messages, sendMessage, cancel, setMessages };
+  return {
+    interrupt,
+    messages,
+    sendMessage,
+    cancel,
+    setInterrupt,
+    setMessages,
+  };
 };

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -131,9 +131,10 @@ export const useLangGraphRuntime = ({
    * @deprecated For thread management use `useCloudThreadListRuntime` instead. This option will be removed in a future version.
    */
   onSwitchToNewThread?: () => Promise<void> | void;
-  onSwitchToThread?: (
-    threadId: string,
-  ) => Promise<{ messages: LangChainMessage[] }>;
+  onSwitchToThread?: (threadId: string) => Promise<{
+    messages: LangChainMessage[];
+    interrupts?: LangGraphInterruptState[];
+  }>;
   adapters?:
     | {
         attachments?: AttachmentAdapter;
@@ -142,10 +143,16 @@ export const useLangGraphRuntime = ({
       }
     | undefined;
 }) => {
-  const { interrupt, messages, sendMessage, cancel, setMessages } =
-    useLangGraphMessages({
-      stream,
-    });
+  const {
+    interrupt,
+    setInterrupt,
+    messages,
+    sendMessage,
+    cancel,
+    setMessages,
+  } = useLangGraphMessages({
+    stream,
+  });
 
   const [isRunning, setIsRunning] = useState(false);
   const handleSendMessage = async (
@@ -178,8 +185,9 @@ export const useLangGraphRuntime = ({
   const switchToThread = !onSwitchToThread
     ? undefined
     : async (externalId: string) => {
-        const { messages } = await onSwitchToThread(externalId);
+        const { messages, interrupts } = await onSwitchToThread(externalId);
         setMessages(messages);
+        setInterrupt(interrupts?.[0]);
       };
 
   const threadList: NonNullable<


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds interrupt persistence support to LangGraph by updating runtime and message handling functions.
> 
>   - **Behavior**:
>     - Adds interrupt persistence support in `useLangGraphRuntime` and `useLangGraphMessages`.
>     - Updates `onSwitchToThread` in `useLangGraphRuntime` to handle `interrupts`.
>     - Modifies `useLangGraphMessages` to include `setInterrupt` and handle `interrupt` events.
>   - **Examples**:
>     - Updates `MyRuntimeProvider.tsx` to include `interrupts` in the returned state from `onSwitchToThread`.
>   - **Types**:
>     - Makes `ns` optional in `LangGraphInterruptState` type in `useLangGraphMessages.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c6d9c49eddd206aeec94bb9bcf11422c3951f6ca. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->