### PR TITLE
fix(assistant-stream): handle CRLF line endings in LineDecoderStream

### DIFF
--- a/.changeset/fix-line-decoder-crlf.md
+++ b/.changeset/fix-line-decoder-crlf.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix(assistant-stream): handle CRLF line endings in LineDecoderStream

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.test.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.test.ts
@@ -161,6 +161,31 @@ describe("AssistantTransportDecoder", () => {
     expect(decodedChunks).toEqual(originalChunks);
   });
 
+  it("should decode SSE with CRLF line endings", async () => {
+    // Simulate a server that uses \r\n line endings (common in HTTP)
+    const sseText =
+      'data: {"type":"text-delta","textDelta":"Hello","path":[]}\r\n\r\n' +
+      "data: [DONE]\r\n\r\n";
+
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(sseText));
+        controller.close();
+      },
+    });
+
+    const decodedStream = stream.pipeThrough(new AssistantTransportDecoder());
+    const decodedChunks = await collectChunks(decodedStream);
+
+    expect(decodedChunks).toHaveLength(1);
+    expect(decodedChunks[0]).toEqual({
+      type: "text-delta",
+      textDelta: "Hello",
+      path: [],
+    });
+  });
+
   it("should throw error when stream ends without [DONE]", async () => {
     // Manually create an SSE stream without [DONE]
     const sseText =

--- a/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { LineDecoderStream } from "./LineDecoderStream";
+
+async function collectLines(stream: ReadableStream<string>): Promise<string[]> {
+  const reader = stream.getReader();
+  const lines: string[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    lines.push(value);
+  }
+  return lines;
+}
+
+function createTextStream(chunks: string[]): ReadableStream<string> {
+  return new ReadableStream<string>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("LineDecoderStream", () => {
+  it("should split lines on LF (\\n)", async () => {
+    const stream = createTextStream(["line1\nline2\nline3\n"]);
+    const lines = await collectLines(
+      stream.pipeThrough(new LineDecoderStream()),
+    );
+    expect(lines).toEqual(["line1", "line2", "line3"]);
+  });
+
+  it("should split lines on CRLF (\\r\\n)", async () => {
+    const stream = createTextStream(["line1\r\nline2\r\nline3\r\n"]);
+    const lines = await collectLines(
+      stream.pipeThrough(new LineDecoderStream()),
+    );
+    expect(lines).toEqual(["line1", "line2", "line3"]);
+  });
+
+  it("should handle CRLF split across chunks", async () => {
+    // The \r is at the end of one chunk and \n at the start of the next
+    const stream = createTextStream(["line1\r", "\nline2\r\n"]);
+    const lines = await collectLines(
+      stream.pipeThrough(new LineDecoderStream()),
+    );
+    expect(lines).toEqual(["line1", "line2"]);
+  });
+
+  it("should handle empty lines with LF", async () => {
+    const stream = createTextStream(["line1\n\nline2\n"]);
+    const lines = await collectLines(
+      stream.pipeThrough(new LineDecoderStream()),
+    );
+    expect(lines).toEqual(["line1", "", "line2"]);
+  });
+
+  it("should handle empty lines with CRLF", async () => {
+    const stream = createTextStream(["line1\r\n\r\nline2\r\n"]);
+    const lines = await collectLines(
+      stream.pipeThrough(new LineDecoderStream()),
+    );
+    expect(lines).toEqual(["line1", "", "line2"]);
+  });
+
+  it("should handle mixed LF and CRLF", async () => {
+    const stream = createTextStream(["line1\nline2\r\nline3\n"]);
+    const lines = await collectLines(
+      stream.pipeThrough(new LineDecoderStream()),
+    );
+    expect(lines).toEqual(["line1", "line2", "line3"]);
+  });
+
+  it("should handle multiple chunks", async () => {
+    const stream = createTextStream(["li", "ne1\nli", "ne2\n"]);
+    const lines = await collectLines(
+      stream.pipeThrough(new LineDecoderStream()),
+    );
+    expect(lines).toEqual(["line1", "line2"]);
+  });
+
+  it("should throw on incomplete line at end of stream", async () => {
+    const stream = createTextStream(["line1\nincomplete"]);
+    await expect(
+      collectLines(stream.pipeThrough(new LineDecoderStream())),
+    ).rejects.toThrow("Stream ended with an incomplete line");
+  });
+
+  it("should handle SSE-like data with CRLF", async () => {
+    const sseData = 'data: {"type":"text"}\r\n\r\ndata: [DONE]\r\n\r\n';
+    const stream = createTextStream([sseData]);
+    const lines = await collectLines(
+      stream.pipeThrough(new LineDecoderStream()),
+    );
+    expect(lines).toEqual(['data: {"type":"text"}', "", "data: [DONE]", ""]);
+  });
+});

--- a/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.ts
+++ b/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.ts
@@ -9,7 +9,9 @@ export class LineDecoderStream extends TransformStream<string, string> {
 
         // Process all complete lines
         for (let i = 0; i < lines.length - 1; i++) {
-          controller.enqueue(lines[i]);
+          // Strip trailing \r to handle \r\n (CRLF) line endings per the SSE spec.
+          const line = lines[i]!;
+          controller.enqueue(line.endsWith("\r") ? line.slice(0, -1) : line);
         }
 
         // Keep the last incomplete line in the buffer


### PR DESCRIPTION
## Summary

`LineDecoderStream` splits on `\n` only, leaving trailing `\r` when servers use `\r\n` (CRLF) line endings — the standard in HTTP. This breaks all four stream decoders in the library:

- **`AssistantTransportDecoder`**: `[DONE]` marker becomes `"[DONE]\r"` → not matched → `JSON.parse("[DONE]\r")` throws `SyntaxError`
- **`SSEDecoder`**: Same `[DONE]` detection failure
- **`UIMessageStreamDecoder`**: Same `[DONE]` detection failure
- **`DataStreamDecoder`**: Trailing `\r` in parsed line values (benign for JSON but incorrect)

Empty-line detection also fails: `"\r" !== ""`, so SSE events are never dispatched incrementally — they batch into `flush()` instead of streaming.

## Fix

Strip trailing `\r` after splitting on `\n` in `LineDecoderStream`. One line change, handles the common CRLF case.

> **Note:** Lone `\r` (CR-only) as a line separator — while technically part of the SSE spec — is not handled. No modern SSE server uses CR-only line endings. Supporting it would require a cross-chunk state machine that conflicts with the project's pragmatic coding style. This can be added in a follow-up if ever needed.

## Test plan

- [x] 9 new unit tests for `LineDecoderStream`: LF, CRLF, mixed, cross-chunk CRLF, empty lines (LF and CRLF), multiple chunks, incomplete stream error, SSE-like CRLF data
- [x] 1 new integration test: `AssistantTransportDecoder` decodes CRLF SSE end-to-end (data + `[DONE]` marker)
- [x] All 169 existing tests pass (`pnpm --filter assistant-stream test`)
- [x] Linter passes (biome via lint-staged)