### PR TITLE
Making Get Started responsive

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -80,7 +80,7 @@ export default function HomePage() {
         </div>
 
         <div>
-          <div className="relative flex h-32 w-full items-center justify-between rounded-3xl border px-16">
+          <div className="relative flex h-32 w-full flex-wrap items-center justify-between rounded-3xl border px-16">
             <p className="text-2xl font-bold">
               Build conversational AI interfaces
             </p>
@@ -210,7 +210,7 @@ function CopyCommandButton() {
         size: "lg",
         variant: "outline",
         className:
-          "bg-background font-bold group relative flex h-12 items-center gap-2 rounded-lg border px-4 py-3 font-mono text-sm transition-all",
+          "bg-background group relative flex h-12 items-center gap-2 rounded-lg border px-4 py-3 font-mono text-sm font-bold transition-all",
       })}
     >
       <span>$ npx assistant-ui init</span>

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -210,7 +210,7 @@ function CopyCommandButton() {
         size: "lg",
         variant: "outline",
         className:
-          "bg-background group relative flex h-12 items-center gap-2 rounded-lg border px-4 py-3 font-mono text-sm font-bold transition-all",
+          "bg-background font-bold group relative flex h-12 items-center gap-2 rounded-lg border px-4 py-3 font-mono text-sm transition-all",
       })}
     >
       <span>$ npx assistant-ui init</span>


### PR DESCRIPTION
ISSUE NO: #1705
Components not aligned in mobile view.

How it looks currently:
<img width="303" alt="Screenshot 2025-03-06 at 12 19 15 PM" src="https://github.com/user-attachments/assets/c2d060e7-3ef2-49fa-8f80-befa96ba1b1f" />

After adding small CSS change:
<img width="305" alt="Screenshot 2025-03-06 at 12 19 42 PM" src="https://github.com/user-attachments/assets/cc50c31d-afd3-4872-85f4-2627057fbb65" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves mobile responsiveness of the 'Get Started' section in `page.tsx` by adding `flex-wrap` to the container div.
> 
>   - **CSS Changes**:
>     - In `page.tsx`, updated the `div` containing the "Build conversational AI interfaces" text to use `flex-wrap` for better alignment on mobile devices.
>     - Adjusted `CopyCommandButton` class to include `font-bold` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1936f5a2b49cef1ddd9dfb53b8d04f51758ff945. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->