### PR TITLE
fix(store,core): stabilize useSyncExternalStore snapshots

### DIFF
--- a/.changeset/good-seas-kiss.md
+++ b/.changeset/good-seas-kiss.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/store": patch
+---
+
+fix(store,core): stabilize useSyncExternalStore snapshots  
+

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -28,7 +28,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     StoreApi<{ useRuntime: RemoteThreadListHook }>
   >;
   private instances = new Map<string, RemoteThreadListHookInstance>();
-  private useAliveThreadsKeysChanged = create(() => ({}));
+  private useAliveThreadsVersion = create<number>(() => 0);
   private parent: ThreadListRuntimeCore;
 
   constructor(
@@ -43,7 +43,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   public startThreadRuntime(threadId: string) {
     if (!this.instances.has(threadId)) {
       this.instances.set(threadId, {});
-      this.useAliveThreadsKeysChanged.setState({}, true);
+      this.useAliveThreadsVersion.setState((version) => version + 1, true);
     }
 
     return new Promise<ThreadRuntimeCore>((resolve, reject) => {
@@ -72,7 +72,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
 
   public stopThreadRuntime(threadId: string) {
     this.instances.delete(threadId);
-    this.useAliveThreadsKeysChanged.setState({}, true);
+    this.useAliveThreadsVersion.setState((version) => version + 1, true);
   }
 
   public setRuntimeHook(newRuntimeHook: RemoteThreadListHook) {
@@ -85,7 +85,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   private _InnerActiveThreadProvider: FC<{
     threadId: string;
   }> = ({ threadId }) => {
-    const { useRuntime } = this.useRuntimeHook();
+    const useRuntime = this.useRuntimeHook((s) => s.useRuntime);
     const runtime = useRuntime();
 
     const threadBinding = (runtime.thread as ThreadRuntimeImpl)
@@ -96,17 +96,16 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
       if (!aliveThread)
         throw new Error("Thread not found. This is a bug in assistant-ui.");
 
-      aliveThread.runtime = threadBinding.getState();
+      const nextRuntime = threadBinding.getState();
+      if (aliveThread.runtime === nextRuntime) {
+        return;
+      }
+
+      aliveThread.runtime = nextRuntime;
       this._notifySubscribers();
     }, [threadId, threadBinding]);
 
-    const isMounted = useRef(false);
-    if (!isMounted.current) {
-      updateRuntime();
-    }
-
     useEffect(() => {
-      isMounted.current = true;
       updateRuntime();
       return threadBinding.outerSubscribe(updateRuntime);
     }, [threadBinding, updateRuntime]);
@@ -163,7 +162,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   public __internal_RenderThreadRuntimes: FC<{
     provider: ComponentType<PropsWithChildren>;
   }> = ({ provider }) => {
-    this.useAliveThreadsKeysChanged(); // trigger re-render on alive threads change
+    this.useAliveThreadsVersion(); // trigger re-render on alive threads change
 
     return Array.from(this.instances.keys()).map((threadId) => (
       <this._OuterActiveThreadProvider

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -514,8 +514,8 @@ export class RemoteThreadListThreadListRuntimeCore
       };
     }, [id]);
 
-    const boundIds = this.useBoundIds();
-    const { Provider } = this.useProvider();
+    const boundIds = this.useBoundIds((state) => state);
+    const Provider = this.useProvider((state) => state.Provider);
 
     const adapters = {
       modelContext: this.contextProvider,

--- a/packages/store/src/__tests__/hooks.test.tsx
+++ b/packages/store/src/__tests__/hooks.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import type { ReactNode } from "react";
+import { StrictMode, type ReactNode } from "react";
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AuiProvider } from "../utils/react-assistant-context";
@@ -89,6 +89,39 @@ describe("store hooks", () => {
     }).toThrow(
       "You tried to return the entire AssistantState. This is not supported due to technical limitations.",
     );
+  });
+
+  it("useAuiState keeps object snapshots stable between notifications", () => {
+    const testClient = createTestAuiClient({ counter: 1 });
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const selector = (s: any) => ({ counter: s.counter });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <StrictMode>
+        <AuiProvider value={testClient.client as never}>{children}</AuiProvider>
+      </StrictMode>
+    );
+
+    const { result, rerender } = renderHook(() => useAuiState(selector), {
+      wrapper,
+    });
+    const firstSnapshot = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(firstSnapshot);
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("getSnapshot should be cached"),
+    );
+
+    act(() => {
+      testClient.state.counter = 2;
+      testClient.notify();
+    });
+
+    expect(result.current).toEqual({ counter: 2 });
+    expect(result.current).not.toBe(firstSnapshot);
   });
 
   it("useAuiEvent subscribes with normalized selector and invokes latest callback", () => {

--- a/packages/store/src/useAuiState.ts
+++ b/packages/store/src/useAuiState.ts
@@ -1,4 +1,9 @@
-import { useSyncExternalStore, useDebugValue } from "react";
+import {
+  useCallback,
+  useDebugValue,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 import type { AssistantState } from "./types/client";
 import { useAui } from "./useAui";
 import { getProxiedAssistantState } from "./utils/proxied-assistant-state";
@@ -21,12 +26,40 @@ import { getProxiedAssistantState } from "./utils/proxied-assistant-state";
 export const useAuiState = <T>(selector: (state: AssistantState) => T): T => {
   const aui = useAui();
   const proxiedState = getProxiedAssistantState(aui);
+  const cacheRef = useRef<{
+    selector: ((state: AssistantState) => T) | undefined;
+    hasValue: boolean;
+    value: T | undefined;
+  }>({
+    selector: undefined,
+    hasValue: false,
+    value: undefined,
+  });
 
-  const slice = useSyncExternalStore(
-    aui.subscribe,
-    () => selector(proxiedState),
-    () => selector(proxiedState),
+  const getSnapshot = () => {
+    if (cacheRef.current.hasValue && cacheRef.current.selector === selector) {
+      return cacheRef.current.value as T;
+    }
+
+    const nextValue = selector(proxiedState);
+    cacheRef.current = {
+      selector,
+      hasValue: true,
+      value: nextValue,
+    };
+    return nextValue;
+  };
+
+  const subscribe = useCallback(
+    (callback: () => void) =>
+      aui.subscribe(() => {
+        cacheRef.current.hasValue = false;
+        callback();
+      }),
+    [aui],
   );
+
+  const slice = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   if (slice === proxiedState) {
     throw new Error(


### PR DESCRIPTION
This PR fixes the React 19 snapshot/render loop (I hit while testing `react-ink` session persistence), where the UI showed `getSnapshot should be cached` and could crash with a max update depth error. This stabilizes `useAuiState` snapshots and removes render-phase runtime updates in the remote thread runtime flow.