### PR TITLE
fix(react): fix typo isInititialState to isInitialState

### DIFF
--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useToolInvocations.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useToolInvocations.ts
@@ -131,7 +131,7 @@ export function useToolInvocations({
   });
 
   const ignoredToolIds = useRef<Set<string>>(new Set());
-  const isInititialState = useRef(true);
+  const isInitialState = useRef(true);
 
   useEffect(() => {
     const processMessages = (
@@ -140,7 +140,7 @@ export function useToolInvocations({
       messages.forEach((message) => {
         message.content.forEach((content) => {
           if (content.type === "tool-call") {
-            if (isInititialState.current) {
+            if (isInitialState.current) {
               ignoredToolIds.current.add(content.toolCallId);
             } else {
               if (ignoredToolIds.current.has(content.toolCallId)) {
@@ -225,8 +225,8 @@ export function useToolInvocations({
 
     processMessages(state.messages);
 
-    if (isInititialState.current) {
-      isInititialState.current = false;
+    if (isInitialState.current) {
+      isInitialState.current = false;
     }
   }, [state, controller, onResult]);
 
@@ -244,7 +244,7 @@ export function useToolInvocations({
   return {
     reset: () => {
       abort();
-      isInititialState.current = true;
+      isInitialState.current = true;
     },
     abort,
     resume: (toolCallId: string, payload: unknown) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes typo `isInititialState` to `isInitialState` in `useToolInvocations.ts`, affecting initial state logic.
> 
>   - **Fixes**:
>     - Corrects typo `isInititialState` to `isInitialState` in `useToolInvocations.ts`.
>     - Affects logic in `useEffect` and `reset` function where initial state is checked and set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for b4484cf77138e23cd8bcf8eea82101eebfa42962. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->