### PR TITLE
Fix: Improve Abort Signal Error Handling

### DIFF
--- a/.changeset/cyan-socks-shop.md
+++ b/.changeset/cyan-socks-shop.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/react-ai-sdk": patch
+---
+
+Modified the `detach` and `cancelRun` methods to create a standardized `Error` object with a JSON-encoded message and a name of `"AbortError"`, improving consistency in how abort reasons are passed and processed.

--- a/.changeset/grumpy-numbers-bake.md
+++ b/.changeset/grumpy-numbers-bake.md
@@ -1,5 +1,0 @@
----
-"@assistant-ui/react": patch
----
-
-Fix internal dependency cycles

--- a/packages/react-ai-sdk/src/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/useChatRuntime.ts
@@ -89,7 +89,7 @@ class ChatRuntimeAdapter implements ChatModelAdapter {
     abortSignal.addEventListener(
       "abort",
       () => {
-        if (!abortSignal.reason?.detach) this.options.onCancel?.();
+        if (!JSON.parse(abortSignal.reason.message).detach) this.options.onCancel?.();
       },
       { once: true },
     );

--- a/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
+++ b/packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx
@@ -387,12 +387,17 @@ export class LocalThreadRuntimeCore
   }
 
   public detach() {
-    this.abortController?.abort({ detach: true });
+    const error = new Error(JSON.stringify({detach: true}));
+    error.name = "AbortError";
+    this.abortController?.abort(error);
     this.abortController = null;
   }
-
+  
   public cancelRun() {
-    this.abortController?.abort({ detach: false });
+    const error = new Error(JSON.stringify({detach: false}));
+    error.name = "AbortError";
+
+    this.abortController?.abort(error);
     this.abortController = null;
   }
 


### PR DESCRIPTION
This pull request introduces changes to improve how abort signals are handled by standardizing the structure of the error object passed during abort operations. The updates ensure consistency and clarity when parsing abort reasons.

### Improvements to abort signal handling:

* [`packages/react-ai-sdk/src/useChatRuntime.ts`](diffhunk://#diff-165e6c523f81605a2328ede068cc76aa835b04b9a436c221ae797beda665c5ccL92-R92): Updated the `abortSignal` event listener to parse the `abortSignal.reason.message` as JSON, ensuring the `detach` property is correctly evaluated.

* [`packages/react/src/runtimes/local/LocalThreadRuntimeCore.tsx`](diffhunk://#diff-20d488ed400ebaf464e7b291191b8bf1faa7925d52d80f9b3407d6ae29f4bd52L390-R400): Modified the `detach` and `cancelRun` methods to create a standardized `Error` object with a JSON-encoded message and a name of `"AbortError"`, improving consistency in how abort reasons are passed and processed.