### PR TITLE
fix(cli): detect dev script and env file from scaffolded project

### DIFF
--- a/.changeset/fix-cli-post-scaffold-hints.md
+++ b/.changeset/fix-cli-post-scaffold-hints.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix(cli): detect dev script and env file from scaffolded project

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -534,15 +534,24 @@ export const create = new Command()
       logger.success("Project created successfully!");
       logger.break();
       const runCmd = pm === "npm" ? "npm run" : pm;
-      const scaffoldedPkg = JSON.parse(
-        fs.readFileSync(path.join(absoluteProjectDir, "package.json"), "utf-8"),
-      );
-      const devScript = scaffoldedPkg.scripts?.dev
-        ? "dev"
-        : scaffoldedPkg.scripts?.start
-          ? "start"
-          : "dev";
-      const envFile = scaffoldedPkg.dependencies?.next ? ".env.local" : ".env";
+      let devScript = "dev";
+      let envFile = ".env.local";
+      try {
+        const scaffoldedPkg = JSON.parse(
+          fs.readFileSync(
+            path.join(absoluteProjectDir, "package.json"),
+            "utf-8",
+          ),
+        );
+        devScript = scaffoldedPkg.scripts?.dev
+          ? "dev"
+          : scaffoldedPkg.scripts?.start
+            ? "start"
+            : "dev";
+        envFile = scaffoldedPkg.dependencies?.next ? ".env.local" : ".env";
+      } catch {
+        // Fall back to defaults if package.json cannot be read
+      }
 
       logger.info("Next steps:");
       logger.info(`  cd ${resolvedProjectDirectory}`);


### PR DESCRIPTION
## Summary

- Post-scaffold "Next steps" instructions now read the scaffolded `package.json` to determine the correct dev command and env file, instead of hardcoding `dev` and `.env.local`
- Fixes incorrect instructions for non-Next.js projects (Expo, React Router, TanStack, etc.)

## What changed

| File | Change |
|------|--------|
| `packages/cli/src/commands/create.ts` | **Updated.** Read scaffolded `package.json` to detect `dev`/`start` script and Next.js dependency for env file hint |

## Before / After

| Project | Before | After |
|---------|--------|-------|
| Next.js (default) | `pnpm dev`, `.env.local` | `pnpm dev`, `.env.local` |
| Expo | `pnpm dev`, `.env.local` | `pnpm start`, `.env` |
| React Router | `pnpm dev`, `.env.local` | `pnpm dev`, `.env` |
| TanStack | `pnpm dev`, `.env.local` | `pnpm dev`, `.env` |

<details>
<summary>Click to expand design decisions and rationale</summary>

### Dev script detection

Reads `scripts.dev` from the scaffolded `package.json`. Falls back to `scripts.start` if no `dev` script exists (Expo only has `start`). Falls back to `dev` if neither exists.

### Env file detection

Next.js uses `.env.local` for secrets (not committed to git). All other frameworks (Vite, Expo) use `.env`. Detected by checking for `next` in `dependencies` — simple, no hardcoded project names.

</details>

## Test plan

- [x] `assistant-ui create --template default` → `pnpm dev`, `.env.local`
- [x] `assistant-ui create --example with-expo` → `pnpm start`, `.env`
- [x] `assistant-ui create --example with-react-router` → `pnpm dev`, `.env`
- [x] `pnpm lint` — clean