### PR TITLE
docs: allow wildcard frame src

### DIFF
--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -1,3 +1,4 @@
+
 import { createMDX } from "fumadocs-mdx/next";
 import { NextConfig } from "next";
 
@@ -5,7 +6,8 @@ const isDev = process.env.NODE_ENV === "development";
 
 const cspHeader = `
     default-src 'self';
-    connect-src 'self' *;
+    connect-src *;
+    frame-src *;
     script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""};
     style-src 'self' 'unsafe-inline';
     img-src 'self' blob: data:;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update CSP in `next.config.ts` to allow all sources for `connect-src` and `frame-src`.
> 
>   - **CSP Changes in `next.config.ts`**:
>     - `connect-src` directive updated to allow all sources (`*`).
>     - Added `frame-src` directive to allow all sources (`*`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 1dc262f8a7a99bef69c8a3a5a88f2aabf703a907. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->