### PR TITLE
Clarify setup by adding instructions for assistant-ui add thread

### DIFF
--- a/apps/docs/content/docs/runtimes/custom/local.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local.mdx
@@ -75,6 +75,15 @@ Use `LocalRuntime` if you need:
   </Step>
   <Step>
 
+    ### Add `assistant-ui` Thread component
+
+    ```sh npm2yarn
+    npx assistant-ui@latest add thread
+    ```
+
+  </Step>
+  <Step>
+
     ### Define a `MyRuntimeProvider` component
 
     Update the `MyModelAdapter` below to integrate with your own custom API.


### PR DESCRIPTION
Local Runtime instructions are missing `add thread` step during project setup.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds missing `add thread` step in Local Runtime setup instructions in `local.mdx`.
> 
>   - **Documentation Update**:
>     - Adds missing `add thread` step in Local Runtime setup instructions in `local.mdx`.
>     - Ensures users include the `assistant-ui` Thread component during setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1a54fcbc6efe9da893296b00c38841b871c7decd. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->