### PR TITLE
refactor: add codemod for ThreadIf -> AuiIf migration

### DIFF
--- a/packages/cli/src/codemods/v0-12/__tests__/primitive-if-to-aui-if.test.ts
+++ b/packages/cli/src/codemods/v0-12/__tests__/primitive-if-to-aui-if.test.ts
@@ -1,0 +1,749 @@
+import { describe, it, expect } from "vitest";
+import jscodeshift, { API } from "jscodeshift";
+import transform from "../primitive-if-to-aui-if";
+
+const j = jscodeshift.withParser("tsx");
+
+function applyTransform(source: string): string | null {
+  const fileInfo = {
+    path: "test.tsx",
+    source,
+  };
+
+  const api: API = {
+    jscodeshift: j,
+    j,
+    stats: () => {},
+    report: () => {},
+  };
+
+  return transform(fileInfo, api, {});
+}
+
+describe("primitive-if-to-aui-if", () => {
+  // ── ThreadPrimitive.If ─────────────────────────────────────────────
+
+  describe("ThreadPrimitive.If", () => {
+    it("should migrate <ThreadPrimitive.If empty> to AuiIf", () => {
+      const input = `
+import { ThreadPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ThreadPrimitive.If empty>
+      <div>Empty</div>
+    </ThreadPrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { ThreadPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.thread.isEmpty}>
+      <div>Empty</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <ThreadPrimitive.If empty={false}>", () => {
+      const input = `
+import { ThreadPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ThreadPrimitive.If empty={false}>
+      <div>Not empty</div>
+    </ThreadPrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { ThreadPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => !s.thread.isEmpty}>
+      <div>Not empty</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <ThreadPrimitive.If running>", () => {
+      const input = `
+import { ThreadPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ThreadPrimitive.If running>
+      <div>Running</div>
+    </ThreadPrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { ThreadPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.thread.isRunning}>
+      <div>Running</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <ThreadPrimitive.If running={false}>", () => {
+      const input = `
+import { ThreadPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ThreadPrimitive.If running={false}>
+      <div>Not running</div>
+    </ThreadPrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { ThreadPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => !s.thread.isRunning}>
+      <div>Not running</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <ThreadPrimitive.If disabled>", () => {
+      const input = `
+import { ThreadPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ThreadPrimitive.If disabled>
+      <div>Disabled</div>
+    </ThreadPrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { ThreadPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.thread.isDisabled}>
+      <div>Disabled</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should handle self-closing ThreadPrimitive.If", () => {
+      const input = `
+import { ThreadPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return <ThreadPrimitive.If empty />;
+}
+`;
+
+      const expected = `
+import { ThreadPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return <AuiIf condition={(s) => s.thread.isEmpty} />;
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+  });
+
+  // ── MessagePrimitive.If ────────────────────────────────────────────
+
+  describe("MessagePrimitive.If", () => {
+    it("should migrate <MessagePrimitive.If user>", () => {
+      const input = `
+import { MessagePrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <MessagePrimitive.If user>
+      <div>User message</div>
+    </MessagePrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.message.role === "user"}>
+      <div>User message</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <MessagePrimitive.If assistant>", () => {
+      const input = `
+import { MessagePrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <MessagePrimitive.If assistant>
+      <div>Assistant message</div>
+    </MessagePrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.message.role === "assistant"}>
+      <div>Assistant message</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <MessagePrimitive.If copied>", () => {
+      const input = `
+import { MessagePrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <MessagePrimitive.If copied>
+      <CheckIcon />
+    </MessagePrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.message.isCopied}>
+      <CheckIcon />
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <MessagePrimitive.If copied={false}>", () => {
+      const input = `
+import { MessagePrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <MessagePrimitive.If copied={false}>
+      <CopyIcon />
+    </MessagePrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => !s.message.isCopied}>
+      <CopyIcon />
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <MessagePrimitive.If speaking>", () => {
+      const input = `
+import { MessagePrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <MessagePrimitive.If speaking>
+      <StopIcon />
+    </MessagePrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.message.speech != null}>
+      <StopIcon />
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <MessagePrimitive.If speaking={false}>", () => {
+      const input = `
+import { MessagePrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <MessagePrimitive.If speaking={false}>
+      <SpeakIcon />
+    </MessagePrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => !s.message.speech != null}>
+      <SpeakIcon />
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <MessagePrimitive.If last>", () => {
+      const input = `
+import { MessagePrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <MessagePrimitive.If last>
+      <div>Last message</div>
+    </MessagePrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.message.isLast}>
+      <div>Last message</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <MessagePrimitive.If hasBranches>", () => {
+      const input = `
+import { MessagePrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <MessagePrimitive.If hasBranches>
+      <BranchPicker />
+    </MessagePrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.message.branchCount >= 2}>
+      <BranchPicker />
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <MessagePrimitive.If hasAttachments>", () => {
+      const input = `
+import { MessagePrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <MessagePrimitive.If hasAttachments>
+      <Attachments />
+    </MessagePrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.message.role === "user" && !!s.message.attachments?.length}>
+      <Attachments />
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <MessagePrimitive.If hasContent>", () => {
+      const input = `
+import { MessagePrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <MessagePrimitive.If hasContent>
+      <Content />
+    </MessagePrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.message.parts.length > 0}>
+      <Content />
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <MessagePrimitive.If lastOrHover>", () => {
+      const input = `
+import { MessagePrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <MessagePrimitive.If lastOrHover>
+      <ActionBar />
+    </MessagePrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.message.isHovering || s.message.isLast}>
+      <ActionBar />
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+  });
+
+  // ── ComposerPrimitive.If ──────────────────────────────────────────
+
+  describe("ComposerPrimitive.If", () => {
+    it("should migrate <ComposerPrimitive.If editing>", () => {
+      const input = `
+import { ComposerPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ComposerPrimitive.If editing>
+      <div>Editing</div>
+    </ComposerPrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { ComposerPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.composer.isEditing}>
+      <div>Editing</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <ComposerPrimitive.If editing={false}>", () => {
+      const input = `
+import { ComposerPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ComposerPrimitive.If editing={false}>
+      <div>Not editing</div>
+    </ComposerPrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { ComposerPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => !s.composer.isEditing}>
+      <div>Not editing</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should migrate <ComposerPrimitive.If dictation>", () => {
+      const input = `
+import { ComposerPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ComposerPrimitive.If dictation>
+      <div>Dictating</div>
+    </ComposerPrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { ComposerPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.composer.dictation != null}>
+      <div>Dictating</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    it("should not add duplicate AuiIf import if already present", () => {
+      const input = `
+import { ThreadPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ThreadPrimitive.If empty>
+      <div>Empty</div>
+    </ThreadPrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { ThreadPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.thread.isEmpty}>
+      <div>Empty</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should handle multiple Primitive.If in the same file", () => {
+      const input = `
+import { ThreadPrimitive, MessagePrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <>
+      <ThreadPrimitive.If running>
+        <div>Running</div>
+      </ThreadPrimitive.If>
+      <MessagePrimitive.If user>
+        <div>User</div>
+      </MessagePrimitive.If>
+    </>
+  );
+}
+`;
+
+      const expected = `
+import { ThreadPrimitive, MessagePrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <>
+      <AuiIf condition={(s) => s.thread.isRunning}>
+        <div>Running</div>
+      </AuiIf>
+      <AuiIf condition={(s) => s.message.role === "user"}>
+        <div>User</div>
+      </AuiIf>
+    </>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should not transform if no @assistant-ui import", () => {
+      const input = `
+function MyComponent() {
+  return (
+    <ThreadPrimitive.If empty>
+      <div>Empty</div>
+    </ThreadPrimitive.If>
+  );
+}
+`;
+
+      expect(applyTransform(input)).toBe(null);
+    });
+
+    it("should not transform non-If member expressions", () => {
+      const input = `
+import { ThreadPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ThreadPrimitive.Root>
+      <div>Hello</div>
+    </ThreadPrimitive.Root>
+  );
+}
+`;
+
+      expect(applyTransform(input)).toBe(null);
+    });
+
+    it("should handle multiple props combined into a single condition", () => {
+      const input = `
+import { ThreadPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ThreadPrimitive.If empty running={false}>
+      <div>Empty and not running</div>
+    </ThreadPrimitive.If>
+  );
+}
+`;
+
+      const expected = `
+import { ThreadPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.thread.isEmpty && !s.thread.isRunning}>
+      <div>Empty and not running</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should preserve other JSX elements alongside migrated ones", () => {
+      const input = `
+import { ThreadPrimitive, ComposerPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ThreadPrimitive.Root>
+      <ThreadPrimitive.If empty>
+        <div>Welcome</div>
+      </ThreadPrimitive.If>
+      <ComposerPrimitive.Input />
+    </ThreadPrimitive.Root>
+  );
+}
+`;
+
+      const expected = `
+import { ThreadPrimitive, ComposerPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ThreadPrimitive.Root>
+      <AuiIf condition={(s) => s.thread.isEmpty}>
+        <div>Welcome</div>
+      </AuiIf>
+      <ComposerPrimitive.Input />
+    </ThreadPrimitive.Root>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+  });
+});

--- a/packages/cli/src/codemods/v0-12/primitive-if-to-aui-if.ts
+++ b/packages/cli/src/codemods/v0-12/primitive-if-to-aui-if.ts
@@ -1,0 +1,296 @@
+import { createTransformer } from "../utils/createTransformer";
+
+type ConditionFragment = {
+  expression: string;
+  negated: boolean;
+};
+
+// Map ThreadPrimitive.If props to condition expressions
+const threadPropMap: Record<
+  string,
+  (value: unknown) => ConditionFragment | null
+> = {
+  empty: (v) => ({
+    expression: "s.thread.isEmpty",
+    negated: v === false,
+  }),
+  running: (v) => ({
+    expression: "s.thread.isRunning",
+    negated: v === false,
+  }),
+  disabled: (v) => ({
+    expression: "s.thread.isDisabled",
+    negated: v === false,
+  }),
+};
+
+// Map MessagePrimitive.If props to condition expressions
+const messagePropMap: Record<
+  string,
+  (value: unknown) => ConditionFragment | null
+> = {
+  user: () => ({ expression: 's.message.role === "user"', negated: false }),
+  assistant: () => ({
+    expression: 's.message.role === "assistant"',
+    negated: false,
+  }),
+  system: () => ({
+    expression: 's.message.role === "system"',
+    negated: false,
+  }),
+  hasBranches: () => ({
+    expression: "s.message.branchCount >= 2",
+    negated: false,
+  }),
+  copied: (v) => ({
+    expression: "s.message.isCopied",
+    negated: v === false,
+  }),
+  last: (v) => ({
+    expression: "s.message.isLast",
+    negated: v === false,
+  }),
+  lastOrHover: () => ({
+    expression: "s.message.isHovering || s.message.isLast",
+    negated: false,
+  }),
+  speaking: (v) => ({
+    expression: "s.message.speech != null",
+    negated: v === false,
+  }),
+  hasAttachments: (v) =>
+    v === true
+      ? {
+          expression:
+            's.message.role === "user" && !!s.message.attachments?.length',
+          negated: false,
+        }
+      : {
+          expression:
+            's.message.role !== "user" || !s.message.attachments?.length',
+          negated: false,
+        },
+  hasContent: (v) => ({
+    expression: "s.message.parts.length > 0",
+    negated: v === false,
+  }),
+  submittedFeedback: (v) => {
+    if (v === null) {
+      return {
+        expression:
+          "(s.message.metadata.submittedFeedback?.type ?? null) === null",
+        negated: false,
+      };
+    }
+    return {
+      expression: `s.message.metadata.submittedFeedback?.type === "${v}"`,
+      negated: false,
+    };
+  },
+};
+
+// Map ComposerPrimitive.If props to condition expressions
+const composerPropMap: Record<
+  string,
+  (value: unknown) => ConditionFragment | null
+> = {
+  editing: (v) => ({
+    expression: "s.composer.isEditing",
+    negated: v === false,
+  }),
+  dictation: (v) => ({
+    expression: "s.composer.dictation != null",
+    negated: v === false,
+  }),
+};
+
+const primitiveMap: Record<
+  string,
+  Record<string, (value: unknown) => ConditionFragment | null>
+> = {
+  ThreadPrimitive: threadPropMap,
+  MessagePrimitive: messagePropMap,
+  ComposerPrimitive: composerPropMap,
+};
+
+/**
+ * Extract the value of a JSX attribute.
+ * - Boolean prop (no value): `<X.If user>` → `true`
+ * - `{true}` / `{false}`: → `true` / `false`
+ * - `{"positive"}`: → `"positive"`
+ * - `{null}`: → `null`
+ */
+const getAttrValue = (j: any, attr: any): unknown => {
+  // Boolean attribute (no value), e.g. `<X.If user>`
+  if (attr.value === null || attr.value === undefined) {
+    return true;
+  }
+
+  // JSX expression container: `{true}`, `{false}`, `{"positive"}`, `{null}`
+  if (j.JSXExpressionContainer.check(attr.value)) {
+    const expr = attr.value.expression;
+    if (j.BooleanLiteral.check(expr)) return expr.value;
+    if (j.Literal.check(expr)) {
+      if (expr.value === null) return null;
+      return expr.value;
+    }
+    if (j.NullLiteral.check(expr)) return null;
+    if (j.Identifier.check(expr) && expr.name === "undefined") return undefined;
+  }
+
+  // String literal
+  if (j.StringLiteral.check(attr.value) || j.Literal.check(attr.value)) {
+    return attr.value.value;
+  }
+
+  return undefined;
+};
+
+const buildConditionString = (fragments: ConditionFragment[]): string => {
+  const parts = fragments.map((f) =>
+    f.negated ? `!${f.expression}` : f.expression,
+  );
+  if (parts.length === 1) return parts[0]!;
+  return parts.join(" && ");
+};
+
+const migratePrimitiveIfToAuiIf = createTransformer(
+  ({ j, root, markAsChanged }) => {
+    let needsAuiIfImport = false;
+
+    // Track which primitive namespaces are imported
+    const importedPrimitives = new Set<string>();
+    root.find(j.ImportDeclaration).forEach((path: any) => {
+      const source = path.value.source.value;
+      if (typeof source === "string" && source.startsWith("@assistant-ui/")) {
+        path.value.specifiers?.forEach((specifier: any) => {
+          if (j.ImportSpecifier.check(specifier)) {
+            const name = String(
+              specifier.local?.name ?? specifier.imported.name,
+            );
+            if (primitiveMap[name]) {
+              importedPrimitives.add(name);
+            }
+          }
+        });
+      }
+    });
+
+    if (importedPrimitives.size === 0) return;
+
+    // Process JSX elements: <ThreadPrimitive.If ...> → <AuiIf condition={...}>
+    root.find(j.JSXOpeningElement).forEach((path: any) => {
+      const name = path.value.name;
+
+      // Check for `<XPrimitive.If ...>`
+      if (!j.JSXMemberExpression.check(name)) return;
+      if (!j.JSXIdentifier.check(name.object)) return;
+      if (!j.JSXIdentifier.check(name.property)) return;
+      if (name.property.name !== "If") return;
+
+      const primitiveName = name.object.name;
+      const propMap = primitiveMap[primitiveName];
+      if (!propMap) return;
+      if (!importedPrimitives.has(primitiveName)) return;
+
+      // Extract props
+      const attrs: any[] = path.value.attributes || [];
+      const fragments: ConditionFragment[] = [];
+      let hasUnknownProp = false;
+
+      for (const attr of attrs) {
+        if (!j.JSXAttribute.check(attr)) {
+          // JSX spread attributes — can't migrate
+          hasUnknownProp = true;
+          continue;
+        }
+        const propName =
+          typeof attr.name.name === "string" ? attr.name.name : null;
+        if (!propName) continue;
+
+        const mapper = propMap[propName];
+        if (!mapper) {
+          hasUnknownProp = true;
+          continue;
+        }
+
+        const value = getAttrValue(j, attr);
+        const fragment = mapper(value);
+        if (fragment) {
+          fragments.push(fragment);
+        }
+      }
+
+      // If we couldn't map all props, skip this element
+      if (hasUnknownProp || fragments.length === 0) return;
+
+      const conditionBody = buildConditionString(fragments);
+
+      // Parse the arrow function as an expression to get a proper AST node
+      const arrowFnAst = j(`(s) => ${conditionBody}`)
+        .find(j.ArrowFunctionExpression)
+        .paths()[0]!.value;
+
+      // Replace <XPrimitive.If ...> with <AuiIf condition={...}>
+      path.value.name = j.jsxIdentifier("AuiIf");
+
+      // Replace all attributes with a single condition prop
+      path.value.attributes = [
+        j.jsxAttribute(
+          j.jsxIdentifier("condition"),
+          j.jsxExpressionContainer(arrowFnAst),
+        ),
+      ];
+
+      needsAuiIfImport = true;
+      markAsChanged();
+    });
+
+    // Update closing elements to match
+    root.find(j.JSXClosingElement).forEach((path: any) => {
+      const name = path.value.name;
+      if (!j.JSXMemberExpression.check(name)) return;
+      if (!j.JSXIdentifier.check(name.object)) return;
+      if (!j.JSXIdentifier.check(name.property)) return;
+      if (name.property.name !== "If") return;
+
+      const primitiveName = name.object.name;
+      if (!primitiveMap[primitiveName]) return;
+      if (!importedPrimitives.has(primitiveName)) return;
+
+      path.value.name = j.jsxIdentifier("AuiIf");
+      markAsChanged();
+    });
+
+    // Add AuiIf import if needed
+    if (needsAuiIfImport) {
+      let hasAuiIfImport = false;
+      let assistantUiImport: any = null;
+
+      root.find(j.ImportDeclaration).forEach((path: any) => {
+        const source = path.value.source.value;
+        if (typeof source === "string" && source.startsWith("@assistant-ui/")) {
+          assistantUiImport = path;
+          path.value.specifiers?.forEach((specifier: any) => {
+            if (
+              j.ImportSpecifier.check(specifier) &&
+              (specifier.imported.name === "AuiIf" ||
+                specifier.local?.name === "AuiIf")
+            ) {
+              hasAuiIfImport = true;
+            }
+          });
+        }
+      });
+
+      if (!hasAuiIfImport && assistantUiImport) {
+        assistantUiImport.value.specifiers.push(
+          j.importSpecifier(j.identifier("AuiIf")),
+        );
+        markAsChanged();
+      }
+    }
+  },
+);
+
+export default migratePrimitiveIfToAuiIf;

--- a/packages/cli/src/lib/upgrade.ts
+++ b/packages/cli/src/lib/upgrade.ts
@@ -13,6 +13,7 @@ const bundle = [
   "v0-11/content-part-to-message-part",
   "v0-12/assistant-api-to-aui",
   "v0-12/event-names-to-camelcase",
+  "v0-12/primitive-if-to-aui-if",
 ];
 
 const log = debug("codemod:upgrade");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add codemod to migrate `ThreadPrimitive.If`, `MessagePrimitive.If`, and `ComposerPrimitive.If` to `AuiIf` with tests and integration into the upgrade process.
> 
>   - **Codemod**:
>     - Adds `primitive-if-to-aui-if.ts` to migrate `ThreadPrimitive.If`, `MessagePrimitive.If`, and `ComposerPrimitive.If` to `AuiIf`.
>     - Handles conditions like `empty`, `running`, `disabled`, `user`, `assistant`, `copied`, `editing`, etc.
>     - Updates import statements to include `AuiIf` if not already present.
>   - **Tests**:
>     - Adds `primitive-if-to-aui-if.test.ts` to test various migration scenarios.
>     - Tests include handling of boolean attributes, self-closing tags, and multiple conditions.
>     - Ensures no duplicate imports and proper handling of non-`If` expressions.
>   - **Integration**:
>     - Updates `upgrade.ts` to include the new codemod in the upgrade process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 5fa689b275c76bb3fe5144c6a6137d9c9c770a41. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->