### PR TITLE
feat: revamp Assistant augmentation mechanism

### DIFF
--- a/packages/react/src/augmentations.ts
+++ b/packages/react/src/augmentations.ts
@@ -1,26 +1,23 @@
-declare global {
-  interface Assistant {
-    Commands: unknown;
-  }
+/**
+ * Module augmentation namespace for assistant-ui type extensions.
+ *
+ * @example
+ * ```typescript
+ * declare module "@assistant-ui/react" {
+ *   namespace Assistant {
+ *     interface Commands {
+ *       myCustomCommand: {
+ *         type: "my-custom-command";
+ *         data: string;
+ *       };
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export namespace Assistant {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  export interface Commands {}
 }
 
-type GetAugmentation<
-  Key extends keyof Assistant,
-  ExpectedType,
-  FallbackType = ExpectedType,
-> = unknown extends Assistant[Key]
-  ? FallbackType
-  : Assistant[Key] extends ExpectedType
-    ? Assistant[Key]
-    : {
-        ErrorMessage: `There is an error in the type you provided for Assistant.${Key}`;
-      };
-
-type UserCommandsRecord = GetAugmentation<
-  "Commands",
-  Record<string, unknown>,
-  Record<string, never>
->;
-
-export type UserCommands =
-  UserCommandsRecord extends Record<string, infer V> ? V : never;
+export type UserCommands = Assistant.Commands[keyof Assistant.Commands];

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,3 +9,5 @@ export * from "./types";
 export * from "./devtools";
 
 export * as INTERNAL from "./internal";
+
+export type { Assistant } from "./augmentations";


### PR DESCRIPTION
Export Assistant augmentation types and simplify how user command
types are inferred.

- Export Assistant type from augmentations via packages/react/src/index.ts
  so consumers can reference augmentation types directly.
- Replace global module augmentation stub with a dedicated Assistant
  namespace and JSDoc example in packages/react/src/augmentations.ts to
  document how to extend Commands.
- Simplify UserCommands type to directly derive union from
  Assistant.Commands (UserCommands = Assistant.Commands[keyof Assistant.Commands])
  and remove complex GetAugmentation helper and global namespace hacks.

This clarifies the public typing surface, makes augmentations easier to
use and understand, and reduces type indirection.