### PR TITLE
fix: message id not found when using messageRepository in external store

### DIFF
--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -34,7 +34,7 @@
     "zustand": "^5.0.6"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.28",
+    "@assistant-ui/react": "^0.10.29",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -25,7 +25,7 @@
     "zod": "^3.25.67"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.28",
+    "@assistant-ui/react": "^0.10.29",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -29,7 +29,7 @@
     "zod": "^3.25.67"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.28",
+    "@assistant-ui/react": "^0.10.29",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -36,7 +36,7 @@
     "react-markdown": "^10.1.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.28",
+    "@assistant-ui/react": "^0.10.29",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint ."
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.28",
+    "@assistant-ui/react": "^0.10.29",
     "@assistant-ui/react-markdown": "^0.10.6",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.10.29
+
+### Patch Changes
+
+- 1f2fb01: fix: message id not found when using messageRepository in external store
+
 ## 0.10.28
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.10.28",
+  "version": "0.10.29",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/external-store/ExternalStoreThreadRuntimeCore.tsx
@@ -123,6 +123,7 @@ export class ExternalStoreThreadRuntimeCore
 
       // Clear and import the message repository
       this.repository.clear();
+      this.assistantOptimisticId = null;
       this.repository.import(store.messageRepository);
 
       messages = this.repository.getMessages();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix message ID not found issue in `ExternalStoreThreadRuntimeCore` by resetting `assistantOptimisticId` before importing message repository.
> 
>   - **Bug Fix**:
>     - In `ExternalStoreThreadRuntimeCore`, set `assistantOptimisticId` to null before importing `store.messageRepository` to fix message ID not found issue.
>   - **Misc**:
>     - Add changeset file `slick-news-watch.md` for patch release.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1f2fb011f744baff70749ebc8132f9316965f59a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->