### PR TITLE
fix(docs): add OpenGraph metadata to playground and safe-content-frame

### DIFF
--- a/apps/docs/app/playground/layout.tsx
+++ b/apps/docs/app/playground/layout.tsx
@@ -2,11 +2,16 @@ import type { Metadata } from "next";
 import { ReactNode, Suspense } from "react";
 import { SubProjectLayout } from "@/components/shared/sub-project-layout";
 import { PlaygroundRuntimeProvider } from "@/contexts/PlaygroundRuntimeProvider";
+import { createOgMetadata } from "@/lib/og";
+
+const title = "Playground";
+const description =
+  "Experiment with different configurations and settings using the Assistant UI Playground.";
 
 export const metadata: Metadata = {
-  title: "Playground",
-  description:
-    "Experiment with different configurations and settings using the Assistant UI Playground.",
+  title,
+  description,
+  ...createOgMetadata(title, description),
 };
 
 export default function PlaygroundLayout({

--- a/apps/docs/app/safe-content-frame/layout.tsx
+++ b/apps/docs/app/safe-content-frame/layout.tsx
@@ -1,11 +1,16 @@
 import type { Metadata } from "next";
 import { ReactNode } from "react";
 import { SubProjectLayout } from "@/components/shared/sub-project-layout";
+import { createOgMetadata } from "@/lib/og";
+
+const title = "Safe Content Frame";
+const description =
+  "Render untrusted HTML content securely in sandboxed iframes with unique origins per render.";
 
 export const metadata: Metadata = {
-  title: "Safe Content Frame Demo - assistant-ui",
-  description:
-    "Render untrusted HTML content securely in sandboxed iframes with unique origins per render.",
+  title,
+  description,
+  ...createOgMetadata(title, description),
 };
 
 export default function SafeContentFrameLayout({


### PR DESCRIPTION
## Summary
- Adds `createOgMetadata` to playground and safe-content-frame layouts
- Ensures social media shares display custom OG images instead of default fallback

## Test plan
- [ ] Verify `/playground` OG image renders correctly
- [ ] Verify `/safe-content-frame` OG image renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `createOgMetadata` to `playground` and `safe-content-frame` layouts for custom OG images in social media sharing.
> 
>   - **Behavior**:
>     - Adds `createOgMetadata` to `metadata` in `playground/layout.tsx` and `safe-content-frame/layout.tsx`.
>     - Ensures custom OG images are used for social media sharing instead of defaults.
>   - **Misc**:
>     - Defines `title` and `description` constants in both layout files for reuse in `metadata`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c35b05eedc44cbc9786ec6f0c4bc6b8feed0990f. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->