### PR TITLE
fix: remove additional dependency cycles

### DIFF
--- a/.changeset/grumpy-numbers-bake.md
+++ b/.changeset/grumpy-numbers-bake.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+Fix internal dependency cycles

--- a/packages/react/src/api/AttachmentRuntime.ts
+++ b/packages/react/src/api/AttachmentRuntime.ts
@@ -1,6 +1,6 @@
 import { SubscribableWithState } from "./subscribable/Subscribable";
 
-import { ComposerRuntimeCoreBinding } from "./ComposerRuntime";
+import type { ComposerRuntimeCoreBinding } from "./RuntimeBindings";
 import {
   Attachment,
   CompleteAttachment,

--- a/packages/react/src/api/ComposerRuntime.ts
+++ b/packages/react/src/api/ComposerRuntime.ts
@@ -5,7 +5,7 @@ import {
   ThreadComposerRuntimeCore,
 } from "../runtimes/core/ComposerRuntimeCore";
 import { Unsubscribe } from "../types";
-import { SubscribableWithState } from "./subscribable/Subscribable";
+
 import { LazyMemoizeSubject } from "./subscribable/LazyMemoizeSubject";
 import {
   AttachmentRuntime,
@@ -18,21 +18,17 @@ import { SKIP_UPDATE } from "./subscribable/SKIP_UPDATE";
 import { ComposerRuntimePath } from "./RuntimePathTypes";
 import { MessageRole, RunConfig } from "../types/AssistantTypes";
 import { EventSubscriptionSubject } from "./subscribable/EventSubscriptionSubject";
+import type {
+  ThreadComposerRuntimeCoreBinding,
+  EditComposerRuntimeCoreBinding,
+  ComposerRuntimeCoreBinding,
+} from "./RuntimeBindings";
 
-export type ThreadComposerRuntimeCoreBinding = SubscribableWithState<
-  ThreadComposerRuntimeCore | undefined,
-  ComposerRuntimePath & { composerSource: "thread" }
->;
-
-export type EditComposerRuntimeCoreBinding = SubscribableWithState<
-  ComposerRuntimeCore | undefined,
-  ComposerRuntimePath & { composerSource: "edit" }
->;
-
-export type ComposerRuntimeCoreBinding = SubscribableWithState<
-  ComposerRuntimeCore | undefined,
-  ComposerRuntimePath
->;
+export type {
+  ThreadComposerRuntimeCoreBinding,
+  EditComposerRuntimeCoreBinding,
+  ComposerRuntimeCoreBinding,
+};
 
 type BaseComposerState = {
   readonly canCancel: boolean;

--- a/packages/react/src/api/MessagePartRuntime.ts
+++ b/packages/react/src/api/MessagePartRuntime.ts
@@ -5,7 +5,7 @@ import {
   ToolCallMessagePartStatus,
 } from "../types/AssistantTypes";
 import { ThreadRuntimeCoreBinding } from "./ThreadRuntime";
-import { MessageStateBinding } from "./MessageRuntime";
+import type { MessageStateBinding } from "./RuntimeBindings";
 import { SubscribableWithState } from "./subscribable/Subscribable";
 import { Unsubscribe } from "../types";
 import { MessagePartRuntimePath } from "./RuntimePathTypes";

--- a/packages/react/src/api/MessageRuntime.ts
+++ b/packages/react/src/api/MessageRuntime.ts
@@ -34,7 +34,7 @@ import { ThreadRuntimeCoreBinding } from "./ThreadRuntime";
 import { NestedSubscriptionSubject } from "./subscribable/NestedSubscriptionSubject";
 import { SKIP_UPDATE } from "./subscribable/SKIP_UPDATE";
 import { ShallowMemoizeSubject } from "./subscribable/ShallowMemoizeSubject";
-import { SubscribableWithState } from "./subscribable/Subscribable";
+import type { MessageStateBinding } from "./RuntimeBindings";
 
 const COMPLETE_STATUS: MessagePartStatus = Object.freeze({
   type: "complete",
@@ -92,10 +92,7 @@ export type MessageState = ThreadMessage & {
   readonly submittedFeedback: SubmittedFeedback | undefined;
 };
 
-export type MessageStateBinding = SubscribableWithState<
-  MessageState,
-  MessageRuntimePath
->;
+export type { MessageStateBinding } from "./RuntimeBindings";
 
 type ReloadConfig = {
   runConfig?: RunConfig;

--- a/packages/react/src/api/RuntimeBindings.ts
+++ b/packages/react/src/api/RuntimeBindings.ts
@@ -1,0 +1,65 @@
+import type {
+  ComposerRuntimeCore,
+  ThreadComposerRuntimeCore,
+} from "../runtimes/core/ComposerRuntimeCore";
+import type { ThreadRuntimeCore } from "../runtimes/core/ThreadRuntimeCore";
+import type { ThreadListRuntimeCore } from "../runtimes/core/ThreadListRuntimeCore";
+import type { SubscribableWithState } from "./subscribable/Subscribable";
+import type { ThreadMessage } from "../types";
+import type {
+  SpeechState,
+  SubmittedFeedback,
+} from "../runtimes/core/ThreadRuntimeCore";
+import type {
+  ComposerRuntimePath,
+  ThreadRuntimePath,
+  ThreadListItemRuntimePath,
+  MessageRuntimePath,
+} from "./RuntimePathTypes";
+
+export type ComposerRuntimeCoreBinding = SubscribableWithState<
+  ComposerRuntimeCore | undefined,
+  ComposerRuntimePath
+>;
+
+export type ThreadComposerRuntimeCoreBinding = SubscribableWithState<
+  ThreadComposerRuntimeCore | undefined,
+  ComposerRuntimePath & { composerSource: "thread" }
+>;
+
+export type EditComposerRuntimeCoreBinding = SubscribableWithState<
+  ComposerRuntimeCore | undefined,
+  ComposerRuntimePath & { composerSource: "edit" }
+>;
+
+export type ThreadRuntimeCoreBinding = SubscribableWithState<
+  ThreadRuntimeCore,
+  ThreadRuntimePath
+>;
+
+export type ThreadListRuntimeCoreBinding = SubscribableWithState<
+  ThreadListRuntimeCore,
+  ThreadListItemRuntimePath
+>;
+
+export type MessageStateBinding = SubscribableWithState<
+  ThreadMessage & {
+    readonly parentId: string | null;
+    readonly isLast: boolean;
+    readonly branchNumber: number;
+    readonly branchCount: number;
+    readonly speech: SpeechState | undefined;
+    readonly submittedFeedback: SubmittedFeedback | undefined;
+  },
+  MessageRuntimePath
+>;
+
+export type ThreadListItemState = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly threadId: string;
+  readonly status: "archived" | "regular" | "new" | "deleted";
+  readonly title?: string | undefined;
+};

--- a/packages/react/src/api/RuntimeBindings.ts
+++ b/packages/react/src/api/RuntimeBindings.ts
@@ -54,12 +54,17 @@ export type MessageStateBinding = SubscribableWithState<
   MessageRuntimePath
 >;
 
+export type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+
 export type ThreadListItemState = {
   readonly isMain: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
+  /**
+   * @deprecated Use `id` instead. This field will be removed in version 0.8.0.
+   */
   readonly threadId: string;
-  readonly status: "archived" | "regular" | "new" | "deleted";
+  readonly status: ThreadListItemStatus;
   readonly title?: string | undefined;
 };

--- a/packages/react/src/api/ThreadListItemRuntime.ts
+++ b/packages/react/src/api/ThreadListItemRuntime.ts
@@ -5,9 +5,12 @@ import { ThreadListRuntimeCoreBinding } from "./ThreadListRuntime";
 
 export type ThreadListItemEventType = "switched-to" | "switched-away";
 
-import type { ThreadListItemState } from "./RuntimeBindings";
+import type {
+  ThreadListItemState,
+  ThreadListItemStatus,
+} from "./RuntimeBindings";
 
-export type { ThreadListItemState };
+export type { ThreadListItemState, ThreadListItemStatus };
 
 export type ThreadListItemRuntime = {
   readonly path: ThreadListItemRuntimePath;

--- a/packages/react/src/api/ThreadListItemRuntime.ts
+++ b/packages/react/src/api/ThreadListItemRuntime.ts
@@ -5,21 +5,9 @@ import { ThreadListRuntimeCoreBinding } from "./ThreadListRuntime";
 
 export type ThreadListItemEventType = "switched-to" | "switched-away";
 
-export type ThreadListItemState = {
-  readonly isMain: boolean;
+import type { ThreadListItemState } from "./RuntimeBindings";
 
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-
-  /**
-   * @deprecated This field was renamed to `id`. This field will be removed in 0.8.0.
-   */
-  readonly threadId: string;
-
-  readonly status: "archived" | "regular" | "new" | "deleted";
-  readonly title?: string | undefined;
-};
+export type { ThreadListItemState };
 
 export type ThreadListItemRuntime = {
   readonly path: ThreadListItemRuntimePath;

--- a/packages/react/src/api/ThreadRuntime.ts
+++ b/packages/react/src/api/ThreadRuntime.ts
@@ -27,7 +27,7 @@ import {
   ThreadListItemRuntimePath,
   ThreadRuntimePath,
 } from "./RuntimePathTypes";
-import { ThreadListItemState } from "./ThreadListItemRuntime";
+import type { ThreadListItemState } from "./RuntimeBindings";
 import { RunConfig } from "../types/AssistantTypes";
 import { EventSubscriptionSubject } from "./subscribable/EventSubscriptionSubject";
 import { symbolInnerMessage } from "../runtimes/external-store/getExternalStoreMessage";

--- a/packages/react/src/runtimes/core/ThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/ThreadListRuntimeCore.tsx
@@ -1,12 +1,13 @@
 import { Unsubscribe } from "../../types";
 import { ThreadRuntimeCore } from "./ThreadRuntimeCore";
+import type { ThreadListItemStatus } from "../../api/RuntimeBindings";
 
 type ThreadListItemCoreState = {
   readonly threadId: string;
   readonly remoteId?: string | undefined;
   readonly externalId?: string | undefined;
 
-  readonly status: "archived" | "regular" | "new" | "deleted";
+  readonly status: ThreadListItemStatus;
   readonly title?: string | undefined;
 
   readonly runtime?: ThreadRuntimeCore | undefined;

--- a/packages/react/src/runtimes/external-store/ExternalStoreRuntimeCore.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreRuntimeCore.tsx
@@ -1,4 +1,4 @@
-import { BaseAssistantRuntimeCore } from "../../internal";
+import { BaseAssistantRuntimeCore } from "../core/BaseAssistantRuntimeCore";
 import { ExternalStoreThreadListRuntimeCore } from "./ExternalStoreThreadListRuntimeCore";
 import { ExternalStoreAdapter } from "./ExternalStoreAdapter";
 import { ExternalStoreThreadRuntimeCore } from "./ExternalStoreThreadRuntimeCore";

--- a/packages/react/src/types/AssistantTypes.ts
+++ b/packages/react/src/types/AssistantTypes.ts
@@ -1,5 +1,5 @@
 import type { CompleteAttachment } from "./AttachmentTypes";
-import { ReadonlyJSONValue } from "assistant-stream/utils";
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import type {
   TextMessagePart,
   ReasoningMessagePart,

--- a/packages/react/src/types/AssistantTypes.ts
+++ b/packages/react/src/types/AssistantTypes.ts
@@ -1,75 +1,32 @@
-import { CompleteAttachment } from "./AttachmentTypes";
-import { ReadonlyJSONObject, ReadonlyJSONValue } from "assistant-stream/utils";
+import type { CompleteAttachment } from "./AttachmentTypes";
+import { ReadonlyJSONValue } from "assistant-stream/utils";
+import type {
+  TextMessagePart,
+  ReasoningMessagePart,
+  SourceMessagePart,
+  ImageMessagePart,
+  FileMessagePart,
+  Unstable_AudioMessagePart,
+  ToolCallMessagePart,
+  ThreadUserMessagePart,
+  ThreadAssistantMessagePart,
+} from "./MessagePartTypes";
 
+// Re-export message part types for convenience
+export type {
+  TextMessagePart,
+  ReasoningMessagePart,
+  SourceMessagePart,
+  ImageMessagePart,
+  FileMessagePart,
+  Unstable_AudioMessagePart,
+  ToolCallMessagePart,
+  ThreadUserMessagePart,
+  ThreadAssistantMessagePart,
+};
+
+// Alias for the role of a thread message
 export type MessageRole = ThreadMessage["role"];
-
-export type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-export type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-export type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly parentId?: string;
-};
-
-export type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-};
-
-export type FileMessagePart = {
-  readonly type: "file";
-  readonly data: string;
-  readonly mimeType: string;
-};
-
-export type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
-  };
-};
-
-export type ToolCallMessagePart<
-  TArgs = ReadonlyJSONObject,
-  TResult = unknown,
-> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly parentId?: string;
-};
-
-export type ThreadUserMessagePart =
-  | TextMessagePart
-  | ImageMessagePart
-  | FileMessagePart
-  | Unstable_AudioMessagePart;
-
-export type ThreadAssistantMessagePart =
-  | TextMessagePart
-  | ReasoningMessagePart
-  | ToolCallMessagePart
-  | SourceMessagePart
-  | FileMessagePart;
 
 type MessageCommonProps = {
   readonly id: string;

--- a/packages/react/src/types/AttachmentTypes.ts
+++ b/packages/react/src/types/AttachmentTypes.ts
@@ -1,4 +1,4 @@
-import { ThreadUserMessagePart } from "./AssistantTypes";
+import type { ThreadUserMessagePart } from "./MessagePartTypes";
 
 export type PendingAttachmentStatus =
   | {

--- a/packages/react/src/types/MessagePartTypes.ts
+++ b/packages/react/src/types/MessagePartTypes.ts
@@ -1,0 +1,69 @@
+import { ReadonlyJSONObject } from "assistant-stream/utils";
+
+export type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+export type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+export type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly parentId?: string;
+};
+
+export type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+};
+
+export type FileMessagePart = {
+  readonly type: "file";
+  readonly data: string;
+  readonly mimeType: string;
+};
+
+export type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
+};
+
+export type ToolCallMessagePart<
+  TArgs = ReadonlyJSONObject,
+  TResult = unknown,
+> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly parentId?: string;
+};
+
+export type ThreadUserMessagePart =
+  | TextMessagePart
+  | ImageMessagePart
+  | FileMessagePart
+  | Unstable_AudioMessagePart;
+
+export type ThreadAssistantMessagePart =
+  | TextMessagePart
+  | ReasoningMessagePart
+  | ToolCallMessagePart
+  | SourceMessagePart
+  | FileMessagePart;

--- a/packages/react/src/types/index.ts
+++ b/packages/react/src/types/index.ts
@@ -87,4 +87,7 @@ export type {
   ToolCallMessagePartProps as ToolCallContentPartProps,
 } from "./MessagePartComponentTypes";
 
+// Thread list item types
+export type { ThreadListItemStatus } from "../api/ThreadListItemRuntime";
+
 export type { Unsubscribe } from "./Unsubscribe";


### PR DESCRIPTION
## Problem

Tests were failing with the error `TypeError: Class extends value undefined is not a constructor or null` due to circular dependencies in the React package import chain. 

This has happened before, so I wrote a quick script to analyze the package and found 7 circular dependencies. Most of them are easily solvable, but there are some that can be discussed at a further point. For now, this PR addresses what can be managed in a patch.

## Root Cause

The critical failure was caused by this circular import chain:

```
ExternalStoreRuntimeCore → internal → api/AssistantRuntime → runtimes → external-store → ExternalStoreRuntimeCore
```

When `ExternalStoreRuntimeCore` tried to extend `BaseAssistantRuntimeCore`, the base class was `undefined` due to the circular dependency preventing proper module initialization.

## Detailed Changes

### 1. ExternalStoreRuntimeCore Import

Importing `BaseAssistantRuntimeCore` through barrel export created a cycle

### 2. `src/types/MessagePartTypes.ts`

`AssistantTypes.ts` and `AttachmentTypes.ts` had circular type dependencies:

- `AssistantTypes` imported `CompleteAttachment`
- `AttachmentTypes` imported `ThreadUserMessagePart`

**Solution**: Extracted shared message part type definitions into dedicated file:

```typescript
// Shared types that both files need
export type TextMessagePart = { ... };
export type ThreadUserMessagePart = ...;
// etc.
```

**Files updated**:

- `AssistantTypes.ts` - Now imports and re-exports from shared file
- `AttachmentTypes.ts` - Now imports `ThreadUserMessagePart` from shared file

### 3. `src/api/RuntimeBindings.ts`

Multiple API runtime files had circular binding dependencies:

- `AttachmentRuntime` ↔ `ComposerRuntime`
- `MessageRuntime` ↔ `MessagePartRuntime`
- `ThreadRuntime` ↔ `MessageRuntime`
- `ThreadRuntime` ↔ `ThreadListItemRuntime`

Centralized shared runtime binding type definitions by the different files:

**Files updated**:

- `AttachmentRuntime.ts` - Imports `ComposerRuntimeCoreBinding` from shared file
- `ComposerRuntime.ts` - Re-exports bindings from shared file
- `MessageRuntime.ts` - Re-exports `MessageStateBinding` from shared file
- `MessagePartRuntime.ts` - Imports `MessageStateBinding` from shared file
- `ThreadRuntime.ts` - Imports `ThreadListItemState` from shared file
- `ThreadListItemRuntime.ts` - Re-exports state from shared file

## Remaining Cycles (3)

The remaining cycles involve complex runtime implementation interdependencies that would require architectural changes to resolve:

1. `ThreadRuntime → MessageRuntime → MessagePartRuntime → ThreadRuntime`
2. `ThreadRuntime ↔ MessageRuntime`
3. `ThreadListRuntime ↔ ThreadListItemRuntime`

These are implementation-level dependencies (not type-only) and don't cause the runtime initialization errors from testing. For now, I kept those cycles and can address at another time if necessary.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes circular dependencies causing runtime errors by restructuring imports and centralizing type definitions.
> 
>   - **Behavior**:
>     - Fixes circular dependencies causing `TypeError: Class extends value undefined` by restructuring imports in `ExternalStoreRuntimeCore.tsx`.
>     - Extracts shared message part types to `MessagePartTypes.ts` to resolve circular type dependencies between `AssistantTypes.ts` and `AttachmentTypes.ts`.
>   - **Imports**:
>     - Centralizes runtime binding type definitions in `RuntimeBindings.ts` to resolve circular dependencies in `AttachmentRuntime.ts`, `ComposerRuntime.ts`, and `MessagePartRuntime.ts`.
>   - **Remaining Cycles**:
>     - Identifies 3 remaining cycles involving `ThreadRuntime`, `MessageRuntime`, and `ThreadListItemRuntime` that require architectural changes but do not cause runtime errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 884cf5b723113355b0241f3ddb9ac301909770ee. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->