### PR TITLE
fix(tap): tapEffectEvent returned frozen callback in production

### DIFF
--- a/.changeset/fix-tap-effect-event-prod.md
+++ b/.changeset/fix-tap-effect-event-prod.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: tapEffectEvent returned a frozen callback in production, breaking consumers that stored the reference externally (e.g. trigger popover plugin registry). Both dev and prod now use the same wrapper that reads the latest callback from the ref at call time — matching the documented "stable reference that always calls the most recent version" contract.

--- a/packages/tap/src/hooks/tap-effect-event.ts
+++ b/packages/tap/src/hooks/tap-effect-event.ts
@@ -29,17 +29,13 @@ export function tapEffectEvent<T extends (...args: any[]) => any>(
     callbackRef.current = callback;
   });
 
-  if (isDevelopment) {
-    const fiber = getCurrentResourceFiber();
-    return tapCallback(
-      ((...args: Parameters<T>) => {
-        if (fiber.renderContext)
-          throw new Error("tapEffectEvent cannot be called during render");
-        return callbackRef.current(...args);
-      }) as T,
-      [fiber],
-    );
-  }
-
-  return callbackRef.current;
+  const fiber = getCurrentResourceFiber();
+  return tapCallback(
+    ((...args: Parameters<T>) => {
+      if (isDevelopment && fiber.renderContext)
+        throw new Error("tapEffectEvent cannot be called during render");
+      return callbackRef.current(...args);
+    }) as T,
+    [fiber],
+  );
 }


### PR DESCRIPTION
## Summary
- Fixes production bug where typing `@` or `/` in the shadcn demo composer sent the keystroke as a message instead of opening the mention/slash popover.
- Root cause: `tapEffectEvent`'s prod path returned `callbackRef.current` directly — a frozen function captured at the first render. External consumers that stored the reference (e.g. `TriggerPopover`'s plugin registry) were stuck with the initial closure, so `handleKeyDown` always saw `open=false` and fell through to composer submit.
- Dev mode used a wrapper that reads the ref at call time, which masked the bug — hence it only reproduced in production builds.
- Unified both paths to use the wrapper; `isDevelopment` now only gates the "called during render" safety check. Matches the documented "stable reference that always calls the most recent version" contract.

## Test plan
- [x] `pnpm test` in `packages/tap` — 144 tests pass
- [x] `next build && next start` for apps/docs: reproduce bug (without fix) — `@` + Enter sends message, popover never opens
- [x] Same prod build with fix: `@` + Enter opens popover, Enter drills into category, no message sent
- [x] Dev server still works identically (no regression)
- [ ] Smoke-test other `tapEffectEvent` consumers (`useAui`, `ExternalThread`, `tap-assistant-context`) in a prod build