### PR TITLE
feat: dummy chat adapter for website

### DIFF
--- a/apps/docs/app/(home)/MyRuntimeProvider.tsx
+++ b/apps/docs/app/(home)/MyRuntimeProvider.tsx
@@ -5,18 +5,49 @@ import {
   SimpleTextAttachmentAdapter,
   AssistantRuntimeProvider,
 } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import {
+  type ChatModelAdapter,
+  type ChatModelRunOptions,
+  useLocalRuntime,
+} from "@assistant-ui/react";
 
-export const MyRuntimeProvider = ({
-  children,
-}: {
-  children: React.ReactNode;
-}) => {
-  const runtime = useChatRuntime({
-    api: "/api/chat",
-    body: {
-      apiKey: process.env["NEXT_PUBLIC_BACKEND_API_KEY"],
-    },
+async function* tokenByToken(str: string) {
+  for (const token of str.split(" ")) {
+    await new Promise((resolve) => setTimeout(resolve, Math.random() * 10 + 5));
+    yield token + " ";
+  }
+}
+
+const LOREM_IPSUM = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
+
+class DummyChatAdapter implements ChatModelAdapter {
+  async *run({ messages, abortSignal }: ChatModelRunOptions) {
+    const text =
+      messages.length === 1
+        ? "This is a mocked chat endpoint for testing purposes. \n\n" +
+          LOREM_IPSUM
+        : LOREM_IPSUM;
+    let output = "";
+
+    for await (const token of tokenByToken(text)) {
+      abortSignal.throwIfAborted();
+
+      output += token;
+
+      yield {
+        content: [
+          {
+            type: "text" as const,
+            text: output,
+          },
+        ],
+      };
+    }
+  }
+}
+
+export function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
+  const runtime = useLocalRuntime(new DummyChatAdapter(), {
     adapters: {
       attachments: new CompositeAttachmentAdapter([
         new SimpleImageAttachmentAdapter(),
@@ -35,4 +66,4 @@ export const MyRuntimeProvider = ({
       {children}
     </AssistantRuntimeProvider>
   );
-};
+}


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Implemented a dummy chat adapter for testing the website interface without backend dependencies. This replaces the API-based chat runtime with a local mock that streams responses token by token.

**New Features**
- Created a `DummyChatAdapter` class that simulates chat responses with Lorem Ipsum text.
- Added token-by-token streaming with random delays to mimic real API behavior.
- Implemented special handling for initial messages with custom intro text.

**Refactors**
- Replaced `useChatRuntime` with `useLocalRuntime` to eliminate backend API dependency.
- Removed API key configuration since it's no longer needed with local runtime.
- Updated component export to use function declaration syntax for consistency.

<!-- End of auto-generated description by mrge. -->

