### PR TITLE
revert: remove turbo-ignore devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.3.2",
     "turbo": "^2.8.13",
-    "turbo-ignore": "^2.8.13",
     "typescript": "^5.9.3"
   },
   "packageManager": "pnpm@10.30.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       turbo:
         specifier: ^2.8.13
         version: 2.8.13
-      turbo-ignore:
-        specifier: ^2.8.13
-        version: 2.8.14
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -12221,10 +12218,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  turbo-ignore@2.8.14:
-    resolution: {integrity: sha512-N0GJBmEbsVlCzSp28+3dops2VFHBYfwxhKyME8K/9mVkiIuuJEHgoLt2AfejEjO2099Upc8k7c+pXWsvMkW7BA==}
-    hasBin: true
-
   turbo-linux-64@2.8.13:
     resolution: {integrity: sha512-j29KnQhHyzdzgCykBFeBqUPS4Wj7lWMnZ8CHqytlYDap4Jy70l4RNG46pOL9+lGu6DepK2s1rE86zQfo0IOdPw==}
     cpu: [x64]
@@ -23496,10 +23489,6 @@ snapshots:
 
   turbo-darwin-arm64@2.8.13:
     optional: true
-
-  turbo-ignore@2.8.14:
-    dependencies:
-      json5: 2.2.3
 
   turbo-linux-64@2.8.13:
     optional: true


### PR DESCRIPTION
## Summary
- Reverts 1fcdec62 ("fix: add turbo-ignore as root devDependency")
- Removes `turbo-ignore` from root `devDependencies` and updates lockfile

## Why
The Vercel "Ignored Build Step" runs `npx turbo-ignore` **before** `pnpm install`, so the devDependency is never available when it's needed. `npx` still downloads it fresh every time regardless.