### PR TITLE
fix(registry): css import syntax

### DIFF
--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -110,7 +110,7 @@ export const registry: RegistryItem[] = [
       "tw-shimmer",
     ],
     css: {
-      "@import \"tw-shimmer\"": {},
+      '@import "tw-shimmer"': {},
     },
   },
   {


### PR DESCRIPTION
resolved bug where `assistant-ui add [component]` command writes an empty `@import;` in css file.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes CSS import syntax in `registry.ts` to correctly import `tw-shimmer`.
> 
>   - **Bug Fix**:
>     - Corrects CSS import syntax in `registry.ts` by changing `@import` to `@import "tw-shimmer"` to fix empty `@import;` issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 842359b764289c95705235069f9267445342efbd. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->