### PR TITLE
fix(docs): add wasm-unsafe-eval to CSP for shiki

### DIFF
--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -7,7 +7,7 @@ const cspHeader = `
     default-src 'self';
     connect-src *;
     frame-src *;
-    script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""};
+    script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'${isDev ? " 'unsafe-eval'" : ""};
     style-src 'self' 'unsafe-inline';
     img-src * blob: data:;
     font-src 'self';


### PR DESCRIPTION
## Summary
- The CSP header added in #3369 is missing `'wasm-unsafe-eval'`, which blocks shiki's WASM-based syntax highlighting engine in production
- All `react-shiki` code blocks on `/tw-shimmer` and `/tw-glass` landing pages silently fail to render on the deployed site
- Adds `'wasm-unsafe-eval'` to `script-src` — a narrow CSP directive that only permits WebAssembly compilation, not general `eval()`

## Test plan
- [ ] Verify code blocks render on `/tw-shimmer` in production preview
- [ ] Verify code blocks render on `/tw-glass` in production preview
- [ ] Confirm no CSP violations in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds 'wasm-unsafe-eval' to CSP in `apps/docs/next.config.ts` to fix Shiki rendering issues on `/tw-shimmer` and `/tw-glass`.
> 
>   - **CSP Update**:
>     - Adds `'wasm-unsafe-eval'` to `script-src` in `apps/docs/next.config.ts` to allow WebAssembly compilation for Shiki's syntax highlighting.
>   - **Behavior**:
>     - Fixes rendering issues for `react-shiki` code blocks on `/tw-shimmer` and `/tw-glass` landing pages.
>     - Ensures no CSP violations occur in the browser console.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c48d9a38e7ca0265fdd94a3255d97f90caeed2dd. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->