### PR TITLE
fix: no duplicate tool calls in edge runtime in case tool-deltas are enabled (take2)

### DIFF
--- a/.changeset/kind-clouds-dance.md
+++ b/.changeset/kind-clouds-dance.md
@@ -2,4 +2,4 @@
 "assistant-stream": patch
 ---
 
-Improved handling of tool-call arguments by ensuring proper closure of arguments text and addressing cases with existing tool call controllers.
+feat: fix duplicate tool calls appearing from ai-sdk

--- a/.changeset/kind-clouds-dance.md
+++ b/.changeset/kind-clouds-dance.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+Improved handling of tool-call arguments by ensuring proper closure of arguments text and addressing cases with existing tool call controllers.

--- a/packages/assistant-stream/src/ai-sdk/language-model.ts
+++ b/packages/assistant-stream/src/ai-sdk/language-model.ts
@@ -92,7 +92,7 @@ export class LanguageModelV1StreamDecoder extends AssistantTransformStream<Langu
               });
               toolController.close();
             }
-            
+
             break;
           }
           case "finish": {

--- a/packages/assistant-stream/src/ai-sdk/language-model.ts
+++ b/packages/assistant-stream/src/ai-sdk/language-model.ts
@@ -81,12 +81,18 @@ export class LanguageModelV1StreamDecoder extends AssistantTransformStream<Langu
 
           case "tool-call": {
             const { toolCallId, toolName, args } = chunk;
-            const toolController = controller.addToolCallPart({
-              toolCallId,
-              toolName,
-              argsText: args,
-            });
-            toolController.close();
+
+            if (currentToolCall?.toolCallId === toolCallId) {
+              currentToolCall.controller.argsText.close();
+            } else {
+              const toolController = controller.addToolCallPart({
+                toolCallId,
+                toolName,
+                argsText: args,
+              });
+              toolController.close();
+            }
+            
             break;
           }
           case "finish": {

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -251,12 +251,17 @@ export class DataStreamDecoder extends PipeableTransformStream<
             case DataStreamStreamChunkType.ToolCall: {
               const { toolCallId, toolName, args } = value;
 
-              const toolCallController = controller.addToolCallPart({
-                toolCallId,
-                toolName,
-                args,
-              });
-              toolCallControllers.set(toolCallId, toolCallController);
+              let toolCallController = toolCallControllers.get(toolCallId);
+              if (toolCallController) {
+                toolCallController.argsText.close();
+              } else {
+                toolCallController = controller.addToolCallPart({
+                  toolCallId,
+                  toolName,
+                  args,
+                });
+                toolCallControllers.set(toolCallId, toolCallController);
+              }
               break;
             }
 


### PR DESCRIPTION
Hi @Yonom,

I still see duplicate tool calls when using the latest releases (after the assistant-stream rewrite) and talking to OpenAI. This should be fixed with #1744, but looks like this was not the case.

I tested 9d3c89d and added the same fix for the `DangerousInBrowserAdapter` in 3eb69c3 (untested). 


<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed duplicate tool calls issue in edge runtime when tool-deltas are enabled. This change prevents multiple tool call controllers from being created for the same tool call ID.

**Bug Fixes**
- Added check to verify if a tool call controller already exists for a given tool call ID
- Closed existing controller's args text stream before proceeding when a duplicate is found
- Prevented creation of duplicate tool call controllers in the DataStreamDecoder

<!-- End of auto-generated description by mrge. -->


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent duplicate tool calls in `DataStreamDecoder` by checking existing `toolCallId` and closing `argsText` if necessary.
> 
>   - **Behavior**:
>     - In `DataStreamDecoder`, modify handling of `ToolCall` chunks to prevent duplicate tool calls by checking existing `toolCallId` in `toolCallControllers`.
>     - If `toolCallController` exists, close `argsText` before creating a new tool call part.
>   - **Misc**:
>     - No changes to other files or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 9d3c89d8633814d501b51c87c8a6aa59ce05e78c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->