### PR TITLE
feat(react-ag-ui): add explicit threadId support

### DIFF
--- a/.changeset/salty-squids-do.md
+++ b/.changeset/salty-squids-do.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+Add explicit threadId support to enable parallel chats with different thread IDs

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -29,6 +29,7 @@ type ResumeRunConfig = {
 
 type CoreOptions = {
   agent: HttpAgent;
+  threadId?: string;
   logger: Logger;
   showThinking: boolean;
   onError?: (error: Error) => void;
@@ -41,6 +42,7 @@ const FALLBACK_USER_STATUS = { type: "complete", reason: "unknown" } as const;
 
 export class AgUiThreadRuntimeCore {
   private agent: HttpAgent;
+  private threadId: string;
   private logger: Logger;
   private showThinking: boolean;
   private onError: ((error: Error) => void) | undefined;
@@ -62,6 +64,7 @@ export class AgUiThreadRuntimeCore {
 
   constructor(options: CoreOptions) {
     this.agent = options.agent;
+    this.threadId = options.threadId ?? this.agent.threadId ?? "main";
     this.logger = options.logger;
     this.showThinking = options.showThinking;
     this.onError = options.onError;
@@ -72,6 +75,9 @@ export class AgUiThreadRuntimeCore {
 
   updateOptions(options: Omit<CoreOptions, "notifyUpdate">) {
     this.agent = options.agent;
+    if (options.threadId !== undefined) {
+      this.threadId = options.threadId;
+    }
     this.logger = options.logger;
     this.showThinking = options.showThinking;
     this.onError = options.onError;
@@ -320,7 +326,7 @@ export class AgUiThreadRuntimeCore {
     runConfig: RunConfig | undefined,
     historyMessages: readonly ThreadMessage[] | undefined,
   ) {
-    const threadId = this.agent.threadId || "main";
+    const threadId = this.threadId;
     const messages = toAgUiMessages(historyMessages ?? this.messages);
     const context = this.runtime?.thread.getModelContext();
     return {

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -40,6 +40,7 @@ export type UseAgUiRuntimeAdapters = {
 
 export type UseAgUiRuntimeOptions = {
   agent: HttpAgent;
+  threadId?: string;
   logger?: Partial<Logger>;
   showThinking?: boolean;
   onError?: (e: Error) => void;

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -31,6 +31,7 @@ export function useAgUiRuntime(
   if (!coreRef.current) {
     coreRef.current = new AgUiThreadRuntimeCore({
       agent: options.agent,
+      ...(options.threadId !== undefined && { threadId: options.threadId }),
       logger,
       showThinking: options.showThinking ?? true,
       ...(options.onError && { onError: options.onError }),
@@ -43,6 +44,7 @@ export function useAgUiRuntime(
   const core = coreRef.current;
   core.updateOptions({
     agent: options.agent,
+    ...(options.threadId !== undefined && { threadId: options.threadId }),
     logger,
     showThinking: options.showThinking ?? true,
     ...(options.onError && { onError: options.onError }),


### PR DESCRIPTION
closes #3207
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add explicit `threadId` support to `AgUiThreadRuntimeCore` for parallel chat sessions with different thread IDs.
> 
>   - **Behavior**:
>     - Adds `threadId` support to `AgUiThreadRuntimeCore` in `AgUiThreadRuntimeCore.ts`, defaulting to `main` if not provided.
>     - Updates `updateOptions()` to handle `threadId` changes.
>     - Modifies `buildRunInput()` to use `threadId`.
>   - **Types**:
>     - Adds optional `threadId` to `CoreOptions` and `UseAgUiRuntimeOptions` in `types.ts`.
>   - **Hooks**:
>     - Updates `useAgUiRuntime()` in `useAgUiRuntime.ts` to pass `threadId` to `AgUiThreadRuntimeCore`.
>   - **Tests**:
>     - Adds tests in `ag-ui-thread-runtime-core.spec.ts` for explicit `threadId` usage and multiple cores with different `threadId`s.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 3d5c0eff2999a80462d11597d9493cccf9651b4a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->