### PR TITLE
fix(react): tool call results

### DIFF
--- a/.changeset/six-apricots-smile.md
+++ b/.changeset/six-apricots-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): avoid crashing when external message conversion receives orphaned tool results without a matching tool call.

--- a/.changeset/tall-maps-try.md
+++ b/.changeset/tall-maps-try.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix(react-langgraph): preserve tuple-stream accumulated messages by skipping updates snapshot replacement after tuple message events.

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -125,6 +125,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
         },
       });
 
+      let hasTupleMessageEvents = false;
       for await (const chunk of response) {
         switch (chunk.event) {
           case LangGraphKnownEventTypes.MessagesPartial:
@@ -133,7 +134,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
             break;
           case LangGraphKnownEventTypes.Updates:
             onUpdates?.(chunk.data);
-            if (Array.isArray(chunk.data.messages)) {
+            if (Array.isArray(chunk.data.messages) && !hasTupleMessageEvents) {
               setMessagesImmediate(
                 accumulator.replaceMessages(chunk.data.messages),
               );
@@ -144,6 +145,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
             onValues?.(chunk.data);
             break;
           case LangGraphKnownEventTypes.Messages: {
+            hasTupleMessageEvents = true;
             const [tupleMessage, tupleMetadata] = (
               chunk as LangChainMessageTupleEvent
             ).data;

--- a/packages/react/src/legacy-runtime/runtime-cores/external-store/external-message-converter.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/external-store/external-message-converter.ts
@@ -77,6 +77,8 @@ const joinExternalMessages = (
       const toolCallIdx = assistantMessage.content.findIndex(
         (c) => c.type === "tool-call" && c.toolCallId === output.toolCallId,
       );
+      // Ignore orphaned tool results so one bad tool message does not
+      // prevent rendering the rest of the conversation.
       if (toolCallIdx !== -1) {
         const toolCall = assistantMessage.content[
           toolCallIdx
@@ -100,10 +102,6 @@ const joinExternalMessages = (
           isError: output.isError,
           messages: output.messages,
         };
-      } else {
-        throw new Error(
-          `Tool call ${output.toolCallId} ${output.toolName} not found in assistant message`,
-        );
       }
     } else {
       const role = output.role;


### PR DESCRIPTION
close #3436
close #3435
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes handling of orphaned tool results and preserves tuple-stream messages in React components.
> 
>   - **Behavior**:
>     - In `external-message-converter.ts`, orphaned tool results are ignored instead of causing errors, allowing the conversation to continue rendering.
>     - In `useLangGraphMessages.ts`, tuple-stream accumulated messages are preserved by skipping updates snapshot replacement after tuple message events.
>   - **Tests**:
>     - Added test in `useLangGraphMessages.test.ts` to verify tuple-accumulated messages are not replaced by updates snapshots.
>     - Added test in `external-message-converter.test.ts` to ensure orphaned tool results are ignored without throwing errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 4973ccd07d448d53e6a642f36f438cbfd23b0e8a. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->