### PR TITLE
fix: remove reset() method on local-runtime

### DIFF
--- a/.changeset/cool-bulldogs-brake.md
+++ b/.changeset/cool-bulldogs-brake.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: remove reset() method on local-runtime

--- a/packages/react/src/runtimes/external-store/useExternalStoreRuntime.tsx
+++ b/packages/react/src/runtimes/external-store/useExternalStoreRuntime.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useState } from "react";
 import { ExternalStoreRuntimeCore } from "./ExternalStoreRuntimeCore";
 import { ExternalStoreAdapter } from "./ExternalStoreAdapter";
 import { AssistantRuntimeImpl } from "../../api/AssistantRuntime";
-import { ThreadRuntimeImpl } from "../../api/ThreadRuntime";
 import { useRuntimeAdapters } from "../adapters/RuntimeAdapterProvider";
 
 export const useExternalStoreRuntime = <T,>(store: ExternalStoreAdapter<T>) => {
@@ -21,8 +20,5 @@ export const useExternalStoreRuntime = <T,>(store: ExternalStoreAdapter<T>) => {
     return runtime.registerModelContextProvider(modelContext);
   }, [modelContext, runtime]);
 
-  return useMemo(
-    () => AssistantRuntimeImpl.create(runtime, ThreadRuntimeImpl),
-    [runtime],
-  );
+  return useMemo(() => new AssistantRuntimeImpl(runtime), [runtime]);
 };

--- a/packages/react/src/runtimes/index.ts
+++ b/packages/react/src/runtimes/index.ts
@@ -5,3 +5,5 @@ export * from "./edge";
 export * from "./external-store";
 export * from "./local";
 export * from "./remote-thread-list";
+
+export { ExportedMessageRepository } from "./utils/MessageRepository";

--- a/packages/react/src/runtimes/local/LocalRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalRuntimeCore.tsx
@@ -1,28 +1,9 @@
-import type { CoreMessage } from "../../types/AssistantTypes";
 import { BaseAssistantRuntimeCore } from "../core/BaseAssistantRuntimeCore";
 import { LocalThreadRuntimeCore } from "./LocalThreadRuntimeCore";
 import { LocalRuntimeOptionsBase } from "./LocalRuntimeOptions";
 import { LocalThreadListRuntimeCore } from "./LocalThreadListRuntimeCore";
 import { ExportedMessageRepository } from "../utils/MessageRepository";
 import { ThreadMessageLike } from "../external-store";
-import { fromThreadMessageLike } from "../external-store/ThreadMessageLike";
-import { generateId } from "../../internal";
-import { getAutoStatus } from "../external-store/auto-status";
-
-const getExportFromInitialMessages = (
-  initialMessages: readonly ThreadMessageLike[],
-): ExportedMessageRepository => {
-  const messages = initialMessages.map((i, idx) => {
-    const isLast = idx === initialMessages.length - 1;
-    return fromThreadMessageLike(i, generateId(), getAutoStatus(isLast, false));
-  });
-  return {
-    messages: messages.map((m, idx) => ({
-      parentId: messages[idx - 1]?.id ?? null,
-      message: m,
-    })),
-  };
-};
 
 export class LocalRuntimeCore extends BaseAssistantRuntimeCore {
   public readonly threads;
@@ -45,20 +26,7 @@ export class LocalRuntimeCore extends BaseAssistantRuntimeCore {
     if (initialMessages) {
       this.threads
         .getMainThreadRuntimeCore()
-        .import(getExportFromInitialMessages(initialMessages));
+        .import(ExportedMessageRepository.fromArray(initialMessages));
     }
-  }
-
-  public reset({
-    initialMessages,
-  }: {
-    initialMessages?: readonly CoreMessage[] | undefined;
-  } = {}) {
-    this.threads.switchToNewThread();
-    if (!initialMessages) return;
-
-    this.threads
-      .getMainThreadRuntimeCore()
-      .import(getExportFromInitialMessages(initialMessages));
   }
 }

--- a/packages/react/src/runtimes/local/useLocalRuntime.tsx
+++ b/packages/react/src/runtimes/local/useLocalRuntime.tsx
@@ -4,37 +4,10 @@ import { useEffect, useMemo, useState } from "react";
 import type { ChatModelAdapter } from "./ChatModelAdapter";
 import { LocalRuntimeCore } from "./LocalRuntimeCore";
 import { LocalRuntimeOptions } from "./LocalRuntimeOptions";
-import {
-  AssistantRuntime,
-  AssistantRuntimeImpl,
-} from "../../api/AssistantRuntime";
-import { ThreadRuntimeImpl } from "../../internal";
 import { useRuntimeAdapters } from "../adapters/RuntimeAdapterProvider";
 import { useRemoteThreadListRuntime } from "../remote-thread-list/useRemoteThreadListRuntime";
 import { useCloudThreadListAdapter } from "../remote-thread-list/adapter/cloud";
-
-export type LocalRuntime = AssistantRuntime & {
-  reset: (options?: Parameters<LocalRuntimeCore["reset"]>[0]) => void;
-};
-
-class LocalRuntimeImpl extends AssistantRuntimeImpl implements LocalRuntime {
-  private constructor(private core: LocalRuntimeCore) {
-    super(core, ThreadRuntimeImpl);
-  }
-
-  public override __internal_bindMethods() {
-    super.__internal_bindMethods();
-    this.reset = this.reset.bind(this);
-  }
-
-  public reset(options?: Parameters<LocalRuntimeCore["reset"]>[0]) {
-    this.core.reset(options);
-  }
-
-  public static override create(_core: LocalRuntimeCore): LocalRuntime {
-    return new LocalRuntimeImpl(_core);
-  }
-}
+import { AssistantRuntimeImpl } from "../../internal";
 
 const useLocalThreadRuntime = (
   adapter: ChatModelAdapter,
@@ -65,7 +38,7 @@ const useLocalThreadRuntime = (
     return runtime.registerModelContextProvider(modelContext);
   }, [modelContext, runtime]);
 
-  return useMemo(() => LocalRuntimeImpl.create(runtime), [runtime]);
+  return useMemo(() => new AssistantRuntimeImpl(runtime), [runtime]);
 };
 
 export const useLocalRuntime = (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `reset()` method from `LocalRuntimeCore` and deprecate in `AssistantRuntime`, replacing with direct import method.
> 
>   - **Behavior**:
>     - Remove `reset()` method from `LocalRuntimeCore` in `LocalRuntimeCore.tsx`.
>     - Deprecate `reset` in `AssistantRuntime` type in `AssistantRuntime.ts`.
>     - Replace `reset()` functionality with `runtime.threads.main.import(ExportedMessageRepository.fromArray(initialMessages))`.
>   - **Imports**:
>     - Remove unused imports in `useExternalStoreRuntime.tsx` and `useLocalRuntime.tsx`.
>     - Add `ExportedMessageRepository` export in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 917f92be7d8d6dd2b3c116be24de0e7c556d2614. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->