### PR TITLE
fix: AssistantCloudThreadHistoryAdapter should not cause errors if not memoized

### DIFF
--- a/.changeset/deep-ants-invent.md
+++ b/.changeset/deep-ants-invent.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: AssistantCloudThreadHistoryAdapter should be stateless

--- a/packages/react/src/cloud/AssistantCloudThreadHistoryAdapter.tsx
+++ b/packages/react/src/cloud/AssistantCloudThreadHistoryAdapter.tsx
@@ -14,6 +14,12 @@ import {
 import { GenericThreadHistoryAdapter } from "../runtimes/adapters/thread-history/ThreadHistoryAdapter";
 import { ReadonlyJSONObject } from "assistant-stream/utils";
 
+// Global WeakMap to store message ID mappings across adapter instances
+const globalMessageIdMapping = new WeakMap<
+  ThreadListItemRuntime,
+  Record<string, string | Promise<string>>
+>();
+
 class FormattedThreadHistoryAdapter<TMessage, TStorageFormat>
   implements GenericThreadHistoryAdapter<TMessage>
 {
@@ -52,7 +58,12 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     private threadListItemRuntime: ThreadListItemRuntime,
   ) {}
 
-  private _getIdForLocalId: Record<string, string | Promise<string>> = {};
+  private get _getIdForLocalId(): Record<string, string | Promise<string>> {
+    if (!globalMessageIdMapping.has(this.threadListItemRuntime)) {
+      globalMessageIdMapping.set(this.threadListItemRuntime, {});
+    }
+    return globalMessageIdMapping.get(this.threadListItemRuntime)!;
+  }
 
   withFormat<TMessage, TStorageFormat>(
     formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make `AssistantCloudThreadHistoryAdapter` stateless using a global `WeakMap` to prevent errors if not memoized.
> 
>   - **Behavior**:
>     - `AssistantCloudThreadHistoryAdapter` is now stateless by using a global `WeakMap` to store message ID mappings.
>     - Ensures no errors occur if the adapter is not memoized.
>   - **Code Changes**:
>     - Added `globalMessageIdMapping` `WeakMap` in `AssistantCloudThreadHistoryAdapter.tsx`.
>     - Replaced instance-specific `_getIdForLocalId` with a getter that accesses `globalMessageIdMapping`.
>   - **Misc**:
>     - Added changeset file `deep-ants-invent.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for a1950fadf73b7624bfed4ae56f8cf6304b026a0a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->