### PR TITLE
docs: fix broken example README links

### DIFF
--- a/examples/with-cloud-standalone/README.md
+++ b/examples/with-cloud-standalone/README.md
@@ -2,7 +2,7 @@
 
 Lightweight cloud persistence for AI SDK apps without assistant-ui components.
 
-> **Want the full assistant-ui experience?** See [with-cloud](../with-cloud) instead, which uses `useChatRuntime` with `<Thread />` and other primitives.
+> **Want the full assistant-ui experience?** See [with-cloud](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-cloud) instead, which uses `useChatRuntime` with `<Thread />` and other primitives.
 
 ## Setup
 

--- a/examples/with-store/README.md
+++ b/examples/with-store/README.md
@@ -122,5 +122,5 @@ useAuiEvent("*", (data) => {
 
 ## Learn More
 
-- [@assistant-ui/store Documentation](../../packages/store/README.md)
+- [@assistant-ui/store Documentation](https://github.com/assistant-ui/assistant-ui/tree/main/packages/store)
 - [Next.js Documentation](https://nextjs.org/docs)

--- a/examples/with-tap-runtime/README.md
+++ b/examples/with-tap-runtime/README.md
@@ -140,7 +140,7 @@ You can extend this example to:
 
 ## Learn More
 
-- [Tap Documentation](../../packages/tap/README.md)
-- [Store Documentation](../../packages/store/README.md)
-- [Client Implementation](../../packages/react/src/client)
+- [Tap Documentation](https://github.com/assistant-ui/assistant-ui/tree/main/packages/tap)
+- [Store Documentation](https://github.com/assistant-ui/assistant-ui/tree/main/packages/store)
+- [Client Implementation](https://github.com/assistant-ui/assistant-ui/tree/main/packages/react/src/client)
 - [Assistant UI Docs](https://assistant-ui.com)


### PR DESCRIPTION
## Summary

- fix the broken `@assistant-ui/store` documentation link in the `with-store` example README
- fix the broken client implementation link in the `with-tap-runtime` example README

## Validation

- verified that `examples/with-store/README.md` now points to `packages/store/README.md`
- verified that `examples/with-tap-runtime/README.md` now points to the existing `packages/react/src/client` directory
- ran `git diff --check`
