### PR TITLE
style: add spacer class for thread viewport layout (non-tailwind)

### DIFF
--- a/packages/styles/src/styles/tailwindcss/thread.css
+++ b/packages/styles/src/styles/tailwindcss/thread.css
@@ -11,6 +11,10 @@
   @apply sticky bottom-0 mt-3 flex w-full max-w-[var(--thread-max-width)] flex-col items-center justify-end rounded-t-lg bg-inherit pb-4;
 }
 
+.aui-thread-viewport-spacer {
+  @apply flex-grow min-h-8;
+}
+
 .aui-thread-scroll-to-bottom {
   @apply absolute -top-8 rounded-full disabled:invisible;
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `.aui-thread-viewport-spacer` class in `thread.css` for flexible spacing in thread viewport layout.
> 
>   - **Styles**:
>     - Adds `.aui-thread-viewport-spacer` class in `thread.css`.
>     - Applies `flex-grow` and `min-h-8` to `.aui-thread-viewport-spacer` for flexible spacing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 729021f97602438a9ef24a236417c6e5ada39f6d. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->