### PR TITLE
fix(serialization): detect duplicate tool call ids in data stream

### DIFF
--- a/.changeset/giant-forks-feel.md
+++ b/.changeset/giant-forks-feel.md
@@ -1,5 +1,0 @@
----
-"assistant-stream": patch
----
-
-fix: detect duplicate tool calls in data stream

--- a/examples/with-assistant-transport/package.json
+++ b/examples/with-assistant-transport/package.json
@@ -10,7 +10,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/postcss": "^4.1.14",
-    "assistant-stream": "^0.2.34",
+    "assistant-stream": "^0.2.35",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.22",

--- a/packages/assistant-stream/CHANGELOG.md
+++ b/packages/assistant-stream/CHANGELOG.md
@@ -1,5 +1,11 @@
 # assistant-stream
 
+## 0.2.35
+
+### Patch Changes
+
+- 7c5943b: fix: detect duplicate tool calls in data stream
+
 ## 0.2.34
 
 ### Patch Changes

--- a/packages/assistant-stream/package.json
+++ b/packages/assistant-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant-stream",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,7 +565,7 @@ importers:
         specifier: ^4.1.14
         version: 4.1.14
       assistant-stream:
-        specifier: ^0.2.34
+        specifier: ^0.2.35
         version: link:../../packages/assistant-stream
       class-variance-authority:
         specifier: ^0.7.1


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add check for duplicate tool call IDs in `DataStreamDecoder` to prevent errors in data processing.
> 
>   - **Behavior**:
>     - In `DataStreamDecoder` in `DataStream.ts`, added check for duplicate `toolCallId` and throw error if duplicate is found.
>   - **Versioning**:
>     - Bump `assistant-stream` version to `0.2.35` in `package.json`.
>     - Update `CHANGELOG.md` to document the fix for duplicate tool call IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 253be702845e11d724619ac41f9f0a5ac0bccbc7. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->