### PR TITLE
feat(core): add ExportedMessageRepository.fromBranchableArray()

### DIFF
--- a/.changeset/feat-branchable-message-repository.md
+++ b/.changeset/feat-branchable-message-repository.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat: add ExportedMessageRepository.fromBranchableArray() for constructing branching message trees from ThreadMessageLike messages

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -424,6 +424,44 @@ const onEdit = async (message: AppendMessage) => {
 };
 ```
 
+### Branching Support
+
+The `messages` array path assumes a linear conversation — each message's parent is the previous message. To support branching (e.g. regenerating responses creates alternative branches), use `ExportedMessageRepository.fromBranchableArray()` combined with `thread.import()`.
+
+Each message must have an explicit `id` and `parentId`. Messages with the same `parentId` create branches:
+
+```tsx
+import {
+  ExportedMessageRepository,
+  useExternalStoreRuntime,
+} from "@assistant-ui/react";
+
+// Your messages from the backend, each with an id and parentId
+const backendMessages = [
+  { id: "user-1", role: "user", content: "Hello", parentId: null },
+  { id: "asst-1", role: "assistant", content: "Hi!", parentId: "user-1" },
+  // A second response to the same user message = a branch
+  { id: "asst-2", role: "assistant", content: "Hey!", parentId: "user-1" },
+];
+
+// Convert to ExportedMessageRepository
+const repo = ExportedMessageRepository.fromBranchableArray(
+  backendMessages.map((m) => ({
+    message: { id: m.id, role: m.role, content: m.content },
+    parentId: m.parentId,
+  })),
+  { headId: "asst-1" }, // which branch to display initially
+);
+
+// Import into the runtime
+runtime.thread.import(repo);
+```
+
+<Callout type="warn">
+  Messages in the array must be ordered so that parents appear before their
+  children. Each message **must** have an `id` field set.
+</Callout>
+
 ### Tool Calling
 
 Support tool calls with proper result handling:

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -39,6 +39,32 @@ export const ExportedMessageRepository = {
       })),
     };
   },
+
+  fromBranchableArray: (
+    items: readonly {
+      message: ThreadMessageLike;
+      parentId: string | null;
+    }[],
+    options?: { headId?: string | null },
+  ): ExportedMessageRepository => {
+    const fallbackStatus = getAutoStatus(false, false, false, false, undefined);
+    return {
+      ...(options?.headId !== undefined
+        ? { headId: options.headId }
+        : undefined),
+      messages: items.map(({ message, parentId }) => {
+        if (!message.id) {
+          throw new Error(
+            "ExportedMessageRepository.fromBranchableArray: Each message must have an 'id' field set.",
+          );
+        }
+        return {
+          parentId,
+          message: fromThreadMessageLike(message, message.id, fallbackStatus),
+        };
+      }),
+    };
+  },
 };
 
 type RepositoryParent = {

--- a/packages/core/src/tests/MessageRepository.test.ts
+++ b/packages/core/src/tests/MessageRepository.test.ts
@@ -457,6 +457,147 @@ describe("MessageRepository", () => {
     });
   });
 
+  describe("ExportedMessageRepository.fromBranchableArray", () => {
+    it("should create a branching tree structure", () => {
+      const items = [
+        {
+          message: {
+            id: "user-1",
+            role: "user" as const,
+            content: [{ type: "text" as const, text: "Hello" }],
+          },
+          parentId: null,
+        },
+        {
+          message: {
+            id: "assistant-1",
+            role: "assistant" as const,
+            content: [{ type: "text" as const, text: "Hi there" }],
+          },
+          parentId: "user-1",
+        },
+        {
+          message: {
+            id: "assistant-2",
+            role: "assistant" as const,
+            content: [{ type: "text" as const, text: "Hey!" }],
+          },
+          parentId: "user-1",
+        },
+      ];
+
+      const result = ExportedMessageRepository.fromBranchableArray(items);
+
+      expect(result.messages).toHaveLength(3);
+      expect(result.messages[0]!.parentId).toBeNull();
+      expect(result.messages[0]!.message.id).toBe("user-1");
+      expect(result.messages[1]!.parentId).toBe("user-1");
+      expect(result.messages[1]!.message.id).toBe("assistant-1");
+      expect(result.messages[2]!.parentId).toBe("user-1");
+      expect(result.messages[2]!.message.id).toBe("assistant-2");
+    });
+
+    it("should support headId option", () => {
+      const items = [
+        {
+          message: {
+            id: "msg-1",
+            role: "user" as const,
+            content: [{ type: "text" as const, text: "Hello" }],
+          },
+          parentId: null,
+        },
+        {
+          message: {
+            id: "msg-2a",
+            role: "assistant" as const,
+            content: [{ type: "text" as const, text: "Branch A" }],
+          },
+          parentId: "msg-1",
+        },
+        {
+          message: {
+            id: "msg-2b",
+            role: "assistant" as const,
+            content: [{ type: "text" as const, text: "Branch B" }],
+          },
+          parentId: "msg-1",
+        },
+      ];
+
+      const result = ExportedMessageRepository.fromBranchableArray(items, {
+        headId: "msg-2b",
+      });
+
+      expect(result.headId).toBe("msg-2b");
+    });
+
+    it("should throw if a message has no id", () => {
+      const items = [
+        {
+          message: {
+            role: "user" as const,
+            content: [{ type: "text" as const, text: "Hello" }],
+          },
+          parentId: null,
+        },
+      ];
+
+      expect(() =>
+        ExportedMessageRepository.fromBranchableArray(items),
+      ).toThrow(/Each message must have an 'id' field set/);
+    });
+
+    it("should handle empty arrays", () => {
+      const result = ExportedMessageRepository.fromBranchableArray([]);
+      expect(result.messages).toHaveLength(0);
+    });
+
+    it("should work with MessageRepository.import for branch switching", () => {
+      const items = [
+        {
+          message: {
+            id: "user-1",
+            role: "user" as const,
+            content: [{ type: "text" as const, text: "Hello" }],
+          },
+          parentId: null,
+        },
+        {
+          message: {
+            id: "assistant-a",
+            role: "assistant" as const,
+            content: [{ type: "text" as const, text: "Response A" }],
+          },
+          parentId: "user-1",
+        },
+        {
+          message: {
+            id: "assistant-b",
+            role: "assistant" as const,
+            content: [{ type: "text" as const, text: "Response B" }],
+          },
+          parentId: "user-1",
+        },
+      ];
+
+      const repo = ExportedMessageRepository.fromBranchableArray(items, {
+        headId: "assistant-a",
+      });
+
+      repository.import(repo);
+
+      // Should show branch A
+      let messages = repository.getMessages();
+      expect(messages.map((m) => m.id)).toEqual(["user-1", "assistant-a"]);
+
+      // Switch to branch B
+      repository.switchToBranch("assistant-b");
+      messages = repository.getMessages();
+      expect(messages.map((m) => m.id)).toEqual(["user-1", "assistant-b"]);
+    });
+  });
+
   describe("Complex scenarios", () => {
     it("should maintain tree structure after deletions", () => {
       const root = createTestMessage({ id: "root-id" });


### PR DESCRIPTION
## Summary

- Add `ExportedMessageRepository.fromBranchableArray()` helper that constructs an `ExportedMessageRepository` from `ThreadMessageLike` messages with explicit `parentId` references, enabling branching support for ExternalStore users
- Users can now build a branching message tree and import it via `runtime.thread.import(repo)` without manually converting `ThreadMessageLike` to `ThreadMessage`
- Each input message must have an `id` field set; messages sharing the same `parentId` create branches
- Add documentation section in the ExternalStore guide with a complete code example
- Closes #3161

## Test plan

- [ ] `pnpm --filter @assistant-ui/core test` passes (87 tests including 5 new ones)
- [ ] Verify `fromBranchableArray` creates correct branch structure (two messages with same parentId)
- [ ] Verify `headId` option selects the initial branch
- [ ] Verify missing `id` throws a clear error
- [ ] Verify integration with `MessageRepository.import()` and `switchToBranch()`
- [ ] Verify docs render correctly at `/docs/runtimes/custom/external-store`