### PR TITLE
fix(react): stabilize runtimeHook identity

### DIFF
--- a/.changeset/steady-hooks-settle.md
+++ b/.changeset/steady-hooks-settle.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+---
+
+fix: stabilize runtimeHook identity in useRemoteThreadListRuntime to avoid unnecessary option updates and thread state churn

--- a/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/useRemoteThreadListRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/useRemoteThreadListRuntime.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import {
   BaseAssistantRuntimeCore,
   AssistantRuntimeImpl,
@@ -46,11 +46,27 @@ const useRemoteThreadListRuntimeImpl = (
 export const useRemoteThreadListRuntime = (
   options: RemoteThreadListOptions,
 ): AssistantRuntime => {
+  const runtimeHookRef = useRef(options.runtimeHook);
+  runtimeHookRef.current = options.runtimeHook;
+
+  const stableRuntimeHook = useCallback(() => {
+    return runtimeHookRef.current();
+  }, []);
+
+  const stableOptions = useMemo<RemoteThreadListOptions>(
+    () => ({
+      adapter: options.adapter,
+      allowNesting: options.allowNesting,
+      runtimeHook: stableRuntimeHook,
+    }),
+    [options.adapter, options.allowNesting, stableRuntimeHook],
+  );
+
   const aui = useAui();
   const isNested = aui.threadListItem.source !== null;
 
   if (isNested) {
-    if (!options.allowNesting) {
+    if (!stableOptions.allowNesting) {
       throw new Error(
         "useRemoteThreadListRuntime cannot be nested inside another RemoteThreadListRuntime. " +
           "Set allowNesting: true to allow nesting (the inner runtime will become a no-op).",
@@ -59,8 +75,8 @@ export const useRemoteThreadListRuntime = (
 
     // If allowNesting is true and already inside a thread list context,
     // just call the runtimeHook directly (no-op behavior)
-    return options.runtimeHook();
+    return stableRuntimeHook();
   }
 
-  return useRemoteThreadListRuntimeImpl(options);
+  return useRemoteThreadListRuntimeImpl(stableOptions);
 };


### PR DESCRIPTION
This PR stabilizes runtimeHook identity in `useRemoteThreadListRuntime` to avoid unnecessary option updates and thread state churn.

close #3328
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Stabilizes `runtimeHook` identity in `useRemoteThreadListRuntime` to prevent unnecessary updates and state churn using `useRef` and `useCallback`.
> 
>   - **Behavior**:
>     - Stabilizes `runtimeHook` identity in `useRemoteThreadListRuntime` to prevent unnecessary option updates and thread state churn.
>     - Uses `useRef` and `useCallback` to maintain stable `runtimeHook` reference in `useRemoteThreadListRuntime`.
>   - **Files Affected**:
>     - `useRemoteThreadListRuntime.ts` in `react-native` and `react` packages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for c599404e270c5db15d77685578744a20c119573a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->