### PR TITLE
fix(ci): resolve track_progress remote ref errors for fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -102,11 +102,25 @@ jobs:
       actions: read
 
     steps:
-      - name: Checkout repository
+      - name: Checkout internal repository
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           fetch-depth: 1
+
+      - name: Checkout fork repository
+        if: |
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # Minimize previous bot comments on fork PRs to keep discussion clean
       # NOTE: Temporary workaround until https://github.com/anthropics/claude-code-action/pull/411 is merged


### PR DESCRIPTION
Fork PRs from branches not named 'main' failed with 'fatal: couldn't find remote ref' errors when track_progress was enabled. PRs from 'main' worked because the base repo also has 'main', so the branch name resolved.

Root cause: The workflow used refs/pull/{number}/head which correctly checks out code but doesn't provide the fork's branch name. When track_progress tried to reference the branch by name, it failed for feature branches that only exist in the fork repo.

Temporary fix: Disable track_progress for fork PRs
Solution: Use conditional checkout
- Internal PRs: Continue using refs/pull/{number}/head (resilient to branch deletion)
- Fork PRs: Checkout directly from fork repository (provides branch name for track_progress)

This maintains full functionality while respecting that refs/pull/{number}/head survives branch deletion for internal PRs, and fork PRs with tracking need the actual branch name available.

Note: Open PRs with base refs before this fix will need to be rebased to include this workflow change to run Claue Code Review action.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes remote ref errors for fork PRs by using conditional checkout in `claude-code-review.yml`.
> 
>   - **Behavior**:
>     - Fixes 'fatal: couldn't find remote ref' errors for fork PRs not from 'main' by using conditional checkout.
>     - Internal PRs use `refs/pull/{number}/head` for resilience to branch deletion.
>     - Fork PRs checkout directly from fork repository to provide branch name.
>   - **Workflow**:
>     - Modifies `claude-code-review.yml` to include separate steps for internal and fork PR checkouts.
>     - Disables `track_progress` for fork PRs temporarily until the branch name is available.
>   - **Notes**:
>     - Open PRs need rebasing to include this workflow change for the action to run.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 8cf16588d67b7391d5c93bac4445b07adb51e94d. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->