### PR TITLE
chore: remove aui-source export condition

### DIFF
--- a/.changeset/remove-aui-source-condition.md
+++ b/.changeset/remove-aui-source-condition.md
@@ -1,0 +1,32 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+"@assistant-ui/store": patch
+"@assistant-ui/tap": patch
+"@assistant-ui/cloud": patch
+"@assistant-ui/cloud-ai-sdk": patch
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/react-a2a": patch
+"@assistant-ui/react-ag-ui": patch
+"@assistant-ui/react-data-stream": patch
+"@assistant-ui/react-google-adk": patch
+"@assistant-ui/react-hook-form": patch
+"@assistant-ui/react-lexical": patch
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-streamdown": patch
+"@assistant-ui/react-syntax-highlighter": patch
+"@assistant-ui/react-o11y": patch
+"@assistant-ui/react-devtools": patch
+"@assistant-ui/react-ink-markdown": patch
+"@assistant-ui/safe-content-frame": patch
+"@assistant-ui/agent-launcher": patch
+"assistant-stream": patch
+"@assistant-ui/heat-graph": patch
+"@assistant-ui/mcp-app-studio": patch
+"@assistant-ui/mcp-docs-server": patch
+---
+
+chore: remove aui-source export condition from package.json exports

--- a/packages/agent-launcher/package.json
+++ b/packages/agent-launcher/package.json
@@ -14,7 +14,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/assistant-stream/package.json
+++ b/packages/assistant-stream/package.json
@@ -16,12 +16,10 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./utils": {
-      "aui-source": "./src/utils.ts",
       "types": "./dist/utils.d.ts",
       "default": "./dist/utils.js"
     }

--- a/packages/cloud-ai-sdk/package.json
+++ b/packages/cloud-ai-sdk/package.json
@@ -15,7 +15,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -14,7 +14,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,32 +14,26 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./internal": {
-      "aui-source": "./src/internal.ts",
       "types": "./dist/internal.d.ts",
       "default": "./dist/internal.js"
     },
     "./store": {
-      "aui-source": "./src/store/index.ts",
       "types": "./dist/store/index.d.ts",
       "default": "./dist/store/index.js"
     },
     "./store/internal": {
-      "aui-source": "./src/store/internal.ts",
       "types": "./dist/store/internal.d.ts",
       "default": "./dist/store/internal.js"
     },
     "./react": {
-      "aui-source": "./src/react/index.ts",
       "types": "./dist/react/index.d.ts",
       "default": "./dist/react/index.js"
     },
     "./*": {
-      "aui-source": "./src/*.ts",
       "types": "./dist/*.d.ts",
       "default": "./dist/*.js"
     }

--- a/packages/heat-graph/package.json
+++ b/packages/heat-graph/package.json
@@ -14,7 +14,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/mcp-app-studio/package.json
+++ b/packages/mcp-app-studio/package.json
@@ -25,22 +25,18 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./cli": {
-      "aui-source": "./src/cli/index.ts",
       "types": "./dist/cli/index.d.ts",
       "default": "./dist/cli/index.js"
     },
     "./core": {
-      "aui-source": "./src/core/index.ts",
       "types": "./dist/core/index.d.ts",
       "default": "./dist/core/index.js"
     },
     "./mcp": {
-      "aui-source": "./src/platforms/mcp/index.ts",
       "types": "./dist/platforms/mcp/index.d.ts",
       "default": "./dist/platforms/mcp/index.js"
     }

--- a/packages/mcp-docs-server/package.json
+++ b/packages/mcp-docs-server/package.json
@@ -15,7 +15,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/react-a2a/package.json
+++ b/packages/react-a2a/package.json
@@ -16,7 +16,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/react-ag-ui/package.json
+++ b/packages/react-ag-ui/package.json
@@ -16,7 +16,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -17,7 +17,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/react-data-stream/package.json
+++ b/packages/react-data-stream/package.json
@@ -15,7 +15,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -14,7 +14,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/react-google-adk/package.json
+++ b/packages/react-google-adk/package.json
@@ -16,12 +16,10 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./server": {
-      "aui-source": "./src/server/index.ts",
       "types": "./dist/server/index.d.ts",
       "default": "./dist/server/index.js"
     }

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -16,7 +16,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/react-ink-markdown/package.json
+++ b/packages/react-ink-markdown/package.json
@@ -17,7 +17,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/react-ink/package.json
+++ b/packages/react-ink/package.json
@@ -15,12 +15,10 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./internal": {
-      "aui-source": "./src/internal.ts",
       "types": "./dist/internal.d.ts",
       "default": "./dist/internal.js"
     }

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -16,7 +16,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/react-lexical/package.json
+++ b/packages/react-lexical/package.json
@@ -16,7 +16,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -16,7 +16,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -14,12 +14,10 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./internal": {
-      "aui-source": "./src/internal.ts",
       "types": "./dist/internal.d.ts",
       "default": "./dist/internal.js"
     }

--- a/packages/react-o11y/package.json
+++ b/packages/react-o11y/package.json
@@ -15,7 +15,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/react-streamdown/package.json
+++ b/packages/react-streamdown/package.json
@@ -16,7 +16,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -16,12 +16,10 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./full": {
-      "aui-source": "./src/full.tsx",
       "types": "./dist/full.d.ts",
       "default": "./dist/full.js"
     }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/safe-content-frame/package.json
+++ b/packages/safe-content-frame/package.json
@@ -15,12 +15,10 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./shadow_dom": {
-      "aui-source": "./src/shadow_dom.ts",
       "types": "./dist/shadow_dom.d.ts",
       "default": "./dist/shadow_dom.js"
     }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -14,7 +14,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/tap/package.json
+++ b/packages/tap/package.json
@@ -14,12 +14,10 @@
   "type": "module",
   "exports": {
     ".": {
-      "aui-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./react": {
-      "aui-source": "./src/react/index.ts",
       "types": "./dist/react/index.d.ts",
       "default": "./dist/react/index.js"
     }

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -139,11 +139,7 @@ async function build() {
     sourceMap: true,
     noEmit: false,
     emitDeclarationOnly: false,
-    // Strip aui-source so build uses dist types, not source
-    customConditions:
-      parsedConfig.options.customConditions?.filter(
-        (c) => c !== "aui-source",
-      ) ?? [],
+    customConditions: parsedConfig.options.customConditions ?? [],
   });
 
   // JS: extension rewriting only

--- a/packages/x-buildutils/ts/base.json
+++ b/packages/x-buildutils/ts/base.json
@@ -10,7 +10,6 @@
     "jsx": "react-jsx",
     "lib": ["dom", "dom.iterable", "ES2023"],
     "stripInternal": true,
-    "noPropertyAccessFromIndexSignature": false,
-    "customConditions": ["aui-source"]
+    "noPropertyAccessFromIndexSignature": false
   }
 }


### PR DESCRIPTION
## Summary
- Remove the `aui-source` custom export condition from all package.json exports
- Remove the `aui-source` filter in x-buildutils build script
- Remove `customConditions: ["aui-source"]` from the shared tsconfig base

## Changeset
Included (patch for all affected packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)