### PR TITLE
fix: no duplicate tool calls in edge runtime in case tool-deltas are enabled

### DIFF
--- a/packages/react/src/runtimes/edge/streams/assistantDecoderStream.ts
+++ b/packages/react/src/runtimes/edge/streams/assistantDecoderStream.ts
@@ -31,7 +31,8 @@ export function assistantDecoderStream() {
   >({
     transform({ type, value }, controller) {
       if (
-        type !== AssistantStreamChunkType.ToolCallDelta &&
+        type !== AssistantStreamChunkType.ToolCall &&
+        type !== AssistantStreamChunkType.ToolCallDelta && 
         type !== AssistantStreamChunkType.Error
       ) {
         endCurrentToolCall(controller);

--- a/packages/react/src/runtimes/edge/streams/assistantDecoderStream.ts
+++ b/packages/react/src/runtimes/edge/streams/assistantDecoderStream.ts
@@ -121,6 +121,10 @@ export function assistantDecoderStream() {
             toolName: toolName,
             args: argsText,
           });
+
+          if (currentToolCall?.id === toolCallId) {
+            currentToolCall = undefined;
+          }
           break;
         }
 


### PR DESCRIPTION
If tool-call-deltas are enabled, a `ToolCall` chunk will call the tool anyways, so there is no need for any fallback-completion for the "current" tool.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent duplicate tool calls in `assistantDecoderStream.ts` by checking for `ToolCall` and `ToolCallDelta` types.
> 
>   - **Behavior**:
>     - In `assistantDecoderStream.ts`, updated `transform` function to prevent duplicate tool calls by checking for `AssistantStreamChunkType.ToolCall` and `ToolCallDelta`.
>     - Ensures no fallback-completion for current tool when `ToolCall` chunk is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 3af2e6744b0b7a9703b78515b627ab22d4edd325. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->