### PR TITLE
refactor: prepare for making type mandatory for Toolkit tools

### DIFF
--- a/packages/assistant-stream/src/core/tool/schema-utils.test.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.test.ts
@@ -141,6 +141,7 @@ describe("toToolsJSONSchema", () => {
           type: "frontend",
           description: "Frontend tool",
           parameters: { type: "object", properties: {} },
+          execute: async () => {},
         },
         backendTool: {
           type: "backend",
@@ -158,6 +159,7 @@ describe("toToolsJSONSchema", () => {
           type: "frontend",
           description: "A frontend tool",
           parameters: { type: "object", properties: { x: { type: "number" } } },
+          execute: async () => {},
         },
       };
 

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -115,7 +115,7 @@ type BackendTool<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
 > = ToolBase<TArgs, TResult> & {
-  type?: "backend" | undefined;
+  type: "backend";
 
   description?: undefined;
   parameters?: undefined;
@@ -128,12 +128,12 @@ type FrontendTool<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
 > = ToolBase<TArgs, TResult> & {
-  type?: "frontend" | undefined;
+  type: "frontend";
 
   description?: string | undefined;
   parameters: StandardSchemaV1<TArgs> | JSONSchema7;
   disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
+  execute: ToolExecuteFunction<TArgs, TResult>;
   experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
 };
 
@@ -141,7 +141,7 @@ type HumanTool<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
 > = ToolBase<TArgs, TResult> & {
-  type?: "human" | undefined;
+  type: "human";
 
   description?: string | undefined;
   parameters: StandardSchemaV1<TArgs> | JSONSchema7;
@@ -156,4 +156,17 @@ export type Tool<
 > =
   | FrontendTool<TArgs, TResult>
   | BackendTool<TArgs, TResult>
-  | HumanTool<TArgs, TResult>;
+  | HumanTool<TArgs, TResult>
+  | ToolWithoutType<TArgs, TResult>;
+
+/**
+ * @deprecated Use `Tool` with an explicit `type` field instead.
+ */
+export type ToolWithoutType<
+  TArgs extends Record<string, unknown> = Record<string, unknown>,
+  TResult = unknown,
+> = (
+  | Omit<FrontendTool<TArgs, TResult>, "type">
+  | Omit<BackendTool<TArgs, TResult>, "type">
+  | Omit<HumanTool<TArgs, TResult>, "type">
+) & { type?: undefined };

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -1,12 +1,16 @@
 import type { Tool } from "assistant-stream";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
 
+type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
+  type: "frontend" | "human";
+}
+  ? T & { render: ToolCallMessagePartComponent<TArgs, TResult> }
+  : T & { render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined };
+
 export type ToolDefinition<
   TArgs extends Record<string, unknown>,
   TResult,
-> = Tool<TArgs, TResult> & {
-  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
-};
+> = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
 
 export type Toolkit = Record<string, ToolDefinition<any, any>>;
 

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useToolInvocations.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useToolInvocations.test.ts
@@ -4,8 +4,9 @@ import type { ThreadAssistantMessage } from "@assistant-ui/core";
 import type { Tool } from "assistant-stream";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { AssistantTransportState, ToolExecutionStatus } from "./types";
-import { useToolInvocations } from "./useToolInvocations";
+import type { AssistantTransportState } from "./types";
+import { ToolExecutionStatus, useToolInvocations } from "./useToolInvocations";
+import { ReadonlyJSONObject } from "assistant-stream/utils";
 
 const createState = (
   messages: ThreadAssistantMessage[],
@@ -34,7 +35,7 @@ const createAssistantMessage = (
       type: "tool-call",
       toolCallId: "tool-1",
       toolName: "weatherSearch",
-      args,
+      args: args as ReadonlyJSONObject,
       argsText,
     },
   ],
@@ -45,6 +46,7 @@ describe("useToolInvocations", () => {
     const execute = vi.fn(async () => ({ forecast: "ok" }));
     const getTools = () => ({
       weatherSearch: {
+        parameters: { type: "object", properties: {} },
         execute,
       } satisfies Tool,
     });
@@ -137,6 +139,7 @@ describe("useToolInvocations", () => {
     );
     const getTools = () => ({
       weatherSearch: {
+        parameters: { type: "object", properties: {} },
         execute,
       } satisfies Tool,
     });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor tool types to make `type` mandatory and update related tests and files for compatibility.
> 
>   - **Tool Types**:
>     - Make `type` field mandatory for `FrontendTool`, `BackendTool`, and `HumanTool` in `tool-types.ts`.
>     - Introduce `ToolWithoutType` type for backward compatibility, marked as deprecated.
>   - **Tests**:
>     - Update `schema-utils.test.ts` to include `execute` function for tools.
>     - Update `useToolInvocations.test.ts` to use `ReadonlyJSONObject` for tool arguments.
>   - **Misc**:
>     - Modify `toolbox.ts` to use `WithRender` type for `ToolDefinition` to handle `render` property based on tool type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 6f44035ce62b375e1f24d88870bddfbf72e7464c. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->