### PR TITLE
fix: biome warning

### DIFF
--- a/examples/with-tanstack/src/routes/__root.tsx
+++ b/examples/with-tanstack/src/routes/__root.tsx
@@ -30,6 +30,7 @@ export const Route = createRootRoute({
 function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
+      {/* biome-ignore lint/style/noHeadElement: TanStack Start uses standard HTML head */}
       <head>
         <HeadContent />
       </head>


### PR DESCRIPTION
Add a biome-ignore inline comment to suppress lint/style/noHeadElement
in the RootDocument component. This prevents the linter from flagging the
standard HTML head element used by TanStack Start, avoiding noisy lint
errors while keeping the intended markup.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `biome-ignore` comment in `RootDocument` to suppress `lint/style/noHeadElement` warning for standard HTML head element.
> 
>   - **Linting**:
>     - Add `biome-ignore` comment in `RootDocument` in `__root.tsx` to suppress `lint/style/noHeadElement` warning for standard HTML head element used by TanStack Start.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for b37b6effad4b884678f03b5c30b5dc96be7cd4ae. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->