### PR TITLE
Add dummy `tsconfig.json` file

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
I work with a local fork of `assistant-ui`, which is stored in a submodule. However, my project (the "parent" one) has its own `tsconfig.json` file, which is being picked up by `assistant-ui` and causing build errors when running `pnpm turbo build`.

This PR adds a dummy `tsconfig.json` file to prevent this error.
