### PR TITLE
fix: add "style" export condition for CSS entries

### DIFF
--- a/.changeset/fix-css-style-export-condition.md
+++ b/.changeset/fix-css-style-export-condition.md
@@ -1,0 +1,7 @@
+---
+"tw-shimmer": patch
+"tw-glass": patch
+"@assistant-ui/react-markdown": patch
+---
+
+fix: add "style" export condition for CSS entries so Tailwind CSS v4 `@import` can resolve packages

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -20,6 +20,7 @@
       "default": "./dist/index.js"
     },
     "./styles/dot.css": {
+      "style": "./styles/dot.css",
       "default": "./styles/dot.css"
     }
   },

--- a/packages/tw-glass/package.json
+++ b/packages/tw-glass/package.json
@@ -17,6 +17,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "style": "./src/index.css",
       "default": "./src/index.css"
     }
   },

--- a/packages/tw-shimmer/package.json
+++ b/packages/tw-shimmer/package.json
@@ -16,6 +16,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "style": "./src/index.css",
       "default": "./src/index.css"
     }
   },


### PR DESCRIPTION
## Summary
- Adds the `"style"` export condition alongside `"default"` for packages that export CSS files. Tailwind CSS v4's `@import` resolver (used during PostCSS processing) looks for `"style"` to resolve a package to its CSS entry point.
- Affects `tw-shimmer`, `tw-glass`, and `@assistant-ui/react-markdown` (`./styles/dot.css`).

Fixes #3824

## Test plan
- [ ] `@import "tw-shimmer"` resolves in a Tailwind v4 + PostCSS project
- [ ] `@import "tw-glass"` resolves in a Tailwind v4 + PostCSS project
- [ ] `@import "@assistant-ui/react-markdown/styles/dot.css"` resolves in a Tailwind v4 + PostCSS project