### PR TITLE
fix(react-ag-ui): convert Zod schemas to JSON Schema

### DIFF
--- a/packages/react-ag-ui/package.json
+++ b/packages/react-ag-ui/package.json
@@ -36,7 +36,8 @@
   },
   "dependencies": {
     "@ag-ui/client": "^0.0.42",
-    "assistant-stream": "^0.2.46"
+    "assistant-stream": "^0.2.46",
+    "zod": "^4.3.5"
   },
   "peerDependencies": {
     "@assistant-ui/react": "^0.11.56",

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { z } from "zod";
+
 type ThreadMessageLike = {
   id: string;
   role: string;
@@ -156,10 +158,12 @@ export const toAgUiTools = (tools: Record<string, any> | undefined) => {
       name,
       description: tool?.description ?? undefined,
       parameters:
-        typeof tool?.parameters?.toJSON === "function"
-          ? tool.parameters.toJSON()
-          : typeof tool?.parameters?.toJSONSchema === "function"
-            ? tool.parameters.toJSONSchema()
-            : tool?.parameters,
+        tool?.parameters instanceof z.ZodType
+          ? z.toJSONSchema(tool.parameters)
+          : typeof tool?.parameters?.toJSON === "function"
+            ? tool.parameters.toJSON()
+            : typeof tool?.parameters?.toJSONSchema === "function"
+              ? tool.parameters.toJSONSchema()
+              : tool?.parameters,
     }));
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1948,6 +1948,9 @@ importers:
       assistant-stream:
         specifier: ^0.2.46
         version: link:../assistant-stream
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.5
     devDependencies:
       '@assistant-ui/react':
         specifier: workspace:*


### PR DESCRIPTION
This PR adds Zod schema detection in `toAgUiTools()` using `z.toJSONSchema()` to prevent `structuredClone` failures when AG-UI client processes tool definitions containing Zod objects.

close #3057
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Convert Zod schemas to JSON Schema in `toAgUiTools()` to prevent `structuredClone` errors.
> 
>   - **Behavior**:
>     - `toAgUiTools()` in `conversions.ts` now converts Zod schemas to JSON Schema using `z.toJSONSchema()` to prevent `structuredClone` errors.
>     - Handles cases where `tool.parameters` is a Zod object, JSON object, or has `toJSON`/`toJSONSchema` methods.
>   - **Dependencies**:
>     - Adds `zod` as a dependency in `package.json`.
>   - **Tests**:
>     - Adds test in `conversions.spec.ts` to verify Zod schema conversion to JSON Schema format.
>     - Ensures converted parameters are plain JSON objects, not Zod instances.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 556765407ada25135ad9c5cf8271b5fd0140de8f. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->