### PR TITLE
Docs(SuggestionAdapter): Correct method name from get to generate

### DIFF
--- a/apps/docs/content/docs/runtimes/custom/local.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local.mdx
@@ -732,7 +732,7 @@ Provide follow-up suggestions:
 
 ```tsx
 const suggestionAdapter: SuggestionAdapter = {
-  async *get({ messages }) {
+  async *generate({ messages }) {
     // Analyze conversation context
     const lastMessage = messages[messages.length - 1];
 


### PR DESCRIPTION
This PR fixes a minor error in the documentation for the `SuggestionAdapter`.

The example code was using the method name `get`, but the correct name according to the type definition is `generate`. This change updates the example to use the correct `generate` method name, which will prevent confusion for developers using the adapter.

Fixes #2537
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects method name from `get` to `generate` in `SuggestionAdapter` example code in `local.mdx`.
> 
>   - **Documentation**:
>     - Corrects method name from `get` to `generate` in `local.mdx` for `SuggestionAdapter` example code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 91fec3b96b9ee7c9a7946fb17620beb5536a6221. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->