### PR TITLE
fix(core): prevent EMPTY_THREAD_ERROR when unstable_Provider delays c…

### DIFF
--- a/.changeset/tender-ducks-write.md
+++ b/.changeset/tender-ducks-write.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): prevent EMPTY_THREAD_ERROR when unstable_Provider delays children

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -82,9 +82,10 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     }
   }
 
-  private _InnerActiveThreadProvider: FC<{
+  private _RuntimeBinder: FC<{
     threadId: string;
-  }> = ({ threadId }) => {
+    provider: ComponentType<PropsWithChildren>;
+  }> = ({ threadId, provider: Provider }) => {
     const { useRuntime } = this.useRuntimeHook();
     const runtime = useRuntime();
 
@@ -110,6 +111,19 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
       updateRuntime();
       return threadBinding.outerSubscribe(updateRuntime);
     }, [threadBinding, updateRuntime]);
+
+    return (
+      <Provider>
+        <this._InitializationHandler runtime={runtime} />
+      </Provider>
+    );
+  };
+
+  private _InitializationHandler: FC<{
+    runtime: AssistantRuntime;
+  }> = ({ runtime }) => {
+    const threadBinding = (runtime.thread as ThreadRuntimeImpl)
+      .__internal_threadBinding;
 
     const aui = useAui();
     const initPromiseRef = useRef<Promise<unknown> | undefined>(undefined);
@@ -153,9 +167,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
 
     return (
       <ThreadListItemRuntimeProvider runtime={runtime}>
-        <Provider>
-          <this._InnerActiveThreadProvider threadId={threadId} />
-        </Provider>
+        <this._RuntimeBinder threadId={threadId} provider={Provider} />
       </ThreadListItemRuntimeProvider>
     );
   });


### PR DESCRIPTION
Closes #3678. Moves runtime binding outside the user's `unstable_Provider` so it executes immediately, even if the Provider delays  rendering children.