### PR TITLE
fix: dont change lockfile as part of precommit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm exec lint-staged
+pnpm --frozen-lockfile exec lint-staged


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `.husky/pre-commit` to prevent lockfile changes during pre-commit hooks using `--frozen-lockfile`.
> 
>   - **Pre-commit Hook**:
>     - Modify `.husky/pre-commit` to use `pnpm --frozen-lockfile exec lint-staged`.
>     - Prevents lockfile changes during pre-commit hooks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 75741c4f3b3c506453ad8a1d9978520e36afe816. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->