### PR TITLE
fix: unmemoized store helpers

### DIFF
--- a/.changeset/nice-breads-attack.md
+++ b/.changeset/nice-breads-attack.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+Memoize useSyncExternalStore calls for combined store

--- a/packages/react/src/context/react/utils/useRuntimeState.ts
+++ b/packages/react/src/context/react/utils/useRuntimeState.ts
@@ -1,4 +1,4 @@
-import { useDebugValue, useSyncExternalStore } from "react";
+import { useCallback, useDebugValue, useSyncExternalStore } from "react";
 import { Unsubscribe } from "../../../types";
 import { ensureBinding } from "./ensureBinding";
 
@@ -14,10 +14,15 @@ export function useRuntimeStateInternal<TState, TSelected>(
   // TODO move to useRuntimeState
   ensureBinding(runtime);
 
+  const getSnapshot = useCallback(
+    () => selector(runtime.getState()),
+    [selector, runtime],
+  );
+
   const slice = useSyncExternalStore(
     runtime.subscribe,
-    () => selector(runtime.getState()),
-    () => selector(runtime.getState()),
+    getSnapshot,
+    getSnapshot,
   );
   useDebugValue(slice);
   return slice;

--- a/packages/react/src/utils/combined/createCombinedStore.ts
+++ b/packages/react/src/utils/combined/createCombinedStore.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import type { Unsubscribe } from "../../types/Unsubscribe";
 
 export type StoreOrRuntime<T> = {
@@ -23,8 +23,10 @@ export const createCombinedStore = <T extends Array<unknown>, R>(stores: {
   };
 
   return (selector: CombinedSelector<T, R>): R => {
-    const getSnapshot = (): R =>
-      selector(...(stores.map((store) => store.getState()) as T));
+    const getSnapshot = useCallback(
+      (): R => selector(...(stores.map((store) => store.getState()) as T)),
+      [selector],
+    );
 
     return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   };


### PR DESCRIPTION
## Fix: Memoize getSnapshot functions to prevent infinite loops

### What was done
- Added `useCallback` memoization to `getSnapshot` functions in `createCombinedStore.ts` and `useRuntimeState.ts`
- Imported `useCallback` from React in both files

### Why was it done
- Fixes React warning: "The result of getSnapshot should be cached to avoid an infinite loop" occurring in `console`
- Components passing inline selector functions to `useCombinedStore` were creating new `getSnapshot` functions on every render
- This caused `useSyncExternalStore` to detect changes and trigger infinite re-renders

### How it was tested
- TypeScript compilation passes (`npx tsc --noEmit`)
- ESLint checks pass
- Changes are backward compatible - no API changes required

**Files changed:**
- `packages/react/src/utils/combined/createCombinedStore.ts`
- `packages/react/src/context/react/utils/useRuntimeState.ts`

**Root cause:** Unstable function references in `useSyncExternalStore` getSnapshot parameter caused by inline selectors in components like `ThreadViewportProvider` and `AssistantRuntimeProviderImpl`.