### PR TITLE
feat(ai-sdk): use cloud threadIds

### DIFF
--- a/.changeset/modern-rockets-press.md
+++ b/.changeset/modern-rockets-press.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+feat: useChatRuntime should use the assistant ui thread id remote id as the threadid by default

--- a/packages/react-ai-sdk/src/ui/use-chat/AssistantChatTransport.tsx
+++ b/packages/react-ai-sdk/src/ui/use-chat/AssistantChatTransport.tsx
@@ -38,6 +38,9 @@ export class AssistantChatTransport<
       ...initOptions,
       prepareSendMessagesRequest: async (options) => {
         const context = this.runtime?.thread.getModelContext();
+        const id =
+          (await this.runtime?.threads.mainItem.initialize())?.remoteId ??
+          options.id;
 
         const optionsEx = {
           ...options,
@@ -55,7 +58,7 @@ export class AssistantChatTransport<
           ...preparedRequest,
           body: preparedRequest?.body ?? {
             ...optionsEx.body,
-            id: options.id,
+            id,
             messages: options.messages,
             trigger: options.trigger,
             messageId: options.messageId,

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.tsx
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.tsx
@@ -6,6 +6,7 @@ import {
   AssistantRuntime,
   unstable_useCloudThreadListAdapter,
   unstable_useRemoteThreadListRuntime,
+  useAssistantState,
 } from "@assistant-ui/react";
 import { useAISDKRuntime, type AISDKRuntimeAdapter } from "./useAISDKRuntime";
 import { ChatInit } from "ai";
@@ -27,8 +28,10 @@ export const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   } = options ?? {};
   const transport = transportOptions ?? new AssistantChatTransport();
 
+  const id = useAssistantState(({ threadListItem }) => threadListItem.id);
   const chat = useChat({
     ...chatOptions,
+    id,
     transport,
   });
 

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/ExternalStoreThreadListRuntimeCore.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/ExternalStoreThreadListRuntimeCore.tsx
@@ -212,8 +212,10 @@ export class ExternalStoreThreadListRuntimeCore
     onDelete(threadId);
   }
 
-  public initialize(): never {
-    throw new Error("Method not implemented.");
+  public initialize(
+    threadId: string,
+  ): Promise<{ remoteId: string; externalId: string | undefined }> {
+    return Promise.resolve({ remoteId: threadId, externalId: undefined });
   }
 
   public generateTitle(): never {

--- a/packages/react/src/legacy-runtime/runtime-cores/local/LocalThreadListRuntimeCore.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/local/LocalThreadListRuntimeCore.tsx
@@ -104,8 +104,10 @@ export class LocalThreadListRuntimeCore
     throw new Error("Method not implemented.");
   }
 
-  public initialize(): never {
-    throw new Error("Method not implemented.");
+  public initialize(
+    threadId: string,
+  ): Promise<{ remoteId: string; externalId: string | undefined }> {
+    return Promise.resolve({ remoteId: threadId, externalId: undefined });
   }
 
   public generateTitle(): never {


### PR DESCRIPTION
Use the assistant UI thread id (remoteId) as the default thread id when
initializing and preparing chat requests.

- Pass the assistant state threadListItem.id into useChat so the runtime
  uses the selected thread id by default.
- In AssistantChatTransport.prepareSendMessagesRequest, initialize the
  main thread and prefer its remoteId when constructing the request
  payload (fall back to options.id if unavailable).
- Implement initialize(threadId) in LocalThreadListRuntimeCore and
  ExternalStoreThreadListRuntimeCore to return a resolved promise with
  { remoteId, externalId } so callers can synchronously obtain the
  remoteId for building requests.
- Add changeset describing the feature.

These changes ensure message requests use the assistant thread's remote
identifier consistently, avoiding mismatches between local and remote
thread ids.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use assistant UI thread id as default in chat requests, ensuring consistent thread id usage across local and remote contexts.
> 
>   - **Behavior**:
>     - Default thread id in `useChat` set to assistant UI thread id (`remoteId`).
>     - `AssistantChatTransport.prepareSendMessagesRequest` prefers `remoteId` over `options.id`.
>   - **Functions**:
>     - `initialize(threadId)` added to `LocalThreadListRuntimeCore` and `ExternalStoreThreadListRuntimeCore`, returning `{ remoteId, externalId }`.
>   - **Misc**:
>     - Add changeset for feature description.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d0bcad3c733b213ebc8c90b877c2c3de623bd0d0. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->