### PR TITLE
refactor(react-devtools): centralize devtools message protocol and payload types

### DIFF
--- a/packages/react-devtools/src/types.ts
+++ b/packages/react-devtools/src/types.ts
@@ -11,3 +11,50 @@ export interface SerializedModelContext {
   callSettings?: Record<string, unknown>;
   config?: Record<string, unknown>;
 }
+
+// Protocol constants
+export const DEVTOOLS_PROTOCOL = "assistant-ui-devtools";
+export const DEVTOOLS_PROTOCOL_VERSION = 1;
+
+// Generic envelope
+export type DevToolsMessage<T> = {
+  protocol: typeof DEVTOOLS_PROTOCOL;
+  version: typeof DEVTOOLS_PROTOCOL_VERSION;
+  payload: T;
+};
+
+export type SubscriptionPayload = {
+  type: "subscription";
+  data: {
+    apiList?: boolean;
+    apis?: number[];
+  };
+};
+
+export type ClearEventsPayload = {
+  type: "clearEvents";
+  data: {
+    apiId: number;
+  };
+};
+
+export type UpdatePayload = {
+  type: "update";
+  data: {
+    apiList?: Array<{ apiId: number }>;
+    apis?: Array<{
+      apiId: number;
+      state: unknown;
+      events: unknown[];
+      modelContext?: unknown;
+    }>;
+  };
+};
+
+export type HostConnectedPayload = {
+  type: "host-connected";
+};
+
+export type FrameToHostPayload = SubscriptionPayload | ClearEventsPayload;
+
+export type HostToFramePayload = UpdatePayload | HostConnectedPayload;


### PR DESCRIPTION
This PR centralizes DevTools iframe message payload types and also introduces a small protocol envelope (name + version).
This allows DevTools to safely ignore unrelated postMessage traffic(e.g. other iframes or extensions) 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Centralizes DevTools message types and introduces a protocol envelope for improved message handling and future-proofing.
> 
>   - **Protocol and Types**:
>     - Introduces `DEVTOOLS_PROTOCOL` and `DEVTOOLS_PROTOCOL_VERSION` constants in `types.ts`.
>     - Defines `DevToolsMessage` type for message envelope in `types.ts`.
>     - Centralizes message payload types in `types.ts`.
>   - **DevToolsHost**:
>     - Updates `DevToolsHost` class in `DevToolsHost.ts` to use `DevToolsMessage` for message handling.
>     - Adds protocol and version checks in `onReceiveMessage()`.
>     - Refactors `sendUpdate()` to include protocol envelope.
>   - **FrameClient**:
>     - Updates `FrameClient` class in `FrameClient.ts` to use `DevToolsMessage` for message handling.
>     - Adds protocol and version checks in `setupMessageListener()`.
>     - Refactors `setSubscription()` and `clearEvents()` to include protocol envelope.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 251620f2030c42be975e8f91e52048a24e4a09eb. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->