### PR TITLE
docs(mcp-app-studio): align landing page copy with current behavior

### DIFF
--- a/apps/docs/app/mcp-app-studio/page.tsx
+++ b/apps/docs/app/mcp-app-studio/page.tsx
@@ -164,6 +164,7 @@ const PLATFORM_CAPABILITIES = [
 const FEATURE_GATE_SNIPPET = `import { useState } from "react";
 import { openModal, useFeature } from "mcp-app-studio";
 
+// Example component; adapt export conventions to your project.
 export function MyApp() {
   const hasWidgetState = useFeature("widgetState"); // ChatGPT-only
   const hasModelContext = useFeature("modelContext"); // Host-dependent
@@ -516,8 +517,8 @@ export default function McpAppStudioPage() {
               Export and ship
             </h2>
             <p className="text-muted-foreground">
-              Your production-ready bundle, ready for ChatGPT, Claude, and other
-              MCP hosts.
+              Your production-ready bundle, ready for MCP hosts like Claude,
+              with optional ChatGPT extensions.
             </p>
           </div>
 
@@ -531,11 +532,11 @@ export default function McpAppStudioPage() {
           <p className="mx-auto max-w-2xl text-center text-muted-foreground text-sm">
             Deploy <code>export/widget/</code> to any static host, then update
             <code> export/manifest.json</code> with the hosted URL and register
-            it with your target host (Claude, ChatGPT, or other MCP hosts). By
-            default export emits <code>index.html, widget.js, widget.css</code>,
-            with optional <code>--inline</code> for single-file HTML. It’s the
-            same app either way; the host controls which capabilities are
-            available.
+            it with your target host. The same widget works across MCP hosts
+            (for example, Claude) and ChatGPT extensions. By default export
+            emits <code>index.html, widget.js, widget.css</code>, with optional{" "}
+            <code>--inline</code> for single-file HTML. It’s the same app either
+            way; the host controls which capabilities are available.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
This updates the MCP App Studio landing page copy to reflect current product behavior and reduce evaluator confusion.

### What changed
- Corrected export messaging to match reality:
  - default export output is `index.html` + `widget.js` + `widget.css`
  - `--inline` is optional for single-file HTML output
- Updated display mode wording from "popup" to "PiP".
- Clarified capability semantics:
  - model context is host-dependent (`ui/update-model-context`), not universally guaranteed
  - added explicit host-modal row for `window.openai.requestModal` (ChatGPT extension)
- Updated the feature-gating snippet to show extension fallback via `openModal(..., fallback)`.
- Improved workbench error fallback copy for hosted docs context (connectivity + local scaffold command).

## Why
The previous page had a few claims/wording choices that were true for earlier iterations but now create ambiguity for users evaluating MCP App Studio. This keeps the page aligned with current MCP-first + optional-extension behavior.

## Validation
- `pnpm exec biome check apps/docs/app/mcp-app-studio/page.tsx`

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update MCP App Studio landing page copy in `page.tsx` to align with current behavior and reduce evaluator confusion.
> 
>   - **Behavior**:
>     - Updated export messaging to reflect default output as `index.html`, `widget.js`, `widget.css` with optional `--inline` for single-file HTML.
>     - Changed display mode wording from "popup" to "PiP".
>     - Clarified model context as host-dependent and added host-modal row for `window.openai.requestModal`.
>     - Updated feature-gating snippet to show extension fallback via `openModal(..., fallback)`.
>     - Improved workbench error fallback copy for hosted docs context.
>   - **Links**:
>     - Renamed `chatgptAppsSdk` to `openaiAppsSdk` and updated links in `OUTBOUND_URLS` and `OUTBOUND_LINKS`.
>     - Added `claudeSubmissionGuide` link to `OUTBOUND_URLS` and `OUTBOUND_LINKS`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 5090184f2c36013585c082909eb6b7ebb8371267. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->