### PR TITLE
fix: correct safe-content-frame package name in changeset

### DIFF
--- a/.changeset/remove-aui-source-condition.md
+++ b/.changeset/remove-aui-source-condition.md
@@ -21,7 +21,7 @@
 "@assistant-ui/react-o11y": patch
 "@assistant-ui/react-devtools": patch
 "@assistant-ui/react-ink-markdown": patch
-"@assistant-ui/safe-content-frame": patch
+"safe-content-frame": patch
 "@assistant-ui/agent-launcher": patch
 "assistant-stream": patch
 "heat-graph": patch

--- a/packages/react/.husky/_/post-checkout
+++ b/packages/react/.husky/_/post-checkout
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GITBUTLER_MANAGED_HOOK_V1
+# This hook auto-cleans GitButler hooks when you checkout away from gitbutler/workspace.
+
+PREV_HEAD=$1
+NEW_HEAD=$2
+BRANCH_CHECKOUT=$3
+
+# Only act on branch checkouts (not file checkouts)
+if [ "$BRANCH_CHECKOUT" != "1" ]; then
+    # Run user's hook if it exists
+    if [ -x "$(dirname "$0")/post-checkout-user" ]; then
+        exec "$(dirname "$0")/post-checkout-user" "$@"
+    fi
+    exit 0
+fi
+
+# Get the new branch name
+NEW_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+# If we just left gitbutler/workspace (and aren't coming back to it)
+PREV_BRANCH=$(git name-rev --name-only "$PREV_HEAD" 2>/dev/null | sed 's|^remotes/||')
+if echo "$PREV_BRANCH" | grep -q "gitbutler/workspace"; then
+    if [ "$NEW_BRANCH" != "gitbutler/workspace" ]; then
+        echo ""
+        echo "NOTE: You have left GitButler's managed workspace branch."
+        echo "Cleaning up GitButler hooks..."
+
+        HOOKS_DIR=$(dirname "$0")
+
+        # Restore pre-commit - but only if it's GitButler-managed
+        if [ -f "$HOOKS_DIR/pre-commit-user" ]; then
+            mv "$HOOKS_DIR/pre-commit-user" "$HOOKS_DIR/pre-commit"
+            echo "  Restored: pre-commit"
+        elif [ -f "$HOOKS_DIR/pre-commit" ]; then
+            # Only remove if it's GitButler-managed (has our signature)
+            if grep -q "GITBUTLER_MANAGED_HOOK_V1" "$HOOKS_DIR/pre-commit"; then
+                rm "$HOOKS_DIR/pre-commit"
+                echo "  Removed: pre-commit (GitButler managed)"
+            else
+                echo "  Warning: pre-commit hook is not GitButler-managed, leaving it untouched"
+            fi
+        fi
+
+        # Run user's post-checkout if it exists, then clean up
+        if [ -x "$HOOKS_DIR/post-checkout-user" ]; then
+            "$HOOKS_DIR/post-checkout-user" "$@"
+            mv "$HOOKS_DIR/post-checkout-user" "$HOOKS_DIR/post-checkout"
+            echo "  Restored: post-checkout"
+        else
+            # Only remove self if we're GitButler-managed (we should be, but check anyway)
+            if grep -q "GITBUTLER_MANAGED_HOOK_V1" "$HOOKS_DIR/post-checkout"; then
+                rm "$HOOKS_DIR/post-checkout"
+                echo "  Removed: post-checkout (GitButler managed)"
+            else
+                echo "  Warning: post-checkout hook is not GitButler-managed, leaving it untouched"
+            fi
+        fi
+
+        echo ""
+        echo "To return to GitButler mode, run: but setup"
+        echo ""
+        exit 0
+    fi
+fi
+
+# Run user's hook if it exists
+if [ -x "$(dirname "$0")/post-checkout-user" ]; then
+    exec "$(dirname "$0")/post-checkout-user" "$@"
+fi
+
+exit 0

--- a/packages/react/.husky/_/pre-commit
+++ b/packages/react/.husky/_/pre-commit
@@ -1,0 +1,43 @@
+#!/bin/sh
+# GITBUTLER_MANAGED_HOOK_V1
+# This hook is managed by GitButler to prevent accidental commits on the workspace branch.
+# Your original pre-commit hook has been preserved as 'pre-commit-user'.
+
+HOOKS_DIR=$(dirname "$0")
+
+# Run user's hook first if it exists - if it fails, stop here
+if [ -x "$HOOKS_DIR/pre-commit-user" ]; then
+    "$HOOKS_DIR/pre-commit-user" "$@" || exit $?
+fi
+
+# Get the current branch name
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+if [ "$BRANCH" = "gitbutler/workspace" ]; then
+    echo ""
+    echo "GITBUTLER_ERROR: Cannot commit directly to gitbutler/workspace branch."
+    echo ""
+    echo "GitButler manages commits on this branch. Please use GitButler to commit your changes:"
+    echo "  - Use the GitButler app to create commits"
+    echo "  - Or run 'but commit' from the command line"
+    echo ""
+    echo "If you want to exit GitButler mode and use normal git:"
+    echo "  - Run 'but teardown' to switch to a regular branch"
+    echo "  - Or directly checkout another branch: git checkout <branch>"
+    echo ""
+    echo "If you no longer have the GitButler CLI installed, you can simply remove this hook and checkout another branch:"
+    printf '  rm "%s/pre-commit"\n' "$HOOKS_DIR"
+    echo ""
+    exit 1
+fi
+
+# Not on workspace branch - run user's original hook if it exists
+if [ -x "$HOOKS_DIR/pre-commit-user" ]; then
+    echo ""
+    echo "WARNING: GitButler's pre-commit hook is still installed but you're not on gitbutler/workspace."
+    echo "If you're no longer using GitButler, you can restore your original hook:"
+    printf '  mv "%s/pre-commit-user" "%s/pre-commit"\n' "$HOOKS_DIR" "$HOOKS_DIR"
+    echo ""
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Fix `@assistant-ui/safe-content-frame` → `safe-content-frame` in changeset (package uses non-scoped name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)