### PR TITLE
chore(docs): update documentation

### DIFF
--- a/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
+++ b/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
@@ -116,9 +116,9 @@ export const defaultComponents = memoizeMarkdownComponents({
           "https://github.com/shikijs/shiki/blob/ac6bea51b807a82e0a5c9a83796c3abdda0fc293/packages/types/src/transformers.ts#L48",
         default: "[]",
       },
+    // This reverts the order of the type table, fumadocs reversed the order on 4/22/25 in:
+    // https://github.com/fuma-nama/fumadocs/commit/3a5595aa65acfa5c20be2377d09c03fbb1de72a6
     }).reverse()
-      // This reverts the order of the type table, fumadocs reversed the order on 4/22/25 in:
-      // https://github.com/fuma-nama/fumadocs/commit/3a5595aa65acfa5c20be2377d09c03fbb1de72a6
   )}
 />
 

--- a/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
+++ b/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
@@ -54,68 +54,72 @@ export const defaultComponents = memoizeMarkdownComponents({
 ### Options
 
 <TypeTable
-  type={{
-    theme: {
-      description: "Shiki built‑in or custom textmate theme(s)",
-      type: "Theme | Themes",
-      typeDescription: "Shiki BundledTheme or Textmate theme object",
-      typeDescriptionLink:
-        "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L51",
-      default: "github‑dark",
-      required: true,
-    },
-    language: {
-      description: "The language for highlighting",
-      type: "Language",
-      typeDescription: "Shiki BundledLanguage or Textmate grammar object",
-      typeDescriptionLink:
-        "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L24",
-      default: "text",
-      required: true,
-    },
-    className: {
-      description: "Custom CSS classes for the `<pre>` element",
-      type: "string",
-      default: "",
-    },
-    style: {
-      description: "Inline styles for the `ShikiHighlighter` component",
-      type: "React.CSSProperties",
-      default: undefined,
-    },
-    cssVariablePrefix: {
-      description:
-        "Prefix of CSS variables used to store the color of the other theme",
-      type: "string",
-      default: "--shiki-",
-    },
-    defaultColor: {
-      description:
-        "The default theme applied to the code (via inline color style). The rest of the themes are applied via CSS variables, and toggled by CSS overrides. For example, if defaultColor is light, then light theme is applied to the code, and the dark theme and other custom themes are applied via CSS variables",
-      type: "light | dark | string | false",
-      default: undefined,
-    },
-    delay: {
-      description:
-        "Delay in milliseconds between consecutive highlights, useful for streamed code responses.",
-      type: "number",
-      default: 0,
-    },
-    customLanguages: {
-      description: "Custom languages to preload for syntax highlighting",
-      type: "Language[]",
-      typeDescriptionLink:
-        "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L24",
-      default: "[]",
-    },
-    transformers: {
-      description: "Transformers for the Shiki pipeline",
-      type: "ShikiTransformer[]",
-      typeDescriptionLink:
-        "https://github.com/shikijs/shiki/blob/ac6bea51b807a82e0a5c9a83796c3abdda0fc293/packages/types/src/transformers.ts#L48",
-      default: "[]",
-    },
-  }}
+  type={Object.fromEntries(
+    Object.entries({
+      theme: {
+        description: "Shiki built-in or custom textmate theme(s)",
+        type: "Theme | Themes",
+        typeDescription: "Shiki BundledTheme or Textmate theme object",
+        typeDescriptionLink:
+          "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L51",
+        default: "github-dark",
+        required: true,
+      },
+      language: {
+        description: "The language for highlighting",
+        type: "Language",
+        typeDescription: "Shiki BundledLanguage or Textmate grammar object",
+        typeDescriptionLink:
+          "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L24",
+        default: "text",
+        required: true,
+      },
+      className: {
+        description: "Custom CSS classes for the `<pre>` element",
+        type: "string",
+        default: "",
+      },
+      style: {
+        description: "Inline styles for the `ShikiHighlighter` component",
+        type: "React.CSSProperties",
+        default: undefined,
+      },
+      cssVariablePrefix: {
+        description:
+          "Prefix of CSS variables used to store the color of the other theme",
+        type: "string",
+        default: "--shiki-",
+      },
+      defaultColor: {
+        description:
+          "The default theme applied to the code (via inline color style). The rest of the themes are applied via CSS variables, and toggled by CSS overrides. For example, if defaultColor is light, then light theme is applied to the code, and the dark theme and other custom themes are applied via CSS variables",
+        type: "light | dark | string | false",
+        default: undefined,
+      },
+      delay: {
+        description:
+          "Delay in milliseconds between consecutive highlights, useful for streamed code responses.",
+        type: "number",
+        default: 0,
+      },
+      customLanguages: {
+        description: "Custom languages to preload for syntax highlighting",
+        type: "Language[]",
+        typeDescriptionLink:
+          "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L24",
+        default: "[]",
+      },
+      transformers: {
+        description: "Transformers for the Shiki pipeline",
+        type: "ShikiTransformer[]",
+        typeDescriptionLink:
+          "https://github.com/shikijs/shiki/blob/ac6bea51b807a82e0a5c9a83796c3abdda0fc293/packages/types/src/transformers.ts#L48",
+        default: "[]",
+      },
+    }).reverse()
+      // This reverts the order of the type table, fumadocs reversed the order on 4/22/25 in:
+      // https://github.com/fuma-nama/fumadocs/commit/3a5595aa65acfa5c20be2377d09c03fbb1de72a6
+  )}
 />
 
 <Callout type="info">

--- a/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
+++ b/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
@@ -60,7 +60,7 @@ export const defaultComponents = memoizeMarkdownComponents({
         theme: {
             description: "Shiki built-in or custom textmate theme(s)",
             type: "string | object",
-            default: "vitesse-dark",
+            default: "github-dark",
             required: true,
         },
         language: {

--- a/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
+++ b/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
@@ -58,6 +58,7 @@ export const defaultComponents = memoizeMarkdownComponents({
     theme: {
       description: "Shiki built‑in or custom textmate theme(s)",
       type: "Theme | Themes",
+      typeDescription: "Shiki BundledTheme or Textmate theme object",
       typeDescriptionLink:
         "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L51",
       default: "github‑dark",
@@ -66,7 +67,7 @@ export const defaultComponents = memoizeMarkdownComponents({
     language: {
       description: "The language for highlighting",
       type: "Language",
-      typeDescription: "Shiki BundledLanguage or Textmate language object",
+      typeDescription: "Shiki BundledLanguage or Textmate grammar object",
       typeDescriptionLink:
         "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L24",
       default: "text",
@@ -80,7 +81,7 @@ export const defaultComponents = memoizeMarkdownComponents({
     style: {
       description: "Inline styles for the `ShikiHighlighter` component",
       type: "React.CSSProperties",
-      default: "{}",
+      default: undefined,
     },
     cssVariablePrefix: {
       description:

--- a/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
+++ b/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
@@ -8,12 +8,12 @@ import { TypeTable } from "fumadocs-ui/components/type-table";
 
 Syntax highlighting for code blocks in markdown.
 
-<Callout type="warn">Syntax highlighting is not included by default.</Callout>
+<Callout type="warn">Syntax highlighting is not enabled in markdown by default.</Callout>
 
 <Callout type="info">
-  `assistant-ui` offers two ways to add syntax highlighting to your markdown: -
-  **react-shiki** (recommended for performance & dynamic language support) -
-  **react-syntax-highlighter** (legacy - Prism or Highlight.js based)
+  `assistant-ui` provides two options for syntax highlighting: 
+  - **react-shiki** (recommended for performance & dynamic language support)
+  - **react-syntax-highlighter** (legacy - Prism or Highlight.js based)
 </Callout>
 
 ---

--- a/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
+++ b/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
@@ -59,7 +59,6 @@ export const defaultComponents = memoizeMarkdownComponents({
       theme: {
         description: "Shiki built-in or custom textmate theme(s)",
         type: "Theme | Themes",
-        typeDescription: "Shiki BundledTheme or Textmate theme object",
         typeDescriptionLink:
           "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L51",
         default: "github-dark",
@@ -68,7 +67,6 @@ export const defaultComponents = memoizeMarkdownComponents({
       language: {
         description: "The language for highlighting",
         type: "Language",
-        typeDescription: "Shiki BundledLanguage or Textmate grammar object",
         typeDescriptionLink:
           "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L24",
         default: "text",
@@ -94,6 +92,8 @@ export const defaultComponents = memoizeMarkdownComponents({
         description:
           "The default theme applied to the code (via inline color style). The rest of the themes are applied via CSS variables, and toggled by CSS overrides. For example, if defaultColor is light, then light theme is applied to the code, and the dark theme and other custom themes are applied via CSS variables",
         type: "light | dark | string | false",
+        typeDescriptionLink:
+          "https://github.com/shikijs/shiki/blob/ac6bea51b807a82e0a5c9a83796c3abdda0fc293/packages/types/src/options.ts#L107",
         default: undefined,
       },
       delay: {
@@ -103,7 +103,7 @@ export const defaultComponents = memoizeMarkdownComponents({
         default: 0,
       },
       customLanguages: {
-        description: "Custom languages to preload for syntax highlighting",
+        description: "Custom languages to preload for highlighting",
         type: "Language[]",
         typeDescriptionLink:
           "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L24",

--- a/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
+++ b/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
@@ -57,7 +57,7 @@ export const defaultComponents = memoizeMarkdownComponents({
   type={Object.fromEntries(
     Object.entries({
       theme: {
-        description: "Shiki built-in or custom textmate theme(s)",
+        description: "Shiki built-in or custom textmate themes. Accepts a single theme or an object of themes mapped to theme mode strings.",
         type: "Theme | Themes",
         typeDescriptionLink:
           "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L51",
@@ -65,35 +65,26 @@ export const defaultComponents = memoizeMarkdownComponents({
         required: true,
       },
       language: {
-        description: "The language for highlighting",
-        type: "Language",
+        description: "Shiki built-in or custom textmate grammar object for highlighting",
+        type: "Language (string | object)",
         typeDescriptionLink:
           "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L24",
         default: "text",
         required: true,
       },
+      as: {
+        description: "The code block container element type",
+        type: "React.ElementType",
+        default: "pre",
+      },
       className: {
-        description: "Custom CSS classes for the `<pre>` element",
+        description: "Custom CSS classes for the container element",
         type: "string",
         default: "",
       },
       style: {
         description: "Inline styles for the `ShikiHighlighter` component",
         type: "React.CSSProperties",
-        default: undefined,
-      },
-      cssVariablePrefix: {
-        description:
-          "Prefix of CSS variables used to store the color of the other theme",
-        type: "string",
-        default: "--shiki-",
-      },
-      defaultColor: {
-        description:
-          "The default theme applied to the code (via inline color style). The rest of the themes are applied via CSS variables, and toggled by CSS overrides. For example, if defaultColor is light, then light theme is applied to the code, and the dark theme and other custom themes are applied via CSS variables",
-        type: "light | dark | string | false",
-        typeDescriptionLink:
-          "https://github.com/shikijs/shiki/blob/ac6bea51b807a82e0a5c9a83796c3abdda0fc293/packages/types/src/options.ts#L107",
         default: undefined,
       },
       delay: {
@@ -107,24 +98,21 @@ export const defaultComponents = memoizeMarkdownComponents({
         type: "Language[]",
         typeDescriptionLink:
           "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L24",
-        default: "[]",
+        default: "",
       },
-      transformers: {
-        description: "Transformers for the Shiki pipeline",
-        type: "ShikiTransformer[]",
+      codeToHastOptions: {
+        description: "All other options supported by Shiki's `codeToHast`",
+        type: "CodeToHastOptions",
         typeDescriptionLink:
-          "https://github.com/shikijs/shiki/blob/ac6bea51b807a82e0a5c9a83796c3abdda0fc293/packages/types/src/transformers.ts#L48",
-        default: "[]",
+          "https://github.com/shikijs/shiki/blob/main/packages/types/src/options.ts#L121",
+        default: "{}",
+        required: true,
       },
     // This reverts the order of the type table, fumadocs reversed the order on 4/22/25 in:
     // https://github.com/fuma-nama/fumadocs/commit/3a5595aa65acfa5c20be2377d09c03fbb1de72a6
     }).reverse()
   )}
 />
-
-<Callout type="info">
-  Support for all Shiki options in react-shiki is coming soon.
-</Callout>
 
 ### Dual/multi theme support
 

--- a/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
+++ b/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
@@ -176,7 +176,7 @@ For more information, see [Shiki's documentation on dual and multi themes](https
 ## react-syntax-highlighter
 
 <Callout type="warn">
-  **This option may be removed in a future release.** Consider using
+  This option may be removed in a future release. Consider using
   [react-shiki](#react-shiki) instead.
 </Callout>
 

--- a/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
+++ b/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
@@ -8,14 +8,12 @@ import { TypeTable } from "fumadocs-ui/components/type-table";
 
 Syntax highlighting for code blocks in markdown.
 
-<Callout type="warn">
-Syntax highlighting is not included by default.
-</Callout>
+<Callout type="warn">Syntax highlighting is not included by default.</Callout>
 
 <Callout type="info">
-`assistant-ui` offers two ways to add syntax highlighting to your markdown:
-- **react-shiki** (recommended for performance & dynamic language support)  
-- **react-syntax-highlighter** (legacy - Prism or Highlight.js based)
+  `assistant-ui` offers two ways to add syntax highlighting to your markdown: -
+  **react-shiki** (recommended for performance & dynamic language support) -
+  **react-syntax-highlighter** (legacy - Prism or Highlight.js based)
 </Callout>
 
 ---
@@ -31,8 +29,8 @@ Syntax highlighting is not included by default.
 npx shadcn@latest add "https://r.assistant-ui.com/shiki-highlighter"
 ```
 
-This adds a `/components/assistant-ui/shiki-highlighter.tsx` file to your project and 
-installs the `react-shiki` dependency. The highlighter can be customized by editing 
+This adds a `/components/assistant-ui/shiki-highlighter.tsx` file to your project and
+installs the `react-shiki` dependency. The highlighter can be customized by editing
 the config in the `shiki-highlighter.tsx` file.
 
   </Step>
@@ -56,59 +54,71 @@ export const defaultComponents = memoizeMarkdownComponents({
 ### Options
 
 <TypeTable
-    type={{
-        theme: {
-            description: "Shiki built-in or custom textmate theme(s)",
-            type: "string | object",
-            default: "github-dark",
-            required: true,
-        },
-        language: {
-            description: "The language for highlighting",
-            type: "BundledLanguage | TextmateLanguage",
-            default: "text",
-            required: true,
-        },
-        className: {
-            description: "Custom CSS classes for the `<pre>` element",
-            type: "string",
-            default: "",
-        },
-        style: {
-            description: "Inline styles for the `ShikiHighlighter` component",
-            type: "CSSProperties",
-            default: "{}",
-        },
-        cssVariablePrefix: {
-            description: "Prefix of CSS variables used to store the color of the other theme",
-            type: "string",
-            default: "--shiki-",
-        },
-        defaultColor: {
-          description: "The default theme applied to the code (via inline color style). The rest of the themes are applied via CSS variables, and toggled by CSS overrides. For example, if defaultColor is light, then light theme is applied to the code, and the dark theme and other custom themes are applied via CSS variables",
-          type: "light | dark | string | false",
-          default: undefined,
-        },
-        delay: {
-            description: "Delay in milliseconds between consecutive highlights, useful for streamed code responses.",
-            type: "number",
-            default: 0,
-        },
-        customLanguages: {
-            description: "Custom languages to preload for syntax highlighting",
-            type: "TextmateLanguage[]",
-            default: "[]",
-        },
-        transformers: {
-            description: "Transformers for the Shiki pipeline",
-            type: "ShikiTransformer[]",
-            default: "[]",
-        },
-    }}
+  type={{
+    theme: {
+      description: "Shiki built‑in or custom textmate theme(s)",
+      type: "Theme | Themes",
+      typeDescriptionLink:
+        "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L51",
+      default: "github‑dark",
+      required: true,
+    },
+    language: {
+      description: "The language for highlighting",
+      type: "Language",
+      typeDescription: "Shiki BundledLanguage or Textmate language object",
+      typeDescriptionLink:
+        "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L24",
+      default: "text",
+      required: true,
+    },
+    className: {
+      description: "Custom CSS classes for the `<pre>` element",
+      type: "string",
+      default: "",
+    },
+    style: {
+      description: "Inline styles for the `ShikiHighlighter` component",
+      type: "React.CSSProperties",
+      default: "{}",
+    },
+    cssVariablePrefix: {
+      description:
+        "Prefix of CSS variables used to store the color of the other theme",
+      type: "string",
+      default: "--shiki-",
+    },
+    defaultColor: {
+      description:
+        "The default theme applied to the code (via inline color style). The rest of the themes are applied via CSS variables, and toggled by CSS overrides. For example, if defaultColor is light, then light theme is applied to the code, and the dark theme and other custom themes are applied via CSS variables",
+      type: "light | dark | string | false",
+      default: undefined,
+    },
+    delay: {
+      description:
+        "Delay in milliseconds between consecutive highlights, useful for streamed code responses.",
+      type: "number",
+      default: 0,
+    },
+    customLanguages: {
+      description: "Custom languages to preload for syntax highlighting",
+      type: "Language[]",
+      typeDescriptionLink:
+        "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L24",
+      default: "[]",
+    },
+    transformers: {
+      description: "Transformers for the Shiki pipeline",
+      type: "ShikiTransformer[]",
+      typeDescriptionLink:
+        "https://github.com/shikijs/shiki/blob/ac6bea51b807a82e0a5c9a83796c3abdda0fc293/packages/types/src/transformers.ts#L48",
+      default: "[]",
+    },
+  }}
 />
 
 <Callout type="info">
-Support for all Shiki options in react-shiki is coming soon.
+  Support for all Shiki options in react-shiki is coming soon.
 </Callout>
 
 ### Dual/multi theme support
@@ -161,8 +171,8 @@ For more information, see [Shiki's documentation on dual and multi themes](https
 ## react-syntax-highlighter
 
 <Callout type="warn">
-**This option may be removed in a future release.**  
-Consider using [react-shiki](#react-shiki) instead.
+  **This option may be removed in a future release.** Consider using
+  [react-shiki](#react-shiki) instead.
 </Callout>
 
 <Steps>

--- a/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
+++ b/apps/docs/content/docs/ui/SyntaxHighlighting.mdx
@@ -57,7 +57,8 @@ export const defaultComponents = memoizeMarkdownComponents({
   type={Object.fromEntries(
     Object.entries({
       theme: {
-        description: "Shiki built-in or custom textmate themes. Accepts a single theme or an object of themes mapped to theme mode strings.",
+        description:
+          "Shiki built-in or custom textmate themes. Accepts a single theme or an object of themes mapped to theme mode strings.",
         type: "Theme | Themes",
         typeDescriptionLink:
           "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L51",
@@ -65,7 +66,8 @@ export const defaultComponents = memoizeMarkdownComponents({
         required: true,
       },
       language: {
-        description: "Shiki built-in or custom textmate grammar object for highlighting",
+        description:
+          "Shiki built-in or custom textmate grammar object for highlighting",
         type: "Language (string | object)",
         typeDescriptionLink:
           "https://github.com/AVGVSTVS96/react-shiki/blob/694433ef697c9791b3816cf94d12d571e8abbb3a/package/src/types.ts#L24",
@@ -78,12 +80,12 @@ export const defaultComponents = memoizeMarkdownComponents({
         default: "pre",
       },
       className: {
-        description: "Custom CSS classes for the container element",
+        description: "Custom CSS classes for the code block container element",
         type: "string",
         default: "",
       },
       style: {
-        description: "Inline styles for the `ShikiHighlighter` component",
+        description: "Inline styles for the code block container element",
         type: "React.CSSProperties",
         default: undefined,
       },


### PR DESCRIPTION
Some minor documentation updates
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Updated `SyntaxHighlighting.mdx` documentation for `react-shiki` and `react-syntax-highlighter` options, including rephrased callouts and updated default values.
> 
>   - **Documentation Updates**:
>     - Rephrased warning about syntax highlighting not being enabled by default in `SyntaxHighlighting.mdx`.
>     - Updated information callout to clarify `assistant-ui` provides two options for syntax highlighting.
>     - Updated default theme for `react-shiki` to `github-dark` and added links to type descriptions in `SyntaxHighlighting.mdx`.
>     - Added note about potential removal of `react-syntax-highlighter` in future releases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1312c3954adb9641784add3ca478dc54e37ceedd. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->