### PR TITLE
fix(core): hide phantom empty bubble for attachment-only messages

### DIFF
--- a/.changeset/fix-phantom-empty-bubble.md
+++ b/.changeset/fix-phantom-empty-bubble.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): hide phantom empty bubble when user message has no text content

--- a/apps/docs/components/builder/builder-preview.tsx
+++ b/apps/docs/components/builder/builder-preview.tsx
@@ -508,7 +508,7 @@ const UserMessage: FC<UserMessageProps> = ({ config }) => {
         <div className="relative min-w-0 max-w-[80%]">
           <div
             className={cn(
-              "aui-user-message-content wrap-break-word px-4 py-2.5",
+              "aui-user-message-content wrap-break-word peer px-4 py-2.5 empty:hidden",
               BORDER_RADIUS_CLASS[styles.borderRadius],
             )}
             style={{ backgroundColor: "var(--aui-user-message-background)" }}
@@ -516,7 +516,7 @@ const UserMessage: FC<UserMessageProps> = ({ config }) => {
             <MessagePrimitive.Parts />
           </div>
           {components.editMessage && (
-            <div className="aui-user-action-bar-wrapper absolute top-1/2 right-0 translate-x-full -translate-y-1/2 pl-2">
+            <div className="aui-user-action-bar-wrapper absolute top-1/2 right-0 translate-x-full -translate-y-1/2 pl-2 peer-empty:hidden">
               <UserActionBar />
             </div>
           )}
@@ -554,7 +554,7 @@ const UserMessage: FC<UserMessageProps> = ({ config }) => {
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
         <div
           className={cn(
-            "aui-user-message-content wrap-break-word px-4 py-2.5",
+            "aui-user-message-content wrap-break-word peer px-4 py-2.5 empty:hidden",
             BORDER_RADIUS_CLASS[styles.borderRadius],
           )}
           style={{ backgroundColor: "var(--aui-user-message-background)" }}
@@ -562,7 +562,7 @@ const UserMessage: FC<UserMessageProps> = ({ config }) => {
           <MessagePrimitive.Parts />
         </div>
         {components.editMessage && (
-          <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2">
+          <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2 peer-empty:hidden">
             <UserActionBar />
           </div>
         )}

--- a/apps/docs/components/docs/assistant/messages.tsx
+++ b/apps/docs/components/docs/assistant/messages.tsx
@@ -22,7 +22,7 @@ import { Reasoning } from "@/components/assistant-ui/reasoning";
 export function UserMessage(): ReactNode {
   return (
     <MessagePrimitive.Root className="flex justify-end py-2" data-role="user">
-      <div className="max-w-[85%] rounded-2xl bg-muted px-3 py-2 text-sm">
+      <div className="max-w-[85%] rounded-2xl bg-muted px-3 py-2 text-sm empty:hidden">
         <MessagePrimitive.Parts />
       </div>
     </MessagePrimitive.Root>

--- a/apps/docs/components/examples/shadcn.tsx
+++ b/apps/docs/components/examples/shadcn.tsx
@@ -405,13 +405,13 @@ const UserMessage: FC = () => {
       <UserMessageAttachments />
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
-        <div className="aui-user-message-content wrap-break-word rounded-2xl bg-muted px-4 py-2.5 text-foreground">
+        <div className="aui-user-message-content wrap-break-word peer rounded-2xl bg-muted px-4 py-2.5 text-foreground empty:hidden">
           <MessagePrimitive.Quote>
             {(quote) => <QuoteBlock {...quote} />}
           </MessagePrimitive.Quote>
           <MessagePrimitive.Parts components={{ Text: DirectiveText }} />
         </div>
-        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2">
+        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2 peer-empty:hidden">
           <UserActionBar />
         </div>
       </div>

--- a/packages/core/src/react/primitives/message/MessageParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageParts.tsx
@@ -440,6 +440,8 @@ const EmptyPartsImpl: FC<MessagePartComponentProps> = ({ components }) => {
 
   if (components?.Empty) return <components.Empty status={status} />;
 
+  if (status.type !== "running") return null;
+
   return (
     <EmptyPartFallback
       status={status}

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -284,10 +284,10 @@ const UserMessage: FC = () => {
       <UserMessageAttachments />
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
-        <div className="aui-user-message-content wrap-break-word rounded-2xl bg-muted px-4 py-2.5 text-foreground">
+        <div className="aui-user-message-content wrap-break-word peer rounded-2xl bg-muted px-4 py-2.5 text-foreground empty:hidden">
           <MessagePrimitive.Parts />
         </div>
-        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2">
+        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2 peer-empty:hidden">
           <UserActionBar />
         </div>
       </div>

--- a/templates/cloud-clerk/components/assistant-ui/thread.tsx
+++ b/templates/cloud-clerk/components/assistant-ui/thread.tsx
@@ -287,10 +287,10 @@ const UserMessage: FC = () => {
       <UserMessageAttachments />
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
-        <div className="aui-user-message-content wrap-break-word rounded-2xl bg-muted px-4 py-2.5 text-foreground">
+        <div className="aui-user-message-content wrap-break-word peer rounded-2xl bg-muted px-4 py-2.5 text-foreground empty:hidden">
           <MessagePrimitive.Parts />
         </div>
-        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2">
+        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2 peer-empty:hidden">
           <UserActionBar />
         </div>
       </div>

--- a/templates/cloud/components/assistant-ui/thread.tsx
+++ b/templates/cloud/components/assistant-ui/thread.tsx
@@ -287,10 +287,10 @@ const UserMessage: FC = () => {
       <UserMessageAttachments />
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
-        <div className="aui-user-message-content wrap-break-word rounded-2xl bg-muted px-4 py-2.5 text-foreground">
+        <div className="aui-user-message-content wrap-break-word peer rounded-2xl bg-muted px-4 py-2.5 text-foreground empty:hidden">
           <MessagePrimitive.Parts />
         </div>
-        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2">
+        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2 peer-empty:hidden">
           <UserActionBar />
         </div>
       </div>

--- a/templates/default/components/assistant-ui/thread.tsx
+++ b/templates/default/components/assistant-ui/thread.tsx
@@ -287,10 +287,10 @@ const UserMessage: FC = () => {
       <UserMessageAttachments />
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
-        <div className="aui-user-message-content wrap-break-word rounded-2xl bg-muted px-4 py-2.5 text-foreground">
+        <div className="aui-user-message-content wrap-break-word peer rounded-2xl bg-muted px-4 py-2.5 text-foreground empty:hidden">
           <MessagePrimitive.Parts />
         </div>
-        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2">
+        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2 peer-empty:hidden">
           <UserActionBar />
         </div>
       </div>

--- a/templates/langgraph/components/assistant-ui/thread.tsx
+++ b/templates/langgraph/components/assistant-ui/thread.tsx
@@ -287,10 +287,10 @@ const UserMessage: FC = () => {
       <UserMessageAttachments />
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
-        <div className="aui-user-message-content wrap-break-word rounded-2xl bg-muted px-4 py-2.5 text-foreground">
+        <div className="aui-user-message-content wrap-break-word peer rounded-2xl bg-muted px-4 py-2.5 text-foreground empty:hidden">
           <MessagePrimitive.Parts />
         </div>
-        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2">
+        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2 peer-empty:hidden">
           <UserActionBar />
         </div>
       </div>

--- a/templates/mcp/components/assistant-ui/thread.tsx
+++ b/templates/mcp/components/assistant-ui/thread.tsx
@@ -284,10 +284,10 @@ const UserMessage: FC = () => {
       <UserMessageAttachments />
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
-        <div className="aui-user-message-content wrap-break-word rounded-2xl bg-muted px-4 py-2.5 text-foreground">
+        <div className="aui-user-message-content wrap-break-word peer rounded-2xl bg-muted px-4 py-2.5 text-foreground empty:hidden">
           <MessagePrimitive.Parts />
         </div>
-        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2">
+        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2 peer-empty:hidden">
           <UserActionBar />
         </div>
       </div>

--- a/templates/minimal/components/assistant-ui/thread.tsx
+++ b/templates/minimal/components/assistant-ui/thread.tsx
@@ -285,10 +285,10 @@ const UserMessage: FC = () => {
       <UserMessageAttachments />
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
-        <div className="aui-user-message-content wrap-break-word rounded-2xl bg-muted px-4 py-2.5 text-foreground">
+        <div className="aui-user-message-content wrap-break-word peer rounded-2xl bg-muted px-4 py-2.5 text-foreground empty:hidden">
           <MessagePrimitive.Parts />
         </div>
-        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2">
+        <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2 peer-empty:hidden">
           <UserActionBar />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **Core fix**: `EmptyPartsImpl` in `MessageParts.tsx` now returns `null` when `status.type !== "running"`, preventing the phantom empty `<p>` element from rendering for non-streaming messages (e.g., user messages with only attachments and no text)
- **UI fix**: Added `peer empty:hidden` on the user message content div and `peer-empty:hidden` on the action bar wrapper across all templates, `@assistant-ui/ui`, and docs components — ensures the empty bubble and its overlapping action bar are both hidden when there are no text parts
- Addresses and fixes [#3478](https://github.com/assistant-ui/assistant-ui/issues/3478) (Issue 1: phantom empty bubble)

## Test plan
- [ ] Send a message with only an image attachment (no text) — verify no empty bubble appears below the attachment
- [ ] Send a message with text + attachment — verify the text bubble and action bar render normally
- [ ] Send a text-only message — verify normal rendering
- [ ] Verify assistant streaming messages still show the loading cursor placeholder
- [ ] Verify assistant completed messages with tool calls don't show a trailing empty bubble