### PR TITLE
refactor(tap): standardize error messages

### DIFF
--- a/packages/tap/src/core/callResourceFn.ts
+++ b/packages/tap/src/core/callResourceFn.ts
@@ -9,7 +9,7 @@ export function callResourceFn<R, P>(resource: Resource<R, P>, props: P): R {
     fnSymbol
   ];
   if (!fn) {
-    throw new Error("ResourceElement.type is not a valid Resource");
+    throw new Error("tap: invalid resource element");
   }
   return fn(props);
 }

--- a/packages/tap/src/core/commit.ts
+++ b/packages/tap/src/core/commit.ts
@@ -9,7 +9,7 @@ export function commitRender<R, P>(
     const cellIndex = task.cellIndex;
     const effectCell = fiber.cells[cellIndex]!;
     if (effectCell.type !== "effect") {
-      throw new Error("Cannot find effect cell");
+      throw new Error("tap: missing effect cell");
     }
 
     // Check if deps changed
@@ -25,9 +25,7 @@ export function commitRender<R, P>(
     if (shouldRunEffect) {
       if (effectCell.mounted) {
         if (typeof effectCell.deps !== typeof task.deps) {
-          throw new Error(
-            "tapEffect called with and without dependencies across re-renders",
-          );
+          throw new Error("tap: inconsistent effect dependencies");
         }
 
         try {
@@ -41,10 +39,7 @@ export function commitRender<R, P>(
       const cleanup = task.effect();
 
       if (cleanup !== undefined && typeof cleanup !== "function") {
-        throw new Error(
-          "An effect function must either return a cleanup function or nothing. " +
-            `Received: ${typeof cleanup}`,
-        );
+        throw new Error("tap: invalid effect return value");
       }
 
       effectCell.mounted = true;

--- a/packages/tap/src/core/createResource.ts
+++ b/packages/tap/src/core/createResource.ts
@@ -90,7 +90,7 @@ export const createResource = <R, P>(
       return false;
     },
     onUnmount: () => {
-      if (!isMounted) throw new Error("Resource not mounted");
+      if (!isMounted) throw new Error("tap: resource not mounted");
       isMounted = false;
 
       unmountResourceFiber(fiber);

--- a/packages/tap/src/core/execution-context.ts
+++ b/packages/tap/src/core/execution-context.ts
@@ -17,10 +17,7 @@ export function withResourceFiber<R, P>(
 
     // ensure hook count matches
     if (fiber.cells.length !== fiber.currentIndex) {
-      throw new Error(
-        `Rendered ${fiber.currentIndex} hooks but expected ${fiber.cells.length}. ` +
-          "Hooks must be called in the exact same order in every render.",
-      );
+      throw new Error("tap: hook order mismatch");
     }
   } finally {
     currentResourceFiber = previousContext;
@@ -28,7 +25,7 @@ export function withResourceFiber<R, P>(
 }
 export function getCurrentResourceFiber(): ResourceFiber<unknown, unknown> {
   if (!currentResourceFiber) {
-    throw new Error("No resource fiber available");
+    throw new Error("tap: no active resource fiber");
   }
   return currentResourceFiber;
 }

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -51,10 +51,7 @@ const flushScheduled = () => {
       flushDepth++;
 
       if (flushDepth > MAX_FLUSH_LIMIT) {
-        throw new Error(
-          `Maximum update depth exceeded. This can happen when a resource ` +
-            `repeatedly calls setState inside tapEffect.`,
-        );
+        throw new Error("tap: maximum update depth exceeded");
       }
 
       try {

--- a/packages/tap/src/hooks/tap-effect.ts
+++ b/packages/tap/src/hooks/tap-effect.ts
@@ -7,10 +7,7 @@ function getEffectCell(): number {
 
   // Check if we're trying to use more hooks than in previous renders
   if (!fiber.isFirstRender && index >= fiber.cells.length) {
-    throw new Error(
-      "Rendered more hooks than during the previous render. " +
-        "Hooks must be called in the exact same order in every render.",
-    );
+    throw new Error("tap: hook order mismatch");
   }
 
   if (!fiber.cells[index]) {
@@ -25,7 +22,7 @@ function getEffectCell(): number {
 
   const cell = fiber.cells[index];
   if (cell.type !== "effect") {
-    throw new Error("Hook order changed between renders");
+    throw new Error("tap: hook order mismatch");
   }
 
   return index;

--- a/packages/tap/src/hooks/tap-state.ts
+++ b/packages/tap/src/hooks/tap-state.ts
@@ -7,14 +7,14 @@ export namespace tapState {
 
 const rerender = (fiber: ResourceFiber<any, any>) => {
   if (fiber.renderContext) {
-    throw new Error("Resource updated during render");
+    throw new Error("tap: state update during render");
   }
 
   if (fiber.isMounted) {
     // Only schedule rerender if currently mounted
     fiber.scheduleRerender();
   } else if (fiber.isNeverMounted) {
-    throw new Error("Resource updated before mount");
+    throw new Error("tap: state update before mount");
   }
 };
 
@@ -26,10 +26,7 @@ function getStateCell<T>(
 
   // Check if we're trying to use more hooks than in previous renders
   if (!fiber.isFirstRender && index >= fiber.cells.length) {
-    throw new Error(
-      "Rendered more hooks than during the previous render. " +
-        "Hooks must be called in the exact same order in every render.",
-    );
+    throw new Error("tap: hook order mismatch");
   }
 
   if (!fiber.cells[index]) {
@@ -61,7 +58,7 @@ function getStateCell<T>(
 
   const cell = fiber.cells[index];
   if (cell.type !== "state") {
-    throw new Error("Hook order changed between renders");
+    throw new Error("tap: hook order mismatch");
   }
 
   return cell as Cell & { type: "state" };


### PR DESCRIPTION
This PR standardizes internal `tap` invariant error messages.
adds a consistent `tap:` prefix to all internal errors and  shortens messages to match React-style invariants
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Standardizes error messages in `tap` package by adding `tap:` prefix and shortening messages across multiple files.
> 
>   - **Error Message Standardization**:
>     - Adds `tap:` prefix to all error messages for consistency.
>     - Shortens error messages to match React-style invariants.
>   - **Affected Files and Functions**:
>     - `callResourceFn()` in `callResourceFn.ts`: Changes "ResourceElement.type is not a valid Resource" to "tap: invalid resource element".
>     - `commitRender()` in `commit.ts`: Updates multiple error messages, e.g., "Cannot find effect cell" to "tap: missing effect cell".
>     - `createResource()` in `createResource.ts`: Changes "Resource not mounted" to "tap: resource not mounted".
>     - `withResourceFiber()` in `execution-context.ts`: Updates "Rendered X hooks but expected Y" to "tap: hook order mismatch".
>     - `flushScheduled()` in `scheduler.ts`: Changes "Maximum update depth exceeded" to "tap: maximum update depth exceeded".
>     - `getEffectCell()` in `tap-effect.ts` and `getStateCell()` in `tap-state.ts`: Updates "Rendered more hooks than during the previous render" to "tap: hook order mismatch".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for efcd1e1cc2263bb3ac674d4107311f93dd6118ac. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->