### PR TITLE
Documentation Updates Based on Code Changes

### DIFF
--- a/apps/docs/content/docs/api-reference/context-providers/AssistantRuntimeProvider.mdx
+++ b/apps/docs/content/docs/api-reference/context-providers/AssistantRuntimeProvider.mdx
@@ -5,7 +5,7 @@ title: <AssistantRuntimeProvider />
 import { ParametersTable } from "@/components/docs";
 import { AssistantRuntimeProvider } from "@/generated/typeDocs";
 
-The `AssistantRuntimeProvider` provides data and APIs used by assistant-ui components.
+The `AssistantRuntimeProvider` now uses a generic type for the runtime prop. This provides data and APIs used by assistant-ui components.
 
 Almost all components in assistant-ui require an `AssistantRuntimeProvider` around them to function properly.
 
@@ -28,3 +28,64 @@ const MyApp = () => {
 #### Properties
 
 <ParametersTable {...AssistantRuntimeProvider} />
+
+The `AssistantRuntimeProvider` now accepts a generic type `T` that extends `AssistantRuntime`. This means you can now pass a specific type of runtime to the `AssistantRuntimeProvider`.
+
+```tsx
+export const AssistantRuntimeProviderImpl = <T extends AssistantRuntime>({
+  children,
+  runtime,
+}: AssistantRuntimeProvider.Props<T>) => {
+  // ...
+};
+```
+
+The `useAssistantRuntime` function has also been updated to use a generic type `T` that extends `AssistantRuntime`.
+
+```tsx
+export function useAssistantRuntime<T extends AssistantRuntime>(options?: {
+  optional?: false | undefined;
+}): T;
+```
+
+The `RemoteThreadListHookInstanceManager` class now accepts a generic type `T` that extends `AssistantRuntime`.
+
+```tsx
+export class RemoteThreadListHookInstanceManager<
+  T extends AssistantRuntime,
+> extends BaseSubscribable {
+  // ...
+};
+```
+
+The `RemoteThreadListThreadListRuntimeCore` class now accepts a generic type `T` that extends `AssistantRuntime`.
+
+```tsx
+export class RemoteThreadListThreadListRuntimeCore<T extends AssistantRuntime>
+  extends BaseSubscribable
+  implements ThreadListRuntimeCore
+{
+  // ...
+};
+```
+
+The `RemoteThreadListOptions` type now accepts a generic type `T` that extends `AssistantRuntime`.
+
+```tsx
+export type RemoteThreadListOptions<
+  T extends AssistantRuntime = AssistantRuntime,
+> = {
+  runtimeHook: () => T;
+  adapter: RemoteThreadListAdapter;
+};
+```
+
+The `useRemoteThreadListRuntime` function now accepts a generic type `T` that extends `AssistantRuntime`.
+
+```tsx
+export const useRemoteThreadListRuntime = <T extends AssistantRuntime>(
+  options: RemoteThreadListOptions<T>,
+): T => {
+  // ...
+};
+```

--- a/apps/docs/content/docs/api-reference/runtimes/AssistantRuntime.mdx
+++ b/apps/docs/content/docs/api-reference/runtimes/AssistantRuntime.mdx
@@ -5,14 +5,14 @@ title: AssistantRuntime
 import { ParametersTable } from "@/components/docs";
 import { AssistantRuntime, AssistantToolUIsState } from "@/generated/typeDocs";
 
-The `AssistantRuntime` is the root runtime of the application.
+The `AssistantRuntime` is the root runtime of the application. It is now a generic type, which allows for more flexibility in its usage.
 
 ### `useAssistantRuntime`
 
 ```tsx
 import { useAssistantRuntime } from "@assistant-ui/react";
 
-const runtime = useAssistantRuntime();
+const runtime = useAssistantRuntime<YourAssistantRuntimeType>();
 ```
 
 <ParametersTable {...AssistantRuntime} />
@@ -31,3 +31,5 @@ const webSearchToolUI = useToolUIs((m) => m.getToolUI("web_search"));
 ```
 
 <ParametersTable {...AssistantToolUIsState} />
+
+Please replace `YourAssistantRuntimeType` with the specific type of AssistantRuntime you are using in your application. The `useAssistantRuntime` hook now requires a type parameter to specify the type of AssistantRuntime. This change allows for more flexibility and type safety when using the AssistantRuntime.

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -45,7 +45,7 @@ const convertMessage = (message: MyMessage): ThreadMessageLike => {
   };
 };
 
-export function MyRuntimeProvider({
+export function MyRuntimeProvider<T extends AssistantRuntime>({
   children,
 }: Readonly<{
   children: ReactNode;
@@ -72,7 +72,7 @@ export function MyRuntimeProvider({
     setIsRunning(false);
   };
 
-  const runtime = useExternalStoreRuntime({
+  const runtime = useExternalStoreRuntime<T>({
     isRunning,
     messages,
     convertMessage,

--- a/apps/docs/content/docs/runtimes/custom/local.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local.mdx
@@ -56,6 +56,7 @@ import {
   AssistantRuntimeProvider,
   useLocalRuntime,
   type ChatModelAdapter,
+  type LocalRuntime,
 } from "@assistant-ui/react";
 
 const MyModelAdapter: ChatModelAdapter = {
@@ -91,7 +92,7 @@ export function MyRuntimeProvider({
 }: Readonly<{
   children: ReactNode;
 }>) {
-  const runtime = useLocalRuntime(MyModelAdapter);
+  const runtime: LocalRuntime = useLocalRuntime(MyModelAdapter);
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>

--- a/apps/docs/content/docs/runtimes/pick-a-runtime.mdx
+++ b/apps/docs/content/docs/runtimes/pick-a-runtime.mdx
@@ -25,3 +25,19 @@ For custom backends, we have two entrypoints for integration:
 
 - [LocalRuntime](/docs/runtimes/custom/local)
 - [ExternalStoreRuntime](/docs/runtimes/custom/external-store)
+
+## Updates
+
+The useRemoteThreadListRuntime function now returns a generic type. This means that the function can now return any type that extends the AssistantRuntime type. This change allows for more flexibility and adaptability in the use of the function.
+
+The AssistantRuntimeProviderImpl function now also accepts a generic type that extends the AssistantRuntime type. This change reflects the update to the useRemoteThreadListRuntime function and ensures consistency across the codebase.
+
+The RemoteThreadListHookInstanceManager class now accepts a generic type that extends the AssistantRuntime type. This update allows the class to manage instances of any type that extends the AssistantRuntime type.
+
+The RemoteThreadListThreadListRuntimeCore class now accepts a generic type that extends the AssistantRuntime type. This update allows the class to manage instances of any type that extends the AssistantRuntime type.
+
+The RemoteThreadListOptions type now accepts a generic type that extends the AssistantRuntime type. This update allows the type to manage options for any type that extends the AssistantRuntime type.
+
+The RemoteThreadListRuntimeCore class now accepts a generic type that extends the AssistantRuntime type. This update allows the class to manage instances of any type that extends the AssistantRuntime type.
+
+The useRemoteThreadListRuntime function now returns a generic type that extends the AssistantRuntime type. This update allows the function to return instances of any type that extends the AssistantRuntime type.


### PR DESCRIPTION
## Documentation Updates

### apps/docs/content/docs/api-reference/context-providers/AssistantRuntimeProvider.mdx
Reason for update: The AssistantRuntimeProvider has been updated to use a generic type for the runtime prop, which needs to be reflected in the documentation.

### apps/docs/content/docs/api-reference/runtimes/AssistantRuntime.mdx
Reason for update: The AssistantRuntime has been updated to be a generic type, which needs to be reflected in the documentation.

### apps/docs/content/docs/runtimes/custom/local.mdx
Reason for update: The LocalRuntime has been exported from useLocalRuntime, which needs to be reflected in the documentation.

### apps/docs/content/docs/runtimes/custom/external-store.mdx
Reason for update: The RemoteThreadListHookInstanceManager has been updated to use a generic type, which needs to be reflected in the documentation.

### apps/docs/content/docs/runtimes/pick-a-runtime.mdx
Reason for update: The useRemoteThreadListRuntime function now returns a generic type, which needs to be reflected in the documentation.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Documentation updated to reflect the use of generic types in `AssistantRuntimeProvider`, `AssistantRuntime`, and related runtime components for improved flexibility and type safety.
> 
>   - **AssistantRuntimeProvider**:
>     - Updated to use a generic type for the runtime prop in `AssistantRuntimeProvider.mdx`.
>     - `useAssistantRuntime` function now uses a generic type.
>     - `RemoteThreadListHookInstanceManager` and `RemoteThreadListThreadListRuntimeCore` classes now accept a generic type.
>   - **AssistantRuntime**:
>     - Updated to be a generic type in `AssistantRuntime.mdx`.
>     - `useAssistantRuntime` hook now requires a type parameter for flexibility and type safety.
>   - **Local and External Store Runtimes**:
>     - `useLocalRuntime` and `useExternalStoreRuntime` functions updated to use generic types in `local.mdx` and `external-store.mdx`.
>   - **Miscellaneous**:
>     - `useRemoteThreadListRuntime` function now returns a generic type in `pick-a-runtime.mdx`.
>     - Documentation reflects updates for consistency and flexibility across the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 7727017923ab3e9a8a1c33920f297bdcbe7fc873. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->