### PR TITLE
fix(example): add alias for `assistant-ui/react-markdown`

### DIFF
--- a/examples/with-openai-assistants/tsconfig.json
+++ b/examples/with-openai-assistants/tsconfig.json
@@ -16,6 +16,7 @@
       "@/*": ["./*"],
       "@assistant-ui/*": ["../../packages/*/src"],
       "@assistant-ui/react/*": ["../../packages/react/src/*"],
+      "@assistant-ui/react-markdown/*": ["../../packages/react-markdown/*"],
       "assistant-stream": ["../../packages/assistant-stream/src"],
       "assistant-stream/*": ["../../packages/assistant-stream/src/*"]
     }


### PR DESCRIPTION
fix openai-assistants example