### PR TITLE
feat: MessageContent.ToolGroup

### DIFF
--- a/.changeset/warm-suits-fall.md
+++ b/.changeset/warm-suits-fall.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: MessageContent.ToolGroup

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -13,11 +13,8 @@ const ratelimit = new Ratelimit({
 
 export async function POST(req: Request) {
   const { messages, tools } = await req.json();
-  console.log("messages", messages);
-  console.log("tools", tools);
   const ip = req.headers.get("x-forwarded-for") ?? "ip";
   const { success } = await ratelimit.limit(ip);
-  console.log(ip, success);
 
   if (!success) {
     return new Response("Rate limit exceeded", { status: 429 });
@@ -38,6 +35,7 @@ export async function POST(req: Request) {
         ]),
       ),
     },
+    onError: console.error,
   });
 
   return result.toDataStreamResponse();

--- a/apps/docs/content/docs/api-reference/primitives/Message.mdx
+++ b/apps/docs/content/docs/api-reference/primitives/Message.mdx
@@ -115,6 +115,38 @@ The content of the message. This renders a separate component for each content p
                 },
               ],
             },
+            {
+              name: "ToolGroup",
+              type: "ComponentType<PropsWithChildren<{ startIndex: number; endIndex: number }>>",
+              description:
+                "Component for rendering grouped consecutive tool calls. When provided, consecutive tool-call content parts will be automatically grouped and wrapped with this component.",
+              children: [
+                {
+                  type: "ToolGroupProps",
+                  parameters: [
+                    {
+                      name: "startIndex",
+                      type: "number",
+                      description: "Index of the first tool call in the group.",
+                      required: true,
+                    },
+                    {
+                      name: "endIndex",
+                      type: "number",
+                      description: "Index of the last tool call in the group.",
+                      required: true,
+                    },
+                    {
+                      name: "children",
+                      type: "ReactNode",
+                      description:
+                        "The rendered tool call components within the group.",
+                      required: true,
+                    },
+                  ],
+                },
+              ],
+            },
           ],
         },
       ],

--- a/apps/docs/content/docs/guides/ToolUI.mdx
+++ b/apps/docs/content/docs/guides/ToolUI.mdx
@@ -43,13 +43,13 @@ const weatherTool = tool({
   execute: async ({ location, unit }) => {
     const weather = await fetchWeatherAPI(location, unit);
     return weather;
-  }
+  },
 });
 
 // Register the tool
 const WeatherTool = makeAssistantTool({
   ...weatherTool,
-  toolName: "getWeather"
+  toolName: "getWeather",
 });
 
 // Create the UI
@@ -77,7 +77,8 @@ const WeatherToolUI = makeAssistantToolUI<
 ```
 
 <Callout type="tip">
-  Tools defined with `makeAssistantTool` can be passed to your backend using the `frontendTools` utility
+  Tools defined with `makeAssistantTool` can be passed to your backend using the
+  `frontendTools` utility
 </Callout>
 
 Learn more about creating tools in the [Tools Guide](/docs/guides/Tools).
@@ -305,8 +306,9 @@ function DynamicToolUI() {
 For tools that need access to parent component props:
 
 <Callout type="tip">
-**Why `useInlineRender`?**
-By default, a tool UI's `render` function is static. Use `useInlineRender` when your UI needs access to dynamic component props (for example, to pass in an `id` or other contextual data).
+  **Why `useInlineRender`?** By default, a tool UI's `render` function is
+  static. Use `useInlineRender` when your UI needs access to dynamic component
+  props (for example, to pass in an `id` or other contextual data).
 </Callout>
 
 ```tsx
@@ -340,7 +342,9 @@ function ProductPage({ productId, productName }) {
 Create tools that collect user input during execution:
 
 <Callout type="tip">
-**Pro tip:** Call `addResult(...)` exactly once to complete the tool call. After it's invoked, the assistant will resume the conversation with your provided data.
+  **Pro tip:** Call `addResult(...)` exactly once to complete the tool call.
+  After it's invoked, the assistant will resume the conversation with your
+  provided data.
 </Callout>
 
 ```tsx
@@ -659,8 +663,41 @@ useAssistantToolUI({
   server.
 </Callout>
 
+### Collapsible Tool Groups
+
+Create collapsible sections for consecutive tool calls:
+
+```tsx
+
+```
+
+### Advanced Tool Group UI
+
+Add progress indicators and enhanced styling:
+
+```tsx
+const ToolGroup = ({ startIndex, endIndex, children }) => {
+  return (
+    <details className="tool-group my-4">
+      <summary className="cursor-pointer rounded bg-gray-50 p-3 hover:bg-gray-100">
+        <span className="font-medium">
+          {endIndex - startIndex + 1} tool calls executed
+        </span>
+        <span className="ml-2 text-sm text-gray-500">
+          (#{startIndex + 1}-{endIndex + 1})
+        </span>
+      </summary>
+      <div className="mt-2 space-y-2 pl-4">{children}</div>
+    </details>
+  );
+};
+
+<Thread components={{ ToolGroup }} />;
+```
+
 ## Related Guides
 
 - [Tools Guide](/docs/guides/Tools) - Learn how to create and use tools with AI models
 - [Tool Fallback](/docs/ui/ToolFallback) - Default UI for tools without custom components
 - [API Reference](/docs/api-reference/primitives/ContentPart) - Detailed type definitions and component APIs
+- [Message Primitive](/docs/api-reference/primitives/Message) - Complete Message component documentation

--- a/packages/react/src/primitives/message/MessageContent.tsx
+++ b/packages/react/src/primitives/message/MessageContent.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { type ComponentType, type FC, memo, useMemo } from "react";
+import {
+  type ComponentType,
+  type FC,
+  memo,
+  PropsWithChildren,
+  useMemo,
+} from "react";
 import {
   TextContentPartProvider,
   useContentPart,
@@ -27,6 +33,70 @@ import type {
 } from "../../types/ContentPartComponentTypes";
 import { ContentPartPrimitiveInProgress } from "../contentPart/ContentPartInProgress";
 import { ContentPartStatus } from "../../types/AssistantTypes";
+import { useShallow } from "zustand/shallow";
+
+type ContentPartRange =
+  | { type: "single"; index: number }
+  | { type: "toolGroup"; startIndex: number; endIndex: number };
+
+/**
+ * Groups consecutive tool-call content parts into ranges.
+ * Always groups tool calls, even if there's only one.
+ */
+const groupContentParts = (
+  contentTypes: readonly string[],
+): ContentPartRange[] => {
+  const ranges: ContentPartRange[] = [];
+  let currentToolGroupStart = -1;
+
+  for (let i = 0; i < contentTypes.length; i++) {
+    const type = contentTypes[i];
+
+    if (type === "tool-call") {
+      // Start a new tool group if we haven't started one
+      if (currentToolGroupStart === -1) {
+        currentToolGroupStart = i;
+      }
+    } else {
+      // End current tool group if it exists
+      if (currentToolGroupStart !== -1) {
+        ranges.push({
+          type: "toolGroup",
+          startIndex: currentToolGroupStart,
+          endIndex: i - 1,
+        });
+        currentToolGroupStart = -1;
+      }
+
+      // Add non-tool-call part individually
+      ranges.push({ type: "single", index: i });
+    }
+  }
+
+  // Handle any remaining tool group at the end
+  if (currentToolGroupStart !== -1) {
+    ranges.push({
+      type: "toolGroup",
+      startIndex: currentToolGroupStart,
+      endIndex: contentTypes.length - 1,
+    });
+  }
+
+  return ranges;
+};
+
+const useMessageContentGroups = (): ContentPartRange[] => {
+  const contentTypes = useMessage(
+    useShallow((m) => m.content.map((c) => c.type)),
+  );
+
+  return useMemo(() => {
+    if (contentTypes.length === 0) {
+      return [];
+    }
+    return groupContentParts(contentTypes);
+  }, [contentTypes]);
+};
 
 export namespace MessagePrimitiveContent {
   export type Props = {
@@ -67,6 +137,58 @@ export namespace MessagePrimitiveContent {
                 Override: ComponentType<ToolCallContentPartProps>;
               }
             | undefined;
+
+          /**
+           * Component for rendering grouped consecutive tool calls.
+           *
+           * When provided, this component will automatically wrap consecutive tool-call
+           * content parts, allowing you to create collapsible sections, custom styling,
+           * or other grouped presentations for multiple tool calls.
+           *
+           * The component receives:
+           * - `startIndex`: The index of the first tool call in the group
+           * - `endIndex`: The index of the last tool call in the group
+           * - `children`: The rendered tool call components
+           *
+           * @example
+           * ```tsx
+           * // Collapsible tool group
+           * ToolGroup: ({ startIndex, endIndex, children }) => (
+           *   <details className="tool-group">
+           *     <summary>
+           *       {endIndex - startIndex + 1} tool calls
+           *     </summary>
+           *     <div className="tool-group-content">
+           *       {children}
+           *     </div>
+           *   </details>
+           * )
+           * ```
+           *
+           * @example
+           * ```tsx
+           * // Custom styled tool group with header
+           * ToolGroup: ({ startIndex, endIndex, children }) => (
+           *   <div className="border rounded-lg p-4 my-2">
+           *     <div className="text-sm text-gray-600 mb-2">
+           *       Tool execution #{startIndex + 1}-{endIndex + 1}
+           *     </div>
+           *     <div className="space-y-2">
+           *       {children}
+           *     </div>
+           *   </div>
+           * )
+           * ```
+           *
+           * @param startIndex - Index of the first tool call in the group
+           * @param endIndex - Index of the last tool call in the group
+           * @param children - Rendered tool call components to display within the group
+           * 
+           * @deprecated This feature is still experimental and subject to change. 
+           */
+          ToolGroup?: ComponentType<
+            PropsWithChildren<{ startIndex: number; endIndex: number }>
+          >;
         }
       | undefined;
   };
@@ -97,6 +219,7 @@ const defaultComponents = {
   Image: () => <ContentPartPrimitiveImage />,
   File: () => null,
   Unstable_Audio: () => null,
+  ToolGroup: ({ children }) => children,
 } satisfies MessagePrimitiveContent.Props["components"];
 
 type MessageContentPartComponentProps = {
@@ -188,7 +311,8 @@ const MessageContentPart = memo(
     prev.components?.Image === next.components?.Image &&
     prev.components?.File === next.components?.File &&
     prev.components?.Unstable_Audio === next.components?.Unstable_Audio &&
-    prev.components?.tools === next.components?.tools,
+    prev.components?.tools === next.components?.tools &&
+    prev.components?.ToolGroup === next.components?.ToolGroup,
 );
 
 const COMPLETE_STATUS: ContentPartStatus = Object.freeze({
@@ -257,19 +381,46 @@ export const MessagePrimitiveContent: FC<MessagePrimitiveContent.Props> = ({
   components,
 }) => {
   const contentLength = useMessage((s) => s.content.length);
+  const contentRanges = useMessageContentGroups();
 
   const contentElements = useMemo(() => {
     if (contentLength === 0) {
       return <EmptyContent components={components} />;
     }
-    return Array.from({ length: contentLength }, (_, index) => (
-      <MessageContentPart
-        key={index}
-        partIndex={index}
-        components={components}
-      />
-    ));
-  }, [contentLength, components]);
+
+    return contentRanges.map((range) => {
+      if (range.type === "single") {
+        return (
+          <MessageContentPart
+            key={range.index}
+            partIndex={range.index}
+            components={components}
+          />
+        );
+      } else {
+        const ToolGroupComponent =
+          components!.ToolGroup ?? defaultComponents.ToolGroup;
+        return (
+          <ToolGroupComponent
+            key={range.startIndex}
+            startIndex={range.startIndex}
+            endIndex={range.endIndex}
+          >
+            {Array.from(
+              { length: range.endIndex - range.startIndex + 1 },
+              (_, i) => (
+                <MessageContentPart
+                  key={i}
+                  partIndex={range.startIndex + i}
+                  components={components}
+                />
+              ),
+            )}
+          </ToolGroupComponent>
+        );
+      }
+    });
+  }, [contentRanges, components, contentLength]);
 
   return <>{contentElements}</>;
 };


### PR DESCRIPTION
Introduce a new ToolGroup component type to the Message primitive API,
enabling automatic grouping and rendering of consecutive tool calls.
Add detailed props documentation for ToolGroup to clarify usage.

Enhance the ToolUI guide with examples demonstrating collapsible tool
groups and advanced UI patterns, including progress indicators and
styling for grouped tool calls.

Remove debug logging from chat API route to clean up server output.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce `ToolGroup` component in `MessageContent` to group consecutive tool calls, update documentation, and remove debug logging from chat API.
> 
>   - **Feature**:
>     - Introduce `ToolGroup` component in `MessageContent.tsx` to group consecutive tool calls.
>     - Automatically groups tool-call content parts, even if there's only one.
>     - Adds `ToolGroup` documentation in `Message.mdx` and examples in `ToolUI.mdx`.
>   - **Documentation**:
>     - Update `Message.mdx` with `ToolGroup` props and usage.
>     - Enhance `ToolUI.mdx` with examples of collapsible tool groups and advanced UI patterns.
>   - **Misc**:
>     - Remove debug logging from `route.ts` in the chat API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for fb4fdd2e2d39e0611bb2792e48f64a9aaf3c5a60. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->