### PR TITLE
feat: expose `hasAttachments` and `isEmpty` state to Composer

### DIFF
--- a/apps/docs/content/docs/api-reference/primitives/Composer.mdx
+++ b/apps/docs/content/docs/api-reference/primitives/Composer.mdx
@@ -227,9 +227,23 @@ Renders children if a condition is met.
       type: "boolean | undefined",
       description: "Render children if the message is being edited.",
     },
+    {
+      name: "hasAttachments",
+      required: false,
+      type: "boolean | undefined",
+      description: "Render children if the composer has attachments.",
+    },
+    {
+      name: "isEmpty",
+      required: false,
+      type: "boolean | undefined",
+      description: "Render children if the composer is empty (no text and no attachments).",
+    },
   ]}
 />
 
 ```tsx
 <Composer.If editing>{/* rendered if message is being edited */}</Composer.If>
+<Composer.If hasAttachments>{/* rendered if composer has attachments */}</Composer.If>
+<Composer.If isEmpty={false}>{/* rendered if composer is not empty */}</Composer.If>
 ```

--- a/packages/react/src/primitives/composer/ComposerIf.tsx
+++ b/packages/react/src/primitives/composer/ComposerIf.tsx
@@ -6,6 +6,8 @@ import type { RequireAtLeastOne } from "../../utils/RequireAtLeastOne";
 
 type ComposerIfFilters = {
   editing: boolean | undefined;
+  hasAttachments: boolean | undefined;
+  isEmpty: boolean | undefined;
 };
 
 export type UseComposerIfProps = RequireAtLeastOne<ComposerIfFilters>;
@@ -14,6 +16,14 @@ const useComposerIf = (props: UseComposerIfProps) => {
   return useAssistantState(({ composer }) => {
     if (props.editing === true && !composer.isEditing) return false;
     if (props.editing === false && composer.isEditing) return false;
+
+    if (props.hasAttachments === true && composer.attachments.length === 0)
+      return false;
+    if (props.hasAttachments === false && composer.attachments.length > 0)
+      return false;
+
+    if (props.isEmpty === true && !composer.isEmpty) return false;
+    if (props.isEmpty === false && composer.isEmpty) return false;
 
     return true;
   });


### PR DESCRIPTION
This PR exposing `hasAttachments` and `isEmpty` state to Composer
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expose `hasAttachments` and `isEmpty` states in `ComposerIf` to conditionally render children based on attachments and emptiness.
> 
>   - **Behavior**:
>     - Exposes `hasAttachments` and `isEmpty` states in `ComposerIf` to conditionally render children based on attachments and emptiness.
>     - Updates `useComposerIf` in `ComposerIf.tsx` to handle `hasAttachments` and `isEmpty` conditions.
>   - **Documentation**:
>     - Updates `Composer.mdx` to include `hasAttachments` and `isEmpty` in the API reference and examples.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for f44ab2d77e590d51111ede8e9cd427350b2bcb68. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->