### PR TITLE
feat(react-ag-ui): support frontend tool execution

### DIFF
--- a/.changeset/agui-tool-execute.md
+++ b/.changeset/agui-tool-execute.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat(react-ag-ui): support frontend tool execution in AG-UI runtime

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -185,6 +185,18 @@ export class AgUiThreadRuntimeCore {
     );
   }
 
+  findMessageIdForToolCall(toolCallId: string): string | undefined {
+    for (const message of this.messages) {
+      if (message.role !== "assistant") continue;
+      for (const part of message.content) {
+        if (part.type === "tool-call" && part.toolCallId === toolCallId) {
+          return message.id;
+        }
+      }
+    }
+    return undefined;
+  }
+
   addToolResult(options: AddToolResultOptions): void {
     let updated = false;
     this.messages = this.messages.map((message) => {


### PR DESCRIPTION
This PR adds support to frontend tool execution in AG-UI.

related #2218
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds frontend tool execution support in AG-UI runtime with new functions and state management in `AgUiThreadRuntimeCore.ts` and `useAgUiRuntime.ts`.
> 
>   - **Behavior**:
>     - Adds frontend tool execution support in `AgUiThreadRuntimeCore.ts` and `useAgUiRuntime.ts`.
>     - Introduces `findMessageIdForToolCall` in `AgUiThreadRuntimeCore` to map tool calls to message IDs.
>     - Manages tool execution status with `useState` in `useAgUiRuntime.ts`.
>   - **Functions**:
>     - Uses `INTERNAL.useToolInvocations` in `useAgUiRuntime.ts` to handle tool invocation lifecycle.
>     - Updates `onCancel` in `useAgUiRuntime.ts` to abort tool invocations.
>   - **Misc**:
>     - Adds changeset file `agui-tool-execute.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c1573ab430ece8890eac548123f4a66296fcc493. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->