### PR TITLE
feat(assistant-transport): surface stream errors to caller

### DIFF
--- a/.changeset/tender-dots-fry.md
+++ b/.changeset/tender-dots-fry.md
@@ -1,0 +1,6 @@
+---
+"assistant-stream": patch
+"@assistant-ui/react": patch
+---
+
+feat(assistant-transport): surface stream errors to caller

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
@@ -374,9 +374,11 @@ export class AssistantMessageAccumulator extends TransformStream<
   constructor({
     initialMessage,
     throttle,
+    onError,
   }: {
     initialMessage?: AssistantMessage;
     throttle?: boolean;
+    onError?: (error: string) => void;
   } = {}) {
     let message = initialMessage ?? createInitialMessage();
     let controller:
@@ -431,6 +433,7 @@ export class AssistantMessageAccumulator extends TransformStream<
             break;
           case "error":
             message = handleErrorChunk(message, chunk);
+            onError?.(chunk.error);
             break;
           case "update-state":
             message = handleUpdateState(message, chunk);

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.tsx
@@ -81,6 +81,7 @@ const useAssistantTransportThreadRuntime = <T,>(
         throw new Error("Response body is null");
       }
 
+      let err: string | undefined;
       const stream = response.body
         .pipeThrough(new DataStreamDecoder())
         .pipeThrough(
@@ -90,6 +91,9 @@ const useAssistantTransportThreadRuntime = <T,>(
                 (agentStateRef.current as ReadonlyJSONValue) ?? null,
             }),
             throttle: isResume,
+            onError: (error) => {
+              err = error;
+            },
           }),
         );
 
@@ -105,6 +109,10 @@ const useAssistantTransportThreadRuntime = <T,>(
 
         agentStateRef.current = chunk.metadata.unstable_state as T;
         rerender((prev) => prev + 1);
+      }
+
+      if (err) {
+        throw new Error(err);
       }
     },
     onFinish: options.onFinish,


### PR DESCRIPTION
Add error propagation for streaming assistant responses so that
errors raised during stream decoding or accumulation are reported
to the transport layer and cause the runtime to fail fast.

- Introduce a local `err` variable in useAssistantTransportRuntime to
  capture errors received from the accumulator's onError callback.
- Pass an onError callback into the accumulator options so the
  accumulator can report string errors back to the transport.
- Throw a new Error(err) after processing a chunk if an error was
  captured, ensuring the caller is notified and can handle the
  failure.
- Wire accumulator to call onError when an "error" chunk is
  encountered.

This prevents silent failures during stream processing and makes
error handling deterministic for resume/throttle flows.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add error propagation for streaming assistant responses, ensuring errors are reported and cause fast failure in `useAssistantTransportRuntime.tsx`.
> 
>   - **Behavior**:
>     - Add error propagation for streaming assistant responses in `useAssistantTransportRuntime.tsx`.
>     - Introduce `err` variable in `useAssistantTransportThreadRuntime` to capture errors from `onError` callback.
>     - Throw `Error(err)` after processing a chunk if an error is captured.
>   - **Accumulator**:
>     - Add `onError` callback to `AssistantMessageAccumulator` in `assistant-message-accumulator.ts`.
>     - Call `onError` when an "error" chunk is encountered.
>   - **Misc**:
>     - Ensure deterministic error handling for resume/throttle flows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c91db449ecb5c1c024fa108b569f67bb0be1478b. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->