### PR TITLE
refactor(store): drop AuiForEach, use length-based list rendering

### DIFF
--- a/apps/docs/content/tap-docs/store/api-reference.mdx
+++ b/apps/docs/content/tap-docs/store/api-reference.mdx
@@ -68,45 +68,30 @@ Provides an `AssistantClient` to the React tree. Child components can access it 
 
 Renders children only when the condition returns `true`. Uses `useAuiState` internally.
 
-### AuiForEach
-
-```tsx
-<AuiForEach
-  keys={(s) => s.todoList.todos.map((t) => t.id)}
->
-  {(itemKey, index) => (
-    <TodoProvider index={index}>
-      <TodoDisplay />
-    </TodoProvider>
-  )}
-</AuiForEach>
-```
-
-Iterates over a list of keys with key-stable rendering. Only re-renders when the key list changes (items added/removed/reordered), not when individual item data changes.
-
-| Prop | Type |
-|------|------|
-| `keys` | `(state: AssistantState) => readonly TKey[]` |
-| `children` | `(itemKey: TKey, index: number) => ReactNode` |
-
-`TKey` extends `string | number`. See [Rendering Lists](/tap-docs/store/rendering-lists) for details.
-
 ### RenderChildrenWithAccessor
 
 ```tsx
 <RenderChildrenWithAccessor
   getItemState={(aui) => aui.todoList().todo({ index }).getState()}
 >
-  {() => <TodoDisplay />}
+  {(getItem) =>
+    children({
+      get todo() {
+        return getItem();
+      },
+    })
+  }
 </RenderChildrenWithAccessor>
 ```
 
-Sets up a lazy item accessor and memoizes the children output. Optimized for the common pattern where children returns a propless component.
+Sets up a lazy item accessor for list rendering. The `getItem` function defers reading state until the consumer accesses it — if the children render function never reads the item, no subscription is created. When children returns a propless component (e.g. `{() => <Todo />}`), the output is automatically memoized.
 
 | Prop | Type |
 |------|------|
 | `getItemState` | `(aui: AssistantClient) => T` |
 | `children` | `(getItem: () => T) => ReactNode` |
+
+See [Rendering Lists](/tap-docs/store/rendering-lists) for the full pattern.
 
 ---
 

--- a/apps/docs/content/tap-docs/store/rendering-lists.mdx
+++ b/apps/docs/content/tap-docs/store/rendering-lists.mdx
@@ -1,183 +1,82 @@
 ---
 title: Rendering Lists
-description: Efficiently render lists of scoped items with AuiForEach and RenderChildrenWithAccessor.
+description: How to efficiently render lists of items from store state.
 ---
 
-The [child scopes](/tap-docs/store/child-scopes) page showed how to wire up parent-child scope relationships. This page covers the rendering side — how to iterate over a list of child scopes efficiently without re-rendering every item when the list changes.
+## The pattern
 
-## The problem
+Rendering a list of items from store state follows a three-step pattern:
 
-A naive approach re-renders the entire list whenever any item's state changes:
-
-```tsx
-const TodoList = () => {
-  const todos = useAuiState((s) => s.todoList.todos);
-  return todos.map((_, index) => (
-    <TodoItem key={index} index={index} />
-  ));
-};
-```
-
-Every state change in any todo causes `todos` to be a new array, which re-renders `TodoList` and recreates all `TodoItem` elements.
-
-## AuiForEach
-
-`AuiForEach` solves this by subscribing to just the **keys** of the list. It only re-renders when items are added, removed, or reordered — not when individual item data changes.
+1. **Subscribe to the list length** with `useAuiState` — re-renders only when items are added or removed
+2. **Memoize the element array** with `useMemo` — avoids recreating elements on unrelated re-renders
+3. **Use `RenderChildrenWithAccessor`** inside each item — defers reading item state until the child actually needs it
 
 ```tsx
-import { AuiForEach } from "@assistant-ui/store";
+import { useMemo } from "react";
+import { useAuiState, RenderChildrenWithAccessor } from "@assistant-ui/store";
 
-<AuiForEach
-  keys={(s) => s.todoList.todos.map((t) => t.id)}
->
-  {(itemId, index) => (
-    <TodoProvider index={index}>
-      <TodoDisplay />
-    </TodoProvider>
-  )}
-</AuiForEach>
-```
-
-### Props
-
-| Prop | Type | Description |
-|------|------|-------------|
-| `keys` | `(state: AssistantState) => readonly TKey[]` | Selector that returns the list of keys. Uses `useAuiState` internally — re-renders only when keys change. |
-| `children` | `(itemKey: TKey, index: number) => ReactNode` | Render function called for each item. Receives the key and index. |
-
-`TKey` extends `string | number`. The key values are used as React keys for reconciliation.
-
-### Key strategies
-
-You can choose between item IDs or indices as keys:
-
-```tsx
-// By ID — items keep identity across reorders
-keys={(s) => s.todoList.todos.map((t) => t.id)}
-
-// By index — simpler, but items lose identity on reorder
-keys={(s) => s.todoList.todos.map((_, i) => i)}
-```
-
-### How it avoids re-renders
-
-`AuiForEach` memoizes the rendered output using the key array as dependencies. When state changes but the key list stays the same, the memoized output is returned and no children are re-created.
-
-## RenderChildrenWithAccessor
-
-For the common pattern where a child component has no props (like `<Foo />`), `RenderChildrenWithAccessor` memoizes the render output so it's only created once per item:
-
-```tsx
-import { RenderChildrenWithAccessor } from "@assistant-ui/store";
-
-<RenderChildrenWithAccessor
-  getItemState={(aui) => aui.todoList().todo({ index }).getState()}
->
-  {() => <TodoDisplay />}
-</RenderChildrenWithAccessor>
-```
-
-### Props
-
-| Prop | Type | Description |
-|------|------|-------------|
-| `getItemState` | `(aui: AssistantClient) => T` | Function to access the item's state from the store. |
-| `children` | `(getItem: () => T) => ReactNode` | Render function. Receives a `getItem` accessor that returns the item's current state when called. |
-
-The `children` output is memoized — calling `getItem()` inside a getter defers the state read until the consumer actually accesses it.
-
-## Full example
-
-Putting it together — a `FooList` component that renders a list of `Foo` items:
-
-### Scope registration
-
-```ts title="lib/store/foo-scope.ts"
-declare module "@assistant-ui/store" {
-  interface ScopeRegistry {
-    fooList: {
-      methods: {
-        getState: () => { foos: { id: string; bar: string }[] };
-        foo: (lookup: { index: number } | { key: string }) => FooMethods;
-        addFoo: () => void;
-      };
-      events: { "fooList.added": { id: string } };
-    };
-    foo: {
-      methods: {
-        getState: () => { id: string; bar: string };
-        updateBar: (newBar: string) => void;
-        remove: () => void;
-      };
-      meta: {
-        source: "fooList";
-        query: { index: number } | { key: string };
-      };
-      events: {
-        "foo.updated": { id: string; newValue: string };
-        "foo.removed": { id: string };
-      };
-    };
-  }
-}
-```
-
-### List component
-
-```tsx title="lib/store/foo-store.tsx"
-import {
-  useAui, AuiProvider, Derived,
-  AuiForEach, RenderChildrenWithAccessor,
-} from "@assistant-ui/store";
-
-const FooProvider = ({
-  index, children,
-}: {
-  index: number;
-  children: ReactNode;
-}) => {
-  const aui = useAui({
-    foo: Derived({
-      source: "fooList",
-      query: { index },
-      get: (aui) => aui.fooList().foo({ index }),
-    }),
-  });
-  return <AuiProvider value={aui}>{children}</AuiProvider>;
-};
-
-export const FooList = ({
+const TodoList = ({
   children,
 }: {
-  children: (item: { foo: FooData }) => ReactNode;
-}) => (
-  <AuiForEach keys={(s) => s.fooList.foos.map((_, index) => index)}>
-    {(index) => (
-      <FooProvider index={index}>
-        <RenderChildrenWithAccessor
-          getItemState={(aui) => aui.fooList().foo({ index }).getState()}
-        >
-          {(getItem) =>
-            children({
-              get foo() {
-                return getItem();
-              },
-            })
-          }
-        </RenderChildrenWithAccessor>
-      </FooProvider>
-    )}
-  </AuiForEach>
-);
+  children: (value: { todo: TodoState }) => ReactNode;
+}) => {
+  const length = useAuiState((s) => s.todoList.todos.length);
+
+  return useMemo(
+    () =>
+      Array.from({ length }, (_, index) => (
+        <TodoProvider key={index} index={index}>
+          <RenderChildrenWithAccessor
+            getItemState={(aui) => aui.todoList().todo({ index }).getState()}
+          >
+            {(getItem) =>
+              children({
+                get todo() {
+                  return getItem();
+                },
+              })
+            }
+          </RenderChildrenWithAccessor>
+        </TodoProvider>
+      )),
+    [length, children],
+  );
+};
 ```
 
-### Usage
+Usage:
 
-```tsx title="app/App.tsx"
-<FooList>
-  {() => <Foo />}
-</FooList>
+```tsx
+<TodoList>
+  {({ todo }) => <TodoCard title={todo.title} />}
+</TodoList>
 ```
 
-The `Foo` component reads its own state via `useAuiState((s) => s.foo)` inside the scoped provider. It re-renders independently when its state changes, without affecting sibling items or the list container.
+## Why this pattern?
 
+### Length-based subscription
+
+Subscribing to `.length` instead of the full array means the list component only re-renders when items are added or removed — not when an individual item's data changes. This is significantly cheaper than subscribing to keys or the full array.
+
+### RenderChildrenWithAccessor
+
+`RenderChildrenWithAccessor` provides a lazy accessor (`getItem`) instead of reading item state eagerly. This means:
+
+- **Deferred reads**: If the children render function never accesses the item, no subscription is created
+- **Propless memoization**: When children returns a propless component (e.g. `{() => <Todo />}`), the output is automatically memoized — it won't re-render on parent updates
+
+The `getItem` function is a getter that reads the latest state on demand. Wrap it in a lazy property (`get todo() { return getItem(); }`) so the state is only read when the consumer accesses it.
+
+## Built-in primitives
+
+All assistant-ui list primitives (Messages, Parts, Attachments, Suggestions, ThreadListItems, etc.) use this pattern internally. When using the children render function API, you get the lazy accessor behavior automatically:
+
+```tsx
+<ThreadPrimitive.Messages>
+  {({ message }) => {
+    // `message` is a lazy getter — state is read here, not above
+    if (message.role === "user") return <MyUserMessage />;
+    return <MyAssistantMessage />;
+  }}
+</ThreadPrimitive.Messages>
+```

--- a/examples/with-store/lib/store/foo-store.tsx
+++ b/examples/with-store/lib/store/foo-store.tsx
@@ -2,15 +2,15 @@
 
 import "./foo-scope";
 
-import type { ReactNode } from "react";
+import { type ReactNode, useMemo } from "react";
 import { resource, tapMemo, tapState } from "@assistant-ui/tap";
 import {
   useAui,
+  useAuiState,
   AuiProvider,
   tapClientList,
   Derived,
   tapAssistantEmit,
-  AuiForEach,
   RenderChildrenWithAccessor,
   type ClientOutput,
 } from "@assistant-ui/store";
@@ -99,22 +99,26 @@ export const FooList = ({
   children,
 }: {
   children: (item: { foo: FooData }) => ReactNode;
-}) => (
-  <AuiForEach keys={(s) => s.fooList.foos.map((_, index) => index)}>
-    {(index) => (
-      <FooProvider index={index}>
-        <RenderChildrenWithAccessor
-          getItemState={(aui) => aui.fooList().foo({ index }).getState()}
-        >
-          {(getItem) =>
-            children({
-              get foo() {
-                return getItem();
-              },
-            })
-          }
-        </RenderChildrenWithAccessor>
-      </FooProvider>
-    )}
-  </AuiForEach>
-);
+}) => {
+  const length = useAuiState((s) => s.fooList.foos.length);
+
+  return useMemo(
+    () =>
+      Array.from({ length }, (_, index) => (
+        <FooProvider key={index} index={index}>
+          <RenderChildrenWithAccessor
+            getItemState={(aui) => aui.fooList().foo({ index }).getState()}
+          >
+            {(getItem) =>
+              children({
+                get foo() {
+                  return getItem();
+                },
+              })
+            }
+          </RenderChildrenWithAccessor>
+        </FooProvider>
+      )),
+    [length, children],
+  );
+};

--- a/packages/core/src/react/primitives/chainOfThought/ChainOfThoughtParts.tsx
+++ b/packages/core/src/react/primitives/chainOfThought/ChainOfThoughtParts.tsx
@@ -5,7 +5,7 @@ import {
   type ReactNode,
   useMemo,
 } from "react";
-import { AuiForEach, RenderChildrenWithAccessor } from "@assistant-ui/store";
+import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
 import type { PartState } from "../../../store/scopes/part";
 import { ChainOfThoughtPartByIndexProvider } from "../../providers/ChainOfThoughtPartByIndexProvider";
 import { MessagePartComponent } from "../message/MessageParts";
@@ -43,27 +43,31 @@ export namespace ChainOfThoughtPrimitiveParts {
 
 const ChainOfThoughtPrimitivePartsInner: FC<{
   children: (value: { part: PartState }) => ReactNode;
-}> = ({ children }) => (
-  <AuiForEach keys={(s) => s.chainOfThought.parts.map((_, index) => index)}>
-    {(index) => (
-      <ChainOfThoughtPartByIndexProvider index={index}>
-        <RenderChildrenWithAccessor
-          getItemState={(aui) =>
-            aui.chainOfThought().part({ index }).getState()
-          }
-        >
-          {(getItem) =>
-            children({
-              get part() {
-                return getItem();
-              },
-            })
-          }
-        </RenderChildrenWithAccessor>
-      </ChainOfThoughtPartByIndexProvider>
-    )}
-  </AuiForEach>
-);
+}> = ({ children }) => {
+  const partsLength = useAuiState((s) => s.chainOfThought.parts.length);
+
+  return useMemo(
+    () =>
+      Array.from({ length: partsLength }, (_, index) => (
+        <ChainOfThoughtPartByIndexProvider key={index} index={index}>
+          <RenderChildrenWithAccessor
+            getItemState={(aui) =>
+              aui.chainOfThought().part({ index }).getState()
+            }
+          >
+            {(getItem) =>
+              children({
+                get part() {
+                  return getItem();
+                },
+              })
+            }
+          </RenderChildrenWithAccessor>
+        </ChainOfThoughtPartByIndexProvider>
+      )),
+    [partsLength, children],
+  );
+};
 
 /**
  * Renders the parts within a chain of thought, with support for collapsed/expanded states.

--- a/packages/core/src/react/primitives/composer/ComposerAttachments.tsx
+++ b/packages/core/src/react/primitives/composer/ComposerAttachments.tsx
@@ -1,10 +1,6 @@
 import type { Attachment } from "../../../types/attachment";
-import { ComponentType, type FC, type ReactNode, memo } from "react";
-import {
-  AuiForEach,
-  RenderChildrenWithAccessor,
-  useAuiState,
-} from "@assistant-ui/store";
+import { ComponentType, type FC, type ReactNode, memo, useMemo } from "react";
+import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
 import { ComposerAttachmentByIndexProvider } from "../../providers/AttachmentByIndexProvider";
 
 type ComposerAttachmentsComponentConfig = {
@@ -88,27 +84,31 @@ ComposerPrimitiveAttachmentByIndex.displayName =
 
 const ComposerPrimitiveAttachmentsInner: FC<{
   children: (value: { attachment: Attachment }) => ReactNode;
-}> = ({ children }) => (
-  <AuiForEach keys={(s) => s.composer.attachments.map((_, index) => index)}>
-    {(index) => (
-      <ComposerAttachmentByIndexProvider index={index}>
-        <RenderChildrenWithAccessor
-          getItemState={(aui) =>
-            aui.composer().attachment({ index }).getState()
-          }
-        >
-          {(getItem) =>
-            children({
-              get attachment() {
-                return getItem();
-              },
-            })
-          }
-        </RenderChildrenWithAccessor>
-      </ComposerAttachmentByIndexProvider>
-    )}
-  </AuiForEach>
-);
+}> = ({ children }) => {
+  const attachmentsCount = useAuiState((s) => s.composer.attachments.length);
+
+  return useMemo(
+    () =>
+      Array.from({ length: attachmentsCount }, (_, index) => (
+        <ComposerAttachmentByIndexProvider key={index} index={index}>
+          <RenderChildrenWithAccessor
+            getItemState={(aui) =>
+              aui.composer().attachment({ index }).getState()
+            }
+          >
+            {(getItem) =>
+              children({
+                get attachment() {
+                  return getItem();
+                },
+              })
+            }
+          </RenderChildrenWithAccessor>
+        </ComposerAttachmentByIndexProvider>
+      )),
+    [attachmentsCount, children],
+  );
+};
 
 export const ComposerPrimitiveAttachments: FC<
   ComposerPrimitiveAttachments.Props

--- a/packages/core/src/react/primitives/message/MessageAttachments.tsx
+++ b/packages/core/src/react/primitives/message/MessageAttachments.tsx
@@ -1,10 +1,6 @@
 import type { CompleteAttachment } from "../../../types/attachment";
-import { ComponentType, type FC, type ReactNode, memo } from "react";
-import {
-  AuiForEach,
-  RenderChildrenWithAccessor,
-  useAuiState,
-} from "@assistant-ui/store";
+import { ComponentType, type FC, type ReactNode, memo, useMemo } from "react";
+import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
 import { MessageAttachmentByIndexProvider } from "../../providers/AttachmentByIndexProvider";
 
 type MessageAttachmentsComponentConfig = {
@@ -88,30 +84,34 @@ MessagePrimitiveAttachmentByIndex.displayName =
 
 const MessagePrimitiveAttachmentsInner: FC<{
   children: (value: { attachment: CompleteAttachment }) => ReactNode;
-}> = ({ children }) => (
-  <AuiForEach
-    keys={(s) => {
-      if (s.message.role !== "user") return [];
-      return s.message.attachments.map((_, index) => index);
-    }}
-  >
-    {(index) => (
-      <MessageAttachmentByIndexProvider index={index}>
-        <RenderChildrenWithAccessor
-          getItemState={(aui) => aui.message().attachment({ index }).getState()}
-        >
-          {(getItem) =>
-            children({
-              get attachment() {
-                return getItem() as CompleteAttachment;
-              },
-            })
-          }
-        </RenderChildrenWithAccessor>
-      </MessageAttachmentByIndexProvider>
-    )}
-  </AuiForEach>
-);
+}> = ({ children }) => {
+  const attachmentsCount = useAuiState((s) => {
+    if (s.message.role !== "user") return 0;
+    return s.message.attachments.length;
+  });
+
+  return useMemo(
+    () =>
+      Array.from({ length: attachmentsCount }, (_, index) => (
+        <MessageAttachmentByIndexProvider key={index} index={index}>
+          <RenderChildrenWithAccessor
+            getItemState={(aui) =>
+              aui.message().attachment({ index }).getState()
+            }
+          >
+            {(getItem) =>
+              children({
+                get attachment() {
+                  return getItem() as CompleteAttachment;
+                },
+              })
+            }
+          </RenderChildrenWithAccessor>
+        </MessageAttachmentByIndexProvider>
+      )),
+    [attachmentsCount, children],
+  );
+};
 
 export const MessagePrimitiveAttachments: FC<
   MessagePrimitiveAttachments.Props

--- a/packages/core/src/react/primitives/message/MessageParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageParts.tsx
@@ -7,7 +7,6 @@ import {
   useMemo,
 } from "react";
 import {
-  AuiForEach,
   RenderChildrenWithAccessor,
   useAuiState,
   useAui,
@@ -582,11 +581,13 @@ const MessagePrimitivePartsInner: FC<{
   children: (value: { part: EnrichedPartState }) => ReactNode;
 }> = ({ children }) => {
   const aui = useAui();
+  const contentLength = useAuiState((s) => s.message.parts.length);
 
-  return (
-    <AuiForEach keys={(s) => s.message.parts.map((_, index) => index)}>
-      {(index) => (
-        <PartByIndexProvider index={index}>
+  // biome-ignore lint/correctness/useExhaustiveDependencies: aui accessors are stable refs
+  return useMemo(
+    () =>
+      Array.from({ length: contentLength }, (_, index) => (
+        <PartByIndexProvider key={index} index={index}>
           <RenderChildrenWithAccessor
             getItemState={(aui) => aui.message().part({ index }).getState()}
           >
@@ -625,8 +626,8 @@ const MessagePrimitivePartsInner: FC<{
             }}
           </RenderChildrenWithAccessor>
         </PartByIndexProvider>
-      )}
-    </AuiForEach>
+      )),
+    [contentLength, children],
   );
 };
 

--- a/packages/core/src/react/primitives/thread/ThreadMessages.tsx
+++ b/packages/core/src/react/primitives/thread/ThreadMessages.tsx
@@ -1,9 +1,11 @@
-import { type ComponentType, type FC, type ReactNode, memo } from "react";
 import {
-  AuiForEach,
-  RenderChildrenWithAccessor,
-  useAuiState,
-} from "@assistant-ui/store";
+  type ComponentType,
+  type FC,
+  type ReactNode,
+  memo,
+  useMemo,
+} from "react";
+import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
 import { MessageByIndexProvider } from "../../providers/MessageByIndexProvider";
 import { MessageState } from "../../../store";
 
@@ -169,10 +171,13 @@ ThreadPrimitiveMessageByIndex.displayName = "ThreadPrimitive.MessageByIndex";
 
 const ThreadPrimitiveMessagesInner: FC<{
   children: (value: { message: MessageState }) => ReactNode;
-}> = ({ children }) => (
-  <AuiForEach keys={(s) => s.thread.messages.map((_, index) => index)}>
-    {(index) => (
-      <MessageByIndexProvider index={index}>
+}> = ({ children }) => {
+  const messagesLength = useAuiState((s) => s.thread.messages.length);
+
+  return useMemo(() => {
+    if (messagesLength === 0) return null;
+    return Array.from({ length: messagesLength }, (_, index) => (
+      <MessageByIndexProvider key={index} index={index}>
         <RenderChildrenWithAccessor
           getItemState={(aui) => aui.thread().message({ index }).getState()}
         >
@@ -185,9 +190,9 @@ const ThreadPrimitiveMessagesInner: FC<{
           }
         </RenderChildrenWithAccessor>
       </MessageByIndexProvider>
-    )}
-  </AuiForEach>
-);
+    ));
+  }, [messagesLength, children]);
+};
 
 /**
  * Renders all messages in the current thread.

--- a/packages/core/src/react/primitives/thread/ThreadSuggestions.tsx
+++ b/packages/core/src/react/primitives/thread/ThreadSuggestions.tsx
@@ -1,5 +1,11 @@
-import { type ComponentType, type FC, type ReactNode, memo } from "react";
-import { AuiForEach, RenderChildrenWithAccessor } from "@assistant-ui/store";
+import {
+  type ComponentType,
+  type FC,
+  type ReactNode,
+  memo,
+  useMemo,
+} from "react";
+import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
 import type { SuggestionState } from "../../../store/scopes/suggestion";
 import { SuggestionByIndexProvider } from "../../providers/SuggestionByIndexProvider";
 
@@ -60,10 +66,15 @@ ThreadPrimitiveSuggestionByIndex.displayName =
 
 const ThreadPrimitiveSuggestionsInner: FC<{
   children: (value: { suggestion: SuggestionState }) => ReactNode;
-}> = ({ children }) => (
-  <AuiForEach keys={(s) => s.suggestions.suggestions.map((_, index) => index)}>
-    {(index) => (
-      <SuggestionByIndexProvider index={index}>
+}> = ({ children }) => {
+  const suggestionsLength = useAuiState(
+    (s) => s.suggestions.suggestions.length,
+  );
+
+  return useMemo(() => {
+    if (suggestionsLength === 0) return null;
+    return Array.from({ length: suggestionsLength }, (_, index) => (
+      <SuggestionByIndexProvider key={index} index={index}>
         <RenderChildrenWithAccessor
           getItemState={(aui) =>
             aui.suggestions().suggestion({ index }).getState()
@@ -78,9 +89,9 @@ const ThreadPrimitiveSuggestionsInner: FC<{
           }
         </RenderChildrenWithAccessor>
       </SuggestionByIndexProvider>
-    )}
-  </AuiForEach>
-);
+    ));
+  }, [suggestionsLength, children]);
+};
 
 /**
  * Renders all suggestions.

--- a/packages/core/src/react/primitives/threadList/ThreadListItems.tsx
+++ b/packages/core/src/react/primitives/threadList/ThreadListItems.tsx
@@ -1,5 +1,5 @@
-import { ComponentType, FC, ReactNode, memo } from "react";
-import { AuiForEach, RenderChildrenWithAccessor } from "@assistant-ui/store";
+import { ComponentType, FC, ReactNode, memo, useMemo } from "react";
+import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
 import type { ThreadListItemState } from "../../../store/scopes/thread-list-item";
 import { ThreadListItemByIndexProvider } from "../../providers/ThreadListItemByIndexProvider";
 
@@ -57,32 +57,37 @@ ThreadListPrimitiveItemByIndex.displayName = "ThreadListPrimitive.ItemByIndex";
 const ThreadListPrimitiveItemsInner: FC<{
   archived: boolean;
   children: (value: { threadListItem: ThreadListItemState }) => ReactNode;
-}> = ({ archived, children }) => (
-  <AuiForEach
-    keys={(s) => {
-      const ids = archived ? s.threads.archivedThreadIds : s.threads.threadIds;
-      return ids.map((_, index) => index);
-    }}
-  >
-    {(index) => (
-      <ThreadListItemByIndexProvider index={index} archived={archived}>
-        <RenderChildrenWithAccessor
-          getItemState={(aui) =>
-            aui.threads().item({ index, archived }).getState()
-          }
+}> = ({ archived, children }) => {
+  const contentLength = useAuiState((s) =>
+    archived ? s.threads.archivedThreadIds.length : s.threads.threadIds.length,
+  );
+
+  return useMemo(
+    () =>
+      Array.from({ length: contentLength }, (_, index) => (
+        <ThreadListItemByIndexProvider
+          key={index}
+          index={index}
+          archived={archived}
         >
-          {(getItem) =>
-            children({
-              get threadListItem() {
-                return getItem();
-              },
-            })
-          }
-        </RenderChildrenWithAccessor>
-      </ThreadListItemByIndexProvider>
-    )}
-  </AuiForEach>
-);
+          <RenderChildrenWithAccessor
+            getItemState={(aui) =>
+              aui.threads().item({ index, archived }).getState()
+            }
+          >
+            {(getItem) =>
+              children({
+                get threadListItem() {
+                  return getItem();
+                },
+              })
+            }
+          </RenderChildrenWithAccessor>
+        </ThreadListItemByIndexProvider>
+      )),
+    [contentLength, archived, children],
+  );
+};
 
 export const ThreadListPrimitiveItems: FC<ThreadListPrimitiveItems.Props> = ({
   archived = false,

--- a/packages/react-ink/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadMessages.tsx
@@ -1,11 +1,7 @@
-import { type ComponentType, type FC, type ReactNode } from "react";
+import { type ComponentType, type FC, type ReactNode, useMemo } from "react";
 import { Box } from "ink";
 import type { ThreadMessage } from "@assistant-ui/core";
-import {
-  AuiForEach,
-  RenderChildrenWithAccessor,
-  useAuiState,
-} from "@assistant-ui/store";
+import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
 import { MessageByIndexProvider } from "@assistant-ui/core/react";
 
 type MessageComponents =
@@ -107,10 +103,13 @@ const ThreadMessageComponent: FC<{ components: MessageComponents }> = ({
 
 const ThreadMessagesInner: FC<{
   children: (value: { message: ThreadMessage }) => ReactNode;
-}> = ({ children }) => (
-  <AuiForEach keys={(s) => s.thread.messages.map((_, index) => index)}>
-    {(index) => (
-      <MessageByIndexProvider index={index}>
+}> = ({ children }) => {
+  const messagesLength = useAuiState((s) => s.thread.messages.length);
+
+  return useMemo(() => {
+    if (messagesLength === 0) return null;
+    return Array.from({ length: messagesLength }, (_, index) => (
+      <MessageByIndexProvider key={index} index={index}>
         <RenderChildrenWithAccessor
           getItemState={(aui) => aui.thread().message({ index }).getState()}
         >
@@ -123,9 +122,9 @@ const ThreadMessagesInner: FC<{
           }
         </RenderChildrenWithAccessor>
       </MessageByIndexProvider>
-    )}
-  </AuiForEach>
-);
+    ));
+  }, [messagesLength, children]);
+};
 
 export const ThreadMessages: FC<ThreadMessagesProps> = ({
   components,

--- a/packages/react-o11y/src/primitives/span/SpanChildren.tsx
+++ b/packages/react-o11y/src/primitives/span/SpanChildren.tsx
@@ -1,5 +1,11 @@
-import { type ComponentType, type FC, type ReactNode, memo } from "react";
-import { AuiForEach, RenderChildrenWithAccessor } from "@assistant-ui/store";
+import {
+  type ComponentType,
+  type FC,
+  type ReactNode,
+  memo,
+  useMemo,
+} from "react";
+import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
 import type { SpanState } from "../../o11y-scope";
 import { SpanByIndexProvider } from "../../context/SpanByIndexProvider";
 
@@ -45,10 +51,13 @@ SpanPrimitiveChildByIndex.displayName = "SpanPrimitive.ChildByIndex";
 
 const SpanPrimitiveChildrenInner: FC<{
   children: (value: { span: SpanState }) => ReactNode;
-}> = ({ children }) => (
-  <AuiForEach keys={(s) => s.span.children.map((_, index) => index)}>
-    {(index) => (
-      <SpanByIndexProvider index={index}>
+}> = ({ children }) => {
+  const childrenLength = useAuiState((s) => s.span.children.length);
+
+  return useMemo(() => {
+    if (childrenLength === 0) return null;
+    return Array.from({ length: childrenLength }, (_, index) => (
+      <SpanByIndexProvider key={index} index={index}>
         <RenderChildrenWithAccessor
           getItemState={(aui) => aui.span().getState()}
         >
@@ -61,9 +70,9 @@ const SpanPrimitiveChildrenInner: FC<{
           }
         </RenderChildrenWithAccessor>
       </SpanByIndexProvider>
-    )}
-  </AuiForEach>
-);
+    ));
+  }, [childrenLength, children]);
+};
 
 const SpanPrimitiveChildrenImpl: FC<SpanPrimitiveChildren.Props> = ({
   components,

--- a/packages/store/src/RenderChildrenWithAccessor.tsx
+++ b/packages/store/src/RenderChildrenWithAccessor.tsx
@@ -1,47 +1,9 @@
 "use client";
 
-import { Fragment, type ReactNode, useMemo, useRef } from "react";
-import type { AssistantClient, AssistantState } from "./types/client";
+import { type ReactNode, useMemo, useRef } from "react";
+import type { AssistantClient } from "./types/client";
 import { useAuiState } from "./useAuiState";
 import { useAui } from "./useAui";
-
-/**
- * Component that iterates over a list of items with key-stable rendering.
- *
- * Only re-renders when the key list changes (items added/removed/reordered),
- * NOT when individual item data changes.
- *
- * @example
- * ```tsx
- * <AuiForEach
- *   keys={(s) => s.fooList.foos.map(f => f.id)}
- * >
- *   {(itemKey, index) => (
- *     <FooProvider index={index}>
- *       <Foo />
- *     </FooProvider>
- *   )}
- * </AuiForEach>
- * ```
- */
-export function AuiForEach<TKey extends string | number>({
-  keys: keysSelector,
-  children,
-}: {
-  keys: (state: AssistantState) => readonly TKey[];
-  children: (itemKey: TKey, index: number) => ReactNode;
-}): ReactNode {
-  const arr = useAuiState(keysSelector);
-
-  return useMemo(
-    () =>
-      arr.map((key, index) => (
-        <Fragment key={key}>{children(key, index)}</Fragment>
-      )),
-    // biome-ignore lint/correctness/useExhaustiveDependencies: shallow memo
-    arr,
-  );
-}
 
 export const useGetItemAccessor = <T,>(
   getItemState: (aui: AssistantClient) => T,

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -2,7 +2,7 @@
 export { useAui } from "./useAui";
 export { useAuiState } from "./useAuiState";
 export { useAuiEvent } from "./useAuiEvent";
-export { AuiForEach, RenderChildrenWithAccessor } from "./AuiForEach";
+export { RenderChildrenWithAccessor } from "./RenderChildrenWithAccessor";
 
 // components
 export { AuiIf } from "./AuiIf";


### PR DESCRIPTION
## Summary
- Remove `AuiForEach` component — its keys-based approach was less efficient than subscribing to `.length` changes
- Revert all list primitives (Messages, Parts, Attachments, Suggestions, ThreadListItems, etc.) to the `useAuiState(length)` + `useMemo(Array.from(...))` pattern
- Keep `RenderChildrenWithAccessor` and the children render function API
- Rename `AuiForEach.tsx` → `RenderChildrenWithAccessor.tsx`
- Add rendering-lists docs page explaining the pattern

## Test plan
- [ ] Build passes for store, core, react, react-ink, react-o11y
- [ ] Verify list rendering works correctly (messages, parts, attachments, suggestions, thread list)
- [ ] Verify children render function API still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)