### PR TITLE
fix: use checked-in bin wrapper for CLI

### DIFF
--- a/.changeset/cli-bin-wrapper.md
+++ b/.changeset/cli-bin-wrapper.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+use checked-in bin wrapper to avoid pnpm install warnings in monorepos

--- a/packages/cli/bin/assistant-ui.js
+++ b/packages/cli/bin/assistant-ui.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/index.js";

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,9 +15,10 @@
   "license": "MIT",
   "type": "module",
   "bin": {
-    "assistant-ui": "./dist/index.js"
+    "assistant-ui": "./bin/assistant-ui.js"
   },
   "files": [
+    "bin",
     "dist",
     "plugin",
     "src",


### PR DESCRIPTION
## Summary

- Replace the CLI's `bin` entry from `./dist/index.js` (build output) to a checked-in `./bin/assistant-ui.js` wrapper, eliminating pnpm install warnings in the monorepo
- Follows the same pattern used by Vite, ESLint, Prettier, and Vitest for handling bin entries in monorepos

### Prerequisites
- Part of a broader Vercel build cleanup alongside turbo-ignore (#3521, merged) and Corepack enablement (Vercel env var change)

## What changed

| File | Change |
|------|--------|
| `packages/cli/bin/assistant-ui.js` | **New.** 2-line checked-in bin wrapper: shebang + `import "../dist/index.js"` |
| `packages/cli/package.json` | **Updated.** `bin` field points to wrapper; `"bin"` added to `files` array |
| `.changeset/cli-bin-wrapper.md` | **New.** Patch changeset |

## Why a bin wrapper

Previously, `bin` pointed directly to `./dist/index.js` — a build output that doesn't exist until after `pnpm build`. During `pnpm install`, pnpm tries to symlink this file for workspace dependents (specifically `create-assistant-ui`), producing:

```
WARN  Failed to create bin at .../node_modules/.bin/assistant-ui.
ENOENT: no such file or directory, open '.../packages/cli/dist/index.js'
```

The wrapper separates two concerns: **install-time symlinking** (needs the file to exist) from **runtime execution** (needs `dist/` to exist). The wrapper always exists in source; `dist/` only needs to exist when the CLI is actually invoked.

## Design decisions

<details>
<summary>Click to expand design decisions and rationale</summary>

### Bin wrapper pattern (Pattern 1) over direct dist reference (Pattern 2)
Researched how major CLI tools handle this. Prettier, ESLint, Vite, and Vitest all use checked-in bin wrappers that delegate to compiled output. Next.js and tsx point directly to dist but accept the monorepo install warnings. Chose the majority pattern.

### Static import over dynamic import
Used `import "../dist/index.js"` (static) rather than `import("../dist/index.js")` (dynamic). Both work identically in ESM — static is simpler and has no async overhead. Matches the Vitest approach.

### File at `bin/assistant-ui.js` rather than package root
Placed in a `bin/` directory following Vite/ESLint/Turbo convention, rather than at the package root (Vitest's `vitest.mjs` approach). Keeps the package root clean.

### `.js` extension, not `.mjs`
The package already has `"type": "module"`, so `.js` is ESM. `.mjs` would be redundant. Vitest uses `.mjs` only because its package doesn't set `"type": "module"`.

### No changes needed to `create-assistant-ui`
`create-assistant-ui` resolves the CLI's bin path by reading `package.json` at runtime — it adapts automatically to the new path. Verified by testing `pnpm --filter=create-assistant-ui exec assistant-ui --help`.

</details>

## Bot review comment dispositions

<details>
<summary>Click to expand triage of bot review comments</summary>

### False positives (2)
- **"bin wrapper imports dist/index.js which doesn't exist before build"** (flagged by @vercel review bot) → This is the entire point of the pattern. The *file* (`bin/assistant-ui.js`) exists at install time so pnpm can symlink it. The *import* only executes at runtime, by which point the package has been built. This is exactly how Vite, ESLint, Prettier, and Vitest handle it.
- **`"sideEffects": false` inconsistent with bin wrapper importing for side effects** (flagged by @claude) → bin files are executed by Node.js directly, never processed by bundlers. The `sideEffects` field has no practical impact on bin entries.

### No issues (3)
- @cubic-dev-ai: no issues found
- @copilot-pull-request-reviewer: reviewed 2/3 files, no comments, confirmed pattern matches `@assistant-ui/x-buildutils`'s existing `bin/aui-build.js`
- @greptile-apps: no substantive comments

</details>

## Test plan

- [x] `pnpm install` produces no bin warnings
- [x] Bin symlink created at `create-assistant-ui/node_modules/.bin/assistant-ui`
- [x] `node packages/cli/bin/assistant-ui.js --help` — CLI loads and prints all commands
- [x] `pnpm --filter=create-assistant-ui exec assistant-ui --help` — works through pnpm's bin symlink
- [x] File has correct permissions (mode 100755), LF line endings, ASCII encoding
- [x] Vercel preview deployment succeeded