### PR TITLE
feat: add on-demand thread loading

### DIFF
--- a/.changeset/fetch-thread-capability.md
+++ b/.changeset/fetch-thread-capability.md
@@ -1,0 +1,11 @@
+---
+"@assistant-ui/react": minor
+"@assistant-ui/cloud": minor
+---
+
+feat: Add thread fetching capability to remote thread list adapter
+
+- Add `fetch` method to `RemoteThreadListAdapter` interface
+- Implement `fetch` in cloud adapter to retrieve individual threads
+- Enhance `switchToThread` to automatically fetch and load threads not present in the current list
+- Add `get` method to `AssistantCloudThreads` for individual thread retrieval

--- a/packages/cloud/src/AssistantCloudThreads.tsx
+++ b/packages/cloud/src/AssistantCloudThreads.tsx
@@ -55,6 +55,10 @@ export class AssistantCloudThreads {
     return this.cloud.makeRequest("/threads", { query });
   }
 
+  public async get(threadId: string): Promise<CloudThread> {
+    return this.cloud.makeRequest(`/threads/${encodeURIComponent(threadId)}`);
+  }
+
   public async create(
     body: AssistantCloudThreadsCreateBody,
   ): Promise<AssistantCloudThreadsCreateResponse> {

--- a/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/adapter/cloud.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/adapter/cloud.tsx
@@ -121,6 +121,16 @@ export const useCloudThreadListAdapter = (
       });
     },
 
+    fetch: async (threadId: string) => {
+      const thread = await cloud.threads.get(threadId);
+      return {
+        status: thread.is_archived ? "archived" : "regular",
+        remoteId: thread.id,
+        title: thread.title,
+        externalId: thread.external_id ?? undefined,
+      };
+    },
+
     unstable_Provider,
   };
 };

--- a/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/adapter/in-memory.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/adapter/in-memory.tsx
@@ -3,6 +3,7 @@ import {
   RemoteThreadInitializeResponse,
   RemoteThreadListAdapter,
   RemoteThreadListResponse,
+  RemoteThreadMetadata,
 } from "../types";
 
 export class InMemoryThreadListAdapter implements RemoteThreadListAdapter {
@@ -34,5 +35,9 @@ export class InMemoryThreadListAdapter implements RemoteThreadListAdapter {
 
   generateTitle(): Promise<AssistantStream> {
     return Promise.resolve(new ReadableStream<AssistantStreamChunk>());
+  }
+
+  fetch(_threadId: string): Promise<RemoteThreadMetadata> {
+    return Promise.reject(new Error("Thread not found"));
   }
 }

--- a/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/types.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/types.tsx
@@ -31,6 +31,7 @@ export type RemoteThreadListAdapter = {
     remoteId: string,
     unstable_messages: readonly ThreadMessage[],
   ): Promise<AssistantStream>;
+  fetch(threadId: string): Promise<RemoteThreadMetadata>;
 
   unstable_Provider?: ComponentType<PropsWithChildren>;
 };


### PR DESCRIPTION
Add a fetch to the RemoteThreadListAdapter and it in
the cloud adapter and in-memory adapter. Expose a get(threadId)
endpoint on AssistantCloudThreads to retrieve individual thread data.

Enhance RemoteThreadListRuntimeCore.switchToThread to automatically
fetch thread metadata when a requested thread is not present in the
current list, then insert the thread into state (threadIds,
archivedThreadIds, threadIdMap, threadData) before initializing the
thread runtime. This allows switching to threads that were not
previously loaded without requiring a full list refresh.

The changes enable on-demand loading of single threads, improve
integration with cloud-thread retrieval, and avoid "Thread not found"
errors when switching to remote-only threads.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add on-demand thread loading by implementing a `fetch` method in adapters and enhancing `switchToThread` for automatic thread retrieval.
> 
>   - **Behavior**:
>     - Add `fetch` method to `RemoteThreadListAdapter` interface for on-demand thread loading.
>     - Implement `fetch` in `cloud.tsx` to retrieve individual threads.
>     - Enhance `switchToThread` in `RemoteThreadListThreadListRuntimeCore.tsx` to fetch and load threads not in the current list.
>     - Add `get` method to `AssistantCloudThreads.tsx` for individual thread retrieval.
>   - **Adapters**:
>     - Implement `fetch` in `in-memory.tsx` to reject with 'Thread not found'.
>   - **Types**:
>     - Add `fetch` method to `RemoteThreadListAdapter` in `types.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for f4286391a99e874bc25d3f0f011b2cf68cda1fb6. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->