### PR TITLE
docs: share layouts between tap and main docs

### DIFF
--- a/apps/docs/app/docs/layout.tsx
+++ b/apps/docs/app/docs/layout.tsx
@@ -1,61 +1,11 @@
-import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import type { ReactNode } from "react";
-import { sharedDocsOptions } from "@/lib/layout.shared";
 import { source } from "@/lib/source";
-import { SidebarTabs } from "@/components/docs/layout/sidebar-tabs";
-import { getSidebarTabs } from "@/components/docs/layout/sidebar-tabs.server";
-import { DocsHeader } from "@/components/docs/layout/docs-header";
-import {
-  DocsSidebarProvider,
-  DocsSidebar,
-} from "@/components/docs/contexts/sidebar";
-import { SidebarContent } from "@/components/docs/layout/sidebar-content";
-import { AssistantPanelProvider } from "@/components/docs/assistant/context";
-import {
-  DocsContent,
-  DocsAssistantPanel,
-} from "@/components/docs/layout/docs-layout";
-import { DocsRuntimeProvider } from "@/contexts/DocsRuntimeProvider";
-import { DocsAssistantRuntimeProvider } from "@/contexts/AssistantRuntimeProvider";
-import { CurrentPageProvider } from "@/components/docs/contexts/current-page";
-import { FloatingComposer } from "@/components/docs/assistant/floating-composer";
+import { DocsRootLayout } from "@/components/docs/layout/docs-root-layout";
 
 export default function Layout({ children }: { children: ReactNode }) {
-  const tabs = getSidebarTabs(source.pageTree);
-
   return (
-    <CurrentPageProvider>
-      <AssistantPanelProvider>
-        <DocsRuntimeProvider>
-          <DocsSidebarProvider>
-            <DocsHeader section="Docs" sectionHref="/docs" />
-            <DocsContent>
-              <DocsLayout
-                {...sharedDocsOptions}
-                tree={source.pageTree}
-                nav={{ enabled: false }}
-                sidebar={{
-                  ...sharedDocsOptions.sidebar,
-                  tabs: false,
-                  banner: <SidebarTabs tabs={tabs} />,
-                }}
-              >
-                {children}
-              </DocsLayout>
-            </DocsContent>
-            <DocsSidebar>
-              <SidebarContent
-                tree={source.pageTree}
-                banner={<SidebarTabs tabs={tabs} />}
-              />
-            </DocsSidebar>
-          </DocsSidebarProvider>
-        </DocsRuntimeProvider>
-        <DocsAssistantRuntimeProvider>
-          <DocsAssistantPanel />
-          <FloatingComposer />
-        </DocsAssistantRuntimeProvider>
-      </AssistantPanelProvider>
-    </CurrentPageProvider>
+    <DocsRootLayout tree={source.pageTree} section="Docs" sectionHref="/docs">
+      {children}
+    </DocsRootLayout>
   );
 }

--- a/apps/docs/app/tap/docs/layout.tsx
+++ b/apps/docs/app/tap/docs/layout.tsx
@@ -1,59 +1,15 @@
-import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import type { ReactNode } from "react";
 import { tapDocs } from "@/lib/source";
-import { getSidebarTabs } from "@/components/docs/layout/sidebar-tabs.server";
-import { AssistantPanelProvider } from "@/components/docs/assistant/context";
-import { DocsRuntimeProvider } from "@/contexts/DocsRuntimeProvider";
-import {
-  DocsSidebar,
-  DocsSidebarProvider,
-} from "@/components/docs/contexts/sidebar";
-import { DocsHeader } from "@/components/docs/layout/docs-header";
-import {
-  DocsAssistantPanel,
-  DocsContent,
-} from "@/components/docs/layout/docs-layout";
-import { sharedDocsOptions } from "@/lib/layout.shared";
-import { SidebarTabs } from "@/components/docs/layout/sidebar-tabs";
-import { CurrentPageProvider } from "@/components/docs/contexts/current-page";
-import { SidebarContent } from "@/components/docs/layout/sidebar-content";
-import { DocsAssistantRuntimeProvider } from "@/contexts/AssistantRuntimeProvider";
+import { DocsRootLayout } from "@/components/docs/layout/docs-root-layout";
 
 export default function Layout({ children }: { children: ReactNode }) {
-  const tabs = getSidebarTabs(tapDocs.pageTree);
-
   return (
-    <CurrentPageProvider>
-      <AssistantPanelProvider>
-        <DocsRuntimeProvider>
-          <DocsSidebarProvider>
-            <DocsHeader section="Tap Docs" sectionHref="/tap/docs" />
-            <DocsContent>
-              <DocsLayout
-                {...sharedDocsOptions}
-                tree={tapDocs.pageTree}
-                nav={{ enabled: false }}
-                sidebar={{
-                  ...sharedDocsOptions.sidebar,
-                  tabs: false,
-                  banner: <SidebarTabs tabs={tabs} />,
-                }}
-              >
-                {children}
-              </DocsLayout>
-            </DocsContent>
-            <DocsSidebar>
-              <SidebarContent
-                tree={tapDocs.pageTree}
-                banner={<SidebarTabs tabs={tabs} />}
-              />
-            </DocsSidebar>
-          </DocsSidebarProvider>
-        </DocsRuntimeProvider>
-        <DocsAssistantRuntimeProvider>
-          <DocsAssistantPanel />
-        </DocsAssistantRuntimeProvider>
-      </AssistantPanelProvider>
-    </CurrentPageProvider>
+    <DocsRootLayout
+      tree={tapDocs.pageTree}
+      section="Tap Docs"
+      sectionHref="/tap/docs"
+    >
+      {children}
+    </DocsRootLayout>
   );
 }

--- a/apps/docs/components/docs/layout/docs-root-layout.tsx
+++ b/apps/docs/components/docs/layout/docs-root-layout.tsx
@@ -1,0 +1,73 @@
+import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import type { PageTree } from "fumadocs-core/server";
+import type { ReactNode } from "react";
+import { sharedDocsOptions } from "@/lib/layout.shared";
+import { SidebarTabs } from "@/components/docs/layout/sidebar-tabs";
+import { getSidebarTabs } from "@/components/docs/layout/sidebar-tabs.server";
+import { DocsHeader } from "@/components/docs/layout/docs-header";
+import {
+  DocsSidebarProvider,
+  DocsSidebar,
+} from "@/components/docs/contexts/sidebar";
+import { SidebarContent } from "@/components/docs/layout/sidebar-content";
+import { AssistantPanelProvider } from "@/components/docs/assistant/context";
+import {
+  DocsContent,
+  DocsAssistantPanel,
+} from "@/components/docs/layout/docs-layout";
+import { DocsRuntimeProvider } from "@/contexts/DocsRuntimeProvider";
+import { DocsAssistantRuntimeProvider } from "@/contexts/AssistantRuntimeProvider";
+import { CurrentPageProvider } from "@/components/docs/contexts/current-page";
+import { FloatingComposer } from "@/components/docs/assistant/floating-composer";
+
+type DocsRootLayoutProps = {
+  tree: PageTree.Root;
+  section: string;
+  sectionHref: string;
+  children: ReactNode;
+};
+
+export function DocsRootLayout({
+  tree,
+  section,
+  sectionHref,
+  children,
+}: DocsRootLayoutProps) {
+  const tabs = getSidebarTabs(tree);
+
+  return (
+    <CurrentPageProvider>
+      <AssistantPanelProvider>
+        <DocsRuntimeProvider>
+          <DocsSidebarProvider>
+            <DocsHeader section={section} sectionHref={sectionHref} />
+            <DocsContent>
+              <DocsLayout
+                {...sharedDocsOptions}
+                tree={tree}
+                nav={{ enabled: false }}
+                sidebar={{
+                  ...sharedDocsOptions.sidebar,
+                  tabs: false,
+                  banner: <SidebarTabs tabs={tabs} />,
+                }}
+              >
+                {children}
+              </DocsLayout>
+            </DocsContent>
+            <DocsSidebar>
+              <SidebarContent
+                tree={tree}
+                banner={<SidebarTabs tabs={tabs} />}
+              />
+            </DocsSidebar>
+          </DocsSidebarProvider>
+        </DocsRuntimeProvider>
+        <DocsAssistantRuntimeProvider>
+          <DocsAssistantPanel />
+          <FloatingComposer />
+        </DocsAssistantRuntimeProvider>
+      </AssistantPanelProvider>
+    </CurrentPageProvider>
+  );
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor documentation layouts by introducing a shared `DocsRootLayout` component for main and tap docs.
> 
>   - **Refactor**:
>     - Introduce `DocsRootLayout` in `docs-root-layout.tsx` to encapsulate shared layout logic for documentation pages.
>     - Replace existing layout logic in `apps/docs/app/docs/layout.tsx` and `apps/docs/app/tap/docs/layout.tsx` with `DocsRootLayout`.
>   - **Behavior**:
>     - `DocsRootLayout` handles sidebar tabs, header, and assistant panel setup for both main and tap docs.
>     - Maintains existing functionality with a more streamlined code structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 357d69e91eafd5f3f9206769c2bbac8310389725. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->