### PR TITLE
fix(react-langgraph): inject text part for attachment-only human messages

### DIFF
--- a/.changeset/fix-langgraph-attachment-only-text.md
+++ b/.changeset/fix-langgraph-attachment-only-text.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix(react-langgraph): inject text part for attachment-only human messages

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -353,6 +353,7 @@ describe("useLangGraphRuntime", () => {
       {
         type: "human",
         content: [
+          { type: "text", text: " " },
           {
             type: "file",
             data: "ZmFrZS1wZGY=",
@@ -363,6 +364,6 @@ describe("useLangGraphRuntime", () => {
         ],
       },
     ]);
-    expect(sentMessages?.[0]?.content?.[0]).not.toHaveProperty("file");
+    expect(sentMessages?.[0]?.content?.[1]).not.toHaveProperty("file");
   });
 });

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -61,6 +61,15 @@ const getMessageContent = (msg: AppendMessage) => {
     ...msg.content,
     ...(msg.attachments?.flatMap((a) => a.content) ?? []),
   ];
+
+  const hasNonText = allContent.some(
+    (part) => part.type === "file" || part.type === "image",
+  );
+  const hasText = allContent.some((part) => part.type === "text");
+  if (hasNonText && !hasText) {
+    allContent.unshift({ type: "text", text: " " });
+  }
+
   const content = allContent.map((part) => {
     const type = part.type;
     switch (type) {


### PR DESCRIPTION
## Summary
- When a user sends only file/image attachments with no text, `getMessageContent` now prepends a placeholder `{ type: "text", text: " " }` part to the LangChain human message
- Fixes backends like AWS Bedrock that require a text block alongside document/image blocks (ValidationException)
- Covers both `file` and `image` attachment types
- Updates existing serialization test to reflect the prepended text part

Fixes #3577

## Test plan
- [ ] `pnpm --filter @assistant-ui/react-langgraph test` passes (47/47)
- [ ] Verify attachment-only send produces `[{ type: "text", text: " " }, { type: "file", ... }]`
- [ ] Verify text + attachment send does NOT inject extra text part
- [ ] Verify text-only send is unaffected