### PR TITLE
feat(ci): upgrade simplify subagent with structured analysis and file-based prompt

### DIFF
--- a/.github/prompts/simplify-review.md
+++ b/.github/prompts/simplify-review.md
@@ -1,18 +1,18 @@
-# Simplify Review Coordinator
+# Simplify Review
 
-You are a code simplification coordinator. Your job is to analyze a PR diff for simplification opportunities, then return a structured summary of findings. You do NOT post any GitHub comments — just return your findings to the caller.
+You are a code simplification specialist. Your job is to analyze a PR diff for simplification opportunities, then return a structured summary of findings. You do NOT post any GitHub comments — just return your findings to the caller.
 
 ## Phase 1: Get Context
 
-1. Run `gh pr diff $PR_NUMBER` to get the full diff
+1. Run `gh pr diff <PR_NUMBER>` to get the full diff (replace `<PR_NUMBER>` with the PR number from your prompt)
 2. Read `AGENTS.md` and `CLAUDE.md` for project conventions
-3. Store the diff text — you will pass it to each sub-agent
+3. Store the diff text for analysis
 
-## Phase 2: Launch Three Research Agents in Parallel
+## Phase 2: Analyze for Simplification
 
-Use the Agent tool to launch all three agents concurrently in a single message. Pass each agent the full diff so it has the complete context.
+Review the changed code for three categories. For each, search the codebase for context — read surrounding files, check for existing patterns, and verify your findings against the actual code.
 
-### Agent 1: Code Reuse Review
+### Code Reuse
 
 For each change:
 
@@ -22,7 +22,7 @@ For each change:
 
 This is a monorepo. Search across `packages/*/src/` for existing utilities.
 
-### Agent 2: Code Quality Review
+### Code Quality
 
 Review the same changes for hacky patterns:
 
@@ -30,11 +30,12 @@ Review the same changes for hacky patterns:
 2. **Parameter sprawl**: adding new parameters to a function instead of generalizing or restructuring existing ones
 3. **Copy-paste with slight variation**: near-duplicate code blocks that should be unified with a shared abstraction
 4. **Leaky abstractions**: exposing internal details that should be encapsulated, or breaking existing abstraction boundaries
-5. **Stringly-typed code**: using raw strings where constants, enums (string unions), or branded types already exist in the codebase
-6. **Unnecessary JSX nesting**: wrapper Boxes/elements that add no layout value — check if inner component props (flexShrink, alignItems, etc.) already provide the needed behavior
-7. **Project convention deviations**: check AGENTS.md and CLAUDE.md for project conventions. Do not flag issues that Biome already enforces (formatting, import sorting, Tailwind class order).
+5. **Unclear naming**: vague variable/function names that obscure intent — look for names that don't clearly convey purpose or type
+6. **Stringly-typed code**: using raw strings where constants, enums (string unions), or branded types already exist in the codebase
+7. **Unnecessary JSX nesting**: wrapper Boxes/elements that add no layout value — check if inner component props (flexShrink, alignItems, etc.) already provide the needed behavior
+8. **Project convention deviations**: check AGENTS.md and CLAUDE.md for project conventions. Do not flag issues that Biome already enforces (formatting, import sorting, Tailwind class order).
 
-### Agent 3: Efficiency Review
+### Efficiency
 
 Review the same changes for efficiency:
 
@@ -46,9 +47,9 @@ Review the same changes for efficiency:
 6. **Overly broad operations**: reading entire files when only a portion is needed, loading all items when filtering for one
 7. **Missing subscription cleanup**: `subscribe()` without corresponding `unsubscribe` in effect or cleanup patterns
 
-## Phase 3: Aggregate and Filter
+## Phase 3: Filter
 
-Wait for all three agents to complete. For each finding:
+For each finding:
 
 - **Keep** if it's genuinely worth changing — a real improvement, not nitpicking
 - **Filter out** if it's a false positive, too minor, or stylistic preference already handled by the linter

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,7 @@ env:
 
     FIRST: Immediately launch a simplification subagent in the background using the Agent tool (with run_in_background: true) with this prompt:
 
-    "Read the file .github/prompts/simplify-review.md and follow its instructions exactly. The PR number is ${{ github.event.pull_request.number }} (use this as $PR_NUMBER). The repository is checked out in the current working directory. Return your findings as a structured summary — do NOT post any GitHub comments yourself."
+    "Read the file .github/prompts/simplify-review.md for guidance on what to look for. The PR number is ${{ github.event.pull_request.number }}. Wherever the file says <PR_NUMBER>, use ${{ github.event.pull_request.number }}. The repository is checked out in the current working directory. Return your findings as a structured summary — do NOT post any GitHub comments yourself."
 
     THEN: While the simplify agent runs in the background, proceed with the review:
 


### PR DESCRIPTION
## Summary

- Upgrade the CI review's simplify subagent from a generic 6-item checklist to a structured 3-category analysis (reuse, quality, efficiency) adapted from the official `/simplify` skill
- Move simplify instructions out of `REVIEW_PROMPT` into `.github/prompts/simplify-review.md` to avoid polluting the main review agent's context
- Only the main review agent posts to GitHub — the simplify subagent is pure research, returning structured findings

### Prerequisites
- PR #3520 (merged) — introduced the initial single-agent simplify subagent

## What changed

| File | Change |
|------|--------|
| `.github/prompts/simplify-review.md` | **New.** Simplify analysis prompt covering 3 categories (reuse: 3 items, quality: 8 items, efficiency: 7 items) adapted from the official `/simplify` skill with monorepo-specific additions |
| `.github/workflows/claude-code-review.yml` | **Updated.** Replaced 28-line inline simplify prompt with 3-line file-read instruction. Expanded FINALLY block so the review agent posts inline comments for simplify findings with deduplication |

## Architecture

The simplify subagent runs as a single background agent analyzing three categories sequentially (not nested sub-agents — Claude Code subagents [cannot spawn sub-agents](https://github.com/anthropics/claude-code/issues/19077)). Findings flow back to the main review agent, which applies final judgment and posts comments.

```
Main Review Agent
├─ FIRST: Agent(background) → Simplify subagent
│         reads .github/prompts/simplify-review.md
│         analyzes: reuse → quality → efficiency
│         returns structured findings
├─ THEN: Full code review (concurrent)
└─ FINALLY: Collect simplify findings
            Post inline comments (deduplicated)
            Post sticky comment with ## Simplify section
```

## Design decisions

<details>
<summary>Click to expand</summary>

### File-based prompt separation
Simplify instructions live in a separate `.md` file instead of inline in REVIEW_PROMPT. The subagent reads it at runtime. This keeps the main review agent's context clean — it only sees a 3-line launch instruction instead of 80+ lines of simplify criteria.

**Alternatives rejected:**
- `--append-system-prompt-file` — loads into main agent's system prompt (same pollution)
- Separate `SIMPLIFY_PROMPT` env var — GHA top-level env vars can't reference each other
- `plugins` input — requires external marketplace repo, over-engineered

### Single agent, not nested sub-agents
Originally designed as a coordinator spawning 3 parallel research agents. Discovered that [subagents cannot spawn sub-agents](https://github.com/anthropics/claude-code/issues/19077) — this is by design, not a bug. Restructured to a single agent analyzing 3 categories sequentially.

### Pure research subagent, single commenter
The simplify subagent never touches GitHub. Only the main review agent posts inline comments and the sticky comment. This avoids the known subagent MCP tool inheritance issues, enables deduplication with review findings, and gives a consistent voice.

### Two-layer filtering
The simplify agent filters false positives in its analysis, then the main review agent applies final judgment on what deserves an inline comment. Two layers of noise reduction.

### Fork PR security
For fork PRs (`pull_request_target`), the checkout contains fork-controlled files. The launch instruction uses "for guidance" framing (not "follow exactly") and `<PR_NUMBER>` placeholder syntax (not `$PR_NUMBER` shell variable) to reduce prompt injection risk. GitHub-level `contents: read` permission is the hard safety boundary.

### Discoverable, not hardcoded
Agents read AGENTS.md/CLAUDE.md at review time to learn conventions. No hardcoded utility names that could go stale. Only structural facts hardcoded: monorepo layout (`packages/*/src/`), linter name (Biome).

</details>

## Bot review comment dispositions

<details>
<summary>Click to expand triage of bot review comments</summary>

### Fixed (3)
- `$PR_NUMBER` shell variable expansion risk → changed to `<PR_NUMBER>` placeholder (greptile)
- "follow exactly" fork injection wording → softened to "for guidance" (Copilot, Codex, Vercel)
- Missing "unclear naming" in quality checklist → added as item 5 (Vercel)

### By-design (2)
- "Redundant re-evaluation of filtered findings" → two-layer filtering is intentional; simplify agent pre-filters, review agent applies final judgment (Vercel)
- "Single-agent pass instead of 3-agent workflow" → subagents cannot spawn sub-agents; single-agent sequential analysis is the correct architecture (cubic-dev-ai, Copilot)

### False positives (2)
- "Phase 2 lacks Agent tool syntax" → Phase 2 no longer spawns agents; it's sequential analysis by a single agent (Vercel)
- "Missing run_in_background for sub-agents" → no sub-agents exist; the single simplify agent is already launched with run_in_background by the main review agent (Copilot)

### Acknowledged, accepted risk (2)
- Fork PR can modify simplify prompt file → pre-existing risk (CLAUDE.md/AGENTS.md also fork-controlled), mitigated by softened wording and GitHub permission boundary (Codex, Copilot, Vercel)
- Old branches without prompt file will fail → graceful degradation; simplify section will say no findings, review still completes (Codex)

</details>

## Deferred / out of scope

- Nested sub-agents (blocked by Claude Code architecture — [#19077](https://github.com/anthropics/claude-code/issues/19077))
- Reading prompt file from base ref instead of fork checkout (would fully eliminate fork injection vector)
- Changes to `claude.yml` (interactive @claude workflow)

## Test plan

- [x] Pushed to PR, CI review triggered
- [ ] Simplify subagent launches in background and completes
- [ ] Sticky comment includes `## Simplify` section with structured findings
- [ ] Inline comments posted for worthy findings (not duplicated with review)
- [ ] Total time stays under 15 minutes