### PR TITLE
feat(react-hook-form): add reset_form tool

### DIFF
--- a/packages/react-hook-form/src/formTools.tsx
+++ b/packages/react-hook-form/src/formTools.tsx
@@ -13,4 +13,9 @@ export const formTools = {
     description: "Submits the form. Confirm with user before submitting.",
     parameters: z.object({}),
   },
+  reset_form: {
+    description:
+      "Resets all form fields to their initial values. Confirm with user before resetting.",
+    parameters: z.object({}),
+  },
 };

--- a/packages/react-hook-form/src/useAssistantForm.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.tsx
@@ -50,6 +50,16 @@ export type UseAssistantFormProps<
                       | undefined;
                   }
                 | undefined;
+              reset_form?:
+                | {
+                    render?:
+                      | ToolCallMessagePartComponent<
+                          z.infer<(typeof formTools.reset_form)["parameters"]>,
+                          unknown
+                        >
+                      | undefined;
+                  }
+                | undefined;
             }
           | undefined;
       }
@@ -64,7 +74,7 @@ export const useAssistantForm = <
   props?: UseAssistantFormProps<TFieldValues, TContext, TTransformedValues>,
 ): UseFormReturn<TFieldValues, TContext, TTransformedValues> => {
   const form = useForm<TFieldValues, TContext, TTransformedValues>(props);
-  const { control, getValues, setValue } = form;
+  const { control, getValues, setValue, reset } = form;
 
   const api = useAssistantApi();
   useEffect(() => {
@@ -113,12 +123,19 @@ export const useAssistantForm = <
             };
           },
         }),
+        reset_form: tool({
+          ...formTools.reset_form,
+          execute: async () => {
+            reset();
+            return { success: true };
+          },
+        }),
       },
     };
     return api.registerModelContextProvider({
       getModelContext: () => value,
     });
-  }, [control, setValue, getValues, api]);
+  }, [control, setValue, getValues, api, reset]);
 
   const renderFormFieldTool = props?.assistant?.tools?.set_form_field?.render;
   useAssistantToolUI(
@@ -136,6 +153,16 @@ export const useAssistantForm = <
       ? {
           toolName: "submit_form",
           render: renderSubmitFormTool,
+        }
+      : null,
+  );
+
+  const renderResetFormTool = props?.assistant?.tools?.reset_form?.render;
+  useAssistantToolUI(
+    renderResetFormTool
+      ? {
+          toolName: "reset_form",
+          render: renderResetFormTool,
         }
       : null,
   );


### PR DESCRIPTION
This PR introduces a new "reset_form" tool to the react-hook-form package.

### Description
It gives the assistant the ability to clear all form fields and reset the form to its initial state. This allows it to handle common user requests like "start over" or "I made a mistake, clear everything."

### How it's implemented:
A `reset_form` tool is defined in `formTools.tsx`.
The `useAssistantForm` hook now uses the `reset` function from `react-hook-form` to implement the tool's `execute` logic.
The necessary types and props for custom UI rendering have been added to keep it consistent with the other tools.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `reset_form` tool to `react-hook-form` for resetting form fields to initial values.
> 
>   - **Behavior**:
>     - Adds `reset_form` tool in `formTools.tsx` to reset form fields to initial values.
>     - Implements `reset_form` execution logic using `reset` function in `useAssistantForm.tsx`.
>   - **UI**:
>     - Adds `reset_form` rendering support in `useAssistantForm.tsx` for custom UI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 0d9250018f7c715534d93080ffe8b0f92b744501. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->