### PR TITLE
feat: Tool.type

### DIFF
--- a/.changeset/upset-cups-start.md
+++ b/.changeset/upset-cups-start.md
@@ -1,0 +1,8 @@
+---
+"assistant-stream": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-edge": patch
+---
+
+feat: Tool.type

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -95,17 +95,59 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<
   TResult
 >;
 
-export type Tool<
+type ToolBase<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
 > = {
-  disabled?: boolean;
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
   /**
    * @deprecated Experimental, API may change.
    */
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+};
+
+type BackendTool<
+  TArgs extends Record<string, unknown> = Record<string, unknown>,
+  TResult = unknown,
+> = ToolBase<TArgs, TResult> & {
+  type?: "backend" | undefined;
+
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+};
+
+type FrontendTool<
+  TArgs extends Record<string, unknown> = Record<string, unknown>,
+  TResult = unknown,
+> = ToolBase<TArgs, TResult> & {
+  type?: "frontend" | undefined;
+
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
   experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
 };
+
+type HumanTool<
+  TArgs extends Record<string, unknown> = Record<string, unknown>,
+  TResult = unknown,
+> = ToolBase<TArgs, TResult> & {
+  type?: "human" | undefined;
+
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+};
+
+export type Tool<
+  TArgs extends Record<string, unknown> = Record<string, unknown>,
+  TResult = unknown,
+> =
+  | FrontendTool<TArgs, TResult>
+  | BackendTool<TArgs, TResult>
+  | HumanTool<TArgs, TResult>;

--- a/packages/react-edge/src/edge/EdgeModelAdapter.ts
+++ b/packages/react-edge/src/edge/EdgeModelAdapter.ts
@@ -94,7 +94,9 @@ const toAISDKTools = (tools: Record<string, Tool<any, any>>) => {
 
 const getEnabledTools = (tools: Record<string, Tool<any, any>>) => {
   return Object.fromEntries(
-    Object.entries(tools).filter(([_, tool]) => !tool.disabled),
+    Object.entries(tools).filter(
+      ([_, tool]) => !tool.disabled && tool.type !== "backend",
+    ),
   );
 };
 

--- a/packages/react/src/model-context/makeAssistantTool.tsx
+++ b/packages/react/src/model-context/makeAssistantTool.tsx
@@ -7,7 +7,10 @@ export type AssistantTool = FC & {
   unstable_tool: AssistantToolProps<any, any>;
 };
 
-export const makeAssistantTool = <TArgs extends Record<string, unknown>, TResult>(
+export const makeAssistantTool = <
+  TArgs extends Record<string, unknown>,
+  TResult,
+>(
   tool: AssistantToolProps<TArgs, TResult>,
 ) => {
   const Tool: AssistantTool = () => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `type` property to `Tool` for differentiating tool types and update filtering logic in `EdgeModelAdapter.ts`.
> 
>   - **Tool Types**:
>     - Introduces `type` property to `Tool` in `tool-types.ts`, with possible values: `frontend`, `backend`, `human`.
>     - Defines `FrontendTool`, `BackendTool`, and `HumanTool` types extending `ToolBase`.
>   - **Behavior Changes**:
>     - `getEnabledTools` in `EdgeModelAdapter.ts` now filters out tools with `type: "backend"`.
>   - **Misc**:
>     - Minor formatting changes in `makeAssistantTool.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 5b371fb46916d4a9883577143fbb3b03c485c7a2. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->