### PR TITLE
registry: do not use motion for MessagePrimitive.Root due to motion ref handling bug

### DIFF
--- a/apps/docs/components/assistant-ui/thread.tsx
+++ b/apps/docs/components/assistant-ui/thread.tsx
@@ -228,10 +228,8 @@ const MessageError: FC = () => {
 const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root asChild>
-      <m.div
-        className="aui-assistant-message-root relative mx-auto w-full max-w-[var(--thread-max-width)] py-4 last:mb-24"
-        initial={{ y: 5, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
+      <div
+        className="aui-assistant-message-root relative mx-auto w-full max-w-[var(--thread-max-width)] animate-in py-4 duration-200 fade-in slide-in-from-bottom-1 last:mb-24"
         data-role="assistant"
       >
         <div className="aui-assistant-message-content mx-2 leading-7 break-words text-foreground">
@@ -248,7 +246,7 @@ const AssistantMessage: FC = () => {
           <BranchPicker />
           <AssistantActionBar />
         </div>
-      </m.div>
+      </div>
     </MessagePrimitive.Root>
   );
 };
@@ -283,10 +281,8 @@ const AssistantActionBar: FC = () => {
 const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root asChild>
-      <m.div
-        className="aui-user-message-root mx-auto grid w-full max-w-[var(--thread-max-width)] auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] gap-y-2 px-2 py-4 first:mt-3 last:mb-5 [&:where(>*)]:col-start-2"
-        initial={{ y: 5, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
+      <div
+        className="aui-user-message-root mx-auto grid w-full max-w-[var(--thread-max-width)] animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] gap-y-2 px-2 py-4 duration-200 fade-in slide-in-from-bottom-1 first:mt-3 last:mb-5 [&:where(>*)]:col-start-2"
         data-role="user"
       >
         <UserMessageAttachments />
@@ -301,7 +297,7 @@ const UserMessage: FC = () => {
         </div>
 
         <BranchPicker className="aui-user-branch-picker col-span-full col-start-1 row-start-3 -mr-1 justify-end" />
-      </m.div>
+      </div>
     </MessagePrimitive.Root>
   );
 };

--- a/apps/registry/components/assistant-ui/thread.tsx
+++ b/apps/registry/components/assistant-ui/thread.tsx
@@ -226,10 +226,8 @@ const MessageError: FC = () => {
 const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root asChild>
-      <m.div
+      <div
         className="aui-assistant-message-root"
-        initial={{ y: 5, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
         data-role="assistant"
       >
         <div className="aui-assistant-message-content">
@@ -246,7 +244,7 @@ const AssistantMessage: FC = () => {
           <BranchPicker />
           <AssistantActionBar />
         </div>
-      </m.div>
+      </div>
     </MessagePrimitive.Root>
   );
 };
@@ -281,10 +279,8 @@ const AssistantActionBar: FC = () => {
 const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root asChild>
-      <m.div
+      <div
         className="aui-user-message-root"
-        initial={{ y: 5, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
         data-role="user"
       >
         <UserMessageAttachments />
@@ -299,7 +295,7 @@ const UserMessage: FC = () => {
         </div>
 
         <BranchPicker className="aui-user-branch-picker" />
-      </m.div>
+      </div>
     </MessagePrimitive.Root>
   );
 };

--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -28,6 +28,7 @@
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.539.0",
     "mermaid": "^11.9.0",
+    "motion": "^12.23.12",
     "next": "^15",
     "react": "19.1.1",
     "react-resizable-panels": "^3.0.4",

--- a/packages/styles/src/styles/tailwindcss/thread.css
+++ b/packages/styles/src/styles/tailwindcss/thread.css
@@ -208,7 +208,7 @@
 /* user message */
 
 .aui-user-message-root {
-  @apply mx-auto grid w-full max-w-[var(--thread-max-width)] auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] gap-y-2 px-2 py-4 first:mt-3 last:mb-5 [&:where(>*)]:col-start-2;
+  @apply mx-auto grid w-full max-w-[var(--thread-max-width)] animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] gap-y-2 px-2 py-4 duration-200 fade-in slide-in-from-bottom-1 first:mt-3 last:mb-5 [&:where(>*)]:col-start-2;
 }
 
 .aui-user-branch-picker {
@@ -262,7 +262,7 @@
 /* assistant message */
 
 .aui-assistant-message-root {
-  @apply relative mx-auto w-full max-w-[var(--thread-max-width)] py-4 last:mb-24;
+  @apply relative mx-auto w-full max-w-[var(--thread-max-width)] animate-in py-4 duration-200 fade-in slide-in-from-bottom-1 last:mb-24;
 }
 
 .aui-assistant-message-avatar {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ importers:
       mermaid:
         specifier: ^11.9.0
         version: 11.11.0
+      motion:
+        specifier: ^12.23.12
+        version: 12.23.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       next:
         specifier: ^15
         version: 15.4.6(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `motion` usage in `MessagePrimitive.Root` components and update animations using Tailwind CSS in `thread.tsx`.
> 
>   - **Behavior**:
>     - Remove `motion` usage in `MessagePrimitive.Root` for `AssistantMessage` and `UserMessage` in `thread.tsx` in both `apps/docs/components/assistant-ui` and `apps/registry/components/assistant-ui`.
>     - Replace `m.div` with `div` and use Tailwind CSS classes for animations.
>   - **Dependencies**:
>     - Add `motion` library to `package.json`.
>   - **Styles**:
>     - Update `thread.css` to include Tailwind CSS animation utilities for `.aui-user-message-root` and `.aui-assistant-message-root`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for ad6e9bd7e883b081721b8194aea730a621bc767d. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->