### PR TITLE
pr/01-fix-cloud-template-url

### DIFF
--- a/.changeset/loud-cheetahs-repair.md
+++ b/.changeset/loud-cheetahs-repair.md
@@ -1,0 +1,7 @@
+---
+"assistant-ui": patch
+"create-assistant-ui": patch
+---
+
+fix(create): point the `cloud` template to the valid
+`assistant-ui-starter-cloud` repository in both CLIs and aligned tests.

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -19,7 +19,7 @@ const templates = {
     hint: "Bare-bones starting point",
   },
   cloud: {
-    url: "https://github.com/assistant-ui/assistant-cloud-starter",
+    url: "https://github.com/assistant-ui/assistant-ui-starter-cloud",
     label: "Cloud",
     hint: "Cloud-backed persistence starter",
   },

--- a/packages/cli/test/commands/create.test.ts
+++ b/packages/cli/test/commands/create.test.ts
@@ -70,7 +70,7 @@ describe("create command template resolution", () => {
     const args = buildCreateNextAppArgs({
       projectDirectory: "my-app",
       usePnpm: true,
-      templateUrl: "https://github.com/assistant-ui/assistant-cloud-starter",
+      templateUrl: "https://github.com/assistant-ui/assistant-ui-starter-cloud",
     });
 
     expect(args).toEqual([
@@ -78,7 +78,7 @@ describe("create command template resolution", () => {
       "my-app",
       "--use-pnpm",
       "-e",
-      "https://github.com/assistant-ui/assistant-cloud-starter",
+      "https://github.com/assistant-ui/assistant-ui-starter-cloud",
     ]);
   });
 

--- a/packages/create-assistant-ui/src/index.ts
+++ b/packages/create-assistant-ui/src/index.ts
@@ -18,7 +18,7 @@ const templates = {
     hint: "Bare-bones starting point",
   },
   cloud: {
-    url: "https://github.com/assistant-ui/assistant-cloud-starter",
+    url: "https://github.com/assistant-ui/assistant-ui-starter-cloud",
     label: "Cloud",
     hint: "Cloud-backed persistence starter",
   },


### PR DESCRIPTION
- Fix template URL in create-assistant-ui package to point to https://github.com/assistant-ui/assistant-ui-starter-cloud.
- Update the CLI create command templates to use the corrected URL.
- Adjust unit test expected args to reflect the new template URL.

This ensures the cloud starter template references the proper repo sonew projects are initialized from the correct repository.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes cloud template URL in `create-assistant-ui` package to ensure correct repository initialization.
> 
>   - **Behavior**:
>     - Fixes cloud template URL in `create-assistant-ui` package to `https://github.com/assistant-ui/assistant-ui-starter-cloud` in `create.ts` and `index.ts`.
>     - Updates CLI create command to use the corrected URL.
>   - **Tests**:
>     - Adjusts unit test expected args in `create.test.ts` to reflect the new template URL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 34c126d1666c80c81731051f554fd3c7bffcbf20. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #3461 
- <kbd>&nbsp;2&nbsp;</kbd> #3460 
- <kbd>&nbsp;1&nbsp;</kbd> #3459 👈 
<!-- GitButler Footer Boundary Bottom -->

