### PR TITLE
fix(react): prevent race condition in useToolInvocation.ts

### DIFF
--- a/.changeset/new-weeks-repeat.md
+++ b/.changeset/new-weeks-repeat.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": major
+---
+
+fix(react): prevent race condition in useToolInvocations when loading historical messages

--- a/apps/docs/content/docs/runtimes/data-stream.mdx
+++ b/apps/docs/content/docs/runtimes/data-stream.mdx
@@ -136,6 +136,13 @@ const runtime = useDataStreamRuntime({
 
 ## Tool Integration
 
+<Callout type="warn">
+  Human-in-the-loop tools (using `human()` for tool interrupts) are not supported
+  in the data stream runtime. If you need human approval workflows or interactive
+  tool UIs, consider using [LocalRuntime](/docs/runtimes/custom/local) or
+  [Assistant Cloud](/docs/cloud/overview) instead.
+</Callout>
+
 ### Frontend Tools
 
 Use the `frontendTools` helper to serialize client-side tools:

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.tsx
@@ -84,6 +84,7 @@ const useAssistantTransportThreadRuntime = <T,>(
   const agentStateRef = useRef(options.initialState);
   const [, rerender] = useState(0);
   const resumeFlagRef = useRef(false);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false);
   const commandQueue = useCommandQueue({
     onQueue: () => runManager.schedule(),
   });
@@ -298,9 +299,11 @@ const useAssistantTransportThreadRuntime = <T,>(
       commandQueue.enqueue(command);
     },
     onLoadExternalState: async (state) => {
+      setIsLoadingHistory(true);
       agentStateRef.current = state as T;
       toolInvocations.reset();
       rerender((prev) => prev + 1);
+      queueMicrotask(() => setIsLoadingHistory(false));
     },
   });
 
@@ -309,6 +312,7 @@ const useAssistantTransportThreadRuntime = <T,>(
     getTools: () => runtime.thread.getModelContext().tools,
     onResult: commandQueue.enqueue,
     setToolStatuses,
+    isLoading: isLoadingHistory,
   });
 
   return runtime;


### PR DESCRIPTION
closes #2656 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes race condition in `useToolInvocations.ts` by adding `isLoading` parameter and updates documentation with a warning about unsupported tools.
> 
>   - **Behavior**:
>     - Fixes race condition in `useToolInvocations` by adding `isLoading` parameter to control initial state transitions.
>     - Adjusts logic to ignore tool calls with complete arguments and results during initial state.
>   - **Documentation**:
>     - Adds warning about unsupported human-in-the-loop tools in `data-stream.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 67e88f4f12c54b50d3663f4889e0c327f37b7451. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->