### PR TITLE
fix: run changeset publish on github actions infra to auth via trusted publishing

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -52,7 +52,7 @@ jobs:
     needs: version
     if: needs.version.outputs.hasChangesets == 'false'
     environment: npm Publish
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code repository
         uses: actions/checkout@v4


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change runner for `publish` job in GitHub Actions from `blacksmith-4vcpu-ubuntu-2404` to `ubuntu-latest`.
> 
>   - **GitHub Actions Workflow**:
>     - Change runner for `publish` job in `changeset.yaml` from `blacksmith-4vcpu-ubuntu-2404` to `ubuntu-latest`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 9c464e78b9aea9cbf802d855cd25d0005d0ac561. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->