### PR TITLE
chore(release): bump react package to 0.11.32 and fix tool args

### DIFF
--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -33,7 +33,7 @@
     "zustand": "^5.0.8"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.31",
+    "@assistant-ui/react": "^0.11.32",
     "@types/react": "*",
     "assistant-cloud": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"

--- a/packages/react-data-stream/package.json
+++ b/packages/react-data-stream/package.json
@@ -29,7 +29,7 @@
     "zod": "^4.1.12"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.31",
+    "@assistant-ui/react": "^0.11.32",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -25,7 +25,7 @@
     "zod": "^4.1.12"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.31",
+    "@assistant-ui/react": "^0.11.32",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -29,7 +29,7 @@
     "zod": "^4.1.12"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.31",
+    "@assistant-ui/react": "^0.11.32",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -36,7 +36,7 @@
     "react-markdown": "^10.1.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.31",
+    "@assistant-ui/react": "^0.11.32",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint ."
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.31",
+    "@assistant-ui/react": "^0.11.32",
     "@assistant-ui/react-markdown": "^0.11.2",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.11.32
+
+### Patch Changes
+
+- fix: Cannot enqueue a chunk into a readable stream that is closed or has been requested to be closed
+
 ## 0.11.31
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.11.31",
+  "version": "0.11.32",
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Update package peer ranges and version 0.11.32
across multiple packages to align with the new release.

In the runtime tool invocation flow, add argsComplete tracking to
tool call state to prevent appending after the args stream is
closed. When argsText updates after a controller is closed, log a
warning in non-production instead of throwing. Ensure we only
append incremental deltas to the argsText stream, close the stream
when the args are complete, and mark hasResult closures as also
setting argsComplete. These changes make the tool invocation
streaming behavior more robust and tolerant of late updates.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `@assistant-ui/react` to `0.11.32` and enhance tool invocation flow in `useToolInvocations.ts` for better args handling.
> 
>   - **Version Update**:
>     - Bump `@assistant-ui/react` version to `0.11.32` in `react-ai-sdk/package.json`, `react-data-stream/package.json`, `react-hook-form/package.json`, and `react-langgraph/package.json`.
>   - **Tool Invocation Flow**:
>     - Add `argsComplete` tracking in `useToolInvocations.ts` to prevent appending after args stream closure.
>     - Log a warning in non-production if `argsText` updates after controller closure.
>     - Append only incremental deltas to `argsText` stream and close stream when args are complete.
>     - Mark `hasResult` closures as setting `argsComplete` in `useToolInvocations.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 8ea32d1709fbcfa3d619be3c1da8ee32e0210099. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->