### PR TITLE
fix: disabled tools should still execute if invoked

### DIFF
--- a/.changeset/new-pumpkins-juggle.md
+++ b/.changeset/new-pumpkins-juggle.md
@@ -1,0 +1,8 @@
+---
+"assistant-stream": patch
+"@assistant-ui/react-edge": patch
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react": patch
+---
+
+fix: disabled tools should still execute if invoked

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -96,6 +96,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<
 >;
 
 export type Tool<TArgs = unknown, TResult = unknown> = {
+  disabled?: boolean;
   description?: string | undefined;
   parameters: StandardSchemaV1<TArgs> | JSONSchema7;
   execute?: ToolExecuteFunction<TArgs, TResult>;

--- a/packages/react-edge/src/edge/EdgeModelAdapter.ts
+++ b/packages/react-edge/src/edge/EdgeModelAdapter.ts
@@ -92,6 +92,12 @@ const toAISDKTools = (tools: Record<string, Tool<any, any>>) => {
   );
 };
 
+const getEnabledTools = (tools: Record<string, Tool<any, any>>) => {
+  return Object.fromEntries(
+    Object.entries(tools).filter(([_, tool]) => !tool.disabled),
+  );
+};
+
 export class EdgeModelAdapter implements ChatModelAdapter {
   constructor(private options: EdgeModelAdapterOptions) {}
 
@@ -128,11 +134,10 @@ export class EdgeModelAdapter implements ChatModelAdapter {
                 this.options.unstable_sendMessageIds ||
                 this.options.sendExtraMessageFields,
             }),
-        tools: context.tools
-          ? this.options.unstable_AISDKInterop === "v2"
-            ? (toAISDKTools(context.tools) as any)
-            : toLanguageModelTools(context.tools)
-          : [],
+        tools:
+          this.options.unstable_AISDKInterop === "v2"
+            ? (toAISDKTools(getEnabledTools(context.tools ?? {})) as any)
+            : toLanguageModelTools(getEnabledTools(context.tools ?? {})),
         unstable_assistantMessageId,
         runConfig,
         ...context.callSettings,

--- a/packages/react/src/model-context/tool.ts
+++ b/packages/react/src/model-context/tool.ts
@@ -1,20 +1,7 @@
-import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { Tool } from "assistant-stream";
-import { JSONSchema7 } from "json-schema";
 
-export function tool<
-  TArgs extends Record<string, unknown>,
-  TResult = any,
->(tool: {
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  execute?: (
-    args: TArgs,
-    context: {
-      toolCallId: string;
-      abortSignal: AbortSignal;
-    },
-  ) => TResult | Promise<TResult>;
-}): Tool<TArgs, TResult> {
+export function tool<TArgs extends Record<string, unknown>, TResult = any>(
+  tool: Tool<TArgs, TResult>,
+): Tool<TArgs, TResult> {
   return tool;
 }

--- a/packages/react/src/model-context/useAssistantTool.tsx
+++ b/packages/react/src/model-context/useAssistantTool.tsx
@@ -11,7 +11,6 @@ import type { Tool } from "assistant-stream";
 export type AssistantToolProps<TArgs, TResult> = Tool<TArgs, TResult> & {
   toolName: string;
   render?: ToolCallContentPartComponent<TArgs, TResult> | undefined;
-  disabled?: boolean | undefined;
 };
 
 export const useAssistantTool = <TArgs, TResult>(
@@ -27,9 +26,7 @@ export const useAssistantTool = <TArgs, TResult>(
   }, [toolUIsStore, tool.toolName, tool.render]);
 
   useEffect(() => {
-    const { toolName, render, disabled, ...rest } = tool;
-    if (disabled) return;
-
+    const { toolName, render, ...rest } = tool;
     const context = {
       tools: {
         [toolName]: rest,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disabled tools are now filtered out using `getEnabledTools()` in `EdgeModelAdapter.ts`, allowing them to execute if invoked.
> 
>   - **Behavior**:
>     - Tools with `disabled` property set to `true` are filtered out using `getEnabledTools()` in `EdgeModelAdapter.ts`.
>     - `useAssistantTool.tsx` no longer checks for `disabled` property before registering tools.
>   - **Types**:
>     - Added `disabled?: boolean` to `Tool` type in `tool-types.ts`.
>   - **Functions**:
>     - Added `getEnabledTools()` in `EdgeModelAdapter.ts` to filter out disabled tools.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 49219894ca7711bb3da57f0917165c9b9e1dd0be. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->