### PR TITLE
fix(ci): unblock version PR from Semver Check required status

### DIFF
--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Check changeset bump types against package versions
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  checks: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -47,6 +48,36 @@ jobs:
           version: pnpm ci:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # hasChangesets == 'true' means the action created/updated the version PR.
+      # ('false' means changesets were already consumed — the version PR was merged.)
+      # GITHUB_TOKEN force-pushes don't trigger pull_request_target workflows,
+      # so the "Semver Check" required status never runs on the version PR.
+      # Post a synthetic pass — the version PR only consumes changesets, never adds them.
+      - name: Mark semver check on version PR
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        continue-on-error: true
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prs = await github.rest.pulls.list({
+              owner, repo,
+              head: `${owner}:changeset-release/main`,
+              state: "open",
+            });
+            if (prs.data.length === 0) return;
+            await github.rest.checks.create({
+              owner, repo,
+              name: "Semver Check",
+              head_sha: prs.data[0].head.sha,
+              status: "completed",
+              conclusion: "success",
+              output: {
+                title: "Skipped — version PR",
+                summary: "Version PR only consumes changesets; no semver check needed.",
+              },
+            });
 
       - name: Detect release packages
         id: release_plan


### PR DESCRIPTION
## Summary

- Fixes the "chore: update versions" PR being permanently blocked by the `Semver Check` required status check
- The changesets bot force-pushes with `GITHUB_TOKEN`, which doesn't trigger `pull_request_target` workflows — so the semver check never runs on the version PR
- Adds a synthetic check run that posts a "Semver Check" pass after the bot updates the version PR
- Pins `actions/github-script` to SHA for supply-chain safety and upgrades to v8

### Prerequisites

- #3531 (adds the `changeset-semver-check.yaml` workflow and `Semver Check` required status)

## What changed

| File | Change |
|------|--------|
| `.github/workflows/changeset.yaml` | **Updated.** Added `checks: write` permission + new step that creates a synthetic "Semver Check" pass on the version PR after the changesets bot force-pushes |
| `.github/workflows/changeset-semver-check.yaml` | **Updated.** Pinned `actions/github-script` from unpinned `@v7` to SHA-pinned `@v8` |

## Why a synthetic check run?

The changesets bot force-pushes `changeset-release/main` using `GITHUB_TOKEN`. GitHub's anti-recursion protection suppresses all workflow triggers from `GITHUB_TOKEN` pushes. The `Semver Check` workflow (which uses `pull_request_target`) never fires, leaving the required status as "Waiting for status to be reported" — permanently blocking merge.

The synthetic pass is correct because the version PR only *consumes* changesets (deletes `.changeset/*.md` files and updates changelogs). It never introduces new ones. If the real check ran, it would always pass with "No changeset files changed in this PR."

## Design decisions

<details>
<summary>Click to expand design decisions and rationale</summary>

### Synthetic pass over GitHub App token
A GitHub App token would make the force-push trigger workflows naturally — the "correct" fix. But it requires creating an App, storing credentials, and modifying the release workflow. The synthetic pass is self-contained, uses the existing `GITHUB_TOKEN` with `checks: write`, and is logically equivalent since the version PR can never have semver violations.

### `continue-on-error: true`
If the Checks API call fails (rate limit, network error, permissions), the release workflow should not be affected. The synthetic check is a convenience — it must never block releases.

### Alternatives considered and rejected
- **`workflow_run` trigger**: Still requires the Checks API to associate with the PR — same approach, more indirection
- **Don't require the check**: Loses enforcement; someone could merge a breaking bump without noticing
- **`paths` filter on the workflow**: GitHub doesn't distinguish "skipped due to paths" from "hasn't run" — both block as "Waiting for status"
- **Inline the check logic in the changesets workflow**: Duplicates ~200 lines of JavaScript for a result that's always "pass"
- **Secondary `push`-triggered workflow**: Same `GITHUB_TOKEN` suppression applies

### SHA pinning and v8 upgrade
`actions/github-script` v8 only changes the Node.js runtime to 24.x — no API changes. SHA pinning prevents supply-chain attacks where a compromised tag could point to malicious code. Matches the pattern already used by checkout, pnpm, and setup-node in this workflow.

</details>

## Deferred / out of scope

- **Migrating to a GitHub App token**: Would eliminate the need for the synthetic check entirely, but requires infra setup beyond this PR's scope
- **Upgrading the existing `github-script@v7` references in `changeset.yaml`**: Only the new step uses v8; upgrading the existing steps is a separate chore

## Test plan

- [x] Verified the changesets workflow runs on push to main — the new step fires when `hasChangesets == 'true'`
- [x] Confirmed `pulls.list` correctly finds the `changeset-release/main` PR
- [x] Confirmed `checks.create` posts the status on the version PR's head commit
- [x] Verified `continue-on-error` allows the workflow to proceed if the step fails