### PR TITLE
fix: incorrect domain in example section of assistant-ui website

### DIFF
--- a/apps/docs/app/(home)/examples/mem0/page.tsx
+++ b/apps/docs/app/(home)/examples/mem0/page.tsx
@@ -12,7 +12,7 @@ export default function Component() {
           <iframe
             title="Mem0 - ChatGPT with memory demo"
             className="h-full w-full border border-gray-200"
-            src="https://demo.mem0.ai/"
+            src="https://mem0-4vmi.vercel.app/"
           />
         </div>
       </div>


### PR DESCRIPTION
The previous example used the `demo.mem0.ai` domain, which has since been changed and no longer renders correctly. This update replaces it with the corresponding Vercel deployment URL to ensure the example remains functional and accurate.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update iframe `src` in `page.tsx` to correct domain for example rendering.
> 
>   - **Behavior**:
>     - Update iframe `src` in `page.tsx` from `https://demo.mem0.ai/` to `https://mem0-4vmi.vercel.app/` to ensure correct rendering of the example.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for a0320e7c8c9e24d1aa48fceddf8fef728f84d8a9. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->