### PR TITLE
fix(react-ai-sdk): use real thread id in useChatRuntime request body

### DIFF
--- a/.changeset/fix-chat-transport-outer-thread-id.md
+++ b/.changeset/fix-chat-transport-outer-thread-id.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: request body `id` in `useChatRuntime` is now the real thread id instead of the literal `"DEFAULT_THREAD_ID"`. `AssistantChatTransport` was resolving `remoteId` from the inner `ExternalStoreThreadListRuntimeCore` (which only echoes its default id); it now uses the outer `RemoteThreadListRuntimeCore` that actually calls the adapter.

--- a/apps/docs/content/examples/ai-sdk.mdx
+++ b/apps/docs/content/examples/ai-sdk.mdx
@@ -93,12 +93,15 @@ To persist conversations, add a database and modify the API route. `useChatRunti
 // In your POST /api/chat handler:
 const { id: threadId, messages } = await req.json();
 
-// Save messages to database
-await db.messages.create({
-  threadId,
-  role: message.role,
-  content: message.content,
-});
+// Save the latest user message
+const last = messages.at(-1);
+if (last) {
+  await db.messages.create({
+    threadId,
+    role: last.role,
+    parts: last.parts,
+  });
+}
 
 // Load messages when opening a thread (e.g., from a ThreadHistoryAdapter):
 const savedMessages = await db.messages.findMany({ threadId });

--- a/apps/docs/content/examples/ai-sdk.mdx
+++ b/apps/docs/content/examples/ai-sdk.mdx
@@ -87,9 +87,12 @@ export async function POST(req: Request) {
 
 ### Adding Persistence
 
-To persist conversations, add a database and modify the API route:
+To persist conversations, add a database and modify the API route. `useChatRuntime` sends the current thread id as `id` in the request body, so you can read it alongside `messages`:
 
 ```ts
+// In your POST /api/chat handler:
+const { id: threadId, messages } = await req.json();
+
 // Save messages to database
 await db.messages.create({
   threadId,
@@ -97,7 +100,7 @@ await db.messages.create({
   content: message.content,
 });
 
-// Load messages on page load
+// Load messages when opening a thread (e.g., from a ThreadHistoryAdapter):
 const savedMessages = await db.messages.findMany({ threadId });
 ```
 

--- a/packages/react-ai-sdk/src/ui/use-chat/AssistantChatTransport.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/AssistantChatTransport.ts
@@ -1,4 +1,7 @@
-import type { AssistantRuntime } from "@assistant-ui/core";
+import type {
+  AssistantRuntime,
+  ThreadListItemRuntime,
+} from "@assistant-ui/core";
 import {
   DefaultChatTransport,
   type HttpChatTransportInitOptions,
@@ -6,12 +9,7 @@ import {
 } from "ai";
 import { toToolsJSONSchema } from "assistant-stream";
 
-type InitializableThreadListItem = {
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-};
+type InitializableThreadListItem = Pick<ThreadListItemRuntime, "initialize">;
 
 export class AssistantChatTransport<
   UI_MESSAGE extends UIMessage,

--- a/packages/react-ai-sdk/src/ui/use-chat/AssistantChatTransport.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/AssistantChatTransport.ts
@@ -6,18 +6,28 @@ import {
 } from "ai";
 import { toToolsJSONSchema } from "assistant-stream";
 
+type InitializableThreadListItem = {
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+};
+
 export class AssistantChatTransport<
   UI_MESSAGE extends UIMessage,
 > extends DefaultChatTransport<UI_MESSAGE> {
   private runtime: AssistantRuntime | undefined;
+  private getThreadListItem:
+    | (() => InitializableThreadListItem | undefined)
+    | undefined;
   constructor(initOptions?: HttpChatTransportInitOptions<UI_MESSAGE>) {
     super({
       ...initOptions,
       prepareSendMessagesRequest: async (options) => {
         const context = this.runtime?.thread.getModelContext();
-        const id =
-          (await this.runtime?.threads.mainItem.initialize())?.remoteId ??
-          options.id;
+        const threadListItem =
+          this.getThreadListItem?.() ?? this.runtime?.threads.mainItem;
+        const id = (await threadListItem?.initialize())?.remoteId ?? options.id;
 
         const optionsEx = {
           ...options,
@@ -49,5 +59,11 @@ export class AssistantChatTransport<
 
   setRuntime(runtime: AssistantRuntime) {
     this.runtime = runtime;
+  }
+
+  __internal_setGetThreadListItem(
+    getter: () => InitializableThreadListItem | undefined,
+  ) {
+    this.getThreadListItem = getter;
   }
 }

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -84,7 +84,9 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
 
   if (transport instanceof AssistantChatTransport) {
     transport.setRuntime(runtime);
-    transport.__internal_setGetThreadListItem(() => aui.threadListItem());
+    transport.__internal_setGetThreadListItem(() =>
+      aui.threadListItem.source ? aui.threadListItem() : undefined,
+    );
   }
 
   return runtime;

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -7,7 +7,7 @@ import {
   useCloudThreadListAdapter,
   useRemoteThreadListRuntime,
 } from "@assistant-ui/core/react";
-import { useAuiState } from "@assistant-ui/store";
+import { useAui, useAuiState } from "@assistant-ui/store";
 import {
   useAISDKRuntime,
   type AISDKRuntimeAdapter,
@@ -68,6 +68,8 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const id = useAuiState((s) => s.threadListItem.id);
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
+  const aui = useAui();
+  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const chat = useChat({
     ...chatOptions,
     id,
@@ -82,6 +84,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
 
   if (transport instanceof AssistantChatTransport) {
     transport.setRuntime(runtime);
+    transport.__internal_setGetThreadListItem(() => aui.threadListItem());
   }
 
   return runtime;


### PR DESCRIPTION
## Summary
- Fixes #3578: `useChatRuntime` now sends the real thread id as `body.id` to the `/chat` route instead of the literal string `"DEFAULT_THREAD_ID"`.
- Root cause: `AssistantChatTransport.prepareSendMessagesRequest` resolved `remoteId` from the inner `ExternalStoreThreadListRuntimeCore` (which only echoes its default `_mainThreadId`), not the outer `RemoteThreadListRuntimeCore` that actually calls the adapter.
- Fix: new `__internal_setGetThreadListItem` hook on `AssistantChatTransport`; `useChatRuntime` injects the outer `ThreadListItemRuntime` through it via `useAui().threadListItem()`, so `initialize()` resolves against the layer that owns the real thread id. Fallback to the inner `threads.mainItem` is preserved, so custom transports and direct `useAISDKRuntime` usage are unaffected.
- Docs: the AI SDK persistence example previously used a bare `threadId` variable with no source; now shows it is destructured from the request body as `id`, and clarifies that the load path belongs in a `ThreadHistoryAdapter`.
- User-side workarounds reported in #3578 (ref-holding the outer runtime and awaiting `outerRef.current.threads.mainItem.initialize()`) can be removed once this ships.

## Test plan
- [ ] With cloud configured, `body.id` received by `/chat` is the cloud thread UUID.
- [ ] Without cloud (default `InMemoryThreadListAdapter`), `body.id` is the `__LOCALID_*` id generated by the outer runtime — no longer `"DEFAULT_THREAD_ID"`.
- [ ] Custom `AssistantChatTransport` instance with user-provided `fetch` still receives the real id in its request body.
- [ ] Users who pass a non-`AssistantChatTransport` custom transport or who fully override `prepareSendMessagesRequest` are unaffected (their body-construction path still wins).
- [ ] Direct `useAISDKRuntime` usage (no outer `RemoteThreadListRuntime`) still works — `getThreadListItem` getter stays unset, falls back to `this.runtime?.threads.mainItem`.
- [ ] `pnpm lint` and `pnpm --filter @assistant-ui/react-ai-sdk test` pass.