### PR TITLE
fix(assistant-stream): throw error when LineDecoderStream ends with incomplete line instead of emitting it

### DIFF
--- a/packages/assistant-stream/CHANGELOG.md
+++ b/packages/assistant-stream/CHANGELOG.md
@@ -1,5 +1,11 @@
 # assistant-stream
 
+## 0.1.1
+
+### Patch Changes
+
+- fix: throw error when LineDecoderStream ends with incomplete line instead of emitting it
+
 ## 0.1.0
 
 ### Patch Changes

--- a/packages/assistant-stream/package.json
+++ b/packages/assistant-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant-stream",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.ts
+++ b/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.ts
@@ -15,10 +15,13 @@ export class LineDecoderStream extends TransformStream<string, string> {
         // Keep the last incomplete line in the buffer
         this.buffer = lines[lines.length - 1] || "";
       },
-      flush: (controller) => {
-        // flush any remaining content in the buffer
+      flush: () => {
+        // If there's content in the buffer when the stream ends, it means
+        // the stream ended with an incomplete line (no trailing newline)
         if (this.buffer) {
-          controller.enqueue(this.buffer);
+          throw new Error(
+            `Stream ended with an incomplete line: "${this.buffer}"`,
+          );
         }
       },
     });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `LineDecoderStream` to throw an error for incomplete lines at stream end, updating version to 0.1.1.
> 
>   - **Behavior**:
>     - In `LineDecoderStream.ts`, modify `flush()` to throw an error if the stream ends with an incomplete line, instead of emitting it.
>   - **Versioning**:
>     - Update version to `0.1.1` in `package.json`.
>     - Add changelog entry for version `0.1.1` in `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for dc3b5e414023a3eb9ce8fe3e0f7f1d3b852fda9b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->