### PR TITLE
refactor: remove -aui- prefix in colors in tailwind styles

### DIFF
--- a/apps/docs/components/assistant-ui/thread.tsx
+++ b/apps/docs/components/assistant-ui/thread.tsx
@@ -227,7 +227,7 @@ const AssistantActionBar: FC = () => {
       hideWhenRunning
       autohide="not-last"
       autohideFloat="single-branch"
-      className="text-muted-foreground data-[floating]:bg-aui-background col-start-3 row-start-2 -ml-1 flex gap-1 data-[floating]:absolute data-[floating]:rounded-md data-[floating]:border data-[floating]:p-1 data-[floating]:shadow-sm"
+      className="text-muted-foreground data-[floating]:bg-background col-start-3 row-start-2 -ml-1 flex gap-1 data-[floating]:absolute data-[floating]:rounded-md data-[floating]:border data-[floating]:p-1 data-[floating]:shadow-sm"
     >
       {/* <MessagePrimitive.If speaking={false}>
         <ActionBarPrimitive.Speak asChild>

--- a/apps/docs/components/docs-chat/thread.tsx
+++ b/apps/docs/components/docs-chat/thread.tsx
@@ -235,7 +235,7 @@ const AssistantActionBar: FC = () => {
       hideWhenRunning
       autohide="not-last"
       autohideFloat="single-branch"
-      className="text-muted-foreground data-[floating]:bg-aui-background col-start-3 row-start-2 -ml-1 flex gap-1 data-[floating]:absolute data-[floating]:rounded-md data-[floating]:border data-[floating]:p-1 data-[floating]:shadow-sm"
+      className="text-muted-foreground data-[floating]:bg-background col-start-3 row-start-2 -ml-1 flex gap-1 data-[floating]:absolute data-[floating]:rounded-md data-[floating]:border data-[floating]:p-1 data-[floating]:shadow-sm"
     >
       <ActionBarPrimitive.Copy asChild>
         <TooltipIconButton tooltip="Copy">

--- a/apps/docs/components/samples/speech-sample.tsx
+++ b/apps/docs/components/samples/speech-sample.tsx
@@ -168,7 +168,7 @@ const AssistantActionBar: FC = () => {
       hideWhenRunning
       autohide="not-last"
       autohideFloat="single-branch"
-      className="text-muted-foreground data-[floating]:bg-aui-background col-start-3 row-start-2 -ml-1 flex gap-1 data-[floating]:absolute data-[floating]:rounded-md data-[floating]:border data-[floating]:p-1 data-[floating]:shadow-sm"
+      className="text-muted-foreground data-[floating]:bg-background col-start-3 row-start-2 -ml-1 flex gap-1 data-[floating]:absolute data-[floating]:rounded-md data-[floating]:border data-[floating]:p-1 data-[floating]:shadow-sm"
     >
       <MessagePrimitive.If speaking={false}>
         <ActionBarPrimitive.Speak asChild>

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -17,12 +17,7 @@ const tailwindStyles = Object.entries({
   return {
     key: key.replace(/^\./, ""),
     value: Object.keys(value)
-      .map((key) =>
-        key
-          .replace(/^\@apply /, "")
-          .replaceAll("-aui-", "-")
-          .replaceAll("max-w-thread", "max-w-aui-thread"),
-      )
+      .map((key) => key.replace(/^\@apply /, ""))
       .filter((k) => k)
       .join(" "),
   };

--- a/packages/styles/src/styles/config.css
+++ b/packages/styles/src/styles/config.css
@@ -5,41 +5,41 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
-  --color-aui-background: hsl(var(--aui-background));
-  --color-aui-foreground: hsl(var(--aui-foreground));
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
 
-  --color-aui-card: hsl(var(--aui-card));
-  --color-aui-card-foreground: hsl(var(--aui-card-foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
 
-  --color-aui-popover: hsl(var(--aui-popover));
-  --color-aui-popover-foreground: hsl(var(--aui-popover-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
 
-  --color-aui-primary: hsl(var(--aui-primary));
-  --color-aui-primary-foreground: hsl(var(--aui-primary-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
 
-  --color-aui-secondary: hsl(var(--aui-secondary));
-  --color-aui-secondary-foreground: hsl(var(--aui-secondary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
 
-  --color-aui-muted: hsl(var(--aui-muted));
-  --color-aui-muted-foreground: hsl(var(--aui-muted-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
 
-  --color-aui-accent: hsl(var(--aui-accent));
-  --color-aui-accent-foreground: hsl(var(--aui-accent-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
 
-  --color-aui-destructive: hsl(var(--aui-destructive));
-  --color-aui-destructive-foreground: hsl(var(--aui-destructive-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
 
-  --color-aui-border: hsl(var(--aui-border));
-  --color-aui-input: hsl(var(--aui-input));
-  --color-aui-ring: hsl(var(--aui-ring));
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
 
-  --color-aui-chart-1: hsl(var(--aui-chart-1));
-  --color-aui-chart-2: hsl(var(--aui-chart-2));
-  --color-aui-chart-3: hsl(var(--aui-chart-3));
-  --color-aui-chart-4: hsl(var(--aui-chart-4));
-  --color-aui-chart-5: hsl(var(--aui-chart-5));
+  --color-chart-1: hsl(var(--chart-1));
+  --color-chart-2: hsl(var(--chart-2));
+  --color-chart-3: hsl(var(--chart-3));
+  --color-chart-4: hsl(var(--chart-4));
+  --color-chart-5: hsl(var(--chart-5));
 
-  --radius-aui-lg: var(--aui-radius);
-  --radius-aui-md: calc(var(--aui-radius) - 2px);
-  --radius-aui-sm: calc(var(--aui-radius) - 4px);
+  --radius-lg: var(--radius);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: calc(var(--radius) - 4px);
 }

--- a/packages/styles/src/styles/tailwindcss/base-components.css
+++ b/packages/styles/src/styles/tailwindcss/base-components.css
@@ -1,26 +1,26 @@
 .aui-root {
-  @apply text-aui-foreground;
+  @apply text-foreground;
 }
 
 .aui-root * {
-  @apply border-aui-border;
+  @apply border-border;
 }
 
 /* shadcn-ui/button */
 .aui-button {
-  @apply focus-visible:ring-aui-ring inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0;
+  @apply focus-visible:ring-ring inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0;
 }
 
 .aui-button-primary {
-  @apply bg-aui-primary text-aui-primary-foreground hover:bg-aui-primary/90 shadow;
+  @apply bg-primary text-primary-foreground hover:bg-primary/90 shadow;
 }
 
 .aui-button-outline {
-  @apply border-aui-input bg-aui-background hover:bg-aui-accent hover:text-aui-accent-foreground border shadow-sm;
+  @apply border-input bg-background hover:bg-accent hover:text-accent-foreground border shadow-sm;
 }
 
 .aui-button-ghost {
-  @apply hover:bg-aui-accent hover:text-aui-accent-foreground;
+  @apply hover:bg-accent hover:text-accent-foreground;
 }
 
 .aui-button-medium {
@@ -47,13 +47,13 @@
 }
 
 .aui-avatar-fallback {
-  @apply bg-aui-muted flex h-full w-full items-center justify-center rounded-full;
+  @apply bg-muted flex h-full w-full items-center justify-center rounded-full;
 }
 
 /* shadcn-ui/tooltip */
 
 .aui-tooltip-content {
-  @apply bg-aui-primary text-aui-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 overflow-hidden rounded-md px-3 py-1.5 text-xs;
+  @apply bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 overflow-hidden rounded-md px-3 py-1.5 text-xs;
 }
 
 /* shadcn-ui/dialog */
@@ -65,5 +65,5 @@
 .aui-dialog-content {
   @apply data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50;
   @apply grid translate-x-[-50%] translate-y-[-50%] shadow-lg duration-200;
-  /* @apply w-full bg-aui-background max-w-lg gap-4 border p-6 sm:rounded-lg; */
+  /* @apply w-full bg-background max-w-lg gap-4 border p-6 sm:rounded-lg; */
 }

--- a/packages/styles/src/styles/tailwindcss/markdown.css
+++ b/packages/styles/src/styles/tailwindcss/markdown.css
@@ -28,7 +28,7 @@
 }
 
 .aui-md-a {
-  @apply text-aui-primary font-medium underline underline-offset-4;
+  @apply text-primary font-medium underline underline-offset-4;
 }
 
 .aui-md-blockquote {
@@ -52,7 +52,7 @@
 }
 
 .aui-md-th {
-  @apply bg-aui-muted px-4 py-2 text-left font-bold first:rounded-tl-lg last:rounded-tr-lg [&[align=center]]:text-center [&[align=right]]:text-right;
+  @apply bg-muted px-4 py-2 text-left font-bold first:rounded-tl-lg last:rounded-tr-lg [&[align=center]]:text-center [&[align=right]]:text-right;
 }
 
 .aui-md-td {
@@ -72,7 +72,7 @@
 }
 
 .aui-md-inline-code {
-  @apply bg-aui-muted rounded border font-semibold;
+  @apply bg-muted rounded border font-semibold;
 }
 
 .aui-code-header-root {

--- a/packages/styles/src/styles/tailwindcss/modal.css
+++ b/packages/styles/src/styles/tailwindcss/modal.css
@@ -1,5 +1,5 @@
 .aui-modal-content {
-  @apply bg-aui-popover text-aui-popover-foreground z-50 h-[500px] w-[400px] overflow-clip rounded-xl border p-0 shadow-md outline-none;
+  @apply bg-popover text-popover-foreground z-50 h-[500px] w-[400px] overflow-clip rounded-xl border p-0 shadow-md outline-none;
   @apply [&>.aui-thread-root]:bg-inherit;
 
   @apply data-[state=closed]:animate-out data-[state=open]:animate-in;

--- a/packages/styles/src/styles/tailwindcss/thread.css
+++ b/packages/styles/src/styles/tailwindcss/thread.css
@@ -1,6 +1,6 @@
 /* thread */
 .aui-thread-root {
-  @apply bg-aui-background box-border flex h-full flex-col overflow-hidden;
+  @apply bg-background box-border flex h-full flex-col overflow-hidden;
 }
 
 .aui-thread-viewport {
@@ -8,7 +8,7 @@
 }
 
 .aui-thread-viewport-footer {
-  @apply sticky bottom-0 mt-3 flex w-full max-w-[var(--aui-thread-max-width)] flex-col items-center justify-end rounded-t-lg bg-inherit pb-4;
+  @apply sticky bottom-0 mt-3 flex w-full max-w-[var(--thread-max-width)] flex-col items-center justify-end rounded-t-lg bg-inherit pb-4;
 }
 
 .aui-thread-scroll-to-bottom {
@@ -20,13 +20,13 @@
 }
 
 .aui-thread-followup-suggestion {
-  @apply bg-aui-background hover:bg-aui-muted/80 rounded-full border px-3 py-1 text-sm transition-colors ease-in;
+  @apply bg-background hover:bg-muted/80 rounded-full border px-3 py-1 text-sm transition-colors ease-in;
 }
 
 /* thread welcome */
 
 .aui-thread-welcome-root {
-  @apply flex w-full max-w-[var(--aui-thread-max-width)] flex-grow flex-col;
+  @apply flex w-full max-w-[var(--thread-max-width)] flex-grow flex-col;
 }
 
 .aui-thread-welcome-center {
@@ -42,7 +42,7 @@
 }
 
 .aui-thread-welcome-suggestion {
-  @apply hover:bg-aui-muted/80 flex max-w-sm grow basis-0 flex-col items-center justify-center rounded-lg border p-3 transition-colors ease-in;
+  @apply hover:bg-muted/80 flex max-w-sm grow basis-0 flex-col items-center justify-center rounded-lg border p-3 transition-colors ease-in;
 }
 
 .aui-thread-welcome-suggestion-text {
@@ -52,11 +52,11 @@
 /* thread composer */
 
 .aui-composer-root {
-  @apply focus-within:border-aui-ring/20 flex w-full flex-wrap items-end rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in;
+  @apply focus-within:border-ring/20 flex w-full flex-wrap items-end rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in;
 }
 
 .aui-composer-input {
-  @apply placeholder:text-aui-muted-foreground max-h-40 flex-grow resize-none border-none bg-transparent px-2 py-4 text-sm outline-none focus:ring-0 disabled:cursor-not-allowed;
+  @apply placeholder:text-muted-foreground max-h-40 flex-grow resize-none border-none bg-transparent px-2 py-4 text-sm outline-none focus:ring-0 disabled:cursor-not-allowed;
 }
 
 .aui-composer-send {
@@ -84,11 +84,11 @@
 }
 
 .aui-attachment-preview-trigger {
-  @apply hover:bg-aui-accent/50 cursor-pointer transition-colors;
+  @apply hover:bg-accent/50 cursor-pointer transition-colors;
 }
 
 .aui-attachment-thumb {
-  @apply bg-aui-muted flex size-10 items-center justify-center rounded border text-sm;
+  @apply bg-muted flex size-10 items-center justify-center rounded border text-sm;
 }
 
 .aui-attachment-text {
@@ -96,22 +96,22 @@
 }
 
 .aui-attachment-name {
-  @apply text-aui-muted-foreground line-clamp-1 text-ellipsis break-all text-xs font-bold;
+  @apply text-muted-foreground line-clamp-1 text-ellipsis break-all text-xs font-bold;
 }
 
 .aui-attachment-type {
-  @apply text-aui-muted-foreground text-xs;
+  @apply text-muted-foreground text-xs;
 }
 
 .aui-attachment-remove {
-  @apply text-aui-muted-foreground [&>svg]:bg-aui-background absolute -right-3 -top-3 size-6 [&>svg]:size-4 [&>svg]:rounded-full;
+  @apply text-muted-foreground [&>svg]:bg-background absolute -right-3 -top-3 size-6 [&>svg]:size-4 [&>svg]:rounded-full;
 }
 
 /* user message */
 
 .aui-user-message-root {
   @apply grid auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] gap-y-2 [&:where(>*)]:col-start-2;
-  @apply w-full max-w-[var(--aui-thread-max-width)] py-4;
+  @apply w-full max-w-[var(--thread-max-width)] py-4;
 }
 
 :where(.aui-user-message-root) > .aui-branch-picker-root {
@@ -125,7 +125,7 @@
 }
 
 .aui-user-message-content {
-  @apply bg-aui-muted text-aui-foreground max-w-[calc(var(--aui-thread-max-width)*0.8)] break-words rounded-3xl px-5 py-2.5;
+  @apply bg-muted text-foreground max-w-[calc(var(--thread-max-width)*0.8)] break-words rounded-3xl px-5 py-2.5;
 
   @apply col-start-2 row-start-2;
 }
@@ -148,11 +148,11 @@
 /* edit composer */
 
 .aui-edit-composer-root {
-  @apply bg-aui-muted my-4 flex w-full max-w-[var(--aui-thread-max-width)] flex-col gap-2 rounded-xl;
+  @apply bg-muted my-4 flex w-full max-w-[var(--thread-max-width)] flex-col gap-2 rounded-xl;
 }
 
 .aui-edit-composer-input {
-  @apply text-aui-foreground flex h-8 w-full resize-none bg-transparent p-4 pb-0 outline-none;
+  @apply text-foreground flex h-8 w-full resize-none bg-transparent p-4 pb-0 outline-none;
 }
 
 .aui-edit-composer-footer {
@@ -163,7 +163,7 @@
 
 .aui-assistant-message-root {
   @apply grid grid-cols-[auto_auto_1fr] grid-rows-[auto_1fr];
-  @apply relative w-full max-w-[var(--aui-thread-max-width)] py-4;
+  @apply relative w-full max-w-[var(--thread-max-width)] py-4;
 }
 
 :where(.aui-assistant-message-root) > .aui-avatar-root {
@@ -185,7 +185,7 @@
 }
 
 .aui-assistant-message-content {
-  @apply text-aui-foreground max-w-[calc(var(--aui-thread-max-width)*0.8)] break-words leading-7;
+  @apply text-foreground max-w-[calc(var(--thread-max-width)*0.8)] break-words leading-7;
 
   @apply col-span-2 col-start-2 row-start-1 my-1.5;
 }
@@ -193,11 +193,11 @@
 /* assistant action bar */
 
 .aui-assistant-action-bar-root {
-  @apply text-aui-muted-foreground flex gap-1;
+  @apply text-muted-foreground flex gap-1;
 
   @apply col-start-3 row-start-2;
   @apply -ml-1;
-  @apply data-[floating]:bg-aui-background data-[floating]:absolute data-[floating]:rounded-md data-[floating]:border data-[floating]:p-1 data-[floating]:shadow-sm;
+  @apply data-[floating]:bg-background data-[floating]:absolute data-[floating]:rounded-md data-[floating]:border data-[floating]:p-1 data-[floating]:shadow-sm;
 }
 
 .aui-assistant-action-bar-feedback-positive {
@@ -211,7 +211,7 @@
 /* branch picker */
 
 .aui-branch-picker-root {
-  @apply text-aui-muted-foreground inline-flex items-center text-xs;
+  @apply text-muted-foreground inline-flex items-center text-xs;
 }
 
 .aui-branch-picker-state {
@@ -235,11 +235,11 @@
 }
 
 .aui-thread-list-item {
-  @apply data-[active]:bg-aui-muted hover:bg-aui-muted focus-visible:bg-aui-muted focus-visible:ring-aui-ring flex items-center gap-2 rounded-lg transition-all focus-visible:outline-none focus-visible:ring-2;
+  @apply data-[active]:bg-muted hover:bg-muted focus-visible:bg-muted focus-visible:ring-ring flex items-center gap-2 rounded-lg transition-all focus-visible:outline-none focus-visible:ring-2;
 }
 
 .aui-thread-list-new {
-  @apply data-[active]:bg-aui-muted hover:bg-aui-muted flex items-center justify-start gap-1 rounded-lg px-2.5 py-2 text-start;
+  @apply data-[active]:bg-muted hover:bg-muted flex items-center justify-start gap-1 rounded-lg px-2.5 py-2 text-start;
 }
 
 .aui-thread-list-new > .lucide-plus {
@@ -255,5 +255,5 @@
 }
 
 .aui-thread-list-item-archive {
-  @apply hover:text-aui-primary text-aui-foreground ml-auto mr-3 size-4 p-0;
+  @apply hover:text-primary text-foreground ml-auto mr-3 size-4 p-0;
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `-aui-` prefix from Tailwind CSS color variables and class names across styles and components for consistency.
> 
>   - **Styles**:
>     - Remove `-aui-` prefix from color variables in `config.css`, affecting variables like `--color-aui-background` to `--color-background`.
>     - Update class names in `base-components.css`, `markdown.css`, `modal.css`, and `thread.css` to remove `-aui-` prefix, e.g., `.aui-root` to `.root`.
>   - **Components**:
>     - Update `className` attributes in `thread.tsx`, `docs-chat/thread.tsx`, and `speech-sample.tsx` to reflect new class names without `-aui-` prefix.
>   - **Scripts**:
>     - Modify `build-registry.ts` to remove `-aui-` prefix handling in `transformClassnames()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 02b9e7aaa08bbfee9d4b20ae3f950eda4efd29ea. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->