### PR TITLE
chore(docs): fix `ExternalStoreRuntime` example

### DIFF
--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -164,45 +164,52 @@ graph TD
     ```tsx title="app/MyRuntimeProvider.tsx"
     "use client";
 
-    import { useState } from "react";
+    import { ThreadMessageLike } from "@assistant-ui/react";
+    import { AppendMessage } from "@assistant-ui/react";
     import {
-      useExternalStoreRuntime,
-      ThreadMessageLike,
-      AppendMessage,
       AssistantRuntimeProvider,
+      useExternalStoreRuntime,
     } from "@assistant-ui/react";
-
-    export function MyRuntimeProvider({ children }) {
-      const [messages, setMessages] = useState<ThreadMessageLike[]>([]);
-      const [isRunning, setIsRunning] = useState(false);
-
+    import { useState } from "react";
+    
+    const convertMessage = (message: ThreadMessageLike) => {
+      return message;
+    };
+    
+    export function MyRuntimeProvider({
+      children,
+    }: Readonly<{
+      children: React.ReactNode;
+    }>) {
+      const [messages, setMessages] = useState<readonly ThreadMessageLike[]>([]);
+    
       const onNew = async (message: AppendMessage) => {
-        // Add user message
+        if (message.content.length !== 1 || message.content[0]?.type !== "text")
+          throw new Error("Only text content is supported");
+    
         const userMessage: ThreadMessageLike = {
           role: "user",
-          content: message.content,
+          content: [{ type: "text", text: message.content[0].text }],
         };
-        setMessages(prev => [...prev, userMessage]);
-
-        // Generate response
-        setIsRunning(true);
-        const response = await callYourAPI(message);
-
+        setMessages((currentMessages) => [...currentMessages, userMessage]);
+    
+        // normally you would perform an API call here to get the assistant response
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    
         const assistantMessage: ThreadMessageLike = {
           role: "assistant",
-          content: response.content,
+          content: [{ type: "text", text: "Hello, world!" }],
         };
-        setMessages(prev => [...prev, assistantMessage]);
-        setIsRunning(false);
+        setMessages((currentMessages) => [...currentMessages, assistantMessage]);
       };
-
-      const runtime = useExternalStoreRuntime({
+    
+      const runtime = useExternalStoreRuntime<ThreadMessageLike>({
         messages,
         setMessages,
-        isRunning,
         onNew,
+        convertMessage,
       });
-
+    
       return (
         <AssistantRuntimeProvider runtime={runtime}>
           {children}


### PR DESCRIPTION
Fix MyRuntimeProvider example in "Getting Started" to use latest API. Old example would not work due to incompatible input parameter type for useExternalStoreRuntime()  giving the following error:
```
Argument of type '{ onNew: (message: AppendMessage) => Promise<void>; }' is not assignable to parameter of type 'ExternalStoreAdapter<unknown>'.
  Property 'convertMessage' is missing in type '{ onNew: (message: AppendMessage) => Promise<void>; }' but required in type 'ExternalStoreMessageConverterAdapter<unknown>'.
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `MyRuntimeProvider` example in `external-store.mdx` to align with the latest API by adding the required `convertMessage` function.
> 
>   - **Behavior**:
>     - Updates `MyRuntimeProvider` example in `external-store.mdx` to include `convertMessage` function required by `useExternalStoreRuntime`.
>     - Ensures `onNew` function checks for text content and simulates an API call with a delay.
>   - **Misc**:
>     - Adjusts import order and usage of `useState` in `MyRuntimeProvider` example.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 511cc659e660e5beb58144ede9f17683755072e7. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->