### PR TITLE
fix: search-agent-for-ecommerce example  should use RSCDisplay

### DIFF
--- a/examples/search-agent-for-e-commerce/src/components/ui/assistant-ui/thread.tsx
+++ b/examples/search-agent-for-e-commerce/src/components/ui/assistant-ui/thread.tsx
@@ -17,6 +17,7 @@ import {
 import { cn } from "@/lib/utils";
 import { ArrowDownIcon, SendHorizontalIcon } from "lucide-react";
 import Image from "next/image";
+import { RSCDisplay } from "@assistant-ui/react-ai-sdk";
 
 export const Thread: FC = () => {
   return (
@@ -155,7 +156,7 @@ const AssistantMessage: FC = () => {
 
       <div className="mt-2 flex-grow">
         <p className="text-foreground max-w-xl whitespace-pre-line break-words">
-          <MessagePrimitive.Content />
+          <MessagePrimitive.Content components={{ Text: RSCDisplay }} />
         </p>
       </div>
     </MessagePrimitive.Root>


### PR DESCRIPTION
fixes #1733

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `AssistantMessage` in `thread.tsx` now uses `RSCDisplay` for rendering text content.
> 
>   - **Behavior**:
>     - In `thread.tsx`, `AssistantMessage` now uses `RSCDisplay` for rendering text content via `MessagePrimitive.Content`.
>   - **Imports**:
>     - Added import for `RSCDisplay` from `@assistant-ui/react-ai-sdk`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for e97b099a37db17acf0dd09b684a64814cebd9b57. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->