### PR TITLE
test(mcp-app-studio): fix smoke/scaffold validation reliability

### DIFF
--- a/packages/mcp-app-studio/scripts/test-scaffold.sh
+++ b/packages/mcp-app-studio/scripts/test-scaffold.sh
@@ -6,7 +6,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PACKAGE_DIR="$(dirname "$SCRIPT_DIR")"
-PROJECT_NAME="${1:-test-chatgpt-app}"
+PROJECT_NAME="${1:-test-mcp-app}"
 INCLUDE_SERVER="--include-server"
 TEST_DIR="/tmp/mcp-app-studio-test"
 
@@ -36,7 +36,9 @@ node "$PACKAGE_DIR/dist/cli/index.js" "$PROJECT_NAME" -y --template poi-map $INC
 echo ""
 echo "📥 Installing dependencies..."
 cd "$TEST_DIR/$PROJECT_NAME"
-npm install
+# This script is often invoked through pnpm workspace scripts. Clear pnpm-style
+# user-agent env so the generated postinstall script exercises the npm path.
+env -u npm_config_user_agent -u npm_config_useragent npm install
 
 # Verify export defaults are written to config file
 echo ""

--- a/packages/mcp-app-studio/src/smoke.test.ts
+++ b/packages/mcp-app-studio/src/smoke.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import {
+  disableDebugMode,
+  enableDebugMode,
+  hasChatGPTExtensions,
+  isMCP,
+} from "./sdk";
+
+describe("smoke", () => {
+  it("exports core runtime helpers", () => {
+    expect(typeof isMCP).toBe("function");
+    expect(typeof hasChatGPTExtensions).toBe("function");
+    expect(typeof enableDebugMode).toBe("function");
+    expect(typeof disableDebugMode).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary
- add a real `packages/mcp-app-studio/src/smoke.test.ts` so `pnpm --filter mcp-app-studio test:smoke` is meaningful and passes
- harden `packages/mcp-app-studio/scripts/test-scaffold.sh` by clearing inherited user-agent env vars before `npm install`
- keep scaffold validation on the intended npm path even when invoked from a pnpm workspace script

## Why
During exhaustive pre-merge validation:
1. `test:smoke` failed because `vitest.smoke.config.ts` included `src/smoke.test.ts`, but the file did not exist.
2. `test:scaffold` could fail when run via pnpm scripts because `npm install` inherited pnpm user-agent env and the generated postinstall script selected pnpm, which can trip strict build-script policies in CI-style environments.

## Validation
- `pnpm --filter mcp-app-studio build`
- `pnpm --filter mcp-app-studio typecheck`
- `pnpm --filter mcp-app-studio test`
- `pnpm --filter mcp-app-studio test:smoke`
- `pnpm --filter mcp-app-studio test:scaffold`

Additionally (cross-repo/end-to-end):
- full local validation in `mcp-app-studio-starter` (`lint`, unit tests, `build`, `export`)
- clean-room scaffold matrix from published CLI (`mcp-app-studio@0.6.1`) across:
  - npm + pnpm
  - `minimal` + `poi-map`
  - `--include-server` + `--no-server`
  - each case: install, build, export, artifact checks

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `smoke.test.ts` for meaningful smoke tests and improve `test-scaffold.sh` reliability by clearing environment variables.
> 
>   - **Tests**:
>     - Add `smoke.test.ts` to `src` to ensure `test:smoke` is meaningful and passes.
>     - Verify exports of core runtime helpers in `smoke.test.ts`.
>   - **Scripts**:
>     - In `test-scaffold.sh`, clear `npm_config_user_agent` and `npm_config_useragent` before `npm install` to prevent issues with pnpm user-agent inheritance.
>     - Change default `PROJECT_NAME` to `test-mcp-app` in `test-scaffold.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 8f75c29739c1680ab09c2ca3545c5fa7f3f69f29. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->