### PR TITLE
fix: shiki styles for non tw users

### DIFF
--- a/.changeset/moody-clocks-do.md
+++ b/.changeset/moody-clocks-do.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/styles": patch
+---
+
+fix: shiki styles for non tw users

--- a/apps/registry/components/assistant-ui/shiki-highlighter.tsx
+++ b/apps/registry/components/assistant-ui/shiki-highlighter.tsx
@@ -38,7 +38,7 @@ export const SyntaxHighlighter: FC<HighlighterProps> = ({
   ...props
 }) => {
   const BASE_STYLES =
-    "[&_pre]:overflow-x-auto [&_pre]:rounded-b-lg [&_pre]:bg-black [&_pre]:p-4 [&_pre]:text-white";
+    "aui-shiki-base";
 
   return (
     <ShikiHighlighter

--- a/packages/styles/src/styles/tailwindcss/markdown.css
+++ b/packages/styles/src/styles/tailwindcss/markdown.css
@@ -1,3 +1,16 @@
+/* code */
+.aui-shiki-base {
+  @apply [&_pre]:overflow-x-auto [&_pre]:rounded-b-lg [&_pre]:bg-black [&_pre]:p-4 [&_pre]:text-white;
+}
+
+.aui-code-header-root {
+  @apply flex items-center justify-between gap-4 rounded-t-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white;
+}
+
+.aui-code-header-language {
+  @apply lowercase [&>span]:text-xs;
+}
+
 /* typography */
 .aui-md-h1 {
   @apply mb-8 scroll-m-20 text-4xl font-extrabold tracking-tight last:mb-0;
@@ -75,10 +88,4 @@
   @apply bg-muted rounded border font-semibold;
 }
 
-.aui-code-header-root {
-  @apply flex items-center justify-between gap-4 rounded-t-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white;
-}
 
-.aui-code-header-language {
-  @apply lowercase [&>span]:text-xs;
-}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces inline styles in `SyntaxHighlighter` with `aui-shiki-base` class and updates `markdown.css` for consistent styling.
> 
>   - **Styling**:
>     - Replaces inline styles in `SyntaxHighlighter` component in `shiki-highlighter.tsx` with `aui-shiki-base` class.
>     - Adds `aui-shiki-base` class to `markdown.css` to apply styles: `overflow-x-auto`, `rounded-b-lg`, `bg-black`, `p-4`, `text-white`.
>   - **Code Cleanup**:
>     - Removes duplicate styles for `.aui-code-header-root` and `.aui-code-header-language` from `markdown.css`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for e4c9ddb025c99b1c40b51cae86b1906a4f357f90. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->