### PR TITLE
docs: Add guide for LaTeX support

### DIFF
--- a/apps/docs/content/docs/guides/Latex.mdx
+++ b/apps/docs/content/docs/guides/Latex.mdx
@@ -1,0 +1,81 @@
+---
+title: LaTeX
+---
+
+import { Steps, Step } from "fumadocs-ui/components/steps";
+import { Callout } from "fumadocs-ui/components/callout";
+
+Render LaTeX mathematical expressions in chat messages using KaTeX.
+
+<Callout type="warn">LaTeX rendering is not enabled in markdown by default.</Callout>
+
+<Steps>
+  <Step>
+
+### Install dependencies
+
+```bash
+npm i katex rehype-katex remark-math
+```
+
+  </Step>
+  <Step>
+
+### Add KaTeX CSS to your layout
+
+```tsx title="/app/layout.tsx"
+import "katex/dist/katex.min.css"; // [!code ++]
+```
+
+  </Step>
+  <Step>
+
+### Update `markdown-text.tsx`
+
+```tsx title="/components/assistant-ui/markdown-text.tsx"
+import remarkMath from "remark-math";     // [!code ++]
+import rehypeKatex from "rehype-katex";   // [!code ++]
+
+const MarkdownTextImpl = () => {
+  return (
+    <MarkdownTextPrimitive
+      remarkPlugins={[remarkGfm, remarkMath]} // add remarkMath // [!code ++]
+      rehypePlugins={[rehypeKatex]}           // add rehypeKatex // [!code ++]
+      className="aui-md"
+      components={defaultComponents}
+    />
+  );
+};
+
+export const MarkdownText = memo(MarkdownTextImpl);
+```
+
+  </Step>
+</Steps>
+
+## Examples
+
+### Inline math
+
+Single dollar signs for inline math: `$E = mc^2$`
+
+### Block math
+
+Double dollar signs for block math:
+
+```
+$$
+\int_{a}^{b} f(x) \, dx = F(b) - F(a)
+$$
+```
+
+### Fenced code blocks
+
+Fenced code blocks with the `math` language identifier:
+
+````
+```math
+\sum_{i=1}^{n} i = \frac{n(n+1)}{2}
+```
+````
+

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Guides",
-  "pages": ["Attachments", "Branching", "Editing", "Speech", "Tools", "ToolUI"]
+  "pages": ["Attachments", "Branching", "Editing", "Speech", "Latex", "Tools", "ToolUI"]
 }


### PR DESCRIPTION
Related discussion: #2205 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a guide for LaTeX support in documentation, detailing installation and configuration for KaTeX rendering in chat messages.
> 
>   - **Documentation**:
>     - Adds `Latex.mdx` guide for rendering LaTeX in chat messages using KaTeX.
>     - Includes steps for installing `katex`, `rehype-katex`, and `remark-math`.
>     - Provides instructions to add KaTeX CSS in `/app/layout.tsx`.
>     - Details updates to `markdown-text.tsx` to include `remarkMath` and `rehypeKatex` plugins.
>     - Offers examples for inline math, block math, and fenced code blocks.
>   - **Meta**:
>     - Updates `meta.json` to include "Latex" in the guides list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 6c601042af20f6be642a9f1b736ca19118ae6223. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->