### PR TITLE
fix(react): ensure scroll to bottom is only triggered after the new message is mounted for anchor="top"

### DIFF
--- a/.changeset/shaggy-boxes-stop.md
+++ b/.changeset/shaggy-boxes-stop.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): ensure scroll to bottom is only triggered after the new message is mounted for anchor="top"

--- a/packages/react/src/primitives/message/MessageRoot.tsx
+++ b/packages/react/src/primitives/message/MessageRoot.tsx
@@ -6,6 +6,7 @@ import {
   forwardRef,
   ComponentPropsWithoutRef,
   useCallback,
+  useEffect,
 } from "react";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import { useManagedRef } from "../../utils/hooks/useManagedRef";
@@ -84,6 +85,14 @@ export namespace MessagePrimitiveRoot {
   export type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
 }
 
+export class NewUserMessageMountedEvent extends Event {
+  static type = "aui-new-user-message-mounted";
+
+  constructor() {
+    super("aui-new-user-message-mounted");
+  }
+}
+
 /**
  * The root container component for a message.
  *
@@ -117,6 +126,19 @@ export const MessagePrimitiveRoot = forwardRef<
     anchorUserMessageRef,
   );
   const messageId = useAuiState((s) => s.message.id);
+  const isLastUser = useAuiState(
+    (s) =>
+      s.message.role === "user" &&
+      s.thread.messages.findLast((m) => m.role === "user")?.id === s.message.id,
+  );
+
+  useEffect(() => {
+    if (isLastUser) {
+      requestAnimationFrame(() => {
+        window.dispatchEvent(new NewUserMessageMountedEvent());
+      });
+    }
+  }, [isLastUser]);
 
   return (
     <ThreadPrimitiveViewportSlack>

--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
@@ -8,6 +8,7 @@ import { useOnScrollToBottom } from "../../utils/hooks/useOnScrollToBottom";
 import { useManagedRef } from "../../utils/hooks/useManagedRef";
 import { writableStore } from "../../context/ReadonlyStore";
 import { useThreadViewportStore } from "../../context/react/ThreadViewportContext";
+import { NewUserMessageMountedEvent } from "../message/MessageRoot";
 
 export namespace useThreadViewportAutoScroll {
   export type Options = {
@@ -125,6 +126,14 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
   useAuiEvent("thread.runStart", () => {
     if (!scrollToBottomOnRunStart) return;
     scrollingToBottomBehaviorRef.current = "auto";
+
+    window.addEventListener(
+      NewUserMessageMountedEvent.type,
+      () => {
+        scrollToBottom("auto");
+      },
+      { once: true },
+    );
     requestAnimationFrame(() => {
       scrollToBottom("auto");
     });


### PR DESCRIPTION
Fixes https://github.com/assistant-ui/assistant-ui/issues/3648

Happy to formalise the new event pattern. I appreciate this is the first of its kind in this project. Also welcome suggestions for how to achieve this direction of communication in a different/more standard way.