### PR TITLE
fix: avoid bracket notation for process.env

### DIFF
--- a/packages/react/src/context/react/utils/ensureBinding.ts
+++ b/packages/react/src/context/react/utils/ensureBinding.ts
@@ -40,7 +40,7 @@ export const ensureBinding = (r: unknown) => {
   runtime.__internal_bindMethods?.();
   runtime.__isBound = true;
 
-  if (process.env["NODE_ENV"] !== "production") {
+  if (process.env.NODE_ENV !== "production") {
     debugVerifyPrototype(runtime, Object.getPrototypeOf(runtime));
   }
 };

--- a/packages/react/src/legacy-runtime/AssistantRuntimeProvider.tsx
+++ b/packages/react/src/legacy-runtime/AssistantRuntimeProvider.tsx
@@ -34,7 +34,7 @@ export const AssistantRuntimeProviderImpl: FC<
   useEffect(() => {
     if (
       typeof process === "undefined" ||
-      process.env["NODE_ENV"] === "production"
+      process.env.NODE_ENV === "production"
     )
       return;
     return DevToolsProviderApi.register(aui);

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useToolInvocations.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useToolInvocations.ts
@@ -181,7 +181,7 @@ export function useToolInvocations({
 
               if (content.argsText !== lastState.argsText) {
                 if (lastState.argsComplete) {
-                  if (process.env["NODE_ENV"] !== "production") {
+                  if (process.env.NODE_ENV !== "production") {
                     console.warn(
                       "argsText updated after controller was closed:",
                       {

--- a/packages/tap/src/core/env.ts
+++ b/packages/tap/src/core/env.ts
@@ -1,4 +1,4 @@
 export const isDevelopment =
   typeof process !== "undefined" &&
-  (process.env["NODE_ENV"] === "development" ||
-    process.env["NODE_ENV"] === "test");
+  (process.env.NODE_ENV === "development" ||
+    process.env.NODE_ENV === "test");

--- a/packages/x-buildutils/ts/base.json
+++ b/packages/x-buildutils/ts/base.json
@@ -10,6 +10,7 @@
     "jsx": "react-jsx",
     "lib": ["dom", "dom.iterable", "ES2023"],
     "stripInternal": true,
+    "noPropertyAccessFromIndexSignature": false,
     "customConditions": ["aui-source"]
   }
 }


### PR DESCRIPTION
fixes #3223
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces bracket notation with dot notation for `process.env.NODE_ENV` access in multiple files and updates TypeScript configuration in `base.json`.
> 
>   - **Behavior**:
>     - Replaces bracket notation `process.env["NODE_ENV"]` with dot notation `process.env.NODE_ENV` in `ensureBinding.ts`, `AssistantRuntimeProvider.tsx`, and `useToolInvocations.ts`.
>     - Updates `isDevelopment` logic in `env.ts` to use dot notation for `process.env.NODE_ENV`.
>   - **Configuration**:
>     - Sets `noPropertyAccessFromIndexSignature` to `false` in `base.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 94a5b5d3bf1a1deeebbcc40117b24b49c32653cd. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->