### PR TITLE
chore: remove outdated husky gotcha from butflow command

### DIFF
--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -12,6 +12,5 @@ The user has requested butflow mode. Implement features, open PRs via GitButler,
 
 ## Gotchas
 
-- **Husky files**: `pnpm install` regenerates `.husky/_/` files in packages — never commit these.
 - **Ambiguous cliIds**: if `but stage` says an ID is ambiguous, re-run `but status -j` and use the longer form.
 - **Multiple PRs**: create one branch per change group, stage files to each, commit/push/PR independently.


### PR DESCRIPTION
## Summary
- Remove husky files gotcha from butflow command — no longer needed since `.husky/_/` is now in `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)