### PR TITLE
Export needed types from `external-store`

### DIFF
--- a/.changeset/nice-jeans-bake.md
+++ b/.changeset/nice-jeans-bake.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: export types from `external-store`

--- a/packages/react/src/runtimes/external-store/index.ts
+++ b/packages/react/src/runtimes/external-store/index.ts
@@ -1,6 +1,8 @@
 export type {
   ExternalStoreAdapter,
   ExternalStoreMessageConverter,
+  ExternalStoreThreadListAdapter,
+  ExternalStoreThreadData
 } from "./ExternalStoreAdapter";
 export type { ThreadMessageLike } from "./ThreadMessageLike";
 export { useExternalStoreRuntime } from "./useExternalStoreRuntime";


### PR DESCRIPTION
I need to use the `ExternalStoreThreadListAdapter` and `ExternalStoreThreadData` types in my application, as I'm trying to ensure all types are strongly typed while using the [external store runtime](https://www.assistant-ui.com/docs/runtimes/custom/external-store).

Specifically, I'm trying to create a `useState` to handle threads. I'm not sure if this would be the right way to do such, though feel free to let me know if it isn't.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add exports for `ExternalStoreThreadListAdapter` and `ExternalStoreThreadData` in `index.ts` for strong typing support.
> 
>   - **Exports**:
>     - Add `ExternalStoreThreadListAdapter` and `ExternalStoreThreadData` to exports in `index.ts` for use in applications requiring strong typing with the external store runtime.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for fa01a6bdf39afec313fc4dd208ec7681638f488b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->