### PR TITLE
Remove incorrect import of `ToolArtifactChunk`

### DIFF
--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -4,7 +4,6 @@ from assistant_stream.assistant_stream_chunk import (
     AssistantStreamChunk,
     TextDeltaChunk,
     ToolResultChunk,
-    ToolArtifactChunk,
     DataChunk,
     ErrorChunk,
 )


### PR DESCRIPTION
This should have been removed in https://github.com/assistant-ui/assistant-ui/pull/1788 together with `ToolArtifactChunk`s definition
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove incorrect import of `ToolArtifactChunk` from `create_run.py`.
> 
>   - **Imports**:
>     - Remove incorrect import of `ToolArtifactChunk` from `create_run.py`. This import was supposed to be removed in a previous PR.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 62b27b5e9d63421e871b7a0ef6b781e3d8be2be5. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->