### PR TITLE
fix: init command does not work on empty folders

### DIFF
--- a/.changeset/free-cows-appear.md
+++ b/.changeset/free-cows-appear.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: init command does not work on empty folders

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -8,7 +8,7 @@ export const init = new Command()
     const child = spawn(
       "npx",
       [
-        `shadcn@latest`,
+        `shadcn@2.3.0`, // TODO 2.4 does not init a project if run in an empty folder
         "add",
         "https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json",
       ],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `init` command in `init.ts` to work in empty folders by specifying `shadcn@2.3.0`.
> 
>   - **Behavior**:
>     - Fixes `init` command in `init.ts` to work in empty folders by specifying `shadcn@2.3.0` instead of the latest version.
>   - **Misc**:
>     - Adds a changeset file `free-cows-appear.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 4bdcc8853ea07ebb5f23e0c7dfe1bb6b4a6be545. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->