### PR TITLE
fix(playground): use full registry URLs in preset registryDependencies

### DIFF
--- a/apps/docs/lib/playground-registry.ts
+++ b/apps/docs/lib/playground-registry.ts
@@ -117,6 +117,7 @@ export function generateRegistryJson(config: BuilderConfig) {
     dependencies: [
       "@assistant-ui/react",
       "@assistant-ui/react-ui",
+      "lucide-react",
       ...(config.components.markdown ? ["@assistant-ui/react-markdown"] : []),
     ],
     registryDependencies,


### PR DESCRIPTION
## Summary
- Playground preset endpoint used bare component names (e.g. `"thread"`) in `registryDependencies`, which shadcn resolved against `ui.shadcn.com` instead of the assistant-ui registry — causing `thread.json not found` errors
- Fixed to use full URLs (e.g. `https://r.assistant-ui.com/thread.json`) matching the convention in `apps/registry/src/registry.ts`
- Fixed output file path from `components/ui/assistant-ui/thread.tsx` to `components/assistant-ui/thread.tsx`
- Removed `thread.json` as a dependency (playground provides its own `thread.tsx`) and instead lists only the transitive deps needed (`tooltip-icon-button`, `markdown-text`, `tool-fallback`, `attachment`)
- Added `tool-fallback` as an explicit dep when markdown is enabled

## Test plan
- [x] Verified production endpoint returns broken response (bare names, wrong path)
- [x] Verified local docs dev server returns fixed response (full URLs, correct path)
- [x] End-to-end test: `aui create --template default --preset 'http://localhost:3000/playground/init?preset=chatgpt'` installs successfully with all components at correct paths