### PR TITLE
fix: add support for artifact and isError for langgraph tool calls

### DIFF
--- a/.changeset/puny-queens-smell.md
+++ b/.changeset/puny-queens-smell.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: addToolResponse ToolResponse support

--- a/.changeset/ripe-owls-arrive.md
+++ b/.changeset/ripe-owls-arrive.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+feat: langgraph human tool call artifact/isError support

--- a/.changeset/rotten-news-wish.md
+++ b/.changeset/rotten-news-wish.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: add support for artifact and isError for langgraph tool calls

--- a/.changeset/silent-phones-tap.md
+++ b/.changeset/silent-phones-tap.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+feat: ToolResponseLike

--- a/apps/docs/components/docs/parameters/context.tsx
+++ b/apps/docs/components/docs/parameters/context.tsx
@@ -36,7 +36,7 @@ export const AssistantToolUIsState: ParametersTableProps = {
             },
             {
               name: "addResult",
-              type: "(result: TResult) => void",
+              type: "(result: TResult | ToolResponse<TResult>) => void",
               description: "Adds a result to the tool call.",
             },
           ],

--- a/apps/docs/components/docs/parameters/runtime.tsx
+++ b/apps/docs/components/docs/parameters/runtime.tsx
@@ -113,7 +113,7 @@ export const AssistantRuntimeProviderProps = () => {
                 },
                 {
                   name: "addToolResult",
-                  type: "(toolCallId: string, result: any) => void",
+                  type: "(options: AddToolResultOptions) => void",
                   required: true,
                   description: "A function to add a tool result.",
                 },

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -12,12 +12,14 @@ import { ParametersTable } from "@/components/docs";
 `ExternalStoreRuntime` bridges your existing state management with assistant-ui components. It requires an `ExternalStoreAdapter<TMessage>` that handles communication between your state and the UI.
 
 **Key differences from `LocalRuntime`:**
+
 - **You own the state** - Full control over message state, thread management, and persistence logic
 - **Bring your own state management** - Works with Redux, Zustand, TanStack Query, or any React state library
 - **Custom message formats** - Use your backend's message structure with automatic conversion
 
 <Callout type="warn">
-`ExternalStoreRuntime` gives you total control over state (persist, sync, share), but you must wire up every callback.
+  `ExternalStoreRuntime` gives you total control over state (persist, sync,
+  share), but you must wire up every callback.
 </Callout>
 
 ## Example Implementation
@@ -288,7 +290,9 @@ Controls how adjacent assistant messages are combined:
 This is useful when your backend sends multiple message chunks that should appear as a single message in the UI.
 
 <Callout type="info">
-`useExternalMessageConverter` provides performance optimization for complex message conversion scenarios. For simpler cases, consider using the basic `convertMessage` approach shown above.
+  `useExternalMessageConverter` provides performance optimization for complex
+  message conversion scenarios. For simpler cases, consider using the basic
+  `convertMessage` approach shown above.
 </Callout>
 
 ### Essential Handlers
@@ -302,7 +306,7 @@ const runtime = useExternalStoreRuntime({
     // Add user message to state
     const userMsg = { role: "user", content: message.content };
     setMessages([...messages, userMsg]);
-    
+
     // Get AI response
     const response = await callAI(message);
     setMessages([...messages, userMsg, response]);
@@ -316,19 +320,17 @@ const runtime = useExternalStoreRuntime({
 const runtime = useExternalStoreRuntime({
   messages,
   setMessages, // Enables branch switching
-  onNew,       // Required
-  onEdit,      // Enables message editing
-  onReload,    // Enables regeneration
-  onCancel,    // Enables cancellation
+  onNew, // Required
+  onEdit, // Enables message editing
+  onReload, // Enables regeneration
+  onCancel, // Enables cancellation
 });
 ```
 
 <Callout type="info">
-Each handler you provide enables specific UI features:
-- `setMessages` → Branch switching
-- `onEdit` → Message editing
-- `onReload` → Regenerate button
-- `onCancel` → Cancel button during generation
+  Each handler you provide enables specific UI features: - `setMessages` →
+  Branch switching - `onEdit` → Message editing - `onReload` → Regenerate button
+  - `onCancel` → Cancel button during generation
 </Callout>
 
 ### Streaming Responses
@@ -383,7 +385,9 @@ const onNew = async (message: AppendMessage) => {
 Enable message editing by implementing the `onEdit` handler:
 
 <Callout type="info">
-You can also implement `onEdit(editedMessage)` and `onRemove(messageId)` callbacks to handle user-initiated edits or deletions in your external store. This enables features like "edit and re-run" on your backend.
+  You can also implement `onEdit(editedMessage)` and `onRemove(messageId)`
+  callbacks to handle user-initiated edits or deletions in your external store.
+  This enables features like "edit and re-run" on your backend.
 </Callout>
 
 ```tsx
@@ -548,7 +552,9 @@ const ThreadContext = createContext<{
   currentThreadId: string;
   setCurrentThreadId: (id: string) => void;
   threads: Map<string, ThreadMessageLike[]>;
-  setThreads: React.Dispatch<React.SetStateAction<Map<string, ThreadMessageLike[]>>>;
+  setThreads: React.Dispatch<
+    React.SetStateAction<Map<string, ThreadMessageLike[]>>
+  >;
 }>({
   currentThreadId: "default",
   setCurrentThreadId: () => {},
@@ -588,7 +594,8 @@ Here's a full implementation with proper context management:
 
 ```tsx
 function ChatWithThreads() {
-  const { currentThreadId, setCurrentThreadId, threads, setThreads } = useThreadContext();
+  const { currentThreadId, setCurrentThreadId, threads, setThreads } =
+    useThreadContext();
   const [threadList, setThreadList] = useState<ExternalStoreThreadData[]>([
     { threadId: "default", status: "regular", title: "New Chat" },
   ]);
@@ -683,7 +690,10 @@ export function App() {
 #### Thread Context Best Practices
 
 <Callout type="info">
-**Critical**: When using `ExternalStoreRuntime` with threads, the `currentThreadId` must be consistent across all components and handlers. Mismatched thread IDs will cause messages to appear in wrong threads or disappear entirely.
+  **Critical**: When using `ExternalStoreRuntime` with threads, the
+  `currentThreadId` must be consistent across all components and handlers.
+  Mismatched thread IDs will cause messages to appear in wrong threads or
+  disappear entirely.
 </Callout>
 
 1. **Centralize Thread State**: Always use a context or global state management solution to ensure thread ID consistency:
@@ -709,13 +719,13 @@ function ThreadList() {
 onSwitchToThread: (threadId) => {
   setCurrentThreadId(threadId);
   // Messages won't update!
-}
+};
 
 // ✅ Good: Complete state update
 onSwitchToThread: (threadId) => {
   setCurrentThreadId(threadId);
   // Messages automatically update via currentMessages = threads.get(currentThreadId)
-}
+};
 ```
 
 3. **Handle Edge Cases**: Always provide fallbacks for missing threads:
@@ -740,10 +750,10 @@ useEffect(() => {
   const saveThread = async () => {
     await api.saveThread(currentThreadId, threads.get(currentThreadId) || []);
   };
-  
+
   const debounced = debounce(saveThread, 1000);
   debounced();
-  
+
   return () => debounced.cancel();
 }, [currentThreadId, threads]);
 ```
@@ -1072,7 +1082,7 @@ setIsRunning(true);
 Assistant messages get automatic status updates:
 
 - `"in_progress"` - When `isRunning` is true
-- `"complete"` - When `isRunning` becomes false  
+- `"complete"` - When `isRunning` becomes false
 - `"cancelled"` - When cancelled via `onCancel`
 
 ### Tool Result Matching
@@ -1084,20 +1094,24 @@ The runtime automatically matches tool results with their calls:
 const messages = [
   {
     role: "assistant",
-    content: [{
-      type: "tool-call",
-      toolCallId: "call_123",
-      toolName: "get_weather",
-      args: { location: "SF" },
-    }],
+    content: [
+      {
+        type: "tool-call",
+        toolCallId: "call_123",
+        toolName: "get_weather",
+        args: { location: "SF" },
+      },
+    ],
   },
   {
     role: "tool",
-    content: [{
-      type: "tool-result",
-      toolCallId: "call_123",
-      result: { temp: 72 },
-    }],
+    content: [
+      {
+        type: "tool-result",
+        toolCallId: "call_123",
+        result: { temp: 72 },
+      },
+    ],
   },
 ];
 // Runtime automatically associates these
@@ -1119,11 +1133,15 @@ const MyComponent = () => {
 ```
 
 <Callout type="info">
-After the chat finishes, use `getExternalStoreMessages(runtime)` to convert back to your domain model. Refer to the API reference for return structures and edge-case behaviors.
+  After the chat finishes, use `getExternalStoreMessages(runtime)` to convert
+  back to your domain model. Refer to the API reference for return structures
+  and edge-case behaviors.
 </Callout>
 
 <Callout type="warning">
-`getExternalStoreMessages` may return multiple messages for a single UI message. This happens because assistant-ui merges adjacent assistant and tool messages for display.
+  `getExternalStoreMessages` may return multiple messages for a single UI
+  message. This happens because assistant-ui merges adjacent assistant and tool
+  messages for display.
 </Callout>
 
 ### Content Part Access
@@ -1190,9 +1208,14 @@ setMessages([...messages, newMessage]);
 Memoize handlers to prevent runtime recreation:
 
 ```tsx
-const onNew = useCallback(async (message: AppendMessage) => {
-  // Handle new message
-}, [/* dependencies */]);
+const onNew = useCallback(
+  async (message: AppendMessage) => {
+    // Handle new message
+  },
+  [
+    /* dependencies */
+  ],
+);
 
 const runtime = useExternalStoreRuntime({
   messages,
@@ -1206,7 +1229,7 @@ const runtime = useExternalStoreRuntime({
 // For large message lists
 const recentMessages = useMemo(
   () => messages.slice(-50), // Show last 50 messages
-  [messages]
+  [messages],
 );
 
 // For expensive conversions
@@ -1219,24 +1242,24 @@ const convertMessage = useCallback((msg) => {
 
 ### When to Choose Which
 
-| Scenario | Recommendation |
-| -------- | -------------- |
-| Quick prototype | `LocalRuntime` |
-| Using Redux/Zustand | `ExternalStoreRuntime` |
-| Need Assistant Cloud integration | `LocalRuntime` |
-| Custom thread storage | Both (`LocalRuntime` with adapter or `ExternalStoreRuntime`) |
-| Simple single thread | `LocalRuntime` |
-| Complex state logic | `ExternalStoreRuntime` |
+| Scenario                         | Recommendation                                               |
+| -------------------------------- | ------------------------------------------------------------ |
+| Quick prototype                  | `LocalRuntime`                                               |
+| Using Redux/Zustand              | `ExternalStoreRuntime`                                       |
+| Need Assistant Cloud integration | `LocalRuntime`                                               |
+| Custom thread storage            | Both (`LocalRuntime` with adapter or `ExternalStoreRuntime`) |
+| Simple single thread             | `LocalRuntime`                                               |
+| Complex state logic              | `ExternalStoreRuntime`                                       |
 
 ### Feature Comparison
 
-| Feature | `LocalRuntime` | `ExternalStoreRuntime` |
-| ------- | ------------ | -------------------- |
-| State Management | Built-in | You provide |
-| Multi-thread | Via Cloud or custom adapter | Via adapter |
-| Message Format | ThreadMessage | Any (with conversion) |
-| Setup Complexity | Low | Medium |
-| Flexibility | Medium | High |
+| Feature          | `LocalRuntime`              | `ExternalStoreRuntime` |
+| ---------------- | --------------------------- | ---------------------- |
+| State Management | Built-in                    | You provide            |
+| Multi-thread     | Via Cloud or custom adapter | Via adapter            |
+| Message Format   | ThreadMessage               | Any (with conversion)  |
+| Setup Complexity | Low                         | Medium                 |
+| Flexibility      | Medium                      | High                   |
 
 ## Common Pitfalls
 
@@ -1250,6 +1273,7 @@ const runtime = useExternalStoreRuntime({ messages, onNew });
 // ✅ Edit button appears
 const runtime = useExternalStoreRuntime({ messages, onNew, onEdit });
 ```
+
 </Callout>
 
 <Callout type="warning">
@@ -1259,7 +1283,7 @@ const runtime = useExternalStoreRuntime({ messages, onNew, onEdit });
 2. Missing `setMessages` for branch switching
 3. Not handling async operations properly
 4. Incorrect message format conversion
-</Callout>
+   </Callout>
 
 ### Debugging Checklist
 
@@ -1274,6 +1298,7 @@ const runtime = useExternalStoreRuntime({ messages, onNew, onEdit });
 Common thread context issues and solutions:
 
 **Messages disappearing when switching threads:**
+
 ```tsx
 // Check 1: Ensure currentThreadId is consistent
 console.log("Runtime threadId:", threadListAdapter.threadId);
@@ -1284,30 +1309,32 @@ console.log("Messages for thread:", threads.get(currentThreadId));
 setMessages: (messages) => {
   console.log("Setting messages for thread:", currentThreadId);
   setThreads((prev) => new Map(prev).set(currentThreadId, messages));
-}
+};
 ```
 
 **Thread list not updating:**
+
 ```tsx
 // Ensure threadList state is properly managed
 onSwitchToNewThread: () => {
   const newId = `thread-${Date.now()}`;
   console.log("Creating new thread:", newId);
-  
+
   // All three updates must happen together
   setThreadList((prev) => [...prev, newThreadData]);
   setThreads((prev) => new Map(prev).set(newId, []));
   setCurrentThreadId(newId);
-}
+};
 ```
 
 **Messages going to wrong thread:**
+
 ```tsx
 // Add validation to prevent race conditions
 const validateThreadContext = () => {
   const runtimeThread = threadListAdapter.threadId;
   const contextThread = currentThreadId;
-  
+
   if (runtimeThread !== contextThread) {
     console.error("Thread mismatch!", { runtimeThread, contextThread });
     throw new Error("Thread context mismatch");
@@ -1318,7 +1345,7 @@ const validateThreadContext = () => {
 onNew: async (message) => {
   validateThreadContext();
   // ... handle message
-}
+};
 ```
 
 ## API Reference
@@ -1345,7 +1372,8 @@ The main interface for connecting your state to assistant-ui.
     {
       name: "isRunning",
       type: "boolean",
-      description: "Whether the assistant is currently generating a response. When true, shows optimistic assistant message",
+      description:
+        "Whether the assistant is currently generating a response. When true, shows optimistic assistant message",
       default: "false",
     },
     {
@@ -1576,7 +1604,8 @@ Enable multi-thread support with custom thread management.
 />
 
 <Callout type="info">
-The thread list adapter enables multi-thread support. Without it, the runtime only manages the current conversation.
+  The thread list adapter enables multi-thread support. Without it, the runtime
+  only manages the current conversation.
 </Callout>
 
 ### Related Runtime APIs
@@ -1591,4 +1620,3 @@ The thread list adapter enables multi-thread support. Without it, the runtime on
 - [Pick a Runtime Guide](/docs/runtimes/pick-a-runtime)
 - [`LocalRuntime` Documentation](/docs/runtimes/custom/local)
 - [Examples Repository](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-external-store)
-

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -18,7 +18,7 @@ import {
   ReadonlyJSONObject,
   ReadonlyJSONValue,
 } from "../../utils/json/json-value";
-import { ToolResponseInit } from "../tool/ToolResponse";
+import { ToolResponseLike } from "../tool/ToolResponse";
 import { promiseWithResolvers } from "../../utils/promiseWithResolvers";
 
 type ToolCallPartInit = {
@@ -26,7 +26,7 @@ type ToolCallPartInit = {
   toolName: string;
   argsText?: string;
   args?: ReadonlyJSONObject;
-  response?: ToolResponseInit<ReadonlyJSONValue>;
+  response?: ToolResponseLike<ReadonlyJSONValue>;
 };
 
 export type AssistantStreamController = {

--- a/packages/assistant-stream/src/core/modules/tool-call.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.ts
@@ -1,6 +1,6 @@
 import { AssistantStream } from "../AssistantStream";
 import { AssistantStreamChunk } from "../AssistantStreamChunk";
-import { ToolResponseInit } from "../tool/ToolResponse";
+import { ToolResponseLike } from "../tool/ToolResponse";
 import { ReadonlyJSONValue } from "../../utils/json/json-value";
 import { UnderlyingReadable } from "../utils/stream/UnderlyingReadable";
 import { createTextStream, TextStreamController } from "./text";
@@ -8,7 +8,7 @@ import { createTextStream, TextStreamController } from "./text";
 export type ToolCallStreamController = {
   argsText: TextStreamController;
 
-  setResponse(response: ToolResponseInit<ReadonlyJSONValue>): void;
+  setResponse(response: ToolResponseLike<ReadonlyJSONValue>): void;
   close(): void;
 };
 
@@ -53,7 +53,7 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
 
   private _argsTextController!: TextStreamController;
 
-  async setResponse(response: ToolResponseInit<ReadonlyJSONValue>) {
+  async setResponse(response: ToolResponseLike<ReadonlyJSONValue>) {
     this._argsTextController.close();
     await Promise.resolve(); // flush microtask queue
     // TODO switch argsTextController to be something that doesn'#t require this

--- a/packages/assistant-stream/src/core/tool/ToolResponse.ts
+++ b/packages/assistant-stream/src/core/tool/ToolResponse.ts
@@ -2,7 +2,7 @@ import { ReadonlyJSONValue } from "../../utils/json/json-value";
 
 const TOOL_RESPONSE_SYMBOL = Symbol.for("aui.tool-response");
 
-export type ToolResponseInit<TResult> = {
+export type ToolResponseLike<TResult> = {
   result: TResult;
   artifact?: ReadonlyJSONValue | undefined;
   isError?: boolean | undefined;
@@ -17,7 +17,7 @@ export class ToolResponse<TResult> {
   readonly result: TResult;
   readonly isError: boolean;
 
-  constructor(options: ToolResponseInit<TResult>) {
+  constructor(options: ToolResponseLike<TResult>) {
     if (options.artifact !== undefined) {
       this.artifact = options.artifact;
     }
@@ -31,5 +31,14 @@ export class ToolResponse<TResult> {
     return (
       typeof obj === "object" && obj !== null && TOOL_RESPONSE_SYMBOL in obj
     );
+  }
+
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any> {
+    if (result instanceof ToolResponse) {
+      return result;
+    }
+    return new ToolResponse({
+      result: result === undefined ? "<no result>" : result,
+    });
   }
 }

--- a/packages/assistant-stream/src/core/tool/index.ts
+++ b/packages/assistant-stream/src/core/tool/index.ts
@@ -1,5 +1,5 @@
 export type { Tool } from "./tool-types";
-export { ToolResponse } from "./ToolResponse";
+export { ToolResponse, type ToolResponseLike } from "./ToolResponse";
 export { ToolExecutionStream } from "./ToolExecutionStream";
 export type { ToolCallReader } from "./tool-types";
 export {

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -52,11 +52,7 @@ function getToolResponse(
       toolCallId: toolCall.toolCallId,
       abortSignal,
     })) as unknown as ReadonlyJSONValue;
-    if (result instanceof ToolResponse)
-      return result as ToolResponse<ReadonlyJSONValue>;
-    return new ToolResponse({
-      result: result === undefined ? "<no result>" : result,
-    });
+    return ToolResponse.toResponse(result);
   };
 
   return getResult(tool.execute);

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -76,6 +76,7 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
         toolCallId: message.tool_call_id,
         result: message.content,
         artifact: message.artifact,
+        isError: message.status === "error",
       };
   }
 };

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -54,6 +54,7 @@ export type LangChainMessage =
       tool_call_id: string;
       name: string;
       artifact?: any;
+      status: "success" | "error";
     }
   | {
       id?: string;

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -232,6 +232,7 @@ export const useLangGraphRuntime = ({
                   name: t.name,
                   tool_call_id: t.id,
                   content: JSON.stringify({ cancelled: true }),
+                  status: "error",
                 }) satisfies LangChainMessage & { type: "tool" },
             )
           : [];
@@ -249,7 +250,13 @@ export const useLangGraphRuntime = ({
         },
       );
     },
-    onAddToolResult: async ({ toolCallId, toolName, result }) => {
+    onAddToolResult: async ({
+      toolCallId,
+      toolName,
+      result,
+      isError,
+      artifact,
+    }) => {
       // TODO parallel human in the loop calls
       await handleSendMessage(
         [
@@ -258,6 +265,8 @@ export const useLangGraphRuntime = ({
             name: toolName,
             tool_call_id: toolCallId,
             content: JSON.stringify(result),
+            artifact,
+            status: isError ? "error" : "success",
           },
         ],
         // TODO reuse runconfig here!

--- a/packages/react/src/runtimes/core/ThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/ThreadRuntimeCore.tsx
@@ -26,7 +26,9 @@ export type AddToolResultOptions = {
   messageId: string;
   toolName: string;
   toolCallId: string;
-  result: any;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
 };
 
 export type SubmitFeedbackOptions = {

--- a/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
@@ -247,9 +247,17 @@ export class ExternalStoreThreadRuntimeCore
   }
 
   public addToolResult(options: AddToolResultOptions) {
-    if (!this._store.onAddToolResult)
+    if (!this._store.onAddToolResult && !this._store.onAddToolResult)
       throw new Error("Runtime does not support tool results.");
-    this._store.onAddToolResult(options);
+    this._store.onAddToolResult?.({
+      messageId: options.messageId,
+      toolName: options.toolName,
+      toolCallId: options.toolCallId,
+      result: options.result,
+      isError: options.isError,
+      artifact: options.artifact,
+    });
+    this._store.onAddToolResult?.(options);
   }
 
   private updateMessages = (messages: readonly ThreadMessage[]) => {

--- a/packages/react/src/runtimes/external-store/external-message-converter.tsx
+++ b/packages/react/src/runtimes/external-store/external-message-converter.tsx
@@ -22,6 +22,8 @@ export namespace useExternalMessageConverter {
         toolCallId: string;
         toolName?: string | undefined;
         result: any;
+        artifact?: any;
+        isError?: boolean;
       };
 
   export type Callback<T> = (message: T) => Message | Message[];
@@ -75,6 +77,8 @@ const joinExternalMessages = (
             ],
           },
           result: output.result,
+          artifact: output.artifact,
+          isError: output.isError,
         };
       } else {
         throw new Error(

--- a/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
@@ -385,6 +385,8 @@ export class LocalThreadRuntimeCore
     messageId,
     toolCallId,
     result,
+    isError,
+    artifact,
   }: AddToolResultOptions) {
     const messageData = this.repository.getMessage(messageId);
     const { parentId } = messageData;
@@ -403,6 +405,8 @@ export class LocalThreadRuntimeCore
       return {
         ...c,
         result,
+        artifact,
+        isError,
       };
     });
 

--- a/packages/react/src/types/ContentPartComponentTypes.tsx
+++ b/packages/react/src/types/ContentPartComponentTypes.tsx
@@ -10,6 +10,7 @@ import type {
   Unstable_AudioContentPart,
 } from "./AssistantTypes";
 import { ContentPartState } from "../api/ContentPartRuntime";
+import { ToolResponse } from "assistant-stream";
 
 export type EmptyContentPartProps = {
   status: ContentPartStatus;
@@ -42,7 +43,7 @@ export type ToolCallContentPartProps<
   TResult = unknown,
 > = ContentPartState &
   ToolCallContentPart<TArgs, TResult> & {
-    addResult: (result: TResult) => void;
+    addResult: (result: TResult | ToolResponse<TResult>) => void;
   };
 
 export type ToolCallContentPartComponent<


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances langgraph tool calls by adding support for artifacts and error states using the new `ToolResponseLike` type.
> 
>   - **Behavior**:
>     - Adds support for `artifact` and `isError` in langgraph tool calls in `convertLangChainMessages.ts` and `useLangGraphRuntime.ts`.
>     - Introduces `ToolResponseLike` type in `ToolResponse.ts` to handle tool call results with artifacts and error states.
>   - **Functions**:
>     - Updates `addToolResult` in `ContentPartRuntime.ts` and `ThreadRuntimeCore.tsx` to accept `ToolResponseLike`.
>     - Modifies `setResponse` in `tool-call.ts` to use `ToolResponseLike`.
>   - **Misc**:
>     - Updates `addResult` type in `ContentPartComponentTypes.tsx` and `context.tsx` to include `ToolResponse<TResult>`.
>     - Adjusts `toolResultStream` in `toolResultStream.ts` to utilize `ToolResponse.toResponse()`.
>     - Documentation updates in `external-store.mdx` for new tool call handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 28c9c6238d695bee77a838bfedf2331ad4a6c4db. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->