### PR TITLE
chore: ignore local .worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 # misc
 .DS_Store
 *.pem
+/.worktrees/
 
 # debug
 .pnpm-debug.log*


### PR DESCRIPTION
## Summary
- add `/.worktrees/` to root `.gitignore`
- keep local worktree metadata out of PR noise

## Scope
- single-file change (`.gitignore`)

## Validation
- verified `.worktrees/` is ignored by git status after updating ignore rules