### PR TITLE
fix(react-ag-ui): preserve user message attachments in AG-UI conversion

### DIFF
--- a/.changeset/fix-ag-ui-user-attachments.md
+++ b/.changeset/fix-ag-ui-user-attachments.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix(react-ag-ui): preserve user message attachments when converting to AG-UI format
+
+- `toAgUiMessages()` previously called `extractText()` for user messages, silently dropping image and file attachments
+- User messages with attachments now emit AG-UI `InputContent[]`: images map to the `image` variant with a `data` or `url` source, files map to the `binary` variant preserving `filename`
+- Falls back to plain string `content` when no binary parts are present, preserving backward compatibility

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -211,6 +211,8 @@ function toInputContent(
 }
 
 function buildUserContent(message: ThreadMessageLike): string | InputContent[] {
+  // File parts in message.content are intentionally skipped: the canonical
+  // binary payload for files always flows through message.attachments.
   const contentParts = Array.isArray(message.content)
     ? message.content.filter(
         (part) => !(isObject(part) && part["type"] === "file"),
@@ -220,6 +222,13 @@ function buildUserContent(message: ThreadMessageLike): string | InputContent[] {
   const attachments = message.attachments ?? [];
 
   const converted: InputContent[] = [];
+
+  // Promote string-form content to a leading text part so it survives when
+  // non-text attachments are present (fromAgUiMessages emits string content).
+  if (typeof message.content === "string" && message.content.length > 0) {
+    converted.push({ type: "text", text: message.content });
+  }
+
   for (const part of contentParts) {
     const input = toInputContent(part, undefined);
     if (input) converted.push(input);
@@ -236,10 +245,14 @@ function buildUserContent(message: ThreadMessageLike): string | InputContent[] {
   }
 
   const hasNonText = converted.some((part) => part.type !== "text");
-  if (!hasNonText) {
-    return extractText(message.content);
-  }
-  return converted;
+  if (hasNonText) return converted;
+
+  // All-text path: collapse to plain string. Join text parts collected from
+  // both content and attachments so attachment-sourced text is not dropped.
+  if (converted.length === 0) return extractText(message.content);
+  return converted
+    .map((part) => (part as { type: "text"; text: string }).text)
+    .join("\n");
 }
 
 function toToolCallPart(value: unknown): ToolCallPart | null {

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -1,6 +1,9 @@
 "use client";
 
+import type { InputContent } from "@ag-ui/client";
 import { type Tool, toToolsJSONSchema } from "assistant-stream";
+
+export type { InputContent };
 
 type AttachmentLike = {
   name?: string | undefined;
@@ -23,25 +26,6 @@ type AgUiToolCall = {
   type: "function";
   function: { name: string; arguments: string };
 };
-
-type InputContentSource =
-  | { type: "data"; value: string; mimeType: string }
-  | { type: "url"; value: string; mimeType?: string };
-
-export type InputContent =
-  | { type: "text"; text: string }
-  | { type: "image"; source: InputContentSource }
-  | { type: "audio"; source: InputContentSource }
-  | { type: "video"; source: InputContentSource }
-  | { type: "document"; source: InputContentSource }
-  | {
-      type: "binary";
-      mimeType: string;
-      id?: string;
-      url?: string;
-      data?: string;
-      filename?: string;
-    };
 
 export type AgUiMessage =
   | {

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -235,7 +235,10 @@ function buildUserContent(message: ThreadMessageLike): string | InputContent[] {
   // both content and attachments so attachment-sourced text is not dropped.
   if (converted.length === 0) return extractText(message.content);
   return converted
-    .map((part) => (part as { type: "text"; text: string }).text)
+    .filter(
+      (part): part is { type: "text"; text: string } => part.type === "text",
+    )
+    .map((part) => part.text)
     .join("\n");
 }
 

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -2,6 +2,12 @@
 
 import { type Tool, toToolsJSONSchema } from "assistant-stream";
 
+type AttachmentLike = {
+  name?: string | undefined;
+  contentType?: string | undefined;
+  content?: readonly unknown[] | undefined;
+};
+
 type ThreadMessageLike = {
   id: string;
   role: string;
@@ -9,6 +15,7 @@ type ThreadMessageLike = {
   name?: string;
   toolCallId?: string;
   error?: string;
+  attachments?: readonly AttachmentLike[];
 };
 
 type AgUiToolCall = {
@@ -17,11 +24,30 @@ type AgUiToolCall = {
   function: { name: string; arguments: string };
 };
 
+type InputContentSource =
+  | { type: "data"; value: string; mimeType: string }
+  | { type: "url"; value: string; mimeType?: string };
+
+export type InputContent =
+  | { type: "text"; text: string }
+  | { type: "image"; source: InputContentSource }
+  | { type: "audio"; source: InputContentSource }
+  | { type: "video"; source: InputContentSource }
+  | { type: "document"; source: InputContentSource }
+  | {
+      type: "binary";
+      mimeType: string;
+      id?: string;
+      url?: string;
+      data?: string;
+      filename?: string;
+    };
+
 export type AgUiMessage =
   | {
       id: string;
       role: string;
-      content: string;
+      content: string | InputContent[];
       name?: string;
       toolCalls?: AgUiToolCall[];
     }
@@ -105,6 +131,115 @@ function extractText(content: unknown): string {
     )
     .map((part) => part.text)
     .join("\n");
+}
+
+function parseDataUrl(
+  value: string,
+): { mimeType: string; data: string } | null {
+  const match = value.match(/^data:([^;,]+)(?:;[^;,]+)*;base64,(.+)$/);
+  if (!match) return null;
+  return { mimeType: match[1]!, data: match[2]! };
+}
+
+const httpUrlPattern = /^https?:\/\//i;
+
+function toInputContent(
+  part: unknown,
+  fallbackMimeType: string | undefined,
+): InputContent | null {
+  if (!isObject(part)) return null;
+  const type = getString(part, "type");
+
+  if (type === "text") {
+    const text = getString(part, "text");
+    if (text === undefined) return null;
+    return { type: "text", text };
+  }
+
+  if (type === "image") {
+    const image = getString(part, "image");
+    if (image === undefined) return null;
+    const parsed = parseDataUrl(image);
+    if (parsed) {
+      return {
+        type: "image",
+        source: {
+          type: "data",
+          value: parsed.data,
+          mimeType: parsed.mimeType,
+        },
+      };
+    }
+    return {
+      type: "image",
+      source: {
+        type: "url",
+        value: image,
+        ...(fallbackMimeType !== undefined
+          ? { mimeType: fallbackMimeType }
+          : {}),
+      },
+    };
+  }
+
+  if (type === "file") {
+    const data = getString(part, "data");
+    if (data === undefined) return null;
+    const partMimeType = getString(part, "mimeType");
+    const filename = getString(part, "filename");
+    const mimeType =
+      partMimeType || fallbackMimeType || "application/octet-stream";
+
+    if (httpUrlPattern.test(data)) {
+      return {
+        type: "binary",
+        mimeType,
+        url: data,
+        ...(filename !== undefined ? { filename } : {}),
+      };
+    }
+    const parsed = parseDataUrl(data);
+    return {
+      type: "binary",
+      mimeType: parsed?.mimeType ?? mimeType,
+      data: parsed?.data ?? data,
+      ...(filename !== undefined ? { filename } : {}),
+    };
+  }
+
+  return null;
+}
+
+function buildUserContent(message: ThreadMessageLike): string | InputContent[] {
+  const contentParts = Array.isArray(message.content)
+    ? message.content.filter(
+        (part) => !(isObject(part) && part["type"] === "file"),
+      )
+    : [];
+
+  const attachments = message.attachments ?? [];
+
+  const converted: InputContent[] = [];
+  for (const part of contentParts) {
+    const input = toInputContent(part, undefined);
+    if (input) converted.push(input);
+  }
+  for (const attachment of attachments) {
+    if (!isObject(attachment)) continue;
+    const attachmentContent = attachment["content"];
+    if (!Array.isArray(attachmentContent)) continue;
+    const fallbackMime = getString(attachment, "contentType");
+    for (const part of attachmentContent) {
+      const input = toInputContent(part, fallbackMime);
+      if (input) converted.push(input);
+    }
+  }
+
+  const hasNonText = converted.some((part) => part.type !== "text");
+  if (!hasNonText) {
+    return extractText(message.content);
+  }
+  return converted;
 }
 
 function toToolCallPart(value: unknown): ToolCallPart | null {
@@ -415,7 +550,10 @@ export function toAgUiMessages(
     const genericMessage: AgUiMessage = {
       id: message.id,
       role: message.role,
-      content: extractText(message.content),
+      content:
+        message.role === "user"
+          ? buildUserContent(message)
+          : extractText(message.content),
     };
     if (message.name) {
       genericMessage.name = message.name;

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -450,6 +450,73 @@ describe("adapter conversions", () => {
     expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
   });
 
+  it("preserves string-form content when non-text attachments are present", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: "What is in this image?",
+        attachments: [
+          {
+            id: "a-1",
+            type: "image",
+            name: "photo.png",
+            content: [
+              {
+                type: "image",
+                image: "data:image/png;base64,AAAA",
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "What is in this image?" },
+        {
+          type: "image",
+          source: {
+            type: "data",
+            value: "AAAA",
+            mimeType: "image/png",
+          },
+        },
+      ],
+    });
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
+  it("preserves text parts from attachments in the string fallback", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [{ type: "text", text: "hi" }],
+        attachments: [
+          {
+            id: "a-1",
+            type: "document",
+            name: "notes.txt",
+            content: [
+              {
+                type: "text",
+                text: "<attachment name=notes.txt>extracted content</attachment>",
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]!.content).toBe(
+      "hi\n<attachment name=notes.txt>extracted content</attachment>",
+    );
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
   it("parses data URL with charset parameter (e.g. SVG)", () => {
     const result = toAgUiMessages([
       {

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
+import { UserMessageSchema } from "@ag-ui/client";
 import {
   fromAgUiMessages,
   toAgUiMessages,
@@ -278,5 +279,252 @@ describe("adapter conversions", () => {
     // Ensure it's not a Zod instance (no Zod methods)
     expect(tools[0]!.parameters).not.toHaveProperty("parse");
     expect(tools[0]!.parameters).not.toHaveProperty("_def");
+  });
+
+  it("returns plain string content when user message has no attachments", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [{ type: "text", text: "Hello" }],
+      },
+    ] as any);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ role: "user", content: "Hello" });
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
+  it("converts image attachment with data URL to AG-UI image source", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [{ type: "text", text: "What is this?" }],
+        attachments: [
+          {
+            id: "a-1",
+            type: "image",
+            name: "photo.png",
+            content: [
+              {
+                type: "image",
+                image: "data:image/png;base64,iVBORw0KGgoAAAA=",
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "What is this?" },
+        {
+          type: "image",
+          source: {
+            type: "data",
+            value: "iVBORw0KGgoAAAA=",
+            mimeType: "image/png",
+          },
+        },
+      ],
+    });
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
+  it("converts image attachment with http URL to AG-UI image url source", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [{ type: "text", text: "hi" }],
+        attachments: [
+          {
+            id: "a-1",
+            type: "image",
+            name: "remote.jpg",
+            contentType: "image/jpeg",
+            content: [
+              { type: "image", image: "https://example.com/remote.jpg" },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "hi" },
+        {
+          type: "image",
+          source: {
+            type: "url",
+            value: "https://example.com/remote.jpg",
+            mimeType: "image/jpeg",
+          },
+        },
+      ],
+    });
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
+  it("converts file attachment to AG-UI binary with filename preserved", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [{ type: "text", text: "review this" }],
+        attachments: [
+          {
+            id: "a-1",
+            type: "document",
+            name: "spec.pdf",
+            contentType: "application/pdf",
+            content: [
+              {
+                type: "file",
+                data: "JVBERi0xLjQK",
+                mimeType: "application/pdf",
+                filename: "spec.pdf",
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "review this" },
+        {
+          type: "binary",
+          mimeType: "application/pdf",
+          data: "JVBERi0xLjQK",
+          filename: "spec.pdf",
+        },
+      ],
+    });
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
+  it("handles user message with only attachment and empty text", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [],
+        attachments: [
+          {
+            id: "a-1",
+            type: "image",
+            name: "pic.png",
+            content: [
+              {
+                type: "image",
+                image: "data:image/png;base64,AAAA",
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "image",
+          source: {
+            type: "data",
+            value: "AAAA",
+            mimeType: "image/png",
+          },
+        },
+      ],
+    });
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
+  it("parses data URL with charset parameter (e.g. SVG)", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [],
+        attachments: [
+          {
+            id: "a-1",
+            type: "image",
+            name: "icon.svg",
+            content: [
+              {
+                type: "image",
+                image:
+                  "data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0=",
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "image",
+          source: {
+            type: "data",
+            value: "PHN2ZyB4bWxucz0=",
+            mimeType: "image/svg+xml",
+          },
+        },
+      ],
+    });
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
+  it("routes http file data to binary.url not binary.data", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [],
+        attachments: [
+          {
+            id: "a-1",
+            type: "file",
+            name: "report.pdf",
+            content: [
+              {
+                type: "file",
+                data: "https://cdn.example.com/report.pdf",
+                mimeType: "application/pdf",
+                filename: "report.pdf",
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "binary",
+          mimeType: "application/pdf",
+          url: "https://cdn.example.com/report.pdf",
+          filename: "report.pdf",
+        },
+      ],
+    });
+    expect((result[0] as any).content[0]).not.toHaveProperty("data");
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- Fix #3810: `toAgUiMessages()` previously called `extractText()` on user messages, silently dropping image and file attachments before they reached the AG-UI backend.
- User messages with attachments now emit `InputContent[]`: images map to the `image` variant with `source: { type: "data" | "url", value, mimeType }`, files map to the `binary` variant preserving `filename`.
- `AgUiMessage.content` widened to `string | InputContent[]`; `ThreadMessageLike` stub extended with `attachments?` field; plain string is still returned when no binary parts are present (backward compatible).
- Data URL parsing handles optional params like `charset=utf-8` (common with SVG); mimeType fallback chain is robust against empty strings.
- Adds 7 test cases covering data URL images, http URL images, file attachments, attachment-only messages, binary.url vs binary.data routing, and SVG with charset — each validated against `@ag-ui/client` `UserMessageSchema`.

## Test plan
- [x] `pnpm --filter=@assistant-ui/react-ag-ui test` — 57/57 passing
- [x] `npx tsc --noEmit` — strict + `exactOptionalPropertyTypes` clean
- [x] `pnpm lint` — no new warnings/errors
- [x] Backward compat: text-only user messages still emit `content: string`
- [x] Every new test validates output against AG-UI Zod `UserMessageSchema.parse()`
- [ ] Verify end-to-end against a real AG-UI backend (e.g. Microsoft Agent Framework `MapAGUI()`) that a user can send an image and the backend receives the binary payload