### PR TITLE
fix(docs): add gap between blog posts

### DIFF
--- a/apps/docs/app/(home)/blog/page.tsx
+++ b/apps/docs/app/(home)/blog/page.tsx
@@ -20,7 +20,7 @@ export default function Page(): React.ReactElement {
   return (
     <main className="mx-auto w-full max-w-screen-sm p-4 py-12">
       <h1 className="mb-4 px-4 pb-2 font-bold text-4xl">assistant-ui Blog</h1>
-      <div className="flex flex-col">
+      <div className="flex flex-col gap-2">
         {posts.map((post) => (
           <Link
             key={post.url}


### PR DESCRIPTION
### Before 
<img width="1919" height="957" alt="Screenshot from 2026-01-12 12-24-57" src="https://github.com/user-attachments/assets/fb7132fa-df37-406d-a226-ac3208f29f87" />

 ###  After 
<img width="1919" height="957" alt="Screenshot from 2026-01-12 12-32-08" src="https://github.com/user-attachments/assets/f6467f36-2007-4ee9-b9f2-77ba9d8f4137" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `gap-2` class to `div` in `page.tsx` for spacing between blog posts.
> 
>   - **UI Improvement**:
>     - Adds `gap-2` class to `div` in `page.tsx` to create space between blog posts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 4807fd84c70aeed97753163244c96290fc888087. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->