### PR TITLE
chore: add human comment review rule to butflow command

### DIFF
--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -12,5 +12,6 @@ The user has requested butflow mode. Implement features, open PRs via GitButler,
 
 ## Gotchas
 
+- **Check for PR comments**: Review and address valid AI review bot comments, only auto-merge if all human comments are addressed.
 - **Ambiguous cliIds**: if `but stage` says an ID is ambiguous, re-run `but status -j` and use the longer form.
 - **Multiple PRs**: create one branch per change group, stage files to each, commit/push/PR independently.


### PR DESCRIPTION
## Summary
- Add gotcha to butflow command: only auto-merge when all human reviewer comments are addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)