### PR TITLE
Fix: Changed module import in docs/getting-started.mdx

### DIFF
--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -372,7 +372,7 @@ If you aren't using Next.js, you can also deploy this endpoint to Cloudflare Wor
 ```tsx title="/app/page.tsx" tab="Thread"
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
-import { ThreadList } from "@/components/assistant-ui/thread";
+import { ThreadList } from "@/components/assistant-ui/thread-list";
 import { Thread } from "@/components/assistant-ui/thread";
 
 const MyApp = () => {


### PR DESCRIPTION
This error occured in my app:  Module '"@/components/assistant-ui/thread"' has no exported member 'ThreadList'.

Reading the documentation (https://www.assistant-ui.com/docs/getting-started#use-it-in-your-app), I think the right import is:  import { ThreadList } from "@/components/assistant-ui/thread-list" !


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix import path for `ThreadList` in `getting-started.mdx` to correct module import error.
> 
>   - **Documentation**:
>     - Fix import path for `ThreadList` in `getting-started.mdx` from `"@/components/assistant-ui/thread"` to `"@/components/assistant-ui/thread-list"` to correct module import error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 4baa8e288c933d3fa2deee47388a64ca5d7d1b54. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->