### PR TITLE
fix: make CLI's add command work w new template

### DIFF
--- a/.changeset/twenty-dancers-judge.md
+++ b/.changeset/twenty-dancers-judge.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: make CLI's add command work w new templates

--- a/packages/cli/src/commands/shadcn/add.ts
+++ b/packages/cli/src/commands/shadcn/add.ts
@@ -2,7 +2,6 @@ import { Command } from "commander";
 import { spawn } from "cross-spawn";
 
 const REGISTRY_BASE_URL = "https://r.assistant-ui.com";
-const SHADCN_COMPONENT_BASE_URL = `${REGISTRY_BASE_URL}/shadcn`;
 
 export const shadcnAdd = new Command()
   .name("add")
@@ -21,7 +20,7 @@ export const shadcnAdd = new Command()
       if (!/^[a-zA-Z0-9-\/]+$/.test(c)) {
         throw new Error(`Invalid component name: ${c}`);
       }
-      return `${SHADCN_COMPONENT_BASE_URL}/${encodeURIComponent(c)}`;
+      return `${REGISTRY_BASE_URL}/${encodeURIComponent(c)}`;
     });
 
     const args = [`shadcn@latest`, "add", ...componentsToAdd];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `shadcnAdd` command in `add.ts` to work with new templates by updating URL construction logic.
> 
>   - **Behavior**:
>     - Fixes `shadcnAdd` command in `add.ts` to work with new templates by updating the URL construction logic.
>     - Removes `SHADCN_COMPONENT_BASE_URL` and uses `REGISTRY_BASE_URL` directly for component URLs.
>   - **Changeset**:
>     - Adds a patch changeset `twenty-dancers-judge.md` for `assistant-ui`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 8368946968c893ef030e4eeb70182483e95136f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->