### PR TITLE
Fix: Add transport parameter to UseChatRuntimeOptions type

### DIFF
--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.tsx
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.tsx
@@ -8,13 +8,14 @@ import {
   unstable_useRemoteThreadListRuntime,
 } from "@assistant-ui/react";
 import { useAISDKRuntime, type AISDKRuntimeAdapter } from "./useAISDKRuntime";
-import { ChatInit } from "ai";
+import { ChatInit, DefaultChatTransport } from "ai";
 import { AssistantChatTransport } from "./AssistantChatTransport";
 
 export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
   ChatInit<UI_MESSAGE> & {
     cloud?: AssistantCloud | undefined;
     adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
+    transport?: DefaultChatTransport<UI_MESSAGE> | undefined;
   };
 
 export const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(


### PR DESCRIPTION
**Problem**
TypeScript users cannot use `AssistantChatTransport` with `useChatRuntime` due to missing type definition, despite runtime support existing.

**Solution**
Add `transport?: DefaultChatTransport<UI_MESSAGE> | undefined` to `UseChatRuntimeOptions` type.

**Before**
```typescript
// TypeScript error - transport not in type definition
const runtime = useChatRuntime({
  transport: new AssistantChatTransport({ api: "/api/chat" })
});
```

**After**
```typescript
// Works without TypeScript errors
const runtime = useChatRuntime({
  transport: new AssistantChatTransport({ api: "/api/chat" })
});
```

**Changes**
- Import `DefaultChatTransport` from "ai"
- Add `transport` parameter to `UseChatRuntimeOptions` type
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `transport` parameter to `UseChatRuntimeOptions` type in `useChatRuntime.tsx` to support `AssistantChatTransport` in TypeScript.
> 
>   - **TypeScript Support**:
>     - Add `transport?: DefaultChatTransport<UI_MESSAGE> | undefined` to `UseChatRuntimeOptions` type in `useChatRuntime.tsx`.
>     - Import `DefaultChatTransport` from `ai`.
>   - **Behavior**:
>     - Allows `AssistantChatTransport` to be used with `useChatRuntime` without TypeScript errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d0e5356ffd3526929709c23543d280ca7b68e41e. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->