### PR TITLE
fix(react): preserve thread metadata during title stream updates

### DIFF
--- a/.changeset/quick-buses-confess.md
+++ b/.changeset/quick-buses-confess.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: avoid stale thread metadata overwrite while streaming generated titles

--- a/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx
@@ -378,12 +378,14 @@ export class RemoteThreadListThreadListRuntimeCore
     for await (const result of messageStream) {
       const newTitle = result.parts.filter((c) => c.type === "text")[0]?.text;
       const state = this._state.baseValue;
+      const currentData = getThreadData(state, data.id);
+      if (!currentData) continue;
       this._state.update({
         ...state,
         threadData: {
           ...state.threadData,
-          [data.id]: {
-            ...data,
+          [currentData.id]: {
+            ...currentData,
             title: newTitle,
           },
         },


### PR DESCRIPTION
## Summary

Fixes #3328 by preventing stale thread metadata from being written back during `generateTitle()` streaming updates in `unstable_useRemoteThreadListRuntime`.

Previously, `generateTitle()` reused a captured `data` snapshot when updating title chunks. During async updates this could overwrite newer thread metadata and cause `threadListItem.remoteId` churn/flicker (`defined -> undefined -> defined`) and excessive rerenders.

## What changed

- In `RemoteThreadListThreadListRuntimeCore.generateTitle()`, title updates now merge into the latest thread data from current state:
  - read current item with `getThreadData(state, data.id)`
  - skip if missing
  - update `title` on `currentData` instead of the captured `data`

## Why this works

`remoteId` and other metadata are no longer vulnerable to stale snapshot overwrites while title chunks stream in, so thread metadata remains stable across stream lifecycle updates.

## Verification

- `pnpm turbo build --filter=@assistant-ui/react`
- `pnpm --filter @assistant-ui/react test`
- `pnpm exec biome check packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/RemoteThreadListThreadListRuntimeCore.tsx`

## Changeset

Included:
- patch release for `@assistant-ui/react`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes stale thread metadata overwrite in `generateTitle()` in `RemoteThreadListThreadListRuntimeCore.tsx` by merging updates with current state, preventing metadata flicker and excessive rerenders.
> 
>   - **Behavior**:
>     - Fixes stale thread metadata overwrite in `generateTitle()` in `RemoteThreadListThreadListRuntimeCore.tsx` by merging updates with current state.
>     - Prevents `threadListItem.remoteId` flicker and excessive rerenders during async title updates.
>   - **Functions**:
>     - `generateTitle()`: Reads current item with `getThreadData(state, data.id)` and updates `title` on `currentData`.
>   - **Misc**:
>     - Adds patch release note for `@assistant-ui/react`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for f77d3412c7cc1c2d89379c34834b5eede2f06158. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->