### PR TITLE
fix(react-ai-sdk): process attachments on assistant messages

### DIFF
--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -223,6 +223,31 @@ export const AISDKMessageConverter = unstable_createMessageConverter(
           id: message.id,
           createdAt,
           content: convertParts(message, metadata),
+          attachments: message.parts
+            ?.filter((p) => p.type === "file")
+            .map((part, idx) => {
+              return {
+                id: idx.toString(),
+                type: part.mediaType.startsWith("image/") ? "image" : "file",
+                name: part.filename ?? "file",
+                content: [
+                  part.mediaType.startsWith("image/")
+                    ? {
+                        type: "image",
+                        image: part.url,
+                        filename: part.filename!,
+                      }
+                    : {
+                        type: "file",
+                        filename: part.filename!,
+                        data: part.url,
+                        mimeType: part.mediaType,
+                      },
+                ],
+                contentType: part.mediaType ?? "unknown/unknown",
+                status: { type: "complete" as const },
+              };
+            }),
           metadata: {
             unstable_annotations: (message as any).annotations,
             unstable_data: Array.isArray((message as any).data)


### PR DESCRIPTION
closes https://github.com/assistant-ui/assistant-ui/issues/2985
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Process attachments in assistant messages in `AISDKMessageConverter` in `convertMessage.ts`, handling both image and non-image files.
> 
>   - **Behavior**:
>     - Process attachments in assistant messages in `AISDKMessageConverter` in `convertMessage.ts`.
>     - Filters `message.parts` for type `file` and maps them to attachment objects with `id`, `type`, `name`, `content`, `contentType`, and `status`.
>     - Handles both image and non-image files, setting `type` to `image` or `file` based on `mediaType`.
>   - **Misc**:
>     - Closes issue #2985.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for a6bc770578b13f89bc4e7358bf5125e8a6743ea6. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->