### PR TITLE
feat: ExportdMessageRepository.fromArray

### DIFF
--- a/.changeset/polite-eyes-punch.md
+++ b/.changeset/polite-eyes-punch.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: ExportdMessageRepository.fromArray


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `fromArray` method to `ExportedMessageRepository` for converting `ThreadMessageLike[]` to repository format in `MessageRepository.tsx`.
> 
>   - **New Feature**:
>     - Adds `fromArray` method to `ExportedMessageRepository` in `MessageRepository.tsx`.
>     - Converts `ThreadMessageLike[]` to `ExportedMessageRepository` format using `fromThreadMessageLike`, `generateId`, and `getAutoStatus`.
>   - **Changeset**:
>     - Adds changeset `polite-eyes-punch.md` for patch update to `@assistant-ui/react`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 14c59d8beae1a4bf0fe7b5f75d2890c60719370e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->