### PR TITLE
feat: useVercelChatChat joinStrategy

### DIFF
--- a/.changeset/late-cars-promise.md
+++ b/.changeset/late-cars-promise.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+feat: useVercelChatChat joinStrategy

--- a/packages/react-ai-sdk/src/ui/use-chat/useVercelUseChatRuntime.tsx
+++ b/packages/react-ai-sdk/src/ui/use-chat/useVercelUseChatRuntime.tsx
@@ -17,6 +17,7 @@ export type VercelUseChatAdapter = {
   adapters?:
     | Omit<NonNullable<ExternalStoreAdapter["adapters"]>, "attachments">
     | undefined;
+  unstable_joinStrategy?: "concat-content" | "none";
 };
 
 export const useVercelUseChatRuntime = (
@@ -27,6 +28,7 @@ export const useVercelUseChatRuntime = (
     callback: convertMessage,
     isRunning: chatHelpers.isLoading,
     messages: chatHelpers.messages,
+    joinStrategy: adapter.unstable_joinStrategy,
   });
 
   const [threadId, setThreadId] = useState<string>(generateId());

--- a/packages/react/src/runtimes/external-store/external-message-converter.tsx
+++ b/packages/react/src/runtimes/external-store/external-message-converter.tsx
@@ -243,7 +243,7 @@ export const useExternalMessageConverter = <T extends WeakKey>({
   callback: useExternalMessageConverter.Callback<T>;
   messages: T[];
   isRunning: boolean;
-  joinStrategy?: "concat-content" | "none";
+  joinStrategy?: "concat-content" | "none" | undefined;
 }) => {
   const state = useMemo(
     () => ({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `unstable_joinStrategy` to `VercelUseChatAdapter` for message joining strategies in `useVercelUseChatRuntime` and `useExternalMessageConverter`.
> 
>   - **Feature**:
>     - Adds `unstable_joinStrategy` to `VercelUseChatAdapter` in `useVercelUseChatRuntime.tsx`.
>     - Supports `"concat-content"` and `"none"` strategies.
>   - **Functionality**:
>     - Passes `joinStrategy` to `useExternalMessageConverter` in `useVercelUseChatRuntime`.
>     - Updates `useExternalMessageConverter` in `external-message-converter.tsx` to handle `joinStrategy` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 031f80b5a71cec0d6f78c7f5258d07564b059a19. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->