### PR TITLE
feat: unify and simplify thread message renderingRefactor message rendering for the native thread list by introducing aflexible components API and consolidating per-message logic.

### DIFF
--- a/packages/react-native/src/context/AssistantContext.tsx
+++ b/packages/react-native/src/context/AssistantContext.tsx
@@ -14,7 +14,7 @@ export const useAssistantRuntime = (): AssistantRuntime => {
   return runtime;
 };
 
-export const AssistantProvider = memo(
+export const AssistantRuntimeProvider = memo(
   ({
     runtime,
     children,

--- a/packages/react-native/src/context/index.ts
+++ b/packages/react-native/src/context/index.ts
@@ -1,1 +1,4 @@
-export { AssistantProvider, useAssistantRuntime } from "./AssistantContext";
+export {
+  AssistantRuntimeProvider,
+  useAssistantRuntime,
+} from "./AssistantContext";

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -92,7 +92,7 @@ export {
 } from "@assistant-ui/store";
 
 // Context providers and hooks
-export { AssistantProvider, useAssistantRuntime } from "./context";
+export { AssistantRuntimeProvider, useAssistantRuntime } from "./context";
 
 // Primitive hooks
 export {
@@ -109,8 +109,6 @@ export {
   useActionBarReload,
   useActionBarFeedbackPositive,
   useActionBarFeedbackNegative,
-  useEditComposerSend,
-  useEditComposerCancel,
   useComposerAddAttachment,
 } from "./primitive-hooks";
 
@@ -148,10 +146,3 @@ export {
 export * from "./model-context";
 export * from "./client";
 export * from "./types";
-
-// Adapters
-export {
-  type TitleGenerationAdapter,
-  createSimpleTitleAdapter,
-  createLocalStorageAdapter,
-} from "./adapters";

--- a/packages/react-native/src/primitive-hooks/index.ts
+++ b/packages/react-native/src/primitive-hooks/index.ts
@@ -15,6 +15,4 @@ export {
   useActionBarFeedbackPositive,
   useActionBarFeedbackNegative,
 } from "./useActionBarFeedback";
-export { useEditComposerSend } from "./useEditComposerSend";
-export { useEditComposerCancel } from "./useEditComposerCancel";
 export { useComposerAddAttachment } from "./useComposerAddAttachment";

--- a/packages/react-native/src/primitive-hooks/useComposerCancel.ts
+++ b/packages/react-native/src/primitive-hooks/useComposerCancel.ts
@@ -6,7 +6,7 @@ export const useComposerCancel = () => {
   const canCancel = useAuiState((s) => s.thread.isRunning);
 
   const cancel = useCallback(() => {
-    aui.threads().thread("main").cancelRun();
+    aui.composer().cancel();
   }, [aui]);
 
   return { cancel, canCancel };

--- a/packages/react-native/src/primitive-hooks/useComposerSend.ts
+++ b/packages/react-native/src/primitive-hooks/useComposerSend.ts
@@ -3,7 +3,9 @@ import { useAui, useAuiState } from "@assistant-ui/store";
 
 export const useComposerSend = () => {
   const aui = useAui();
-  const canSend = useAuiState((s) => !s.composer.isEmpty);
+  const canSend = useAuiState(
+    (s) => !s.thread.isRunning && s.composer.isEditing && !s.composer.isEmpty,
+  );
 
   const send = useCallback(() => {
     aui.composer().send();

--- a/packages/react-native/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.tsx
@@ -1,51 +1,125 @@
-import { type ReactElement, useCallback } from "react";
+import { type ComponentType, type FC, memo, useCallback } from "react";
 import { FlatList, type FlatListProps } from "react-native";
 import type { ThreadMessage } from "@assistant-ui/core";
-import { useAui, useAuiState, AuiProvider, Derived } from "@assistant-ui/store";
+import { useAuiState } from "@assistant-ui/store";
+import { MessageByIndexProvider } from "@assistant-ui/core/react";
+
+type MessageComponents =
+  | {
+      Message: ComponentType;
+      EditComposer?: ComponentType | undefined;
+      UserEditComposer?: ComponentType | undefined;
+      AssistantEditComposer?: ComponentType | undefined;
+      SystemEditComposer?: ComponentType | undefined;
+      UserMessage?: ComponentType | undefined;
+      AssistantMessage?: ComponentType | undefined;
+      SystemMessage?: ComponentType | undefined;
+    }
+  | {
+      Message?: ComponentType | undefined;
+      EditComposer?: ComponentType | undefined;
+      UserEditComposer?: ComponentType | undefined;
+      AssistantEditComposer?: ComponentType | undefined;
+      SystemEditComposer?: ComponentType | undefined;
+      UserMessage: ComponentType;
+      AssistantMessage: ComponentType;
+      SystemMessage?: ComponentType | undefined;
+    };
 
 export type ThreadMessagesProps = Omit<
   FlatListProps<ThreadMessage>,
   "data" | "renderItem"
 > & {
-  renderMessage: (props: {
-    message: ThreadMessage;
-    index: number;
-  }) => ReactElement;
+  components: MessageComponents;
 };
 
-const MessageScope = ({
-  index,
-  children,
-}: {
-  index: number;
-  children: ReactElement;
+const DEFAULT_SYSTEM_MESSAGE = () => null;
+
+const getComponent = (
+  components: MessageComponents,
+  role: ThreadMessage["role"],
+  isEditing: boolean,
+) => {
+  switch (role) {
+    case "user":
+      if (isEditing) {
+        return (
+          components.UserEditComposer ??
+          components.EditComposer ??
+          components.UserMessage ??
+          (components.Message as ComponentType)
+        );
+      } else {
+        return components.UserMessage ?? (components.Message as ComponentType);
+      }
+    case "assistant":
+      if (isEditing) {
+        return (
+          components.AssistantEditComposer ??
+          components.EditComposer ??
+          components.AssistantMessage ??
+          (components.Message as ComponentType)
+        );
+      } else {
+        return (
+          components.AssistantMessage ?? (components.Message as ComponentType)
+        );
+      }
+    case "system":
+      if (isEditing) {
+        return (
+          components.SystemEditComposer ??
+          components.EditComposer ??
+          components.SystemMessage ??
+          (components.Message as ComponentType)
+        );
+      } else {
+        return (
+          components.SystemMessage ??
+          (components.Message as ComponentType) ??
+          DEFAULT_SYSTEM_MESSAGE
+        );
+      }
+    default: {
+      const _exhaustiveCheck: never = role;
+      throw new Error(`Unknown message role: ${_exhaustiveCheck}`);
+    }
+  }
+};
+
+const ThreadMessageComponent: FC<{ components: MessageComponents }> = ({
+  components,
 }) => {
-  const aui = useAui({
-    message: Derived({
-      source: "thread",
-      query: { type: "index", index },
-      get: (aui) => aui.threads().thread("main").message({ index }),
-    }),
-  });
+  const role = useAuiState((s) => s.message.role);
+  const isEditing = useAuiState((s) => s.message.composer.isEditing);
+  const Component = getComponent(components, role, isEditing);
 
-  return <AuiProvider value={aui}>{children}</AuiProvider>;
+  return <Component />;
 };
+
+const ThreadMessageByIndex = memo(
+  ({ index, components }: { index: number; components: MessageComponents }) => {
+    return (
+      <MessageByIndexProvider index={index}>
+        <ThreadMessageComponent components={components} />
+      </MessageByIndexProvider>
+    );
+  },
+  (prev, next) =>
+    prev.index === next.index && prev.components === next.components,
+);
 
 export const ThreadMessages = ({
-  renderMessage,
+  components,
   ...flatListProps
 }: ThreadMessagesProps) => {
   const messages = useAuiState((s) => s.thread.messages);
 
   const renderItem = useCallback(
-    ({ item, index }: { item: ThreadMessage; index: number }) => {
-      return (
-        <MessageScope index={index}>
-          {renderMessage({ message: item as ThreadMessage, index })}
-        </MessageScope>
-      );
+    ({ index }: { item: ThreadMessage; index: number }) => {
+      return <ThreadMessageByIndex index={index} components={components} />;
     },
-    [renderMessage],
+    [components],
   );
 
   const keyExtractor = useCallback((item: ThreadMessage) => item.id, []);


### PR DESCRIPTION
- Replace individual renderMessage prop with a components prop that accepts either a Message-focused or role-focused component set.
- Add getComponent helper to choose the appropriate component for a message based on role and editing state (user/assistant/system), with sensible fallbacks and a default no-op system renderer.
- Introduce ThreadMessageComponent and ThreadMessageByIndex to read message-specific store state and render the resolved component.
- Simplify composer actions: tighten canSend condition to require a non-running thread and editing non-empty composer; change cancel to call aui.composer().cancel().
- Remove unused exported hooks useEditComposerSend and useEditComposerCancel.

These changes centralize rendering rules, improve type safety formessage components, and make composer send/cancel behavior clearer andmore accurate.