### PR TITLE
feat(react-ink): add file storage adapter

### DIFF
--- a/.changeset/file-storage-react-ink.md
+++ b/.changeset/file-storage-react-ink.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react-ink": patch
+---
+
+feat(react-ink): add file storage adapter

--- a/apps/docs/content/docs/ink/adapters.mdx
+++ b/apps/docs/content/docs/ink/adapters.mdx
@@ -1,9 +1,21 @@
 ---
 title: Adapters
-description: Title generation adapters for React Ink.
+description: Title generation and storage adapters for React Ink.
 ---
 
 Adapters customize runtime behavior. They can be passed as options to `useLocalRuntime` or `useRemoteThreadListRuntime`.
+
+## createFileStorageAdapter
+
+A `RemoteThreadListAdapter` that persists threads and messages to a local directory. See [Custom Backend → Option 2](/docs/ink/custom-backend#option-2-local-file-persistence) for usage.
+
+```ts
+import { createFileStorageAdapter } from "@assistant-ui/react-ink";
+
+const adapter = createFileStorageAdapter({
+  dir: "/path/to/threads",
+});
+```
 
 ## RemoteThreadListAdapter
 

--- a/apps/docs/content/docs/ink/adapters.mdx
+++ b/apps/docs/content/docs/ink/adapters.mdx
@@ -17,6 +17,30 @@ const adapter = createFileStorageAdapter({
 });
 ```
 
+## TitleGenerationAdapter
+
+Produces a thread title from a thread's messages. Pass one as the `titleGenerator` option to `createFileStorageAdapter`, or call it from a custom `RemoteThreadListAdapter`.
+
+```ts
+type TitleGenerationAdapter = {
+  generateTitle(messages: readonly ThreadMessage[]): Promise<string>;
+};
+```
+
+`createSimpleTitleAdapter` is the built-in implementation; it derives the title from the first user message, truncated to 50 characters.
+
+```ts
+import {
+  createFileStorageAdapter,
+  createSimpleTitleAdapter,
+} from "@assistant-ui/react-ink";
+
+const adapter = createFileStorageAdapter({
+  dir: "/path/to/threads",
+  titleGenerator: createSimpleTitleAdapter(),
+});
+```
+
 ## RemoteThreadListAdapter
 
 Title generation is configured via the `generateTitle` method on `RemoteThreadListAdapter`. See the [Custom Backend](/docs/ink/custom-backend) page for a full example.

--- a/apps/docs/content/docs/ink/custom-backend.mdx
+++ b/apps/docs/content/docs/ink/custom-backend.mdx
@@ -103,7 +103,7 @@ Writes are atomic (temp file + `rename`), so a crash mid-write cannot leave a pa
 |---|---|
 | `dir` | Directory where thread files are stored. Created if missing. |
 | `prefix` | Key prefix for stored files. Defaults to `@assistant-ui:`. Useful when two apps share a directory. |
-| `titleGenerator` | Optional [`TitleGenerationAdapter`](/docs/ink/adapters) that auto-generates thread titles from the first messages. Pass `createSimpleTitleAdapter()` for the built-in implementation. |
+| `titleGenerator` | Optional [`TitleGenerationAdapter`](/docs/ink/adapters#titlegenerationadapter) that auto-generates thread titles from the first messages. Pass `createSimpleTitleAdapter()` for the built-in implementation. |
 
 ### When this fits
 

--- a/apps/docs/content/docs/ink/custom-backend.mdx
+++ b/apps/docs/content/docs/ink/custom-backend.mdx
@@ -59,7 +59,57 @@ This gives you:
 - In-memory thread list (lost on process exit)
 - Multi-thread support
 
-## Option 2: Full backend thread management
+## Option 2: Local file persistence
+
+When you want threads and messages to survive across sessions without running a backend, use `createFileStorageAdapter`. It writes each thread to a JSON file on disk and plugs into `useRemoteThreadListRuntime`.
+
+```tsx title="app.tsx"
+import { join } from "node:path";
+import { homedir } from "node:os";
+import {
+  useLocalRuntime,
+  useRemoteThreadListRuntime,
+  createFileStorageAdapter,
+  AssistantRuntimeProvider,
+} from "@assistant-ui/react-ink";
+import { myChatAdapter } from "./adapters/my-chat-adapter.js";
+
+const threadListAdapter = createFileStorageAdapter({
+  dir: join(homedir(), ".my-cli", "threads"),
+});
+
+function useAppRuntime() {
+  return useRemoteThreadListRuntime({
+    runtimeHook: () => useLocalRuntime(myChatAdapter),
+    adapter: threadListAdapter,
+  });
+}
+
+export function App() {
+  const runtime = useAppRuntime();
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {/* your chat UI */}
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+Writes are atomic (temp file + `rename`), so a crash mid-write cannot leave a partial JSON file. The directory is created lazily on first write.
+
+### Options
+
+| Option | Description |
+|---|---|
+| `dir` | Directory where thread files are stored. Created if missing. |
+| `prefix` | Key prefix for stored files. Defaults to `@assistant-ui:`. Useful when two apps share a directory. |
+| `titleGenerator` | Optional [`TitleGenerationAdapter`](/docs/ink/adapters) — auto-generate thread titles from the first messages. |
+
+### When this fits
+
+Designed for single-process terminal apps where one user has one CLI running at a time. The wrapped read-modify-write on the thread list isn't lock-safe, so two CLI processes pointed at the same directory can lose updates to thread metadata (rename, archive). If that's your scenario, use Option 3 instead.
+
+## Option 3: Full backend thread management
 
 When you want your backend to own thread state (e.g. for persistence across sessions, team sharing, or server-side history), implement a `RemoteThreadListAdapter`.
 
@@ -194,10 +244,11 @@ export function App() {
 
 ## Which option to choose?
 
-| | Option 1: ChatModelAdapter | Option 2: RemoteThreadListAdapter |
-|---|---|---|
-| **Thread storage** | In-memory (process lifetime) | Your backend |
-| **Message storage** | In-memory | On-device (can add history adapter for server-side) |
-| **Cross-session persistence** | No | Yes |
-| **Setup complexity** | Minimal | Moderate |
-| **Best for** | CLI tools, demos, prototypes | Production apps with persistence |
+| | Option 1: ChatModelAdapter | Option 2: FileStorage | Option 3: RemoteThreadListAdapter |
+|---|---|---|---|
+| **Thread storage** | In-memory (process lifetime) | Local disk | Your backend |
+| **Message storage** | In-memory | Local disk | In-memory (can add history adapter for server-side) |
+| **Cross-session persistence** | No | Yes | Yes |
+| **Multi-process safe** | N/A | No | Depends on backend |
+| **Setup complexity** | Minimal | Minimal | Moderate |
+| **Best for** | Demos, prototypes | Local CLI tools | Production apps with sync / team sharing |

--- a/apps/docs/content/docs/ink/custom-backend.mdx
+++ b/apps/docs/content/docs/ink/custom-backend.mdx
@@ -103,7 +103,7 @@ Writes are atomic (temp file + `rename`), so a crash mid-write cannot leave a pa
 |---|---|
 | `dir` | Directory where thread files are stored. Created if missing. |
 | `prefix` | Key prefix for stored files. Defaults to `@assistant-ui:`. Useful when two apps share a directory. |
-| `titleGenerator` | Optional [`TitleGenerationAdapter`](/docs/ink/adapters) — auto-generate thread titles from the first messages. |
+| `titleGenerator` | Optional [`TitleGenerationAdapter`](/docs/ink/adapters) that auto-generates thread titles from the first messages. Pass `createSimpleTitleAdapter()` for the built-in implementation. |
 
 ### When this fits
 
@@ -244,7 +244,7 @@ export function App() {
 
 ## Which option to choose?
 
-| | Option 1: ChatModelAdapter | Option 2: FileStorage | Option 3: RemoteThreadListAdapter |
+| | Option 1: ChatModelAdapter | Option 2: createFileStorageAdapter | Option 3: RemoteThreadListAdapter |
 |---|---|---|---|
 | **Thread storage** | In-memory (process lifetime) | Local disk | Your backend |
 | **Message storage** | In-memory | Local disk | In-memory (can add history adapter for server-side) |

--- a/packages/core/src/react/index.ts
+++ b/packages/core/src/react/index.ts
@@ -147,6 +147,10 @@ export {
   createLocalStorageAdapter,
   type AsyncStorageLike,
 } from "./adapters/LocalStorageThreadListAdapter";
+export {
+  createSimpleTitleAdapter,
+  type TitleGenerationAdapter,
+} from "./adapters/TitleGenerationAdapter";
 
 // AssistantProvider base
 export {

--- a/packages/core/src/react/index.ts
+++ b/packages/core/src/react/index.ts
@@ -143,6 +143,10 @@ export { useRemoteThreadListRuntime } from "./runtimes/useRemoteThreadListRuntim
 export { useCloudThreadListAdapter } from "./runtimes/cloud/useCloudThreadListAdapter";
 export { useAssistantCloudThreadHistoryAdapter } from "./runtimes/cloud/AssistantCloudThreadHistoryAdapter";
 export { CloudFileAttachmentAdapter } from "./runtimes/cloud/CloudFileAttachmentAdapter";
+export {
+  createLocalStorageAdapter,
+  type AsyncStorageLike,
+} from "./adapters/LocalStorageThreadListAdapter";
 
 // AssistantProvider base
 export {

--- a/packages/react-ink/package.json
+++ b/packages/react-ink/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
+    "@types/node": "^25.9.1",
     "@types/react": "^19.2.15",
     "ink": "^7.0.3",
     "ink-testing-library": "^4.0.0",

--- a/packages/react-ink/src/adapters/FileStorage.test.ts
+++ b/packages/react-ink/src/adapters/FileStorage.test.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createFileStorageAdapter, FileStorage } from "./FileStorage";
+
+const tempDirs: string[] = [];
+
+const createTempDir = async () => {
+  const dir = await mkdtemp(join(tmpdir(), "react-ink-file-storage-"));
+  tempDirs.push(dir);
+  return dir;
+};
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map(async (dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("FileStorage", () => {
+  it("returns null for missing keys", async () => {
+    const dir = await createTempDir();
+    const storage = new FileStorage({ dir });
+
+    await expect(storage.getItem("missing")).resolves.toBeNull();
+  });
+
+  it("writes, reads, and overwrites values", async () => {
+    const dir = await createTempDir();
+    const storage = new FileStorage({ dir });
+
+    await storage.setItem("@assistant-ui:threads", '{"count":1}');
+    await expect(storage.getItem("@assistant-ui:threads")).resolves.toBe(
+      '{"count":1}',
+    );
+
+    await storage.setItem("@assistant-ui:threads", '{"count":2}');
+    await expect(storage.getItem("@assistant-ui:threads")).resolves.toBe(
+      '{"count":2}',
+    );
+
+    const files = await readdir(dir);
+    expect(files).toEqual(["%40assistant-ui%3Athreads.json"]);
+  });
+
+  it("removes existing keys and ignores missing ones", async () => {
+    const dir = await createTempDir();
+    const storage = new FileStorage({ dir });
+
+    await storage.setItem("thread-1", "hello");
+    await storage.removeItem("thread-1");
+    await storage.removeItem("thread-1");
+
+    await expect(storage.getItem("thread-1")).resolves.toBeNull();
+  });
+
+  it("uses unique temp files for concurrent writes", async () => {
+    const dir = await createTempDir();
+    const storage = new FileStorage({ dir });
+
+    await Promise.all([
+      storage.setItem("thread-1", "first"),
+      storage.setItem("thread-1", "second"),
+    ]);
+
+    const finalValue = await storage.getItem("thread-1");
+    expect(["first", "second"]).toContain(finalValue);
+
+    const files = await readdir(dir);
+    expect(files).toEqual(["thread-1.json"]);
+  });
+});
+
+describe("createFileStorageAdapter", () => {
+  it("persists thread metadata via the local storage adapter", async () => {
+    const dir = await createTempDir();
+    const adapter = createFileStorageAdapter({
+      dir,
+      prefix: "@assistant-ui:test:",
+    });
+
+    await expect(adapter.list()).resolves.toEqual({ threads: [] });
+    await expect(adapter.initialize("thread-1")).resolves.toEqual({
+      externalId: undefined,
+      remoteId: "thread-1",
+    });
+
+    await expect(adapter.fetch("thread-1")).resolves.toEqual({
+      externalId: undefined,
+      remoteId: "thread-1",
+      status: "regular",
+      title: undefined,
+    });
+
+    const threadsFile = join(dir, "%40assistant-ui%3Atest%3Athreads.json");
+    await expect(readFile(threadsFile, "utf8")).resolves.toContain("thread-1");
+  });
+});

--- a/packages/react-ink/src/adapters/FileStorage.test.ts
+++ b/packages/react-ink/src/adapters/FileStorage.test.ts
@@ -23,14 +23,14 @@ afterEach(async () => {
 describe("FileStorage", () => {
   it("returns null for missing keys", async () => {
     const dir = await createTempDir();
-    const storage = new FileStorage({ dir });
+    const storage = new FileStorage(dir);
 
     await expect(storage.getItem("missing")).resolves.toBeNull();
   });
 
   it("writes, reads, and overwrites values", async () => {
     const dir = await createTempDir();
-    const storage = new FileStorage({ dir });
+    const storage = new FileStorage(dir);
 
     await storage.setItem("@assistant-ui:threads", '{"count":1}');
     await expect(storage.getItem("@assistant-ui:threads")).resolves.toBe(
@@ -48,7 +48,7 @@ describe("FileStorage", () => {
 
   it("removes existing keys and ignores missing ones", async () => {
     const dir = await createTempDir();
-    const storage = new FileStorage({ dir });
+    const storage = new FileStorage(dir);
 
     await storage.setItem("thread-1", "hello");
     await storage.removeItem("thread-1");
@@ -59,7 +59,7 @@ describe("FileStorage", () => {
 
   it("uses unique temp files for concurrent writes", async () => {
     const dir = await createTempDir();
-    const storage = new FileStorage({ dir });
+    const storage = new FileStorage(dir);
 
     await Promise.all([
       storage.setItem("thread-1", "first"),
@@ -97,5 +97,58 @@ describe("createFileStorageAdapter", () => {
 
     const threadsFile = join(dir, "%40assistant-ui%3Atest%3Athreads.json");
     await expect(readFile(threadsFile, "utf8")).resolves.toContain("thread-1");
+  });
+
+  it("persists rename, archive, unarchive, and delete across reloads", async () => {
+    const dir = await createTempDir();
+    const adapter = createFileStorageAdapter({ dir });
+
+    await adapter.initialize("thread-1");
+    await adapter.rename("thread-1", "Renamed");
+    await adapter.archive("thread-1");
+
+    await expect(
+      createFileStorageAdapter({ dir }).fetch("thread-1"),
+    ).resolves.toEqual({
+      remoteId: "thread-1",
+      externalId: undefined,
+      status: "archived",
+      title: "Renamed",
+    });
+
+    await adapter.unarchive("thread-1");
+    await expect(
+      createFileStorageAdapter({ dir }).fetch("thread-1"),
+    ).resolves.toEqual({
+      remoteId: "thread-1",
+      externalId: undefined,
+      status: "regular",
+      title: "Renamed",
+    });
+
+    await adapter.delete("thread-1");
+    await expect(createFileStorageAdapter({ dir }).list()).resolves.toEqual({
+      threads: [],
+    });
+  });
+
+  it("generates and persists titles via the titleGenerator", async () => {
+    const dir = await createTempDir();
+    const adapter = createFileStorageAdapter({
+      dir,
+      titleGenerator: { generateTitle: async () => "Generated title" },
+    });
+
+    await adapter.initialize("thread-1");
+    await adapter.generateTitle("thread-1", []);
+
+    await expect(
+      createFileStorageAdapter({ dir }).fetch("thread-1"),
+    ).resolves.toEqual({
+      remoteId: "thread-1",
+      externalId: undefined,
+      status: "regular",
+      title: "Generated title",
+    });
   });
 });

--- a/packages/react-ink/src/adapters/FileStorage.ts
+++ b/packages/react-ink/src/adapters/FileStorage.ts
@@ -5,8 +5,8 @@ import type { RemoteThreadListAdapter } from "@assistant-ui/core";
 import {
   createLocalStorageAdapter,
   type AsyncStorageLike,
+  type TitleGenerationAdapter,
 } from "@assistant-ui/core/react";
-import type { TitleGenerationAdapter } from "@assistant-ui/core/react/adapters/TitleGenerationAdapter";
 
 export type { AsyncStorageLike } from "@assistant-ui/core/react";
 

--- a/packages/react-ink/src/adapters/FileStorage.ts
+++ b/packages/react-ink/src/adapters/FileStorage.ts
@@ -8,12 +8,6 @@ import {
   type TitleGenerationAdapter,
 } from "@assistant-ui/core/react";
 
-export type { AsyncStorageLike } from "@assistant-ui/core/react";
-
-export type FileStorageOptions = {
-  dir: string;
-};
-
 export type CreateFileStorageAdapterOptions = {
   dir: string;
   prefix?: string | undefined;
@@ -27,12 +21,9 @@ const isEnoent = (error: unknown): boolean =>
   (error as { code: unknown }).code === "ENOENT";
 
 export class FileStorage implements AsyncStorageLike {
-  private dir: string;
   private ready: Promise<void> | undefined;
 
-  public constructor(options: FileStorageOptions) {
-    this.dir = options.dir;
-  }
+  constructor(private dir: string) {}
 
   private getFilePath(key: string) {
     return join(this.dir, `${encodeURIComponent(key)}.json`);
@@ -40,7 +31,12 @@ export class FileStorage implements AsyncStorageLike {
 
   private ensureDir(): Promise<void> {
     if (!this.ready) {
-      this.ready = mkdir(this.dir, { recursive: true }).then(() => undefined);
+      this.ready = mkdir(this.dir, { recursive: true })
+        .then(() => undefined)
+        .catch((error) => {
+          this.ready = undefined;
+          throw error;
+        });
     }
     return this.ready;
   }
@@ -80,7 +76,7 @@ export const createFileStorageAdapter = (
   const { dir, prefix, titleGenerator } = options;
 
   return createLocalStorageAdapter({
-    storage: new FileStorage({ dir }),
+    storage: new FileStorage(dir),
     prefix,
     titleGenerator,
   });

--- a/packages/react-ink/src/adapters/FileStorage.ts
+++ b/packages/react-ink/src/adapters/FileStorage.ts
@@ -1,0 +1,87 @@
+import { randomUUID } from "node:crypto";
+import { readFile, mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { RemoteThreadListAdapter } from "@assistant-ui/core";
+import {
+  createLocalStorageAdapter,
+  type AsyncStorageLike,
+} from "@assistant-ui/core/react";
+import type { TitleGenerationAdapter } from "@assistant-ui/core/react/adapters/TitleGenerationAdapter";
+
+export type { AsyncStorageLike } from "@assistant-ui/core/react";
+
+export type FileStorageOptions = {
+  dir: string;
+};
+
+export type CreateFileStorageAdapterOptions = {
+  dir: string;
+  prefix?: string | undefined;
+  titleGenerator?: TitleGenerationAdapter | undefined;
+};
+
+const isEnoent = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  (error as { code: unknown }).code === "ENOENT";
+
+export class FileStorage implements AsyncStorageLike {
+  private dir: string;
+  private ready: Promise<void> | undefined;
+
+  public constructor(options: FileStorageOptions) {
+    this.dir = options.dir;
+  }
+
+  private getFilePath(key: string) {
+    return join(this.dir, `${encodeURIComponent(key)}.json`);
+  }
+
+  private ensureDir(): Promise<void> {
+    if (!this.ready) {
+      this.ready = mkdir(this.dir, { recursive: true }).then(() => undefined);
+    }
+    return this.ready;
+  }
+
+  async getItem(key: string): Promise<string | null> {
+    try {
+      return await readFile(this.getFilePath(key), "utf8");
+    } catch (error) {
+      if (isEnoent(error)) return null;
+      throw error;
+    }
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    await this.ensureDir();
+
+    const targetPath = this.getFilePath(key);
+    const tempPath = `${targetPath}.${randomUUID()}.tmp`;
+
+    try {
+      await writeFile(tempPath, value, "utf8");
+      await rename(tempPath, targetPath);
+    } catch (error) {
+      await rm(tempPath, { force: true }).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async removeItem(key: string): Promise<void> {
+    await rm(this.getFilePath(key), { force: true });
+  }
+}
+
+export const createFileStorageAdapter = (
+  options: CreateFileStorageAdapterOptions,
+): RemoteThreadListAdapter => {
+  const { dir, prefix, titleGenerator } = options;
+
+  return createLocalStorageAdapter({
+    storage: new FileStorage({ dir }),
+    prefix,
+    titleGenerator,
+  });
+};

--- a/packages/react-ink/src/adapters/index.ts
+++ b/packages/react-ink/src/adapters/index.ts
@@ -1,0 +1,7 @@
+export {
+  createFileStorageAdapter,
+  FileStorage,
+  type AsyncStorageLike,
+  type CreateFileStorageAdapterOptions,
+  type FileStorageOptions,
+} from "./FileStorage";

--- a/packages/react-ink/src/adapters/index.ts
+++ b/packages/react-ink/src/adapters/index.ts
@@ -1,7 +1,0 @@
-export {
-  createFileStorageAdapter,
-  FileStorage,
-  type AsyncStorageLike,
-  type CreateFileStorageAdapterOptions,
-  type FileStorageOptions,
-} from "./FileStorage";

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -114,11 +114,12 @@ export {
 export { useRemoteThreadListRuntime } from "./runtimes/useRemoteThreadListRuntime";
 export {
   createFileStorageAdapter,
-  FileStorage,
-  type AsyncStorageLike,
   type CreateFileStorageAdapterOptions,
-  type FileStorageOptions,
-} from "./adapters";
+} from "./adapters/FileStorage";
+export {
+  createSimpleTitleAdapter,
+  type TitleGenerationAdapter,
+} from "@assistant-ui/core/react";
 
 // Primitives
 export * as ThreadPrimitive from "./primitives/thread";

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -112,6 +112,13 @@ export {
   type LocalRuntimeOptions,
 } from "./runtimes/useLocalRuntime";
 export { useRemoteThreadListRuntime } from "./runtimes/useRemoteThreadListRuntime";
+export {
+  createFileStorageAdapter,
+  FileStorage,
+  type AsyncStorageLike,
+  type CreateFileStorageAdapterOptions,
+  type FileStorageOptions,
+} from "./adapters";
 
 // Primitives
 export * as ThreadPrimitive from "./primitives/thread";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3516,6 +3516,9 @@ importers:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15


### PR DESCRIPTION
This PR adds a file-based storage utility and `createFileStorageAdapter()` to `@assistant-ui/react-ink` so terminal apps can persist thread data locally