### PR TITLE
fix(react): handle smooth streaming behaviour for initial chunk if running

### DIFF
--- a/.changeset/rare-clowns-enjoy.md
+++ b/.changeset/rare-clowns-enjoy.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react": patch
 ---
 
-Fix smooth streaming behaviour to include first chunk
+fix(react): smooth streaming behaviour to include first chunk

--- a/packages/react/src/utils/smooth/useSmooth.tsx
+++ b/packages/react/src/utils/smooth/useSmooth.tsx
@@ -117,18 +117,27 @@ export const useSmooth = (
 
     if (idRef.current !== id || !text.startsWith(animatorRef.targetText)) {
       idRef.current = id;
-      setText(text);
 
-      animatorRef.currentText = text;
-      animatorRef.targetText = text;
-      animatorRef.stop();
+      if (state.status.type === "running") {
+        // New streaming message → animate from empty string
+        setText("");
+        animatorRef.currentText = "";
+        animatorRef.targetText = text;
+        animatorRef.start();
+      } else {
+        // Completed message → display immediately
+        setText(text);
+        animatorRef.currentText = text;
+        animatorRef.targetText = text;
+        animatorRef.stop();
+      }
 
       return;
     }
 
     animatorRef.targetText = text;
     animatorRef.start();
-  }, [setText, animatorRef, id, smooth, text]);
+  }, [setText, animatorRef, id, smooth, text, state.status.type]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
Fixes https://github.com/assistant-ui/assistant-ui/issues/3282

If the incoming message part is running, we initialise the displayed text with an empty string so that the first chunk is treated correctly.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes smooth streaming behavior in `useSmooth.tsx` by initializing `displayedText` with an empty string if status is "running".
> 
>   - **Behavior**:
>     - Fixes smooth streaming behavior in `useSmooth.tsx` by initializing `displayedText` with an empty string if `state.status.type` is "running".
>   - **Misc**:
>     - Adds changeset file `rare-clowns-enjoy.md` for patch update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c37923f022e433ac18012b6f935c2ea4e5319252. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->