### PR TITLE
fix(docs): simplify MCP App Studio title

### DIFF
--- a/apps/docs/app/mcp-app-studio/layout.tsx
+++ b/apps/docs/app/mcp-app-studio/layout.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from "react";
 import { SubProjectLayout } from "@/components/shared/sub-project-layout";
 import { createOgMetadata } from "@/lib/og";
 
-const title = "MCP App Studio by assistant-ui";
+const title = "MCP App Studio";
 const description =
   "Build and preview MCP Apps locally. A development workbench with live preview, mock tool responses, and production export.";
 


### PR DESCRIPTION
## Summary
- Removes "by assistant-ui" suffix from MCP App Studio page title
- Affects both the page `<title>` and OpenGraph image

## Test plan
- [ ] Verify page title displays as "MCP App Studio"
- [ ] Verify OG image renders with simplified title

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes "by assistant-ui" suffix from `title` in `layout.tsx`, affecting page `<title>` and OpenGraph metadata.
> 
>   - **Behavior**:
>     - Removes "by assistant-ui" suffix from `title` in `layout.tsx`, affecting both page `<title>` and OpenGraph metadata.
>   - **Misc**:
>     - Updates `title` constant in `layout.tsx` to "MCP App Studio".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d64ae28d22d0501fadbbabfeb0ae1225598661e2. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->