### PR TITLE
fix: useAssistant should correctly display

### DIFF
--- a/.changeset/sour-phones-join.md
+++ b/.changeset/sour-phones-join.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-edge": patch
+---
+
+fix: useAssistant should correctly display


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactors message conversion logic in `convertMessage.ts` by introducing `convertParts` function and updates `AISDKMessageConverter` to use it.
> 
>   - **Functionality**:
>     - Introduces `convertParts` function in `convertMessage.ts` to handle message part conversion logic.
>     - Refactors `AISDKMessageConverter` to use `convertParts` for `user`, `system`, and `assistant` roles.
>   - **Error Handling**:
>     - Throws error for unsupported message part types in `convertParts`.
>     - Throws error for unsupported message roles in `AISDKMessageConverter`.
>   - **Changeset**:
>     - Adds patch updates for `@assistant-ui/react-ai-sdk` and `@assistant-ui/react-edge`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 3b827e8538485b5c37aefb50b6a2865f6dabcbad. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->