### PR TITLE
feat: Add `preprocess` prop to process raw text before markdown rendering

### DIFF
--- a/.changeset/moody-stingrays-tan.md
+++ b/.changeset/moody-stingrays-tan.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-markdown": patch
+---
+
+Add `preprocess` prop to allow processing raw text before markdown processing

--- a/packages/react-markdown/src/primitives/MarkdownText.tsx
+++ b/packages/react-markdown/src/primitives/MarkdownText.tsx
@@ -54,15 +54,28 @@ export type MarkdownTextPrimitiveProps = Omit<
       >
     | undefined;
   smooth?: boolean | undefined;
+  preprocess?: (text: string) => string;
 };
 
 const MarkdownTextInner: FC<MarkdownTextPrimitiveProps> = ({
   components: userComponents,
   componentsByLanguage,
   smooth = true,
+  preprocess,
   ...rest
 }) => {
-  const { text } = useSmooth(useMessagePartText(), smooth);
+  const messagePartText = useMessagePartText();
+
+  const processedMessagePart = useMemo(() => {
+    if (!preprocess) return messagePartText;
+
+    return {
+      ...messagePartText,
+      text: preprocess(messagePartText.text),
+    };
+  }, [messagePartText, preprocess]);
+
+  const { text } = useSmooth(processedMessagePart, smooth);
 
   const {
     pre = DefaultPre,

--- a/packages/react-markdown/src/primitives/MarkdownText.tsx
+++ b/packages/react-markdown/src/primitives/MarkdownText.tsx
@@ -44,6 +44,10 @@ export type MarkdownTextPrimitiveProps = Omit<
         CodeHeader?: ComponentType<CodeHeaderProps> | undefined;
       })
     | undefined;
+  /**
+   * Language-specific component overrides.
+   * @example { mermaid: { SyntaxHighlighter: MermaidDiagram } }
+   */
   componentsByLanguage?:
     | Record<
         string,
@@ -54,6 +58,9 @@ export type MarkdownTextPrimitiveProps = Omit<
       >
     | undefined;
   smooth?: boolean | undefined;
+  /**
+   * Function to transform text before markdown processing.
+   */
   preprocess?: (text: string) => string;
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `preprocess` prop to `MarkdownTextPrimitiveProps` in `MarkdownText.tsx` for text transformation before markdown processing.
> 
>   - **Behavior**:
>     - Add `preprocess` prop to `MarkdownTextPrimitiveProps` in `MarkdownText.tsx` for text transformation before markdown processing.
>     - Applies `preprocess` function to `messagePartText` if provided, using `useMemo`.
>   - **Misc**:
>     - No changes to existing functionality or other components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 3ffa0ae3f15a20c5f2e529b1ab2dbcd0ec2cce9a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->