### PR TITLE
fix: Last is not a partial call error

### DIFF
--- a/packages/assistant-stream/CHANGELOG.md
+++ b/packages/assistant-stream/CHANGELOG.md
@@ -1,5 +1,11 @@
 # assistant-stream
 
+## 0.2.11
+
+### Patch Changes
+
+- fix: Last is not a partial call error
+
 ## 0.2.10
 
 ### Patch Changes

--- a/packages/assistant-stream/package.json
+++ b/packages/assistant-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant-stream",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/assistant-stream/src/core/modules/tool-call.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.ts
@@ -53,8 +53,10 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
 
   private _argsTextController!: TextStreamController;
 
-  setResponse(response: ToolResponseInit<ReadonlyJSONValue>) {
+  async setResponse(response: ToolResponseInit<ReadonlyJSONValue>) {
     this._argsTextController.close();
+    await Promise.resolve(); // flush microtask queue
+    // TODO switch argsTextController to be something that doesn'#t require this
     this._controller.enqueue({
       type: "result",
       path: [],

--- a/packages/react-edge/package.json
+++ b/packages/react-edge/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@ai-sdk/provider": "^1.1.3",
-    "assistant-stream": "^0.2.10",
+    "assistant-stream": "^0.2.11",
     "json-schema": "^0.4.0",
     "zod": "^3.25.28",
     "zod-to-json-schema": "^3.24.5"

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -25,7 +25,7 @@
     "zod": "^3.25.28"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.13",
+    "@assistant-ui/react": "^0.10.14",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -22,12 +22,12 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "assistant-stream": "^0.2.10",
+    "assistant-stream": "^0.2.11",
     "uuid": "^11.1.0",
     "zod": "^3.25.28"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.13",
+    "@assistant-ui/react": "^0.10.14",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -34,7 +34,7 @@
     "react-markdown": "^10.1.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.13",
+    "@assistant-ui/react": "^0.10.14",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint ."
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.13",
+    "@assistant-ui/react": "^0.10.14",
     "@assistant-ui/react-markdown": "^0.10.4",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @assistant-ui/react
 
+## 0.10.14
+
+### Patch Changes
+
+- fix: Last is not a partial call error
+- Updated dependencies
+  - assistant-stream@0.2.11
+
 ## 0.10.13
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.10.13",
+  "version": "0.10.14",
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -64,7 +64,7 @@
     "@radix-ui/react-use-callback-ref": "^1.1.1",
     "@radix-ui/react-use-escape-keydown": "^1.1.1",
     "@standard-schema/spec": "^1.0.0",
-    "assistant-stream": "^0.2.10",
+    "assistant-stream": "^0.2.11",
     "json-schema": "^0.4.0",
     "nanoid": "5.1.5",
     "react-textarea-autosize": "^8.5.9",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix 'Last is not a partial call' error in `ToolCallStreamControllerImpl` and update package versions to reflect the fix.
> 
>   - **Behavior**:
>     - Fix 'Last is not a partial call' error in `ToolCallStreamControllerImpl` by making `setResponse` asynchronous and flushing the microtask queue.
>   - **Version Updates**:
>     - Bump version of `assistant-stream` to `0.2.11` in `package.json`.
>     - Update dependencies in `react-edge`, `react-hook-form`, `react-langgraph`, `react-markdown`, `react-syntax-highlighter`, and `react` to use `assistant-stream@0.2.11`.
>     - Update `@assistant-ui/react` to `0.10.14` in `react-hook-form`, `react-langgraph`, `react-markdown`, and `react-syntax-highlighter`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for df10491369f92cd781a64035300e6e59f85755fd. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->