### PR TITLE
feat(store): improve error when components are used outside any AssistantProvider

### DIFF
--- a/packages/store/src/ScopeRegistry.ts
+++ b/packages/store/src/ScopeRegistry.ts
@@ -53,6 +53,6 @@ export function getDefaultScopeInitializer<K extends keyof AssistantScopes>(
 /**
  * Get all registered scope names.
  */
-export function getRegisteredScopes(): (keyof AssistantScopes)[] {
-  return Array.from(scopeRegistry.keys());
+export function hasRegisteredScope(name: keyof AssistantScopes): boolean {
+  return scopeRegistry.has(name);
 }

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -65,10 +65,17 @@ export type ScopeQuery<T extends ScopeDefinition> = T["query"];
  * Type for a scope field - a function that returns the current API value,
  * with source and query metadata attached
  */
-export type ScopeField<T extends ScopeDefinition> = (() => ScopeValue<T>) & {
-  source: ScopeSource<T>;
-  query: ScopeQuery<T>;
-};
+export type ScopeField<T extends ScopeDefinition> = (() => ScopeValue<T>) &
+  (
+    | {
+        source: ScopeSource<T>;
+        query: ScopeQuery<T>;
+      }
+    | {
+        source: null;
+        query: null;
+      }
+  );
 
 /**
  * Props passed to a derived scope resource element


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves error handling for components outside `AssistantProvider` by adding no-op functions and updating scope checks.
> 
>   - **Behavior**:
>     - In `AssistantContext.tsx`, added no-op functions `NO_OP_SUBSCRIBE`, `NO_OP_FLUSH_SYNC`, and `NO_OP_SCOPE_FIELD` to handle cases where components are used outside `AssistantProvider`.
>     - `NO_OP_SCOPE_FIELD` throws an error if accessed, indicating the need for `AssistantProvider`.
>     - Updated `AssistantContext` to use these no-op functions for `subscribe`, `flushSync`, and registered scopes.
>   - **Functions**:
>     - Replaced `getRegisteredScopes` with `hasRegisteredScope` in `ScopeRegistry.ts` to check if a scope is registered.
>   - **Types**:
>     - Updated `ScopeField` in `types.ts` to allow `source` and `query` to be null.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for f074adf343d1b4a7c7d9344b0430009db4a9ab31. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->