### PR TITLE
fix: update metadata base URL retrieval logic

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -7,14 +7,6 @@ import { Provider } from "./provider";
 import { cn } from "@/lib/utils";
 
 const getMetadataBase = () => {
-  const appUrl = process.env["NEXT_PUBLIC_APP_URL"];
-  if (appUrl) {
-    return new URL(appUrl);
-  }
-  const vercelUrl = process.env["VERCEL_URL"];
-  if (vercelUrl) {
-    return new URL(`https://${vercelUrl}`);
-  }
   if (process.env.NODE_ENV === "production") {
     return new URL("https://www.assistant-ui.com");
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies metadata base URL retrieval in `layout.tsx` by removing environment variable checks for `NEXT_PUBLIC_APP_URL` and `VERCEL_URL`.
> 
>   - **Behavior**:
>     - Simplifies `getMetadataBase()` in `layout.tsx` by removing checks for `NEXT_PUBLIC_APP_URL` and `VERCEL_URL`.
>     - Now only checks `NODE_ENV` to determine if the base URL should be `https://www.assistant-ui.com` or `http://localhost:3000`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 3f98fb32f51d9de676593f27a2a0473c88a21323. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->