### PR TITLE
Fix MessageRepository error text

### DIFF
--- a/packages/react/src/runtimes/utils/MessageRepository.tsx
+++ b/packages/react/src/runtimes/utils/MessageRepository.tsx
@@ -330,7 +330,7 @@ export class MessageRepository {
 
     if (!message)
       throw new Error(
-        "MessageRepository(deleteMessage): Optimistic message not found. This is likely an internal bug in assistant-ui.",
+        "MessageRepository(deleteMessage): Message not found. This is likely an internal bug in assistant-ui.",
       );
 
     const replacement =


### PR DESCRIPTION
## Summary
- fix error text in `deleteMessage`

## Testing
- `pnpm test` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850d26a6eb08331afacc64cea9062c2
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update error message in `deleteMessage` function of `MessageRepository.tsx` for clarity.
> 
>   - **Error Message Update**:
>     - In `MessageRepository.tsx`, updated error message in `deleteMessage` from "Optimistic message not found" to "Message not found".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 5cad8fd639f37aa70fa11947b5e24106504681b1. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->