### PR TITLE
chore: unskip test

### DIFF
--- a/packages/tap/src/__tests__/strictmode/tap-strictmode-rerender-sources.test.ts
+++ b/packages/tap/src/__tests__/strictmode/tap-strictmode-rerender-sources.test.ts
@@ -263,7 +263,7 @@ describe("Tap Strict Mode - Rerender Sources", () => {
 
       // Wait for setTimeout
       await new Promise((resolve) => setTimeout(resolve, 50));
-
+ 
       // React behavior: setTimeout callbacks run TWICE, then renders double
       expect(events).toEqual([
         "render count=0",
@@ -399,7 +399,7 @@ describe("Tap Strict Mode - Rerender Sources", () => {
   });
 
   describe("Source 8: setState with function updater", () => {
-    it.skip("should double-render with function updater in flushResourcesSync", () => {
+    it("should double-render with function updater in flushResourcesSync", () => {
       const events: string[] = [];
 
       const TestResource = resource(() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Unskips a test for double-rendering with function updater in `flushResourcesSync` in `tap-strictmode-rerender-sources.test.ts`.
> 
>   - **Tests**:
>     - Unskips test `should double-render with function updater in flushResourcesSync` in `tap-strictmode-rerender-sources.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 83321eaf87c333260d7bfc6f16676115d3a363ad. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->