### PR TITLE
feat(react-ink): add direct named exports for Bun compile compatibility

### DIFF
--- a/.changeset/react-ink-named-exports.md
+++ b/.changeset/react-ink-named-exports.md
@@ -1,0 +1,15 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+Add direct named exports for all primitives alongside existing namespace exports.
+
+Bundlers that use static analysis for tree-shaking (notably Bun `--compile`) cannot trace dynamic property access through `export * as Namespace` re-export chains. This causes symbols like `MessagePrimitive.Root` to be dropped at compile time.
+
+Both import patterns now work:
+```ts
+import { MessagePrimitive } from "@assistant-ui/react-ink"   // namespace (existing)
+import { MessageRoot } from "@assistant-ui/react-ink"         // named (new)
+```
+
+Zero breaking changes — purely additive.

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -101,7 +101,7 @@ export {
   useRemoteThreadListRuntime,
 } from "./runtimes";
 
-// Primitives
+// Primitives — namespace exports (existing API)
 export * as ThreadPrimitive from "./primitives/thread";
 export * as ComposerPrimitive from "./primitives/composer";
 export * as MessagePrimitive from "./primitives/message";
@@ -113,6 +113,133 @@ export * as ThreadListItemPrimitive from "./primitives/threadListItem";
 export * as ChainOfThoughtPrimitive from "./primitives/chainOfThought";
 export * as SuggestionPrimitive from "./primitives/suggestion";
 export * as ToolCallPrimitive from "./primitives/toolCall";
+
+// Primitives — direct named exports (bundler-safe for Bun compile / tree-shaking)
+export {
+  Root as ThreadRoot,
+  type RootProps as ThreadRootProps,
+  Messages as ThreadMessages,
+  type MessagesProps as ThreadMessagesProps,
+  MessageByIndex as ThreadMessageByIndex,
+  Empty as ThreadEmpty,
+  type EmptyProps as ThreadEmptyProps,
+  If as ThreadIf,
+  type IfProps as ThreadIfProps,
+  Suggestion as ThreadSuggestion,
+  type SuggestionProps as ThreadSuggestionProps,
+  Suggestions as ThreadSuggestions,
+  SuggestionByIndex as ThreadSuggestionByIndex,
+} from "./primitives/thread";
+
+export {
+  Root as MessageRoot,
+  type RootProps as MessageRootProps,
+  Content as MessageContent,
+  type ContentProps as MessageContentProps,
+  Parts as MessageParts,
+  PartByIndex as MessagePartByIndex,
+  If as MessageIf,
+  type IfProps as MessageIfProps,
+  Attachments as MessageAttachments,
+  AttachmentByIndex as MessageAttachmentByIndex,
+} from "./primitives/message";
+
+export {
+  Root as ComposerRoot,
+  type RootProps as ComposerRootProps,
+  Attachments as ComposerAttachments,
+  AttachmentByIndex as ComposerAttachmentByIndex,
+  Input as ComposerInput,
+  type InputProps as ComposerInputProps,
+  Send as ComposerSend,
+  type SendProps as ComposerSendProps,
+  Cancel as ComposerCancel,
+  type CancelProps as ComposerCancelProps,
+  AddAttachment as ComposerAddAttachment,
+  type AddAttachmentProps as ComposerAddAttachmentProps,
+  If as ComposerIf,
+} from "./primitives/composer";
+
+export {
+  Root as ThreadListRoot,
+  type RootProps as ThreadListRootProps,
+  Items as ThreadListItems,
+  type ItemsProps as ThreadListItemsProps,
+  New as ThreadListNew,
+  type NewProps as ThreadListNewProps,
+} from "./primitives/threadList";
+
+export {
+  Copy as ActionBarCopy,
+  type CopyProps as ActionBarCopyProps,
+  Edit as ActionBarEdit,
+  type EditProps as ActionBarEditProps,
+  Reload as ActionBarReload,
+  type ReloadProps as ActionBarReloadProps,
+  FeedbackPositive as ActionBarFeedbackPositive,
+  type FeedbackPositiveProps as ActionBarFeedbackPositiveProps,
+  FeedbackNegative as ActionBarFeedbackNegative,
+  type FeedbackNegativeProps as ActionBarFeedbackNegativeProps,
+} from "./primitives/actionBar";
+
+export {
+  Previous as BranchPickerPrevious,
+  type PreviousProps as BranchPickerPreviousProps,
+  Next as BranchPickerNext,
+  type NextProps as BranchPickerNextProps,
+  Number as BranchPickerNumber,
+  type NumberProps as BranchPickerNumberProps,
+  Count as BranchPickerCount,
+  type CountProps as BranchPickerCountProps,
+} from "./primitives/branchPicker";
+
+export {
+  Root as AttachmentRoot,
+  type RootProps as AttachmentRootProps,
+  Name as AttachmentName,
+  type NameProps as AttachmentNameProps,
+  Thumb as AttachmentThumb,
+  type ThumbProps as AttachmentThumbProps,
+  Remove as AttachmentRemove,
+  type RemoveProps as AttachmentRemoveProps,
+} from "./primitives/attachment";
+
+export {
+  Root as ThreadListItemRoot,
+  type RootProps as ThreadListItemRootProps,
+  Title as ThreadListItemTitle,
+  Trigger as ThreadListItemTrigger,
+  type TriggerProps as ThreadListItemTriggerProps,
+  Delete as ThreadListItemDelete,
+  type DeleteProps as ThreadListItemDeleteProps,
+  Archive as ThreadListItemArchive,
+  type ArchiveProps as ThreadListItemArchiveProps,
+  Unarchive as ThreadListItemUnarchive,
+  type UnarchiveProps as ThreadListItemUnarchiveProps,
+} from "./primitives/threadListItem";
+
+export {
+  Root as ChainOfThoughtRoot,
+  type RootProps as ChainOfThoughtRootProps,
+  AccordionTrigger as ChainOfThoughtAccordionTrigger,
+  type AccordionTriggerProps as ChainOfThoughtAccordionTriggerProps,
+  Parts as ChainOfThoughtParts,
+} from "./primitives/chainOfThought";
+
+export {
+  Title as SuggestionTitle,
+  type TitleProps as SuggestionTitleProps,
+  Description as SuggestionDescription,
+  type DescriptionProps as SuggestionDescriptionProps,
+  Trigger as SuggestionTrigger,
+  type TriggerProps as SuggestionTriggerProps,
+} from "./primitives/suggestion";
+
+export {
+  Fallback as ToolCallFallback,
+  type FallbackProps as ToolCallFallbackProps,
+  type ToolCallStatus,
+} from "./primitives/toolCall";
 
 // Re-export shared providers from core/react
 export {


### PR DESCRIPTION
## Summary

- Add direct named exports for all 11 primitive groups in `@assistant-ui/react-ink`, alongside the existing `export * as XPrimitive` namespace exports
- Fixes symbol elimination when consuming the package via `bun build --compile`, where the tree-shaker cannot trace dynamic property access (`MessagePrimitive.Root`) through namespace re-export chains

## Problem

`@assistant-ui/react-ink` only exports namespace objects:

```ts
export * as MessagePrimitive from "./primitives/message"
```

When a consumer accesses `MessagePrimitive.Root`, Bun's compile-time tree-shaker sees a dynamic property access on a re-exported namespace and drops the symbol. This causes `MessageRoot is not defined` at runtime in any CLI tool built with `bun build --compile`.

This affects the exact target audience for a terminal UI library.

## Solution

Add direct named exports from each primitive barrel, re-aliasing short names back to their full prefixed form:

```ts
// Namespace (existing, unchanged)
export * as MessagePrimitive from "./primitives/message";

// Named (new, bundler-safe)
export {
  Root as MessageRoot,
  Content as MessageContent,
  // ...
} from "./primitives/message";
```

Both import patterns now work:

```ts
import { MessagePrimitive } from "@assistant-ui/react-ink"   // namespace
import { MessageRoot } from "@assistant-ui/react-ink"         // named (new)
```

All named exports re-export from the existing barrel files (no deep imports), so the barrel remains the single source of truth.

## Scope

- **11 primitive groups**: Thread, Message, Composer, ThreadList, ActionBar, BranchPicker, Attachment, ThreadListItem, ChainOfThought, Suggestion, ToolCall
- **All value and type exports** included (components + props types)
- **Zero breaking changes** — purely additive, no existing exports removed or renamed

## Verification

- `pnpm build --filter @assistant-ui/react-ink` passes
- `vitest run` — 2/2 tests pass
- Both `MessagePrimitive` (namespace) and `MessageRoot` (named) resolve in dist output
- Changeset included (patch bump)

## Context

We hit this building [Lobster AI](https://github.com/the-omics-os/lobster)'s terminal interface with `bun build --compile` + `@assistant-ui/react-ink`.