### PR TITLE
fix(core): add typeof process guard in useCloudThreadListAdapter

### DIFF
--- a/.changeset/fix-process-env-guard.md
+++ b/.changeset/fix-process-env-guard.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: restore `typeof process` runtime guard in useCloudThreadListAdapter

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -26,7 +26,9 @@ type CloudThreadListAdapterOptions = {
   delete?: ((threadId: string) => Promise<void>) | undefined;
 };
 
-const baseUrl = process?.env?.["NEXT_PUBLIC_ASSISTANT_BASE_URL"];
+const baseUrl =
+  typeof process !== "undefined" &&
+  process?.env?.["NEXT_PUBLIC_ASSISTANT_BASE_URL"];
 const autoCloud = baseUrl
   ? new AssistantCloud({ baseUrl, anonymous: true })
   : undefined;


### PR DESCRIPTION
The refactor in #3534 replaced the runtime `typeof process !== "undefined"` guard with a TypeScript `declare const process`, which only satisfies the compiler but crashes in browser environments where `process` is undeclared.

Restores the original guard from packages/react.

Fixes #3555.