### PR TITLE
feat: useToolArgsFieldStatus API

### DIFF
--- a/.changeset/polite-points-exist.md
+++ b/.changeset/polite-points-exist.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react": patch
 ---
 
-feat: unstable_getToolArgsFieldStatus
+feat: useToolArgsFieldStatus

--- a/.changeset/polite-points-exist.md
+++ b/.changeset/polite-points-exist.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: unstable_getToolArgsFieldStatus

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,4 +7,6 @@ export * from "./runtimes";
 export * from "./types";
 export * from "./ui";
 
+export { getToolArgsFieldStatus as unstable_getToolArgsFieldStatus } from "./utils/json/parse-partial-json";
+
 export * as INTERNAL from "./internal";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,6 @@ export * from "./runtimes";
 export * from "./types";
 export * from "./ui";
 
-export { getToolArgsFieldStatus as unstable_getToolArgsFieldStatus } from "./utils/json/parse-partial-json";
+export { useToolArgsFieldStatus as unstable_useToolArgsFieldStatus } from "./utils/json/parse-partial-json";
 
 export * as INTERNAL from "./internal";

--- a/packages/react/src/utils/json/fix-json.ts
+++ b/packages/react/src/utils/json/fix-json.ts
@@ -40,7 +40,7 @@ type State =
 // Please note that invalid JSON is not considered/covered, because it
 // is assumed that the resulting JSON will be processed by a standard
 // JSON parser that will detect any invalid JSON.
-export function fixJson(input: string): string {
+export function fixJson(input: string): [string, number] {
   const stack: State[] = ["ROOT"];
   let lastValidIndex = -1;
   let literalStart: number | null = null;
@@ -372,6 +372,7 @@ export function fixJson(input: string): string {
   }
 
   let result = input.slice(0, lastValidIndex + 1);
+  let partialCount = 0;
 
   for (let i = stack.length - 1; i >= 0; i--) {
     const state = stack[i];
@@ -379,6 +380,7 @@ export function fixJson(input: string): string {
     switch (state) {
       case "INSIDE_STRING": {
         result += '"';
+        partialCount++;
         break;
       }
 
@@ -389,6 +391,7 @@ export function fixJson(input: string): string {
       case "INSIDE_OBJECT_BEFORE_VALUE":
       case "INSIDE_OBJECT_AFTER_VALUE": {
         result += "}";
+        partialCount++;
         break;
       }
 
@@ -396,6 +399,7 @@ export function fixJson(input: string): string {
       case "INSIDE_ARRAY_AFTER_COMMA":
       case "INSIDE_ARRAY_AFTER_VALUE": {
         result += "]";
+        partialCount++;
         break;
       }
 
@@ -413,5 +417,5 @@ export function fixJson(input: string): string {
     }
   }
 
-  return result;
+  return [result, partialCount];
 }

--- a/packages/react/src/utils/json/parse-partial-json.ts
+++ b/packages/react/src/utils/json/parse-partial-json.ts
@@ -4,6 +4,8 @@ import {
   ContentPartStatus,
   ToolCallContentPartStatus,
 } from "../../types/AssistantTypes";
+import { useContentPart } from "../../context";
+import { useEffect } from "react";
 
 const PARTIAL_JSON_COUNT_SYMBOL = Symbol("partial-json-count");
 export const parsePartialJson = (json: string) => {
@@ -21,6 +23,8 @@ export const parsePartialJson = (json: string) => {
   }
 };
 
+const COMPLETE_STATUS = Object.freeze({ type: "complete" });
+
 const getFieldStatus = (
   lastState: ContentPartStatus,
   args: unknown,
@@ -28,13 +32,13 @@ const getFieldStatus = (
   partialCount: number,
 ): ContentPartStatus => {
   if (fieldPath.length === 0) return lastState;
-  if (partialCount === 1) return { type: "complete" };
-  if (typeof args !== "object" || args === null) return { type: "complete" };
+  if (partialCount === 1) return COMPLETE_STATUS;
+  if (typeof args !== "object" || args === null) return COMPLETE_STATUS;
 
   const path = fieldPath.at(-1)!;
   const argsKeys = Object.keys(args);
   const isLast = argsKeys.indexOf(path) === argsKeys.length - 1;
-  if (!isLast) return { type: "complete" };
+  if (!isLast) return COMPLETE_STATUS;
 
   return getFieldStatus(
     lastState,
@@ -44,16 +48,23 @@ const getFieldStatus = (
   );
 };
 
-export const getToolArgsFieldStatus = (
+const getToolArgsFieldStatus = (
   status: ToolCallContentPartStatus,
   args: Record<string, unknown>,
   fieldPath: string[],
 ): ContentPartStatus => {
   const partialCount = (args as any)[PARTIAL_JSON_COUNT_SYMBOL] ?? 0;
-  if (partialCount === 0) return { type: "complete" };
+  if (partialCount === 0) return COMPLETE_STATUS;
 
   const lastState: ContentPartStatus =
-    status.type !== "requires-action" ? status : { type: "complete" };
+    status.type !== "requires-action" ? status : COMPLETE_STATUS;
 
   return getFieldStatus(lastState, args, fieldPath, partialCount);
+};
+
+export const useToolArgsFieldStatus = (fieldPath: string[]) => {
+  return useContentPart((p) => {
+    if (p.type !== "tool-call") throw new Error("not a tool call");
+    return getToolArgsFieldStatus(p.status, p.args, fieldPath);
+  });
 };

--- a/packages/react/src/utils/json/parse-partial-json.ts
+++ b/packages/react/src/utils/json/parse-partial-json.ts
@@ -1,14 +1,59 @@
 import sjson from "secure-json-parse";
 import { fixJson } from "./fix-json";
+import {
+  ContentPartStatus,
+  ToolCallContentPartStatus,
+} from "../../types/AssistantTypes";
 
+const PARTIAL_JSON_COUNT_SYMBOL = Symbol("partial-json-count");
 export const parsePartialJson = (json: string) => {
   try {
     return sjson.parse(json);
   } catch {
     try {
-      return sjson.parse(fixJson(json));
+      const [fixedJson, partialCount] = fixJson(json);
+      const res = sjson.parse(fixedJson);
+      res[PARTIAL_JSON_COUNT_SYMBOL] = partialCount;
+      return res;
     } catch {
       return undefined;
     }
   }
+};
+
+const getFieldStatus = (
+  lastState: ContentPartStatus,
+  args: unknown,
+  fieldPath: string[],
+  partialCount: number,
+): ContentPartStatus => {
+  if (fieldPath.length === 0) return lastState;
+  if (partialCount === 1) return { type: "complete" };
+  if (typeof args !== "object" || args === null) return { type: "complete" };
+
+  const path = fieldPath.at(-1)!;
+  const argsKeys = Object.keys(args);
+  const isLast = argsKeys.indexOf(path) === argsKeys.length - 1;
+  if (!isLast) return { type: "complete" };
+
+  return getFieldStatus(
+    lastState,
+    args[path as keyof typeof args],
+    fieldPath.slice(0, -1),
+    partialCount - 1,
+  );
+};
+
+export const getToolArgsFieldStatus = (
+  status: ToolCallContentPartStatus,
+  args: Record<string, unknown>,
+  fieldPath: string[],
+): ContentPartStatus => {
+  const partialCount = (args as any)[PARTIAL_JSON_COUNT_SYMBOL] ?? 0;
+  if (partialCount === 0) return { type: "complete" };
+
+  const lastState: ContentPartStatus =
+    status.type !== "requires-action" ? status : { type: "complete" };
+
+  return getFieldStatus(lastState, args, fieldPath, partialCount);
 };

--- a/packages/react/src/utils/json/parse-partial-json.ts
+++ b/packages/react/src/utils/json/parse-partial-json.ts
@@ -31,17 +31,22 @@ const getFieldStatus = (
   partialCount: number,
 ): ContentPartStatus => {
   if (fieldPath.length === 0) return lastState;
-  if (partialCount === 1) return COMPLETE_STATUS;
   if (typeof args !== "object" || args === null) return COMPLETE_STATUS;
 
   const path = fieldPath.at(-1)!;
+
+  // If the expected property does not exist, mark as incomplete
+  if (!Object.prototype.hasOwnProperty.call(args, path)) {
+    return lastState;
+  }
+
   const argsKeys = Object.keys(args);
-  const isLast = argsKeys.indexOf(path) === argsKeys.length - 1;
+  const isLast = argsKeys[argsKeys.length - 1] === path;
   if (!isLast) return COMPLETE_STATUS;
 
   return getFieldStatus(
     lastState,
-    args[path as keyof typeof args],
+    (args as Record<string, unknown>)[path],
     fieldPath.slice(0, -1),
     partialCount - 1,
   );

--- a/packages/react/src/utils/json/parse-partial-json.ts
+++ b/packages/react/src/utils/json/parse-partial-json.ts
@@ -5,7 +5,6 @@ import {
   ToolCallContentPartStatus,
 } from "../../types/AssistantTypes";
 import { useContentPart } from "../../context";
-import { useEffect } from "react";
 
 const PARTIAL_JSON_COUNT_SYMBOL = Symbol("partial-json-count");
 export const parsePartialJson = (json: string) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `unstable_useToolArgsFieldStatus` API and enhances JSON parsing to track partial JSON completion using a new partial count mechanism.
> 
>   - **New API**:
>     - Adds `useToolArgsFieldStatus` in `parse-partial-json.ts` to determine JSON field status.
>     - Exports `useToolArgsFieldStatus` as `unstable_useToolArgsFieldStatus` in `index.ts`.
>   - **JSON Parsing**:
>     - Modifies `fixJson` in `fix-json.ts` to return a tuple `[string, number]` indicating fixed JSON and partial count.
>     - Updates `parsePartialJson` in `parse-partial-json.ts` to use the partial count for tracking JSON completion.
>   - **Field Status**:
>     - Implements `getFieldStatus` and `getToolArgsFieldStatus` in `parse-partial-json.ts` to assess JSON field completion based on partial count.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for ca43d1d35592e962558cdfdcda29b28e1c905a50. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->