### PR TITLE
fix(react-ai-sdk): preserve attatchments when loading via setMessages

### DIFF
--- a/.changeset/many-roses-shout.md
+++ b/.changeset/many-roses-shout.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix(react-ai-sdk): preserve attachments when loading messages via setMessages

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.tsx
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.tsx
@@ -18,13 +18,13 @@ import {
 import { sliceMessagesUntil } from "../utils/sliceMessagesUntil";
 import { toCreateMessage } from "../utils/toCreateMessage";
 import { vercelAttachmentAdapter } from "../utils/vercelAttachmentAdapter";
-import { getVercelAIMessages } from "../getVercelAIMessages";
 import { AISDKMessageConverter } from "../utils/convertMessage";
 import {
   type AISDKStorageFormat,
   aiSDKV5FormatAdapter,
 } from "../adapters/aiSDKFormatAdapter";
 import { useExternalHistory } from "./useExternalHistory";
+import { threadMessageToUIMessage } from "../utils/threadMessageToUIMessage";
 
 export type CustomToCreateMessageFunction = <
   UI_MESSAGE extends UIMessage = UIMessage,
@@ -156,17 +156,11 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     messages,
     setMessages: (messages) =>
       chatHelpers.setMessages(
-        messages
-          .map(getVercelAIMessages<UI_MESSAGE>)
-          .filter(Boolean)
-          .flat(),
+        messages.map(threadMessageToUIMessage) as UI_MESSAGE[],
       ),
     onImport: (messages) =>
       chatHelpers.setMessages(
-        messages
-          .map(getVercelAIMessages<UI_MESSAGE>)
-          .filter(Boolean)
-          .flat(),
+        messages.map(threadMessageToUIMessage) as UI_MESSAGE[],
       ),
     onCancel: async () => {
       chatHelpers.stop();

--- a/packages/react-ai-sdk/src/ui/utils/threadMessageToUIMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/threadMessageToUIMessage.ts
@@ -1,0 +1,39 @@
+import type { ThreadMessage } from "@assistant-ui/react";
+import type { UIMessage } from "@ai-sdk/react";
+
+export function threadMessageToUIMessage(message: ThreadMessage): UIMessage {
+  const parts: NonNullable<UIMessage["parts"]> = [];
+
+  for (const content of message.content) {
+    if (content.type === "text") {
+      parts.push({ type: "text", text: content.text });
+    }
+  }
+
+  if (message.attachments) {
+    for (const attachment of message.attachments) {
+      const content = attachment.content[0];
+      if (attachment.type === "image" && content?.type === "image") {
+        parts.push({
+          type: "file",
+          filename: attachment.name,
+          mediaType: attachment.contentType,
+          url: content.image,
+        });
+      } else if (attachment.type === "file" && content?.type === "file") {
+        parts.push({
+          type: "file",
+          filename: attachment.name,
+          mediaType: attachment.contentType,
+          url: content.data,
+        });
+      }
+    }
+  }
+
+  return {
+    id: message.id,
+    role: message.role,
+    parts: parts,
+  } as UIMessage;
+}


### PR DESCRIPTION
closes https://github.com/assistant-ui/assistant-ui/issues/2985
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes attachment preservation in `react-ai-sdk` by using `threadMessageToUIMessage` for message conversion in `useAISDKRuntime.tsx`.
> 
>   - **Behavior**:
>     - Fixes attachment preservation when loading messages via `setMessages` in `useAISDKRuntime.tsx`.
>     - Replaces `getVercelAIMessages` with `threadMessageToUIMessage` for message conversion.
>   - **Functions**:
>     - Adds `threadMessageToUIMessage` in `threadMessageToUIMessage.ts` to convert `ThreadMessage` to `UIMessage`, preserving text and attachments.
>   - **Misc**:
>     - Removes unused import `getVercelAIMessages` from `useAISDKRuntime.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 7d49b1ba6da11a4aabb2e5fb15cedb1facd29685. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->