### PR TITLE
feat: bindExternalStoreMessage

### DIFF
--- a/.changeset/fresh-sloths-shine.md
+++ b/.changeset/fresh-sloths-shine.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+feat: bindExternalStoreMessage

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -1157,6 +1157,29 @@ const ToolUI = makeAssistantToolUI({
 });
 ```
 
+### Binding External Messages Manually
+
+Use `bindExternalStoreMessage` to attach your original message to a `ThreadMessage` or message part object. This is useful when you construct `ThreadMessage` objects yourself (outside of the built-in message converter) and want `getExternalStoreMessages` to work with them.
+
+```tsx
+import {
+  bindExternalStoreMessage,
+  getExternalStoreMessages,
+} from "@assistant-ui/react";
+
+// Attach your original message to a ThreadMessage
+bindExternalStoreMessage(threadMessage, originalMessage);
+
+// Later, retrieve it
+const original = getExternalStoreMessages(threadMessage);
+```
+
+<Callout type="warn">
+  This API is experimental and may change without notice.
+</Callout>
+
+`bindExternalStoreMessage` is a no-op if the target already has a bound message. It mutates the target object in place.
+
 ## Debugging
 
 ### Common Debugging Scenarios

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -101,6 +101,7 @@ export type { ThreadMessageLike } from "./utils/thread-message-like";
 export {
   getExternalStoreMessage,
   getExternalStoreMessages,
+  bindExternalStoreMessage,
 } from "./utils/external-store-message";
 
 // ExportedMessageRepository

--- a/packages/core/src/runtime/utils/external-store-message.ts
+++ b/packages/core/src/runtime/utils/external-store-message.ts
@@ -18,6 +18,21 @@ export const getExternalStoreMessage = <T>(input: ThreadMessage) => {
 
 const EMPTY_ARRAY: never[] = [];
 
+/**
+ * Attach the original external store message(s) to a ThreadMessage or message part.
+ * This is a no-op if the target already has a bound message.
+ * Use `getExternalStoreMessages` to retrieve the bound messages later.
+ *
+ * @deprecated This API is experimental and may change without notice.
+ */
+export const bindExternalStoreMessage = <T>(
+  target: object,
+  message: T | T[],
+): void => {
+  if (symbolInnerMessage in target) return;
+  (target as WithInnerMessages<T>)[symbolInnerMessage] = message;
+};
+
 export const getExternalStoreMessages = <T>(
   input:
     | { messages: readonly ThreadMessage[] }

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -10,7 +10,7 @@ import type {
 import type { ExternalStoreAdapter } from "./external-store-adapter";
 import {
   getExternalStoreMessages,
-  symbolInnerMessage,
+  bindExternalStoreMessage,
 } from "../../runtime/utils/external-store-message";
 import { ThreadMessageConverter } from "./thread-message-converter";
 import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
@@ -208,7 +208,7 @@ export class ExternalStoreThreadRuntimeCore
               idx.toString(),
               autoStatus,
             );
-            (newMessage as any)[symbolInnerMessage] = m;
+            bindExternalStoreMessage(newMessage, m);
             return newMessage;
           });
 

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/getExternalStoreMessage.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/getExternalStoreMessage.ts
@@ -1,5 +1,6 @@
 export {
   getExternalStoreMessage,
   getExternalStoreMessages,
+  bindExternalStoreMessage,
 } from "@assistant-ui/core";
 export { symbolInnerMessage } from "@assistant-ui/core/internal";

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/index.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/index.ts
@@ -3,6 +3,7 @@ export type { ThreadMessageLike } from "@assistant-ui/core";
 export {
   getExternalStoreMessage,
   getExternalStoreMessages,
+  bindExternalStoreMessage,
 } from "@assistant-ui/core";
 export type {
   ExternalStoreAdapter,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `bindExternalStoreMessage` to attach original messages to `ThreadMessage` objects, enhancing message retrieval capabilities.
> 
>   - **Feature**:
>     - Adds `bindExternalStoreMessage` function to attach original messages to `ThreadMessage` objects in `external-store-message.ts`.
>     - Updates `external-store-thread-runtime-core.ts` and `external-message-converter.ts` to use `bindExternalStoreMessage` for message handling.
>   - **Documentation**:
>     - Adds section on `bindExternalStoreMessage` in `external-store.mdx`.
>   - **Exports**:
>     - Exports `bindExternalStoreMessage` in `getExternalStoreMessage.ts` and `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for dc0e59c74447e2f61495a49461e93ea5ca059a5f. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->