### PR TITLE
docs: add docs for event wildcard

### DIFF
--- a/apps/docs/content/docs/guides/context-api.mdx
+++ b/apps/docs/content/docs/guides/context-api.mdx
@@ -191,6 +191,11 @@ useAssistantEvent({ event: "composer.send", scope: "*" }, (e) => {
 useAssistantEvent({ event: "thread.run-start", scope: "thread" }, (e) => {
   console.log("Run started in current thread:", e);
 });
+
+// Listen to ALL events using wildcard (new)
+useAssistantEvent("*", (e) => {
+  console.log("Event occurred:", e.event, "with payload:", e.payload);
+});
 ```
 
 Event names follow the pattern `source.event` where source indicates the originating scope.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for using a wildcard in `useAssistantEvent` to listen to all events in `context-api.mdx`.
> 
>   - **Documentation**:
>     - Adds example in `context-api.mdx` for using `useAssistantEvent` with a wildcard `"*"` to listen to all events.
>     - Demonstrates logging event name and payload for all events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1a03253ff028e5a5561dfbd15222a124f4e60dee. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->