### PR TITLE
fix: add image message part support and sanitize function

### DIFF
--- a/.changeset/smooth-monkeys-destroy.md
+++ b/.changeset/smooth-monkeys-destroy.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-ai-sdk-v4": patch
+"@assistant-ui/react": patch
+---
+
+fix: add image message part support and sanitize function

--- a/packages/react-ai-sdk-v4/src/converters/toLanguageModelMessages.ts
+++ b/packages/react-ai-sdk-v4/src/converters/toLanguageModelMessages.ts
@@ -155,8 +155,9 @@ export function toLanguageModelMessages(
           switch (type) {
             case "reasoning":
             case "source":
-            case "file": {
-              break; // reasoning, source, and file parts are omitted
+            case "file":
+            case "image": {
+              break; // reasoning, source, file, and image parts are omitted
             }
 
             case "text": {

--- a/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
+++ b/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
@@ -77,8 +77,13 @@ export const fromThreadMessageLike = (
       ? [{ type: "text" as const, text: like.content }]
       : like.content;
   
-  const sanitizeImageContent = ({ image, ...rest }: ImageMessagePart): ImageMessagePart | null => {
-    const match = image.match(/^data:image\/(png|jpeg|jpg|gif|webp);base64,(.*)$/);
+  const sanitizeImageContent = ({
+    image,
+    ...rest
+  }: ImageMessagePart): ImageMessagePart | null => {
+    const match = image.match(
+      /^data:image\/(png|jpeg|jpg|gif|webp);base64,(.*)$/,
+    );
     if (match) {
       return { ...rest, image };
     }

--- a/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
+++ b/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
@@ -82,7 +82,8 @@ export const fromThreadMessageLike = (
     if (match) {
       return { ...rest, image };
     }
-    console.warn(`Invalid image data:`, image);
+    console.warn(`Invalid image data format detected`);
+    return null;
     return null;
   };
 

--- a/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
+++ b/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
@@ -84,7 +84,6 @@ export const fromThreadMessageLike = (
     }
     console.warn(`Invalid image data format detected`);
     return null;
-    return null;
   };
 
   if (role !== "user" && attachments?.length)

--- a/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
+++ b/packages/react/src/runtimes/external-store/ThreadMessageLike.tsx
@@ -76,7 +76,7 @@ export const fromThreadMessageLike = (
     typeof like.content === "string"
       ? [{ type: "text" as const, text: like.content }]
       : like.content;
-  
+
   const sanitizeImageContent = ({
     image,
     ...rest
@@ -117,7 +117,7 @@ export const fromThreadMessageLike = (
               case "file":
               case "source":
                 return part;
-              
+
               case "image":
                 return sanitizeImageContent(part);
 

--- a/packages/react/src/types/MessagePartTypes.ts
+++ b/packages/react/src/types/MessagePartTypes.ts
@@ -66,4 +66,5 @@ export type ThreadAssistantMessagePart =
   | ReasoningMessagePart
   | ToolCallMessagePart
   | SourceMessagePart
-  | FileMessagePart;
+  | FileMessagePart
+  | ImageMessagePart;


### PR DESCRIPTION
- Introduced `sanitizeImageContent` function to validate image data.
- Updated `fromThreadMessageLike` to handle image message parts.
- Modified `ThreadAssistantMessagePart` type to include `ImageMessagePart`.
- Adjusted message conversion logic to omit image parts.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for image message parts with validation and update message conversion logic to handle them.
> 
>   - **Behavior**:
>     - `fromThreadMessageLike` in `ThreadMessageLike.tsx` now handles `ImageMessagePart` with `sanitizeImageContent` function to validate image data.
>     - `toLanguageModelMessages` in `toLanguageModelMessages.ts` updated to omit `image` parts in assistant messages.
>   - **Types**:
>     - `ThreadAssistantMessagePart` in `MessagePartTypes.ts` updated to include `ImageMessagePart`.
>   - **Functions**:
>     - Introduced `sanitizeImageContent` in `ThreadMessageLike.tsx` to validate base64 image data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 2a6ef6c713272805c2dc5574d349e662f5b0fde0. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->