### PR TITLE
fix: add import attributes for json files in react and react-ui packages + specify engines field in package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,6 +45,6 @@
     "url": "https://github.com/assistant-ui/assistant-ui/issues"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20.10.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,5 +43,8 @@
   },
   "bugs": {
     "url": "https://github.com/assistant-ui/assistant-ui/issues"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -84,5 +84,8 @@
   },
   "bugs": {
     "url": "https://github.com/assistant-ui/assistant-ui/issues"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -86,6 +86,6 @@
     "url": "https://github.com/assistant-ui/assistant-ui/issues"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20.10.0"
   }
 }

--- a/packages/react-ui/src/tailwindcss/index.ts
+++ b/packages/react-ui/src/tailwindcss/index.ts
@@ -1,10 +1,10 @@
 import plugin from "tailwindcss/plugin.js";
-import baseComponentsCSS from "../../dist/styles/tailwindcss/base-components.css.json";
-import threadCSS from "../../dist/styles/tailwindcss/thread.css.json";
-import modalCSS from "../../dist/styles/tailwindcss/modal.css.json";
-import defaultThemeCSS from "../../dist/styles/themes/default.css.json";
-import shadcnExtrasCSS from "../../dist/styles/themes/shadcn-extras.css.json";
-import markdownCSS from "../../dist/styles/tailwindcss/markdown.css.json";
+import baseComponentsCSS from "../../dist/styles/tailwindcss/base-components.css.json" with { type: "json" };
+import threadCSS from "../../dist/styles/tailwindcss/thread.css.json" with { type: "json" };
+import modalCSS from "../../dist/styles/tailwindcss/modal.css.json" with { type: "json" };
+import defaultThemeCSS from "../../dist/styles/themes/default.css.json" with { type: "json" };
+import shadcnExtrasCSS from "../../dist/styles/themes/shadcn-extras.css.json" with { type: "json" };
+import markdownCSS from "../../dist/styles/tailwindcss/markdown.css.json" with { type: "json" };
 
 type AssistantTailwindPluginColors = {
   border: string;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -133,6 +133,6 @@
     "url": "https://github.com/assistant-ui/assistant-ui/issues"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20.10.0"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -131,5 +131,8 @@
   },
   "bugs": {
     "url": "https://github.com/assistant-ui/assistant-ui/issues"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/packages/react/src/tailwindcss/index.ts
+++ b/packages/react/src/tailwindcss/index.ts
@@ -1,9 +1,9 @@
 import plugin from "tailwindcss/plugin.js";
-import baseComponentsCSS from "../../dist/styles/tailwindcss/base-components.css.json";
-import threadCSS from "../../dist/styles/tailwindcss/thread.css.json";
-import modalCSS from "../../dist/styles/tailwindcss/modal.css.json";
-import defaultThemeCSS from "../../dist/styles/themes/default.css.json";
-import shadcnExtrasCSS from "../../dist/styles/themes/shadcn-extras.css.json";
+import baseComponentsCSS from "../../dist/styles/tailwindcss/base-components.css.json" with { type: "json" };
+import threadCSS from "../../dist/styles/tailwindcss/thread.css.json" with { type: "json" };
+import modalCSS from "../../dist/styles/tailwindcss/modal.css.json" with { type: "json" };
+import defaultThemeCSS from "../../dist/styles/themes/default.css.json" with { type: "json" };
+import shadcnExtrasCSS from "../../dist/styles/themes/shadcn-extras.css.json" with { type: "json" };
 
 type AssistantTailwindPluginColors = {
   border: string;
@@ -77,10 +77,7 @@ const auiPlugin = plugin.withOptions<AssisstantTailwindPluginOptions>(
         addComponents(modalCSS);
       }
     },
-  ({
-    colors = {},
-    shadcn = false,
-  } = {}) => {
+  ({ colors = {}, shadcn = false } = {}) => {
     const prefix = !shadcn ? "--aui-" : "--";
     return {
       safelist: [{ pattern: /^aui-/ }],


### PR DESCRIPTION
Addresses #1650 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add JSON import attributes and specify Node.js engine version in package.json for react and react-ui packages.
> 
>   - **JSON Import Attributes**:
>     - Added `with { type: "json" }` to JSON imports in `index.ts` in `react-ui/src/tailwindcss` and `react/src/tailwindcss`.
>   - **Node.js Engine Specification**:
>     - Added `"engines": { "node": ">=18" }` to `package.json` in `cli`, `react`, and `react-ui` packages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for b713121f89dbb1bbbe360939d41c5b3bf4c746bf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->