### PR TITLE
fix(react): argsText key reordering during streaming

### DIFF
--- a/.changeset/busy-bags-write.md
+++ b/.changeset/busy-bags-write.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): handle argsText key reordering when previous argsText is incomplete


### PR DESCRIPTION
closes https://github.com/assistant-ui/assistant-ui/issues/3351
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `argsText` key reordering handling in `useToolInvocations` to ensure correct processing of complete JSON objects during streaming.
> 
>   - **Behavior**:
>     - Fixes handling of `argsText` key reordering in `useToolInvocations` when transitioning from streaming to complete state.
>     - Ensures complete JSON objects are processed correctly even if key order changes.
>     - Throws error if `argsText` is not appended correctly.
>   - **Functions**:
>     - Modifies `useToolInvocations` in `useToolInvocations.ts` to handle complete `argsText` reordering.
>     - Uses `isArgsTextComplete` to check JSON completeness before processing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 60622ee35cb8a02cbbd21c6e05df16ff7e0faae2. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->