### PR TITLE
feat: early return ChatModelAdapter.run on cancellation

### DIFF
--- a/.changeset/cute-swans-hope.md
+++ b/.changeset/cute-swans-hope.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: early return ChatModelAdapter.run on cancellation


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `performRoundtrip` in `LocalThreadRuntimeCore.tsx` to handle early return on cancellation by checking `abortSignal.aborted`.
> 
>   - **Behavior**:
>     - `performRoundtrip` in `LocalThreadRuntimeCore.tsx` now checks `abortSignal.aborted` to return early on cancellation.
>     - Updates message status to `incomplete` with reason `cancelled` if aborted.
>   - **Misc**:
>     - Sets `abortController` to `null` in `finally` block of `performRoundtrip`.
>     - Adds changeset `cute-swans-hope.md` for patch update to `@assistant-ui/react`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 492e2b3851671a3623252416be5d63657c29f203. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->