### PR TITLE
Added a Manta graph button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![npm version](https://img.shields.io/npm/v/assistant-ui)](https://www.npmjs.com/package/@assistant-ui/react)
 [![npm downloads](https://img.shields.io/npm/dm/@assistant-ui/react)](https://www.npmjs.com/package/@assistant-ui/react)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/assistant-ui/assistant-ui)
-[![](https://getmanta.ai/api/badges?text=Manta%20Graph&link=assistant-ui)](https://getmanta.ai/assistant-ui)
+[![Manta Graph badge](https://getmanta.ai/api/badges?text=Manta%20Graph&link=assistant-ui)](https://getmanta.ai/assistant-ui)
 [![Weave Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fapp.workweave.ai%2Fapi%2Frepository%2Fbadge%2Forg_GhSIrtWo37b5B3Mv0At3wQ1Q%2F722184017&cacheSeconds=3600)](https://app.workweave.ai/reports/repository/org_GhSIrtWo37b5B3Mv0At3wQ1Q/722184017)
 ![Backed by Y Combinator](https://img.shields.io/badge/Backed_by-Y_Combinator-orange)
 


### PR DESCRIPTION
Manta Graph can be opened through a button in README, to see the solution in a form of interactive graph.

<img width="700" height="590" alt="image" src="https://github.com/user-attachments/assets/5eca7fa7-bc20-4765-b474-7a18b54b277c" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added Manta Graph button to `README.md` for interactive graph access.
> 
>   - **Documentation**:
>     - Added Manta Graph button to `README.md` for interactive graph access.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 548537bca9c08ae95e89c2eda69e2b3cef9ae58e. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->