### PR TITLE
fix: disable declarations for apps

### DIFF
--- a/packages/tsconfig/app-base.json
+++ b/packages/tsconfig/app-base.json
@@ -2,6 +2,8 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./base.json",
   "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
     "paths": {
       "@/*": ["./*"],
       "@assistant-ui/*": ["../../packages/*/src"],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disable TypeScript declaration and declaration map generation in `app-base.json`.
> 
>   - **TypeScript Configuration**:
>     - In `app-base.json`, set `compilerOptions.declaration` to `false` to disable declaration file generation.
>     - Set `compilerOptions.declarationMap` to `false` to disable declaration map generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for f6aa3afa45a008c4f9ad743601c3f03b14e062f0. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->