### PR TITLE
feat(store): add AuiForEach and RenderChildrenWithAccessor

### DIFF
--- a/apps/docs/content/tap-docs/meta.json
+++ b/apps/docs/content/tap-docs/meta.json
@@ -23,6 +23,7 @@
     "store/events",
     "store/meta",
     "store/child-scopes",
+    "store/rendering-lists",
     "store/sibling-scopes",
     "store/api-reference"
   ]

--- a/apps/docs/content/tap-docs/store/api-reference.mdx
+++ b/apps/docs/content/tap-docs/store/api-reference.mdx
@@ -68,6 +68,46 @@ Provides an `AssistantClient` to the React tree. Child components can access it 
 
 Renders children only when the condition returns `true`. Uses `useAuiState` internally.
 
+### AuiForEach
+
+```tsx
+<AuiForEach
+  keys={(s) => s.todoList.todos.map((t) => t.id)}
+>
+  {(itemKey, index) => (
+    <TodoProvider index={index}>
+      <TodoDisplay />
+    </TodoProvider>
+  )}
+</AuiForEach>
+```
+
+Iterates over a list of keys with key-stable rendering. Only re-renders when the key list changes (items added/removed/reordered), not when individual item data changes.
+
+| Prop | Type |
+|------|------|
+| `keys` | `(state: AssistantState) => readonly TKey[]` |
+| `children` | `(itemKey: TKey, index: number) => ReactNode` |
+
+`TKey` extends `string | number`. See [Rendering Lists](/tap-docs/store/rendering-lists) for details.
+
+### RenderChildrenWithAccessor
+
+```tsx
+<RenderChildrenWithAccessor
+  getItemState={(aui) => aui.todoList().todo({ index }).getState()}
+>
+  {() => <TodoDisplay />}
+</RenderChildrenWithAccessor>
+```
+
+Sets up a lazy item accessor and memoizes the children output. Optimized for the common pattern where children returns a propless component.
+
+| Prop | Type |
+|------|------|
+| `getItemState` | `(aui: AssistantClient) => T` |
+| `children` | `(getItem: () => T) => ReactNode` |
+
 ---
 
 ## Resource utilities

--- a/apps/docs/content/tap-docs/store/rendering-lists.mdx
+++ b/apps/docs/content/tap-docs/store/rendering-lists.mdx
@@ -1,0 +1,183 @@
+---
+title: Rendering Lists
+description: Efficiently render lists of scoped items with AuiForEach and RenderChildrenWithAccessor.
+---
+
+The [child scopes](/tap-docs/store/child-scopes) page showed how to wire up parent-child scope relationships. This page covers the rendering side — how to iterate over a list of child scopes efficiently without re-rendering every item when the list changes.
+
+## The problem
+
+A naive approach re-renders the entire list whenever any item's state changes:
+
+```tsx
+const TodoList = () => {
+  const todos = useAuiState((s) => s.todoList.todos);
+  return todos.map((_, index) => (
+    <TodoItem key={index} index={index} />
+  ));
+};
+```
+
+Every state change in any todo causes `todos` to be a new array, which re-renders `TodoList` and recreates all `TodoItem` elements.
+
+## AuiForEach
+
+`AuiForEach` solves this by subscribing to just the **keys** of the list. It only re-renders when items are added, removed, or reordered — not when individual item data changes.
+
+```tsx
+import { AuiForEach } from "@assistant-ui/store";
+
+<AuiForEach
+  keys={(s) => s.todoList.todos.map((t) => t.id)}
+>
+  {(itemId, index) => (
+    <TodoProvider index={index}>
+      <TodoDisplay />
+    </TodoProvider>
+  )}
+</AuiForEach>
+```
+
+### Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `keys` | `(state: AssistantState) => readonly TKey[]` | Selector that returns the list of keys. Uses `useAuiState` internally — re-renders only when keys change. |
+| `children` | `(itemKey: TKey, index: number) => ReactNode` | Render function called for each item. Receives the key and index. |
+
+`TKey` extends `string | number`. The key values are used as React keys for reconciliation.
+
+### Key strategies
+
+You can choose between item IDs or indices as keys:
+
+```tsx
+// By ID — items keep identity across reorders
+keys={(s) => s.todoList.todos.map((t) => t.id)}
+
+// By index — simpler, but items lose identity on reorder
+keys={(s) => s.todoList.todos.map((_, i) => i)}
+```
+
+### How it avoids re-renders
+
+`AuiForEach` memoizes the rendered output using the key array as dependencies. When state changes but the key list stays the same, the memoized output is returned and no children are re-created.
+
+## RenderChildrenWithAccessor
+
+For the common pattern where a child component has no props (like `<Foo />`), `RenderChildrenWithAccessor` memoizes the render output so it's only created once per item:
+
+```tsx
+import { RenderChildrenWithAccessor } from "@assistant-ui/store";
+
+<RenderChildrenWithAccessor
+  getItemState={(aui) => aui.todoList().todo({ index }).getState()}
+>
+  {() => <TodoDisplay />}
+</RenderChildrenWithAccessor>
+```
+
+### Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `getItemState` | `(aui: AssistantClient) => T` | Function to access the item's state from the store. |
+| `children` | `(getItem: () => T) => ReactNode` | Render function. Receives a `getItem` accessor that returns the item's current state when called. |
+
+The `children` output is memoized — calling `getItem()` inside a getter defers the state read until the consumer actually accesses it.
+
+## Full example
+
+Putting it together — a `FooList` component that renders a list of `Foo` items:
+
+### Scope registration
+
+```ts title="lib/store/foo-scope.ts"
+declare module "@assistant-ui/store" {
+  interface ScopeRegistry {
+    fooList: {
+      methods: {
+        getState: () => { foos: { id: string; bar: string }[] };
+        foo: (lookup: { index: number } | { key: string }) => FooMethods;
+        addFoo: () => void;
+      };
+      events: { "fooList.added": { id: string } };
+    };
+    foo: {
+      methods: {
+        getState: () => { id: string; bar: string };
+        updateBar: (newBar: string) => void;
+        remove: () => void;
+      };
+      meta: {
+        source: "fooList";
+        query: { index: number } | { key: string };
+      };
+      events: {
+        "foo.updated": { id: string; newValue: string };
+        "foo.removed": { id: string };
+      };
+    };
+  }
+}
+```
+
+### List component
+
+```tsx title="lib/store/foo-store.tsx"
+import {
+  useAui, AuiProvider, Derived,
+  AuiForEach, RenderChildrenWithAccessor,
+} from "@assistant-ui/store";
+
+const FooProvider = ({
+  index, children,
+}: {
+  index: number;
+  children: ReactNode;
+}) => {
+  const aui = useAui({
+    foo: Derived({
+      source: "fooList",
+      query: { index },
+      get: (aui) => aui.fooList().foo({ index }),
+    }),
+  });
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+};
+
+export const FooList = ({
+  children,
+}: {
+  children: (item: { foo: FooData }) => ReactNode;
+}) => (
+  <AuiForEach keys={(s) => s.fooList.foos.map((_, index) => index)}>
+    {(index) => (
+      <FooProvider index={index}>
+        <RenderChildrenWithAccessor
+          getItemState={(aui) => aui.fooList().foo({ index }).getState()}
+        >
+          {(getItem) =>
+            children({
+              get foo() {
+                return getItem();
+              },
+            })
+          }
+        </RenderChildrenWithAccessor>
+      </FooProvider>
+    )}
+  </AuiForEach>
+);
+```
+
+### Usage
+
+```tsx title="app/App.tsx"
+<FooList>
+  {() => <Foo />}
+</FooList>
+```
+
+The `Foo` component reads its own state via `useAuiState((s) => s.foo)` inside the scoped provider. It re-renders independently when its state changes, without affecting sibling items or the list container.
+

--- a/examples/with-store/lib/example-app.tsx
+++ b/examples/with-store/lib/example-app.tsx
@@ -169,7 +169,7 @@ export const ExampleApp = () => {
           </p>
         </div>
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          <FooList components={{ Foo }} />
+          <FooList>{() => <Foo />}</FooList>
         </div>
         <EventLog />
       </div>

--- a/examples/with-store/lib/store/foo-store.tsx
+++ b/examples/with-store/lib/store/foo-store.tsx
@@ -2,15 +2,16 @@
 
 import "./foo-scope";
 
-import React from "react";
+import type { ReactNode } from "react";
 import { resource, tapMemo, tapState } from "@assistant-ui/tap";
 import {
   useAui,
   AuiProvider,
   tapClientList,
   Derived,
-  useAuiState,
   tapAssistantEmit,
+  AuiForEach,
+  RenderChildrenWithAccessor,
   type ClientOutput,
 } from "@assistant-ui/store";
 
@@ -76,17 +77,17 @@ export const FooListResource = resource(
   },
 );
 
-export const FooProvider = ({
+const FooProvider = ({
   index,
   children,
 }: {
   index: number;
-  children: React.ReactNode;
+  children: ReactNode;
 }) => {
   const aui = useAui({
     foo: Derived({
       source: "fooList",
-      query: { index: index },
+      query: { index },
       get: (aui) => aui.fooList().foo({ index }),
     }),
   });
@@ -95,19 +96,25 @@ export const FooProvider = ({
 };
 
 export const FooList = ({
-  components,
+  children,
 }: {
-  components: { Foo: React.ComponentType };
-}) => {
-  const fooListState = useAuiState((s) => s.fooList.foos.length);
-
-  return (
-    <>
-      {Array.from({ length: fooListState }, (_, index) => (
-        <FooProvider key={index} index={index}>
-          <components.Foo />
-        </FooProvider>
-      ))}
-    </>
-  );
-};
+  children: (item: { foo: FooData }) => ReactNode;
+}) => (
+  <AuiForEach keys={(s) => s.fooList.foos.map((_, index) => index)}>
+    {(index) => (
+      <FooProvider index={index}>
+        <RenderChildrenWithAccessor
+          getItemState={(aui) => aui.fooList().foo({ index }).getState()}
+        >
+          {(getItem) =>
+            children({
+              get foo() {
+                return getItem();
+              },
+            })
+          }
+        </RenderChildrenWithAccessor>
+      </FooProvider>
+    )}
+  </AuiForEach>
+);

--- a/packages/store/src/AuiForEach.tsx
+++ b/packages/store/src/AuiForEach.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Fragment, type ReactNode, useMemo, useRef } from "react";
+import type { AssistantClient, AssistantState } from "./types/client";
+import { useAuiState } from "./useAuiState";
+import { useAui } from "./useAui";
+
+/**
+ * Component that iterates over a list of items with key-stable rendering.
+ *
+ * Only re-renders when the key list changes (items added/removed/reordered),
+ * NOT when individual item data changes.
+ *
+ * @example
+ * ```tsx
+ * <AuiForEach
+ *   keys={(s) => s.fooList.foos.map(f => f.id)}
+ * >
+ *   {(itemKey, index) => (
+ *     <FooProvider index={index}>
+ *       <Foo />
+ *     </FooProvider>
+ *   )}
+ * </AuiForEach>
+ * ```
+ */
+export function AuiForEach<TKey extends string | number>({
+  keys: keysSelector,
+  children,
+}: {
+  keys: (state: AssistantState) => readonly TKey[];
+  children: (itemKey: TKey, index: number) => ReactNode;
+}): ReactNode {
+  const arr = useAuiState(keysSelector);
+
+  return useMemo(
+    () =>
+      arr.map((key, index) => (
+        <AuiForEachElement key={key} index={index} itemKey={key}>
+          {children}
+        </AuiForEachElement>
+      )),
+    // biome-ignore lint/correctness/useExhaustiveDependencies: shallow memo
+    arr,
+  );
+}
+
+const AuiForEachElement = <TKey extends string | number>({
+  itemKey,
+  index,
+  children,
+}: {
+  itemKey: TKey;
+  index: number;
+  children: (itemKey: TKey, index: number) => ReactNode;
+}) => {
+  return <Fragment>{children(itemKey, index)}</Fragment>;
+};
+
+export const useGetItemAccessor = <T,>(
+  getItemState: (aui: AssistantClient) => T,
+) => {
+  const aui = useAui();
+
+  // if the consumer never accesses the item, do not trigger rerenders
+  const cacheRef = useRef<T | undefined>(undefined);
+  useAuiState(() => {
+    if (cacheRef.current === undefined) {
+      cacheRef.current = getItemState(aui);
+    }
+    return cacheRef.current;
+  });
+
+  return () => {
+    cacheRef.current = undefined; // clear the cache (rerender on next state change)
+
+    return getItemState(aui);
+  };
+};
+
+const EMPTY_OBJECT = Object.freeze({});
+
+/**
+ * Component that sets up a lazy item accessor and memoizes propless children.
+ *
+ * For the common pattern where children returns a component without props
+ * (e.g. `<Foo />`), the output is memoized and not re-created on parent re-renders.
+ *
+ * @example
+ * ```tsx
+ * <RenderChildrenWithAccessor
+ *   getItemState={(aui) => aui.fooList().foo({ index }).getState()}
+ * >
+ *   {() => <Foo />}
+ * </RenderChildrenWithAccessor>
+ * ```
+ */
+export function RenderChildrenWithAccessor<T>({
+  getItemState,
+  children,
+}: {
+  getItemState: (aui: AssistantClient) => T;
+  children: (getItem: () => T) => ReactNode;
+}): ReactNode {
+  const getItem = useGetItemAccessor(getItemState);
+  return useMemoizedProplessComponent(children(getItem));
+}
+
+const useMemoizedProplessComponent = (node: ReactNode) => {
+  const el =
+    typeof node === "object" && node != null && "type" in node ? node : null;
+  const resultType = el?.type;
+  const resultKey = el?.key;
+  const resultProps =
+    typeof el?.props === "object" &&
+    el.props != null &&
+    Object.entries(el.props).length === 0
+      ? EMPTY_OBJECT
+      : el?.props;
+
+  return (
+    // biome-ignore lint/correctness/useExhaustiveDependencies: optimization
+    useMemo(() => el, [resultType, resultKey, resultProps]) ?? node
+  );
+};

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -2,6 +2,7 @@
 export { useAui } from "./useAui";
 export { useAuiState } from "./useAuiState";
 export { useAuiEvent } from "./useAuiEvent";
+export { AuiForEach, RenderChildrenWithAccessor } from "./AuiForEach";
 
 // components
 export { AuiIf } from "./AuiIf";


### PR DESCRIPTION
## Summary

- **`AuiForEach`** — key-stable list iteration component that only re-renders when keys change (items added/removed/reordered), not on individual item state changes
- **`RenderChildrenWithAccessor`** — memoizes propless children output with lazy item state accessor via `useGetItemAccessor`
- Updated `with-store` example to use the new API
- Added "Rendering Lists" docs page and API reference entries

## Test plan

- [ ] `pnpm turbo build --filter=@assistant-ui/store` passes
- [ ] `pnpm --filter @assistant-ui/store test` passes
- [ ] `with-store` example compiles and renders correctly
- [ ] Docs page renders at `/tap-docs/store/rendering-lists`

🤖 Generated with [Claude Code](https://claude.com/claude-code)