### PR TITLE
feat: ThreadRuntime.unstable_resumeRun

### DIFF
--- a/.changeset/tough-forks-wait.md
+++ b/.changeset/tough-forks-wait.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: ThreadRuntime.unstable_resumeRun

--- a/packages/react/src/api/ThreadRuntime.ts
+++ b/packages/react/src/api/ThreadRuntime.ts
@@ -5,6 +5,7 @@ import {
   SpeechState,
   ThreadRuntimeEventType,
   StartRunConfig,
+  ResumeRunConfig,
 } from "../runtimes/core/ThreadRuntimeCore";
 import { ExportedMessageRepository } from "../runtimes/utils/MessageRepository";
 import { AppendMessage, ThreadMessage, Unsubscribe } from "../types";
@@ -31,11 +32,25 @@ import { RunConfig } from "../types/AssistantTypes";
 import { EventSubscriptionSubject } from "./subscribable/EventSubscriptionSubject";
 import { symbolInnerMessage } from "../runtimes/external-store/getExternalStoreMessage";
 import { ModelContext } from "../model-context";
+import { ChatModelRunResult } from "../runtimes";
 
 export type CreateStartRunConfig = {
   parentId: string | null;
   sourceId?: string | null | undefined;
   runConfig?: RunConfig | undefined;
+};
+
+export type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream: AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+const toResumeRunConfig = (message: CreateResumeRunConfig): ResumeRunConfig => {
+  return {
+    parentId: message.parentId ?? null,
+    sourceId: message.sourceId ?? null,
+    runConfig: message.runConfig ?? {},
+    stream: message.stream,
+  };
 };
 
 const toStartRunConfig = (message: CreateStartRunConfig): StartRunConfig => {
@@ -211,6 +226,13 @@ export type ThreadRuntime = {
    * @param config The configuration for starting the run
    */
   startRun(config: CreateStartRunConfig): void;
+
+  /**
+   * Resume a run with the given configuration.
+   * @param config The configuration for resuming the run
+   **/
+  unstable_resumeRun(config: CreateResumeRunConfig): void;
+
   subscribe(callback: () => void): Unsubscribe;
   cancelRun(): void;
   getModelContext(): ModelContext;
@@ -336,6 +358,10 @@ export class ThreadRuntimeImpl implements ThreadRuntime {
         ? { parentId: configOrParentId }
         : configOrParentId;
     return this._threadBinding.getState().startRun(toStartRunConfig(config));
+  }
+
+  public unstable_resumeRun(config: CreateResumeRunConfig) {
+    return this._threadBinding.getState().resumeRun(toResumeRunConfig(config));
   }
 
   public cancelRun() {

--- a/packages/react/src/runtimes/core/BaseThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/BaseThreadRuntimeCore.tsx
@@ -14,6 +14,7 @@ import {
   SubmittedFeedback,
   ThreadRuntimeEventType,
   StartRunConfig,
+  ResumeRunConfig,
 } from "../core/ThreadRuntimeCore";
 import { DefaultEditComposerRuntimeCore } from "../composer/DefaultEditComposerRuntimeCore";
 import { SpeechSynthesisAdapter } from "../adapters/speech/SpeechAdapterTypes";
@@ -41,6 +42,7 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   public abstract get capabilities(): RuntimeCapabilities;
   public abstract append(message: AppendMessage): void;
   public abstract startRun(config: StartRunConfig): void;
+  public abstract resumeRun(config: ResumeRunConfig): void;
   public abstract addToolResult(options: AddToolResultOptions): void;
   public abstract cancelRun(): void;
 

--- a/packages/react/src/runtimes/core/ThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/ThreadRuntimeCore.tsx
@@ -3,6 +3,7 @@ import { AppendMessage, ThreadMessage } from "../../types";
 import { RunConfig } from "../../types/AssistantTypes";
 import type { Unsubscribe } from "../../types/Unsubscribe";
 import { SpeechSynthesisAdapter } from "../adapters/speech/SpeechAdapterTypes";
+import { ChatModelRunResult } from "../local";
 import { ExportedMessageRepository } from "../utils/MessageRepository";
 import {
   ComposerRuntimeCore,
@@ -57,6 +58,10 @@ export type StartRunConfig = {
   runConfig: RunConfig;
 };
 
+export type ResumeRunConfig = StartRunConfig & {
+  stream: AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
 export type ThreadRuntimeCore = Readonly<{
   getMessageById: (messageId: string) =>
     | {
@@ -70,6 +75,7 @@ export type ThreadRuntimeCore = Readonly<{
 
   append: (message: AppendMessage) => void;
   startRun: (config: StartRunConfig) => void;
+  resumeRun: (config: ResumeRunConfig) => void;
   cancelRun: () => void;
 
   addToolResult: (options: AddToolResultOptions) => void;

--- a/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
@@ -209,6 +209,10 @@ export class ExternalStoreThreadRuntimeCore
     await this._store.onReload(config.parentId, config);
   }
 
+  public async resumeRun(): Promise<void> {
+    throw new Error("Runtime does not support resuming runs.");
+  }
+
   public cancelRun(): void {
     if (!this._store.onCancel)
       throw new Error("Runtime does not support cancelling runs.");

--- a/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
@@ -9,6 +9,7 @@ import {
   ThreadSuggestion,
   ThreadRuntimeCore,
   StartRunConfig,
+  ResumeRunConfig,
 } from "../core/ThreadRuntimeCore";
 import { BaseThreadRuntimeCore } from "../core/BaseThreadRuntimeCore";
 import { RunConfig } from "../../types/AssistantTypes";
@@ -137,6 +138,10 @@ export class LocalThreadRuntimeCore
       this.repository.resetHead(newMessage.id);
       this._notifySubscribers();
     }
+  }
+
+  public resumeRun({ stream, ...startConfig }: ResumeRunConfig): Promise<void> {
+    return this.startRun(startConfig, () => stream);
   }
 
   public async startRun(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `unstable_resumeRun` method to `ThreadRuntime` for resuming runs, with implementation in `LocalThreadRuntimeCore` and error handling in `ExternalStoreThreadRuntimeCore`.
> 
>   - **Behavior**:
>     - Adds `unstable_resumeRun` method to `ThreadRuntime` in `ThreadRuntime.ts` for resuming runs with `CreateResumeRunConfig`.
>     - Implements `resumeRun` in `LocalThreadRuntimeCore.tsx` to handle run resumption using a stream.
>     - Throws error for `resumeRun` in `ExternalStoreThreadRuntimeCore.tsx`, indicating lack of support.
>   - **Types**:
>     - Introduces `ResumeRunConfig` in `ThreadRuntimeCore.tsx` extending `StartRunConfig` with a `stream` property.
>     - Adds `CreateResumeRunConfig` type in `ThreadRuntime.ts`.
>   - **Core Changes**:
>     - Updates `BaseThreadRuntimeCore.tsx` to include abstract `resumeRun` method.
>     - Modifies `ThreadRuntimeCore.tsx` to include `resumeRun` in `ThreadRuntimeCore` interface.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for e037c060ba7eac4f8e20e8d41a993febd25da933. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->