### PR TITLE
feat: ChainOfThoughtPrimitive

### DIFF
--- a/.changeset/bright-doodles-travel.md
+++ b/.changeset/bright-doodles-travel.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: ChainOfThoughtPrimitive

--- a/packages/react/CHAIN_OF_THOUGHT.spec.md
+++ b/packages/react/CHAIN_OF_THOUGHT.spec.md
@@ -1,0 +1,179 @@
+# Chain of Thought Implementation Spec
+
+## Overview
+Add a new `chainOfThought` client scope for rendering reasoning and tool-call parts in an accordion UI pattern.
+
+## Client Scope
+
+### 1. Type Registration (`types/scopes/chainOfThought.ts`)
+
+```typescript
+export type ChainOfThoughtPart = ToolCallPart | ReasoningPart;
+
+export type ChainOfThoughtState = {
+  readonly parts: readonly ChainOfThoughtPart[];
+  readonly collapsed: boolean;
+  readonly status: MessagePartStatus; // status of the last part
+};
+
+export type ChainOfThoughtMethods = {
+  getState(): ChainOfThoughtState;
+  setCollapsed(collapsed: boolean): void;
+};
+
+export type ChainOfThoughtMeta = {
+  source: "message";
+  query: { type: "chainOfThought" };
+};
+
+export type ChainOfThoughtClientSchema = {
+  state: ChainOfThoughtState;
+  methods: ChainOfThoughtMethods;
+  meta: ChainOfThoughtMeta;
+};
+```
+
+Register in `types/store-augmentation.ts`:
+```typescript
+chainOfThought: ChainOfThoughtClientSchema;
+```
+
+### 2. Client Implementation (`client/ChainOfThoughtClient.ts`)
+
+```typescript
+export const ChainOfThoughtClient = resource(({
+  parts
+}: {
+  parts: readonly ChainOfThoughtPart[];
+}): ClientOutput<"chainOfThought"> => {
+  const [collapsed, setCollapsed] = tapState(true);
+
+  const status = tapMemo<MessagePartStatus>(() => {
+    const lastPart = parts[parts.length - 1];
+    return lastPart?.status ?? { type: "complete" };
+  }, [parts]);
+
+  const state = tapMemo<ChainOfThoughtState>(
+    () => ({ parts, collapsed, status }),
+    [parts, collapsed, status]
+  );
+
+  return {
+    state,
+    methods: {
+      getState: () => state,
+      setCollapsed,
+    },
+  };
+});
+```
+
+### 3. Context Providers (`context/providers/ChainOfThoughtProvider.tsx`)
+
+**ChainOfThoughtByIndicesProvider**: Extracts parts from message by index range and sets up chainOfThought client.
+
+```typescript
+export const ChainOfThoughtByIndicesProvider = ({
+  startIndex,
+  endIndex,
+  children
+}: {
+  startIndex: number;
+  endIndex: number;
+  children: ReactNode;
+}) => {
+  const parts = useAuiState(({ message }) =>
+    message.parts.slice(startIndex, endIndex + 1) as ChainOfThoughtPart[]
+  );
+
+  const aui = useAui({
+    chainOfThought: ChainOfThoughtClient({ parts })
+  });
+
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+};
+```
+
+## Primitives
+
+### 1. ChainOfThoughtPrimitive.Root
+
+Container component. Sets up the chainOfThought client provider.
+
+### 2. ChainOfThoughtPrimitive.AccordionTrigger
+
+Button that toggles `collapsed` state via `aui.chainOfThought().setCollapsed(!collapsed)`.
+
+### 3. ChainOfThoughtPrimitive.Parts
+
+```typescript
+namespace ChainOfThoughtPrimitiveParts {
+  export type Props = {
+    components?: {
+      Reasoning?: ReasoningMessagePartComponent;
+      ToolFallback?: ToolCallMessagePartComponent;
+    };
+  };
+}
+```
+
+**Behavior:**
+- Reads `collapsed` and `parts` from chainOfThought state
+- When collapsed, shows no parts
+- When expanded, shows all parts
+- Renders each part using provided `Reasoning` or `ToolFallback` component
+
+## MessagePrimitive.Parts Integration
+
+Update `MessagePrimitiveParts.Props`:
+
+```typescript
+components?: {
+  // existing fields...
+  ChainOfThought?: ComponentType;
+}
+```
+
+**Logic:**
+
+**Mutual Exclusivity:** When `ChainOfThought` is provided, the following components are **completely ignored**:
+- `Reasoning`
+- `tools` (both `by_name` and `Fallback`)
+- `ReasoningGroup`
+- `ToolGroup`
+
+**Extraction & Rendering:**
+1. Identify consecutive reasoning/tool-call parts in the message
+2. For each group found:
+   - Calculate `startIndex` and `endIndex` of the group
+   - Wrap in `<ChainOfThoughtByIndicesProvider startIndex={...} endIndex={...}>` internally
+   - Render `<ChainOfThought />` inside the provider (no props passed to component)
+3. Non-reasoning/tool parts render normally (Text, Image, File, etc.)
+
+**Implementation in `groupMessageParts()`:**
+- When `ChainOfThought` is provided, create `chainOfThoughtGroup` ranges instead of separate `toolGroup` and `reasoningGroup` ranges
+- A chainOfThoughtGroup includes both consecutive tool-call AND reasoning parts together
+
+## File Structure
+
+```
+packages/react/src/
+├── types/scopes/chainOfThought.ts
+├── client/ChainOfThoughtClient.ts
+├── context/providers/ChainOfThoughtByIndicesProvider.tsx
+└── primitives/chainOfThought/
+    ├── index.ts
+    ├── ChainOfThoughtRoot.tsx
+    ├── ChainOfThoughtAccordionTrigger.tsx
+    └── ChainOfThoughtParts.tsx
+```
+
+## Implementation Notes
+
+- Default `collapsed: true` in client
+- `collapsed` state managed by `tapState` in client
+- `status` derived from last part's status in client
+- Follow existing primitive patterns (see MessageParts, PartByIndex)
+- `ChainOfThoughtByIndicesProvider` extracts parts from message by index range
+- ChainOfThoughtPrimitive.Accordion will be added later - not in scope
+- When `ChainOfThought` is provided to MessagePrimitive.Parts, reasoning and tool parts are **never** rendered through normal flow

--- a/packages/react/src/client/ChainOfThoughtClient.ts
+++ b/packages/react/src/client/ChainOfThoughtClient.ts
@@ -1,0 +1,43 @@
+import { resource, tapMemo, tapState } from "@assistant-ui/tap";
+import { type ClientOutput } from "@assistant-ui/store";
+import type {
+  ChainOfThoughtState,
+  ChainOfThoughtPart,
+} from "../types/scopes/chainOfThought";
+import type { MessagePartStatus } from "../types/AssistantTypes";
+import type { PartMethods } from "../types/scopes/part";
+
+const COMPLETE_STATUS: MessagePartStatus = Object.freeze({
+  type: "complete",
+});
+
+export const ChainOfThoughtClient = resource(
+  ({
+    parts,
+    getMessagePart,
+  }: {
+    parts: readonly ChainOfThoughtPart[];
+    getMessagePart: (selector: { index: number }) => PartMethods;
+  }): ClientOutput<"chainOfThought"> => {
+    const [collapsed, setCollapsed] = tapState(true);
+
+    const status = tapMemo(() => {
+      const lastPart = parts[parts.length - 1];
+      return lastPart?.status ?? COMPLETE_STATUS;
+    }, [parts]);
+
+    const state = tapMemo<ChainOfThoughtState>(
+      () => ({ parts, collapsed, status }),
+      [parts, collapsed, status],
+    );
+
+    return {
+      state,
+      methods: {
+        getState: () => state,
+        setCollapsed,
+        part: getMessagePart,
+      },
+    };
+  },
+);

--- a/packages/react/src/client/index.ts
+++ b/packages/react/src/client/index.ts
@@ -10,3 +10,4 @@ export {
   InMemoryThreadList,
   type InMemoryThreadListProps,
 } from "./InMemoryThreadList";
+export { ChainOfThoughtClient } from "./ChainOfThoughtClient";

--- a/packages/react/src/context/providers/ChainOfThoughtByIndicesProvider.tsx
+++ b/packages/react/src/context/providers/ChainOfThoughtByIndicesProvider.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { type FC, type PropsWithChildren } from "react";
+import { useAui, useAuiState, AuiProvider } from "@assistant-ui/store";
+import { ChainOfThoughtClient } from "../../client/ChainOfThoughtClient";
+import type { ChainOfThoughtPart } from "../../types/scopes/chainOfThought";
+
+export const ChainOfThoughtByIndicesProvider: FC<
+  PropsWithChildren<{
+    startIndex: number;
+    endIndex: number;
+  }>
+> = ({ startIndex, endIndex, children }) => {
+  const parts = useAuiState(({ message }) =>
+    message.parts.slice(startIndex, endIndex + 1),
+  ) as ChainOfThoughtPart[];
+
+  const parentAui = useAui();
+
+  const aui = useAui({
+    chainOfThought: ChainOfThoughtClient({
+      parts,
+      getMessagePart: ({ index }) => {
+        if (index < 0 || index >= parts.length) {
+          throw new Error(
+            `ChainOfThought part index ${index} is out of bounds (0..${parts.length - 1})`,
+          );
+        }
+        return parentAui.message().part({ index: startIndex + index });
+      },
+    }),
+  });
+
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+};

--- a/packages/react/src/context/providers/ChainOfThoughtPartByIndexProvider.tsx
+++ b/packages/react/src/context/providers/ChainOfThoughtPartByIndexProvider.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { type FC, type PropsWithChildren } from "react";
+import { useAui, AuiProvider, Derived } from "@assistant-ui/store";
+
+export const ChainOfThoughtPartByIndexProvider: FC<
+  PropsWithChildren<{
+    index: number;
+  }>
+> = ({ index, children }) => {
+  const aui = useAui({
+    part: Derived({
+      source: "chainOfThought",
+      query: { type: "index", index },
+      get: (aui) => aui.chainOfThought().part({ index }),
+    }),
+  });
+
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+};

--- a/packages/react/src/primitives/chainOfThought/CHAIN_OF_THOUGHT.spec.md
+++ b/packages/react/src/primitives/chainOfThought/CHAIN_OF_THOUGHT.spec.md
@@ -1,0 +1,68 @@
+ChainOfThought Primitive
+
+Overview
+
+- Groups consecutive reasoning and tool-call message parts into a collapsible "chain of thought" section.
+- Built on the part-scope mechanism shared with `MessagePrimitiveParts`, using `Derived` for part resolution.
+- Each part within the chain of thought gets its own part scope via `ChainOfThoughtPartByIndexProvider`.
+- Rendering is delegated to the shared `MessagePartComponent`, supporting the same component configuration as `MessagePrimitiveParts`.
+
+Architecture
+
+ChainOfThoughtState
+
+```typescript
+type ChainOfThoughtState = {
+  readonly startIndex: number; // index of the first CoT part in the parent message
+  readonly parts: readonly ChainOfThoughtPart[];
+  readonly collapsed: boolean;
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+```
+
+ChainOfThoughtMethods
+
+```typescript
+type ChainOfThoughtMethods = {
+  getState(): ChainOfThoughtState;
+  setCollapsed(collapsed: boolean): void;
+  part(selector: { index: number }): PartMethods;
+};
+```
+
+- `part({ index })` delegates to the parent message's `part()` at offset `startIndex + index`.
+
+ChainOfThoughtClient
+
+- Resource params: `{ startIndex, parts, getMessagePart }`.
+- `getMessagePart` is a callback that resolves to the parent message's `part()` method.
+- The `part` method implementation: `({ index }) => getMessagePart({ index: startIndex + index })`.
+
+Providers
+
+ChainOfThoughtByIndicesProvider
+
+- Wraps a range of message parts (startIndex..endIndex) into a chain of thought scope.
+- Reads parts from the parent message state, passes `startIndex` and `getMessagePart` to `ChainOfThoughtClient`.
+- Used internally by `MessagePrimitiveParts` when `ChainOfThought` component is configured.
+
+ChainOfThoughtPartByIndexProvider
+
+- Follows the same pattern as `PartByIndexProvider`.
+- Reads `startIndex` from chain of thought state.
+- Creates a `Derived` part scope: `source: "message"`, `query: { type: "index", index: startIndex + index }`.
+- Delegates `get` to `aui.chainOfThought().part({ index })`.
+
+Rendering (ChainOfThoughtPrimitiveParts)
+
+- Accepts `components` prop with the same type as `MessagePrimitiveParts.Props["components"]`.
+- Reads `collapsed` and `parts.length` from chain of thought state.
+- When collapsed, renders nothing.
+- When expanded, renders each part via `ChainOfThoughtPartByIndexProvider` + `MessagePartComponent`.
+- `MessagePartComponent` is the shared rendering component exported from `MessageParts.tsx`.
+
+Integration with MessagePrimitiveParts
+
+- When `components.ChainOfThought` is set, `MessagePrimitiveParts` groups consecutive tool-call and reasoning parts into `chainOfThoughtGroup` ranges.
+- Each group is wrapped in `ChainOfThoughtByIndicesProvider`, which sets up the chain of thought scope.
+- The user's `ChainOfThought` component renders inside that scope and can use `ChainOfThoughtPrimitive.Parts` to render individual parts through the part-scope mechanism.

--- a/packages/react/src/primitives/chainOfThought/ChainOfThoughtAccordionTrigger.tsx
+++ b/packages/react/src/primitives/chainOfThought/ChainOfThoughtAccordionTrigger.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import {
+  ActionButtonElement,
+  ActionButtonProps,
+  createActionButton,
+} from "../../utils/createActionButton";
+import { useCallback } from "react";
+import { useAuiState, useAui } from "@assistant-ui/store";
+
+const useChainOfThoughtAccordionTrigger = () => {
+  const aui = useAui();
+  const collapsed = useAuiState(
+    ({ chainOfThought }) => chainOfThought.collapsed,
+  );
+
+  const callback = useCallback(() => {
+    aui.chainOfThought().setCollapsed(!collapsed);
+  }, [aui, collapsed]);
+
+  return callback;
+};
+
+export namespace ChainOfThoughtPrimitiveAccordionTrigger {
+  export type Element = ActionButtonElement;
+  /**
+   * Props for the ChainOfThoughtPrimitive.AccordionTrigger component.
+   * Inherits all button element props and action button functionality.
+   */
+  export type Props = ActionButtonProps<
+    typeof useChainOfThoughtAccordionTrigger
+  >;
+}
+
+/**
+ * A button component that toggles the collapsed state of the chain of thought accordion.
+ *
+ * This component automatically handles the toggle functionality, expanding or collapsing
+ * the chain of thought parts when clicked.
+ *
+ * @example
+ * ```tsx
+ * <ChainOfThoughtPrimitive.AccordionTrigger>
+ *   Toggle Reasoning
+ * </ChainOfThoughtPrimitive.AccordionTrigger>
+ * ```
+ */
+export const ChainOfThoughtPrimitiveAccordionTrigger = createActionButton(
+  "ChainOfThoughtPrimitive.AccordionTrigger",
+  useChainOfThoughtAccordionTrigger,
+);

--- a/packages/react/src/primitives/chainOfThought/ChainOfThoughtParts.tsx
+++ b/packages/react/src/primitives/chainOfThought/ChainOfThoughtParts.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { type FC, useMemo } from "react";
+import { useAuiState } from "@assistant-ui/store";
+import { ChainOfThoughtPartByIndexProvider } from "../../context/providers/ChainOfThoughtPartByIndexProvider";
+import { MessagePartComponent } from "../message/MessageParts";
+import type {
+  ReasoningMessagePartComponent,
+  ToolCallMessagePartComponent,
+} from "../../types/MessagePartComponentTypes";
+
+export namespace ChainOfThoughtPrimitiveParts {
+  export type Props = {
+    /**
+     * Component configuration for rendering chain of thought parts.
+     */
+    components?: {
+      /** Component for rendering reasoning parts */
+      Reasoning?: ReasoningMessagePartComponent | undefined;
+      /** Fallback component for tool-call parts */
+      tools?: {
+        Fallback?: ToolCallMessagePartComponent | undefined;
+      };
+    };
+  };
+}
+
+/**
+ * Renders the parts within a chain of thought, with support for collapsed/expanded states.
+ *
+ * When collapsed, no parts are shown. When expanded, all parts are rendered
+ * using the provided component configuration through the part scope mechanism.
+ *
+ * @example
+ * ```tsx
+ * <ChainOfThoughtPrimitive.Parts
+ *   components={{
+ *     Reasoning: ({ text }) => <p className="reasoning">{text}</p>,
+ *     tools: {
+ *       Fallback: ({ toolName }) => <div>Tool: {toolName}</div>
+ *     }
+ *   }}
+ * />
+ * ```
+ */
+export const ChainOfThoughtPrimitiveParts: FC<
+  ChainOfThoughtPrimitiveParts.Props
+> = ({ components }) => {
+  const collapsed = useAuiState(
+    ({ chainOfThought }) => chainOfThought.collapsed,
+  );
+  const partsLength = useAuiState(
+    ({ chainOfThought }) => chainOfThought.parts.length,
+  );
+
+  const messageComponents = useMemo(
+    () => ({
+      Reasoning: components?.Reasoning,
+      tools: {
+        Fallback: components?.tools?.Fallback,
+      },
+    }),
+    [components?.Reasoning, components?.tools?.Fallback],
+  );
+
+  const elements = useMemo(() => {
+    if (collapsed) return null;
+
+    return Array.from({ length: partsLength }, (_, index) => (
+      <ChainOfThoughtPartByIndexProvider key={index} index={index}>
+        <MessagePartComponent components={messageComponents} />
+      </ChainOfThoughtPartByIndexProvider>
+    ));
+  }, [collapsed, partsLength, messageComponents]);
+
+  return <>{elements}</>;
+};
+
+ChainOfThoughtPrimitiveParts.displayName = "ChainOfThoughtPrimitive.Parts";

--- a/packages/react/src/primitives/chainOfThought/ChainOfThoughtRoot.tsx
+++ b/packages/react/src/primitives/chainOfThought/ChainOfThoughtRoot.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Primitive } from "@radix-ui/react-primitive";
+import { type ComponentRef, forwardRef, ComponentPropsWithoutRef } from "react";
+
+type PrimitiveDivProps = ComponentPropsWithoutRef<typeof Primitive.div>;
+
+export namespace ChainOfThoughtPrimitiveRoot {
+  export type Element = ComponentRef<typeof Primitive.div>;
+  export type Props = PrimitiveDivProps;
+}
+
+/**
+ * The root container for chain of thought components.
+ *
+ * This component provides a wrapper for chain of thought content,
+ * including reasoning and tool-call parts that can be collapsed in an accordion.
+ *
+ * @example
+ * ```tsx
+ * <ChainOfThoughtPrimitive.Root>
+ *   <ChainOfThoughtPrimitive.AccordionTrigger>
+ *     Toggle reasoning
+ *   </ChainOfThoughtPrimitive.AccordionTrigger>
+ *   <ChainOfThoughtPrimitive.Parts />
+ * </ChainOfThoughtPrimitive.Root>
+ * ```
+ */
+export const ChainOfThoughtPrimitiveRoot = forwardRef<
+  ChainOfThoughtPrimitiveRoot.Element,
+  ChainOfThoughtPrimitiveRoot.Props
+>((props, ref) => {
+  return <Primitive.div {...props} ref={ref} />;
+});
+
+ChainOfThoughtPrimitiveRoot.displayName = "ChainOfThoughtPrimitive.Root";

--- a/packages/react/src/primitives/chainOfThought/index.ts
+++ b/packages/react/src/primitives/chainOfThought/index.ts
@@ -1,0 +1,14 @@
+export {
+  ChainOfThoughtPrimitiveRoot as Root,
+  type ChainOfThoughtPrimitiveRoot as RootPrimitive,
+} from "./ChainOfThoughtRoot";
+
+export {
+  ChainOfThoughtPrimitiveAccordionTrigger as AccordionTrigger,
+  type ChainOfThoughtPrimitiveAccordionTrigger as AccordionTriggerPrimitive,
+} from "./ChainOfThoughtAccordionTrigger";
+
+export {
+  ChainOfThoughtPrimitiveParts as Parts,
+  type ChainOfThoughtPrimitiveParts as PartsPrimitive,
+} from "./ChainOfThoughtParts";

--- a/packages/react/src/primitives/index.ts
+++ b/packages/react/src/primitives/index.ts
@@ -3,6 +3,7 @@ export * as ActionBarMorePrimitive from "./actionBarMore";
 export * as AssistantModalPrimitive from "./assistantModal";
 export * as AttachmentPrimitive from "./attachment";
 export * as BranchPickerPrimitive from "./branchPicker";
+export * as ChainOfThoughtPrimitive from "./chainOfThought";
 export * as ComposerPrimitive from "./composer";
 export * as MessagePartPrimitive from "./messagePart";
 export * as ErrorPrimitive from "./error";

--- a/packages/react/src/types/scopes/chainOfThought.ts
+++ b/packages/react/src/types/scopes/chainOfThought.ts
@@ -1,0 +1,42 @@
+import type {
+  MessagePartStatus,
+  ToolCallMessagePartStatus,
+} from "../AssistantTypes";
+import type { PartMethods, PartState } from "./part";
+
+export type ChainOfThoughtPart = Extract<
+  PartState,
+  { type: "tool-call" } | { type: "reasoning" }
+>;
+
+export type ChainOfThoughtState = {
+  readonly parts: readonly ChainOfThoughtPart[];
+  readonly collapsed: boolean;
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+export type ChainOfThoughtMethods = {
+  /**
+   * Get the current state of the chain of thought.
+   */
+  getState(): ChainOfThoughtState;
+  /**
+   * Set the collapsed state of the chain of thought accordion.
+   */
+  setCollapsed(collapsed: boolean): void;
+  /**
+   * Get the part methods for a specific part within this chain of thought.
+   */
+  part(selector: { index: number }): PartMethods;
+};
+
+export type ChainOfThoughtMeta = {
+  source: "message";
+  query: { type: "chainOfThought" };
+};
+
+export type ChainOfThoughtClientSchema = {
+  state: ChainOfThoughtState;
+  methods: ChainOfThoughtMethods;
+  meta: ChainOfThoughtMeta;
+};

--- a/packages/react/src/types/scopes/index.ts
+++ b/packages/react/src/types/scopes/index.ts
@@ -60,3 +60,10 @@ export type {
   ModelContextMethods,
   ModelContextClientSchema,
 } from "./modelContext";
+export type {
+  ChainOfThoughtState,
+  ChainOfThoughtMethods,
+  ChainOfThoughtMeta,
+  ChainOfThoughtClientSchema,
+  ChainOfThoughtPart,
+} from "./chainOfThought";

--- a/packages/react/src/types/scopes/part.ts
+++ b/packages/react/src/types/scopes/part.ts
@@ -30,12 +30,17 @@ export type PartMethods = {
   __internal_getRuntime?(): MessagePartRuntime;
 };
 
-export type PartMeta = {
-  source: "message";
-  query:
-    | { type: "index"; index: number }
-    | { type: "toolCallId"; toolCallId: string };
-};
+export type PartMeta =
+  | {
+      source: "message";
+      query:
+        | { type: "index"; index: number }
+        | { type: "toolCallId"; toolCallId: string };
+    }
+  | {
+      source: "chainOfThought";
+      query: { type: "index"; index: number };
+    };
 
 export type PartClientSchema = {
   state: PartState;

--- a/packages/react/src/types/store-augmentation.ts
+++ b/packages/react/src/types/store-augmentation.ts
@@ -11,6 +11,7 @@ import type { ToolsClientSchema } from "./scopes/tools";
 import type { ModelContextClientSchema } from "./scopes/modelContext";
 import type { SuggestionsClientSchema } from "./scopes/suggestions";
 import type { SuggestionClientSchema } from "./scopes/suggestion";
+import type { ChainOfThoughtClientSchema } from "./scopes/chainOfThought";
 
 declare module "@assistant-ui/store" {
   interface ClientRegistry {
@@ -25,5 +26,6 @@ declare module "@assistant-ui/store" {
     modelContext: ModelContextClientSchema;
     suggestions: SuggestionsClientSchema;
     suggestion: SuggestionClientSchema;
+    chainOfThought: ChainOfThoughtClientSchema;
   }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `ChainOfThoughtPrimitive` to group reasoning and tool-call parts into a collapsible section with new types, client implementations, context providers, and UI components.
> 
>   - **Feature**:
>     - Introduces `ChainOfThoughtPrimitive` to group reasoning and tool-call parts into a collapsible section.
>     - Adds `ChainOfThoughtClient` in `ChainOfThoughtClient.ts` to manage state and methods for chain of thought.
>     - Implements `ChainOfThoughtByIndicesProvider` and `ChainOfThoughtPartByIndexProvider` for context management.
>   - **Types**:
>     - Defines `ChainOfThoughtState`, `ChainOfThoughtMethods`, and `ChainOfThoughtClientSchema` in `chainOfThought.ts`.
>     - Registers `chainOfThought` in `store-augmentation.ts`.
>   - **UI Components**:
>     - Adds `ChainOfThoughtPrimitiveRoot`, `ChainOfThoughtPrimitiveAccordionTrigger`, and `ChainOfThoughtPrimitiveParts` for UI rendering.
>     - Updates `MessagePrimitiveParts` to integrate `ChainOfThought` component, allowing mutual exclusivity with other components like `Reasoning` and `ToolGroup`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d24f2d63da4bb7302c7ef2987c807a7d49834577. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->