### PR TITLE
fix(docs): remove stale example links

### DIFF
--- a/apps/docs/content/docs/runtimes/data-stream.mdx
+++ b/apps/docs/content/docs/runtimes/data-stream.mdx
@@ -342,9 +342,7 @@ const runtime = useDataStreamRuntime({
 
 ## Examples
 
-- **[Basic Data Stream Example](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-data-stream)** - Simple streaming chat
-- **[Tool Integration Example](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-data-stream-tools)** - Frontend and backend tools
-- **[Authentication Example](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-data-stream-auth)** - Secure endpoints
+Explore our [examples repository](https://github.com/assistant-ui/assistant-ui/tree/main/examples) for implementation references.
 
 ## API Reference
 

--- a/apps/docs/content/docs/runtimes/pick-a-runtime.mdx
+++ b/apps/docs/content/docs/runtimes/pick-a-runtime.mdx
@@ -189,7 +189,6 @@ Explore our implementation examples:
 - **[External Store Example](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-external-store)** - `ExternalStoreRuntime` with custom state
 - **[Assistant Cloud Example](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-cloud)** - Multi-thread with cloud persistence
 - **[LangGraph Example](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-langgraph)** - Agent workflows
-- **[OpenAI Assistants Example](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-openai-assistants)** - OpenAI Assistants API
 
 ## Common Pitfalls to Avoid
 


### PR DESCRIPTION
Remove stale example links (with-data-stream, with-data-stream-tools, with-data-stream-auth, with-openai-assistants) that 404 as these examples don't currently exist in the repo
----
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove stale example links from documentation and replace with a general link to the examples repository.
> 
>   - **Docs Update**:
>     - In `data-stream.mdx`, removed stale example links for `with-data-stream`, `with-data-stream-tools`, and `with-data-stream-auth`. Added a general link to the examples repository.
>     - In `pick-a-runtime.mdx`, removed stale example link for `with-openai-assistants`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d4229f2c57aff12ddb7381cb250c240c72a30cbe. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->