### PR TITLE
Fix autoscroll state update timing

### DIFF
--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.tsx
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.tsx
@@ -55,9 +55,16 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
       }
 
       if (newIsAtBottom !== isAtBottom) {
-        writableStore(threadViewportStore).setState({
-          isAtBottom: newIsAtBottom,
-        });
+        const updateState = () =>
+          writableStore(threadViewportStore).setState({
+            isAtBottom: newIsAtBottom,
+          });
+
+        if (newIsAtBottom && isScrollingToBottomRef.current) {
+          requestAnimationFrame(updateState);
+        } else {
+          updateState();
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- fix thread viewport scrolling logic to update `isAtBottom` after scroll completes

## Testing
- `npx tsc -p packages/assistant-stream/tsconfig.json` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850d3a2206c833189d6c048e3136c24
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `isAtBottom` state update timing in `useThreadViewportAutoScroll` to occur after scroll completes using `requestAnimationFrame`.
> 
>   - **Behavior**:
>     - Fixes `isAtBottom` state update timing in `useThreadViewportAutoScroll` to occur after scroll completes.
>     - Uses `requestAnimationFrame` for state update when `isScrollingToBottomRef` is true.
>   - **Testing**:
>     - `npx tsc -p packages/assistant-stream/tsconfig.json` fails due to npm registry block.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c149b1bfd643e9707e11540e35d5055b512708fe. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->