### PR TITLE
fix(mcp-app-studio): avoid unintended 1.0.0 release

### DIFF
--- a/.changeset/mcp-app-studio-tool-metadata.md
+++ b/.changeset/mcp-app-studio-tool-metadata.md
@@ -1,5 +1,5 @@
 ---
-"mcp-app-studio": major
+"mcp-app-studio": minor
 ---
 
 Adopt MCP-first breaking changes: remove the dedicated ChatGPT platform/entrypoint, treat ChatGPT as an MCP host, and align runtime metadata/extensions on the MCP bridge.


### PR DESCRIPTION
## Summary
- change the existing `mcp-app-studio` changeset from `major` to `minor`
- keep breaking-change semantics while preserving pre-1.0 versioning (`0.5.2 -> 0.6.0`)

## Why
The merged MCP-first PR introduced a breaking change, but for a `0.x` package we want a minor bump rather than jumping to `1.0.0`.

## Verification
- `pnpm changeset status --since=origin/main --output changeset-status.json` reports `mcp-app-studio` with `newVersion: 0.6.0`.