### PR TITLE
feat(docs): update CSS import paths in getting-started guide

### DIFF
--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -738,9 +738,9 @@ export function cn(...inputs: ClassValue[]) {
        The components above reference CSS class names like `aui-thread-root`, `aui-composer-input`, etc. These are normally replaced by our CLI with Tailwind class names, but in this case you'll use our pre-compiled CSS files without a need for Tailwind:
 
 ```ts
-import "@assistant-ui/react-ui/styles/index.css";
-import "@assistant-ui/react-ui/styles/markdown.css";
-// import "@assistant-ui/react-ui/styles/modal.css";  // for future reference, only if you use our modal component
+import "@assistant-ui/styles/index.css";
+import "@assistant-ui/styles/markdown.css";
+// import "@assistant-ui/styles/modal.css";  // for future reference, only if you use our modal component
 ```
 
         </Step>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update CSS import paths in `getting-started.mdx` for accurate documentation.
> 
>   - **Documentation**:
>     - Update CSS import paths in `getting-started.mdx` to `@assistant-ui/styles/index.css` and `@assistant-ui/styles/markdown.css`.
>     - Commented out import for `modal.css` for future reference.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for ba19e68755ac33300c8612b873ac3fd1dbeeffe9. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->