### PR TITLE
fix(core): guard against undefined attachments in MessagePrimitive.Attachments

### DIFF
--- a/.changeset/fix-message-attachments-null-guard.md
+++ b/.changeset/fix-message-attachments-null-guard.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): guard MessagePrimitive.Attachments against missing user message attachments

--- a/packages/core/src/react/primitives/composer/ComposerAttachments.tsx
+++ b/packages/core/src/react/primitives/composer/ComposerAttachments.tsx
@@ -85,9 +85,7 @@ ComposerPrimitiveAttachmentByIndex.displayName =
 const ComposerPrimitiveAttachmentsInner: FC<{
   children: (value: { attachment: Attachment }) => ReactNode;
 }> = ({ children }) => {
-  const attachmentsCount = useAuiState(
-    (s) => (s.composer.attachments ?? []).length,
-  );
+  const attachmentsCount = useAuiState((s) => s.composer.attachments.length);
 
   return useMemo(
     () =>

--- a/packages/core/src/react/primitives/composer/ComposerAttachments.tsx
+++ b/packages/core/src/react/primitives/composer/ComposerAttachments.tsx
@@ -85,7 +85,9 @@ ComposerPrimitiveAttachmentByIndex.displayName =
 const ComposerPrimitiveAttachmentsInner: FC<{
   children: (value: { attachment: Attachment }) => ReactNode;
 }> = ({ children }) => {
-  const attachmentsCount = useAuiState((s) => s.composer.attachments.length);
+  const attachmentsCount = useAuiState(
+    (s) => (s.composer.attachments ?? []).length,
+  );
 
   return useMemo(
     () =>

--- a/packages/core/src/react/primitives/message/MessageAttachments.test.tsx
+++ b/packages/core/src/react/primitives/message/MessageAttachments.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ReactElement } from "react";
+import { MessagePrimitiveAttachments } from "./MessageAttachments";
+
+const mockUseAuiState = vi.fn();
+type UseAuiStateSelector = Parameters<
+  typeof import("@assistant-ui/store")["useAuiState"]
+>[0];
+type AttachmentsElement = ReactElement<{ children: () => null }>;
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useMemo: (factory: () => unknown) => factory(),
+  };
+});
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  return {
+    ...actual,
+    useAuiState: (selector: UseAuiStateSelector) => mockUseAuiState(selector),
+  };
+});
+
+const renderAttachmentsInner = () => {
+  const element = MessagePrimitiveAttachments({
+    children: () => null,
+  }) as AttachmentsElement;
+
+  const Inner = element.type as (props: typeof element.props) => unknown;
+  return Inner(element.props);
+};
+
+describe("MessagePrimitiveAttachments", () => {
+  it("treats missing user message attachments as empty", () => {
+    mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) =>
+      selector({
+        message: {
+          role: "user",
+          attachments: undefined,
+        },
+      } as never),
+    );
+
+    expect(() => renderAttachmentsInner()).not.toThrow();
+    expect(renderAttachmentsInner()).toEqual([]);
+  });
+});

--- a/packages/core/src/react/primitives/message/MessageAttachments.tsx
+++ b/packages/core/src/react/primitives/message/MessageAttachments.tsx
@@ -87,7 +87,7 @@ const MessagePrimitiveAttachmentsInner: FC<{
 }> = ({ children }) => {
   const attachmentsCount = useAuiState((s) => {
     if (s.message.role !== "user") return 0;
-    return s.message.attachments.length;
+    return (s.message.attachments ?? []).length;
   });
 
   return useMemo(


### PR DESCRIPTION
## Summary

- `MessagePrimitiveAttachmentsInner` accesses `s.message.attachments.length` without a null guard, even though `ThreadMessageLike.attachments` is declared as optional (`attachments?:`)
- When messages are loaded from external history (e.g. via `ThreadHistoryAdapter.load()`) without an explicit `attachments` field, this crashes with `TypeError: Cannot read properties of undefined (reading 'length')`
- The crash occurs inside `useAuiState` / `useSyncExternalStore`, which causes the entire component tree to unmount (black screen)

## The fix

Added `?? []` null guard to both `MessagePrimitiveAttachments` and `ComposerPrimitiveAttachments`:

```typescript
// Before (crashes when attachments is undefined):
return s.message.attachments.length;

// After:
return (s.message.attachments ?? []).length;
```

## Context

Other code paths in the codebase already guard correctly:
- `fromThreadMessageLike` (line 223): `attachments ?? []`
- `MessageIf.ts` (lines 52, 58): `attachments?.length`
- `thread-message-client.ts` (line 88): `(message.attachments ?? []).map(...)`
- `message-runtime-client.ts` (line 85): `(runtimeState.attachments ?? []).map(...)`

`MessagePrimitiveAttachments` was the only unguarded access path.

## Reproduction

1. Use `useRemoteThreadListRuntime` with a custom `ThreadHistoryAdapter`
2. Return `ThreadMessageLike` messages from `load()` without `attachments` field (valid per the type)
3. Navigate to a thread with user messages
4. **Crash**: `TypeError: Cannot read properties of undefined (reading 'length')`