### PR TITLE
fix(tap): tapRef should not support callback functions

### DIFF
--- a/.changeset/chilly-doodles-do.md
+++ b/.changeset/chilly-doodles-do.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: tapRef should not support callback fns

--- a/packages/react/src/utils/tap-store/tap-api.ts
+++ b/packages/react/src/utils/tap-store/tap-api.ts
@@ -40,7 +40,7 @@ export const tapApi = <TApi extends ApiObject & { getState: () => any }>(
     key?: string | undefined;
   },
 ) => {
-  const ref = tapRef(() => api);
+  const ref = tapRef(api);
   tapEffect(() => {
     ref.current = api;
   });

--- a/packages/tap/src/hooks/tap-memo.ts
+++ b/packages/tap/src/hooks/tap-memo.ts
@@ -2,10 +2,10 @@ import { tapRef } from "./tap-ref";
 import { depsShallowEqual } from "./depsShallowEqual";
 
 export const tapMemo = <T>(fn: () => T, deps: readonly unknown[]) => {
-  const dataRef = tapRef(() => ({
-    value: fn(),
-    deps,
-  }));
+  const dataRef = tapRef<{ value: T; deps: readonly unknown[] }>();
+  if (!dataRef.current) {
+    dataRef.current = { value: fn(), deps };
+  }
 
   if (!depsShallowEqual(dataRef.current.deps, deps)) {
     dataRef.current.value = fn();

--- a/packages/tap/src/hooks/tap-ref.ts
+++ b/packages/tap/src/hooks/tap-ref.ts
@@ -4,16 +4,11 @@ export interface RefObject<T> {
   current: T;
 }
 
-export function tapRef<T>(initialValue: T | (() => T)): RefObject<T>;
+export function tapRef<T>(initialValue: T): RefObject<T>;
 export function tapRef<T = undefined>(): RefObject<T | undefined>;
-export function tapRef<T>(
-  initialValue?: T | (() => T),
-): RefObject<T | undefined> {
+export function tapRef<T>(initialValue?: T): RefObject<T | undefined> {
   const [state] = tapState(() => ({
-    current:
-      initialValue !== undefined && typeof initialValue === "function"
-        ? (initialValue as () => T)()
-        : initialValue,
+    current: initialValue,
   }));
   return state;
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove callback function support from `tapRef` and update usages in `tap-api.ts` and `tap-memo.ts`.
> 
>   - **Behavior**:
>     - `tapRef` no longer supports callback functions as initial values in `tap-ref.ts`.
>     - Updated `tapApi` in `tap-api.ts` to use `tapRef(api)` instead of `tapRef(() => api)`.
>     - Updated `tapMemo` in `tap-memo.ts` to initialize `dataRef` without a callback.
>   - **Misc**:
>     - Added changeset `chilly-doodles-do.md` to document the patch update for `@assistant-ui/tap`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 9a37f97d5a99ebe61a6ca5b26956d47b1ffd1e84. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->