### PR TITLE
fix(react-google-adk): skip partial functionCall events in AdkEventAccumulator

### DIFF
--- a/.changeset/fix-partial-function-call.md
+++ b/.changeset/fix-partial-function-call.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: skip partial functionCall events in AdkEventAccumulator to prevent incomplete tool calls from hanging the runtime

--- a/packages/react-google-adk/src/AdkEventAccumulator.test.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.test.ts
@@ -132,6 +132,84 @@ describe("AdkEventAccumulator - function calls", () => {
     expect(tc).toHaveLength(1);
     expect(tc![0]!.id).toBeTruthy();
   });
+
+  it("skips partial functionCall events", () => {
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "agent",
+        partial: true,
+        content: {
+          role: "model",
+          parts: [{ functionCall: { name: "search", id: "tc-1", args: {} } }],
+        },
+      }),
+    );
+    expect(msgs).toHaveLength(0);
+  });
+
+  it("emits functionCall only from the final aggregated event", () => {
+    const acc = new AdkEventAccumulator();
+    // Partial event with empty args
+    acc.processEvent(
+      makeEvent({
+        author: "agent",
+        partial: true,
+        content: {
+          role: "model",
+          parts: [{ functionCall: { name: "search", id: "tc-1", args: {} } }],
+        },
+      }),
+    );
+    // Final event with complete args
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "agent",
+        content: {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                name: "search",
+                id: "tc-1",
+                args: { q: "test" },
+              },
+            },
+          ],
+        },
+      }),
+    );
+    const aiMsg = msgs[0] as AdkMessage & { type: "ai" };
+    expect(aiMsg.tool_calls).toHaveLength(1);
+    expect(aiMsg.tool_calls![0]).toMatchObject({
+      id: "tc-1",
+      name: "search",
+      args: { q: "test" },
+    });
+  });
+
+  it("skips partial special function calls (confirmation/auth)", () => {
+    const acc = new AdkEventAccumulator();
+    acc.processEvent(
+      makeEvent({
+        author: "agent",
+        partial: true,
+        content: {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                name: "adk_request_confirmation",
+                id: "tc-1",
+                args: {},
+              },
+            },
+          ],
+        },
+      }),
+    );
+    expect(acc.getToolConfirmations()).toHaveLength(0);
+  });
 });
 
 describe("AdkEventAccumulator - function responses", () => {

--- a/packages/react-google-adk/src/AdkEventAccumulator.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.ts
@@ -323,7 +323,7 @@ export class AdkEventAccumulator {
 
   private processPart(part: AdkEventPart, event: AdkEvent): void {
     // Detect special ADK function calls
-    if (part.functionCall) {
+    if (part.functionCall && !event.partial) {
       const name = part.functionCall.name;
 
       // Tool confirmation request
@@ -387,8 +387,9 @@ export class AdkEventAccumulator {
       return;
     }
 
-    // Function call (including special ones above — still create tool-call parts)
+    // Function call — skip partial events (args may be incomplete)
     if (part.functionCall) {
+      if (event.partial) return;
       const msg = this.getOrCreateAiMessage(event);
       const toolCall: AdkToolCall = {
         id: part.functionCall.id ?? uuidv4(),


### PR DESCRIPTION
## Summary

- Skip partial SSE events for `functionCall` parts in `AdkEventAccumulator.processPart()` — partial events from ADK carry incomplete/empty args that cause the runtime to hang waiting for tool responses
- Guard both regular function calls (`if (event.partial) return`) and special ADK function calls (confirmation/auth) with `!event.partial` check
- Add 3 test cases covering: partial skip, partial-then-final aggregation, and partial special function calls

Closes #3754

## Test plan

- [ ] `pnpm --filter @assistant-ui/react-google-adk test` passes (133 tests)
- [ ] Verify partial functionCall events produce no tool_calls entries
- [ ] Verify final aggregated event correctly emits tool_calls with complete args
- [ ] Verify partial `adk_request_confirmation` events are not pushed to toolConfirmations