### PR TITLE
docs: update toolgroup doc

### DIFF
--- a/apps/docs/content/docs/ui/ToolGroup.mdx
+++ b/apps/docs/content/docs/ui/ToolGroup.mdx
@@ -12,23 +12,28 @@ The ToolGroup component wraps consecutive tool-call message parts, enabling you 
 
 Pass the `ToolGroup` component to the `MessagePrimitive.Parts` component
 
-```tsx twoslash title="/components/assistant-ui/thread.tsx" {1,11}
-// @filename: /components/assistant-ui/tool-group.tsx
+```tsx twoslash title="/components/assistant-ui/thread.tsx"
 import { FC, PropsWithChildren } from "react";
-export const ToolGroup: FC<
-  PropsWithChildren<{ startIndex: number; endIndex: number }>
-> = ({ children }) => children;
-
-// @filename: ./thread.tsx
-import { FC } from "react";
 import { MessagePrimitive } from "@assistant-ui/react";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 
 const AssistantActionBar: FC = () => null;
 const BranchPicker: FC<{ className?: string }> = () => null;
 
 // ---cut---
-import { ToolGroup } from "@/components/assistant-ui/tool-group";
+const ToolGroup: FC<
+  PropsWithChildren<{ startIndex: number; endIndex: number }>
+> = ({ startIndex, endIndex, children }) => {
+  const toolCount = endIndex - startIndex + 1;
+
+  return (
+    <details className="my-2">
+      <summary className="cursor-pointer font-medium">
+        {toolCount} tool {toolCount === 1 ? "call" : "calls"}
+      </summary>
+      <div className="space-y-2 pl-4">{children}</div>
+    </details>
+  );
+};
 
 const AssistantMessage: FC = () => {
   return (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates `ToolGroup.mdx` documentation with detailed usage examples and prop descriptions for the `ToolGroup` component.
> 
>   - **Documentation**:
>     - Updates `ToolGroup.mdx` to include detailed examples of `ToolGroup` usage, such as collapsible sections and styled groups.
>     - Adds prop descriptions for `startIndex`, `endIndex`, and `children` in `ToolGroup.mdx`.
>     - Improves code snippets to demonstrate practical implementation of `ToolGroup` in applications.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 42ddd1916b61e3a7abe35dd9bb48575c49aa578c. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->