### PR TITLE
fix(langgraph): guard against undefined thread.extras and use for send

### DIFF
--- a/.changeset/langgraph-extras-fix.md
+++ b/.changeset/langgraph-extras-fix.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: Handle undefined extras in useLangGraphInterruptState
+
+Fixed an issue where useLangGraphInterruptState would throw errors when thread extras are undefined (e.g., with EMPTY_THREAD_CORE). The hook now safely returns undefined when extras are not available, and uses useAssistantApi for imperative operations in useLangGraphSend to avoid similar issues.

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -8,6 +8,7 @@ import {
   OnMetadataEventCallback,
 } from "./types";
 import {
+  useAssistantApi,
   useAssistantState,
   useExternalMessageConverter,
   useExternalStoreRuntime,
@@ -99,17 +100,25 @@ const asLangGraphRuntimeExtras = (extras: unknown): LangGraphRuntimeExtras => {
 };
 
 export const useLangGraphInterruptState = () => {
-  const { interrupt } = useAssistantState(({ thread }) =>
-    asLangGraphRuntimeExtras(thread.extras),
-  );
+  const interrupt = useAssistantState(({ thread }) => {
+    const extras = thread.extras;
+    if (!extras) return undefined;
+    return asLangGraphRuntimeExtras(extras).interrupt;
+  });
   return interrupt;
 };
 
 export const useLangGraphSend = () => {
-  const { send } = useAssistantState(({ thread }) =>
-    asLangGraphRuntimeExtras(thread.extras),
-  );
-  return send;
+  const api = useAssistantApi();
+
+  return (
+    messages: LangChainMessage[],
+    config: LangGraphSendMessageConfig,
+  ) => {
+    const extras = api.thread().getState().extras;
+    const { send } = asLangGraphRuntimeExtras(extras);
+    return send(messages, config);
+  };
 };
 
 export const useLangGraphSendCommand = () => {


### PR DESCRIPTION
Ensure safely handle threads without extras (eg EMPTY_THREAD_CORE).
- Change useLangGraphInterruptState to return undefined when thread.extras
  is missing instead of destructuring and throwing.
- Replace direct assistant state grab in useLangGraphSend with an
  imperative call via useAssistantApi().thread().getState() to read extras
  at call time and invoke the underlying send implementation with the
  provided messages and config.

This prevents runtime errors when extras are undefined and avoids stale
reads of thread extras for sends.