### PR TITLE
chore: re-enable 8 biome lint rules

### DIFF
--- a/apps/devtools-extension/content.ts
+++ b/apps/devtools-extension/content.ts
@@ -1,13 +1,13 @@
 // Content script - runs in isolated context
 // Bridges communication between the page (inject script) and the extension (background/devtools)
 
-(function () {
+(() => {
   console.log("[assistant-ui DevTools] Content script loaded");
 
   // Inject the inject.js script into the page context
   const script = document.createElement("script");
   script.src = chrome.runtime.getURL("inject.js");
-  script.onload = function () {
+  script.onload = () => {
     script.remove();
   };
   (document.head || document.documentElement).appendChild(script);

--- a/apps/devtools-extension/inject.ts
+++ b/apps/devtools-extension/inject.ts
@@ -3,7 +3,7 @@
 
 import { ExtensionHost } from "@assistant-ui/react-devtools";
 
-(function () {
+(() => {
   let extensionHost: ExtensionHost | undefined;
 
   // Function to check for assistant-ui and initialize ExtensionHost

--- a/apps/docs/lib/docs-toolkit.tsx
+++ b/apps/docs/lib/docs-toolkit.tsx
@@ -46,7 +46,7 @@ const geocodeLocationTool = {
       );
     }
 
-    const { name, latitude, longitude } = result?.result;
+    const { name, latitude, longitude } = result.result;
     return (
       <ToolCard>
         <ToolCardIcon>

--- a/biome.json
+++ b/biome.json
@@ -27,10 +27,8 @@
       "suspicious": {
         "noExplicitAny": "off",
         "noArrayIndexKey": "off",
-        "noEmptyInterface": "off",
         "useIterableCallbackReturn": "off",
         "noThenProperty": "off",
-        "noConfusingVoidType": "off",
         "noImplicitAnyLet": "off",
         "noAssignInExpressions": "off",
         "noRedeclare": "off",
@@ -40,8 +38,6 @@
             "allowedLabels": ["DEV"]
           }
         },
-        "noDoubleEquals": "off",
-        "noPrototypeBuiltins": "off",
         "noDocumentCookie": "off",
         "noReactForwardRef": "off"
       },
@@ -92,17 +88,13 @@
         },
         "useHookAtTopLevel": "off",
         "noSwitchDeclarations": "off",
-        "noUnsafeOptionalChaining": "off",
         "useUniqueElementIds": "off"
       },
       "complexity": {
         "noForEach": "off",
         "noBannedTypes": "off",
-        "noUselessConstructor": "off",
         "noStaticOnlyClass": "off",
-        "useArrowFunction": "off",
         "noThisInStatic": "off",
-        "useFlatMap": "off",
         "useLiteralKeys": "off"
       },
       "a11y": {

--- a/packages/assistant-stream/src/utils/json/parse-partial-json-object.ts
+++ b/packages/assistant-stream/src/utils/json/parse-partial-json-object.ts
@@ -75,7 +75,7 @@ const getFieldState = (
   const [field, ...restPath] = fieldPath as [string, ...string[]];
 
   // 3) field doesn't yet exist in parent: return "partial"
-  if (!Object.prototype.hasOwnProperty.call(parent, field)) return "partial";
+  if (!Object.hasOwn(parent, field)) return "partial";
 
   const [partialField, ...restPartialPath] = parentMeta.partialPath;
 

--- a/packages/assistant-stream/src/utils/promiseWithResolvers.ts
+++ b/packages/assistant-stream/src/utils/promiseWithResolvers.ts
@@ -1,4 +1,4 @@
-export const promiseWithResolvers = function <T>() {
+export const promiseWithResolvers = <T>() => {
   let resolve: ((value: T | PromiseLike<T>) => void) | undefined;
   let reject: ((reason?: unknown) => void) | undefined;
   const promise = new Promise<T>((res, rej) => {

--- a/packages/core/src/runtime/api/attachment-runtime.ts
+++ b/packages/core/src/runtime/api/attachment-runtime.ts
@@ -105,10 +105,6 @@ export class MessageAttachmentRuntimeImpl extends AttachmentRuntimeImpl<"message
     return "message";
   }
 
-  constructor(core: AttachmentSnapshotBinding<"message">) {
-    super(core);
-  }
-
   public remove(): never {
     throw new Error("Message attachments cannot be removed");
   }

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -71,7 +71,7 @@ export const useExternalHistory = <TMessage>(
           const messages = tempRepo.getMessages();
 
           onSetMessagesRef.current(
-            messages.map(getExternalStoreMessages<TMessage>).flat(),
+            messages.flatMap(getExternalStoreMessages<TMessage>),
           );
 
           historyIds.current = new Set(

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -24,8 +24,7 @@ function stripClosingDelimiters(json: string): string {
   return json.replace(/[}\]"]+$/, "");
 }
 
-const hasOwn = (value: object, key: string) =>
-  Object.prototype.hasOwnProperty.call(value, key);
+const hasOwn = (value: object, key: string) => Object.hasOwn(value, key);
 
 const stabilizeToolArgsValue = (
   value: unknown,

--- a/packages/react-devtools/src/utils/toolNormalization.ts
+++ b/packages/react-devtools/src/utils/toolNormalization.ts
@@ -41,7 +41,7 @@ const mapToNormalizedTool = (
     tool.disabled = raw["disabled"] as boolean;
   }
 
-  if (Object.prototype.hasOwnProperty.call(raw, "parameters")) {
+  if (Object.hasOwn(raw, "parameters")) {
     tool.parameters = toJsonSchema(raw["parameters"]);
   }
 

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -30,8 +30,7 @@ const uiMessageToDataPart = (ui: UIMessage): DataMessagePart => ({
   data: ui.props,
 });
 
-const hasOwn = (value: object, key: string) =>
-  Object.prototype.hasOwnProperty.call(value, key);
+const hasOwn = (value: object, key: string) => Object.hasOwn(value, key);
 
 const stabilizeToolArgsValue = (
   value: unknown,

--- a/packages/react/src/augmentations.ts
+++ b/packages/react/src/augmentations.ts
@@ -22,8 +22,10 @@
  * ```
  */
 export namespace Assistant {
+  // biome-ignore lint/suspicious/noEmptyInterface: declaration merging
   export interface Commands {}
 
+  // biome-ignore lint/suspicious/noEmptyInterface: declaration merging
   export interface ExternalState {}
 }
 

--- a/packages/react/src/utils/hooks/useManagedRef.ts
+++ b/packages/react/src/utils/hooks/useManagedRef.ts
@@ -1,9 +1,9 @@
 import { useCallback, useRef } from "react";
 
 export const useManagedRef = <TNode>(
-  callback: (node: TNode) => (() => void) | void,
+  callback: (node: TNode) => (() => void) | undefined,
 ) => {
-  const cleanupRef = useRef<(() => void) | void>(undefined);
+  const cleanupRef = useRef<(() => void) | undefined>(undefined);
 
   const ref = useCallback(
     (el: TNode | null) => {

--- a/packages/store/src/types/client.ts
+++ b/packages/store/src/types/client.ts
@@ -61,6 +61,7 @@ export type ClientSchema<
  * }
  * ```
  */
+// biome-ignore lint/suspicious/noEmptyInterface: declaration merging
 export interface ScopeRegistry {}
 
 type ClientEventsType<K extends ClientNames> = Record<

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -36,7 +36,7 @@ export type Cell =
     }
   | {
       readonly type: "effect";
-      cleanup: tapEffect.Destructor | void;
+      cleanup: tapEffect.Destructor | undefined;
       deps: readonly unknown[] | null | undefined;
     };
 

--- a/packages/tap/src/hooks/tap-effect.ts
+++ b/packages/tap/src/hooks/tap-effect.ts
@@ -10,7 +10,7 @@ const newEffect = (): Cell & { type: "effect" } => ({
 
 export namespace tapEffect {
   export type Destructor = () => void;
-  export type EffectCallback = () => void | Destructor;
+  export type EffectCallback = () => Destructor | undefined;
 }
 
 export function tapEffect(effect: tapEffect.EffectCallback): void;

--- a/packages/ui/src/components/ui/field.tsx
+++ b/packages/ui/src/components/ui/field.tsx
@@ -204,7 +204,7 @@ function FieldError({
       ...new Map(errors.map((error) => [error?.message, error])).values(),
     ];
 
-    if (uniqueErrors?.length == 1) {
+    if (uniqueErrors?.length === 1) {
       return uniqueErrors[0]?.message;
     }
 


### PR DESCRIPTION
## Summary
Re-enable 8 biome lint rules that were previously disabled, fixing all violations:

1. **`complexity/noUselessConstructor`** (1 fix) — removed redundant constructor in `attachment-runtime.ts`
2. **`complexity/useFlatMap`** (1 fix) — `.map().flat()` → `.flatMap()` in `useExternalHistory.ts`
3. **`suspicious/noDoubleEquals`** (1 fix) — `==` → `===` in `field.tsx`
4. **`correctness/noUnsafeOptionalChaining`** (1 fix) — removed unnecessary `?.` in `docs-toolkit.tsx`
5. **`suspicious/noEmptyInterface`** (3 fixes) — added `biome-ignore` for intentional declaration-merging interfaces
6. **`complexity/useArrowFunction`** (4 fixes) — function expressions → arrow functions (auto-fixed)
7. **`suspicious/noConfusingVoidType`** (4 fixes) — `void` → `undefined` in union types
8. **`suspicious/noPrototypeBuiltins`** (4 fixes) — `.hasOwnProperty()` → `Object.hasOwn()`

## Test plan
- [x] `pnpm lint` passes
- [x] All 32 packages build
- [x] All 35 test suites pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)