### PR TITLE
fix: declare ENABLE_EXPERIMENTAL_COREPACK in turbo.json globalPassThroughEnv

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
-  "globalEnv": ["ENABLE_EXPERIMENTAL_COREPACK"],
+  "globalPassThroughEnv": ["ENABLE_EXPERIMENTAL_COREPACK"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- Adds `ENABLE_EXPERIMENTAL_COREPACK` to `globalPassThroughEnv` in `turbo.json`
- Silences Turborepo warnings about this undeclared Vercel platform variable that appear for all 16 packages during CI builds

## Context
Vercel sets `ENABLE_EXPERIMENTAL_COREPACK` to enable Corepack (for pnpm 10+). Turborepo's strict mode on Vercel warns when env vars are set but not declared in `turbo.json`.

This variable belongs in `globalPassThroughEnv` (not `globalEnv`) because pnpm is pinned via the `packageManager` field — the variable only controls how Corepack activates that pinned version, not which version runs. Using `globalPassThroughEnv` avoids unnecessarily splitting cache keys between local (unset) and CI (set) environments.

## What changed

| File | Change |
|------|--------|
| `turbo.json` | **Updated.** Added `globalPassThroughEnv: ["ENABLE_EXPERIMENTAL_COREPACK"]` |

## Design decisions

<details>
<summary>Click to expand</summary>

### `globalPassThroughEnv` vs `globalEnv`
Initially used `globalEnv`, which hashes the variable into every cache key. Switched to `globalPassThroughEnv` because the pnpm version is pinned (`"packageManager": "pnpm@10.30.3"`), so the variable doesn't affect build output — it only controls the Corepack activation mechanism. This preserves cross-environment cache sharing.

</details>

## Test plan
- [ ] Verify Vercel deploy no longer shows `ENABLE_EXPERIMENTAL_COREPACK` warnings