### PR TITLE
feat: add `ComposerPrimitive.AttachmentDropzone` in thread.tsx by default

### DIFF
--- a/apps/docs/components/assistant-ui/thread.tsx
+++ b/apps/docs/components/assistant-ui/thread.tsx
@@ -165,7 +165,7 @@ const Composer: FC = () => {
     <div className="aui-composer-wrapper sticky bottom-0 mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col gap-4 overflow-visible rounded-t-3xl bg-background pb-4 md:pb-6">
       <ThreadScrollToBottom />
       <ComposerPrimitive.Root className="aui-composer-root relative flex w-full flex-col">
-        <ComposerPrimitive.AttachmentDropzone className="aui-composer-attachment-dropzone group/input-group flex w-full flex-col rounded-3xl border border-input bg-background px-1 pt-2 shadow-xs transition-[color,box-shadow] outline-none has-[textarea:focus-visible]:border-ring has-[textarea:focus-visible]:ring-[3px] has-[textarea:focus-visible]:ring-ring/50 dark:bg-background data-[dragging=true]:border-dashed data-[dragging=true]:border-ring data-[dragging=true]:bg-accent/50">
+        <ComposerPrimitive.AttachmentDropzone className="aui-composer-attachment-dropzone group/input-group flex w-full flex-col rounded-3xl border border-input bg-background px-1 pt-2 shadow-xs transition-[color,box-shadow] outline-none has-[textarea:focus-visible]:border-ring has-[textarea:focus-visible]:ring-[3px] has-[textarea:focus-visible]:ring-ring/50 data-[dragging=true]:border-dashed data-[dragging=true]:border-ring data-[dragging=true]:bg-accent/50 dark:bg-background">
           <ComposerAttachments />
           <ComposerPrimitive.Input
             placeholder="Send a message..."

--- a/apps/registry/components/assistant-ui/thread.tsx
+++ b/apps/registry/components/assistant-ui/thread.tsx
@@ -175,7 +175,7 @@ const Composer: FC = () => {
     <div className="aui-composer-wrapper sticky bottom-0 mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col gap-4 overflow-visible rounded-t-3xl bg-background pb-4 md:pb-6">
       <ThreadScrollToBottom />
       <ComposerPrimitive.Root className="aui-composer-root relative flex w-full flex-col">
-        <ComposerPrimitive.AttachmentDropzone className="aui-composer-attachment-dropzone group/input-group flex w-full flex-col rounded-3xl border border-input bg-background px-1 pt-2 shadow-xs transition-[color,box-shadow] outline-none has-[textarea:focus-visible]:border-ring has-[textarea:focus-visible]:ring-[3px] has-[textarea:focus-visible]:ring-ring/50 dark:bg-background data-[dragging=true]:border-dashed data-[dragging=true]:border-ring data-[dragging=true]:bg-accent/50">
+        <ComposerPrimitive.AttachmentDropzone className="aui-composer-attachment-dropzone group/input-group flex w-full flex-col rounded-3xl border border-input bg-background px-1 pt-2 shadow-xs transition-[color,box-shadow] outline-none has-[textarea:focus-visible]:border-ring has-[textarea:focus-visible]:ring-[3px] has-[textarea:focus-visible]:ring-ring/50 data-[dragging=true]:border-dashed data-[dragging=true]:border-ring data-[dragging=true]:bg-accent/50 dark:bg-background">
           <ComposerAttachments />
           <ComposerPrimitive.Input
             placeholder="Send a message..."


### PR DESCRIPTION
Also adds to docs site
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `ComposerPrimitive.AttachmentDropzone` to `Composer` in `thread.tsx` for both `docs` and `registry`, enabling attachment drag-and-drop by default.
> 
>   - **Behavior**:
>     - Add `ComposerPrimitive.AttachmentDropzone` to `Composer` in `thread.tsx` in both `docs` and `registry` components.
>     - Supports drag-and-drop for attachments with visual feedback (dashed border, accent background) when dragging.
>   - **UI**:
>     - Updates `Composer` layout to include `AttachmentDropzone` by default.
>     - Adjusts styling for `AttachmentDropzone` to match existing UI elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c60efc25618a6571a46c71e28c25a937104d1cb7. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->