### PR TITLE
fix(mcp-docs-server): zod version compatibility issue

### DIFF
--- a/.changeset/cold-worms-swim.md
+++ b/.changeset/cold-worms-swim.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/mcp-docs-server": patch
+---
+
+fix zod version compatibility issue that caused the mcp server to fail

--- a/packages/mcp-docs-server/src/tools/docs.ts
+++ b/packages/mcp-docs-server/src/tools/docs.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { stat, lstat } from "fs/promises";
 import { join, extname } from "path";
 import { DOCS_PATH, MDX_EXTENSION, MAX_FILE_SIZE } from "../constants.js";

--- a/packages/mcp-docs-server/src/tools/examples.ts
+++ b/packages/mcp-docs-server/src/tools/examples.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { readFile, readdir, lstat } from "fs/promises";
 import { join, extname } from "path";
 import { CODE_EXAMPLES_PATH, MAX_FILE_SIZE } from "../constants.js";

--- a/packages/mcp-docs-server/src/tools/tests/mcp-protocol.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/mcp-protocol.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { server } from "../../index.js";
+import {
+  InitializeRequestSchema,
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+  type InitializeRequest,
+  type ListToolsRequest,
+  type CallToolRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+
+describe("MCP Protocol Integration", () => {
+  // These tests verify the MCP protocol layer handles requests correctly
+  // and that parameter schemas are properly converted to JSON schemas
+  it("should handle Initialize request", async () => {
+    const request: InitializeRequest = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {
+          tools: {},
+        },
+        clientInfo: {
+          name: "test-client",
+          version: "1.0.0",
+        },
+      },
+    };
+
+    // Parse and validate the request
+    const parsed = InitializeRequestSchema.parse(request);
+    expect(parsed).toBeDefined();
+    
+    // The server should have an initialize handler set up
+    const handlers = (server as any).server._requestHandlers;
+    expect(handlers).toBeDefined();
+    expect(handlers.get("initialize")).toBeDefined();
+  });
+
+  it("should handle ListTools request", async () => {
+    const request: ListToolsRequest = {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    };
+
+    // Parse and validate the request
+    const parsed = ListToolsRequestSchema.parse(request);
+    expect(parsed).toBeDefined();
+    
+    // The server should have a tools/list handler
+    const handlers = (server as any).server._requestHandlers;
+    expect(handlers.get("tools/list")).toBeDefined();
+    
+    // Call the handler
+    const handler = handlers.get("tools/list");
+    const result = await handler(parsed, {});
+    
+    expect(result).toBeDefined();
+    expect(result.tools).toBeInstanceOf(Array);
+    expect(result.tools).toHaveLength(2);
+    
+    // Check the tools have proper JSON schemas
+    const docsTool = result.tools.find((t: any) => t.name === "assistantUIDocs");
+    expect(docsTool).toBeDefined();
+    expect(docsTool.inputSchema).toBeDefined();
+    expect(docsTool.inputSchema.type).toBe("object");
+    expect(docsTool.inputSchema.properties).toBeDefined();
+    
+    const examplesTool = result.tools.find((t: any) => t.name === "assistantUIExamples");
+    expect(examplesTool).toBeDefined();
+    expect(examplesTool.inputSchema).toBeDefined();
+    expect(examplesTool.inputSchema.type).toBe("object");
+    expect(examplesTool.inputSchema.properties).toBeDefined();
+  });
+
+  it("should handle CallTool request for assistantUIDocs", async () => {
+    const request: CallToolRequest = {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: {
+        name: "assistantUIDocs",
+        arguments: {
+          paths: ["/"],
+        },
+      },
+    };
+
+    // Parse and validate the request
+    const parsed = CallToolRequestSchema.parse(request);
+    expect(parsed).toBeDefined();
+    
+    // The server should have a tools/call handler
+    const handlers = (server as any).server._requestHandlers;
+    expect(handlers.get("tools/call")).toBeDefined();
+    
+    // Call the handler through the MCP protocol layer
+    const handler = handlers.get("tools/call");
+    const result = await handler(parsed, {});
+    
+    expect(result).toBeDefined();
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe("text");
+  });
+
+  it("should handle CallTool request for assistantUIExamples with no arguments", async () => {
+    const request: CallToolRequest = {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: {
+        name: "assistantUIExamples",
+        arguments: {},
+      },
+    };
+
+    // Parse and validate the request
+    const parsed = CallToolRequestSchema.parse(request);
+    expect(parsed).toBeDefined();
+    
+    // The server should have a tools/call handler
+    const handlers = (server as any).server._requestHandlers;
+    expect(handlers.get("tools/call")).toBeDefined();
+    
+    // Call the handler
+    const handler = handlers.get("tools/call");
+    const result = await handler(parsed, {});
+    
+    expect(result).toBeDefined();
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe("text");
+  });
+});

--- a/packages/mcp-docs-server/src/tools/tests/mcp-protocol.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/mcp-protocol.test.ts
@@ -14,8 +14,6 @@ describe("MCP Protocol Integration", () => {
   // and that parameter schemas are properly converted to JSON schemas
   it("should handle Initialize request", async () => {
     const request: InitializeRequest = {
-      jsonrpc: "2.0",
-      id: 1,
       method: "initialize",
       params: {
         protocolVersion: "2024-11-05",
@@ -32,7 +30,7 @@ describe("MCP Protocol Integration", () => {
     // Parse and validate the request
     const parsed = InitializeRequestSchema.parse(request);
     expect(parsed).toBeDefined();
-    
+
     // The server should have an initialize handler set up
     const handlers = (server as any).server._requestHandlers;
     expect(handlers).toBeDefined();
@@ -41,8 +39,6 @@ describe("MCP Protocol Integration", () => {
 
   it("should handle ListTools request", async () => {
     const request: ListToolsRequest = {
-      jsonrpc: "2.0",
-      id: 2,
       method: "tools/list",
       params: {},
     };
@@ -50,27 +46,31 @@ describe("MCP Protocol Integration", () => {
     // Parse and validate the request
     const parsed = ListToolsRequestSchema.parse(request);
     expect(parsed).toBeDefined();
-    
+
     // The server should have a tools/list handler
     const handlers = (server as any).server._requestHandlers;
     expect(handlers.get("tools/list")).toBeDefined();
-    
+
     // Call the handler
     const handler = handlers.get("tools/list");
     const result = await handler(parsed, {});
-    
+
     expect(result).toBeDefined();
     expect(result.tools).toBeInstanceOf(Array);
     expect(result.tools).toHaveLength(2);
-    
+
     // Check the tools have proper JSON schemas
-    const docsTool = result.tools.find((t: any) => t.name === "assistantUIDocs");
+    const docsTool = result.tools.find(
+      (t: any) => t.name === "assistantUIDocs",
+    );
     expect(docsTool).toBeDefined();
     expect(docsTool.inputSchema).toBeDefined();
     expect(docsTool.inputSchema.type).toBe("object");
     expect(docsTool.inputSchema.properties).toBeDefined();
-    
-    const examplesTool = result.tools.find((t: any) => t.name === "assistantUIExamples");
+
+    const examplesTool = result.tools.find(
+      (t: any) => t.name === "assistantUIExamples",
+    );
     expect(examplesTool).toBeDefined();
     expect(examplesTool.inputSchema).toBeDefined();
     expect(examplesTool.inputSchema.type).toBe("object");
@@ -79,8 +79,6 @@ describe("MCP Protocol Integration", () => {
 
   it("should handle CallTool request for assistantUIDocs", async () => {
     const request: CallToolRequest = {
-      jsonrpc: "2.0",
-      id: 3,
       method: "tools/call",
       params: {
         name: "assistantUIDocs",
@@ -93,15 +91,15 @@ describe("MCP Protocol Integration", () => {
     // Parse and validate the request
     const parsed = CallToolRequestSchema.parse(request);
     expect(parsed).toBeDefined();
-    
+
     // The server should have a tools/call handler
     const handlers = (server as any).server._requestHandlers;
     expect(handlers.get("tools/call")).toBeDefined();
-    
+
     // Call the handler through the MCP protocol layer
     const handler = handlers.get("tools/call");
     const result = await handler(parsed, {});
-    
+
     expect(result).toBeDefined();
     expect(result.content).toBeDefined();
     expect(result.content[0].type).toBe("text");
@@ -109,8 +107,6 @@ describe("MCP Protocol Integration", () => {
 
   it("should handle CallTool request for assistantUIExamples with no arguments", async () => {
     const request: CallToolRequest = {
-      jsonrpc: "2.0",
-      id: 4,
       method: "tools/call",
       params: {
         name: "assistantUIExamples",
@@ -121,15 +117,15 @@ describe("MCP Protocol Integration", () => {
     // Parse and validate the request
     const parsed = CallToolRequestSchema.parse(request);
     expect(parsed).toBeDefined();
-    
+
     // The server should have a tools/call handler
     const handlers = (server as any).server._requestHandlers;
     expect(handlers.get("tools/call")).toBeDefined();
-    
+
     // Call the handler
     const handler = handlers.get("tools/call");
     const result = await handler(parsed, {});
-    
+
     expect(result).toBeDefined();
     expect(result.content).toBeDefined();
     expect(result.content[0].type).toBe("text");


### PR DESCRIPTION
Use zod/v3 imports to resolve the issue in mcp-docs-server where the mcp sdk doesn’t support zod v4.

Add more robust testing
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix Zod v3 compatibility in MCP docs server and add robust MCP protocol integration tests.
> 
>   - **Compatibility**:
>     - Change `zod` imports to `zod/v3` in `docs.ts` and `examples.ts` to resolve compatibility issues with MCP SDK.
>   - **Testing**:
>     - Add `mcp-protocol.test.ts` to test MCP protocol integration, covering `Initialize`, `ListTools`, and `CallTool` requests.
>     - Ensure handlers for `initialize`, `tools/list`, and `tools/call` are correctly set up and invoked.
>     - Validate JSON schema conversion for `assistantUIDocs` and `assistantUIExamples` tools.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 5a590a1eb8b4880ccb58d538b57c7461f10b8e79. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->