### PR TITLE
fix(react): data-status stuck on running when smooth streaming disabled

### DIFF
--- a/.changeset/fix-smooth-status.md
+++ b/.changeset/fix-smooth-status.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): data-status stuck on running when smooth streaming disabled

--- a/packages/react/src/utils/smooth/useSmooth.tsx
+++ b/packages/react/src/utils/smooth/useSmooth.tsx
@@ -96,12 +96,12 @@ export const useSmooth = (
   useEffect(() => {
     if (smoothStatusStore) {
       const target =
-        displayedText !== text || state.status.type === "running"
+        smooth && (displayedText !== text || state.status.type === "running")
           ? SMOOTH_STATUS
           : state.status;
       writableStore(smoothStatusStore).setState(target, true);
     }
-  }, [smoothStatusStore, text, displayedText, state.status]);
+  }, [smoothStatusStore, smooth, text, displayedText, state.status]);
 
   const [animatorRef] = useState<TextStreamAnimator>(
     new TextStreamAnimator(text, setText),


### PR DESCRIPTION
fixes #2667
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `data-status` stuck on 'running' when smooth streaming is disabled by updating `useEffect` in `useSmooth.tsx`.
> 
>   - **Behavior**:
>     - Fixes `data-status` stuck on 'running' when smooth streaming is disabled in `useSmooth.tsx`.
>     - Modifies `useEffect` to conditionally set status based on `smooth` flag.
>   - **Misc**:
>     - Adds changeset file `fix-smooth-status.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for f4d383fc9f35862a2abdeb4d039c99427b16fa96. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->