### PR TITLE
typo: update Decomposition.mdx to fix Composer.Send typo in the code snippet

### DIFF
--- a/apps/docs/content/docs/legacy/styled/Decomposition.mdx
+++ b/apps/docs/content/docs/legacy/styled/Decomposition.mdx
@@ -180,10 +180,10 @@ const MyComposerAction: FC = () => {
   return (
     <>
       <ThreadPrimitive.If running={false}>
-        <ComposerSend />
+        <Composer.Send />
       </ThreadPrimitive.If>
       <ThreadPrimitive.If running>
-        <ComposerCancel />
+        <Composer.Cancel />
       </ThreadPrimitive.If>
     </>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes component name typos in `Decomposition.mdx` code snippet, changing `ComposerSend` to `Composer.Send` and `ComposerCancel` to `Composer.Cancel`.
> 
>   - **Fixes**:
>     - Corrects component names in `Decomposition.mdx` code snippet from `ComposerSend` to `Composer.Send` and `ComposerCancel` to `Composer.Cancel`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1da8d0d8d3b319e1c53d34409135623e7729853c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->