### PR TITLE
docs: improve deprecation messages for speech API

### DIFF
--- a/packages/react/src/client/types/Message.ts
+++ b/packages/react/src/client/types/Message.ts
@@ -21,15 +21,17 @@ export type MessageClientState = ThreadMessage & {
    *
    * To enable text-to-speech, provide a `SpeechSynthesisAdapter` to the runtime.
    *
-   * @example, using `useChatRuntime`:
-   *
+   * @example
+   * ```ts
    * import { WebSpeechSynthesisAdapter } from "@assistant-ui/react";
    * import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+   *
    * const runtime = useChatRuntime({
    *   adapters: {
    *     speech: new WebSpeechSynthesisAdapter(),
    *   },
    * });
+   * ```
    */
   readonly speech: SpeechState | undefined;
   /**
@@ -57,11 +59,11 @@ export type MessageClientApi = {
 
   reload(config?: { runConfig?: RunConfig }): void;
   /**
-   * @deprecated The `speak()` method is deprecated. Use the `AssistantActionBar.Speak` component instead.
+   * @deprecated The `speak()` method is deprecated. Use the `ActionBarPrimitive.Speak` component instead.
    */
   speak(): void;
   /**
-   * @deprecated The `stopSpeaking()` method is deprecated. Use the `AssistantActionBar.StopSpeaking` component instead.
+   * @deprecated The `stopSpeaking()` method is deprecated. Use the `ActionBarPrimitive.StopSpeaking` component instead.
    */
   stopSpeaking(): void;
   submitFeedback(feedback: { type: "positive" | "negative" }): void;


### PR DESCRIPTION
closes https://github.com/assistant-ui/assistant-ui/issues/2956
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves deprecation messages for speech API in `Message.ts`, providing clearer guidance on alternatives.
> 
>   - **Deprecation Messages**:
>     - Updated deprecation message for `speech` property in `MessageClientState` to specify removal in a future version and suggest using `SpeechSynthesisAdapter`.
>     - Updated deprecation message for `speak()` method in `MessageClientApi` to suggest using `AssistantActionBar.Speak`.
>     - Updated deprecation message for `stopSpeaking()` method in `MessageClientApi` to suggest using `AssistantActionBar.StopSpeaking`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for e3761e4d7904efd8acaa465d0de0dac9f985d20d. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->