### PR TITLE
fix(react-ai-sdk): do not send message when start run is set to false

### DIFF
--- a/.changeset/fifty-toes-enter.md
+++ b/.changeset/fifty-toes-enter.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+Don't send message in react ai sdk when startrun is set to false

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.tsx
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.tsx
@@ -178,9 +178,22 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       const createMessage = (
         customToCreateMessage ?? toCreateMessage
       )<UI_MESSAGE>(message);
-      await chatHelpers.sendMessage(createMessage, {
-        metadata: message.runConfig,
-      });
+
+      if (message.startRun === false) {
+        chatHelpers.setMessages((messages) => [
+          ...messages,
+          {
+            ...createMessage,
+            id: crypto.randomUUID(),
+            role: createMessage.role ?? "user",
+            metadata: message.runConfig,
+          } as UI_MESSAGE,
+        ]);
+      } else {
+        await chatHelpers.sendMessage(createMessage, {
+          metadata: message.runConfig,
+        });
+      }
     },
     onEdit: async (message) => {
       const newMessages = sliceMessagesUntil(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent message sending in `useAISDKRuntime` when `startRun` is `false`, appending it to chat instead.
> 
>   - **Behavior**:
>     - In `useAISDKRuntime`, prevent sending a message if `message.startRun` is `false`.
>     - Instead, append the message to the chat with a generated `id` and default `role` as `user`.
>   - **Misc**:
>     - Add changeset file `fifty-toes-enter.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 852f605f1f767aa02df37748be1d395f45a0dbbe. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->