### PR TITLE
fix(cli): correct URL for init command

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -38,7 +38,7 @@ export const init = new Command()
         [
           `shadcn@latest`,
           "add",
-          "https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json.json",
+          "https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json",
         ],
         {
           stdio: "inherit",


### PR DESCRIPTION
Closes #2966 
The 'init' command was failing because the underlying 'shadcn add' command was appending an extra '/json' to the registry URL, resulting in a 404 error.
This reverts a portion of the change from PR #2942 which, while standardizing other registry URLs, had an unintended side effect on the 'init' command 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes URL in `init` command in `init.ts` to prevent 404 error by removing extra `/json` from the registry URL.
> 
>   - **Behavior**:
>     - Fixes URL in `init` command in `init.ts` to prevent 404 error by removing extra `/json` from the registry URL.
>     - Reverts part of PR #2942 that caused the issue.
>   - **Misc**:
>     - Closes issue #2966.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 164ebfebf51fac49dc207de18ebc666a9316612a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->