### PR TITLE
fix: do not crash on tool call with empty argsText

### DIFF
--- a/.changeset/curly-pens-wash.md
+++ b/.changeset/curly-pens-wash.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: do not crash on tool call with empty argsText

--- a/.changeset/curly-pens-wash.md
+++ b/.changeset/curly-pens-wash.md
@@ -1,5 +1,0 @@
----
-"assistant-stream": patch
----
-
-fix: do not crash on tool call with empty argsText

--- a/packages/assistant-stream/CHANGELOG.md
+++ b/packages/assistant-stream/CHANGELOG.md
@@ -1,5 +1,11 @@
 # assistant-stream
 
+## 0.0.32
+
+### Patch Changes
+
+- 545a17c: fix: do not crash on tool call with empty argsText
+
 ## 0.0.31
 
 ### Patch Changes

--- a/packages/assistant-stream/package.json
+++ b/packages/assistant-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant-stream",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/assistant-stream/src/core/effects/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/effects/ToolExecutionStream.ts
@@ -55,11 +55,18 @@ export class ToolExecutionStream extends PipeableTransformStream<
 
               const { toolCallId, toolName } = chunk.meta;
               const argsText = toolCallArgsText[toolCallId];
-              if (!argsText)
-                throw new Error("Unexpected tool call without args");
 
               const promise = withPromiseOrValue(
                 () => {
+                  if (!argsText) {
+                    console.log(
+                      "Encountered tool call without argsText, this should never happen",
+                    );
+                    throw new Error(
+                      "Encountered tool call without argsText, this is unexpected.",
+                    );
+                  }
+
                   let args;
                   try {
                     args = sjson.parse(argsText);

--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -34,7 +34,7 @@
     "zustand": "^5.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.8.19",
+    "@assistant-ui/react": "^0.8.20",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -30,7 +30,7 @@
     "zod": "^3.24.2"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.8.19",
+    "@assistant-ui/react": "^0.8.20",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -31,7 +31,7 @@
     "zod": "^3.24.2"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.8.19",
+    "@assistant-ui/react": "^0.8.20",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -34,7 +34,7 @@
     "react-markdown": "^10.1.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.8.19",
+    "@assistant-ui/react": "^0.8.20",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -27,7 +27,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap --clean"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.8.19",
+    "@assistant-ui/react": "^0.8.20",
     "@assistant-ui/react-markdown": "^0.8.1",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @assistant-ui/react
 
+## 0.8.20
+
+### Patch Changes
+
+- Updated dependencies [545a17c]
+  - assistant-stream@0.0.32
+
 ## 0.8.19
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.8.19",
+  "version": "0.8.20",
   "license": "MIT",
   "exports": {
     ".": {
@@ -71,7 +71,7 @@
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-use-callback-ref": "^1.1.0",
     "@radix-ui/react-use-escape-keydown": "^1.1.0",
-    "assistant-stream": "^0.0.31",
+    "assistant-stream": "^0.0.32",
     "json-schema": "^0.4.0",
     "nanoid": "5.1.5",
     "react-textarea-autosize": "^8.5.9",


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed a bug that prevented crashes when tool calls have empty argsText. This improves error handling in the assistant-stream package by gracefully handling unexpected empty arguments.

**Bug Fixes**
- Added proper error handling for tool calls with empty argsText instead of crashing
- Improved error messaging to better identify the unexpected condition
- Added logging to help diagnose when this edge case occurs

<!-- End of auto-generated description by mrge. -->

<!-- MRGE_STACK_DESCRIPTION_START -->
This PR is part of a [stack](https://docs.mrge.io/overview), managed by [mrge](https://mrge.io):

* `main` (default branch)
* [#1640: Test code for DataStream.ts (generated by Tom, AI test code agent)](https://github.com/assistant-ui/assistant-ui/pull/1640)
* **[#1804: fix: do not crash on tool call with empty argsText](https://github.com/assistant-ui/assistant-ui/pull/1804)** ⬅️ Current PR ([View on mrge](https://mrge.io/pr/assistant-ui/assistant-ui/pull/1804))

---
<!-- MRGE_STACK_DESCRIPTION_END -->



