### PR TITLE
fix: part ordering

### DIFF
--- a/packages/react/src/client/ThreadMessageClient.tsx
+++ b/packages/react/src/client/ThreadMessageClient.tsx
@@ -82,8 +82,8 @@ export const ThreadMessageClient = resource(
     const parts = tapLookupResources(
       message.content.map((part, idx) => [
         "toolCallId" in part && part.toolCallId != null
-          ? part.toolCallId
-          : String(idx),
+          ? `toolCallId-${part.toolCallId}`
+          : `index-${idx}`,
         ThreadMessagePartClient({ part }),
       ]),
     );

--- a/packages/react/src/legacy-runtime/client/MessageRuntimeClient.ts
+++ b/packages/react/src/legacy-runtime/client/MessageRuntimeClient.ts
@@ -72,8 +72,8 @@ export const MessageClient = resource(
     const parts = tapLookupResources(
       runtimeState.content.map((part, idx) => [
         "toolCallId" in part && part.toolCallId != null
-          ? part.toolCallId
-          : String(idx),
+          ? `toolCallId-${part.toolCallId}`
+          : `index-${idx}`,
         MessagePartByIndex({ runtime, index: idx }),
       ]),
     );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update key generation for message parts in `ThreadMessageClient.tsx` and `MessageRuntimeClient.ts` to use `toolCallId-` or `index-` prefixes.
> 
>   - **Behavior**:
>     - Update key generation for message parts in `ThreadMessageClient.tsx` and `MessageRuntimeClient.ts`.
>     - Keys now prefixed with `toolCallId-` if `toolCallId` exists, otherwise `index-`.
>   - **Files Affected**:
>     - `ThreadMessageClient.tsx`: Changes in `tapLookupResources` for `message.content`.
>     - `MessageRuntimeClient.ts`: Changes in `tapLookupResources` for `runtimeState.content`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 74456ff440848d019fe6fd2809c73d733fa72e6a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->