### PR TITLE
feat(assistant): ToolCallMessagePart.messages for subagent messages

### DIFF
--- a/packages/react/src/types/MessagePartTypes.ts
+++ b/packages/react/src/types/MessagePartTypes.ts
@@ -1,4 +1,5 @@
 import { ReadonlyJSONObject } from "assistant-stream/utils";
+import type { ThreadMessage } from "./AssistantTypes";
 
 export type TextMessagePart = {
   readonly type: "text";
@@ -56,6 +57,7 @@ export type ToolCallMessagePart<
   readonly artifact?: unknown;
   readonly interrupt?: { type: "human"; payload: unknown };
   readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
 };
 
 export type ThreadUserMessagePart =


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for nested `ToolCallMessagePart` messages in `useToolInvocations.ts` and extend `ToolCallMessagePart` type in `MessagePartTypes.ts`.
> 
>   - **Behavior**:
>     - `useToolInvocations.ts`: Adds recursive processing of nested `ToolCallMessagePart` messages using `processMessages` function.
>     - Handles `messages` field in `ToolCallMessagePart` for subagent messages.
>   - **Types**:
>     - `MessagePartTypes.ts`: Adds `messages` field to `ToolCallMessagePart` type for nested `ThreadMessage[]`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for af93ef277a54d21b5d0df63889090db11977787f. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->