### PR TITLE
fix: error message contrast in dark mode

### DIFF
--- a/.changeset/smart-panthers-laugh.md
+++ b/.changeset/smart-panthers-laugh.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/styles": patch
+---
+
+fix: error message contrast in dark mode

--- a/packages/styles/src/styles/tailwindcss/thread.css
+++ b/packages/styles/src/styles/tailwindcss/thread.css
@@ -197,7 +197,7 @@
 }
 
 .aui-message-error-root {
-  @apply border-destructive bg-destructive/10 text-destructive mt-2 rounded-md border p-3 text-sm;
+  @apply border-destructive bg-destructive/10 dark:text-red-200 dark:bg-destructive/5 text-destructive mt-2 rounded-md border p-3 text-sm;
 }
 
 .aui-message-error-message {


### PR DESCRIPTION
accidentally merged before pushing this
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves error message contrast in dark mode in `thread.css`.
> 
>   - **Styles**:
>     - In `thread.css`, updated `.aui-message-error-root` to improve contrast in dark mode by applying `dark:text-red-200` and `dark:bg-destructive/5`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 8bbb564e624e3176510ac6e9c48a8835f89451e4. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->