### PR TITLE
fix(docs): convert analytics tests from node:test to vitest

### DIFF
--- a/apps/docs/lib/analytics.test.ts
+++ b/apps/docs/lib/analytics.test.ts
@@ -1,8 +1,7 @@
-import assert from "node:assert/strict";
-import test from "node:test";
+import { expect, it } from "vitest";
 import { analytics } from "./analytics";
 
-test("analytics does not throw when umami exists without track", () => {
+it("analytics does not throw when umami exists without track", () => {
   const globalObject = globalThis as { window?: unknown };
   const previousWindow = globalObject.window;
 
@@ -11,9 +10,9 @@ test("analytics does not throw when umami exists without track", () => {
       umami: {},
     };
 
-    assert.doesNotThrow(() => {
+    expect(() => {
       analytics.cta.clicked("get_started", "header");
-    });
+    }).not.toThrow();
   } finally {
     if (previousWindow === undefined) {
       delete globalObject.window;

--- a/apps/docs/lib/assistant-analytics-helpers.test.ts
+++ b/apps/docs/lib/assistant-analytics-helpers.test.ts
@@ -1,5 +1,4 @@
-import assert from "node:assert/strict";
-import test from "node:test";
+import { expect, it } from "vitest";
 import {
   consumeRunStartedAt,
   getComposerMessageMetrics,
@@ -8,43 +7,43 @@ import {
   recordRunStartedAt,
 } from "./assistant-analytics-helpers";
 
-test("getComposerMessageMetrics returns undefined for empty composer", () => {
+it("getComposerMessageMetrics returns undefined for empty composer", () => {
   const metrics = getComposerMessageMetrics({
     isEmpty: true,
     text: "ignored",
     attachments: [{}, {}],
   });
 
-  assert.equal(metrics, undefined);
+  expect(metrics).toBeUndefined();
 });
 
-test("getComposerMessageMetrics returns message and attachment sizes", () => {
+it("getComposerMessageMetrics returns message and attachment sizes", () => {
   const metrics = getComposerMessageMetrics({
     isEmpty: false,
     text: "Hello",
     attachments: [{ id: "a" }, { id: "b" }],
   });
 
-  assert.deepEqual(metrics, {
+  expect(metrics).toEqual({
     messageLength: 5,
     attachmentsCount: 2,
   });
 });
 
-test("getComposerMessageMetrics keeps attachment-only sends", () => {
+it("getComposerMessageMetrics keeps attachment-only sends", () => {
   const metrics = getComposerMessageMetrics({
     isEmpty: false,
     text: "",
     attachments: [{ id: "attachment" }],
   });
 
-  assert.deepEqual(metrics, {
+  expect(metrics).toEqual({
     messageLength: 0,
     attachmentsCount: 1,
   });
 });
 
-test("queueMicrotaskSafe reads state after synchronous updates", async () => {
+it("queueMicrotaskSafe reads state after synchronous updates", async () => {
   let value = 1;
 
   const captured = await new Promise<number>((resolve) => {
@@ -52,21 +51,21 @@ test("queueMicrotaskSafe reads state after synchronous updates", async () => {
     value = 2;
   });
 
-  assert.equal(captured, 2);
+  expect(captured).toBe(2);
 });
 
-test("run-start tracking keeps separate start times per thread run", () => {
+it("run-start tracking keeps separate start times per thread run", () => {
   const runStarts = new Map<string, number[]>();
 
   recordRunStartedAt(runStarts, "thread-1", 100);
   recordRunStartedAt(runStarts, "thread-1", 200);
 
-  assert.equal(consumeRunStartedAt(runStarts, "thread-1"), 100);
-  assert.equal(consumeRunStartedAt(runStarts, "thread-1"), 200);
-  assert.equal(consumeRunStartedAt(runStarts, "thread-1"), undefined);
+  expect(consumeRunStartedAt(runStarts, "thread-1")).toBe(100);
+  expect(consumeRunStartedAt(runStarts, "thread-1")).toBe(200);
+  expect(consumeRunStartedAt(runStarts, "thread-1")).toBeUndefined();
 });
 
-test("run-start cleanup removes only stale entries", () => {
+it("run-start cleanup removes only stale entries", () => {
   const runStarts = new Map<string, number[]>();
 
   recordRunStartedAt(runStarts, "thread-1", 100);
@@ -75,6 +74,6 @@ test("run-start cleanup removes only stale entries", () => {
 
   pruneStaleRunStarts(runStarts, 400, 150);
 
-  assert.deepEqual(runStarts.get("thread-1"), [300]);
-  assert.deepEqual(runStarts.get("thread-2"), [350]);
+  expect(runStarts.get("thread-1")).toEqual([300]);
+  expect(runStarts.get("thread-2")).toEqual([350]);
 });

--- a/apps/docs/lib/assistant-metrics.test.ts
+++ b/apps/docs/lib/assistant-metrics.test.ts
@@ -1,8 +1,7 @@
-import assert from "node:assert/strict";
-import test from "node:test";
+import { expect, it } from "vitest";
 import { getAssistantMessageTokenUsage } from "./assistant-metrics";
 
-test("getAssistantMessageTokenUsage returns empty for zero-token custom usage", () => {
+it("getAssistantMessageTokenUsage returns empty for zero-token custom usage", () => {
   const usage = getAssistantMessageTokenUsage({
     role: "assistant",
     metadata: {
@@ -14,10 +13,10 @@ test("getAssistantMessageTokenUsage returns empty for zero-token custom usage", 
     },
   });
 
-  assert.deepEqual(usage, {});
+  expect(usage).toEqual({});
 });
 
-test("getAssistantMessageTokenUsage returns totals for positive usage", () => {
+it("getAssistantMessageTokenUsage returns totals for positive usage", () => {
   const usage = getAssistantMessageTokenUsage({
     role: "assistant",
     metadata: {
@@ -30,7 +29,7 @@ test("getAssistantMessageTokenUsage returns totals for positive usage", () => {
     },
   });
 
-  assert.deepEqual(usage, {
+  expect(usage).toEqual({
     totalTokens: 10,
     inputTokens: 4,
     outputTokens: 6,


### PR DESCRIPTION
## Summary
- Three test files in `apps/docs/lib/` used `node:test` (`import test from "node:test"` + `assert`) but the docs app runs `vitest run`, causing "No test suite found" errors
- Converted all three files to use vitest's `it` and `expect` APIs
- Affects: `analytics.test.ts`, `assistant-analytics-helpers.test.ts`, `assistant-metrics.test.ts`

## Context
These tests were added in #3222 and haven't been caught on main because CI only runs "Test Changed Packages" — since no subsequent main commits touched `apps/docs`, the broken tests were never re-executed.

## Test plan
- [ ] CI passes (all 3 test suites should now be found by vitest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Convert `node:test` tests to `vitest` in `analytics.test.ts`, `assistant-analytics-helpers.test.ts`, and `assistant-metrics.test.ts`.
> 
>   - **Test Conversion**:
>     - Convert `analytics.test.ts`, `assistant-analytics-helpers.test.ts`, and `assistant-metrics.test.ts` from `node:test` to `vitest`.
>     - Replace `assert` with `expect` and `test` with `it` in all three files.
>   - **Context**:
>     - Original tests used `node:test`, causing "No test suite found" errors with `vitest`.
>     - Tests were not caught on main due to CI configuration only running tests on changed packages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 9cbf30338815c283d1ccd70ff62a958a13caf4c3. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->