### PR TITLE
docs: update Mastra docs to use useChatRuntime

### DIFF
--- a/apps/docs/content/docs/runtimes/mastra/separate-server-integration.mdx
+++ b/apps/docs/content/docs/runtimes/mastra/separate-server-integration.mdx
@@ -140,14 +140,19 @@ Open the main page file in your assistant-ui frontend project (usually `app/page
 ```tsx {10} title="app/page.tsx"
 "use client";
 import { Thread } from "@/components/assistant-ui/thread";
-import { useDataStreamRuntime } from "@assistant-ui/react-data-stream";
+import {
+  useChatRuntime,
+  AssistantChatTransport,
+} from "@assistant-ui/react-ai-sdk";
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { ThreadList } from "@/components/assistant-ui/thread-list";
 
 export default function Home() {
   // Point the runtime to the Mastra server endpoint
-  const runtime = useDataStreamRuntime({
-    api: "http://localhost:4111/api/agents/chefAgent/stream",
+  const runtime = useChatRuntime({
+    transport: new AssistantChatTransport({
+      api: "MASTRA_ENDPOINT",
+    }),
   });
 
   return (

--- a/packages/x-buildutils/eslint/index.ts
+++ b/packages/x-buildutils/eslint/index.ts
@@ -21,7 +21,11 @@ const eslintConfig = [
       "next-env.d.ts",
     ],
   },
-  ...compat.extends("next/core-web-vitals", "next/typescript", "plugin:workspaces/recommended"),
+  ...compat.extends(
+    "next/core-web-vitals",
+    "next/typescript",
+    "plugin:workspaces/recommended",
+  ),
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "off",


### PR DESCRIPTION
Update the Mastra separate-server integration example to use the
chat-focused runtime and transport API. Replace useDataStreamRuntime
withChatRuntime and configure an AssistantChatTransport that
accepts a MASTRA_ENDPOINT token instead of a hardcoded localhost
stream URL.

This clarifies the intended integration approach and avoids exposing
a local endpoint in docs while demonstrating the chat transport
configuration.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update Mastra docs to use `useChatRuntime` and `AssistantChatTransport`, and improve ESLint config formatting.
> 
>   - **Documentation**:
>     - Update `separate-server-integration.mdx` to use `useChatRuntime` and `AssistantChatTransport` instead of `useDataStreamRuntime`.
>     - Replace hardcoded localhost URL with `MASTRA_ENDPOINT` token for API configuration.
>   - **ESLint Configuration**:
>     - Minor formatting change in `index.ts` to improve readability of `compat.extends` call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 210ceb50f7e19280da7c6bd70cb5980e1a2ba45f. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->