### PR TITLE
fix(react-ag-ui): use `threadId` instead of hardcoded `main`

### DIFF
--- a/.changeset/fix-ag-ui-threadid.md
+++ b/.changeset/fix-ag-ui-threadid.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix(react-ag-ui): use `threadId` instead of hardcoded `main`

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -280,7 +280,7 @@ export class AgUiThreadRuntimeCore {
     runConfig: RunConfig | undefined,
     historyMessages: readonly ThreadMessage[] | undefined,
   ) {
-    const threadId = "main";
+    const threadId = this.agent.threadId || "main";
     const messages = toAgUiMessages(historyMessages ?? this.messages);
     const context = this.runtime?.thread.getModelContext();
     return {


### PR DESCRIPTION
This PR uses `threadId` instead of hardcoded `main`.

close #3087
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace hardcoded `threadId` with dynamic `this.agent.threadId` in `AgUiThreadRuntimeCore.ts`.
> 
>   - **Behavior**:
>     - In `AgUiThreadRuntimeCore.ts`, replace hardcoded `threadId` "main" with `this.agent.threadId || "main"` in `buildRunInput()`.
>   - **Misc**:
>     - Add changeset file `fix-ag-ui-threadid.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 4799f6d7f54fbacca3ef1c98b584ebfafc234971. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->