### PR TITLE
feat(core): enable attatchments on assistant messages

### DIFF
--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -320,6 +320,7 @@ export class AgUiThreadRuntimeCore {
       createdAt: new Date(),
       status: { type: "running" },
       content: [],
+      attachments: [],
       metadata: {
         unstable_state: this.stateSnapshot ?? null,
         unstable_annotations: [],

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -223,6 +223,31 @@ export const AISDKMessageConverter = unstable_createMessageConverter(
           id: message.id,
           createdAt,
           content: convertParts(message, metadata),
+          attachments: message.parts
+            ?.filter((p) => p.type === "file")
+            .map((part, idx) => {
+              return {
+                id: idx.toString(),
+                type: part.mediaType.startsWith("image/") ? "image" : "file",
+                name: part.filename ?? "file",
+                content: [
+                  part.mediaType.startsWith("image/")
+                    ? {
+                        type: "image",
+                        image: part.url,
+                        filename: part.filename!,
+                      }
+                    : {
+                        type: "file",
+                        filename: part.filename!,
+                        data: part.url,
+                        mimeType: part.mediaType,
+                      },
+                ],
+                contentType: part.mediaType ?? "unknown/unknown",
+                status: { type: "complete" as const },
+              };
+            }),
           metadata: {
             unstable_annotations: (message as any).annotations,
             unstable_data: Array.isArray((message as any).data)

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/ThreadMessageLike.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/ThreadMessageLike.tsx
@@ -95,9 +95,6 @@ export const fromThreadMessageLike = (
     return null;
   };
 
-  if (role !== "user" && attachments?.length)
-    throw new Error("attachments are only supported for user messages");
-
   if (role !== "assistant" && status)
     throw new Error("status is only supported for assistant messages");
 
@@ -160,6 +157,7 @@ export const fromThreadMessageLike = (
             }
           })
           .filter((c) => !!c),
+        attachments: attachments ?? [],
         status: status ?? fallbackStatus,
         metadata: {
           unstable_state: metadata?.unstable_state ?? null,

--- a/packages/react/src/legacy-runtime/runtime-cores/local/LocalThreadRuntimeCore.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/local/LocalThreadRuntimeCore.tsx
@@ -191,6 +191,7 @@ export class LocalThreadRuntimeCore
       role: "assistant",
       status: { type: "running" },
       content: [],
+      attachments: [],
       metadata: {
         unstable_state: this.state,
         unstable_annotations: [],

--- a/packages/react/src/types/AssistantTypes.ts
+++ b/packages/react/src/types/AssistantTypes.ts
@@ -124,6 +124,7 @@ export type ThreadUserMessage = MessageCommonProps & {
 export type ThreadAssistantMessage = MessageCommonProps & {
   readonly role: "assistant";
   readonly content: readonly ThreadAssistantMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
   readonly status: MessageStatus;
   readonly metadata: {
     readonly unstable_state: ReadonlyJSONValue;


### PR DESCRIPTION
closes https://github.com/assistant-ui/assistant-ui/issues/2985
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable attachments for assistant messages by updating message conversion, type definitions, and runtime handling.
> 
>   - **Behavior**:
>     - Enable attachments for assistant messages in `convertMessage.ts` by filtering and mapping `message.parts` with type `file`.
>     - Remove error for non-user message attachments in `fromThreadMessageLike()` in `ThreadMessageLike.tsx`.
>   - **Types**:
>     - Add `attachments` to `ThreadAssistantMessage` in `AssistantTypes.ts`.
>   - **Runtime**:
>     - Initialize `attachments` as an empty array for assistant messages in `LocalThreadRuntimeCore.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for e7313e91c0244df3b5f61e025ccccc86355ae9e0. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->