### PR TITLE
fix: build and lint

### DIFF
--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -61,15 +61,18 @@ const getMessageContent = (msg: AppendMessage) => {
       case "file":
         return {
           type: "file" as const,
-          file: { filename: part.filename, file_data: part.data, mime_type: part.mimeType }
+          file: {
+            filename: part.filename ?? "file",
+            file_data: part.data,
+            mime_type: part.mimeType,
+          },
         };
 
       case "tool-call":
         throw new Error("Tool call appends are not supported.");
 
       default:
-        const _exhaustiveCheck: "reasoning" | "source" | "audio" =
-          type;
+        const _exhaustiveCheck: "reasoning" | "source" | "audio" = type;
         throw new Error(
           `Unsupported append message part type: ${_exhaustiveCheck}`,
         );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix default filename handling in `getMessageContent` in `useLangGraphRuntime.ts`.
> 
>   - **Behavior**:
>     - In `useLangGraphRuntime.ts`, `getMessageContent` now defaults `filename` to "file" if `part.filename` is undefined.
>     - Ensures all file message parts have a valid filename.
>   - **Misc**:
>     - Minor formatting change in `getMessageContent` for `_exhaustiveCheck` declaration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1f67efdb6d9abb7a2108f9561efd5faa3a932c9e. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->