### PR TITLE
Fix typo in sliceMessagesUntil

### DIFF
--- a/packages/react-ai-sdk/src/ui/utils/sliceMessagesUntil.tsx
+++ b/packages/react-ai-sdk/src/ui/utils/sliceMessagesUntil.tsx
@@ -9,7 +9,7 @@ export const sliceMessagesUntil = (
   let messageIdx = messages.findIndex((m) => m.id === messageId);
   if (messageIdx === -1)
     throw new Error(
-      "useVercelAIThreadState: Message not found. This is liekly an internal bug in assistant-ui.",
+      "useVercelAIThreadState: Message not found. This is likely an internal bug in assistant-ui.",
     );
 
   while (messages[messageIdx + 1]?.role === "assistant") {


### PR DESCRIPTION
## Summary
- fix a typo in the `sliceMessagesUntil` error message

## Testing
- `npm test --silent` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850cc6a26288331bfad5226c2a9efa0