### PR TITLE
feat(react-ai-sdk): allow passing id generator to the AISdkRuntime

### DIFF
--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.tsx
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.tsx
@@ -27,6 +27,7 @@ export type AISDKRuntimeAdapter = {
         history?: ThreadHistoryAdapter | undefined;
       })
     | undefined;
+  idGenerator?: () => string;
 };
 
 export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
@@ -72,7 +73,10 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       ),
     onCancel: async () => chatHelpers.stop(),
     onNew: async (message) => {
-      const createMessage = await toCreateMessage<UI_MESSAGE>(message);
+      const createMessage = await toCreateMessage<UI_MESSAGE>(
+        message,
+        adapter.idGenerator,
+      );
       await chatHelpers.sendMessage(createMessage, {
         metadata: message.runConfig,
       });
@@ -84,7 +88,10 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       );
       chatHelpers.setMessages(newMessages);
 
-      const createMessage = await toCreateMessage<UI_MESSAGE>(message);
+      const createMessage = await toCreateMessage<UI_MESSAGE>(
+        message,
+        adapter.idGenerator,
+      );
       await chatHelpers.sendMessage(createMessage, {
         metadata: message.runConfig,
       });

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
@@ -11,6 +11,7 @@ import {
 
 export const toCreateMessage = async <UI_MESSAGE extends UIMessage = UIMessage>(
   message: AppendMessage,
+  idGenerator?: () => string,
 ): Promise<CreateUIMessage<UI_MESSAGE>> => {
   const textParts = message.content
     .filter((part) => part.type === "text")
@@ -54,7 +55,7 @@ export const toCreateMessage = async <UI_MESSAGE extends UIMessage = UIMessage>(
   parts.push(...attachmentParts);
 
   return {
-    id: generateId(),
+    id: idGenerator?.() ?? generateId(),
     role: message.role,
     parts,
   } satisfies CreateUIMessage<UIMessage> as CreateUIMessage<UI_MESSAGE>;


### PR DESCRIPTION
When sending messages, the generated IDs are not using the ID generator defined in chatHelpers from ai-sdk.

Currently, the Chat object in ai-sdk does not expose the ID generator. As a workaround, we can pass the generator directly to useAISDKRuntime.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add optional ID generator to `useAISDKRuntime` for custom message ID generation.
> 
>   - **Feature**:
>     - Add optional `idGenerator` parameter to `AISDKRuntimeAdapter` in `useAISDKRuntime.tsx`.
>     - Pass `idGenerator` to `toCreateMessage` in `useAISDKRuntime` for message ID generation.
>   - **Functionality**:
>     - Modify `toCreateMessage` in `toCreateMessage.ts` to use `idGenerator` if provided, otherwise fallback to `generateId()`.
>   - **Behavior**:
>     - Allows custom ID generation for messages in `useAISDKRuntime`.
>     - Default behavior remains unchanged if `idGenerator` is not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1361839b8ccc8321316a424b367b0aba74786976. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 1361839b8ccc8321316a424b367b0aba74786976. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->