### PR TITLE
fix(react-langgraph): correctly return externalId on thread creation

### DIFF
--- a/.changeset/soft-roses-turn.md
+++ b/.changeset/soft-roses-turn.md
@@ -1,5 +1,9 @@
 ---
 "@assistant-ui/react-langgraph": minor
+"@assistant-ui/react": patch
 ---
 
-fix(react-langgraph): correctly return externalId on thread creation
+fix: resolve "Thread not found" error in thread creation
+
+- fix(react-langgraph): correctly return externalId shape from useLangGraphRuntime create function
+- fix(react): properly handle missing create function in cloud adapter initialize method

--- a/.changeset/soft-roses-turn.md
+++ b/.changeset/soft-roses-turn.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": minor
+---
+
+fix(react-langgraph): correctly return externalId on thread creation

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -346,7 +346,8 @@ export const useLangGraphRuntime = ({
       }
 
       if (api.threadListItem.source) {
-        return api.threadListItem().initialize();
+        const { externalId } = await api.threadListItem().initialize();
+        return { externalId };
       }
 
       throw new Error(

--- a/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/adapter/cloud.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/adapter/cloud.tsx
@@ -88,9 +88,13 @@ export const useCloudThreadListAdapter = (
     },
 
     initialize: async () => {
-      const createTask = adapter.create?.() ?? Promise.resolve();
-      const t = await createTask;
-      const external_id = t ? t.externalId : undefined;
+      let external_id: string | undefined;
+
+      if (adapter.create) {
+        const result = await adapter.create();
+        external_id = result.externalId;
+      }
+
       const { thread_id: remoteId } = await cloud.threads.create({
         last_message_at: new Date(),
         external_id,


### PR DESCRIPTION
 This PR fixes a `Thread not found` error  by correcting how th `externalId` is handled during thread creation in nested runtimes.
  
  ### The Bug
  
  The `create` function in `useLangGraphRuntime` was returning an object with an incorrect shape, causing the  `externalId` to be lost.
  
  ### The Fix
 
 In `useLangGraphRuntime`: The `create` function now correctly destructures the `externalId` from the result of api.threadListItem().initialize()` and returns it in the expected format.
 
In `cloud.tsx`: The `initialize` method now explicitly checks if adapter.create exists before calling it.
Reference - https://canary.discord.com/channels/1251324227668283443/1268446361192497164/threads/1447348641218957474

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `Thread not found` error in `useLangGraphRuntime` by correctly handling `externalId` during thread creation.
> 
>   - **Bug Fix**:
>     - Fix `Thread not found` error in `useLangGraphRuntime` by correctly handling `externalId` during thread creation.
>   - **Implementation**:
>     - In `useLangGraphRuntime`, update `create` function to destructure `externalId` from `api.threadListItem().initialize()` and return it in the correct format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for f87fa3ecb673cfb31b2845463cc9dcdde7476e40. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->