### PR TITLE
fix(registry): replace `<Image />` with `<img />` for attachment previews

### DIFF
--- a/apps/docs/components/assistant-ui/attachment.tsx
+++ b/apps/docs/components/assistant-ui/attachment.tsx
@@ -74,7 +74,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
         "block h-auto max-h-[80vh] w-auto max-w-full object-contain",
         isLoaded
           ? "aui-attachment-preview-image-loaded"
-          : "aui-attachment-preview-image-loading invisible"
+          : "aui-attachment-preview-image-loading invisible",
       )}
       onLoad={() => setIsLoaded(true)}
     />

--- a/apps/registry/components/assistant-ui/attachment.tsx
+++ b/apps/registry/components/assistant-ui/attachment.tsx
@@ -74,7 +74,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
         "block h-auto max-h-[80vh] w-auto max-w-full object-contain",
         isLoaded
           ? "aui-attachment-preview-image-loaded"
-          : "aui-attachment-preview-image-loading invisible"
+          : "aui-attachment-preview-image-loading invisible",
       )}
       onLoad={() => setIsLoaded(true)}
     />

--- a/examples/with-ag-ui/components/assistant-ui/attachment.tsx
+++ b/examples/with-ag-ui/components/assistant-ui/attachment.tsx
@@ -74,7 +74,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
         "block h-auto max-h-[80vh] w-auto max-w-full object-contain",
         isLoaded
           ? "aui-attachment-preview-image-loaded"
-          : "aui-attachment-preview-image-loading invisible"
+          : "aui-attachment-preview-image-loading invisible",
       )}
       onLoad={() => setIsLoaded(true)}
     />

--- a/examples/with-ai-sdk-v6/components/assistant-ui/attachment.tsx
+++ b/examples/with-ai-sdk-v6/components/assistant-ui/attachment.tsx
@@ -74,7 +74,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
         "block h-auto max-h-[80vh] w-auto max-w-full object-contain",
         isLoaded
           ? "aui-attachment-preview-image-loaded"
-          : "aui-attachment-preview-image-loading invisible"
+          : "aui-attachment-preview-image-loading invisible",
       )}
       onLoad={() => setIsLoaded(true)}
     />

--- a/examples/with-assistant-transport/components/assistant-ui/attachment.tsx
+++ b/examples/with-assistant-transport/components/assistant-ui/attachment.tsx
@@ -74,7 +74,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
         "block h-auto max-h-[80vh] w-auto max-w-full object-contain",
         isLoaded
           ? "aui-attachment-preview-image-loaded"
-          : "aui-attachment-preview-image-loading invisible"
+          : "aui-attachment-preview-image-loading invisible",
       )}
       onLoad={() => setIsLoaded(true)}
     />

--- a/examples/with-cloud/components/assistant-ui/attachment.tsx
+++ b/examples/with-cloud/components/assistant-ui/attachment.tsx
@@ -74,7 +74,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
         "block h-auto max-h-[80vh] w-auto max-w-full object-contain",
         isLoaded
           ? "aui-attachment-preview-image-loaded"
-          : "aui-attachment-preview-image-loading invisible"
+          : "aui-attachment-preview-image-loading invisible",
       )}
       onLoad={() => setIsLoaded(true)}
     />

--- a/examples/with-custom-thread-list/components/assistant-ui/attachment.tsx
+++ b/examples/with-custom-thread-list/components/assistant-ui/attachment.tsx
@@ -74,7 +74,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
         "block h-auto max-h-[80vh] w-auto max-w-full object-contain",
         isLoaded
           ? "aui-attachment-preview-image-loaded"
-          : "aui-attachment-preview-image-loading invisible"
+          : "aui-attachment-preview-image-loading invisible",
       )}
       onLoad={() => setIsLoaded(true)}
     />

--- a/examples/with-elevenlabs-scribe/components/assistant-ui/attachment.tsx
+++ b/examples/with-elevenlabs-scribe/components/assistant-ui/attachment.tsx
@@ -74,7 +74,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
         "block h-auto max-h-[80vh] w-auto max-w-full object-contain",
         isLoaded
           ? "aui-attachment-preview-image-loaded"
-          : "aui-attachment-preview-image-loading invisible"
+          : "aui-attachment-preview-image-loading invisible",
       )}
       onLoad={() => setIsLoaded(true)}
     />

--- a/examples/with-external-store/components/assistant-ui/attachment.tsx
+++ b/examples/with-external-store/components/assistant-ui/attachment.tsx
@@ -74,7 +74,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
         "block h-auto max-h-[80vh] w-auto max-w-full object-contain",
         isLoaded
           ? "aui-attachment-preview-image-loaded"
-          : "aui-attachment-preview-image-loading invisible"
+          : "aui-attachment-preview-image-loading invisible",
       )}
       onLoad={() => setIsLoaded(true)}
     />

--- a/examples/with-ffmpeg/components/assistant-ui/attachment.tsx
+++ b/examples/with-ffmpeg/components/assistant-ui/attachment.tsx
@@ -74,7 +74,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
         "block h-auto max-h-[80vh] w-auto max-w-full object-contain",
         isLoaded
           ? "aui-attachment-preview-image-loaded"
-          : "aui-attachment-preview-image-loading invisible"
+          : "aui-attachment-preview-image-loading invisible",
       )}
       onLoad={() => setIsLoaded(true)}
     />

--- a/examples/with-langgraph/components/assistant-ui/attachment.tsx
+++ b/examples/with-langgraph/components/assistant-ui/attachment.tsx
@@ -74,7 +74,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
         "block h-auto max-h-[80vh] w-auto max-w-full object-contain",
         isLoaded
           ? "aui-attachment-preview-image-loaded"
-          : "aui-attachment-preview-image-loading invisible"
+          : "aui-attachment-preview-image-loading invisible",
       )}
       onLoad={() => setIsLoaded(true)}
     />

--- a/examples/with-parent-id-grouping/components/assistant-ui/attachment.tsx
+++ b/examples/with-parent-id-grouping/components/assistant-ui/attachment.tsx
@@ -74,7 +74,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
         "block h-auto max-h-[80vh] w-auto max-w-full object-contain",
         isLoaded
           ? "aui-attachment-preview-image-loaded"
-          : "aui-attachment-preview-image-loading invisible"
+          : "aui-attachment-preview-image-loading invisible",
       )}
       onLoad={() => setIsLoaded(true)}
     />

--- a/examples/with-react-hook-form/components/assistant-ui/attachment.tsx
+++ b/examples/with-react-hook-form/components/assistant-ui/attachment.tsx
@@ -74,7 +74,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
         "block h-auto max-h-[80vh] w-auto max-w-full object-contain",
         isLoaded
           ? "aui-attachment-preview-image-loaded"
-          : "aui-attachment-preview-image-loading invisible"
+          : "aui-attachment-preview-image-loading invisible",
       )}
       onLoad={() => setIsLoaded(true)}
     />


### PR DESCRIPTION
next.js image component doesn’t play well with remote images, better to use normal img tag here.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replace `next/image` with `img` for attachment previews to improve remote image handling across multiple components.
> 
>   - **Behavior**:
>     - Replace `next/image` with `img` in `AttachmentPreview` component for better remote image handling.
>     - Update `onLoad` event to set `isLoaded` state in `AttachmentPreview`.
>   - **Files Affected**:
>     - `attachment.tsx` in `apps/docs/components/assistant-ui` and `apps/registry/components/assistant-ui`.
>     - `attachment.tsx` in `examples/with-ag-ui/components/assistant-ui` and `examples/with-ai-sdk-v6/components/assistant-ui`.
>     - `attachment.tsx` in `examples/with-assistant-transport/components/assistant-ui` and 8 other places.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 5c9a2060e02782f482fe3c19e7d8eb19bd5bea4d. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->