### PR TITLE
fix(registry): thread component centering

### DIFF
--- a/.changeset/eight-cycles-speak.md
+++ b/.changeset/eight-cycles-speak.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/styles": patch
+---
+
+fix(registry): thread component centering

--- a/apps/docs/components/assistant-ui/thread.tsx
+++ b/apps/docs/components/assistant-ui/thread.tsx
@@ -52,7 +52,9 @@ export const Thread: FC = () => {
                 AssistantMessage,
               }}
             />
-            <div className="aui-thread-viewport-spacer min-h-8 grow" />
+            <ThreadPrimitive.If empty={false}>
+              <div className="aui-thread-viewport-spacer min-h-8 grow" />
+            </ThreadPrimitive.If>
             <Composer />
           </ThreadPrimitive.Viewport>
         </ThreadPrimitive.Root>
@@ -78,9 +80,9 @@ const ThreadScrollToBottom: FC = () => {
 const ThreadWelcome: FC = () => {
   return (
     <ThreadPrimitive.Empty>
-      <div className="aui-thread-welcome-root mx-auto mb-16 flex w-full max-w-[var(--thread-max-width)] flex-grow flex-col">
+      <div className="aui-thread-welcome-root mx-auto my-auto flex w-full max-w-[var(--thread-max-width)] flex-grow flex-col">
         <div className="aui-thread-welcome-center flex w-full flex-grow flex-col items-center justify-center">
-          <div className="aui-thread-welcome-message flex size-full flex-col justify-center px-8 md:mt-20">
+          <div className="aui-thread-welcome-message flex size-full flex-col justify-center px-8">
             <m.div
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}

--- a/packages/styles/src/styles/tailwindcss/thread.css
+++ b/packages/styles/src/styles/tailwindcss/thread.css
@@ -31,7 +31,7 @@
 /* thread welcome */
 
 .aui-thread-welcome-root {
-  @apply mx-auto mb-16 flex w-full max-w-[var(--thread-max-width)] flex-grow flex-col;
+  @apply mx-auto my-auto flex w-full max-w-[var(--thread-max-width)] flex-grow flex-col;
 }
 
 .aui-thread-welcome-center {
@@ -39,7 +39,7 @@
 }
 
 .aui-thread-welcome-message {
-  @apply flex size-full flex-col justify-center px-8 md:mt-20;
+  @apply flex size-full flex-col justify-center px-8;
 }
 
 .aui-thread-welcome-message-motion-1 {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix thread component centering by adjusting CSS and conditional rendering in `thread.tsx`.
> 
>   - **Behavior**:
>     - Wraps `aui-thread-viewport-spacer` in `ThreadPrimitive.If` in `thread.tsx` to conditionally render spacer.
>   - **Styles**:
>     - Change `mb-16` to `my-auto` in `aui-thread-welcome-root` in `thread.css` for vertical centering.
>     - Remove `md:mt-20` from `aui-thread-welcome-message` in `thread.css` for consistent spacing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 0d2c9a027867d3d68a7c184973d370423012ca55. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->