### PR TITLE
refactor: cleanup options

### DIFF
--- a/apps/docs/app/examples/layout.tsx
+++ b/apps/docs/app/examples/layout.tsx
@@ -1,21 +1,12 @@
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import type { ReactNode } from "react";
-import { baseOptions } from "../../lib/layout.shared";
+import { sharedDocsOptions } from "../../lib/layout.shared";
 import { Footer } from "@/components/common";
 import { examples } from "@/lib/source";
 
-// Create a hybrid options that uses baseOptions for navbar but adds sidebar functionality
-const examplesOptions = {
-  ...baseOptions,
-  tree: examples.pageTree,
-  sidebar: {
-    defaultOpenLevel: 0,
-  },
-};
-
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <DocsLayout {...examplesOptions}>
+    <DocsLayout {...sharedDocsOptions} tree={examples.pageTree}>
       {children}
       <Footer />
     </DocsLayout>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `layout.tsx` to use `sharedDocsOptions` instead of custom `examplesOptions`.
> 
>   - **Refactor**:
>     - Replace `examplesOptions` with `sharedDocsOptions` in `layout.tsx`.
>     - Remove custom `examplesOptions` object, directly use `sharedDocsOptions` with `tree` prop set to `examples.pageTree`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 99a1f3ba5dae35b7e7ebcab613ef2c88c13aa49d. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->