### PR TITLE
fix: make addResult typesafe

### DIFF
--- a/.changeset/tricky-trainers-hammer.md
+++ b/.changeset/tricky-trainers-hammer.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: make addResult typesafe

--- a/packages/react/src/types/ContentPartComponentTypes.tsx
+++ b/packages/react/src/types/ContentPartComponentTypes.tsx
@@ -42,7 +42,7 @@ export type ToolCallContentPartProps<
   TResult = unknown,
 > = ContentPartState &
   ToolCallContentPart<TArgs, TResult> & {
-    addResult: (result: any) => void;
+    addResult: (result: TResult) => void;
   };
 
 export type ToolCallContentPartComponent<


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `addResult` typesafe by changing its parameter type from `any` to `TResult` in `ToolCallContentPartProps`.
> 
>   - **Type Safety**:
>     - Change `addResult` parameter type from `any` to `TResult` in `ToolCallContentPartProps` in `ContentPartComponentTypes.tsx` to ensure type safety.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 42484850cc2449613c3f60f7aed7bba140d9e98a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->