### PR TITLE
fix(cli): test failed

### DIFF
--- a/packages/cli/test/utils/logger.test.ts
+++ b/packages/cli/test/utils/logger.test.ts
@@ -30,12 +30,18 @@ describe("logger utilities", () => {
   });
 
   it("should log error messages in red with cross", () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
     logger.error("Test error message");
 
-    expect(consoleLogSpy).toHaveBeenCalledOnce();
-    const message = consoleLogSpy.mock.calls[0]?.[0] as string;
+    expect(consoleErrorSpy).toHaveBeenCalledOnce();
+    const message = consoleErrorSpy.mock.calls[0]?.[0] as string;
     expect(message).toContain("✗");
     expect(message).toContain("Test error message");
+
+    consoleErrorSpy.mockRestore();
   });
 
   it("should log warning messages in yellow with warning icon", () => {


### PR DESCRIPTION
This PR fixes the issue when the cli test case failed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `logger.test.ts` to correctly test error logging using `console.error` instead of `console.log`.
> 
>   - **Test Fix**:
>     - In `logger.test.ts`, change `console.log` to `console.error` in the error logging test to correctly test `logger.error()`.
>     - Add `consoleErrorSpy` to mock `console.error` and restore it after the test.
>   - **Misc**:
>     - No changes to the actual logger functionality, only test adjustments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for fd4605ad658bfd0c32ade36a0f1f1d5563af0940. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->