### PR TITLE
fix: support for langgraph error sse

### DIFF
--- a/.changeset/unlucky-balloons-shop.md
+++ b/.changeset/unlucky-balloons-shop.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: support for langgraph error events
+

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -72,6 +72,7 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
             }),
           ) ?? []),
         ],
+        ...(message.status && { status: message.status }),
       };
     case "tool":
       return {

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -1,3 +1,4 @@
+import { MessageStatus } from "@assistant-ui/react";
 import { ReadonlyJSONObject } from "assistant-stream/utils";
 
 export type LangChainToolCallChunk = {
@@ -77,25 +78,7 @@ export type LangChainMessage =
       content: AssistantMessageContent;
       tool_call_chunks?: LangChainToolCallChunk[];
       tool_calls?: LangChainToolCall[];
-      status?:
-        | {
-            type: "running";
-          }
-        | {
-            type: "complete";
-            reason: "stop" | "unknown";
-          }
-        | {
-            type: "incomplete";
-            reason:
-              | "cancelled"
-              | "tool-calls"
-              | "length"
-              | "content-filter"
-              | "other"
-              | "error";
-            error?: any;
-          };
+      status?: MessageStatus;
     };
 
 export type LangChainMessageChunk = {

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -77,6 +77,25 @@ export type LangChainMessage =
       content: AssistantMessageContent;
       tool_call_chunks?: LangChainToolCallChunk[];
       tool_calls?: LangChainToolCall[];
+      status?:
+        | {
+            type: "running";
+          }
+        | {
+            type: "complete";
+            reason: "stop" | "unknown";
+          }
+        | {
+            type: "incomplete";
+            reason:
+              | "cancelled"
+              | "tool-calls"
+              | "length"
+              | "content-filter"
+              | "other"
+              | "error";
+            error?: any;
+          };
     };
 
 export type LangChainMessageChunk = {

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -136,7 +136,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
           case LangGraphKnownEventTypes.Info:
             onInfo?.(chunk.data);
             break;
-          case LangGraphKnownEventTypes.Error:
+          case LangGraphKnownEventTypes.Error: {
             onError?.(chunk.data);
             // Update the last AI message with error status
             // Assumes last AI message is the one the error relates to
@@ -157,6 +157,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
               setMessages(accumulator.addMessages([errorMessage]));
             }
             break;
+          }
           default:
             if (onCustomEvent) {
               onCustomEvent(chunk.event, chunk.data);


### PR DESCRIPTION
Updates last message status when an error event is received from langgraph - enables error display and UI

`types.ts`: add message status types

`useLangGraphMessages.ts`: update last AI message status on error

`convertLangChainMessages.ts`: pass through message status

fixes #2134

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds support for updating AI message status on langgraph error events, with changes in `useLangGraphMessages.ts`, `types.ts`, and `convertLangChainMessages.ts`.
> 
>   - **Behavior**:
>     - Updates last AI message status to "incomplete" with error details when an error event is received in `useLangGraphMessages.ts`.
>     - Adds test case in `useLangGraphMessages.test.ts` to verify AI message status update on error event.
>   - **Types**:
>     - Adds `status` field to `LangChainMessage` type in `types.ts` to support message status tracking.
>   - **Conversion**:
>     - Passes through `status` in `convertLangChainMessages` function in `convertLangChainMessages.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for a0487d40fb15a8ba46108956c56a817893c24746. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->