### PR TITLE
fix(docs): add centering and padding to layout containers

### DIFF
--- a/apps/docs/app/safe-content-frame/page.tsx
+++ b/apps/docs/app/safe-content-frame/page.tsx
@@ -129,7 +129,7 @@ export default function SafeContentFramePage() {
   };
 
   return (
-    <div className="container max-w-screen-xl space-y-12 px-4 py-12">
+    <div className="container mx-auto max-w-screen-xl space-y-12 px-4 py-12">
       <div className="flex flex-col items-center space-y-6 text-center">
         <div className="flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm">
           <Shield className="size-4" />

--- a/apps/docs/app/safe-content-frame/safe-content-frame-layout-client.tsx
+++ b/apps/docs/app/safe-content-frame/safe-content-frame-layout-client.tsx
@@ -35,7 +35,7 @@ export function SafeContentFrameLayoutClient({
   return (
     <div className="flex min-h-screen flex-col">
       <header className="sticky top-0 z-50 w-full border-border/40 border-b border-dashed bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-        <div className="container flex h-14 max-w-screen-2xl items-center">
+        <div className="container mx-auto flex h-14 max-w-screen-2xl items-center px-4">
           <div className="mr-4 flex">
             <Link href="/" className="flex items-center space-x-2">
               <Image
@@ -82,7 +82,7 @@ export function SafeContentFrameLayoutClient({
       </header>
       <main className="flex-1">{children}</main>
       <footer className="border-t border-dashed py-6 md:py-0">
-        <div className="container flex h-14 max-w-screen-2xl items-center justify-between text-muted-foreground text-sm">
+        <div className="container mx-auto flex h-14 max-w-screen-2xl items-center justify-between px-4 text-muted-foreground text-sm">
           <p>
             By{" "}
             <Link

--- a/apps/docs/app/tw-shimmer/page.tsx
+++ b/apps/docs/app/tw-shimmer/page.tsx
@@ -52,7 +52,7 @@ export default function TwShimmerPage() {
   }, []);
 
   return (
-    <div className="container max-w-7xl space-y-16 px-4 py-12">
+    <div className="container mx-auto max-w-7xl space-y-16 px-4 py-12">
       <HighlightStyles />
       <div className="mx-auto flex w-fit flex-col items-center space-y-6 text-center">
         <div className="flex cursor-default rounded-full bg-border p-px">

--- a/apps/docs/app/tw-shimmer/tw-shimmer-layout-client.tsx
+++ b/apps/docs/app/tw-shimmer/tw-shimmer-layout-client.tsx
@@ -36,7 +36,7 @@ export function TwShimmerLayoutClient({
   return (
     <div className="flex min-h-screen flex-col">
       <header className="sticky top-0 z-50 w-full border-border/40 border-b border-dashed bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-        <div className="container flex h-14 max-w-screen-2xl items-center">
+        <div className="container mx-auto flex h-14 max-w-screen-2xl items-center px-4">
           <div className="mr-4 flex">
             <Link href="/" className="flex items-center space-x-2">
               <Image
@@ -83,7 +83,7 @@ export function TwShimmerLayoutClient({
       </header>
       <main className="flex-1">{children}</main>
       <footer className="border-t border-dashed py-6 md:py-0">
-        <div className="container flex h-14 max-w-screen-2xl items-center justify-between text-muted-foreground text-sm">
+        <div className="container mx-auto flex h-14 max-w-screen-2xl items-center justify-between px-4 text-muted-foreground text-sm">
           <p>
             By{" "}
             <Link


### PR DESCRIPTION
Fixes layout alignment on /safe-content-frame and /tw-shimmer pages by adding `mx-auto` and `px-4` to container elements.

Replaces #2972 stuck on CodeQL.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add centering and padding to layout containers in `safe-content-frame` and `tw-shimmer` pages.
> 
>   - **Layout Changes**:
>     - Add `mx-auto` and `px-4` to container elements in `safe-content-frame/page.tsx` and `tw-shimmer/page.tsx` for centering and padding.
>     - Update `safe-content-frame-layout-client.tsx` and `tw-shimmer-layout-client.tsx` to include `mx-auto` and `px-4` in header and footer containers.
>   - **Misc**:
>     - Replaces PR #2972 due to branch name issues with CodeQL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for b09cc1fca7a944507d98986a029961ef3c1e83c6. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->