### PR TITLE
Documentation Updates Based on Code Changes

### DIFF
--- a/apps/docs/content/docs/api-reference/context-providers/TextContentPartProvider.mdx
+++ b/apps/docs/content/docs/api-reference/context-providers/TextContentPartProvider.mdx
@@ -24,3 +24,11 @@ const MyApp = () => {
 #### Properties
 
 <ParametersTable {...AssistantRuntimeProvider} />
+
+The `ThreadMessageLike` type now includes a new role: "data". This role can be used to represent data-related messages in the thread.
+
+The `MessageRole` type has also been updated to include the "data" role.
+
+The `CoreToolCallContentPart` and `ToolCallContentPart` types now have a generic parameter `TArgs` that extends `ReadonlyJSONObject` by default. This change allows for more flexibility when defining the arguments for a tool call.
+
+Please note that these changes may require updates to your existing code if you are using these types.

--- a/apps/docs/content/docs/api-reference/primitives/ContentPart.mdx
+++ b/apps/docs/content/docs/api-reference/primitives/ContentPart.mdx
@@ -1,6 +1,6 @@
 ---
 title: ContentPartPrimitive
-description: A part of a message's content. Content parts may be text, image, tool call or UI elements.
+description: A part of a message's content. Content parts may be text, image, tool call, UI elements, or data.
 ---
 
 import { ParametersTable } from "@/components/docs";
@@ -12,7 +12,7 @@ import {
 } from "@/generated/typeDocs";
 
 Each message can have any number of content parts.  
-Content parts are usually one of text, reasoning, audio or tool-call.
+Content parts are usually one of text, reasoning, audio, tool-call, or data.
 
 ## Content Part Types
 
@@ -31,6 +31,10 @@ Audio content that can be played back.
 ### Tool Call
 
 Interactive elements that represent tool operations.
+
+### Data
+
+This is a new type of content part that represents data.
 
 ## Anatomy
 
@@ -116,6 +120,7 @@ import { MessagePrimitive } from "@assistant/react";
     Text: MyText,
     Reasoning: MyReasoning,
     Audio: MyAudio,
+    Data: MyData,
     tools: {
       by_name: {
         get_weather: MyWeatherToolUI,
@@ -135,7 +140,7 @@ import { TextContentPartProvider } from "@assistant-ui/react";
 
 <TextContentPartProvider text="Hello world" isRunning={false}>
   <ContentPart.Text />
-</TextContentPartProvider>;
+</ContentPartProvider>;
 ```
 
 ## Runtime API

--- a/apps/docs/content/docs/api-reference/primitives/Message.mdx
+++ b/apps/docs/content/docs/api-reference/primitives/Message.mdx
@@ -32,7 +32,7 @@ const AssistantMessage = () => (
 
 ### Root
 
-Containts all parts of the message.
+Contains all parts of the message.
 
 This primitive renders a `<div>` element unless `asChild` is set.
 
@@ -154,6 +154,11 @@ Renders children if a condition is met.
       description:
         "Render children if the message is the last or hovered over.",
     },
+    {
+      name: "data",
+      type: "boolean | undefined",
+      description: "Render children if the message role is data.",
+    },
   ]}
 />
 
@@ -163,5 +168,8 @@ Renders children if a condition is met.
 </Message.If>
 <Message.If assistant>
   {/* rendered if message is from the assistant */}
+</Message.If>
+<Message.If data>
+  {/* rendered if message role is data */}
 </Message.If>
 ```

--- a/apps/docs/content/docs/api-reference/runtimes/MessageRuntime.mdx
+++ b/apps/docs/content/docs/api-reference/runtimes/MessageRuntime.mdx
@@ -47,3 +47,24 @@ const text = useEditComposer((m) => m.text);
 ```
 
 <ParametersTable {...EditComposerState} />
+
+### `ThreadMessageLike`
+
+The `ThreadMessageLike` type has been updated to include a new role: "data". This role is read-only and can be one of the following: "assistant", "user", "system", or "data".
+
+```tsx
+export type ThreadMessageLike = {
+  readonly role: "assistant" | "user" | "system" | "data";
+  ...
+};
+```
+
+### `MessageRole`
+
+The `MessageRole` type has also been updated to include the new "data" role. This role can be one of the following: "user", "assistant", "system", or "data".
+
+```tsx
+export type MessageRole = "user" | "assistant" | "system" | "data";
+```
+
+Please note that these changes may affect how messages are handled in your application, especially if your code relies on the specific roles of messages.

--- a/apps/docs/content/docs/api-reference/runtimes/ThreadRuntime.mdx
+++ b/apps/docs/content/docs/api-reference/runtimes/ThreadRuntime.mdx
@@ -59,3 +59,25 @@ const isAtBottom = useThreadViewport((m) => m.isAtBottom);
 ```
 
 <ParametersTable {...ThreadViewportState} />
+
+### `ThreadMessageLike`
+
+The `ThreadMessageLike` type has been updated to include a new role: "data". This role can be used in addition to the existing "assistant", "user", and "system" roles. The order of imports in the `ThreadMessageLike.tsx` file has also been rearranged, but this does not affect the functionality.
+
+```tsx
+export type ThreadMessageLike = {
+  readonly role: "assistant" | "user" | "system" | "data";
+  readonly content:
+    | string
+    | readonly (
+```
+
+### `MessageRole`
+
+The `MessageRole` type in `AssistantTypes.ts` has also been updated to include the "data" role.
+
+```tsx
+export type MessageRole = "user" | "assistant" | "system" | "data";
+```
+
+Please note that these changes may require updates to any code that uses these types.

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -22,7 +22,7 @@ Unless you are storing messages as `ThreadMessage`, you need to define a `conver
 
 ```tsx twoslash title="@/app/MyRuntimeProvider.tsx"
 type MyMessage = {
-  role: "user" | "assistant";
+  role: "user" | "assistant" | "system" | "data";
   content: string;
 };
 const backendApi = async (input: string): Promise<MyMessage> => {


### PR DESCRIPTION
## Documentation Updates

### apps/docs/content/docs/api-reference/runtimes/MessageRuntime.mdx
Reason for update: The code changes include modifications to the ThreadMessageLike and MessageRole types, which are likely documented in this file.

### apps/docs/content/docs/api-reference/runtimes/ThreadRuntime.mdx
Reason for update: The ThreadMessageLike type, which has been modified in the code changes, is likely documented in this file.

### apps/docs/content/docs/api-reference/primitives/Message.mdx
Reason for update: The MessageRole type, which has been modified in the code changes, is likely documented in this file.

### apps/docs/content/docs/runtimes/custom/external-store.mdx
Reason for update: The code changes were made in the external-store directory, so this documentation file may need to be updated to reflect those changes.

### apps/docs/content/docs/api-reference/primitives/ContentPart.mdx
Reason for update: The code changes include modifications to the ContentPart types, which are likely documented in this file.

### apps/docs/content/docs/api-reference/context-providers/TextContentPartProvider.mdx
Reason for update: The code changes include modifications to the TextContentPart type, which is likely documented in this file.

