### PR TITLE
fix: tailwind prettier config in docs and @assistant-ui/styles

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,6 +10,12 @@
     "lint": "next lint",
     "postinstall": "fumadocs-mdx"
   },
+  "prettier": {
+    "plugins": [
+      "prettier-plugin-tailwindcss"
+    ],
+    "tailwindStylesheet": "app/globals.css"
+  },
   "dependencies": {
     "@ai-sdk/openai": "^2.0.15",
     "@ai-sdk/provider": "^2.0.0",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,7 +14,7 @@
     "plugins": [
       "prettier-plugin-tailwindcss"
     ],
-    "tailwindStylesheet": "app/globals.css"
+    "tailwindStylesheet": "app/global.css"
   },
   "dependencies": {
     "@ai-sdk/openai": "^2.0.15",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -14,6 +14,12 @@
     "README.md"
   ],
   "sideEffects": false,
+  "prettier": {
+    "plugins": [
+      "prettier-plugin-tailwindcss"
+    ],
+    "tailwindStylesheet": "src/styles/index.css"
+  },
   "scripts": {
     "build": "tsx scripts/build.mts",
     "lint": "eslint ."


### PR DESCRIPTION
Define tailwindStylesheet for tailwind v4 support, and define plugin in docs and @assistant-ui/styles
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Tailwind CSS support to Prettier configuration in `docs` and `styles` packages by defining `tailwindStylesheet` and adding `prettier-plugin-tailwindcss`.
> 
>   - **Prettier Configuration**:
>     - Adds `prettier-plugin-tailwindcss` to `prettier` plugins in `apps/docs/package.json` and `packages/styles/package.json`.
>     - Sets `tailwindStylesheet` to `app/globals.css` in `apps/docs/package.json`.
>     - Sets `tailwindStylesheet` to `src/styles/index.css` in `packages/styles/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1d39f150ecedf403b013ab54a2362a89bf9563e2. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->