### PR TITLE
feat: allow forwarding portal props for assistant modal content

### DIFF
--- a/.changeset/rare-sheep-punch.md
+++ b/.changeset/rare-sheep-punch.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: allow forwarding portal props for assistant modal content

--- a/packages/react/src/primitives/assistantModal/AssistantModalContent.tsx
+++ b/packages/react/src/primitives/assistantModal/AssistantModalContent.tsx
@@ -10,6 +10,7 @@ export namespace AssistantModalPrimitiveContent {
   export type Props = ComponentPropsWithoutRef<
     typeof PopoverPrimitive.Content
   > & {
+    portalProps?: ComponentPropsWithoutRef<typeof PopoverPrimitive.Portal> | undefined;
     dissmissOnInteractOutside?: boolean | undefined;
   };
 }
@@ -25,6 +26,7 @@ export const AssistantModalPrimitiveContent = forwardRef<
       align,
       onInteractOutside,
       dissmissOnInteractOutside = false,
+      portalProps,
       ...props
     }: ScopedProps<AssistantModalPrimitiveContent.Props>,
     forwardedRef,
@@ -32,7 +34,7 @@ export const AssistantModalPrimitiveContent = forwardRef<
     const scope = usePopoverScope(__scopeAssistantModal);
 
     return (
-      <PopoverPrimitive.Portal {...scope}>
+      <PopoverPrimitive.Portal {...scope} {...portalProps}>
         <PopoverPrimitive.Content
           {...scope}
           {...props}

--- a/packages/react/src/primitives/assistantModal/AssistantModalContent.tsx
+++ b/packages/react/src/primitives/assistantModal/AssistantModalContent.tsx
@@ -10,7 +10,9 @@ export namespace AssistantModalPrimitiveContent {
   export type Props = ComponentPropsWithoutRef<
     typeof PopoverPrimitive.Content
   > & {
-    portalProps?: ComponentPropsWithoutRef<typeof PopoverPrimitive.Portal> | undefined;
+    portalProps?:
+      | ComponentPropsWithoutRef<typeof PopoverPrimitive.Portal>
+      | undefined;
     dissmissOnInteractOutside?: boolean | undefined;
   };
 }


### PR DESCRIPTION
closes https://github.com/assistant-ui/assistant-ui/issues/2132
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `portalProps` to `AssistantModalPrimitiveContent` to allow forwarding properties to `PopoverPrimitive.Portal`.
> 
>   - **Behavior**:
>     - Adds `portalProps` to `AssistantModalPrimitiveContent.Props` in `AssistantModalContent.tsx` to allow forwarding properties to `PopoverPrimitive.Portal`.
>     - Updates `AssistantModalPrimitiveContent` to spread `portalProps` onto `PopoverPrimitive.Portal` in `AssistantModalContent.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 4e3cc8f1de3558ffc94afb2f24671b262fde2786. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->