### PR TITLE
Revert "chore: update versions (#3232)"

### DIFF
--- a/.changeset/agui-tool-execute.md
+++ b/.changeset/agui-tool-execute.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat(react-ag-ui): support frontend tool execution in AG-UI runtime

--- a/.changeset/fancy-pots-hear.md
+++ b/.changeset/fancy-pots-hear.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/tap": patch
+---
+
+fix: use bracket notation for process.env

--- a/.changeset/fix-duplicate-toolcallid.md
+++ b/.changeset/fix-duplicate-toolcallid.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: duplicate key toolCallId error in HITL tools (#3197)

--- a/.changeset/fix-suggestion-runconfig.md
+++ b/.changeset/fix-suggestion-runconfig.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): runConfig not applied when clicking Suggestion with send=true

--- a/.changeset/fuzzy-pumpkins-obey.md
+++ b/.changeset/fuzzy-pumpkins-obey.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix(cli): make `init` command work in non-interactive environments

--- a/.changeset/langgraph-tool-execute.md
+++ b/.changeset/langgraph-tool-execute.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+feat(react-langgraph): support frontend tool execution in LangGraph runtime

--- a/.changeset/quote-selected-text.md
+++ b/.changeset/quote-selected-text.md
@@ -1,0 +1,17 @@
+---
+"@assistant-ui/react": minor
+---
+
+feat: Quote Selected Text primitives
+
+Added new primitives and hooks for quoting selected text from messages:
+
+- `SelectionToolbarPrimitive.Root` - Floating toolbar that appears on text selection within a message
+- `SelectionToolbarPrimitive.Quote` - Button inside the floating toolbar to capture the selection as a quote
+- `ComposerPrimitive.Quote` - Container for quote preview (renders only when quote is set)
+- `ComposerPrimitive.QuoteText` - Displays the quoted text
+- `ComposerPrimitive.QuoteDismiss` - Button to clear the quote
+- `useMessageQuote()` - Hook to read quote info from message metadata
+- `QuoteInfo` type - `{ text: string; messageId: string }`
+- `ComposerRuntime.setQuote()` - Programmatic API to set/clear quotes
+- `MessagePrimitive.Root` now renders `data-message-id` attribute

--- a/.changeset/support-editing-messages.md
+++ b/.changeset/support-editing-messages.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat(assistant-transport): support editing messages

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,11 +1,5 @@
 # assistant-ui
 
-## 0.0.79
-
-### Patch Changes
-
-- b6bb85e: fix(cli): make `init` command work in non-interactive environments
-
 ## 0.0.78
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant-ui",
-  "version": "0.0.79",
+  "version": "0.0.78",
   "description": "CLI for assistant-ui",
   "keywords": [
     "cli",

--- a/packages/react-a2a/CHANGELOG.md
+++ b/packages/react-a2a/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @assistant-ui/react-a2a
 
-## 1.0.0
-
-### Patch Changes
-
-- Updated dependencies [2eba036]
-- Updated dependencies [bf1a109]
-- Updated dependencies [cab9f9a]
-- Updated dependencies [6e5bdc9]
-- Updated dependencies [6a3b8d9]
-  - @assistant-ui/react@0.13.0
-
 ## 0.2.4
 
 ### Patch Changes

--- a/packages/react-a2a/package.json
+++ b/packages/react-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-a2a",
-  "version": "1.0.0",
+  "version": "0.2.4",
   "description": "A2A protocol adapter for assistant-ui",
   "keywords": [
     "a2a",
@@ -37,7 +37,7 @@
     "uuid": "^13.0.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.13.0",
+    "@assistant-ui/react": "^0.12.9",
     "@types/react": "*",
     "react": "^18 || ^19"
   },

--- a/packages/react-ag-ui/CHANGELOG.md
+++ b/packages/react-ag-ui/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @assistant-ui/react-ag-ui
 
-## 1.0.0
-
-### Patch Changes
-
-- b1c8579: feat(react-ag-ui): support frontend tool execution in AG-UI runtime
-- Updated dependencies [2eba036]
-- Updated dependencies [bf1a109]
-- Updated dependencies [cab9f9a]
-- Updated dependencies [6e5bdc9]
-- Updated dependencies [6a3b8d9]
-  - @assistant-ui/react@0.13.0
-
 ## 0.0.15
 
 ### Patch Changes

--- a/packages/react-ag-ui/package.json
+++ b/packages/react-ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-ag-ui",
-  "version": "1.0.0",
+  "version": "0.0.15",
   "description": "AG-UI protocol adapter for assistant-ui",
   "keywords": [
     "ag-ui",
@@ -40,7 +40,7 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.13.0",
+    "@assistant-ui/react": "^0.12.9",
     "@types/react": "*",
     "react": "^18 || ^19"
   },

--- a/packages/react-ai-sdk/CHANGELOG.md
+++ b/packages/react-ai-sdk/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @assistant-ui/react-ai-sdk
 
-## 2.0.0
-
-### Patch Changes
-
-- bf1a109: fix: duplicate key toolCallId error in HITL tools (#3197)
-- Updated dependencies [2eba036]
-- Updated dependencies [bf1a109]
-- Updated dependencies [cab9f9a]
-- Updated dependencies [6e5bdc9]
-- Updated dependencies [6a3b8d9]
-  - @assistant-ui/react@0.13.0
-
 ## 1.3.6
 
 ### Patch Changes

--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-ai-sdk",
-  "version": "2.0.0",
+  "version": "1.3.6",
   "description": "Vercel AI SDK adapter for assistant-ui",
   "keywords": [
     "ai-sdk",
@@ -39,7 +39,7 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.13.0",
+    "@assistant-ui/react": "^0.12.9",
     "@types/react": "*",
     "assistant-cloud": "*",
     "react": "^18 || ^19"

--- a/packages/react-data-stream/CHANGELOG.md
+++ b/packages/react-data-stream/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @assistant-ui/react-data-stream
 
-## 1.0.0
-
-### Patch Changes
-
-- Updated dependencies [2eba036]
-- Updated dependencies [bf1a109]
-- Updated dependencies [cab9f9a]
-- Updated dependencies [6e5bdc9]
-- Updated dependencies [6a3b8d9]
-  - @assistant-ui/react@0.13.0
-
 ## 0.12.4
 
 ### Patch Changes

--- a/packages/react-data-stream/package.json
+++ b/packages/react-data-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-data-stream",
-  "version": "1.0.0",
+  "version": "0.12.4",
   "description": "Data stream adapter for assistant-ui",
   "keywords": [
     "data-stream",
@@ -37,7 +37,7 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.13.0",
+    "@assistant-ui/react": "^0.12.9",
     "@types/react": "*",
     "react": "^18 || ^19"
   },

--- a/packages/react-devtools/CHANGELOG.md
+++ b/packages/react-devtools/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @assistant-ui/react-devtools
 
-## 1.0.0
-
-### Patch Changes
-
-- Updated dependencies [2eba036]
-- Updated dependencies [bf1a109]
-- Updated dependencies [cab9f9a]
-- Updated dependencies [6e5bdc9]
-- Updated dependencies [6a3b8d9]
-  - @assistant-ui/react@0.13.0
-  - @assistant-ui/tap@0.4.6
-
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-devtools",
-  "version": "1.0.0",
+  "version": "0.2.3",
   "description": "React development tools for assistant-ui components",
   "keywords": [
     "assistant-ui",
@@ -34,8 +34,8 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.13.0",
-    "@assistant-ui/tap": "^0.4.6",
+    "@assistant-ui/react": "^0.12.9",
+    "@assistant-ui/tap": "^0.4.5",
     "@types/react": "*",
     "@types/react-dom": "*",
     "react": "^18 || ^19",

--- a/packages/react-hook-form/CHANGELOG.md
+++ b/packages/react-hook-form/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @assistant-ui/react-hook-form
 
-## 1.0.0
-
-### Patch Changes
-
-- Updated dependencies [2eba036]
-- Updated dependencies [bf1a109]
-- Updated dependencies [cab9f9a]
-- Updated dependencies [6e5bdc9]
-- Updated dependencies [6a3b8d9]
-  - @assistant-ui/react@0.13.0
-
 ## 0.12.3
 
 ### Patch Changes

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-hook-form",
-  "version": "1.0.0",
+  "version": "0.12.3",
   "description": "React Hook Form integration for assistant-ui",
   "keywords": [
     "react-hook-form",
@@ -36,7 +36,7 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.13.0",
+    "@assistant-ui/react": "^0.12.9",
     "@types/react": "*",
     "react": "^18 || ^19",
     "react-hook-form": "^7"

--- a/packages/react-langgraph/CHANGELOG.md
+++ b/packages/react-langgraph/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @assistant-ui/react-langgraph
 
-## 1.0.0
-
-### Patch Changes
-
-- d31a9dc: feat(react-langgraph): support frontend tool execution in LangGraph runtime
-- Updated dependencies [2eba036]
-- Updated dependencies [bf1a109]
-- Updated dependencies [cab9f9a]
-- Updated dependencies [6e5bdc9]
-- Updated dependencies [6a3b8d9]
-  - @assistant-ui/react@0.13.0
-
 ## 0.12.4
 
 ### Patch Changes

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-langgraph",
-  "version": "1.0.0",
+  "version": "0.12.4",
   "description": "LangGraph adapter for assistant-ui",
   "keywords": [
     "langgraph",
@@ -39,7 +39,7 @@
     "uuid": "^13.0.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.13.0",
+    "@assistant-ui/react": "^0.12.9",
     "@types/react": "*",
     "react": "^18 || ^19"
   },

--- a/packages/react-markdown/CHANGELOG.md
+++ b/packages/react-markdown/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @assistant-ui/react-markdown
 
-## 1.0.0
-
-### Patch Changes
-
-- Updated dependencies [2eba036]
-- Updated dependencies [bf1a109]
-- Updated dependencies [cab9f9a]
-- Updated dependencies [6e5bdc9]
-- Updated dependencies [6a3b8d9]
-  - @assistant-ui/react@0.13.0
-
 ## 0.12.3
 
 ### Patch Changes

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-markdown",
-  "version": "1.0.0",
+  "version": "0.12.3",
   "description": "Markdown rendering for assistant-ui",
   "keywords": [
     "markdown",
@@ -45,7 +45,7 @@
     "react-markdown": "^10.1.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.13.0",
+    "@assistant-ui/react": "^0.12.9",
     "@types/react": "*",
     "react": "^18 || ^19"
   },

--- a/packages/react-streamdown/CHANGELOG.md
+++ b/packages/react-streamdown/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @assistant-ui/react-streamdown
 
-## 1.0.0
-
-### Patch Changes
-
-- Updated dependencies [2eba036]
-- Updated dependencies [bf1a109]
-- Updated dependencies [cab9f9a]
-- Updated dependencies [6e5bdc9]
-- Updated dependencies [6a3b8d9]
-  - @assistant-ui/react@0.13.0
-
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/react-streamdown/package.json
+++ b/packages/react-streamdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-streamdown",
-  "version": "1.0.0",
+  "version": "0.1.2",
   "description": "Streamdown-based markdown rendering for assistant-ui",
   "keywords": [
     "markdown",
@@ -41,7 +41,7 @@
     "streamdown": "^2.1.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.13.0",
+    "@assistant-ui/react": "^0.12.9",
     "@streamdown/code": "^1.0.0",
     "@streamdown/cjk": "^1.0.0",
     "@streamdown/math": "^1.0.0",

--- a/packages/react-syntax-highlighter/CHANGELOG.md
+++ b/packages/react-syntax-highlighter/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @assistant-ui/react-syntax-highlighter
 
-## 1.0.0
-
-### Patch Changes
-
-- Updated dependencies [2eba036]
-- Updated dependencies [bf1a109]
-- Updated dependencies [cab9f9a]
-- Updated dependencies [6e5bdc9]
-- Updated dependencies [6a3b8d9]
-  - @assistant-ui/react@0.13.0
-  - @assistant-ui/react-markdown@1.0.0
-
 ## 0.12.3
 
 ### Patch Changes

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-syntax-highlighter",
-  "version": "1.0.0",
+  "version": "0.12.3",
   "description": "Syntax highlighting for assistant-ui",
   "keywords": [
     "syntax-highlighter",
@@ -39,8 +39,8 @@
     "build": "aui-build"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.13.0",
-    "@assistant-ui/react-markdown": "^1.0.0",
+    "@assistant-ui/react": "^0.12.9",
+    "@assistant-ui/react-markdown": "^0.12.3",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",
     "react": "^18 || ^19",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,31 +1,5 @@
 # @assistant-ui/react
 
-## 0.13.0
-
-### Minor Changes
-
-- 6e5bdc9: feat: Quote Selected Text primitives
-
-  Added new primitives and hooks for quoting selected text from messages:
-  - `SelectionToolbarPrimitive.Root` - Floating toolbar that appears on text selection within a message
-  - `SelectionToolbarPrimitive.Quote` - Button inside the floating toolbar to capture the selection as a quote
-  - `ComposerPrimitive.Quote` - Container for quote preview (renders only when quote is set)
-  - `ComposerPrimitive.QuoteText` - Displays the quoted text
-  - `ComposerPrimitive.QuoteDismiss` - Button to clear the quote
-  - `useMessageQuote()` - Hook to read quote info from message metadata
-  - `QuoteInfo` type - `{ text: string; messageId: string }`
-  - `ComposerRuntime.setQuote()` - Programmatic API to set/clear quotes
-  - `MessagePrimitive.Root` now renders `data-message-id` attribute
-
-### Patch Changes
-
-- 2eba036: fix: use bracket notation for process.env
-- bf1a109: fix: duplicate key toolCallId error in HITL tools (#3197)
-- cab9f9a: fix(react): runConfig not applied when clicking Suggestion with send=true
-- 6a3b8d9: feat(assistant-transport): support editing messages
-- Updated dependencies [2eba036]
-  - @assistant-ui/tap@0.4.6
-
 ## 0.12.9
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react",
-  "version": "0.13.0",
+  "version": "0.12.9",
   "description": "TypeScript/React library for AI Chat",
   "keywords": [
     "radix-ui",
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "assistant-cloud": "^0.1.17",
-    "@assistant-ui/tap": "^0.4.6",
+    "@assistant-ui/tap": "^0.4.5",
     "@assistant-ui/store": "^0.1.6",
     "@radix-ui/primitive": "^1.1.3",
     "@radix-ui/react-compose-refs": "^1.1.2",

--- a/packages/tap/CHANGELOG.md
+++ b/packages/tap/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @assistant-ui/tap
 
-## 0.4.6
-
-### Patch Changes
-
-- 2eba036: fix: use bracket notation for process.env
-
 ## 0.4.5
 
 ### Patch Changes

--- a/packages/tap/package.json
+++ b/packages/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/tap",
-  "version": "0.4.6",
+  "version": "0.4.5",
   "description": "Zero-dependency reactive state management inspired by React hooks",
   "keywords": [
     "state-management",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2078,7 +2078,7 @@ importers:
         specifier: ^0.1.6
         version: link:../store
       '@assistant-ui/tap':
-        specifier: ^0.4.6
+        specifier: ^0.4.5
         version: link:../tap
       '@radix-ui/primitive':
         specifier: ^1.1.3


### PR DESCRIPTION
## Summary
- Reverts the accidentally merged version bump commit (77a24438e)
- Version numbers in that commit were incorrect
- Packages have NOT been published to npm yet, so no downstream impact
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts incorrect version bump commit `77a24438e` affecting multiple package files, with no downstream impact as packages were not published.
> 
>   - **Reversion**:
>     - Reverts version bump commit `77a24438e` due to incorrect version numbers.
>     - Affects `package.json` and `CHANGELOG.md` in `packages/cli`, `packages/react-a2a`, and `packages/react-ag-ui`.
>   - **Impact**:
>     - No packages were published to npm, so no downstream impact.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for db59fee8249b2739efb875b27d5a54ca7f2da4d9. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->