### PR TITLE
feat(cli): add with-react-ink example to project scaffolding

### DIFF
--- a/.changeset/add-react-ink-to-cli.md
+++ b/.changeset/add-react-ink-to-cli.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+feat(cli): add with-react-ink example to project scaffolding

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -187,6 +187,14 @@ export const PROJECT_METADATA: ProjectMetadata[] = [
     hasLocalComponents: false,
   },
   {
+    name: "with-react-ink",
+    label: "React Ink",
+    description: "Terminal UI chat",
+    category: "example",
+    path: "examples/with-react-ink",
+    hasLocalComponents: true,
+  },
+  {
     name: "with-react-router",
     label: "React Router",
     description: "React Router v7 + Vite",

--- a/packages/cli/test/commands/create.test.ts
+++ b/packages/cli/test/commands/create.test.ts
@@ -178,8 +178,11 @@ describe("PROJECT_METADATA", () => {
   it("examples have correct hasLocalComponents values", () => {
     const examples = PROJECT_METADATA.filter((m) => m.category === "example");
     const withLocalComponents = examples.filter((e) => e.hasLocalComponents);
-    // with-expo is a React Native example that ships its own components
-    expect(withLocalComponents.map((e) => e.name)).toEqual(["with-expo"]);
+    // with-expo and with-react-ink ship their own components (no shadcn)
+    expect(withLocalComponents.map((e) => e.name)).toEqual([
+      "with-expo",
+      "with-react-ink",
+    ]);
   });
 
   it("every entry has a path", () => {


### PR DESCRIPTION
## Summary

- Register the `with-react-ink` example in the CLI so users can scaffold terminal chat apps via `npx assistant-ui create --example with-react-ink`
- Requires #3535 (core zod fix) — without it, esbuild can't bundle `@assistant-ui/core` in the standalone project

## What changed

| File | Change |
|------|--------|
| `packages/cli/src/commands/create.ts` | **Updated.** Add `with-react-ink` entry to `PROJECT_METADATA` array (category: example, hasLocalComponents: true) |
| `.changeset/add-react-ink-to-cli.md` | **New.** Patch changeset for the CLI package |

## Design decisions

<details>
<summary>Click to expand design decisions and rationale</summary>

### `hasLocalComponents: true`
The ink example has no shadcn UI components and no `@/components/assistant-ui/` imports. Setting this flag skips CSS transforms, tsconfig path cleanup, and shadcn component installation — all web-specific steps that would either no-op or fail for a Node.js terminal app. Same pattern used by `with-expo`.

### Category: example, not template
Consistent with `with-expo` as an alternate-platform showcase. Templates imply opinionated, production-ready starters; examples demonstrate a specific integration.

</details>

## Prerequisites

- #3535 (`fix(core): remove zod dependency`) must merge first. Without it, `@assistant-ui/core` statically imports zod (an optional peer dep), which causes esbuild to fail when bundling the ink example in a standalone project where zod isn't installed.

## Test plan

- [x] Built CLI, verified `with-react-ink` appears in `--help` output
- [x] Scaffolded standalone project via CLI, installed patched core, ran `pnpm dev` — terminal chat works
- [x] Transform pipeline correctly handles non-Next.js project (workspace refs → latest, no shadcn steps)