### PR TITLE
fix(ci): use head_sha when checking out PR commits

### DIFF
--- a/.github/workflows/fix-lint.yaml
+++ b/.github/workflows/fix-lint.yaml
@@ -92,14 +92,14 @@ jobs:
         if: fromJson(steps.check-permission.outputs.result).authorized == true && fromJson(steps.get-pr.outputs.result).is_fork == false
         uses: actions/checkout@v6
         with:
-          ref: ${{ fromJson(steps.get-pr.outputs.result).head_ref }}
+          ref: ${{ fromJson(steps.get-pr.outputs.result).head_sha }}
           fetch-depth: 1
 
       - name: Checkout PR (forked repo)
         if: fromJson(steps.check-permission.outputs.result).authorized == true && fromJson(steps.get-pr.outputs.result).is_fork == true
         uses: actions/checkout@v6
         with:
-          ref: ${{ fromJson(steps.get-pr.outputs.result).head_ref }}
+          ref: ${{ fromJson(steps.get-pr.outputs.result).head_sha }}
           fetch-depth: 1
           repository: ${{ format('{0}/{1}', fromJson(steps.get-pr.outputs.result).fork_owner, fromJson(steps.get-pr.outputs.result).fork_repo) }}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change checkout reference from `head_ref` to `head_sha` in `.github/workflows/fix-lint.yaml` for precise commit checkout.
> 
>   - **Behavior**:
>     - Change checkout reference from `head_ref` to `head_sha` in `.github/workflows/fix-lint.yaml`.
>     - Ensures exact commit is checked out for both same repo and forked repo scenarios.
>   - **Files**:
>     - Modifies `.github/workflows/fix-lint.yaml` to use `head_sha` for checkout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 115fd19175f7106a7f6ba6d2902e3985070075e9. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->