### PR TITLE
fix: pin nanoid to 3.3.8 for now

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -45,7 +45,7 @@
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.475.0",
     "motion": "^12.4.1",
-    "nanoid": "^5.0.9",
+    "nanoid": "3.3.8",
     "next": "15.1.6",
     "openai": "^4.83.0",
     "react": "19.0.0",

--- a/examples/search-agent-for-e-commerce/package.json
+++ b/examples/search-agent-for-e-commerce/package.json
@@ -22,7 +22,7 @@
     "embla-carousel-autoplay": "^8.5.2",
     "embla-carousel-react": "^8.5.2",
     "lucide-react": "^0.475.0",
-    "nanoid": "^5.0.9",
+    "nanoid": "3.3.8",
     "next": "15.1.6",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/examples/with-cloud/package.json
+++ b/examples/with-cloud/package.json
@@ -15,7 +15,7 @@
     "@assistant-ui/react-ui": "workspace:^",
     "ai": "^4.1.25",
     "jsonwebtoken": "^9.0.2",
-    "nanoid": "^5.0.9",
+    "nanoid": "3.3.8",
     "next": "15.1.6",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/examples/with-langgraph/package.json
+++ b/examples/with-langgraph/package.json
@@ -20,7 +20,7 @@
     "js-cookie": "^3.0.5",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.475.0",
-    "nanoid": "^5.0.9",
+    "nanoid": "3.3.8",
     "next": "15.1.6",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/examples/with-vercel-ai-rsc/package.json
+++ b/examples/with-vercel-ai-rsc/package.json
@@ -20,7 +20,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.475.0",
-    "nanoid": "^5.0.9",
+    "nanoid": "3.3.8",
     "next": "15.1.6",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/packages/assistant-stream/CHANGELOG.md
+++ b/packages/assistant-stream/CHANGELOG.md
@@ -1,5 +1,11 @@
 # assistant-stream
 
+## 0.0.21
+
+### Patch Changes
+
+- fix: pin nanoid version for CJS compat
+
 ## 0.0.20
 
 ### Patch Changes

--- a/packages/assistant-stream/package.json
+++ b/packages/assistant-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant-stream",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "license": "MIT",
   "exports": {
     ".": {
@@ -57,7 +57,7 @@
     "url": "https://github.com/assistant-ui/assistant-ui/issues"
   },
   "dependencies": {
-    "nanoid": "^5.0.9",
+    "nanoid": "3.3.8",
     "secure-json-parse": "^3.0.2"
   }
 }

--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -34,7 +34,7 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.83",
+    "@assistant-ui/react": "^0.7.84",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -30,7 +30,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.83",
+    "@assistant-ui/react": "^0.7.84",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -31,7 +31,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.83",
+    "@assistant-ui/react": "^0.7.84",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -44,7 +44,7 @@
     "react-markdown": "^9.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.83",
+    "@assistant-ui/react": "^0.7.84",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -27,7 +27,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap --clean"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.7.83",
+    "@assistant-ui/react": "^0.7.84",
     "@assistant-ui/react-markdown": "^0.7.20",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @assistant-ui/react
 
+## 0.7.84
+
+### Patch Changes
+
+- fix: pin nanoid version for CJS compat
+- Updated dependencies
+  - assistant-stream@0.0.21
+
 ## 0.7.83
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.7.83",
+  "version": "0.7.84",
   "license": "MIT",
   "exports": {
     ".": {
@@ -85,7 +85,7 @@
     "classnames": "^2.5.1",
     "json-schema": "^0.4.0",
     "lucide-react": "^0.475.0",
-    "nanoid": "^5.0.9",
+    "nanoid": "3.3.8",
     "react-textarea-autosize": "^8.5.7",
     "secure-json-parse": "^3.0.2",
     "zod": "^3.24.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,8 @@ importers:
         specifier: ^12.4.1
         version: 12.4.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       nanoid:
-        specifier: ^5.0.9
-        version: 5.0.9
+        specifier: 3.3.8
+        version: 3.3.8
       next:
         specifier: 15.1.6
         version: 15.1.6(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -424,8 +424,8 @@ importers:
         specifier: ^0.475.0
         version: 0.475.0(react@19.0.0)
       nanoid:
-        specifier: ^5.0.9
-        version: 5.0.9
+        specifier: 3.3.8
+        version: 3.3.8
       next:
         specifier: 15.1.6
         version: 15.1.6(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -552,8 +552,8 @@ importers:
         specifier: ^9.0.2
         version: 9.0.2
       nanoid:
-        specifier: ^5.0.9
-        version: 5.0.9
+        specifier: 3.3.8
+        version: 3.3.8
       next:
         specifier: 15.1.6
         version: 15.1.6(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -874,8 +874,8 @@ importers:
         specifier: ^0.475.0
         version: 0.475.0(react@19.0.0)
       nanoid:
-        specifier: ^5.0.9
-        version: 5.0.9
+        specifier: 3.3.8
+        version: 3.3.8
       next:
         specifier: 15.1.6
         version: 15.1.6(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1144,8 +1144,8 @@ importers:
         specifier: ^0.475.0
         version: 0.475.0(react@19.0.0)
       nanoid:
-        specifier: ^5.0.9
-        version: 5.0.9
+        specifier: 3.3.8
+        version: 3.3.8
       next:
         specifier: 15.1.6
         version: 15.1.6(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1196,8 +1196,8 @@ importers:
   packages/assistant-stream:
     dependencies:
       nanoid:
-        specifier: ^5.0.9
-        version: 5.0.9
+        specifier: 3.3.8
+        version: 3.3.8
       secure-json-parse:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1373,8 +1373,8 @@ importers:
         specifier: ^0.475.0
         version: 0.475.0(react@19.0.0)
       nanoid:
-        specifier: ^5.0.9
-        version: 5.0.9
+        specifier: 3.3.8
+        version: 3.3.8
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -6186,11 +6186,6 @@ packages:
   nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@5.0.9:
-    resolution: {integrity: sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==}
-    engines: {node: ^18 || >=20}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -12804,8 +12799,6 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.8: {}
-
-  nanoid@5.0.9: {}
 
   natural-compare@1.4.0: {}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pin `nanoid` to version `3.3.8` across multiple packages for CJS compatibility and update package versions accordingly.
> 
>   - **Dependencies**:
>     - Pin `nanoid` to version `3.3.8` in `apps/docs/package.json`, `examples/search-agent-for-e-commerce/package.json`, and `packages/react/package.json` for CJS compatibility.
>     - Update `@assistant-ui/react` peer dependency to `^0.7.84` in `packages/react-ai-sdk/package.json`, `packages/react-hook-form/package.json`, and `packages/react-langgraph/package.json`.
>   - **Version Updates**:
>     - Bump version to `0.0.21` in `packages/assistant-stream/package.json`.
>     - Bump version to `0.7.84` in `packages/react/package.json`.
>   - **Changelog**:
>     - Add entry for version `0.0.21` in `packages/assistant-stream/CHANGELOG.md` noting the `nanoid` version pinning.
>     - Add entry for version `0.7.84` in `packages/react/CHANGELOG.md` noting the `nanoid` version pinning and dependency updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 7d532bcb3ad17d07aa0fdf5be22b1f15a877ec55. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->