### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/registry.yaml
+++ b/.github/workflows/registry.yaml
@@ -1,4 +1,6 @@
 name: Deploy Shadcn Registry
+permissions:
+  contents: read
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_REGISTRY_PROJECT_ID }}


### PR DESCRIPTION
Potential fix for [https://github.com/assistant-ui/assistant-ui/security/code-scanning/6](https://github.com/assistant-ui/assistant-ui/security/code-scanning/6)

To fix this problem, we should add an explicit `permissions` block to scope the permission assigned to the GITHUB_TOKEN. Since there is no evidence the workflow needs to write to the repository, we can set `contents: read` for least privilege. The recommended best practice is to place the `permissions` block at the workflow root (top level), right after the `name:` and before the first key like `env:` or `on:`—this cascades the value to all jobs. Alternatively, you can place it at the job level if only some jobs need custom permissions, but for this workflow, a global read-only restriction is appropriate.  
We will insert the following block near the top, after `name: ...`:

```yaml
permissions:
  contents: read
```

No new methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds read-only permissions to GITHUB_TOKEN in `registry.yaml` to address security alert.
> 
>   - **Security**:
>     - Adds `permissions: contents: read` to `.github/workflows/registry.yaml` to restrict GITHUB_TOKEN to read-only access.
>     - Addresses code scanning alert no. 6 regarding missing permissions in the workflow.
>   - **Best Practices**:
>     - Places `permissions` block at the workflow root for global application.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for bc8e8bd5a820a9e0f25e4b0757e256cf09a8f6b1. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->