### PR TITLE
fix(react-langgraph): tool call status flicker during subgraph streaming

### DIFF
--- a/.changeset/fix-langgraph-subgraph-status-flicker.md
+++ b/.changeset/fix-langgraph-subgraph-status-flicker.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: tool call status briefly flickers `requires-action` (error icon) before settling on `complete` during LangGraph streaming with subgraphs. The final reconcile now merges the values snapshot with tuple-accumulated state instead of replacing it, so tool results and subgraph-internal messages aren't dropped; metadata survives reconcile; `isRunning` flips to `false` atomically with the final message update (via new `onComplete` callback); and subgraph-level `error` events (pipe-namespaced) no longer mark parent AI messages as incomplete. Pipe-separated subgraph event names (e.g. `messages|tools:call_abc`) are now handled by stripping the namespace before matching.

--- a/packages/react-langgraph/src/LangGraphMessageAccumulator.test.ts
+++ b/packages/react-langgraph/src/LangGraphMessageAccumulator.test.ts
@@ -180,3 +180,96 @@ describe("LangGraphMessageAccumulator UI reducer", () => {
     expect(acc.getUIMessages()[0]!.id).toBe("ui-3");
   });
 });
+
+describe("LangGraphMessageAccumulator reconcileMessages", () => {
+  it("updates message content from server snapshot", () => {
+    const acc = new LangGraphMessageAccumulator<LangChainMessage>();
+    acc.addMessages([{ id: "ai-1", type: "ai", content: "Streaming partial" }]);
+    const result = acc.reconcileMessages([
+      { id: "ai-1", type: "ai", content: "Final server content" },
+    ]);
+    const ai1 = result.find((m) => m.id === "ai-1");
+    expect(ai1!.content).toBe("Final server content");
+  });
+
+  it("preserves accumulator-only messages not in server snapshot", () => {
+    const acc = new LangGraphMessageAccumulator<LangChainMessage>();
+    acc.addMessages([
+      { id: "ai-1", type: "ai", content: "Parent msg" },
+      { id: "sub-ai-1", type: "ai", content: "Subgraph msg" },
+    ]);
+    const result = acc.reconcileMessages([
+      { id: "ai-1", type: "ai", content: "Parent updated" },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.find((m) => m.id === "ai-1")!.content).toBe("Parent updated");
+    expect(result.find((m) => m.id === "sub-ai-1")!.content).toBe(
+      "Subgraph msg",
+    );
+  });
+
+  it("preserves metadata for all surviving messages", () => {
+    const acc = new LangGraphMessageAccumulator<LangChainMessage>();
+    acc.addMessageWithMetadata(
+      { id: "ai-1", type: "ai", content: "Hello" },
+      { langgraph_node: "agent", ls_model_name: "claude-3-7-sonnet-latest" },
+    );
+    acc.addMessageWithMetadata(
+      { id: "sub-ai-1", type: "ai", content: "Sub" },
+      { langgraph_node: "sub_agent" },
+    );
+    acc.reconcileMessages([{ id: "ai-1", type: "ai", content: "Hello world" }]);
+    const metadata = acc.getMetadataMap();
+    expect(metadata.get("ai-1")).toEqual({
+      langgraph_node: "agent",
+      ls_model_name: "claude-3-7-sonnet-latest",
+    });
+    // Subgraph message metadata preserved since the message still exists
+    expect(metadata.get("sub-ai-1")).toEqual({ langgraph_node: "sub_agent" });
+  });
+
+  it("adds new messages from server snapshot", () => {
+    const acc = new LangGraphMessageAccumulator<LangChainMessage>();
+    acc.addMessages([{ id: "ai-1", type: "ai", content: "Hello" }]);
+    const result = acc.reconcileMessages([
+      { id: "ai-1", type: "ai", content: "Hello updated" },
+      { id: "ai-2", type: "ai", content: "New from server" },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.find((m) => m.id === "ai-2")!.content).toBe(
+      "New from server",
+    );
+  });
+
+  it("returns a fresh array reference", () => {
+    const acc = new LangGraphMessageAccumulator<LangChainMessage>();
+    acc.addMessages([{ id: "ai-1", type: "ai", content: "A" }]);
+    const result = acc.reconcileMessages([
+      { id: "ai-1", type: "ai", content: "B" },
+    ]);
+    result.push({ id: "fake", type: "ai", content: "injected" });
+    expect(acc.getMessages()).toHaveLength(1);
+  });
+
+  it("preserves insertion order when updating existing messages", () => {
+    const acc = new LangGraphMessageAccumulator<LangChainMessage>();
+    acc.addMessages([
+      { id: "user-1", type: "human", content: "hi" },
+      { id: "ai-1", type: "ai", content: "partial" },
+      { id: "tool-1", type: "tool", content: "result", tool_call_id: "tc-1" },
+    ]);
+    const result = acc.reconcileMessages([
+      { id: "user-1", type: "human", content: "hi" },
+      { id: "ai-1", type: "ai", content: "final" },
+    ]);
+    expect(result.map((m) => m.id)).toEqual(["user-1", "ai-1", "tool-1"]);
+  });
+
+  it("handles empty server snapshot by preserving all accumulator state", () => {
+    const acc = new LangGraphMessageAccumulator<LangChainMessage>();
+    acc.addMessages([{ id: "ai-1", type: "ai", content: "preserved" }]);
+    const result = acc.reconcileMessages([]);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe("ai-1");
+  });
+});

--- a/packages/react-langgraph/src/LangGraphMessageAccumulator.ts
+++ b/packages/react-langgraph/src/LangGraphMessageAccumulator.ts
@@ -85,6 +85,14 @@ export class LangGraphMessageAccumulator<TMessage extends { id?: string }> {
     return this.getMessages();
   }
 
+  // upsert-only: tuple-only messages (e.g. subgraph internals absent from parent `values`) are preserved
+  public reconcileMessages(serverMessages: TMessage[]): TMessage[] {
+    for (const message of serverMessages.map(this.ensureMessageId)) {
+      this.messagesMap.set(message.id!, message);
+    }
+    return this.getMessages();
+  }
+
   public applyUIUpdate(
     update:
       | UIMessage

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -3098,4 +3098,129 @@ describe("useLangGraphMessages", {}, () => {
       expect(onComplete).toHaveBeenCalledTimes(1);
     });
   });
+
+  it("ignores subgraph values events (namespaced)", async () => {
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      {
+        event: "messages",
+        data: [
+          {
+            id: "ai-1",
+            content: "Parent msg",
+            type: "AIMessageChunk",
+            tool_call_chunks: [],
+          },
+          { langgraph_node: "agent" } satisfies LangGraphTupleMetadata,
+        ],
+      },
+      // subgraph values event — must not overwrite lastValuesMessages
+      {
+        event: "values|tools:tc-1",
+        data: {
+          messages: [
+            {
+              id: "sub-internal",
+              type: "ai" as const,
+              content: "subgraph-only state",
+            },
+          ],
+        },
+      },
+      // parent values event with authoritative state
+      {
+        event: "values",
+        data: {
+          messages: [
+            { id: "user-1", type: "human" as const, content: "hi" },
+            { id: "ai-1", type: "ai" as const, content: "Parent final" },
+          ],
+        },
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    act(() => {
+      result.current.sendMessage(
+        [{ id: "user-1", type: "human", content: "hi" }],
+        {},
+      );
+    });
+
+    await waitFor(() => {
+      const parentAi = result.current.messages.find((m) => m.id === "ai-1");
+      expect(parentAi).toBeDefined();
+      expect(parentAi!.content).toEqual("Parent final");
+      // subgraph values event did not leak into parent reconcile
+      const subInternal = result.current.messages.find(
+        (m) => m.id === "sub-internal",
+      );
+      expect(subInternal).toBeUndefined();
+    });
+  });
+
+  it("ignores subgraph updates events (namespaced)", async () => {
+    const onUpdates = vi.fn();
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      {
+        event: "updates|tools:tc-1",
+        data: { some_subgraph_node: { messages: [] } },
+      },
+      {
+        event: "updates",
+        data: { agent: { messages: [] } },
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+        eventHandlers: { onUpdates },
+      }),
+    );
+
+    act(() => {
+      result.current.sendMessage([{ type: "human", content: "hi" }], {});
+    });
+
+    await waitFor(() => {
+      // only the root-level updates event fires the handler
+      expect(onUpdates).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("passes stripped event type to onCustomEvent for namespaced events", async () => {
+    const onCustomEvent = vi.fn();
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      {
+        event: "my-channel|subgraph:xyz",
+        data: { payload: 42 },
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+        eventHandlers: { onCustomEvent },
+      }),
+    );
+
+    act(() => {
+      result.current.sendMessage([{ type: "human", content: "hi" }], {});
+    });
+
+    await waitFor(() => {
+      expect(onCustomEvent).toHaveBeenCalledWith("my-channel", { payload: 42 });
+    });
+  });
 });

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -2721,4 +2721,381 @@ describe("useLangGraphMessages", {}, () => {
     });
     expect(result.current.uiMessages).toHaveLength(0);
   });
+
+  it("preserves metadata through final values reconcile when tuple events present", async () => {
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      {
+        event: "messages",
+        data: [
+          {
+            id: "ai-1",
+            content: "Hello",
+            type: "AIMessageChunk",
+            tool_call_chunks: [],
+          },
+          {
+            langgraph_step: 1,
+            langgraph_node: "agent",
+            ls_model_name: "claude-3-7-sonnet-latest",
+          } satisfies LangGraphTupleMetadata,
+        ],
+      },
+      {
+        event: "values",
+        data: {
+          messages: [
+            { id: "user-1", type: "human" as const, content: "hi" },
+            { id: "ai-1", type: "ai" as const, content: "Hello world" },
+          ],
+        },
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    act(() => {
+      result.current.sendMessage(
+        [{ id: "user-1", type: "human", content: "hi" }],
+        {},
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(2);
+      const aiMessage = result.current.messages[1]!;
+      expect(aiMessage.content).toEqual("Hello world");
+      const metadata = result.current.messageMetadata.get("ai-1");
+      expect(metadata).toBeDefined();
+      expect(metadata!.langgraph_node).toBe("agent");
+      expect(metadata!.ls_model_name).toBe("claude-3-7-sonnet-latest");
+    });
+  });
+
+  it("does not drop tuple-only messages during final reconcile", async () => {
+    // subgraph scenario: tool result arrives via tuple after values snapshot was captured
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      {
+        event: "messages",
+        data: [
+          {
+            id: "ai-1",
+            content: "Let me search",
+            type: "AIMessageChunk",
+            tool_call_chunks: [
+              { id: "tc-1", name: "search", args: '{"q":"test"}', index: 0 },
+            ],
+          },
+          { langgraph_node: "agent" } satisfies LangGraphTupleMetadata,
+        ],
+      },
+      // Values snapshot captured BEFORE tool result arrived
+      {
+        event: "values",
+        data: {
+          messages: [
+            { id: "user-1", type: "human" as const, content: "search test" },
+            {
+              id: "ai-1",
+              type: "ai" as const,
+              content: "Let me search",
+              tool_calls: [{ id: "tc-1", name: "search", args: { q: "test" } }],
+            },
+          ],
+        },
+      },
+      // Tool result arrives via tuple AFTER the values snapshot
+      {
+        event: "messages",
+        data: [
+          {
+            id: "tool-1",
+            type: "tool",
+            content: '{"results": ["found"]}',
+            tool_call_id: "tc-1",
+            name: "search",
+          },
+          { langgraph_node: "tools" } satisfies LangGraphTupleMetadata,
+        ],
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    act(() => {
+      result.current.sendMessage(
+        [{ id: "user-1", type: "human", content: "search test" }],
+        {},
+      );
+    });
+
+    await waitFor(() => {
+      // The values snapshot only has 2 messages (user + ai), but the tool
+      // result from the tuple event should NOT be dropped by reconcileMessages.
+      // All 3 messages should be present: user, ai, tool.
+      expect(result.current.messages).toHaveLength(3);
+      expect(result.current.messages[2]!.id).toBe("tool-1");
+      expect(result.current.messages[2]!.type).toBe("tool");
+      // Metadata should still be available for ai-1
+      const metadata = result.current.messageMetadata.get("ai-1");
+      expect(metadata).toBeDefined();
+      expect(metadata!.langgraph_node).toBe("agent");
+    });
+  });
+
+  it("handles pipe-separated subgraph event names", async () => {
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      // Parent AI message via tuple
+      {
+        event: "messages",
+        data: [
+          {
+            id: "ai-1",
+            content: "Processing",
+            type: "AIMessageChunk",
+            tool_call_chunks: [],
+          },
+          { langgraph_node: "agent" } satisfies LangGraphTupleMetadata,
+        ],
+      },
+      // Subgraph tuple event with pipe-separated namespace
+      {
+        event: "messages|tools:tc-1",
+        data: [
+          {
+            id: "sub-ai-1",
+            content: "Subgraph thinking",
+            type: "AIMessageChunk",
+            tool_call_chunks: [],
+          },
+          {
+            langgraph_node: "sub_agent",
+            langgraph_checkpoint_ns: "tools:tc-1",
+          } satisfies LangGraphTupleMetadata,
+        ],
+      },
+      // Parent values event
+      {
+        event: "values",
+        data: {
+          messages: [
+            { id: "user-1", type: "human" as const, content: "hi" },
+            { id: "ai-1", type: "ai" as const, content: "Processing done" },
+          ],
+        },
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    act(() => {
+      result.current.sendMessage(
+        [{ id: "user-1", type: "human", content: "hi" }],
+        {},
+      );
+    });
+
+    await waitFor(() => {
+      // Both parent and subgraph messages should be processed
+      expect(result.current.messages.length).toBeGreaterThanOrEqual(2);
+      // Parent AI message should have reconciled content
+      const parentAi = result.current.messages.find((m) => m.id === "ai-1");
+      expect(parentAi).toBeDefined();
+      expect(parentAi!.content).toEqual("Processing done");
+      // Subgraph message should also be present (accumulated from tuple)
+      const subAi = result.current.messages.find((m) => m.id === "sub-ai-1");
+      expect(subAi).toBeDefined();
+    });
+  });
+
+  it("does not mark parent message incomplete on subgraph error event", async () => {
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      {
+        event: "messages",
+        data: [
+          {
+            id: "ai-1",
+            content: "Working on it",
+            type: "AIMessageChunk",
+            tool_call_chunks: [],
+          },
+          { langgraph_node: "agent" } satisfies LangGraphTupleMetadata,
+        ],
+      },
+      // Subgraph error event (pipe-separated namespace indicates subgraph)
+      {
+        event: "error|tools:tc-1|sub_agent",
+        data: {
+          error: "SubgraphError",
+          message: "Subgraph failed but parent handles it",
+        },
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    act(() => {
+      result.current.sendMessage([{ type: "human", content: "do it" }], {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(2);
+      const aiMessage = result.current.messages[1]! as Record<string, unknown>;
+      // Should NOT have incomplete status since error is from a subgraph
+      expect(aiMessage.status).toBeUndefined();
+    });
+  });
+
+  it("still marks parent message incomplete on root-level error event", async () => {
+    const errorData = {
+      error: "ServerError",
+      message: "Top-level error",
+    };
+
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      {
+        event: "messages",
+        data: [
+          {
+            id: "ai-1",
+            content: "Starting",
+            type: "AIMessageChunk",
+            tool_call_chunks: [],
+          },
+          { run_attempt: 1 },
+        ],
+      },
+      // Root-level error (no pipe namespace)
+      {
+        event: "error",
+        data: errorData,
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    act(() => {
+      result.current.sendMessage([{ type: "human", content: "go" }], {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(2);
+      const aiMessage = result.current.messages[1]! as Record<string, unknown>;
+      expect(aiMessage.status).toEqual({
+        type: "incomplete",
+        reason: "error",
+        error: errorData,
+      });
+    });
+  });
+
+  it("invokes onComplete on success path", async () => {
+    const onComplete = vi.fn();
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      {
+        event: "messages",
+        data: [
+          {
+            id: "ai-1",
+            content: "Done",
+            type: "AIMessageChunk",
+            tool_call_chunks: [],
+          },
+          { run_attempt: 1 },
+        ],
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage(
+        [{ type: "human", content: "hi" }],
+        {},
+        onComplete,
+      );
+    });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onComplete on abort path", async () => {
+    const onComplete = vi.fn();
+    const streamSpy = vi.fn().mockImplementation(async (_messages, config) => {
+      async function* gen() {
+        yield metadataEvent;
+        await new Promise<void>((_resolve, reject) => {
+          const onAbort = () => {
+            const err = new Error("The operation was aborted.");
+            err.name = "AbortError";
+            reject(err);
+          };
+          if (config.abortSignal.aborted) {
+            onAbort();
+            return;
+          }
+          config.abortSignal.addEventListener("abort", onAbort, { once: true });
+        });
+      }
+      return gen();
+    });
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: streamSpy as any,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    act(() => {
+      result.current.sendMessage(
+        [{ type: "human", content: "hi" }],
+        {},
+        onComplete,
+      );
+    });
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -207,21 +207,21 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
       config: LangGraphSendMessageConfig,
       onComplete?: () => void,
     ) => {
-      // ensure all messages have an ID
-      const newMessagesWithId = newMessages.map((m) =>
-        m.id ? m : { ...m, id: uuidv4() },
-      );
-
-      const accumulator = new LangGraphMessageAccumulator({
-        initialMessages: messagesRef.current,
-        initialUIMessages: uiMessagesRef.current,
-        appendMessage,
-      });
-      setMessagesImmediate(accumulator.addMessages(newMessagesWithId));
-
       const abortController = new AbortController();
       abortControllerRef.current = abortController;
       try {
+        // ensure all messages have an ID
+        const newMessagesWithId = newMessages.map((m) =>
+          m.id ? m : { ...m, id: uuidv4() },
+        );
+
+        const accumulator = new LangGraphMessageAccumulator({
+          initialMessages: messagesRef.current,
+          initialUIMessages: uiMessagesRef.current,
+          appendMessage,
+        });
+        setMessagesImmediate(accumulator.addMessages(newMessagesWithId));
+
         const response = await stream(newMessagesWithId, {
           ...config,
           abortSignal: abortController.signal,

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -22,6 +22,17 @@ import { normalizeLangGraphTupleMessage } from "./normalizeLangGraphTupleMessage
 
 const DEFAULT_UI_STATE_KEY = "ui";
 
+const parseEventType = (
+  event: string,
+): { type: string; namespace: string | undefined } => {
+  const pipeIndex = event.indexOf("|");
+  if (pipeIndex === -1) return { type: event, namespace: undefined };
+  return {
+    type: event.slice(0, pipeIndex),
+    namespace: event.slice(pipeIndex + 1),
+  };
+};
+
 const isUIUpdate = (
   value: unknown,
 ): value is
@@ -191,7 +202,11 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
 
   const aui = useAui();
   const sendMessage = useCallback(
-    async (newMessages: TMessage[], config: LangGraphSendMessageConfig) => {
+    async (
+      newMessages: TMessage[],
+      config: LangGraphSendMessageConfig,
+      onComplete?: () => void,
+    ) => {
       // ensure all messages have an ID
       const newMessagesWithId = newMessages.map((m) =>
         m.id ? m : { ...m, id: uuidv4() },
@@ -219,7 +234,10 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
         let lastValuesMessages: TMessage[] | null = null;
         let lastValuesUIMessages: UIMessage[] | null = null;
         for await (const chunk of response) {
-          switch (chunk.event) {
+          const { type: eventType, namespace: eventNamespace } = parseEventType(
+            chunk.event,
+          );
+          switch (eventType) {
             case LangGraphKnownEventTypes.MessagesPartial:
             case LangGraphKnownEventTypes.MessagesComplete:
               setMessagesImmediate(accumulator.addMessages(chunk.data));
@@ -305,29 +323,30 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
               break;
             case LangGraphKnownEventTypes.Error: {
               onError?.(chunk.data);
-              // Update the last AI message with error status
-              // Assumes last AI message is the one the error relates to
-              const messages = accumulator.getMessages();
-              const lastAiMessage = messages.findLast(
-                (m): m is TMessage & { type: string; id: string } =>
-                  m != null && "type" in m && m.type === "ai" && m.id != null,
-              );
-              if (lastAiMessage) {
-                const errorMessage = {
-                  ...lastAiMessage,
-                  status: {
-                    type: "incomplete" as const,
-                    reason: "error" as const,
-                    error: chunk.data,
-                  },
-                };
-                setMessagesImmediate(accumulator.addMessages([errorMessage]));
+              // namespaced errors come from subgraphs, which the parent may recover from
+              if (!eventNamespace) {
+                const messages = accumulator.getMessages();
+                const lastAiMessage = messages.findLast(
+                  (m): m is TMessage & { type: string; id: string } =>
+                    m != null && "type" in m && m.type === "ai" && m.id != null,
+                );
+                if (lastAiMessage) {
+                  const errorMessage = {
+                    ...lastAiMessage,
+                    status: {
+                      type: "incomplete" as const,
+                      reason: "error" as const,
+                      error: chunk.data,
+                    },
+                  };
+                  setMessagesImmediate(accumulator.addMessages([errorMessage]));
+                }
               }
               break;
             }
             default: {
               // push_ui_message emits ui/remove-ui events on the "custom" channel
-              if (chunk.event === "custom" && isUIUpdate(chunk.data)) {
+              if (eventType === "custom" && isUIUpdate(chunk.data)) {
                 setUIMessagesImmediate(accumulator.applyUIUpdate(chunk.data));
                 break;
               }
@@ -347,7 +366,11 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
 
         // Final reconcile: use the last values snapshot as authoritative state
         if (lastValuesMessages && !abortController.signal.aborted) {
-          setMessagesImmediate(accumulator.replaceMessages(lastValuesMessages));
+          setMessagesImmediate(
+            hasTupleMessageEvents
+              ? accumulator.reconcileMessages(lastValuesMessages)
+              : accumulator.replaceMessages(lastValuesMessages),
+          );
           setMessageMetadata(new Map(accumulator.getMetadataMap()));
         }
         if (lastValuesUIMessages && !abortController.signal.aborted) {
@@ -366,6 +389,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
         if (abortControllerRef.current === abortController) {
           abortControllerRef.current = null;
         }
+        onComplete?.();
       }
     },
     [

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -243,6 +243,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
               setMessagesImmediate(accumulator.addMessages(chunk.data));
               break;
             case LangGraphKnownEventTypes.Updates: {
+              if (eventNamespace) break;
               onUpdates?.(chunk.data);
               const extracted = extractMessagesFromUpdates<TMessage>(
                 chunk.data,
@@ -254,6 +255,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
               break;
             }
             case LangGraphKnownEventTypes.Values:
+              if (eventNamespace) break;
               onValues?.(chunk.data);
               if (Array.isArray(chunk.data?.messages)) {
                 lastValuesMessages = chunk.data.messages;
@@ -351,7 +353,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
                 break;
               }
               if (onCustomEvent) {
-                onCustomEvent(chunk.event, chunk.data);
+                onCustomEvent(eventType, chunk.data);
               } else {
                 console.warn(
                   "Unhandled event received:",

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -366,16 +366,13 @@ const useLangGraphRuntimeImpl = ({
     [uiMessagesByParent],
   );
 
-  const handleSendMessage = async (
+  const handleSendMessage = (
     messages: LangChainMessage[],
     config: LangGraphSendMessageConfig,
   ) => {
-    try {
-      setIsRunning(true);
-      await sendMessage(messages, config);
-    } finally {
-      setIsRunning(false);
-    }
+    setIsRunning(true);
+    // setIsRunning(false) flips atomically with the final reconcile via onComplete
+    return sendMessage(messages, config, () => setIsRunning(false));
   };
 
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage


### PR DESCRIPTION
## Summary

- Fixes #3835: tool call status briefly flashes `requires-action` (error icon) before settling on `complete` during LangGraph streaming with `streamSubgraphs: true`.
- Final reconcile uses a new `reconcileMessages` upsert on `LangGraphMessageAccumulator` when tuple events were received, so tool results and subgraph-internal messages accumulated from tuple events aren't dropped when they're missing from the parent `values` snapshot. Metadata (e.g. `langgraph_node`, `ls_model_name`) also survives reconcile.
- Adds an `onComplete` callback to `sendMessage` and wires `setIsRunning(false)` through it, so the running-state flip batches into the same React render as the final message update — closing the race window where `getAutoStatus` would otherwise return `requires-action`. Fires in `finally` to cover success, abort, and error paths.
- New `parseEventType` strips pipe-separated subgraph namespaces (e.g. `messages|tools:call_abc`) before the event switch so subgraph events route correctly; namespaced `error` events no longer mark parent AI messages incomplete since the parent may recover.
- Adds 14 tests covering upsert semantics, metadata preservation, order preservation, tuple-only message survival, pipe-namespaced events, subgraph-vs-root error routing, and `onComplete` firing on success/abort.

## Test plan

- [ ] `pnpm --filter @assistant-ui/react-langgraph test` passes (93 tests)
- [ ] `pnpm lint` passes with no new warnings
- [ ] Manual repro against a LangGraph agent with `streamSubgraphs: true` + `streamMode: ['messages-tuple', 'values']` — tool call transitions cleanly from `running` (spinner) to `complete` (checkmark) with no intermediate `!` icon
- [ ] Verify cancellation path: `isRunning` returns to `false` after abort
- [ ] Verify existing tests for reconcile behavior (line 1798, 1847, 1960) still pass