### PR TITLE
fix: restore assistant message refresh branching functionality

### DIFF
--- a/.changeset/local-runtime-fixes.md
+++ b/.changeset/local-runtime-fixes.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: LocalThreadRuntime deleting branches during message reloads

--- a/packages/react/src/legacy-runtime/runtime-cores/local/LocalThreadRuntimeCore.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/local/LocalThreadRuntimeCore.tsx
@@ -184,8 +184,6 @@ export class LocalThreadRuntimeCore
   ): Promise<void> {
     this.ensureInitialized();
 
-    this.repository.resetHead(parentId);
-
     // add assistant message
     const id = generateId();
     let message: ThreadAssistantMessage = {
@@ -255,7 +253,7 @@ export class LocalThreadRuntimeCore
     runConfig: RunConfig | undefined,
     runCallback?: ChatModelAdapter["run"],
   ) {
-    const messages = this.repository.getMessages();
+    const messages = parentId ? this.repository.getMessages(parentId) : [];
 
     // abort existing run
     this.abortController?.abort();
@@ -328,6 +326,10 @@ export class LocalThreadRuntimeCore
           type: "running",
         },
       });
+
+      // Switch to the new message branch right after adding it for the first time
+      this.repository.resetHead(message.id);
+      this._notifySubscribers();
     }
 
     try {

--- a/packages/react/src/legacy-runtime/runtime-cores/utils/MessageRepository.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/utils/MessageRepository.tsx
@@ -252,10 +252,30 @@ export class MessageRepository {
 
   /**
    * Gets all messages in the current active branch, from root to head.
-   * @returns Array of messages in the current branch
+   * @param headId - Optional ID of the head message to get messages for. If not provided, uses the current head.
+   * @returns Array of messages in the specified branch
    */
-  getMessages() {
-    return this._messages.value;
+  getMessages(headId?: string) {
+    if (headId === undefined || headId === this.head?.current.id) {
+      return this._messages.value;
+    }
+
+    const headMessage = this.messages.get(headId);
+    if (!headMessage) {
+      throw new Error(
+        "MessageRepository(getMessages): Head message not found. This is likely an internal bug in assistant-ui.",
+      );
+    }
+
+    const messages = new Array<ThreadMessage>(headMessage.level + 1);
+    for (
+      let current: RepositoryMessage | null = headMessage;
+      current;
+      current = current.prev
+    ) {
+      messages[current.level] = current.current;
+    }
+    return messages;
   }
 
   /**


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes branch deletion issue in `LocalThreadRuntimeCore` by adjusting message retrieval and branch management to maintain correct branches during reloads.
> 
>   - **Behavior**:
>     - Fixes branch deletion issue in `LocalThreadRuntimeCore` during message reloads by adjusting message retrieval and branch management.
>     - Ensures correct branch is maintained and switched to when new messages are added or runs are started.
>   - **Functions**:
>     - Modifies `getMessages()` in `MessageRepository` to handle optional `headId` for retrieving messages from specific branches.
>     - Adjusts `performRoundtrip()` in `LocalThreadRuntimeCore.tsx` to use `getMessages(parentId)` for message retrieval.
>     - Adds branch switching logic in `performRoundtrip()` to reset head to new message branch after adding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1e6dee338d6c7edbdaae148c42a87ee98bea9a2a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->