### PR TITLE
fix(registry): Update attachment component

### DIFF
--- a/apps/registry/components/assistant-ui/attachment.tsx
+++ b/apps/registry/components/assistant-ui/attachment.tsx
@@ -7,9 +7,8 @@ import {
   AttachmentPrimitive,
   ComposerPrimitive,
   MessagePrimitive,
-  useAssistantApi,
   useAssistantState,
-  useAttachment,
+  useAssistantApi,
 } from "@assistant-ui/react";
 import { useShallow } from "zustand/shallow";
 import {
@@ -48,11 +47,12 @@ const useFileSrc = (file: File | undefined) => {
 };
 
 const useAttachmentSrc = () => {
-  const { file, src } = useAttachment(
-    useShallow((a): { file?: File; src?: string } => {
-      if (a.type !== "image") return {};
-      if (a.file) return { file: a.file };
-      const src = a.content?.filter((c) => c.type === "image")[0]?.image;
+  const { file, src } = useAssistantState(
+    useShallow(({ attachment }): { file?: File; src?: string } => {
+      if (attachment.type !== "image") return {};
+      if (attachment.file) return { file: attachment.file };
+      const src = attachment.content?.filter((c) => c.type === "image")[0]
+        ?.image;
       if (!src) return {};
       return { src };
     }),
@@ -110,7 +110,9 @@ const AttachmentPreviewDialog: FC<PropsWithChildren> = ({ children }) => {
 };
 
 const AttachmentThumb: FC = () => {
-  const isImage = useAttachment((a) => a.type === "image");
+  const isImage = useAssistantState(
+    ({ attachment }) => attachment.type === "image",
+  );
   const src = useAttachmentSrc();
 
   return (
@@ -129,7 +131,8 @@ const AttachmentThumb: FC = () => {
 
 const AttachmentUI: FC = () => {
   const api = useAssistantApi();
-  const isComposer = api.attachment.source !== "message";
+  const isComposer = api.attachment.source === "composer";
+
   const isImage = useAssistantState(
     ({ attachment }) => attachment.type === "image",
   );


### PR DESCRIPTION
for new API
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `useAttachment` with `useAssistantState` in `attachment.tsx` to align with new API for handling attachment state.
> 
>   - **Behavior**:
>     - Replaces `useAttachment` with `useAssistantState` in `useAttachmentSrc()` and `AttachmentThumb` to handle attachment state.
>     - Changes `isComposer` logic in `AttachmentUI` to check if `api.attachment.source` is `composer`.
>   - **Functions**:
>     - Updates `useAttachmentSrc()` to use `useAssistantState` for retrieving file and src.
>     - Updates `AttachmentThumb` to use `useAssistantState` for checking if attachment type is image.
>   - **Misc**:
>     - Minor import reordering in `attachment.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d1991701234acaa98c3a2defd247f27c3ffeaa77. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->