### PR TITLE
fix: correct thread empty checks and devtools mode

### DIFF
--- a/packages/react-devtools/src/DevToolsModal.tsx
+++ b/packages/react-devtools/src/DevToolsModal.tsx
@@ -14,7 +14,7 @@ const isDarkMode = (): boolean => {
 
 const DevToolsModalImpl = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const [darkMode, setDarkMode] = useState(isDarkMode());
+  const [darkMode, setDarkMode] = useState(false);
   const [buttonHover, setButtonHover] = useState(false);
   const [closeHover, setCloseHover] = useState(false);
 

--- a/packages/react/src/primitives/thread/ThreadEmpty.tsx
+++ b/packages/react/src/primitives/thread/ThreadEmpty.tsx
@@ -10,7 +10,9 @@ export namespace ThreadPrimitiveEmpty {
 export const ThreadPrimitiveEmpty: FC<ThreadPrimitiveEmpty.Props> = ({
   children,
 }) => {
-  const empty = useAssistantState(({ thread }) => thread.messages.length === 0);
+  const empty = useAssistantState(
+    ({ thread }) => thread.messages.length === 0 && !thread.isLoading,
+  );
   return empty ? children : null;
 };
 

--- a/packages/react/src/primitives/thread/ThreadIf.tsx
+++ b/packages/react/src/primitives/thread/ThreadIf.tsx
@@ -14,8 +14,10 @@ type UseThreadIfProps = RequireAtLeastOne<ThreadIfFilters>;
 
 const useThreadIf = (props: UseThreadIfProps) => {
   return useAssistantState(({ thread }) => {
-    if (props.empty === true && thread.messages.length !== 0) return false;
-    if (props.empty === false && thread.messages.length === 0) return false;
+    const isEmpty = thread.messages.length === 0 && !thread.isLoading;
+    if (props.empty === true && !isEmpty) return false;
+    if (props.empty === false && isEmpty) return false;
+
     if (props.running === true && !thread.isRunning) return false;
     if (props.running === false && thread.isRunning) return false;
     if (props.disabled === true && !thread.isDisabled) return false;


### PR DESCRIPTION
Update thread empty detection to consider loading state so that
components treat a thread as empty only when there are no messages
and the thread is not currently loading. This prevents flicker or
incorrect UI when messages are being fetched or processed.

- thread/ThreadEmpty.tsx: include !thread.isLoading in empty check.
- thread/ThreadIf.tsx: compute isEmpty using messages.length and
  isLoading, and adjust empty prop logic to use isEmpty.

Also initialize DevToolsModal darkMode to false instead of calling
isDarkMode() at mount to avoid relying on environment during server
render or initial render side-effects.