### PR TITLE
fix(registry): process `base-components.css`

### DIFF
--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -2,6 +2,7 @@ import { promises as fs, readFileSync } from "node:fs";
 import * as path from "node:path";
 import { registry } from "../src/registry";
 import { RegistryItem } from "@/src/schema";
+import baseComponentsStyles from "../../../packages/styles/dist/styles/tailwindcss/base-components.css.json";
 import threadStyles from "../../../packages/styles/dist/styles/tailwindcss/thread.css.json";
 import modalStyles from "../../../packages/styles/dist/styles/tailwindcss/modal.css.json";
 import markdownStyles from "../../../packages/styles/dist/styles/tailwindcss/markdown.css.json";
@@ -10,6 +11,7 @@ const REGISTRY_PATH = path.join(process.cwd(), "dist");
 
 const tailwindStyles = Object.entries({
   ".aui-root": {},
+  ...baseComponentsStyles,
   ...threadStyles,
   ...modalStyles,
   ...markdownStyles,

--- a/packages/styles/scripts/build.mts
+++ b/packages/styles/scripts/build.mts
@@ -2,6 +2,7 @@ import { Build } from "@assistant-ui/x-buildutils";
 
 await Build.start().transpileCSS({
   jsonEntrypoints: [
+    "src/styles/tailwindcss/base-components.css",
     "src/styles/tailwindcss/modal.css",
     "src/styles/tailwindcss/thread.css",
     "src/styles/tailwindcss/markdown.css",


### PR DESCRIPTION
Fixes a bug where some classnames were not processed and tranformed into tailwind classes for the registry