### PR TITLE
Add 'data' type to ThreadMessageLike

### DIFF
--- a/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
+++ b/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
@@ -1,17 +1,17 @@
 import { generateId } from "../../internal";
 import {
-  MessageStatus,
-  TextContentPart,
-  ImageContentPart,
-  UIContentPart,
-  ThreadMessage,
-  ThreadAssistantContentPart,
-  ThreadAssistantMessage,
-  ThreadUserContentPart,
-  ThreadUserMessage,
-  ThreadSystemMessage,
   CompleteAttachment,
   FileContentPart,
+  ImageContentPart,
+  MessageStatus,
+  TextContentPart,
+  ThreadAssistantContentPart,
+  ThreadAssistantMessage,
+  ThreadMessage,
+  ThreadSystemMessage,
+  ThreadUserContentPart,
+  ThreadUserMessage,
+  UIContentPart,
   Unstable_AudioContentPart,
 } from "../../types";
 import { ReasoningContentPart, ThreadStep } from "../../types/AssistantTypes";
@@ -22,7 +22,7 @@ import {
 import { parsePartialJson } from "../../utils/json/parse-partial-json";
 
 export type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "user" | "system" | "data";
   readonly content:
     | string
     | readonly (

--- a/packages/react/src/types/AssistantTypes.ts
+++ b/packages/react/src/types/AssistantTypes.ts
@@ -1,11 +1,11 @@
 import type { ReactNode } from "react";
-import { CompleteAttachment } from "./AttachmentTypes";
 import {
   ReadonlyJSONObject,
   ReadonlyJSONValue,
 } from "../utils/json/json-value";
+import { CompleteAttachment } from "./AttachmentTypes";
 
-export type MessageRole = "user" | "assistant" | "system";
+export type MessageRole = "user" | "assistant" | "system" | "data";
 
 export type TextContentPart = {
   readonly type: "text";


### PR DESCRIPTION
For Vercel AI SDK compatibility with messages, ThreadMessageLike needs to be able to accept a 'data' role as well, otherweise we get a type error like the following:
<img width="825" alt="Screenshot 2025-02-12 at 11 12 10 AM" src="https://github.com/user-attachments/assets/645b7feb-754a-4031-9bdc-46b89f18434a" />

Where "Message[]" is from the "ai" package

`import { AssistantRuntimeProvider } from '@assistant-ui/react';
import { useChatRuntime } from '@assistant-ui/react-ai-sdk';
import { Message } from 'ai';
export function MyRuntimeProvider({
  children,
  chatId,
  namespace,
  messages
}: Readonly<{
  children: React.ReactNode;
  messages: Message[];
}>) {
  // const initialMessages = messages.map((msg) => ({
  //   role: msg.role as 'system' | 'user' | 'assistant',
  //   content: msg.content,
  //   createdAt: msg.createdAt
  // }));

  const runtime = useChatRuntime({
    api: '/api/chat',
    initialMessages: messages
  });
  return (
    <AssistantRuntimeProvider runtime={runtime}>
      {children}
    </AssistantRuntimeProvider>
  );
}`

Currently for this code to work, the commented out code is required, because MessageThreadLike doesn't allow for the role: 'data' that is present in the Message type from the "ai" package
