### PR TITLE
fix(ui): transparent background on `ThreadPrimitive.ViewportFooter`

### DIFF
--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -58,7 +58,7 @@ export const Thread: FC = () => {
           }}
         />
 
-        <ThreadPrimitive.ViewportFooter className="aui-thread-viewport-footer sticky bottom-0 mx-auto mt-auto flex w-full max-w-(--thread-max-width) flex-col gap-4 overflow-visible rounded-t-3xl pb-4 md:pb-6">
+        <ThreadPrimitive.ViewportFooter className="aui-thread-viewport-footer sticky bottom-0 mx-auto mt-auto flex w-full max-w-(--thread-max-width) flex-col gap-4 overflow-visible rounded-t-3xl bg-background pb-4 md:pb-6">
           <ThreadScrollToBottom />
           <Composer />
         </ThreadPrimitive.ViewportFooter>


### PR DESCRIPTION
Accidental removal og bg-background caused gap beneath composer to be transparent, this PR restores bg-background on `ThreadPrimitive.ViewportFooter`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `bg-background` class to `ThreadPrimitive.ViewportFooter` in `thread.tsx` to fix transparency issue.
> 
>   - **UI Fix**:
>     - Adds `bg-background` class to `ThreadPrimitive.ViewportFooter` in `thread.tsx` to fix transparency issue beneath the composer.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for d7ae352249be2e06f13e60833be883b84edabb7b. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->