### PR TITLE
fix(react): runConfig not applied

### DIFF
--- a/.changeset/fix-suggestion-runconfig.md
+++ b/.changeset/fix-suggestion-runconfig.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): runConfig not applied when clicking Suggestion with send=true

--- a/packages/react/src/primitives/suggestion/SuggestionTrigger.tsx
+++ b/packages/react/src/primitives/suggestion/SuggestionTrigger.tsx
@@ -37,7 +37,10 @@ const useSuggestionTrigger = ({
     const isRunning = aui.thread().getState().isRunning;
 
     if (resolvedSend && !isRunning) {
-      aui.thread().append(prompt);
+      aui.thread().append({
+        content: [{ type: "text", text: prompt }],
+        runConfig: aui.composer().getState().runConfig,
+      });
       if (clearComposer) {
         aui.composer().setText("");
       }

--- a/packages/react/src/primitives/thread/ThreadSuggestion.tsx
+++ b/packages/react/src/primitives/thread/ThreadSuggestion.tsx
@@ -50,7 +50,10 @@ const useThreadSuggestion = ({
     const isRunning = aui.thread().getState().isRunning;
 
     if (resolvedSend && !isRunning) {
-      aui.thread().append(prompt);
+      aui.thread().append({
+        content: [{ type: "text", text: prompt }],
+        runConfig: aui.composer().getState().runConfig,
+      });
       if (clearComposer) {
         aui.composer().setText("");
       }


### PR DESCRIPTION
This PR fixes `runConfig` is not applied on Suggestions

close #2299
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `runConfig` not applied when clicking Suggestion with `send=true` in `SuggestionTrigger.tsx` and `ThreadSuggestion.tsx`.
> 
>   - **Behavior**:
>     - Fixes `runConfig` not applied when clicking Suggestion with `send=true` in `SuggestionTrigger.tsx` and `ThreadSuggestion.tsx`.
>     - Modifies `aui.thread().append()` to include `runConfig` from `aui.composer().getState().runConfig`.
>   - **Misc**:
>     - Adds changeset file `fix-suggestion-runconfig.md` for patch release.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for ac630b04535e5ec83409c88ca15d25f4705a35a2. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->