### PR TITLE
docs: add section about usage with react 18 and older versions

### DIFF
--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -19,6 +19,7 @@
     "migrations",
     "legacy",
     "components",
-    "reference"
+    "reference",
+    "react-compatibility"
   ]
 }

--- a/apps/docs/content/docs/react-compatibility.mdx
+++ b/apps/docs/content/docs/react-compatibility.mdx
@@ -15,7 +15,7 @@ This guide provides instructions for configuring assistant-ui to work with React
 
 ## React 18
 
-If you're using React 18, you need to update shadcn/ui components to work with `forwardRef`. Specifically, you need to modify the Button component.
+If you're using React 18, you need to update the shadcn/ui components to work with `forwardRef`. Specifically, you need to modify the Button component.
 
 ### Updating the Button Component
 

--- a/apps/docs/content/docs/react-compatibility.mdx
+++ b/apps/docs/content/docs/react-compatibility.mdx
@@ -70,11 +70,11 @@ Button.displayName = "Button";
 
 ## React 17
 
-For React 17 compatibility, you need to apply all the steps for **React 18** above, plus add a polyfill for the `useExternalStore` hook that's used by zustand.
+For React 17 compatibility, you need to apply all the steps for **React 18** above, plus add a polyfill for the `useSyncExternalStore` hook that's used by zustand.
 
 ### Patching Zustand with patch-package
 
-Since the assistant-ui uses zustand internally, which depends on `useExternalStore`, you'll need to patch the zustand package directly:
+Since the assistant-ui uses zustand internally, which depends on `useSyncExternalStore`, you'll need to patch the zustand package directly:
 
 1. Install the required packages:
 

--- a/apps/docs/content/docs/react-compatibility.mdx
+++ b/apps/docs/content/docs/react-compatibility.mdx
@@ -70,7 +70,7 @@ Button.displayName = "Button";
 
 ## React 17
 
-For React 17 compatibility, you need to apply all the steps for **React 18** above, plus add a polyfill for the `useSyncExternalStore` hook that's used by zustand.
+For React 17 compatibility, in addition to the modifications outlined for React 18, you must also include a polyfill for the `useSyncExternalStore` hook (utilized by zustand).
 
 ### Patching Zustand with patch-package
 

--- a/apps/docs/content/docs/react-compatibility.mdx
+++ b/apps/docs/content/docs/react-compatibility.mdx
@@ -1,0 +1,151 @@
+---
+title: Using old React versions
+description: Guide for using assistant-ui with older React versions (18, 17, 16)
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+<Callout type="warning" title="Older React Versions">
+  Older React versions are not continuously tested. If you encounter any issues
+  with integration, please contact us for help by joining our
+  [Discord](https://discord.gg/S9dwgCNEFs).
+</Callout>
+
+This guide provides instructions for configuring assistant-ui to work with React 18 or older versions.
+
+## React 18
+
+If you're using React 18, you need to update shadcn/ui components to work with `forwardRef`. Specifically, you need to modify the Button component.
+
+### Updating the Button Component
+
+Navigate to your button component file (typically `/components/ui/button.tsx`) and wrap the Button component with `forwardRef`:
+
+```tsx
+// Before
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+// After
+const Button = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<"button"> &
+    VariantProps<typeof buttonVariants> & {
+      asChild?: boolean;
+    }
+>(({ className, variant, size, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Button.displayName = "Button";
+```
+
+**Note:** If you're using a lower React version (17 or 16), you'll also need to follow the instructions for that version.
+
+## React 17
+
+For React 17 compatibility, you need to apply all the steps for **React 18** above, plus add a polyfill for the `useExternalStore` hook that's used by zustand.
+
+### Patching Zustand with patch-package
+
+Since the assistant-ui uses zustand internally, which depends on `useExternalStore`, you'll need to patch the zustand package directly:
+
+1. Install the required packages:
+
+```bash
+npm install use-sync-external-store patch-package
+# or
+yarn add use-sync-external-store patch-package
+```
+
+2. Add a postinstall script to your package.json:
+
+```json
+{
+  "scripts": {
+    "postinstall": "patch-package"
+  }
+}
+```
+
+3. Create a patch for zustand by creating a file at `patches/zustand+5.x.x.patch` (replace 5.x.x with the installed zustand version, which you can find by examining `package-lock.json` or `yarn.lock`) with the following content:
+
+```diff
+diff --git a/node_modules/zustand/react.js b/node_modules/zustand/react.js
+index 7599cfb..64530a8 100644
+--- a/node_modules/zustand/react.js
++++ b/node_modules/zustand/react.js
+@@ -1,6 +1,6 @@
+ 'use strict';
+
+-var React = require('react');
++var React = require('use-sync-external-store/shim');
+ var vanilla = require('zustand/vanilla');
+
+ const identity = (arg) => arg;
+@@ -10,7 +10,7 @@ function useStore(api, selector = identity) {
+     () => selector(api.getState()),
+     () => selector(api.getInitialState())
+   );
+-  React.useDebugValue(slice);
++  //React.useDebugValue(slice);
+   return slice;
+ }
+ const createImpl = (createState) => {
+```
+
+4. Run the postinstall script to apply the patch:
+
+```bash
+npm run postinstall
+# or
+yarn postinstall
+```
+
+This patch replaces the React import in zustand with the polyfill from `use-sync-external-store/shim` and comments out the `useDebugValue` call which isn't needed.
+
+**Note:** If you're using React 16, you'll also need to follow the instructions for that version.
+
+## React 16
+
+<Callout type="info" title="Incomplete Section">
+  This section is incomplete and contributions are welcome. If you're using
+  React 16 and have successfully integrated assistant-ui, please consider
+  contributing to this documentation.
+</Callout>
+
+For React 16 compatibility, you need to apply all the steps for **React 18** and **React 17** above.
+
+## Additional Resources
+
+If you encounter any issues with React compatibility, please:
+
+1. Check that all required dependencies are installed
+2. Ensure your component modifications are correctly implemented
+3. Join our [Discord](https://discord.gg/S9dwgCNEFs) community for direct support


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for using `assistant-ui` with React 18, 17, and 16, including component updates and dependency patching.
> 
>   - **Documentation**:
>     - Adds `react-compatibility.mdx` to guide using `assistant-ui` with React 18, 17, and 16.
>     - Includes instructions for updating components with `forwardRef` for React 18.
>     - Provides steps to patch `zustand` for React 17 using `use-sync-external-store`.
>     - Notes incomplete section for React 16, inviting contributions.
>   - **Meta Update**:
>     - Updates `meta.json` to include `react-compatibility` in the documentation index.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for f01f3c93929d46d47f15e0c7f85867cf35314e74. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->