### PR TITLE
fix: persistence should store all messages beyond the first two

### DIFF
--- a/.changeset/silly-walls-send.md
+++ b/.changeset/silly-walls-send.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: persistence only saving the first two messages

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.tsx
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.tsx
@@ -97,7 +97,7 @@ export const useExternalHistory = <TMessage,>(
           message.status.type === "complete" ||
           message.status.type === "incomplete"
         ) {
-          if (historyIds.current.has(message.id)) return;
+          if (historyIds.current.has(message.id)) break;
           historyIds.current.add(message.id);
 
           const parentId = i > 0 ? messages[i - 1]!.id : null;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes message persistence bug in `useExternalHistory` to store all messages beyond the first two.
> 
>   - **Behavior**:
>     - Fixes bug in `useExternalHistory` in `useExternalHistory.tsx` where only the first two messages were persisted.
>     - Changes condition from `return` to `break` to ensure all messages are processed.
>   - **Misc**:
>     - Adds changeset file `silly-walls-send.md` for patch release.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 787712817e9e795a09db62e593983ed5cbd709d9. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->