### PR TITLE
fix: make text-delta support reasoning part type

### DIFF
--- a/.changeset/nice-beers-sing.md
+++ b/.changeset/nice-beers-sing.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: make text-delta support reasoning part type

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
@@ -155,7 +155,7 @@ const handleTextDelta = (
   chunk: AssistantStreamChunk & { type: "text-delta" },
 ): AssistantMessage => {
   return updatePartForPath(message, chunk, (part) => {
-    if (part.type === "text") {
+    if (part.type === "text" || part.type === "reasoning") {
       return { ...part, text: part.text + chunk.textDelta };
     } else if (part.type === "tool-call") {
       const newArgsText = part.argsText + chunk.textDelta;


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed text-delta handling to support reasoning part type in assistant messages. This change allows the frontend to properly display reasoning content from language models without errors.

**Bug Fixes**
- Updated the `handleTextDelta` function to accept chunks with `reasoning` type in addition to `text` type.
- Fixed the "text-delta received but part is neither text nor tool-call" error when displaying reasoning content.

**Migration**
- No migration steps needed - existing code using text parts will continue to work as before.

<!-- End of auto-generated description by mrge. -->

When trying to use the reasoning model  in Yonom/assistant-ui-langgraph-fastapi project, I want to output the reasoning content generated by the model. I have modified the backend to enable it to output reasoning content in the following format:
`g: "ok.".`
And we also added the display of reasoning content in the AssistantMessage component in frontend:
`<MessagePrimitive.Content components={{ Text: MarkdownText, Reasoning: ReasoningText }} />`
However, it was found that the frontend would report the following error:
"text-delta received but part is neither text nor tool-call"
It was found that handleTextDelta function in assistant-ui\packages\assistant-stream\src\core\accumulators\assistant-message-accumulator.ts does not support chunks with reasoning meta.type .
After modifying the method, the frontend can output reasoning content normally.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `handleTextDelta` in `assistant-message-accumulator.ts` to support `reasoning` part type, fixing frontend error handling for reasoning content.
> 
>   - **Behavior**:
>     - Modify `handleTextDelta` in `assistant-message-accumulator.ts` to support `reasoning` part type, allowing reasoning content to be processed without errors.
>   - **Error Handling**:
>     - Fix error "text-delta received but part is neither text nor tool-call" by including `reasoning` in supported types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 66de4b0f3e09d11e09152d82467132777eb6ef8e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->