### PR TITLE
feat(ci): add changeset semver check with cascade impact analysis

### DIFF
--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze Changeset Bump Types
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 2
     outputs:
       has_violations: ${{ steps.check.outputs.has_violations }}
@@ -67,8 +67,9 @@ jobs:
                 newVersion: bumpVersion(v.version, v.bumpType),
               }));
 
-              while (queue.length > 0) {
-                const { pkg, newVersion } = queue.shift();
+              let qi = 0;
+              while (qi < queue.length) {
+                const { pkg, newVersion } = queue[qi++];
                 const dependents = revDeps.get(pkg) || [];
                 for (const dep of dependents) {
                   if (visited.has(dep.name)) continue;
@@ -137,8 +138,12 @@ jobs:
             const packagesDir = "packages";
             for (const dir of fs.readdirSync(packagesDir)) {
               const pkgJsonPath = path.join(packagesDir, dir, "package.json");
-              if (!fs.existsSync(pkgJsonPath)) continue;
-              const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+              let pkgJson;
+              try {
+                pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+              } catch {
+                continue;
+              }
               if (pkgJson.private) continue;
               const major = parseInt(pkgJson.version.split(".")[0], 10);
               pkgMap.set(pkgJson.name, { major, version: pkgJson.version });
@@ -150,6 +155,7 @@ jobs:
               };
               for (const [depName, range] of Object.entries(allDeps)) {
                 if (typeof range !== "string" || !range.startsWith("^")) continue;
+                if (!pkgMap.has(depName)) continue;
                 if (!revDeps.has(depName)) revDeps.set(depName, []);
                 revDeps.get(depName).push({
                   name: pkgJson.name,
@@ -296,7 +302,7 @@ jobs:
     name: Confirm Semver-Breaking Bump
     needs: analyze
     if: needs.analyze.outputs.has_violations == 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 5
     environment: confirm-semver-bump
     steps:
@@ -307,7 +313,7 @@ jobs:
     name: Semver Check
     if: always()
     needs: [analyze, confirm]
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 1
     steps:
       - name: Check result


### PR DESCRIPTION
## Summary

- Adds a CI gate that detects semver-breaking changeset bumps (minor/major on 0.x packages, major on 1.x+) and requires maintainer approval before merge
- Shows cascade impact analysis on every PR with changesets — which downstream packages get auto-patched and whether those patches break their consumers' `^` ranges
- Uses GitHub environment approvals as the confirmation mechanism (native "Review pending deployments" button)
- Supports fork PRs via `pull_request_target`

## What changed

| File | Change |
|------|--------|
| `.github/workflows/changeset-semver-check.yaml` | **New.** Three-job workflow: `analyze` (detect violations + cascade), `confirm` (environment gate), `result` (required status check) |

## How the three-job gate works

```
analyze ──→ confirm ──→ result (required check)
              ↑              ↑
        only if violations   always runs
        (environment gate)   passes if analyze OK
                             AND confirm OK (when needed)
```

GitHub doesn't allow a skipped job to satisfy a required check. The `result` job solves this by always running and checking the other jobs' outcomes explicitly.

## Design decisions

<details>
<summary>Click to expand design decisions and rationale</summary>

### Environment approval over labels
Initially used a `allow-non-patch-bump` label for override. Switched to GitHub environment (`confirm-semver-bump`) which provides a native "Review pending deployments" button — cleaner UX, no label sprawl, any team member with write access can approve.

### Version-aware rules instead of flat "no minor/major"
`^0.12.15` locks to minor (`<0.13.0`), so minor bumps are breaking. `^1.3.12` locks to major (`<2.0.0`), so only major bumps are breaking. Rules are tiered accordingly.

### 0.0.x patch bumps intentionally NOT flagged
All `0.0.x` packages in this repo are pre-stable leaves with no internal dependents. Flagging their patches would create noise for accepted instability. Documented in code comment.

### `pull_request_target` for fork support
Fork PRs can't access target repo environments under `pull_request`. `pull_request_target` runs in the target repo's context. Security is acceptable because only data files (changeset YAML + package.json) are read — no fork code is executed. The inline `github-script` comes from the workflow on `main`, not from the PR.

### PR-scoped changeset scanning
Scanning all `.changeset/*.md` files would re-flag old approved changesets from previous PRs sitting on `main`. Scoped to PR-changed files via `git diff --name-only --diff-filter=ACM BASE_SHA HEAD_SHA`.

### No semver library
`actions/github-script` has no npm dependencies available. Caret range logic is straightforward for stable `X.Y.Z` versions (three tiers: `^0.0.Z` exact, `^0.X.Z` minor-locked, `^X.Y.Z` major-locked). No prerelease versions exist in this repo.

### Always-visible cascade
Initially cascade only showed for violations. Changed so safe PRs also get an informational "Changeset Impact Summary" showing blast radius, and breaking cascade entries surface as `core.warning()` annotations in the PR checks tab.

</details>

## Bot review comment dispositions

<details>
<summary>Click to expand triage of bot review comments (23 comments)</summary>

### Fixed (12)
- `visited.add` before range check — suppressed cascade entries (cubic-dev-ai, Copilot, greptile, vercel)
- Scans all changesets instead of PR-changed files (chatgpt-codex, Copilot)
- Unknown/private packages cause NaN (Copilot, claude)
- No try-catch around `JSON.parse` (claude, vercel)
- `revDeps` indexes third-party packages (claude)
- Parameter misleadingly named `violations` instead of `bumps` (claude)

### By-design (3)
- 0.0.x patch bumps not flagged → intentional, documented in code comment (Copilot, claude, vercel)

### False positives (6)
- `actions/checkout@v6` doesn't exist → v6 is valid, released 2026 (claude x2)
- Pre-release versions produce NaN → no pre-release versions in this repo (greptile, claude, vercel)
- `breakingCascade` filter duplicated → not duplicated in current code (claude)

### Still open (2)
- Add clarifying comment for `isOutsideCaretRange(depVersion, ...)` call semantics (claude) — minor readability
- `git diff` may fail if base SHA not reachable from PR head (Copilot) — mitigated by fallback to scan all files

</details>

## Deferred / out of scope

- **Pre-release version handling**: No pre-release versions exist; `npm-publish.yaml` already rejects them
- **Posting PR comments**: Job summary linked from the check is sufficient
- **Validating against npm registry**: Already done in `npm-publish.yaml`

## Test plan

- [x] Tested locally with a patch-only changeset — informational summary renders correctly
- [x] Tested locally with a minor changeset on a 0.x package — violation summary with cascade annotations renders
- [x] Verified cascade BFS correctly handles 0.0.x chain recursion (breaking cascades propagate further)
- [x] Verified PR-scoping excludes pre-existing changesets on main