### PR TITLE
refactor: deprecate ThreadPrimitive.Empty in favor of AuiIf

### DIFF
--- a/apps/docs/components/docs/samples/dictation.tsx
+++ b/apps/docs/components/docs/samples/dictation.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/assistant-ui/attachment";
 import {
   ActionBarPrimitive,
+  AuiIf,
   BranchPickerPrimitive,
   ComposerPrimitive,
   ErrorPrimitive,
@@ -82,7 +83,7 @@ const ThreadScrollToBottom: FC = () => {
 
 const ThreadWelcome: FC = () => {
   return (
-    <ThreadPrimitive.Empty>
+    <AuiIf condition={(s) => s.thread.isEmpty}>
       <div className="aui-thread-welcome-root mx-auto mb-16 flex w-full max-w-[var(--thread-max-width)] flex-grow flex-col">
         <div className="aui-thread-welcome-center flex w-full flex-grow flex-col items-center justify-center">
           <div className="aui-thread-welcome-message flex size-full flex-col justify-center px-8 md:mt-20">
@@ -95,7 +96,7 @@ const ThreadWelcome: FC = () => {
           </div>
         </div>
       </div>
-    </ThreadPrimitive.Empty>
+    </AuiIf>
   );
 };
 
@@ -147,9 +148,9 @@ const Composer: FC = () => {
   return (
     <div className="aui-composer-wrapper sticky bottom-0 mx-auto flex w-full max-w-(--thread-max-width) flex-col gap-4 overflow-visible rounded-t-3xl bg-background pb-4 md:pb-6">
       <ThreadScrollToBottom />
-      <ThreadPrimitive.Empty>
+      <AuiIf condition={(s) => s.thread.isEmpty}>
         <ThreadWelcomeSuggestions />
-      </ThreadPrimitive.Empty>
+      </AuiIf>
       <ComposerPrimitive.Root className="aui-composer-root relative flex w-full flex-col rounded-3xl border border-border bg-muted px-1 pt-2 shadow-[0_9px_9px_0px_rgba(0,0,0,0.01),0_2px_5px_0px_rgba(0,0,0,0.06)] dark:border-muted-foreground/15">
         <ComposerAttachments />
         <ComposerPrimitive.Input

--- a/apps/docs/components/docs/samples/speech.tsx
+++ b/apps/docs/components/docs/samples/speech.tsx
@@ -84,7 +84,7 @@ const ThreadScrollToBottom: FC = () => {
 
 const ThreadWelcome: FC = () => {
   return (
-    <ThreadPrimitive.Empty>
+    <AuiIf condition={(s) => s.thread.isEmpty}>
       <div className="aui-thread-welcome-root mx-auto mb-16 flex w-full max-w-(--thread-max-width) grow flex-col">
         <div className="aui-thread-welcome-center flex w-full grow flex-col items-center justify-center">
           <div className="aui-thread-welcome-message flex size-full flex-col justify-center px-8 md:mt-20">
@@ -97,7 +97,7 @@ const ThreadWelcome: FC = () => {
           </div>
         </div>
       </div>
-    </ThreadPrimitive.Empty>
+    </AuiIf>
   );
 };
 
@@ -149,9 +149,9 @@ const Composer: FC = () => {
   return (
     <div className="aui-composer-wrapper sticky bottom-0 mx-auto flex w-full max-w-(--thread-max-width) flex-col gap-4 overflow-visible rounded-t-3xl bg-background pb-4 md:pb-6">
       <ThreadScrollToBottom />
-      <ThreadPrimitive.Empty>
+      <AuiIf condition={(s) => s.thread.isEmpty}>
         <ThreadWelcomeSuggestions />
-      </ThreadPrimitive.Empty>
+      </AuiIf>
       <ComposerPrimitive.Root className="aui-composer-root relative flex w-full flex-col rounded-3xl border border-border bg-muted px-1 pt-2 shadow-[0_9px_9px_0px_rgba(0,0,0,0.01),0_2px_5px_0px_rgba(0,0,0,0.06)] dark:border-muted-foreground/15">
         <ComposerAttachments />
         <ComposerPrimitive.Input

--- a/apps/docs/components/examples/chatgpt.tsx
+++ b/apps/docs/components/examples/chatgpt.tsx
@@ -26,14 +26,14 @@ export const ChatGPT: FC = () => {
   return (
     <ThreadPrimitive.Root className="dark flex h-full flex-col items-stretch bg-[#212121] px-4 text-foreground">
       <ThreadPrimitive.Viewport className="flex grow flex-col gap-8 overflow-y-scroll pt-16">
-        <ThreadPrimitive.Empty>
+        <AuiIf condition={(s) => s.thread.isEmpty}>
           <div className="flex grow flex-col items-center justify-center">
             <Avatar.Root className="flex h-12 w-12 items-center justify-center rounded-3xl border border-white/15 shadow">
               <Avatar.AvatarFallback>C</Avatar.AvatarFallback>
             </Avatar.Root>
             <p className="mt-4 text-white text-xl">How can I help you today?</p>
           </div>
-        </ThreadPrimitive.Empty>
+        </AuiIf>
 
         <ThreadPrimitive.Messages
           components={{

--- a/apps/docs/components/examples/grok.tsx
+++ b/apps/docs/components/examples/grok.tsx
@@ -34,12 +34,12 @@ import { GrokIcon } from "@/components/icons/grok";
 export const Grok: FC = () => {
   return (
     <ThreadPrimitive.Root className="flex h-full flex-col items-stretch bg-[#fdfdfd] px-4 dark:bg-[#141414]">
-      <ThreadPrimitive.Empty>
+      <AuiIf condition={(s) => s.thread.isEmpty}>
         <div className="flex h-full flex-col items-center justify-center">
           <GrokIcon className="mb-6 h-10 text-[#0d0d0d] dark:text-white" />
           <Composer />
         </div>
-      </ThreadPrimitive.Empty>
+      </AuiIf>
 
       <AuiIf condition={(s) => s.thread.isEmpty === false}>
         <ThreadPrimitive.Viewport className="flex grow flex-col overflow-y-scroll pt-16">

--- a/apps/docs/components/examples/perplexity.tsx
+++ b/apps/docs/components/examples/perplexity.tsx
@@ -39,9 +39,9 @@ export const Perplexity: FC = () => {
         ["--thread-max-width" as string]: "42rem",
       }}
     >
-      <ThreadPrimitive.Empty>
+      <AuiIf condition={(s) => s.thread.isEmpty}>
         <ThreadWelcome />
-      </ThreadPrimitive.Empty>
+      </AuiIf>
       <AuiIf condition={(s) => !s.thread.isEmpty}>
         <ThreadPrimitive.Viewport className="flex h-full flex-col items-center overflow-y-scroll scroll-smooth bg-inherit px-4 pt-8">
           <ThreadPrimitive.Messages

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/thread.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/thread.mdx
@@ -14,7 +14,7 @@ import { ThreadPrimitive } from "@assistant-ui/react";
 const Thread = () => (
   <ThreadPrimitive.Root>
     <ThreadPrimitive.Viewport>
-      <ThreadPrimitive.Empty>...</ThreadPrimitive.Empty>
+      <AuiIf condition={(s) => s.thread.isEmpty}>...</AuiIf>
       <ThreadPrimitive.Messages components={...} />
     </ThreadPrimitive.Viewport>
     <Composer />

--- a/apps/docs/content/docs/ui/thread.mdx
+++ b/apps/docs/content/docs/ui/thread.mdx
@@ -20,7 +20,7 @@ import { ThreadPrimitive, SelectionToolbarPrimitive, AuiIf } from "@assistant-ui
 
 <ThreadPrimitive.Root>
   <ThreadPrimitive.Viewport>
-    <ThreadPrimitive.Empty />
+    <AuiIf condition={(s) => s.thread.isEmpty} />
     <ThreadPrimitive.Messages
       components={{
         EditComposer,

--- a/apps/docs/content/examples/chatgpt.mdx
+++ b/apps/docs/content/examples/chatgpt.mdx
@@ -43,14 +43,14 @@ export const ChatGPT = () => {
   return (
     <ThreadPrimitive.Root className="dark flex h-full flex-col bg-[#212121] text-foreground">
       <ThreadPrimitive.Viewport className="flex flex-grow flex-col gap-8 overflow-y-scroll pt-16">
-        <ThreadPrimitive.Empty>
+        <AuiIf condition={(s) => s.thread.isEmpty}>
           <div className="flex flex-grow flex-col items-center justify-center">
             <Avatar.Root className="flex h-12 w-12 items-center justify-center rounded-[24px] border border-white/15">
               <Avatar.AvatarFallback>C</Avatar.AvatarFallback>
             </Avatar.Root>
             <p className="mt-4 text-white text-xl">How can I help you today?</p>
           </div>
-        </ThreadPrimitive.Empty>
+        </AuiIf>
 
         <ThreadPrimitive.Messages
           components={{ UserMessage, EditComposer, AssistantMessage }}

--- a/apps/docs/content/examples/grok.mdx
+++ b/apps/docs/content/examples/grok.mdx
@@ -42,12 +42,12 @@ import {
 export const Grok = () => {
   return (
     <ThreadPrimitive.Root className="flex h-full flex-col bg-[#fdfdfd] px-4 dark:bg-[#141414]">
-      <ThreadPrimitive.Empty>
+      <AuiIf condition={(s) => s.thread.isEmpty}>
         <div className="flex h-full flex-col items-center justify-center">
           <GrokLogo className="mb-6 h-10 text-[#0d0d0d] dark:text-white" />
           <Composer />
         </div>
-      </ThreadPrimitive.Empty>
+      </AuiIf>
 
       <ThreadPrimitive.Viewport className="flex grow flex-col overflow-y-scroll pt-16">
         <ThreadPrimitive.Messages components={{ Message: ChatMessage }} />

--- a/apps/docs/content/examples/perplexity.mdx
+++ b/apps/docs/content/examples/perplexity.mdx
@@ -45,7 +45,7 @@ export const Thread = () => {
       className="dark h-full bg-[#1a1a1a] text-[#f5f5f5]"
       style={{ ["--thread-max-width"]: "42rem" }}
     >
-      <ThreadPrimitive.Empty>
+      <AuiIf condition={(s) => s.thread.isEmpty}>
         <div className="flex h-full w-full items-center justify-center">
           <div className="flex w-full max-w-[var(--thread-max-width)] flex-col gap-12">
             <p className="text-4xl text-[#f5f5f5] md:text-5xl">
@@ -62,7 +62,7 @@ export const Thread = () => {
             </ComposerPrimitive.Root>
           </div>
         </div>
-      </ThreadPrimitive.Empty>
+      </AuiIf>
 
       <ThreadPrimitive.Viewport>
         <ThreadPrimitive.Messages components={{ UserMessage, AssistantMessage }} />

--- a/packages/cli/src/codemods/v0-12/__tests__/primitive-if-to-aui-if.test.ts
+++ b/packages/cli/src/codemods/v0-12/__tests__/primitive-if-to-aui-if.test.ts
@@ -585,6 +585,96 @@ function MyComponent() {
     });
   });
 
+  // ── ThreadPrimitive.Empty ───────────────────────────────────────────
+
+  describe("ThreadPrimitive.Empty", () => {
+    it("should migrate <ThreadPrimitive.Empty> to AuiIf", () => {
+      const input = `
+import { ThreadPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <ThreadPrimitive.Empty>
+      <div>Welcome</div>
+    </ThreadPrimitive.Empty>
+  );
+}
+`;
+
+      const expected = `
+import { ThreadPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <AuiIf condition={(s) => s.thread.isEmpty}>
+      <div>Welcome</div>
+    </AuiIf>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should handle self-closing <ThreadPrimitive.Empty />", () => {
+      const input = `
+import { ThreadPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return <ThreadPrimitive.Empty />;
+}
+`;
+
+      const expected = `
+import { ThreadPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return <AuiIf condition={(s) => s.thread.isEmpty} />;
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+
+    it("should handle ThreadPrimitive.Empty alongside ThreadPrimitive.If", () => {
+      const input = `
+import { ThreadPrimitive } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <>
+      <ThreadPrimitive.Empty>
+        <div>Welcome</div>
+      </ThreadPrimitive.Empty>
+      <ThreadPrimitive.If running>
+        <div>Running</div>
+      </ThreadPrimitive.If>
+    </>
+  );
+}
+`;
+
+      const expected = `
+import { ThreadPrimitive, AuiIf } from "@assistant-ui/react";
+
+function MyComponent() {
+  return (
+    <>
+      <AuiIf condition={(s) => s.thread.isEmpty}>
+        <div>Welcome</div>
+      </AuiIf>
+      <AuiIf condition={(s) => s.thread.isRunning}>
+        <div>Running</div>
+      </AuiIf>
+    </>
+  );
+}
+`;
+
+      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+    });
+  });
+
   // ── Edge cases ─────────────────────────────────────────────────────
 
   describe("edge cases", () => {

--- a/packages/react/src/primitives/thread/ThreadEmpty.ts
+++ b/packages/react/src/primitives/thread/ThreadEmpty.ts
@@ -7,12 +7,13 @@ export namespace ThreadPrimitiveEmpty {
   export type Props = PropsWithChildren;
 }
 
+/**
+ * @deprecated Use `<AuiIf condition={(s) => s.thread.isEmpty} />` instead.
+ */
 export const ThreadPrimitiveEmpty: FC<ThreadPrimitiveEmpty.Props> = ({
   children,
 }) => {
-  const empty = useAuiState(
-    (s) => s.thread.messages.length === 0 && !s.thread.isLoading,
-  );
+  const empty = useAuiState((s) => s.thread.isEmpty);
   return empty ? children : null;
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Deprecates `ThreadPrimitive.Empty` in favor of `AuiIf` with condition `s.thread.isEmpty`, updating components, examples, and tests accordingly.
> 
>   - **Deprecation**:
>     - Deprecates `ThreadPrimitive.Empty` in `ThreadEmpty.ts` in favor of `AuiIf` with condition `s.thread.isEmpty`.
>   - **Code Changes**:
>     - Replaces `ThreadPrimitive.Empty` with `AuiIf` in `dictation.tsx`, `speech.tsx`, and `chatgpt.tsx`.
>     - Updates `grok.tsx` and `perplexity.tsx` to use `AuiIf` instead of `ThreadPrimitive.Empty`.
>     - Modifies `api-reference/primitives/thread.mdx` and `ui/thread.mdx` to reflect the deprecation.
>   - **Tests**:
>     - Adds tests in `primitive-if-to-aui-if.test.ts` to ensure `ThreadPrimitive.Empty` is correctly transformed to `AuiIf`.
>     - Updates `primitive-if-to-aui-if.ts` to handle the transformation logic for `ThreadPrimitive.Empty`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 531a83d7db28d9742bbf046f025ce8ec7533e60c. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->