### PR TITLE
feat: MessageRepository should delete dangling messages on resetHead

### DIFF
--- a/.changeset/major-books-clap.md
+++ b/.changeset/major-books-clap.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: MessageRepository should delete dangling messages on resetHead

--- a/packages/react/src/runtimes/utils/MessageRepository.tsx
+++ b/packages/react/src/runtimes/utils/MessageRepository.tsx
@@ -414,8 +414,7 @@ export class MessageRepository {
    */
   resetHead(messageId: string | null) {
     if (messageId === null) {
-      this.head = null;
-      this._messages.dirty();
+      this.clear();
       return;
     }
 
@@ -424,6 +423,21 @@ export class MessageRepository {
       throw new Error(
         "MessageRepository(resetHead): Branch not found. This is likely an internal bug in assistant-ui.",
       );
+
+    if (message.children.length > 0) {
+      const toRemove = [...message.children];
+      while (toRemove.length > 0) {
+        const childId = toRemove.pop()!;
+        const childMessage = this.messages.get(childId);
+        if (childMessage) {
+          toRemove.push(...childMessage.children);
+          this.messages.delete(childId);
+        }
+      }
+
+      message.children = [];
+      message.next = null;
+    }
 
     this.head = message;
     for (

--- a/packages/react/src/runtimes/utils/MessageRepository.tsx
+++ b/packages/react/src/runtimes/utils/MessageRepository.tsx
@@ -425,15 +425,16 @@ export class MessageRepository {
       );
 
     if (message.children.length > 0) {
-      const toRemove = [...message.children];
-      while (toRemove.length > 0) {
-        const childId = toRemove.pop()!;
-        const childMessage = this.messages.get(childId);
-        if (childMessage) {
-          toRemove.push(...childMessage.children);
-          this.messages.delete(childId);
+      const deleteDescendants = (msg: RepositoryMessage) => {
+        for (const childId of msg.children) {
+          const childMessage = this.messages.get(childId);
+          if (childMessage) {
+            deleteDescendants(childMessage);
+            this.messages.delete(childId);
+          }
         }
-      }
+      };
+      deleteDescendants(message);
 
       message.children = [];
       message.next = null;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `resetHead()` in `MessageRepository` now deletes all descendant messages when resetting the head to a message with children, with a new test verifying this behavior.
> 
>   - **Behavior**:
>     - `resetHead()` in `MessageRepository.tsx` now deletes all descendant messages when resetting the head to a message with children.
>     - Calls `clear()` when `resetHead()` is called with `null`.
>   - **Tests**:
>     - Adds test `should remove children when resetting head to a message with children` in `MessageRepository.test.ts` to verify descendant deletion behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 15361fe515f3bc07a47ffb174705907959084d6c. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->