### PR TITLE
fix: avoid side-effects by using <reference>

### DIFF
--- a/packages/core/src/react/index.ts
+++ b/packages/core/src/react/index.ts
@@ -1,4 +1,4 @@
-import "./types/store-augmentation";
+/// <reference path="./types/store-augmentation.ts" />
 
 export * from "./model-context";
 export * from "./client";

--- a/packages/core/src/react/types/store-augmentation.ts
+++ b/packages/core/src/react/types/store-augmentation.ts
@@ -1,5 +1,3 @@
-import "@assistant-ui/store";
-
 import type { ToolsClientSchema } from "./scopes/tools";
 import type { DataRenderersClientSchema } from "./scopes/dataRenderers";
 

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -1,5 +1,4 @@
-// scope registration (module augmentation side effect)
-import "./scope-registration";
+/// <reference path="./scope-registration.ts" />
 
 // scopes
 export * from "./scopes";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,4 @@
-import "@assistant-ui/core/react"; // store-augmentation side-effect (tools, dataRenderers scopes)
+/// <reference types="@assistant-ui/core/react" />
 
 // Re-export from @assistant-ui/store
 export {

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -61,6 +61,44 @@ async function buildValidExportsMap(): Promise<Map<string, Set<string>>> {
   return map;
 }
 
+/**
+ * Restore /// <reference> directives in .d.ts files.
+ *
+ * TypeScript's declaration emitter drops /// <reference path> and
+ * /// <reference types> directives from source files, but they are needed
+ * to keep module-augmentation files in the .d.ts import graph.
+ */
+async function restoreReferenceDirectives(program: ts.Program): Promise<void> {
+  for (const sourceFile of program.getSourceFiles()) {
+    if (sourceFile.isDeclarationFile) continue;
+
+    const pathRefs = sourceFile.referencedFiles;
+    const typeRefs = sourceFile.typeReferenceDirectives;
+    if (pathRefs.length === 0 && typeRefs.length === 0) continue;
+
+    const srcRelative = path.relative(process.cwd(), sourceFile.fileName);
+    if (!srcRelative.startsWith("src/")) continue;
+
+    const dtsPath = srcRelative
+      .replace(/^src\//, "dist/")
+      .replace(/\.tsx?$/, ".d.ts");
+
+    try {
+      const content = await fs.readFile(dtsPath, "utf-8");
+      const directives = [
+        ...pathRefs.map((ref) => {
+          const refPath = ref.fileName.replace(/\.tsx?$/, ".d.ts");
+          return `/// <reference path="${refPath}" />`;
+        }),
+        ...typeRefs.map((ref) => `/// <reference types="${ref.fileName}" />`),
+      ].join("\n");
+      await fs.writeFile(dtsPath, `${directives}\n${content}`);
+    } catch {
+      // .d.ts file may not exist (e.g. test-only source files)
+    }
+  }
+}
+
 async function build() {
   await fs.rm("dist", { recursive: true, force: true });
 
@@ -123,6 +161,8 @@ async function build() {
       >,
     ],
   });
+
+  await restoreReferenceDirectives(program);
 
   const diagnostics = ts
     .getPreEmitDiagnostics(program)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces module augmentation imports with `/// <reference>` directives to avoid side-effects and adds a function to restore these directives in `.d.ts` files.
> 
>   - **Behavior**:
>     - Replaces module augmentation imports with `/// <reference>` directives in `index.ts` files in `packages/core/src/react`, `packages/core/src/store`, and `packages/react/src`.
>     - Introduces `restoreReferenceDirectives()` in `packages/x-buildutils/src/index.ts` to restore `/// <reference>` directives in `.d.ts` files.
>   - **Misc**:
>     - Removes import of `@assistant-ui/store` in `store-augmentation.ts` to prevent side-effects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=assistant-ui%2Fassistant-ui&utm_source=github&utm_medium=referral)<sup> for f513e062171680517aec322acf298a92071bdedf. You can [customize](https://app.ellipsis.dev/assistant-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->