### PR TITLE
security: remove fork PR review support from Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,8 +9,6 @@ on:
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
-  pull_request_target:
-    types: [opened, synchronize, ready_for_review, reopened]
 
 concurrency:
   group: claude-code-review-${{ github.event.pull_request.number }}
@@ -96,14 +94,7 @@ env:
 
 jobs:
   claude-review:
-    # Only run if at least one review scenario matches
-    if: |
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo != null &&
-      (
-        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-        (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
-      )
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     permissions:
@@ -114,123 +105,16 @@ jobs:
       actions: read
 
     steps:
-      - name: Checkout internal repository
-        if: |
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+      - name: Checkout repository
         uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           fetch-depth: 1
 
-      - name: Checkout fork repository
-        if: |
-          github.event_name == 'pull_request_target' &&
-          github.event.pull_request.head.repo.full_name != github.repository
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 1
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Minimize previous bot comments on fork PRs to keep discussion clean
-      # NOTE: Temporary workaround until https://github.com/anthropics/claude-code-action/pull/411 is merged
-      # PR #411 adds sticky_comment_app_bot_id/name config to make sticky comments work with github-actions[bot]
-      # Uses GraphQL script instead of int128/hide-comment-action or step-security fork for no external dependencies
-      - name: Minimize previous fork PR comments
-        if: |
-          github.event_name == 'pull_request_target' &&
-          github.event.pull_request.head.repo.full_name != github.repository
-        uses: actions/github-script@v8
-        with:
-          script: |
-            try {
-              const owner = context.repo.owner;
-              const repo = context.repo.repo;
-              const prNumber = context.issue.number;
-              let hasNextPage = true;
-              let afterCursor = null;
-              let minimizedCount = 0;
-
-              core.info(`Checking for previous github-actions comments on PR #${prNumber}...`);
-
-              while (hasNextPage) {
-                const { repository } = await github.graphql(`
-                  query($owner: String!, $repo: String!, $prNumber: Int!, $after: String) {
-                    repository(owner: $owner, name: $repo) {
-                      pullRequest(number: $prNumber) {
-                        comments(first: 100, after: $after) {
-                          nodes {
-                            id
-                            author { login }
-                            isMinimized
-                          }
-                          pageInfo {
-                            hasNextPage
-                            endCursor
-                          }
-                        }
-                      }
-                    }
-                  }
-                `, { owner, repo, prNumber, after: afterCursor });
-
-                const comments = repository.pullRequest.comments.nodes;
-                const pageInfo = repository.pullRequest.comments.pageInfo;
-
-                // Filter for non-minimized github-actions comments
-                const botComments = comments.filter(c =>
-                  c.author?.login === 'github-actions' && !c.isMinimized
-                );
-
-                core.info(`Found ${botComments.length} non-minimized bot comment(s) in this batch`);
-
-                // Minimize each bot comment
-                for (const comment of botComments) {
-                  await github.graphql(`
-                    mutation($commentId: ID!) {
-                      minimizeComment(input: { subjectId: $commentId, classifier: OUTDATED }) {
-                        minimizedComment { isMinimized }
-                      }
-                    }
-                  `, { commentId: comment.id });
-                  minimizedCount++;
-                }
-
-                hasNextPage = pageInfo.hasNextPage;
-                afterCursor = pageInfo.endCursor;
-              }
-
-              core.info(`✓ Successfully minimized ${minimizedCount} previous comment(s)`);
-            } catch (error) {
-              core.setFailed(`Failed to minimize comments: ${error.message}`);
-            }
-
-      # Same-repo PRs: Use pull_request trigger + OIDC → claude[bot]
-      - name: Internal Review
-        if: |
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+      - name: Review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: ${{ env.REVIEW_PROMPT }}
-          use_sticky_comment: ${{ fromJSON(env.USE_STICKY_COMMENT) }}
-          track_progress: ${{ fromJSON(env.TRACK_PROGRESS) }}
-          claude_args: ${{ env.CLAUDE_ARGS }}
-          additional_permissions: ${{ env.ADDITIONAL_PERMISSIONS }}
-
-      # Fork PRs: Use pull_request_target trigger + github_token → github-actions[bot]
-      - name: Fork Review
-        if: |
-          github.event_name == 'pull_request_target' &&
-          github.event.pull_request.head.repo.full_name != github.repository
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          allowed_non_write_users: '*'
           prompt: ${{ env.REVIEW_PROMPT }}
           use_sticky_comment: ${{ fromJSON(env.USE_STICKY_COMMENT) }}
           track_progress: ${{ fromJSON(env.TRACK_PROGRESS) }}


### PR DESCRIPTION
## Summary

- Remove `pull_request_target` trigger and all fork PR review support from the Claude Code Review workflow to eliminate a security vulnerability
- Fork contributors could inject malicious hooks/MCP servers via `.claude/settings.json` and `.mcp.json` that auto-execute in CI with access to secrets
- Same-repo PR reviews are completely unchanged
- Fork PRs now skip the workflow cleanly (no red CI status)

## What changed

| File | Change |
|------|--------|
| `.github/workflows/claude-code-review.yml` | **Updated.** Removed `pull_request_target` trigger, fork checkout step, fork review step, 60-line GraphQL comment minimization script, and all fork-specific conditionals. Added same-repo guard to prevent failed runs on fork PRs. |

## Security rationale

The `pull_request_target` event checks out fork code onto a runner that has access to `CLAUDE_CODE_OAUTH_TOKEN`, `GITHUB_TOKEN`, and OIDC tokens. Claude Code in CI mode (`-p` flag) auto-loads project-level hooks from `.claude/settings.json` and MCP servers from `.mcp.json` **without trust verification**. A malicious fork contributor could add config files that execute arbitrary commands and exfiltrate secrets.

Even with config sanitization (deleting `.claude/` and `.mcp.json`), prompt injection through source files and PR body remains an unsolved risk — Claude reads fork code deeply during review and the PR body is interpolated directly into the prompt.

Removing fork reviews entirely eliminates the attack surface. Can be revisited when the upstream action ([anthropics/claude-code-action#939](https://github.com/anthropics/claude-code-action/issues/939)) adds a secure fork review mode.

<details>
<summary>Design decisions</summary>

### Remove rather than harden

Considered splitting into two jobs with permission isolation, config sanitization (`rm -rf .claude && rm -f .mcp.json`), and `persist-credentials: false`. This blocks deterministic attacks (hooks, MCP) but not prompt injection through code files, which Claude reads deeply via the simplify subagent and inline review. Since the `CLAUDE_CODE_OAUTH_TOKEN` must be in the environment for Claude to function, prompt injection can exfiltrate it via PR comments — an allowed output channel that can't be blocked.

### Same-repo guard on job condition

Added `github.event.pull_request.head.repo.full_name == github.repository` to the job `if` condition. Without this, `pull_request` events still fire for fork PRs but secrets aren't available, causing a red CI status on external contributions. The guard ensures fork PRs skip cleanly.

### Keep permissions unchanged

`id-token: write` and `issues: read` are still needed for same-repo OIDC auth and CI status checking respectively.

</details>

<details>
<summary>Bot review comment dispositions</summary>

### Fixed (2)
- Missing same-repo guard causes fork PRs to fail with red CI (flagged by Copilot, cubic-dev-ai) — fixed by adding `github.event.pull_request.head.repo.full_name == github.repository` to the job `if`

### By-design (1)
- "Removal of pull_request_target eliminates security safeguards, exposing CLAUDE_CODE_OAUTH_TOKEN to untrusted fork code" (flagged by Vercel) → This misreads the change. The *previous* setup exposed `CLAUDE_CODE_OAUTH_TOKEN` to fork code via `pull_request_target`. Removing it *eliminates* that exposure. Fork PRs now don't run the workflow at all.

### By-design (1)
- "Fork PRs will no longer be reviewed" (flagged by greptile) → Intentional. Documented in PR description and design decisions.

</details>

## Deferred / out of scope

- Re-enabling fork PR reviews once `claude-code-action` supports a secure fork review mode (upstream [#939](https://github.com/anthropics/claude-code-action/issues/939))
- Network isolation / secret-injecting proxy approaches

## Test plan

- [x] Workflow YAML validates correctly (`gh workflow view` recognizes it)
- [x] All env vars, permissions, and action config unchanged for same-repo path
- [x] No stale fork references remain in the file
- [x] Same-repo guard prevents fork PRs from triggering failed runs
- [x] No changeset needed (workflow-only change, not a published package)