### PR TITLE
Documentation Updates Based on Code Changes

### DIFF
--- a/apps/docs/content/docs/api-reference/context-providers/TextContentPartProvider.mdx
+++ b/apps/docs/content/docs/api-reference/context-providers/TextContentPartProvider.mdx
@@ -24,3 +24,39 @@ const MyApp = () => {
 #### Properties
 
 <ParametersTable {...AssistantRuntimeProvider} />
+
+The `ThreadMessageLike` type now includes a new role: "data". This role can be used to represent data-specific messages in a thread.
+
+```tsx
+export type ThreadMessageLike = {
+  readonly role: "assistant" | "user" | "system" | "data";
+  readonly content:
+    | string
+    | readonly (
+```
+
+The `MessageRole` type has also been updated to include the "data" role.
+
+```tsx
+export type MessageRole = "user" | "assistant" | "system" | "data";
+```
+
+The `CoreToolCallContentPart` and `ToolCallContentPart` types now have a more specific type for the `TArgs` parameter, which extends `ReadonlyJSONObject`.
+
+```tsx
+export type CoreToolCallContentPart<
+  TArgs extends ReadonlyJSONObject = ReadonlyJSONObject,
+  TResult = unknown,
+> = {
+  readonly type: "tool-call";
+```
+
+```tsx
+export type ToolCallContentPart<
+  TArgs extends ReadonlyJSONObject = ReadonlyJSONObject,
+  TResult = unknown,
+> = CoreToolCallContentPart<TArgs, TResult> & {
+  readonly argsText: string;
+```
+
+Please note that these changes may require updates to your existing code if you are using these types.

--- a/apps/docs/content/docs/api-reference/primitives/ContentPart.mdx
+++ b/apps/docs/content/docs/api-reference/primitives/ContentPart.mdx
@@ -1,6 +1,6 @@
 ---
 title: ContentPartPrimitive
-description: A part of a message's content. Content parts may be text, image, tool call or UI elements.
+description: A part of a message's content. Content parts may be text, image, tool call, UI elements or data.
 ---
 
 import { ParametersTable } from "@/components/docs";
@@ -12,7 +12,7 @@ import {
 } from "@/generated/typeDocs";
 
 Each message can have any number of content parts.  
-Content parts are usually one of text, reasoning, audio or tool-call.
+Content parts are usually one of text, reasoning, audio, tool-call or data.
 
 ## Content Part Types
 
@@ -31,6 +31,10 @@ Audio content that can be played back.
 ### Tool Call
 
 Interactive elements that represent tool operations.
+
+### Data
+
+Data content that can be processed or displayed.
 
 ## Anatomy
 
@@ -116,6 +120,7 @@ import { MessagePrimitive } from "@assistant/react";
     Text: MyText,
     Reasoning: MyReasoning,
     Audio: MyAudio,
+    Data: MyData,
     tools: {
       by_name: {
         get_weather: MyWeatherToolUI,

--- a/apps/docs/content/docs/api-reference/primitives/Message.mdx
+++ b/apps/docs/content/docs/api-reference/primitives/Message.mdx
@@ -32,7 +32,7 @@ const AssistantMessage = () => (
 
 ### Root
 
-Containts all parts of the message.
+Contains all parts of the message.
 
 This primitive renders a `<div>` element unless `asChild` is set.
 
@@ -165,3 +165,22 @@ Renders children if a condition is met.
   {/* rendered if message is from the assistant */}
 </Message.If>
 ```
+
+### ThreadMessageLike
+
+ThreadMessageLike has been updated to include a new role "data". This role can be used to represent messages that contain data.
+
+```tsx
+export type ThreadMessageLike = {
+  readonly role: "assistant" | "user" | "system" | "data";
+  readonly content:
+    | string
+    | readonly (
+```
+
+The role of a message can be one of the following:
+
+- "assistant": The message is from the assistant.
+- "user": The message is from the user.
+- "system": The message is a system message.
+- "data": The message contains data.

--- a/apps/docs/content/docs/api-reference/primitives/Thread.mdx
+++ b/apps/docs/content/docs/api-reference/primitives/Thread.mdx
@@ -26,7 +26,7 @@ const Thread = () => (
 
 ### Root
 
-Containts all parts of the thread.
+Contains all parts of the thread.
 
 This primitive renders a `<div>` element unless `asChild` is set.
 
@@ -56,7 +56,7 @@ This primitive renders a `<div>` element unless `asChild` is set.
       type: "boolean",
       default: "true",
       description:
-        "Whether to automatically scroll to the bottom of the viewport when new messages are added while the viewport is was previously scrolled to the bottom.",
+        "Whether to automatically scroll to the bottom of the viewport when new messages are added while the viewport was previously scrolled to the bottom.",
     },
   ]}
 />
@@ -195,3 +195,36 @@ Renders children if a condition is met.
   {/* rendered if thread is not empty */}
 </Thread.If>
 ```
+
+### ThreadMessageLike
+
+The `ThreadMessageLike` type is used to represent a message in the thread. It has been updated to include a new role: "data".
+
+```tsx
+export type ThreadMessageLike = {
+  readonly role: "assistant" | "user" | "system" | "data";
+  readonly content:
+    | string
+    | readonly (
+        | TextContentPart
+        | ImageContentPart
+        | UIContentPart
+        | ThreadAssistantContentPart
+        | ThreadUserContentPart
+        | ReasoningContentPart
+        | CompleteAttachment
+        | FileContentPart
+        | Unstable_AudioContentPart
+      )[];
+  readonly id: string;
+  readonly status: MessageStatus;
+  readonly timestamp: number;
+};
+```
+
+The `role` property can now be one of the following values:
+
+- "assistant": The message was sent by the assistant.
+- "user": The message was sent by the user.
+- "system": The message was sent by the system.
+- "data": The message contains data.

--- a/apps/docs/content/docs/api-reference/runtimes/AssistantRuntime.mdx
+++ b/apps/docs/content/docs/api-reference/runtimes/AssistantRuntime.mdx
@@ -31,3 +31,57 @@ const webSearchToolUI = useToolUIs((m) => m.getToolUI("web_search"));
 ```
 
 <ParametersTable {...AssistantToolUIsState} />
+
+### ThreadMessageLike
+
+The `ThreadMessageLike` type represents a message in a thread. It has a `role` property that can be one of the following: `"assistant"`, `"user"`, `"system"`, or `"data"`.
+
+```tsx
+export type ThreadMessageLike = {
+  readonly role: "assistant" | "user" | "system" | "data";
+  readonly content:
+    | string
+    | readonly (
+        | TextContentPart
+        | ImageContentPart
+        | UIContentPart
+        | ReasoningContentPart
+        | ThreadAssistantContentPart
+        | ThreadUserContentPart
+        | Unstable_AudioContentPart
+        | CompleteAttachment
+        | FileContentPart
+      )[];
+};
+```
+
+### MessageRole
+
+The `MessageRole` type has been updated to include `"data"` as a possible value. This type is used to define the role of a message in a thread.
+
+```tsx
+export type MessageRole = "user" | "assistant" | "system" | "data";
+```
+
+### CoreToolCallContentPart and ToolCallContentPart
+
+The `CoreToolCallContentPart` and `ToolCallContentPart` types have been updated. The `TArgs` type now extends `ReadonlyJSONObject`.
+
+```tsx
+export type CoreToolCallContentPart<
+  TArgs extends ReadonlyJSONObject = ReadonlyJSONObject,
+  TResult = unknown,
+> = {
+  readonly type: "tool-call";
+  readonly tool: string;
+  readonly args: TArgs;
+  readonly result?: TResult;
+};
+
+export type ToolCallContentPart<
+  TArgs extends ReadonlyJSONObject = ReadonlyJSONObject,
+  TResult = unknown,
+> = CoreToolCallContentPart<TArgs, TResult> & {
+  readonly argsText: string;
+};
+```

--- a/apps/docs/content/docs/api-reference/runtimes/MessageRuntime.mdx
+++ b/apps/docs/content/docs/api-reference/runtimes/MessageRuntime.mdx
@@ -47,3 +47,39 @@ const text = useEditComposer((m) => m.text);
 ```
 
 <ParametersTable {...EditComposerState} />
+
+### `ThreadMessageLike`
+
+The `ThreadMessageLike` type has been updated to include a new role: "data". This role can be used to represent messages that contain data-related content.
+
+```tsx
+export type ThreadMessageLike = {
+  readonly role: "assistant" | "user" | "system" | "data";
+  readonly content:
+    | string
+    | readonly (
+        | TextContentPart
+        | ImageContentPart
+        | UIContentPart
+        | ThreadAssistantContentPart
+        | ThreadUserContentPart
+        | ReasoningContentPart
+        | Unstable_AudioContentPart
+        | CompleteAttachment
+        | FileContentPart
+      )[];
+  readonly id: string;
+  readonly status: MessageStatus;
+  readonly timestamp: number;
+};
+```
+
+### `MessageRole`
+
+The `MessageRole` type in `AssistantTypes.ts` has also been updated to include the "data" role.
+
+```tsx
+export type MessageRole = "user" | "assistant" | "system" | "data";
+```
+
+These changes may affect the way messages are handled in the runtime, particularly in functions or components that use the `ThreadMessageLike` or `MessageRole` types.

--- a/apps/docs/content/docs/guides/Attachments.mdx
+++ b/apps/docs/content/docs/guides/Attachments.mdx
@@ -29,3 +29,36 @@ const runtime = useChatRuntime({
   },
 });
 ```
+
+## Changes in Import Statements
+
+The order of import statements in `ThreadMessageLike.tsx` has been changed. This change does not affect the functionality of attachments. The import statements are now organized in a way that groups similar types together.
+
+```tsx
+import {
+  CompleteAttachment,
+  FileContentPart,
+  ImageContentPart,
+  MessageStatus,
+  TextContentPart,
+  ThreadAssistantContentPart,
+  ThreadAssistantMessage,
+  ThreadMessage,
+  ThreadSystemMessage,
+  ThreadUserContentPart,
+  ThreadUserMessage,
+  UIContentPart,
+  Unstable_AudioContentPart,
+} from "../../types";
+import { ReasoningContentPart, ThreadStep } from "../../types/AssistantTypes";
+```
+
+## Message Role Update
+
+The `MessageRole` type has been updated to include a new role: "data". This change does not affect the functionality of attachments but provides more flexibility in defining the role of a message.
+
+```tsx
+export type MessageRole = "user" | "assistant" | "system" | "data";
+```
+
+Please note that these changes do not require any modifications to the way attachments are handled in your application.

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -22,7 +22,7 @@ Unless you are storing messages as `ThreadMessage`, you need to define a `conver
 
 ```tsx twoslash title="@/app/MyRuntimeProvider.tsx"
 type MyMessage = {
-  role: "user" | "assistant";
+  role: "user" | "assistant" | "system" | "data";
   content: string;
 };
 const backendApi = async (input: string): Promise<MyMessage> => {


### PR DESCRIPTION
## Documentation Updates

### apps/docs/content/docs/api-reference/primitives/Message.mdx
Reason for update: The role of the ThreadMessageLike has been updated to include "data". This change should be reflected in the documentation.

### apps/docs/content/docs/api-reference/primitives/Thread.mdx
Reason for update: The ThreadMessageLike type is used here and its role has been updated.

### apps/docs/content/docs/api-reference/runtimes/AssistantRuntime.mdx
Reason for update: The MessageRole type has been updated in AssistantTypes.ts, which might affect the AssistantRuntime.

### apps/docs/content/docs/api-reference/runtimes/MessageRuntime.mdx
Reason for update: The MessageRole type has been updated in AssistantTypes.ts, which might affect the MessageRuntime.

### apps/docs/content/docs/runtimes/custom/external-store.mdx
Reason for update: The code changes were made in the external-store directory, so this documentation might need to be updated.

### apps/docs/content/docs/guides/Attachments.mdx
Reason for update: The order of import statements in ThreadMessageLike.tsx has been changed, which might affect how attachments are handled.

### apps/docs/content/docs/api-reference/context-providers/TextContentPartProvider.mdx
Reason for update: The TextContentPart type is imported in the changed files, so this documentation might need to be updated.

### apps/docs/content/docs/api-reference/primitives/ContentPart.mdx
Reason for update: The UIContentPart and other content part types are imported in the changed files, so this documentation might need to be updated.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Documentation updated to reflect changes in `ThreadMessageLike`, `MessageRole`, `CoreToolCallContentPart`, and `ToolCallContentPart` types across multiple files.
> 
>   - **Documentation Updates**:
>     - `ThreadMessageLike` type updated to include "data" role in `Message.mdx`, `Thread.mdx`, `AssistantRuntime.mdx`, `MessageRuntime.mdx`, and `TextContentPartProvider.mdx`.
>     - `MessageRole` type updated to include "data" role in `AssistantRuntime.mdx`, `MessageRuntime.mdx`, and `TextContentPartProvider.mdx`.
>     - `CoreToolCallContentPart` and `ToolCallContentPart` types updated to extend `ReadonlyJSONObject` in `AssistantRuntime.mdx` and `TextContentPartProvider.mdx`.
>   - **Miscellaneous**:
>     - Fixed typos in `Message.mdx` and `Thread.mdx`.
>     - Updated import statement order in `Attachments.mdx` for better organization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for dc6fe4a3c17ae61454e8ab7eb8895fbdeb431e16. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->