### PR TITLE
refactor: split tsconfig into browser and node bases

### DIFF
--- a/packages/agent-launcher/tsconfig.json
+++ b/packages/agent-launcher/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "extends": "@assistant-ui/x-buildutils/ts/base-node",
   "include": ["src"]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "extends": "@assistant-ui/x-buildutils/ts/base-node",
   "include": ["src"]
 }

--- a/packages/cloud/src/tests/setup.ts
+++ b/packages/cloud/src/tests/setup.ts
@@ -1,11 +1,11 @@
 // This file contains setup code for tests
 import { vi } from "vitest";
 
-// Set up global mocks if needed
+// Set up globalThis mocks if needed
 // Using a fixed date to avoid recursive calls
-const OriginalDate = global.Date;
+const OriginalDate = globalThis.Date;
 const fixedDate = new OriginalDate("2023-01-01");
-global.Date = vi.fn(() => fixedDate) as any;
-global.Date.now = vi.fn(() => fixedDate.getTime());
+globalThis.Date = vi.fn(() => fixedDate) as any;
+globalThis.Date.now = vi.fn(() => fixedDate.getTime());
 
-// Add any other global setup needed for tests
+// Add any other globalThis setup needed for tests

--- a/packages/create-assistant-ui/tsconfig.json
+++ b/packages/create-assistant-ui/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "extends": "@assistant-ui/x-buildutils/ts/base-node",
   "include": ["src"]
 }

--- a/packages/mcp-app-studio/tsconfig.json
+++ b/packages/mcp-app-studio/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "extends": "@assistant-ui/x-buildutils/ts/base-node",
   "include": ["src"]
 }

--- a/packages/mcp-docs-server/tsconfig.json
+++ b/packages/mcp-docs-server/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "extends": "@assistant-ui/x-buildutils/ts/base-node",
   "include": ["src"]
 }

--- a/packages/x-buildutils/package.json
+++ b/packages/x-buildutils/package.json
@@ -15,7 +15,8 @@
   "files": [
     "bin",
     "src",
-    "ts"
+    "ts",
+    "types"
   ],
   "bin": {
     "aui-build": "./bin/aui-build.js"

--- a/packages/x-buildutils/ts/base-node.json
+++ b/packages/x-buildutils/ts/base-node.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "types": ["node", "browser-process"]
+  }
+}

--- a/packages/x-buildutils/ts/base.json
+++ b/packages/x-buildutils/ts/base.json
@@ -2,6 +2,12 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@tsconfig/strictest/tsconfig.json",
   "compilerOptions": {
+    "typeRoots": [
+      "${configDir}/node_modules/@types",
+      "${configDir}/../../node_modules/@types",
+      "${configDir}/node_modules/@assistant-ui/x-buildutils/types"
+    ],
+    "types": ["browser-process"],
     "moduleResolution": "bundler",
     "target": "ESNext",
     "module": "ESNext",
@@ -9,7 +15,6 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "lib": ["dom", "dom.iterable", "ES2023"],
-    "types": ["node"],
     "stripInternal": true,
     "noPropertyAccessFromIndexSignature": false
   }

--- a/packages/x-buildutils/tsconfig.json
+++ b/packages/x-buildutils/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "./ts/base",
+  "extends": "./ts/base-node",
   "include": ["src", "bin"]
 }

--- a/packages/x-buildutils/types/browser-process/index.d.ts
+++ b/packages/x-buildutils/types/browser-process/index.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Minimal ambient declaration for `process` in browser packages.
+ * Bundlers like webpack/vite replace `process.env.NODE_ENV` at build time.
+ * This avoids pulling in the full @types/node dependency.
+ */
+declare const process: { env: Record<string, string | undefined> };


### PR DESCRIPTION
## Summary
- Split `base.json` into browser-safe `base.json` and Node.js `base-node.json` to prevent `@types/node` globals leaking into browser packages
- Browser packages get a minimal `process` ambient type via `browser-process` typeRoots entry (only `process.env` for bundler-replaced values)
- Node packages (`cli`, `mcp-docs-server`, `mcp-app-studio`, `agent-launcher`, `create-assistant-ui`, `x-buildutils`) use `base-node.json` with full `@types/node`
- Replace `global` with `globalThis` in `assistant-cloud` test setup

## Test plan
- [x] All 32 packages build successfully
- [x] All 35 test suites pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)