### PR TITLE
docs: change icon for toolui

### DIFF
--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -4,7 +4,7 @@ import {
   ProjectorIcon,
   SparklesIcon,
   WalletIcon,
-  LayoutTemplateIcon,
+  BoltIcon,
 } from "lucide-react";
 import icon from "@/public/favicon/icon.svg";
 import Image from "next/image";
@@ -68,7 +68,7 @@ export const baseOptions: BaseLayoutProps = {
     {
       text: "Tool UI",
       url: "https://tool-ui.com",
-      icon: <LayoutTemplateIcon />,
+      icon: <BoltIcon />,
       external: true,
     },
     {


### PR DESCRIPTION
Replace the imported LayoutTemplateIcon with BoltIcon from lucide-react
and update the Tool UI nav item to use the BoltIcon. This corrects an
incorrect/missing icon import and ensures the documentation layout shows
the intended icon for the external Tool UI link.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `LayoutTemplateIcon` with `BoltIcon` for Tool UI nav item in `layout.shared.tsx` to ensure correct icon display.
> 
>   - **Behavior**:
>     - Replace `LayoutTemplateIcon` with `BoltIcon` for Tool UI nav item in `layout.shared.tsx`.
>     - Ensures correct icon is displayed for external Tool UI link.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 45dabc4b18193a8a6c6fd22cfcd806aa7706fafb. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->