### PR TITLE
fix: handle StateProxy in JSON serializer

### DIFF
--- a/python/assistant-stream/pyproject.toml
+++ b/python/assistant-stream/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "assistant-stream"
-version = "0.0.26"
+version = "0.0.28"
 description = ""
 authors = [
   { name="Simon Farshid", email="simon@assistant-ui.com" },

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -52,17 +52,8 @@ class RunController:
         """Add a tool call to the stream."""
         if tool_call_id is None:
             tool_call_id = generate_openai_style_tool_call_id()
-        
-        # If parent_id is set, emit a ToolCallBeginChunk
-        if self._parent_id:
-            begin_chunk = ToolCallBeginChunk(
-                tool_call_id=tool_call_id,
-                tool_name=tool_name,
-                parent_id=self._parent_id
-            )
-            self._flush_and_put_chunk(begin_chunk)
 
-        stream, controller = await create_tool_call(tool_name, tool_call_id)
+        stream, controller = await create_tool_call(tool_name, tool_call_id, self._parent_id)
         self._dispose_callbacks.append(controller.close)
 
         self.add_stream(stream)

--- a/python/assistant-stream/src/assistant_stream/modules/tool_call.py
+++ b/python/assistant-stream/src/assistant_stream/modules/tool_call.py
@@ -18,7 +18,7 @@ def generate_openai_style_tool_call_id():
 
 
 class ToolCallController:
-    def __init__(self, queue, tool_name: str, tool_call_id: str):
+    def __init__(self, queue, tool_name: str, tool_call_id: str, parent_id: str = None):
         self.tool_name = tool_name
         self.tool_call_id = tool_call_id
         self.queue = queue
@@ -27,6 +27,7 @@ class ToolCallController:
         begin_chunk = ToolCallBeginChunk(
             tool_call_id=self.tool_call_id,
             tool_name=self.tool_name,
+            parent_id=parent_id,
         )
         self.queue.put_nowait(begin_chunk)
 
@@ -75,9 +76,10 @@ class ToolCallController:
 async def create_tool_call(
     tool_name: str,
     tool_call_id: str,
+    parent_id: str = None,
 ) -> tuple[AsyncGenerator[AssistantStreamChunk, None], ToolCallController]:
     queue = asyncio.Queue()
-    controller = ToolCallController(queue, tool_name, tool_call_id)
+    controller = ToolCallController(queue, tool_name, tool_call_id, parent_id)
 
     async def stream():
         while True:

--- a/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
@@ -2,11 +2,20 @@ from assistant_stream.assistant_stream_chunk import (
     AssistantStreamChunk,
 )
 import json
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Any
 from assistant_stream.serialization.assistant_stream_response import (
     AssistantStreamResponse,
 )
 from assistant_stream.serialization.stream_encoder import StreamEncoder
+from assistant_stream.state_proxy import StateProxy
+
+
+class StateProxyJSONEncoder(json.JSONEncoder):
+    """Custom JSON encoder that can handle StateProxy objects."""
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, StateProxy):
+            return obj._get_value()
+        return super().default(obj)
 
 
 class DataStreamEncoder(StreamEncoder):
@@ -16,32 +25,32 @@ class DataStreamEncoder(StreamEncoder):
     def encode_chunk(self, chunk: AssistantStreamChunk) -> str:
         if chunk.type == "text-delta":
             if hasattr(chunk, 'parent_id') and chunk.parent_id:
-                return f"aui-text-delta:{json.dumps({'textDelta': chunk.text_delta, 'parentId': chunk.parent_id})}\n"
+                return f"aui-text-delta:{json.dumps({'textDelta': chunk.text_delta, 'parentId': chunk.parent_id}, cls=StateProxyJSONEncoder)}\n"
             else:
-                return f"0:{json.dumps(chunk.text_delta)}\n"
+                return f"0:{json.dumps(chunk.text_delta, cls=StateProxyJSONEncoder)}\n"
         elif chunk.type == "reasoning-delta":
             if hasattr(chunk, 'parent_id') and chunk.parent_id:
-                return f"aui-reasoning-delta:{json.dumps({'reasoningDelta': chunk.reasoning_delta, 'parentId': chunk.parent_id})}\n"
+                return f"aui-reasoning-delta:{json.dumps({'reasoningDelta': chunk.reasoning_delta, 'parentId': chunk.parent_id}, cls=StateProxyJSONEncoder)}\n"
             else:
-                return f"g:{json.dumps(chunk.reasoning_delta)}\n"
+                return f"g:{json.dumps(chunk.reasoning_delta, cls=StateProxyJSONEncoder)}\n"
         elif chunk.type == "tool-call-begin":
             data = {"toolCallId": chunk.tool_call_id, "toolName": chunk.tool_name}
             if hasattr(chunk, 'parent_id') and chunk.parent_id:
                 data["parentId"] = chunk.parent_id
-            return f'b:{json.dumps(data)}\n'
+            return f'b:{json.dumps(data, cls=StateProxyJSONEncoder)}\n'
         elif chunk.type == "tool-call-delta":
-            return f'c:{json.dumps({ "toolCallId": chunk.tool_call_id, "argsTextDelta": chunk.args_text_delta })}\n'
+            return f'c:{json.dumps({ "toolCallId": chunk.tool_call_id, "argsTextDelta": chunk.args_text_delta }, cls=StateProxyJSONEncoder)}\n'
         elif chunk.type == "tool-result":
             res = {"toolCallId": chunk.tool_call_id, "result": chunk.result}
             if chunk.artifact is not None:
                 res["artifact"] = chunk.artifact
             if chunk.is_error:
                 res["isError"] = chunk.is_error
-            return f"a:{json.dumps(res)}\n"
+            return f"a:{json.dumps(res, cls=StateProxyJSONEncoder)}\n"
         elif chunk.type == "data":
-            return f"2:{json.dumps([chunk.data])}\n"
+            return f"2:{json.dumps([chunk.data], cls=StateProxyJSONEncoder)}\n"
         elif chunk.type == "error":
-            return f"3:{json.dumps(chunk.error)}\n"
+            return f"3:{json.dumps(chunk.error, cls=StateProxyJSONEncoder)}\n"
         elif chunk.type == "source":
             source_data = {
                 "sourceType": chunk.source_type,
@@ -52,9 +61,9 @@ class DataStreamEncoder(StreamEncoder):
                 source_data["title"] = chunk.title
             if hasattr(chunk, 'parent_id') and chunk.parent_id:
                 source_data["parentId"] = chunk.parent_id
-            return f"h:{json.dumps(source_data)}\n"
+            return f"h:{json.dumps(source_data, cls=StateProxyJSONEncoder)}\n"
         elif chunk.type == "update-state":
-            return f"aui-state:{json.dumps(chunk.operations)}\n"
+            return f"aui-state:{json.dumps(chunk.operations, cls=StateProxyJSONEncoder)}\n"
 
     def get_media_type(self) -> str:
         return "text/plain"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `StateProxyJSONEncoder` for JSON serialization and refactor tool call handling to include `parent_id`.
> 
>   - **Serialization**:
>     - Added `StateProxyJSONEncoder` in `data_stream.py` to handle `StateProxy` objects in JSON serialization.
>     - Updated `DataStreamEncoder.encode_chunk()` to use `StateProxyJSONEncoder` for all JSON serialization cases.
>   - **Tool Call Handling**:
>     - Refactored `create_tool_call()` in `tool_call.py` to accept `parent_id` and pass it to `ToolCallController`.
>     - Removed redundant `ToolCallBeginChunk` emission in `add_tool_call()` in `create_run.py`.
>   - **Versioning**:
>     - Updated version in `pyproject.toml` from `0.0.26` to `0.0.28`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for e51c8815ffd07ba531e3748e77da873870fc0d2a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->