### PR TITLE
fix: reasoning content render (#1720)

### DIFF
--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -1,7 +1,7 @@
 import { Message } from "@ai-sdk/ui-utils";
 import { useExternalMessageConverter } from "@assistant-ui/react";
 import { ToolCallContentPart } from "@assistant-ui/react";
-import { TextContentPart } from "@assistant-ui/react";
+import { TextContentPart, ReasoningContentPart } from "@assistant-ui/react";
 import { CompleteAttachment } from "@assistant-ui/react";
 
 export const convertMessage: useExternalMessageConverter.Callback<Message> = (
@@ -42,6 +42,12 @@ export const convertMessage: useExternalMessageConverter.Callback<Message> = (
         id: message.id,
         createdAt: message.createdAt,
         content: [
+          ...(message.reasoning ? [
+            {
+              type: 'reasoning',
+              text: message.reasoning,
+            } satisfies ReasoningContentPart,
+          ] : []),
           ...(message.content
             ? [
                 {

--- a/packages/react-ui/src/ui/assistant-message.tsx
+++ b/packages/react-ui/src/ui/assistant-message.tsx
@@ -73,6 +73,7 @@ const AssistantMessageContent = forwardRef<
         components={{
           ...componentsProp,
           Text: componentsProp?.Text ?? components.Text ?? ContentPart.Text,
+          Reasoning: componentsProp?.Reasoning ?? components.Reasoning ?? ContentPart.Reasoning,
           Empty: componentsProp?.Empty ?? components.Empty,
           tools: toolsComponents,
         }}

--- a/packages/react-ui/src/ui/content-part.tsx
+++ b/packages/react-ui/src/ui/content-part.tsx
@@ -20,6 +20,19 @@ export const Text: FC = () => {
   );
 };
 
-const exports = { Text: withSmoothContextProvider(Text) };
+export const Reasoning: FC = () => {
+  const status = useSmoothStatus();
+  return (
+    <ContentPartPrimitive.Reasoning
+      className={classNames(
+        "aui-text aui-reasoning",
+        status.type === "running" && "aui-text-running",
+      )}
+      component="p"
+    />
+  );
+};
+
+const exports = { Text: withSmoothContextProvider(Text), Reasoning: withSmoothContextProvider(Reasoning) };
 
 export default exports;

--- a/packages/react-ui/src/ui/thread-config.tsx
+++ b/packages/react-ui/src/ui/thread-config.tsx
@@ -18,6 +18,7 @@ import {
   AssistantRuntimeProvider,
   AssistantToolUI,
   useAssistantRuntime,
+  ReasoningContentPartComponent,
 } from "@assistant-ui/react";
 
 export type SuggestionConfig = {
@@ -43,6 +44,7 @@ export type AssistantMessageConfig = {
   components?:
     | {
         Text?: TextContentPartComponent | undefined;
+        Reasoning?: ReasoningContentPartComponent | undefined;
         Empty?: EmptyContentPartComponent | undefined;
         ToolFallback?: ComponentType<ToolCallContentPartProps> | undefined;
         Footer?: ComponentType | undefined;

--- a/packages/react/src/primitives/contentPart/ContentPartReasoning.tsx
+++ b/packages/react/src/primitives/contentPart/ContentPartReasoning.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Primitive } from "@radix-ui/react-primitive";
+import {
+  type ComponentRef,
+  forwardRef,
+  ComponentPropsWithoutRef,
+  ElementType,
+} from "react";
+import { useContentPartReasoning } from "./useContentPartReasoning";
+import { useSmooth } from "../../utils/smooth/useSmooth";
+
+export namespace ContentPartPrimitiveReasoning {
+  export type Element = ComponentRef<typeof Primitive.span>;
+  export type Props = Omit<
+    ComponentPropsWithoutRef<typeof Primitive.span>,
+    "children" | "asChild"
+  > & {
+    smooth?: boolean;
+    component?: ElementType;
+  };
+}
+
+export const ContentPartPrimitiveReasoning = forwardRef<
+  ContentPartPrimitiveReasoning.Element,
+  ContentPartPrimitiveReasoning.Props
+>(({ smooth = true, component: Component = "span", ...rest }, forwardedRef) => {
+  const { text, status } = useSmooth(useContentPartReasoning(), smooth);
+
+  return (
+    <Component data-status={status.type} {...rest} ref={forwardedRef}>
+      {text}
+    </Component>
+  );
+});
+
+ContentPartPrimitiveReasoning.displayName = "ContentPartPrimitive.Reasoning";

--- a/packages/react/src/primitives/contentPart/index.ts
+++ b/packages/react/src/primitives/contentPart/index.ts
@@ -1,3 +1,4 @@
 export { ContentPartPrimitiveText as Text } from "./ContentPartText";
+export { ContentPartPrimitiveReasoning as Reasoning } from "./ContentPartReasoning";
 export { ContentPartPrimitiveImage as Image } from "./ContentPartImage";
 export { ContentPartPrimitiveInProgress as InProgress } from "./ContentPartInProgress";

--- a/packages/react/src/runtimes/edge/streams/assistantDecoderStream.ts
+++ b/packages/react/src/runtimes/edge/streams/assistantDecoderStream.ts
@@ -152,8 +152,14 @@ export function assistantDecoderStream() {
           });
           break;
 
-        // TODO
         case AssistantStreamChunkType.ReasoningDelta:
+          controller.enqueue({
+            type: "reasoning",
+            textDelta: value,
+          });
+          break;
+
+        // TODO
         case AssistantStreamChunkType.StartStep:
           break;
 

--- a/packages/react/src/utils/smooth/useSmooth.tsx
+++ b/packages/react/src/utils/smooth/useSmooth.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useMessage } from "../../context";
-import { ContentPartStatus, TextContentPart } from "../../types/AssistantTypes";
+import { ContentPartStatus, ReasoningContentPart, TextContentPart } from "../../types/AssistantTypes";
 import { useCallbackRef } from "@radix-ui/react-use-callback-ref";
 import { useSmoothStatusStore } from "./SmoothContext";
 import { writableStore } from "../../context/ReadonlyStore";
@@ -67,9 +67,9 @@ const SMOOTH_STATUS: ContentPartStatus = Object.freeze({
 });
 
 export const useSmooth = (
-  state: ContentPartState & TextContentPart,
+  state: (ContentPartState & TextContentPart) | (ContentPartState & ReasoningContentPart),
   smooth: boolean = false,
-): ContentPartState & TextContentPart => {
+): (ContentPartState & TextContentPart) | (ContentPartState & ReasoningContentPart) => {
   const { text } = state;
   const id = useMessage({
     optional: true,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for rendering reasoning content in assistant messages by introducing `ReasoningContentPart` and updating relevant components and utilities.
> 
>   - **Behavior**:
>     - Add `ReasoningContentPart` to `convertMessage` in `convertMessage.ts` to handle reasoning content in assistant messages.
>     - Update `AssistantMessageContent` in `assistant-message.tsx` to include `Reasoning` component.
>   - **Components**:
>     - Add `Reasoning` component to `content-part.tsx` using `ContentPartPrimitive.Reasoning`.
>     - Export `ContentPartPrimitiveReasoning` in `index.ts`.
>   - **Utilities**:
>     - Add `ReasoningContentPart` handling to `useSmooth` in `useSmooth.tsx` for smooth rendering of reasoning content.
>   - **Configuration**:
>     - Add `Reasoning` component support to `AssistantMessageConfig` in `thread-config.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 10ac214e21af692011e359593582d61f81cd399f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->