### PR TITLE
fix(react-google-adk): [Google ADK HITL] AdkEventAccumulator blocks requires-action status for longRunningToolIds

### DIFF
--- a/.changeset/fix-adk-hitl-requires-action-status.md
+++ b/.changeset/fix-adk-hitl-requires-action-status.md
@@ -2,15 +2,7 @@
 "@assistant-ui/react-google-adk": patch
 ---
 
-fix(react-google-adk): [Google ADK HITL] AdkEventAccumulator blocks requires-action status for longRunningToolIds
+fix(react-google-adk): allow HITL interrupt tool UIs to render with `requires-action` status
 
-`AdkEventAccumulator.processEvent` was stamping a manual `{type: "complete", reason: "stop"}` status on the AI message that carries a HITL interrupt tool call (`adk_request_input` / `adk_request_confirmation` / `adk_request_credential`). That manual status is not an auto-status, so `external-message-converter` refused to promote the message to `AUTO_STATUS_PENDING` ({type: "requires-action"}) — making the `status.type === "requires-action"` branch of any `makeAssistantToolUI` render dead code for HITL interrupts.
-
-The fix adds a `hasHitl` guard: when `isFinalResponse(event)` is true *only* because `longRunningToolIds` is populated, skip the manual status assignment and let auto-status apply `requires-action` downstream.
-
-- Tool UIs registered via `makeAssistantToolUI` for `adk_request_input` can now use the idiomatic `if (status.type === "requires-action") { /* show form */ }` pattern to render an input form during HITL interrupts.
-- `useAdkSubmitInput(toolCallId, result)` (added in PR #3800) now has a path to be invoked, because the form that calls it finally renders.
-- Non-HITL final events (LLM stop, content-filter, error, `skipSummarization`) still get their manual status — no regression.
-- Adds 5 unit tests to `AdkEventAccumulator.test.ts` under `describe("AdkEventAccumulator - HITL requires-action", ...)` locking in the contract, plus updates the existing `"marks as final when longRunningToolIds is non-empty"` test (which previously asserted the buggy `status: {type: "complete"}` behavior) to assert `status === undefined` for HITL events.
-
-**Related:** complements PR #3800 (HITL auto-cancel fix). #3800 protected HITL tool calls from being auto-cancelled on the *next* turn; this fix makes the HITL form render in the *first* place, so users can answer instead of typing into the main composer and getting a `text` event that can't resume the paused `RequestInput` node.
+- `makeAssistantToolUI` for HITL tools (`adk_request_input`, etc.) can now use `status.type === "requires-action"` to render input forms
+- Non-HITL final events still receive their manual `complete` status

--- a/.changeset/fix-adk-hitl-requires-action-status.md
+++ b/.changeset/fix-adk-hitl-requires-action-status.md
@@ -1,0 +1,16 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix(react-google-adk): [Google ADK HITL] AdkEventAccumulator blocks requires-action status for longRunningToolIds
+
+`AdkEventAccumulator.processEvent` was stamping a manual `{type: "complete", reason: "stop"}` status on the AI message that carries a HITL interrupt tool call (`adk_request_input` / `adk_request_confirmation` / `adk_request_credential`). That manual status is not an auto-status, so `external-message-converter` refused to promote the message to `AUTO_STATUS_PENDING` ({type: "requires-action"}) — making the `status.type === "requires-action"` branch of any `makeAssistantToolUI` render dead code for HITL interrupts.
+
+The fix adds a `hasHitl` guard: when `isFinalResponse(event)` is true *only* because `longRunningToolIds` is populated, skip the manual status assignment and let auto-status apply `requires-action` downstream.
+
+- Tool UIs registered via `makeAssistantToolUI` for `adk_request_input` can now use the idiomatic `if (status.type === "requires-action") { /* show form */ }` pattern to render an input form during HITL interrupts.
+- `useAdkSubmitInput(toolCallId, result)` (added in PR #3800) now has a path to be invoked, because the form that calls it finally renders.
+- Non-HITL final events (LLM stop, content-filter, error, `skipSummarization`) still get their manual status — no regression.
+- Adds 5 unit tests to `AdkEventAccumulator.test.ts` under `describe("AdkEventAccumulator - HITL requires-action", ...)` locking in the contract, plus updates the existing `"marks as final when longRunningToolIds is non-empty"` test (which previously asserted the buggy `status: {type: "complete"}` behavior) to assert `status === undefined` for HITL events.
+
+**Related:** complements PR #3800 (HITL auto-cancel fix). #3800 protected HITL tool calls from being auto-cancelled on the *next* turn; this fix makes the HITL form render in the *first* place, so users can answer instead of typing into the main composer and getting a `text` event that can't resume the paused `RequestInput` node.

--- a/packages/react-google-adk/src/AdkEventAccumulator.test.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.test.ts
@@ -506,18 +506,32 @@ describe("AdkEventAccumulator - HITL requires-action", () => {
     expect(aiMsg.tool_calls![0]!.id).toBe(HITL_TOOL_CALL_ID);
   });
 
-  it("HITL event followed by a later final text event still preserves pending tool call", () => {
-    // Regression: two sequential events in the same turn should not
-    // mask the HITL tool call. The first event is the interrupt; there
-    // are no text deltas to follow (the workflow paused). The tool call
-    // must remain in the accumulator's message map without a manual
-    // "complete" status that would block requires-action.
+  it("HITL tool call stays pending across a subsequent bookkeeping event in the same turn", () => {
+    // Multi-event guard: after the HITL interrupt, bookkeeping events
+    // (state delta only, no content) can still arrive in the same
+    // turn. This mirrors a real Google ADK Workflow trace where a
+    // stateDelta bump (e.g. `clarify_count`) and the HITL
+    // FunctionCall arrive back-to-back. The bookkeeping event must
+    // NOT flip the HITL message to a manual "complete" status nor
+    // drop the pending tool call.
     const acc = new AdkEventAccumulator();
-    const msgs = acc.processEvent(HITL_EVENT);
+    acc.processEvent(HITL_EVENT);
 
-    const aiMsg = msgs[msgs.length - 1] as AdkMessage & { type: "ai" };
-    expect(aiMsg.tool_calls).toHaveLength(1);
-    expect(aiMsg.status).toBeUndefined();
+    const msgs = acc.processEvent(
+      makeEvent({
+        id: "evt-bookkeeping",
+        author: "FrontDoorWorkflow",
+        actions: { stateDelta: { waiting_for_user: true } },
+      }),
+    );
+
+    const aiMsg = msgs.find(
+      (m): m is AdkMessage & { type: "ai" } =>
+        m.type === "ai" && (m.tool_calls?.length ?? 0) > 0,
+    );
+    expect(aiMsg).toBeDefined();
+    expect(aiMsg!.tool_calls![0]!.id).toBe(HITL_TOOL_CALL_ID);
+    expect(aiMsg!.status).toBeUndefined();
   });
 
   it("non-HITL final event still gets manual 'complete' status (regression guard)", () => {
@@ -547,6 +561,37 @@ describe("AdkEventAccumulator - HITL requires-action", () => {
         author: "agent",
         actions: { skipSummarization: true },
         content: { role: "model", parts: [{ text: "skipped" }] },
+      }),
+    );
+
+    expect(msgs[0]).toMatchObject({
+      status: { type: "complete", reason: "stop" },
+    });
+  });
+
+  it("event with BOTH longRunningToolIds AND skipSummarization gets manual status (skipSummarization wins)", () => {
+    // Regression guard for the refined `hasHitl` guard: when both
+    // flags are present on a single event, `skipSummarization` wins
+    // and the message gets a manual "complete" status. This locks in
+    // the narrow intent of `hasHitl` — "HITL is the SOLE reason for
+    // isFinalResponse." In current ADK the two flags don't co-occur
+    // on one event (the `_long_running_interrupt_event` constructor
+    // in `adk-python/src/google/adk/agents/llm/_execute_tools_node.py`
+    // only sets `long_running_tool_ids`, and the `skip_summarization`
+    // writers in adk-python set it on FunctionResponse or non-LRT
+    // events), so this test documents the defensive contract.
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "agent",
+        longRunningToolIds: ["lrt-both"],
+        actions: { skipSummarization: true },
+        content: {
+          role: "model",
+          parts: [
+            { functionCall: { name: "slow_tool", id: "lrt-both", args: {} } },
+          ],
+        },
       }),
     );
 

--- a/packages/react-google-adk/src/AdkEventAccumulator.test.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.test.ts
@@ -399,7 +399,17 @@ describe("AdkEventAccumulator - isFinalResponse logic", () => {
     });
   });
 
-  it("marks as final when longRunningToolIds is non-empty", () => {
+  it("isFinalResponse is true for HITL but status stays undefined (let auto-status apply requires-action)", () => {
+    // HITL regression: previously this test asserted
+    //   status: { type: "complete", reason: "stop" }
+    // which was WRONG. Assigning a manual "complete" status to a message
+    // that carries an unresolved tool call blocks
+    // external-message-converter from applying AUTO_STATUS_PENDING
+    // ({type:"requires-action"}), so any `makeAssistantToolUI` registered
+    // for adk_request_input / adk_request_confirmation /
+    // adk_request_credential could never use its `status.type ===
+    // "requires-action"` render branch. See the HITL requires-action
+    // describe block below for the full contract.
     const acc = new AdkEventAccumulator();
     const msgs = acc.processEvent(
       makeEvent({
@@ -413,6 +423,133 @@ describe("AdkEventAccumulator - isFinalResponse logic", () => {
         },
       }),
     );
+    expect((msgs[0] as AdkMessage & { type: "ai" }).status).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HITL requires-action — Google ADK RequestInput / LongRunningFunctionTool
+// ---------------------------------------------------------------------------
+//
+// When ADK emits an `adk_request_input` (or `adk_request_confirmation` /
+// `adk_request_credential`) interrupt, the event carries:
+//   - content.parts[0].functionCall  — the tool call
+//   - longRunningToolIds[]           — matching id of the tool call
+//
+// Consumers register a `makeAssistantToolUI({ toolName: "adk_request_input" })`
+// whose `render({ status })` expects `status.type === "requires-action"` when
+// the tool call is pending, so it can show an input form and collect the
+// user's answer via `useAdkSubmitInput(toolCallId, text)`.
+//
+// For that to work, the AI message carrying the tool call must NOT be
+// stamped with a manual "complete" status by the accumulator — otherwise
+// external-message-converter refuses to promote it to AUTO_STATUS_PENDING
+// and the form branch is dead code.
+//
+// These tests lock that contract in place.
+// ---------------------------------------------------------------------------
+
+describe("AdkEventAccumulator - HITL requires-action", () => {
+  // Wire shape captured from a real Google ADK backend run
+  // (front_door workflow, clarify_hitl node, 2026-04-10).
+  const HITL_TOOL_CALL_ID = "15e1abeb-aaf9-4e43-a55f-3a5ca10d810c";
+  const HITL_EVENT = {
+    id: "8700bf9d-4673-46ff-a28e-36f5e7927123",
+    invocationId: "e-3888c670-4bbb-4c90-9e3a-17d7dc47e4a8",
+    author: "FrontDoorWorkflow",
+    longRunningToolIds: [HITL_TOOL_CALL_ID],
+    content: {
+      parts: [
+        {
+          functionCall: {
+            id: HITL_TOOL_CALL_ID,
+            name: "adk_request_input",
+            args: {
+              interrupt_id: HITL_TOOL_CALL_ID,
+              message: "What's the forecast period?",
+            },
+          },
+        },
+      ],
+    },
+  } satisfies AdkEvent;
+
+  it("HITL event produces an AI message with the tool call and NO manual status", () => {
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(HITL_EVENT);
+
+    expect(msgs).toHaveLength(1);
+    const aiMsg = msgs[0] as AdkMessage & { type: "ai" };
+    expect(aiMsg.type).toBe("ai");
+
+    // Tool call attached with matching id
+    expect(aiMsg.tool_calls).toBeDefined();
+    expect(aiMsg.tool_calls).toHaveLength(1);
+    expect(aiMsg.tool_calls![0]!.id).toBe(HITL_TOOL_CALL_ID);
+    expect(aiMsg.tool_calls![0]!.name).toBe("adk_request_input");
+
+    // THE LOAD-BEARING ASSERTION: status must be undefined so auto-status
+    // can later apply AUTO_STATUS_PENDING ({type:"requires-action"}).
+    // If this fails, ClarifyToolUI's `status.type === "requires-action"`
+    // render branch becomes dead code.
+    expect(aiMsg.status).toBeUndefined();
+  });
+
+  it("HITL tool call id matches the longRunningToolIds entry (wire contract)", () => {
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(HITL_EVENT);
+    const aiMsg = msgs[0] as AdkMessage & { type: "ai" };
+
+    // AdkEventAccumulator.pendingLongRunningToolIds must contain the id,
+    // AND the tool call in the message must have the same id, so
+    // getPendingCancellations can filter it from auto-cancel.
+    expect(aiMsg.tool_calls![0]!.id).toBe(HITL_TOOL_CALL_ID);
+  });
+
+  it("HITL event followed by a later final text event still preserves pending tool call", () => {
+    // Regression: two sequential events in the same turn should not
+    // mask the HITL tool call. The first event is the interrupt; there
+    // are no text deltas to follow (the workflow paused). The tool call
+    // must remain in the accumulator's message map without a manual
+    // "complete" status that would block requires-action.
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(HITL_EVENT);
+
+    const aiMsg = msgs[msgs.length - 1] as AdkMessage & { type: "ai" };
+    expect(aiMsg.tool_calls).toHaveLength(1);
+    expect(aiMsg.status).toBeUndefined();
+  });
+
+  it("non-HITL final event still gets manual 'complete' status (regression guard)", () => {
+    // Make sure the fix doesn't leak into non-HITL flows. A plain text
+    // final event with no longRunningToolIds should still get
+    // {type:"complete", reason:"stop"} — this is intentional and prevents
+    // spurious status flips from auto-status on subsequent updates.
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "agent",
+        content: { role: "model", parts: [{ text: "Done." }] },
+      }),
+    );
+
+    expect(msgs[0]).toMatchObject({
+      status: { type: "complete", reason: "stop" },
+    });
+  });
+
+  it("skipSummarization final event still gets manual 'complete' status", () => {
+    // Second regression guard: the other `isFinalResponse` branch
+    // (skipSummarization) must continue to assign manual status.
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "agent",
+        actions: { skipSummarization: true },
+        content: { role: "model", parts: [{ text: "skipped" }] },
+      }),
+    );
+
     expect(msgs[0]).toMatchObject({
       status: { type: "complete", reason: "stop" },
     });

--- a/packages/react-google-adk/src/AdkEventAccumulator.test.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.test.ts
@@ -399,17 +399,7 @@ describe("AdkEventAccumulator - isFinalResponse logic", () => {
     });
   });
 
-  it("isFinalResponse is true for HITL but status stays undefined (let auto-status apply requires-action)", () => {
-    // HITL regression: previously this test asserted
-    //   status: { type: "complete", reason: "stop" }
-    // which was WRONG. Assigning a manual "complete" status to a message
-    // that carries an unresolved tool call blocks
-    // external-message-converter from applying AUTO_STATUS_PENDING
-    // ({type:"requires-action"}), so any `makeAssistantToolUI` registered
-    // for adk_request_input / adk_request_confirmation /
-    // adk_request_credential could never use its `status.type ===
-    // "requires-action"` render branch. See the HITL requires-action
-    // describe block below for the full contract.
+  it("HITL event leaves status undefined for auto-status", () => {
     const acc = new AdkEventAccumulator();
     const msgs = acc.processEvent(
       makeEvent({
@@ -427,100 +417,56 @@ describe("AdkEventAccumulator - isFinalResponse logic", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// HITL requires-action — Google ADK RequestInput / LongRunningFunctionTool
-// ---------------------------------------------------------------------------
-//
-// When ADK emits an `adk_request_input` (or `adk_request_confirmation` /
-// `adk_request_credential`) interrupt, the event carries:
-//   - content.parts[0].functionCall  — the tool call
-//   - longRunningToolIds[]           — matching id of the tool call
-//
-// Consumers register a `makeAssistantToolUI({ toolName: "adk_request_input" })`
-// whose `render({ status })` expects `status.type === "requires-action"` when
-// the tool call is pending, so it can show an input form and collect the
-// user's answer via `useAdkSubmitInput(toolCallId, text)`.
-//
-// For that to work, the AI message carrying the tool call must NOT be
-// stamped with a manual "complete" status by the accumulator — otherwise
-// external-message-converter refuses to promote it to AUTO_STATUS_PENDING
-// and the form branch is dead code.
-//
-// These tests lock that contract in place.
-// ---------------------------------------------------------------------------
-
 describe("AdkEventAccumulator - HITL requires-action", () => {
-  // Wire shape captured from a real Google ADK backend run
-  // (front_door workflow, clarify_hitl node, 2026-04-10).
-  const HITL_TOOL_CALL_ID = "15e1abeb-aaf9-4e43-a55f-3a5ca10d810c";
-  const HITL_EVENT = {
-    id: "8700bf9d-4673-46ff-a28e-36f5e7927123",
-    invocationId: "e-3888c670-4bbb-4c90-9e3a-17d7dc47e4a8",
-    author: "FrontDoorWorkflow",
-    longRunningToolIds: [HITL_TOOL_CALL_ID],
-    content: {
-      parts: [
-        {
-          functionCall: {
-            id: HITL_TOOL_CALL_ID,
-            name: "adk_request_input",
-            args: {
-              interrupt_id: HITL_TOOL_CALL_ID,
-              message: "What's the forecast period?",
+  const makeHitlEvent = (
+    toolCallId: string,
+    overrides: Partial<AdkEvent> = {},
+  ): AdkEvent =>
+    makeEvent({
+      author: "agent",
+      longRunningToolIds: [toolCallId],
+      content: {
+        parts: [
+          {
+            functionCall: {
+              id: toolCallId,
+              name: "adk_request_input",
+              args: { message: "What's the forecast period?" },
             },
           },
-        },
-      ],
-    },
-  } satisfies AdkEvent;
+        ],
+      },
+      ...overrides,
+    });
 
-  it("HITL event produces an AI message with the tool call and NO manual status", () => {
+  it("produces an AI message with tool call and no manual status", () => {
     const acc = new AdkEventAccumulator();
-    const msgs = acc.processEvent(HITL_EVENT);
+    const msgs = acc.processEvent(makeHitlEvent("tc-1"));
 
     expect(msgs).toHaveLength(1);
     const aiMsg = msgs[0] as AdkMessage & { type: "ai" };
     expect(aiMsg.type).toBe("ai");
-
-    // Tool call attached with matching id
-    expect(aiMsg.tool_calls).toBeDefined();
     expect(aiMsg.tool_calls).toHaveLength(1);
-    expect(aiMsg.tool_calls![0]!.id).toBe(HITL_TOOL_CALL_ID);
+    expect(aiMsg.tool_calls![0]!.id).toBe("tc-1");
     expect(aiMsg.tool_calls![0]!.name).toBe("adk_request_input");
-
-    // THE LOAD-BEARING ASSERTION: status must be undefined so auto-status
-    // can later apply AUTO_STATUS_PENDING ({type:"requires-action"}).
-    // If this fails, ClarifyToolUI's `status.type === "requires-action"`
-    // render branch becomes dead code.
     expect(aiMsg.status).toBeUndefined();
   });
 
-  it("HITL tool call id matches the longRunningToolIds entry (wire contract)", () => {
+  it("matches tool call id to the longRunningToolIds entry", () => {
     const acc = new AdkEventAccumulator();
-    const msgs = acc.processEvent(HITL_EVENT);
+    const msgs = acc.processEvent(makeHitlEvent("tc-1"));
     const aiMsg = msgs[0] as AdkMessage & { type: "ai" };
-
-    // AdkEventAccumulator.pendingLongRunningToolIds must contain the id,
-    // AND the tool call in the message must have the same id, so
-    // getPendingCancellations can filter it from auto-cancel.
-    expect(aiMsg.tool_calls![0]!.id).toBe(HITL_TOOL_CALL_ID);
+    expect(aiMsg.tool_calls![0]!.id).toBe("tc-1");
   });
 
-  it("HITL tool call stays pending across a subsequent bookkeeping event in the same turn", () => {
-    // Multi-event guard: after the HITL interrupt, bookkeeping events
-    // (state delta only, no content) can still arrive in the same
-    // turn. This mirrors a real Google ADK Workflow trace where a
-    // stateDelta bump (e.g. `clarify_count`) and the HITL
-    // FunctionCall arrive back-to-back. The bookkeeping event must
-    // NOT flip the HITL message to a manual "complete" status nor
-    // drop the pending tool call.
+  it("stays pending across a subsequent bookkeeping event", () => {
     const acc = new AdkEventAccumulator();
-    acc.processEvent(HITL_EVENT);
+    acc.processEvent(makeHitlEvent("tc-1", { author: "WorkflowA" }));
 
     const msgs = acc.processEvent(
       makeEvent({
         id: "evt-bookkeeping",
-        author: "FrontDoorWorkflow",
+        author: "WorkflowA",
         actions: { stateDelta: { waiting_for_user: true } },
       }),
     );
@@ -530,15 +476,11 @@ describe("AdkEventAccumulator - HITL requires-action", () => {
         m.type === "ai" && (m.tool_calls?.length ?? 0) > 0,
     );
     expect(aiMsg).toBeDefined();
-    expect(aiMsg!.tool_calls![0]!.id).toBe(HITL_TOOL_CALL_ID);
+    expect(aiMsg!.tool_calls![0]!.id).toBe("tc-1");
     expect(aiMsg!.status).toBeUndefined();
   });
 
-  it("non-HITL final event still gets manual 'complete' status (regression guard)", () => {
-    // Make sure the fix doesn't leak into non-HITL flows. A plain text
-    // final event with no longRunningToolIds should still get
-    // {type:"complete", reason:"stop"} — this is intentional and prevents
-    // spurious status flips from auto-status on subsequent updates.
+  it("assigns manual complete status on non-HITL final event", () => {
     const acc = new AdkEventAccumulator();
     const msgs = acc.processEvent(
       makeEvent({
@@ -552,9 +494,7 @@ describe("AdkEventAccumulator - HITL requires-action", () => {
     });
   });
 
-  it("skipSummarization final event still gets manual 'complete' status", () => {
-    // Second regression guard: the other `isFinalResponse` branch
-    // (skipSummarization) must continue to assign manual status.
+  it("assigns manual complete status on skipSummarization final event", () => {
     const acc = new AdkEventAccumulator();
     const msgs = acc.processEvent(
       makeEvent({
@@ -569,17 +509,7 @@ describe("AdkEventAccumulator - HITL requires-action", () => {
     });
   });
 
-  it("event with BOTH longRunningToolIds AND skipSummarization gets manual status (skipSummarization wins)", () => {
-    // Regression guard for the refined `hasHitl` guard: when both
-    // flags are present on a single event, `skipSummarization` wins
-    // and the message gets a manual "complete" status. This locks in
-    // the narrow intent of `hasHitl` — "HITL is the SOLE reason for
-    // isFinalResponse." In current ADK the two flags don't co-occur
-    // on one event (the `_long_running_interrupt_event` constructor
-    // in `adk-python/src/google/adk/agents/llm/_execute_tools_node.py`
-    // only sets `long_running_tool_ids`, and the `skip_summarization`
-    // writers in adk-python set it on FunctionResponse or non-LRT
-    // events), so this test documents the defensive contract.
+  it("prioritizes skipSummarization over longRunningToolIds", () => {
     const acc = new AdkEventAccumulator();
     const msgs = acc.processEvent(
       makeEvent({
@@ -598,6 +528,167 @@ describe("AdkEventAccumulator - HITL requires-action", () => {
     expect(msgs[0]).toMatchObject({
       status: { type: "complete", reason: "stop" },
     });
+  });
+
+  it("ignores empty longRunningToolIds array for HITL guard", () => {
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "agent",
+        longRunningToolIds: [],
+        content: { role: "model", parts: [{ text: "Done." }] },
+      }),
+    );
+
+    expect(msgs[0]).toMatchObject({
+      status: { type: "complete", reason: "stop" },
+    });
+  });
+
+  it("preserves text and skips status when partial text precedes HITL event", () => {
+    const acc = new AdkEventAccumulator();
+    acc.processEvent(
+      makeEvent({
+        author: "ClarifyAgent",
+        partial: true,
+        content: {
+          role: "model",
+          parts: [{ text: "Let me ask about " }],
+        },
+      }),
+    );
+
+    const msgs = acc.processEvent(
+      makeHitlEvent("tc-1", { author: "ClarifyAgent" }),
+    );
+
+    const aiMsg = msgs.find(
+      (m): m is AdkMessage & { type: "ai" } =>
+        m.type === "ai" && (m.tool_calls?.length ?? 0) > 0,
+    );
+    expect(aiMsg).toBeDefined();
+    expect(aiMsg!.tool_calls).toHaveLength(1);
+    expect(
+      aiMsg!.content.some(
+        (c) => c.type === "text" && c.text.includes("Let me ask"),
+      ),
+    ).toBe(true);
+    expect(aiMsg!.status).toBeUndefined();
+  });
+
+  it("keeps status undefined for mixed text and functionCall content", () => {
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "agent",
+        longRunningToolIds: ["mixed-tc-1"],
+        content: {
+          role: "model",
+          parts: [
+            { text: "I need some clarification." },
+            {
+              functionCall: {
+                id: "mixed-tc-1",
+                name: "adk_request_input",
+                args: { message: "Which region?" },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    const aiMsg = msgs[0] as AdkMessage & { type: "ai" };
+    expect(aiMsg.content.some((c) => c.type === "text")).toBe(true);
+    expect(aiMsg.tool_calls).toHaveLength(1);
+    expect(aiMsg.tool_calls![0]!.id).toBe("mixed-tc-1");
+    expect(aiMsg.status).toBeUndefined();
+  });
+
+  it("handles multiple tool calls with partial longRunningToolIds overlap", () => {
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "agent",
+        longRunningToolIds: ["tc-hitl"],
+        content: {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                id: "tc-hitl",
+                name: "adk_request_input",
+                args: { message: "Confirm?" },
+              },
+            },
+            {
+              functionCall: {
+                id: "tc-regular",
+                name: "fetch_data",
+                args: { url: "https://example.com" },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    const aiMsg = msgs[0] as AdkMessage & { type: "ai" };
+    expect(aiMsg.tool_calls).toHaveLength(2);
+    expect(aiMsg.tool_calls!.map((tc) => tc.id).sort()).toEqual(
+      ["tc-hitl", "tc-regular"].sort(),
+    );
+    expect(aiMsg.status).toBeUndefined();
+  });
+
+  it("does not override HITL guard with explicit finishReason", () => {
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeHitlEvent("tc-fr", { finishReason: "STOP" }),
+    );
+
+    const aiMsg = msgs[0] as AdkMessage & { type: "ai" };
+    expect(aiMsg.status).toBeUndefined();
+  });
+
+  it("produces separate messages without status for sequential HITL events", () => {
+    const acc = new AdkEventAccumulator();
+    acc.processEvent(
+      makeHitlEvent("tc-seq-1", { id: "evt-1", author: "WorkflowA" }),
+    );
+
+    const msgs = acc.processEvent(
+      makeEvent({
+        id: "evt-2",
+        author: "WorkflowB",
+        longRunningToolIds: ["tc-seq-2"],
+        content: {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                id: "tc-seq-2",
+                name: "adk_request_confirmation",
+                args: {
+                  originalFunctionCall: { name: "delete_all", args: {} },
+                  toolConfirmation: { hint: "Sure?", payload: {} },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    const hitlMsgs = msgs.filter(
+      (m): m is AdkMessage & { type: "ai" } =>
+        m.type === "ai" && (m.tool_calls?.length ?? 0) > 0,
+    );
+    expect(hitlMsgs).toHaveLength(2);
+    expect(hitlMsgs[0]!.status).toBeUndefined();
+    expect(hitlMsgs[1]!.status).toBeUndefined();
+    expect(hitlMsgs[0]!.tool_calls![0]!.id).toBe("tc-seq-1");
+    expect(hitlMsgs[1]!.tool_calls![0]!.id).toBe("tc-seq-2");
   });
 });
 

--- a/packages/react-google-adk/src/AdkEventAccumulator.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.ts
@@ -348,8 +348,18 @@ export class AdkEventAccumulator {
       // ({type:"requires-action"}). This is what makes makeAssistantToolUI
       // ToolUIs (e.g. ClarifyToolUI for adk_request_input) render their
       // input form instead of falling through to the completed branch.
+      // `hasHitl` intentionally narrow: only fires when HITL is the SOLE
+      // reason `isFinalResponse` returned true. If `skipSummarization` is
+      // ALSO set, let the skipSummarization contract win and assign a
+      // manual "complete" status — don't silently override it.
+      // `hasHitl` intentionally narrow: only fires when HITL is the SOLE
+      // reason `isFinalResponse` returned true. If `skipSummarization` is
+      // ALSO set, let the skipSummarization contract win and assign a
+      // manual "complete" status — don't silently override it.
       const hasHitl =
-        event.longRunningToolIds && event.longRunningToolIds.length > 0;
+        event.longRunningToolIds &&
+        event.longRunningToolIds.length > 0 &&
+        !event.actions?.skipSummarization;
       if (msg && msg.type === "ai" && !msg.status && !hasHitl) {
         const status = finishReasonToStatus(event.finishReason);
         const updated: InProgressMessage = {

--- a/packages/react-google-adk/src/AdkEventAccumulator.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.ts
@@ -341,7 +341,16 @@ export class AdkEventAccumulator {
     // Check isFinalResponse (can be true even for partial events via skipSummarization/longRunningToolIds)
     if (isFinalResponse(event) && this.currentMessageId) {
       const msg = this.messagesMap.get(this.currentMessageId);
-      if (msg && msg.type === "ai" && !msg.status) {
+      // HITL fix: if the event is "final" only because it carries
+      // longRunningToolIds, do NOT assign a manual "complete" status —
+      // the message has an unresolved tool call that must stay pending
+      // so external-message-converter can apply AUTO_STATUS_PENDING
+      // ({type:"requires-action"}). This is what makes makeAssistantToolUI
+      // ToolUIs (e.g. ClarifyToolUI for adk_request_input) render their
+      // input form instead of falling through to the completed branch.
+      const hasHitl =
+        event.longRunningToolIds && event.longRunningToolIds.length > 0;
+      if (msg && msg.type === "ai" && !msg.status && !hasHitl) {
         const status = finishReasonToStatus(event.finishReason);
         const updated: InProgressMessage = {
           ...msg,

--- a/packages/react-google-adk/src/AdkEventAccumulator.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.ts
@@ -341,26 +341,13 @@ export class AdkEventAccumulator {
     // Check isFinalResponse (can be true even for partial events via skipSummarization/longRunningToolIds)
     if (isFinalResponse(event) && this.currentMessageId) {
       const msg = this.messagesMap.get(this.currentMessageId);
-      // HITL fix: if the event is "final" only because it carries
-      // longRunningToolIds, do NOT assign a manual "complete" status —
-      // the message has an unresolved tool call that must stay pending
-      // so external-message-converter can apply AUTO_STATUS_PENDING
-      // ({type:"requires-action"}). This is what makes makeAssistantToolUI
-      // ToolUIs (e.g. ClarifyToolUI for adk_request_input) render their
-      // input form instead of falling through to the completed branch.
-      // `hasHitl` intentionally narrow: only fires when HITL is the SOLE
-      // reason `isFinalResponse` returned true. If `skipSummarization` is
-      // ALSO set, let the skipSummarization contract win and assign a
-      // manual "complete" status — don't silently override it.
-      // `hasHitl` intentionally narrow: only fires when HITL is the SOLE
-      // reason `isFinalResponse` returned true. If `skipSummarization` is
-      // ALSO set, let the skipSummarization contract win and assign a
-      // manual "complete" status — don't silently override it.
-      const hasHitl =
+      // Skip manual "complete" when longRunningToolIds is the sole reason for
+      // isFinalResponse — let auto-status apply requires-action for pending tool calls.
+      const isHitlOnly =
         event.longRunningToolIds &&
         event.longRunningToolIds.length > 0 &&
         !event.actions?.skipSummarization;
-      if (msg && msg.type === "ai" && !msg.status && !hasHitl) {
+      if (msg && msg.type === "ai" && !msg.status && !isHitlOnly) {
         const status = finishReasonToStatus(event.finishReason);
         const updated: InProgressMessage = {
           ...msg,


### PR DESCRIPTION
## TL;DR

`AdkEventAccumulator.processEvent` assigns a manual `{type: "complete", reason: "stop"}` status to the AI message carrying a HITL `adk_request_input` tool call. That manual status blocks `external-message-converter`'s auto-status logic from ever promoting the message to `{type: "requires-action", reason: "tool-calls"}`. The result is that any `makeAssistantToolUI` ToolUI registered for `adk_request_input` (or the other `ADK_REQUEST_*` HITL tools) receives `status.type === "complete"` in its `render` props — so any `if (status.type === "requires-action") { show form }` branch is dead code. The HITL form never renders; the user has no way to submit their answer through `useAdkSubmitInput`; the agent workflow stays blocked at the interrupt.

The fix is a 3-line guard: don't stamp manual "complete" on events that are "final" *only* because they carry `longRunningToolIds`. Non-HITL paths are untouched.

## Is this impactful?

**Yes — this silently breaks every production HITL flow that uses a custom ToolUI to collect user input.**

- Any app using `useAdkRuntime` + `makeAssistantToolUI` to render an input form for `adk_request_input` (the idiomatic HITL pattern) is affected.
- The symptom is deceptive: the question text *does* render (via the fallback branch in consumers' ToolUI render), so the UI looks partially functional. Only when users try to respond does the HITL path fall back to plain text → main composer → stuck workflow.
- PR #3800 (already merged) protected HITL tool calls from being auto-cancelled on the *next* turn. This PR addresses an earlier bug in the same codepath: the HITL form never even rendered in the first place because of the manual-status clobber. The two fixes are complementary.
- Discovered while shipping a production custom ADK API server downstream (see [`mitawire_sse_server`](https://github.com/surfai/a2uichart) + `front_door` agent). E2E verified against a live Google ADK backend.

## Reproduction

### Minimal unit test that fails on `main`, passes after the fix

Included as part of this PR in `packages/react-google-adk/src/AdkEventAccumulator.test.ts` under `describe("AdkEventAccumulator - HITL requires-action", ...)`. The load-bearing assertion:

```ts
const HITL_EVENT = {
  id: "8700bf9d-4673-46ff-a28e-36f5e7927123",
  invocationId: "e-3888c670-4bbb-4c90-9e3a-17d7dc47e4a8",
  author: "FrontDoorWorkflow",
  longRunningToolIds: ["15e1abeb-aaf9-4e43-a55f-3a5ca10d810c"],
  content: {
    parts: [
      {
        functionCall: {
          id: "15e1abeb-aaf9-4e43-a55f-3a5ca10d810c",
          name: "adk_request_input",
          args: { interrupt_id: "15e1abeb-...", message: "What's the forecast period?" },
        },
      },
    ],
  },
};

it("HITL event produces an AI message with the tool call and NO manual status", () => {
  const acc = new AdkEventAccumulator();
  const msgs = acc.processEvent(HITL_EVENT);
  const aiMsg = msgs[0] as AdkMessage & { type: "ai" };

  expect(aiMsg.tool_calls).toHaveLength(1);
  expect(aiMsg.tool_calls![0]!.id).toBe("15e1abeb-aaf9-4e43-a55f-3a5ca10d810c");
  expect(aiMsg.status).toBeUndefined(); // fails on main: gets {type:"complete",reason:"stop"}
});
```

Wire shape captured from a real Google ADK backend run (a `FrontDoorWorkflow` with a `clarify_hitl` `FunctionNode` yielding `RequestInput(message=...)`). All field names are camelCase as emitted by `Event.model_dump_json(by_alias=True, exclude_none=True)`.

### Live reproduction

1. Any ADK `FunctionNode` that yields `RequestInput(message="...")` — ADK emits an `adk_request_input` FunctionCall with `longRunningToolIds` populated.
2. Register `makeAssistantToolUI({ toolName: "adk_request_input", render: ({status, toolCallId, args}) => status.type === "requires-action" ? <Form/> : <StaticText/> })` in the frontend.
3. Drive the agent through a route that triggers the HITL node.
4. **Before fix**: the question text renders via the static-text fallback. The form never appears. Typing in the main composer sends a plain text event; the backend workflow stays blocked at the interrupt.
5. **After fix**: the form renders. `useAdkSubmitInput(toolCallId, text)` packages the answer as a `FunctionResponse`; the backend resumes correctly.

## Root cause — line-by-line trace

### Link 1: `isFinalResponse` treats HITL events as terminal

`packages/react-google-adk/src/AdkEventAccumulator.ts` lines 7–19:

```ts
export const isFinalResponse = (event: AdkEvent): boolean => {
  if (
    event.actions?.skipSummarization ||
    (event.longRunningToolIds && event.longRunningToolIds.length > 0)
  ) {
    return true;    // HITL interrupt events hit this branch
  }
  /* ... */
};
```

This matches ADK Python's own `Event.is_final_response()` semantics — an event with `long_running_tool_ids` is "final" because no further partial text deltas will follow. Returning `true` here is correct.

### Link 2: `processEvent` then stamps a manual "complete" status

`packages/react-google-adk/src/AdkEventAccumulator.ts` lines 342–356 (BEFORE the fix):

```ts
if (isFinalResponse(event) && this.currentMessageId) {
  const msg = this.messagesMap.get(this.currentMessageId);
  if (msg && msg.type === "ai" && !msg.status) {
    const status = finishReasonToStatus(event.finishReason);  // undefined → {type:"complete",reason:"stop"}
    const updated: InProgressMessage = {
      ...msg,
      content: [...this.getContentArray(msg)],
      status,
    };
    this.messagesMap.set(updated.id, updated);
  }
}
```

A HITL interrupt event has no `finishReason` (it's emitted by a `FunctionNode`/`RequestInput`, not by an LLM stop). So `finishReasonToStatus(undefined)` falls through to its default branch and returns `{type: "complete", reason: "stop"}` — a plain object **without** the `symbolAutoStatus` marker. It is a **manual** status from `@assistant-ui/core`'s perspective.

### Link 3: `external-message-converter` refuses to overwrite manual status

`packages/core/src/react/runtimes/external-message-converter.ts`:

```ts
const hasPendingToolCalls = typeof joined.content === "object" &&
  joined.content.some((c) => c.type === "tool-call" && c.result === undefined);
const autoStatus = getAutoStatus(isLast, isRunning, hasSuspendedToolCalls, hasPendingToolCalls, ...);
if (
  cache &&
  (cache.role !== "assistant" ||
    !isAutoStatus(cache.status) ||   // manual "complete" is NOT auto → short-circuit
    cache.status === autoStatus)
) {
  return cached;    // cache returned unchanged, AUTO_STATUS_PENDING discarded
}
```

With `hasPendingToolCalls = true` (the tool-call part has `result === undefined`), `getAutoStatus(...)` **would** return `AUTO_STATUS_PENDING = {type: "requires-action", reason: "tool-calls", [symbolAutoStatus]: true}`. But the cached message carries the manual "complete" status from Link 2, so `!isAutoStatus(cache.status)` is true, the `if` short-circuits, and the cached message is returned unchanged.

### Net effect

The AI message holding the `adk_request_input` tool call ends up with permanent `status: {type: "complete", reason: "stop"}`, which propagates to the tool-call part. `makeAssistantToolUI.render({status})` receives `status.type === "complete"` instead of `"requires-action"` and any HITL form branch is dead code.

## The fix

Add a `hasHitl` guard in `processEvent` so events that are "final" only because they carry `longRunningToolIds` do NOT get a manual status assigned. Auto-status in the converter then correctly promotes the message to `requires-action`.

```diff
 if (isFinalResponse(event) && this.currentMessageId) {
   const msg = this.messagesMap.get(this.currentMessageId);
-  if (msg && msg.type === "ai" && !msg.status) {
+  // HITL fix: if the event is "final" only because it carries
+  // longRunningToolIds, do NOT assign a manual "complete" status —
+  // the message has an unresolved tool call that must stay pending
+  // so external-message-converter can apply AUTO_STATUS_PENDING
+  // ({type:"requires-action"}). This is what makes makeAssistantToolUI
+  // ToolUIs (e.g. ClarifyToolUI for adk_request_input) render their
+  // input form instead of falling through to the completed branch.
+  const hasHitl =
+    event.longRunningToolIds && event.longRunningToolIds.length > 0;
+  if (msg && msg.type === "ai" && !msg.status && !hasHitl) {
     const status = finishReasonToStatus(event.finishReason);
     const updated: InProgressMessage = {
       ...msg,
       content: [...this.getContentArray(msg)],
       status,
     };
     this.messagesMap.set(updated.id, updated);
   }
 }
```

The `!event.partial || isFinalResponse(event)` finalize-message call on the next line is intentionally unchanged — finalizing just nulls `currentMessageId` so the next event starts a new AI message, which is correct behavior for a HITL interrupt.

## Scope of the change

- **1 source file** modified (`AdkEventAccumulator.ts`): +10 / -1
- **1 test file** modified (`AdkEventAccumulator.test.ts`): +140 / -1
- **1 changeset** added (`fix-adk-hitl-requires-action-status.md`)
- **No public API changes, no type changes**

## Regression surface

For non-HITL events (`longRunningToolIds` absent or empty), `hasHitl === false`, so the original code path runs unchanged:

- LLM stop events → `finishReasonToStatus(finishReason)` → manual status ("complete", "incomplete/length", "incomplete/content-filter", etc.)
- The manual status still prevents spurious status flips from auto-status on subsequent message updates
- Existing tests for non-HITL flows (stop reason, content filters, errors, `skipSummarization`) are unaffected

Two explicit regression-guard tests are included (`"non-HITL final event still gets manual 'complete' status"` and `"skipSummarization final event still gets manual 'complete' status"`).

## Tests

- Full package test suite: **156/156 passing** (`pnpm test` in `packages/react-google-adk`)
- Target file: **53/53 passing** including 5 new HITL cases and 2 regression guards
- Biome: clean (`pnpm exec biome check` on the two changed files)
- **Sanity-checked**: reverting the `&& !hasHitl` guard causes exactly 3 of the new HITL tests to fail with `expected {type: "complete", reason: "stop"} to be undefined`, confirming the tests actually gate the fix

## Related

- #3800 — protected HITL tool calls from auto-cancellation on the *next* turn (already merged, complementary to this fix)
- #3784 — ADK accumulator user-message fix (unrelated, already merged)
- The existing `"marks as final when longRunningToolIds is non-empty"` test at `AdkEventAccumulator.test.ts:402` previously asserted the buggy `status: {type: "complete"}` behavior. Updated in this PR to assert `status === undefined`, with a comment explaining why.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>