### PR TITLE
fix(docs): remove duplicate runtimes

### DIFF
--- a/apps/docs/content/examples/ai-sdk.mdx
+++ b/apps/docs/content/examples/ai-sdk.mdx
@@ -4,12 +4,9 @@ description: Chat persistence with AI SDK
 ---
 
 import { Shadcn } from "@/components/examples/shadcn";
-import { DocsRuntimeProvider } from "@/contexts/DocsRuntimeProvider";
 
 <div className="not-prose h-[600px]">
-  <DocsRuntimeProvider>
-    <Shadcn />
-  </DocsRuntimeProvider>
+  <Shadcn />
 </div>
 
 ## Overview

--- a/apps/docs/content/examples/chatgpt.mdx
+++ b/apps/docs/content/examples/chatgpt.mdx
@@ -4,12 +4,9 @@ description: Customized colors and styles for a ChatGPT look and feel
 ---
 
 import { ChatGPT } from "@/components/examples/chatgpt";
-import { DocsRuntimeProvider } from "@/contexts/DocsRuntimeProvider";
 
 <div className="not-prose h-[600px]">
-  <DocsRuntimeProvider>
-    <ChatGPT />
-  </DocsRuntimeProvider>
+  <ChatGPT />
 </div>
 
 ## Overview

--- a/apps/docs/content/examples/claude.mdx
+++ b/apps/docs/content/examples/claude.mdx
@@ -4,12 +4,9 @@ description: Customized colors and styles for a Claude look and feel
 ---
 
 import { Claude } from "@/components/examples/claude";
-import { DocsRuntimeProvider } from "@/contexts/DocsRuntimeProvider";
 
 <div className="not-prose h-[600px]">
-  <DocsRuntimeProvider>
-    <Claude />
-  </DocsRuntimeProvider>
+  <Claude />
 </div>
 
 ## Overview

--- a/apps/docs/content/examples/grok.mdx
+++ b/apps/docs/content/examples/grok.mdx
@@ -3,13 +3,10 @@ title: Grok Clone
 description: Customized colors and styles for a Grok look and feel
 ---
 
-import { DocsRuntimeProvider } from "@/contexts/DocsRuntimeProvider";
 import { Grok } from "@/components/examples/grok";
 
 <div className="not-prose h-[600px]">
-  <DocsRuntimeProvider>
-    <Grok />
-  </DocsRuntimeProvider>
+  <Grok />
 </div>
 
 ## Overview

--- a/apps/docs/content/examples/modal.mdx
+++ b/apps/docs/content/examples/modal.mdx
@@ -4,12 +4,9 @@ description: Floating button that opens an AI assistant chat box
 ---
 
 import { ModalChat } from "@/components/examples/modal";
-import { DocsRuntimeProvider } from "@/contexts/DocsRuntimeProvider";
 
 <div className="h-[500px]">
-  <DocsRuntimeProvider>
-    <ModalChat />
-  </DocsRuntimeProvider>
+  <ModalChat />
 </div>
 
 ## Overview

--- a/apps/docs/content/examples/perplexity.mdx
+++ b/apps/docs/content/examples/perplexity.mdx
@@ -4,12 +4,9 @@ description: Dark theme with cyan accents for a Perplexity look and feel
 ---
 
 import { Perplexity } from "@/components/examples/perplexity";
-import { DocsRuntimeProvider } from "@/contexts/DocsRuntimeProvider";
 
 <div className="not-prose h-[600px]">
-  <DocsRuntimeProvider>
-    <Perplexity />
-  </DocsRuntimeProvider>
+  <Perplexity />
 </div>
 
 ## Overview


### PR DESCRIPTION
This PR removes duplicate runtimes to avoid tools be register twice on docs site.

Issue:

<img width="896" height="1168" alt="ScreenShot 2026-02-08 at 21 57 12@2x" src="https://github.com/user-attachments/assets/2ee25bb1-efb4-40e1-9e4d-88ae07807d70" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes duplicate `DocsRuntimeProvider` wrappers from example files to prevent double registration of runtimes.
> 
>   - **Behavior**:
>     - Removes `DocsRuntimeProvider` wrapper from components in `ai-sdk.mdx`, `chatgpt.mdx`, and `claude.mdx` to prevent duplicate runtime registration.
>     - Similar removal in `grok.mdx`, `modal.mdx`, and `perplexity.mdx`.
>   - **Misc**:
>     - Simplifies component structure by directly using components like `Shadcn`, `ChatGPT`, `Claude`, `Grok`, `ModalChat`, and `Perplexity` without additional runtime context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1efd35e289ba00cd26927b7a2106fbf39715fd50. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->