### PR TITLE
fix: DataRenderers not in scope

### DIFF
--- a/.changeset/wise-cars-jump.md
+++ b/.changeset/wise-cars-jump.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+fix: DataRenderers not in scope

--- a/packages/core/src/react/RuntimeAdapter.ts
+++ b/packages/core/src/react/RuntimeAdapter.ts
@@ -5,7 +5,7 @@ import {
   baseRuntimeAdapterTransformScopes,
 } from "../store/internal";
 import { attachTransformScopes } from "@assistant-ui/store";
-import { Tools } from "./model-context";
+import { DataRenderers, Tools } from "./model-context";
 
 export const RuntimeAdapter = resource((runtime: AssistantRuntime) =>
   tapResource(RuntimeAdapterResource(runtime)),
@@ -16,6 +16,10 @@ attachTransformScopes(RuntimeAdapter, (scopes, parent) => {
 
   if (!result.tools && parent.tools.source === null) {
     result.tools = Tools({});
+  }
+
+  if (!result.dataRenderers && parent.dataRenderers.source === null) {
+    result.dataRenderers = DataRenderers();
   }
 
   return result;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes scoping issue for `DataRenderers` in `RuntimeAdapter.ts` by initializing it when not present and parent source is null.
> 
>   - **Behavior**:
>     - Fixes scoping issue for `DataRenderers` in `RuntimeAdapter.ts` by initializing it when not present and `parent.dataRenderers.source` is null.
>   - **Imports**:
>     - Adds `DataRenderers` to imports in `RuntimeAdapter.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 9fa4befe9f681c84a42d3b649e8fb454616d6921. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->