### PR TITLE
fix: set user RSCDisplay

### DIFF
--- a/examples/search-agent-for-e-commerce/src/components/ui/assistant-ui/thread.tsx
+++ b/examples/search-agent-for-e-commerce/src/components/ui/assistant-ui/thread.tsx
@@ -140,7 +140,7 @@ const UserMessage: FC = () => {
     <MessagePrimitive.Root className="relative mb-6 flex w-full max-w-2xl flex-col items-end gap-2 pl-24">
       <div className="relative mr-1 flex items-start gap-3">
         <p className="bg-foreground/5 text-foreground max-w-xl whitespace-pre-line break-words rounded-3xl px-5 py-2.5">
-          <MessagePrimitive.Content />
+          <MessagePrimitive.Content components={{ Text: RSCDisplay }} />
         </p>
       </div>
     </MessagePrimitive.Root>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sets `components` prop of `MessagePrimitive.Content` to use `RSCDisplay` in `UserMessage` component.
> 
>   - **Behavior**:
>     - Updates `UserMessage` component in `thread.tsx` to set `components` prop of `MessagePrimitive.Content` to `{ Text: RSCDisplay }`.
>     - Affects rendering of user messages in the e-commerce assistant UI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 8619d04e9d7c1a2642485ad94dedb4ea8e9edfc2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->