### PR TITLE
fix: attachments should not cause infinite rerenders

### DIFF
--- a/.changeset/tender-poets-drive.md
+++ b/.changeset/tender-poets-drive.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: attachments should not cause infinite rerenders

--- a/packages/react/src/legacy-runtime/client/AttachmentRuntimeClient.ts
+++ b/packages/react/src/legacy-runtime/client/AttachmentRuntimeClient.ts
@@ -1,0 +1,22 @@
+import { resource } from "../../../../tap/dist/core/resource";
+import { AttachmentClientApi } from "../../client/types/Attachment";
+import { tapApi } from "../../utils/tap-store";
+import { AttachmentRuntime } from "../runtime";
+import { tapSubscribable } from "../util-hooks/tapSubscribable";
+
+export const AttachmentRuntimeClient = resource(
+  ({ runtime }: { runtime: AttachmentRuntime }) => {
+    const state = tapSubscribable(runtime);
+    const api = tapApi<AttachmentClientApi>({
+      getState: () => state,
+      remove: runtime.remove,
+      __internal_getRuntime: () => runtime,
+    });
+
+    return {
+      state: state,
+      api,
+      key: undefined,
+    };
+  },
+);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `AttachmentRuntimeClient` to manage attachment states, refactoring `ComposerClient` and `MessageClient` to prevent infinite rerenders.
> 
>   - **Behavior**:
>     - Introduces `AttachmentRuntimeClient` in `AttachmentRuntimeClient.ts` to manage attachment states and APIs.
>     - Refactors `ComposerClient` in `ComposerRuntimeClient.ts` to use `AttachmentRuntimeClient`, preventing infinite rerenders by managing attachment states with `tapLookupResources`.
>     - Refactors `MessageClient` in `MessageRuntimeClient.ts` to use `AttachmentRuntimeClient`, ensuring efficient attachment state management and preventing rerenders.
>   - **Misc**:
>     - Removes inline attachment management logic in `ComposerRuntimeClient.ts` and `MessageRuntimeClient.ts`, replacing it with `attachments.api` from `AttachmentRuntimeClient`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 4044319ff96161ba78d9d97ee5aff88df3a9ac47. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->