### PR TITLE
build: throw an error if type builds fail

### DIFF
--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -71,9 +71,15 @@ const transpileTypescriptDts = async () => {
   ]);
   child.stdout.pipe(process.stdout);
   child.stderr.pipe(process.stderr);
-  return new Promise((r, e) => {
-    child.on("exit", r);
-    child.on("error", e);
+  return new Promise((resolve, reject) => {
+    child.on("exit", (code) => {
+      if (code !== 0) {
+        reject(new Error(`TypeScript type generation failed with exit code ${code}`));
+      } else {
+        resolve(code);
+      }
+    });
+    child.on("error", reject);
   });
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `transpileTypescriptDts()` now throws an error if TypeScript type generation fails, improving error handling in the build process.
> 
>   - **Behavior**:
>     - `transpileTypescriptDts()` in `index.ts` now throws an error if TypeScript type generation fails, rejecting the promise with an error message including the exit code.
>   - **Error Handling**:
>     - Adds error handling for non-zero exit codes in `transpileTypescriptDts()` to ensure build failures are reported.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 32f99f02e3f590547906add2e40fa0e2dc9d0180. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->