### PR TITLE
fix(core): ExternalStoreThreadListRuntimeCore mainThreadId not set

### DIFF
--- a/.changeset/fix-external-store-main-thread-id.md
+++ b/.changeset/fix-external-store-main-thread-id.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): ExternalStoreThreadListRuntimeCore mainThreadId not set from adapter on initial load

--- a/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
@@ -148,9 +148,11 @@ export class ExternalStoreThreadListRuntimeCore
         this.adapter.archivedThreads?.map((t) => t.id) ?? EMPTY_ARRAY;
     }
 
-    if (previousThreadId !== newThreadId) {
+    if (initialLoad || previousThreadId !== newThreadId) {
       this._mainThreadId = newThreadId;
-      this._mainThread = this.threadFactory();
+      if (!initialLoad) {
+        this._mainThread = this.threadFactory();
+      }
     }
 
     this._notifySubscribers();

--- a/packages/core/src/tests/external-store-thread-list.test.ts
+++ b/packages/core/src/tests/external-store-thread-list.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { ExternalStoreThreadListRuntimeCore } from "../runtimes/external-store/external-store-thread-list-runtime-core";
+
+const createMockThreadFactory = () =>
+  vi.fn(
+    () =>
+      ({
+        __internal_setAdapter: vi.fn(),
+      }) as any,
+  );
+
+describe("ExternalStoreThreadListRuntimeCore", () => {
+  describe("mainThreadId initialization", () => {
+    it("should set mainThreadId to DEFAULT_THREAD_ID when no threadId provided", () => {
+      const factory = createMockThreadFactory();
+      const core = new ExternalStoreThreadListRuntimeCore({}, factory);
+      expect(core.mainThreadId).toBe("DEFAULT_THREAD_ID");
+    });
+
+    it("should set mainThreadId from adapter.threadId on construction", () => {
+      const factory = createMockThreadFactory();
+      const core = new ExternalStoreThreadListRuntimeCore(
+        { threadId: "my-thread-123" },
+        factory,
+      );
+      expect(core.mainThreadId).toBe("my-thread-123");
+    });
+
+    it("should retain mainThreadId when setAdapter is called with same threadId after construction", () => {
+      const factory = createMockThreadFactory();
+      const adapter = { threadId: "my-thread-123" };
+      const core = new ExternalStoreThreadListRuntimeCore(adapter, factory);
+
+      // Simulate useEffect calling setAdapter again with same adapter
+      core.__internal_setAdapter(adapter);
+
+      expect(core.mainThreadId).toBe("my-thread-123");
+    });
+
+    it("should update mainThreadId when adapter threadId changes", () => {
+      const factory = createMockThreadFactory();
+      const core = new ExternalStoreThreadListRuntimeCore(
+        { threadId: "thread-1" },
+        factory,
+      );
+      expect(core.mainThreadId).toBe("thread-1");
+
+      core.__internal_setAdapter({ threadId: "thread-2" });
+      expect(core.mainThreadId).toBe("thread-2");
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes ExternalStoreThreadListRuntimeCore `mainThreadId` not set from adapter on initial load.

close #2577
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `mainThreadId` initialization issue in `ExternalStoreThreadListRuntimeCore` and adds tests for verification.
> 
>   - **Behavior**:
>     - Fixes `mainThreadId` not set on initial load in `ExternalStoreThreadListRuntimeCore` by modifying `__internal_setAdapter()` to handle `initialLoad`.
>   - **Tests**:
>     - Adds tests in `external-store-thread-list.test.ts` to verify `mainThreadId` initialization and updates, including cases with no `threadId`, provided `threadId`, and changes in `adapter.threadId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 401d874a4822785f85939e1c88d4f8a4f41509a7. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->