### PR TITLE
chore(ci): remove redundant build step from workflow

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -83,8 +83,5 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build packages
-        run: pnpm build
-
       - name: Publish to npm
         run: pnpm ci:publish


### PR DESCRIPTION
Remove the explicit "Build packages" step from the changeset CI
workflow. The build is unnecessary because the pipeline runs the
install step with the lockfile and the publish job handles any
required build tasks, so removing the redundant pnpm build step
simplifies the workflow and avoids duplicate work.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant `Build packages` step from `changeset.yaml` to simplify CI workflow.
> 
>   - **CI Workflow**:
>     - Remove `Build packages` step from `changeset.yaml`.
>     - Simplifies workflow by eliminating redundant `pnpm build` step.
>     - `pnpm install --frozen-lockfile` and `pnpm ci:publish` handle necessary tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 93a0c2f0ca36bb73b67cff0662e8c15fadc3d59e. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->