### PR TITLE
chore(ci): attempt fix trusted publishing

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -56,6 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_LOGLEVEL: verbose # TODO remove this once changeset is fixed
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code repository
         uses: actions/checkout@v4


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update permissions in `changeset.yaml` to fix trusted publishing in CI workflow.
> 
>   - **CI Workflow**:
>     - Update `.github/workflows/changeset.yaml` to add `id-token: write` and `contents: read` permissions under `publish` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 2f82bd89f1ae836c8539f3701e259d017fddc2f0. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->