### PR TITLE
fix(react-ag-ui): auto-resume run after tool execution

### DIFF
--- a/.changeset/ag-ui-tool-result-resume.md
+++ b/.changeset/ag-ui-tool-result-resume.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix(react-ag-ui): auto-resume run after frontend tool execution completes

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -76,7 +76,13 @@ export class RunAggregator {
         break;
       }
       case "RUN_FINISHED": {
-        this.status = { type: "complete", reason: "unknown" };
+        const hasUnresolvedToolCalls = Array.from(this.toolCalls.values()).some(
+          (tc) => tc.result === undefined,
+        );
+
+        this.status = hasUnresolvedToolCalls
+          ? { type: "requires-action", reason: "tool-calls" }
+          : { type: "complete", reason: "unknown" };
         this.emit();
         break;
       }

--- a/packages/react-langgraph/src/index.ts
+++ b/packages/react-langgraph/src/index.ts
@@ -26,6 +26,10 @@ export type {
   OnMessageChunkCallback,
   OnValuesEventCallback,
   OnUpdatesEventCallback,
+  OnMetadataEventCallback,
+  OnInfoEventCallback,
+  OnErrorEventCallback,
+  OnCustomEventCallback,
 } from "./types";
 
 export { LangGraphMessageAccumulator } from "./LangGraphMessageAccumulator";


### PR DESCRIPTION
This PR adds auto-resume run after tool execution complete.

close #3348
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds auto-resume functionality for runs after tool execution in `react-ag-ui`, with tests and minor type exports.
> 
>   - **Behavior**:
>     - Implements auto-resume of runs in `AgUiThreadRuntimeCore.ts` after tool execution completes if all tool results are available.
>     - Updates `RunAggregator` in `run-aggregator.ts` to set status to `requires-action` if tool results are missing at `RUN_FINISHED`.
>   - **Tests**:
>     - Adds tests in `ag-ui-thread-runtime-core.spec.ts` for auto-resume functionality and scenarios where not all tool results are available.
>     - Adds tests in `run-aggregator.spec.ts` to verify status changes based on tool call results.
>   - **Misc**:
>     - Exports additional types in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 39956ba4e618f37abbe0c6c255e9041b8371bd15. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->