### PR TITLE
feat(share): add ThreadReadOnly, share primitives, serialization, and…

### DIFF
--- a/.changeset/shareable-chat-links.md
+++ b/.changeset/shareable-chat-links.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+feat(share): add ThreadReadOnly, share primitives, serialization, and export utilitie

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/action-bar.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/action-bar.mdx
@@ -322,3 +322,64 @@ Export as JSON:
   Export JSON
 </ActionBarPrimitive.ExportMarkdown>
 ```
+
+### Share
+
+Shares a single message (and optionally the full thread). Serializes the message to a JSON-safe format and passes it to the `onShare` callback. The developer handles persistence, link generation, etc.
+
+This primitive renders a `<button>` element unless `asChild` is set.
+
+<ParametersTable
+  type="ActionBarPrimitiveShareProps"
+  parameters={[
+    {
+      name: "asChild",
+    },
+    {
+      name: "onShare",
+      type: "(data: { message: SerializedThreadMessage; thread?: SerializedThreadMessage[] }) => void | Promise<void>",
+      description:
+        "Callback that receives the serialized message data.",
+    },
+    {
+      name: "includeThread",
+      type: "boolean",
+      default: "false",
+      description:
+        "When true, the full thread is included in the data passed to onShare.",
+    },
+  ]}
+/>
+
+#### Examples
+
+Share a single message:
+
+```tsx
+<ActionBarPrimitive.Share
+  onShare={async ({ message }) => {
+    await fetch("/api/share-message", {
+      method: "POST",
+      body: JSON.stringify(message),
+    });
+  }}
+>
+  Share
+</ActionBarPrimitive.Share>
+```
+
+Share with full thread context:
+
+```tsx
+<ActionBarPrimitive.Share
+  includeThread
+  onShare={async ({ message, thread }) => {
+    await fetch("/api/share", {
+      method: "POST",
+      body: JSON.stringify({ message, thread }),
+    });
+  }}
+>
+  Share with context
+</ActionBarPrimitive.Share>
+```

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/thread.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/thread.mdx
@@ -372,3 +372,41 @@ const SuggestionItem = () => (
 <Callout type="info">
 Configure suggestions using the `Suggestions()` API in your runtime provider. See the [Suggestions guide](/docs/guides/suggestions) for details.
 </Callout>
+
+### Share
+
+Shares the entire thread conversation. Serializes all messages to a JSON-safe format and passes them to the `onShare` callback.
+
+This primitive renders a `<button>` element unless `asChild` is set.
+
+<ParametersTable
+  type="ThreadPrimitiveShareProps"
+  parameters={[
+    {
+      name: "asChild",
+    },
+    {
+      name: "onShare",
+      type: "(data: SerializedThreadMessage[]) => void | Promise<void>",
+      description:
+        "Callback that receives all thread messages in serialized (JSON-safe) format.",
+    },
+  ]}
+/>
+
+#### Examples
+
+```tsx
+<ThreadPrimitive.Share
+  onShare={async (messages) => {
+    const res = await fetch("/api/share", {
+      method: "POST",
+      body: JSON.stringify(messages),
+    });
+    const { url } = await res.json();
+    await navigator.clipboard.writeText(url);
+  }}
+>
+  Share conversation
+</ThreadPrimitive.Share>
+```

--- a/apps/docs/content/docs/primitives/action-bar.mdx
+++ b/apps/docs/content/docs/primitives/action-bar.mdx
@@ -236,6 +236,45 @@ Downloads message as Markdown or calls custom handler. Renders a `<button>` elem
 
 <PrimitivesTypeTable type="ActionBarPrimitiveExportMarkdownProps" parameters={ActionBarPrimitiveDocs.ExportMarkdown.props.filter(p => p.name !== "asChild")} />
 
+### Share
+
+Shares a single message (and optionally the full thread). Renders a `<button>` element unless `asChild` is set.
+
+```tsx
+<ActionBarPrimitive.Share
+  onShare={async ({ message, thread }) => {
+    await fetch("/api/share", {
+      method: "POST",
+      body: JSON.stringify({ message }),
+    });
+  }}
+>
+  Share
+</ActionBarPrimitive.Share>
+```
+
+<ParametersTable
+  type="ActionBarPrimitiveShareProps"
+  parameters={[
+    {
+      name: "asChild",
+    },
+    {
+      name: "onShare",
+      type: "(data: { message: SerializedThreadMessage; thread?: SerializedThreadMessage[] }) => void | Promise<void>",
+      description:
+        "Callback that receives the serialized message. The developer handles persistence, link generation, etc.",
+    },
+    {
+      name: "includeThread",
+      type: "boolean",
+      default: "false",
+      description:
+        "When true, the full thread is included in the data passed to onShare.",
+    },
+  ]}
+/>
+
 ## Patterns
 
 ### Assistant Action Bar

--- a/apps/docs/content/docs/primitives/thread.mdx
+++ b/apps/docs/content/docs/primitives/thread.mdx
@@ -363,6 +363,40 @@ Self-contained suggestion button. Renders a `<button>` element unless `asChild` 
 
 <PrimitivesTypeTable type="ThreadPrimitiveSuggestionProps" parameters={ThreadPrimitiveDocs.Suggestion.props.filter(p => p.name !== "asChild")} />
 
+### Share
+
+Shares the entire thread conversation. Renders a `<button>` element unless `asChild` is set.
+
+```tsx
+<ThreadPrimitive.Share
+  onShare={async (messages) => {
+    const res = await fetch("/api/share", {
+      method: "POST",
+      body: JSON.stringify(messages),
+    });
+    const { url } = await res.json();
+    await navigator.clipboard.writeText(url);
+  }}
+>
+  Share conversation
+</ThreadPrimitive.Share>
+```
+
+<ParametersTable
+  type="ThreadPrimitiveShareProps"
+  parameters={[
+    {
+      name: "asChild",
+    },
+    {
+      name: "onShare",
+      type: "(data: SerializedThreadMessage[]) => void | Promise<void>",
+      description:
+        "Callback that receives all thread messages in serialized (JSON-safe) format. The developer handles persistence, URL generation, etc.",
+    },
+  ]}
+/>
+
 ### Empty
 
 <Callout type="warn">

--- a/apps/docs/content/docs/utilities/meta.json
+++ b/apps/docs/content/docs/utilities/meta.json
@@ -2,5 +2,5 @@
   "title": "Utilities",
   "icon": "Wrench",
   "root": true,
-  "pages": ["heat-graph", "tw-shimmer"]
+  "pages": ["sharing", "heat-graph", "tw-shimmer"]
 }

--- a/apps/docs/content/docs/utilities/sharing.mdx
+++ b/apps/docs/content/docs/utilities/sharing.mdx
@@ -1,0 +1,92 @@
+---
+title: Sharing & Read-Only Views
+description: Export conversations and render read-only thread views.
+---
+
+assistant-ui provides utilities for sharing conversations: read-only thread views, serialization, and export formats.
+
+## ThreadReadOnly
+
+Renders a conversation in read-only mode. Accepts both live `ThreadMessage[]` and serialized `SerializedThreadMessage[]` (auto-detected). Copy is enabled; all other actions are disabled.
+
+```tsx
+import { ThreadReadOnly, ThreadPrimitive } from "@assistant-ui/react";
+
+const SharePage = ({ messages }) => (
+  <ThreadReadOnly messages={messages}>
+    <ThreadPrimitive.Messages>
+      {({ message }) => <MyMessageComponent />}
+    </ThreadPrimitive.Messages>
+  </ThreadReadOnly>
+);
+```
+
+<ParametersTable
+  type="ThreadReadOnlyProps"
+  parameters={[
+    {
+      name: "messages",
+      type: "ThreadMessage[] | SerializedThreadMessage[]",
+      description: "The messages to render. Serialized messages are auto-deserialized.",
+    },
+    {
+      name: "children",
+      type: "ReactNode",
+      description: "Thread primitives to compose the read-only view.",
+    },
+  ]}
+/>
+
+## Serialization
+
+Convert between `ThreadMessage` (runtime) and `SerializedThreadMessage` (JSON-safe) formats.
+
+```tsx
+import { serializeMessages, deserializeMessages } from "@assistant-ui/react";
+
+// Serialize for storage/transport
+const serialized = serializeMessages(messages);
+const json = JSON.stringify(serialized); // safe
+
+// Deserialize back to ThreadMessage[]
+const restored = deserializeMessages(serialized);
+```
+
+**What changes during serialization:**
+- `createdAt: Date` → `string` (ISO format)
+- `attachment.file` (File/Blob) → removed
+- `attachment.status` → omitted (re-added as `{ type: "complete" }` on deserialize)
+
+## Export Utilities
+
+### toMarkdown
+
+Converts messages to a human-readable Markdown string. Handles text, tool calls, reasoning, sources, images, and files.
+
+```tsx
+import { toMarkdown } from "@assistant-ui/react";
+
+const md = toMarkdown(messages);
+// **User:**
+// How do I use React hooks?
+//
+// ---
+//
+// **Assistant:**
+// React hooks are functions that...
+```
+
+### toJSON
+
+Exports messages as a JSON string. Messages are serialized automatically.
+
+```tsx
+import { toJSON } from "@assistant-ui/react";
+
+const json = toJSON(messages); // compact
+const pretty = toJSON(messages, { pretty: true }); // indented
+```
+
+## Share Primitives
+
+See [ThreadPrimitive.Share](/docs/primitives/thread#share) and [ActionBarPrimitive.Share](/docs/primitives/action-bar#share) for the share button primitives.

--- a/examples/with-external-store/app/api/share/[id]/route.ts
+++ b/examples/with-external-store/app/api/share/[id]/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { getThread } from "../store";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const thread = getThread(id);
+  if (!thread) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(thread);
+}

--- a/examples/with-external-store/app/api/share/route.ts
+++ b/examples/with-external-store/app/api/share/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { saveThread } from "./store";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const messages = body?.messages;
+  if (!Array.isArray(messages)) {
+    return NextResponse.json(
+      { error: "messages array required" },
+      { status: 400 },
+    );
+  }
+  const thread = saveThread(messages);
+  return NextResponse.json({ id: thread.id });
+}

--- a/examples/with-external-store/app/api/share/store.ts
+++ b/examples/with-external-store/app/api/share/store.ts
@@ -1,0 +1,24 @@
+import type { SerializedThreadMessage } from "@assistant-ui/react";
+
+type SharedThread = {
+  id: string;
+  messages: SerializedThreadMessage[];
+  createdAt: string;
+};
+
+const store = new Map<string, SharedThread>();
+
+export function saveThread(messages: SerializedThreadMessage[]): SharedThread {
+  const id = crypto.randomUUID();
+  const thread: SharedThread = {
+    id,
+    messages,
+    createdAt: new Date().toISOString(),
+  };
+  store.set(id, thread);
+  return thread;
+}
+
+export function getThread(id: string): SharedThread | undefined {
+  return store.get(id);
+}

--- a/examples/with-external-store/app/page.tsx
+++ b/examples/with-external-store/app/page.tsx
@@ -1,7 +1,50 @@
 "use client";
 
 import { Thread } from "@/components/assistant-ui/thread";
-import { useAui, AuiProvider, Suggestions } from "@assistant-ui/react";
+import { useState } from "react";
+import {
+  useAui,
+  AuiProvider,
+  Suggestions,
+  ThreadPrimitive,
+} from "@assistant-ui/react";
+
+function ShareButton() {
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+
+  return (
+    <div className="flex items-center gap-2">
+      {shareUrl && (
+        <a
+          href={shareUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-500 text-xs underline"
+        >
+          Open shared link
+        </a>
+      )}
+      <ThreadPrimitive.Share
+        onShare={async (messages) => {
+          const res = await fetch("/api/share", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ messages }),
+          });
+          if (!res.ok) return;
+          const { id } = await res.json();
+          if (!id) return;
+          const url = `${window.location.origin}/share/${id}`;
+          await navigator.clipboard.writeText(url);
+          setShareUrl(url);
+        }}
+        className="rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground text-sm hover:bg-primary/90"
+      >
+        Share
+      </ThreadPrimitive.Share>
+    </div>
+  );
+}
 
 function ThreadWithSuggestions() {
   const aui = useAui({
@@ -20,7 +63,15 @@ function ThreadWithSuggestions() {
   });
   return (
     <AuiProvider value={aui}>
-      <Thread />
+      <div className="flex h-full flex-col">
+        <div className="flex items-center justify-between border-b px-4 py-2">
+          <h1 className="font-semibold text-sm">External Store Example</h1>
+          <ShareButton />
+        </div>
+        <div className="flex-1 overflow-hidden">
+          <Thread />
+        </div>
+      </div>
     </AuiProvider>
   );
 }

--- a/examples/with-external-store/app/share/[id]/page.tsx
+++ b/examples/with-external-store/app/share/[id]/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import { ThreadReadOnly } from "@assistant-ui/react";
+import type { SerializedThreadMessage } from "@assistant-ui/react";
+import { Thread } from "@/components/assistant-ui/thread";
+
+type SharedThread = {
+  id: string;
+  messages: SerializedThreadMessage[];
+  createdAt: string;
+};
+
+export default function SharePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const [thread, setThread] = useState<SharedThread | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/share/${id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("Thread not found");
+        return res.json();
+      })
+      .then(setThread)
+      .catch((err) => setError(err.message));
+  }, [id]);
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  if (!thread) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <main className="flex h-dvh flex-col">
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <div>
+          <h1 className="font-semibold text-lg">Shared Conversation</h1>
+          <p className="text-muted-foreground text-sm">
+            {thread.messages.length} messages &middot;{" "}
+            {new Date(thread.createdAt).toLocaleDateString()}
+          </p>
+        </div>
+      </div>
+      <div className="flex-1 overflow-hidden [&_.aui-composer-root]:pointer-events-none [&_.aui-composer-root]:opacity-50 [&_.aui-thread-welcome-root]:hidden">
+        <ThreadReadOnly messages={thread.messages}>
+          <Thread />
+        </ThreadReadOnly>
+      </div>
+    </main>
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -265,3 +265,22 @@ export {
   getEnabledTools,
   createRequestHeaders,
 } from "./runtimes/assistant-transport/utils";
+
+// === share ===
+
+export type {
+  SerializedThreadMessage,
+  SerializedAttachment,
+  SerializedSystemMessage,
+  SerializedUserMessage,
+  SerializedAssistantMessage,
+} from "./share/types";
+
+export {
+  serializeMessages,
+  deserializeMessages,
+  isSerializedMessages,
+} from "./share/serialization";
+
+export { toMarkdown } from "./share/export-markdown";
+export { toJSON, type ToJSONOptions } from "./share/export-json";

--- a/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
+++ b/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
@@ -186,7 +186,7 @@ export class ReadonlyThreadRuntimeCore
     edit: false,
     reload: false,
     cancel: false,
-    unstable_copy: false,
+    unstable_copy: true,
     speech: false,
     dictation: false,
     attachments: false,

--- a/packages/core/src/share/export-json.ts
+++ b/packages/core/src/share/export-json.ts
@@ -1,0 +1,18 @@
+import type { ThreadMessage } from "../types/message";
+import type { SerializedThreadMessage } from "./types";
+import { serializeMessages, isSerializedMessages } from "./serialization";
+
+export type ToJSONOptions = {
+  pretty?: boolean;
+};
+
+export const toJSON = (
+  messages: readonly (ThreadMessage | SerializedThreadMessage)[],
+  options?: ToJSONOptions,
+): string => {
+  const serialized = isSerializedMessages(messages)
+    ? messages
+    : serializeMessages(messages as readonly ThreadMessage[]);
+
+  return JSON.stringify(serialized, null, options?.pretty ? 2 : undefined);
+};

--- a/packages/core/src/share/export-markdown.ts
+++ b/packages/core/src/share/export-markdown.ts
@@ -1,0 +1,46 @@
+import type { ThreadMessage } from "../types/message";
+import type { SerializedThreadMessage } from "./types";
+
+const formatRole = (role: string): string => {
+  const capitalized = role.charAt(0).toUpperCase() + role.slice(1);
+  return `**${capitalized}:**`;
+};
+
+const formatPart = (part: { type: string; [key: string]: unknown }): string => {
+  switch (part.type) {
+    case "text":
+      return part.text as string;
+    case "reasoning":
+      return `> *Reasoning:* ${part.text as string}`;
+    case "tool-call":
+      return `\`\`\`tool-call\nTool: ${part.toolName as string}\nArgs: ${(part.argsText as string) ?? JSON.stringify(part.args)}\n\`\`\``;
+    case "source": {
+      const title = (part.title as string) ?? "Source";
+      const url = part.url as string | undefined;
+      return url ? `[${title}](${url})` : `*${title}*`;
+    }
+    case "image":
+      return `![image](${(part.image as string) ?? "[embedded image]"})`;
+    case "file":
+      return `[file: ${(part.name as string) ?? "file"}]`;
+    default:
+      return "";
+  }
+};
+
+const formatMessage = (
+  message: ThreadMessage | SerializedThreadMessage,
+): string => {
+  const parts = message.content
+    .map((part) => formatPart(part as { type: string; [key: string]: unknown }))
+    .filter(Boolean)
+    .join("\n\n");
+  return `${formatRole(message.role)}\n${parts}`;
+};
+
+export const toMarkdown = (
+  messages: readonly (ThreadMessage | SerializedThreadMessage)[],
+): string => {
+  if (messages.length === 0) return "";
+  return messages.map(formatMessage).join("\n\n---\n\n");
+};

--- a/packages/core/src/share/serialization.ts
+++ b/packages/core/src/share/serialization.ts
@@ -1,0 +1,76 @@
+import type { ThreadMessage } from "../types/message";
+import type { CompleteAttachment } from "../types/attachment";
+import type { SerializedThreadMessage, SerializedAttachment } from "./types";
+
+const serializeAttachment = (
+  att: CompleteAttachment,
+): SerializedAttachment => ({
+  id: att.id,
+  type: att.type,
+  name: att.name,
+  ...(att.contentType !== undefined && { contentType: att.contentType }),
+  content: att.content,
+});
+
+const serializeMessage = (message: ThreadMessage): SerializedThreadMessage => {
+  const { createdAt, ...rest } = message;
+
+  if ("attachments" in rest && Array.isArray(rest.attachments)) {
+    const { attachments, ...withoutAttachments } = rest;
+    return {
+      ...withoutAttachments,
+      createdAt: createdAt.toISOString(),
+      attachments: attachments.map(serializeAttachment),
+    } as SerializedThreadMessage;
+  }
+
+  return {
+    ...rest,
+    createdAt: createdAt.toISOString(),
+  } as SerializedThreadMessage;
+};
+
+export const serializeMessages = (
+  messages: readonly ThreadMessage[],
+): SerializedThreadMessage[] => messages.map(serializeMessage);
+
+const deserializeMessage = (
+  message: SerializedThreadMessage,
+): ThreadMessage => {
+  if (!message.id || !message.role || typeof message.createdAt !== "string") {
+    throw new Error(
+      "Invalid serialized message: missing required fields (id, role, createdAt)",
+    );
+  }
+
+  const createdAt = new Date(message.createdAt);
+  if (Number.isNaN(createdAt.getTime())) {
+    throw new Error(`Invalid createdAt value: ${message.createdAt}`);
+  }
+
+  const base = {
+    ...message,
+    createdAt,
+  };
+
+  if ("attachments" in message && Array.isArray(message.attachments)) {
+    return {
+      ...base,
+      attachments: message.attachments.map((att) => ({
+        ...att,
+        status: { type: "complete" as const },
+      })),
+    } as ThreadMessage;
+  }
+
+  return base as ThreadMessage;
+};
+
+export const deserializeMessages = (
+  messages: readonly SerializedThreadMessage[],
+): ThreadMessage[] => messages.map(deserializeMessage);
+
+export const isSerializedMessages = (
+  messages: readonly (ThreadMessage | SerializedThreadMessage)[],
+): messages is readonly SerializedThreadMessage[] =>
+  messages.length > 0 && typeof messages[0]!.createdAt === "string";

--- a/packages/core/src/share/types.ts
+++ b/packages/core/src/share/types.ts
@@ -1,0 +1,39 @@
+import type {
+  ThreadSystemMessage,
+  ThreadUserMessage,
+  ThreadAssistantMessage,
+  ThreadUserMessagePart,
+} from "../types/message";
+
+export type SerializedAttachment = {
+  id: string;
+  type: "image" | "document" | "file" | (string & {});
+  name: string;
+  contentType?: string | undefined;
+  content: ThreadUserMessagePart[];
+};
+
+export type SerializedSystemMessage = Omit<ThreadSystemMessage, "createdAt"> & {
+  createdAt: string;
+};
+
+export type SerializedUserMessage = Omit<
+  ThreadUserMessage,
+  "createdAt" | "attachments"
+> & {
+  createdAt: string;
+  attachments?: SerializedAttachment[];
+};
+
+export type SerializedAssistantMessage = Omit<
+  ThreadAssistantMessage,
+  "createdAt" | "attachments"
+> & {
+  createdAt: string;
+  attachments?: SerializedAttachment[];
+};
+
+export type SerializedThreadMessage =
+  | SerializedSystemMessage
+  | SerializedUserMessage
+  | SerializedAssistantMessage;

--- a/packages/core/src/tests/export-json.test.ts
+++ b/packages/core/src/tests/export-json.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { toJSON } from "../share/export-json";
+import type { ThreadMessage } from "../types/message";
+
+const user = (text: string): ThreadMessage =>
+  ({
+    id: "u-1",
+    role: "user",
+    createdAt: new Date("2026-03-25T10:00:00Z"),
+    content: [{ type: "text", text }],
+    attachments: [],
+    metadata: { custom: {} },
+  }) as ThreadMessage;
+
+const assistant = (text: string): ThreadMessage =>
+  ({
+    id: "a-1",
+    role: "assistant",
+    createdAt: new Date("2026-03-25T10:00:01Z"),
+    content: [{ type: "text", text }],
+    status: { type: "complete", reason: "stop" },
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {},
+    },
+  }) as ThreadMessage;
+
+describe("toJSON", () => {
+  it("returns valid JSON string", () => {
+    const result = toJSON([user("Hello"), assistant("Hi")]);
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+
+  it("returns pretty-printed JSON when requested", () => {
+    const result = toJSON([user("Hello")], { pretty: true });
+    expect(result).toContain("\n");
+  });
+
+  it("returns compact JSON by default", () => {
+    const result = toJSON([user("Hello")]);
+    expect(result).not.toContain("\n");
+  });
+
+  it("serializes messages (Date → string)", () => {
+    const result = JSON.parse(toJSON([user("Hello")]));
+    expect(result[0].createdAt).toBe("2026-03-25T10:00:00.000Z");
+  });
+
+  it("handles empty array", () => {
+    expect(toJSON([])).toBe("[]");
+  });
+});

--- a/packages/core/src/tests/export-markdown.test.ts
+++ b/packages/core/src/tests/export-markdown.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { toMarkdown } from "../share/export-markdown";
+import type { ThreadMessage } from "../types/message";
+
+const user = (text: string): ThreadMessage =>
+  ({
+    id: `u-${Math.random()}`,
+    role: "user",
+    createdAt: new Date(),
+    content: [{ type: "text", text }],
+    attachments: [],
+    metadata: { custom: {} },
+  }) as ThreadMessage;
+
+const assistant = (text: string): ThreadMessage =>
+  ({
+    id: `a-${Math.random()}`,
+    role: "assistant",
+    createdAt: new Date(),
+    content: [{ type: "text", text }],
+    status: { type: "complete", reason: "stop" },
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {},
+    },
+  }) as ThreadMessage;
+
+describe("toMarkdown", () => {
+  it("formats user and assistant messages", () => {
+    const result = toMarkdown([user("Hello"), assistant("Hi there")]);
+    expect(result).toContain("**User:**");
+    expect(result).toContain("Hello");
+    expect(result).toContain("**Assistant:**");
+    expect(result).toContain("Hi there");
+  });
+
+  it("handles tool call parts", () => {
+    const msg = {
+      id: "a-1",
+      role: "assistant",
+      createdAt: new Date(),
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "tc-1",
+          toolName: "search",
+          args: { query: "test" },
+          argsText: '{"query":"test"}',
+        },
+      ],
+      status: { type: "complete", reason: "stop" },
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+    } as ThreadMessage;
+    const result = toMarkdown([msg]);
+    expect(result).toContain("search");
+  });
+
+  it("handles reasoning parts", () => {
+    const msg = {
+      id: "a-1",
+      role: "assistant",
+      createdAt: new Date(),
+      content: [
+        { type: "reasoning", text: "thinking about it" },
+        { type: "text", text: "Here is my answer" },
+      ],
+      status: { type: "complete", reason: "stop" },
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+    } as ThreadMessage;
+    const result = toMarkdown([msg]);
+    expect(result).toContain("thinking about it");
+    expect(result).toContain("Here is my answer");
+  });
+
+  it("handles system messages", () => {
+    const msg = {
+      id: "s-1",
+      role: "system",
+      createdAt: new Date(),
+      content: [{ type: "text", text: "You are helpful" }],
+      metadata: { custom: {} },
+    } as ThreadMessage;
+    const result = toMarkdown([msg]);
+    expect(result).toContain("**System:**");
+    expect(result).toContain("You are helpful");
+  });
+
+  it("handles empty messages array", () => {
+    expect(toMarkdown([])).toBe("");
+  });
+
+  it("handles source parts", () => {
+    const msg = {
+      id: "a-1",
+      role: "assistant",
+      createdAt: new Date(),
+      content: [
+        { type: "text", text: "According to sources" },
+        {
+          type: "source",
+          id: "s-1",
+          title: "Wikipedia",
+          url: "https://en.wikipedia.org",
+          sourceType: "url",
+        },
+      ],
+      status: { type: "complete", reason: "stop" },
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+    } as ThreadMessage;
+    const result = toMarkdown([msg]);
+    expect(result).toContain("Wikipedia");
+    expect(result).toContain("https://en.wikipedia.org");
+  });
+});

--- a/packages/core/src/tests/serialization.test.ts
+++ b/packages/core/src/tests/serialization.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { serializeMessages, deserializeMessages } from "../share/serialization";
+import type { ThreadMessage } from "../types/message";
+
+const makeUserMessage = (overrides?: Partial<ThreadMessage>): ThreadMessage =>
+  ({
+    id: "msg-1",
+    role: "user" as const,
+    createdAt: new Date("2026-03-25T10:00:00Z"),
+    content: [{ type: "text" as const, text: "Hello" }],
+    attachments: [],
+    metadata: { custom: {} },
+    ...overrides,
+  }) as ThreadMessage;
+
+const makeAssistantMessage = (
+  overrides?: Partial<ThreadMessage>,
+): ThreadMessage =>
+  ({
+    id: "msg-2",
+    role: "assistant" as const,
+    createdAt: new Date("2026-03-25T10:00:01Z"),
+    content: [{ type: "text" as const, text: "Hi there" }],
+    status: { type: "complete" as const, reason: "stop" as const },
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {},
+    },
+    ...overrides,
+  }) as ThreadMessage;
+
+describe("serializeMessages", () => {
+  it("converts Date to ISO string", () => {
+    const messages = [makeUserMessage()];
+    const result = serializeMessages(messages);
+    expect(result[0]!.createdAt).toBe("2026-03-25T10:00:00.000Z");
+  });
+
+  it("strips attachment file and status", () => {
+    const messages = [
+      makeUserMessage({
+        attachments: [
+          {
+            id: "att-1",
+            type: "document",
+            name: "test.pdf",
+            contentType: "application/pdf",
+            status: { type: "complete" as const },
+            content: [{ type: "text" as const, text: "pdf content" }],
+            file: new File([""], "test.pdf"),
+          },
+        ],
+      }),
+    ];
+    const result = serializeMessages(messages);
+    const att = (result[0] as any).attachments[0];
+    expect(att.file).toBeUndefined();
+    expect(att.status).toBeUndefined();
+    expect(att.id).toBe("att-1");
+    expect(att.content).toEqual([{ type: "text", text: "pdf content" }]);
+  });
+
+  it("preserves message content and metadata", () => {
+    const messages = [makeAssistantMessage()];
+    const result = serializeMessages(messages);
+    expect(result[0]!.content).toEqual([{ type: "text", text: "Hi there" }]);
+    expect(result[0]!.id).toBe("msg-2");
+  });
+
+  it("produces valid JSON", () => {
+    const messages = [makeUserMessage(), makeAssistantMessage()];
+    const result = serializeMessages(messages);
+    const json = JSON.stringify(result);
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+});
+
+describe("deserializeMessages", () => {
+  it("converts ISO string back to Date", () => {
+    const serialized = serializeMessages([makeUserMessage()]);
+    const result = deserializeMessages(serialized);
+    expect(result[0]!.createdAt).toBeInstanceOf(Date);
+    expect(result[0]!.createdAt.toISOString()).toBe("2026-03-25T10:00:00.000Z");
+  });
+
+  it("re-adds attachment status", () => {
+    const messages = [
+      makeUserMessage({
+        attachments: [
+          {
+            id: "att-1",
+            type: "document",
+            name: "test.pdf",
+            status: { type: "complete" as const },
+            content: [{ type: "text" as const, text: "content" }],
+          },
+        ],
+      }),
+    ];
+    const serialized = serializeMessages(messages);
+    const result = deserializeMessages(serialized);
+    expect((result[0] as any).attachments[0].status).toEqual({
+      type: "complete",
+    });
+  });
+
+  it("roundtrips messages without loss", () => {
+    const messages = [makeUserMessage(), makeAssistantMessage()];
+    const serialized = serializeMessages(messages);
+    const deserialized = deserializeMessages(serialized);
+    expect(deserialized[0]!.id).toBe("msg-1");
+    expect(deserialized[0]!.role).toBe("user");
+    expect(deserialized[1]!.id).toBe("msg-2");
+    expect(deserialized[1]!.role).toBe("assistant");
+  });
+
+  it("throws on missing required fields", () => {
+    expect(() => deserializeMessages([{} as any])).toThrow();
+  });
+
+  it("throws on invalid createdAt", () => {
+    expect(() =>
+      deserializeMessages([{ ...makeUserMessage(), createdAt: 123 } as any]),
+    ).toThrow();
+  });
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -385,6 +385,28 @@ export type { ToolExecutionStatus } from "./internal";
 
 export type { Assistant } from "./augmentations";
 
+// === share ===
+
+export { ThreadReadOnly } from "./share/ThreadReadOnly";
+
+export type {
+  SerializedThreadMessage,
+  SerializedAttachment,
+  SerializedSystemMessage,
+  SerializedUserMessage,
+  SerializedAssistantMessage,
+} from "@assistant-ui/core";
+
+export {
+  serializeMessages,
+  deserializeMessages,
+  isSerializedMessages,
+  toMarkdown,
+  toJSON,
+} from "@assistant-ui/core";
+
+export type { ToJSONOptions } from "@assistant-ui/core";
+
 // ============================================================================
 // Backwards compatibility - deprecated exports
 // ============================================================================

--- a/packages/react/src/primitives/actionBar.ts
+++ b/packages/react/src/primitives/actionBar.ts
@@ -7,3 +7,4 @@ export { ActionBarPrimitiveStopSpeaking as StopSpeaking } from "./actionBar/Acti
 export { ActionBarPrimitiveFeedbackPositive as FeedbackPositive } from "./actionBar/ActionBarFeedbackPositive";
 export { ActionBarPrimitiveFeedbackNegative as FeedbackNegative } from "./actionBar/ActionBarFeedbackNegative";
 export { ActionBarPrimitiveExportMarkdown as ExportMarkdown } from "./actionBar/ActionBarExportMarkdown";
+export { ActionBarPrimitiveShare as Share } from "./actionBar/ActionBarShare";

--- a/packages/react/src/primitives/actionBar/ActionBarShare.tsx
+++ b/packages/react/src/primitives/actionBar/ActionBarShare.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { forwardRef, useCallback } from "react";
+import { composeEventHandlers } from "@radix-ui/primitive";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAui, useAuiState } from "@assistant-ui/store";
+import type { SerializedThreadMessage } from "@assistant-ui/core";
+import { serializeMessages } from "@assistant-ui/core";
+import type { ActionButtonProps } from "../../utils/createActionButton";
+
+const useActionBarShare = ({
+  onShare,
+  includeThread = false,
+}: {
+  onShare: (data: {
+    message: SerializedThreadMessage;
+    thread?: SerializedThreadMessage[];
+  }) => void | Promise<void>;
+  includeThread?: boolean;
+}) => {
+  const aui = useAui();
+  const hasContent = useAuiState((s) => {
+    return (
+      (s.message.role !== "assistant" ||
+        s.message.status?.type !== "running") &&
+      s.message.parts.some((c) => c.type === "text" && c.text.length > 0)
+    );
+  });
+
+  const callback = useCallback(async () => {
+    const message = aui.message().getState();
+    const serialized = serializeMessages([message])[0]!;
+
+    const data: {
+      message: SerializedThreadMessage;
+      thread?: SerializedThreadMessage[];
+    } = { message: serialized };
+
+    if (includeThread) {
+      const threadMessages = aui.thread().getState().messages;
+      data.thread = serializeMessages(threadMessages);
+    }
+
+    await onShare(data);
+  }, [aui, onShare, includeThread]);
+
+  if (!hasContent) return null;
+  return callback;
+};
+
+export namespace ActionBarPrimitiveShare {
+  export type Element = HTMLButtonElement;
+  export type Props = ActionButtonProps<typeof useActionBarShare>;
+}
+
+export const ActionBarPrimitiveShare = forwardRef<
+  ActionBarPrimitiveShare.Element,
+  ActionBarPrimitiveShare.Props
+>(({ onShare, includeThread, onClick, disabled, ...props }, forwardedRef) => {
+  const callback = useActionBarShare({
+    onShare,
+    includeThread: includeThread ?? false,
+  });
+  return (
+    <Primitive.button
+      type="button"
+      {...props}
+      ref={forwardedRef}
+      disabled={disabled || !callback}
+      onClick={composeEventHandlers(onClick, () => {
+        void callback?.();
+      })}
+    />
+  );
+});
+
+ActionBarPrimitiveShare.displayName = "ActionBarPrimitive.Share";

--- a/packages/react/src/primitives/thread.ts
+++ b/packages/react/src/primitives/thread.ts
@@ -13,3 +13,4 @@ export {
   ThreadPrimitiveSuggestions as Suggestions,
   ThreadPrimitiveSuggestionByIndex as SuggestionByIndex,
 } from "./thread/ThreadSuggestions";
+export { ThreadPrimitiveShare as Share } from "./thread/ThreadShare";

--- a/packages/react/src/primitives/thread/ThreadShare.tsx
+++ b/packages/react/src/primitives/thread/ThreadShare.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { forwardRef, useCallback } from "react";
+import { composeEventHandlers } from "@radix-ui/primitive";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAui } from "@assistant-ui/store";
+import type { SerializedThreadMessage } from "@assistant-ui/core";
+import { serializeMessages } from "@assistant-ui/core";
+import type { ComponentPropsWithoutRef } from "react";
+
+const useThreadShare = ({
+  onShare,
+}: {
+  onShare: (data: SerializedThreadMessage[]) => void | Promise<void>;
+}) => {
+  const aui = useAui();
+
+  const callback = useCallback(async () => {
+    const messages = aui.thread().getState().messages;
+    const serialized = serializeMessages(messages);
+    await onShare(serialized);
+  }, [aui, onShare]);
+
+  return callback;
+};
+
+export namespace ThreadPrimitiveShare {
+  export type Element = HTMLButtonElement;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.button> & {
+    onShare: (data: SerializedThreadMessage[]) => void | Promise<void>;
+  };
+}
+
+export const ThreadPrimitiveShare = forwardRef<
+  ThreadPrimitiveShare.Element,
+  ThreadPrimitiveShare.Props
+>(({ onShare, onClick, disabled, ...props }, forwardedRef) => {
+  const callback = useThreadShare({ onShare });
+  return (
+    <Primitive.button
+      type="button"
+      {...props}
+      ref={forwardedRef}
+      disabled={disabled}
+      onClick={composeEventHandlers(onClick, () => {
+        void callback();
+      })}
+    />
+  );
+});
+
+ThreadPrimitiveShare.displayName = "ThreadPrimitive.Share";

--- a/packages/react/src/share/ThreadReadOnly.tsx
+++ b/packages/react/src/share/ThreadReadOnly.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { type FC, type PropsWithChildren, useMemo } from "react";
+import type {
+  ThreadMessage,
+  SerializedThreadMessage,
+} from "@assistant-ui/core";
+import { deserializeMessages, isSerializedMessages } from "@assistant-ui/core";
+import { ReadonlyThreadProvider } from "@assistant-ui/core/react";
+
+export namespace ThreadReadOnly {
+  export type Props = PropsWithChildren<{
+    messages: readonly ThreadMessage[] | readonly SerializedThreadMessage[];
+  }>;
+}
+
+export const ThreadReadOnly: FC<ThreadReadOnly.Props> = ({
+  messages,
+  children,
+}) => {
+  const threadMessages = useMemo(() => {
+    if (isSerializedMessages(messages)) {
+      return deserializeMessages(messages);
+    }
+    return messages as readonly ThreadMessage[];
+  }, [messages]);
+
+  return (
+    <ReadonlyThreadProvider messages={threadMessages}>
+      {children}
+    </ReadonlyThreadProvider>
+  );
+};

--- a/packages/react/src/tests/thread-share.test.tsx
+++ b/packages/react/src/tests/thread-share.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { ThreadPrimitiveShare } from "../primitives/thread/ThreadShare";
+import { ActionBarPrimitiveShare } from "../primitives/actionBar/ActionBarShare";
+
+describe("ThreadPrimitiveShare", () => {
+  it("has correct display name", () => {
+    expect(ThreadPrimitiveShare.displayName).toBe("ThreadPrimitive.Share");
+  });
+});
+
+describe("ActionBarPrimitiveShare", () => {
+  it("has correct display name", () => {
+    expect(ActionBarPrimitiveShare.displayName).toBe(
+      "ActionBarPrimitive.Share",
+    );
+  });
+});


### PR DESCRIPTION
 Adds support for shareable chat links: ThreadReadOnly for read-only thread views, ThreadPrimitive.Share/ActionBarPrimitive.Share primitives, message serializatio (serializeMessages/deserializeMessages), and export utilities (toMarkdown, toJSON). Includes example with share API routes and docs. 

https://github.com/user-attachments/assets/8905980c-0648-41e4-b55a-0ffc178838f5

