### PR TITLE
feat(py/assistant-stream): add append_reasoning API

### DIFF
--- a/python/assistant-stream/src/assistant_stream/assistant_stream_chunk.py
+++ b/python/assistant-stream/src/assistant_stream/assistant_stream_chunk.py
@@ -10,6 +10,12 @@ class TextDeltaChunk:
 
 
 @dataclass
+class ReasoningDeltaChunk:
+    reasoning_delta: str
+    type: str = "reasoning-delta"
+
+
+@dataclass
 class ToolCallBeginChunk:
     tool_call_id: str
     tool_name: str
@@ -69,6 +75,7 @@ class UpdateStateChunk:
 # Define the union type for AssistantStreamChunk
 AssistantStreamChunk = Union[
     TextDeltaChunk,
+    ReasoningDeltaChunk,
     ToolCallBeginChunk,
     ToolCallDeltaChunk,
     ToolResultChunk,

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -3,6 +3,7 @@ from typing import Any, AsyncGenerator, Callable, Coroutine, List
 from assistant_stream.assistant_stream_chunk import (
     AssistantStreamChunk,
     TextDeltaChunk,
+    ReasoningDeltaChunk,
     ToolResultChunk,
     DataChunk,
     ErrorChunk,
@@ -26,6 +27,11 @@ class RunController:
     def append_text(self, text_delta: str) -> None:
         """Append a text delta to the stream."""
         chunk = TextDeltaChunk(text_delta=text_delta)
+        self._flush_and_put_chunk(chunk)
+
+    def append_reasoning(self, reasoning_delta: str) -> None:
+        """Append a reasoning delta to the stream."""
+        chunk = ReasoningDeltaChunk(reasoning_delta=reasoning_delta)
         self._flush_and_put_chunk(chunk)
 
     async def add_tool_call(

--- a/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
@@ -16,6 +16,8 @@ class DataStreamEncoder(StreamEncoder):
     def encode_chunk(self, chunk: AssistantStreamChunk) -> str:
         if chunk.type == "text-delta":
             return f"0:{json.dumps(chunk.text_delta)}\n"
+        elif chunk.type == "reasoning-delta":
+            return f"g:{json.dumps(chunk.reasoning_delta)}\n"
         elif chunk.type == "tool-call-begin":
             return f'b:{json.dumps({ "toolCallId": chunk.tool_call_id, "toolName": chunk.tool_name })}\n'
         elif chunk.type == "tool-call-delta":

--- a/python/assistant-stream/tests/test_reasoning.py
+++ b/python/assistant-stream/tests/test_reasoning.py
@@ -1,0 +1,59 @@
+import asyncio
+import pytest
+from assistant_stream import create_run, RunController
+
+
+@pytest.mark.asyncio
+async def test_append_reasoning():
+    """Test that append_reasoning works correctly."""
+    reasoning_chunks = []
+
+    async def collect_chunks(chunks):
+        async for chunk in chunks:
+            if chunk.type == "reasoning-delta":
+                reasoning_chunks.append(chunk)
+
+    async def run_callback(controller: RunController):
+        controller.append_reasoning("This is ")
+        controller.append_reasoning("reasoning content")
+
+    # Create the run and collect chunks
+    chunks = create_run(run_callback)
+    await collect_chunks(chunks)
+
+    # Verify the reasoning chunks
+    assert len(reasoning_chunks) == 2
+    assert reasoning_chunks[0].reasoning_delta == "This is "
+    assert reasoning_chunks[1].reasoning_delta == "reasoning content"
+
+
+@pytest.mark.asyncio
+async def test_mixed_text_and_reasoning():
+    """Test that append_text and append_reasoning can be used together."""
+    collected_chunks = []
+
+    async def collect_chunks(chunks):
+        async for chunk in chunks:
+            if chunk.type in ["text-delta", "reasoning-delta"]:
+                collected_chunks.append(chunk)
+
+    async def run_callback(controller: RunController):
+        controller.append_text("This is text")
+        controller.append_reasoning("This is reasoning")
+        controller.append_text("More text")
+        controller.append_reasoning("More reasoning")
+
+    # Create the run and collect chunks
+    chunks = create_run(run_callback)
+    await collect_chunks(chunks)
+
+    # Verify the chunks
+    assert len(collected_chunks) == 4
+    assert collected_chunks[0].type == "text-delta"
+    assert collected_chunks[0].text_delta == "This is text"
+    assert collected_chunks[1].type == "reasoning-delta"
+    assert collected_chunks[1].reasoning_delta == "This is reasoning"
+    assert collected_chunks[2].type == "text-delta"
+    assert collected_chunks[2].text_delta == "More text"
+    assert collected_chunks[3].type == "reasoning-delta"
+    assert collected_chunks[3].reasoning_delta == "More reasoning"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `append_reasoning()` to handle reasoning deltas in the assistant stream, with encoding and tests.
> 
>   - **Behavior**:
>     - Adds `append_reasoning()` method to `RunController` in `create_run.py` to append reasoning deltas.
>     - Updates `DataStreamEncoder` in `data_stream.py` to encode `ReasoningDeltaChunk` with prefix `g:`.
>   - **Models**:
>     - Adds `ReasoningDeltaChunk` class to `assistant_stream_chunk.py`.
>     - Updates `AssistantStreamChunk` union to include `ReasoningDeltaChunk`.
>   - **Tests**:
>     - Adds `test_reasoning.py` to test `append_reasoning()` and mixed usage with `append_text()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for b2fef894ea3061592a7c448d7528182a5ed86ecc. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->