### PR TITLE
fix: syntax error in external-store.mdx

### DIFF
--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -1277,13 +1277,15 @@ const runtime = useExternalStoreRuntime({ messages, onNew, onEdit });
 </Callout>
 
 <Callout type="warning">
+
 **State not updating**: Common causes:
 
 1. Mutating arrays instead of creating new ones
 2. Missing `setMessages` for branch switching
 3. Not handling async operations properly
 4. Incorrect message format conversion
-   </Callout>
+
+</Callout>
 
 ### Debugging Checklist
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes syntax error in `external-store.mdx` by correcting the closing tag for a `Callout` component.
> 
>   - **Syntax Fix**:
>     - Corrected closing tag for `Callout` component in `external-store.mdx` to fix rendering issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 79de2dadddfec466a556ae598b63738e4a8d83cc. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->