### PR TITLE
fix: submittedFeedback

### DIFF
--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -33,7 +33,7 @@
     "zustand": "^5.0.8"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.32",
+    "@assistant-ui/react": "^0.11.33",
     "@types/react": "*",
     "assistant-cloud": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"

--- a/packages/react-data-stream/package.json
+++ b/packages/react-data-stream/package.json
@@ -29,7 +29,7 @@
     "zod": "^4.1.12"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.32",
+    "@assistant-ui/react": "^0.11.33",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -25,7 +25,7 @@
     "zod": "^4.1.12"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.32",
+    "@assistant-ui/react": "^0.11.33",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -29,7 +29,7 @@
     "zod": "^4.1.12"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.32",
+    "@assistant-ui/react": "^0.11.33",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -36,7 +36,7 @@
     "react-markdown": "^10.1.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.32",
+    "@assistant-ui/react": "^0.11.33",
     "@types/react": "*",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint ."
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.11.32",
+    "@assistant-ui/react": "^0.11.33",
     "@assistant-ui/react-markdown": "^0.11.2",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @assistant-ui/react
 
+## 0.11.33
+
+### Patch Changes
+
+- refactor: move submittedFeedback to metadata, add ThreadMessageLike support
+
 ## 0.11.32
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "conversational-ui",
     "conversational-ai"
   ],
-  "version": "0.11.32",
+  "version": "0.11.33",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react/src/client/types/Message.ts
+++ b/packages/react/src/client/types/Message.ts
@@ -20,6 +20,9 @@ export type MessageClientState = ThreadMessage & {
    * @deprecated This API is still under active development and might change without notice.
    */
   readonly speech: SpeechState | undefined;
+  /**
+   * @deprecated Use `message.metadata.submittedFeedback` instead. This will be removed in 0.12.0.
+   */
   readonly submittedFeedback: SubmittedFeedback | undefined;
 
   readonly composer: ComposerClientState;

--- a/packages/react/src/legacy-runtime/runtime-cores/core/ThreadRuntimeCore.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/core/ThreadRuntimeCore.tsx
@@ -116,7 +116,7 @@ export type ThreadRuntimeCore = Readonly<{
 
   // TODO deprecate for a more elegant solution
   // /**
-  //  * @deprecated This field is deprecated and will be removed in 0.8.0.
+  //  * @deprecated This field is deprecated and will be removed in 0.12.0.
   //  * Please migrate to using `AssistantRuntimeCore.Provider` instead.
   //  */
   extras: unknown;

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/ExternalStoreAdapter.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/ExternalStoreAdapter.tsx
@@ -69,7 +69,7 @@ type ExternalStoreAdapterBase<T> = {
   onLoadExternalState?: ((state: any) => void) | undefined;
   onNew: (message: AppendMessage) => Promise<void>;
   onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
-  onReload?: // TODO: remove parentId in 0.8.0
+  onReload?: // TODO: remove parentId in 0.12.0
   | ((parentId: string | null, config: StartRunConfig) => Promise<void>)
     | undefined;
   onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/ExternalStoreThreadRuntimeCore.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/ExternalStoreThreadRuntimeCore.tsx
@@ -339,7 +339,7 @@ export class ExternalStoreThreadRuntimeCore
         messages.flatMap(getExternalStoreMessage).filter((m) => m != null),
       );
     } else {
-      // TODO mark this as readonly in v0.8.0
+      // TODO mark this as readonly in v0.12.0
       this._store.setMessages?.(messages as ThreadMessage[]);
     }
   };

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/ThreadMessageLike.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/ThreadMessageLike.tsx
@@ -57,6 +57,7 @@ export type ThreadMessageLike = {
           | undefined;
         readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
         readonly steps?: readonly ThreadStep[] | undefined;
+        readonly submittedFeedback?: { readonly type: "positive" | "negative" };
         readonly custom?: Record<string, unknown> | undefined;
       }
     | undefined;
@@ -161,6 +162,9 @@ export const fromThreadMessageLike = (
           unstable_data: metadata?.unstable_data ?? [],
           custom: metadata?.custom ?? {},
           steps: metadata?.steps ?? [],
+          ...(metadata?.submittedFeedback && {
+            submittedFeedback: metadata.submittedFeedback,
+          }),
         },
       } satisfies ThreadAssistantMessage;
 

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/getExternalStoreMessage.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/getExternalStoreMessage.tsx
@@ -10,7 +10,7 @@ type WithInnerMessages<T> = {
 };
 
 /**
- * @deprecated Use `getExternalStoreMessages` (plural) instead. This function will be removed in 0.8.0.
+ * @deprecated Use `getExternalStoreMessages` (plural) instead. This function will be removed in 0.12.0.
  */
 export const getExternalStoreMessage = <T,>(input: ThreadMessage) => {
   const withInnerMessages = input as WithInnerMessages<T>;
@@ -22,7 +22,7 @@ const EMPTY_ARRAY: never[] = [];
 export const getExternalStoreMessages = <T,>(
   input: ThreadState | ThreadMessage | ThreadMessage["content"][number],
 ) => {
-  // TODO temp until 0.8.0 (migrate useExternalStoreRuntime to always set an array)
+  // TODO temp until 0.12.0 (migrate useExternalStoreRuntime to always set an array)
 
   const container = (
     "messages" in input ? input.messages : input

--- a/packages/react/src/legacy-runtime/runtime/MessageRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime/MessageRuntime.ts
@@ -89,6 +89,9 @@ export type MessageState = ThreadMessage & {
    * @deprecated This API is still under active development and might change without notice.
    */
   readonly speech: SpeechState | undefined;
+  /**
+   * @deprecated Use `message.metadata.submittedFeedback` instead. This will be removed in 0.12.0.
+   */
   readonly submittedFeedback: SubmittedFeedback | undefined;
 };
 

--- a/packages/react/src/legacy-runtime/runtime/RuntimeBindings.ts
+++ b/packages/react/src/legacy-runtime/runtime/RuntimeBindings.ts
@@ -49,6 +49,7 @@ export type MessageStateBinding = SubscribableWithState<
     readonly branchNumber: number;
     readonly branchCount: number;
     readonly speech: SpeechState | undefined;
+    /** @deprecated Use `message.metadata.submittedFeedback` instead. This will be removed in 0.12.0. */
     readonly submittedFeedback: SubmittedFeedback | undefined;
   },
   MessageRuntimePath
@@ -62,7 +63,7 @@ export type ThreadListItemState = {
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
   /**
-   * @deprecated Use `id` instead. This field will be removed in version 0.8.0.
+   * @deprecated Use `id` instead. This field will be removed in version 0.12.0.
    */
   readonly threadId: string;
   readonly status: ThreadListItemStatus;

--- a/packages/react/src/legacy-runtime/runtime/ThreadListRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime/ThreadListRuntime.ts
@@ -67,7 +67,7 @@ const getThreadListItemState = (
   if (!threadData) return SKIP_UPDATE;
   return {
     id: threadData.id,
-    threadId: threadData.id, // TODO remove in 0.8.0
+    threadId: threadData.id, // TODO remove in 0.12.0
     remoteId: threadData.remoteId,
     externalId: threadData.externalId,
     title: threadData.title,

--- a/packages/react/src/legacy-runtime/runtime/ThreadRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime/ThreadRuntime.ts
@@ -124,14 +124,14 @@ export type ThreadListItemRuntimeBinding = SubscribableWithState<
 export type ThreadState = {
   /**
    * The thread ID.
-   * @deprecated This field is deprecated and will be removed in 0.8.0. Use `useThreadListItem().id` instead.
+   * @deprecated This field is deprecated and will be removed in 0.12.0. Use `useThreadListItem().id` instead.
    */
   readonly threadId: string;
 
   /**
    * The thread metadata.
    *
-   * @deprecated Use `useThreadListItem()` instead. This field is deprecated and will be removed in 0.8.0.
+   * @deprecated Use `useThreadListItem()` instead. This field is deprecated and will be removed in 0.12.0.
    */
   readonly metadata: ThreadListItemState;
 
@@ -241,7 +241,7 @@ export type ThreadRuntime = {
   append(message: CreateAppendMessage): void;
 
   /**
-   * @deprecated pass an object with `parentId` instead. This will be removed in 0.8.0.
+   * @deprecated pass an object with `parentId` instead. This will be removed in 0.12.0.
    */
   startRun(parentId: string | null): void;
   /**

--- a/packages/react/src/primitives/actionBar/ActionBarFeedbackNegative.tsx
+++ b/packages/react/src/primitives/actionBar/ActionBarFeedbackNegative.tsx
@@ -27,7 +27,7 @@ export const ActionBarPrimitiveFeedbackNegative = forwardRef<
   ActionBarPrimitiveFeedbackNegative.Props
 >(({ onClick, disabled, ...props }, forwardedRef) => {
   const isSubmitted = useAssistantState(
-    (s) => s.message.submittedFeedback?.type === "negative",
+    (s) => s.message.metadata.submittedFeedback?.type === "negative",
   );
   const callback = useActionBarFeedbackNegative();
   return (

--- a/packages/react/src/primitives/actionBar/ActionBarFeedbackPositive.tsx
+++ b/packages/react/src/primitives/actionBar/ActionBarFeedbackPositive.tsx
@@ -26,7 +26,7 @@ export const ActionBarPrimitiveFeedbackPositive = forwardRef<
   ActionBarPrimitiveFeedbackPositive.Props
 >(({ onClick, disabled, ...props }, forwardedRef) => {
   const isSubmitted = useAssistantState(
-    (s) => s.message.submittedFeedback?.type === "positive",
+    (s) => s.message.metadata.submittedFeedback?.type === "positive",
   );
   const callback = useActionBarFeedbackPositive();
   return (

--- a/packages/react/src/primitives/message/MessageIf.tsx
+++ b/packages/react/src/primitives/message/MessageIf.tsx
@@ -28,7 +28,6 @@ const useMessageIf = (props: UseMessageIfProps) => {
       branchCount,
       isLast,
       speech,
-      submittedFeedback,
       isCopied,
       isHovering,
     } = message;
@@ -65,7 +64,8 @@ const useMessageIf = (props: UseMessageIfProps) => {
 
     if (
       props.submittedFeedback !== undefined &&
-      (submittedFeedback?.type ?? null) !== props.submittedFeedback
+      (message.metadata.submittedFeedback?.type ?? null) !==
+        props.submittedFeedback
     )
       return false;
 

--- a/packages/react/src/types/AssistantTypes.ts
+++ b/packages/react/src/types/AssistantTypes.ts
@@ -96,6 +96,11 @@ export type ThreadSystemMessage = MessageCommonProps & {
   readonly role: "system";
   readonly content: readonly [TextMessagePart];
   readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
     readonly custom: Record<string, unknown>;
   };
 };
@@ -105,6 +110,11 @@ export type ThreadUserMessage = MessageCommonProps & {
   readonly content: readonly ThreadUserMessagePart[];
   readonly attachments: readonly CompleteAttachment[];
   readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
     readonly custom: Record<string, unknown>;
   };
 };
@@ -144,6 +154,7 @@ type BaseThreadMessage = {
     readonly unstable_annotations?: readonly ReadonlyJSONValue[];
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: { readonly type: "positive" | "negative" };
     readonly custom: Record<string, unknown>;
   };
   readonly attachments?: ThreadUserMessage["attachments"];


### PR DESCRIPTION
Update deprecation timelines and message handling to align with
coming 0..0 changes, bump package versions/peer ranges.

- Mark submittedFeedback as deprecated in RuntimeBindings and add
  JSDoc pointing to message.metadata.submittedFeedback and removal in
  0.12.0.
- Update several deprecation comments from 0.8.0 to 0.12.0 across runtime
  utilities and core files (getExternalStoreMessage, ThreadRuntimeCore,
  ExternalStoreAdapter, and related TODOs) to reflect the new removal
  timeline.
- Adjust external-store helpers' temporary comment to 0.12.0 to signal
  migration to always use arrays for messages.
- Remove usage of the old submittedFeedback field from MessageIf and
  start relying on message.metadata.submittedFeedback (prepare runtime
  code for the metadata-based feedback shape).
- Add explicit undefined typed metadata fields and a submittedFeedback
  metadata shape to AssistantTypes to prevent incompatible shapes and
  allow proper narrowing.
- Bump @assistant-ui/react peer dependency ranges in react-hook-form and
  react-ai-sdk to ^0.11.33 and increment packages/react version to
  0.11.33.

These changes prepare the codebase for the metadata-driven feedback
shape, keep deprecation timelines consistent, and update package
compatibility.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Deprecate `submittedFeedback` field in favor of metadata, update deprecation timelines, and bump package versions for compatibility.
> 
>   - **Behavior**:
>     - Deprecate `submittedFeedback` field in favor of `message.metadata.submittedFeedback` across `MessageClientState`, `MessageState`, and `MessageRuntime`.
>     - Update deprecation timelines from 0.8.0 to 0.12.0 in `ThreadRuntimeCore`, `ExternalStoreAdapter`, and `ThreadRuntime`.
>     - Remove `submittedFeedback` usage from `MessageIf.tsx` and `MessageIf` component now uses `message.metadata.submittedFeedback`.
>   - **Metadata**:
>     - Add `submittedFeedback` metadata shape to `AssistantTypes` and `ThreadMessageLike`.
>     - Ensure `submittedFeedback` is included in `ThreadAssistantMessage` metadata.
>   - **Package Updates**:
>     - Bump `@assistant-ui/react` peer dependency to ^0.11.33 in `react-hook-form`, `react-ai-sdk`, `react-data-stream`, `react-langgraph`, `react-markdown`, and `react-syntax-highlighter`.
>     - Update `packages/react` version to 0.11.33.
>   - **Misc**:
>     - Update `CHANGELOG.md` to reflect changes in version 0.11.33.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for b4398b388e354bfa63601eb2d267b4c246d9a064. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->