### PR TITLE
fix: new thread functionality no longer working with new threadlistruntime

### DIFF
--- a/.changeset/small-shrimps-reflect.md
+++ b/.changeset/small-shrimps-reflect.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: new thread functionality no longer working with new threadlistruntime

--- a/packages/react/src/runtimes/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/react/src/runtimes/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
@@ -14,7 +14,10 @@ import {
 import { UseBoundStore, StoreApi, create } from "zustand";
 import { useAssistantRuntime } from "../../context";
 import { ThreadListItemRuntimeProvider } from "../../context/providers/ThreadListItemRuntimeProvider";
-import { useThreadListItem } from "../../context/react/ThreadListItemContext";
+import {
+  useThreadListItem,
+  useThreadListItemRuntime,
+} from "../../context/react/ThreadListItemContext";
 import { ThreadRuntimeCore, ThreadRuntimeImpl } from "../../internal";
 import { BaseSubscribable } from "./BaseSubscribable";
 import { AssistantRuntime } from "../../api";
@@ -111,11 +114,9 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     }, [threadBinding, updateRuntime]);
 
     // auto initialize thread
+    const threadListItemRuntime = useThreadListItemRuntime();
     useEffect(() => {
       return runtime.threads.main.unstable_on("initialize", () => {
-        const threadListItemRuntime = runtime.threads.mainItem;
-        if (threadListItemRuntime.getState().id !== id) return;
-
         if (threadListItemRuntime.getState().status === "new") {
           threadListItemRuntime.initialize();
 
@@ -123,12 +124,11 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
           const dispose = runtime.thread.unstable_on("run-end", () => {
             dispose();
 
-            if (threadListItemRuntime.getState().id !== id) return;
             threadListItemRuntime.generateTitle();
           });
         }
       });
-    }, [runtime, id]);
+    }, [runtime, threadListItemRuntime]);
 
     return null;
   };


### PR DESCRIPTION
fixes #2292

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes thread initialization and title generation in `RemoteThreadListHookInstanceManager` by using `useThreadListItemRuntime`.
> 
>   - **Behavior**:
>     - Fixes thread initialization in `RemoteThreadListHookInstanceManager` by using `useThreadListItemRuntime` instead of `runtime.threads.mainItem`.
>     - Ensures correct thread title generation after initialization.
>   - **Imports**:
>     - Adds `useThreadListItemRuntime` to imports from `ThreadListItemContext`.
>     - Removes unused `useAssistantRuntime` import.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 8910346d45cf5d8fa1667b1116c17929b9509e54. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->