### PR TITLE
feat: add `thread.reset()` method

### DIFF
--- a/.changeset/thin-plums-collect.md
+++ b/.changeset/thin-plums-collect.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: add `runtime.thread.reset()` method for clearing thread

--- a/packages/react/src/api/AssistantRuntime.ts
+++ b/packages/react/src/api/AssistantRuntime.ts
@@ -49,7 +49,7 @@ export type AssistantRuntime = {
   registerModelConfigProvider(provider: ModelContextProvider): Unsubscribe;
 
   /**
-   * @deprecated Deprecated. Please use `runtime.threads.main.import(ExportedMessageRepository.fromArray(initialMessages))`.
+   * @deprecated Deprecated. Please use `runtime.thread.reset(initialMessages)`.
    */
   reset: unknown; // make it a type error
 };

--- a/packages/react/src/api/AssistantRuntime.ts
+++ b/packages/react/src/api/AssistantRuntime.ts
@@ -49,7 +49,7 @@ export type AssistantRuntime = {
   registerModelConfigProvider(provider: ModelContextProvider): Unsubscribe;
 
   /**
-   * @deprecated Deprecated. Please use `runtime.thread.reset(initialMessages)`.
+   * @deprecated Use `runtime.thread.reset(initialMessages)`.
    */
   reset: unknown; // make it a type error
 };

--- a/packages/react/src/api/ThreadRuntime.ts
+++ b/packages/react/src/api/ThreadRuntime.ts
@@ -266,6 +266,14 @@ export type ThreadRuntime = {
 
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;
+
+  /**
+   * Reset the thread with optional initial messages.
+   *
+   * @param initialMessages - Optional array of initial messages to populate the thread
+   */
+  reset(initialMessages?: CreateAppendMessage[]): void;
+
   getMesssageByIndex(idx: number): MessageRuntime;
   getMesssageById(messageId: string): MessageRuntime;
 
@@ -340,6 +348,7 @@ export class ThreadRuntimeImpl implements ThreadRuntime {
     this.stopSpeaking = this.stopSpeaking.bind(this);
     this.export = this.export.bind(this);
     this.import = this.import.bind(this);
+    this.reset = this.reset.bind(this);
     this.getMesssageByIndex = this.getMesssageByIndex.bind(this);
     this.getMesssageById = this.getMesssageById.bind(this);
     this.subscribe = this.subscribe.bind(this);
@@ -401,6 +410,12 @@ export class ThreadRuntimeImpl implements ThreadRuntime {
 
   public import(data: ExportedMessageRepository) {
     this._threadBinding.getState().import(data);
+  }
+
+  public reset(initialMessages?: CreateAppendMessage[]) {
+    const messages =
+      initialMessages?.map((message) => toAppendMessage([], message)) ?? [];
+    this._threadBinding.getState().reset(messages);
   }
 
   public getMesssageByIndex(idx: number) {

--- a/packages/react/src/api/ThreadRuntime.ts
+++ b/packages/react/src/api/ThreadRuntime.ts
@@ -9,6 +9,7 @@ import {
 } from "../runtimes/core/ThreadRuntimeCore";
 import { ExportedMessageRepository } from "../runtimes/utils/MessageRepository";
 import { AppendMessage, ThreadMessage, Unsubscribe } from "../types";
+import { ThreadMessageLike } from "../runtimes/external-store";
 import {
   MessageRuntime,
   MessageRuntimeImpl,
@@ -272,7 +273,7 @@ export type ThreadRuntime = {
    *
    * @param initialMessages - Optional array of initial messages to populate the thread
    */
-  reset(initialMessages?: CreateAppendMessage[]): void;
+  reset(initialMessages?: readonly ThreadMessageLike[]): void;
 
   getMesssageByIndex(idx: number): MessageRuntime;
   getMesssageById(messageId: string): MessageRuntime;
@@ -412,10 +413,8 @@ export class ThreadRuntimeImpl implements ThreadRuntime {
     this._threadBinding.getState().import(data);
   }
 
-  public reset(initialMessages?: CreateAppendMessage[]) {
-    const messages =
-      initialMessages?.map((message) => toAppendMessage([], message)) ?? [];
-    this._threadBinding.getState().reset(messages);
+  public reset(initialMessages?: readonly ThreadMessageLike[]) {
+    this._threadBinding.getState().reset(initialMessages);
   }
 
   public getMesssageByIndex(idx: number) {

--- a/packages/react/src/runtimes/core/BaseThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/BaseThreadRuntimeCore.tsx
@@ -22,6 +22,7 @@ import { FeedbackAdapter } from "../adapters/feedback/FeedbackAdapter";
 import { AttachmentAdapter } from "../adapters/attachment";
 import { getThreadMessageText } from "../../utils/getThreadMessageText";
 import { ModelContextProvider } from "../../model-context";
+import { ThreadMessageLike } from "../external-store";
 
 type BaseThreadAdapters = {
   speech?: SpeechSynthesisAdapter | undefined;
@@ -192,6 +193,10 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
     this.repository.clear();
     this.repository.import(data);
     this._notifySubscribers();
+  }
+
+  public reset(initialMessages?: ThreadMessageLike[]) {
+    this.import(ExportedMessageRepository.fromArray(initialMessages ?? []));
   }
 
   private _eventSubscribers = new Map<

--- a/packages/react/src/runtimes/core/BaseThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/BaseThreadRuntimeCore.tsx
@@ -195,7 +195,7 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
     this._notifySubscribers();
   }
 
-  public reset(initialMessages?: ThreadMessageLike[]) {
+  public reset(initialMessages?: readonly ThreadMessageLike[]) {
     this.import(ExportedMessageRepository.fromArray(initialMessages ?? []));
   }
 

--- a/packages/react/src/runtimes/core/ThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/ThreadRuntimeCore.tsx
@@ -119,7 +119,7 @@ export type ThreadRuntimeCore = Readonly<{
   import(repository: ExportedMessageRepository): void;
   export(): ExportedMessageRepository;
 
-  reset(initialMessages?: ThreadMessageLike[]): void;
+  reset(initialMessages?: readonly ThreadMessageLike[]): void;
 
   unstable_on(event: ThreadRuntimeEventType, callback: () => void): Unsubscribe;
 }>;

--- a/packages/react/src/runtimes/core/ThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/core/ThreadRuntimeCore.tsx
@@ -6,6 +6,7 @@ import type { Unsubscribe } from "../../types/Unsubscribe";
 import { SpeechSynthesisAdapter } from "../adapters/speech/SpeechAdapterTypes";
 import { ChatModelRunOptions, ChatModelRunResult } from "../local";
 import { ExportedMessageRepository } from "../utils/MessageRepository";
+import { ThreadMessageLike } from "../external-store";
 import {
   ComposerRuntimeCore,
   ThreadComposerRuntimeCore,
@@ -117,6 +118,8 @@ export type ThreadRuntimeCore = Readonly<{
 
   import(repository: ExportedMessageRepository): void;
   export(): ExportedMessageRepository;
+
+  reset(initialMessages?: ThreadMessageLike[]): void;
 
   unstable_on(event: ThreadRuntimeEventType, callback: () => void): Unsubscribe;
 }>;

--- a/packages/react/src/runtimes/remote-thread-list/EMPTY_THREAD_CORE.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/EMPTY_THREAD_CORE.tsx
@@ -163,6 +163,10 @@ export const EMPTY_THREAD_CORE: ThreadRuntimeCore = {
     return { messages: [] };
   },
 
+  reset() {
+    throw EMPTY_THREAD_ERROR;
+  },
+
   unstable_on() {
     return () => {};
   },


### PR DESCRIPTION
Improve API by adding reset method `runtime.thread.reset()`

Usage: `runtime.thread.reset(initialMessages)`
Replaces: `runtime.threads.main.import(ExportedMessageRepository.fromArray(initialMessages))`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `reset` method to `ThreadRuntime` for resetting threads with initial messages, updating deprecated methods accordingly.
> 
>   - **Behavior**:
>     - Adds `reset(initialMessages)` method to `ThreadRuntime` in `ThreadRuntime.ts` for resetting threads with optional initial messages.
>     - Updates deprecated `reset` method in `AssistantRuntime.ts` to use `runtime.thread.reset(initialMessages)`.
>   - **Implementation**:
>     - Implements `reset` method in `ThreadRuntimeImpl` in `ThreadRuntime.ts` and binds it.
>     - Implements `reset` method in `BaseThreadRuntimeCore.tsx` to import messages from `ExportedMessageRepository`.
>     - Adds `reset` method to `EMPTY_THREAD_CORE.tsx` that throws an error.
>   - **Misc**:
>     - Imports `ThreadMessageLike` in `ThreadRuntime.ts` and `BaseThreadRuntimeCore.tsx` for type definition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 30a40bb4be0a458488a44406c72d3a4172185ed6. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->