### PR TITLE
fix: fixed reasoning component render error

### DIFF
--- a/.changeset/rude-dogs-compete.md
+++ b/.changeset/rude-dogs-compete.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: allow useContentPartText on reasoning parts

--- a/packages/react/src/primitives/contentPart/useContentPartText.tsx
+++ b/packages/react/src/primitives/contentPart/useContentPartText.tsx
@@ -6,7 +6,7 @@ import { TextContentPart } from "../../types";
 
 export const useContentPartText = () => {
   const text = useContentPart((c) => {
-    if (c.type !== "text")
+    if (c.type !== "text" && c.type !== "reasoning")
       throw new Error(
         "ContentPartText can only be used inside text content parts.",
       );

--- a/packages/react/src/primitives/contentPart/useContentPartText.tsx
+++ b/packages/react/src/primitives/contentPart/useContentPartText.tsx
@@ -8,7 +8,7 @@ export const useContentPartText = () => {
   const text = useContentPart((c) => {
     if (c.type !== "text" && c.type !== "reasoning")
       throw new Error(
-        "ContentPartText can only be used inside text content parts.",
+        "ContentPartText can only be used inside text or reasoning content parts.",
       );
 
     return c as ContentPartState & TextContentPart;

--- a/packages/react/src/primitives/contentPart/useContentPartText.tsx
+++ b/packages/react/src/primitives/contentPart/useContentPartText.tsx
@@ -2,7 +2,7 @@
 
 import { ContentPartState } from "../../api/ContentPartRuntime";
 import { useContentPart } from "../../context/react/ContentPartContext";
-import { TextContentPart } from "../../types";
+import { TextContentPart, ReasoningContentPart } from "../../types";
 
 export const useContentPartText = () => {
   const text = useContentPart((c) => {
@@ -11,7 +11,7 @@ export const useContentPartText = () => {
         "ContentPartText can only be used inside text or reasoning content parts.",
       );
 
-    return c as ContentPartState & TextContentPart;
+    return c as ContentPartState & (TextContentPart | ReasoningContentPart);
   });
 
   return text;


### PR DESCRIPTION
I my project, used like this:
```
<MessagePrimitive.Content
       components={{
          Text: MarkdownText,
          Reasoning: <MarkdownText />,
        }}
/>

const MarkdownTextImpl = () => {
  return (
    <MarkdownTextPrimitive
      remarkPlugins={[remarkGfm]}
      className="aui-md"
      components={defaultComponents}
    />
  );
};

export const MarkdownText = memo(MarkdownTextImpl);
```
And this will throw Error like this:
![image](https://github.com/user-attachments/assets/bfd8b1f3-e660-4adf-b36d-9b66c7d073a9)

So, I have to make pnpm patches like this:
```
diff --git a/dist/primitives/contentPart/useContentPartText.mjs b/dist/primitives/contentPart/useContentPartText.mjs
index addde04ce2067ae7f68078b1fd8849ce5dadfe1a..613d625858e11e26af959755e5b0a52a66045d9d 100644
--- a/dist/primitives/contentPart/useContentPartText.mjs
+++ b/dist/primitives/contentPart/useContentPartText.mjs
@@ -4,7 +4,7 @@
 import { useContentPart } from "../../context/react/ContentPartContext.mjs";
 var useContentPartText = () => {
   const text = useContentPart((c) => {
-    if (c.type !== "text")
+    if (c.type !== "text" && c.type !== "reasoning")
       throw new Error(
         "ContentPartText can only be used inside text content parts."
       );
```

I think the best way is create a Pull Request, anyone other can resolve at the same.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `useContentPartText` to handle `reasoning` type, preventing errors for non-text content parts.
> 
>   - **Behavior**:
>     - Modify `useContentPartText` in `useContentPartText.tsx` to handle `reasoning` type in addition to `text` type.
>     - Prevents error when `c.type` is `reasoning` by allowing it in the condition check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c4d0590ff79d0385cdf40c953baf4eaff21d65e7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->