### PR TITLE
feat(cloud): add format parameter to message list API

### DIFF
--- a/.changeset/cloud-format-parameter.md
+++ b/.changeset/cloud-format-parameter.md
@@ -1,0 +1,10 @@
+---
+"assistant-cloud": minor
+"@assistant-ui/react": patch
+---
+
+Add format parameter support to assistant-cloud client library
+
+- Add optional `format` query parameter to `AssistantCloudThreadMessages.list()` method
+- Update cloud history adapter to pass format parameter when loading messages
+- Enables backend-level message format conversion when supported by the cloud backend

--- a/packages/cloud/src/AssistantCloudThreadMessages.tsx
+++ b/packages/cloud/src/AssistantCloudThreadMessages.tsx
@@ -11,6 +11,10 @@ export type CloudMessage = {
   content: ReadonlyJSONObject;
 };
 
+type AssistantCloudThreadMessageListQuery = {
+  format?: string;
+};
+
 type AssistantCloudThreadMessageListResponse = {
   messages: CloudMessage[];
 };
@@ -30,9 +34,11 @@ export class AssistantCloudThreadMessages {
 
   public async list(
     threadId: string,
+    query?: AssistantCloudThreadMessageListQuery,
   ): Promise<AssistantCloudThreadMessageListResponse> {
     return this.cloud.makeRequest(
       `/threads/${encodeURIComponent(threadId)}/messages`,
+      { query },
     );
   }
 

--- a/packages/react/src/cloud/AssistantCloudThreadHistoryAdapter.tsx
+++ b/packages/react/src/cloud/AssistantCloudThreadHistoryAdapter.tsx
@@ -83,8 +83,12 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   async load() {
     const remoteId = this.threadListItemRuntime.getState().remoteId;
     if (!remoteId) return { messages: [] };
-    const { messages } =
-      await this.cloudRef.current.threads.messages.list(remoteId);
+    const { messages } = await this.cloudRef.current.threads.messages.list(
+      remoteId,
+      {
+        format: "aui/v0",
+      },
+    );
     const payload = {
       messages: messages
         .filter(
@@ -132,8 +136,12 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     const remoteId = this.threadListItemRuntime.getState().remoteId;
     if (!remoteId) return { messages: [] };
 
-    const { messages } =
-      await this.cloudRef.current.threads.messages.list(remoteId);
+    const { messages } = await this.cloudRef.current.threads.messages.list(
+      remoteId,
+      {
+        format,
+      },
+    );
 
     return {
       messages: messages


### PR DESCRIPTION
- Add optional format query parameter to AssistantCloudThreadMessages.list()
- Update cloud history adapter to pass format when loading messages
- Enables backend-level message format conversion when supported
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add optional `format` parameter to `AssistantCloudThreadMessages.list()` and update `AssistantCloudThreadHistoryAdapter` to support backend-level message format conversion.
> 
>   - **Behavior**:
>     - Add optional `format` query parameter to `AssistantCloudThreadMessages.list()` for backend-level message format conversion.
>     - Update `AssistantCloudThreadHistoryAdapter` to pass `format` when loading messages.
>   - **Types**:
>     - Add `AssistantCloudThreadMessageListQuery` type with optional `format` field in `AssistantCloudThreadMessages.tsx`.
>   - **Misc**:
>     - Document changes in `.changeset/cloud-format-parameter.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 58597dd9f4ebcbbed61493741b3d70ddd30480ea. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->