### PR TITLE
docs: callout no HITL support in data stream runtime

### DIFF
--- a/apps/docs/content/docs/runtimes/data-stream.mdx
+++ b/apps/docs/content/docs/runtimes/data-stream.mdx
@@ -136,6 +136,13 @@ const runtime = useDataStreamRuntime({
 
 ## Tool Integration
 
+<Callout type="warn">
+  Human-in-the-loop tools (using `human()` for tool interrupts) are not supported
+  in the data stream runtime. If you need human approval workflows or interactive
+  tool UIs, consider using [LocalRuntime](/docs/runtimes/custom/local) or
+  [Assistant Cloud](/docs/cloud/overview) instead.
+</Callout>
+
 ### Frontend Tools
 
 Use the `frontendTools` helper to serialize client-side tools:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a warning in `data-stream.mdx` about no support for human-in-the-loop tools in the data stream runtime.
> 
>   - **Documentation**:
>     - Adds a warning callout in `data-stream.mdx` about the lack of support for human-in-the-loop tools in the data stream runtime.
>     - Suggests using `LocalRuntime` or `Assistant Cloud` for human approval workflows or interactive tool UIs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for ff4e10576ad8ac77f1e3374df095b163946d0824. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->