### PR TITLE
fix: move ThreadPrimitiveViewportProvider to AssistantRuntimeProvider

### DIFF
--- a/apps/docs/components/assistant-ui/thread.tsx
+++ b/apps/docs/components/assistant-ui/thread.tsx
@@ -74,7 +74,7 @@ export const Thread: FC = () => {
 
 const ThreadScrollToBottom: FC = () => {
   return (
-    <ThreadPrimitive.ScrollToBottom behavior="instant" asChild>
+    <ThreadPrimitive.ScrollToBottom asChild>
       <TooltipIconButton
         tooltip="Scroll to bottom"
         variant="outline"
@@ -230,25 +230,23 @@ const MessageError: FC = () => {
 
 const AssistantMessage: FC = () => {
   return (
-    <MessagePrimitive.Root asChild>
-      <div
-        className="aui-assistant-message-root relative mx-auto w-full max-w-[var(--thread-max-width)] animate-in py-4 duration-150 ease-out fade-in slide-in-from-bottom-1"
-        data-role="assistant"
-      >
-        <div className="aui-assistant-message-content mx-2 leading-7 break-words text-foreground">
-          <MessagePrimitive.Parts
-            components={{
-              Text: MarkdownText,
-              tools: { Fallback: ToolFallback },
-            }}
-          />
-          <MessageError />
-        </div>
+    <MessagePrimitive.Root
+      className="aui-assistant-message-root relative mx-auto w-full max-w-[var(--thread-max-width)] animate-in py-4 duration-150 ease-out fade-in slide-in-from-bottom-1"
+      data-role="assistant"
+    >
+      <div className="aui-assistant-message-content mx-2 leading-7 break-words text-foreground">
+        <MessagePrimitive.Parts
+          components={{
+            Text: MarkdownText,
+            tools: { Fallback: ToolFallback },
+          }}
+        />
+        <MessageError />
+      </div>
 
-        <div className="aui-assistant-message-footer mt-2 ml-2 flex">
-          <BranchPicker />
-          <AssistantActionBar />
-        </div>
+      <div className="aui-assistant-message-footer mt-2 ml-2 flex">
+        <BranchPicker />
+        <AssistantActionBar />
       </div>
     </MessagePrimitive.Root>
   );

--- a/apps/docs/components/samples/speech-sample.tsx
+++ b/apps/docs/components/samples/speech-sample.tsx
@@ -218,25 +218,23 @@ const MessageError: FC = () => {
 
 const AssistantMessage: FC = () => {
   return (
-    <MessagePrimitive.Root asChild>
-      <div
-        className="aui-assistant-message-root relative mx-auto w-full max-w-[var(--thread-max-width)] py-4 last:mb-24"
-        data-role="assistant"
-      >
-        <div className="aui-assistant-message-content mx-2 leading-7 break-words text-foreground">
-          <MessagePrimitive.Parts
-            components={{
-              Text: MarkdownText,
-              tools: { Fallback: ToolFallback },
-            }}
-          />
-          <MessageError />
-        </div>
+    <MessagePrimitive.Root
+      className="aui-assistant-message-root relative mx-auto w-full max-w-[var(--thread-max-width)] py-4 last:mb-24"
+      data-role="assistant"
+    >
+      <div className="aui-assistant-message-content mx-2 leading-7 break-words text-foreground">
+        <MessagePrimitive.Parts
+          components={{
+            Text: MarkdownText,
+            tools: { Fallback: ToolFallback },
+          }}
+        />
+        <MessageError />
+      </div>
 
-        <div className="aui-assistant-message-footer mt-2 ml-2 flex">
-          <BranchPicker />
-          <AssistantActionBar />
-        </div>
+      <div className="aui-assistant-message-footer mt-2 ml-2 flex">
+        <BranchPicker />
+        <AssistantActionBar />
       </div>
     </MessagePrimitive.Root>
   );

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -437,25 +437,23 @@ const MessageError: FC = () => {
 
 const AssistantMessage: FC = () => {
   return (
-    <MessagePrimitive.Root asChild>
-      <div
-        className="aui-assistant-message-root"
-        data-role="assistant"
-      >
-        <div className="aui-assistant-message-content">
-          <MessagePrimitive.Parts
-            components={{
-              Text: MarkdownText,
-              tools: { Fallback: ToolFallback },
-            }}
-          />
-          <MessageError />
-        </div>
+    <MessagePrimitive.Root
+      className="aui-assistant-message-root"
+      data-role="assistant"
+    >
+      <div className="aui-assistant-message-content">
+        <MessagePrimitive.Parts
+          components={{
+            Text: MarkdownText,
+            tools: { Fallback: ToolFallback },
+          }}
+        />
+        <MessageError />
+      </div>
 
-        <div className="aui-assistant-message-footer">
-          <BranchPicker />
-          <AssistantActionBar />
-        </div>
+      <div className="aui-assistant-message-footer">
+        <BranchPicker />
+        <AssistantActionBar />
       </div>
     </MessagePrimitive.Root>
   );
@@ -490,24 +488,22 @@ const AssistantActionBar: FC = () => {
 
 const UserMessage: FC = () => {
   return (
-    <MessagePrimitive.Root asChild>
-      <div
-        className="aui-user-message-root"
-        data-role="user"
-      >
-        <UserMessageAttachments />
+    <MessagePrimitive.Root
+      className="aui-user-message-root"
+      data-role="user"
+    >
+      <UserMessageAttachments />
 
-        <div className="aui-user-message-content-wrapper">
-          <div className="aui-user-message-content">
-            <MessagePrimitive.Parts />
-          </div>
-          <div className="aui-user-action-bar-wrapper">
-            <UserActionBar />
-          </div>
+      <div className="aui-user-message-content-wrapper">
+        <div className="aui-user-message-content">
+          <MessagePrimitive.Parts />
         </div>
-
-        <BranchPicker className="aui-user-branch-picker" />
+        <div className="aui-user-action-bar-wrapper">
+          <UserActionBar />
+        </div>
       </div>
+
+      <BranchPicker className="aui-user-branch-picker" />
     </MessagePrimitive.Root>
   );
 };

--- a/apps/registry/components/assistant-ui/thread.tsx
+++ b/apps/registry/components/assistant-ui/thread.tsx
@@ -74,7 +74,7 @@ export const Thread: FC = () => {
 
 const ThreadScrollToBottom: FC = () => {
   return (
-    <ThreadPrimitive.ScrollToBottom behavior="instant" asChild>
+    <ThreadPrimitive.ScrollToBottom asChild>
       <TooltipIconButton
         tooltip="Scroll to bottom"
         variant="outline"
@@ -240,25 +240,23 @@ const MessageError: FC = () => {
 
 const AssistantMessage: FC = () => {
   return (
-    <MessagePrimitive.Root asChild>
-      <div
-        className="aui-assistant-message-root relative mx-auto w-full max-w-[var(--thread-max-width)] animate-in py-4 duration-150 ease-out fade-in slide-in-from-bottom-1"
-        data-role="assistant"
-      >
-        <div className="aui-assistant-message-content mx-2 leading-7 break-words text-foreground">
-          <MessagePrimitive.Parts
-            components={{
-              Text: MarkdownText,
-              tools: { Fallback: ToolFallback },
-            }}
-          />
-          <MessageError />
-        </div>
+    <MessagePrimitive.Root
+      className="aui-assistant-message-root relative mx-auto w-full max-w-[var(--thread-max-width)] animate-in py-4 duration-150 ease-out fade-in slide-in-from-bottom-1"
+      data-role="assistant"
+    >
+      <div className="aui-assistant-message-content mx-2 leading-7 break-words text-foreground">
+        <MessagePrimitive.Parts
+          components={{
+            Text: MarkdownText,
+            tools: { Fallback: ToolFallback },
+          }}
+        />
+        <MessageError />
+      </div>
 
-        <div className="aui-assistant-message-footer mt-2 ml-2 flex">
-          <BranchPicker />
-          <AssistantActionBar />
-        </div>
+      <div className="aui-assistant-message-footer mt-2 ml-2 flex">
+        <BranchPicker />
+        <AssistantActionBar />
       </div>
     </MessagePrimitive.Root>
   );

--- a/packages/react/src/context/react/AssistantApiContext.tsx
+++ b/packages/react/src/context/react/AssistantApiContext.tsx
@@ -42,7 +42,6 @@ import {
   ThreadListClientApi,
   ThreadListClientState,
 } from "../../client/types/ThreadList";
-import { ThreadPrimitiveViewportProvider } from "../providers/ThreadViewportProvider";
 import { DevToolsProviderApi } from "../../devtools/DevToolsHooks";
 import {
   AssistantClientProps,
@@ -354,11 +353,7 @@ export const AssistantProvider: FC<
 
   return (
     <AssistantApiContext.Provider value={api}>
-      {/* TODO temporarily allow accessing viewport state from outside the viewport */}
-      {/* TODO figure out if this behavior should be deprecated, since it is quite hacky */}
-      <ThreadPrimitiveViewportProvider>
-        {children}
-      </ThreadPrimitiveViewportProvider>
+      {children}
     </AssistantApiContext.Provider>
   );
 };

--- a/packages/react/src/legacy-runtime/AssistantRuntimeProvider.tsx
+++ b/packages/react/src/legacy-runtime/AssistantRuntimeProvider.tsx
@@ -8,6 +8,7 @@ import {
 import { AssistantRuntime } from "./runtime/AssistantRuntime";
 import { AssistantRuntimeCore } from "./runtime-cores/core/AssistantRuntimeCore";
 import { RuntimeAdapter } from "./RuntimeAdapter";
+import { ThreadPrimitiveViewportProvider } from "../context/providers/ThreadViewportProvider";
 
 export namespace AssistantProvider {
   export type Props = PropsWithChildren<{
@@ -36,7 +37,11 @@ export const AssistantRuntimeProviderImpl: FC<AssistantProvider.Props> = ({
     <AssistantProvider api={api}>
       {RenderComponent && <RenderComponent />}
 
-      {children}
+      {/* TODO temporarily allow accessing viewport state from outside the viewport */}
+      {/* TODO figure out if this behavior should be deprecated, since it is quite hacky */}
+      <ThreadPrimitiveViewportProvider>
+        {children}
+      </ThreadPrimitiveViewportProvider>
     </AssistantProvider>
   );
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move `ThreadPrimitiveViewportProvider` to `AssistantRuntimeProvider` and update `AssistantMessage` component structure.
> 
>   - **Behavior**:
>     - Move `ThreadPrimitiveViewportProvider` from `AssistantApiContext.tsx` to `AssistantRuntimeProvider.tsx` to manage viewport state.
>     - Remove `behavior="instant"` from `ThreadPrimitive.ScrollToBottom` in `thread.tsx` and `speech-sample.tsx`.
>   - **Components**:
>     - Update `AssistantMessage` component structure in `thread.tsx`, `speech-sample.tsx`, and `getting-started.mdx` to remove `asChild` prop from `MessagePrimitive.Root`.
>   - **Context**:
>     - Remove `ThreadPrimitiveViewportProvider` from `AssistantApiContext.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 9b572e8a1c70bc5e4f008203edb4c70eb6b38bcc. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->