### PR TITLE
Allow Attachments in AISDKRuntimeAdapter

### DIFF
--- a/.changeset/stale-schools-chew.md
+++ b/.changeset/stale-schools-chew.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+Stop omitting attachments from AISDKRuntimeAdapter there dosnt seem to be a reason for it and adding attachment adapters still work its just the type that says its not allowed

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.tsx
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.tsx
@@ -11,7 +11,7 @@ import { AISDKMessageConverter } from "../utils/convertMessage";
 
 export type AISDKRuntimeAdapter = {
   adapters?:
-    | Omit<NonNullable<ExternalStoreAdapter["adapters"]>, "attachments">
+    | NonNullable<ExternalStoreAdapter["adapters"]>
     | undefined;
 };
 


### PR DESCRIPTION
Stop omitting attachments from AISDKRuntimeAdapter there dosn't seem to be a reason for it and adding attachment adapters still work its just the type that says its not allowed