### PR TITLE
fix: do not close assistant stream tool call args text controller early

### DIFF
--- a/packages/assistant-stream/src/ai-sdk/index.ts
+++ b/packages/assistant-stream/src/ai-sdk/index.ts
@@ -22,7 +22,11 @@ export const fromStreamText = (
     transform(chunk, controller) {
       const { type } = chunk;
 
-      if (type !== "tool-call-delta" && type !== "error") {
+      if (
+        type !== "tool-call-delta" &&
+        type !== "error" &&
+        (type as string) !== "tool-result"
+      ) {
         endCurrentToolCallArgsText();
       }
 

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -254,10 +254,9 @@ export class DataStreamDecoder extends PipeableTransformStream<
               const toolCallController = controller.addToolCallPart({
                 toolCallId,
                 toolName,
+                args,
               });
               toolCallControllers.set(toolCallId, toolCallController);
-              toolCallController.argsText.append(JSON.stringify(args));
-              toolCallController.argsText.close();
               break;
             }
 

--- a/packages/assistant-stream/src/core/serialization/data-stream/chunk-types.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/chunk-types.ts
@@ -1,4 +1,7 @@
-import { ReadonlyJSONValue } from "../../utils/json/json-value";
+import {
+  ReadonlyJSONObject,
+  ReadonlyJSONValue,
+} from "../../utils/json/json-value";
 
 export type DataStreamChunk = {
   [K in DataStreamStreamChunkType]: {
@@ -46,7 +49,7 @@ type DataStreamStreamChunkValue = {
   [DataStreamStreamChunkType.ToolCall]: {
     toolCallId: string;
     toolName: string;
-    args: unknown;
+    args: ReadonlyJSONObject;
   };
   [DataStreamStreamChunkType.StartToolCall]: {
     toolCallId: string;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix premature closure of tool call arguments text controller by updating conditions and adding flush logic in `index.ts` and `language-model.ts`.
> 
>   - **Behavior**:
>     - Prevent premature closing of tool call arguments text controller in `fromStreamText()` in `index.ts` and `LanguageModelV1StreamDecoder` in `language-model.ts`.
>     - Modify conditions in `transform()` to keep the controller open for `tool-result` type.
>     - Add `flush()` method to ensure proper closure of tool calls.
>   - **Types**:
>     - Update `ToolCallPartInit` type in `assistant-stream.ts` to include `argsText`.
>     - Change `args` type to `ReadonlyJSONObject` in `chunk-types.ts`.
>   - **Misc**:
>     - Remove redundant `argsText` append and close operations in `DataStreamDecoder` in `DataStream.ts` and `LanguageModelV1StreamDecoder` in `language-model.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 42587c1ee0972073f4bd438304fe6b7a17e65843. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->