### PR TITLE
Fix: Export missing adapter primitives

### DIFF
--- a/.changeset/fluffy-brooms-dream.md
+++ b/.changeset/fluffy-brooms-dream.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+Fix: Export missing adapter primitives

--- a/packages/react/src/runtimes/adapters/index.ts
+++ b/packages/react/src/runtimes/adapters/index.ts
@@ -2,3 +2,5 @@ export * from "./attachment";
 export * from "./feedback";
 export * from "./speech";
 export * from "./suggestion";
+export * from "./RuntimeAdapterProvider";
+export * from "./thread-history/ThreadHistoryAdapter";


### PR DESCRIPTION
The `RuntimeAdapterProvider` and `ThreadHistoryAdapter` were not being re-exported from the adapter barrel file (`packages/react/src/runtimes/adapters/index.ts`).

This change adds the missing exports to ensure these components are part of the public API and can be imported by you when using the `@assistant-ui/react` package.

fixes #2052 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add missing exports for `RuntimeAdapterProvider` and `ThreadHistoryAdapter` in `index.ts` to ensure public API access.
> 
>   - **Exports**:
>     - Add missing exports for `RuntimeAdapterProvider` and `ThreadHistoryAdapter` in `index.ts` to ensure they are part of the public API for `@assistant-ui/react`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 8928e37d293c939f88dcf676b720829c1b80e486. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->