### PR TITLE
fix: type error

### DIFF
--- a/packages/react/src/utils/smooth/useSmooth.tsx
+++ b/packages/react/src/utils/smooth/useSmooth.tsx
@@ -2,7 +2,11 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useMessage } from "../../context";
-import { ContentPartStatus, TextContentPart } from "../../types/AssistantTypes";
+import {
+  ContentPartStatus,
+  ReasoningContentPart,
+  TextContentPart,
+} from "../../types/AssistantTypes";
 import { useCallbackRef } from "@radix-ui/react-use-callback-ref";
 import { useSmoothStatusStore } from "./SmoothContext";
 import { writableStore } from "../../context/ReadonlyStore";
@@ -67,9 +71,9 @@ const SMOOTH_STATUS: ContentPartStatus = Object.freeze({
 });
 
 export const useSmooth = (
-  state: ContentPartState & TextContentPart,
+  state: ContentPartState & (TextContentPart | ReasoningContentPart),
   smooth: boolean = false,
-): ContentPartState & TextContentPart => {
+): ContentPartState & (TextContentPart | ReasoningContentPart) => {
   const { text } = state;
   const id = useMessage({
     optional: true,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix type error in `useSmooth` by updating type definitions to include `ReasoningContentPart`.
> 
>   - **Type Fix**:
>     - Update `useSmooth` function in `useSmooth.tsx` to accept `ContentPartState & (TextContentPart | ReasoningContentPart)` instead of `ContentPartState & TextContentPart`.
>     - Adjust return type of `useSmooth` to `ContentPartState & (TextContentPart | ReasoningContentPart)`.
>   - **Imports**:
>     - Add `ReasoningContentPart` to imports from `AssistantTypes`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 9e43c16b623d5b5dda20c1da9d8e57daf5cd63b6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->