### PR TITLE
chore: bump react package to 0.11.25

### DIFF
--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -33,7 +33,7 @@
     "zustand": "^5.0.8"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.24",
+    "@assistant-ui/react": "^0.11.25",
     "@types/react": "*",
     "assistant-cloud": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"

--- a/packages/react-data-stream/package.json
+++ b/packages/react-data-stream/package.json
@@ -29,7 +29,7 @@
     "zod": "^4.1.11"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.24",
+    "@assistant-ui/react": "^0.11.25",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -25,7 +25,7 @@
     "zod": "^4.1.11"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.24",
+    "@assistant-ui/react": "^0.11.25",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -29,7 +29,7 @@
     "zod": "^4.1.11"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.24",
+    "@assistant-ui/react": "^0.11.25",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -36,7 +36,7 @@
     "react-markdown": "^10.1.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.24",
+    "@assistant-ui/react": "^0.11.25",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint ."
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.24",
+    "@assistant-ui/react": "^0.11.25",
     "@assistant-ui/react-markdown": "^0.11.0",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.11.25
+
+### Patch Changes
+
+- feat: ToolCallMessagePart.messages for subagent messages
+
 ## 0.11.24
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.11.24",
+  "version": "0.11.25",
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
package peer dependencies and release notes 0.1125.

-ump @assistant-ui peerDependency to0.11.25 across multiple
  packages (react-hook-form, react-langgraph, react-syntax-highlighter,
  react-data-stream, react-markdown, react-ai-sdk) to align with the new
  core package version.
- Update packages/react version to 0.11.25.
- Add CHANGELOG entry for 0.11.25 noting the 
  ToolCallMessagePart.messages feature for subagent messages.

These changes prepare and publish the 0.11.25 patch release and ensure
peer dependency consistency across packages.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `@assistant-ui/react` to 0.11.25 and update peer dependencies across packages for release preparation.
> 
>   - **Version Update**:
>     - Update `@assistant-ui/react` version to 0.11.25 in `package.json`.
>     - Add CHANGELOG entry for version 0.11.25, noting `ToolCallMessagePart.messages` feature.
>   - **Peer Dependencies**:
>     - Bump `@assistant-ui/react` peerDependency to 0.11.25 in `react-hook-form`, `react-langgraph`, `react-syntax-highlighter`, `react-data-stream`, `react-markdown`, `react-ai-sdk`.
>   - **Release Preparation**:
>     - Ensure peer dependency consistency across packages for 0.11.25 release.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 7e1e1003918bbf3d484c96f14d5c1e5cca4ff544. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->