### PR TITLE
fix: add assistant-stream/utils subpath import workaround

### DIFF
--- a/.changeset/khaki-seals-smash.md
+++ b/.changeset/khaki-seals-smash.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: add assistant-stream/utils subpath import workaround

--- a/packages/assistant-stream/utils/README.md
+++ b/packages/assistant-stream/utils/README.md
@@ -1,0 +1,1 @@
+This directory exists to support subpath imports for TypeScript projects using --moduleResolution node.

--- a/packages/assistant-stream/utils/package.json
+++ b/packages/assistant-stream/utils/package.json
@@ -1,0 +1,5 @@
+{
+  "type": "module",
+  "main": "../dist/utils.js",
+  "types": "../dist/utils.d.ts"
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add workaround for subpath imports in TypeScript by adding `package.json` and `README.md` to `utils` directory in `assistant-stream`.
> 
>   - **Subpath Import Workaround**:
>     - Adds `package.json` to `utils` directory in `assistant-stream` to support subpath imports for TypeScript with `--moduleResolution node`.
>     - Specifies `type` as `module`, `main` as `../dist/utils.js`, and `types` as `../dist/utils.d.ts` in `package.json`.
>   - **Documentation**:
>     - Adds `README.md` to `utils` directory explaining the purpose of the directory for subpath imports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 97286a84c12ce5f7bdaaf205d329dd52dfc47501. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->