### PR TITLE
fix: show eslint warnings in editor

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
 link-workspace-packages=true
 prefer-workspace-packages=true
+public-hoist-pattern[]=*@nextui-org/*
+public-hoist-pattern[]=*eslint*

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,0 +1,1 @@
+export { default } from "./packages/x-buildutils/eslint";

--- a/packages/x-buildutils/package.json
+++ b/packages/x-buildutils/package.json
@@ -12,6 +12,7 @@
     "@tsconfig/strictest": "^2.0.5",
     "cross-spawn": "^7.0.6",
     "esbuild-plugin-file-path-extensions": "^2.1.4",
+    "eslint-config-next": "15.3.1",
     "postcss": "^8.5.3",
     "postcss-js": "^4.0.1",
     "tsup": "8.4.0",
@@ -20,6 +21,7 @@
   "devDependencies": {
     "@types/cross-spawn": "^6.0.6",
     "@types/node": "^22.14.1",
-    "@types/postcss-js": "^4.0.4"
+    "@types/postcss-js": "^4.0.4",
+    "jiti": "^2.4.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1771,6 +1771,9 @@ importers:
       esbuild-plugin-file-path-extensions:
         specifier: ^2.1.4
         version: 2.1.4
+      eslint-config-next:
+        specifier: 15.3.1
+        version: 15.3.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
@@ -1793,6 +1796,9 @@ importers:
       '@types/postcss-js':
         specifier: ^4.0.4
         version: 4.0.4
+      jiti:
+        specifier: ^2.4.2
+        version: 2.4.2
 
 packages:
 
@@ -3263,8 +3269,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.0.0
+      react-dom: 19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Show ESLint warnings in the editor by configuring ESLint and updating dependencies.
> 
>   - **Behavior**:
>     - ESLint warnings are now shown in the editor by exporting ESLint configuration from `eslint.config.ts`.
>   - **Configuration**:
>     - Updates `.npmrc` to include `public-hoist-pattern` for `*@nextui-org/*` and `*eslint*`.
>   - **Dependencies**:
>     - Adds `eslint-config-next` to dependencies in `packages/x-buildutils/package.json`.
>     - Adds `jiti` to devDependencies in `packages/x-buildutils/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 72544124c77baa92f94d262104577497120239a0. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->