### PR TITLE
fix(docs): allow User-Agent header

### DIFF
--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -26,7 +26,7 @@ function corsHeaders(req: Request) {
   return {
     "Access-Control-Allow-Origin": origin,
     "Access-Control-Allow-Methods": "POST, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Allow-Headers": "Content-Type, User-Agent",
   };
 }
 


### PR DESCRIPTION
This is required for safari + Expo web (the expo demo is using the docs site endpoint for its api chat.