### PR TITLE
chore(docs): add info on changesets to `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,3 +37,24 @@ To run the examples project in development mode:
 cd examples/<your-example>
 pnpm dev
 ```
+
+### Adding a changeset
+
+Every pull request that changes packages must include a changeset, otherwise your changes won't be published to npm.
+
+Note, this does not apply to packages like `@assistant-ui/docs` or `@assistant-ui/shadcn-registry` which are not published to npm, they are deployed on Vercel.
+
+Create a changeset by running:
+
+```sh
+pnpm changeset
+```
+
+This will detect which packages changed and prompt you to select type (major, minor, patch) and a description of your changes. For now, most changes in assistant-ui should be classified as a patch.
+
+If you forget to add a changeset before merging, create a new PR and run `pnpm changeset` locally to create a changeset. You'll be prompted to manually select the packages that were changed, set update type, and add description. Commit the changeset file, push the changes, and merge the PR.
+
+You can also add changesets on open PRs directly from GitHub using the changeset bot's link in PR comments.
+
+### Releasing
+Our CI checks for changesets in `.changeset/` on `main` and will create an "update versions" PR which versions the packages, updates the changelog, and publishes the packages to npm on merge.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds changeset instructions to `CONTRIBUTING.md`, detailing creation, exceptions, and release process.
> 
>   - **Documentation**:
>     - Adds a section on changesets to `CONTRIBUTING.md`.
>     - Explains that every PR changing packages must include a changeset, except for non-npm packages like `@assistant-ui/docs`.
>     - Details the process to create a changeset using `pnpm changeset` and how to handle missed changesets.
>     - Describes how to add changesets via GitHub using the changeset bot.
>     - Outlines the release process where CI checks for changesets and creates an "update versions" PR.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 3abb5e09b6fa293734f0c9998b8ff3b03e13092a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->