### PR TITLE
fix(core): respect attachment changes in edit composer

### DIFF
--- a/.changeset/sixty-rings-end.md
+++ b/.changeset/sixty-rings-end.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): respect attachment changes in edit composer

--- a/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
@@ -1,9 +1,21 @@
-import type { AppendMessage, ThreadMessage } from "../../types";
+import type {
+  AppendMessage,
+  CompleteAttachment,
+  ThreadMessage,
+} from "../../types";
 import { getThreadMessageText } from "../../utils/text";
 import type { AttachmentAdapter } from "../../adapters/attachment";
 import type { DictationAdapter } from "../../adapters/speech";
 import type { ThreadRuntimeCore } from "../interfaces/thread-runtime-core";
 import { BaseComposerRuntimeCore } from "./base-composer-runtime-core";
+
+const attachmentsEqual = (
+  a: readonly CompleteAttachment[],
+  b: readonly CompleteAttachment[],
+): boolean => {
+  if (a.length !== b.length) return false;
+  return a.every((att, i) => att.id === b[i]!.id);
+};
 
 export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
   public get canCancel() {
@@ -20,6 +32,7 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
 
   private _nonTextParts;
   private _previousText;
+  private _previousAttachments;
   private _parentId;
   private _sourceId;
   constructor(
@@ -41,7 +54,8 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
     this.setText(this._previousText);
 
     this.setRole(message.role);
-    this.setAttachments(message.attachments ?? []);
+    this._previousAttachments = message.attachments ?? [];
+    this.setAttachments(this._previousAttachments);
 
     this._nonTextParts = message.content.filter((part) => part.type !== "text");
 
@@ -52,10 +66,22 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
     message: Omit<AppendMessage, "parentId" | "sourceId">,
   ) {
     const text = getThreadMessageText(message as AppendMessage);
-    if (text !== this._previousText) {
+    const currentAttachments = message.attachments ?? [];
+    const didAttachmentsChange = !attachmentsEqual(
+      currentAttachments,
+      this._previousAttachments,
+    );
+
+    if (text !== this._previousText || didAttachmentsChange) {
+      // Only re-inject original non-text content parts if the user
+      // did not modify attachments; otherwise respect their changes.
+      const content = didAttachmentsChange
+        ? message.content
+        : [...message.content, ...this._nonTextParts];
+
       this.runtime.append({
         ...message,
-        content: [...message.content, ...this._nonTextParts] as any,
+        content: content as any,
         parentId: this._parentId,
         sourceId: this._sourceId,
       });

--- a/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
@@ -73,8 +73,9 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
     );
 
     if (text !== this._previousText || didAttachmentsChange) {
-      // Only re-inject original non-text content parts if the user
-      // did not modify attachments; otherwise respect their changes.
+      // Re-inject original non-text content parts (file parts, image parts,etc.) only when attachments are unchanged. When attachments changed,
+      // we drop _nonTextParts entirely — this assumes all non-text content parts are attachment-derived.
+      // Future non-attachment content types would need separate tracking here.
       const content = didAttachmentsChange
         ? message.content
         : [...message.content, ...this._nonTextParts];


### PR DESCRIPTION
closes https://github.com/assistant-ui/assistant-ui/issues/3476
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `DefaultEditComposerRuntimeCore` now respects attachment changes in the edit composer by tracking and comparing attachment states.
> 
>   - **Behavior**:
>     - `DefaultEditComposerRuntimeCore` now respects attachment changes in `handleSend()`.
>     - Introduces `attachmentsEqual()` to compare attachment arrays.
>     - If attachments change, original non-text parts are not re-injected.
>   - **State Management**:
>     - Adds `_previousAttachments` to track previous attachment state.
>     - Updates `_previousAttachments` in constructor and `handleSend()`.
>   - **Misc**:
>     - Imports `CompleteAttachment` type in `default-edit-composer-runtime-core.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 2d291d0f4d67512042f707a8e67c00811a4111a5. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->