### PR TITLE
fix(use-external-store-runtime): use-effects dependency

### DIFF
--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/useExternalStoreRuntime.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/useExternalStoreRuntime.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { ExternalStoreRuntimeCore } from "./ExternalStoreRuntimeCore";
-import { ExternalStoreAdapter } from "./ExternalStoreAdapter";
 import {
   AssistantRuntime,
   AssistantRuntimeImpl,
 } from "../../runtime/AssistantRuntime";
 import { useRuntimeAdapters } from "../adapters/RuntimeAdapterProvider";
+import { ExternalStoreAdapter } from "./ExternalStoreAdapter";
+import { ExternalStoreRuntimeCore } from "./ExternalStoreRuntimeCore";
 
 export const useExternalStoreRuntime = <T,>(
   store: ExternalStoreAdapter<T>,
@@ -16,7 +16,7 @@ export const useExternalStoreRuntime = <T,>(
 
   useEffect(() => {
     runtime.setAdapter(store);
-  });
+  }, [runtime, store]);
 
   const { modelContext } = useRuntimeAdapters() ?? {};
 


### PR DESCRIPTION
This commit ensures that `runtime.setAdapter` is called again if the reference to `store` changes.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `useEffect` dependency in `useExternalStoreRuntime` to update `runtime.setAdapter` when `store` changes.
> 
>   - **Behavior**:
>     - Fixes `useEffect` dependency in `useExternalStoreRuntime` to include `store`, ensuring `runtime.setAdapter` is called when `store` changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for ecd1b10a4a2d21ed5da477113fb783a8065ab5cd. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->