### PR TITLE
fix(docs): fix example githubLinks

### DIFF
--- a/apps/docs/lib/examples.ts
+++ b/apps/docs/lib/examples.ts
@@ -30,7 +30,7 @@ const INTERNAL_EXAMPLES: ExampleItem[] = [
     description: "Customized colors and styles for a ChatGPT look and feel.",
     link: "/examples/chatgpt",
     githubLink:
-      "https://github.com/assistant-ui/assistant-ui/blob/main/apps/docs/components/chatgpt/ChatGPT.tsx",
+      "https://github.com/assistant-ui/assistant-ui/blob/main/apps/docs/components/example/chatgpt/ChatGPT.tsx",
   },
   {
     title: "Claude Clone",
@@ -38,7 +38,7 @@ const INTERNAL_EXAMPLES: ExampleItem[] = [
     description: "Customized colors and styles for a Claude look and feel.",
     link: "/examples/claude",
     githubLink:
-      "https://github.com/assistant-ui/assistant-ui/blob/main/apps/docs/components/claude/Claude.tsx",
+      "https://github.com/assistant-ui/assistant-ui/blob/main/apps/docs/components/example/claude/Claude.tsx",
   },
   {
     title: "Grok Clone",
@@ -54,7 +54,7 @@ const INTERNAL_EXAMPLES: ExampleItem[] = [
     description: "Customized colors and styles for a Perplexity look and feel.",
     link: "/examples/perplexity",
     githubLink:
-      "https://github.com/assistant-ui/assistant-ui/blob/main/apps/docs/components/perplexity/thread.tsx",
+      "https://github.com/assistant-ui/assistant-ui/blob/main/apps/docs/components/example/perplexity/thread.tsx",
   },
   {
     title: "AI SDK",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix incorrect GitHub links for ChatGPT, Claude, and Perplexity examples in `examples.ts`.
> 
>   - **Fixes**:
>     - Corrects `githubLink` for "ChatGPT Clone" in `examples.ts` to `/components/example/chatgpt/ChatGPT.tsx`.
>     - Corrects `githubLink` for "Claude Clone" in `examples.ts` to `/components/example/claude/Claude.tsx`.
>     - Corrects `githubLink` for "Perplexity Clone" in `examples.ts` to `/components/example/perplexity/thread.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 2fac397bde941c0b2d73c715b77614265e588b35. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->