### PR TITLE
fix(mcp-docs-server): logger warn method

### DIFF
--- a/.changeset/warn-console.md
+++ b/.changeset/warn-console.md
@@ -1,0 +1,4 @@
+---
+"@assistant-ui/mcp-docs-server": patch
+---
+use console.warn for logger.warn

--- a/packages/mcp-docs-server/src/utils/logger.ts
+++ b/packages/mcp-docs-server/src/utils/logger.ts
@@ -13,6 +13,6 @@ export const logger = {
     console.error(`[ERROR] ${message}`, ...args);
   },
   warn: (message: string, ...args: any[]) => {
-    console.error(`[WARN] ${message}`, ...args);
+    console.warn(`[WARN] ${message}`, ...args);
   },
 };


### PR DESCRIPTION
## Summary
- use `console.warn` in mcp-docs-server logger
- remove unnecessary logger test
- add changeset

## Testing
- `pnpm --filter=@assistant-ui/mcp-docs-server lint`
- `pnpm --filter=@assistant-ui/mcp-docs-server test`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685156477e98832c9dc0bfb3aaba3cc9
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `logger.warn` to use `console.warn` instead of `console.error` in `logger.ts`.
> 
>   - **Behavior**:
>     - Change `logger.warn` to use `console.warn` instead of `console.error` in `logger.ts`.
>   - **Misc**:
>     - Add changeset `warn-console.md` to document the change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c68cd3454135bbfdfad3002af5057b3275fdf155. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->