### PR TITLE
Fix mutable default arg in StateProxy

### DIFF
--- a/python/assistant-stream/src/assistant_stream/state_proxy.py
+++ b/python/assistant-stream/src/assistant_stream/state_proxy.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Union, TYPE_CHECKING
+from typing import Any, List, Optional, Union, TYPE_CHECKING
 
 
 # Avoid circular import
@@ -19,10 +19,14 @@ class StateProxy:
     def _get_value(self):
         return self._manager.get_value_at_path(self._path)
 
-    def __init__(self, state_manager: "StateManager", path: List[str] = []):
+    def __init__(
+        self,
+        state_manager: "StateManager",
+        path: Optional[List[str]] | None = None,
+    ) -> None:
         """Initialize with state manager and current path."""
         self._manager = state_manager
-        self._path = path
+        self._path = path or []
 
     def __getitem__(self, key: Union[str, int]) -> Union["StateProxy", Any]:
         """Access nested values with dict-style syntax. Returns primitives directly except strings."""


### PR DESCRIPTION
## Summary
- avoid using a mutable default list in `StateProxy.__init__`

## Testing
- `pytest -q python/assistant-stream/tests` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_6850cd3502f0833186cc8228e087c222
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix mutable default argument in `StateProxy.__init__` by using `Optional[List[str]]` with a default of `None`.
> 
>   - **Behavior**:
>     - Fix mutable default argument in `StateProxy.__init__` by changing `path` from `List[str]` to `Optional[List[str]]` with a default of `None`.
>     - Ensures `path` is initialized to an empty list if `None` is provided.
>   - **Imports**:
>     - Add `Optional` to imports in `state_proxy.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for a92b771f8836a1ac6c89110cb19b8a14d3f6eb41. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->