### PR TITLE
chore(ci): add EXPO_PUBLIC_CHAT_ENDPOINT_URL env var

### DIFF
--- a/.github/workflows/expo.yaml
+++ b/.github/workflows/expo.yaml
@@ -17,6 +17,7 @@ permissions:
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_EXPO_PROJECT_ID }}
+  EXPO_PUBLIC_CHAT_ENDPOINT_URL: https://www.assistant-ui.com/api/chat
 
 jobs:
   deploy-production:


### PR DESCRIPTION
Add EXPO_PUBLIC_CHAT_ENDPOINT_URL to the Expo workflow environment sothe deployed app has the correct public chat API endpoint. This ensuresruntime code can read the endpoint from env and route chat requests tothe production API.