### PR TITLE
fix(runtime): import unstable_RemoteThreadListAdapter as RemoteThreadListAdapter

### DIFF
--- a/apps/docs/content/docs/runtimes/custom/local.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local.mdx
@@ -410,7 +410,7 @@ import {
   useThreadListItem,
   RuntimeAdapterProvider,
   AssistantRuntimeProvider,
-  type RemoteThreadListAdapter,
+  type unstable_RemoteThreadListAdapter as RemoteThreadListAdapter,
   type ThreadHistoryAdapter,
 } from "@assistant-ui/react";
 import { createAssistantStream } from "assistant-stream";


### PR DESCRIPTION
Use the unstable-prefixed export from @assistant-ui/react and alias it
to RemoteThreadListAdapter. This aligns the local docs example with the
library's current API, avoiding a broken or missing type import and
preventing type errors when building or editing the docs.
<!-- ELLIPSIS_HIDDEN -->

fixes #2314

----

> [!IMPORTANT]
> Alias `unstable_RemoteThreadListAdapter` to `RemoteThreadListAdapter` in `local.mdx` to align with `@assistant-ui/react` API.
> 
>   - **Import Change**:
>     - In `local.mdx`, import `unstable_RemoteThreadListAdapter` as `RemoteThreadListAdapter` from `@assistant-ui/react` to align with the library's API and prevent type errors in documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for afc81b94b94c6c3c86e40798eee95523946cb479. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->