### PR TITLE
fix(docs): broken discord link on `/docs/runtimes/pick-a-runtime`

### DIFF
--- a/apps/docs/content/docs/runtimes/pick-a-runtime.mdx
+++ b/apps/docs/content/docs/runtimes/pick-a-runtime.mdx
@@ -223,5 +223,5 @@ Explore our implementation examples:
 5. **Consider Assistant Cloud** for production persistence
 
 <Callout type="info">
-Need help? Join our [Discord community](https://discord.gg/assistant-ui) or check the [GitHub](https://github.com/assistant-ui/assistant-ui).
+Need help? Join our [Discord community](https://discord.gg/S9dwgCNEFs) or check the [GitHub](https://github.com/assistant-ui/assistant-ui).
 </Callout>


### PR DESCRIPTION
This PR updates a non-working Discord invite link in the documentation. 

**Old:** https://discord.gg/assistant-ui
**New:** https://discord.gg/S9dwgCNEFs

Found the link on the pick runtime page.

No package changes were made, so no changeset is required for npm publishing. 
This is purely a documentation update.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update broken Discord link in `pick-a-runtime.mdx` documentation.
> 
>   - **Documentation**:
>     - Update Discord link in `pick-a-runtime.mdx` from `https://discord.gg/assistant-ui` to `https://discord.gg/S9dwgCNEFs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 23cb122670aa791e07d6f38a93edc130087e7fc0. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->