### PR TITLE
fix: external-store reset/import fixes

### DIFF
--- a/.changeset/heavy-baths-run.md
+++ b/.changeset/heavy-baths-run.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: reset assistantOptimisticId on import

--- a/.changeset/shiny-hairs-fry.md
+++ b/.changeset/shiny-hairs-fry.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: drop resetScheduled mechanism


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes in `ExternalStoreThreadRuntimeCore` to remove `_resetScheduled` and reset `_assistantOptimisticId` on import.
> 
>   - **Behavior**:
>     - Remove `_resetScheduled` mechanism from `ExternalStoreThreadRuntimeCore`.
>     - Reset `_assistantOptimisticId` to `null` during `import()` in `ExternalStoreThreadRuntimeCore`.
>   - **Changesets**:
>     - Add changeset `heavy-baths-run.md` to document reset of `assistantOptimisticId` on import.
>     - Add changeset `shiny-hairs-fry.md` to document removal of `resetScheduled` mechanism.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 2072ed34f8b5441db53c086c837c61123b3e7ea4. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->