### PR TITLE
fix: include scope registration types so AssistantState has all properties

### DIFF
--- a/.changeset/fix-assistant-state-types.md
+++ b/.changeset/fix-assistant-state-types.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+---
+
+fix: include scope registration types so AssistantState has all properties

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference types="@assistant-ui/core/store" />
 /// <reference types="@assistant-ui/core/react" />
 
 // Re-export core types

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference types="@assistant-ui/core/store" />
 /// <reference types="@assistant-ui/core/react" />
 
 // Re-export core types

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference types="@assistant-ui/core/store" />
 /// <reference types="@assistant-ui/core/react" />
 
 // Re-export from @assistant-ui/store


### PR DESCRIPTION
## Summary
- Add `/// <reference types="@assistant-ui/core/store" />` to `@assistant-ui/react`, `@assistant-ui/react-native`, and `@assistant-ui/react-ink`
- This ensures the `ScopeRegistry` module augmentation from `@assistant-ui/core/store` is loaded, so `AssistantState` correctly includes all properties (`message`, `thread`, `composer`, etc.)
- Without this, TypeScript users see `Property 'message' does not exist on type 'AssistantState'` when using `useAssistantState`

Closes #3731

## Test plan
- [x] `pnpm turbo build` succeeds for all three packages
- [x] `pnpm --filter @assistant-ui/react test` — 201 tests pass
- [x] Verified `dist/index.d.ts` includes the new reference directive for all three packages
- [x] `pnpm lint` clean (only pre-existing warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)