### PR TITLE
ci: remove redundant build step from publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -36,9 +36,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build packages
-        run: pnpm build
-
       - name: Publish to npm
         run: pnpm ci:publish
         env:


### PR DESCRIPTION
Remove the explicit "Build packages" step from the npm publish
workflow in favor of relying on the publish script's own build or
the ci:publish process. This streamlines the workflow, avoids
duplicated work, and reduces CI time by preventing an extra
unnecessary build step.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant build step from npm publish workflow to streamline process and reduce CI time.
> 
>   - **Workflow Changes**:
>     - Remove `Build packages` step from `.github/workflows/npm-publish.yaml`.
>     - Rely on `pnpm ci:publish` for building packages, streamlining the process and reducing CI time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 95bdede3856ad13212cd8e0c16116677d61a731b. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->