### PR TITLE
fix: ToolResponse instanceof check via named symbol

### DIFF
--- a/.changeset/hungry-wings-occur.md
+++ b/.changeset/hungry-wings-occur.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: ToolResponse instanceof check via named symbol

--- a/packages/assistant-stream/src/core/ToolResponse.ts
+++ b/packages/assistant-stream/src/core/ToolResponse.ts
@@ -1,5 +1,7 @@
 import { ReadonlyJSONValue } from "./utils/json/json-value";
 
+const TOOL_RESPONSE_SYMBOL = Symbol.for("aui.tool-response");
+
 export type ToolResponseInit<TResult> = {
   result: TResult;
   artifact?: ReadonlyJSONValue | undefined;
@@ -7,6 +9,10 @@ export type ToolResponseInit<TResult> = {
 };
 
 export class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL]() {
+    return true;
+  }
+
   readonly artifact?: ReadonlyJSONValue | undefined;
   readonly result: TResult;
   readonly isError: boolean;
@@ -15,5 +21,11 @@ export class ToolResponse<TResult> {
     this.artifact = options.artifact;
     this.result = options.result;
     this.isError = options.isError ?? false;
+  }
+
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<unknown> {
+    return (
+      typeof obj === "object" && obj !== null && TOOL_RESPONSE_SYMBOL in obj
+    );
   }
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed ToolResponse instanceof check using a named symbol to prevent version mismatch issues. This approach ensures reliable type checking even when multiple versions of the package exist in the same application.

**Bug Fixes**
- Added a Symbol.for() implementation to make instanceof checks resilient against version mismatches
- Implemented Symbol.hasInstance to properly identify ToolResponse objects across different package versions
- Created a named symbol (TOOL_RESPONSE_SYMBOL) that works consistently in JavaScript's global symbol registry

<!-- End of auto-generated description by mrge. -->

To be resiient against version mismatches