### PR TITLE
fix(docs): add registry as dev dependency to fix Vercel build

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -70,6 +70,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@assistant-ui/shadcn-registry": "workspace:*",
     "@tailwindcss/postcss": "^4.1.17",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/mdx": "^2.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.2.7)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
     devDependencies:
+      '@assistant-ui/shadcn-registry':
+        specifier: workspace:*
+        version: link:../registry
       '@tailwindcss/postcss':
         specifier: ^4.1.17
         version: 4.1.17
@@ -2443,28 +2446,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.8':
     resolution: {integrity: sha512-Uo1OJnIkJgSgF+USx970fsM/drtPcQ39I+JO+Fjsaa9ZdCN1oysQmy6oAGbyESlouz+rzEckLTF6DS7cWse95g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.8':
     resolution: {integrity: sha512-YGLkqU91r1276uwSjiUD/xaVikdxgV1QpsicT0bIA1TaieM6E5ibMZeSyjQ/izBn4tKQthUSsVZacmoJfa3pDA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.8':
     resolution: {integrity: sha512-QDPMD5bQz6qOVb3kiBui0zKZXASLo0NIQ9JVJio5RveBEFgDgsvJFUvZIbMbUZT3T00M/1wdzwWXk4GIh0KaAw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.8':
     resolution: {integrity: sha512-H4IoCHvL1fXKDrTALeTKMiE7GGWFAraDwBYFquE/L/5r1927Te0mYIGseXi4F+lrrwhSWbSGt5qPFswNoBaCxg==}


### PR DESCRIPTION
The manual installation tabs were appearing empty on Vercel because
the docs build didn't trigger the registry build. The component-source.tsx
reads registry files from ../registry/dist/, but those files are gitignored
and only created during build.

By adding @assistant-ui/shadcn-registry as a workspace dev dependency,
turbo now builds the registry before the docs, ensuring the JSON files
exist at build time.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `@assistant-ui/shadcn-registry` as a dev dependency to ensure registry files are built before docs, fixing empty manual installation tabs on Vercel.
> 
>   - **Build Process**:
>     - Adds `@assistant-ui/shadcn-registry` as a dev dependency in `package.json` to ensure registry files are built before docs.
>     - Fixes issue where manual installation tabs were empty on Vercel due to missing registry files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 237c042be15fadac9984b3605749ee1ddcc00abb. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->