### PR TITLE
fix: add fill-mode-both to thread welcome animation to prevent flicker

### DIFF
--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -86,10 +86,10 @@ const ThreadWelcome: FC = () => {
     <div className="aui-thread-welcome-root mx-auto my-auto flex w-full max-w-(--thread-max-width) grow flex-col">
       <div className="aui-thread-welcome-center flex w-full grow flex-col items-center justify-center">
         <div className="aui-thread-welcome-message flex size-full flex-col justify-center px-4">
-          <h1 className="aui-thread-welcome-message-inner fade-in slide-in-from-bottom-1 animate-in font-semibold text-2xl duration-200">
+          <h1 className="aui-thread-welcome-message-inner fade-in slide-in-from-bottom-1 animate-in fill-mode-both font-semibold text-2xl duration-200">
             Hello there!
           </h1>
-          <p className="aui-thread-welcome-message-inner fade-in slide-in-from-bottom-1 animate-in text-muted-foreground text-xl delay-75 duration-200">
+          <p className="aui-thread-welcome-message-inner fade-in slide-in-from-bottom-1 animate-in fill-mode-both text-muted-foreground text-xl delay-75 duration-200">
             How can I help you today?
           </p>
         </div>


### PR DESCRIPTION
closes https://github.com/assistant-ui/assistant-ui/issues/3156

https://github.com/user-attachments/assets/523d75ea-6c3f-4e08-a6d5-87674c720a5d


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `fill-mode-both` to `ThreadWelcome` animation in `thread.tsx` to prevent flicker.
> 
>   - **Behavior**:
>     - Adds `fill-mode-both` to `h1` and `p` elements in `ThreadWelcome` component in `thread.tsx` to prevent flicker during animation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for fa18c5f908bdc341cec6c64bee02bfab5355c70a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->