### PR TITLE
fix(react): add DataMessagePart to ThreadUserMessagePart

### DIFF
--- a/.changeset/moody-pots-work.md
+++ b/.changeset/moody-pots-work.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: add DataMessagePart to ThreadUserMessagePart for parity with ThreadAssistantMessagePart

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/ThreadMessageLike.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/ThreadMessageLike.tsx
@@ -187,14 +187,11 @@ export const fromThreadMessageLike = (
             case "image":
             case "audio":
             case "file":
+            case "data":
               return part;
 
             default: {
-              const unhandledType:
-                | "tool-call"
-                | "reasoning"
-                | "source"
-                | "data" = type;
+              const unhandledType: "tool-call" | "reasoning" | "source" = type;
               throw new Error(
                 `Unsupported user message part type: ${unhandledType}`,
               );

--- a/packages/react/src/types/MessagePartTypes.ts
+++ b/packages/react/src/types/MessagePartTypes.ts
@@ -70,6 +70,7 @@ export type ThreadUserMessagePart =
   | TextMessagePart
   | ImageMessagePart
   | FileMessagePart
+  | DataMessagePart
   | Unstable_AudioMessagePart;
 
 export type ThreadAssistantMessagePart =


### PR DESCRIPTION
Closes #3312
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `DataMessagePart` to `ThreadUserMessagePart` for consistency with `ThreadAssistantMessagePart`, updating `fromThreadMessageLike()` to handle `data` type for user messages.
> 
>   - **Behavior**:
>     - Add `DataMessagePart` to `ThreadUserMessagePart` in `MessagePartTypes.ts` for consistency with `ThreadAssistantMessagePart`.
>     - Update `fromThreadMessageLike()` in `ThreadMessageLike.tsx` to handle `data` type for user messages.
>   - **Misc**:
>     - Update changeset file to reflect the addition of `DataMessagePart` to `ThreadUserMessagePart`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for b71676e62d3faa6aeeab83d59376e1492b22cdeb. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->