### PR TITLE
refactor(react): replace zod with json schema in makeAssistantVisisbl…

### DIFF
--- a/packages/react/src/model-context/makeAssistantVisible.tsx
+++ b/packages/react/src/model-context/makeAssistantVisible.tsx
@@ -11,18 +11,21 @@ import {
   createContext,
   useContext,
 } from "react";
-import { z } from "zod";
 import { useAssistantApi } from "../context/react/AssistantApiContext";
 import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import { tool } from "./tool";
 
-// TODO replace zod with json-schema so we can drop the zod dep
-
 const click = tool({
-  parameters: z.object({
-    clickId: z.string(),
-  }),
-  execute: async ({ clickId }) => {
+  parameters: {
+    type: "object",
+    properties: {
+      clickId: {
+        type: "string",
+      },
+    },
+    required: ["clickId"],
+  },
+  execute: async ({ clickId }: { clickId: string }) => {
     const escapedClickId = CSS.escape(clickId);
     const el = document.querySelector(`[data-click-id='${escapedClickId}']`);
     if (el instanceof HTMLElement) {
@@ -38,11 +41,19 @@ const click = tool({
 });
 
 const edit = tool({
-  parameters: z.object({
-    editId: z.string(),
-    value: z.string(),
-  }),
-  execute: async ({ editId, value }) => {
+  parameters: {
+    type: "object",
+    properties: {
+      editId: {
+        type: "string",
+      },
+      value: {
+        type: "string",
+      },
+    },
+    required: ["editId", "value"],
+  },
+  execute: async ({ editId, value }: { editId: string; value: string }) => {
     const escapedEditId = CSS.escape(editId);
     const el = document.querySelector(`[data-edit-id='${escapedEditId}']`);
     if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {


### PR DESCRIPTION
This change addresses a TODO comment to replace the zod dependency with the existing json-schema library for defining 
tool parameters.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `makeAssistantVisible.tsx` to replace `zod` with `json-schema` for tool parameters and update `execute` functions with TypeScript annotations.
> 
>   - **Refactor**:
>     - Replace `zod` with `json-schema` for `parameters` in `click` and `edit` tools in `makeAssistantVisible.tsx`.
>     - Update `execute` functions to use TypeScript type annotations for parameter validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 500d64e361fc5f285128ad4f59a2f3273e1a32ab. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->