### PR TITLE
Add mergeModelContexts unit tests

### DIFF
--- a/packages/react/src/tests/ModelContextTypes.test.ts
+++ b/packages/react/src/tests/ModelContextTypes.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { mergeModelContexts, ModelContext, ModelContextProvider } from "../model-context/ModelContextTypes";
+
+const createProvider = (context: ModelContext): ModelContextProvider => ({
+  getModelContext: () => context,
+});
+
+// Simple tool placeholders
+const toolA = {} as any;
+const toolB = {} as any;
+
+describe("mergeModelContexts", () => {
+  it("merges system strings based on priority", () => {
+    const high = createProvider({ priority: 2, system: "high" });
+    const low = createProvider({ priority: 1, system: "low" });
+    const result = mergeModelContexts(new Set([low, high]));
+    expect(result.system).toBe("high\n\nlow");
+  });
+
+  it("overrides config and callSettings from lower priority", () => {
+    const high = createProvider({
+      priority: 5,
+      config: { modelName: "gpt4" },
+      callSettings: { temperature: 0.3 },
+    });
+    const low = createProvider({
+      priority: 1,
+      config: { modelName: "gpt3", baseUrl: "http://foo" },
+      callSettings: { temperature: 0.9 },
+    });
+    const result = mergeModelContexts(new Set([high, low]));
+    expect(result.config).toEqual({ modelName: "gpt3", baseUrl: "http://foo" });
+    expect(result.callSettings).toEqual({ temperature: 0.9 });
+  });
+
+  it("throws when tool names collide with different instances", () => {
+    const high = createProvider({ priority: 1, tools: { a: toolA } });
+    const low = createProvider({ priority: 0, tools: { a: toolB } });
+    expect(() => mergeModelContexts(new Set([high, low]))).toThrow(
+      /already exists/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for mergeModelContexts

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68508f720534833198c13fcf249fcc68
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add unit tests for `mergeModelContexts` in `ModelContextTypes.test.ts`, covering system string merging, config overriding, and tool name collision handling.
> 
>   - **Unit Tests**:
>     - Add unit tests for `mergeModelContexts` in `ModelContextTypes.test.ts`.
>     - Test merging of system strings based on priority.
>     - Test overriding of `config` and `callSettings` from lower priority contexts.
>     - Test error throwing when tool names collide with different instances.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 2da4573846ab6ad4fec93017bf1ccb6668b305f5. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->