### PR TITLE
ci: move npm-publish to its own separate action

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -6,7 +6,6 @@ on:
       - main
 
 permissions:
-  id-token: write
   contents: write
   pull-requests: write
 
@@ -19,10 +18,8 @@ env:
 
 jobs:
   version:
+    name: Create Version PR
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    outputs:
-      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
-      needsPublish: ${{ steps.check-publish.outputs.needsPublish }}
     steps:
       - name: Checkout code repository
         uses: actions/checkout@v6
@@ -57,21 +54,17 @@ jobs:
         run: |
           needs_publish="false"
           for pkg in packages/*/package.json; do
-            # Skip if no packages found
             [ -f "$pkg" ] || continue
 
-            # Get package name and version
             name=$(jq -r '.name' "$pkg")
             version=$(jq -r '.version' "$pkg")
             private=$(jq -r '.private // false' "$pkg")
 
-            # Skip private packages
             if [ "$private" = "true" ]; then
               echo "Skipping private package: $name"
               continue
             fi
 
-            # Check if this version exists on npm
             if npm view "${name}@${version}" version 2>/dev/null | grep -q "${version}"; then
               echo "✓ ${name}@${version} already published"
             else
@@ -81,40 +74,14 @@ jobs:
           done
 
           echo "needsPublish=${needs_publish}" >> $GITHUB_OUTPUT
-          echo "Needs publish: ${needs_publish}"
 
-  publish:
-    needs: version
-    if: needs.version.outputs.hasChangesets == 'false' && needs.version.outputs.needsPublish == 'true'
-    environment: npm Publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code repository
-        uses: actions/checkout@v6
+      - name: Trigger npm publish
+        if: steps.changesets.outputs.hasChangesets == 'false' && steps.check-publish.outputs.needsPublish == 'true'
+        uses: actions/github-script@v7
         with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Cache turbo build setup
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.ref }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-${{ github.ref }}-
-            ${{ runner.os }}-turbo-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Publish to npm
-        run: pnpm ci:publish
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'npm-publish'
+            });

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -11,7 +11,7 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - ".github/workflows/code-quality.yaml"
-  pull_request_target:
+  pull_request:
     branches: [main]
     paths:
       - "packages/**"
@@ -34,7 +34,6 @@ jobs:
       - name: Checkout code repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Install pnpm
@@ -60,7 +59,6 @@ jobs:
       - name: Checkout code repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Install pnpm
@@ -86,7 +84,7 @@ jobs:
 
       - name: Build packages
         run: |
-          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
             # PR: Build packages changed compared to base branch
             pnpm turbo build --filter="...[origin/${{ github.base_ref }}]"
           else
@@ -103,7 +101,6 @@ jobs:
       - name: Checkout code repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Install pnpm
@@ -129,7 +126,7 @@ jobs:
 
       - name: Run tests
         run: |
-          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
             # PR: Test packages changed compared to base branch
             pnpm turbo test --filter="...[origin/${{ github.base_ref }}]"
           else

--- a/.github/workflows/fix-lint.yaml
+++ b/.github/workflows/fix-lint.yaml
@@ -19,7 +19,40 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 5
     steps:
+      - name: Check commenter permissions
+        uses: actions/github-script@v8
+        id: check-permission
+        with:
+          script: |
+            const { owner, repo } = context.issue;
+            const commenter = context.payload.comment.user.login;
+
+            try {
+              const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username: commenter
+              });
+
+              const allowedPermissions = ['admin', 'write'];
+              const hasPermission = allowedPermissions.includes(permission.permission);
+
+              console.log(`User ${commenter} has permission: ${permission.permission}`);
+
+              if (!hasPermission) {
+                core.setFailed(`User ${commenter} does not have write access to this repository`);
+                return { authorized: false };
+              }
+
+              return { authorized: true };
+            } catch (error) {
+              core.setFailed(`Failed to check permissions: ${error.message}`);
+              return { authorized: false };
+            }
+          result-encoding: json
+
       - name: Get PR information
+        if: fromJson(steps.check-permission.outputs.result).authorized == true
         uses: actions/github-script@v8
         id: get-pr
         with:
@@ -31,15 +64,15 @@ jobs:
                 repo,
                 pull_number: number
               });
-              
+
               const isFork = pr.data.head.repo.full_name !== pr.data.base.repo.full_name;
-              
+
               // Log information for debugging
               console.log(`PR ${number}: head_ref=${pr.data.head.ref}, is_fork=${isFork}`);
               if (isFork) {
                 console.log(`Fork: ${pr.data.head.repo.full_name}`);
               }
-              
+
               return {
                 head_ref: pr.data.head.ref,
                 head_sha: pr.data.head.sha,
@@ -56,14 +89,14 @@ jobs:
           result-encoding: json
 
       - name: Checkout PR (same repo)
-        if: fromJson(steps.get-pr.outputs.result).is_fork == false
+        if: fromJson(steps.check-permission.outputs.result).authorized == true && fromJson(steps.get-pr.outputs.result).is_fork == false
         uses: actions/checkout@v6
         with:
           ref: ${{ fromJson(steps.get-pr.outputs.result).head_ref }}
           fetch-depth: 1
 
       - name: Checkout PR (forked repo)
-        if: fromJson(steps.get-pr.outputs.result).is_fork == true
+        if: fromJson(steps.check-permission.outputs.result).authorized == true && fromJson(steps.get-pr.outputs.result).is_fork == true
         uses: actions/checkout@v6
         with:
           ref: ${{ fromJson(steps.get-pr.outputs.result).head_ref }}
@@ -71,21 +104,26 @@ jobs:
           repository: ${{ format('{0}/{1}', fromJson(steps.get-pr.outputs.result).fork_owner, fromJson(steps.get-pr.outputs.result).fork_repo) }}
 
       - name: Install pnpm
+        if: fromJson(steps.check-permission.outputs.result).authorized == true
         uses: pnpm/action-setup@v4
 
       - name: Setup node.js
+        if: fromJson(steps.check-permission.outputs.result).authorized == true
         uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "pnpm"
 
       - name: Install dependencies
+        if: fromJson(steps.check-permission.outputs.result).authorized == true
         run: pnpm install --frozen-lockfile
 
       - name: Run Biome fix
+        if: fromJson(steps.check-permission.outputs.result).authorized == true
         run: pnpm biome:fix
 
       - name: Commit changes
+        if: fromJson(steps.check-permission.outputs.result).authorized == true
         id: commit
         run: |
           git config --local user.email "action@github.com"
@@ -100,7 +138,7 @@ jobs:
           fi
 
       - name: Push changes
-        if: steps.commit.outputs.changes_made == 'true'
+        if: fromJson(steps.check-permission.outputs.result).authorized == true && steps.commit.outputs.changes_made == 'true'
         id: push
         run: |
           # Try to push changes
@@ -115,15 +153,19 @@ jobs:
           fi
 
       - name: Comment on PR
+        if: always()
         uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo, number } = context.issue;
+            const authorized = '${{ fromJson(steps.check-permission.outputs.result).authorized }}' === 'true';
             const changes_made = '${{ steps.commit.outputs.changes_made }}' === 'true';
             const push_failed = '${{ steps.push.outputs.failed }}' === 'true';
 
             let message;
-            if (changes_made && push_failed) {
+            if (!authorized) {
+              message = '❌ Only repository collaborators with write access can use the `/fix-lint` command.';
+            } else if (changes_made && push_failed) {
               message = '❌ Failed to push lint fixes. Please ensure "Allow edits from maintainers" is enabled in your PR settings.';
             } else if (changes_made) {
               message = '✅ Lint issues fixed and committed to this PR!';

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,0 +1,45 @@
+name: npm Publish
+
+on:
+  repository_dispatch:
+    types: [npm-publish]
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  CI: true
+
+jobs:
+  publish:
+    name: Publish to npm
+    if: github.ref == 'refs/heads/main'
+    environment: npm Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          # No cache - hardened against cache poisoning for sensitive publish operations
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Publish to npm
+        run: pnpm ci:publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Separate npm publish into its own GitHub Action, refine permissions and conditions in workflows.
> 
>   - **Workflows**:
>     - Move npm publish process from `changeset.yaml` to new `npm-publish.yaml` workflow.
>     - Trigger `npm-publish.yaml` via `repository_dispatch` event.
>     - Remove `publish` job from `changeset.yaml`.
>   - **Permissions**:
>     - Add permission check for `/fix-lint` command in `fix-lint.yaml`.
>     - Ensure only users with `admin` or `write` permissions can trigger lint fixes.
>   - **Conditions**:
>     - Change `pull_request_target` to `pull_request` in `code-quality.yaml` for build and test jobs.
>     - Add condition to `npm-publish.yaml` to only run on `main` branch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 6bf0382bd52147d9bb2f59aa152ea3a750986606. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->