### PR TITLE
docs(mcp-app-studio): update widget→app terminology and enable demo mode

### DIFF
--- a/apps/docs/app/mcp-app-studio/page.tsx
+++ b/apps/docs/app/mcp-app-studio/page.tsx
@@ -98,7 +98,7 @@ const WORKBENCH_URL =
 
 export default function McpAppStudioPage() {
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const iframeSrc = `${WORKBENCH_URL}?component=poi-map`;
+  const iframeSrc = `${WORKBENCH_URL}?component=poi-map&demo=true`;
 
   // Listen for fullscreen messages from workbench iframe
   useEffect(() => {
@@ -340,7 +340,7 @@ function HeroShowcase({ onFullscreen }: { onFullscreen: () => void }) {
   const [isLoaded, setIsLoaded] = useState(false);
   const [hasError, setHasError] = useState(false);
 
-  const iframeSrc = `${WORKBENCH_URL}?component=poi-map`;
+  const iframeSrc = `${WORKBENCH_URL}?component=poi-map&demo=true`;
 
   return (
     <div className="hero-showcase-section relative">


### PR DESCRIPTION
## Summary
- Replace all 'widget' terminology with 'app' in the MCP App Studio page
- Deploy mcp-app-studio-starter to Vercel and use production URL in iframe
- Add `demo=true` query param to iframe URL to show proper demo mode behavior

## Changes
- Updated terminology throughout `apps/docs/app/mcp-app-studio/page.tsx`
- Set default WORKBENCH_URL to `https://mcp-app-studio-starter.vercel.app`
- Added `&demo=true` param to iframe src for proper demo mode

## Test plan
- [ ] Verify iframe loads the production workbench
- [ ] Verify demo mode shows appropriate messages for local-only features

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update terminology from 'widget' to 'app' and enable demo mode in `page.tsx`.
> 
>   - **Terminology Update**:
>     - Replace 'widget' with 'app' throughout `page.tsx`.
>   - **Demo Mode**:
>     - Set `WORKBENCH_URL` default to `https://mcp-app-studio-starter.vercel.app`.
>     - Add `&demo=true` to `iframeSrc` in `McpAppStudioPage` and `HeroShowcase`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 9309e1d00dd5131cb481eded9552d61ea05a9901. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->