### PR TITLE
fix(react): bind `this` context when calling `__internal_setGetInitializePromise`

### DIFF
--- a/.changeset/fix-this-context-binding.md
+++ b/.changeset/fix-this-context-binding.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): bind `this` context when calling `__internal_setGetInitializePromise`

--- a/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/RemoteThreadListHookInstanceManager.tsx
@@ -112,7 +112,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
         "__internal_setGetInitializePromise"
       ];
       if (typeof setGetInitializePromise === "function") {
-        setGetInitializePromise(() => initPromiseRef.current);
+        setGetInitializePromise.call(runtimeCore, () => initPromiseRef.current);
       }
     }, [threadBinding]);
 


### PR DESCRIPTION
This PR binds `this` context when calling `__internal_setGetInitializePromise`

fixes #3093
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `this` context binding for `__internal_setGetInitializePromise` in `RemoteThreadListHookInstanceManager.tsx`.
> 
>   - **Behavior**:
>     - Fixes `this` context binding for `__internal_setGetInitializePromise` in `RemoteThreadListHookInstanceManager.tsx`.
>     - Ensures `setGetInitializePromise` is called with the correct `runtimeCore` context.
>   - **Misc**:
>     - Adds changeset file `fix-this-context-binding.md` for version tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 777422f78f8ad8a2dc054799fd3a670c3f61271b. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->