### PR TITLE
fix: test file

### DIFF
--- a/packages/cli/src/codemods/v0-11/__tests__/content-part-to-message-part.test.ts
+++ b/packages/cli/src/codemods/v0-11/__tests__/content-part-to-message-part.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
 import transform from "../content-part-to-message-part";
-import jscodeshift from "jscodeshift";
+import jscodeshift, { API } from "jscodeshift";
 
 const transformer = transform;
 
 function applyTransform(source: string): string {
   const fileInfo = { path: "test.tsx", source };
   const api = { jscodeshift: jscodeshift.withParser("tsx") };
-  const result = transformer(fileInfo, api, {});
+  const result = transformer(fileInfo, api as API, {});
   return result || source;
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames `ContentPart` to `MessagePart` in test cases and updates `applyTransform()` to cast `api` as `API`.
> 
>   - **Behavior**:
>     - Updates `applyTransform()` in `content-part-to-message-part.test.ts` to cast `api` as `API`.
>     - Renames `ContentPart` to `MessagePart` in import statements, hooks, JSX member expressions, and type annotations.
>     - Ensures non-`@assistant-ui/react` imports remain unchanged.
>   - **Tests**:
>     - Adds test cases to verify renaming of `ContentPart` to `MessagePart` in various contexts, including complex type unions and generics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for b5d5ed7caada4021511c3a961cabc013113f4b41. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->