### PR TITLE
feat(core): add initialThreadId to useRemoteThreadListRuntime

### DIFF
--- a/.changeset/initial-thread-id.md
+++ b/.changeset/initial-thread-id.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat(core): add `initialThreadId` option to `useRemoteThreadListRuntime`

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -141,7 +141,11 @@ export class RemoteThreadListThreadListRuntimeCore
         Fragment) as ComponentType<PropsWithChildren>,
     }));
     this.__internal_setOptions(options);
-    this.switchToNewThread();
+    if (options.initialThreadId) {
+      this.switchToThread(options.initialThreadId);
+    } else {
+      this.switchToNewThread();
+    }
   }
 
   private useProvider;

--- a/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
+++ b/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
@@ -43,6 +43,9 @@ export const useRemoteThreadListRuntime = (
   const runtimeHookRef = useRef(options.runtimeHook);
   runtimeHookRef.current = options.runtimeHook;
 
+  // initialThreadId is only consumed by the constructor; capture once via ref
+  const initialThreadIdRef = useRef(options.initialThreadId);
+
   const stableRuntimeHook = useCallback(() => {
     return runtimeHookRef.current();
   }, []);
@@ -51,6 +54,7 @@ export const useRemoteThreadListRuntime = (
     () => ({
       adapter: options.adapter,
       allowNesting: options.allowNesting,
+      initialThreadId: initialThreadIdRef.current,
       runtimeHook: stableRuntimeHook,
     }),
     [options.adapter, options.allowNesting, stableRuntimeHook],

--- a/packages/core/src/runtimes/remote-thread-list/types.ts
+++ b/packages/core/src/runtimes/remote-thread-list/types.ts
@@ -40,6 +40,13 @@ export type RemoteThreadListOptions = {
   adapter: RemoteThreadListAdapter;
 
   /**
+   * When provided, the runtime starts on this thread instead of creating a
+   * new empty thread. Useful for URL-based routing (e.g. `/chat/[threadId]`)
+   * where the initial thread is known at mount time.
+   */
+  initialThreadId?: string | undefined;
+
+  /**
    * When true, if this runtime is used inside another RemoteThreadListRuntime,
    * it becomes a no-op and simply calls the runtimeHook directly.
    * This allows wrapping runtimes that internally use RemoteThreadListRuntime.


### PR DESCRIPTION
## Summary

Adds an optional `initialThreadId` to `RemoteThreadListOptions`. When provided, the runtime starts on the specified thread instead of creating a new empty thread.

This eliminates the need for the fragile `useEffect` + `switchToThread` workaround that every app with URL-based thread routing currently requires, which causes:
- Flash of the welcome screen before the real thread loads
- Race conditions with `isLoading` starting as `false`
- Complex ref tracking to avoid infinite redirect loops

### Usage

```tsx
const runtime = useRemoteThreadListRuntime({
  runtimeHook: MyRuntimeHook,
  adapter: myAdapter,
  initialThreadId: convIdFromUrl, // new option
});
```

## Related issues

- Closes #3721
- Closes #3603
- Relates to #1924
- Relates to PR #3623
- Relates to discussion #2037
- Relates to discussion #2683

## Changes

- `types.ts`: Added `initialThreadId?: string` to `RemoteThreadListOptions`
- `RemoteThreadListThreadListRuntimeCore.tsx`: Constructor calls `switchToThread(initialThreadId)` when provided, otherwise falls back to `switchToNewThread()`
- `useRemoteThreadListRuntime.ts`: Included `initialThreadId` in `stableOptions` and dependency array