### PR TITLE
chore(cli): add shipables.json for plugin skills

### DIFF
--- a/.changeset/cli-add-shipables.md
+++ b/.changeset/cli-add-shipables.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+chore: add shipables.json for CLI plugin skills

--- a/packages/cli/plugin/skills/assistant-ui/shipables.json
+++ b/packages/cli/plugin/skills/assistant-ui/shipables.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "keywords": [
+    "assistant-ui",
+    "chat",
+    "ai",
+    "chatbot",
+    "react",
+    "ai-sdk",
+    "shadcn",
+    "thread",
+    "copilot",
+    "assistant"
+  ],
+  "categories": ["frameworks", "ai-ml"],
+  "author": {
+    "name": "Yonom",
+    "github": "Yonom"
+  },
+  "repository": "https://github.com/assistant-ui/assistant-ui",
+  "homepage": "https://www.assistant-ui.com"
+}


### PR DESCRIPTION
## Summary
- Add `shipables.json` metadata file for the assistant-ui CLI plugin skill, including keywords, categories, author, and repository info

## Changeset
Included (patch for assistant-ui CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)