### PR TITLE
docs: fix broken documentation links

### DIFF
--- a/apps/docs/content/docs/ui/Reasoning.mdx
+++ b/apps/docs/content/docs/ui/Reasoning.mdx
@@ -170,5 +170,5 @@ These can be customized by modifying the CSS variables in your component.
 
 ## Related Components
 
-- [ToolGroup](/ui/ToolGroup) - Similar grouping pattern for tool calls
-- [PartGrouping](/ui/PartGrouping) - Experimental API for grouping message parts
+- [ToolGroup](/docs/ui/ToolGroup) - Similar grouping pattern for tool calls
+- [PartGrouping](/docs/ui/PartGrouping) - Experimental API for grouping message parts


### PR DESCRIPTION
Update Related Components links to use correct /docs/ui/ prefix instead of /ui/
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken links in `Reasoning.mdx` by updating `/ui/` prefix to `/docs/ui/` for related components.
> 
>   - **Documentation**:
>     - Fix broken links in `Reasoning.mdx` by updating `/ui/` prefix to `/docs/ui/` for `ToolGroup` and `PartGrouping` links.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for b78639276b048a2a2f09e3519a68461af115e404. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->