### PR TITLE
ci: fix npm publish task unnecessary runs

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -22,6 +22,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
+      needsPublish: ${{ steps.check-publish.outputs.needsPublish }}
     steps:
       - name: Checkout code repository
         uses: actions/checkout@v6
@@ -50,9 +51,41 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check if any packages need publishing
+        id: check-publish
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          needs_publish="false"
+          for pkg in packages/*/package.json; do
+            # Skip if no packages found
+            [ -f "$pkg" ] || continue
+
+            # Get package name and version
+            name=$(jq -r '.name' "$pkg")
+            version=$(jq -r '.version' "$pkg")
+            private=$(jq -r '.private // false' "$pkg")
+
+            # Skip private packages
+            if [ "$private" = "true" ]; then
+              echo "Skipping private package: $name"
+              continue
+            fi
+
+            # Check if this version exists on npm
+            if npm view "${name}@${version}" version 2>/dev/null | grep -q "${version}"; then
+              echo "✓ ${name}@${version} already published"
+            else
+              echo "✗ ${name}@${version} needs publishing"
+              needs_publish="true"
+            fi
+          done
+
+          echo "needsPublish=${needs_publish}" >> $GITHUB_OUTPUT
+          echo "Needs publish: ${needs_publish}"
+
   publish:
     needs: version
-    if: needs.version.outputs.hasChangesets == 'false'
+    if: needs.version.outputs.hasChangesets == 'false' && needs.version.outputs.needsPublish == 'true'
     environment: npm Publish
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add a check step to the version job that verifies if any packages have versions not yet on npm. The publish job only runs when there are packages that actually need publishing, preventing unnecessary review requests.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a check in the CI workflow to prevent unnecessary npm publish tasks by verifying package versions against npm.
> 
>   - **Behavior**:
>     - Adds a check in `version` job in `.github/workflows/changeset.yaml` to verify if any packages need publishing by comparing package versions with npm.
>     - `publish` job now runs only if there are packages that need publishing, preventing unnecessary runs.
>   - **Workflow**:
>     - New step `check-publish` added to `version` job to determine if any package versions are not on npm.
>     - Updates `publish` job condition to include `needs.version.outputs.needsPublish == 'true'`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 90b60952f13a2c1977873807335f4b893f2b91ae. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->