### PR TITLE
fix: notify when suggestions change

### DIFF
--- a/.changeset/fifty-camels-begin.md
+++ b/.changeset/fifty-camels-begin.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: notify when suggestions change

--- a/packages/react/src/legacy-runtime/runtime-cores/local/LocalThreadRuntimeCore.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/local/LocalThreadRuntimeCore.tsx
@@ -206,6 +206,7 @@ export class LocalThreadRuntimeCore
       this._suggestions = [];
       this._suggestionsController?.abort();
       this._suggestionsController = null;
+      this._notifySubscribers();
 
       do {
         message = await this.performRoundtrip(
@@ -234,11 +235,13 @@ export class LocalThreadRuntimeCore
         for await (const r of promiseOrGenerator) {
           if (signal.aborted) break;
           this._suggestions = r;
+          this._notifySubscribers();
         }
       } else {
         const result = await promiseOrGenerator;
         if (signal.aborted) return;
         this._suggestions = result;
+        this._notifySubscribers();
       }
     }
   }


### PR DESCRIPTION
fixes #2492

Call _notifySubscribers() after clearing or updating the cached
_suggestions in LocalThreadRuntimeCore. Previously subscribers were
not informed when suggestions were reset to an empty array or when
partial/complete suggestion results arrived from the generator or
promise. This caused subscribers to show stale suggestion state.

Now the runtime emits updates immediately after:
- abort/clear of suggestions
- each incremental generator yield
- the final promise result

This ensures UI and other listeners receive timely updates and stay
in sync with the runtime suggestion state.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes notification issue in `LocalThreadRuntimeCore` by calling `_notifySubscribers()` after suggestion changes to ensure timely updates.
> 
>   - **Behavior**:
>     - Calls `_notifySubscribers()` after clearing or updating `_suggestions` in `LocalThreadRuntimeCore`.
>     - Notifies subscribers after abort/clear of suggestions, each incremental generator yield, and the final promise result.
>     - Ensures UI and listeners receive timely updates and stay in sync with suggestion state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 27afc4627b255fc10d71c58bc976cc83ba6352b0. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->