### PR TITLE
fix: format process.env checks to satisfy biome

### DIFF
--- a/packages/react/src/legacy-runtime/AssistantRuntimeProvider.tsx
+++ b/packages/react/src/legacy-runtime/AssistantRuntimeProvider.tsx
@@ -32,10 +32,7 @@ export const AssistantRuntimeProviderImpl: FC<
   const aui = useAui({ threads: RuntimeAdapter(runtime) }, { parent: parent });
 
   useEffect(() => {
-    if (
-      typeof process === "undefined" ||
-      process.env.NODE_ENV === "production"
-    )
+    if (typeof process === "undefined" || process.env.NODE_ENV === "production")
       return;
     return DevToolsProviderApi.register(aui);
   }, [aui]);

--- a/packages/tap/src/core/env.ts
+++ b/packages/tap/src/core/env.ts
@@ -1,4 +1,3 @@
 export const isDevelopment =
   typeof process !== "undefined" &&
-  (process.env.NODE_ENV === "development" ||
-    process.env.NODE_ENV === "test");
+  (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test");


### PR DESCRIPTION
## Summary
- Collapse multiline `if` conditions in `AssistantRuntimeProvider.tsx` and `env.ts` to single lines
- These formatting errors were introduced by #3243 (bracket-to-dot notation change shortened lines below biome's 80-char threshold)

## Test plan
- [ ] Verify `pnpm lint` passes in CI
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Collapse multiline `if` conditions to single lines in `AssistantRuntimeProvider.tsx` and `env.ts` to satisfy biome formatting rules.
> 
>   - **Formatting**:
>     - Collapse multiline `if` condition in `useEffect` in `AssistantRuntimeProvider.tsx` to a single line.
>     - Collapse multiline `if` condition in `isDevelopment` in `env.ts` to a single line.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 870b6cf81e26cf10cab0bc5d51c3789fe8a73ae3. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->