### PR TITLE
fix(store,react): handle derived scope invalidation on thread switch

### DIFF
--- a/.changeset/derived-scope-invalidation.md
+++ b/.changeset/derived-scope-invalidation.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/store": patch
+"@assistant-ui/react": patch
+---
+
+fix(store,react): handle derived scope invalidation on thread switch

--- a/packages/react/src/primitives/message/MessageRoot.tsx
+++ b/packages/react/src/primitives/message/MessageRoot.tsx
@@ -16,32 +16,37 @@ import { ThreadPrimitiveViewportSlack } from "../thread/ThreadViewportSlack";
 
 const useIsHoveringRef = () => {
   const aui = useAui();
-  const message = useAuiState(() => aui.message());
 
   const callbackRef = useCallback(
     (el: HTMLElement) => {
-      const handleMouseEnter = () => {
-        message.setIsHovering(true);
+      const trySetIsHovering = (value: boolean) => {
+        try {
+          aui.message().setIsHovering(value);
+        } catch (e) {
+          if (!(e instanceof Error) || e.name !== "InvalidDerivedScopeError") {
+            throw e;
+          }
+        }
       };
-      const handleMouseLeave = () => {
-        message.setIsHovering(false);
-      };
+
+      const handleMouseEnter = () => trySetIsHovering(true);
+      const handleMouseLeave = () => trySetIsHovering(false);
 
       el.addEventListener("mouseenter", handleMouseEnter);
       el.addEventListener("mouseleave", handleMouseLeave);
 
       if (el.matches(":hover")) {
         // TODO this is needed for SSR to work, figure out why
-        queueMicrotask(() => message.setIsHovering(true));
+        queueMicrotask(() => trySetIsHovering(true));
       }
 
       return () => {
         el.removeEventListener("mouseenter", handleMouseEnter);
         el.removeEventListener("mouseleave", handleMouseLeave);
-        message.setIsHovering(false);
+        trySetIsHovering(false);
       };
     },
-    [message],
+    [aui],
   );
 
   return useManagedRef(callbackRef);

--- a/packages/store/src/InvalidDerivedScopeError.ts
+++ b/packages/store/src/InvalidDerivedScopeError.ts
@@ -1,0 +1,7 @@
+/** @internal */
+export class InvalidDerivedScopeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidDerivedScopeError";
+  }
+}

--- a/packages/store/src/LookupBoundsError.ts
+++ b/packages/store/src/LookupBoundsError.ts
@@ -1,0 +1,7 @@
+/** @internal */
+export class LookupBoundsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LookupBoundsError";
+  }
+}

--- a/packages/store/src/__tests__/derived-scope-invalidation.test.tsx
+++ b/packages/store/src/__tests__/derived-scope-invalidation.test.tsx
@@ -1,0 +1,227 @@
+// @vitest-environment jsdom
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resource, tapState, withKey } from "@assistant-ui/tap";
+import { AuiProvider } from "../utils/react-assistant-context";
+import { Derived } from "../Derived";
+import { tapClientLookup } from "../tapClientLookup";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+import type { ClientOutput } from "../types/client";
+
+type ItemState = { id: string; value: string };
+
+declare module "@assistant-ui/store" {
+  interface ScopeRegistry {
+    testList: {
+      methods: {
+        getState: () => { items: ItemState[]; shouldThrowBug: boolean };
+        setItems: (items: ItemState[]) => void;
+        setShouldThrowBug: (value: boolean) => void;
+        item: (
+          selector: { index: number } | { id: string },
+        ) => ClientOutput<"testItem">;
+      };
+    };
+    testItem: {
+      methods: {
+        getState: () => ItemState;
+      };
+      meta: { source: "testList"; query: { index: number } };
+    };
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const TestItemClient = resource(
+  ({ item }: { item: ItemState }): ClientOutput<"testItem"> => {
+    return {
+      getState: () => item,
+    };
+  },
+);
+
+const TestListClient = resource(
+  ({
+    initialItems,
+  }: {
+    initialItems: ItemState[];
+  }): ClientOutput<"testList"> => {
+    const [items, setItems] = tapState(initialItems);
+    const [shouldThrowBug, setShouldThrowBug] = tapState(false);
+
+    const lookup = tapClientLookup(
+      () => items.map((item) => withKey(item.id, TestItemClient({ item }))),
+      [items],
+    );
+
+    return {
+      getState: () => ({ items, shouldThrowBug }),
+      setItems,
+      setShouldThrowBug,
+      item: (selector) => {
+        if (shouldThrowBug) {
+          throw new TypeError("bug in testList.item");
+        }
+
+        if ("id" in selector) {
+          return lookup.get({ key: selector.id });
+        }
+
+        return lookup.get({ index: selector.index });
+      },
+    };
+  },
+);
+
+const createWrapper = (initialItems: ItemState[]) => {
+  let rootAui: ReturnType<typeof useAui> | null = null;
+
+  const RootProvider = ({ children }: { children: ReactNode }) => {
+    const aui = useAui({
+      testList: TestListClient({ initialItems }),
+    });
+    rootAui = aui;
+    return <AuiProvider value={aui}>{children}</AuiProvider>;
+  };
+
+  const DerivedProvider = ({ children }: { children: ReactNode }) => {
+    const aui = useAui({
+      testItem: Derived({
+        source: "testList",
+        query: { index: 0 },
+        get: (aui) => aui.testList().item({ index: 0 }),
+      }),
+    });
+
+    return <AuiProvider value={aui}>{children}</AuiProvider>;
+  };
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <RootProvider>
+      <DerivedProvider>{children}</DerivedProvider>
+    </RootProvider>
+  );
+
+  return {
+    wrapper,
+    getRootAui: () => {
+      if (!rootAui) {
+        throw new Error("root aui not initialized");
+      }
+
+      return rootAui;
+    },
+  };
+};
+
+class TestErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null as Error | null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(_error: Error, _info: ErrorInfo) {}
+
+  render() {
+    if (this.state.error) {
+      return <div data-testid="error">{this.state.error.message}</div>;
+    }
+
+    return this.props.children;
+  }
+}
+
+describe("derived scope invalidation", () => {
+  it("returns the previous selector value when a real Derived scope becomes invalid", () => {
+    const { wrapper, getRootAui } = createWrapper([
+      { id: "a", value: "first" },
+    ]);
+
+    const { result } = renderHook(() => useAuiState((s) => s.testItem.value), {
+      wrapper,
+    });
+
+    expect(result.current).toBe("first");
+
+    act(() => {
+      getRootAui().testList().setItems([]);
+    });
+
+    expect(result.current).toBe("first");
+  });
+
+  it("throws on first render when the Derived scope is initially invalid", () => {
+    const { wrapper } = createWrapper([]);
+
+    expect(() => {
+      renderHook(() => useAuiState((s) => s.testItem.value), { wrapper });
+    }).toThrow("tapClientLookup: Index 0 out of bounds");
+  });
+
+  it("propagates non-lookup errors after a prior successful resolution", () => {
+    const { wrapper, getRootAui } = createWrapper([
+      { id: "a", value: "first" },
+    ]);
+
+    const Consumer = () => {
+      const value = useAuiState((s) => s.testItem.value);
+      return <div data-testid="value">{value}</div>;
+    };
+
+    render(
+      <TestErrorBoundary>
+        {wrapper({ children: <Consumer /> })}
+      </TestErrorBoundary>,
+    );
+
+    expect(screen.getByTestId("value").textContent).toBe("first");
+
+    act(() => {
+      getRootAui().testList().setShouldThrowBug(true);
+    });
+
+    return waitFor(() => {
+      expect(screen.getByTestId("error").textContent).toContain(
+        "bug in testList.item",
+      );
+    });
+  });
+
+  it("continues updating normally when the derived scope stays valid", () => {
+    const { wrapper, getRootAui } = createWrapper([
+      { id: "a", value: "first" },
+    ]);
+
+    const { result } = renderHook(() => useAuiState((s) => s.testItem.value), {
+      wrapper,
+    });
+
+    expect(result.current).toBe("first");
+
+    act(() => {
+      getRootAui()
+        .testList()
+        .setItems([{ id: "b", value: "updated" }]);
+    });
+
+    return waitFor(() => {
+      expect(result.current).toBe("updated");
+    });
+  });
+});

--- a/packages/store/src/tapClientLookup.ts
+++ b/packages/store/src/tapClientLookup.ts
@@ -7,6 +7,7 @@ import {
 import type { ClientMethods } from "./types/client";
 import { ClientResource } from "./tapClientResource";
 import { wrapperResource } from "./wrapperResource";
+import { LookupBoundsError } from "./LookupBoundsError";
 
 type InferClientState<TMethods> = TMethods extends {
   getState: () => infer S;
@@ -62,7 +63,7 @@ export function tapClientLookup<TMethods extends ClientMethods>(
     get: (lookup: { index: number } | { key: string }) => {
       if ("index" in lookup) {
         if (lookup.index < 0 || lookup.index >= keys.length) {
-          throw new Error(
+          throw new LookupBoundsError(
             `tapClientLookup: Index ${lookup.index} out of bounds (length: ${keys.length})`,
           );
         }
@@ -71,7 +72,9 @@ export function tapClientLookup<TMethods extends ClientMethods>(
 
       const index = keyToIndex[lookup.key];
       if (index === undefined) {
-        throw new Error(`tapClientLookup: Key "${lookup.key}" not found`);
+        throw new LookupBoundsError(
+          `tapClientLookup: Key "${lookup.key}" not found`,
+        );
       }
       return resources[index]!.methods;
     },

--- a/packages/store/src/tapClientResource.ts
+++ b/packages/store/src/tapClientResource.ts
@@ -27,6 +27,14 @@ type ClientInternal = {
   [SYMBOL_GET_OUTPUT]: ClientMethods;
 };
 
+export const isClientMethods = (value: unknown): boolean => {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    SYMBOL_GET_OUTPUT in (value as object)
+  );
+};
+
 export const getClientState = (client: ClientMethods) => {
   const output = (client as unknown as ClientInternal)[SYMBOL_GET_OUTPUT];
   if (!output) {

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -39,6 +39,8 @@ import {
 import { NotificationManager } from "./utils/NotificationManager";
 import { withAssistantTapContextProvider } from "./utils/tap-assistant-context";
 import { tapClientResource } from "./tapClientResource";
+import { InvalidDerivedScopeError } from "./InvalidDerivedScopeError";
+import { LookupBoundsError } from "./LookupBoundsError";
 import { getClientIndex } from "./utils/tap-client-stack-context";
 import {
   PROXIED_ASSISTANT_STATE_SYMBOL,
@@ -240,7 +242,21 @@ const DerivedClientAccessorResource = resource(
     const get = tapEffectEvent(() => element.props);
 
     return tapMemo(() => {
-      const clientFunction = () => get().get(clientRef.current!);
+      let hasResolved = false;
+      const clientFunction = () => {
+        try {
+          const client = get().get(clientRef.current!);
+          hasResolved = true;
+          return client;
+        } catch (e) {
+          if (hasResolved && e instanceof LookupBoundsError) {
+            throw new InvalidDerivedScopeError(
+              `Derived scope "${name}" is no longer valid: ${e.message}`,
+            );
+          }
+          throw e;
+        }
+      };
       const metaMemo = {};
       Object.defineProperties(clientFunction, {
         source: {

--- a/packages/store/src/useAuiState.ts
+++ b/packages/store/src/useAuiState.ts
@@ -1,7 +1,14 @@
-import { useSyncExternalStore, useDebugValue } from "react";
+import {
+  useCallback,
+  useDebugValue,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 import type { AssistantState } from "./types/client";
 import { useAui } from "./useAui";
 import { getProxiedAssistantState } from "./utils/proxied-assistant-state";
+import { InvalidDerivedScopeError } from "./InvalidDerivedScopeError";
+import { isClientMethods } from "./tapClientResource";
 
 /**
  * Hook to access a slice of the assistant state with automatic subscription
@@ -21,12 +28,29 @@ import { getProxiedAssistantState } from "./utils/proxied-assistant-state";
 export const useAuiState = <T>(selector: (state: AssistantState) => T): T => {
   const aui = useAui();
   const proxiedState = getProxiedAssistantState(aui);
+  const prevSliceRef = useRef<{ hasValue: boolean; value: T }>({
+    hasValue: false,
+    value: undefined as T,
+  });
 
-  const slice = useSyncExternalStore(
-    aui.subscribe,
-    () => selector(proxiedState),
-    () => selector(proxiedState),
-  );
+  const getSnapshot = useCallback(() => {
+    try {
+      const nextValue = selector(proxiedState);
+      prevSliceRef.current = { hasValue: true, value: nextValue };
+      return nextValue;
+    } catch (e) {
+      if (
+        e instanceof InvalidDerivedScopeError &&
+        prevSliceRef.current.hasValue &&
+        !isClientMethods(prevSliceRef.current.value)
+      ) {
+        return prevSliceRef.current.value;
+      }
+      throw e;
+    }
+  }, [selector, proxiedState]);
+
+  const slice = useSyncExternalStore(aui.subscribe, getSnapshot, getSnapshot);
 
   if (slice === proxiedState) {
     throw new Error(


### PR DESCRIPTION
This PR adds explicit derived-scope invalidation and teaches useAuiState to reuse the previous hook-local value only during that invalidation window, while preserving normal failures for real bugs and first-render errors. Derived scopes could remain mounted after their parent lookup became invalid during thread switches, causing zombie-child crashes. 

Also fixes MessageRoot to avoid holding a stale aui.message() handle.