### PR TITLE
fix(registry-build): add registry.json to hosted registry

### DIFF
--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -4,6 +4,7 @@ import { registry } from "../src/registry";
 import { RegistryItem } from "@/src/schema";
 
 const REGISTRY_PATH = path.join(process.cwd(), "dist");
+const REGISTRY_INDEX_PATH = path.join(REGISTRY_PATH, "registry.json");
 
 async function buildRegistry(registry: RegistryItem[]) {
   await fs.mkdir(REGISTRY_PATH, { recursive: true });
@@ -30,6 +31,19 @@ async function buildRegistry(registry: RegistryItem[]) {
 
     await fs.writeFile(p, JSON.stringify(payload, null, 2), "utf8");
   }
+
+  const registryIndex = {
+    $schema: "https://ui.shadcn.com/schema/registry.json",
+    name: "assistant-ui",
+    homepage: "https://assistant-ui.com",
+    items: registry,
+  };
+
+  await fs.writeFile(
+    REGISTRY_INDEX_PATH,
+    JSON.stringify(registryIndex, null, 2),
+    "utf8",
+  );
 }
 
 await buildRegistry(registry);


### PR DESCRIPTION
build script now deploys registry.json to https://r.assistant-ui.com/registry.json

this allows @assistant-ui to be added to the shadcn cli trusted registries, enabling namespace support out of the box:

`xpx shadcn@latest add @assistant-ui/thread` (pending merge of https://github.com/shadcn-ui/ui/pull/8312)