### PR TITLE
feat(react): support custom components for data message

### DIFF
--- a/.changeset/data-parts-rendering.md
+++ b/.changeset/data-parts-rendering.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat(react): support custom components for "data" message parts

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/message-part.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/message-part.mdx
@@ -11,7 +11,7 @@ import {
 } from "@/generated/typeDocs";
 
 Each message can have any number of message parts.
-Message parts are usually one of text, reasoning, audio or tool-call.
+Message parts are usually one of text, reasoning, audio, tool-call, or data.
 
 ## Message part Types
 
@@ -31,6 +31,10 @@ Audio content that can be played back.
 
 Interactive elements that represent tool operations.
 
+### Data
+
+Custom data events that can be rendered as UI at their position in the message stream. Each data part has a `name` and a `data` payload.
+
 ## Anatomy
 
 ```tsx
@@ -46,7 +50,7 @@ const TextMessagePart = () => {
 ### Plain Text
 
 ```tsx
-import { MessagePartPrimitive } from "@assistant/react";
+import { MessagePartPrimitive } from "@assistant-ui/react";
 
 <MessagePartPrimitive.Text />;
 ```
@@ -70,7 +74,7 @@ Coming soon.
 Renders children only if the message part is in progress.
 
 ```tsx
-import { MessagePartPrimitive } from "@assistant/react";
+import { MessagePartPrimitive } from "@assistant-ui/react";
 
 <MessagePartPrimitive.InProgress>
   <LoadingIndicator />
@@ -101,6 +105,68 @@ const MyWeatherToolUI = makeAssistantToolUI({
 });
 ```
 
+### Data UI
+
+You can map data events to UI components, similar to tool UIs. There are two approaches:
+
+#### Inline configuration
+
+Pass a `data` config to `MessagePrimitive.Parts`:
+
+```tsx
+<MessagePrimitive.Parts
+  components={{
+    data: {
+      by_name: {
+        my_chart: ({ name, data }) => <ChartComponent data={data} />,
+      },
+      Fallback: ({ name, data }) => (
+        <pre>{JSON.stringify(data, null, 2)}</pre>
+      ),
+    },
+  }}
+/>
+```
+
+#### Global registration
+
+Use `makeAssistantDataUI` or `useAssistantDataUI` to register data UIs globally. Global registrations take priority over inline configuration.
+
+```tsx
+import { makeAssistantDataUI } from "@assistant-ui/react";
+
+const MyChartUI = makeAssistantDataUI({
+  name: "my_chart",
+  render: ({ name, data }) => <ChartComponent data={data} />,
+});
+
+// Place inside AssistantRuntimeProvider
+function App() {
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+      <MyChartUI />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+The hook variant allows access to component state:
+
+```tsx
+import { useAssistantDataUI } from "@assistant-ui/react";
+
+function MyComponent() {
+  useAssistantDataUI({
+    name: "my_chart",
+    render: ({ name, data }) => <ChartComponent data={data} />,
+  });
+  return null;
+}
+```
+
+Each data component receives the full data part as props: `{ type: "data", name: string, data: T, status: MessagePartStatus }`.
+
 ## Context Provider
 
 Message part context is provided by `MessagePrimitive.Parts` or `TextMessagePartProvider`
@@ -108,7 +174,7 @@ Message part context is provided by `MessagePrimitive.Parts` or `TextMessagePart
 ### MessagePrimitive.Parts
 
 ```tsx
-import { MessagePrimitive } from "@assistant/react";
+import { MessagePrimitive } from "@assistant-ui/react";
 
 <MessagePrimitive.Parts
   components={{
@@ -120,6 +186,12 @@ import { MessagePrimitive } from "@assistant/react";
         get_weather: MyWeatherToolUI,
       },
       Fallback: MyFallbackToolUI,
+    },
+    data: {
+      by_name: {
+        my_chart: MyChartComponent,
+      },
+      Fallback: GenericDataComponent,
     },
   }}
 />;

--- a/packages/react/src/client/DataRenderers.ts
+++ b/packages/react/src/client/DataRenderers.ts
@@ -1,0 +1,42 @@
+import { resource, tapState, tapCallback } from "@assistant-ui/tap";
+import { type ClientOutput } from "@assistant-ui/store";
+import { DataRenderersState } from "../types/scopes";
+import { DataMessagePartComponent } from "../types";
+
+export const DataRenderers = resource((): ClientOutput<"dataRenderers"> => {
+  const [state, setState] = tapState<DataRenderersState>(() => ({
+    renderers: {},
+  }));
+
+  const setDataUI = tapCallback(
+    (name: string, render: DataMessagePartComponent) => {
+      setState((prev) => {
+        return {
+          ...prev,
+          renderers: {
+            ...prev.renderers,
+            [name]: [...(prev.renderers[name] ?? []), render],
+          },
+        };
+      });
+
+      return () => {
+        setState((prev) => {
+          return {
+            ...prev,
+            renderers: {
+              ...prev.renderers,
+              [name]: prev.renderers[name]?.filter((r) => r !== render) ?? [],
+            },
+          };
+        });
+      };
+    },
+    [],
+  );
+
+  return {
+    getState: () => state,
+    setDataUI,
+  };
+});

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -16,6 +16,7 @@ import { withKey } from "@assistant-ui/tap";
 import type { Attachment } from "../types/AttachmentTypes";
 import { ModelContext } from "./ModelContextClient";
 import { Tools } from "./Tools";
+import { DataRenderers } from "./DataRenderers";
 import { Suggestions } from "./Suggestions";
 import {
   ThreadAssistantMessagePart,
@@ -492,6 +493,9 @@ attachTransformScopes(ExternalThread, (scopes, parent) => {
   }
   if (!result.tools && parent.tools.source === null) {
     result.tools = Tools({});
+  }
+  if (!result.dataRenderers && parent.dataRenderers.source === null) {
+    result.dataRenderers = DataRenderers();
   }
   if (!result.suggestions && parent.suggestions.source === null) {
     result.suggestions = Suggestions();

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -12,6 +12,7 @@ import type { ResourceElement } from "@assistant-ui/tap";
 import { Suggestions } from "./Suggestions";
 import { ModelContext } from "./ModelContextClient";
 import { Tools } from "./Tools";
+import { DataRenderers } from "./DataRenderers";
 
 export type InMemoryThreadListProps = {
   thread: (threadId: string) => ResourceElement<ClientOutput<"thread">>;
@@ -199,6 +200,9 @@ attachTransformScopes(InMemoryThreadList, (scopes, parent) => {
   }
   if (!result.tools && parent.tools.source === null) {
     result.tools = Tools({});
+  }
+  if (!result.dataRenderers && parent.dataRenderers.source === null) {
+    result.dataRenderers = DataRenderers();
   }
   if (!result.suggestions && parent.suggestions.source === null) {
     result.suggestions = Suggestions();

--- a/packages/react/src/client/index.ts
+++ b/packages/react/src/client/index.ts
@@ -1,5 +1,6 @@
 export { ModelContext as ModelContextClient } from "./ModelContextClient";
 export { Tools } from "./Tools";
+export { DataRenderers } from "./DataRenderers";
 export { Suggestions, type SuggestionConfig } from "./Suggestions";
 export {
   ExternalThread,

--- a/packages/react/src/model-context/index.ts
+++ b/packages/react/src/model-context/index.ts
@@ -3,12 +3,20 @@ export {
   type AssistantToolUI,
   makeAssistantToolUI,
 } from "./makeAssistantToolUI";
+export {
+  type AssistantDataUI,
+  makeAssistantDataUI,
+} from "./makeAssistantDataUI";
 export { useAssistantInstructions } from "./useAssistantInstructions";
 export { useAssistantTool, type AssistantToolProps } from "./useAssistantTool";
 export {
   useAssistantToolUI,
   type AssistantToolUIProps,
 } from "./useAssistantToolUI";
+export {
+  useAssistantDataUI,
+  type AssistantDataUIProps,
+} from "./useAssistantDataUI";
 export { useInlineRender } from "./useInlineRender";
 
 export type { ModelContext, ModelContextProvider } from "./ModelContextTypes";
@@ -22,6 +30,7 @@ export { makeAssistantVisible } from "./makeAssistantVisible";
 export type { Toolkit, ToolDefinition } from "./toolbox";
 
 export { Tools } from "../client/Tools";
+export { DataRenderers } from "../client/DataRenderers";
 
 export { Suggestions, type SuggestionConfig } from "../client/Suggestions";
 

--- a/packages/react/src/model-context/makeAssistantDataUI.tsx
+++ b/packages/react/src/model-context/makeAssistantDataUI.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import type { FC } from "react";
+import {
+  type AssistantDataUIProps,
+  useAssistantDataUI,
+} from "./useAssistantDataUI";
+
+export type AssistantDataUI = FC & {
+  unstable_data: AssistantDataUIProps;
+};
+
+export const makeAssistantDataUI = <T = any>(
+  dataUI: AssistantDataUIProps<T>,
+) => {
+  const DataUI: AssistantDataUI = () => {
+    useAssistantDataUI(dataUI);
+    return null;
+  };
+  DataUI.unstable_data = dataUI;
+  return DataUI;
+};

--- a/packages/react/src/model-context/useAssistantDataUI.tsx
+++ b/packages/react/src/model-context/useAssistantDataUI.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAui } from "@assistant-ui/store";
+import type { DataMessagePartComponent } from "../types/MessagePartComponentTypes";
+
+export type AssistantDataUIProps<T = any> = {
+  name: string;
+  render: DataMessagePartComponent<T>;
+};
+
+export const useAssistantDataUI = (dataUI: AssistantDataUIProps | null) => {
+  const aui = useAui();
+  useEffect(() => {
+    if (!dataUI?.name || !dataUI?.render) return undefined;
+    return aui.dataRenderers().setDataUI(dataUI.name, dataUI.render);
+  }, [aui, dataUI?.name, dataUI?.render]);
+};

--- a/packages/react/src/primitives/message/MessagePartsGrouped.tsx
+++ b/packages/react/src/primitives/message/MessagePartsGrouped.tsx
@@ -16,6 +16,8 @@ import { MessagePartPrimitiveText } from "../messagePart/MessagePartText";
 import { MessagePartPrimitiveImage } from "../messagePart/MessagePartImage";
 import type {
   Unstable_AudioMessagePartComponent,
+  DataMessagePartComponent,
+  DataMessagePartProps,
   EmptyMessagePartComponent,
   TextMessagePartComponent,
   ImageMessagePartComponent,
@@ -153,6 +155,17 @@ export namespace MessagePrimitiveUnstable_PartsGrouped {
           File?: FileMessagePartComponent | undefined;
           /** Component for rendering audio content (experimental) */
           Unstable_Audio?: Unstable_AudioMessagePartComponent | undefined;
+          /** Configuration for data part rendering */
+          data?:
+            | {
+                /** Map data event names to specific components */
+                by_name?:
+                  | Record<string, DataMessagePartComponent | undefined>
+                  | undefined;
+                /** Fallback component for unmatched data events */
+                Fallback?: DataMessagePartComponent | undefined;
+              }
+            | undefined;
           /** Configuration for tool call rendering */
           tools?:
             | {
@@ -228,6 +241,21 @@ const ToolUIDisplay = ({
   return <Render {...props} />;
 };
 
+const DataUIDisplay = ({
+  Fallback,
+  ...props
+}: {
+  Fallback: DataMessagePartComponent | undefined;
+} & DataMessagePartProps) => {
+  const Render = useAuiState((s) => {
+    const Render = s.dataRenderers.renderers[props.name] ?? Fallback;
+    if (Array.isArray(Render)) return Render[0] ?? Fallback;
+    return Render;
+  });
+  if (!Render) return null;
+  return <Render {...props} />;
+};
+
 const defaultComponents = {
   Text: () => (
     <p style={{ whiteSpace: "pre-line" }}>
@@ -258,6 +286,7 @@ const MessagePartComponent: FC<MessagePartComponentProps> = ({
     File = defaultComponents.File,
     Unstable_Audio: Audio = defaultComponents.Unstable_Audio,
     tools = {},
+    data,
   } = {},
 }) => {
   const aui = useAui();
@@ -302,8 +331,10 @@ const MessagePartComponent: FC<MessagePartComponentProps> = ({
     case "audio":
       return <Audio {...part} />;
 
-    case "data":
-      return null;
+    case "data": {
+      const Data = data?.by_name?.[part.name] ?? data?.Fallback;
+      return <DataUIDisplay {...part} Fallback={Data} />;
+    }
 
     default:
       const unhandledType: never = type;
@@ -335,6 +366,7 @@ const MessagePart = memo(
     prev.components?.File === next.components?.File &&
     prev.components?.Unstable_Audio === next.components?.Unstable_Audio &&
     prev.components?.tools === next.components?.tools &&
+    prev.components?.data === next.components?.data &&
     prev.components?.Group === next.components?.Group,
 );
 

--- a/packages/react/src/tests/DataRenderers.test.ts
+++ b/packages/react/src/tests/DataRenderers.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import type { DataMessagePartComponent } from "../types/MessagePartComponentTypes";
+import type { DataRenderersState } from "../types/scopes/dataRenderers";
+
+/**
+ * Tests for the DataRenderers state management logic.
+ *
+ * Since the DataRenderers resource relies on @assistant-ui/tap's resource system
+ * (which requires fiber infrastructure), we test the core state logic directly.
+ */
+describe("DataRenderers state logic", () => {
+  // Replicate the state management logic from DataRenderers.ts
+  const createState = (): {
+    state: DataRenderersState;
+    setDataUI: (name: string, render: DataMessagePartComponent) => () => void;
+  } => {
+    let state: DataRenderersState = { renderers: {} };
+
+    const setDataUI = (name: string, render: DataMessagePartComponent) => {
+      state = {
+        ...state,
+        renderers: {
+          ...state.renderers,
+          [name]: [...(state.renderers[name] ?? []), render],
+        },
+      };
+
+      return () => {
+        state = {
+          ...state,
+          renderers: {
+            ...state.renderers,
+            [name]: state.renderers[name]?.filter((r) => r !== render) ?? [],
+          },
+        };
+      };
+    };
+
+    return {
+      get state() {
+        return state;
+      },
+      setDataUI,
+    };
+  };
+
+  describe("initial state", () => {
+    it("should start with empty renderers", () => {
+      const { state } = createState();
+      expect(state.renderers).toEqual({});
+    });
+  });
+
+  describe("setDataUI", () => {
+    it("should register a data renderer", () => {
+      const s = createState();
+      const Component = (() => null) as unknown as DataMessagePartComponent;
+
+      s.setDataUI("my-event", Component);
+
+      expect(s.state.renderers["my-event"]).toHaveLength(1);
+      expect(s.state.renderers["my-event"]![0]).toBe(Component);
+    });
+
+    it("should register multiple renderers for the same name", () => {
+      const s = createState();
+      const Component1 = (() => null) as unknown as DataMessagePartComponent;
+      const Component2 = (() => null) as unknown as DataMessagePartComponent;
+
+      s.setDataUI("my-event", Component1);
+      s.setDataUI("my-event", Component2);
+
+      expect(s.state.renderers["my-event"]).toHaveLength(2);
+      expect(s.state.renderers["my-event"]![0]).toBe(Component1);
+      expect(s.state.renderers["my-event"]![1]).toBe(Component2);
+    });
+
+    it("should register renderers for different names independently", () => {
+      const s = createState();
+      const Component1 = (() => null) as unknown as DataMessagePartComponent;
+      const Component2 = (() => null) as unknown as DataMessagePartComponent;
+
+      s.setDataUI("event-a", Component1);
+      s.setDataUI("event-b", Component2);
+
+      expect(s.state.renderers["event-a"]).toHaveLength(1);
+      expect(s.state.renderers["event-b"]).toHaveLength(1);
+      expect(s.state.renderers["event-a"]![0]).toBe(Component1);
+      expect(s.state.renderers["event-b"]![0]).toBe(Component2);
+    });
+
+    it("should unregister a renderer when cleanup is called", () => {
+      const s = createState();
+      const Component = (() => null) as unknown as DataMessagePartComponent;
+
+      const unsubscribe = s.setDataUI("my-event", Component);
+      expect(s.state.renderers["my-event"]).toHaveLength(1);
+
+      unsubscribe();
+      expect(s.state.renderers["my-event"]).toHaveLength(0);
+    });
+
+    it("should only unregister the specific renderer on cleanup", () => {
+      const s = createState();
+      const Component1 = (() => null) as unknown as DataMessagePartComponent;
+      const Component2 = (() => null) as unknown as DataMessagePartComponent;
+
+      const unsub1 = s.setDataUI("my-event", Component1);
+      s.setDataUI("my-event", Component2);
+
+      unsub1();
+
+      expect(s.state.renderers["my-event"]).toHaveLength(1);
+      expect(s.state.renderers["my-event"]![0]).toBe(Component2);
+    });
+
+    it("should not affect other names when unregistering", () => {
+      const s = createState();
+      const Component1 = (() => null) as unknown as DataMessagePartComponent;
+      const Component2 = (() => null) as unknown as DataMessagePartComponent;
+
+      const unsub1 = s.setDataUI("event-a", Component1);
+      s.setDataUI("event-b", Component2);
+
+      unsub1();
+
+      expect(s.state.renderers["event-a"]).toHaveLength(0);
+      expect(s.state.renderers["event-b"]).toHaveLength(1);
+    });
+  });
+});
+
+describe("Data part component resolution", () => {
+  // Replicate the component lookup logic from MessageParts.tsx
+  const resolveDataComponent = (
+    partName: string,
+    inlineConfig?: {
+      by_name?: Record<string, DataMessagePartComponent | undefined>;
+      Fallback?: DataMessagePartComponent;
+    },
+    globalRenderers?: Record<string, DataMessagePartComponent[]>,
+  ): DataMessagePartComponent | undefined => {
+    const inlineFallback =
+      inlineConfig?.by_name?.[partName] ?? inlineConfig?.Fallback;
+    const globalRenderer = globalRenderers?.[partName];
+
+    // Global takes priority (first element), then inline fallback
+    if (globalRenderer && globalRenderer.length > 0) {
+      return globalRenderer[0] ?? inlineFallback;
+    }
+    return inlineFallback;
+  };
+
+  it("should return undefined when no config provided", () => {
+    expect(resolveDataComponent("my-event")).toBeUndefined();
+  });
+
+  it("should return undefined when config has no matching name and no fallback", () => {
+    expect(resolveDataComponent("my-event", { by_name: {} })).toBeUndefined();
+  });
+
+  it("should resolve by_name component", () => {
+    const Component = (() => null) as unknown as DataMessagePartComponent;
+    const result = resolveDataComponent("my-event", {
+      by_name: { "my-event": Component },
+    });
+    expect(result).toBe(Component);
+  });
+
+  it("should fall back to Fallback when name not in by_name", () => {
+    const Fallback = (() => null) as unknown as DataMessagePartComponent;
+    const result = resolveDataComponent("unknown-event", {
+      by_name: {},
+      Fallback,
+    });
+    expect(result).toBe(Fallback);
+  });
+
+  it("should prefer by_name over Fallback", () => {
+    const SpecificComponent = (() =>
+      null) as unknown as DataMessagePartComponent;
+    const Fallback = (() => null) as unknown as DataMessagePartComponent;
+    const result = resolveDataComponent("my-event", {
+      by_name: { "my-event": SpecificComponent },
+      Fallback,
+    });
+    expect(result).toBe(SpecificComponent);
+  });
+
+  it("should prefer global registration over inline config", () => {
+    const InlineComponent = (() => null) as unknown as DataMessagePartComponent;
+    const GlobalComponent = (() => null) as unknown as DataMessagePartComponent;
+
+    const result = resolveDataComponent(
+      "my-event",
+      { by_name: { "my-event": InlineComponent } },
+      { "my-event": [GlobalComponent] },
+    );
+    expect(result).toBe(GlobalComponent);
+  });
+
+  it("should fall back to inline when global has no match", () => {
+    const InlineComponent = (() => null) as unknown as DataMessagePartComponent;
+
+    const result = resolveDataComponent(
+      "my-event",
+      { by_name: { "my-event": InlineComponent } },
+      {},
+    );
+    expect(result).toBe(InlineComponent);
+  });
+
+  it("should fall back to inline Fallback when global has empty array", () => {
+    const Fallback = (() => null) as unknown as DataMessagePartComponent;
+
+    const result = resolveDataComponent(
+      "my-event",
+      { Fallback },
+      { "my-event": [] },
+    );
+    expect(result).toBe(Fallback);
+  });
+});

--- a/packages/react/src/types/MessagePartComponentTypes.tsx
+++ b/packages/react/src/types/MessagePartComponentTypes.tsx
@@ -1,6 +1,7 @@
 import type { ComponentType, PropsWithChildren } from "react";
 import type {
   MessagePartStatus,
+  DataMessagePart,
   FileMessagePart,
   ImageMessagePart,
   ReasoningMessagePart,
@@ -43,6 +44,12 @@ export type Unstable_AudioMessagePartProps = MessagePartState &
   Unstable_AudioMessagePart;
 export type Unstable_AudioMessagePartComponent =
   ComponentType<Unstable_AudioMessagePartProps>;
+
+export type DataMessagePartProps<T = any> = MessagePartState &
+  DataMessagePart<T>;
+export type DataMessagePartComponent<T = any> = ComponentType<
+  DataMessagePartProps<T>
+>;
 
 export type ToolCallMessagePartProps<
   TArgs = any,

--- a/packages/react/src/types/index.ts
+++ b/packages/react/src/types/index.ts
@@ -43,6 +43,8 @@ export type {
   FileMessagePartProps,
   Unstable_AudioMessagePartComponent,
   Unstable_AudioMessagePartProps,
+  DataMessagePartComponent,
+  DataMessagePartProps,
   ToolCallMessagePartComponent,
   ToolCallMessagePartProps,
   ReasoningGroupProps,

--- a/packages/react/src/types/scopes/dataRenderers.ts
+++ b/packages/react/src/types/scopes/dataRenderers.ts
@@ -1,0 +1,15 @@
+import type { DataMessagePartComponent } from "../MessagePartComponentTypes";
+import type { Unsubscribe } from "../Unsubscribe";
+
+export type DataRenderersState = {
+  renderers: Record<string, DataMessagePartComponent[]>;
+};
+
+export type DataRenderersMethods = {
+  getState(): DataRenderersState;
+  setDataUI(name: string, render: DataMessagePartComponent): Unsubscribe;
+};
+
+export type DataRenderersClientSchema = {
+  methods: DataRenderersMethods;
+};

--- a/packages/react/src/types/scopes/index.ts
+++ b/packages/react/src/types/scopes/index.ts
@@ -44,6 +44,11 @@ export type {
 } from "./attachment";
 export type { ToolsState, ToolsMethods, ToolsClientSchema } from "./tools";
 export type {
+  DataRenderersState,
+  DataRenderersMethods,
+  DataRenderersClientSchema,
+} from "./dataRenderers";
+export type {
   SuggestionsState,
   SuggestionsMethods,
   SuggestionsClientSchema,

--- a/packages/react/src/types/store-augmentation.ts
+++ b/packages/react/src/types/store-augmentation.ts
@@ -8,6 +8,7 @@ import type { PartClientSchema } from "./scopes/part";
 import type { ComposerClientSchema } from "./scopes/composer";
 import type { AttachmentClientSchema } from "./scopes/attachment";
 import type { ToolsClientSchema } from "./scopes/tools";
+import type { DataRenderersClientSchema } from "./scopes/dataRenderers";
 import type { ModelContextClientSchema } from "./scopes/modelContext";
 import type { SuggestionsClientSchema } from "./scopes/suggestions";
 import type { SuggestionClientSchema } from "./scopes/suggestion";
@@ -23,6 +24,7 @@ declare module "@assistant-ui/store" {
     composer: ComposerClientSchema;
     attachment: AttachmentClientSchema;
     tools: ToolsClientSchema;
+    dataRenderers: DataRenderersClientSchema;
     modelContext: ModelContextClientSchema;
     suggestions: SuggestionsClientSchema;
     suggestion: SuggestionClientSchema;


### PR DESCRIPTION
This PR supports custom components for data message parts.

close #3314
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for custom components for data message parts with inline and global configuration options.
> 
>   - **Behavior**:
>     - Adds support for custom components for `data` message parts in `MessageParts.tsx` and `MessagePartsGrouped.tsx`.
>     - Supports inline and global registration of data components using `makeAssistantDataUI` and `useAssistantDataUI`.
>   - **Components**:
>     - Introduces `DataRenderers` in `DataRenderers.ts` to manage data component registration.
>     - Updates `ExternalThread.ts` and `InMemoryThreadList.ts` to include `DataRenderers`.
>   - **Types**:
>     - Adds `DataMessagePartComponent` and `DataMessagePartProps` in `MessagePartComponentTypes.tsx`.
>     - Defines `DataRenderersState` and `DataRenderersMethods` in `dataRenderers.ts`.
>   - **Tests**:
>     - Adds `DataRenderers.test.ts` to test data renderer registration and component resolution logic.
>   - **Documentation**:
>     - Updates `message-part.mdx` to document new data message part capabilities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for e19c49753b1336682b6ab741e2a07f6448bc91f4. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->