### PR TITLE
fix(react-ag-ui): route tool results

### DIFF
--- a/.changeset/quiet-bottles-argue.md
+++ b/.changeset/quiet-bottles-argue.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix(react-ag-ui): route tool results to the latest pending tool call and avoid false auto-resume triggers


### PR DESCRIPTION
This PR routes tool results to the latest pending tool call and avoids false auto-resume triggers.

follow-up fix #3348
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes tool result routing in `AgUiThreadRuntimeCore` to target latest pending tool call and prevent false auto-resume triggers.
> 
>   - **Behavior**:
>     - `findMessageIdForToolCall()` in `AgUiThreadRuntimeCore.ts` now returns the latest pending message ID for a given `toolCallId`.
>     - `addToolResult()` in `AgUiThreadRuntimeCore.ts` updates tool call results only if a matching tool call is found, preventing false auto-resume.
>   - **Tests**:
>     - Added test `prefers latest pending message when toolCallId is reused` in `ag-ui-thread-runtime-core.spec.ts` to verify correct message ID selection.
>     - Added test `does not auto-resume when addToolResult does not match a tool call` in `ag-ui-thread-runtime-core.spec.ts` to ensure no auto-resume on unmatched tool calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 71d8449cceca6ef38e882c49076d60148ed08a53. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->