### PR TITLE
fix: correct package names in changeset

### DIFF
--- a/.changeset/remove-aui-source-condition.md
+++ b/.changeset/remove-aui-source-condition.md
@@ -5,7 +5,7 @@
 "@assistant-ui/react-ink": patch
 "@assistant-ui/store": patch
 "@assistant-ui/tap": patch
-"@assistant-ui/cloud": patch
+"assistant-cloud": patch
 "@assistant-ui/cloud-ai-sdk": patch
 "@assistant-ui/react-ai-sdk": patch
 "@assistant-ui/react-langgraph": patch
@@ -24,8 +24,8 @@
 "@assistant-ui/safe-content-frame": patch
 "@assistant-ui/agent-launcher": patch
 "assistant-stream": patch
-"@assistant-ui/heat-graph": patch
-"@assistant-ui/mcp-app-studio": patch
+"heat-graph": patch
+"mcp-app-studio": patch
 "@assistant-ui/mcp-docs-server": patch
 ---
 


### PR DESCRIPTION
## Summary
- Fix incorrect package names in `remove-aui-source-condition` changeset:
  - `@assistant-ui/cloud` → `assistant-cloud`
  - `@assistant-ui/heat-graph` → `heat-graph`
  - `@assistant-ui/mcp-app-studio` → `mcp-app-studio`

These packages use non-scoped names, causing `changesets` to fail with "package not in workspace" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)