### PR TITLE
fix(cli): detect package manager from user agent

### DIFF
--- a/.changeset/fix-cli-package-manager-detection.md
+++ b/.changeset/fix-cli-package-manager-detection.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix(cli): detect package manager from npm_config_user_agent before falling back to detect-package-manager

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -384,7 +384,7 @@ export function resolveCreateProjectDirectory(params: {
   return undefined;
 }
 
-function resolvePackageManager(opts: {
+export function resolvePackageManager(opts: {
   useNpm?: boolean;
   usePnpm?: boolean;
   useYarn?: boolean;

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -155,8 +155,11 @@ export const init = new Command()
     }
 
     try {
+      // resolvePackageManagerName calls detect({ cwd: path.dirname(dir) }),
+      // which is designed for `create` where the dir doesn't exist yet.
+      // For init, targetDir IS the project root, so append a dummy segment.
       const pm = await resolvePackageManagerName(
-        targetDir,
+        path.join(targetDir, "_"),
         resolvePackageManager(opts),
       );
       const [dlxCmd, dlxArgs] = dlxCommand(pm);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,10 +2,7 @@ import { Command, Option } from "commander";
 import { spawn } from "cross-spawn";
 import fs from "node:fs";
 import path from "node:path";
-import {
-  dlxCommand,
-  resolvePackageManagerName,
-} from "../lib/create-project";
+import { dlxCommand, resolvePackageManagerName } from "../lib/create-project";
 import { logger } from "../lib/utils/logger";
 import { create, resolvePackageManager } from "./create";
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,8 +2,12 @@ import { Command, Option } from "commander";
 import { spawn } from "cross-spawn";
 import fs from "node:fs";
 import path from "node:path";
+import {
+  dlxCommand,
+  resolvePackageManagerName,
+} from "../lib/create-project";
 import { logger } from "../lib/utils/logger";
-import { create } from "./create";
+import { create, resolvePackageManager } from "./create";
 
 const DEFAULT_REGISTRY_URL =
   "https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json";
@@ -151,6 +155,12 @@ export const init = new Command()
     }
 
     try {
+      const pm = await resolvePackageManagerName(
+        targetDir,
+        resolvePackageManager(opts),
+      );
+      const [dlxCmd, dlxArgs] = dlxCommand(pm);
+
       const { initArgs, addArgs } = createExistingProjectInitPlan({
         yes: opts.yes,
         overwrite: opts.overwrite,
@@ -158,9 +168,9 @@ export const init = new Command()
       });
 
       if (initArgs) {
-        await runSpawn("npx", initArgs, targetDir);
+        await runSpawn(dlxCmd, [...dlxArgs, ...initArgs], targetDir);
       }
-      await runSpawn("npx", addArgs, targetDir);
+      await runSpawn(dlxCmd, [...dlxArgs, ...addArgs], targetDir);
 
       logger.break();
       logger.success("Project initialized successfully!");

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -89,11 +89,23 @@ export async function downloadProject(
   }
 }
 
+function detectFromUserAgent(): PackageManagerName | undefined {
+  const ua = process.env.npm_config_user_agent;
+  if (!ua) return undefined;
+  if (ua.startsWith("bun/")) return "bun";
+  if (ua.startsWith("pnpm/")) return "pnpm";
+  if (ua.startsWith("yarn/")) return "yarn";
+  if (ua.startsWith("npm/")) return "npm";
+  return undefined;
+}
+
 export async function resolvePackageManagerName(
   projectDir: string,
   packageManager?: PackageManagerName,
 ): Promise<PackageManagerName> {
   if (packageManager) return packageManager;
+  const fromAgent = detectFromUserAgent();
+  if (fromAgent) return fromAgent;
   try {
     return await detect({ cwd: path.dirname(projectDir) });
   } catch {


### PR DESCRIPTION
## Summary
- Checks `npm_config_user_agent` env var before falling back to `detect-package-manager` library, so `bunx create-assistant-ui` correctly uses bun (instead of picking yarn/npm from global installs)
- Fixes `init` command which hardcoded `npx` — now uses the detected package manager's dlx equivalent
- Exports `resolvePackageManager` from create.ts for reuse in init.ts

## Test plan
- [x] `pnpm --filter assistant-ui test` — all 153 tests pass
- [x] Type check passes
- [ ] Verify `bunx create-assistant-ui` uses bun
- [ ] Verify `npx create-assistant-ui` uses npm
- [ ] Verify `pnpm dlx create-assistant-ui` uses pnpm

🤖 Generated with [Claude Code](https://claude.com/claude-code)