### PR TITLE
chore: mark all old context API hooks as deprecated

### DIFF
--- a/.changeset/clear-doors-dig.md
+++ b/.changeset/clear-doors-dig.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+chore: mark all old context API hooks as deprecated

--- a/apps/docs/components/assistant-ui/attachment-old.tsx
+++ b/apps/docs/components/assistant-ui/attachment-old.tsx
@@ -6,7 +6,8 @@ import {
   AttachmentPrimitive,
   ComposerPrimitive,
   MessagePrimitive,
-  useAttachment,
+  useAssistantState,
+  useAssistantApi,
 } from "@assistant-ui/react";
 import { useShallow } from "zustand/shallow";
 import {
@@ -44,8 +45,8 @@ const useFileSrc = (file: File | undefined) => {
 };
 
 const useAttachmentSrc = () => {
-  const { file, src } = useAttachment(
-    useShallow((a): { file?: File; src?: string } => {
+  const { file, src } = useAssistantState(
+    useShallow(({ attachment: a }): { file?: File; src?: string } => {
       if (a.type !== "image") return {};
       if (a.file) return { file: a.file };
       const src = a.content?.filter((c) => c.type === "image")[0]?.image;
@@ -106,7 +107,9 @@ const AttachmentPreviewDialog: FC<PropsWithChildren> = ({ children }) => {
 };
 
 const AttachmentThumb: FC = () => {
-  const isImage = useAttachment((a) => a.type === "image");
+  const isImage = useAssistantState(
+    ({ attachment }) => attachment.type === "image",
+  );
   const src = useAttachmentSrc();
   return (
     <Avatar className="flex size-10 items-center justify-center rounded border bg-muted text-sm">
@@ -119,9 +122,10 @@ const AttachmentThumb: FC = () => {
 };
 
 const AttachmentUI: FC = () => {
-  const canRemove = useAttachment((a) => a.source !== "message");
-  const typeLabel = useAttachment((a) => {
-    const type = a.type;
+  const api = useAssistantApi();
+  const canRemove = api.attachment.source !== "message";
+  const typeLabel = useAssistantState(({ attachment }) => {
+    const type = attachment.type;
     switch (type) {
       case "image":
         return "Image";

--- a/apps/docs/content/docs/copilots/model-context.mdx
+++ b/apps/docs/content/docs/copilots/model-context.mdx
@@ -33,7 +33,6 @@ import {
   makeAssistantVisible,
   makeAssistantTool,
   tool,
-  useAssistantRuntime,
 } from "@assistant-ui/react";
 import { z } from "zod";
 
@@ -75,12 +74,12 @@ function Form() {
 The context provider system allows components to contribute to the model context. Here's a typical usage pattern:
 
 ```tsx
-import { useAssistantRuntime, tool } from "@assistant-ui/react";
+import { useAssistantApi, tool } from "@assistant-ui/react";
 import { useEffect } from "react";
 import { z } from "zod";
 
 function MyComponent() {
-  const assistantRuntime = useAssistantRuntime();
+  const api = useAssistantApi();
 
   // Define tool using the tool() helper
   const myTool = tool({
@@ -95,13 +94,13 @@ function MyComponent() {
 
   useEffect(() => {
     // Register context provider
-    return assistantRuntime.registerModelContextProvider({
+    return api.modelContext().register({
       getModelContext: () => ({
         system: "You are a helpful search assistant...",
         tools: { myTool },
       }),
     });
-  }, [assistantRuntime]); // Re-register if runtime changes
+  }, [api]); // Re-register if api changes
 
   return <div>{/* component content */}</div>;
 }

--- a/apps/docs/content/docs/copilots/motivation.mdx
+++ b/apps/docs/content/docs/copilots/motivation.mdx
@@ -143,14 +143,14 @@ function SmartTransactionHistory() {
 Finally, let's add dynamic context based on the user's transaction patterns:
 
 ```tsx
-import { useAssistantRuntime } from "@assistant-ui/react";
+import { useAssistantApi } from "@assistant-ui/react";
 import { useEffect } from "react";
 
 function SmartTransactionHistory({ userProfile }) {
-  const assistantRuntime = useAssistantRuntime();
+  const api = useAssistantApi();
 
   useEffect(() => {
-    return assistantRuntime.registerModelContextProvider({
+    return api.modelContext().register({
       getModelContext: () => ({
         system: `
           User spending patterns:
@@ -160,7 +160,7 @@ function SmartTransactionHistory({ userProfile }) {
         `,
       }),
     });
-  }, [assistantRuntime, userProfile]);
+  }, [api, userProfile]);
 
   // Previous components...
 }

--- a/apps/docs/content/docs/guides/Attachments.mdx
+++ b/apps/docs/content/docs/guides/Attachments.mdx
@@ -508,14 +508,14 @@ class ValidatedImageAdapter implements AttachmentAdapter {
 Enable multi-file selection with custom limits:
 
 ```tsx
-const composer = useComposer();
+const api = useAssistantApi();
 
 const handleMultipleFiles = async (files: FileList) => {
   const maxFiles = 5;
   const filesToAdd = Array.from(files).slice(0, maxFiles);
 
   for (const file of filesToAdd) {
-    await composer.addAttachment({ file });
+    await api.composer().addAttachment({ file });
   }
 };
 ```

--- a/apps/docs/content/docs/guides/Tools.mdx
+++ b/apps/docs/content/docs/guides/Tools.mdx
@@ -165,15 +165,15 @@ function App() {
 
 ### 4. Advanced: Direct Context Registration
 
-Use `registerModelContextProvider` when you need to configure more than just tools:
+Use `api.modelContext().register()` when you need to configure more than just tools:
 
 ```tsx
-import { tool, useAssistantRuntime } from "@assistant-ui/react";
+import { tool, useAssistantApi } from "@assistant-ui/react";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 
 function MyComponent() {
-  const runtime = useAssistantRuntime();
+  const api = useAssistantApi();
   const [isCreativeMode, setIsCreativeMode] = useState(false);
 
   useEffect(() => {
@@ -188,7 +188,7 @@ function MyComponent() {
     });
 
     // Register tools with model configuration
-    return runtime.registerModelContextProvider({
+    return api.modelContext().register({
       getModelContext: () => ({
         tools: { calculate: calculateTool },
         callSettings: {
@@ -198,7 +198,7 @@ function MyComponent() {
         priority: 10, // Higher priority overrides other providers
       }),
     });
-  }, [runtime, isCreativeMode]);
+  }, [api, isCreativeMode]);
 
   return <div>{/* Your component */}</div>;
 }

--- a/apps/docs/content/docs/ui/PartGrouping.mdx
+++ b/apps/docs/content/docs/ui/PartGrouping.mdx
@@ -515,12 +515,12 @@ Adjust group appearance based on content:
 
 ```tsx
 import { FC, PropsWithChildren } from "react";
-import { useMessage } from "@assistant-ui/react";
+import { useAssistantState } from "@assistant-ui/react";
 
 const DynamicGroup: FC<
   PropsWithChildren<{ groupKey: string | undefined; indices: number[] }>
 > = ({ groupKey, indices, children }) => {
-  const parts = useMessage((m) => m.content);
+  const parts = useAssistantState(({ message }) => message.content);
   const groupParts = indices.map((i) => parts[i]);
 
   // Analyze group content

--- a/apps/registry/components/assistant-ui/follow-up-suggestions.tsx
+++ b/apps/registry/components/assistant-ui/follow-up-suggestions.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useThread, ThreadPrimitive } from "@assistant-ui/react";
+import { useAssistantState, ThreadPrimitive } from "@assistant-ui/react";
 import type { FC } from "react";
 
 export const ThreadFollowupSuggestions: FC = () => {
-  const suggestions = useThread((t) => t.suggestions);
+  const suggestions = useAssistantState(({ thread }) => thread.suggestions);
   return (
     <ThreadPrimitive.If empty={false} running={false}>
       <div className="aui-thread-followup-suggestions flex min-h-8 items-center justify-center gap-2">

--- a/apps/registry/components/assistant-ui/mermaid-diagram.tsx
+++ b/apps/registry/components/assistant-ui/mermaid-diagram.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMessagePart } from "@assistant-ui/react";
+import { useAssistantState } from "@assistant-ui/react";
 import type { SyntaxHighlighterProps } from "@assistant-ui/react-markdown";
 import mermaid from "mermaid";
 import { FC, useEffect, useRef } from "react";
@@ -46,7 +46,7 @@ export const MermaidDiagram: FC<MermaidDiagramProps> = ({
   const ref = useRef<HTMLPreElement>(null);
 
   // Detect when this code block is complete
-  const isComplete = useMessagePart((part) => {
+  const isComplete = useAssistantState(({ part }) => {
     if (part.type !== "text") return false;
 
     // Find the position of this code block

--- a/examples/with-ffmpeg/app/page.tsx
+++ b/examples/with-ffmpeg/app/page.tsx
@@ -3,7 +3,7 @@
 import {
   useAssistantInstructions,
   useAssistantTool,
-  useThreadComposer,
+  useAssistantState,
 } from "@assistant-ui/react";
 import { z } from "zod";
 import { FFmpeg } from "@ffmpeg/ffmpeg";
@@ -152,7 +152,9 @@ const FfmpegTool: FC<{ file: File }> = ({ file }) => {
 
 export default function Home() {
   const [lastFile, setLastFile] = useState<File | null>(null);
-  const attachments = useThreadComposer((c) => c.attachments);
+  const attachments = useAssistantState(
+    ({ thread }) => thread.composer.attachments,
+  );
   useEffect(() => {
     const lastAttachment = attachments[attachments.length - 1];
     if (!lastAttachment) return;

--- a/packages/react/src/context/react/AssistantApiContext.tsx
+++ b/packages/react/src/context/react/AssistantApiContext.tsx
@@ -32,8 +32,6 @@ import {
   AttachmentClientState,
 } from "../../client/types/Attachment";
 import { Unsubscribe } from "@assistant-ui/tap";
-import { ModelContextProvider } from "../../model-context";
-import { AssistantRuntime } from "../../legacy-runtime/runtime/AssistantRuntime";
 import {
   AssistantEvent,
   AssistantEventCallback,
@@ -139,11 +137,6 @@ export type AssistantApi = {
     event: AssistantEventSelector<TEvent>,
     callback: AssistantEventCallback<TEvent>,
   ): Unsubscribe;
-
-  // temp
-  registerModelContextProvider(provider: ModelContextProvider): void;
-  /** @internal */
-  __internal_getRuntime?(): AssistantRuntime;
 };
 
 export const createAssistantApiField = <
@@ -251,12 +244,6 @@ const AssistantApiContext = createContext<AssistantApi>({
   on: (selector) => {
     const { scope } = normalizeEventSelector(selector);
     throw new Error(`Event scope is not available in this component: ${scope}`);
-  },
-
-  registerModelContextProvider: () => {
-    throw new Error(
-      "Registering model context providers is only available inside <AssistantProvider />",
-    );
   },
 });
 

--- a/packages/react/src/legacy-runtime/hooks/AssistantContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/AssistantContext.ts
@@ -6,6 +6,8 @@ import type { ThreadListRuntime } from "../runtime/ThreadListRuntime";
 import { createStateHookForRuntime } from "../../context/react/utils/createStateHookForRuntime";
 
 /**
+ * @deprecated Use `useAssistantApi()` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ *
  * Hook to access the AssistantRuntime from the current context.
  *
  * The AssistantRuntime provides access to the top-level assistant state and actions,
@@ -17,13 +19,21 @@ import { createStateHookForRuntime } from "../../context/react/utils/createState
  *
  * @example
  * ```tsx
+ * // Before:
  * function MyComponent() {
  *   const runtime = useAssistantRuntime();
- *
  *   const handleNewThread = () => {
  *     runtime.switchToNewThread();
  *   };
+ *   return <button onClick={handleNewThread}>New Thread</button>;
+ * }
  *
+ * // After:
+ * function MyComponent() {
+ *   const api = useAssistantApi();
+ *   const handleNewThread = () => {
+ *     api.threads().switchToNewThread();
+ *   };
  *   return <button onClick={handleNewThread}>New Thread</button>;
  * }
  * ```
@@ -50,4 +60,8 @@ export function useAssistantRuntime(options?: {
 const useThreadListRuntime = (opt: {
   optional: boolean | undefined;
 }): ThreadListRuntime | null => useAssistantRuntime(opt)?.threads ?? null;
+
+/**
+ * @deprecated Use `useAssistantState(({ threads }) => threads)` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ */
 export const useThreadList = createStateHookForRuntime(useThreadListRuntime);

--- a/packages/react/src/legacy-runtime/hooks/AttachmentContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/AttachmentContext.ts
@@ -4,6 +4,9 @@ import { AttachmentRuntime } from "../runtime/AttachmentRuntime";
 import { createStateHookForRuntime } from "../../context/react/utils/createStateHookForRuntime";
 import { useAssistantApi, useAssistantState } from "../../context/react";
 
+/**
+ * @deprecated Use `useAssistantApi()` with `api.attachment()` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ */
 export function useAttachmentRuntime(options?: {
   optional?: false | undefined;
 }): AttachmentRuntime;
@@ -80,6 +83,9 @@ export function useMessageAttachmentRuntime(options?: {
   return attachmentRuntime as AttachmentRuntime<"message">;
 }
 
+/**
+ * @deprecated Use `useAssistantState(({ attachment }) => attachment)` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ */
 export const useAttachment = createStateHookForRuntime(useAttachmentRuntime);
 
 export const useThreadComposerAttachment = createStateHookForRuntime(

--- a/packages/react/src/legacy-runtime/hooks/ComposerContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/ComposerContext.ts
@@ -5,6 +5,8 @@ import { ComposerRuntime } from "../runtime/ComposerRuntime";
 import { createStateHookForRuntime } from "../../context/react/utils/createStateHookForRuntime";
 
 /**
+ * @deprecated Use `useAssistantApi()` with `api.composer()` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ *
  * Hook to access the ComposerRuntime from the current context.
  *
  * The ComposerRuntime provides access to composer state and actions for message
@@ -18,21 +20,42 @@ import { createStateHookForRuntime } from "../../context/react/utils/createState
  *
  * @example
  * ```tsx
+ * // Before:
  * function ComposerActions() {
  *   const runtime = useComposerRuntime();
- *
  *   const handleSend = () => {
  *     if (runtime.getState().canSend) {
  *       runtime.send();
  *     }
  *   };
- *
  *   const handleCancel = () => {
  *     if (runtime.getState().canCancel) {
  *       runtime.cancel();
  *     }
  *   };
+ *   return (
+ *     <div>
+ *       <button onClick={handleSend}>Send</button>
+ *       <button onClick={handleCancel}>Cancel</button>
+ *     </div>
+ *   );
+ * }
  *
+ * // After:
+ * function ComposerActions() {
+ *   const api = useAssistantApi();
+ *   const canSend = useAssistantState(({ composer }) => composer.canSend);
+ *   const canCancel = useAssistantState(({ composer }) => composer.canCancel);
+ *   const handleSend = () => {
+ *     if (canSend) {
+ *       api.composer().send();
+ *     }
+ *   };
+ *   const handleCancel = () => {
+ *     if (canCancel) {
+ *       api.composer().cancel();
+ *     }
+ *   };
  *   return (
  *     <div>
  *       <button onClick={handleSend}>Send</button>
@@ -64,6 +87,8 @@ export function useComposerRuntime(options?: {
 }
 
 /**
+ * @deprecated Use `useAssistantState(({ composer }) => composer)` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ *
  * Hook to access the current composer state.
  *
  * This hook provides reactive access to the composer's state, including text content,
@@ -74,11 +99,25 @@ export function useComposerRuntime(options?: {
  *
  * @example
  * ```tsx
+ * // Before:
  * function ComposerStatus() {
  *   const text = useComposer((state) => state.text);
  *   const canSend = useComposer((state) => state.canSend);
  *   const attachmentCount = useComposer((state) => state.attachments.length);
+ *   return (
+ *     <div>
+ *       Text: {text.length} chars,
+ *       Attachments: {attachmentCount},
+ *       Can send: {canSend}
+ *     </div>
+ *   );
+ * }
  *
+ * // After:
+ * function ComposerStatus() {
+ *   const text = useAssistantState(({ composer }) => composer.text);
+ *   const canSend = useAssistantState(({ composer }) => composer.canSend);
+ *   const attachmentCount = useAssistantState(({ composer }) => composer.attachments.length);
  *   return (
  *     <div>
  *       Text: {text.length} chars,

--- a/packages/react/src/legacy-runtime/hooks/MessageContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/MessageContext.ts
@@ -6,6 +6,8 @@ import { createStateHookForRuntime } from "../../context/react/utils/createState
 import { EditComposerRuntime } from "../runtime";
 
 /**
+ * @deprecated Use `useAssistantApi()` with `api.message()` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ *
  * Hook to access the MessageRuntime from the current context.
  *
  * The MessageRuntime provides access to message-level state and actions,
@@ -17,17 +19,32 @@ import { EditComposerRuntime } from "../runtime";
  *
  * @example
  * ```tsx
+ * // Before:
  * function MessageActions() {
  *   const runtime = useMessageRuntime();
- *
  *   const handleReload = () => {
  *     runtime.reload();
  *   };
- *
  *   const handleEdit = () => {
  *     runtime.startEdit();
  *   };
+ *   return (
+ *     <div>
+ *       <button onClick={handleReload}>Reload</button>
+ *       <button onClick={handleEdit}>Edit</button>
+ *     </div>
+ *   );
+ * }
  *
+ * // After:
+ * function MessageActions() {
+ *   const api = useAssistantApi();
+ *   const handleReload = () => {
+ *     api.message().reload();
+ *   };
+ *   const handleEdit = () => {
+ *     api.message().startEdit();
+ *   };
  *   return (
  *     <div>
  *       <button onClick={handleReload}>Reload</button>
@@ -59,6 +76,8 @@ export function useMessageRuntime(options?: {
 }
 
 /**
+ * @deprecated Use `useAssistantState(({ message }) => message)` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ *
  * Hook to access the current message state.
  *
  * This hook provides reactive access to the message's state, including content,
@@ -69,11 +88,23 @@ export function useMessageRuntime(options?: {
  *
  * @example
  * ```tsx
+ * // Before:
  * function MessageContent() {
  *   const role = useMessage((state) => state.role);
  *   const content = useMessage((state) => state.content);
  *   const isLoading = useMessage((state) => state.status.type === "running");
+ *   return (
+ *     <div className={`message-${role}`}>
+ *       {isLoading ? "Loading..." : content.map(part => part.text).join("")}
+ *     </div>
+ *   );
+ * }
  *
+ * // After:
+ * function MessageContent() {
+ *   const role = useAssistantState(({ message }) => message.role);
+ *   const content = useAssistantState(({ message }) => message.content);
+ *   const isLoading = useAssistantState(({ message }) => message.status.type === "running");
  *   return (
  *     <div className={`message-${role}`}>
  *       {isLoading ? "Loading..." : content.map(part => part.text).join("")}
@@ -87,6 +118,10 @@ export const useMessage = createStateHookForRuntime(useMessageRuntime);
 const useEditComposerRuntime = (opt: {
   optional: boolean | undefined;
 }): EditComposerRuntime | null => useMessageRuntime(opt)?.composer ?? null;
+
+/**
+ * @deprecated Use `useAssistantState(({ message }) => message.composer)` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ */
 export const useEditComposer = createStateHookForRuntime(
   useEditComposerRuntime,
 );

--- a/packages/react/src/legacy-runtime/hooks/MessagePartContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/MessagePartContext.ts
@@ -4,6 +4,9 @@ import { MessagePartRuntime } from "../runtime/MessagePartRuntime";
 import { createStateHookForRuntime } from "../../context/react/utils/createStateHookForRuntime";
 import { useAssistantApi, useAssistantState } from "../../context/react";
 
+/**
+ * @deprecated Use `useAssistantApi()` with `api.part()` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ */
 export function useMessagePartRuntime(options?: {
   optional?: false | undefined;
 }): MessagePartRuntime;
@@ -23,4 +26,7 @@ export function useMessagePartRuntime(options?: {
   return runtime;
 }
 
+/**
+ * @deprecated Use `useAssistantState(({ part }) => part)` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ */
 export const useMessagePart = createStateHookForRuntime(useMessagePartRuntime);

--- a/packages/react/src/legacy-runtime/hooks/ThreadContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/ThreadContext.ts
@@ -12,6 +12,8 @@ import {
 } from "../../context/react";
 
 /**
+ * @deprecated Use `useAssistantApi()` with `api.thread()` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ *
  * Hook to access the ThreadRuntime from the current context.
  *
  * The ThreadRuntime provides access to thread-level state and actions,
@@ -23,13 +25,21 @@ import {
  *
  * @example
  * ```tsx
+ * // Before:
  * function MyComponent() {
  *   const runtime = useThreadRuntime();
- *
  *   const handleSendMessage = (text: string) => {
  *     runtime.append({ role: "user", content: [{ type: "text", text }] });
  *   };
+ *   return <button onClick={() => handleSendMessage("Hello!")}>Send</button>;
+ * }
  *
+ * // After:
+ * function MyComponent() {
+ *   const api = useAssistantApi();
+ *   const handleSendMessage = (text: string) => {
+ *     api.thread().append({ role: "user", content: [{ type: "text", text }] });
+ *   };
  *   return <button onClick={() => handleSendMessage("Hello!")}>Send</button>;
  * }
  * ```
@@ -52,6 +62,8 @@ export function useThreadRuntime(options?: { optional?: boolean | undefined }) {
 }
 
 /**
+ * @deprecated Use `useAssistantState(({ thread }) => thread)` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ *
  * Hook to access the current thread state.
  *
  * This hook provides reactive access to the thread's state, including messages,
@@ -62,10 +74,17 @@ export function useThreadRuntime(options?: { optional?: boolean | undefined }) {
  *
  * @example
  * ```tsx
+ * // Before:
  * function ThreadStatus() {
  *   const isRunning = useThread((state) => state.isRunning);
  *   const messageCount = useThread((state) => state.messages.length);
+ *   return <div>Running: {isRunning}, Messages: {messageCount}</div>;
+ * }
  *
+ * // After:
+ * function ThreadStatus() {
+ *   const isRunning = useAssistantState(({ thread }) => thread.isRunning);
+ *   const messageCount = useAssistantState(({ thread }) => thread.messages.length);
  *   return <div>Running: {isRunning}, Messages: {messageCount}</div>;
  * }
  * ```
@@ -75,10 +94,17 @@ export const useThread = createStateHookForRuntime(useThreadRuntime);
 const useThreadComposerRuntime = (opt: {
   optional: boolean | undefined;
 }): ThreadComposerRuntime | null => useThreadRuntime(opt)?.composer ?? null;
+
+/**
+ * @deprecated Use `useAssistantState(({ thread }) => thread.composer)` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ */
 export const useThreadComposer = createStateHookForRuntime(
   useThreadComposerRuntime,
 );
 
+/**
+ * @deprecated Use `useAssistantState(({ thread }) => thread.modelContext)` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ */
 export function useThreadModelContext(options?: {
   optional?: false | undefined;
 }): ModelContext;

--- a/packages/react/src/legacy-runtime/hooks/ThreadListItemContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/ThreadListItemContext.ts
@@ -4,6 +4,9 @@ import { ThreadListItemRuntime } from "../runtime/ThreadListItemRuntime";
 import { createStateHookForRuntime } from "../../context/react/utils/createStateHookForRuntime";
 import { useAssistantApi, useAssistantState } from "../../context/react";
 
+/**
+ * @deprecated Use `useAssistantApi()` with `api.threadListItem()` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ */
 export function useThreadListItemRuntime(options?: {
   optional?: false | undefined;
 }): ThreadListItemRuntime;
@@ -25,6 +28,9 @@ export function useThreadListItemRuntime(options?: {
   return runtime;
 }
 
+/**
+ * @deprecated Use `useAssistantState(({ threadListItem }) => threadListItem)` instead. See migration guide: https://docs.assistant-ui.com/docs/migrations/v0-12
+ */
 export const useThreadListItem = createStateHookForRuntime(
   useThreadListItemRuntime,
 );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Deprecate old context API hooks in favor of `useAssistantApi()` and `useAssistantState()` with updated documentation and migration guides.
> 
>   - **Deprecation**:
>     - Mark all old context API hooks as deprecated in `AssistantContext.ts`, `AttachmentContext.ts`, `ComposerContext.ts`, `MessageContext.ts`, `MessagePartContext.ts`, `ThreadContext.ts`, and `ThreadListItemContext.ts`.
>     - Add deprecation warnings and migration guides to use `useAssistantApi()` and `useAssistantState()` instead.
>   - **API Changes**:
>     - Replace `useAttachment`, `useComposer`, `useMessage`, `useMessagePart`, `useThread`, `useThreadComposer`, `useThreadList`, `useThreadListItem`, and `useThreadModelContext` with `useAssistantState()` in various files.
>     - Update `useAssistantApi()` usage in `AssistantApiContext.tsx` and other files to reflect new API structure.
>   - **Documentation**:
>     - Update examples and documentation in `model-context.mdx`, `motivation.mdx`, `Attachments.mdx`, `Tools.mdx`, and `PartGrouping.mdx` to use new API.
>     - Provide migration guides in code comments for deprecated hooks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 07a28731198773f1b75f0ed39e01442312fbaa25. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->