### PR TITLE
fix(ci): Add `rootDir` to `tsconfig.json` in `@assistant-ui/react`

### DIFF
--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@assistant-ui/x-buildutils/ts/base",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
Addition of `rootDir` to `packages/react/tesconfig.json`

```json
"compilerOptions": {
  "rootDir": "src"
},
```


This is needed to fix build errors when deploying on node22