### PR TITLE
Remove double onAddToolResult call in ExternalStoreThreadRuntimeCore

### DIFF
--- a/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
@@ -252,14 +252,6 @@ export class ExternalStoreThreadRuntimeCore
   public addToolResult(options: AddToolResultOptions) {
     if (!this._store.onAddToolResult && !this._store.onAddToolResult)
       throw new Error("Runtime does not support tool results.");
-    this._store.onAddToolResult?.({
-      messageId: options.messageId,
-      toolName: options.toolName,
-      toolCallId: options.toolCallId,
-      result: options.result,
-      isError: options.isError,
-      artifact: options.artifact,
-    });
     this._store.onAddToolResult?.(options);
   }
 


### PR DESCRIPTION
In our case, this caused double LLM streams to be spawned after calling `addResult` on our tool approval UI.

Not sure if this double call is intentional but doesn't look like it.