### PR TITLE
refactor: rename interrupt -> human for tool input handling

### DIFF
--- a/apps/docs/content/docs/guides/ToolUI.mdx
+++ b/apps/docs/content/docs/guides/ToolUI.mdx
@@ -378,9 +378,20 @@ const DatePickerToolUI = makeAssistantToolUI<
 
 ### Multi-Step Interactions
 
-Build complex workflows with tool interrupts for multi-step user interactions:
+Build complex workflows with human-in-the-loop patterns for multi-step user interactions:
 
 ```tsx
+const DeleteProjectTool = makeAssistantTool({
+  toolName: "deleteProject",
+  execute: async ({ projectId }, { human }) => {
+    const response = await human({ action, details });
+    if (!response.approved) throw new Error("Project deletion cancelled");
+
+    await deleteProject(projectId);
+    return { success: true };
+  },
+});
+
 const ApprovalTool = makeAssistantTool({
   ...tool({
     description: "Request user approval for an action",
@@ -388,9 +399,9 @@ const ApprovalTool = makeAssistantTool({
       action: z.string(),
       details: z.any(),
     }),
-    execute: async ({ action, details }, { interrupt }) => {
+    execute: async ({ action, details }, { human }) => {
       // Request approval from user
-      const response = await interrupt({ action, details });
+      const response = await human({ action, details });
 
       return {
         approved: response.approved,
@@ -411,14 +422,14 @@ const ApprovalTool = makeAssistantTool({
       );
     }
 
-    // Show approval UI during interrupt
+    // Show approval UI when waiting for user input
     if (interrupt) {
       return (
         <div className="rounded border-2 border-yellow-400 p-4">
           <h4 className="font-bold">Approval Required</h4>
-          <p className="my-2">{interrupt.action}</p>
+          <p className="my-2">{interrupt.payload.action}</p>
           <pre className="rounded bg-gray-100 p-2 text-sm">
-            {JSON.stringify(interrupt.details, null, 2)}
+            {JSON.stringify(interrupt.payload.details, null, 2)}
           </pre>
 
           <div className="mt-4 flex gap-2">
@@ -452,7 +463,7 @@ const ApprovalTool = makeAssistantTool({
 ```
 
 <Callout type="tip">
-  Use tool interrupts (`interrupt()` / `resume()`) for workflows that need to
+  Use tool human input (`human()` / `resume()`) for workflows that need to
   pause tool execution and wait for user input. Use `addResult()` for "human
   tools" where the AI requests a tool call but the entire execution happens
   through user interaction.
@@ -620,16 +631,16 @@ type ToolUIRenderProps<TArgs, TResult> = {
   resume: (payload: unknown) => void;
 
   // Interrupt state
-  interrupt?: unknown; // Payload from context.interrupt()
+  interrupt?: { type: "human"; payload: unknown }; // Payload from context.human()
 
   // Optional artifact data
   artifact?: unknown;
 };
 ```
 
-### Interrupt Handling
+### Human Input Handling
 
-When a tool calls `interrupt()` during execution, the payload becomes available in the render function:
+When a tool calls `human()` during execution, the payload becomes available in the render function as `interrupt.payload`:
 
 ```tsx
 const ConfirmationToolUI = makeAssistantToolUI<
@@ -642,7 +653,7 @@ const ConfirmationToolUI = makeAssistantToolUI<
     if (interrupt) {
       return (
         <div className="confirmation-dialog">
-          <p>Confirm: {interrupt.message}</p>
+          <p>Confirm: {interrupt.payload.message}</p>
           <button onClick={() => resume(true)}>Yes</button>
           <button onClick={() => resume(false)}>No</button>
         </div>
@@ -659,7 +670,7 @@ const ConfirmationToolUI = makeAssistantToolUI<
 });
 ```
 
-Learn more about tool interrupts in the [Tools Guide](/docs/guides/Tools#tool-interrupts).
+Learn more about tool human input in the [Tools Guide](/docs/guides/Tools#tool-human-input).
 
 ## Best Practices
 

--- a/apps/docs/content/docs/guides/Tools.mdx
+++ b/apps/docs/content/docs/guides/Tools.mdx
@@ -359,9 +359,9 @@ const RefundTool = makeAssistantTool({
 });
 ```
 
-### Tool Interrupts
+### Tool Human Input
 
-Tools can interrupt their execution to request user input or approval before continuing. This is useful for:
+Tools can pause their execution to request user input or approval before continuing. This is useful for:
 
 - Requesting user confirmation for sensitive operations
 - Collecting additional information mid-execution
@@ -379,9 +379,9 @@ const confirmationTool = tool({
     subject: z.string(),
     body: z.string(),
   }),
-  execute: async ({ to, subject, body }, { interrupt }) => {
+  execute: async ({ to, subject, body }, { human }) => {
     // Request user confirmation before sending
-    const confirmed = await interrupt({
+    const confirmed = await human({
       type: "confirmation",
       action: "send-email",
       details: { to, subject },
@@ -404,13 +404,13 @@ const EmailTool = makeAssistantTool({
   ...confirmationTool,
   toolName: "sendEmail",
   render: ({ args, result, interrupt, resume }) => {
-    // The interrupt payload is available when the tool is interrupted
+    // The interrupt payload is available when the tool is waiting for user input
     if (interrupt) {
       return (
         <div className="confirmation-dialog">
           <h3>Confirm Email</h3>
-          <p>Send email to: {interrupt.details.to}</p>
-          <p>Subject: {interrupt.details.subject}</p>
+          <p>Send email to: {interrupt.payload.details.to}</p>
+          <p>Subject: {interrupt.payload.details.subject}</p>
           <div className="actions">
             <button onClick={() => resume(true)}>Confirm</button>
             <button onClick={() => resume(false)}>Cancel</button>
@@ -434,16 +434,17 @@ const EmailTool = makeAssistantTool({
 });
 ```
 
-#### Interrupt Behavior
+#### Human Input Behavior
 
-- **Payload**: The object passed to `interrupt()` is available in the `render` function as the `interrupt` prop
-- **Resume**: Call `resume(payload)` to continue execution - the payload becomes the resolved value of the `interrupt()` call
-- **Multiple Interrupts**: If `interrupt()` is called multiple times, previous interrupts are automatically rejected with an error
-- **Cancellation**: If the tool execution is aborted (e.g., user cancels the message), all pending interrupts are rejected
+- **Payload**: The object passed to `human()` is available in the `render` function as `interrupt.payload`
+- **Type**: The `interrupt` object has the structure `{ type: "human", payload: ... }`
+- **Resume**: Call `resume(payload)` to continue execution - the payload becomes the resolved value of the `human()` call
+- **Multiple Requests**: If `human()` is called multiple times, previous requests are automatically rejected with an error
+- **Cancellation**: If the tool execution is aborted (e.g., user cancels the message), all pending requests are rejected
 
-#### Advanced Interrupt Patterns
+#### Advanced Human Input Patterns
 
-You can use interrupts for complex multi-step interactions:
+You can use human input for complex multi-step interactions:
 
 ```tsx
 const wizardTool = tool({
@@ -451,18 +452,18 @@ const wizardTool = tool({
   parameters: z.object({
     dataSource: z.string(),
   }),
-  execute: async ({ dataSource }, { interrupt }) => {
+  execute: async ({ dataSource }, { human }) => {
     // Step 1: Load data
     const data = await loadData(dataSource);
 
     // Step 2: Request user to select columns
-    const selectedColumns = await interrupt({
+    const selectedColumns = await human({
       type: "column-selection",
       availableColumns: data.columns,
     });
 
     // Step 3: Request processing options
-    const options = await interrupt({
+    const options = await human({
       type: "processing-options",
       columns: selectedColumns,
     });
@@ -477,19 +478,19 @@ const WizardTool = makeAssistantTool({
   ...wizardTool,
   toolName: "dataWizard",
   render: ({ args, result, interrupt, resume }) => {
-    if (interrupt?.type === "column-selection") {
+    if (interrupt?.payload.type === "column-selection") {
       return (
         <ColumnSelector
-          columns={interrupt.availableColumns}
+          columns={interrupt.payload.availableColumns}
           onSelect={(cols) => resume(cols)}
         />
       );
     }
 
-    if (interrupt?.type === "processing-options") {
+    if (interrupt?.payload.type === "processing-options") {
       return (
         <ProcessingOptions
-          columns={interrupt.columns}
+          columns={interrupt.payload.columns}
           onConfirm={(opts) => resume(opts)}
         />
       );
@@ -505,9 +506,9 @@ const WizardTool = makeAssistantTool({
 ```
 
 <Callout type="note">
-  When a tool calls `interrupt()` multiple times (e.g., for multi-step
-  workflows), each new interrupt automatically rejects any previous pending
-  interrupt. Make sure to handle potential errors if you need to support
+  When a tool calls `human()` multiple times (e.g., for multi-step
+  workflows), each new request automatically rejects any previous pending
+  request. Make sure to handle potential errors if you need to support
   cancellation of earlier steps.
 </Callout>
 
@@ -711,10 +712,10 @@ Tools receive additional context during execution:
 execute: async (args, context) => {
   // context.abortSignal - AbortSignal for cancellation
   // context.toolCallId - Unique identifier for this invocation
-  // context.interrupt - Function to interrupt execution and request user input
+  // context.human - Function to request human input
 
   // Example: Request user confirmation
-  const userResponse = await context.interrupt({
+  const userResponse = await context.human({
     message: "Are you sure?",
   });
 };
@@ -724,7 +725,7 @@ The execution context provides:
 
 - **`abortSignal`**: An `AbortSignal` that triggers when the tool execution is cancelled
 - **`toolCallId`**: A unique identifier for this specific tool invocation
-- **`interrupt`**: A function that pauses execution and requests user input. The payload passed to `interrupt()` becomes available in the render function, and the value passed to `resume()` becomes the resolved value of the `interrupt()` call
+- **`human`**: A function that pauses execution and requests user input. The payload passed to `human()` becomes available in the render function, and the value passed to `resume()` becomes the resolved value of the `human()` call
 
 ## Runtime Integration
 

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -80,7 +80,7 @@ export interface ToolCallReader<
 export type ToolExecutionContext = {
   toolCallId: string;
   abortSignal: AbortSignal;
-  interrupt: (payload: unknown) => Promise<unknown>;
+  human: (payload: unknown) => Promise<unknown>;
 };
 
 export type ToolExecuteFunction<TArgs, TResult> = (

--- a/packages/react/src/client/types/Part.ts
+++ b/packages/react/src/client/types/Part.ts
@@ -27,8 +27,8 @@ export type MessagePartClientApi = {
   addToolResult(result: any | ToolResponse<any>): void;
 
   /**
-   * Resume an interrupted tool call with a payload.
-   * This is useful when a tool has interrupted its execution and is waiting for user input.
+   * Resume a tool call that is waiting for human input with a payload.
+   * This is useful when a tool has requested human input and is waiting for a response.
    */
   resumeToolCall(payload: unknown): void;
 

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/auto-status.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/auto-status.tsx
@@ -11,7 +11,7 @@ const AUTO_STATUS_PENDING = Object.freeze({
   reason: "tool-calls",
 });
 
-const AUTO_STATUS_SUSPENDED = Object.freeze({
+const AUTO_STATUS_INTERRUPT = Object.freeze({
   type: "requires-action",
   reason: "interrupt",
 });
@@ -22,13 +22,13 @@ export const isAutoStatus = (status: MessageStatus) =>
 export const getAutoStatus = (
   isLast: boolean,
   isRunning: boolean,
-  hasSuspendedToolCalls: boolean,
+  hasInterruptedToolCalls: boolean,
   hasPendingToolCalls: boolean,
 ) =>
   isLast && isRunning
     ? AUTO_STATUS_RUNNING
-    : hasSuspendedToolCalls
-      ? AUTO_STATUS_SUSPENDED
+    : hasInterruptedToolCalls
+      ? AUTO_STATUS_INTERRUPT
       : hasPendingToolCalls
         ? AUTO_STATUS_PENDING
         : AUTO_STATUS_COMPLETE;

--- a/packages/react/src/legacy-runtime/runtime/MessagePartRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime/MessagePartRuntime.ts
@@ -31,8 +31,8 @@ export type MessagePartRuntime = {
   addToolResult(result: any | ToolResponse<any>): void;
 
   /**
-   * Resume an interrupted tool call with a payload.
-   * This is useful when a tool has interrupted its execution and is waiting for user input.
+   * Resume a tool call that is waiting for human input with a payload.
+   * This is useful when a tool has requested human input and is waiting for a response.
    */
   resumeToolCall(payload: unknown): void;
 

--- a/packages/react/src/model-context/frame/AssistantFrameProvider.ts
+++ b/packages/react/src/model-context/frame/AssistantFrameProvider.ts
@@ -133,9 +133,9 @@ export class AssistantFrameProvider {
           ? await tool.execute(message.args, {
               toolCallId: message.id,
               abortSignal: new AbortController().signal,
-              interrupt: async () => {
+              human: async () => {
                 throw new Error(
-                  "Tool interrupt is not supported in frame context",
+                  "Tool human input is not supported in frame context",
                 );
               },
             })

--- a/packages/react/src/types/MessagePartTypes.ts
+++ b/packages/react/src/types/MessagePartTypes.ts
@@ -54,7 +54,7 @@ export type ToolCallMessagePart<
   readonly isError?: boolean | undefined;
   readonly argsText: string;
   readonly artifact?: unknown;
-  readonly interrupt?: unknown;
+  readonly interrupt?: { type: "human"; payload: unknown };
   readonly parentId?: string;
 };
 


### PR DESCRIPTION
Rename the tool interruption API and related names from "interrupt" to
"human" to better reflect that these calls represent tools awaiting
human input rather than an interruption of execution.

- Update function and parameter names: interrupt -> human across tool
  execution, streaming, and execution context types.
- Change resumeToolCall doc comment to clarify that it resumes tools
  waiting for human input.
- Update error messages to reference "human input" instead of
  "interrupt".
- Rename auto status constant from AUTO_STATUS_SUSPENDED to
  AUTO_STATUS_INTERRUPT and update getAutoStatus parameter/branch to
  reflect "hasInterruptedToolCalls" naming.

This clarifies intent and makes the API naming consistent for tools
that request human responses. Tests and usages should use the new
"human" callbacks and parameter names.