### PR TITLE
Documentation Updates Based on Code Changes

### DIFF
--- a/apps/docs/content/docs/api-reference/context-providers/AssistantRuntimeProvider.mdx
+++ b/apps/docs/content/docs/api-reference/context-providers/AssistantRuntimeProvider.mdx
@@ -5,7 +5,7 @@ title: <AssistantRuntimeProvider />
 import { ParametersTable } from "@/components/docs";
 import { AssistantRuntimeProvider } from "@/generated/typeDocs";
 
-The `AssistantRuntimeProvider` provides data and APIs used by assistant-ui components.
+The `AssistantRuntimeProvider` now supports generic types and provides data and APIs used by assistant-ui components.
 
 Almost all components in assistant-ui require an `AssistantRuntimeProvider` around them to function properly.
 
@@ -28,3 +28,53 @@ const MyApp = () => {
 #### Properties
 
 <ParametersTable {...AssistantRuntimeProvider} />
+
+The `AssistantRuntimeProvider` now accepts a generic type `T` that extends `AssistantRuntime`. This allows you to specify the type of runtime you are providing.
+
+```tsx
+export const AssistantRuntimeProviderImpl = <T extends AssistantRuntime>({
+  children,
+  runtime,
+}: AssistantRuntimeProvider.Props<T>) => {
+  // ...
+};
+```
+
+The `useAssistantRuntime` function also now accepts a generic type `T` that extends `AssistantRuntime`. This allows you to specify the type of runtime you are using.
+
+```tsx
+export function useAssistantRuntime<T extends AssistantRuntime>(options?: {
+   optional?: boolean | undefined;
+}): T | null;
+```
+
+The `RemoteThreadListHookInstanceManager` class now accepts a generic type `T` that extends `AssistantRuntime`. This allows you to specify the type of runtime you are managing.
+
+```tsx
+export class RemoteThreadListHookInstanceManager<
+  T extends AssistantRuntime,
+> extends BaseSubscribable {
+  // ...
+};
+```
+
+The `RemoteThreadListThreadListRuntimeCore` class now accepts a generic type `T` that extends `AssistantRuntime`. This allows you to specify the type of runtime you are using.
+
+```tsx
+export class RemoteThreadListThreadListRuntimeCore<T extends AssistantRuntime>
+   extends BaseSubscribable
+   implements ThreadListRuntimeCore
+{
+  // ...
+};
+```
+
+The `useRemoteThreadListRuntime` function now accepts a generic type `T` that extends `AssistantRuntime`. This allows you to specify the type of runtime you are using.
+
+```tsx
+export const useRemoteThreadListRuntime = <T extends AssistantRuntime>(
+  options: RemoteThreadListOptions<T>,
+): T => {
+  // ...
+};
+```

--- a/apps/docs/content/docs/api-reference/runtimes/AssistantRuntime.mdx
+++ b/apps/docs/content/docs/api-reference/runtimes/AssistantRuntime.mdx
@@ -5,7 +5,7 @@ title: AssistantRuntime
 import { ParametersTable } from "@/components/docs";
 import { AssistantRuntime, AssistantToolUIsState } from "@/generated/typeDocs";
 
-The `AssistantRuntime` is the root runtime of the application.
+The `AssistantRuntime` is the root runtime of the application. It now supports generic types.
 
 ### `useAssistantRuntime`
 
@@ -13,6 +13,14 @@ The `AssistantRuntime` is the root runtime of the application.
 import { useAssistantRuntime } from "@assistant-ui/react";
 
 const runtime = useAssistantRuntime();
+```
+
+This hook now supports generic types. You can specify the type of the runtime when calling the hook.
+
+```tsx
+import { useAssistantRuntime } from "@assistant-ui/react";
+
+const runtime = useAssistantRuntime<MyRuntimeType>();
 ```
 
 <ParametersTable {...AssistantRuntime} />

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -110,3 +110,28 @@ const WeatherToolUI = makeAssistantToolUI({
   },
 });
 ```
+
+## Updates
+
+The RemoteThreadListHookInstanceManager class has been updated to support generic types. This means that the `runtimeHook` in `RemoteThreadListOptions` now returns a generic type `T` that extends `AssistantRuntime`. This change allows for more flexibility and type safety when using the `useRemoteThreadListRuntime` function.
+
+```tsx
+export type RemoteThreadListOptions<
+  T extends AssistantRuntime = AssistantRuntime,
+> = {
+  runtimeHook: () => T;
+  adapter: RemoteThreadListAdapter;
+};
+
+export const useRemoteThreadListRuntime = <T extends AssistantRuntime>(
+  options: RemoteThreadListOptions<T>,
+): T => {
+  const [runtime] = useState(() => new RemoteThreadListRuntimeCore(options));
+  useEffect(() => {
+    runtime.threads.__internal_setOptions(options);
+    runtime.threads.__internal_load();
+  }, [runtime, options]);
+  return useMemo(() => AssistantRuntimeImpl.create(runtime) as T, [runtime]);
+};
+```
+This update allows you to specify the type of `AssistantRuntime` that your `runtimeHook` returns, providing better type safety and code clarity.

--- a/apps/docs/content/docs/runtimes/custom/local.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local.mdx
@@ -86,12 +86,12 @@ const MyModelAdapter: ChatModelAdapter = {
   },
 };
 
-export function MyRuntimeProvider({
+export function MyRuntimeProvider<T extends LocalRuntime>({
   children,
 }: Readonly<{
   children: ReactNode;
 }>) {
-  const runtime = useLocalRuntime(MyModelAdapter);
+  const runtime = useLocalRuntime<T>(MyModelAdapter);
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>

--- a/apps/docs/content/docs/runtimes/pick-a-runtime.mdx
+++ b/apps/docs/content/docs/runtimes/pick-a-runtime.mdx
@@ -25,3 +25,34 @@ For custom backends, we have two entrypoints for integration:
 
 - [LocalRuntime](/docs/runtimes/custom/local)
 - [ExternalStoreRuntime](/docs/runtimes/custom/external-store)
+
+## Updates
+
+The useRemoteThreadListRuntime function has been updated to support generic types. This means that the function can now accept and return any type that extends the AssistantRuntime type. This allows for more flexibility and type safety when using the function.
+
+Here is the updated function signature:
+
+```typescript
+export const useRemoteThreadListRuntime = <T extends AssistantRuntime>(
+  options: RemoteThreadListOptions<T>,
+): T => {
+  const [runtime] = useState(() => new RemoteThreadListRuntimeCore(options));
+  useEffect(() => {
+    runtime.threads.__internal_setOptions(options);
+    runtime.threads.__internal_load();
+  }, [runtime, options]);
+  return useMemo(() => AssistantRuntimeImpl.create(runtime) as T, [runtime]);
+};
+```
+
+This change affects the following files:
+
+- AssistantRuntimeProvider.tsx
+- AssistantContext.ts
+- index.ts
+- RemoteThreadListHookInstanceManager.tsx
+- RemoteThreadListThreadListRuntimeCore.tsx
+- types.tsx
+- useRemoteThreadListRuntime.tsx
+
+Please refer to the code changes for more details.


### PR DESCRIPTION
## Documentation Updates

### apps/docs/content/docs/api-reference/context-providers/AssistantRuntimeProvider.mdx
Reason for update: The AssistantRuntimeProvider has been updated to support generic types, which should be reflected in the documentation.

### apps/docs/content/docs/api-reference/runtimes/AssistantRuntime.mdx
Reason for update: The AssistantRuntime has been updated to support generic types, which should be reflected in the documentation.

### apps/docs/content/docs/runtimes/custom/local.mdx
Reason for update: The local runtime has been updated to export a new type, LocalRuntime, which should be documented.

### apps/docs/content/docs/runtimes/custom/external-store.mdx
Reason for update: The RemoteThreadListHookInstanceManager class has been updated to support generic types, which should be reflected in the documentation.

### apps/docs/content/docs/runtimes/pick-a-runtime.mdx
Reason for update: The useRemoteThreadListRuntime function has been updated to support generic types, which should be reflected in the documentation.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Documentation updated to reflect support for generic types in AssistantRuntime components and functions.
> 
>   - **AssistantRuntimeProvider**:
>     - Updated to support generic types in `AssistantRuntimeProvider.mdx`.
>     - `AssistantRuntimeProviderImpl` and `useAssistantRuntime` now accept generic type `T` extending `AssistantRuntime`.
>     - `RemoteThreadListHookInstanceManager` and `RemoteThreadListThreadListRuntimeCore` classes updated for generics.
>   - **AssistantRuntime**:
>     - Documentation in `AssistantRuntime.mdx` updated to reflect support for generic types.
>     - `useAssistantRuntime` hook now supports specifying runtime type.
>   - **ExternalStoreRuntime**:
>     - `RemoteThreadListHookInstanceManager` class updated for generics in `external-store.mdx`.
>     - `useRemoteThreadListRuntime` function updated for type safety.
>   - **LocalRuntime**:
>     - `MyRuntimeProvider` updated to support generic types in `local.mdx`.
>   - **General Updates**:
>     - `useRemoteThreadListRuntime` function updated for generics in `pick-a-runtime.mdx`.
>     - Affects `AssistantRuntimeProvider.tsx`, `AssistantContext.ts`, `index.ts`, `RemoteThreadListHookInstanceManager.tsx`, `RemoteThreadListThreadListRuntimeCore.tsx`, `types.tsx`, `useRemoteThreadListRuntime.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 48c704f23b78efb96cb4d5fd6693ae6378fc9c69. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->