### PR TITLE
chore: add support for external prs to fix prettier (attempt)

### DIFF
--- a/.github/workflows/fix-prettier.yaml
+++ b/.github/workflows/fix-prettier.yaml
@@ -7,35 +7,62 @@ on:
 jobs:
   fix-prettier:
     name: Fix Prettier Issues
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/fix-prettier') && github.event.comment.user.type == 'User' && github.event.comment.user.site_admin == false }}
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/fix-prettier') && github.event.comment.user.type == 'User' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - name: Get PR branch
+      - name: Get PR information
         uses: actions/github-script@v7
         id: get-pr
         with:
           script: |
             const { owner, repo, number } = context.issue;
-            const pr = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: number
-            });
-            return {
-              head_ref: pr.data.head.ref,
-              head_sha: pr.data.head.sha,
-              base_ref: pr.data.base.ref
-            };
+            try {
+              const pr = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: number
+              });
+              
+              const isFork = pr.data.head.repo.full_name !== pr.data.base.repo.full_name;
+              
+              // Log information for debugging
+              console.log(`PR ${number}: head_ref=${pr.data.head.ref}, is_fork=${isFork}`);
+              if (isFork) {
+                console.log(`Fork: ${pr.data.head.repo.full_name}`);
+              }
+              
+              return {
+                head_ref: pr.data.head.ref,
+                head_sha: pr.data.head.sha,
+                base_ref: pr.data.base.ref,
+                is_fork: isFork,
+                fork_owner: isFork ? pr.data.head.repo.owner.login : null,
+                fork_repo: isFork ? pr.data.head.repo.name : null,
+                pr_number: number
+              };
+            } catch (error) {
+              core.setFailed(`Failed to get PR information: ${error.message}`);
+              return null;
+            }
           result-encoding: json
 
-      - name: Checkout PR
+      - name: Checkout PR (same repo)
+        if: fromJson(steps.get-pr.outputs.result).is_fork == false
         uses: actions/checkout@v4
         with:
           ref: ${{ fromJson(steps.get-pr.outputs.result).head_ref }}
           fetch-depth: 0
+
+      - name: Checkout PR (forked repo)
+        if: fromJson(steps.get-pr.outputs.result).is_fork == true
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ fromJson(steps.get-pr.outputs.result).head_ref }}
+          fetch-depth: 0
+          repository: ${{ format('{0}/{1}', fromJson(steps.get-pr.outputs.result).fork_owner, fromJson(steps.get-pr.outputs.result).fork_repo) }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -68,7 +95,18 @@ jobs:
 
       - name: Push changes
         if: steps.commit.outputs.changes_made == 'true'
-        run: git push origin ${{ fromJson(steps.get-pr.outputs.result).head_ref }}
+        id: push
+        run: |
+          # Try to push changes
+          if git push origin ${{ fromJson(steps.get-pr.outputs.result).head_ref }}; then
+            echo "Successfully pushed changes"
+            echo "failed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Failed to push changes - this might be due to permissions"
+            echo "The contributor may need to enable 'Allow edits from maintainers' in their PR"
+            echo "failed=true" >> $GITHUB_OUTPUT
+            exit 1
+          fi
 
       - name: Comment on PR
         uses: actions/github-script@v7
@@ -76,9 +114,16 @@ jobs:
           script: |
             const { owner, repo, number } = context.issue;
             const changes_made = '${{ steps.commit.outputs.changes_made }}' === 'true';
-            const message = changes_made
-              ? '✅ Prettier issues fixed and committed to this PR!'
-              : '✅ No prettier issues found in this PR!';
+            const push_failed = '${{ steps.push.outputs.failed }}' === 'true';
+
+            let message;
+            if (changes_made && push_failed) {
+              message = '❌ Failed to push prettier fixes. Please ensure "Allow edits from maintainers" is enabled in your PR settings.';
+            } else if (changes_made) {
+              message = '✅ Prettier issues fixed and committed to this PR!';
+            } else {
+              message = '✅ No prettier issues found in this PR!';
+            }
 
             await github.rest.issues.createComment({
               owner,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances the Prettier fix workflow to support external PRs, handle forked repositories, and improve error handling for push operations.
> 
>   - **Workflow Enhancements**:
>     - Updates `.github/workflows/fix-prettier.yaml` to support external PRs by checking if a PR is from a forked repo.
>     - Adds logic to handle forked repositories by setting `repository` in `actions/checkout@v4`.
>     - Logs PR information for debugging purposes.
>   - **Error Handling**:
>     - Adds error handling for failed pushes due to permission issues, suggesting enabling 'Allow edits from maintainers'.
>     - Updates the comment logic to reflect push success or failure in `fix-prettier.yaml`.
>   - **Misc**:
>     - Removes `site_admin` check from the workflow trigger condition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 203b3c61bbec324854ec909493f5eec330e958f1. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->