### PR TITLE
fix: properly deprecate and alias useLocalThreadRuntime

### DIFF
--- a/.changeset/restore-use-local-thread-runtime.md
+++ b/.changeset/restore-use-local-thread-runtime.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: restore `useLocalThreadRuntime` export as deprecated alias to `useLocalRuntime`

--- a/packages/react/src/legacy-runtime/runtime-cores/local/index.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/local/index.ts
@@ -1,4 +1,10 @@
 export { useLocalRuntime } from "./useLocalRuntime";
+
+/**
+ * @deprecated Use `useLocalRuntime` instead.
+ */
+export { useLocalRuntime as useLocalThreadRuntime } from "./useLocalRuntime";
+
 export type { LocalRuntimeOptions } from "./LocalRuntimeOptions";
 export type {
   ChatModelAdapter,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Restores `useLocalThreadRuntime` as a deprecated alias for `useLocalRuntime` to maintain backward compatibility.
> 
>   - **Deprecation and Alias**:
>     - Restores `useLocalThreadRuntime` as a deprecated alias for `useLocalRuntime` in `index.ts`.
>     - Adds a deprecation comment to guide users to use `useLocalRuntime` instead.
>   - **Documentation**:
>     - Adds a changeset file `restore-use-local-thread-runtime.md` to document the change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for e40690910c748cf3945f4b478a70682520b72603. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->