### PR TITLE
fix: patch Safari/iOS attachment issue by adding/removing input element to DOM

### DIFF
--- a/.changeset/wicked-chicken-warn.md
+++ b/.changeset/wicked-chicken-warn.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: patch Safari/iOS attachment issue by adding/removing input element to DOM

--- a/packages/react/src/primitives/composer/ComposerAddAttachment.tsx
+++ b/packages/react/src/primitives/composer/ComposerAddAttachment.tsx
@@ -26,15 +26,23 @@ const useComposerAddAttachment = ({
     if (attachmentAccept !== "*") {
       input.accept = attachmentAccept;
     }
-
+    
+    document.body.appendChild(input);
+    
     input.onchange = (e) => {
       const fileList = (e.target as HTMLInputElement).files;
       if (!fileList) return;
       for (const file of fileList) {
         composerRuntime.addAttachment(file);
       }
+
+      document.body.removeChild(input);
     };
 
+    input.oncancel = () => {
+      document.body.removeChild(input);
+    }
+    
     input.click();
   }, [composerRuntime, multiple]);
 

--- a/packages/react/src/primitives/composer/ComposerAddAttachment.tsx
+++ b/packages/react/src/primitives/composer/ComposerAddAttachment.tsx
@@ -21,6 +21,7 @@ const useComposerAddAttachment = ({
     const input = document.createElement("input");
     input.type = "file";
     input.multiple = multiple;
+    input.hidden = true;
 
     const attachmentAccept = composerRuntime.getAttachmentAccept();
     if (attachmentAccept !== "*") {

--- a/packages/react/src/primitives/composer/ComposerAddAttachment.tsx
+++ b/packages/react/src/primitives/composer/ComposerAddAttachment.tsx
@@ -40,7 +40,9 @@ const useComposerAddAttachment = ({
     };
 
     input.oncancel = () => {
-      document.body.removeChild(input);
+      if (!input.files || input.files.length === 0) {
+        document.body.removeChild(input);
+      }
     }
     
     input.click();


### PR DESCRIPTION
Problem: Upon clicking the add attachment button, the file does not get attached because the input element is absent in the DOM.

Solution: 
1. Add the input element to the DOM so that it becomes clickable.
2. Remove it from DOM after usage.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Safari/iOS attachment issue by appending/removing input element to/from DOM in `useComposerAddAttachment`.
> 
>   - **Behavior**:
>     - Fixes Safari/iOS attachment issue by appending input element to DOM in `useComposerAddAttachment` in `ComposerAddAttachment.tsx`.
>     - Removes input element from DOM after file selection or cancellation.
>   - **Functions**:
>     - Modifies `useComposerAddAttachment` to append and remove input element from DOM.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 12e3058480bfdec9da65b30cac6915d175b393bb. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->