### PR TITLE
feat: add localStorage persistence, thread list reload, and thread metadata

### DIFF
--- a/.changeset/feat-localstorage-adapter.md
+++ b/.changeset/feat-localstorage-adapter.md
@@ -1,0 +1,11 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+feat: add localStorage persistence support and thread list reload
+
+- Wire `createLocalStorageAdapter` into `useLocalRuntime` via `storage` option
+- Export `createLocalStorageAdapter`, `AsyncStorageLike`, `TitleGenerationAdapter` publicly
+- Add `reload()` method to `ThreadListRuntime` for re-fetching thread list
+- Add optional `metadata` field to `RemoteThreadMetadata` and `ThreadListItemState`

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
@@ -17,9 +17,9 @@ import { RuntimeAdapterProvider } from "../runtimes/RuntimeAdapterProvider";
 import type { TitleGenerationAdapter } from "./TitleGenerationAdapter";
 
 export type AsyncStorageLike = {
-  getItem(key: string): Promise<string | null>;
-  setItem(key: string, value: string): Promise<void>;
-  removeItem(key: string): Promise<void>;
+  getItem(key: string): string | null | Promise<string | null>;
+  setItem(key: string, value: string): void | Promise<void>;
+  removeItem(key: string): void | Promise<void>;
 };
 
 type LocalStorageAdapterOptions = {

--- a/packages/core/src/react/index.ts
+++ b/packages/core/src/react/index.ts
@@ -211,3 +211,13 @@ export {
   splitLocalRuntimeOptions,
   type LocalRuntimeOptions,
 } from "./runtimes/useLocalRuntime";
+
+// Adapters
+export {
+  createLocalStorageAdapter,
+  type AsyncStorageLike,
+} from "./adapters/LocalStorageThreadListAdapter";
+export {
+  type TitleGenerationAdapter,
+  createSimpleTitleAdapter,
+} from "./adapters/TitleGenerationAdapter";

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -94,6 +94,7 @@ export class RemoteThreadListThreadListRuntimeCore
                 externalId: thread.externalId,
                 status: thread.status,
                 title: thread.title,
+                metadata: thread.metadata,
                 initializeTask: Promise.resolve({
                   remoteId: thread.remoteId,
                   externalId: thread.externalId,
@@ -164,6 +165,11 @@ export class RemoteThreadListThreadListRuntimeCore
     this.getLoadThreadsPromise(); // begin loading on initial bind
   }
 
+  public reload() {
+    this._loadThreadsPromise = undefined;
+    return this.getLoadThreadsPromise();
+  }
+
   public get isLoading() {
     return this._state.value.isLoading;
   }
@@ -224,6 +230,7 @@ export class RemoteThreadListThreadListRuntimeCore
           externalId: remoteMetadata.externalId,
           status: remoteMetadata.status,
           title: remoteMetadata.title,
+          metadata: remoteMetadata.metadata,
         } as RemoteThreadData,
       };
 

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -36,6 +36,7 @@ export class RemoteThreadListThreadListRuntimeCore
   private readonly _hookManager: RemoteThreadListHookInstanceManager;
 
   private _loadThreadsPromise: Promise<void> | undefined;
+  private _loadGeneration = 0;
 
   private _mainThreadId!: string;
   private readonly _state = new OptimisticState<RemoteThreadState>({
@@ -54,6 +55,7 @@ export class RemoteThreadListThreadListRuntimeCore
   public getLoadThreadsPromise() {
     // TODO this needs to be cached in case this promise is loaded during suspense
     if (!this._loadThreadsPromise) {
+      const generation = this._loadGeneration;
       this._loadThreadsPromise = this._state
         .optimisticUpdate({
           execute: () => this._options.adapter.list(),
@@ -64,6 +66,9 @@ export class RemoteThreadListThreadListRuntimeCore
             };
           },
           then: (state, l) => {
+            // Guard against stale responses from a superseded reload
+            if (generation !== this._loadGeneration) return state;
+
             const newThreadIds = [];
             const newArchivedThreadIds = [];
             const newThreadIdMap = {} as Record<string, THREAD_MAPPING_ID>;
@@ -102,18 +107,22 @@ export class RemoteThreadListThreadListRuntimeCore
               };
             }
 
+            // Preserve the new (unsaved) thread if one exists
+            const newThreadId = state.newThreadId;
+            if (newThreadId) {
+              const newMappingId = state.threadIdMap[newThreadId];
+              if (newMappingId && state.threadData[newMappingId]) {
+                newThreadIdMap[newThreadId] = newMappingId;
+                newThreadData[newMappingId] = state.threadData[newMappingId]!;
+              }
+            }
+
             return {
               ...state,
               threadIds: newThreadIds,
               archivedThreadIds: newArchivedThreadIds,
-              threadIdMap: {
-                ...state.threadIdMap,
-                ...newThreadIdMap,
-              },
-              threadData: {
-                ...state.threadData,
-                ...newThreadData,
-              },
+              threadIdMap: newThreadIdMap,
+              threadData: newThreadData,
             };
           },
         })
@@ -166,6 +175,7 @@ export class RemoteThreadListThreadListRuntimeCore
   }
 
   public reload() {
+    this._loadGeneration++;
     this._loadThreadsPromise = undefined;
     return this.getLoadThreadsPromise();
   }

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -117,6 +117,17 @@ export class RemoteThreadListThreadListRuntimeCore
               }
             }
 
+            // Preserve the main thread's local ID alias so it stays resolvable.
+            // Only add the alias — never copy stale data; the fresh load is authoritative.
+            const mainMappingId = state.threadIdMap[this._mainThreadId];
+            if (
+              mainMappingId &&
+              newThreadData[mainMappingId] &&
+              !newThreadIdMap[this._mainThreadId]
+            ) {
+              newThreadIdMap[this._mainThreadId] = mainMappingId;
+            }
+
             return {
               ...state,
               threadIds: newThreadIds,

--- a/packages/core/src/react/runtimes/useLocalRuntime.ts
+++ b/packages/core/src/react/runtimes/useLocalRuntime.ts
@@ -11,9 +11,17 @@ import { useRemoteThreadListRuntime } from "./useRemoteThreadListRuntime";
 import { useCloudThreadListAdapter } from "./cloud/useCloudThreadListAdapter";
 import { useRuntimeAdapters } from "./RuntimeAdapterProvider";
 import type { AssistantCloud } from "assistant-cloud";
+import {
+  createLocalStorageAdapter,
+  type AsyncStorageLike,
+} from "../adapters/LocalStorageThreadListAdapter";
+import type { TitleGenerationAdapter } from "../adapters/TitleGenerationAdapter";
 
 export type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
   cloud?: AssistantCloud | undefined;
+  storage?: AsyncStorageLike | undefined;
+  storagePrefix?: string | undefined;
+  titleGenerator?: TitleGenerationAdapter | undefined;
   initialMessages?: readonly ThreadMessageLike[] | undefined;
   adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
 };
@@ -67,6 +75,9 @@ export const splitLocalRuntimeOptions = <T extends LocalRuntimeOptions>(
 ) => {
   const {
     cloud,
+    storage,
+    storagePrefix,
+    titleGenerator,
     initialMessages,
     maxSteps,
     adapters,
@@ -77,6 +88,9 @@ export const splitLocalRuntimeOptions = <T extends LocalRuntimeOptions>(
   return {
     localRuntimeOptions: {
       cloud,
+      storage,
+      storagePrefix,
+      titleGenerator,
       initialMessages,
       maxSteps,
       adapters,
@@ -88,14 +102,29 @@ export const splitLocalRuntimeOptions = <T extends LocalRuntimeOptions>(
 
 export const useLocalRuntime = (
   chatModel: ChatModelAdapter,
-  { cloud, ...options }: LocalRuntimeOptions = {},
+  {
+    cloud,
+    storage,
+    storagePrefix,
+    titleGenerator,
+    ...options
+  }: LocalRuntimeOptions = {},
 ): AssistantRuntime => {
   const cloudAdapter = useCloudThreadListAdapter({ cloud });
+  const localStorageAdapter = useMemo(() => {
+    if (!storage) return undefined;
+    return createLocalStorageAdapter({
+      storage,
+      prefix: storagePrefix,
+      titleGenerator,
+    });
+  }, [storage, storagePrefix, titleGenerator]);
+
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
       return useLocalThreadRuntime(chatModel, options);
     },
-    adapter: cloudAdapter,
+    adapter: localStorageAdapter ?? cloudAdapter,
     allowNesting: true,
   });
 };

--- a/packages/core/src/react/runtimes/useLocalRuntime.ts
+++ b/packages/core/src/react/runtimes/useLocalRuntime.ts
@@ -110,6 +110,12 @@ export const useLocalRuntime = (
     ...options
   }: LocalRuntimeOptions = {},
 ): AssistantRuntime => {
+  if (storage && cloud) {
+    throw new Error(
+      "useLocalRuntime: `storage` and `cloud` options are mutually exclusive. Provide only one.",
+    );
+  }
+
   const cloudAdapter = useCloudThreadListAdapter({ cloud });
   const localStorageAdapter = useMemo(() => {
     if (!storage) return undefined;

--- a/packages/core/src/runtime/api/bindings.ts
+++ b/packages/core/src/runtime/api/bindings.ts
@@ -46,4 +46,5 @@ export type ThreadListItemState = {
   readonly externalId: string | undefined;
   readonly status: import("../interfaces/thread-list-runtime-core").ThreadListItemStatus;
   readonly title?: string | undefined;
+  readonly metadata?: Readonly<Record<string, unknown>> | undefined;
 };

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -46,6 +46,8 @@ export type ThreadListRuntime = {
 
   switchToThread(threadId: string): Promise<void>;
   switchToNewThread(): Promise<void>;
+
+  reload(): Promise<void>;
 };
 
 const getThreadListState = (
@@ -75,6 +77,7 @@ const getThreadListItemState = (
     externalId: threadData.externalId,
     title: threadData.title,
     status: threadData.status,
+    metadata: threadData.metadata,
     isMain: threadData.id === threadList.mainThreadId,
   };
 };
@@ -130,6 +133,7 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
   protected __internal_bindMethods() {
     this.switchToThread = this.switchToThread.bind(this);
     this.switchToNewThread = this.switchToNewThread.bind(this);
+    this.reload = this.reload.bind(this);
     this.getState = this.getState.bind(this);
     this.subscribe = this.subscribe.bind(this);
     this.getById = this.getById.bind(this);
@@ -144,6 +148,13 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
 
   public switchToNewThread(): Promise<void> {
     return this._core.switchToNewThread();
+  }
+
+  public reload(): Promise<void> {
+    if (this._core.reload) {
+      return this._core.reload();
+    }
+    return Promise.resolve();
   }
 
   public getState(): ThreadListState {

--- a/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
@@ -10,6 +10,7 @@ export type ThreadListItemCoreState = {
 
   readonly status: ThreadListItemStatus;
   readonly title?: string | undefined;
+  readonly metadata?: Readonly<Record<string, unknown>> | undefined;
 
   readonly runtime?: ThreadRuntimeCore | undefined;
 };
@@ -33,6 +34,7 @@ export type ThreadListRuntimeCore = {
   switchToNewThread(): Promise<void>;
 
   getLoadThreadsPromise(): Promise<void>;
+  reload?(): Promise<void>;
 
   detach(threadId: string): Promise<void>;
   rename(threadId: string, newTitle: string): Promise<void>;

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -7,6 +7,7 @@ export type RemoteThreadData =
       readonly externalId: undefined;
       readonly status: "new";
       readonly title: undefined;
+      readonly metadata?: Readonly<Record<string, unknown>> | undefined;
     }
   | {
       readonly id: string;
@@ -15,6 +16,7 @@ export type RemoteThreadData =
       readonly externalId: undefined;
       readonly status: "regular" | "archived";
       readonly title?: string | undefined;
+      readonly metadata?: Readonly<Record<string, unknown>> | undefined;
     }
   | {
       readonly id: string;
@@ -23,6 +25,7 @@ export type RemoteThreadData =
       readonly externalId: string | undefined;
       readonly status: "regular" | "archived";
       readonly title?: string | undefined;
+      readonly metadata?: Readonly<Record<string, unknown>> | undefined;
     };
 
 export type THREAD_MAPPING_ID = string & { __brand: "THREAD_MAPPING_ID" };

--- a/packages/core/src/runtimes/remote-thread-list/types.ts
+++ b/packages/core/src/runtimes/remote-thread-list/types.ts
@@ -12,6 +12,7 @@ export type RemoteThreadMetadata = {
   readonly remoteId: string;
   readonly externalId?: string | undefined;
   readonly title?: string | undefined;
+  readonly metadata?: Readonly<Record<string, unknown>> | undefined;
 };
 
 export type RemoteThreadListResponse = {

--- a/packages/core/src/store/scopes/thread-list-item.ts
+++ b/packages/core/src/store/scopes/thread-list-item.ts
@@ -7,6 +7,7 @@ export type ThreadListItemState = {
   readonly externalId: string | undefined;
   readonly title?: string | undefined;
   readonly status: ThreadListItemStatus;
+  readonly metadata?: Readonly<Record<string, unknown>> | undefined;
 };
 
 export type ThreadListItemMethods = {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -153,6 +153,16 @@ export { useLocalRuntime } from "./legacy-runtime/runtime-cores/local/useLocalRu
 export { useLocalRuntime as useLocalThreadRuntime } from "./legacy-runtime/runtime-cores/local/useLocalRuntime";
 export type { LocalRuntimeOptions } from "./legacy-runtime/runtime-cores/local/LocalRuntimeOptions";
 
+// --- localStorage adapter ---
+export {
+  createLocalStorageAdapter,
+  type AsyncStorageLike,
+} from "@assistant-ui/core/react";
+export {
+  type TitleGenerationAdapter,
+  createSimpleTitleAdapter,
+} from "@assistant-ui/core/react";
+
 // --- remote-thread-list ---
 export { useRemoteThreadListRuntime } from "./legacy-runtime/runtime-cores/remote-thread-list/useRemoteThreadListRuntime";
 /** @deprecated Use `useRemoteThreadListRuntime` instead. */


### PR DESCRIPTION
## Summary

- Wire `createLocalStorageAdapter` into `useLocalRuntime` via new `storage`, `storagePrefix`, and `titleGenerator` options
- Export `createLocalStorageAdapter`, `AsyncStorageLike`, `TitleGenerationAdapter`, and `createSimpleTitleAdapter` publicly from `@assistant-ui/core/react` and `@assistant-ui/react`
- Add `reload()` method to `ThreadListRuntime` for re-fetching the thread list from the adapter
- Add optional `metadata` field to `RemoteThreadMetadata`, `RemoteThreadData`, `ThreadListItemCoreState`, and `ThreadListItemState`

## Test plan

- [x] Build passes (`pnpm turbo build --filter=@assistant-ui/core --filter=@assistant-ui/react`)
- [x] All 52 core tests pass (`pnpm --filter @assistant-ui/core test`)
- [x] No new lint errors introduced
- [ ] Manual test: `useLocalRuntime(model, { storage: localStorage })` persists threads across page reloads
- [ ] Manual test: `runtime.threads.reload()` re-fetches thread list from adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)