### PR TITLE
fix: normalize attachment-only sends for langgraph

### DIFF
--- a/.changeset/fix-normalize-attachment-only-sends--20260310134223.md
+++ b/.changeset/fix-normalize-attachment-only-sends--20260310134223.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: normalize attachment-only sends for langgraph
+
+Attachment-only user sends now normalize to include a minimal text part alongside file content. This prevents duplicate/invalid message payloads and improves compatibility with backends that require text + document blocks (for example, Bedrock Converse).

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -173,12 +173,21 @@ export abstract class BaseComposerRuntimeCore
     const quote = this._quote;
     this._quote = undefined;
     this._emptyTextAndAttachments();
+    const resolvedAttachments = await attachments;
+    const hasAttachments = resolvedAttachments.some(
+      (a) => (a.content?.length ?? 0) > 0,
+    );
+    const hasUserText = text.trim().length > 0;
 
     const message: Omit<AppendMessage, "parentId" | "sourceId"> = {
       createdAt: new Date(),
       role: this.role,
-      content: text ? [{ type: "text", text }] : [],
-      attachments: await attachments,
+      content: hasUserText
+        ? [{ type: "text", text }]
+        : hasAttachments
+          ? [{ type: "text", text: " " }]
+          : [],
+      attachments: resolvedAttachments,
       runConfig: this.runConfig,
       metadata: { custom: { ...(quote ? { quote } : {}) } },
     };

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -170,25 +170,20 @@ export abstract class BaseComposerRuntimeCore
         : [];
 
     const text = this.text;
+    const createdAt = new Date();
+    const role = this.role;
+    const runConfig = this.runConfig;
     const quote = this._quote;
     this._quote = undefined;
     this._emptyTextAndAttachments();
     const resolvedAttachments = await attachments;
-    const hasAttachments = resolvedAttachments.some(
-      (a) => (a.content?.length ?? 0) > 0,
-    );
-    const hasUserText = text.trim().length > 0;
 
     const message: Omit<AppendMessage, "parentId" | "sourceId"> = {
-      createdAt: new Date(),
-      role: this.role,
-      content: hasUserText
-        ? [{ type: "text", text }]
-        : hasAttachments
-          ? [{ type: "text", text: " " }]
-          : [],
+      createdAt,
+      role,
+      content: text ? [{ type: "text", text }] : [],
       attachments: resolvedAttachments,
-      runConfig: this.runConfig,
+      runConfig,
       metadata: { custom: { ...(quote ? { quote } : {}) } },
     };
 

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import {
+  type AttachmentAdapter,
   AssistantRuntime,
   AssistantRuntimeProvider,
+  useAui,
 } from "@assistant-ui/react";
 import { useLangGraphRuntime, useLangGraphSend } from "./useLangGraphRuntime";
 import { mockStreamCallbackFactory } from "./testUtils";
@@ -290,5 +292,157 @@ describe("useLangGraphRuntime", () => {
 
     // Should not throw any errors even when events are processed without handlers
     expect(runtimeResult.current).toBeDefined();
+  });
+
+  it("sends one stream request for attachment-only composer message", async () => {
+    const streamMock = vi
+      .fn()
+      .mockImplementation(() => mockStreamCallbackFactory([])());
+
+    const attachmentAdapter: AttachmentAdapter = {
+      accept: "application/pdf",
+      add: vi.fn().mockImplementation(async ({ file }) => ({
+        id: "att-1",
+        type: "document",
+        name: file.name,
+        contentType: file.type,
+        file,
+        status: { type: "requires-action", reason: "composer-send" },
+      })),
+      remove: vi.fn().mockResolvedValue(undefined),
+      send: vi.fn().mockImplementation(async (attachment) => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return {
+          ...attachment,
+          status: { type: "complete" },
+          content: [
+            {
+              type: "file",
+              filename: attachment.name,
+              data: "ZmFrZS1iYXNlNjQ=",
+              mimeType: attachment.contentType ?? "application/pdf",
+            },
+          ],
+        };
+      }),
+    };
+
+    const { result: runtimeResult } = renderHook(
+      () =>
+        useLangGraphRuntime({
+          stream: streamMock,
+          adapters: { attachments: attachmentAdapter },
+        }),
+      {},
+    );
+    const wrapper = wrapperFactory(runtimeResult.current);
+
+    const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+    await act(async () => {
+      await auiResult.current
+        .composer()
+        .addAttachment(
+          new File(["fake pdf bytes"], "example.pdf", {
+            type: "application/pdf",
+          }),
+        );
+    });
+
+    act(() => {
+      auiResult.current.composer().send();
+    });
+
+    await waitFor(() => {
+      expect(streamMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(streamMock).toHaveBeenCalledTimes(1);
+    expect(attachmentAdapter.send).toHaveBeenCalledTimes(1);
+    expect(
+      auiResult.current
+        .thread()
+        .getState()
+        .messages.filter((m) => m.role === "user"),
+    ).toHaveLength(1);
+
+    const [messages] = streamMock.mock.calls[0]!;
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.type).toBe("human");
+    expect(messages[0]!.content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        file: {
+          filename: "example.pdf",
+          file_data: "ZmFrZS1iYXNlNjQ=",
+          mime_type: "application/pdf",
+        },
+      },
+    ]);
+  });
+
+  it("injects text part for file-only thread append", async () => {
+    const streamMock = vi
+      .fn()
+      .mockImplementation(() => mockStreamCallbackFactory([])());
+
+    const { result: runtimeResult } = renderHook(
+      () =>
+        useLangGraphRuntime({
+          stream: streamMock,
+        }),
+      {},
+    );
+    const wrapper = wrapperFactory(runtimeResult.current);
+
+    const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+    act(() => {
+      auiResult.current.thread().append({
+        role: "user",
+        content: [],
+        attachments: [
+          {
+            id: "att-1",
+            type: "document",
+            name: "example.pdf",
+            contentType: "application/pdf",
+            status: { type: "complete" },
+            content: [
+              {
+                type: "file",
+                filename: "example.pdf",
+                data: "ZmFrZS1iYXNlNjQ=",
+                mimeType: "application/pdf",
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    await waitFor(() => {
+      expect(streamMock).toHaveBeenCalledTimes(1);
+    });
+
+    const [messages] = streamMock.mock.calls[0]!;
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.type).toBe("human");
+    expect(messages[0]!.content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        file: {
+          filename: "example.pdf",
+          file_data: "ZmFrZS1iYXNlNjQ=",
+          mime_type: "application/pdf",
+        },
+      },
+    ]);
   });
 });

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -59,7 +59,14 @@ const getMessageContent = (msg: AppendMessage) => {
     ...msg.content,
     ...(msg.attachments?.flatMap((a) => a.content) ?? []),
   ];
-  const content = allContent.map((part) => {
+  const hasFile = allContent.some((part) => part.type === "file");
+  const hasText = allContent.some((part) => part.type === "text");
+  const normalizedContent =
+    hasFile && !hasText
+      ? ([{ type: "text", text: " " }, ...allContent] as const)
+      : allContent;
+
+  const content = normalizedContent.map((part) => {
     const type = part.type;
     switch (type) {
       case "text":

--- a/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
+++ b/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
@@ -188,6 +188,44 @@ describe("BaseComposerRuntimeCore", () => {
     expect(composer.sentMessages[0]!.content).toEqual([]);
   });
 
+  it("send with empty text and attachment injects placeholder text content", async () => {
+    const pending = makePendingAttachment("att-1", "doc.pdf");
+    const completedFromAdapter = {
+      id: "att-1",
+      type: "document" as const,
+      name: "doc.pdf",
+      contentType: "application/pdf",
+      content: [
+        {
+          type: "file" as const,
+          filename: "doc.pdf",
+          data: "ZmFrZS1iYXNlNjQ=",
+          mimeType: "application/pdf",
+        },
+      ],
+      status: { type: "complete" as const },
+    };
+
+    const adapter: AttachmentAdapter = {
+      accept: "*",
+      add: vi.fn().mockResolvedValue(pending),
+      remove: vi.fn(),
+      send: vi.fn().mockResolvedValue(completedFromAdapter),
+    };
+    composer.setAttachmentAdapter(adapter);
+
+    await composer.addAttachment(new File(["data"], "doc.pdf"));
+    await composer.send();
+
+    expect(composer.sentMessages).toHaveLength(1);
+    expect(composer.sentMessages[0]!.content).toEqual([
+      { type: "text", text: " " },
+    ]);
+    expect(composer.sentMessages[0]!.attachments).toEqual([
+      completedFromAdapter,
+    ]);
+  });
+
   it("addAttachment throws when no adapter", async () => {
     const file = new File(["data"], "test.txt");
     await expect(composer.addAttachment(file)).rejects.toThrow(

--- a/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
+++ b/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
@@ -4,6 +4,7 @@ import type { AttachmentAdapter } from "../legacy-runtime/runtime-cores/adapters
 import type { DictationAdapter } from "../legacy-runtime/runtime-cores/adapters/speech/SpeechAdapterTypes";
 import type {
   AppendMessage,
+  CompleteAttachment,
   CreateAttachment,
   PendingAttachment,
 } from "@assistant-ui/core";
@@ -188,7 +189,7 @@ describe("BaseComposerRuntimeCore", () => {
     expect(composer.sentMessages[0]!.content).toEqual([]);
   });
 
-  it("send with empty text and attachment injects placeholder text content", async () => {
+  it("send with empty text and attachment keeps empty content", async () => {
     const pending = makePendingAttachment("att-1", "doc.pdf");
     const completedFromAdapter = {
       id: "att-1",
@@ -218,12 +219,61 @@ describe("BaseComposerRuntimeCore", () => {
     await composer.send();
 
     expect(composer.sentMessages).toHaveLength(1);
-    expect(composer.sentMessages[0]!.content).toEqual([
-      { type: "text", text: " " },
-    ]);
+    expect(composer.sentMessages[0]!.content).toEqual([]);
     expect(composer.sentMessages[0]!.attachments).toEqual([
       completedFromAdapter,
     ]);
+  });
+
+  it("send snapshots role and runConfig before awaiting attachment upload", async () => {
+    const pending = makePendingAttachment("att-1", "doc.pdf");
+
+    let resolveSend: ((value: CompleteAttachment) => void) | undefined;
+    const sendPromise = new Promise<CompleteAttachment>((resolve) => {
+      resolveSend = resolve;
+    });
+
+    const adapter: AttachmentAdapter = {
+      accept: "*",
+      add: vi.fn().mockResolvedValue(pending),
+      remove: vi.fn(),
+      send: vi.fn().mockReturnValue(sendPromise),
+    };
+    composer.setAttachmentAdapter(adapter);
+
+    await composer.addAttachment(new File(["data"], "doc.pdf"));
+    composer.setRole("assistant");
+    const originalRunConfig = { custom: { model: "model-a" } };
+    composer.setRunConfig(originalRunConfig);
+
+    const sending = composer.send();
+
+    composer.setRole("user");
+    const changedRunConfig = { custom: { model: "model-b" } };
+    composer.setRunConfig(changedRunConfig);
+
+    resolveSend?.({
+      id: "att-1",
+      type: "document",
+      name: "doc.pdf",
+      contentType: "application/pdf",
+      content: [
+        {
+          type: "file",
+          filename: "doc.pdf",
+          data: "ZmFrZS1iYXNlNjQ=",
+          mimeType: "application/pdf",
+        },
+      ],
+      status: { type: "complete" },
+    });
+
+    await sending;
+
+    expect(composer.sentMessages).toHaveLength(1);
+    expect(composer.sentMessages[0]!.role).toBe("assistant");
+    expect(composer.sentMessages[0]!.runConfig).toBe(originalRunConfig);
+    expect(composer.sentMessages[0]!.runConfig).not.toBe(changedRunConfig);
   });
 
   it("addAttachment throws when no adapter", async () => {


### PR DESCRIPTION
Fixes #3577

## Summary
- normalize composer sends so attachment-only messages include a placeholder text part (`" "`)
- add defensive normalization in `useLangGraphRuntime` to prepend placeholder text when file content exists without text
- add regressions for attachment-only composer send and file-only thread append in LangGraph runtime
- add core composer regression for empty-text + attachment send

## Why
Fixes duplicate/invalid attachment-only message behavior and ensures Bedrock-compatible text+file payloads for human messages.

## Validation
- `pnpm test` (full turbo test matrix)
- `pnpm --filter @assistant-ui/react-langgraph test`
- `pnpm --filter @assistant-ui/react test`
- `pnpm --filter @assistant-ui/core test`

