### PR TITLE
refactor: update AuiIf convention to use (s) => s... convention

### DIFF
--- a/apps/docs/components/builder/builder-code-output.tsx
+++ b/apps/docs/components/builder/builder-code-output.tsx
@@ -141,7 +141,7 @@ export function Thread() {
       >
         ${
           components.threadWelcome
-            ? `<AuiIf condition={({ thread }) => thread.isEmpty}>
+            ? `<AuiIf condition={(s) => s.thread.isEmpty}>
           <ThreadWelcome />
         </AuiIf>`
             : ""
@@ -229,7 +229,7 @@ function ComposerAction() {
     <div className="relative mx-2 mb-2 flex items-center justify-between">
       ${components.attachments ? "<ComposerAddAttachment />" : "<div />"}
 
-      <AuiIf condition={({ thread }) => !thread.isRunning}>
+      <AuiIf condition={(s) => !s.thread.isRunning}>
         <ComposerPrimitive.Send asChild>
           <TooltipIconButton
             tooltip="Send message"
@@ -249,7 +249,7 @@ function ComposerAction() {
         </ComposerPrimitive.Send>
       </AuiIf>
 
-      <AuiIf condition={({ thread }) => thread.isRunning}>
+      <AuiIf condition={(s) => s.thread.isRunning}>
         <ComposerPrimitive.Cancel asChild>
           <Button
             type="button"
@@ -381,7 +381,7 @@ function AssistantMessage() {
         <MessageError />${
           components.loadingIndicator !== "none"
             ? `
-        <AuiIf condition={({ thread, message }) => thread.isRunning && message.content.length === 0}>
+        <AuiIf condition={(s) => s.thread.isRunning && s.message.content.length === 0}>
           <div className="flex items-center gap-2 text-muted-foreground">
             <LoaderIcon className="size-4 animate-spin" />${
               components.loadingIndicator === "text"
@@ -402,7 +402,7 @@ function AssistantMessage() {
       ${
         components.followUpSuggestions
           ? `
-      <AuiIf condition={({ thread }) => !thread.isRunning}>
+      <AuiIf condition={(s) => !s.thread.isRunning}>
         <div className="mt-4 flex flex-wrap gap-2">
           <ThreadPrimitive.Suggestion
             prompt="Tell me more"
@@ -461,10 +461,10 @@ function AssistantActionBar() {
         components.actionBar.copy
           ? `<ActionBarPrimitive.Copy asChild>
         <TooltipIconButton tooltip="Copy">
-          <AuiIf condition={({ message }) => message.isCopied}>
+          <AuiIf condition={(s) => s.message.isCopied}>
             <CheckIcon />
           </AuiIf>
-          <AuiIf condition={({ message }) => !message.isCopied}>
+          <AuiIf condition={(s) => !s.message.isCopied}>
             <CopyIcon />
           </AuiIf>
         </TooltipIconButton>

--- a/apps/docs/components/builder/builder-preview.tsx
+++ b/apps/docs/components/builder/builder-preview.tsx
@@ -225,13 +225,13 @@ export function BuilderPreview({ config }: BuilderPreviewProps) {
             className="aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth px-4 pt-4"
           >
             {components.threadWelcome && (
-              <AuiIf condition={({ thread }) => thread.isEmpty}>
+              <AuiIf condition={(s) => s.thread.isEmpty}>
                 <ThreadWelcome config={config} />
               </AuiIf>
             )}
 
             {!components.threadWelcome && (
-              <AuiIf condition={({ thread }) => thread.isEmpty}>
+              <AuiIf condition={(s) => s.thread.isEmpty}>
                 <div className="grow" />
               </AuiIf>
             )}
@@ -414,7 +414,7 @@ const ComposerAction: FC<ComposerActionProps> = ({ config }) => {
         <div />
       )}
 
-      <AuiIf condition={({ thread }) => !thread.isRunning}>
+      <AuiIf condition={(s) => !s.thread.isRunning}>
         <ComposerPrimitive.Send asChild>
           <TooltipIconButton
             tooltip="Send message"
@@ -434,7 +434,7 @@ const ComposerAction: FC<ComposerActionProps> = ({ config }) => {
         </ComposerPrimitive.Send>
       </AuiIf>
 
-      <AuiIf condition={({ thread }) => thread.isRunning}>
+      <AuiIf condition={(s) => s.thread.isRunning}>
         <ComposerPrimitive.Cancel asChild>
           <Button
             type="button"
@@ -691,7 +691,7 @@ const AssistantMessage: FC<AssistantMessageProps> = ({ config }) => {
           </div>
 
           {components.followUpSuggestions && (
-            <AuiIf condition={({ thread }) => !thread.isRunning}>
+            <AuiIf condition={(s) => !s.thread.isRunning}>
               <FollowUpSuggestions />
             </AuiIf>
           )}
@@ -760,10 +760,10 @@ const AssistantActionBar: FC<AssistantActionBarProps> = ({ config }) => {
       {actionBar.copy && (
         <ActionBarPrimitive.Copy asChild>
           <TooltipIconButton tooltip="Copy">
-            <AuiIf condition={({ message }) => message.isCopied}>
+            <AuiIf condition={(s) => s.message.isCopied}>
               <CheckIcon />
             </AuiIf>
-            <AuiIf condition={({ message }) => !message.isCopied}>
+            <AuiIf condition={(s) => !s.message.isCopied}>
               <CopyIcon />
             </AuiIf>
           </TooltipIconButton>

--- a/apps/docs/components/docs/assistant/composer.tsx
+++ b/apps/docs/components/docs/assistant/composer.tsx
@@ -155,7 +155,7 @@ export function AssistantComposer({
 export function AssistantComposerAction(): ReactNode {
   return (
     <>
-      <AuiIf condition={({ thread }) => !thread.isRunning}>
+      <AuiIf condition={(s) => !s.thread.isRunning}>
         <ComposerPrimitive.Send asChild>
           <Button type="submit" size="icon" className="size-7 rounded-lg">
             <ArrowUpIcon className="size-4" />
@@ -163,7 +163,7 @@ export function AssistantComposerAction(): ReactNode {
         </ComposerPrimitive.Send>
       </AuiIf>
 
-      <AuiIf condition={({ thread }) => thread.isRunning}>
+      <AuiIf condition={(s) => s.thread.isRunning}>
         <ComposerPrimitive.Cancel asChild>
           <Button
             type="button"

--- a/apps/docs/components/docs/assistant/thread.tsx
+++ b/apps/docs/components/docs/assistant/thread.tsx
@@ -55,7 +55,7 @@ export function AssistantThread(): React.ReactNode {
     <ThreadPrimitive.Root className="flex h-full flex-col bg-background">
       <PendingMessageHandler />
       <ThreadPrimitive.Viewport className="scrollbar-none flex flex-1 flex-col overflow-y-auto px-3 pt-3">
-        <AuiIf condition={({ thread }) => thread.isEmpty}>
+        <AuiIf condition={(s) => s.thread.isEmpty}>
           <AssistantWelcome />
         </AuiIf>
 

--- a/apps/docs/components/docs/samples/speech.tsx
+++ b/apps/docs/components/docs/samples/speech.tsx
@@ -172,7 +172,7 @@ const ComposerAction: FC = () => {
     <div className="aui-composer-action-wrapper relative mx-1 mt-2 mb-2 flex items-center justify-between">
       <ComposerAddAttachment />
 
-      <AuiIf condition={({ thread }) => !thread.isRunning}>
+      <AuiIf condition={(s) => !s.thread.isRunning}>
         <ComposerPrimitive.Send asChild>
           <TooltipIconButton
             tooltip="Send message"
@@ -188,7 +188,7 @@ const ComposerAction: FC = () => {
         </ComposerPrimitive.Send>
       </AuiIf>
 
-      <AuiIf condition={({ thread }) => thread.isRunning}>
+      <AuiIf condition={(s) => s.thread.isRunning}>
         <ComposerPrimitive.Cancel asChild>
           <Button
             type="button"
@@ -247,14 +247,14 @@ const AssistantActionBar: FC = () => {
       autohideFloat="single-branch"
       className="aui-assistant-action-bar-root col-start-3 row-start-2 -ml-1 flex gap-1 text-muted-foreground data-floating:absolute data-floating:rounded-md data-floating:border data-floating:bg-background data-floating:p-1 data-floating:shadow-sm"
     >
-      <AuiIf condition={({ message }) => message.speech == null}>
+      <AuiIf condition={(s) => s.message.speech == null}>
         <ActionBarPrimitive.Speak asChild>
           <TooltipIconButton tooltip="Read aloud">
             <AudioLinesIcon />
           </TooltipIconButton>
         </ActionBarPrimitive.Speak>
       </AuiIf>
-      <AuiIf condition={({ message }) => message.speech != null}>
+      <AuiIf condition={(s) => s.message.speech != null}>
         <ActionBarPrimitive.StopSpeaking asChild>
           <TooltipIconButton tooltip="Stop">
             <StopCircleIcon />
@@ -263,10 +263,10 @@ const AssistantActionBar: FC = () => {
       </AuiIf>
       <ActionBarPrimitive.Copy asChild>
         <TooltipIconButton tooltip="Copy">
-          <AuiIf condition={({ message }) => message.isCopied}>
+          <AuiIf condition={(s) => s.message.isCopied}>
             <CheckIcon />
           </AuiIf>
-          <AuiIf condition={({ message }) => !message.isCopied}>
+          <AuiIf condition={(s) => !s.message.isCopied}>
             <CopyIcon />
           </AuiIf>
         </TooltipIconButton>

--- a/apps/docs/components/examples/chatgpt.tsx
+++ b/apps/docs/components/examples/chatgpt.tsx
@@ -49,12 +49,12 @@ export const ChatGPT: FC = () => {
           placeholder="Message ChatGPT"
           className="h-12 max-h-40 grow resize-none bg-transparent p-3.5 text-sm text-white outline-none placeholder:text-white/50"
         />
-        <AuiIf condition={({ thread }) => !thread.isRunning}>
+        <AuiIf condition={(s) => !s.thread.isRunning}>
           <ComposerPrimitive.Send className="m-2 flex size-8 items-center justify-center rounded-full bg-white transition-opacity disabled:opacity-10">
             <ArrowUpIcon className="size-5 text-black [&_path]:stroke-1 [&_path]:stroke-black" />
           </ComposerPrimitive.Send>
         </AuiIf>
-        <AuiIf condition={({ thread }) => thread.isRunning}>
+        <AuiIf condition={(s) => s.thread.isRunning}>
           <ComposerPrimitive.Cancel className="m-2 flex size-8 items-center justify-center rounded-full bg-white">
             <div className="size-2.5 bg-black" />
           </ComposerPrimitive.Cancel>
@@ -141,10 +141,10 @@ const AssistantMessage: FC = () => {
             </ActionBarPrimitive.Reload>
             <ActionBarPrimitive.Copy asChild>
               <TooltipIconButton tooltip="Copy" className="text-[#b4b4b4]">
-                <AuiIf condition={({ message }) => message.isCopied}>
+                <AuiIf condition={(s) => s.message.isCopied}>
                   <CheckIcon />
                 </AuiIf>
-                <AuiIf condition={({ message }) => !message.isCopied}>
+                <AuiIf condition={(s) => !s.message.isCopied}>
                   <CopyIcon />
                 </AuiIf>
               </TooltipIconButton>

--- a/apps/docs/components/examples/claude.tsx
+++ b/apps/docs/components/examples/claude.tsx
@@ -94,7 +94,7 @@ export const Claude: FC = () => {
 const ChatMessage: FC = () => {
   return (
     <MessagePrimitive.Root className="group relative mx-auto mt-1 mb-1 block w-full max-w-3xl">
-      <AuiIf condition={({ message }) => message.role === "user"}>
+      <AuiIf condition={(s) => s.message.role === "user"}>
         <div className="group/user wrap-break-word relative inline-flex max-w-[75ch] flex-col gap-2 rounded-xl bg-[#DDD9CE] py-2.5 pr-6 pl-2.5 text-[#1a1a18] transition-all dark:bg-[#393937] dark:text-[#eee]">
           <div className="relative flex flex-row gap-2">
             <div className="shrink-0 self-start transition-all duration-300">
@@ -128,7 +128,7 @@ const ChatMessage: FC = () => {
         </div>
       </AuiIf>
 
-      <AuiIf condition={({ message }) => message.role === "assistant"}>
+      <AuiIf condition={(s) => s.message.role === "assistant"}>
         <div className="relative mb-12 font-serif">
           <div className="relative leading-[1.65rem]">
             <div className="grid grid-cols-1 gap-2.5">
@@ -157,7 +157,7 @@ const ChatMessage: FC = () => {
                   <ReloadIcon width={20} height={20} />
                 </ActionBarPrimitive.Reload>
               </div>
-              <AuiIf condition={({ message }) => message.isLast}>
+              <AuiIf condition={(s) => s.message.isLast}>
                 <p className="mt-2 w-full text-right text-[#8a8985] text-[0.65rem] leading-[0.85rem] opacity-90 sm:text-[0.75rem] dark:text-[#b8b5a9]">
                   Claude can make mistakes. Please double-check responses.
                 </p>

--- a/apps/docs/components/examples/grok.tsx
+++ b/apps/docs/components/examples/grok.tsx
@@ -242,10 +242,10 @@ const MessageTimingDisplay: FC = () => {
 
 const useAttachmentSrc = () => {
   const { file, src } = useAuiState(
-    useShallow(({ attachment }): { file?: File; src?: string } => {
-      if (attachment.type !== "image") return {};
-      if (attachment.file) return { file: attachment.file };
-      const src = attachment.content?.filter((c) => c.type === "image")[0]
+    useShallow((s): { file?: File; src?: string } => {
+      if (s.attachment.type !== "image") return {};
+      if (s.attachment.file) return { file: s.attachment.file };
+      const src = s.attachment.content?.filter((c) => c.type === "image")[0]
         ?.image;
       if (!src) return {};
       return { src };
@@ -273,7 +273,7 @@ const GrokAttachment: FC = () => {
   return (
     <AttachmentPrimitive.Root className="group/attachment relative">
       <div className="flex h-12 items-center gap-2 overflow-hidden rounded-xl border border-[#e5e5e5] bg-[#f0f0f0] p-0.5 transition-colors hover:border-[#d0d0d0] dark:border-[#2a2a2a] dark:bg-[#252525] dark:hover:border-[#3a3a3a]">
-        <AuiIf condition={({ attachment }) => attachment.type === "image"}>
+        <AuiIf condition={(s) => s.attachment.type === "image"}>
           {src ? (
             <img
               className="h-full w-12 rounded-[9px] object-cover"
@@ -286,7 +286,7 @@ const GrokAttachment: FC = () => {
             </div>
           )}
         </AuiIf>
-        <AuiIf condition={({ attachment }) => attachment.type !== "image"}>
+        <AuiIf condition={(s) => s.attachment.type !== "image"}>
           <div className="flex h-full w-12 items-center justify-center rounded-[9px] bg-[#e5e5e5] text-[#6b6b6b] dark:bg-[#3a3a3a] dark:text-[#9a9a9a]">
             <AttachmentPrimitive.unstable_Thumb className="text-xs" />
           </div>

--- a/apps/docs/components/examples/perplexity.tsx
+++ b/apps/docs/components/examples/perplexity.tsx
@@ -42,7 +42,7 @@ export const Perplexity: FC = () => {
       <ThreadPrimitive.Empty>
         <ThreadWelcome />
       </ThreadPrimitive.Empty>
-      <AuiIf condition={({ thread }) => !thread.isEmpty}>
+      <AuiIf condition={(s) => !s.thread.isEmpty}>
         <ThreadPrimitive.Viewport className="flex h-full flex-col items-center overflow-y-scroll scroll-smooth bg-inherit px-4 pt-8">
           <ThreadPrimitive.Messages
             components={{
@@ -151,7 +151,7 @@ const Composer: FC = () => {
 const ComposerAction: FC = () => {
   return (
     <>
-      <AuiIf condition={({ thread }) => !thread.isRunning}>
+      <AuiIf condition={(s) => !s.thread.isRunning}>
         <ComposerPrimitive.Send asChild>
           <TooltipIconButton
             tooltip="Send"
@@ -162,7 +162,7 @@ const ComposerAction: FC = () => {
           </TooltipIconButton>
         </ComposerPrimitive.Send>
       </AuiIf>
-      <AuiIf condition={({ thread }) => thread.isRunning}>
+      <AuiIf condition={(s) => s.thread.isRunning}>
         <ComposerPrimitive.Cancel asChild>
           <TooltipIconButton
             tooltip="Cancel"
@@ -221,10 +221,10 @@ const AssistantActionBar: FC = () => {
           tooltip="Copy"
           className="text-[#808080] hover:bg-[#3a3a3a] hover:text-[#f5f5f5]"
         >
-          <AuiIf condition={({ message }) => message.isCopied}>
+          <AuiIf condition={(s) => s.message.isCopied}>
             <CheckIcon className="text-[#20b8cd]" />
           </AuiIf>
-          <AuiIf condition={({ message }) => !message.isCopied}>
+          <AuiIf condition={(s) => !s.message.isCopied}>
             <CopyIcon />
           </AuiIf>
         </TooltipIconButton>

--- a/apps/docs/content/docs/(docs)/guides/chain-of-thought.mdx
+++ b/apps/docs/content/docs/(docs)/guides/chain-of-thought.mdx
@@ -46,7 +46,7 @@ const ChainOfThought: FC = () => {
       <ChainOfThoughtPrimitive.AccordionTrigger className="flex w-full cursor-pointer items-center gap-2 px-4 py-2 font-medium text-sm hover:bg-muted/50">
         Thinking
       </ChainOfThoughtPrimitive.AccordionTrigger>
-      <AuiIf condition={({ chainOfThought }) => !chainOfThought.collapsed}>
+      <AuiIf condition={(s) => !s.chainOfThought.collapsed}>
         <ChainOfThoughtPrimitive.Parts
           components={{ Reasoning, tools: { Fallback: ToolFallback } }}
         />
@@ -110,7 +110,7 @@ A button that toggles the collapsed/expanded state. Collapsed by default.
 Renders the grouped parts when expanded (nothing when collapsed).
 
 ```tsx
-<AuiIf condition={({ chainOfThought }) => !chainOfThought.collapsed}>
+<AuiIf condition={(s) => !s.chainOfThought.collapsed}>
   <ChainOfThoughtPrimitive.Parts
     components={{
       Reasoning,
@@ -140,10 +140,10 @@ import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
 const ChainOfThoughtAccordionTrigger = () => {
   return (
     <ChainOfThoughtPrimitive.AccordionTrigger className="flex w-full cursor-pointer items-center gap-2 px-4 py-2 text-sm">
-      <AuiIf condition={({ chainOfThought }) => chainOfThought.collapsed}>
+      <AuiIf condition={(s) => s.chainOfThought.collapsed}>
         <ChevronRightIcon className="size-4" />
       </AuiIf>
-      <AuiIf condition={({ chainOfThought }) => !chainOfThought.collapsed}>
+      <AuiIf condition={(s) => !s.chainOfThought.collapsed}>
         <ChevronDownIcon className="size-4" />
       </AuiIf>
       Thinking

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/action-bar.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/action-bar.mdx
@@ -156,10 +156,10 @@ Show a different icon for a few seconds after the message is copied.
 
 ```tsx
 <ActionBarPrimitive.Copy>
-  <AuiIf condition={({ message }) => !message.isCopied}>
+  <AuiIf condition={(s) => !s.message.isCopied}>
     <CopyIcon />
   </AuiIf>
-  <AuiIf condition={({ message }) => message.isCopied}>
+  <AuiIf condition={(s) => s.message.isCopied}>
     <CopySuccessIcon />
   </AuiIf>
 </ActionBarPrimitive.Copy>

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/assistant-if.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/assistant-if.mdx
@@ -11,7 +11,7 @@ Conditionally render children based on assistant state.
 ```tsx
 import { AuiIf } from "@assistant-ui/react";
 
-<AuiIf condition={({ thread }) => thread.isEmpty}>
+<AuiIf condition={(s) => s.thread.isEmpty}>
   <WelcomeScreen />
 </AuiIf>
 ```
@@ -80,20 +80,20 @@ The condition function receives an `AssistantState` object with the following pr
 
 ```tsx
 // Show welcome screen when thread is empty
-<AuiIf condition={({ thread }) => thread.isEmpty}>
+<AuiIf condition={(s) => s.thread.isEmpty}>
   <WelcomeScreen />
 </AuiIf>
 
 // Show loading indicator while running
-<AuiIf condition={({ thread }) => thread.isRunning}>
+<AuiIf condition={(s) => s.thread.isRunning}>
   <LoadingSpinner />
 </AuiIf>
 
 // Conditional send/cancel button
-<AuiIf condition={({ thread }) => !thread.isRunning}>
+<AuiIf condition={(s) => !s.thread.isRunning}>
   <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
 </AuiIf>
-<AuiIf condition={({ thread }) => thread.isRunning}>
+<AuiIf condition={(s) => s.thread.isRunning}>
   <ComposerPrimitive.Cancel>Cancel</ComposerPrimitive.Cancel>
 </AuiIf>
 ```
@@ -102,32 +102,32 @@ The condition function receives an `AssistantState` object with the following pr
 
 ```tsx
 // Show avatar only for assistant messages
-<AuiIf condition={({ message }) => message.role === "assistant"}>
+<AuiIf condition={(s) => s.message.role === "assistant"}>
   <AssistantAvatar />
 </AuiIf>
 
 // Show disclaimer on last message
-<AuiIf condition={({ message }) => message.isLast}>
+<AuiIf condition={(s) => s.message.isLast}>
   <Disclaimer />
 </AuiIf>
 
 // Toggle copy icon based on copied state
 <ActionBarPrimitive.Copy>
-  <AuiIf condition={({ message }) => !message.isCopied}>
+  <AuiIf condition={(s) => !s.message.isCopied}>
     <CopyIcon />
   </AuiIf>
-  <AuiIf condition={({ message }) => message.isCopied}>
+  <AuiIf condition={(s) => s.message.isCopied}>
     <CheckIcon />
   </AuiIf>
 </ActionBarPrimitive.Copy>
 
 // Show speak/stop button based on speech state
-<AuiIf condition={({ message }) => message.speech == null}>
+<AuiIf condition={(s) => s.message.speech == null}>
   <ActionBarPrimitive.Speak>
     <SpeakIcon />
   </ActionBarPrimitive.Speak>
 </AuiIf>
-<AuiIf condition={({ message }) => message.speech != null}>
+<AuiIf condition={(s) => s.message.speech != null}>
   <ActionBarPrimitive.StopSpeaking>
     <StopIcon />
   </ActionBarPrimitive.StopSpeaking>
@@ -138,12 +138,12 @@ The condition function receives an `AssistantState` object with the following pr
 
 ```tsx
 // Show placeholder when composer is empty
-<AuiIf condition={({ composer }) => composer.isEmpty}>
+<AuiIf condition={(s) => s.composer.isEmpty}>
   <PlaceholderText />
 </AuiIf>
 
 // Show attachment preview when editing
-<AuiIf condition={({ composer }) => composer.isEditing}>
+<AuiIf condition={(s) => s.composer.isEditing}>
   <EditingIndicator />
 </AuiIf>
 ```
@@ -152,15 +152,15 @@ The condition function receives an `AssistantState` object with the following pr
 
 ```tsx
 // Combine multiple conditions
-<AuiIf condition={({ thread, message }) =>
-  !thread.isRunning && message.role === "assistant"
+<AuiIf condition={(s) =>
+  !s.thread.isRunning && s.message.role === "assistant"
 }>
   <ActionBar />
 </AuiIf>
 
 // Custom logic
-<AuiIf condition={({ thread }) =>
-  thread.messages.length > 0 && !thread.isRunning
+<AuiIf condition={(s) =>
+  s.thread.messages.length > 0 && !s.thread.isRunning
 }>
   <FollowUpSuggestions />
 </AuiIf>
@@ -173,7 +173,7 @@ You can import the `AuiIf.Condition` type for typing your condition functions:
 ```tsx
 import { AuiIf } from "@assistant-ui/react";
 
-const isThreadEmpty: AuiIf.Condition = ({ thread }) => thread.isEmpty;
+const isThreadEmpty: AuiIf.Condition = (s) => s.thread.isEmpty;
 
 <AuiIf condition={isThreadEmpty}>
   <WelcomeScreen />
@@ -188,12 +188,12 @@ const isThreadEmpty: AuiIf.Condition = ({ thread }) => thread.isEmpty;
 
 | Before | After |
 |--------|-------|
-| `<ThreadPrimitive.If empty>` | `<AuiIf condition={({ thread }) => thread.isEmpty}>` |
-| `<ThreadPrimitive.If running>` | `<AuiIf condition={({ thread }) => thread.isRunning}>` |
-| `<ThreadPrimitive.If running={false}>` | `<AuiIf condition={({ thread }) => !thread.isRunning}>` |
-| `<MessagePrimitive.If user>` | `<AuiIf condition={({ message }) => message.role === "user"}>` |
-| `<MessagePrimitive.If assistant>` | `<AuiIf condition={({ message }) => message.role === "assistant"}>` |
-| `<MessagePrimitive.If copied>` | `<AuiIf condition={({ message }) => message.isCopied}>` |
-| `<MessagePrimitive.If speaking>` | `<AuiIf condition={({ message }) => message.speech != null}>` |
-| `<MessagePrimitive.If last>` | `<AuiIf condition={({ message }) => message.isLast}>` |
-| `<ComposerPrimitive.If editing>` | `<AuiIf condition={({ composer }) => composer.isEditing}>` |
+| `<ThreadPrimitive.If empty>` | `<AuiIf condition={(s) => s.thread.isEmpty}>` |
+| `<ThreadPrimitive.If running>` | `<AuiIf condition={(s) => s.thread.isRunning}>` |
+| `<ThreadPrimitive.If running={false}>` | `<AuiIf condition={(s) => !s.thread.isRunning}>` |
+| `<MessagePrimitive.If user>` | `<AuiIf condition={(s) => s.message.role === "user"}>` |
+| `<MessagePrimitive.If assistant>` | `<AuiIf condition={(s) => s.message.role === "assistant"}>` |
+| `<MessagePrimitive.If copied>` | `<AuiIf condition={(s) => s.message.isCopied}>` |
+| `<MessagePrimitive.If speaking>` | `<AuiIf condition={(s) => s.message.speech != null}>` |
+| `<MessagePrimitive.If last>` | `<AuiIf condition={(s) => s.message.isLast}>` |
+| `<ComposerPrimitive.If editing>` | `<AuiIf condition={(s) => s.composer.isEditing}>` |

--- a/apps/docs/content/docs/(reference)/legacy/styled/decomposition.mdx
+++ b/apps/docs/content/docs/(reference)/legacy/styled/decomposition.mdx
@@ -181,10 +181,10 @@ import { AuiIf } from "@assistant-ui/react";
 const MyComposerAction: FC = () => {
   return (
     <>
-      <AuiIf condition={({ thread }) => !thread.isRunning}>
+      <AuiIf condition={(s) => !s.thread.isRunning}>
         <Composer.Send />
       </AuiIf>
-      <AuiIf condition={({ thread }) => thread.isRunning}>
+      <AuiIf condition={(s) => s.thread.isRunning}>
         <Composer.Cancel />
       </AuiIf>
     </>

--- a/apps/docs/content/docs/ui/thread.mdx
+++ b/apps/docs/content/docs/ui/thread.mdx
@@ -76,7 +76,7 @@ export default function Chat() {
 ### Welcome Screen
 
 ```tsx
-<AuiIf condition={({ thread }) => thread.isEmpty}>
+<AuiIf condition={(s) => s.thread.isEmpty}>
   <ThreadWelcome />
 </AuiIf>
 ```
@@ -84,7 +84,7 @@ export default function Chat() {
 ### Viewport Spacer
 
 ```tsx
-<AuiIf condition={({ thread }) => !thread.isEmpty}>
+<AuiIf condition={(s) => !s.thread.isEmpty}>
   <div className="min-h-8 grow" />
 </AuiIf>
 ```
@@ -92,13 +92,13 @@ export default function Chat() {
 ### Conditional Send/Cancel Button
 
 ```tsx
-<AuiIf condition={({ thread }) => !thread.isRunning}>
+<AuiIf condition={(s) => !s.thread.isRunning}>
   <ComposerPrimitive.Send>
     Send
   </ComposerPrimitive.Send>
 </AuiIf>
 
-<AuiIf condition={({ thread }) => thread.isRunning}>
+<AuiIf condition={(s) => s.thread.isRunning}>
   <ComposerPrimitive.Cancel>
     Cancel
   </ComposerPrimitive.Cancel>
@@ -354,15 +354,15 @@ Conditionally renders children based on assistant state. This is a generic compo
 ```tsx
 import { AuiIf } from "@assistant-ui/react";
 
-<AuiIf condition={({ thread }) => thread.isEmpty}>
+<AuiIf condition={(s) => s.thread.isEmpty}>
   <WelcomeScreen />
 </AuiIf>
 
-<AuiIf condition={({ thread }) => thread.isRunning}>
+<AuiIf condition={(s) => s.thread.isRunning}>
   <LoadingIndicator />
 </AuiIf>
 
-<AuiIf condition={({ message }) => message.role === "assistant"}>
+<AuiIf condition={(s) => s.message.role === "assistant"}>
   <AssistantAvatar />
 </AuiIf>
 ```

--- a/apps/docs/lib/playground-registry.ts
+++ b/apps/docs/lib/playground-registry.ts
@@ -199,7 +199,7 @@ export function Thread() {
       >
         ${
           components.threadWelcome
-            ? `<AuiIf condition={({ thread }) => thread.isEmpty}>
+            ? `<AuiIf condition={(s) => s.thread.isEmpty}>
           <ThreadWelcome />
         </AuiIf>`
             : ""
@@ -366,7 +366,7 @@ function ComposerAction() {
     <div className="relative mx-2 mb-2 flex items-center justify-between">
       ${components.attachments ? "<ComposerAddAttachment />" : "<div />"}
 
-      <AuiIf condition={({ thread }) => !thread.isRunning}>
+      <AuiIf condition={(s) => !s.thread.isRunning}>
         <ComposerPrimitive.Send asChild>
           <TooltipIconButton
             tooltip="Send message"
@@ -386,7 +386,7 @@ function ComposerAction() {
         </ComposerPrimitive.Send>
       </AuiIf>
 
-      <AuiIf condition={({ thread }) => thread.isRunning}>
+      <AuiIf condition={(s) => s.thread.isRunning}>
         <ComposerPrimitive.Cancel asChild>
           <Button
             type="button"
@@ -554,7 +554,7 @@ function AssistantMessage() {
         <MessageError />${
           components.loadingIndicator !== "none"
             ? `
-        <AuiIf condition={({ thread, message }) => thread.isRunning && message.content.length === 0}>
+        <AuiIf condition={(s) => s.thread.isRunning && s.message.content.length === 0}>
           <div className="flex items-center gap-2 text-muted-foreground">
             <LoaderIcon className="size-4 animate-spin" />${
               components.loadingIndicator === "text"
@@ -575,7 +575,7 @@ function AssistantMessage() {
       ${
         components.followUpSuggestions
           ? `
-      <AuiIf condition={({ thread }) => !thread.isRunning}>
+      <AuiIf condition={(s) => !s.thread.isRunning}>
         <div className="mt-4 flex flex-wrap gap-2">
           <ThreadPrimitive.Suggestion
             prompt="Tell me more"
@@ -638,10 +638,10 @@ function AssistantActionBar() {
         components.actionBar.copy
           ? `<ActionBarPrimitive.Copy asChild>
         <TooltipIconButton tooltip="Copy">
-          <AuiIf condition={({ message }) => message.isCopied}>
+          <AuiIf condition={(s) => s.message.isCopied}>
             <CheckIcon />
           </AuiIf>
-          <AuiIf condition={({ message }) => !message.isCopied}>
+          <AuiIf condition={(s) => !s.message.isCopied}>
             <CopyIcon />
           </AuiIf>
         </TooltipIconButton>

--- a/examples/with-tap-runtime/app/page.tsx
+++ b/examples/with-tap-runtime/app/page.tsx
@@ -4,7 +4,7 @@ import { Thread } from "@/components/assistant-ui/thread";
 import { useAuiState } from "@assistant-ui/react";
 
 export default function Home() {
-  const isEmpty = useAuiState((state) => state.threads.main.isEmpty);
+  const isEmpty = useAuiState((s) => s.threads.main.isEmpty);
 
   return (
     <div className="flex h-full flex-col">

--- a/packages/cli/src/codemods/v0-12/__tests__/assistant-api-to-aui.test.ts
+++ b/packages/cli/src/codemods/v0-12/__tests__/assistant-api-to-aui.test.ts
@@ -482,7 +482,7 @@ import { AssistantIf } from "@assistant-ui/react";
 
 function MyComponent() {
   return (
-    <AssistantIf condition={(state) => state.thread.isRunning}>
+    <AssistantIf condition={(s) => s.thread.isRunning}>
       <div>Running...</div>
     </AssistantIf>
   );
@@ -494,7 +494,7 @@ import { AuiIf } from "@assistant-ui/react";
 
 function MyComponent() {
   return (
-    <AuiIf condition={(state) => state.thread.isRunning}>
+    <AuiIf condition={(s) => s.thread.isRunning}>
       <div>Running...</div>
     </AuiIf>
   );
@@ -543,7 +543,7 @@ function MyComponent() {
 
   return (
     <AssistantProvider>
-      <AssistantIf condition={(state) => state.thread.isRunning}>
+      <AssistantIf condition={(s) => s.thread.isRunning}>
         <button onClick={() => api.composer().send()}>Send</button>
       </AssistantIf>
     </AssistantProvider>
@@ -559,7 +559,7 @@ function MyComponent() {
 
   return (
     <AuiProvider>
-      <AuiIf condition={(state) => state.thread.isRunning}>
+      <AuiIf condition={(s) => s.thread.isRunning}>
         <button onClick={() => aui.composer().send()}>Send</button>
       </AuiIf>
     </AuiProvider>
@@ -576,7 +576,7 @@ function MyComponent() {
 import { AssistantIf } from "@assistant-ui/react";
 
 function MyComponent() {
-  return <AssistantIf condition={(state) => state.thread.isRunning} />;
+  return <AssistantIf condition={(s) => s.thread.isRunning} />;
 }
 `;
 
@@ -584,7 +584,7 @@ function MyComponent() {
 import { AuiIf } from "@assistant-ui/react";
 
 function MyComponent() {
-  return <AuiIf condition={(state) => state.thread.isRunning} />;
+  return <AuiIf condition={(s) => s.thread.isRunning} />;
 }
 `;
 

--- a/packages/react/src/primitives/composer/ComposerIf.ts
+++ b/packages/react/src/primitives/composer/ComposerIf.ts
@@ -31,7 +31,7 @@ export namespace ComposerPrimitiveIf {
 }
 
 /**
- * @deprecated Use `<AuiIf condition={({ composer }) => ...} />` instead.
+ * @deprecated Use `<AuiIf condition={(s) => s.composer...} />` instead.
  */
 export const ComposerPrimitiveIf: FC<ComposerPrimitiveIf.Props> = ({
   children,

--- a/packages/react/src/primitives/message/MessageIf.ts
+++ b/packages/react/src/primitives/message/MessageIf.ts
@@ -78,7 +78,7 @@ export namespace MessagePrimitiveIf {
 }
 
 /**
- * @deprecated Use `<AuiIf condition={({ message }) => ...} />` instead.
+ * @deprecated Use `<AuiIf condition={(s) => s.message...} />` instead.
  */
 export const MessagePrimitiveIf: FC<MessagePrimitiveIf.Props> = ({
   children,

--- a/packages/react/src/primitives/thread/ThreadIf.ts
+++ b/packages/react/src/primitives/thread/ThreadIf.ts
@@ -31,7 +31,7 @@ export namespace ThreadPrimitiveIf {
 }
 
 /**
- * @deprecated Use `<AuiIf condition={({ thread }) => ...} />` instead.
+ * @deprecated Use `<AuiIf condition={(s) => s.thread...} />` instead.
  */
 export const ThreadPrimitiveIf: FC<ThreadPrimitiveIf.Props> = ({
   children,

--- a/packages/store/SPEC.md
+++ b/packages/store/SPEC.md
@@ -50,7 +50,7 @@ Selectors: `"client.event"` | `{ scope: "parent", event }` | `{ scope: "*", even
 ### AuiProvider / AuiIf
 ```typescript
 <AuiProvider value={aui}>{children}</AuiProvider>
-<AuiIf condition={(state) => boolean}>{children}</AuiIf>
+<AuiIf condition={(s) => boolean}>{children}</AuiIf>
 ```
 
 ### Derived

--- a/packages/store/src/useAuiState.ts
+++ b/packages/store/src/useAuiState.ts
@@ -15,7 +15,7 @@ import { useAui } from "./useAui";
  *   foo: RootScope({ ... }),
  * });
  *
- * const bar = useAuiState((state) => state.foo.bar);
+ * const bar = useAuiState((s) => s.foo.bar);
  * ```
  */
 export const useAuiState = <T>(selector: (state: AssistantState) => T): T => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `AuiIf` usage across components and documentation to use a simplified state access pattern `(s) => s...`, and add deprecation notices for older conditional components.
> 
>   - **Refactor `AuiIf` usage**:
>     - Change condition function parameter from destructured object to single parameter `s` in `builder-code-output.tsx`, `builder-preview.tsx`, and `composer.tsx`.
>     - Update `AuiIf` usage in `thread.tsx`, `speech.tsx`, and `chatgpt.tsx` to use `(s) => s...` pattern.
>     - Apply `(s) => s...` pattern in `claude.tsx`, `grok.tsx`, and `perplexity.tsx`.
>     - Modify `chain-of-thought.mdx`, `action-bar.mdx`, and `assistant-if.mdx` to reflect new `AuiIf` pattern.
>     - Update `decomposition.mdx` and `thread.mdx` with new `AuiIf` usage.
>   - **Deprecation Notices**:
>     - Add deprecation notice for `ComposerPrimitiveIf`, `MessagePrimitiveIf`, and `ThreadPrimitiveIf` in their respective files, suggesting to use `AuiIf` instead.
>   - **Tests and Examples**:
>     - Update tests in `assistant-api-to-aui.test.ts` to reflect new `AuiIf` usage.
>     - Modify examples in `playground-registry.ts` and `page.tsx` to use updated `AuiIf` pattern.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 0f134b1be247bca3a9b00689e98c5d4f6847bbd6. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->