### PR TITLE
fix: better partial tool call args parsing

### DIFF
--- a/.changeset/sour-hairs-draw.md
+++ b/.changeset/sour-hairs-draw.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: better partial tool call args parsing

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -7,6 +7,7 @@ import {
 import { LangChainMessage } from "./types";
 import { ToolCallMessagePart } from "@assistant-ui/react";
 import { ThreadUserMessage } from "@assistant-ui/react";
+import { parsePartialJsonObject } from "assistant-stream/utils";
 
 const contentToParts = (content: LangChainMessage["content"]) => {
   if (typeof content === "string")
@@ -87,10 +88,12 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
               type: "tool-call",
               toolCallId: chunk.id,
               toolName: chunk.name,
-              args: chunk.args,
-              argsText:
-                message.tool_call_chunks?.find((c) => c.id === chunk.id)
-                  ?.args ?? JSON.stringify(chunk.args),
+              args: chunk.partial_json
+                ? (parsePartialJsonObject(chunk.partial_json) ?? {})
+                : chunk.args,
+              argsText: chunk.partial_json
+                ? chunk.partial_json
+                : JSON.stringify(chunk.args),
             }),
           ) ?? []),
         ],

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -11,8 +11,8 @@ export type LangChainToolCallChunk = {
 export type LangChainToolCall = {
   id: string;
   name: string;
-  argsText: string;
   args: ReadonlyJSONObject;
+  partial_json?: string;
 };
 
 export type MessageContentText = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves tool call argument parsing by using `parsePartialJsonObject` for partial JSON in `convertLangChainMessages.ts`.
> 
>   - **Behavior**:
>     - In `convertLangChainMessages.ts`, `convertLangChainMessages` now uses `parsePartialJsonObject` to parse `partial_json` for tool call arguments.
>     - `args` and `argsText` are conditionally set based on `partial_json` presence, improving partial JSON handling.
>   - **Types**:
>     - Add `partial_json` optional property to `LangChainToolCall` in `types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for dfded8d0b6f12ea5b3a4ee7f4e86d09f1d3819e1. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->