### PR TITLE
fix(react): duplicate toolCallId parts

### DIFF
--- a/.changeset/dull-clouds-judge.md
+++ b/.changeset/dull-clouds-judge.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): duplicate `toolCallId` parts when joining consecutive assistant snapshots in the external message converter.


### PR DESCRIPTION
close #3463
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes duplicate `toolCallId` parts in assistant snapshots by merging tool calls with the same `toolCallId`.
> 
>   - **Behavior**:
>     - Fixes duplicate `toolCallId` parts when joining consecutive assistant snapshots in `external-message-converter.ts`.
>     - Merges tool calls with the same `toolCallId` across assistant messages.
>   - **Tests**:
>     - Adds test `merges duplicate toolCallId across assistant snapshots` in `convertMessage.test.ts`.
>     - Adds test `should merge duplicate tool calls by toolCallId across assistant messages` in `external-message-converter.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for e15e05cc0a68e45f2954a2654d83ebc7d395602d. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->