### PR TITLE
feat(core): support external source attachments

### DIFF
--- a/.changeset/external-source-attachments.md
+++ b/.changeset/external-source-attachments.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+feat: support external source attachments in composer
+
+`addAttachment()` now accepts either a `File` or a `CreateAttachment` descriptor, allowing users to add attachments from external sources (URLs, API data, CMS references) without creating dummy `File` objects or requiring an `AttachmentAdapter`.

--- a/apps/docs/components/docs/parameters-table.context.ts
+++ b/apps/docs/components/docs/parameters-table.context.ts
@@ -23,9 +23,10 @@ const BaseComposerState: ParametersTableProps = {
     },
     {
       name: "addAttachment",
-      type: "(attachment: Attachment) => void",
+      type: "(file: File | CreateAttachment) => Promise<void>",
       required: true,
-      description: "A function to add an attachment to the composer.",
+      description:
+        "A function to add an attachment to the composer. Accepts a File (processed through the AttachmentAdapter) or a CreateAttachment descriptor for external-source attachments.",
     },
     {
       name: "removeAttachment",

--- a/apps/docs/content/docs/(docs)/guides/attachments.mdx
+++ b/apps/docs/content/docs/(docs)/guides/attachments.mdx
@@ -479,6 +479,31 @@ class ValidatedImageAdapter implements AttachmentAdapter {
 }
 ```
 
+### External Source Attachments
+
+Add attachments from external sources (URLs, API data, CMS references) without needing a `File` object or an `AttachmentAdapter`:
+
+```tsx
+const aui = useAui();
+
+// Add an attachment from an external source
+await aui.composer().addAttachment({
+  name: "report.pdf",
+  contentType: "application/pdf",
+  content: [{ type: "text", text: "Extracted document content..." }],
+});
+
+// Optionally provide id and type
+await aui.composer().addAttachment({
+  id: "cms-doc-123",
+  type: "document",
+  name: "Product Spec",
+  content: [{ type: "text", text: "Product specification content..." }],
+});
+```
+
+External attachments are added as complete attachments directly — they skip the `AttachmentAdapter` entirely and can be removed without one.
+
 ### Multiple File Selection
 
 Enable multi-file selection with custom limits:

--- a/apps/docs/content/docs/(docs)/guides/context-api.mdx
+++ b/apps/docs/content/docs/(docs)/guides/context-api.mdx
@@ -191,7 +191,8 @@ api.part().getState();
 aui.composer().send();
 aui.composer().setText(text);
 aui.composer().setRole(role);
-aui.composer().addAttachment(file);
+aui.composer().addAttachment(file); // File object
+aui.composer().addAttachment({ name, content }); // external source
 aui.composer().clearAttachments();
 aui.composer().reset();
 aui.composer().getState();
@@ -449,10 +450,10 @@ const isRunning = useAuiState((s) => s.thread.isRunning);
 
 ### Hooks
 
-| Hook                                | Purpose                    | Returns        |
-| ----------------------------------- | -------------------------- | -------------- |
+| Hook                          | Purpose                    | Returns        |
+| ----------------------------- | -------------------------- | -------------- |
 | `useAuiState(selector)`       | Subscribe to state changes | Selected value |
-| `useAui()`                 | Get API instance           | API object     |
+| `useAui()`                    | Get API instance           | API object     |
 | `useAuiEvent(event, handler)` | Subscribe to events        | void           |
 
 ### Scope States
@@ -469,28 +470,28 @@ const isRunning = useAuiState((s) => s.thread.isRunning);
 
 ### Available Actions by Scope
 
-| Scope          | Actions                                                               | Use Cases                                 |
-| -------------- | --------------------------------------------------------------------- | ----------------------------------------- |
-| ThreadList     | `switchToNewThread()`, `switchToThread(id)`, `getState()`             | Thread navigation and creation            |
-| ThreadListItem | `switchTo()`, `rename(title)`, `archive()`, `unarchive()`, `delete()` | Thread management operations              |
-| Thread         | `append(message)`, `startRun()`, `cancelRun()`, `switchToNewThread()` | Message handling and conversation control |
-| Message        | `reload()`, `speak()`, `stopSpeaking()`, `submitFeedback(feedback)`   | Message interactions and regeneration     |
-| Composer       | `send()`, `setText(text)`, `addAttachment(file)`, `reset()`           | Text input and message composition        |
-| Part           | `addResult(result)`, `getState()`                                     | Tool call result handling                 |
-| Attachment     | `remove()`, `getState()`                                              | File management                           |
+| Scope          | Actions                                                                   | Use Cases                                 |
+| -------------- | ------------------------------------------------------------------------- | ----------------------------------------- |
+| ThreadList     | `switchToNewThread()`, `switchToThread(id)`, `getState()`                 | Thread navigation and creation            |
+| ThreadListItem | `switchTo()`, `rename(title)`, `archive()`, `unarchive()`, `delete()`     | Thread management operations              |
+| Thread         | `append(message)`, `startRun()`, `cancelRun()`, `switchToNewThread()`     | Message handling and conversation control |
+| Message        | `reload()`, `speak()`, `stopSpeaking()`, `submitFeedback(feedback)`       | Message interactions and regeneration     |
+| Composer       | `send()`, `setText(text)`, `addAttachment(file \| attachment)`, `reset()` | Text input and message composition        |
+| Part           | `addResult(result)`, `getState()`                                         | Tool call result handling                 |
+| Attachment     | `remove()`, `getState()`                                                  | File management                           |
 
 ### Common Events
 
-| Event                            | Description                   |
-| -------------------------------- | ----------------------------- |
-| `thread.runStart`                | Assistant starts generating   |
-| `thread.runEnd`                  | Assistant finishes generating |
-| `thread.initialize`              | Thread is initialized         |
-| `thread.modelContextUpdate`      | Model context is updated      |
-| `composer.send`                  | Message is sent               |
-| `composer.attachmentAdd`         | Attachment added to composer  |
-| `threadListItem.switchedTo`      | Switched to a thread          |
-| `threadListItem.switchedAway`    | Switched away from a thread   |
+| Event                         | Description                   |
+| ----------------------------- | ----------------------------- |
+| `thread.runStart`             | Assistant starts generating   |
+| `thread.runEnd`               | Assistant finishes generating |
+| `thread.initialize`           | Thread is initialized         |
+| `thread.modelContextUpdate`   | Model context is updated      |
+| `composer.send`               | Message is sent               |
+| `composer.attachmentAdd`      | Attachment added to composer  |
+| `threadListItem.switchedTo`   | Switched to a thread          |
+| `threadListItem.switchedAway` | Switched away from a thread   |
 
 ## Troubleshooting
 

--- a/packages/core/src/runtime/api/attachment-runtime.ts
+++ b/packages/core/src/runtime/api/attachment-runtime.ts
@@ -1,9 +1,4 @@
-import type {
-  Attachment,
-  CompleteAttachment,
-  PendingAttachment,
-  Unsubscribe,
-} from "../../types";
+import type { Attachment, CompleteAttachment, Unsubscribe } from "../../types";
 import type { SubscribableWithState } from "../../subscribable/subscribable";
 
 import type { ComposerRuntimeCoreBinding } from "./bindings";
@@ -13,7 +8,7 @@ type MessageAttachmentState = CompleteAttachment & {
   readonly source: "message";
 };
 
-type ThreadComposerAttachmentState = PendingAttachment & {
+type ThreadComposerAttachmentState = Attachment & {
   readonly source: "thread-composer";
 };
 

--- a/packages/core/src/runtime/api/composer-runtime.ts
+++ b/packages/core/src/runtime/api/composer-runtime.ts
@@ -1,6 +1,6 @@
 import type {
   Attachment,
-  PendingAttachment,
+  CreateAttachment,
   MessageRole,
   RunConfig,
   QuoteInfo,
@@ -65,8 +65,6 @@ type BaseComposerState = {
 
 export type ThreadComposerState = BaseComposerState & {
   readonly type: "thread";
-
-  readonly attachments: readonly PendingAttachment[];
 };
 
 export type EditComposerState = BaseComposerState & {
@@ -131,10 +129,13 @@ export type ComposerRuntime = {
   getState(): ComposerState;
 
   /**
-   * Given a standard js File object, add it to the composer. A composer can have multiple attachments.
-   * @param file The file to add to the composer.
+   * Add an attachment to the composer. Accepts either a standard File object
+   * (processed through the AttachmentAdapter) or a CreateAttachment descriptor
+   * for external-source attachments (URLs, API data, CMS references) that
+   * bypasses the adapter entirely.
+   * @param fileOrAttachment The file or attachment descriptor to add.
    */
-  addAttachment(file: File): Promise<void>;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
 
   /**
    * Set the text of the composer.
@@ -260,10 +261,10 @@ export abstract class ComposerRuntimeImpl implements ComposerRuntime {
     core.setRunConfig(runConfig);
   }
 
-  public addAttachment(file: File) {
+  public addAttachment(fileOrAttachment: File | CreateAttachment) {
     const core = this._core.getState();
     if (!core) throw new Error("Composer is not available");
-    return core.addAttachment(file);
+    return core.addAttachment(fileOrAttachment);
   }
 
   public reset() {

--- a/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
@@ -1,4 +1,4 @@
-import type { AppendMessage, PendingAttachment } from "../../types";
+import type { AppendMessage } from "../../types";
 import type { AttachmentAdapter } from "../../adapters/attachment";
 import type { DictationAdapter } from "../../adapters/speech";
 import type { ThreadComposerRuntimeCore } from "../interfaces/composer-runtime-core";
@@ -12,10 +12,6 @@ export class DefaultThreadComposerRuntimeCore
   private _canCancel = false;
   public get canCancel() {
     return this._canCancel;
-  }
-
-  public override get attachments(): readonly PendingAttachment[] {
-    return super.attachments as readonly PendingAttachment[];
   }
 
   protected getAttachmentAdapter() {

--- a/packages/core/src/runtime/interfaces/composer-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/composer-runtime-core.ts
@@ -3,7 +3,7 @@ import type {
   RunConfig,
   QuoteInfo,
   Attachment,
-  PendingAttachment,
+  CreateAttachment,
   Unsubscribe,
 } from "../../types";
 import type { DictationAdapter } from "../../adapters/speech";
@@ -25,7 +25,7 @@ export type ComposerRuntimeCore = Readonly<{
   attachments: readonly Attachment[];
   attachmentAccept: string;
 
-  addAttachment: (file: File) => Promise<void>;
+  addAttachment: (fileOrAttachment: File | CreateAttachment) => Promise<void>;
   removeAttachment: (attachmentId: string) => Promise<void>;
 
   text: string;
@@ -58,7 +58,4 @@ export type ComposerRuntimeCore = Readonly<{
   ) => Unsubscribe;
 }>;
 
-export type ThreadComposerRuntimeCore = ComposerRuntimeCore &
-  Readonly<{
-    attachments: readonly PendingAttachment[];
-  }>;
+export type ThreadComposerRuntimeCore = ComposerRuntimeCore;

--- a/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
+++ b/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
@@ -72,7 +72,7 @@ export const EMPTY_THREAD_CORE: ThreadRuntimeCore = {
     attachments: [],
     attachmentAccept: "*",
 
-    async addAttachment() {
+    async addAttachment(_fileOrAttachment) {
       throw EMPTY_THREAD_ERROR;
     },
 

--- a/packages/core/src/store/scopes/composer.ts
+++ b/packages/core/src/store/scopes/composer.ts
@@ -1,5 +1,6 @@
 import type {
   Attachment,
+  CreateAttachment,
   MessageRole,
   RunConfig,
   QuoteInfo,
@@ -36,7 +37,7 @@ export type ComposerMethods = {
   setText(text: string): void;
   setRole(role: MessageRole): void;
   setRunConfig(runConfig: RunConfig): void;
-  addAttachment(file: File): Promise<void>;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
   clearAttachments(): Promise<void>;
   attachment(selector: { index: number } | { id: string }): AttachmentMethods;
   reset(): Promise<void>;

--- a/packages/core/src/types/attachment.ts
+++ b/packages/core/src/types/attachment.ts
@@ -43,3 +43,11 @@ export type CompleteAttachment = BaseAttachment & {
 };
 
 export type Attachment = PendingAttachment | CompleteAttachment;
+
+export type CreateAttachment = {
+  id?: string;
+  type?: "image" | "document" | "file" | (string & {});
+  name: string;
+  contentType?: string;
+  content: ThreadUserMessagePart[];
+};

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -32,6 +32,7 @@ export type {
   PendingAttachment,
   CompleteAttachment,
   AttachmentStatus,
+  CreateAttachment,
 } from "./attachment";
 
 export type { Unsubscribe } from "./unsubscribe";

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -15,6 +15,7 @@ import {
 import { withKey } from "@assistant-ui/tap";
 import type {
   Attachment,
+  CreateAttachment,
   ThreadAssistantMessagePart,
   ThreadUserMessagePart,
   ThreadMessage,
@@ -308,17 +309,29 @@ const ComposerClientResource = resource(
       setText,
       setRole,
       setRunConfig,
-      addAttachment: async (file: File) => {
-        const newAttachment: Attachment = {
-          id: Math.random().toString(36).substring(7),
-          type: "file",
-          name: file.name,
-          contentType: file.type,
-          file,
-          status: { type: "complete" },
-          content: [],
-        };
-        setAttachments([...attachments, newAttachment]);
+      addAttachment: async (fileOrAttachment: File | CreateAttachment) => {
+        if (fileOrAttachment instanceof File) {
+          const newAttachment: Attachment = {
+            id: Math.random().toString(36).substring(7),
+            type: "file",
+            name: fileOrAttachment.name,
+            contentType: fileOrAttachment.type,
+            file: fileOrAttachment,
+            status: { type: "complete" },
+            content: [],
+          };
+          setAttachments([...attachments, newAttachment]);
+        } else {
+          const newAttachment: Attachment = {
+            id: fileOrAttachment.id ?? Math.random().toString(36).substring(7),
+            type: fileOrAttachment.type ?? "document",
+            name: fileOrAttachment.name,
+            contentType: fileOrAttachment.contentType,
+            content: fileOrAttachment.content,
+            status: { type: "complete" },
+          };
+          setAttachments([...attachments, newAttachment]);
+        }
       },
       clearAttachments: async () => {
         setAttachments([]);


### PR DESCRIPTION
This PR supports external source attachments in `@assistant-ui/core` and `@assistant-ui/react`.

close #2578

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Support for external source attachments added to `@assistant-ui/core` and `@assistant-ui/react`, allowing attachments without `File` objects or `AttachmentAdapter`.
> 
>   - **Behavior**:
>     - `addAttachment()` in `BaseComposerRuntimeCore` now accepts `File` or `CreateAttachment`, enabling external source attachments without `AttachmentAdapter`.
>     - External attachments are added as complete and can be removed without an adapter.
>   - **API Changes**:
>     - Updated `ComposerRuntime` and `ComposerMethods` to support `CreateAttachment`.
>     - `AttachmentAdapter` no longer required for external attachments.
>   - **Documentation**:
>     - Updated `attachments.mdx` and `context-api.mdx` to include examples and explanations for external source attachments.
>   - **Tests**:
>     - Added tests in `BaseComposerRuntimeCore.test.ts` for `CreateAttachment` handling, including adding, removing, and sending attachments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 4b08002271f23a29f089c5f2f2b5a41a0f32f4cb. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->