### PR TITLE
Fix memoization node comparison

### DIFF
--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -24,7 +24,9 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsx scripts/build.mts",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-primitive": "^2.1.3",
@@ -51,7 +53,8 @@
     "eslint-config-next": "15.3.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "tsx": "^4.20.3"
+    "tsx": "^4.20.3",
+    "vitest": "^3.2.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/react-markdown/src/memoization.test.tsx
+++ b/packages/react-markdown/src/memoization.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import type { Element } from "hast";
+import { areNodesEqual } from "./memoization";
+
+const createNode = (overrides: Partial<Element> = {}): Element => ({
+  type: "element",
+  tagName: "p",
+  properties: { className: "foo" },
+  children: [],
+  ...overrides,
+});
+
+describe("areNodesEqual", () => {
+  it("returns false if either node is undefined", () => {
+    expect(areNodesEqual(undefined, createNode())).toBe(false);
+    expect(areNodesEqual(createNode(), undefined)).toBe(false);
+  });
+
+  it("compares node type and tag name", () => {
+    const base = createNode();
+    expect(areNodesEqual(base, { ...base, tagName: "div" })).toBe(false);
+    expect(areNodesEqual(base, { ...base, type: "text" as any })).toBe(false);
+  });
+
+  it("ignores position when comparing properties", () => {
+    const prev = createNode({ properties: { className: "foo", position: 1 } });
+    const next = createNode({ properties: { className: "foo", position: 2 } });
+    expect(areNodesEqual(prev, next)).toBe(true);
+  });
+
+  it("detects differences in children", () => {
+    const prev = createNode({ children: [{ type: "text", value: "a" }] as any });
+    const next = createNode({ children: [{ type: "text", value: "b" }] as any });
+    expect(areNodesEqual(prev, next)).toBe(false);
+  });
+});

--- a/packages/react-markdown/src/memoization.tsx
+++ b/packages/react-markdown/src/memoization.tsx
@@ -20,12 +20,21 @@ export const areNodesEqual = (
   prev: Element | undefined,
   next: Element | undefined,
 ) => {
-  // TODO troubleshoot why this is triggering for code blocks
   if (!prev || !next) return false;
-  const isEqual =
-    JSON.stringify(prev?.properties) === JSON.stringify(next?.properties) &&
-    areChildrenEqual(prev?.children, next?.children);
-  return isEqual;
+
+  if (prev.type !== next.type) return false;
+  if (prev.tagName !== next.tagName) return false;
+
+  const sanitize = (props: Element["properties"]) => {
+    const { position, ...rest } = (props as Record<string, unknown>) || {};
+    return rest;
+  };
+
+  return (
+    JSON.stringify(sanitize(prev.properties)) ===
+      JSON.stringify(sanitize(next.properties)) &&
+    areChildrenEqual(prev.children, next.children)
+  );
 };
 
 export const memoCompareNodes = (

--- a/packages/react-markdown/vitest.config.ts
+++ b/packages/react-markdown/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.{ts,tsx}"],
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1777,6 +1777,9 @@ importers:
       tsx:
         specifier: ^4.20.3
         version: 4.20.3
+      vitest:
+        specifier: ^3.2.3
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@24.0.1)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.20.3)
 
   packages/react-syntax-highlighter:
     devDependencies:


### PR DESCRIPTION
## Summary
- improve memoization of markdown components by taking tag name and element type into account
- sanitize properties when comparing nodes to prevent needless re-renders
- add unit tests for `areNodesEqual`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68513d58099c832cb66806e12ff37578