### PR TITLE
dx: auto generate deps changeset

### DIFF
--- a/.changeset/dx-use-taze.md
+++ b/.changeset/dx-use-taze.md
@@ -1,0 +1,21 @@
+---
+"assistant-ui": patch
+"@assistant-ui/cloud-ai-sdk": patch
+"assistant-cloud": patch
+"mcp-app-studio": patch
+"@assistant-ui/mcp-docs-server": patch
+"@assistant-ui/react-ag-ui": patch
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-data-stream": patch
+"@assistant-ui/react-devtools": patch
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-syntax-highlighter": patch
+"@assistant-ui/react": patch
+"@assistant-ui/store": patch
+"@assistant-ui/tap": patch
+"tw-glass": patch
+"tw-shimmer": patch
+---
+
+chore: update dependencies

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "turbo test",
     "prepare": "husky",
     "deps:check": "npx taze major -f -r",
-    "deps:update": "npx taze major -f -w -r && cd examples/with-expo && npx expo install --fix && cd ../.. && pnpm install"
+    "deps:update": "npx taze major -f -w -r && cd examples/with-expo && npx expo install --fix && cd ../.. && pnpm install && bash scripts/generate-deps-changeset.sh"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.5",

--- a/scripts/generate-deps-changeset.sh
+++ b/scripts/generate-deps-changeset.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Generate a changeset for dependency updates.
+# Detects which published packages had their package.json modified (staged + unstaged)
+# and creates a changeset with patch bumps for each.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Find all modified package.json files (staged + unstaged, excluding lockfile)
+changed_pkgjsons=$(git diff --name-only HEAD -- '**/package.json' 'package.json' 2>/dev/null || true)
+if [ -z "$changed_pkgjsons" ]; then
+  changed_pkgjsons=$(git diff --name-only --cached -- '**/package.json' 'package.json' 2>/dev/null || true)
+fi
+if [ -z "$changed_pkgjsons" ]; then
+  echo "No package.json changes detected."
+  exit 0
+fi
+
+# Collect published package names from modified package.json files
+packages=()
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  filepath="$REPO_ROOT/$file"
+  [ -f "$filepath" ] || continue
+
+  # Skip private packages
+  is_private=$(node -e "const p=require('$filepath'); console.log(p.private === true ? 'true' : 'false')")
+  [ "$is_private" = "true" ] && continue
+
+  # Get package name
+  name=$(node -e "console.log(require('$filepath').name || '')")
+  [ -z "$name" ] && continue
+
+  packages+=("$name")
+done <<< "$changed_pkgjsons"
+
+if [ ${#packages[@]} -eq 0 ]; then
+  echo "No published packages were modified."
+  exit 0
+fi
+
+# Generate a random changeset filename
+slug=$(node -e "
+const adj=['bright','calm','cool','dull','fair','fast','flat','fond','free','full','glad','gold','good','gray','half','hard','high','holy','huge','just','keen','kind','last','lean','left','long','loud','main','mild','neat','nice','bold','pale','past','pink','poor','pure','rare','raw','rich','ripe','rude','safe','same','shy','slim','slow','soft','some','sure','tall','thin','tiny','true','ugly','vast','warm','weak','wide','wild','wise','worn','zero'];
+const noun=['ants','bats','bees','bugs','cats','cows','cups','dogs','dots','eels','eggs','elms','emus','fans','figs','fish','foes','fox','gems','hats','hens','ices','inks','jams','jars','jets','keys','kits','laws','maps','mice','moms','nets','nuts','oaks','orbs','owls','pans','peas','pens','pigs','pins','pots','rats','rays','rods','rugs','seas','suns','teas','toys','urns','vans','wars','yaks','zoos'];
+const verb=['add','aim','ask','beg','bid','bow','buy','cry','cut','dig','dip','eat','end','eye','fan','fit','fix','fly','get','gig','gum','hid','hug','jam','jog','kid','lay','let','lie','log','mix','nap','nod','own','pay','peg','pet','pin','pop','put','ran','rip','rob','rot','rub','run','saw','set','sew','sit','sly','tap','try','tug','use','vow','wag','win','yap','zip'];
+const r=a=>a[Math.floor(Math.random()*a.length)];
+console.log(r(adj)+'-'+r(noun)+'-'+r(verb));
+")
+
+changeset_file="$REPO_ROOT/.changeset/${slug}.md"
+
+# Build changeset content
+{
+  echo "---"
+  for pkg in "${packages[@]}"; do
+    echo "\"$pkg\": patch"
+  done
+  echo "---"
+  echo ""
+  echo "chore: update dependencies"
+} > "$changeset_file"
+
+echo "Created changeset: .changeset/${slug}.md (${#packages[@]} packages)"
+printf "  %s\n" "${packages[@]}"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Automates changeset generation for dependency updates by adding a script to detect modified `package.json` files and update changesets accordingly.
> 
>   - **Scripts**:
>     - Adds `scripts/generate-deps-changeset.sh` to automate changeset generation for modified `package.json` files.
>     - Script detects modified `package.json` files, skips private packages, and generates a changeset with patch bumps.
>   - **Package.json**:
>     - Updates `deps:update` script to include `bash scripts/generate-deps-changeset.sh`.
>   - **Changesets**:
>     - Adds `.changeset/dx-use-taze.md` with patch updates for multiple packages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for 596181dca28ea541f43553d0ae82958e5ae63b5d. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->