### PR TITLE
fix(core, store): stabilize AuiForEach selectors to prevent useSyncExternalStore loops

### DIFF
--- a/.changeset/fix-aui-foreach-infinite-loop.md
+++ b/.changeset/fix-aui-foreach-infinite-loop.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/store": patch
+---
+
+fix(core, store): stabilize AuiForEach selectors to prevent useSyncExternalStore infinite loops

--- a/packages/core/src/react/primitives/chainOfThought/ChainOfThoughtParts.tsx
+++ b/packages/core/src/react/primitives/chainOfThought/ChainOfThoughtParts.tsx
@@ -45,7 +45,7 @@ const ChainOfThoughtPrimitivePartsInner: FC<{
   children: (value: { part: PartState }) => ReactNode;
 }> = ({ children }) => (
   <AuiForEach keys={(s) => s.chainOfThought.parts.map((_, index) => index)}>
-    {(index) => (
+    {(_idx, index) => (
       <ChainOfThoughtPartByIndexProvider index={index}>
         <RenderChildrenWithAccessor
           getItemState={(aui) =>

--- a/packages/core/src/react/primitives/composer/ComposerAttachments.tsx
+++ b/packages/core/src/react/primitives/composer/ComposerAttachments.tsx
@@ -89,8 +89,8 @@ ComposerPrimitiveAttachmentByIndex.displayName =
 const ComposerPrimitiveAttachmentsInner: FC<{
   children: (value: { attachment: Attachment }) => ReactNode;
 }> = ({ children }) => (
-  <AuiForEach keys={(s) => s.composer.attachments.map((_, index) => index)}>
-    {(index) => (
+  <AuiForEach keys={(s) => s.composer.attachments.map((a) => a.id)}>
+    {(_attachmentId, index) => (
       <ComposerAttachmentByIndexProvider index={index}>
         <RenderChildrenWithAccessor
           getItemState={(aui) =>

--- a/packages/core/src/react/primitives/message/MessageAttachments.tsx
+++ b/packages/core/src/react/primitives/message/MessageAttachments.tsx
@@ -92,10 +92,10 @@ const MessagePrimitiveAttachmentsInner: FC<{
   <AuiForEach
     keys={(s) => {
       if (s.message.role !== "user") return [];
-      return s.message.attachments.map((_, index) => index);
+      return s.message.attachments.map((a) => a.id);
     }}
   >
-    {(index) => (
+    {(_attachmentId, index) => (
       <MessageAttachmentByIndexProvider index={index}>
         <RenderChildrenWithAccessor
           getItemState={(aui) => aui.message().attachment({ index }).getState()}

--- a/packages/core/src/react/primitives/message/MessageParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageParts.tsx
@@ -585,7 +585,7 @@ const MessagePrimitivePartsInner: FC<{
 
   return (
     <AuiForEach keys={(s) => s.message.parts.map((_, index) => index)}>
-      {(index) => (
+      {(_idx, index) => (
         <PartByIndexProvider index={index}>
           <RenderChildrenWithAccessor
             getItemState={(aui) => aui.message().part({ index }).getState()}

--- a/packages/core/src/react/primitives/thread/ThreadMessages.tsx
+++ b/packages/core/src/react/primitives/thread/ThreadMessages.tsx
@@ -170,8 +170,8 @@ ThreadPrimitiveMessageByIndex.displayName = "ThreadPrimitive.MessageByIndex";
 const ThreadPrimitiveMessagesInner: FC<{
   children: (value: { message: MessageState }) => ReactNode;
 }> = ({ children }) => (
-  <AuiForEach keys={(s) => s.thread.messages.map((_, index) => index)}>
-    {(index) => (
+  <AuiForEach keys={(s) => s.thread.messages.map((m) => m.id)}>
+    {(_msgId, index) => (
       <MessageByIndexProvider index={index}>
         <RenderChildrenWithAccessor
           getItemState={(aui) => aui.thread().message({ index }).getState()}

--- a/packages/core/src/react/primitives/thread/ThreadSuggestions.tsx
+++ b/packages/core/src/react/primitives/thread/ThreadSuggestions.tsx
@@ -62,7 +62,7 @@ const ThreadPrimitiveSuggestionsInner: FC<{
   children: (value: { suggestion: SuggestionState }) => ReactNode;
 }> = ({ children }) => (
   <AuiForEach keys={(s) => s.suggestions.suggestions.map((_, index) => index)}>
-    {(index) => (
+    {(_idx, index) => (
       <SuggestionByIndexProvider index={index}>
         <RenderChildrenWithAccessor
           getItemState={(aui) =>

--- a/packages/core/src/react/primitives/threadList/ThreadListItems.tsx
+++ b/packages/core/src/react/primitives/threadList/ThreadListItems.tsx
@@ -59,12 +59,9 @@ const ThreadListPrimitiveItemsInner: FC<{
   children: (value: { threadListItem: ThreadListItemState }) => ReactNode;
 }> = ({ archived, children }) => (
   <AuiForEach
-    keys={(s) => {
-      const ids = archived ? s.threads.archivedThreadIds : s.threads.threadIds;
-      return ids.map((_, index) => index);
-    }}
+    keys={(s) => (archived ? s.threads.archivedThreadIds : s.threads.threadIds)}
   >
-    {(index) => (
+    {(_threadId, index) => (
       <ThreadListItemByIndexProvider index={index} archived={archived}>
         <RenderChildrenWithAccessor
           getItemState={(aui) =>

--- a/packages/store/src/AuiForEach.tsx
+++ b/packages/store/src/AuiForEach.tsx
@@ -6,6 +6,24 @@ import { useAuiState } from "./useAuiState";
 import { useAui } from "./useAui";
 
 /**
+ * Stabilizes an array reference so that a new array with identical elements
+ * (by strict equality) keeps the previous reference. This prevents
+ * useSyncExternalStore infinite-loop re-renders when selectors derive new
+ * arrays whose contents haven't actually changed.
+ */
+function useShallowArray<T>(arr: readonly T[]): readonly T[] {
+  const ref = useRef(arr);
+  if (
+    arr !== ref.current &&
+    (arr.length !== ref.current.length ||
+      arr.some((v, i) => v !== ref.current[i]))
+  ) {
+    ref.current = arr;
+  }
+  return ref.current;
+}
+
+/**
  * Component that iterates over a list of items with key-stable rendering.
  *
  * Only re-renders when the key list changes (items added/removed/reordered),
@@ -31,7 +49,8 @@ export function AuiForEach<TKey extends string | number>({
   keys: (state: AssistantState) => readonly TKey[];
   children: (itemKey: TKey, index: number) => ReactNode;
 }): ReactNode {
-  const arr = useAuiState(keysSelector);
+  const rawArr = useAuiState(keysSelector);
+  const arr = useShallowArray(rawArr);
 
   return useMemo(
     () =>


### PR DESCRIPTION
## Summary

Copied from #3647 (by @samdickson22) to an internal branch for review.

Selectors passed to `AuiForEach` that create new arrays on every call (e.g. `ids.map((_, i) => i)`) trigger infinite re-render loops with `useSyncExternalStore`. Fixed by:

- **Returning stable array references from state** where possible (ThreadListItems, ComposerAttachments, MessageAttachments)
- **Using ID-based keys** instead of index-based keys where items have IDs (ThreadMessages, attachments)
- **Adding `useShallowArray` safety net** in `AuiForEach` for cases where selectors must derive new arrays (suggestions, parts)

## Changed files

| File | Fix |
|------|-----|
| `packages/store/src/AuiForEach.tsx` | Added `useShallowArray` to stabilize array references |
| `threadList/ThreadListItems.tsx` | Return `threadIds` directly (stable state ref) |
| `thread/ThreadMessages.tsx` | `.map(m => m.id)` (stable IDs) |
| `thread/ThreadSuggestions.tsx` | Index mapping, stabilized by `useShallowArray` |
| `composer/ComposerAttachments.tsx` | `.map(a => a.id)` |
| `message/MessageAttachments.tsx` | `.map(a => a.id)` |
| `chainOfThought/ChainOfThoughtParts.tsx` | Index mapping, stabilized by `useShallowArray` |
| `message/MessageParts.tsx` | Index mapping, stabilized by `useShallowArray` |

## Test plan

- [ ] Verify ThreadListPrimitive.Items renders without infinite loop
- [ ] Verify ThreadPrimitive.Messages renders correctly
- [ ] Verify message sending still works
- [ ] All core tests pass