### PR TITLE
fix(registry): Trim whitespace in shiki-highlighter.tsx

### DIFF
--- a/apps/registry/components/assistant-ui/shiki-highlighter.tsx
+++ b/apps/registry/components/assistant-ui/shiki-highlighter.tsx
@@ -48,7 +48,7 @@ export const SyntaxHighlighter: FC<HighlighterProps> = ({
       showLanguage={showLanguage}
       className={cn(BASE_STYLES, className)}
     >
-      {code}
+      {code.trim()}
     </ShikiHighlighter>
   );
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Trim whitespace from `code` prop in `SyntaxHighlighter` component in `shiki-highlighter.tsx`.
> 
>   - **Behavior**:
>     - Trims whitespace from `code` prop in `SyntaxHighlighter` component in `shiki-highlighter.tsx` using `code.trim()`.
>     - Ensures no leading or trailing whitespace in rendered code blocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for e53987844eef81e48605947dea9ec4516d4ffb67. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->