### PR TITLE
fix: circular import caused zod schemas to break

### DIFF
--- a/.changeset/shiny-news-kneel.md
+++ b/.changeset/shiny-news-kneel.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-edge": patch
+---
+
+fix: circular import causes zod schemas to break

--- a/packages/assistant-stream/package.json
+++ b/packages/assistant-stream/package.json
@@ -4,34 +4,19 @@
   "license": "MIT",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
     },
     "./ai-sdk": {
-      "import": {
-        "types": "./dist/ai-sdk.d.mts",
-        "default": "./dist/ai-sdk.mjs"
-      },
-      "require": {
-        "types": "./dist/ai-sdk.d.ts",
-        "default": "./dist/ai-sdk.js"
-      }
+      "types": "./dist/ai-sdk.d.ts",
+      "import": "./dist/ai-sdk.mjs",
+      "require": "./dist/ai-sdk.js"
     },
     "./utils": {
-      "import": {
-        "types": "./dist/utils.d.mts",
-        "default": "./dist/utils.mjs"
-      },
-      "require": {
-        "types": "./dist/utils.d.ts",
-        "default": "./dist/utils.js"
-      }
+      "types": "./dist/utils.d.ts",
+      "import": "./dist/utils.mjs",
+      "require": "./dist/utils.js"
     }
   },
   "source": "./src/index.ts",

--- a/packages/react-edge/src/edge/EdgeRuntimeRequestOptions.ts
+++ b/packages/react-edge/src/edge/EdgeRuntimeRequestOptions.ts
@@ -1,90 +1,10 @@
-import { JSONSchema7 } from "json-schema";
 import { z } from "zod";
 import {
   LanguageModelConfigSchema,
   LanguageModelV1CallSettingsSchema,
-} from "./createEdgeRuntimeAPI";
-
-const LanguageModelV1FunctionToolSchema = z.object({
-  type: z.literal("function"),
-  name: z.string(),
-  description: z.string().optional(),
-  parameters: z.custom<JSONSchema7>(
-    (val) => typeof val === "object" && val !== null,
-  ),
-});
-
-const TextContentPartSchema = z.object({
-  type: z.literal("text"),
-  text: z.string(),
-});
-
-const ImageContentPartSchema = z.object({
-  type: z.literal("image"),
-  image: z.string(),
-});
-
-const FileContentPartSchema = z.object({
-  type: z.literal("file"),
-  data: z.string(),
-  mimeType: z.string(),
-});
-
-const Unstable_AudioContentPart = z.object({
-  type: z.literal("audio"),
-  audio: z.object({
-    data: z.string(),
-    format: z.union([z.literal("mp3"), z.literal("wav")]),
-  }),
-});
-
-const CoreToolCallContentPartSchema = z.object({
-  type: z.literal("tool-call"),
-  toolCallId: z.string(),
-  toolName: z.string(),
-  args: z.record(z.unknown()),
-  result: z.unknown().optional(),
-  isError: z.boolean().optional(),
-});
-
-const CoreUserMessageSchema = z.object({
-  role: z.literal("user"),
-  content: z
-    .array(
-      z.discriminatedUnion("type", [
-        TextContentPartSchema,
-        ImageContentPartSchema,
-        FileContentPartSchema,
-        Unstable_AudioContentPart,
-      ]),
-    )
-    .min(1)
-    .readonly(),
-});
-
-const CoreAssistantMessageSchema = z.object({
-  role: z.literal("assistant"),
-  content: z
-    .array(
-      z.discriminatedUnion("type", [
-        TextContentPartSchema,
-        CoreToolCallContentPartSchema,
-      ]),
-    )
-    .min(1)
-    .readonly(),
-});
-
-const CoreSystemMessageSchema = z.object({
-  role: z.literal("system"),
-  content: z.tuple([TextContentPartSchema]).readonly(),
-});
-
-const CoreMessageSchema = z.discriminatedUnion("role", [
-  CoreSystemMessageSchema,
-  CoreUserMessageSchema,
-  CoreAssistantMessageSchema,
-]);
+  LanguageModelV1FunctionToolSchema,
+  CoreMessageSchema,
+} from "./schemas";
 
 export const EdgeRuntimeRequestOptionsSchema = z
   .object({

--- a/packages/react-edge/src/edge/createEdgeRuntimeAPI.ts
+++ b/packages/react-edge/src/edge/createEdgeRuntimeAPI.ts
@@ -19,27 +19,14 @@ import {
 import { LanguageModelV1StreamDecoder } from "assistant-stream/ai-sdk";
 import { ThreadMessage, Tool } from "@assistant-ui/react";
 import { CoreMessage } from "./CoreTypes";
-
-export const LanguageModelV1CallSettingsSchema = z.object({
-  maxTokens: z.number().int().positive().optional(),
-  temperature: z.number().optional(),
-  topP: z.number().optional(),
-  presencePenalty: z.number().optional(),
-  frequencyPenalty: z.number().optional(),
-  seed: z.number().int().optional(),
-  headers: z.record(z.string().optional()).optional(),
-});
+import {
+  LanguageModelConfigSchema,
+  LanguageModelV1CallSettingsSchema,
+} from "./schemas";
 
 export type LanguageModelV1CallSettings = z.infer<
   typeof LanguageModelV1CallSettingsSchema
 >;
-
-export const LanguageModelConfigSchema = z.object({
-  apiKey: z.string().optional(),
-  baseUrl: z.string().optional(),
-  modelName: z.string().optional(),
-});
-
 export type LanguageModelConfig = z.infer<typeof LanguageModelConfigSchema>;
 
 type LanguageModelCreator = (

--- a/packages/react-edge/src/edge/schemas.ts
+++ b/packages/react-edge/src/edge/schemas.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+import { JSONSchema7 } from "json-schema";
+
+export const LanguageModelV1FunctionToolSchema = z.object({
+  type: z.literal("function"),
+  name: z.string(),
+  description: z.string().optional(),
+  parameters: z.custom<JSONSchema7>(
+    (val) => typeof val === "object" && val !== null,
+  ),
+});
+
+export const TextContentPartSchema = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+});
+
+export const ImageContentPartSchema = z.object({
+  type: z.literal("image"),
+  image: z.string(),
+});
+
+export const FileContentPartSchema = z.object({
+  type: z.literal("file"),
+  data: z.string(),
+  mimeType: z.string(),
+});
+
+export const Unstable_AudioContentPart = z.object({
+  type: z.literal("audio"),
+  audio: z.object({
+    data: z.string(),
+    format: z.union([z.literal("mp3"), z.literal("wav")]),
+  }),
+});
+
+export const CoreToolCallContentPartSchema = z.object({
+  type: z.literal("tool-call"),
+  toolCallId: z.string(),
+  toolName: z.string(),
+  args: z.record(z.unknown()),
+  result: z.unknown().optional(),
+  isError: z.boolean().optional(),
+});
+
+export const CoreUserMessageSchema = z.object({
+  role: z.literal("user"),
+  content: z
+    .array(
+      z.discriminatedUnion("type", [
+        TextContentPartSchema,
+        ImageContentPartSchema,
+        FileContentPartSchema,
+        Unstable_AudioContentPart,
+      ]),
+    )
+    .min(1)
+    .readonly(),
+});
+
+export const CoreAssistantMessageSchema = z.object({
+  role: z.literal("assistant"),
+  content: z
+    .array(
+      z.discriminatedUnion("type", [
+        TextContentPartSchema,
+        CoreToolCallContentPartSchema,
+      ]),
+    )
+    .min(1)
+    .readonly(),
+});
+
+export const CoreSystemMessageSchema = z.object({
+  role: z.literal("system"),
+  content: z.tuple([TextContentPartSchema]).readonly(),
+});
+
+export const CoreMessageSchema = z.discriminatedUnion("role", [
+  CoreSystemMessageSchema,
+  CoreUserMessageSchema,
+  CoreAssistantMessageSchema,
+]);
+
+export const LanguageModelV1CallSettingsSchema = z.object({
+  maxTokens: z.number().int().positive().optional(),
+  temperature: z.number().optional(),
+  topP: z.number().optional(),
+  presencePenalty: z.number().optional(),
+  frequencyPenalty: z.number().optional(),
+  seed: z.number().int().optional(),
+  headers: z.record(z.string().optional()).optional(),
+});
+
+export const LanguageModelConfigSchema = z.object({
+  apiKey: z.string().optional(),
+  baseUrl: z.string().optional(),
+  modelName: z.string().optional(),
+});


### PR DESCRIPTION
fixes  #1867

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor schema imports to `schemas.ts` to fix circular import issues and simplify exports in `assistant-stream`'s `package.json`.
> 
>   - **Refactoring**:
>     - Moved schema definitions to `schemas.ts` to resolve circular import issues in `EdgeRuntimeRequestOptions.ts` and `createEdgeRuntimeAPI.ts`.
>     - Updated imports in `EdgeRuntimeRequestOptions.ts` and `createEdgeRuntimeAPI.ts` to use `schemas.ts`.
>   - **Package Configuration**:
>     - Simplified exports in `package.json` of `assistant-stream` by removing nested `import` and `require` objects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 171b1e766c78e293600587028bae942a91a7822c. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->