### PR TITLE
fix: guard clipboard availability before calling writeText

### DIFF
--- a/.changeset/fix-clipboard-guard.md
+++ b/.changeset/fix-clipboard-guard.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+fix: guard `navigator.clipboard` availability and swallow write rejections in `ActionBarPrimitive.Copy`. Previously, copy clicks in SSR, non-HTTPS contexts, or older browsers without the Clipboard API threw a `ReferenceError`, and permission-denied rejections surfaced as unhandled promise rejections. The web copyToClipboard implementation in `@assistant-ui/react` now early-rejects when the API is unavailable, and `useActionBarCopy` in `@assistant-ui/core` silently absorbs the rejection so the rest of the UI is unaffected.

--- a/apps/docs/components/docs/assistant/markdown.tsx
+++ b/apps/docs/components/docs/assistant/markdown.tsx
@@ -11,11 +11,12 @@ import {
   useIsMarkdownCodeBlock,
 } from "@assistant-ui/react-markdown";
 import remarkGfm from "remark-gfm";
-import { type CSSProperties, type FC, memo, useState } from "react";
+import { type CSSProperties, type FC, memo } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import ShikiHighlighter from "react-shiki";
 import Link from "next/link";
+import { useCopyToClipboard } from "@assistant-ui/ui/hooks/use-copy-to-clipboard";
 
 const MarkdownTextImpl = () => {
   return (
@@ -28,24 +29,6 @@ const MarkdownTextImpl = () => {
 };
 
 export const MarkdownText = memo(MarkdownTextImpl);
-
-const useCopyToClipboard = ({
-  copiedDuration = 3000,
-}: {
-  copiedDuration?: number;
-} = {}) => {
-  const [isCopied, setIsCopied] = useState<boolean>(false);
-
-  const copyToClipboard = (value: string) => {
-    if (!value) return;
-    navigator.clipboard.writeText(value).then(() => {
-      setIsCopied(true);
-      setTimeout(() => setIsCopied(false), copiedDuration);
-    });
-  };
-
-  return { isCopied, copyToClipboard };
-};
 
 const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
   const { isCopied, copyToClipboard } = useCopyToClipboard();

--- a/packages/core/src/react/primitive-hooks/useActionBarCopy.ts
+++ b/packages/core/src/react/primitive-hooks/useActionBarCopy.ts
@@ -27,11 +27,15 @@ export const useActionBarCopy = ({
     if (!valueToCopy) return;
 
     const write = copyToClipboard ?? (() => {});
-    const result = write(valueToCopy);
-    Promise.resolve(result).then(() => {
-      aui.message().setIsCopied(true);
-      setTimeout(() => aui.message().setIsCopied(false), copiedDuration);
-    });
+    // The rejection handler swallows clipboard write failures (permission denied,
+    // API unavailable) so they don't surface as unhandled promise rejections.
+    Promise.resolve(write(valueToCopy)).then(
+      () => {
+        aui.message().setIsCopied(true);
+        setTimeout(() => aui.message().setIsCopied(false), copiedDuration);
+      },
+      () => {},
+    );
   }, [aui, isEditing, composerValue, copiedDuration, copyToClipboard]);
 
   return { copy, disabled, isCopied };

--- a/packages/react/src/primitives/actionBar/ActionBarCopy.tsx
+++ b/packages/react/src/primitives/actionBar/ActionBarCopy.tsx
@@ -38,7 +38,12 @@ const useActionBarPrimitiveCopy = ({
 } = {}) => {
   const { copy, disabled } = useActionBarCopy({
     copiedDuration,
-    copyToClipboard: (text) => navigator.clipboard.writeText(text),
+    copyToClipboard: (text) => {
+      if (typeof navigator === "undefined" || !navigator.clipboard) {
+        return Promise.reject(new Error("Clipboard API is unavailable"));
+      }
+      return navigator.clipboard.writeText(text);
+    },
   });
   if (disabled) return null;
   return copy;

--- a/packages/ui/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/ui/src/components/assistant-ui/markdown-text.tsx
@@ -55,12 +55,17 @@ const useCopyToClipboard = ({
   const [isCopied, setIsCopied] = useState<boolean>(false);
 
   const copyToClipboard = (value: string) => {
-    if (!value) return;
+    if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
 
-    navigator.clipboard.writeText(value).then(() => {
-      setIsCopied(true);
-      setTimeout(() => setIsCopied(false), copiedDuration);
-    });
+    navigator.clipboard.writeText(value).then(
+      () => {
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), copiedDuration);
+      },
+      () => {},
+    );
   };
 
   return { isCopied, copyToClipboard };

--- a/packages/ui/src/hooks/use-copy-to-clipboard.ts
+++ b/packages/ui/src/hooks/use-copy-to-clipboard.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState } from "react";
+
+export type UseCopyToClipboardOptions = {
+  copiedDuration?: number;
+};
+
+export const useCopyToClipboard = ({
+  copiedDuration = 3000,
+}: UseCopyToClipboardOptions = {}) => {
+  const [isCopied, setIsCopied] = useState<boolean>(false);
+
+  const copyToClipboard = (value: string) => {
+    if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
+
+    navigator.clipboard.writeText(value).then(
+      () => {
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), copiedDuration);
+      },
+      () => {},
+    );
+  };
+
+  return { isCopied, copyToClipboard };
+};

--- a/templates/cloud-clerk/components/assistant-ui/markdown-text.tsx
+++ b/templates/cloud-clerk/components/assistant-ui/markdown-text.tsx
@@ -55,12 +55,17 @@ const useCopyToClipboard = ({
   const [isCopied, setIsCopied] = useState<boolean>(false);
 
   const copyToClipboard = (value: string) => {
-    if (!value) return;
+    if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
 
-    navigator.clipboard.writeText(value).then(() => {
-      setIsCopied(true);
-      setTimeout(() => setIsCopied(false), copiedDuration);
-    });
+    navigator.clipboard.writeText(value).then(
+      () => {
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), copiedDuration);
+      },
+      () => {},
+    );
   };
 
   return { isCopied, copyToClipboard };

--- a/templates/cloud/components/assistant-ui/markdown-text.tsx
+++ b/templates/cloud/components/assistant-ui/markdown-text.tsx
@@ -55,12 +55,17 @@ const useCopyToClipboard = ({
   const [isCopied, setIsCopied] = useState<boolean>(false);
 
   const copyToClipboard = (value: string) => {
-    if (!value) return;
+    if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
 
-    navigator.clipboard.writeText(value).then(() => {
-      setIsCopied(true);
-      setTimeout(() => setIsCopied(false), copiedDuration);
-    });
+    navigator.clipboard.writeText(value).then(
+      () => {
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), copiedDuration);
+      },
+      () => {},
+    );
   };
 
   return { isCopied, copyToClipboard };

--- a/templates/default/components/assistant-ui/markdown-text.tsx
+++ b/templates/default/components/assistant-ui/markdown-text.tsx
@@ -55,12 +55,17 @@ const useCopyToClipboard = ({
   const [isCopied, setIsCopied] = useState<boolean>(false);
 
   const copyToClipboard = (value: string) => {
-    if (!value) return;
+    if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
 
-    navigator.clipboard.writeText(value).then(() => {
-      setIsCopied(true);
-      setTimeout(() => setIsCopied(false), copiedDuration);
-    });
+    navigator.clipboard.writeText(value).then(
+      () => {
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), copiedDuration);
+      },
+      () => {},
+    );
   };
 
   return { isCopied, copyToClipboard };

--- a/templates/langgraph/components/assistant-ui/markdown-text.tsx
+++ b/templates/langgraph/components/assistant-ui/markdown-text.tsx
@@ -55,12 +55,17 @@ const useCopyToClipboard = ({
   const [isCopied, setIsCopied] = useState<boolean>(false);
 
   const copyToClipboard = (value: string) => {
-    if (!value) return;
+    if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
 
-    navigator.clipboard.writeText(value).then(() => {
-      setIsCopied(true);
-      setTimeout(() => setIsCopied(false), copiedDuration);
-    });
+    navigator.clipboard.writeText(value).then(
+      () => {
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), copiedDuration);
+      },
+      () => {},
+    );
   };
 
   return { isCopied, copyToClipboard };

--- a/templates/mcp/components/assistant-ui/markdown-text.tsx
+++ b/templates/mcp/components/assistant-ui/markdown-text.tsx
@@ -55,12 +55,17 @@ const useCopyToClipboard = ({
   const [isCopied, setIsCopied] = useState<boolean>(false);
 
   const copyToClipboard = (value: string) => {
-    if (!value) return;
+    if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
 
-    navigator.clipboard.writeText(value).then(() => {
-      setIsCopied(true);
-      setTimeout(() => setIsCopied(false), copiedDuration);
-    });
+    navigator.clipboard.writeText(value).then(
+      () => {
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), copiedDuration);
+      },
+      () => {},
+    );
   };
 
   return { isCopied, copyToClipboard };

--- a/templates/minimal/components/assistant-ui/markdown-text.tsx
+++ b/templates/minimal/components/assistant-ui/markdown-text.tsx
@@ -55,12 +55,17 @@ const useCopyToClipboard = ({
   const [isCopied, setIsCopied] = useState<boolean>(false);
 
   const copyToClipboard = (value: string) => {
-    if (!value) return;
+    if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
 
-    navigator.clipboard.writeText(value).then(() => {
-      setIsCopied(true);
-      setTimeout(() => setIsCopied(false), copiedDuration);
-    });
+    navigator.clipboard.writeText(value).then(
+      () => {
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), copiedDuration);
+      },
+      () => {},
+    );
   };
 
   return { isCopied, copyToClipboard };


### PR DESCRIPTION
## Summary

- Guard against missing Clipboard API (`navigator.clipboard` undefined in non-HTTPS contexts, older browsers, or SSR) by checking availability before calling `writeText`
- Handle promise rejections from clipboard write failures (e.g. permission denied)

**Affected locations:**
- `packages/react` — `ActionBarCopy` primitive
- `packages/ui` — `useCopyToClipboard` hook in markdown-text
- `apps/docs` — docs site markdown copy button
- All 6 templates (`default`, `cloud`, `cloud-clerk`, `langgraph`, `mcp`, `minimal`)