### PR TITLE
fix(assistant-stream): forward full tool response from data stream

### DIFF
--- a/.changeset/stupid-books-cheer.md
+++ b/.changeset/stupid-books-cheer.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: correctly forward tool result from data stream

--- a/.changeset/stupid-books-cheer.md
+++ b/.changeset/stupid-books-cheer.md
@@ -1,5 +1,0 @@
----
-"assistant-stream": patch
----
-
-fix: correctly forward tool result from data stream

--- a/examples/with-ai-sdk/app/assistant.tsx
+++ b/examples/with-ai-sdk/app/assistant.tsx
@@ -1,49 +1,8 @@
 "use client";
 
-import {
-  AssistantRuntimeProvider,
-  makeAssistantTool,
-} from "@assistant-ui/react";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 import { Thread } from "@/components/assistant-ui/thread";
-import { z } from "zod";
-
-const MyToolUI = makeAssistantTool({
-  toolName: "my_tool",
-  parameters: z.object({
-    name: z.string(),
-    age: z.number(),
-    nicknames: z.array(z.string()),
-  }),
-  streamCall: async (reader) => {
-    reader.args.streamText("name").pipeTo(
-      new WritableStream({
-        write: (value) => console.log("NAME UPDATE", value),
-      }),
-    );
-
-    const test = await reader.args.get("name");
-    console.log(test);
-
-    reader.args.streamValues("age").pipeTo(
-      new WritableStream({
-        write: (value) => console.log("AGE UPDATE", value),
-      }),
-    );
-
-    const test2 = await reader.args.get("age");
-    console.log(test2);
-
-    for await (const nickname of reader.args.forEach("nicknames")) {
-      console.log("NICKNAME", nickname);
-    }
-
-    console.log(await reader.response.get());
-  },
-  execute: () => {
-    return "hi!";
-  },
-});
 
 export const Assistant = () => {
   const runtime = useChatRuntime({
@@ -54,7 +13,6 @@ export const Assistant = () => {
     <AssistantRuntimeProvider runtime={runtime}>
       <div className="grid h-dvh gap-x-2 px-4 py-4">
         <Thread />
-        <MyToolUI />
       </div>
     </AssistantRuntimeProvider>
   );

--- a/examples/with-ai-sdk/app/assistant.tsx
+++ b/examples/with-ai-sdk/app/assistant.tsx
@@ -38,7 +38,10 @@ const MyToolUI = makeAssistantTool({
       console.log("NICKNAME", nickname);
     }
 
-    console.log(await reader.result.get());
+    console.log(await reader.response.get());
+  },
+  execute: () => {
+    return "hi!";
   },
 });
 

--- a/packages/assistant-stream/CHANGELOG.md
+++ b/packages/assistant-stream/CHANGELOG.md
@@ -1,5 +1,11 @@
 # assistant-stream
 
+## 0.1.5
+
+### Patch Changes
+
+- 2e4a7c1: fix: correctly forward tool result from data stream
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/assistant-stream/package.json
+++ b/packages/assistant-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant-stream",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.ts
@@ -379,10 +379,10 @@ export class ToolCallArgsReaderImpl<T> implements ToolCallArgsReader<T> {
 export class ToolCallResponseReaderImpl<TResult>
   implements ToolCallResponseReader<TResult>
 {
-  constructor(private readonly resultPromise: Promise<ToolResponse<TResult>>) {}
+  constructor(private readonly promise: Promise<ToolResponse<TResult>>) {}
 
   public get() {
-    return this.resultPromise;
+    return this.promise;
   }
 }
 

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.ts
@@ -6,9 +6,10 @@ import {
 import {
   ToolCallArgsReader,
   ToolCallReader,
-  ToolCallResultReader,
+  ToolCallResponseReader,
 } from "./tool-types";
 import { TypeAtPath, TypePath } from "./type-path-utils";
+import { ToolResponse } from "./ToolResponse";
 
 // TODO: remove dispose
 
@@ -375,10 +376,10 @@ export class ToolCallArgsReaderImpl<T> implements ToolCallArgsReader<T> {
   }
 }
 
-export class ToolCallResultReaderImpl<TResult>
-  implements ToolCallResultReader<TResult>
+export class ToolCallResponseReaderImpl<TResult>
+  implements ToolCallResponseReader<TResult>
 {
-  constructor(private readonly resultPromise: Promise<TResult>) {}
+  constructor(private readonly resultPromise: Promise<ToolResponse<TResult>>) {}
 
   public get() {
     return this.resultPromise;
@@ -389,9 +390,9 @@ export class ToolCallReaderImpl<TArgs, TResult>
   implements ToolCallReader<TArgs, TResult>
 {
   public readonly args: ToolCallArgsReaderImpl<TArgs>;
-  public readonly result: ToolCallResultReaderImpl<TResult>;
+  public readonly response: ToolCallResponseReaderImpl<TResult>;
   private readonly writable: WritableStream<string>;
-  private readonly resolve: (value: TResult | PromiseLike<TResult>) => void;
+  private readonly resolve: (value: ToolResponse<TResult>) => void;
 
   public argsText: string = "";
 
@@ -400,9 +401,9 @@ export class ToolCallReaderImpl<TArgs, TResult>
     this.writable = stream.writable;
     this.args = new ToolCallArgsReaderImpl<TArgs>(stream.readable);
 
-    const { promise, resolve } = promiseWithResolvers<TResult>();
+    const { promise, resolve } = promiseWithResolvers<ToolResponse<TResult>>();
     this.resolve = resolve;
-    this.result = new ToolCallResultReaderImpl<TResult>(promise);
+    this.response = new ToolCallResponseReaderImpl<TResult>(promise);
   }
 
   async appendArgsTextDelta(text: string): Promise<void> {
@@ -418,7 +419,14 @@ export class ToolCallReaderImpl<TArgs, TResult>
     this.argsText += text;
   }
 
-  setResult(value: TResult | PromiseLike<TResult>): void {
+  setResponse(value: ToolResponse<TResult>): void {
     this.resolve(value);
   }
+
+  result = {
+    get: async () => {
+      const response = await this.response.get();
+      return response.result;
+    },
+  };
 }

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -3,6 +3,7 @@ import { TypeAtPath, TypePath } from "./type-path-utils";
 import { DeepPartial } from "ai";
 import { AsyncIterableStream } from "../../utils";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { ToolResponse } from "./ToolResponse";
 
 /**
  * Interface for reading tool call arguments from a stream, which are
@@ -58,13 +59,20 @@ export interface ToolCallArgsReader<TArgs> {
     : never;
 }
 
-export interface ToolCallResultReader<TResult> {
-  get: () => Promise<TResult>;
+export interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
 }
 
 export interface ToolCallReader<TArgs, TResult> {
   args: ToolCallArgsReader<TArgs>;
-  result: ToolCallResultReader<TResult>;
+  response: ToolCallResponseReader<TResult>;
+
+  /**
+   * @deprecated Deprecated. Use `response.get().result` instead.
+   */
+  result: {
+    get: () => Promise<TResult>;
+  };
 }
 
 type ToolExecutionContext = {

--- a/packages/react-edge/package.json
+++ b/packages/react-edge/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@ai-sdk/provider": "^1.1.3",
-    "assistant-stream": "^0.1.4",
+    "assistant-stream": "^0.1.5",
     "json-schema": "^0.4.0",
     "zod": "^3.24.3",
     "zod-to-json-schema": "^3.24.5"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -27,7 +27,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap --clean"
   },
   "dependencies": {
-    "assistant-stream": "^0.1.4",
+    "assistant-stream": "^0.1.5",
     "uuid": "^11.1.0",
     "zod": "^3.24.3"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -68,7 +68,7 @@
     "@radix-ui/react-slot": "^1.2.0",
     "@radix-ui/react-use-callback-ref": "^1.1.1",
     "@radix-ui/react-use-escape-keydown": "^1.1.1",
-    "assistant-stream": "^0.1.4",
+    "assistant-stream": "^0.1.5",
     "nanoid": "5.1.5",
     "react-textarea-autosize": "^8.5.9",
     "zod": "^3.24.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1419,7 +1419,7 @@ importers:
         specifier: '*'
         version: 19.1.2(@types/react@19.1.2)
       assistant-stream:
-        specifier: ^0.1.4
+        specifier: ^0.1.5
         version: link:../assistant-stream
       nanoid:
         specifier: 5.1.5
@@ -1523,7 +1523,7 @@ importers:
         specifier: '*'
         version: 19.1.2(@types/react@19.1.2)
       assistant-stream:
-        specifier: ^0.1.4
+        specifier: ^0.1.5
         version: link:../assistant-stream
       json-schema:
         specifier: ^0.4.0
@@ -1600,7 +1600,7 @@ importers:
         specifier: '*'
         version: 19.1.2
       assistant-stream:
-        specifier: ^0.1.4
+        specifier: ^0.1.5
         version: link:../assistant-stream
       react:
         specifier: 19.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1419,7 +1419,7 @@ importers:
         specifier: '*'
         version: 19.1.2(@types/react@19.1.2)
       assistant-stream:
-        specifier: ^0.1.3
+        specifier: ^0.1.4
         version: link:../assistant-stream
       nanoid:
         specifier: 5.1.5
@@ -1523,7 +1523,7 @@ importers:
         specifier: '*'
         version: 19.1.2(@types/react@19.1.2)
       assistant-stream:
-        specifier: ^0.1.3
+        specifier: ^0.1.4
         version: link:../assistant-stream
       json-schema:
         specifier: ^0.4.0
@@ -1600,7 +1600,7 @@ importers:
         specifier: '*'
         version: 19.1.2
       assistant-stream:
-        specifier: ^0.1.3
+        specifier: ^0.1.4
         version: link:../assistant-stream
       react:
         specifier: 19.0.0


### PR DESCRIPTION
Refactor ToolCallReader to handle ToolResponse objects instead of just
results, enabling access to additional metadata in tool responses. Rename
related classes and methods to reflect this changee.g., result → response).

Update example usage to log the full response. Bump assistant-stream
dependency version to ^0.1.4 to include these fixes.

This ensures tool call results are correctly forwarded and accessible,
improving the reliability and extensibility of tool call handling.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `ToolCallReader` to handle `ToolResponse` objects, update example usage, and bump `assistant-stream` version to `^0.1.5`.
> 
>   - **Behavior**:
>     - Refactor `ToolCallReader` to handle `ToolResponse` objects instead of just results, allowing access to additional metadata.
>     - Update example usage in `assistant.tsx` to log the full response.
>     - Bump `assistant-stream` dependency version to `^0.1.5` in `package.json` files.
>   - **Classes and Methods**:
>     - Rename `ToolCallResultReader` to `ToolCallResponseReader` and `result` to `response` in `ToolCallReaderImpl`.
>     - Add `setResponse()` method in `ToolCallReaderImpl` to set the full `ToolResponse`.
>     - Deprecate `result.get()` in favor of `response.get().result` in `tool-types.ts`.
>   - **Misc**:
>     - Update `CHANGELOG.md` to reflect the changes in version `0.1.5`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 78e20c2bea6c2ec41ad810e1690e57484b6bedb7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->