### PR TITLE
fix(assistant-stream): remove language model spec adapter tool-call check

### DIFF
--- a/packages/assistant-stream/src/ai-sdk/language-model.ts
+++ b/packages/assistant-stream/src/ai-sdk/language-model.ts
@@ -22,11 +22,7 @@ export class LanguageModelV1StreamDecoder extends AssistantTransformStream<Langu
     super({
       transform(chunk, controller) {
         const { type } = chunk;
-        if (
-          type === "text-delta" ||
-          type === "reasoning" ||
-          type === "tool-call"
-        ) {
+        if (type === "text-delta" || type === "reasoning") {
           endCurrentToolCall();
         }
 


### PR DESCRIPTION
which would otherwise collide with the deduplication check
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `tool-call` type check in `LanguageModelV1StreamDecoder` to prevent deduplication collision.
> 
>   - **Behavior**:
>     - Removes `tool-call` type check in `transform()` of `LanguageModelV1StreamDecoder` in `language-model.ts`, preventing `endCurrentToolCall()` from being called for `tool-call` type.
>     - This change avoids collision with deduplication logic for tool calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 3eea34e26f5dfc6ec49bc5f6d57591fbae562414. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->