### PR TITLE
docs: update AI SDK chat runtime examples and API docs

### DIFF
--- a/apps/docs/content/docs/api-reference/context-providers/AssistantRuntimeProvider.mdx
+++ b/apps/docs/content/docs/api-reference/context-providers/AssistantRuntimeProvider.mdx
@@ -13,9 +13,14 @@ You must either wrap your app in an `AssistantRuntimeProvider` or pass a `runtim
 
 ```tsx {1, 8, 10}
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useChatRuntime, AssistantChatTransport } from "@assistant-ui/react-ai-sdk";
 
 const MyApp = () => {
-  const runtime = useChatRuntime({ api: "/api/chat" });
+  const runtime = useChatRuntime({
+    transport: new AssistantChatTransport({
+      api: "/api/chat",
+    }),
+  });
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>

--- a/apps/docs/content/docs/api-reference/integrations/vercel-ai-sdk.mdx
+++ b/apps/docs/content/docs/api-reference/integrations/vercel-ai-sdk.mdx
@@ -5,19 +5,118 @@ title: "@assistant-ui/react-ai-sdk"
 Vercel AI SDK integration for assistant-ui.
 
 import { ParametersTable } from "@/components/docs";
+import { Callout } from "fumadocs-ui/components/callout";
+
+<Callout type="info">
+  This package provides integration with AI SDK v5. For AI SDK v4, see the [AI
+  SDK v4 (Legacy)](/docs/runtimes/ai-sdk/v4-legacy) documentation.
+</Callout>
 
 ## API Reference
 
-### `useVercelUseChatRuntime`
+### `useChatRuntime`
 
-Convert Vercel AI SDK chat helpers into a `AssistantRuntime`.
+Creates a runtime directly with AI SDK v5's `useChat` hook integration. This is the recommended approach for most use cases.
 
 ```tsx
-import { useVercelUseChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime, AssistantChatTransport } from "@assistant-ui/react-ai-sdk";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
 
 const MyRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
-  const chat = useChat();
-  const runtime = useVercelUseChatRuntime(chat);
+  const runtime = useChatRuntime({
+    transport: new AssistantChatTransport({
+      api: "/api/chat",
+    }),
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+};
+```
+
+To customize the API endpoint, simply change the `api` parameter:
+
+```tsx
+const runtime = useChatRuntime({
+  transport: new AssistantChatTransport({
+    api: "/my-custom-api/chat",
+  }),
+});
+```
+
+<ParametersTable
+  parameters={[
+    {
+      name: "options",
+      type: "UseChatRuntimeOptions",
+      description: "Configuration options for the chat runtime.",
+      children: [
+        {
+          type: "UseChatRuntimeOptions",
+          parameters: [
+            {
+              name: "api",
+              type: "string",
+              description: "The API endpoint URL. Defaults to '/api/chat'.",
+            },
+            {
+              name: "transport",
+              type: "ChatTransport",
+              description:
+                "Custom transport implementation. Defaults to AssistantChatTransport which forwards system messages and tools.",
+            },
+            {
+              name: "cloud",
+              type: "AssistantCloud",
+              description:
+                "Optional AssistantCloud instance for chat persistence.",
+            },
+            {
+              name: "initialMessages",
+              type: "UIMessage[]",
+              description: "Initial messages to populate the chat.",
+            },
+            {
+              name: "onFinish",
+              type: "(message: UIMessage) => void",
+              description: "Callback when a message completes streaming.",
+            },
+            {
+              name: "onError",
+              type: "(error: Error) => void",
+              description: "Callback for handling errors.",
+            },
+          ],
+        },
+      ],
+    },
+  ]}
+/>
+
+<Callout type="info">
+  By default, `useChatRuntime` uses `AssistantChatTransport` which automatically
+  forwards system messages and frontend tools to your backend API. This enables
+  your backend to receive the full context from the assistant-ui.
+</Callout>
+
+### `useAISDKRuntime`
+
+For advanced use cases where you need direct access to the `useChat` hook from AI SDK.
+
+```tsx
+import { useChat } from "@ai-sdk/react";
+import { useAISDKRuntime } from "@assistant-ui/react-ai-sdk";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+
+const MyRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
+  const chat = useChat({
+    api: "/api/chat",
+  });
+
+  const runtime = useAISDKRuntime(chat);
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
@@ -32,110 +131,27 @@ const MyRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
     {
       name: "chat",
       type: "ReturnType<typeof useChat>",
-      description: "The UseChatHelpers from @ai-sdk/react.",
+      description: "The chat helpers from @ai-sdk/react's useChat hook.",
     },
-  ]}
-/>
-
-### `useVercelUseAssistantRuntime`
-
-Convert Vercel AI SDK assistant helpers into a `AssistantRuntime`.
-
-```tsx
-import { useVercelUseAssistantRuntime } from "@assistant-ui/react-ai-sdk";
-
-const MyRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
-  const assistant = useAssistant();
-  const runtime = useVercelUseAssistantRuntime(assistant);
-
-  return (
-    <AssistantRuntimeProvider runtime={runtime}>
-      {children}
-    </AssistantRuntimeProvider>
-  );
-};
-```
-
-<ParametersTable
-  parameters={[
     {
-      name: "assistant",
-      type: "ReturnType<typeof useAssistant>",
-      description: "The UseAssistantHelpers from @ai-sdk/react.",
-    },
-  ]}
-/>
-
-### `useVercelRSCRuntime`
-
-Convert Vercel RSC runtime into a `AssistantRuntime`.
-
-```tsx
-import { useVercelRSCRuntime } from "@assistant-ui/react-ai-sdk";
-
-const MyRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
-  const [messages, setMessages] = useUIState<typeof AI>();
-
-  const onNew = async (m: AppendMessage) => {
-    if (m.content[0]?.type !== "text")
-      throw new Error("Only text messages are supported");
-
-    const input = m.content[0].text;
-    setMessages((currentConversation) => [
-      ...currentConversation,
-      { id: nanoid(), role: "user", display: input },
-    ]);
-
-    const message = await continueConversation(input);
-
-    setMessages((currentConversation) => [...currentConversation, message]);
-  };
-
-  const runtime = useVercelRSCRuntime({ messages, onNew });
-
-  return (
-    <AssistantRuntimeProvider runtime={runtime}>
-      {children}
-    </AssistantRuntimeProvider>
-  );
-};
-```
-
-<ParametersTable
-  parameters={[
-    {
-      name: "adapter",
-      type: "VercelRSCAdapter<TMessage>",
-      description: "The Vercel RSC adapter to use.",
+      name: "options",
+      type: "AISDKRuntimeOptions",
+      description: "Optional configuration options.",
       children: [
         {
-          type: "VercelRSCAdapter<TMessage>",
+          type: "AISDKRuntimeOptions",
           parameters: [
             {
-              name: "messages",
-              type: "readonly ThreadMessage[]",
-              description: "The messages in the thread.",
-            },
-            {
-              name: "onNew",
-              type: "(message: AppendMessage) => Promise<void>",
-              description: "A function to append a message to the thread.",
-            },
-            {
-              name: "onEdit",
-              type: "(message: AppendMessage) => Promise<void>",
-              description: "A function to edit a message.",
-            },
-            {
-              name: "onReload",
-              type: "(parentId: string | null) => Promise<void>",
-              description: "A function to reload a message.",
-            },
-            {
-              name: "convertMessage",
-              type: "(message: TMessage) => VercelRSCMessage",
+              name: "cloud",
+              type: "AssistantCloud",
               description:
-                "A function to convert messages to the VercelRSCMessage format. Only required if your message objects are not already compatible with Vercel RSC.",
+                "Optional AssistantCloud instance for chat persistence.",
+            },
+            {
+              name: "adapters",
+              type: "RuntimeAdapters",
+              description:
+                "Optional runtime adapters for attachments, feedback, speech, etc.",
             },
           ],
         },
@@ -143,3 +159,96 @@ const MyRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
     },
   ]}
 />
+
+### `AssistantChatTransport`
+
+A transport that extends the default AI SDK transport to automatically forward system messages and frontend tools to your backend.
+
+```tsx
+import { AssistantChatTransport } from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+
+const runtime = useChatRuntime({
+  transport: new AssistantChatTransport({
+    api: "/my-custom-api/chat",
+  }),
+});
+```
+
+<ParametersTable
+  parameters={[
+    {
+      name: "options",
+      type: "HttpChatTransportInitOptions",
+      description: "Transport configuration options.",
+      children: [
+        {
+          type: "HttpChatTransportInitOptions",
+          parameters: [
+            {
+              name: "api",
+              type: "string",
+              description: "The API endpoint URL.",
+            },
+            {
+              name: "headers",
+              type: "Record<string, string> | Headers",
+              description: "Optional headers to include in requests.",
+            },
+            {
+              name: "credentials",
+              type: "RequestCredentials",
+              description: "Optional credentials mode for fetch requests.",
+            },
+          ],
+        },
+      ],
+    },
+  ]}
+/>
+
+### `frontendTools`
+
+Helper function to convert frontend tool definitions to AI SDK format for use in your backend.
+
+```tsx
+import { frontendTools } from "@assistant-ui/react-ai-sdk";
+import { streamText, convertToModelMessages } from "ai";
+import { openai } from "@ai-sdk/openai";
+
+export async function POST(req: Request) {
+  const { messages, system, tools } = await req.json();
+
+  const result = streamText({
+    model: openai("gpt-4o"),
+    system,
+    messages: convertToModelMessages(messages),
+    tools: {
+      // Wrap frontend tools with the helper
+      ...frontendTools(tools),
+      // Your backend tools
+      myBackendTool: tool({
+        // ...
+      }),
+    },
+  });
+
+  return result.toUIMessageStreamResponse();
+}
+```
+
+<ParametersTable
+  parameters={[
+    {
+      name: "tools",
+      type: "Record<string, unknown>",
+      description:
+        "Frontend tools object forwarded from AssistantChatTransport.",
+    },
+  ]}
+/>
+
+<Callout type="info">
+  The `frontendTools` helper converts frontend tool definitions to the AI SDK
+  format and ensures they are properly handled by the streaming response.
+</Callout>

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -1453,13 +1453,15 @@ If you aren't using Next.js, you can also deploy this endpoint to Cloudflare Wor
 
 ```tsx title="/app/page.tsx" tab="Thread"
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime, AssistantChatTransport } from "@assistant-ui/react-ai-sdk";
 import { ThreadList } from "@/components/assistant-ui/thread-list";
 import { Thread } from "@/components/assistant-ui/thread";
 
 const MyApp = () => {
   const runtime = useChatRuntime({
-    api: "/api/chat",
+    transport: new AssistantChatTransport({
+      api: "/api/chat",
+    }),
   });
 
   return (
@@ -1477,12 +1479,14 @@ const MyApp = () => {
 // run `npx shadcn@latest add "https://r.assistant-ui.com/assistant-modal"`
 
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime, AssistantChatTransport } from "@assistant-ui/react-ai-sdk";
 import { AssistantModal } from "@/components/assistant-ui/assistant-modal";
 
 const MyApp = () => {
   const runtime = useChatRuntime({
-    api: "/api/chat",
+    transport: new AssistantChatTransport({
+      api: "/api/chat",
+    }),
   });
 
   return (

--- a/apps/docs/content/docs/runtimes/ai-sdk/use-chat.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/use-chat.mdx
@@ -94,10 +94,14 @@ export async function POST(req: Request) {
 
 import { Thread } from "@/components/assistant-ui/thread";
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime, AssistantChatTransport } from "@assistant-ui/react-ai-sdk";
 
 export default function Home() {
-  const runtime = useChatRuntime();
+  const runtime = useChatRuntime({
+    transport: new AssistantChatTransport({
+      api: "/api/chat",
+    }),
+  });
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>

--- a/apps/docs/content/docs/runtimes/langserve.mdx
+++ b/apps/docs/content/docs/runtimes/langserve.mdx
@@ -26,7 +26,7 @@ cd my-app
   </Step>
   <Step>
 
-### Install `@langchain/core`, `ai-sdk` and `@assistant-ui/react`
+### Install `@langchain/core`, AI SDK and `@assistant-ui/react`
 
 ```sh npm2yarn
 npm install @assistant-ui/react @assistant-ui/react-ai-sdk ai @ai-sdk/react @langchain/core
@@ -71,19 +71,14 @@ export async function POST(req: Request) {
 
 import { useChat } from "@ai-sdk/react";
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
-import { useVercelUseChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 
 export function MyRuntimeProvider({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const chat = useChat({
-    api: "/api/chat",
-    unstable_AISDKInterop: true,
-  });
-
-  const runtime = useVercelUseChatRuntime(chat);
+  const runtime = useChatRuntime();
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>

--- a/apps/docs/content/docs/runtimes/mastra/full-stack-integration.mdx
+++ b/apps/docs/content/docs/runtimes/mastra/full-stack-integration.mdx
@@ -52,7 +52,7 @@ export async function POST(req: Request) {
     messages,
   });
 
-  return result.toDataStreamResponse();
+  return result.toUIMessageStreamResponse();
 }
 ```
 
@@ -184,8 +184,8 @@ export async function POST(req: Request) {
   // Stream the response using the agent
   const result = await agent.stream(messages);
 
-  // Return the result as a data stream response
-  return result.toDataStreamResponse();
+  // Return the result as a UI message stream response
+  return result.toUIMessageStreamResponse();
 }
 ```
 
@@ -194,7 +194,7 @@ Key changes:
 - We import the `mastra` instance created in `mastra/index.ts`. Make sure the import path (`@/mastra`) is correct for your project setup (you might need `~/mastra`, `../../../mastra`, etc., depending on your path aliases and project structure).
 - We retrieve the `chefAgent` using `mastra.getAgent("chefAgent")`.
 - Instead of calling the AI SDK's `streamText` directly, we call `agent.stream(messages)` to process the chat messages using the agent's configuration and model.
-- The result is still returned in a format compatible with assistant-ui using `toDataStreamResponse()`.
+- The result is still returned in a format compatible with assistant-ui using `toUIMessageStreamResponse()`.
 
 Your API route is now powered by Mastra!
 


### PR DESCRIPTION
Update examples and API reference to use new chat transport
integration with AssistantChatTransport and useRuntime options.
- Replace direct useChat or legacy helpers with useChatRuntime configured
  with AssistantChatTransport (api: "/api/chat") in docs examples.
- Add AssistantChatTransport import and example to AssistantRuntimeProvider
  and use-chat pages so runtime creation demonstrates transport usage.
- Revise Vercel AI SDK integration doc:
  - Rename example to useChatRuntime and show AssistantChatTransport.
  - Add info callout about AI SDK v5 vs v4 (legacy).
  - Provide customization example for api endpoint.
  - Replace parameter table entry for chat with a detailed
    UseChatRuntimeOptions schema (api, transport, cloud, initialMessages,
    onFinish, onError).
  - Add callout explaining AssistantChatTransport behavior (forwards system
    messages and tools).
- Add note about advanced use case useAISDKRuntime and useChat hook.

These changes clarify recommended runtime usage, document transport
configuration, and improve guidance for v5 vs legacy integrations.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update documentation to use `useChatRuntime` with `AssistantChatTransport`, providing examples and guidance for AI SDK v5 integration.
> 
>   - **Behavior**:
>     - Update examples to use `useChatRuntime` with `AssistantChatTransport` in `AssistantRuntimeProvider.mdx`, `vercel-ai-sdk.mdx`, and `getting-started.mdx`.
>     - Add customization example for API endpoint in `vercel-ai-sdk.mdx`.
>     - Replace `toDataStreamResponse` with `toUIMessageStreamResponse` in `full-stack-integration.mdx`.
>   - **Documentation**:
>     - Add callouts explaining AI SDK v5 vs v4 in `vercel-ai-sdk.mdx`.
>     - Provide detailed `UseChatRuntimeOptions` schema in `vercel-ai-sdk.mdx`.
>     - Explain `AssistantChatTransport` behavior and `frontendTools` usage in `use-chat.mdx`.
>   - **Misc**:
>     - Fix typos and update references to AI SDK v5 in `langserve.mdx` and `use-chat.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 2edd20c1bb49999eeafae01055600bbf4f6da50d. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->