### PR TITLE
feat(mcp-app-studio): upgrade @modelcontextprotocol/ext-apps to ^1.5.0

### DIFF
--- a/packages/mcp-app-studio/package.json
+++ b/packages/mcp-app-studio/package.json
@@ -81,7 +81,7 @@
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
-    "@modelcontextprotocol/ext-apps": "^1.3.1",
+    "@modelcontextprotocol/ext-apps": "^1.5.0",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/packages/mcp-app-studio/src/platforms/mcp/bridge.ts
+++ b/packages/mcp-app-studio/src/platforms/mcp/bridge.ts
@@ -123,7 +123,7 @@ export class MCPBridge implements ExtendedBridge {
       this.contextCallbacks.forEach((cb) => cb(ctx));
     };
 
-    this.app.onteardown = async () => {
+    this.app.onteardown = async (_params, _extra) => {
       for (const cb of this.teardownCallbacks) {
         await cb();
       }
@@ -308,10 +308,15 @@ export class MCPBridge implements ExtendedBridge {
   }
 
   setListToolsHandler(handler: ListToolsHandler): void {
-    this.app.onlisttools = async (params) => {
+    this.app.onlisttools = async (params, _extra) => {
       const cursor = params?.cursor as string | undefined;
-      const tools = await handler(cursor);
-      return { tools };
+      const toolNames = await handler(cursor);
+      return {
+        tools: toolNames.map((name) => ({
+          name,
+          inputSchema: { type: "object" as const },
+        })),
+      };
     };
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2570,8 +2570,8 @@ importers:
         specifier: workspace:*
         version: link:../x-buildutils
       '@modelcontextprotocol/ext-apps':
-        specifier: ^1.3.1
-        version: 1.3.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        specifier: ^1.5.0
+        version: 1.5.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -6127,11 +6127,11 @@ packages:
   '@mjackson/node-fetch-server@0.2.0':
     resolution: {integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==}
 
-  '@modelcontextprotocol/ext-apps@1.3.2':
-    resolution: {integrity: sha512-DGG1FxN3s8g4KV+BF64dxph8j2mtxgU56Lu/WgBjylomqRIPshW0ut47OtBN4+V8r+Qp8kKUvCOBBzPY9+GurA==}
+  '@modelcontextprotocol/ext-apps@1.5.0':
+    resolution: {integrity: sha512-q4fut89TOoP2LEPHSGfZErIf1K1xOTTzV+41h/bB2BqKw2gKb0uLKbHusOy1UtbY0puS16zBho/vFp3f5XMVbQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.24.0
+      '@modelcontextprotocol/sdk': ^1.29.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
       zod: ^3.25.0 || ^4.0.0
@@ -17809,7 +17809,7 @@ snapshots:
 
   '@mjackson/node-fetch-server@0.2.0': {}
 
-  '@modelcontextprotocol/ext-apps@1.3.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
+  '@modelcontextprotocol/ext-apps@1.5.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       zod: 4.3.6


### PR DESCRIPTION
## Summary
- Upgrade `@modelcontextprotocol/ext-apps` from `^1.3.1` to `^1.5.0`
- Adapt bridge to breaking changes in handler signatures:
  - `onlisttools`: now takes `(params, extra)` and expects full tool objects (with `name` + `inputSchema`) instead of strings
  - `onteardown`: now takes `(params, extra)` parameters

## Changeset
Not included — `mcp-app-studio` is a non-scoped package and this is a devDependency update with no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)