### PR TITLE
fix(homepage): fix composer action colors and spacing in shadcn demo

### DIFF
--- a/apps/docs/components/examples/shadcn.tsx
+++ b/apps/docs/components/examples/shadcn.tsx
@@ -287,7 +287,7 @@ const Composer: FC = () => {
 
 const ComposerAction: FC = () => {
   return (
-    <div className="aui-composer-action-wrapper relative mx-2 mb-2 flex items-center justify-between">
+    <div className="aui-composer-action-wrapper relative mx-1 mb-1.75 flex items-center justify-between">
       <ComposerAddAttachment />
       <AuiIf condition={(s) => !s.thread.isRunning}>
         <ComposerPrimitive.Send asChild>
@@ -525,7 +525,7 @@ export const Shadcn: FC = () => {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   return (
-    <div className="flex h-full w-full bg-background [--primary-foreground:0_0%_98%] [--primary:0_0%_9%] dark:[--primary-foreground:0_0%_9%] dark:[--primary:0_0%_98%]">
+    <div className="flex h-full w-full bg-background">
       <div className="hidden md:block">
         <Sidebar collapsed={sidebarCollapsed} />
       </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes UI spacing in `ComposerAction` and removes custom CSS variables in `Shadcn` component.
> 
>   - **UI Adjustments**:
>     - Update `ComposerAction` component spacing by changing `mx-2 mb-2` to `mx-1 mb-1.75`.
>     - Remove custom CSS variables for `--primary-foreground` and `--primary` in `Shadcn` component's main `div`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for eccd33478a98615953697e18334f587193954460. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->