### PR TITLE
docs: fix and document race condition bug in custom thread history adapter example

### DIFF
--- a/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
+++ b/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
@@ -217,6 +217,42 @@ When the hook mounts it calls `list()` on your adapter, hydrates existing thread
 - `generateTitle()` powers the automatic title button and expects an `AssistantStream`.
 - Provide a `runtimeHook` that always returns a fresh runtime instance per active thread.
 
+## Avoiding Race Conditions in History Adapters
+
+<Callout type="warn">
+When implementing a custom history adapter, you must await thread initialization before saving messages. Failing to do so can cause the first message to be lost due to a race condition.
+</Callout>
+
+If you're building a history adapter that persists messages to your own database, use `api.threadListItem().initialize()` to ensure the thread is fully initialized before saving:
+
+```tsx
+import { useAssistantApi } from "@assistant-ui/react";
+
+// Inside your unstable_Provider component
+const api = useAssistantApi();
+
+const history = useMemo<ThreadHistoryAdapter>(
+  () => ({
+    async append(message) {
+      // Wait for initialization to complete and get the remoteId
+      const { remoteId } = await api.threadListItem().initialize();
+
+      // Now safe to save the message using the remoteId
+      await saveMessageToDatabase(remoteId, message);
+    },
+    // ...
+  }),
+  [api],
+);
+```
+
+The `initialize()` method:
+- Can be called multiple times safely
+- Always waits for the initial `initialize()` call to complete
+- Returns the same `remoteId` on subsequent calls
+
+See `AssistantCloudThreadHistoryAdapter` in the source code for a production-ready reference implementation.
+
 ## Optional Adapters
 
 If you need history or attachment support, expose them via `unstable_Provider`. The cloud implementation wraps each thread runtime with `RuntimeAdapterProvider` to inject:

--- a/apps/docs/content/docs/runtimes/custom/local.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local.mdx
@@ -415,7 +415,7 @@ For custom thread storage, use `useRemoteThreadListRuntime` with your own adapte
 ```tsx
 import {
   unstable_useRemoteThreadListRuntime as useRemoteThreadListRuntime,
-  useThreadListItem,
+  useAssistantApi,
   RuntimeAdapterProvider,
   AssistantRuntimeProvider,
   type unstable_RemoteThreadListAdapter as RemoteThreadListAdapter,
@@ -487,13 +487,13 @@ export function MyRuntimeProvider({ children }) {
       // The Provider component adds thread-specific adapters
       unstable_Provider: ({ children }) => {
         // This runs in the context of each thread
-        const threadListItem = useThreadListItem();
-        const remoteId = threadListItem.remoteId;
+        const api = useAssistantApi();
 
         // Create thread-specific history adapter
         const history = useMemo<ThreadHistoryAdapter>(
           () => ({
             async load() {
+              const { remoteId } = api.threadListItem().getState();
               if (!remoteId) return { messages: [] };
 
               const messages = await db.messages.findByThreadId(remoteId);
@@ -508,10 +508,8 @@ export function MyRuntimeProvider({ children }) {
             },
 
             async append(message) {
-              if (!remoteId) {
-                console.warn("Cannot save message - thread not initialized");
-                return;
-              }
+              // Wait for initialization to get remoteId (safe to call multiple times)
+              const { remoteId } = await api.threadListItem().initialize();
 
               await db.messages.create({
                 threadId: remoteId,
@@ -522,7 +520,7 @@ export function MyRuntimeProvider({ children }) {
               });
             },
           }),
-          [remoteId],
+          [api],
         );
 
         const adapters = useMemo(() => ({ history }), [history]);
@@ -569,6 +567,31 @@ The complete multi-thread implementation requires:
 4. **runtimeHook** - Creates a basic `LocalRuntime` (adapters are added by Provider)
 
 Without the history adapter, threads would have no message persistence, making them effectively useless. The Provider pattern allows you to add thread-specific functionality while keeping the runtime creation simple.
+
+<Callout type="warn" title="Avoiding Race Conditions">
+When implementing a history adapter, `append()` may be called before the thread is fully initialized, causing the first message to be lost. Instead of checking `if (!remoteId)`, await initialization to ensure the `remoteId` is available:
+
+```tsx
+import { useAssistantApi } from "@assistant-ui/react";
+
+// Inside your unstable_Provider component
+const api = useAssistantApi();
+
+const history = useMemo<ThreadHistoryAdapter>(
+  () => ({
+    async append(message) {
+      // Wait for initialization - safe to call multiple times
+      const { remoteId } = await api.threadListItem().initialize();
+      await db.messages.create({ threadId: remoteId, ...message });
+    },
+    // ...
+  }),
+  [api],
+);
+```
+
+See `AssistantCloudThreadHistoryAdapter` in the source for a production reference.
+</Callout>
 
 #### Database Schema Example
 


### PR DESCRIPTION
## Summary
- Fix bug in custom thread history adapter example that caused first message to be lost
- Add documentation explaining the race condition and correct pattern

## Problem
The example code in `local.mdx` had a bug where `append()` would silently drop messages if called before the thread was initialized:

```tsx
if (!remoteId) {
  console.warn("Cannot save message - thread not initialized");
  return; // message lost!
}
```

This was reported in #2869 and #2104.

## Fix
Use `await api.threadListItem().initialize()` which waits for initialization to complete before saving, ensuring no messages are lost:

```tsx
const { remoteId } = await api.threadListItem().initialize();
// now safe to save
```

## Changes
- `apps/docs/content/docs/runtimes/custom/local.mdx`: Fixed example code and added warning callout
- `apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx`: Added "Avoiding Race Conditions in History Adapters" section

Closes #2869
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes race condition in custom thread history adapter example by ensuring thread initialization is awaited before saving messages, and documents the solution.
> 
>   - **Behavior**:
>     - Fixes race condition in `local.mdx` example where `append()` could drop messages if called before thread initialization.
>     - Uses `await api.threadListItem().initialize()` to ensure thread is initialized before saving messages.
>   - **Documentation**:
>     - Adds explanation of race condition and solution in `custom-thread-list.mdx` under "Avoiding Race Conditions in History Adapters".
>     - Adds warning callout in `local.mdx` to highlight the importance of awaiting initialization.
>   - **References**:
>     - Closes issues #2869 and #2104.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 53f86dedb21e20707695f6b7ea4f53a72b7358c0. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->