### PR TITLE
fix(tap): prevent version rollback crash

### DIFF
--- a/.changeset/fix-tap-version-rollback.md
+++ b/.changeset/fix-tap-version-rollback.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix(tap): prevent rollback crash when tapResourceRoot version falls below committedVersion

--- a/packages/tap/src/tapResourceRoot.ts
+++ b/packages/tap/src/tapResourceRoot.ts
@@ -58,7 +58,7 @@ export const tapResourceRoot = <TState>(
     );
   }, [element.type, element.key]);
 
-  setRootVersion(fiber.root, 0);
+  setRootVersion(fiber.root, fiber.root.committedVersion);
   const render = renderResourceFiber(fiber, element.props);
 
   const isMountedRef = tapRef(false);


### PR DESCRIPTION
This PR fixes `tapResourceRoot` always passing hardcoded `0` to `setRootVersion`, which crashes when `committedVersion` has advanced past `0` after an async `handleUpdate` commit.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix crash in `tapResourceRoot.ts` by setting root version to `committedVersion` instead of `0`.
> 
>   - **Bug Fix**:
>     - In `tapResourceRoot.ts`, change `setRootVersion(fiber.root, 0)` to `setRootVersion(fiber.root, fiber.root.committedVersion)` to prevent crashes when `committedVersion` is greater than `0`.
>   - **Misc**:
>     - Add changeset file `fix-tap-version-rollback.md` to document the patch update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 45f22829d1485a3eb68ec2b7c497609bb301e74a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->