### PR TITLE
fix: if tool calls have no argsText, assume empty object instead of crashing

### DIFF
--- a/.changeset/slow-beans-hang.md
+++ b/.changeset/slow-beans-hang.md
@@ -1,0 +1,6 @@
+---
+"assistant-stream": patch
+"@assistant-ui/react": patch
+---
+
+fix: if tool calls have no argsText, assume empty object instead of crashing

--- a/packages/assistant-stream/src/core/modules/tool-call.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.ts
@@ -24,15 +24,26 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
         this._argsTextController = c;
       },
     });
+
+    let hasArgsText = false;
     this._mergeTask = stream.pipeTo(
       new WritableStream({
         write: (chunk) => {
           switch (chunk.type) {
             case "text-delta":
+              hasArgsText = true;
               this._controller.enqueue(chunk);
               break;
 
             case "part-finish":
+              if (!hasArgsText) {
+                // if no argsText was provided, assume empty object
+                this._controller.enqueue({
+                  type: "text-delta",
+                  textDelta: "{}",
+                  path: [],
+                });
+              }
               this._controller.enqueue({
                 type: "tool-call-args-text-finish",
                 path: [],

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -114,15 +114,6 @@ export class ToolExecutionStream extends PipeableTransformStream<
 
               const promise = withPromiseOrValue(
                 () => {
-                  if (!streamController.argsText) {
-                    console.log(
-                      "Encountered tool call without args, this should never happen",
-                    );
-                    throw new Error(
-                      "Encountered tool call without args, this is unexpected.",
-                    );
-                  }
-
                   let args;
                   try {
                     args = sjson.parse(streamController.argsText);


### PR DESCRIPTION
fixes 2190
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Assume empty object for missing `argsText` in tool calls to prevent crashes.
> 
>   - **Behavior**:
>     - In `tool-call.ts`, if `argsText` is missing, enqueue an empty object (`{}`) instead of crashing.
>     - Removed error logging and exception for missing `argsText` in `ToolExecutionStream.ts`.
>   - **Changeset**:
>     - Adds a patch update for `assistant-stream` and `@assistant-ui/react`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1330cdaa2141c9192001cfcf9547e31b50e5b161. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->