### PR TITLE
feat: tighten tool args type to be object

### DIFF
--- a/.changeset/dirty-streets-care.md
+++ b/.changeset/dirty-streets-care.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: tighten tool args type to be object

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -95,7 +95,10 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<
   TResult
 >;
 
-export type Tool<TArgs = unknown, TResult = unknown> = {
+export type Tool<
+  TArgs extends Record<string, unknown> = Record<string, unknown>,
+  TResult = unknown,
+> = {
   disabled?: boolean;
   description?: string | undefined;
   parameters: StandardSchemaV1<TArgs> | JSONSchema7;

--- a/packages/react/src/model-context/makeAssistantTool.tsx
+++ b/packages/react/src/model-context/makeAssistantTool.tsx
@@ -7,7 +7,7 @@ export type AssistantTool = FC & {
   unstable_tool: AssistantToolProps<any, any>;
 };
 
-export const makeAssistantTool = <TArgs, TResult>(
+export const makeAssistantTool = <TArgs extends Record<string, unknown>, TResult>(
   tool: AssistantToolProps<TArgs, TResult>,
 ) => {
   const Tool: AssistantTool = () => {

--- a/packages/react/src/model-context/useAssistantTool.tsx
+++ b/packages/react/src/model-context/useAssistantTool.tsx
@@ -8,12 +8,18 @@ import {
 import type { ToolCallContentPartComponent } from "../types/ContentPartComponentTypes";
 import type { Tool } from "assistant-stream";
 
-export type AssistantToolProps<TArgs, TResult> = Tool<TArgs, TResult> & {
+export type AssistantToolProps<
+  TArgs extends Record<string, unknown>,
+  TResult,
+> = Tool<TArgs, TResult> & {
   toolName: string;
   render?: ToolCallContentPartComponent<TArgs, TResult> | undefined;
 };
 
-export const useAssistantTool = <TArgs, TResult>(
+export const useAssistantTool = <
+  TArgs extends Record<string, unknown>,
+  TResult,
+>(
   tool: AssistantToolProps<TArgs, TResult>,
 ) => {
   const assistantRuntime = useAssistantRuntime();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Tighten tool argument types to be objects by requiring `TArgs` to extend `Record<string, unknown>` in `tool-types.ts`, `makeAssistantTool.tsx`, and `useAssistantTool.tsx`.
> 
>   - **Type Changes**:
>     - In `tool-types.ts`, `Tool<TArgs, TResult>` now requires `TArgs` to extend `Record<string, unknown>`.
>     - In `makeAssistantTool.tsx`, `makeAssistantTool<TArgs, TResult>` now requires `TArgs` to extend `Record<string, unknown>`.
>     - In `useAssistantTool.tsx`, `useAssistantTool<TArgs, TResult>` now requires `TArgs` to extend `Record<string, unknown>`.
>   - **Misc**:
>     - Adds changeset file `dirty-streets-care.md` to document the patch update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c9304067c97014f7720990806991a7c3fae06401. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->