### PR TITLE
fix(react-ai-sdk): pass through data-* parts without normalizing to type: "data"

### DIFF
--- a/packages/core/src/runtime/utils/thread-message-like.ts
+++ b/packages/core/src/runtime/utils/thread-message-like.ts
@@ -80,7 +80,7 @@ const convertDataPrefixedPart = (
   data: unknown,
 ): DataMessagePart | undefined => {
   if (!type.startsWith("data-")) return undefined;
-  return { type: "data", name: type.substring(5), data };
+  return { type, name: type.substring(5), data };
 };
 
 export const fromThreadMessageLike = (

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -51,7 +51,7 @@ export type Unstable_AudioMessagePart = {
 };
 
 export type DataMessagePart<T = any> = {
-  readonly type: "data";
+  readonly type: `data-${string}`;
   readonly name: string;
   readonly data: T;
 };

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -142,7 +142,7 @@ function convertParts(
 
       if (part.type.startsWith("data-")) {
         return {
-          type: "data",
+          type: part.type,
           name: part.type.substring(5),
           data: (part as any).data,
         } satisfies DataMessagePart;


### PR DESCRIPTION
## Problem

The \`AISDKMessageConverter\` in \`convertParts\` currently normalizes all \`data-*\` message parts by replacing the original \`type\` with \`"data"\`:

\`\`\`ts
if (type.startsWith("data-")) {
  return {
    type: "data",               // <-- original type is lost
    name: type.substring(5),
    data: (part as any).data,
  } satisfies DataMessagePart;
}
\`\`\`

This creates an inconsistency. The AI SDK v5 defines \`DataUIPart<T>\` with the full prefixed type as the discriminator:

\`\`\`ts
type DataUIPart<DATA_TYPES> = ValueOf<{
  [NAME in keyof DATA_TYPES & string]: {
    type: \`data-\${NAME}\`;   // e.g. "data-attachment"
    data: DATA_TYPES[NAME];
  };
}>;
\`\`\`

The AI SDK also provides \`isDataUIPart()\` which checks \`part.type.startsWith("data-")\`. Both of these rely on the \`type\` field carrying the full \`"data-attachment"\` value.

But after the converter runs, parts in the assistant-ui state have \`type: "data"\` instead of \`type: "data-attachment"\`. This means:

1. Consumers cannot use the same type constants across the transport layer and the UI layer. On the transport side \`type\` is \`"data-attachment"\`, but in the assistant-ui state it becomes \`"data"\`.
2. The AI SDK's own \`isDataUIPart()\` returns \`false\` for converted parts because \`"data".startsWith("data-")\` is false.
3. Consumers are forced to use a secondary \`name\` field for discrimination, which is not part of the AI SDK's \`DataUIPart<T>\` type at all.

## Solution

Preserve the original \`part.type\` instead of replacing it with \`"data"\`:

\`\`\`ts
if (type.startsWith("data-")) {
  return {
    type,                        // preserves "data-attachment", "data-reference", etc.
    name: type.substring(5),
    data: (part as any).data,
  };
}
\`\`\`

The \`name\` and \`data\` fields are kept for backward compatibility, but the \`type\` now matches the AI SDK format throughout the entire pipeline.

## Related

Companion change to #3392, which added support for \`data-*\` prefixed types in the \`@assistant-ui/react\` package.