### PR TITLE
fix: moduleResolution node support

### DIFF
--- a/.changeset/rude-aliens-float.md
+++ b/.changeset/rude-aliens-float.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-syntax-highlighter": patch
+---
+
+fix: moduleResolution node support

--- a/packages/react-syntax-highlighter/full/README.md
+++ b/packages/react-syntax-highlighter/full/README.md
@@ -1,0 +1,1 @@
+This directory exists to support subpath imports for TypeScript projects using --moduleResolution node.

--- a/packages/react-syntax-highlighter/full/package.json
+++ b/packages/react-syntax-highlighter/full/package.json
@@ -1,0 +1,5 @@
+{
+  "type": "module",
+  "main": "../dist/full.js",
+  "types": "../dist/full.d.ts"
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for TypeScript subpath imports with `--moduleResolution node` in `@assistant-ui/react-syntax-highlighter`.
> 
>   - **Support for TypeScript**:
>     - Adds `full/README.md` to explain subpath imports support for TypeScript with `--moduleResolution node`.
>     - Introduces `full/package.json` with `type: module`, `main` pointing to `../dist/full.js`, and `types` to `../dist/full.d.ts`.
>   - **Changeset**:
>     - Adds changeset `rude-aliens-float.md` for `@assistant-ui/react-syntax-highlighter` as a patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 3227215169fb686d36ebde1d7d6ce3ffcb424c1a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->