### PR TITLE
fix: reset new thread id after initialization

### DIFF
--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
@@ -330,9 +330,19 @@ export class RemoteThreadListThreadListRuntimeCore
     ) {
       await this._state.waitForUpdate();
     }
+    let state = this._state.value;
+    let threadId: string | undefined = state.newThreadId;
 
-    const state = this._state.value;
-    let threadId: string | undefined = this._state.value.newThreadId;
+    // the previous new thread may have already been initialized
+    if (threadId !== undefined) {
+      const data = getThreadData(state, threadId);
+      if (data && data.status !== "new") {
+        this._state.update({ ...state, newThreadId: undefined });
+        state = this._state.value;
+        threadId = undefined;
+      }
+    }
+
     if (threadId === undefined) {
       do {
         threadId = `__LOCALID_${generateId()}`;


### PR DESCRIPTION
## Summary
- clear stale `newThreadId` if previous thread initialized so new thread creation works

## Testing
- `pnpm --filter=@assistant-ui/react lint`
- `pnpm --filter=@assistant-ui/react test` (fails: Cannot find package 'assistant-stream/utils')

------
https://chatgpt.com/codex/tasks/task_e_68966bc07910832cae7810971ee19eac
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes stale `newThreadId` issue in `RemoteThreadListThreadListRuntimeCore` to ensure new thread creation works correctly.
> 
>   - **Behavior**:
>     - In `RemoteThreadListThreadListRuntimeCore`, reset `newThreadId` if the previous thread is initialized to ensure new thread creation works.
>   - **Testing**:
>     - Linting and testing commands provided, but tests fail due to missing package `assistant-stream/utils`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for ce610119480082b28a5dd46798c1a591dddea1b3. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->