### PR TITLE
fix(react-ag-ui): support explicit threadId for parallel chat sessions

### DIFF
--- a/.changeset/large-jokes-notice.md
+++ b/.changeset/large-jokes-notice.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix(react-ag-ui): support explicit threadId for parallel chat sessions

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -29,6 +29,7 @@ type ResumeRunConfig = {
 
 type CoreOptions = {
   agent: HttpAgent;
+  threadId?: string;
   logger: Logger;
   showThinking: boolean;
   onError?: (error: Error) => void;
@@ -41,6 +42,7 @@ const FALLBACK_USER_STATUS = { type: "complete", reason: "unknown" } as const;
 
 export class AgUiThreadRuntimeCore {
   private agent: HttpAgent;
+  private threadId: string;
   private logger: Logger;
   private showThinking: boolean;
   private onError: ((error: Error) => void) | undefined;
@@ -62,6 +64,7 @@ export class AgUiThreadRuntimeCore {
 
   constructor(options: CoreOptions) {
     this.agent = options.agent;
+    this.threadId = options.threadId ?? this.agent.threadId ?? "main";
     this.logger = options.logger;
     this.showThinking = options.showThinking;
     this.onError = options.onError;
@@ -72,11 +75,16 @@ export class AgUiThreadRuntimeCore {
 
   updateOptions(options: Omit<CoreOptions, "notifyUpdate">) {
     this.agent = options.agent;
+    this.threadId = options.threadId ?? this.agent.threadId ?? this.threadId;
     this.logger = options.logger;
     this.showThinking = options.showThinking;
     this.onError = options.onError;
     this.onCancel = options.onCancel;
     this.history = options.history;
+  }
+
+  setThreadId(threadId: string) {
+    this.threadId = threadId;
   }
 
   attachRuntime(runtime: AssistantRuntime) {
@@ -365,7 +373,7 @@ export class AgUiThreadRuntimeCore {
     runConfig: RunConfig | undefined,
     historyMessages: readonly ThreadMessage[] | undefined,
   ) {
-    const threadId = this.agent.threadId || "main";
+    const threadId = this.threadId;
     const messages = toAgUiMessages(historyMessages ?? this.messages);
     const context = this.runtime?.thread.getModelContext();
     return {

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -40,6 +40,7 @@ export type UseAgUiRuntimeAdapters = {
 
 export type UseAgUiRuntimeOptions = {
   agent: HttpAgent;
+  threadId?: string;
   logger?: Partial<Logger>;
   showThinking?: boolean;
   onError?: (e: Error) => void;

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -33,6 +33,7 @@ export function useAgUiRuntime(
   if (!coreRef.current) {
     coreRef.current = new AgUiThreadRuntimeCore({
       agent: options.agent,
+      ...(options.threadId !== undefined && { threadId: options.threadId }),
       logger,
       showThinking: options.showThinking ?? true,
       ...(options.onError && { onError: options.onError }),
@@ -45,6 +46,7 @@ export function useAgUiRuntime(
   const core = coreRef.current;
   core.updateOptions({
     agent: options.agent,
+    ...(options.threadId !== undefined && { threadId: options.threadId }),
     logger,
     showThinking: options.showThinking ?? true,
     ...(options.onError && { onError: options.onError }),
@@ -89,6 +91,7 @@ export function useAgUiRuntime(
       onSwitchToThread: onSwitchToThread
         ? async (threadId: string) => {
             toolInvocationsRef.current.reset();
+            core.setThreadId(threadId);
             const result = await onSwitchToThread(threadId);
             core.applyExternalMessages(result.messages);
             if (result.state) {


### PR DESCRIPTION
closes #3207 
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for explicit `threadId` in `AgUiThreadRuntimeCore` for parallel chat sessions, with fallback and update mechanisms.
> 
>   - **Behavior**:
>     - Adds support for explicit `threadId` in `AgUiThreadRuntimeCore` to manage parallel chat sessions.
>     - Defaults to `agent.threadId` or "main" if no explicit `threadId` is provided.
>     - Updates `threadId` via `setThreadId()` and `updateOptions()` methods.
>   - **Types**:
>     - Adds optional `threadId` to `CoreOptions` and `UseAgUiRuntimeOptions` in `types.ts`.
>   - **Hooks**:
>     - Updates `useAgUiRuntime()` in `useAgUiRuntime.ts` to handle `threadId` in options.
>   - **Tests**:
>     - Adds tests in `ag-ui-thread-runtime-core.spec.ts` to verify `threadId` handling, including explicit setting, fallback, and updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 4cd2700b9d6f58a6b70f690c7d5f5c0f5d1665f2. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->