### PR TITLE
feat(ci): add simplify subagent to Claude code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,7 +32,38 @@ env:
     COMMIT: ${{ github.event.pull_request.head.sha }}
     Note: The PR branch is already checked out in the current working directory.
 
-    Gather Context (complete these steps FIRST, silently - don't report on this process):
+    FIRST: Immediately launch a simplification subagent in the background using the Agent tool (with run_in_background: true) with the following prompt:
+
+    ---
+    You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability. You prioritize readable, explicit code over overly compact solutions.
+
+    Analyze the PR diff by running `gh pr diff ${{ github.event.pull_request.number }}` and identify simplification opportunities in the changed code.
+
+    Look for:
+
+    1. **Unnecessary complexity and nesting** - deep nesting, convoluted control flow
+    2. **Redundant code and abstractions** - duplicated logic, unnecessary wrappers
+    3. **Unclear naming** - vague variable/function names that obscure intent
+    4. **Overly clever code** - nested ternaries, dense one-liners that sacrifice readability
+    5. **Consolidation opportunities** - related logic that could be grouped
+    6. **Project standard deviations** - check CLAUDE.md and AGENTS.md for project conventions
+
+    Maintain balance — avoid suggesting over-simplification that would:
+    - Create overly clever solutions harder to understand
+    - Combine too many concerns into single functions
+    - Remove helpful abstractions that improve organization
+    - Prioritize "fewer lines" over readability
+
+    For each issue worth fixing, use `mcp__github_inline_comment__create_inline_comment` to post an actionable inline comment on the specific code. Each comment should explain what to simplify and suggest the improvement. Only flag things genuinely worth changing.
+
+    Do not make any code changes. Do not post inline comments for positive observations.
+
+    When done, report a brief summary of your findings.
+    ---
+
+    THEN: While the simplify agent runs in the background, proceed with the review:
+
+    Gather Context (complete these steps silently - don't report on this process):
     1. Check CI status: Use mcp__github_ci__get_ci_status to see if tests passed/failed
     2. Get previous reviews: Run gh pr view ${{ github.event.pull_request.number }} --comments
     3. Identify previous bot reviews and track which issues were raised before
@@ -78,13 +109,13 @@ env:
 
     You have been provided with the mcp__github_comment__update_claude_comment tool to update your comment. This tool automatically handles PR comments. Only the body parameter is required - the tool automatically knows which comment to update.
 
-    IMPORTANT: Submit your review feedback by updating the Claude comment using mcp__github_comment__update_claude_comment. This will be displayed as your PR review.
+    FINALLY: Once your review is complete, wait for the background simplify agent to finish. Collect its summary, then submit one final comment using mcp__github_comment__update_claude_comment that includes your full review followed by a `## Simplify` section with the agent's summary. If no simplification issues were found, note that the code looks clean.
 
   # Allowed tools:
   # - mcp__github_inline_comment__create_inline_comment: Create inline code comments
   # - Bash(gh ...): Read-only GitHub CLI commands for PR/issue info
   # Note: gh pr comment is NOT allowed - Claude must use update_claude_comment only
-  CLAUDE_ARGS: '--allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+  CLAUDE_ARGS: '--allowedTools "Agent,mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary

- Adds a code simplification pass to the Claude CI review workflow, running in parallel as a background subagent
- The simplify agent analyzes the PR diff for unnecessary complexity, unclear naming, DRY violations, and project standard deviations
- Posts inline comments for actionable simplification suggestions, and appends a `## Simplify` section to the review sticky comment
- Entirely read-only — no commits, no edits, just comments

## What changed

| File | Change |
|------|--------|
| `.github/workflows/claude-code-review.yml` | **Updated.** Added simplify subagent prompt, restructured review flow to launch simplify in background first, collect results at end |

## How it works

The review prompt now has three phases:

1. **FIRST** — Launch a simplification subagent in the background via the Agent tool
2. **THEN** — Proceed with the existing review (unchanged logic)
3. **FINALLY** — Wait for the background simplify agent, collect its summary, and post one combined comment with both review and simplify sections

The simplify agent runs fully in parallel with the review, reading the diff independently and posting inline comments for anything worth flagging.

## Design decisions

<details>
<summary>Click to expand design decisions and rationale</summary>

### Subagent over second CI step
Using a background subagent within a single Claude run instead of two separate `claude-code-action` steps. This avoids double setup cost, double billing, and session chaining complexity while keeping the two concerns (review vs simplify) in separate context windows.

### Background agent for parallelism
The simplify agent launches immediately via `run_in_background: true` so it runs concurrently with the review. Total time is `max(review, simplify)` instead of additive.

### Inlined prompt instead of separate env var
GitHub Actions top-level `env:` values cannot reference sibling env vars (`${{ env.X }}` resolves to empty string within the same `env:` block). The simplify prompt must be inlined within `REVIEW_PROMPT`.

### Read-only constraint
The bot never commits. All findings are posted as inline PR comments. GitHub-level `contents: read` permission is the hard safety boundary.

### Agent tool added to allowedTools
The `Agent` tool cannot be scoped like `Bash(pattern:*)`. Subagent tool inheritance has known bugs (subagents may access tools beyond the parent's allowedTools). The GitHub Actions `permissions` block (`contents: read`) is the real guard — the subagent can't do anything destructive even if it tries.

</details>

## Deferred / out of scope

- Scoping subagent tool access (blocked by upstream Claude Code bugs)
- Conditional simplify execution based on review severity
- Extracting the simplify prompt to a separate file

## Test plan

- [x] Verified YAML syntax is valid
- [ ] Deploy and observe on a real PR to confirm the subagent launches, posts inline comments, and the final sticky comment includes the Simplify section