### PR TITLE
feat:thread.import() should reset the MessageRepository

### DIFF
--- a/.changeset/quiet-panthers-pump.md
+++ b/.changeset/quiet-panthers-pump.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat:thread.import() should reset the MessageRepository

--- a/packages/react/src/runtimes/core/BaseThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/BaseThreadRuntimeCore.tsx
@@ -167,13 +167,14 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
     }
   }
 
+  // TODO import()/export() on external store doesn't make much sense
   public export() {
     return this.repository.export();
   }
 
   public import(data: ExportedMessageRepository) {
     this.ensureInitialized();
-
+    this.repository.clear();
     this.repository.import(data);
     this._notifySubscribers();
   }

--- a/packages/react/src/runtimes/utils/MessageRepository.tsx
+++ b/packages/react/src/runtimes/utils/MessageRepository.tsx
@@ -287,6 +287,16 @@ export class MessageRepository {
     this._messages.dirty();
   }
 
+  clear(): void {
+    this.messages.clear();
+    this.head = null;
+    this.root = {
+      children: [],
+      next: null,
+    };
+    this._messages.dirty();
+  }
+
   export(): ExportedMessageRepository {
     const exportItems: ExportedMessageRepository["messages"] = [];
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `import()` in `BaseThreadRuntimeCore` now resets `MessageRepository` before importing data, ensuring a clean state.
> 
>   - **Behavior**:
>     - `import()` in `BaseThreadRuntimeCore` now calls `clear()` on `MessageRepository` before importing data, ensuring the repository is reset.
>   - **Functions**:
>     - Adds `clear()` method to `MessageRepository` to reset `messages`, `head`, and `root`.
>   - **Misc**:
>     - Adds changeset file `quiet-panthers-pump.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 931ef86759ab216da2f591be62aec760e55932aa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->