### PR TITLE
fix(x-buildutils): rewrite non-public package sub-paths in declaration emit

### DIFF
--- a/packages/x-buildutils/src/extension-transformer.ts
+++ b/packages/x-buildutils/src/extension-transformer.ts
@@ -2,17 +2,71 @@ import ts from "typescript";
 import path from "node:path";
 
 /**
- * Creates a transformer that rewrites extensionless imports to .js
+ * "@assistant-ui/core/types/attachment"
+ *   → { packageName: "@assistant-ui/core", subpath: "./types/attachment" }
+ */
+function parsePackageName(
+  specifier: string,
+): { packageName: string; subpath: string } | null {
+  if (specifier.startsWith(".") || specifier.startsWith("/")) return null;
+
+  const parts = specifier.split("/");
+  let packageName: string;
+  let rest: string[];
+
+  if (specifier.startsWith("@")) {
+    if (parts.length < 2) return null;
+    packageName = `${parts[0]}/${parts[1]}`;
+    rest = parts.slice(2);
+  } else {
+    packageName = parts[0]!;
+    rest = parts.slice(1);
+  }
+
+  const subpath = rest.length > 0 ? `./${rest.join("/")}` : ".";
+  return { packageName, subpath };
+}
+
+/**
+ * Returns the root package name if the specifier is an invalid sub-path
+ * of a known dependency; null otherwise (no rewrite needed).
+ *
+ * Wildcard exports (e.g. "./*") are intentionally NOT treated as valid —
+ * they only exist to prevent TS2742 during declaration emit. The
+ * transformer rewrites these back to the root specifier.
+ */
+function rewritePackageSubpath(
+  specifier: string,
+  validExportsMap: Map<string, Set<string>>,
+): string | null {
+  const parsed = parsePackageName(specifier);
+  if (!parsed || parsed.subpath === ".") return null;
+
+  const validPaths = validExportsMap.get(parsed.packageName);
+  if (!validPaths) return null;
+
+  if (validPaths.has(parsed.subpath)) return null;
+
+  return parsed.packageName;
+}
+
+/**
+ * TypeScript AST transformer for import specifier rewriting.
+ *
+ * 1. Rewrites extensionless relative imports to `.js` (both JS and .d.ts).
+ * 2. When `validExportsMap` is provided (afterDeclarations only), rewrites
+ *    non-public package sub-path references to the root specifier — fixing
+ *    TS2742 ("inferred type cannot be named") in emitted declarations.
  */
 export function createExtensionTransformer(
   program: ts.Program,
+  validExportsMap?: Map<string, Set<string>>,
 ): ts.TransformerFactory<ts.SourceFile> {
   return (context) => {
     const { factory } = context;
     const options = program.getCompilerOptions();
 
     const rewrite = (sourceFileName: string, specifier: string): string => {
-      // Only rewrite relative imports without extensions
       if (!specifier.startsWith("./") && !specifier.startsWith("../")) {
         return specifier;
       }
@@ -20,7 +74,6 @@ export function createExtensionTransformer(
         return specifier;
       }
 
-      // Check if it resolves to an index file
       const resolved = ts.resolveModuleName(
         specifier,
         sourceFileName,
@@ -42,14 +95,14 @@ export function createExtensionTransformer(
 
     const visit = (sourceFileName: string): ts.Visitor => {
       const visitor: ts.Visitor = (node) => {
-        // import { foo } from "./bar"
         if (
           ts.isImportDeclaration(node) &&
           node.moduleSpecifier &&
           ts.isStringLiteral(node.moduleSpecifier)
         ) {
-          const newSpec = rewrite(sourceFileName, node.moduleSpecifier.text);
-          if (newSpec !== node.moduleSpecifier.text) {
+          const spec = node.moduleSpecifier.text;
+          const newSpec = rewrite(sourceFileName, spec);
+          if (newSpec !== spec) {
             return factory.updateImportDeclaration(
               node,
               node.modifiers,
@@ -58,16 +111,28 @@ export function createExtensionTransformer(
               node.attributes,
             );
           }
+          if (validExportsMap) {
+            const rewritten = rewritePackageSubpath(spec, validExportsMap);
+            if (rewritten) {
+              return factory.updateImportDeclaration(
+                node,
+                node.modifiers,
+                node.importClause,
+                factory.createStringLiteral(rewritten),
+                node.attributes,
+              );
+            }
+          }
         }
 
-        // export { foo } from "./bar"
         if (
           ts.isExportDeclaration(node) &&
           node.moduleSpecifier &&
           ts.isStringLiteral(node.moduleSpecifier)
         ) {
-          const newSpec = rewrite(sourceFileName, node.moduleSpecifier.text);
-          if (newSpec !== node.moduleSpecifier.text) {
+          const spec = node.moduleSpecifier.text;
+          const newSpec = rewrite(sourceFileName, spec);
+          if (newSpec !== spec) {
             return factory.updateExportDeclaration(
               node,
               node.modifiers,
@@ -77,9 +142,21 @@ export function createExtensionTransformer(
               node.attributes,
             );
           }
+          if (validExportsMap) {
+            const rewritten = rewritePackageSubpath(spec, validExportsMap);
+            if (rewritten) {
+              return factory.updateExportDeclaration(
+                node,
+                node.modifiers,
+                node.isTypeOnly,
+                node.exportClause,
+                factory.createStringLiteral(rewritten),
+                node.attributes,
+              );
+            }
+          }
         }
 
-        // import("./bar")
         if (
           ts.isCallExpression(node) &&
           node.expression.kind === ts.SyntaxKind.ImportKeyword &&
@@ -94,6 +171,31 @@ export function createExtensionTransformer(
               node.expression,
               undefined,
               [factory.createStringLiteral(newSpec)],
+            );
+          }
+        }
+
+        // import("pkg/internal/path").Type in .d.ts files
+        if (
+          validExportsMap &&
+          ts.isImportTypeNode(node) &&
+          ts.isLiteralTypeNode(node.argument) &&
+          ts.isStringLiteral(node.argument.literal)
+        ) {
+          const rewritten = rewritePackageSubpath(
+            node.argument.literal.text,
+            validExportsMap,
+          );
+          if (rewritten) {
+            return factory.updateImportTypeNode(
+              node,
+              factory.createLiteralTypeNode(
+                factory.createStringLiteral(rewritten),
+              ),
+              node.attributes,
+              node.qualifier,
+              node.typeArguments,
+              node.isTypeOf,
             );
           }
         }

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -4,6 +4,63 @@ import path from "node:path";
 import { glob } from "tinyglobby";
 import { createExtensionTransformer } from "./extension-transformer";
 
+/**
+ * Builds a map of package name → set of exact export sub-paths
+ * by reading the `exports` field of each dependency's package.json.
+ */
+async function buildValidExportsMap(): Promise<Map<string, Set<string>>> {
+  const map = new Map<string, Set<string>>();
+
+  try {
+    const pkgJson = JSON.parse(await fs.readFile("package.json", "utf-8"));
+    const allDeps = {
+      ...pkgJson.dependencies,
+      ...pkgJson.peerDependencies,
+    };
+
+    for (const depName of Object.keys(allDeps)) {
+      try {
+        const depPkgPath = path.resolve(
+          "node_modules",
+          depName,
+          "package.json",
+        );
+        const depPkg = JSON.parse(await fs.readFile(depPkgPath, "utf-8"));
+
+        if (depPkg.exports) {
+          const validPaths = new Set<string>();
+
+          if (
+            typeof depPkg.exports === "string" ||
+            Array.isArray(depPkg.exports)
+          ) {
+            validPaths.add(".");
+          } else {
+            const keys = Object.keys(depPkg.exports);
+            const hasSubpaths = keys.some((k) => k.startsWith("."));
+            if (hasSubpaths) {
+              for (const key of keys) {
+                if (key.startsWith(".")) validPaths.add(key);
+              }
+            } else {
+              // Conditional exports (e.g. { "import": "...", "require": "..." })
+              validPaths.add(".");
+            }
+          }
+
+          map.set(depName, validPaths);
+        }
+      } catch {
+        // Dependency not resolvable — skip
+      }
+    }
+  } catch {
+    // No package.json — skip
+  }
+
+  return map;
+}
+
 async function build() {
   await fs.rm("dist", { recursive: true, force: true });
 
@@ -34,6 +91,8 @@ async function build() {
     path.dirname(configPath),
   );
 
+  const validExportsMap = await buildValidExportsMap();
+
   const program = ts.createProgram(files, {
     ...parsedConfig.options,
     outDir: "dist",
@@ -49,11 +108,17 @@ async function build() {
       ) ?? [],
   });
 
-  const transformer = createExtensionTransformer(program);
+  // JS: extension rewriting only
+  // .d.ts: extension rewriting + package sub-path rewriting
+  const extensionTransformer = createExtensionTransformer(program);
+  const declarationTransformer = createExtensionTransformer(
+    program,
+    validExportsMap,
+  );
   const emitResult = program.emit(undefined, undefined, undefined, false, {
-    before: [transformer],
+    before: [extensionTransformer],
     afterDeclarations: [
-      transformer as unknown as ts.TransformerFactory<
+      declarationTransformer as unknown as ts.TransformerFactory<
         ts.Bundle | ts.SourceFile
       >,
     ],


### PR DESCRIPTION
This PR adds `ImportTypeNode` handling to the `afterDeclarations` transformer, rewriting internal dependency paths (e.g. `import("@assistant-ui/core/types/attachment")`) to root specifiers in emitted `.d.ts` files. 

related to [TS2742](https://typescript.tv/errors/ts2742/).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds handling for non-public package sub-paths in TypeScript declaration files to fix TS2742 errors by rewriting to root specifiers.
> 
>   - **Behavior**:
>     - Adds `ImportTypeNode` handling in `createExtensionTransformer` to rewrite internal dependency paths to root specifiers in `.d.ts` files.
>     - Fixes TS2742 error by rewriting non-public package sub-paths to root specifiers.
>   - **Functions**:
>     - Adds `parsePackageName()` to parse package names and subpaths.
>     - Adds `rewritePackageSubpath()` to determine if a subpath is valid and rewrite if necessary.
>     - Adds `buildValidExportsMap()` in `index.ts` to build a map of valid export paths from dependencies' `package.json` files.
>   - **Build Process**:
>     - Modifies `build()` in `index.ts` to use `buildValidExportsMap()` and pass `validExportsMap` to `createExtensionTransformer`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 0a3df59a1afc5fcfba5e35ffda76757455aec66d. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->