### PR TITLE
fix: maintain chronological order for parts without parentId in PartsGroupedByParentId

### DIFF
--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -34,7 +34,7 @@
     "zustand": "^5.0.6"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.30",
+    "@assistant-ui/react": "^0.10.31",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -25,7 +25,7 @@
     "zod": "^3.25.67"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.30",
+    "@assistant-ui/react": "^0.10.31",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -29,7 +29,7 @@
     "zod": "^3.25.67"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.30",
+    "@assistant-ui/react": "^0.10.31",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -36,7 +36,7 @@
     "react-markdown": "^10.1.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.30",
+    "@assistant-ui/react": "^0.10.31",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint ."
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.30",
+    "@assistant-ui/react": "^0.10.31",
     "@assistant-ui/react-markdown": "^0.10.6",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.10.31
+
+### Patch Changes
+
+- fix: maintain chronological order for parts without parentId in PartsGroupedByParentId
+
 ## 0.10.30
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.10.30",
+  "version": "0.10.31",
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `groupMessagePartsByParentId` in `MessagePartsGroupedByParentId.tsx` now maintains chronological order for parts without `parentId`, and updates `@assistant-ui/react` peer dependency to `^0.10.31`.
> 
>   - **Behavior**:
>     - `groupMessagePartsByParentId` in `MessagePartsGroupedByParentId.tsx` now maintains chronological order for parts without `parentId`.
>   - **Dependencies**:
>     - Update `@assistant-ui/react` peer dependency to `^0.10.31` in `package.json` files for `react-ai-sdk`, `react-hook-form`, `react-langgraph`, `react-markdown`, and `react-syntax-highlighter`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 5e2d1a4097c1e6beed66fa69eef457505c4fd87a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->