### PR TITLE
chore(docs): add troubleshooting for tool UI streaming flicker

### DIFF
--- a/apps/docs/content/docs/runtimes/custom/local.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local.mdx
@@ -538,7 +538,12 @@ export function MyRuntimeProvider({ children }) {
 ```
 
 <Callout type="info" title="Returning a title from generateTitle">
-  The `generateTitle` method must return an <code>AssistantStream</code> containing the title text. The easiest, type-safe way is to use <code>createAssistantStream</code> and call <code>controller.appendText(newTitle)</code> followed by <code>controller.close()</code>. Returning a raw <code>ReadableStream</code> won't update the thread list UI.
+  The `generateTitle` method must return an <code>AssistantStream</code>{" "}
+  containing the title text. The easiest, type-safe way is to use{" "}
+  <code>createAssistantStream</code> and call{" "}
+  <code>controller.appendText(newTitle)</code> followed by{" "}
+  <code>controller.close()</code>. Returning a raw <code>ReadableStream</code>{" "}
+  won't update the thread list UI.
 </Callout>
 
 #### Understanding the Architecture
@@ -854,9 +859,9 @@ function MyCustomRuntimeProvider({ children }) {
 </Callout>
 
 <Callout type="warning">
-  **`useThreadRuntime` vs `useLocalThreadRuntime`:** 
-  - `useThreadRuntime` - Access the current thread's runtime from within components 
-  - `useLocalThreadRuntime` - Create a new single-thread runtime instance
+  **`useThreadRuntime` vs `useLocalThreadRuntime`:** - `useThreadRuntime` -
+  Access the current thread's runtime from within components -
+  `useLocalThreadRuntime` - Create a new single-thread runtime instance
 </Callout>
 
 ## Integration Examples
@@ -998,6 +1003,74 @@ async *run({ messages }) { // ✅ Correct
 async run({ messages }) {  // ❌ Wrong for streaming
 ```
 </Callout>
+
+### Tool UI Flickers or Disappears During Streaming
+
+A common issue when implementing a streaming `ChatModelAdapter` is seeing a tool's UI appear for a moment and then disappear. This is caused by failing to accumulate the `tool_calls` correctly across multiple stream chunks. State must be stored **outside** the streaming loop to persist.
+
+**❌ Incorrect: Forgetting Previous Tool Calls**
+
+This implementation incorrectly re-creates the `content` array for every chunk. If a later chunk contains only text, tool calls from previous chunks are lost, causing the UI to disappear.
+
+```tsx
+// This implementation incorrectly re-creates the `content` array for every chunk.
+// If a later chunk contains only text, tool calls from previous chunks are lost.
+async *run({ messages, abortSignal, context }) {
+  const stream = await backendApi({ messages, abortSignal, context });
+  let text = "";
+
+  for await (const chunk of stream) {
+    // ❌ DON'T: This overwrites toolCalls with only the current chunk's data
+    const toolCalls = chunk.tool_calls || [];
+    const content = [{ type: "text", text }];
+    for (const toolCall of toolCalls) {
+      content.push({
+        type: "tool-call",
+        toolName: toolCall.name,
+        toolCallId: toolCall.id,
+        args: toolCall.args,
+      });
+    }
+    yield { content }; // This yield might not contain the tool call anymore
+  }
+}
+```
+
+**✅ Correct: Accumulating State**
+
+This implementation uses a `Map` outside the loop to remember all tool calls.
+
+```tsx
+// This implementation uses a Map outside the loop to remember all tool calls.
+async *run({ messages, abortSignal, context }) {
+  const stream = await backendApi({ messages, abortSignal, context });
+  let text = "";
+  // ✅ DO: Declare state outside the loop
+  const toolCallsMap = new Map();
+
+  for await (const chunk of stream) {
+    text += chunk.content || "";
+
+    // ✅ DO: Add/update tool calls in the persistent map
+    for (const toolCall of chunk.tool_calls || []) {
+      toolCallsMap.set(toolCall.toolCallId, {
+        type: "tool-call",
+        toolName: toolCall.name,
+        toolCallId: toolCall.id,
+        args: toolCall.args,
+      });
+    }
+
+    // ✅ DO: Build content from accumulated state
+    const content = [
+      ...(text ? [{ type: "text", text }] : []),
+      ...Array.from(toolCallsMap.values()),
+    ];
+
+    yield { content }; // Yield the complete, correct state every time
+  }
+}
+```
 
 ### Debug Tips
 


### PR DESCRIPTION
Closes #1718
 
 ### Problem
   
 When implementing a custom `ChatModelAdapter` for streaming, a common pitfall is to handle state incorrectly across 
 multiple data chunks. If the adapter doesn't accumulate `tool_calls`, any UI for that tool will appear briefly on screen
  then disappear as soon as a new chunk arrives without the tool call data.
 This can be a frustrating and difficult bug to diagnose for new users of the library.
    
 ### Solution
 
This PR adds a new entry to the "Troubleshooting" section of the `LocalRuntime` documentation. This new guide:

 1.  Clearly describes the "flickering tool UI" problem.
 2.  Provides an explicit code example of the **incorrect** implementation that causes the bug.
 3.  Provides a clear, **correct** implementation that uses a `Map` to properly accumulate state across the entire stream.

By documenting this common pitfall and its solution directly, this change will help future users avoid the issue and improve their developer experience.
