### PR TITLE
feat(react): add `submitMode` prop

### DIFF
--- a/.changeset/submit-on-ctrl-enter.md
+++ b/.changeset/submit-on-ctrl-enter.md
@@ -2,8 +2,8 @@
 "@assistant-ui/react": patch
 ---
 
-feat(ComposerInput): add submitMode prop
+feat(react): add submitMode prop
 
-Add submitMode prop to ComposerInput with two options: "enter" (default) and "ctrlEnter". This controls keyboard submission behavior - "ctrlEnter" mode allows plain Enter to insert newlines for easier multi-line message composition.
+Add submitMode prop to ComposerInput with three options: "enter" (default), "ctrlEnter", and "none". This controls keyboard submission behavior - "ctrlEnter" mode allows plain Enter to insert newlines for easier multi-line message composition, "none" disables keyboard submission entirely.
 
 The existing submitOnEnter prop is now deprecated but still supported for backward compatibility.

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/composer.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/composer.mdx
@@ -84,14 +84,32 @@ This primitive renders a `<textarea>` element unless `asChild` is set.
     {
       name: "asChild",
     },
+    {
+      name: "submitMode",
+      type: '"enter" | "ctrlEnter" | "none"',
+      default: '"enter"',
+      description:
+        'Controls how the Enter key submits messages. "enter": plain Enter submits (Shift+Enter for newline). "ctrlEnter": Ctrl/Cmd+Enter submits (plain Enter for newline). "none": keyboard submission disabled.',
+    },
   ]}
 />
 
 #### Keyboard Shortcuts
 
+Default (`submitMode="enter"`):
+
 | Key | Description |
 | --- | --- |
 | <Kbd>Enter</Kbd> | Sends the message. |
+| <Kbd>Shift + Enter</Kbd> | Inserts a newline. |
+| <Kbd>Escape</Kbd> | Sends a cancel action. |
+
+With `submitMode="ctrlEnter"`:
+
+| Key | Description |
+| --- | --- |
+| <Kbd>Ctrl/Cmd + Enter</Kbd> | Sends the message. |
+| <Kbd>Enter</Kbd> | Inserts a newline. |
 | <Kbd>Escape</Kbd> | Sends a cancel action. |
 
 ### Send


### PR DESCRIPTION
## Summary

  Add `submitOnCtrlEnter` prop to `ComposerInput` for Ctrl/Cmd+Enter submission mode. When enabled, plain Enter
  inserts newlines and Ctrl/Cmd+Enter submits - common pattern in Slack/Discord for multi-line messages.

  ## Changes

  - Add `submitOnCtrlEnter` boolean prop (default: `false`)
  - Update keyboard handler to support two modes:
    - **Default**: Plain Enter submits (unchanged behavior)
    - **Ctrl+Enter mode**: Plain Enter = newline, Ctrl/Cmd+Enter = submit
  - Add console warning when both `submitOnEnter` and `submitOnCtrlEnter` are `true`
  - Cross-platform: supports both Ctrl (Windows/Linux) and Cmd (macOS)

  ## Testing

  Manually tested all combinations in `with-ai-sdk-v6` example:

  **Default mode** (`submitOnCtrlEnter={false}`):
  - ✅ Enter submits, Shift+Enter newline (original behavior preserved)

  **Ctrl+Enter mode** (`submitOnCtrlEnter={true}`):
  - ✅ Enter = newline, Ctrl/Cmd+Enter = submit
  - ✅ Multi-line composition works

  **Both true**:
  - ✅ Warning displays, `submitOnCtrlEnter` takes precedence

  ## Backward Compatible

  - Default value `false` preserves existing behavior
  - No breaking changes