### PR TITLE
feat(core): support nested tool-call messages in threads

### DIFF
--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -33,7 +33,7 @@
     "zustand": "^5.0.8"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.25",
+    "@assistant-ui/react": "^0.11.26",
     "@types/react": "*",
     "assistant-cloud": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"

--- a/packages/react-data-stream/package.json
+++ b/packages/react-data-stream/package.json
@@ -29,7 +29,7 @@
     "zod": "^4.1.11"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.25",
+    "@assistant-ui/react": "^0.11.26",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -25,7 +25,7 @@
     "zod": "^4.1.11"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.25",
+    "@assistant-ui/react": "^0.11.26",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -29,7 +29,7 @@
     "zod": "^4.1.11"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.25",
+    "@assistant-ui/react": "^0.11.26",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -36,7 +36,7 @@
     "react-markdown": "^10.1.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.25",
+    "@assistant-ui/react": "^0.11.26",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint ."
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.25",
+    "@assistant-ui/react": "^0.11.26",
     "@assistant-ui/react-markdown": "^0.11.0",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.11.26
+
+### Patch Changes
+
+- feat: Add support for nested tool calls in assistant transport. Tool calls can now include a `messages` field containing nested `ThreadMessage[]`, enabling subagent tool calls to be automatically invoked by `useToolInvocations`.
+
 ## 0.11.25
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.11.25",
+  "version": "0.11.26",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/ThreadMessageLike.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/ThreadMessageLike.tsx
@@ -42,6 +42,7 @@ export type ThreadMessageLike = {
             readonly result?: any | undefined;
             readonly isError?: boolean | undefined;
             readonly parentId?: string | undefined;
+            readonly messages?: readonly ThreadMessage[] | undefined;
           }
       )[];
   readonly id?: string | undefined;
@@ -122,11 +123,12 @@ export const fromThreadMessageLike = (
                 return sanitizeImageContent(part);
 
               case "tool-call": {
-                const { parentId, ...basePart } = part;
+                const { parentId, messages, ...basePart } = part;
                 const commonProps = {
                   ...basePart,
                   toolCallId: part.toolCallId ?? "tool-" + generateId(),
                   ...(parentId !== undefined && { parentId }),
+                  ...(messages !== undefined && { messages }),
                 };
 
                 if (part.args) {


### PR DESCRIPTION
Add for nested tool-call messages by accepting an optional
messages: ThreadMessage[] field on ThreadMessage-like tool-call parts
and propagate it through the runtime message normalization.

Bump package versions to 0.11.26 across React packages and update peer
dependency ranges to reference @assistant-ui/react ^0.11.26. Remove the
separate changeset file now that the change is applied. This enables
subagent tool calls to include nested message threads so useToolInvocations
can automatically invoke nested tools.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for nested tool-call messages in threads by updating `ThreadMessageLike` and bumping package versions to 0.11.26.
> 
>   - **Behavior**:
>     - Add `messages` field to `ThreadMessageLike` in `ThreadMessageLike.tsx` to support nested tool-call messages.
>     - Update `fromThreadMessageLike` function to handle `messages` field, enabling nested tool invocations.
>   - **Package Updates**:
>     - Bump version to 0.11.26 in `react-ai-sdk/package.json`, `react-data-stream/package.json`, and `react-hook-form/package.json`.
>     - Update peer dependency `@assistant-ui/react` to ^0.11.26 in `react-langgraph/package.json`, `react-markdown/package.json`, and `react-syntax-highlighter/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d99fdf28f0941c8076be1fc0219d98e7a52cfca1. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->