### PR TITLE
fix: drop ToolResponseBrand

### DIFF
--- a/.changeset/common-rockets-smash.md
+++ b/.changeset/common-rockets-smash.md
@@ -1,0 +1,6 @@
+---
+"assistant-stream": patch
+"@assistant-ui/react": patch
+---
+
+fix: drop ToolResponseBrand

--- a/packages/assistant-stream/src/core/ToolResponse.ts
+++ b/packages/assistant-stream/src/core/ToolResponse.ts
@@ -1,8 +1,5 @@
 import { ReadonlyJSONValue } from "./utils/json/json-value";
 
-// Brand symbol to ensure type safety
-declare const ToolResponseBrand: unique symbol;
-
 export type ToolResponseInit<TResult> = {
   result: TResult;
   artifact?: ReadonlyJSONValue | undefined;
@@ -13,7 +10,6 @@ export class ToolResponse<TResult> {
   readonly artifact?: ReadonlyJSONValue | undefined;
   readonly result: TResult;
   readonly isError: boolean;
-  readonly [ToolResponseBrand]!: true;
 
   constructor(options: ToolResponseInit<TResult>) {
     this.artifact = options.artifact;


### PR DESCRIPTION
fixes  #1794
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `ToolResponseBrand` symbol from `ToolResponse.ts` to simplify type safety handling.
> 
>   - **Type Safety**:
>     - Remove `ToolResponseBrand` symbol from `ToolResponse.ts`, eliminating type branding.
>   - **Changeset**:
>     - Add changeset `common-rockets-smash.md` marking patch updates for `assistant-stream` and `@assistant-ui/react`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 54e87036e901ebc07c291f2c09441b02606a970f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->