### PR TITLE
ref(docs): rename "AI-Assisted Development" to "Agent Skills"

### DIFF
--- a/apps/docs/content/docs/(docs)/index.mdx
+++ b/apps/docs/content/docs/(docs)/index.mdx
@@ -57,7 +57,7 @@ npx assistant-ui@latest create -t mcp
     href="/docs/installation"
   />
   <Card
-    title="AI-Assisted Development"
+    title="Agent Skills"
     description="Use AI tools to build with assistant-ui faster"
     href="/docs/llm"
   />

--- a/apps/docs/content/docs/(docs)/llm.mdx
+++ b/apps/docs/content/docs/(docs)/llm.mdx
@@ -1,5 +1,5 @@
 ---
-title: "AI-Assisted Development"
+title: "Agent Skills"
 description: Use AI tools to build with assistant-ui faster. AI-accessible documentation, Claude Code skills, and MCP integration.
 ---
 


### PR DESCRIPTION
Update documentation title and card label to use "Agent Skills"
instead of "AI-Assisted Development". This clarifies the focus on
reusable agent capabilities (skills) and aligns the docs header with
the linked content.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renames "AI-Assisted Development" to "Agent Skills" in documentation to emphasize agent capabilities.
> 
>   - **Documentation**:
>     - Rename "AI-Assisted Development" to "Agent Skills" in `index.mdx` and `llm.mdx`.
>     - Update card title and page title to reflect the new focus on agent capabilities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 6b18685dbc9a399c20cb85d36471113109ed05dc. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->