### PR TITLE
ci: increase timeout

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -55,7 +55,7 @@ jobs:
   build:
     name: Build Changed Packages
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout code repository
         uses: actions/checkout@v6


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase `timeout-minutes` from 5 to 10 in `build` job in `code-quality.yaml`.
> 
>   - **CI Configuration**:
>     - Increase `timeout-minutes` from 5 to 10 in `build` job in `code-quality.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for ab2f860d4614e21fca881d8c85f08aa9355bf2e6. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->