### PR TITLE
draft of arbitrary role support

### DIFF
--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -295,6 +295,39 @@ This is useful when your backend sends multiple message chunks that should appea
   `convertMessage` approach shown above.
 </Callout>
 
+### Role Mapping
+
+When integrating with frameworks like LangChain or multi-agent systems that use custom role names, you can use role mapping to convert them to assistant-ui's core roles (`user`, `assistant`, `system`):
+
+```tsx
+const runtime = useExternalStoreRuntime({
+  messages,
+  onNew,
+  // Map custom roles to assistant-ui roles
+  roleMapping: {
+    human: "user",
+    ai: "assistant",
+    agent: "assistant",
+    moderator: "system",
+  },
+});
+```
+
+When roles are mapped, the original role is preserved in `metadata.custom.originalRole` for display purposes:
+
+```tsx
+// Input message with custom role
+const message = {
+  role: "ai",
+  content: "Hello from AI agent",
+};
+
+// After conversion with role mapping
+// The message will have:
+// - role: "assistant" (for UI components)
+// - metadata.custom.originalRole: "ai" (for display)
+```
+
 ### Essential Handlers
 
 #### Basic Chat (onNew only)
@@ -1427,6 +1460,12 @@ The main interface for connecting your state to assistant-ui.
         "Convert your message format to assistant-ui format. Not needed if using ThreadMessage type",
     },
     {
+      name: "roleMapping",
+      type: "RoleMapping",
+      description:
+        "Map custom role names (e.g., 'human', 'ai') to assistant-ui's core roles ('user', 'assistant', 'system')",
+    },
+    {
       name: "joinStrategy",
       type: '"concat-content" | "none"',
       description: "How to join adjacent assistant messages when converting",
@@ -1494,8 +1533,8 @@ A flexible message format that can be converted to assistant-ui's internal forma
   parameters={[
     {
       name: "role",
-      type: '"assistant" | "user" | "system"',
-      description: "The role of the message sender",
+      type: '"assistant" | "user" | "system" | string',
+      description: "The role of the message sender. Can be a core role or any custom string (will be mapped using roleMapping if provided)",
       required: true,
     },
     {

--- a/apps/docs/content/docs/runtimes/custom/local.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local.mdx
@@ -290,6 +290,42 @@ const MyModelAdapter: ChatModelAdapter = {
 };
 ```
 
+## Role Mapping
+
+When integrating with frameworks like LangChain or multi-agent systems that use custom role names, you can use role mapping to convert them to assistant-ui's core roles (`user`, `assistant`, `system`):
+
+```tsx
+const runtime = useLocalRuntime(MyModelAdapter, {
+  // Map custom roles to assistant-ui roles
+  roleMapping: {
+    human: "user",
+    ai: "assistant",
+    agent: "assistant",
+    moderator: "system",
+  },
+});
+```
+
+When roles are mapped, the original role is preserved in `metadata.custom.originalRole` for display purposes:
+
+```tsx
+// Initial messages with custom roles
+const runtime = useLocalRuntime(MyModelAdapter, {
+  initialMessages: [
+    { role: "human", content: "Hello!" },
+    { role: "ai", content: "Hi there!" },
+  ],
+  roleMapping: {
+    human: "user",
+    ai: "assistant",
+  },
+});
+
+// After conversion, messages will have:
+// - role: "user"/"assistant" (for UI components)
+// - metadata.custom.originalRole: "human"/"ai" (for display)
+```
+
 ## Tool Calling
 
 `LocalRuntime` supports OpenAI-compatible function calling with automatic or human-in-the-loop execution.

--- a/packages/react/src/runtimes/external-store/ExternalStoreAdapter.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreAdapter.tsx
@@ -8,6 +8,7 @@ import {
 import { FeedbackAdapter } from "../adapters/feedback/FeedbackAdapter";
 import { SpeechSynthesisAdapter } from "../adapters/speech/SpeechAdapterTypes";
 import { ThreadMessageLike } from "./ThreadMessageLike";
+import { RoleMapping } from "./RoleMapping";
 
 export type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
   status: TState;
@@ -68,6 +69,7 @@ type ExternalStoreAdapterBase<T> = {
     | ((options: AddToolResultOptions) => Promise<void> | void)
     | undefined;
   convertMessage?: ExternalStoreMessageConverter<T> | undefined;
+  roleMapping?: RoleMapping | undefined;
   adapters?:
     | {
         attachments?: AttachmentAdapter | undefined;

--- a/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
@@ -143,6 +143,7 @@ export class ExternalStoreThreadRuntimeCore
             messageLike,
             idx.toString(),
             autoStatus,
+            store.roleMapping,
           );
           (newMessage as any)[symbolInnerMessage] = m;
           return newMessage;

--- a/packages/react/src/runtimes/external-store/RoleMapping.ts
+++ b/packages/react/src/runtimes/external-store/RoleMapping.ts
@@ -1,0 +1,18 @@
+export type RoleMapping = {
+  [externalRole: string]: "user" | "assistant" | "system";
+};
+
+export const mapRole = (
+  role: string,
+  mapping?: RoleMapping,
+): "user" | "assistant" | "system" => {
+  if (role === "user" || role === "assistant" || role === "system") {
+    return role;
+  }
+
+  if (mapping && role in mapping) {
+    return mapping[role]!;
+  }
+
+  return "assistant";
+};

--- a/packages/react/src/runtimes/external-store/index.ts
+++ b/packages/react/src/runtimes/external-store/index.ts
@@ -15,3 +15,5 @@ export {
   convertExternalMessages as unstable_convertExternalMessages,
 } from "./external-message-converter";
 export { createMessageConverter as unstable_createMessageConverter } from "./createMessageConverter";
+export type { RoleMapping } from "./RoleMapping";
+export { mapRole } from "./RoleMapping";

--- a/packages/react/src/runtimes/local/LocalRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalRuntimeCore.tsx
@@ -26,7 +26,12 @@ export class LocalRuntimeCore extends BaseAssistantRuntimeCore {
     if (initialMessages) {
       this.threads
         .getMainThreadRuntimeCore()
-        .import(ExportedMessageRepository.fromArray(initialMessages));
+        .import(
+          ExportedMessageRepository.fromArray(
+            initialMessages,
+            this._options.roleMapping,
+          ),
+        );
     }
   }
 }

--- a/packages/react/src/runtimes/local/LocalRuntimeOptions.tsx
+++ b/packages/react/src/runtimes/local/LocalRuntimeOptions.tsx
@@ -6,6 +6,7 @@ import { SpeechSynthesisAdapter } from "../adapters/speech/SpeechAdapterTypes";
 import { ChatModelAdapter } from "./ChatModelAdapter";
 import { AssistantCloud } from "assistant-cloud";
 import { SuggestionAdapter } from "../adapters";
+import { RoleMapping } from "../external-store";
 
 export type LocalRuntimeOptionsBase = {
   maxSteps?: number | undefined;
@@ -22,6 +23,8 @@ export type LocalRuntimeOptionsBase = {
    * Names of tools that are allowed to interrupt the run in order to wait for human/external approval.
    */
   unstable_humanToolNames?: string[] | undefined;
+
+  roleMapping?: RoleMapping | undefined;
 };
 
 // TODO align LocalRuntimeOptions with LocalRuntimeOptionsBase
@@ -40,6 +43,7 @@ export const splitLocalRuntimeOptions = <T extends LocalRuntimeOptions>(
     maxSteps,
     adapters,
     unstable_humanToolNames,
+    roleMapping,
     ...rest
   } = options;
 
@@ -50,6 +54,7 @@ export const splitLocalRuntimeOptions = <T extends LocalRuntimeOptions>(
       maxSteps,
       adapters,
       unstable_humanToolNames,
+      roleMapping,
     },
     otherOptions: rest,
   };

--- a/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
@@ -132,10 +132,15 @@ export class LocalThreadRuntimeCore
   public async append(message: AppendMessage): Promise<void> {
     this.ensureInitialized();
 
-    const newMessage = fromThreadMessageLike(message, generateId(), {
-      type: "complete",
-      reason: "unknown",
-    });
+    const newMessage = fromThreadMessageLike(
+      message,
+      generateId(),
+      {
+        type: "complete",
+        reason: "unknown",
+      },
+      this._options.roleMapping,
+    );
     this.repository.addOrUpdateMessage(message.parentId, newMessage);
     this._options.adapters.history?.append({
       parentId: message.parentId,

--- a/packages/react/src/runtimes/utils/MessageRepository.tsx
+++ b/packages/react/src/runtimes/utils/MessageRepository.tsx
@@ -1,6 +1,6 @@
 import type { ThreadMessage } from "../../types";
 import { generateId, generateOptimisticId } from "../../utils/idUtils";
-import { ThreadMessageLike } from "../external-store";
+import { ThreadMessageLike, RoleMapping } from "../external-store";
 import { getAutoStatus } from "../external-store/auto-status";
 import { fromThreadMessageLike } from "../external-store/ThreadMessageLike";
 
@@ -58,13 +58,20 @@ export const ExportedMessageRepository = {
    * Creates parent-child relationships based on the order of messages in the array.
    *
    * @param messages - Array of message-like objects to convert
+   * @param roleMapping - Optional role mapping configuration
    * @returns ExportedMessageRepository with parent-child relationships established
    */
   fromArray: (
     messages: readonly ThreadMessageLike[],
+    roleMapping?: RoleMapping,
   ): ExportedMessageRepository => {
     const conv = messages.map((m) =>
-      fromThreadMessageLike(m, generateId(), getAutoStatus(false, false)),
+      fromThreadMessageLike(
+        m,
+        generateId(),
+        getAutoStatus(false, false),
+        roleMapping,
+      ),
     );
 
     return {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds role mapping support to `ExternalStoreRuntime` and `LocalRuntime`, allowing custom roles to be mapped to core roles (`user`, `assistant`, `system`).
> 
>   - **Role Mapping**:
>     - Adds `roleMapping` option to `useExternalStoreRuntime` and `useLocalRuntime` for mapping custom roles to core roles (`user`, `assistant`, `system`).
>     - Updates `fromThreadMessageLike()` in `ThreadMessageLike.tsx` to use `mapRole()` for role conversion.
>     - Preserves original role in `metadata.custom.originalRole`.
>   - **Code Changes**:
>     - Adds `RoleMapping` type and `mapRole()` function in `RoleMapping.ts`.
>     - Updates `ExternalStoreThreadRuntimeCore.tsx` and `LocalThreadRuntimeCore.tsx` to pass `roleMapping` to `fromThreadMessageLike()`.
>     - Modifies `MessageRepository.tsx` to include `roleMapping` in `fromArray()` method.
>     - Updates documentation in `external-store.mdx` and `local.mdx` to include role mapping examples.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c20f70a764e89c5c432e981629f31d757e6017c6. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->