### PR TITLE
Add attachment paste functionality to ComposerInput

### DIFF
--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -167,6 +167,5 @@ export const ComposerPrimitiveInput = forwardRef<
   },
 );
 
-// paste, if on paste check if thread supports attachments. If so try to add, some will error.
 
 ComposerPrimitiveInput.displayName = "ComposerPrimitive.Input";

--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -33,7 +33,7 @@ export namespace ComposerPrimitiveInput {
     unstable_focusOnScrollToBottom?: boolean | undefined;
     unstable_focusOnThreadSwitched?: boolean | undefined;
     addAttachmentOnPaste?: boolean | undefined;
-  }
+  };
 }
 
 export const ComposerPrimitiveInput = forwardRef<
@@ -108,7 +108,7 @@ export const ComposerPrimitiveInput = forwardRef<
         try {
           e.preventDefault();
           await Promise.all(
-            files.map(file => composerRuntime.addAttachment(file))
+            files.map((file) => composerRuntime.addAttachment(file)),
           );
         } catch (error) {
           console.error("Error adding attachment:", error);
@@ -169,6 +169,5 @@ export const ComposerPrimitiveInput = forwardRef<
     );
   },
 );
-
 
 ComposerPrimitiveInput.displayName = "ComposerPrimitive.Input";

--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -105,11 +105,14 @@ export const ComposerPrimitiveInput = forwardRef<
       const files = Array.from(e.clipboardData?.files || []);
 
       if (threadCapabilities.attachments && files.length > 0) {
-        await Promise.all(
-          files.map(file => composerRuntime.addAttachment(file))
-        );
-        
-        e.preventDefault();
+        try {
+          e.preventDefault();
+          await Promise.all(
+            files.map(file => composerRuntime.addAttachment(file))
+          );
+        } catch (error) {
+          console.error("Error adding attachment:", error);
+        }
       }
     };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds attachment paste functionality to `ComposerPrimitiveInput` in `ComposerInput.tsx` with a new `addAttachmentOnPaste` prop and `handlePaste` function.
> 
>   - **Feature Addition**:
>     - Adds `addAttachmentOnPaste` prop to `ComposerPrimitiveInput` in `ComposerInput.tsx` to enable attachment pasting.
>     - Implements `handlePaste` function to handle clipboard events and add attachments using `composerRuntime.addAttachment()`.
>     - Prevents default paste behavior and logs errors if attachment addition fails.
>   - **Event Handling**:
>     - Uses `composeEventHandlers` to integrate `handlePaste` with existing `onPaste` event in `ComposerPrimitiveInput`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 4723caa1bc57efef7af2cfa9657394c7f649557c. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->