### PR TITLE
feat: ExternalStoreAdapter.messageRepository API

### DIFF
--- a/.changeset/shaggy-trains-walk.md
+++ b/.changeset/shaggy-trains-walk.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: ExternalStoreAdapter.messageRepository API

--- a/packages/react/src/runtimes/external-store/ExternalStoreAdapter.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreAdapter.tsx
@@ -8,6 +8,7 @@ import {
 import { FeedbackAdapter } from "../adapters/feedback/FeedbackAdapter";
 import { SpeechSynthesisAdapter } from "../adapters/speech/SpeechAdapterTypes";
 import { ThreadMessageLike } from "./ThreadMessageLike";
+import { ExportedMessageRepository } from "../utils/MessageRepository";
 
 export type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
   status: TState;
@@ -53,7 +54,8 @@ type ExternalStoreAdapterBase<T> = {
   isDisabled?: boolean | undefined;
   isRunning?: boolean | undefined;
   isLoading?: boolean | undefined;
-  messages: readonly T[];
+  messages?: readonly T[];
+  messageRepository?: ExportedMessageRepository;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   extras?: unknown;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `messageRepository` API to `ExternalStoreAdapter`, updating `ExternalStoreThreadRuntimeCore` to handle message repositories or arrays.
> 
>   - **API Addition**:
>     - Introduces `messageRepository` to `ExternalStoreAdapter` in `ExternalStoreAdapter.tsx`.
>     - Allows `ExternalStoreAdapter` to use either `messages` or `messageRepository`.
>   - **Behavior**:
>     - In `ExternalStoreThreadRuntimeCore`, handles `messageRepository` by clearing and importing it, or processes `messages` array if provided.
>     - Throws error if neither `messages` nor `messageRepository` is provided.
>     - Updates message handling logic to accommodate `messageRepository`.
>   - **Misc**:
>     - Updates `ExternalStoreThreadRuntimeCore` to notify subscribers and manage message conversion and repository updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1d86160f26c1da6a0876d0b0e28879752ebb4722. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->