### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,4 +1,6 @@
 name: Code Quality
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/assistant-ui/assistant-ui/security/code-scanning/9](https://github.com/assistant-ui/assistant-ui/security/code-scanning/9)

To fix this problem, add a `permissions` block that explicitly limits the default privileges used by the workflow. Since all steps in the workflow only need to check out and read the repository code (not write), the minimal required permission is `contents: read`. This can be added at the workflow root (top-level, after the `name` and before `on`), or to the `lint` job specifically. For clarity and future expansion, it is recommended to add it to the workflow root, so all jobs are covered unless they require something more permissive. Only lines at the top of `.github/workflows/code-quality.yaml` need to be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `permissions: contents: read` to `.github/workflows/code-quality.yaml` to limit default privileges to read-only access.
> 
>   - **Security**:
>     - Adds `permissions: contents: read` to `.github/workflows/code-quality.yaml` to limit default privileges to read-only access.
>     - Applies at the workflow root to cover all jobs, ensuring minimal permissions unless more are needed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d52b9049626a371dd2df05f0c83e8c0bb3313089. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->