### PR TITLE
export useChatThreadRuntime and related types

### DIFF
--- a/packages/react-ai-sdk/src/ui/index.ts
+++ b/packages/react-ai-sdk/src/ui/index.ts
@@ -1,3 +1,9 @@
 export { useAISDKRuntime } from "./use-chat/useAISDKRuntime";
-export { useChatRuntime } from "./use-chat/useChatRuntime";
+export {
+  useChatRuntime,
+  useChatThreadRuntime,
+  type UseChatRuntimeOptions,
+} from "./use-chat/useChatRuntime";
 export { AssistantChatTransport } from "./use-chat/AssistantChatTransport";
+
+export type { unstable_RemoteThreadListAdapter } from "@assistant-ui/react";


### PR DESCRIPTION
Fixes https://github.com/assistant-ui/assistant-ui/issues/2573
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Export `useChatThreadRuntime` and related types in `index.ts` to address issue #2573.
> 
>   - **Exports**:
>     - Export `useChatThreadRuntime` and `UseChatRuntimeOptions` from `use-chat/useChatRuntime` in `index.ts`.
>     - Export `unstable_RemoteThreadListAdapter` type from `@assistant-ui/react` in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d23fc2c40f0c5bf9d97540f8a8e4128a4f69e680. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->