### PR TITLE
fix: race condition on RemoteThreadListRuntime causing crash

### DIFF
--- a/.changeset/nice-hotels-write.md
+++ b/.changeset/nice-hotels-write.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: race condition in RemoteThreadListRuntime causing app crash on thread deletion

--- a/packages/react/src/context/providers/ThreadListItemProvider.tsx
+++ b/packages/react/src/context/providers/ThreadListItemProvider.tsx
@@ -2,6 +2,8 @@
 
 import { type FC, type PropsWithChildren } from "react";
 import { useAui, AuiProvider, Derived } from "@assistant-ui/store";
+import type { ThreadListItemRuntime } from "../../legacy-runtime/runtime/ThreadListItemRuntime";
+import { ThreadListItemClient } from "../../legacy-runtime/client/ThreadListItemRuntimeClient";
 
 export const ThreadListItemByIndexProvider: FC<
   PropsWithChildren<{
@@ -20,17 +22,13 @@ export const ThreadListItemByIndexProvider: FC<
   return <AuiProvider value={aui}>{children}</AuiProvider>;
 };
 
-export const ThreadListItemByIdProvider: FC<
+export const ThreadListItemRuntimeProvider: FC<
   PropsWithChildren<{
-    id: string;
+    runtime: ThreadListItemRuntime;
   }>
-> = ({ id, children }) => {
+> = ({ runtime, children }) => {
   const aui = useAui({
-    threadListItem: Derived({
-      source: "threads",
-      query: { type: "id", id },
-      get: (aui) => aui.threads().item({ id }),
-    }),
+    threadListItem: ThreadListItemClient({ runtime }),
   });
 
   return <AuiProvider value={aui}>{children}</AuiProvider>;

--- a/packages/react/src/context/providers/index.ts
+++ b/packages/react/src/context/providers/index.ts
@@ -1,7 +1,7 @@
 export { AssistantRuntimeProvider } from "../../legacy-runtime/AssistantRuntimeProvider";
 export {
   ThreadListItemByIndexProvider,
-  ThreadListItemByIdProvider,
+  ThreadListItemRuntimeProvider,
 } from "./ThreadListItemProvider";
 export { MessageByIndexProvider } from "./MessageByIndexProvider";
 export { PartByIndexProvider } from "./PartByIndexProvider";

--- a/packages/react/src/legacy-runtime/client/ThreadListRuntimeClient.ts
+++ b/packages/react/src/legacy-runtime/client/ThreadListRuntimeClient.ts
@@ -57,10 +57,10 @@ export const ThreadListClient = resource(
     const state = tapMemo<ThreadsState>(() => {
       return {
         mainThreadId: runtimeState.mainThreadId,
-        newThreadId: runtimeState.newThread ?? null,
+        newThreadId: runtimeState.newThreadId ?? null,
         isLoading: runtimeState.isLoading,
-        threadIds: runtimeState.threads,
-        archivedThreadIds: runtimeState.archivedThreads,
+        threadIds: runtimeState.threadIds,
+        archivedThreadIds: runtimeState.archivedThreadIds,
         threadItems: threadItems.state,
 
         main: main.state,

--- a/packages/react/src/legacy-runtime/runtime-cores/core/ThreadListRuntimeCore.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/core/ThreadListRuntimeCore.tsx
@@ -21,7 +21,7 @@ export type ThreadListRuntimeCore = {
   threadIds: readonly string[];
   archivedThreadIds: readonly string[];
 
-  readonly threadData: Readonly<Record<string, ThreadListItemCoreState>>;
+  readonly threadItems: Readonly<Record<string, ThreadListItemCoreState>>;
 
   getMainThreadRuntimeCore(): ThreadRuntimeCore;
   getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/ExternalStoreThreadListRuntimeCore.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/ExternalStoreThreadListRuntimeCore.tsx
@@ -47,7 +47,7 @@ export class ExternalStoreThreadListRuntimeCore
     return this._archivedThreads;
   }
 
-  public get threadData() {
+  public get threadItems() {
     return this._threadData;
   }
 

--- a/packages/react/src/legacy-runtime/runtime-cores/local/LocalThreadListRuntimeCore.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/local/LocalThreadListRuntimeCore.tsx
@@ -50,7 +50,7 @@ export class LocalThreadListRuntimeCore
     return DEFAULT_THREAD_ID;
   }
 
-  public get threadData() {
+  public get threadItems() {
     return DEFAULT_THREAD_DATA;
   }
 

--- a/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
@@ -156,7 +156,7 @@ export class RemoteThreadListThreadListRuntimeCore
     threadData: {},
   });
 
-  public get threadData() {
+  public get threadItems() {
     return this._state.value.threadData;
   }
 
@@ -240,12 +240,12 @@ export class RemoteThreadListThreadListRuntimeCore
     this._state.subscribe(() => this._notifySubscribers());
     this._hookManager = new RemoteThreadListHookInstanceManager(
       options.runtimeHook,
+      this,
     );
     this.useProvider = create(() => ({
       Provider: options.adapter.unstable_Provider ?? Fragment,
     }));
     this.__internal_setOptions(options);
-
     this.switchToNewThread();
   }
 

--- a/packages/react/src/legacy-runtime/runtime/RuntimeBindings.ts
+++ b/packages/react/src/legacy-runtime/runtime/RuntimeBindings.ts
@@ -64,10 +64,6 @@ export type ThreadListItemState = {
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
-  /**
-   * @deprecated Use `id` instead. This field will be removed in version 0.12.0.
-   */
-  readonly threadId: string;
   readonly status: ThreadListItemStatus;
   readonly title?: string | undefined;
 };

--- a/packages/react/src/legacy-runtime/runtime/ThreadListRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime/ThreadListRuntime.ts
@@ -18,9 +18,9 @@ import { NestedSubscriptionSubject } from "./subscribable/NestedSubscriptionSubj
 
 export type ThreadListState = {
   readonly mainThreadId: string;
-  readonly newThread: string | undefined;
-  readonly threads: readonly string[];
-  readonly archivedThreads: readonly string[];
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
   readonly threadItems: Readonly<
     Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>
@@ -49,11 +49,11 @@ const getThreadListState = (
 ): ThreadListState => {
   return {
     mainThreadId: threadList.mainThreadId,
-    newThread: threadList.newThreadId,
-    threads: threadList.threadIds,
-    archivedThreads: threadList.archivedThreadIds,
+    newThreadId: threadList.newThreadId,
+    threadIds: threadList.threadIds,
+    archivedThreadIds: threadList.archivedThreadIds,
     isLoading: threadList.isLoading,
-    threadItems: threadList.threadData,
+    threadItems: threadList.threadItems,
   };
 };
 
@@ -67,7 +67,6 @@ const getThreadListItemState = (
   if (!threadData) return SKIP_UPDATE;
   return {
     id: threadData.id,
-    threadId: threadData.id, // TODO remove in 0.12.0
     remoteId: threadData.remoteId,
     externalId: threadData.externalId,
     title: threadData.title,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes race condition in `RemoteThreadListRuntime` by updating provider components and renaming variables for clarity.
> 
>   - **Behavior**:
>     - Fixes race condition in `RemoteThreadListRuntime` causing crashes on thread deletion.
>     - Updates `ThreadListItemRuntimeProvider` to use `ThreadListItemClient` with `runtime` in `ThreadListItemProvider.tsx`.
>   - **Renames**:
>     - `ThreadListItemByIdProvider` to `ThreadListItemRuntimeProvider`.
>     - `threadData` to `threadItems` in `ThreadListRuntimeCore.tsx`, `ExternalStoreThreadListRuntimeCore.tsx`, `LocalThreadListRuntimeCore.tsx`, and `RemoteThreadListThreadListRuntimeCore.tsx`.
>     - `newThread` to `newThreadId`, `threads` to `threadIds`, and `archivedThreads` to `archivedThreadIds` in `ThreadListRuntime.ts` and `ThreadListRuntimeClient.ts`.
>   - **Misc**:
>     - Removes deprecated `threadId` field from `ThreadListItemState` in `RuntimeBindings.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 8b5dbada99bc3cefd0c94259e640f984f23a1b67. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->