### PR TITLE
pr/03-scaffold-catalog

### DIFF
--- a/.changeset/eager-students-jog.md
+++ b/.changeset/eager-students-jog.md
@@ -1,0 +1,6 @@
+---
+"assistant-ui": patch
+---
+
+refactor(create): consolidate template and example scaffold metadata into a
+single catalog used by create flows while preserving latest-source behavior.

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -3,55 +3,16 @@ import chalk from "chalk";
 import { spawn } from "cross-spawn";
 import path from "node:path";
 import * as p from "@clack/prompts";
+import {
+  exampleNames,
+  isTemplateName,
+  resolveTemplateSourceUrl,
+  templateNames,
+  templatePickerOptions,
+  type TemplateName,
+} from "../lib/scaffold-catalog";
 import { logger } from "../lib/utils/logger";
 import { createFromExample } from "../lib/create-from-example";
-
-// Keep in sync with packages/create-assistant-ui/src/index.ts
-const templates = {
-  default: {
-    url: "https://github.com/assistant-ui/assistant-ui-starter",
-    label: "Default",
-    hint: "Default template with Vercel AI SDK",
-  },
-  minimal: {
-    url: "https://github.com/assistant-ui/assistant-ui-starter-minimal",
-    label: "Minimal",
-    hint: "Bare-bones starting point",
-  },
-  cloud: {
-    url: "https://github.com/assistant-ui/assistant-ui-starter-cloud",
-    label: "Cloud",
-    hint: "Cloud-backed persistence starter",
-  },
-  "cloud-clerk": {
-    url: "https://github.com/assistant-ui/assistant-ui-starter-cloud-clerk",
-    label: "Cloud + Clerk",
-    hint: "Cloud-backed starter with Clerk auth",
-  },
-  langgraph: {
-    url: "https://github.com/assistant-ui/assistant-ui-starter-langgraph",
-    label: "LangGraph",
-    hint: "LangGraph starter template",
-  },
-  mcp: {
-    url: "https://github.com/assistant-ui/assistant-ui-starter-mcp",
-    label: "MCP",
-    hint: "MCP starter template",
-  },
-} as const;
-
-type TemplateName = keyof typeof templates;
-const templateNames = Object.keys(templates) as TemplateName[];
-
-const templatePickerOptions: Array<{
-  value: TemplateName;
-  label: string;
-  hint: string;
-}> = templateNames.map((name) => ({
-  value: name,
-  label: templates[name].label,
-  hint: templates[name].hint,
-}));
 
 export async function resolveCreateTemplateName(params: {
   template?: string;
@@ -174,7 +135,7 @@ export const create = new Command()
   )
   .option(
     "-e, --example <example>",
-    "create from an example (e.g., with-langgraph, with-ai-sdk-v6)",
+    `create from an example (${exampleNames.join(", ")})`,
   )
   .option(
     "-p, --preset <url>",
@@ -226,13 +187,13 @@ export const create = new Command()
       process.exit(0);
     }
 
-    const templateUrl = templates[templateName]?.url;
-
-    if (!templateUrl) {
+    if (!isTemplateName(templateName)) {
       logger.error(`Unknown template: ${opts.template}`);
       logger.info(`Available templates: ${templateNames.join(", ")}`);
       process.exit(1);
     }
+
+    const templateUrl = resolveTemplateSourceUrl(templateName);
 
     logger.info(`Creating project with template: ${templateName}`);
     logger.break();

--- a/packages/cli/src/lib/create-from-example.ts
+++ b/packages/cli/src/lib/create-from-example.ts
@@ -3,6 +3,12 @@ import * as path from "node:path";
 import { spawn } from "node:child_process";
 import { sync as globSync } from "glob";
 import { detect } from "detect-package-manager";
+import {
+  exampleNames,
+  isExampleName,
+  resolveExampleSourceSpecifier,
+  type ExampleName,
+} from "./scaffold-catalog";
 import { logger } from "./utils/logger";
 
 export interface CreateFromExampleOptions {
@@ -13,35 +19,19 @@ export interface CreateFromExampleOptions {
   useBun?: boolean;
 }
 
-const VALID_EXAMPLES = [
-  "with-ag-ui",
-  "with-ai-sdk-v6",
-  "with-artifacts",
-  "with-assistant-transport",
-  "with-chain-of-thought",
-  "with-cloud",
-  "with-custom-thread-list",
-  "with-elevenlabs-scribe",
-  "with-external-store",
-  "with-ffmpeg",
-  "with-langgraph",
-  "with-parent-id-grouping",
-  "with-react-hook-form",
-  "with-react-router",
-  "with-tanstack",
-];
-
 export async function createFromExample(
   projectDir: string,
   exampleName: string,
   opts: CreateFromExampleOptions,
 ): Promise<void> {
   // 1. Validate example name
-  if (!VALID_EXAMPLES.includes(exampleName)) {
+  if (!isExampleName(exampleName)) {
     logger.error(`Unknown example: ${exampleName}`);
-    logger.info(`Available examples: ${VALID_EXAMPLES.join(", ")}`);
+    logger.info(`Available examples: ${exampleNames.join(", ")}`);
     process.exit(1);
   }
+
+  const validExampleName = exampleName;
 
   const absoluteProjectDir = path.resolve(projectDir);
 
@@ -54,12 +44,12 @@ export async function createFromExample(
     }
   }
 
-  logger.info(`Creating project from example: ${exampleName}`);
+  logger.info(`Creating project from example: ${validExampleName}`);
   logger.break();
 
   // 2. Download example using degit
   logger.step("Downloading example...");
-  await downloadExample(exampleName, absoluteProjectDir);
+  await downloadExample(validExampleName, absoluteProjectDir);
 
   // 3. Transform package.json
   logger.step("Transforming package.json...");
@@ -118,10 +108,10 @@ export async function createFromExample(
 }
 
 async function downloadExample(
-  exampleName: string,
+  exampleName: ExampleName,
   destDir: string,
 ): Promise<void> {
-  const degitPath = `assistant-ui/assistant-ui/examples/${exampleName}`;
+  const degitPath = resolveExampleSourceSpecifier(exampleName);
 
   return new Promise((resolve, reject) => {
     const child = spawn("npx", ["degit", degitPath, destDir, "--force"], {

--- a/packages/cli/src/lib/scaffold-catalog.ts
+++ b/packages/cli/src/lib/scaffold-catalog.ts
@@ -1,0 +1,164 @@
+interface ScaffoldCatalogEntry {
+  label: string;
+  hint: string;
+  sourcePath: string;
+}
+
+export const scaffoldCatalog = {
+  templates: {
+    default: {
+      label: "Default",
+      hint: "Default template with Vercel AI SDK",
+      sourcePath: "assistant-ui/assistant-ui-starter",
+    },
+    minimal: {
+      label: "Minimal",
+      hint: "Bare-bones starting point",
+      sourcePath: "assistant-ui/assistant-ui-starter-minimal",
+    },
+    cloud: {
+      label: "Cloud",
+      hint: "Cloud-backed persistence starter",
+      sourcePath: "assistant-ui/assistant-ui-starter-cloud",
+    },
+    "cloud-clerk": {
+      label: "Cloud + Clerk",
+      hint: "Cloud-backed starter with Clerk auth",
+      sourcePath: "assistant-ui/assistant-ui-starter-cloud-clerk",
+    },
+    langgraph: {
+      label: "LangGraph",
+      hint: "LangGraph starter template",
+      sourcePath: "assistant-ui/assistant-ui-starter-langgraph",
+    },
+    mcp: {
+      label: "MCP",
+      hint: "MCP starter template",
+      sourcePath: "assistant-ui/assistant-ui-starter-mcp",
+    },
+  },
+  examples: {
+    "with-ag-ui": {
+      label: "AG-UI",
+      hint: "AG-UI protocol integration example",
+      sourcePath: "examples/with-ag-ui",
+    },
+    "with-ai-sdk-v6": {
+      label: "AI SDK v6",
+      hint: "Vercel AI SDK v6 integration example",
+      sourcePath: "examples/with-ai-sdk-v6",
+    },
+    "with-artifacts": {
+      label: "Artifacts",
+      hint: "Artifacts and generated output example",
+      sourcePath: "examples/with-artifacts",
+    },
+    "with-assistant-transport": {
+      label: "Assistant Transport",
+      hint: "Assistant transport protocol example",
+      sourcePath: "examples/with-assistant-transport",
+    },
+    "with-chain-of-thought": {
+      label: "Chain Of Thought",
+      hint: "Chain-of-thought rendering example",
+      sourcePath: "examples/with-chain-of-thought",
+    },
+    "with-cloud": {
+      label: "Cloud",
+      hint: "Assistant Cloud integration example",
+      sourcePath: "examples/with-cloud",
+    },
+    "with-custom-thread-list": {
+      label: "Custom Thread List",
+      hint: "Custom thread list UI example",
+      sourcePath: "examples/with-custom-thread-list",
+    },
+    "with-elevenlabs-scribe": {
+      label: "ElevenLabs Scribe",
+      hint: "ElevenLabs Scribe integration example",
+      sourcePath: "examples/with-elevenlabs-scribe",
+    },
+    "with-external-store": {
+      label: "External Store",
+      hint: "External store runtime example",
+      sourcePath: "examples/with-external-store",
+    },
+    "with-ffmpeg": {
+      label: "FFmpeg",
+      hint: "Audio/video processing with FFmpeg example",
+      sourcePath: "examples/with-ffmpeg",
+    },
+    "with-langgraph": {
+      label: "LangGraph",
+      hint: "LangGraph integration example",
+      sourcePath: "examples/with-langgraph",
+    },
+    "with-parent-id-grouping": {
+      label: "Parent ID Grouping",
+      hint: "Parent-id grouping behavior example",
+      sourcePath: "examples/with-parent-id-grouping",
+    },
+    "with-react-hook-form": {
+      label: "React Hook Form",
+      hint: "React Hook Form integration example",
+      sourcePath: "examples/with-react-hook-form",
+    },
+    "with-react-router": {
+      label: "React Router",
+      hint: "React Router integration example",
+      sourcePath: "examples/with-react-router",
+    },
+    "with-tanstack": {
+      label: "TanStack",
+      hint: "TanStack integration example",
+      sourcePath: "examples/with-tanstack",
+    },
+  },
+} as const satisfies {
+  templates: Record<string, ScaffoldCatalogEntry>;
+  examples: Record<string, ScaffoldCatalogEntry>;
+};
+
+export type TemplateName = keyof typeof scaffoldCatalog.templates;
+export type ExampleName = keyof typeof scaffoldCatalog.examples;
+
+export const templateNames = Object.keys(
+  scaffoldCatalog.templates,
+) as TemplateName[];
+
+export const exampleNames = Object.keys(
+  scaffoldCatalog.examples,
+) as ExampleName[];
+
+export const templatePickerOptions: Array<{
+  value: TemplateName;
+  label: string;
+  hint: string;
+}> = templateNames.map((name) => {
+  const template = scaffoldCatalog.templates[name];
+  return {
+    value: name,
+    label: template.label,
+    hint: template.hint,
+  };
+});
+
+export function isTemplateName(value: string): value is TemplateName {
+  return Object.hasOwn(scaffoldCatalog.templates, value);
+}
+
+export function isExampleName(value: string): value is ExampleName {
+  return Object.hasOwn(scaffoldCatalog.examples, value);
+}
+
+export function resolveTemplateSourceUrl(templateName: TemplateName): string {
+  const sourcePath = scaffoldCatalog.templates[templateName].sourcePath;
+  return `https://github.com/${sourcePath}`;
+}
+
+export function resolveExampleSourceSpecifier(
+  exampleName: ExampleName,
+): string {
+  const sourcePath = scaffoldCatalog.examples[exampleName].sourcePath;
+  return `assistant-ui/assistant-ui/${sourcePath}`;
+}

--- a/packages/cli/test/commands/create.test.ts
+++ b/packages/cli/test/commands/create.test.ts
@@ -5,6 +5,7 @@ import {
   resolveCreateProjectDirectory,
   resolveCreateTemplateName,
 } from "../../src/commands/create";
+import { resolveTemplateSourceUrl } from "../../src/lib/scaffold-catalog";
 
 describe("create command template resolution", () => {
   it("exposes --preset option", () => {
@@ -67,10 +68,12 @@ describe("create command template resolution", () => {
   });
 
   it("builds create-next-app args from parsed create options", () => {
+    const cloudTemplateUrl = resolveTemplateSourceUrl("cloud");
+
     const args = buildCreateNextAppArgs({
       projectDirectory: "my-app",
       usePnpm: true,
-      templateUrl: "https://github.com/assistant-ui/assistant-ui-starter-cloud",
+      templateUrl: cloudTemplateUrl,
     });
 
     expect(args).toEqual([
@@ -78,7 +81,7 @@ describe("create command template resolution", () => {
       "my-app",
       "--use-pnpm",
       "-e",
-      "https://github.com/assistant-ui/assistant-ui-starter-cloud",
+      cloudTemplateUrl,
     ]);
   });
 

--- a/packages/cli/test/lib/scaffold-catalog.test.ts
+++ b/packages/cli/test/lib/scaffold-catalog.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  isExampleName,
+  isTemplateName,
+  resolveExampleSourceSpecifier,
+  resolveTemplateSourceUrl,
+  templateNames,
+} from "../../src/lib/scaffold-catalog";
+
+describe("scaffold catalog", () => {
+  it("keeps template names in the catalog", () => {
+    expect(templateNames).toContain("default");
+    expect(templateNames).toContain("cloud-clerk");
+  });
+
+  it("resolves template sources to latest starter repositories", () => {
+    expect(resolveTemplateSourceUrl("default")).toBe(
+      "https://github.com/assistant-ui/assistant-ui-starter",
+    );
+    expect(resolveTemplateSourceUrl("cloud")).toBe(
+      "https://github.com/assistant-ui/assistant-ui-starter-cloud",
+    );
+  });
+
+  it("resolves example sources to latest monorepo paths", () => {
+    expect(resolveExampleSourceSpecifier("with-langgraph")).toBe(
+      "assistant-ui/assistant-ui/examples/with-langgraph",
+    );
+  });
+
+  it("narrows scaffold names with type guards", () => {
+    expect(isTemplateName("cloud")).toBe(true);
+    expect(isTemplateName("unknown-template")).toBe(false);
+    expect(isExampleName("with-react-router")).toBe(true);
+    expect(isExampleName("unknown-example")).toBe(false);
+  });
+});


### PR DESCRIPTION
- Add ScaffoldCatalogEntry type and scaffoldCatalog constant with templates (default, minimal, cloud, cloud-clerk, langgraph, mcp)
 and examples (multiple integration and demo examples).
- Export TemplateName and ExampleName union types derived from the catalog keys and arrays (templateNames, exampleNames) for easy iteration.
- Provide helper utilities:
 - templatePickerOptions to populate UI pickers with value/label/hint.
 - isTemplateName and isExampleName type guards.
 - resolveTemplateSourceUrl and resolveExampleSourceSpecifier to compute remote source references.
- Use `as const` and satisfies checks for stronger typing and safety.

This consolidates scaffold data in one place, improves type safety,
and enables reuse of catalog metadata across CLI flows and UI forms.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #3461 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #3460 
- <kbd>&nbsp;1&nbsp;</kbd> #3459 
<!-- GitButler Footer Boundary Bottom -->

