### PR TITLE
feat(store): add forwardTransformScopes utility

### DIFF
--- a/.changeset/store-forward-transform-scopes.md
+++ b/.changeset/store-forward-transform-scopes.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+feat: add forwardTransformScopes utility

--- a/packages/store/src/attachTransformScopes.ts
+++ b/packages/store/src/attachTransformScopes.ts
@@ -31,6 +31,25 @@ export function attachTransformScopes<
   r[TRANSFORM_SCOPES] = transform;
 }
 
+export function forwardTransformScopes<
+  T extends (...args: any[]) => ResourceElement<any>,
+  S extends (...args: any[]) => ResourceElement<any>,
+>(target: T, source: S): void {
+  const sourceTransform = getTransformScopes(source);
+  if (!sourceTransform) return;
+
+  const r = target as T & ResourceWithTransformScopes;
+  const existingTransform = r[TRANSFORM_SCOPES];
+  if (existingTransform) {
+    r[TRANSFORM_SCOPES] = (scopes, parent) => {
+      sourceTransform(scopes, parent);
+      existingTransform(scopes, parent);
+    };
+  } else {
+    r[TRANSFORM_SCOPES] = sourceTransform;
+  }
+}
+
 export function getTransformScopes<
   T extends (...args: any[]) => ResourceElement<any>,
 >(resource: T): TransformScopesFn | undefined {

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -10,7 +10,10 @@ export { AuiProvider } from "./utils/react-assistant-context";
 
 // resources
 export { Derived } from "./Derived";
-export { attachTransformScopes } from "./attachTransformScopes";
+export {
+  attachTransformScopes,
+  forwardTransformScopes,
+} from "./attachTransformScopes";
 export type { ScopesConfig } from "./attachTransformScopes";
 
 // tap hooks


### PR DESCRIPTION
## Summary
- Add `forwardTransformScopes` function to copy/compose transform scopes from one resource to another
- Export from `@assistant-ui/store` package index

## Changeset
Included (patch for @assistant-ui/store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)