### PR TITLE
fix(react): preserve message metadata in `useThreadRuntime().append()`

### DIFF
--- a/.changeset/quiet-icons-pull.md
+++ b/.changeset/quiet-icons-pull.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): preserve message metadata in useThreadRuntime().append()

--- a/packages/react/src/api/ThreadRuntime.ts
+++ b/packages/react/src/api/ThreadRuntime.ts
@@ -72,6 +72,9 @@ export type CreateAppendMessage =
       role?: AppendMessage["role"] | undefined;
       content: AppendMessage["content"];
       attachments?: AppendMessage["attachments"] | undefined;
+      metadata?: AppendMessage["metadata"] | undefined;
+      createdAt?: Date | undefined;
+      runConfig?: AppendMessage["runConfig"] | undefined;
       startRun?: boolean | undefined;
     };
 
@@ -92,16 +95,16 @@ const toAppendMessage = (
     };
   }
 
-  if (message.role && message.parentId && message.attachments) {
-    return message as AppendMessage;
-  }
-
   return {
-    ...message,
+    createdAt: message.createdAt ?? new Date(),
     parentId: message.parentId ?? messages.at(-1)?.id ?? null,
     sourceId: message.sourceId ?? null,
     role: message.role ?? "user",
+    content: message.content,
     attachments: message.attachments ?? [],
+    metadata: message.metadata ?? { custom: {} },
+    runConfig: message.runConfig ?? {},
+    startRun: message.startRun,
   } as AppendMessage;
 };
 


### PR DESCRIPTION
The `toAppendMessage` function was overwriting  user-provided metadata with  `{ custom: {} }`. Add metadata field to `CreateAppendMessage` type, preserve user values with proper fallback.

Replace unsafe spread operator to prevent id field leakage

Add `runConfig` and `createdAt` field support

fixes #1728
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `toAppendMessage` in `ThreadRuntime.ts` to preserve user metadata, add `metadata`, `createdAt`, `runConfig` fields, and prevent `id` leakage.
> 
>   - **Behavior**:
>     - Fix `toAppendMessage` in `ThreadRuntime.ts` to preserve user-provided `metadata` instead of overwriting with `{ custom: {} }`.
>     - Add `metadata`, `createdAt`, and `runConfig` fields to `CreateAppendMessage` type in `ThreadRuntime.ts`.
>   - **Security**:
>     - Replace unsafe spread operator in `toAppendMessage` to prevent `id` field leakage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c756bb1a9ff3afcf9bc035d20af7202daee67dba. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->