### PR TITLE
docs: fix typo in ComposerRunTime

### DIFF
--- a/apps/docs/content/docs/api-reference/runtimes/ComposerRuntime.mdx
+++ b/apps/docs/content/docs/api-reference/runtimes/ComposerRuntime.mdx
@@ -7,15 +7,15 @@ The composer runtime allows you to view or edit anything related to how new info
 import { ParametersTable } from "@/components/docs";
 import { ComposerRuntime, ThreadComposerRuntime, ThreadComposerState, EditComposerState } from "@/generated/typeDocs";
 
-### `useComposer`
+### `useComposerRuntime`
 
 Grabs the nearest composer (whether it’s the edit composer or the thread’s composer):
 
 ```tsx
 // Example
-import { useComposer } from "@assistant-ui/react";
+import { useComposerRuntime } from "@assistant-ui/react";
 
-const composerRuntime = useComposer();
+const composerRuntime = useComposerRuntime();
 
 // set the text
 composerRuntime.setText("Hello from the composer runtime");


### PR DESCRIPTION
fix typo in ComposerRunTime Hook Document
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo in `ComposerRuntime.mdx` by renaming `useComposer` to `useComposerRuntime`.
> 
>   - **Documentation**:
>     - Fix typo in `ComposerRuntime.mdx` by renaming `useComposer` to `useComposerRuntime` in the example code and headings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 5903aa883d2fe25fac31ff3a7b4abb16e68b95e5. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->