### PR TITLE
fix(react): duplicate toolcalls

### DIFF
--- a/.changeset/fix-duplicate-toolcallid.md
+++ b/.changeset/fix-duplicate-toolcallid.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: duplicate key toolCallId error in HITL tools (#3197)

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -25,7 +25,7 @@ const convertParts = (
     return [];
   }
 
-  return message.parts
+  const converted = message.parts
     .filter((p) => p.type !== "step-start" && p.type !== "file")
     .map((part) => {
       const type = part.type;
@@ -132,6 +132,15 @@ const convertParts = (
       return null;
     })
     .filter(Boolean) as any[];
+
+  const seenToolCallIds = new Set<string>();
+  return converted.filter((part: any) => {
+    if (part.type === "tool-call" && part.toolCallId != null) {
+      if (seenToolCallIds.has(part.toolCallId)) return false;
+      seenToolCallIds.add(part.toolCallId);
+    }
+    return true;
+  });
 };
 
 export const AISDKMessageConverter = unstable_createMessageConverter(

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useToolInvocations.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useToolInvocations.ts
@@ -233,6 +233,13 @@ export function useToolInvocations({
               }
 
               if (content.result !== undefined && !lastState.hasResult) {
+                lastToolStates.current[content.toolCallId] = {
+                  hasResult: true,
+                  argsComplete: true,
+                  argsText: lastState.argsText,
+                  controller: lastState.controller,
+                };
+
                 lastState.controller.setResponse(
                   new ToolResponse({
                     result: content.result as ReadonlyJSONValue,
@@ -241,13 +248,6 @@ export function useToolInvocations({
                   }),
                 );
                 lastState.controller.close();
-
-                lastToolStates.current[content.toolCallId] = {
-                  hasResult: true,
-                  argsComplete: true,
-                  argsText: lastState.argsText,
-                  controller: lastState.controller,
-                };
               }
             }
 


### PR DESCRIPTION
This PR fixes duplicate toolcall ids error.

close #3197
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes duplicate `toolCallId` error in HITL tools by filtering duplicates in `convertMessage.ts` and updating state correctly in `useToolInvocations.ts`.
> 
>   - **Behavior**:
>     - Fixes duplicate `toolCallId` error in HITL tools by filtering out duplicates in `convertParts()` in `convertMessage.ts`.
>     - Ensures `lastToolStates` is updated correctly in `useToolInvocations()` in `useToolInvocations.ts` to prevent duplicate state entries.
>   - **Misc**:
>     - Adds a changeset file `fix-duplicate-toolcallid.md` to document the patch changes for `@assistant-ui/react` and `@assistant-ui/react-ai-sdk`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d4275d67046e42d38fd73f35eada6edf2707eada. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->