### PR TITLE
fix: attachment naming

### DIFF
--- a/.changeset/late-shrimps-breathe.md
+++ b/.changeset/late-shrimps-breathe.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fixes attachment naming

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -162,13 +162,13 @@ export const AISDKMessageConverter = unstable_createMessageConverter(
           createdAt,
           content: convertParts(message),
           attachments: message.parts
-            ?.filter((p: any) => p.type === "file")
-            .map((part: any, idx) => ({
+            ?.filter((p) => p.type === "file")
+            .map((part, idx) => ({
               id: idx.toString(),
               type: "file" as const,
-              name: part.name ?? part.url ?? "file",
+              name: part.filename ?? "file",
               content: [],
-              contentType: part.mediaType ?? part.mimeType ?? "unknown/unknown",
+              contentType: part.mediaType ?? "unknown/unknown",
               status: { type: "complete" as const },
             })),
         };


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `convertMessage.ts`, update filename determination logic to use `part.filename` not `part.name`, and remove any casts and invalid properties.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 9f8b1ac5fb5324a85db567dd2cbe2c31c2ab5abb. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->