### PR TITLE
chore: move changeset publish to npm Publish environment

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -17,6 +17,8 @@ env:
 jobs:
   version:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     steps:
       - name: Checkout code repository
         uses: actions/checkout@v4
@@ -32,6 +34,40 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create version PR
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          commit: "chore: update versions"
+          title: "chore: update versions"
+          version: pnpm ci:version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: version
+    if: needs.version.outputs.hasChangesets == 'false'
+    environment: npm Publish
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+
       - name: Cache turbo build setup
         uses: actions/cache@v4
         with:
@@ -43,13 +79,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Create and publish versions
-        uses: changesets/action@v1
-        with:
-          commit: "chore: update versions"
-          title: "chore: update versions"
-          version: pnpm ci:version
-          publish: pnpm ci:publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Build packages
+        run: pnpm build
+
+      - name: Publish to npm
+        run: pnpm ci:publish

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,12 @@
 packages:
-- packages/*
-- examples/*
-- apps/*
+  - packages/*
+  - examples/*
+  - apps/*
+strictDepBuilds: true
+verifyDepsBeforeRun: true
 onlyBuiltDependencies:
-- "@tailwindcss/oxide"
-- esbuild
-- sharp
-- unrs-resolver
+  - "@tailwindcss/oxide@4.1.17"
+  - esbuild@0.25.12
+  - esbuild@0.27.0
+  - sharp@0.34.5
+  - unrs-resolver@1.11.1


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor GitHub Actions to separate versioning and publishing, and enforce stricter dependency management in `pnpm-workspace.yaml`.
> 
>   - **Workflow Changes**:
>     - Splits `changeset.yaml` into `version` and `publish` jobs.
>     - `publish` job now runs only if `version` job outputs `hasChangesets` as `false`.
>     - Adds `Build packages` and `Publish to npm` steps in `publish` job.
>   - **Dependency Management**:
>     - Adds `strictDepBuilds: true` and `verifyDepsBeforeRun: true` to `pnpm-workspace.yaml`.
>     - Updates `onlyBuiltDependencies` in `pnpm-workspace.yaml` with specific versions for dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for e754fa789af8e2eba8b1bd54a086b1ec17a6800c. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->