### PR TITLE
fix(message): add missing condition in `MessageIf`

### DIFF
--- a/.changeset/neat-boxes-count.md
+++ b/.changeset/neat-boxes-count.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(message): add missing condition in `MessageIf`

--- a/packages/react/src/primitives/message/MessageIf.tsx
+++ b/packages/react/src/primitives/message/MessageIf.tsx
@@ -49,6 +49,7 @@ const useMessageIf = (props: UseMessageIfProps) => {
 
       if (props.lastOrHover === true && !isHovering && !isLast) return false;
       if (props.last === true && !isLast) return false;
+      if (props.last === false && isLast) return false;
 
       if (props.copied === true && !isCopied) return false;
       if (props.copied === false && isCopied) return false;

--- a/packages/react/src/primitives/message/MessageIf.tsx
+++ b/packages/react/src/primitives/message/MessageIf.tsx
@@ -48,8 +48,7 @@ const useMessageIf = (props: UseMessageIfProps) => {
       if (props.system && role !== "system") return false;
 
       if (props.lastOrHover === true && !isHovering && !isLast) return false;
-      if (props.last === true && !isLast) return false;
-      if (props.last === false && isLast) return false;
+      if (props.last !== undefined && props.last !== isLast) return false;
 
       if (props.copied === true && !isCopied) return false;
       if (props.copied === false && isCopied) return false;


### PR DESCRIPTION
Add condition to exclude last message when last prop is false.
This prevents rendering the last message incorrectly when last is
explicitly set to false, fixes #2042
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a condition in `useMessageIf` in `MessageIf.tsx` to prevent rendering the last message when `last` is false, fixing issue #2042.
> 
>   - **Behavior**:
>     - Adds condition `if (props.last === false && isLast) return false;` in `useMessageIf` in `MessageIf.tsx`.
>     - Prevents rendering the last message when `last` is explicitly set to false.
>   - **Issue Fix**:
>     - Fixes issue #2042 related to incorrect rendering of the last message.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 2ee8fd3e87c335ae6375fd022a5a7eebdd9a7849. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->