### PR TITLE
fix: reset interrupt state in useLangGraphRuntime hook

### DIFF
--- a/.changeset/khaki-numbers-shave.md
+++ b/.changeset/khaki-numbers-shave.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: reset interrupt state in useLangGraphRuntime hook

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -221,6 +221,7 @@ export const useLangGraphRuntime = ({
       : async () => {
           await onSwitchToNewThread();
           setMessages([]);
+          setInterrupt(undefined);
         },
     onSwitchToThread: switchToThread,
   };


### PR DESCRIPTION
close https://github.com/assistant-ui/assistant-ui/issues/2161
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Resets interrupt state in `useLangGraphRuntime` when switching to a new thread to prevent state carryover.
> 
>   - **Behavior**:
>     - Resets `interrupt` state to `undefined` in `useLangGraphRuntime` when switching to a new thread using `onSwitchToNewThread`.
>   - **Files**:
>     - Modifies `useLangGraphRuntime.ts` to include the reset of the interrupt state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 4951bc712a940980b27eb5ea9b1a8fdc57fbb789. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->