### PR TITLE
feat(react): add message-level component scope clients

### DIFF
--- a/packages/react/src/client/ComponentClient.ts
+++ b/packages/react/src/client/ComponentClient.ts
@@ -1,0 +1,119 @@
+import { resource, tapEffect, tapMemo, tapRef } from "@assistant-ui/tap";
+import { type ClientOutput, tapAssistantEmit } from "@assistant-ui/store";
+import type { ComponentMessagePart } from "../types/MessagePartTypes";
+import type {
+  ComponentLifecycle,
+  ComponentState,
+} from "../types/scopes/component";
+
+const COMPONENT_LIFECYCLES: readonly ComponentLifecycle[] = [
+  "mounting",
+  "active",
+  "complete",
+  "error",
+  "cancelled",
+];
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};
+
+const isComponentLifecycle = (value: unknown): value is ComponentLifecycle => {
+  return (
+    typeof value === "string" &&
+    (COMPONENT_LIFECYCLES as readonly string[]).includes(value)
+  );
+};
+
+const getComponentSeq = (value: unknown): number => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return 0;
+};
+
+export const getComponentMetadataState = (
+  unstableState: unknown,
+  instanceId: string | undefined,
+) => {
+  if (!instanceId || !isObjectRecord(unstableState)) return undefined;
+  const components = unstableState.components;
+  if (!isObjectRecord(components)) return undefined;
+  return components[instanceId];
+};
+
+export type ComponentClientProps = {
+  messageId: string;
+  part: ComponentMessagePart;
+  componentState: unknown;
+};
+
+export const ComponentClient = resource(
+  ({
+    messageId,
+    part,
+    componentState,
+  }: ComponentClientProps): ClientOutput<"component"> => {
+    const emit = tapAssistantEmit();
+    const previousRef = tapRef<{
+      seq: number;
+      lifecycle: ComponentLifecycle;
+    } | null>(null);
+
+    const state = tapMemo<ComponentState>(() => {
+      const metadataState = isObjectRecord(componentState)
+        ? componentState
+        : {};
+      const lifecycle = isComponentLifecycle(metadataState.lifecycle)
+        ? metadataState.lifecycle
+        : "mounting";
+      const seq = getComponentSeq(metadataState.seq);
+
+      return {
+        messageId,
+        name: part.name,
+        ...(part.instanceId !== undefined
+          ? { instanceId: part.instanceId }
+          : {}),
+        ...(part.parentId !== undefined ? { parentId: part.parentId } : {}),
+        props: part.props ?? {},
+        state:
+          "state" in metadataState
+            ? (metadataState.state as unknown)
+            : undefined,
+        lifecycle,
+        seq,
+      };
+    }, [messageId, part, componentState]);
+
+    tapEffect(() => {
+      const previous = previousRef.current;
+      previousRef.current = {
+        seq: state.seq,
+        lifecycle: state.lifecycle,
+      };
+
+      if (!previous) return;
+      if (!state.instanceId) return;
+      if (state.seq <= previous.seq) return;
+
+      emit("component.state", {
+        messageId: state.messageId,
+        instanceId: state.instanceId,
+        seq: state.seq,
+        state: state.state,
+      });
+
+      if (state.lifecycle !== previous.lifecycle) {
+        emit("component.lifecycle", {
+          messageId: state.messageId,
+          instanceId: state.instanceId,
+          lifecycle: state.lifecycle,
+          seq: state.seq,
+        });
+      }
+    }, [state, emit]);
+
+    return {
+      getState: () => state,
+    };
+  },
+);

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -20,8 +20,10 @@ import { Suggestions } from "./Suggestions";
 import {
   ThreadAssistantMessagePart,
   ThreadUserMessagePart,
+  ComponentMessagePart,
 } from "../types/MessagePartTypes";
 import type { ThreadMessage } from "../types";
+import { ComponentClient, getComponentMetadataState } from "./ComponentClient";
 
 export type ExternalThreadMessage = ThreadMessage & {
   id: string;
@@ -63,6 +65,42 @@ const MessageClient = resource(
         ),
       [message.content],
     );
+
+    const componentClients = tapClientLookup(() => {
+      const entries: {
+        part: ComponentMessagePart;
+        index: number;
+        key: string;
+      }[] = [];
+      let componentIndex = 0;
+
+      for (const part of message.content) {
+        if (part.type !== "component") continue;
+        const index = componentIndex++;
+        entries.push({
+          part,
+          index,
+          key:
+            part.instanceId !== undefined
+              ? `instanceId-${part.instanceId}`
+              : `index-${index}`,
+        });
+      }
+
+      return entries.map(({ part, key }) =>
+        withKey(
+          key,
+          ComponentClient({
+            messageId: message.id,
+            part,
+            componentState: getComponentMetadataState(
+              message.metadata.unstable_state,
+              part.instanceId,
+            ),
+          }),
+        ),
+      );
+    }, [message.id, message.content, message.metadata.unstable_state]);
 
     const attachmentClients = tapClientLookup(
       () =>
@@ -144,6 +182,14 @@ const MessageClient = resource(
       switchToBranch: () => {},
       getCopyText: () =>
         message.content.map((c) => ("text" in c ? c.text : "")).join(""),
+      component: (selector) => {
+        if ("index" in selector) {
+          return componentClients.get(selector);
+        }
+        return componentClients.get({
+          key: `instanceId-${selector.instanceId}`,
+        });
+      },
       part: (selector) => {
         if ("index" in selector) {
           return partClients.get(selector);

--- a/packages/react/src/client/ThreadMessageClient.tsx
+++ b/packages/react/src/client/ThreadMessageClient.tsx
@@ -12,9 +12,11 @@ import {
   ThreadAssistantMessagePart,
   ThreadUserMessagePart,
   Attachment,
+  ComponentMessagePart,
   ThreadMessage,
 } from "../types";
 import { NoOpComposerClient } from "./NoOpComposerClient";
+import { ComponentClient, getComponentMetadataState } from "./ComponentClient";
 
 const ThreadMessagePartClient = resource(
   ({
@@ -82,6 +84,43 @@ export const ThreadMessageClient = resource(
         ),
       [message.content],
     );
+
+    const components = tapClientLookup(() => {
+      const entries: {
+        part: ComponentMessagePart;
+        index: number;
+        key: string;
+      }[] = [];
+      let componentIndex = 0;
+
+      for (const part of message.content) {
+        if (part.type !== "component") continue;
+
+        const index = componentIndex++;
+        entries.push({
+          part,
+          index,
+          key:
+            part.instanceId !== undefined
+              ? `instanceId-${part.instanceId}`
+              : `index-${index}`,
+        });
+      }
+
+      return entries.map(({ part, key }) =>
+        withKey(
+          key,
+          ComponentClient({
+            messageId: message.id,
+            part,
+            componentState: getComponentMetadataState(
+              message.metadata.unstable_state,
+              part.instanceId,
+            ),
+          }),
+        ),
+      );
+    }, [message.id, message.content, message.metadata.unstable_state]);
 
     const attachments = tapClientLookup(
       () =>
@@ -162,6 +201,13 @@ export const ThreadMessageClient = resource(
             return "";
           })
           .join("\n");
+      },
+      component: (selector) => {
+        if ("index" in selector) {
+          return components.get(selector);
+        } else {
+          return components.get({ key: `instanceId-${selector.instanceId}` });
+        }
       },
       setIsCopied,
       setIsHovering,

--- a/packages/react/src/tests/message-component-client.test.tsx
+++ b/packages/react/src/tests/message-component-client.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment jsdom
+
+import type { RefObject } from "react";
+import { renderHook } from "@testing-library/react";
+import { useAui } from "@assistant-ui/store";
+import { describe, expect, it, vi } from "vitest";
+import type { ThreadAssistantMessage } from "../types";
+import type {
+  MessageRuntime,
+  MessageState as RuntimeMessageState,
+} from "../legacy-runtime/runtime/MessageRuntime";
+import type { MessagePartRuntime } from "../legacy-runtime/runtime/MessagePartRuntime";
+import { MessageClient } from "../legacy-runtime/client/MessageRuntimeClient";
+import { ThreadMessageClient } from "../client/ThreadMessageClient";
+
+const flushMicrotaskQueue = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createAssistantMessage = (
+  unstableState: unknown,
+  content: ThreadAssistantMessage["content"],
+): ThreadAssistantMessage => ({
+  id: "m1",
+  role: "assistant",
+  createdAt: new Date("2026-02-15T12:00:00Z"),
+  content,
+  status: { type: "complete", reason: "stop" },
+  metadata: {
+    unstable_state:
+      unstableState as ThreadAssistantMessage["metadata"]["unstable_state"],
+    unstable_annotations: [],
+    unstable_data: [],
+    steps: [],
+    custom: {},
+  },
+});
+
+const createFakeMessageRuntime = (
+  initialState: RuntimeMessageState,
+): MessageRuntime & { setState: (state: RuntimeMessageState) => void } => {
+  let state = initialState;
+  const listeners = new Set<() => void>();
+
+  const partRuntimeForIndex = (index: number): MessagePartRuntime =>
+    ({
+      path: {} as MessagePartRuntime["path"],
+      getState: () => {
+        const part = state.content[index];
+        if (!part) throw new Error(`No part at index ${index}`);
+        return {
+          ...part,
+          status: { type: "complete" as const },
+        };
+      },
+      subscribe: (callback: () => void) => {
+        listeners.add(callback);
+        return () => listeners.delete(callback);
+      },
+      addToolResult: () => {},
+      resumeToolCall: () => {},
+    }) as MessagePartRuntime;
+
+  const runtime = {
+    path: {} as MessageRuntime["path"],
+    composer: {
+      getState: () => ({
+        text: "",
+        role: "user",
+        attachments: [],
+        runConfig: {},
+        isEditing: true,
+        canCancel: false,
+        attachmentAccept: "*",
+        isEmpty: true,
+        dictation: undefined,
+        quote: undefined,
+      }),
+      subscribe: () => () => {},
+      unstable_on: () => () => {},
+      setText: () => {},
+      setRole: () => {},
+      setRunConfig: () => {},
+      addAttachment: async () => {},
+      reset: async () => {},
+      clearAttachments: async () => {},
+      send: () => {},
+      cancel: () => {},
+      beginEdit: () => {},
+      startDictation: () => {},
+      stopDictation: () => {},
+      setQuote: () => {},
+      getAttachmentByIndex: () => {
+        throw new Error("No composer attachments in fake runtime");
+      },
+    } as unknown as MessageRuntime["composer"],
+    getState: () => state,
+    subscribe: (callback: () => void) => {
+      listeners.add(callback);
+      return () => listeners.delete(callback);
+    },
+    reload: () => {},
+    speak: () => {},
+    stopSpeaking: () => {},
+    submitFeedback: () => {},
+    switchToBranch: () => {},
+    unstable_getCopyText: () => "",
+    getMessagePartByIndex: (index: number) => partRuntimeForIndex(index),
+    getMessagePartByToolCallId: (toolCallId: string) => {
+      const index = state.content.findIndex(
+        (part) => part.type === "tool-call" && part.toolCallId === toolCallId,
+      );
+      if (index === -1) throw new Error(`No tool part for id ${toolCallId}`);
+      return partRuntimeForIndex(index);
+    },
+    getAttachmentByIndex: () => {
+      throw new Error("No message attachments in fake runtime");
+    },
+    setState: (next: RuntimeMessageState) => {
+      state = next;
+      for (const callback of listeners) callback();
+    },
+  };
+
+  return runtime as MessageRuntime & {
+    setState: (state: RuntimeMessageState) => void;
+  };
+};
+
+describe("message.component client", () => {
+  it("resolves components by component index and instanceId with hydrated state", () => {
+    const message = createAssistantMessage(
+      {
+        components: {
+          card_1: { seq: 5, lifecycle: "active", state: { title: "Primary" } },
+          card_2: {
+            seq: 2,
+            lifecycle: "mounting",
+            state: { title: "Secondary" },
+          },
+        },
+      },
+      [
+        { type: "component", name: "status-card", instanceId: "card_2" },
+        { type: "text", text: "between" },
+        { type: "component", name: "status-card", instanceId: "card_1" },
+      ],
+    );
+
+    const { result } = renderHook(
+      ({ currentMessage }) => {
+        return useAui({
+          message: ThreadMessageClient({ message: currentMessage, index: 0 }),
+        });
+      },
+      { initialProps: { currentMessage: message } },
+    );
+
+    const firstByIndex = result.current
+      .message()
+      .component({ index: 0 })
+      .getState();
+    const secondByIndex = result.current
+      .message()
+      .component({ index: 1 })
+      .getState();
+    const byInstanceId = result.current
+      .message()
+      .component({ instanceId: "card_1" })
+      .getState();
+
+    expect(firstByIndex.instanceId).toBe("card_2");
+    expect(firstByIndex.seq).toBe(2);
+    expect(firstByIndex.lifecycle).toBe("mounting");
+    expect(firstByIndex.state).toEqual({ title: "Secondary" });
+
+    expect(secondByIndex.instanceId).toBe("card_1");
+    expect(secondByIndex.seq).toBe(5);
+    expect(secondByIndex.lifecycle).toBe("active");
+    expect(secondByIndex.state).toEqual({ title: "Primary" });
+
+    expect(byInstanceId.instanceId).toBe("card_1");
+    expect(byInstanceId.seq).toBe(5);
+  });
+
+  it("emits scoped component lifecycle/state events when seq advances", async () => {
+    const lifecycleSpy = vi.fn();
+    const stateSpy = vi.fn();
+
+    const initialMessage = createAssistantMessage(
+      {
+        components: {
+          card_1: { seq: 1, lifecycle: "mounting", state: { phase: "draft" } },
+        },
+      },
+      [{ type: "component", name: "status-card", instanceId: "card_1" }],
+    );
+
+    const { result, rerender } = renderHook(
+      ({ currentMessage }) => {
+        return useAui({
+          message: ThreadMessageClient({ message: currentMessage, index: 0 }),
+        });
+      },
+      { initialProps: { currentMessage: initialMessage } },
+    );
+
+    const unsubLifecycle = result.current.on(
+      { scope: "message", event: "component.lifecycle" },
+      lifecycleSpy,
+    );
+    const unsubState = result.current.on(
+      { scope: "message", event: "component.state" },
+      stateSpy,
+    );
+
+    await flushMicrotaskQueue();
+    expect(lifecycleSpy).not.toHaveBeenCalled();
+    expect(stateSpy).not.toHaveBeenCalled();
+
+    rerender({
+      currentMessage: createAssistantMessage(
+        {
+          components: {
+            card_1: { seq: 2, lifecycle: "active", state: { phase: "ready" } },
+          },
+        },
+        [{ type: "component", name: "status-card", instanceId: "card_1" }],
+      ),
+    });
+
+    await flushMicrotaskQueue();
+
+    expect(lifecycleSpy).toHaveBeenCalledWith({
+      messageId: "m1",
+      instanceId: "card_1",
+      lifecycle: "active",
+      seq: 2,
+    });
+    expect(stateSpy).toHaveBeenCalledWith({
+      messageId: "m1",
+      instanceId: "card_1",
+      seq: 2,
+      state: { phase: "ready" },
+    });
+
+    unsubLifecycle();
+    unsubState();
+  });
+
+  it("hydrates legacy MessageClient component state", () => {
+    const initialState = createAssistantMessage(
+      {
+        components: {
+          card_9: { seq: 3, lifecycle: "active", state: { label: "init" } },
+        },
+      },
+      [{ type: "component", name: "status-chip", instanceId: "card_9" }],
+    ) as RuntimeMessageState;
+
+    const runtime = createFakeMessageRuntime(initialState);
+    const threadIdRef = { current: "thread-1" } as RefObject<string>;
+
+    const { result } = renderHook(() => {
+      return useAui({
+        message: MessageClient({ runtime, threadIdRef }),
+      });
+    });
+
+    const componentState = result.current
+      .message()
+      .component({ instanceId: "card_9" })
+      .getState();
+
+    expect(componentState.instanceId).toBe("card_9");
+    expect(componentState.seq).toBe(3);
+    expect(componentState.state).toEqual({ label: "init" });
+
+    const byIndex = result.current.message().component({ index: 0 }).getState();
+    expect(byIndex.instanceId).toBe("card_9");
+    expect(byIndex.seq).toBe(3);
+  });
+});

--- a/packages/react/src/types/scopes/component.ts
+++ b/packages/react/src/types/scopes/component.ts
@@ -1,0 +1,51 @@
+import type { ReadonlyJSONObject } from "assistant-stream/utils";
+
+export type ComponentLifecycle =
+  | "mounting"
+  | "active"
+  | "complete"
+  | "error"
+  | "cancelled";
+
+export type ComponentState = {
+  readonly messageId: string;
+  readonly instanceId?: string;
+  readonly name: string;
+  readonly parentId?: string;
+  readonly props: ReadonlyJSONObject;
+  readonly state: unknown;
+  readonly lifecycle: ComponentLifecycle;
+  readonly seq: number;
+};
+
+export type ComponentMethods = {
+  getState(): ComponentState;
+};
+
+export type ComponentMeta = {
+  source: "message";
+  query:
+    | { type: "instanceId"; instanceId: string }
+    | { type: "index"; index: number };
+};
+
+export type ComponentEvents = {
+  "component.lifecycle": {
+    messageId: string;
+    instanceId: string;
+    lifecycle: ComponentLifecycle;
+    seq: number;
+  };
+  "component.state": {
+    messageId: string;
+    instanceId: string;
+    seq: number;
+    state: unknown;
+  };
+};
+
+export type ComponentClientSchema = {
+  methods: ComponentMethods;
+  meta: ComponentMeta;
+  events: ComponentEvents;
+};

--- a/packages/react/src/types/scopes/index.ts
+++ b/packages/react/src/types/scopes/index.ts
@@ -24,6 +24,14 @@ export type {
   MessageClientSchema,
 } from "./message";
 export type {
+  ComponentState,
+  ComponentLifecycle,
+  ComponentMethods,
+  ComponentMeta,
+  ComponentEvents,
+  ComponentClientSchema,
+} from "./component";
+export type {
   PartState,
   PartMethods,
   PartMeta,

--- a/packages/react/src/types/scopes/message.ts
+++ b/packages/react/src/types/scopes/message.ts
@@ -8,6 +8,7 @@ import type { MessageRuntime } from "../../legacy-runtime/runtime";
 import type { ComposerMethods, ComposerState } from "./composer";
 import type { PartMethods, PartState } from "./part";
 import type { AttachmentMethods } from "./attachment";
+import type { ComponentMethods } from "./component";
 
 export type MessageState = ThreadMessage & {
   readonly parentId: string | null;
@@ -58,6 +59,9 @@ export type MessageMethods = {
     branchId?: string;
   }): void;
   getCopyText(): string;
+  component(
+    selector: { index: number } | { instanceId: string },
+  ): ComponentMethods;
   part(selector: { index: number } | { toolCallId: string }): PartMethods;
   attachment(selector: { index: number } | { id: string }): AttachmentMethods;
   setIsCopied(value: boolean): void;

--- a/packages/react/src/types/store-augmentation.ts
+++ b/packages/react/src/types/store-augmentation.ts
@@ -4,6 +4,7 @@ import type { ThreadsClientSchema } from "./scopes/threads";
 import type { ThreadListItemClientSchema } from "./scopes/threadListItem";
 import type { ThreadClientSchema } from "./scopes/thread";
 import type { MessageClientSchema } from "./scopes/message";
+import type { ComponentClientSchema } from "./scopes/component";
 import type { PartClientSchema } from "./scopes/part";
 import type { ComposerClientSchema } from "./scopes/composer";
 import type { AttachmentClientSchema } from "./scopes/attachment";
@@ -19,6 +20,7 @@ declare module "@assistant-ui/store" {
     threadListItem: ThreadListItemClientSchema;
     thread: ThreadClientSchema;
     message: MessageClientSchema;
+    component: ComponentClientSchema;
     part: PartClientSchema;
     composer: ComposerClientSchema;
     attachment: AttachmentClientSchema;


### PR DESCRIPTION
## Summary
- add `component` scope schema and store augmentation for message-level component clients
- add `message.component({ index | instanceId })` lookup API
- hydrate component state from `metadata.unstable_state.components[instanceId]` in ThreadMessageClient, MessageRuntimeClient, and ExternalThread
- emit scoped `component.lifecycle` and `component.state` events on seq-forward transitions
- add contract tests for lookup ordering, hydration, and scoped emits

## Validation
- `pnpm --filter @assistant-ui/react test -- src/tests/message-component-client.test.tsx`