### PR TITLE
ci: add turbo cache env to code-quality workflow

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -55,6 +55,9 @@ jobs:
     name: Build Changed Packages
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
+    env:
+      TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      TURBO_TEAM: team_wMOIFNoci5XladVuagdOVUQZ
     steps:
       - name: Checkout code repository
         uses: actions/checkout@v6
@@ -96,6 +99,9 @@ jobs:
     name: Test Changed Packages
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 5
+    env:
+      TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      TURBO_TEAM: team_wMOIFNoci5XladVuagdOVUQZ
     # Note: No dependency on 'build' job - Turbo handles test->build dependencies internally via dependsOn
     steps:
       - name: Checkout code repository


### PR DESCRIPTION
testing for faster workflow runs with turbo caching
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add turbo caching environment variables to `code-quality.yaml` to improve workflow performance.
> 
>   - **Environment Variables**:
>     - Add `TURBO_TOKEN` and `TURBO_TEAM` to `build` and `test` jobs in `code-quality.yaml` for turbo caching.
>   - **Performance**:
>     - Aims to speed up workflow runs by utilizing turbo caching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 259adf21baa190d50f7c1006117de8f542fd8636. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->