### PR TITLE
feat(store): add useAuiStateShallow hook for object selectors

### DIFF
--- a/.changeset/shallow-state-selector.md
+++ b/.changeset/shallow-state-selector.md
@@ -1,0 +1,25 @@
+---
+"@assistant-ui/store": minor
+---
+
+feat: add useAuiStateShallow hook to prevent infinite re-renders
+
+When using `useAuiState` with selectors that return objects or arrays, React's `useSyncExternalStore` triggers infinite re-renders because each selector call creates a new object reference that fails `Object.is` comparison.
+
+This adds `useAuiStateShallow` which uses shallow equality comparison to maintain stable references when the object contents are identical.
+
+```typescript
+// ❌ Causes infinite re-render loop
+const { count, isActive } = useAuiState(({ thread }) => ({
+  count: thread.messages.length,
+  isActive: thread.status?.type === "running",
+}));
+
+// ✅ Works correctly with shallow comparison
+const { count, isActive } = useAuiStateShallow(({ thread }) => ({
+  count: thread.messages.length,
+  isActive: thread.status?.type === "running",
+}));
+```
+
+Also exports the `shallow` utility function for custom equality comparisons.

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,7 +1,10 @@
 // hooks
 export { useAui } from "./useAui";
-export { useAuiState } from "./useAuiState";
+export { useAuiState, useAuiStateShallow } from "./useAuiState";
 export { useAuiEvent } from "./useAuiEvent";
+
+// utilities
+export { shallow } from "./shallow";
 
 // components
 export { AuiIf } from "./AuiIf";

--- a/packages/store/src/shallow.ts
+++ b/packages/store/src/shallow.ts
@@ -1,0 +1,46 @@
+/**
+ * Shallow comparison function for objects and arrays.
+ * Returns true if both values are shallowly equal.
+ *
+ * Used by useAuiStateShallow to prevent infinite re-renders
+ * when selectors return new object references with identical values.
+ */
+export function shallow<T>(a: T, b: T): boolean {
+  if (Object.is(a, b)) {
+    return true;
+  }
+
+  if (
+    typeof a !== "object" ||
+    a === null ||
+    typeof b !== "object" ||
+    b === null
+  ) {
+    return false;
+  }
+
+  if (Array.isArray(a) !== Array.isArray(b)) {
+    return false;
+  }
+
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  for (const key of keysA) {
+    if (
+      !Object.prototype.hasOwnProperty.call(b, key) ||
+      !Object.is(
+        (a as Record<string, unknown>)[key],
+        (b as Record<string, unknown>)[key],
+      )
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/store/src/useAuiState.tsx
+++ b/packages/store/src/useAuiState.tsx
@@ -1,7 +1,13 @@
-import { useSyncExternalStore, useDebugValue } from "react";
+import {
+  useSyncExternalStore,
+  useDebugValue,
+  useRef,
+  useCallback,
+} from "react";
 import type { AssistantState } from "./types/client";
 import { useAui } from "./useAui";
 import { getProxiedAssistantState } from "./utils/proxied-assistant-state";
+import { shallow } from "./shallow";
 
 /**
  * Hook to access a slice of the assistant state with automatic subscription
@@ -26,6 +32,65 @@ export const useAuiState = <T,>(selector: (state: AssistantState) => T): T => {
     aui.subscribe,
     () => selector(proxiedState),
     () => selector(proxiedState),
+  );
+
+  if (slice === proxiedState) {
+    throw new Error(
+      "You tried to return the entire AssistantState. This is not supported due to technical limitations.",
+    );
+  }
+
+  useDebugValue(slice);
+
+  return slice;
+};
+
+/**
+ * Hook to access a slice of the assistant state with shallow equality comparison.
+ *
+ * Use this when your selector returns an object or array. Without shallow comparison,
+ * selectors that return new object references on every call will cause infinite
+ * re-renders due to useSyncExternalStore's Object.is comparison.
+ *
+ * @param selector - Function to select a slice of the state (may return objects/arrays)
+ * @returns The selected state slice (stable reference if shallowly equal)
+ *
+ * @example
+ * ```typescript
+ * // ❌ BAD: useAuiState with object return causes infinite loop
+ * const { count, isActive } = useAuiState(({ thread }) => ({
+ *   count: thread.messages.length,
+ *   isActive: thread.status?.type === "running",
+ * }));
+ *
+ * // ✅ GOOD: useAuiStateShallow handles object returns safely
+ * const { count, isActive } = useAuiStateShallow(({ thread }) => ({
+ *   count: thread.messages.length,
+ *   isActive: thread.status?.type === "running",
+ * }));
+ * ```
+ */
+export const useAuiStateShallow = <T,>(
+  selector: (state: AssistantState) => T,
+): T => {
+  const aui = useAui();
+  const proxiedState = getProxiedAssistantState(aui);
+  const prevRef = useRef<T | undefined>(undefined);
+
+  // Memoize selector to maintain stable reference
+  const stableSelector = useCallback(() => {
+    const next = selector(proxiedState);
+    if (prevRef.current !== undefined && shallow(prevRef.current, next)) {
+      return prevRef.current;
+    }
+    prevRef.current = next;
+    return next;
+  }, [selector, proxiedState]);
+
+  const slice = useSyncExternalStore(
+    aui.subscribe,
+    stableSelector,
+    stableSelector,
   );
 
   if (slice === proxiedState) {


### PR DESCRIPTION
## Summary

When using `useAuiState` with selectors that return objects or arrays, React's `useSyncExternalStore` triggers infinite re-renders because each selector call creates a new object reference that fails `Object.is` comparison.

This PR adds `useAuiStateShallow` which uses shallow equality comparison to maintain stable references when the object contents are identical.

## Problem

```typescript
// ❌ Causes infinite re-render loop
const { count, isActive } = useAuiState(({ thread }) => ({
  count: thread.messages.length,
  isActive: thread.status?.type === "running",
}));
```

The selector returns a new `{}` object on every call. `useSyncExternalStore` uses `Object.is` to compare snapshots:
- New object `{count: 5, isActive: true}` !== previous object `{count: 5, isActive: true}`
- React thinks state changed → re-render → new selector call → new object → infinite loop

## Solution

```typescript
// ✅ Works correctly with shallow comparison  
const { count, isActive } = useAuiStateShallow(({ thread }) => ({
  count: thread.messages.length,
  isActive: thread.status?.type === "running",
}));
```

`useAuiStateShallow` caches the previous result and returns it if shallowly equal to the new result, maintaining reference stability.

## Changes

- **`shallow.ts`** — New shallow equality utility function
- **`useAuiState.tsx`** — Added `useAuiStateShallow` hook alongside existing `useAuiState`
- **`index.ts`** — Export `useAuiStateShallow` and `shallow`

## Prior Art

This follows the same pattern as [Zustand's `useShallow`](https://github.com/pmndrs/zustand#using-zustand-without-react) which solves the identical problem with `useSyncExternalStore`.

## Real-world Impact

We hit this bug while building a production LangGraph multi-agent chat app with assistant-ui. The `ChainOfThoughtPrimitive` component crashed with infinite loops when trying to count reasoning/tool-call parts:

```typescript
// Our workaround: split into separate primitive selectors
const reasoningCount = useAuiState(({ chainOfThought }) =>
  chainOfThought.parts.reduce((n, p) => n + (p.type === "reasoning" ? 1 : 0), 0)
);
const toolCount = useAuiState(({ chainOfThought }) =>
  chainOfThought.parts.reduce((n, p) => n + (p.type === "tool-call" ? 1 : 0), 0)
);

// With this PR, this natural pattern would work:
const { reasoningCount, toolCount } = useAuiStateShallow(({ chainOfThought }) => ({
  reasoningCount: chainOfThought.parts.filter(p => p.type === "reasoning").length,
  toolCount: chainOfThought.parts.filter(p => p.type === "tool-call").length,
}));
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `useAuiStateShallow` hook and `shallow` utility to prevent infinite re-renders with object/array selectors.
> 
>   - **New Hook**:
>     - Adds `useAuiStateShallow` in `useAuiState.tsx` to prevent infinite re-renders by using shallow equality comparison for selectors returning objects or arrays.
>   - **Utility Function**:
>     - Introduces `shallow` function in `shallow.ts` for shallow comparison of objects and arrays.
>   - **Exports**:
>     - Updates `index.ts` to export `useAuiStateShallow` and `shallow`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for ac66206b08058472e93cd052f1f3e63d32c8b4fd. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->