### PR TITLE
fix(build): Preserve Zod schema inference by explicitly passing parameters

### DIFF
--- a/packages/react-hook-form/src/useAssistantForm.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.tsx
@@ -25,35 +25,35 @@ export type UseAssistantFormProps<
   TTransformedValues,
 > = UseFormProps<TFieldValues, TContext, TTransformedValues> & {
   assistant?:
+  | {
+    tools?:
     | {
-        tools?:
-          | {
-              set_form_field?:
-                | {
-                    render?:
-                      | ToolCallContentPartComponent<
-                          z.infer<
-                            (typeof formTools.set_form_field)["parameters"]
-                          >,
-                          unknown
-                        >
-                      | undefined;
-                  }
-                | undefined;
-              submit_form?:
-                | {
-                    render?:
-                      | ToolCallContentPartComponent<
-                          z.infer<(typeof formTools.submit_form)["parameters"]>,
-                          unknown
-                        >
-                      | undefined;
-                  }
-                | undefined;
-            }
-          | undefined;
+      set_form_field?:
+      | {
+        render?:
+        | ToolCallContentPartComponent<
+          z.infer<
+            (typeof formTools.set_form_field)["parameters"]
+          >,
+          unknown
+        >
+        | undefined;
       }
+      | undefined;
+      submit_form?:
+      | {
+        render?:
+        | ToolCallContentPartComponent<
+          z.infer<(typeof formTools.submit_form)["parameters"]>,
+          unknown
+        >
+        | undefined;
+      }
+      | undefined;
+    }
     | undefined;
+  }
+  | undefined;
 };
 
 export const useAssistantForm = <
@@ -74,6 +74,7 @@ export const useAssistantForm = <
       tools: {
         set_form_field: tool({
           ...formTools.set_form_field,
+          parameters: formTools.set_form_field.parameters,
           execute: async (args) => {
             setValue(
               args.name as Path<TFieldValues>,
@@ -123,9 +124,9 @@ export const useAssistantForm = <
   useAssistantToolUI(
     renderFormFieldTool
       ? {
-          toolName: "set_form_field",
-          render: renderFormFieldTool,
-        }
+        toolName: "set_form_field",
+        render: renderFormFieldTool,
+      }
       : null,
   );
 
@@ -133,9 +134,9 @@ export const useAssistantForm = <
   useAssistantToolUI(
     renderSubmitFormTool
       ? {
-          toolName: "submit_form",
-          render: renderSubmitFormTool,
-        }
+        toolName: "submit_form",
+        render: renderSubmitFormTool,
+      }
       : null,
   );
 


### PR DESCRIPTION
Explicitly pass `parameters` to `set_form_field` tool to preserve Zod schema inference. The spread was widening the type, leaving args untyped.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Explicitly pass `parameters` to `set_form_field` tool in `useAssistantForm.tsx` to preserve Zod schema inference, preventing type widening.
> 
>   - **Behavior**:
>     - Explicitly pass `parameters` to `set_form_field` tool in `useAssistantForm.tsx` to preserve Zod schema inference.
>     - Previously, the spread operator widened the type, leaving arguments untyped.
>   - **Functions**:
>     - Update `useAssistantForm` to include `parameters` in `set_form_field` tool configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1e2e1f89757e2318cbfd4a36252f3a3e5d26f762. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->