### PR TITLE
ci: test publish without env

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -53,7 +53,6 @@ jobs:
   publish:
     needs: version
     if: needs.version.outputs.hasChangesets == 'false'
-    environment: npm Publish
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code repository


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `environment` from `publish` job in `changeset.yaml` to simplify workflow configuration.
> 
>   - **CI Workflow**:
>     - Remove `environment: npm Publish` from `publish` job in `changeset.yaml`. This simplifies the workflow configuration by not specifying an environment for the `publish` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for a58c9418caa899f3c4eac1d51489c3260164ab10. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->