### PR TITLE
fix(react-native): export ExportedMessageRepository

### DIFF
--- a/.changeset/fix-react-native-exported-message-repository.md
+++ b/.changeset/fix-react-native-exported-message-repository.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-native": patch
+---
+
+fix: export ExportedMessageRepository and ExportedMessageRepositoryItem from react-native

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -168,6 +168,9 @@ export type {
 
 export { mergeModelContexts } from "@assistant-ui/core";
 
+export type { ExportedMessageRepositoryItem } from "@assistant-ui/core";
+export { ExportedMessageRepository } from "@assistant-ui/core";
+
 export type { Tool } from "assistant-stream";
 
 export { tool } from "@assistant-ui/core";


### PR DESCRIPTION
## Summary

- Export `ExportedMessageRepository` and `ExportedMessageRepositoryItem` from `@assistant-ui/react-native`
- These types are needed for `thread.import()` and `thread.export()` which are available via the already-exported `ThreadRuntime`
- Aligns react-native exports with `@assistant-ui/react` which already exports both

## Test plan

- [ ] Verify `ExportedMessageRepository` is importable from `@assistant-ui/react-native`
- [ ] Verify no other exports are affected