### PR TITLE
fix: remove hardcoded title if its empty

### DIFF
--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
@@ -421,8 +421,7 @@ export class RemoteThreadListThreadListRuntimeCore
     );
     const messageStream = AssistantMessageStream.fromAssistantStream(stream);
     for await (const result of messageStream) {
-      const newTitle =
-        result.parts.filter((c) => c.type === "text")[0]?.text ?? "New Thread";
+      const newTitle = result.parts.filter((c) => c.type === "text")[0]?.text;
       const state = this._state.baseValue;
       this._state.update({
         ...state,


### PR DESCRIPTION
instead, rely on the UI fallback; addresses #1852
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes hardcoded fallback title in `generateTitle` method of `RemoteThreadListThreadListRuntimeCore.tsx`, relying on UI fallback if title is empty.
> 
>   - **Behavior**:
>     - Removes hardcoded fallback title "New Thread" in `generateTitle` method of `RemoteThreadListThreadListRuntimeCore.tsx`.
>     - Relies on UI fallback if title is empty, addressing issue #1852.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for cb1a2c5ecf8836f96ef866da1b55331064642847. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->