### PR TITLE
fix: assistant message accumulator typesafety

### DIFF
--- a/packages/assistant-stream/src/core/AssistantStreamChunk.ts
+++ b/packages/assistant-stream/src/core/AssistantStreamChunk.ts
@@ -82,7 +82,7 @@ export type AssistantStreamChunk = { readonly path: readonly number[] } & (
     }
   | {
       readonly type: "result";
-      readonly artifact?: ReadonlyJSONValue | undefined;
+      readonly artifact?: ReadonlyJSONValue;
       readonly result: ReadonlyJSONValue;
       readonly isError: boolean;
     }

--- a/packages/assistant-stream/src/core/modules/tool-call.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.ts
@@ -57,7 +57,9 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
     this._controller.enqueue({
       type: "result",
       path: [],
-      artifact: response.artifact,
+      ...(response.artifact !== undefined
+        ? { artifact: response.artifact }
+        : {}),
       result: response.result,
       isError: response.isError ?? false,
     });

--- a/packages/assistant-stream/src/core/tool/ToolResponse.ts
+++ b/packages/assistant-stream/src/core/tool/ToolResponse.ts
@@ -13,12 +13,14 @@ export class ToolResponse<TResult> {
     return true;
   }
 
-  readonly artifact?: ReadonlyJSONValue | undefined;
+  readonly artifact?: ReadonlyJSONValue;
   readonly result: TResult;
   readonly isError: boolean;
 
   constructor(options: ToolResponseInit<TResult>) {
-    this.artifact = options.artifact;
+    if (options.artifact !== undefined) {
+      this.artifact = options.artifact;
+    }
     this.result = options.result;
     this.isError = options.isError ?? false;
   }

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -94,7 +94,9 @@ export async function unstable_runPendingTools(
             return {
               ...p,
               state: "result" as const,
-              artifact: result.artifact,
+              ...(result.artifact !== undefined
+                ? { artifact: result.artifact }
+                : {}),
               result: result.result as ReadonlyJSONValue,
               isError: result.isError,
             };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances type safety and state handling in assistant message accumulators by adding `update-state` chunk type and refining `artifact` inclusion logic.
> 
>   - **Behavior**:
>     - Adds handling for `update-state` chunk type in `assistant-message-accumulator.ts`.
>     - Ensures `artifact` is only included in `result` chunks when defined in `AssistantStreamChunk.ts`, `tool-call.ts`, and `toolResultStream.ts`.
>   - **Error Handling**:
>     - Adds error checks for `partial-call` state in `handleToolCallArgsTextFinish()` in `assistant-message-accumulator.ts`.
>   - **Misc**:
>     - Imports `ObjectStreamAccumulator` in `assistant-message-accumulator.ts` for state updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 504c59a20ee0337227bbba2e9b729e097583835b. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->