### PR TITLE
fix(ui): thread viewport top padding causing first assistant message to overflow and inconsistent anchoring

### DIFF
--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -44,7 +44,7 @@ export const Thread: FC = () => {
     >
       <ThreadPrimitive.Viewport
         turnAnchor="top"
-        className="aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth px-4 pt-4"
+        className="aui-thread-viewport relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth px-4"
       >
         <AuiIf condition={(s) => s.thread.isEmpty}>
           <ThreadWelcome />


### PR DESCRIPTION
Before:
![before](https://github.com/user-attachments/assets/ffe88087-0a05-4e00-b054-60a427afcd62)

After:
<img width="2559" height="1599" alt="after" src="https://github.com/user-attachments/assets/90e5a5a5-20b8-4cee-a37d-8f58279441f2" />
