### PR TITLE
feat: add mastra to meta.json

### DIFF
--- a/apps/docs/content/docs/runtimes/meta.json
+++ b/apps/docs/content/docs/runtimes/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "pick-a-runtime",
     "ai-sdk",
+    "mastra",
     "langgraph",
     "langserve",
     "external-store",


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added Mastra to the runtimes documentation navigation menu. This change makes the Mastra runtime discoverable in the docs alongside other runtimes like LangGraph and LangServe.

- **New Features**
  - Added Mastra to the navigation structure in the runtimes documentation.
  - Updated meta.json to include Mastra in the pages array for proper menu rendering.

<!-- End of auto-generated description by mrge. -->


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `mastra` to `meta.json` to include it in the documentation structure.
> 
>   - **Documentation**:
>     - Add `mastra` to the `pages` array in `meta.json` to include it in the documentation structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 40e8447b5ee2a5ee5c10af7dc0d87d5565efeba7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->