### PR TITLE
fix(react): prevent crash on new thread creation

### DIFF
--- a/.changeset/purple-bottles-do.md
+++ b/.changeset/purple-bottles-do.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": minor
+---
+
+fix(react): prevent crash on new thread creation


### PR DESCRIPTION
  This PR fixes a  race condition in the useRemoteThreadListRuntime hook that occurs when a user is implementing a  thread list.

 ### Problem:

  When the runtime is initialized, it immediately creates a new thread for the user to interact with. However, the 
  switchToThread function did not wait for the new thread's runtime to be fully created before notifying the UI to 
  re-render. This resulted in the UI attempting to render an input field for a thread that wasn't ready, leading to a 
  crash with the error: `Uncaught Error: This is the empty thread, a placeholder for the main thread....`

Reference - https://canary.discord.com/channels/1251324227668283443/1268446361192497164/threads/1442287267602501783

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes race condition in `switchToThread()` in `RemoteThreadListThreadListRuntimeCore.tsx` to prevent UI crash on new thread creation.
> 
>   - **Behavior**:
>     - Fixes race condition in `switchToThread()` in `RemoteThreadListThreadListRuntimeCore.tsx` by awaiting `task` to ensure thread runtime is fully initialized before UI re-renders.
>     - Prevents crash when rendering input field for uninitialized thread, resolving error: `Uncaught Error: This is the empty thread, a placeholder for the main thread...`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 3f621792b2aa9eae5ac16a63cbee753652bca84f. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->