### PR TITLE
fix: race condition in generateTitle when a newly running thread is detached

### DIFF
--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -34,7 +34,7 @@
     "zustand": "^5.0.6"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.31",
+    "@assistant-ui/react": "^0.10.32",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -25,7 +25,7 @@
     "zod": "^3.25.67"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.31",
+    "@assistant-ui/react": "^0.10.32",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -29,7 +29,7 @@
     "zod": "^3.25.67"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.31",
+    "@assistant-ui/react": "^0.10.32",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -36,7 +36,7 @@
     "react-markdown": "^10.1.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.31",
+    "@assistant-ui/react": "^0.10.32",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint ."
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.10.31",
+    "@assistant-ui/react": "^0.10.32",
     "@assistant-ui/react-markdown": "^0.10.6",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.10.32
+
+### Patch Changes
+
+- fix: race condition in generateTitle when a newly running thread is detached
+
 ## 0.10.31
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.10.31",
+  "version": "0.10.32",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
@@ -14,10 +14,7 @@ import {
 import { UseBoundStore, StoreApi, create } from "zustand";
 import { useAssistantRuntime } from "../../context";
 import { ThreadListItemRuntimeProvider } from "../../context/providers/ThreadListItemRuntimeProvider";
-import {
-  useThreadListItem,
-  useThreadListItemRuntime,
-} from "../../context/react/ThreadListItemContext";
+import { useThreadListItem } from "../../context/react/ThreadListItemContext";
 import { ThreadRuntimeCore, ThreadRuntimeImpl } from "../../internal";
 import { BaseSubscribable } from "./BaseSubscribable";
 import { AssistantRuntime } from "../../api";
@@ -65,10 +62,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
 
   public getThreadRuntimeCore(threadId: string) {
     const instance = this.instances.get(threadId);
-    if (!instance)
-      throw new Error(
-        "getThreadRuntimeCore not found. This is a bug in assistant-ui.",
-      );
+    if (!instance) return undefined;
     return instance.runtime;
   }
 
@@ -117,9 +111,10 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     }, [threadBinding, updateRuntime]);
 
     // auto initialize thread
-    const threadListItemRuntime = useThreadListItemRuntime();
     useEffect(() => {
-      return runtime.threads.main.unstable_on("initialize", () => {
+      return runtime.threads.getById(id).unstable_on("initialize", () => {
+        const threadListItemRuntime = runtime.threads.getItemById(id);
+
         if (threadListItemRuntime.getState().status === "new") {
           threadListItemRuntime.initialize();
 
@@ -131,7 +126,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
           });
         }
       });
-    }, [runtime, threadListItemRuntime]);
+    }, [runtime, id]);
 
     return null;
   };

--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
@@ -418,7 +418,11 @@ export class RemoteThreadListThreadListRuntimeCore
     if (data.status === "new") throw new Error("Thread is not yet initialized");
 
     const { remoteId } = await data.initializeTask;
-    const messages = this.getThreadRuntimeCore(threadId).messages;
+
+    const runtimeCore = this._hookManager.getThreadRuntimeCore(data.threadId);
+    if (!runtimeCore) return; // thread is no longer running
+
+    const messages = runtimeCore.messages;
     const stream = await this._options.adapter.generateTitle(
       remoteId,
       messages,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix race condition in `generateTitle` for detached threads and update `@assistant-ui/react` peer dependencies.
> 
>   - **Behavior**:
>     - Fix race condition in `generateTitle` in `RemoteThreadListThreadListRuntimeCore.tsx` when a thread is detached and no longer running.
>     - Update `getThreadRuntimeCore()` in `RemoteThreadListHookInstanceManager.tsx` to return `undefined` if the instance is not found.
>   - **Package Updates**:
>     - Update `@assistant-ui/react` peer dependency to `^0.10.32` in `react-ai-sdk/package.json`, `react-hook-form/package.json`, `react-langgraph/package.json`, `react-markdown/package.json`, and `react-syntax-highlighter/package.json`.
>     - Bump version to `0.10.32` in `react/package.json` and update `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for ee91571a1caf64f0b336153e607eab4e410f85a7. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->