### PR TITLE
style: format multiline and objects for readability

### DIFF
--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -92,7 +92,9 @@ export async function unstable_runPendingTools(
         part,
         human ??
           (async () => {
-            throw new Error("Tool human input is not supported in this context");
+            throw new Error(
+              "Tool human input is not supported in this context",
+            );
           }),
       );
       if (promiseOrUndefined) {
@@ -137,12 +139,6 @@ export function toolResultStream(
     execute: (toolCall) =>
       getToolResponse(toolsFn(), abortSignalFn(), toolCall, human),
     streamCall: ({ reader, ...context }) =>
-      getToolStreamResponse(
-        toolsFn(),
-        abortSignalFn(),
-        reader,
-        context,
-        human,
-      ),
+      getToolStreamResponse(toolsFn(), abortSignalFn(), reader, context, human),
   });
 }

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useToolInvocations.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useToolInvocations.ts
@@ -87,7 +87,10 @@ export function useToolInvocations({
           humanInputRef.current.set(toolCallId, { resolve, reject });
           setToolStatuses((prev) => ({
             ...prev,
-            [toolCallId]: { type: "interrupt", payload: { type: "human", payload } },
+            [toolCallId]: {
+              type: "interrupt",
+              payload: { type: "human", payload },
+            },
           }));
         });
       },
@@ -233,7 +236,9 @@ export function useToolInvocations({
         });
         handlers.resolve(payload);
       } else {
-        throw new Error(`Tool call ${toolCallId} is not waiting for human input`);
+        throw new Error(
+          `Tool call ${toolCallId} is not waiting for human input`,
+        );
       }
     },
   };


### PR DESCRIPTION
Wrap long throw messages and object literals across multiple lines to improve
readability and maintain consistent formatting with project style rules.

- Wrap Error constructor messages to avoid very long single-line strings.
- Expand inline object literals to multiple lines where nested properties
  caused long single-line expressions.
- Reflow a function call to a single line where appropriate to match surrounding
  formatting.

These changes only reformat code (no logic changes).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reformats long strings and object literals for improved readability in `toolResultStream.ts` and `useToolInvocations.ts`.
> 
>   - **Formatting**:
>     - Wraps long `Error` messages across multiple lines in `toolResultStream.ts` and `useToolInvocations.ts`.
>     - Expands inline object literals to multiple lines in `useToolInvocations.ts` for better readability.
>     - Reflows a function call to a single line in `toolResultStream.ts` to match surrounding code style.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for b6a2db0001ca61f99251ed023492dd5a30ca7be7. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->