### PR TITLE
fix(react-langgraph): normalize messages-tuple events

### DIFF
--- a/.changeset/swift-owls-share.md
+++ b/.changeset/swift-owls-share.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix(react-langgraph): normalize messages-tuple events for Python LangGraph compatibility

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -61,7 +61,8 @@ export const appendLangChainChunk = (
   const newToolCalls = [...(prev.tool_calls ?? [])];
   for (const chunk of curr.tool_call_chunks ?? []) {
     const existing = newToolCalls[chunk.index - 1] ?? { partial_json: "" };
-    const partialJson = existing.partial_json + chunk.args;
+    const partialJson =
+      existing.partial_json + (chunk.args ?? chunk.args_json ?? "");
     newToolCalls[chunk.index - 1] = {
       ...chunk,
       ...existing,

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -90,4 +90,41 @@ describe("convertLangChainMessages metadata", () => {
       metadata: { custom: {} },
     });
   });
+
+  it("uses args_json fallback for tool call args text", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: [
+        {
+          id: "tool-1",
+          name: "fetch_page_content",
+          args: {},
+        },
+      ],
+      tool_call_chunks: [
+        {
+          id: "tool-1",
+          index: 1,
+          name: "fetch_page_content",
+          args_json: '{"url":"https://example.com"}',
+        },
+      ],
+    });
+
+    if (!("content" in result)) {
+      throw new Error("Expected assistant message content");
+    }
+    const toolCallPart = result.content.find(
+      (part) => part.type === "tool-call",
+    );
+    expect(toolCallPart).toMatchObject({
+      type: "tool-call",
+      toolCallId: "tool-1",
+      toolName: "fetch_page_content",
+      args: { url: "https://example.com" },
+      argsText: '{"url":"https://example.com"}',
+    });
+  });
 });

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -119,9 +119,13 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
     case "ai":
       const toolCallParts =
         message.tool_calls?.map((chunk): ToolCallMessagePart => {
+          const matchingToolCallChunk = message.tool_call_chunks?.find(
+            (c) => c.id === chunk.id,
+          );
           const argsText =
             chunk.partial_json ??
-            message.tool_call_chunks?.find((c) => c.id === chunk.id)?.args ??
+            matchingToolCallChunk?.args ??
+            matchingToolCallChunk?.args_json ??
             JSON.stringify(chunk.args);
 
           return {

--- a/packages/react-langgraph/src/normalizeLangGraphTupleMessage.ts
+++ b/packages/react-langgraph/src/normalizeLangGraphTupleMessage.ts
@@ -1,0 +1,110 @@
+import {
+  LangChainMessage,
+  LangChainMessageChunk,
+  LangChainToolCallChunk,
+} from "./types";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object";
+
+const normalizeToolCallChunk = (
+  value: unknown,
+): LangChainToolCallChunk | null => {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.id !== "string" ||
+    typeof value.name !== "string" ||
+    typeof value.index !== "number"
+  ) {
+    return null;
+  }
+
+  const args =
+    typeof value.args === "string"
+      ? value.args
+      : typeof value.args_json === "string"
+        ? value.args_json
+        : "";
+
+  return {
+    ...(value as LangChainToolCallChunk),
+    args,
+  };
+};
+
+const normalizeLangChainMessageChunk = (
+  value: Record<string, unknown>,
+): LangChainMessageChunk | null => {
+  if (value.type !== "AIMessageChunk" && value.type !== "ai") return null;
+  if (value.id !== undefined && typeof value.id !== "string") return null;
+  if (
+    value.content !== undefined &&
+    typeof value.content !== "string" &&
+    !Array.isArray(value.content)
+  ) {
+    return null;
+  }
+  if (
+    value.tool_call_chunks !== undefined &&
+    !Array.isArray(value.tool_call_chunks)
+  ) {
+    return null;
+  }
+
+  const normalizedToolCallChunks = value.tool_call_chunks?.flatMap((chunk) => {
+    const normalized = normalizeToolCallChunk(chunk);
+    return normalized ? [normalized] : [];
+  });
+
+  return {
+    ...(value as LangChainMessageChunk),
+    type: "AIMessageChunk",
+    ...(normalizedToolCallChunks && {
+      tool_call_chunks: normalizedToolCallChunks,
+    }),
+  };
+};
+
+const isLangChainMessage = (
+  value: Record<string, unknown>,
+): value is LangChainMessage => {
+  return (
+    value.type === "system" ||
+    value.type === "human" ||
+    value.type === "tool" ||
+    value.type === "ai"
+  );
+};
+
+export type NormalizedLangGraphTupleMessage =
+  | {
+      kind: "chunk";
+      message: LangChainMessageChunk;
+    }
+  | {
+      kind: "message";
+      message: LangChainMessage;
+    };
+
+export const normalizeLangGraphTupleMessage = (
+  value: unknown,
+): NormalizedLangGraphTupleMessage | null => {
+  if (!isRecord(value)) return null;
+
+  const normalizedChunk = normalizeLangChainMessageChunk(value);
+  if (normalizedChunk) {
+    return {
+      kind: "chunk",
+      message: normalizedChunk,
+    };
+  }
+
+  if (isLangChainMessage(value)) {
+    return {
+      kind: "message",
+      message: value,
+    };
+  }
+
+  return null;
+};

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -5,7 +5,8 @@ export type LangChainToolCallChunk = {
   index: number;
   id: string;
   name: string;
-  args: string;
+  args?: string;
+  args_json?: string;
 };
 
 export type LangChainToolCall = {
@@ -147,7 +148,7 @@ export type LangGraphTupleMetadata = Record<string, unknown>;
 
 export type LangChainMessageTupleEvent = {
   event: LangGraphKnownEventTypes.Messages;
-  data: [LangChainMessageChunk, LangGraphTupleMetadata];
+  data: [LangChainMessage | LangChainMessageChunk, LangGraphTupleMetadata];
 };
 
 export type OnMessageChunkCallback = (


### PR DESCRIPTION
This PR normalizes `messages-tuple` events for Python LangGraph compatibility.

close #3431
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Normalize `messages-tuple` events for Python LangGraph compatibility, using `args_json` as a fallback for tool call arguments.
> 
>   - **Behavior**:
>     - Normalizes `messages-tuple` events for Python LangGraph compatibility in `useLangGraphMessages.ts`.
>     - Uses `args_json` as a fallback for tool call arguments in `appendLangChainChunk.ts` and `convertLangChainMessages.ts`.
>   - **Functions**:
>     - Adds `normalizeLangGraphTupleMessage` to handle normalization of tuple messages in `normalizeLangGraphTupleMessage.ts`.
>     - Updates `convertLangChainMessages` to use `args_json` fallback.
>   - **Tests**:
>     - Adds tests for `args_json` fallback and message normalization in `convertLangChainMessages.test.ts` and `useLangGraphMessages.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for cdb8215e3a640d6965536fa8c223ea41080d69c9. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->