### PR TITLE
fix: circular dependency in react package

### DIFF
--- a/.changeset/bumpy-peaches-float.md
+++ b/.changeset/bumpy-peaches-float.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+Fix circular dependency in ThreadMessageLike

--- a/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
+++ b/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
@@ -1,5 +1,5 @@
 import { parsePartialJsonObject } from "assistant-stream/utils";
-import { generateId } from "../../internal";
+import { generateId } from "../../utils/idUtils";
 import {
   MessageStatus,
   TextMessagePart,


### PR DESCRIPTION
# Fix: Resolve circular dependency
## Problem

I was going through an upgrade to `v0.10` and noticed I was getting a lot of errors and after going through the source I found that the`@assistant-ui/react` package had a circular dependency that was causing runtime errors, specifically:

```
"Class extends value undefined is not a constructor or null"
```

This error can be found with the circular import chain between:
1. `internal.ts` → `ThreadMessageLike.tsx` (via `fromThreadMessageLike` export)
2. `ThreadMessageLike.tsx` → `internal.ts` (via `generateId` import)

## Dependency Cycle

1. **`internal.ts`** (line 14) exports:
   ```typescript
   export { fromThreadMessageLike } from "./runtimes/external-store/ThreadMessageLike";
   ```

2. **`ThreadMessageLike.tsx`** (line 2) imports:
   ```typescript
   import { generateId } from "../../internal";
   ```

3. **`internal.ts`** (line 7) also exports:
   ```typescript
   export { generateId } from "./utils/idUtils";
   ```

This created the cycle: **`internal.ts` → `ThreadMessageLike.tsx` → `internal.ts`**

## Proposed solution

Break the circular dependency by having `ThreadMessageLike.tsx` import `generateId` directly from its source:

```diff
- import { generateId } from "../../internal";
+ import { generateId } from "../../utils/idUtils";
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes circular dependency in `ThreadMessageLike.tsx` by changing `generateId` import to resolve runtime errors.
> 
>   - **Dependency Fix**:
>     - Breaks circular dependency in `ThreadMessageLike.tsx` by changing import of `generateId` from `../../internal` to `../../utils/idUtils`.
>   - **Problem**:
>     - Circular dependency between `internal.ts` and `ThreadMessageLike.tsx` caused runtime error: "Class extends value undefined is not a constructor or null".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 21d4cf3998ff02ce602c09a3f174913d4cc136bf. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->