### PR TITLE
feat(react-langgraph): support `additional_kwargs.metadata`

### DIFF
--- a/.changeset/langgraph-metadata-support.md
+++ b/.changeset/langgraph-metadata-support.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": minor
+---
+
+feat(react-langgraph): support `additional_kwargs.metadata` in LangGraph message converter, mapping it to `ThreadMessage.metadata.custom`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build & Development Commands
 
 ```bash
-# Install dependencies (use pnpm, requires Node.js >=24, pnpm 10.28.2)
+# Install dependencies (use pnpm, requires Node.js >=24, pnpm >=10)
 pnpm install
 
 # Initial build (required before development - packages depend on each other's outputs)
@@ -30,6 +30,9 @@ pnpm test
 # Run tests for a specific package
 pnpm --filter @assistant-ui/react test
 pnpm --filter @assistant-ui/react test:watch  # watch mode
+
+# Clean all build artifacts, node_modules, and caches
+pnpm cleanup
 ```
 
 ## Changesets
@@ -46,9 +49,11 @@ This does NOT apply to private packages like `@assistant-ui/docs`, `@assistant-u
 
 Biome enforces all formatting and linting. Key rules:
 - **Tailwind class sorting**: `useSortedClasses` is ERROR level — applies to `className`, `clsx`, `cva`, `tw`, `twMerge`, `cn`, `twJoin`, `tv`
-- **Exhaustive dependencies**: ERROR level — includes custom `tap*` hooks (`tapEffect`, `tapMemo`, `tapCallback`, etc.)
-- Double quotes, semicolons, trailing commas, 80-char line width
+- **Exhaustive dependencies**: ERROR level — includes custom hooks: `tapEffect`, `tapMemo`, `tapCallback`, `tapConst`, `tapResources`; `tapEffectEvent` is marked as stable result
+- 2-space indentation, double quotes, semicolons, trailing commas, 80-char line width, LF line endings
+- `noExplicitAny` and all a11y rules are OFF
 - Pre-commit hook runs `biome check --fix` via lint-staged on all changed files
+- **Autofix CI**: PRs automatically get Biome lint fixes pushed via `autofix-ci/action`
 
 ## Architecture Overview
 
@@ -57,6 +62,7 @@ Biome enforces all formatting and linting. Key rules:
 - **packages/**: Published npm packages
 - **apps/**: Internal applications (docs, registry, devtools)
 - **examples/**: Example implementations for various integrations
+- **python/**: Python backend packages (`assistant-stream`, `assistant-transport-backend`, `langgraph-cloud-api`, etc.)
 
 ### Core Packages
 
@@ -84,7 +90,15 @@ Biome enforces all formatting and linting. Key rules:
 - Bridges `@assistant-ui/tap` with React components
 - `useAui`, `useAuiState`, `useAuiEvent` hooks
 
-**`@assistant-ui/react-native`** - React Native bindings (new)
+**`@assistant-ui/core`** - Shared logic used by both React and React Native packages
+
+**`@assistant-ui/cloud`** - Cloud persistence and thread management
+
+**`@assistant-ui/ui`** - Pre-built shadcn/ui component set (distinct from `@assistant-ui/styles`)
+
+**`@assistant-ui/cli`** (`create-assistant-ui`) - CLI scaffolding tool (`npx assistant-ui create` / `npx assistant-ui init`)
+
+**`@assistant-ui/react-native`** - React Native bindings
 - Mirrors the React package structure (primitives, hooks, context, runtimes)
 - Depends on `@assistant-ui/core` for shared logic
 
@@ -98,6 +112,9 @@ Biome enforces all formatting and linting. Key rules:
 - **`@assistant-ui/react-hook-form`**: React Hook Form integration
 - **`@assistant-ui/react-markdown`**: Markdown rendering
 - **`@assistant-ui/react-syntax-highlighter`**: Code highlighting
+- **`@assistant-ui/react-streamdown`**: Streaming markdown renderer
+- **`@assistant-ui/react-o11y`**: Observability and waterfall UI
+- **`@assistant-ui/react-devtools`**: Devtools panel
 - **`@assistant-ui/styles`**: Pre-built CSS for non-Tailwind users
 
 ### Runtime Architecture

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { convertLangChainMessages } from "./convertLangChainMessages";
+
+describe("convertLangChainMessages metadata", () => {
+  it("passes additional_kwargs.metadata to system message", () => {
+    const result = convertLangChainMessages({
+      type: "system",
+      id: "sys-1",
+      content: "You are a helpful assistant.",
+      additional_kwargs: {
+        metadata: { speaker_name: "System" },
+      },
+    });
+
+    expect(result).toMatchObject({
+      role: "system",
+      metadata: { custom: { speaker_name: "System" } },
+    });
+  });
+
+  it("passes additional_kwargs.metadata to human message", () => {
+    const result = convertLangChainMessages({
+      type: "human",
+      id: "human-1",
+      content: "Hello!",
+      additional_kwargs: {
+        metadata: { speaker_name: "Presenter" },
+      },
+    });
+
+    expect(result).toMatchObject({
+      role: "user",
+      metadata: { custom: { speaker_name: "Presenter" } },
+    });
+  });
+
+  it("passes additional_kwargs.metadata to ai message", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "Hi there!",
+      additional_kwargs: {
+        metadata: { model: "gpt-4", speaker_name: "Assistant" },
+      },
+    });
+
+    expect(result).toMatchObject({
+      role: "assistant",
+      metadata: { custom: { model: "gpt-4", speaker_name: "Assistant" } },
+    });
+  });
+
+  it("defaults to empty metadata when additional_kwargs.metadata is absent", () => {
+    const system = convertLangChainMessages({
+      type: "system",
+      id: "sys-1",
+      content: "Hello",
+    });
+    expect(system).toMatchObject({
+      metadata: { custom: {} },
+    });
+
+    const human = convertLangChainMessages({
+      type: "human",
+      id: "human-1",
+      content: "Hello",
+    });
+    expect(human).toMatchObject({
+      metadata: { custom: {} },
+    });
+
+    const ai = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "Hello",
+    });
+    expect(ai).toMatchObject({
+      metadata: { custom: {} },
+    });
+  });
+
+  it("defaults to empty metadata when additional_kwargs exists but has no metadata", () => {
+    const ai = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "Hello",
+      additional_kwargs: {},
+    });
+    expect(ai).toMatchObject({
+      metadata: { custom: {} },
+    });
+  });
+});

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -12,6 +12,11 @@ import {
   ReadonlyJSONObject,
 } from "assistant-stream/utils";
 
+const getCustomMetadata = (
+  additionalKwargs: Record<string, unknown> | undefined,
+): Record<string, unknown> =>
+  (additionalKwargs?.metadata as Record<string, unknown>) ?? {};
+
 const warnedMessagePartTypes = new Set<string>();
 const warnForUnknownMessagePartType = (type: string) => {
   if (
@@ -102,12 +107,14 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
         role: "system",
         id: message.id,
         content: [{ type: "text", text: message.content }],
+        metadata: { custom: getCustomMetadata(message.additional_kwargs) },
       };
     case "human":
       return {
         role: "user",
         id: message.id,
         content: contentToParts(message.content),
+        metadata: { custom: getCustomMetadata(message.additional_kwargs) },
       };
     case "ai":
       const toolCallParts =
@@ -143,6 +150,7 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
         role: "assistant",
         id: message.id,
         content: [...contentToParts(allContent), ...toolCallParts],
+        metadata: { custom: getCustomMetadata(message.additional_kwargs) },
         ...(message.status && { status: message.status }),
       };
     case "tool":

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -125,6 +125,7 @@ export type LangChainMessage =
       additional_kwargs?: {
         reasoning?: MessageContentReasoning;
         tool_outputs?: MessageContentComputerCall[];
+        metadata?: Record<string, unknown>;
       };
     };
 


### PR DESCRIPTION
This PR adds support to `additional_kwargs.metadata` mapping it to `ThreadMessage.metadata.custom` in `@assistant-ui/react-langgraph`.

close #2491
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Support `additional_kwargs.metadata` in `convertLangChainMessages`, mapping to `ThreadMessage.metadata.custom`.
> 
>   - **Behavior**:
>     - `convertLangChainMessages` in `convertLangChainMessages.ts` now maps `additional_kwargs.metadata` to `ThreadMessage.metadata.custom`.
>     - Defaults to empty metadata if `additional_kwargs.metadata` is absent or undefined.
>   - **Tests**:
>     - Added tests in `convertLangChainMessages.test.ts` to verify metadata mapping for `system`, `human`, and `ai` message types.
>     - Tests ensure default empty metadata when `additional_kwargs.metadata` is missing.
>   - **Types**:
>     - Updated `LangChainMessage` type in `types.ts` to include `metadata` in `additional_kwargs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 2dc435f993cdc15b3d5c212112e4b787feb7be6f. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->