### PR TITLE
registry: use import type for type import

### DIFF
--- a/apps/registry/components/assistant-ui/tool-fallback.tsx
+++ b/apps/registry/components/assistant-ui/tool-fallback.tsx
@@ -1,4 +1,4 @@
-import { ToolCallMessagePartComponent } from "@assistant-ui/react";
+import type { ToolCallMessagePartComponent } from "@assistant-ui/react";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION
fixes #2398
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `import` to `import type` for `ToolCallMessagePartComponent` in `tool-fallback.tsx`.
> 
>   - **Imports**:
>     - Change `import` to `import type` for `ToolCallMessagePartComponent` in `tool-fallback.tsx` to ensure it's treated as a type-only import.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c2edbd221bea0c6fc006d5f67dc99cd774ff4fd7. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->