### PR TITLE
feat: Windows support for MCP docs server + assistant-ui monorepo build

### DIFF
--- a/.changeset/cute-dolls-wash.md
+++ b/.changeset/cute-dolls-wash.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/mcp-docs-server": patch
+---
+
+Comprehensive Windows support - replace Unix commands with cross-platform Node.js APIs, normalize paths for consistency, and improve path handling in build utilities

--- a/packages/mcp-docs-server/package.json
+++ b/packages/mcp-docs-server/package.json
@@ -8,7 +8,7 @@
     "assistant-ui-mcp": "./dist/stdio.js"
   },
   "scripts": {
-    "clean": "rm -rf dist .docs",
+    "clean": "tsx scripts/clean.mts",
     "prepare-docs": "cross-env PREPARE=true node ./dist/prepare-docs/prepare.js",
     "build:cli": "tsup src/stdio.ts src/prepare-docs/prepare.ts src/index.ts --format esm --treeshake=smallest --splitting",
     "build": "pnpm clean && pnpm build:cli && pnpm prepare-docs",

--- a/packages/mcp-docs-server/scripts/clean.mts
+++ b/packages/mcp-docs-server/scripts/clean.mts
@@ -1,0 +1,6 @@
+import { rm } from "fs/promises";
+
+await Promise.all([
+  rm("dist", { recursive: true, force: true }),
+  rm(".docs", { recursive: true, force: true })
+]);

--- a/packages/mcp-docs-server/src/prepare-docs/code-examples.ts
+++ b/packages/mcp-docs-server/src/prepare-docs/code-examples.ts
@@ -135,7 +135,8 @@ export async function prepareCodeExamples(): Promise<void> {
             break;
           }
 
-          markdown += `## ${file.path}\n\n`;
+          // Normalize Windows backslashes to forward slashes for consistent markdown output
+          markdown += `## ${file.path.replace(/\\/g, "/")}\n\n`;
           markdown += `\`\`\`${getFileType(file.path)}\n`;
           markdown += file.content;
           markdown += `\n\`\`\`\n\n`;

--- a/packages/mcp-docs-server/src/utils/security.ts
+++ b/packages/mcp-docs-server/src/utils/security.ts
@@ -6,6 +6,11 @@ export function sanitizePath(userPath: string): string {
     throw new Error("Invalid path: Path must be a non-empty string");
   }
 
+  // Check for traversal patterns before normalization - defense in depth
+  if (userPath.includes("../") || userPath.includes("..\\")) {
+    throw new Error("Invalid path: Directory traversal attempt detected");
+  }
+
   const normalized = normalize(userPath);
 
   if (path.isAbsolute(normalized)) {
@@ -43,7 +48,8 @@ export function sanitizePath(userPath: string): string {
     }
   }
 
-  return relativePath;
+  // Always return Unix-style paths for consistency across platforms
+  return relativePath.replace(/\\/g, "/");
 }
 
 export function isValidPathCharacters(path: string): boolean {

--- a/packages/mcp-docs-server/src/utils/tests/security.test.ts
+++ b/packages/mcp-docs-server/src/utils/tests/security.test.ts
@@ -111,7 +111,7 @@ describe("sanitizePath", () => {
 
       it("should reject UNC paths", () => {
         expect(() => sanitizePath("\\\\server\\share")).toThrow(
-          "Invalid path: Path contains invalid Windows characters",
+          "Invalid path: Absolute paths are not allowed",
         );
       });
     });

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -26,7 +26,8 @@ const transformCssToJson = async (files: string[]) => {
         postcssJs.objectify(root),
       );
 
-      const outputFile = "dist/" + file.split("/").slice(1).join("/") + ".json";
+      const outputFile =
+        path.join("dist", ...file.split(/[/\\]/).slice(1)) + ".json";
       const outputContent = JSON.stringify(formattedComponents, null, 2);
 
       await fs.mkdir(path.dirname(outputFile), { recursive: true });


### PR DESCRIPTION
- Replace Unix rm command with cross-platform Node.js fs.rm() in clean script
- Enhance path sanitization with early traversal detection for Windows backslash paths
- Normalize all API paths to forward slashes for cross-platform consistency
- Fix path separator handling in build utilities and code examples generation
- Update tests to reflect correct Node.js path behavior for UNC paths

All 71 tests passing on Windows. Maintains security while ensuring cross-platform compatibility.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance Windows compatibility for MCP docs server by replacing Unix commands with Node.js APIs, normalizing paths, and updating tests.
> 
>   - **Cross-Platform Compatibility**:
>     - Replace Unix `rm` command with `fs.rm()` in `clean.mts`.
>     - Normalize paths to forward slashes in `code-examples.ts` and `security.ts`.
>     - Update path handling in `index.ts` to support both Unix and Windows separators.
>   - **Security and Path Handling**:
>     - Enhance path sanitization in `security.ts` to detect Windows backslash paths early.
>     - Update `security.test.ts` to reflect correct Node.js path behavior for UNC paths.
>   - **Miscellaneous**:
>     - Update `package.json` to use `tsx` for the `clean` script.
>     - All 71 tests passing on Windows, ensuring cross-platform compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 7fe94ae57f3cd2cb3158d6330281823914fd0e4a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->