### PR TITLE
Add support to check `<MessagePrimitive.If last>`

### DIFF
--- a/.changeset/tall-humans-pretend.md
+++ b/.changeset/tall-humans-pretend.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: MessagePrimitive.If last

--- a/packages/react/src/primitives/message/MessageIf.tsx
+++ b/packages/react/src/primitives/message/MessageIf.tsx
@@ -15,6 +15,7 @@ type MessageIfFilters = {
   hasBranches: boolean | undefined;
   copied: boolean | undefined;
   lastOrHover: boolean | undefined;
+  last: boolean | undefined;
   speaking: boolean | undefined;
   hasAttachments: boolean | undefined;
   hasContent: boolean | undefined;
@@ -47,6 +48,7 @@ const useMessageIf = (props: UseMessageIfProps) => {
       if (props.system && role !== "system") return false;
 
       if (props.lastOrHover === true && !isHovering && !isLast) return false;
+      if (props.last === true && !isLast) return false;
 
       if (props.copied === true && !isCopied) return false;
       if (props.copied === false && isCopied) return false;


### PR DESCRIPTION
Previously, you could only check if a message was last *or* hovering. This change allows checking if a message is *only* last. For example:

```tsx
// components/assistant-ui/thread.tsx
const AssistantMessage: FC = () => {

  return (
    <MessagePrimitive.Root className="grid grid-cols-[auto_auto_1fr] grid-rows-[auto_1fr] relative w-full max-w-[var(--thread-max-width)] py-4">
      <div className="text-foreground max-w-[calc(var(--thread-max-width)*0.8)] break-words leading-7 col-span-2 col-start-2 row-start-1 my-1.5">
        <div className="flex gap-2 items-center">
          {/*
            Render a loading spinner if the message is currently being generated, but ONLY on the current (last) message.
          */}
          <ThreadPrimitive.If running>
            <MessagePrimitive.If last>
              <SpinningLoader/>
              <p className="opacity-50"><i>Generating message...</i></p>
            </MessagePrimitive.If>
          </ThreadPrimitive.If>
        </div>
        <MessagePrimitive.Content components={{ Text: MarkdownText }} />
      </div>

      <AssistantActionBar />

      <BranchPicker className="col-start-2 row-start-2 -ml-2 mr-2" />
    </MessagePrimitive.Root>
  );
};
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support to check if a message is only the last one using a new `last` filter in `MessageIf.tsx`.
> 
>   - **Behavior**:
>     - Adds support to check if a message is only the last one using `last` filter in `useMessageIf` in `MessageIf.tsx`.
>     - Previously, only `lastOrHover` was available, which checked for last or hovering states.
>   - **Types**:
>     - Adds `last: boolean | undefined` to `MessageIfFilters` in `MessageIf.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 83121849e19cd66ecc4185502c14b4c5df320c35. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->