### PR TITLE
chore(docs): add page for `makeAssistantToolUI`

### DIFF
--- a/apps/docs/content/docs/copilots/make-assistant-tool-ui.mdx
+++ b/apps/docs/content/docs/copilots/make-assistant-tool-ui.mdx
@@ -1,0 +1,77 @@
+---
+title: makeAssistantToolUI
+description: Reference for the makeAssistantToolUI utility.
+---
+
+import { ParametersTable } from "@/components/docs";
+
+# `makeAssistantToolUI`
+
+The `makeAssistantToolUI` utility is used to register a tool UI component with the Assistant.
+
+## Usage
+
+```tsx
+import { makeAssistantToolUI } from "assistant-ui/react";
+
+const MyToolUI = makeAssistantToolUI({
+  toolName: "myTool",
+  render: ({ args, result, status }) => {
+    // render your tool UI here
+  },
+});
+```
+
+## API
+
+### `makeAssistantToolUI(tool)`
+
+#### Parameters
+
+<ParametersTable
+  type="AssistantToolUIProps<TArgs, TResult>"
+  parameters={[
+    {
+      name: "toolName",
+      type: "string",
+      description: "The name of the tool. This must match the name of the tool defined in the assistant.",
+    },
+    {
+      name: "render",
+      type: "function",
+      description: "A function that renders the tool UI. It receives an object with the following properties: `args` (any): The arguments passed to the tool. `result` (any): The result of the tool execution. `status` (\"requires_action\" | \"in_progress\" | \"complete\" | \"error\"): The status of the tool execution.",
+    },
+  ]}
+/>
+
+#### Returns
+
+A React functional component that should be included in your component tree. This component doesn't render anything itself, but it registers the tool UI with the Assistant.
+
+## Example
+
+```tsx
+import { makeAssistantToolUI } from "assistant-ui/react";
+import { AssistantRuntimeProvider } from "assistant-ui/react/providers"; // Assuming this path
+
+const GetWeatherUI = makeAssistantToolUI({
+  toolName: "get_weather",
+  render: ({ args, result, status }) => {
+    if (status === "requires_action") return <p>Getting weather for {args.location}...</p>;
+    if (status === "in_progress") return <p>Loading...</p>;
+    if (status === "error") return <p>Error getting weather.</p>;
+    if (status === "complete") return <p>The weather is {result.weather}.</p>;
+    return null;
+  },
+});
+
+function App() {
+  return (
+    <AssistantRuntimeProvider>
+      {/* ...your other components */}
+      <GetWeatherUI />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+This example shows how to create a simple UI for a `get_weather` tool. The UI will display different messages depending on the status of the tool execution.

--- a/apps/docs/content/docs/copilots/make-assistant-tool-ui.mdx
+++ b/apps/docs/content/docs/copilots/make-assistant-tool-ui.mdx
@@ -12,7 +12,7 @@ The `makeAssistantToolUI` utility is used to register a tool UI component with t
 ## Usage
 
 ```tsx
-import { makeAssistantToolUI } from "assistant-ui/react";
+import { makeAssistantToolUI } from "assistant-ui/";
 
 const MyToolUI = makeAssistantToolUI({
   toolName: "myTool",
@@ -46,13 +46,13 @@ const MyToolUI = makeAssistantToolUI({
 
 #### Returns
 
-A React functional component that should be included in your component tree. This component doesn't render anything itself, but it registers the tool UI with the Assistant.
+A  functional component that should be included in your component tree. This component doesn't render anything itself, but it registers the tool UI with the Assistant.
 
 ## Example
 
 ```tsx
-import { makeAssistantToolUI } from "assistant-ui/react";
-import { AssistantRuntimeProvider } from "assistant-ui/react/providers"; // Assuming this path
+import { makeAssistantToolUI } from "assistant-ui/";
+import { AssistantRuntimeProvider } from "assistant-ui/"; // Assuming this path
 
 const GetWeatherUI = makeAssistantToolUI({
   toolName: "get_weather",

--- a/apps/docs/content/docs/copilots/make-assistant-tool-ui.mdx
+++ b/apps/docs/content/docs/copilots/make-assistant-tool-ui.mdx
@@ -51,7 +51,7 @@ A React functional component that should be included in your component tree. Thi
 
 ```tsx
 import { makeAssistantToolUI } from "assistant-ui/react";
-import { AssistantRuntimeProvider } from "assistant-ui/react/providers"; // Assuming this path
+import { AssistantRuntimeProvider } from "assistant-ui/react";
 
 const GetWeatherUI = makeAssistantToolUI({
   toolName: "get_weather",

--- a/apps/docs/content/docs/copilots/make-assistant-tool-ui.mdx
+++ b/apps/docs/content/docs/copilots/make-assistant-tool-ui.mdx
@@ -1,6 +1,5 @@
 ---
 title: makeAssistantToolUI
-description: Reference for the makeAssistantToolUI utility.
 ---
 
 import { ParametersTable } from "@/components/docs";
@@ -12,7 +11,7 @@ The `makeAssistantToolUI` utility is used to register a tool UI component with t
 ## Usage
 
 ```tsx
-import { makeAssistantToolUI } from "assistant-ui/";
+import { makeAssistantToolUI } from "assistant-ui/react";
 
 const MyToolUI = makeAssistantToolUI({
   toolName: "myTool",
@@ -46,13 +45,13 @@ const MyToolUI = makeAssistantToolUI({
 
 #### Returns
 
-A  functional component that should be included in your component tree. This component doesn't render anything itself, but it registers the tool UI with the Assistant.
+A React functional component that should be included in your component tree. This component doesn't render anything itself, but it registers the tool UI with the Assistant.
 
 ## Example
 
 ```tsx
-import { makeAssistantToolUI } from "assistant-ui/";
-import { AssistantRuntimeProvider } from "assistant-ui/"; // Assuming this path
+import { makeAssistantToolUI } from "assistant-ui/react";
+import { AssistantRuntimeProvider } from "assistant-ui/react/providers"; // Assuming this path
 
 const GetWeatherUI = makeAssistantToolUI({
   toolName: "get_weather",

--- a/apps/docs/content/docs/copilots/meta.json
+++ b/apps/docs/content/docs/copilots/meta.json
@@ -4,6 +4,7 @@
     "motivation",
     "make-assistant-visible",
     "make-assistant-tool",
+    "make-assistant-tool-ui",
     "use-assistant-instructions",
     "model-context"
   ]


### PR DESCRIPTION
Testing Google's [Jules Agent](https://jules.google.com), it's available for free!

This commit introduces a new documentation page for the `makeAssistantToolUI` utility.

The page includes:
- An explanation of the utility's purpose.
- Usage examples demonstrating how to register a tool UI.
- API documentation for `makeAssistantToolUI`, detailing its parameters and return value, using the custom `ParametersTable` component for clarity.
- An example illustrating how to display different UI elements based on tool execution status.

This new documentation page is located in the "Copilots" section.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds documentation for `makeAssistantToolUI` utility, including usage, API, and examples, and updates `meta.json`.
> 
>   - **Documentation**:
>     - Adds `make-assistant-tool-ui.mdx` to document `makeAssistantToolUI` utility.
>     - Includes purpose, usage examples, API details, and a status-based UI example.
>     - Uses `ParametersTable` for parameter clarity.
>   - **Meta Update**:
>     - Updates `meta.json` to include `make-assistant-tool-ui` in the Copilots section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d64f01c50389e0524233fb6e5a96aa07bf5957cc. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->