### PR TITLE
fix: exclude build output dirs from turbo cache inputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,16 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["**/*.*", "!.next", "!.turbo"],
+      "inputs": [
+        "**/*.*",
+        "!.next",
+        "!.turbo",
+        "!dist",
+        "!build",
+        "!generated",
+        "!.output",
+        "!.source"
+      ],
       "outputs": [
         "dist",
         ".next/**",


### PR DESCRIPTION
## Summary

- Turbo's `inputs` hash included build output directories (`dist`, `build`, `generated`, `.output`, `.source`), causing `@assistant-ui/docs` and `with-tanstack` to never cache
- Added these directories to the `inputs` exclusion list alongside the already-excluded `.next` and `.turbo`
- After fix: docs build caches in ~1s (down from ~31s), with-tanstack in ~355ms (down from ~6s)

## What changed

| File | Change |
|------|--------|
| `turbo.json` | **Updated.** Added `!dist`, `!build`, `!generated`, `!.output`, `!.source` to the `inputs` exclusion list |

## Root cause analysis

The `inputs` glob `**/*.*` controls which files Turbo hashes to determine cache validity. Only `.next` and `.turbo` were excluded, but the `outputs` config also lists `dist`, `generated/**`, `.output/**`, and `build/**`. Turbo does **not** auto-exclude outputs from inputs.

This was invisible for most packages because they're Next.js apps (output goes to `.next/`, already excluded). Two packages broke:

- **`with-tanstack`** (Vite + TanStack Start/Nitro) — outputs to `dist/`. Nitro generates non-deterministic output, so `dist/nitro.json` and `dist/server/index.mjs` changed on every build, invalidating the hash every time.
- **`@assistant-ui/docs`** (fumadocs-mdx) — `.source/browser.ts` and `.source/server.ts` are regenerated by fumadocs-mdx during `next build`, changing the input hash.

## Design decisions

<details>
<summary>Click to expand design decisions and rationale</summary>

### Exclude all output directories, not just the two broken ones

Rather than only adding `!dist` and `!.source`, all output-pattern directories are excluded (`!build`, `!generated`, `!.output`). These are all build artifacts with zero hand-written source files (verified via `git ls-files`). Excluding them defensively prevents the same bug from surfacing if a new package uses one of these output dirs.

### `inputs` vs `outputs` are independent

This change only affects cache **key computation** (which files are hashed). It does **not** affect cache **storage/restoration** (which files are saved and restored on cache hit). The `outputs` config is unchanged — Turbo still caches and restores all output directories.

### `!generated` only excludes root-level `generated/`

The exclusion `!generated` matches `generated/` at the package root only (e.g., `apps/docs/generated/typeDocs.ts`). Nested `generated/` directories like `apps/docs/components/tool-ui/weather-widget/generated/weather-runtime-core.generated.ts` — a committed source file imported by docs code — remain in the input hash and correctly invalidate the cache when changed.

### `.source` is excluded from inputs but not in `outputs`

The other four excluded directories (`dist`, `build`, `generated`, `.output`) are all present in the `outputs` array — they're build artifacts that Turbo caches and restores. `.source` is different: it's an intermediate artifact regenerated by fumadocs-mdx's `postinstall` hook (which runs after every `pnpm install`), so it's always present before the build starts. It doesn't need to be cached/restored, only excluded from the input hash so it doesn't cause spurious cache misses.

</details>

## Test plan

- [x] Ran `pnpm turbo build --filter=with-tanstack` twice consecutively — second run: 8/8 cached, FULL TURBO (355ms)
- [x] Ran `pnpm turbo build --filter=@assistant-ui/docs` twice consecutively — second run: 16/16 cached, FULL TURBO (1s)
- [x] Verified via turbo run summaries that `dist/nitro.json` and `.source/browser.ts` no longer appear in the changed inputs between runs
- [x] Verified nested `components/.../generated/weather-runtime-core.generated.ts` is still tracked as an input (not affected by `!generated`)
- [x] Confirmed none of the excluded directories contain hand-written source files (`git ls-files` returns 0 tracked files for all except one auto-generated file in a nested `generated/` directory, which is unaffected)