### PR TITLE
docs: add YC pill

### DIFF
--- a/apps/docs/app/(home)/home/YCPill.tsx
+++ b/apps/docs/app/(home)/home/YCPill.tsx
@@ -1,0 +1,16 @@
+"use client";
+export function YCPill() {
+  return (
+    <div className="flex justify-center">
+      <a
+        className="rainbow-border relative items-center justify-center rounded-full p-[1px] text-sm after:absolute after:inset-0 after:-z-10 after:block after:rounded-full"
+        href="https://www.ycombinator.com/companies/assistant-ui"
+      >
+        <span className="bg-background inline-flex items-center gap-1 overflow-clip whitespace-nowrap rounded-full px-5 py-1.5">
+          <div>Backed by</div>
+          <div className="text-[#f60]">Y Combinator</div>
+        </span>
+      </a>
+    </div>
+  );
+}

--- a/apps/docs/app/(home)/home/YCPill.tsx
+++ b/apps/docs/app/(home)/home/YCPill.tsx
@@ -4,7 +4,7 @@ export function YCPill() {
     <div className="flex justify-center">
       <a
         className="rainbow-border relative items-center justify-center rounded-full p-[1px] text-sm after:absolute after:inset-0 after:-z-10 after:block after:rounded-full"
-        href="https://www.ycombinator.com/companies/assistant-ui"
+        href="https://www.ycombinator.com/launches/Mnc-assistant-ui-open-source-typescript-react-library-for-ai-chat"
       >
         <span className="bg-background inline-flex items-center gap-1 overflow-clip whitespace-nowrap rounded-full px-5 py-1.5">
           <div>Backed by</div>

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -18,10 +18,12 @@ import { ArrowRight } from "lucide-react";
 import { MyRuntimeProvider } from "./MyRuntimeProvider";
 import { Marquee } from "@/components/magicui/marquee";
 import { useMediaQuery } from "@/lib/useMediaQuery";
+import { YCPill } from "./home/YCPill";
 
 export default function HomePage() {
   return (
     <main className="container relative z-[2] max-w-[1100px] px-2 py-16 lg:py-16">
+      <YCPill />
       <Hero />
       <div className="mx-auto mt-6 flex h-[650px] w-full max-w-screen-xl flex-col overflow-hidden rounded-lg border shadow">
         <MyRuntimeProvider>

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -181,3 +181,41 @@
 @utility animate-shine {
   animation: shine var(--duration) infinite linear;
 }
+
+@property --angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+@keyframes rotate {
+  to {
+    --angle: 360deg;
+  }
+}
+
+.rainbow-border {
+  animation: rotate 10s linear infinite;
+  background: linear-gradient(
+    var(--angle),
+    #02fcef70 0,
+    #ffb52b70 50%,
+    #a02bfe70 100%
+  );
+
+  &:after {
+    animation: rotate 10s linear infinite;
+    background: linear-gradient(
+      var(--angle),
+      #02fcef70 0,
+      #ffb52b70 50%,
+      #a02bfe70 100%
+    );
+    filter: blur(10px);
+    transition: all 0.4s ease-out;
+  }
+
+  &:hover:after {
+    transform: scale(1.1, 1.1);
+  }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `YCPill` component to homepage with rotating rainbow border effect to indicate Y Combinator backing.
> 
>   - **Component Addition**:
>     - Adds `YCPill` component in `YCPill.tsx` to display "Backed by Y Combinator" with a link to Y Combinator's page.
>     - Integrates `YCPill` into `HomePage` in `page.tsx`.
>   - **Styling**:
>     - Adds `.rainbow-border` class in `global.css` for rotating rainbow border effect.
>     - Defines `@keyframes rotate` and `@property --angle` in `global.css` for animation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1fb8149bcfdda8b4ec8f06264e53e78beadd68f9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->