### PR TITLE
feat: ThreadListItem.detach()

### DIFF
--- a/.changeset/sour-dogs-cry.md
+++ b/.changeset/sour-dogs-cry.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-edge": patch
+"@assistant-ui/react": patch
+---
+
+feat: ThreadListItem.detach()

--- a/packages/react-edge/src/edge/EdgeModelAdapter.ts
+++ b/packages/react-edge/src/edge/EdgeModelAdapter.ts
@@ -122,7 +122,9 @@ export class EdgeModelAdapter implements ChatModelAdapter {
         ? await this.options.headers()
         : this.options.headers;
 
-    abortSignal.addEventListener("abort", () => this.options.onCancel);
+    abortSignal.addEventListener("abort", () => {
+      if (!abortSignal.reason?.detach) this.options.onCancel?.();
+    });
 
     const headers = new Headers(headersValue);
     headers.set("Content-Type", "application/json");

--- a/packages/react-edge/src/edge/EdgeModelAdapter.ts
+++ b/packages/react-edge/src/edge/EdgeModelAdapter.ts
@@ -124,7 +124,7 @@ export class EdgeModelAdapter implements ChatModelAdapter {
 
     abortSignal.addEventListener("abort", () => {
       if (!abortSignal.reason?.detach) this.options.onCancel?.();
-    });
+    }, { once: true });
 
     const headers = new Headers(headersValue);
     headers.set("Content-Type", "application/json");

--- a/packages/react-edge/src/edge/EdgeModelAdapter.ts
+++ b/packages/react-edge/src/edge/EdgeModelAdapter.ts
@@ -122,9 +122,13 @@ export class EdgeModelAdapter implements ChatModelAdapter {
         ? await this.options.headers()
         : this.options.headers;
 
-    abortSignal.addEventListener("abort", () => {
-      if (!abortSignal.reason?.detach) this.options.onCancel?.();
-    }, { once: true });
+    abortSignal.addEventListener(
+      "abort",
+      () => {
+        if (!abortSignal.reason?.detach) this.options.onCancel?.();
+      },
+      { once: true },
+    );
 
     const headers = new Headers(headersValue);
     headers.set("Content-Type", "application/json");

--- a/packages/react/src/api/ThreadListItemRuntime.ts
+++ b/packages/react/src/api/ThreadListItemRuntime.ts
@@ -34,6 +34,11 @@ export type ThreadListItemRuntime = {
   unarchive(): Promise<void>;
   delete(): Promise<void>;
 
+  /**
+   * Detaches the ThreadListItem instance, unmounting the ThreadRuntime hook.
+   */
+  detach(): void;
+
   subscribe(callback: () => void): Unsubscribe;
 
   unstable_on(
@@ -68,6 +73,7 @@ export class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
     this.subscribe = this.subscribe.bind(this);
     this.unstable_on = this.unstable_on.bind(this);
     this.getState = this.getState.bind(this);
+    this.detach = this.detach.bind(this);
   }
 
   public getState(): ThreadListItemState {
@@ -131,5 +137,11 @@ export class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
 
   public subscribe(callback: () => void): Unsubscribe {
     return this._core.subscribe(callback);
+  }
+
+  public detach(): void {
+    const state = this._core.getState();
+
+    this._threadListBinding.detach(state.id);
   }
 }

--- a/packages/react/src/runtimes/core/ThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/ThreadListRuntimeCore.tsx
@@ -30,6 +30,7 @@ export type ThreadListRuntimeCore = {
   getLoadThreadsPromise(): Promise<void>;
   // getLoadArchivedThreadsPromise(): Promise<void>;
 
+  detach(threadId: string): Promise<void>;
   rename(threadId: string, newTitle: string): Promise<void>;
   archive(threadId: string): Promise<void>;
   unarchive(threadId: string): Promise<void>;

--- a/packages/react/src/runtimes/external-store/ExternalStoreThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreThreadListRuntimeCore.tsx
@@ -139,6 +139,10 @@ export class ExternalStoreThreadListRuntimeCore
     onRename(threadId, newTitle);
   }
 
+  public async detach(): Promise<void> {
+    // no-op
+  }
+
   public async archive(threadId: string): Promise<void> {
     const onArchive = this.adapter.onArchive;
     if (!onArchive)

--- a/packages/react/src/runtimes/local/LocalThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalThreadListRuntimeCore.tsx
@@ -74,6 +74,10 @@ export class LocalThreadListRuntimeCore
     throw new Error("Method not implemented.");
   }
 
+  public detach(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
   public unarchive(): Promise<void> {
     throw new Error("Method not implemented.");
   }

--- a/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
@@ -371,8 +371,13 @@ export class LocalThreadRuntimeCore
     return message;
   }
 
+  public detach() {
+    this.abortController?.abort({ detach: true });
+    this.abortController = null;
+  }
+
   public cancelRun() {
-    this.abortController?.abort();
+    this.abortController?.abort({ detach: false });
     this.abortController = null;
   }
 

--- a/packages/react/src/runtimes/local/useLocalRuntime.tsx
+++ b/packages/react/src/runtimes/local/useLocalRuntime.tsx
@@ -29,6 +29,12 @@ const useLocalThreadRuntime = (
   const [runtime] = useState(() => new LocalRuntimeCore(opt, initialMessages));
 
   useEffect(() => {
+    return () => {
+      runtime.threads.getMainThreadRuntimeCore().detach();
+    };
+  });
+
+  useEffect(() => {
     runtime.threads.getMainThreadRuntimeCore().__internal_setOptions(opt);
     runtime.threads.getMainThreadRuntimeCore().__internal_load();
   }, [runtime, opt]);

--- a/packages/react/src/runtimes/local/useLocalRuntime.tsx
+++ b/packages/react/src/runtimes/local/useLocalRuntime.tsx
@@ -32,7 +32,7 @@ const useLocalThreadRuntime = (
     return () => {
       runtime.threads.getMainThreadRuntimeCore().detach();
     };
-  });
+  }, [runtime]);
 
   useEffect(() => {
     runtime.threads.getMainThreadRuntimeCore().__internal_setOptions(opt);

--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 "use client";
 
 import {
@@ -138,6 +139,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   private _OuterActiveThreadProvider: FC<{
     threadId: string;
     provider: ComponentType<PropsWithChildren>;
+    // eslint-disable-next-line react/display-name
   }> = memo(({ threadId, provider: Provider }) => {
     const assistantRuntime = useAssistantRuntime();
     const threadListItemRuntime = useMemo(

--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
@@ -528,10 +528,17 @@ export class RemoteThreadListThreadListRuntimeCore
     });
   }
 
+  public async detach(threadId: string): Promise<void> {
+    await this._ensureThreadIsNotMain(threadId);
+    this._hookManager.stopThreadRuntime(threadId);
+  }
+
   private useBoundIds = create<string[]>(() => []);
 
   public __internal_RenderComponent: FC = () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const id = useId();
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
       this.useBoundIds.setState((s) => [...s, id], true);
       return () => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `detach()` method to `ThreadListItem` and related components to unmount thread runtime hooks and handle abort signals.
> 
>   - **Behavior**:
>     - Adds `detach()` method to `ThreadListItemRuntime` and `ThreadListItemRuntimeImpl` in `ThreadListItemRuntime.ts` to unmount the `ThreadRuntime` hook.
>     - Updates `EdgeModelAdapter` in `EdgeModelAdapter.ts` to handle abort signals with a `detach` reason.
>     - Implements `detach()` in `RemoteThreadListThreadListRuntimeCore.tsx` and `LocalThreadRuntimeCore.tsx` to stop thread runtime and handle abort signals.
>   - **Runtimes**:
>     - Adds `detach()` method to `ThreadListRuntimeCore` in `ThreadListRuntimeCore.tsx`.
>     - Implements `detach()` as a no-op in `ExternalStoreThreadListRuntimeCore.tsx` and throws an error in `LocalThreadListRuntimeCore.tsx`.
>   - **Hooks**:
>     - Uses `detach()` in `useLocalRuntime.tsx` to unmount main thread runtime on component unmount.
>     - Updates `RemoteThreadListHookInstanceManager.tsx` to manage thread runtime instances and stop them using `detach()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for e632caf6f0d3fd6adac7cd2c38e592c95053c53b. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->