### PR TITLE
Add support for dynamic headers in EdgeChatAdapter

### DIFF
--- a/.changeset/public-laws-build.md
+++ b/.changeset/public-laws-build.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+Add support for dynamic headers in EdgeChatAdapter


### PR DESCRIPTION
Closes #1703 

This PR enhances the EdgeChatAdapter by adding support for dynamic headers in API requests.

### Motivation:
This change allows for dynamic generation of headers at request time, which is useful for:

- Authentication tokens that need to be refreshed
- Headers that depend on the current state of the application
- Headers that require async operations to generate

### Changes:

- Added a new HeadersValue type to represent header values (either a Record or Headers object)
- Enhanced the headers option in EdgeChatAdapterOptions to accept either:
- A static headers object (as before)
- A function that returns a Promise of headers
- Updated the request handling to resolve dynamic headers when a function is provided
- Added JSDoc comments to improve developer experience

### Testing:
The implementation maintains backward compatibility with existing code while adding the new functionality.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for dynamic headers in `EdgeChatAdapter` by allowing `headers` to be a function returning a promise.
> 
>   - **Behavior**:
>     - `EdgeChatAdapterOptions.headers` now accepts a function returning a `Promise` of headers, in addition to static headers.
>     - `run()` in `EdgeChatAdapter` resolves dynamic headers if a function is provided.
>   - **Types**:
>     - Adds `HeadersValue` type for header values in `EdgeChatAdapter.ts`.
>   - **Documentation**:
>     - Adds JSDoc comments for `headers` in `EdgeChatAdapterOptions`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c41ed254125d680d92c81fdc63593ffe9b437e37. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->