### PR TITLE
fix(ci): `@assistant-ui/react` build error

### DIFF
--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -201,7 +201,7 @@ export const ComposerPrimitiveInput = forwardRef<
         name="input"
         value={value}
         {...rest}
-        ref={ref as any}
+        ref={ref as React.ForwardedRef<HTMLTextAreaElement>}
         disabled={isDisabled}
         onChange={composeEventHandlers(onChange, (e) => {
           if (!composerRuntime.getState().isEditing) return;

--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -201,7 +201,7 @@ export const ComposerPrimitiveInput = forwardRef<
         name="input"
         value={value}
         {...rest}
-        ref={ref}
+        ref={ref as any}
         disabled={isDisabled}
         onChange={composeEventHandlers(onChange, (e) => {
           if (!composerRuntime.getState().isEditing) return;


### PR DESCRIPTION
Fix ref type error in `ComposerInput` with TypeScript 5.9

To solve this, I asserted the ref type as `React.ForwardedRef<HTMLTextAreaElement>` because `ComposerPrimitive.Input` is designed for textarea elements.