### PR TITLE
revert: remove unnecessary scope registration reference directives

### DIFF
--- a/.changeset/fix-assistant-state-types.md
+++ b/.changeset/fix-assistant-state-types.md
@@ -1,7 +1,0 @@
----
-"@assistant-ui/react": patch
-"@assistant-ui/react-native": patch
-"@assistant-ui/react-ink": patch
----
-
-fix: include scope registration types so AssistantState has all properties

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -1,4 +1,3 @@
-/// <reference types="@assistant-ui/core/store" />
 /// <reference types="@assistant-ui/core/react" />
 
 // Re-export core types

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,4 +1,3 @@
-/// <reference types="@assistant-ui/core/store" />
 /// <reference types="@assistant-ui/core/react" />
 
 // Re-export core types

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,3 @@
-/// <reference types="@assistant-ui/core/store" />
 /// <reference types="@assistant-ui/core/react" />
 
 // Re-export from @assistant-ui/store


### PR DESCRIPTION
## Summary
- Reverts #3749
- Testing confirmed the `/// <reference types="@assistant-ui/core/store" />` directives were unnecessary — the existing value exports from `@assistant-ui/core/store` (e.g. `Suggestions`, `ModelContext`) already transitively load the `ScopeRegistry` augmentation
- `useAssistantState((s) => s.message)` compiles correctly without the explicit reference

## Test plan
- [x] Created minimal TypeScript reproduction confirming `s.message` resolves with and without the directive
- [x] Verified the transitive chain: `react/index.d.ts` → `export { Suggestions } from "@assistant-ui/core/store"` → `core/store/index.d.ts` → `/// <reference path="./scope-registration.d.ts" />`

🤖 Generated with [Claude Code](https://claude.com/claude-code)