### PR TITLE
feat: include AI SDK errors in message auto-status

### DIFF
--- a/.changeset/error-autostatus.md
+++ b/.changeset/error-autostatus.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/react-ai-sdk": patch
+---
+
+feat: display AI SDK errors

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.tsx
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.tsx
@@ -47,7 +47,13 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const messages = AISDKMessageConverter.useThreadMessages({
     isRunning,
     messages: chatHelpers.messages,
-    metadata: useMemo(() => ({ toolStatuses }), [toolStatuses]),
+    metadata: useMemo(
+      () => ({
+        toolStatuses,
+        ...(chatHelpers.error && { error: chatHelpers.error.message }),
+      }),
+      [toolStatuses, chatHelpers.error],
+    ),
   });
 
   const [runtimeRef] = useState(() => ({

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/ExternalStoreThreadRuntimeCore.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/ExternalStoreThreadRuntimeCore.tsx
@@ -162,7 +162,13 @@ export class ExternalStoreThreadRuntimeCore
             if (!store.convertMessage) return m;
 
             const isLast = idx === store.messages!.length - 1;
-            const autoStatus = getAutoStatus(isLast, isRunning, false, false);
+            const autoStatus = getAutoStatus(
+              isLast,
+              isRunning,
+              false,
+              false,
+              undefined,
+            );
 
             if (
               cache &&

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/external-message-converter.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/external-message-converter.tsx
@@ -10,6 +10,7 @@ import { fromThreadMessageLike, ThreadMessageLike } from "./ThreadMessageLike";
 import { getAutoStatus, isAutoStatus } from "./auto-status";
 import { ThreadMessage, ToolCallMessagePart } from "../../../types";
 import { ToolExecutionStatus } from "../assistant-transport/useToolInvocations";
+import { ReadonlyJSONValue } from "assistant-stream/utils";
 
 export namespace useExternalMessageConverter {
   export type Message =
@@ -30,6 +31,7 @@ export namespace useExternalMessageConverter {
 
   export type Metadata = {
     readonly toolStatuses?: Record<string, ToolExecutionStatus>;
+    readonly error?: ReadonlyJSONValue;
   };
 
   export type Callback<T> = (
@@ -263,6 +265,7 @@ export const convertExternalMessages = <T extends WeakKey>(
       isRunning,
       hasSuspendedToolCalls,
       hasPendingToolCalls,
+      isLast ? metadata.error : undefined,
     );
     const newMessage = fromThreadMessageLike(
       joined,
@@ -348,6 +351,7 @@ export const useExternalMessageConverter = <T extends WeakKey>({
           isRunning,
           hasSuspendedToolCalls,
           hasPendingToolCalls,
+          isLast ? state.metadata.error : undefined,
         );
 
         if (

--- a/packages/react/src/legacy-runtime/runtime-cores/utils/MessageRepository.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/utils/MessageRepository.tsx
@@ -67,7 +67,7 @@ export const ExportedMessageRepository = {
       fromThreadMessageLike(
         m,
         generateId(),
-        getAutoStatus(false, false, false, false),
+        getAutoStatus(false, false, false, false, undefined),
       ),
     );
 


### PR DESCRIPTION
fixes #2674

Add support for propagating AI SDK errors into message auto-status so
errors are surfaced in the thread runtime and UI.

- Extend getAutoStatus to accept an optional Error and produce an
  "incomplete" status with reason "error" when the last message has an
  error. Mark auto-generated statuses with an internal symbol so they
  can be reliably detected via isAutoStatus.
- Thread and external-store converters now forward metadata.error to
  getAutoStatus for the last message, ensuring error-aware statuses are
  created when appropriate.
- Include chatHelpers.error in AISDKMessageConverter metadata so the
  runtime receives SDK errors from the UI layer.
- Update call sites to pass the new error parameter while preserving
  previous behavior when no error is present.
- Add changeset entry documenting the feature.

This change makes error conditions from the AI SDK visible in message
status handling and the UI for better error feedback.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Propagate AI SDK errors into message auto-status for enhanced error visibility in UI and runtime.
> 
>   - **Behavior**:
>     - `getAutoStatus` in `auto-status.tsx` now accepts an optional `error` parameter, returning an "incomplete" status with reason "error" if the last message has an error.
>     - `isAutoStatus` updated to detect auto-generated statuses using a symbol.
>     - `useAISDKRuntime.tsx` and `ExternalStoreThreadRuntimeCore.tsx` forward `metadata.error` to `getAutoStatus` for error-aware statuses.
>   - **Metadata**:
>     - `AISDKMessageConverter` in `useAISDKRuntime.tsx` includes `chatHelpers.error` in metadata.
>     - `external-message-converter.tsx` and `MessageRepository.tsx` updated to handle new error parameter in `getAutoStatus`.
>   - **Misc**:
>     - Add changeset entry `error-autostatus.md` documenting the feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for baf94a431b2f6547750253bcd335cba2640e5068. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->