### PR TITLE
feat: useAssistantTransportState

### DIFF
--- a/.changeset/quick-items-allow.md
+++ b/.changeset/quick-items-allow.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: useAssistantTransportState

--- a/packages/react/src/augmentations.ts
+++ b/packages/react/src/augmentations.ts
@@ -11,6 +11,12 @@
  *         data: string;
  *       };
  *     }
+ *
+ *     interface ExternalState {
+ *       myCustomState: {
+ *         foo: string;
+ *       };
+ *     }
  *   }
  * }
  * ```
@@ -18,6 +24,12 @@
 export namespace Assistant {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   export interface Commands {}
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  export interface ExternalState {}
 }
 
 export type UserCommands = Assistant.Commands[keyof Assistant.Commands];
+export type UserExternalState = keyof Assistant.ExternalState extends never
+  ? Record<string, unknown>
+  : Assistant.ExternalState[keyof Assistant.ExternalState];

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/index.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/index.ts
@@ -1,6 +1,7 @@
 export {
   useAssistantTransportRuntime,
   useAssistantTransportSendCommand,
+  useAssistantTransportState,
 } from "./useAssistantTransportRuntime";
 export type {
   AssistantTransportConnectionMetadata,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `useAssistantTransportState` hook for managing external state in assistant transport runtime.
> 
>   - **New Hook**:
>     - Adds `useAssistantTransportState` in `useAssistantTransportRuntime.tsx` to manage external state in assistant transport.
>     - Supports optional selector function for state selection.
>   - **Namespace Augmentation**:
>     - Defines `ExternalState` interface in `augmentations.ts` for type extensions.
>     - Adds `UserExternalState` type for handling external state.
>   - **Exports**:
>     - Exports `useAssistantTransportState` from `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for da7dbffbdb0438544f7e86b32bc080d692d85c05. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->