### PR TITLE
fix(types): provide fallback for augmentation

### DIFF
--- a/packages/react/src/augmentations.ts
+++ b/packages/react/src/augmentations.ts
@@ -7,15 +7,20 @@ declare global {
 type GetAugmentation<
   Key extends keyof Assistant,
   ExpectedType,
+  FallbackType = ExpectedType,
 > = unknown extends Assistant[Key]
-  ? ExpectedType
+  ? FallbackType
   : Assistant[Key] extends ExpectedType
     ? Assistant[Key]
     : {
         ErrorMessage: `There is an error in the type you provided for Assistant.${Key}`;
       };
 
-type UserCommandsRecord = GetAugmentation<"Commands", Record<string, unknown>>;
+type UserCommandsRecord = GetAugmentation<
+  "Commands",
+  Record<string, unknown>,
+  Record<string, never>
+>;
 
 export type UserCommands =
   UserCommandsRecord extends Record<string, infer V> ? V : never;


### PR DESCRIPTION
AdjustAugmentation to accept an explicit fallback type and use it
when Assistant[Key] is unknown. Specify Record<string, never> as the
fallback for the "Commands" augmentation so that UserCommands resolves
to never instead of an unconstrained unknown-based record.

This prevents accidental widening of UserCommands when the Assistant
type lacks a concrete Commands definition and makes type behavior
more predictable for downstream consumers.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `GetAugmentation` in `augmentations.ts` to use a fallback type, ensuring `UserCommands` resolves to `never` if `Assistant.Commands` is unknown.
> 
>   - **Types**:
>     - Modify `GetAugmentation` in `augmentations.ts` to accept a `FallbackType` parameter, defaulting to `ExpectedType`.
>     - Change `UserCommandsRecord` to use `GetAugmentation` with `Record<string, never>` as `FallbackType`.
>   - **Behavior**:
>     - Ensures `UserCommands` resolves to `never` if `Assistant.Commands` is unknown, preventing type widening.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for aa75fd591d0aecc28ff39a3c67a5eb2378f90418. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->