### PR TITLE
fix: refactor ollama example to use streamText

### DIFF
--- a/examples/local-ollama/app/api/chat/route.ts
+++ b/examples/local-ollama/app/api/chat/route.ts
@@ -1,10 +1,15 @@
-import { createOllama } from "ollama-ai-provider";
-import { createEdgeRuntimeAPI } from "@assistant-ui/react/edge";
+import { ollama } from "ollama-ai-provider";
+import { streamText } from "ai";
 
-const local_ollama = createOllama({
-  baseURL: process.env.OLLAMA_API_URL,
-});
+const OLLAMA_MODEL = "llama3.1"
 
-export const { POST } = createEdgeRuntimeAPI({
-  model: local_ollama("llama3.1"),
-});
+export const maxDuration = 30;
+ 
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const result = streamText({
+    model: ollama(OLLAMA_MODEL),
+    messages,
+  });
+  return result.toDataStreamResponse();
+}

--- a/examples/local-ollama/package.json
+++ b/examples/local-ollama/package.json
@@ -12,6 +12,7 @@
     "@assistant-ui/react": "workspace:*",
     "@assistant-ui/react-markdown": "workspace:*",
     "@assistant-ui/react-ui": "workspace:^",
+    "ai": "^4.1.25",
     "next": "15.1.6",
     "ollama-ai-provider": "^1.2.0",
     "react": "19.0.0",


### PR DESCRIPTION
Fix for this issue: https://github.com/assistant-ui/assistant-ui/issues/1746

This makes the Ollama example to work out of the box (at least on my machine 😅).

This replaces the `EdgeRuntimeAPI` implementation with a `streamtext` from the `ai` package.

This follows the current code examples provided in the Getting Started docs when selecting code for Ollama: https://www.assistant-ui.com/docs/getting-started#setup-backend-endpoint

I also took the liberty of making the model name a constant for easier swapping. 💅 


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor Ollama example to use `streamText` from `ai` package and add model name constant.
> 
>   - **Behavior**:
>     - Replaces `createEdgeRuntimeAPI` with `streamText` in `route.ts` for handling POST requests.
>     - Introduces `OLLAMA_MODEL` constant for model name in `route.ts`.
>   - **Dependencies**:
>     - Adds `ai` package to `package.json` dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 5797aa3992f10be54c6a580ce69b2b7a9167a948. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->