### PR TITLE
fix: avoid infinite loop in runtime state

### DIFF
--- a/packages/react/src/context/react/utils/useRuntimeState.ts
+++ b/packages/react/src/context/react/utils/useRuntimeState.ts
@@ -33,7 +33,7 @@ export function useRuntimeStateInternal<TState, TSelected>(
   // TODO move to useRuntimeState
   ensureBinding(runtime);
 
-  const lastSnapshot = useRef<TSelected | TState>(null);
+  const lastSnapshot = useRef<TSelected | TState>(undefined);
 
   const getSnapshot = useCallback(() => {
     const newSnapshot = selector(runtime.getState());


### PR DESCRIPTION
Fixes infinite refetching loop triggered by importing `{ useThread }`. 

More specifically, two errors are currently thrown when you import `useThread`
`The result of getSnapshot should be cached to avoid an infinite loop` -> `Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.`

Details on the error, including steps to reproduce, and testing of this change, is in a Neeto I recorded [here](https://erichasegawa.neetorecord.com/watch/8b248975de50cb802128) (1 minute video that should provide all context needed for reviewing)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes infinite loop in `useRuntimeStateInternal` by caching snapshots and using shallow equality check to prevent excessive updates.
> 
>   - **Behavior**:
>     - Fixes infinite loop in `useRuntimeStateInternal` by caching snapshots with `useRef` and comparing with `shallowEqual`.
>     - Prevents `Maximum update depth exceeded` error when importing `useThread`.
>   - **Functions**:
>     - Adds `shallowEqual` function to compare snapshots in `useRuntimeState.ts`.
>     - Modifies `getSnapshot` in `useRuntimeStateInternal` to use `useCallback` and `useRef` for caching.
>   - **Imports**:
>     - Adds `useRef` and `useCallback` to imports in `useRuntimeState.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d8c6a04d9d4e4f657b56fc34df40f0f6ebaa4f5e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->