### PR TITLE
feat: assistant transport runtime prepareRequestBody

### DIFF
--- a/.changeset/hungry-experts-strive.md
+++ b/.changeset/hungry-experts-strive.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: assistant transport prepareRequestBody support

--- a/apps/docs/content/docs/runtimes/assistant-transport.mdx
+++ b/apps/docs/content/docs/runtimes/assistant-transport.mdx
@@ -336,6 +336,7 @@ The `useAssistantTransportRuntime` hook is used to configure the runtime. It acc
   converter: (state: T, connectionMetadata: ConnectionMetadata) => AssistantTransportState,
   headers?: Record<string, string> | (() => Promise<Record<string, string>>),
   body?: object,
+  prepareSendCommandsRequest?: (body: SendCommandsRequestBody) => Record<string, unknown> | Promise<Record<string, unknown>>,
   capabilities?: { edit?: boolean },
   onResponse?: (response: Response) => void,
   onFinish?: () => void,
@@ -509,6 +510,36 @@ const runtime = useAssistantTransportRuntime({
     customField: "value",
     requestId: crypto.randomUUID(),
     timestamp: Date.now(),
+  }),
+});
+```
+
+### Transforming the Request Body
+
+Use `prepareSendCommandsRequest` to transform the entire request body before it is sent to the backend. This receives the fully assembled body object and returns the (potentially transformed) body.
+
+```typescript
+const runtime = useAssistantTransportRuntime({
+  // ... other options
+  prepareSendCommandsRequest: (body) => ({
+    ...body,
+    trackingId: crypto.randomUUID(),
+  }),
+});
+```
+
+This is useful for adding tracking IDs, transforming commands, or injecting metadata that depends on the assembled request:
+
+```typescript
+const runtime = useAssistantTransportRuntime({
+  // ... other options
+  prepareSendCommandsRequest: (body) => ({
+    ...body,
+    commands: body.commands.map((cmd) =>
+      cmd.type === "add-message"
+        ? { ...cmd, trackingId: crypto.randomUUID() }
+        : cmd,
+    ),
   }),
 });
 ```

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/index.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/index.ts
@@ -7,4 +7,5 @@ export type {
   AssistantTransportConnectionMetadata,
   AssistantTransportCommand,
   AssistantTransportProtocol,
+  SendCommandsRequestBody,
 } from "./types";

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/types.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/types.ts
@@ -83,6 +83,16 @@ export type HeadersValue = Record<string, string> | Headers;
 
 export type AssistantTransportProtocol = "data-stream" | "assistant-transport";
 
+export type SendCommandsRequestBody = {
+  commands: QueuedCommand[];
+  state: unknown;
+  system: string | undefined;
+  tools: Record<string, unknown> | undefined;
+  threadId: string | null;
+  parentId?: string | null;
+  [key: string]: unknown;
+};
+
 export type AssistantTransportOptions<T> = {
   initialState: T;
   api: string;
@@ -91,6 +101,21 @@ export type AssistantTransportOptions<T> = {
   converter: AssistantTransportStateConverter<T>;
   headers: HeadersValue | (() => Promise<HeadersValue>);
   body?: object | (() => Promise<object | undefined>);
+  /**
+   * Transform the request body before it is sent to the API.
+   * Receives the fully assembled body and returns the (potentially transformed) body.
+   *
+   * @example
+   * ```ts
+   * prepareSendCommandsRequest: (body) => ({
+   *   ...body,
+   *   trackingId: crypto.randomUUID(),
+   * })
+   * ```
+   */
+  prepareSendCommandsRequest?: (
+    body: SendCommandsRequestBody,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>;
   onResponse?: (response: Response) => void;
   onFinish?: () => void;
   onError?: (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `prepareSendCommandsRequest` to transform request body in assistant transport runtime.
> 
>   - **Behavior**:
>     - Add `prepareSendCommandsRequest` option to `useAssistantTransportRuntime` in `useAssistantTransportRuntime.ts` to transform request body before sending.
>     - Document `prepareSendCommandsRequest` usage in `assistant-transport.mdx`.
>   - **Types**:
>     - Add `SendCommandsRequestBody` type in `types.ts` to define request body structure.
>   - **Exports**:
>     - Export `SendCommandsRequestBody` in `index.ts` and `assistant-transport/index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for a600ad80f4a9b62390ec327392c03a84084fc6de. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->