### PR TITLE
fix(core): remove zod dependency from @assistant-ui/core

### DIFF
--- a/.changeset/remove-zod-from-core.md
+++ b/.changeset/remove-zod-from-core.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+Remove zod dependency by using assistant-stream's toJSONSchema utility for schema serialization in AssistantFrameProvider

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,6 @@
     "@types/react": "*",
     "react": "^18 || ^19",
     "assistant-cloud": "^0.1.21",
-    "zod": "^4.0.0",
     "zustand": "^5.0.11"
   },
   "peerDependenciesMeta": {
@@ -78,9 +77,6 @@
       "optional": true
     },
     "react": {
-      "optional": true
-    },
-    "zod": {
       "optional": true
     },
     "zustand": {

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -1,7 +1,6 @@
 import { ModelContextProvider, ModelContext } from "../types";
 import type { Unsubscribe } from "../../types";
-import { Tool } from "assistant-stream";
-import { z } from "zod";
+import { Tool, toJSONSchema } from "assistant-stream";
 import {
   FrameMessage,
   FRAME_MESSAGE_CHANNEL,
@@ -11,10 +10,7 @@ import {
 
 const serializeTool = (tool: Tool<any, any>): SerializedTool => ({
   ...(tool.description && { description: tool.description }),
-  parameters:
-    tool.parameters instanceof z.ZodType
-      ? ((z as any).toJSONSchema?.(tool.parameters) ?? tool.parameters)
-      : tool.parameters,
+  parameters: tool.parameters ? toJSONSchema(tool.parameters) : undefined,
   ...(tool.disabled !== undefined && { disabled: tool.disabled }),
   ...(tool.type && { type: tool.type }),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2052,9 +2052,6 @@ importers:
       nanoid:
         specifier: ^5.1.6
         version: 5.1.6
-      zod:
-        specifier: ^4.0.0
-        version: 4.3.6
     devDependencies:
       '@assistant-ui/store':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- **`@assistant-ui/core` no longer requires `zod` at runtime** — the static `import { z } from "zod"` in `AssistantFrameProvider` is replaced with `assistant-stream`'s `toJSONSchema` utility, which uses Standard Schema duck-typing instead of `instanceof`
- Broadens schema support beyond Zod to any StandardSchemaV1-compliant library (Valibot, ArkType, etc.)
- Removes `zod` from `peerDependencies` entirely since it was the only import

## What changed

| File | Change |
|------|--------|
| `packages/core/src/model-context/frame/provider.ts` | **Updated.** Replaced `import { z } from "zod"` with `import { toJSONSchema } from "assistant-stream"`. Simplified `serializeTool` from a 3-line `instanceof z.ZodType` check to `toJSONSchema(tool.parameters)`. |
| `packages/core/package.json` | **Updated.** Removed `zod` from `peerDependencies` and `peerDependenciesMeta`. |
| `.changeset/remove-zod-from-core.md` | **New.** Patch changeset for `@assistant-ui/core`. |

## Why this matters

`@assistant-ui/core` declared `zod` as an optional peer dependency, but `provider.ts` had a top-level static `import { z } from "zod"`. Since `provider.ts` is re-exported through `index.ts → model-context/ → frame/`, **anyone importing anything from `@assistant-ui/core` would crash if zod wasn't installed** — making the "optional" claim false at runtime.

## Design decisions

<details>
<summary>Click to expand design decisions and rationale</summary>

### Use `assistant-stream`'s `toJSONSchema` instead of dynamic `import("zod")`

The alternative was `await import("zod")` with a try/catch, but this would require making `serializeTool` → `serializeModelContext` → `broadcastUpdate` all async — unnecessary complexity since `assistant-stream` already exports a synchronous, duck-typed `toJSONSchema()` that handles Zod 4 via `~standard.toJSONSchema`, plus `.toJSONSchema()`, `.toJSON()`, and plain JSON Schema fallback. This pattern is already used elsewhere in core (`runtimes/assistant-transport/utils.ts` imports `toToolsJSONSchema`).

### Keep `serializeTool` rather than switching to `toToolsJSONSchema`

`SerializedTool` includes `disabled` and `type` fields that `ToolJSONSchema` from `assistant-stream` doesn't carry — these are needed for the frame protocol. So `serializeTool` isn't a true duplicate.

</details>

## Bot review comment dispositions

<details>
<summary>Click to expand triage of bot review comments</summary>

### By-design (3)

- **Zod v3 takes a different path** (claude[bot]) → Zod v3 schemas without StandardSchema support fall through to the same `return schema as JSONSchema7` result. Functionally equivalent.
- **Static vs instance `toJSONSchema` paths** (claude[bot]) → `z.toJSONSchema(schema)` and `schema["~standard"].toJSONSchema()` produce equivalent output for Zod v4. Tests confirm this.
- **`.toJSON()` fallback widens risk surface** (claude[bot]) → Pre-existing behavior in `assistant-stream`, not introduced here. Actually strictly better than the old code which would send raw Zod objects across postMessage.

### False positives (3)

- **Reverse dep graph single-pass bug** (greptile, cubic, chatgpt-codex) → These comments are on `.github/workflows/changeset-semver-check.yaml`, a file from a different branch included in the diff due to branch history. Not part of this PR's changes.

</details>

## Deferred / out of scope

- `packages/react-devtools/src/utils/toolNormalization.ts` still uses the old `instanceof z.ZodType` + `z.toJSONSchema` pattern — could be updated separately

## Test plan

- [x] `pnpm --filter @assistant-ui/core test` — 51 tests pass
- [x] `pnpm --filter @assistant-ui/react test` — all pass, including 8 AssistantFrame integration tests that exercise Zod schema serialization
- [x] `pnpm turbo build --filter=@assistant-ui/core` — builds cleanly
- [x] `pnpm install` — no peer dep warnings
- [x] `/simplify` review — no issues found