### PR TITLE
fix: build

### DIFF
--- a/packages/react-a2a/src/useA2AMessages.ts
+++ b/packages/react-a2a/src/useA2AMessages.ts
@@ -7,6 +7,7 @@ import {
   A2ATaskState,
   A2AArtifact,
   A2ASendMessageConfig,
+  A2AStreamCallback,
   OnTaskUpdateEventCallback,
   OnArtifactsEventCallback,
   OnErrorEventCallback,
@@ -15,13 +16,6 @@ import {
 } from "./types";
 
 export type A2AMessagesEvent<_TMessage> = A2AEvent;
-
-export type A2AStreamCallback<TMessage> = (
-  messages: TMessage[],
-  config: A2ASendMessageConfig & { abortSignal: AbortSignal },
-) =>
-  | Promise<AsyncGenerator<A2AMessagesEvent<TMessage>>>
-  | AsyncGenerator<A2AMessagesEvent<TMessage>>;
 
 const DEFAULT_APPEND_MESSAGE = <TMessage>(
   _: TMessage | undefined,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor A2A message handling for improved merging, conversion, and runtime management across multiple files.
> 
>   - **Behavior**:
>     - Refactor `appendA2AChunk` to improve merging of `tool_calls` and `artifacts`.
>     - Update `convertA2AMessage` to handle `tool-call` and `data` types in `convertA2AMessages.ts`.
>     - Modify `useA2ARuntime` to handle `A2AMessage` streaming and task state management.
>   - **Functions**:
>     - Change `convertA2AMessages` to use `convertA2AMessage` for individual message conversion.
>     - Update `useA2AMessages` to include `A2AStreamCallback` and refactor `sendMessage` logic.
>   - **Types**:
>     - Add `A2AStreamCallback` type to `useA2AMessages.ts` and `useA2ARuntime.ts`.
>     - Refactor type handling in `appendA2AChunk.ts` for `A2AMessage` merging.
>   - **Misc**:
>     - Remove redundant `A2AStreamCallback` type definition from `useA2AMessages.ts`.
>     - Adjust `getMessageContent` in `useA2ARuntime.ts` to handle `data` type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for fb7f6cdbc6de4428f1e29ec553289e59a2ed4596. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->