### PR TITLE
feat(react-langgraph): add unstable_threadListAdapter option

### DIFF
--- a/.changeset/langgraph-custom-thread-list-adapter.md
+++ b/.changeset/langgraph-custom-thread-list-adapter.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+feat: add `unstable_threadListAdapter` option to `useLangGraphRuntime` for backing the thread list with a custom `RemoteThreadListAdapter` (e.g. one backed by `client.threads.search()`) without requiring assistant-cloud

--- a/apps/docs/content/docs/runtimes/langgraph/index.mdx
+++ b/apps/docs/content/docs/runtimes/langgraph/index.mdx
@@ -399,6 +399,51 @@ const runtime = useLangGraphRuntime({
 
 See the [Cloud Persistence guide](/docs/cloud/langgraph) for detailed setup instructions.
 
+### Custom Thread List
+
+To surface pre-existing LangGraph `thread_id`s in the thread picker without running assistant-cloud, pass a `RemoteThreadListAdapter` via `unstable_threadListAdapter`. A common implementation backs `list()` with `client.threads.search()` and `initialize()` with `client.threads.create()`.
+
+```typescript
+import type { RemoteThreadListAdapter } from "@assistant-ui/react";
+import { Client } from "@langchain/langgraph-sdk";
+
+const client = new Client({ apiUrl: process.env.NEXT_PUBLIC_LANGGRAPH_API_URL });
+
+const threadListAdapter: RemoteThreadListAdapter = {
+  async list() {
+    const threads = await client.threads.search({ limit: 50 });
+    return {
+      threads: threads.map((t) => ({
+        status: "regular",
+        remoteId: t.thread_id,
+        externalId: t.thread_id,
+        title: (t.metadata as { title?: string } | undefined)?.title,
+      })),
+    };
+  },
+  async initialize(threadId) {
+    const t = await client.threads.create();
+    return { remoteId: threadId, externalId: t.thread_id };
+  },
+  async delete(remoteId) {
+    await client.threads.delete(remoteId);
+  },
+  // rename, archive, unarchive, fetch, generateTitle — see link below
+};
+
+const runtime = useLangGraphRuntime({
+  stream: async function* (messages, { initialize }) { /* ... */ },
+  load: async (externalId) => { /* ... */ },
+  unstable_threadListAdapter: threadListAdapter,
+});
+```
+
+Setting `remoteId === externalId` keeps the ids assistant-ui stores aligned with the LangGraph thread ids your `load` and `stream` callbacks receive. See the [Custom Thread List guide](/docs/runtimes/custom/custom-thread-list) for the full adapter contract.
+
+<Callout type="info">
+  When `unstable_threadListAdapter` is provided, the `cloud`, `create`, and `delete` options are ignored — the adapter owns the full thread-list lifecycle.
+</Callout>
+
 ## Message Editing & Regeneration
 
 LangGraph uses server-side checkpoints for state management. To support message editing (branching) and regeneration, you need to provide a `getCheckpointId` callback that resolves the appropriate checkpoint for server-side forking.

--- a/apps/docs/content/docs/runtimes/langgraph/index.mdx
+++ b/apps/docs/content/docs/runtimes/langgraph/index.mdx
@@ -421,9 +421,9 @@ const threadListAdapter: RemoteThreadListAdapter = {
       })),
     };
   },
-  async initialize(threadId) {
+  async initialize() {
     const t = await client.threads.create();
-    return { remoteId: threadId, externalId: t.thread_id };
+    return { remoteId: t.thread_id, externalId: t.thread_id };
   },
   async delete(remoteId) {
     await client.threads.delete(remoteId);

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import type { AssistantRuntime, AttachmentAdapter } from "@assistant-ui/core";
+import type {
+  AssistantRuntime,
+  AttachmentAdapter,
+  RemoteThreadListAdapter,
+} from "@assistant-ui/core";
 import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
 import { useAui } from "@assistant-ui/store";
 import { useLangGraphRuntime, useLangGraphSend } from "./useLangGraphRuntime";
@@ -365,5 +369,50 @@ describe("useLangGraphRuntime", () => {
       },
     ]);
     expect(sentMessages?.[0]?.content?.[1]).not.toHaveProperty("file");
+  });
+
+  it("should use unstable_threadListAdapter in place of the cloud adapter", async () => {
+    const list = vi.fn(async () => ({
+      threads: [
+        {
+          status: "regular" as const,
+          remoteId: "lg-thread-1",
+          externalId: "lg-thread-1",
+          title: "Existing LangGraph thread",
+        },
+      ],
+    }));
+    const adapter: RemoteThreadListAdapter = {
+      list,
+      initialize: vi.fn(async () => ({
+        remoteId: "lg-thread-1",
+        externalId: "lg-thread-1",
+      })),
+      rename: vi.fn(async () => {}),
+      archive: vi.fn(async () => {}),
+      unarchive: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+      generateTitle: vi.fn(async () => new ReadableStream()),
+      fetch: vi.fn(async () => ({
+        status: "regular" as const,
+        remoteId: "lg-thread-1",
+        externalId: "lg-thread-1",
+      })),
+    };
+
+    const streamMock = vi
+      .fn()
+      .mockImplementation(() => mockStreamCallbackFactory([])());
+
+    renderHook(() =>
+      useLangGraphRuntime({
+        stream: streamMock,
+        unstable_threadListAdapter: adapter,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(list).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -31,6 +31,7 @@ import {
 } from "@assistant-ui/core/react";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import type { AssistantCloud } from "assistant-cloud";
+import type { RemoteThreadListAdapter } from "@assistant-ui/core";
 import { convertLangChainMessages } from "./convertLangChainMessages";
 import {
   type LangGraphCommand,
@@ -259,6 +260,17 @@ export type UseLangGraphRuntimeOptions = {
       }
     | undefined;
   cloud?: AssistantCloud | undefined;
+  /**
+   * A `RemoteThreadListAdapter` to use instead of the cloud adapter. Provide
+   * this to back the thread list with a custom store (e.g. LangGraph
+   * `client.threads.search()`) so pre-existing LangGraph thread ids appear in
+   * the UI and can be switched between without assistant-cloud.
+   *
+   * When provided, `cloud`, `create`, and `delete` are ignored — the adapter
+   * owns the full thread list lifecycle. The `externalId` returned by the
+   * adapter's `list()` / `initialize()` is what the `load` callback receives.
+   */
+  unstable_threadListAdapter?: RemoteThreadListAdapter | undefined;
 };
 
 const truncateLangChainMessages = (
@@ -578,6 +590,7 @@ const useLangGraphRuntimeImpl = ({
 
 export const useLangGraphRuntime = ({
   cloud,
+  unstable_threadListAdapter,
   create,
   delete: deleteFn,
   ...options
@@ -598,12 +611,15 @@ export const useLangGraphRuntime = ({
     },
     delete: deleteFn,
   });
+
+  const adapter = unstable_threadListAdapter ?? cloudAdapter;
+
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
       // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       return useLangGraphRuntimeImpl(options);
     },
-    adapter: cloudAdapter,
+    adapter,
     allowNesting: true,
   });
 };


### PR DESCRIPTION
## Summary
- Adds `unstable_threadListAdapter?: RemoteThreadListAdapter` to `useLangGraphRuntime`, letting callers back the thread list with a custom store (e.g. `client.threads.search()`) so pre-existing LangGraph thread ids appear in the UI without running assistant-cloud.
- When the adapter is provided, `cloud` / `create` / `delete` are ignored — the adapter owns the full thread-list lifecycle, and the `externalId` it returns from `list()` / `initialize()` is what the `load` callback receives.
- Mirrors the `sessionAdapter` escape hatch already exposed by `useAdkRuntime` for API consistency across runtime packages.
- Documents the new option in `runtimes/langgraph/index.mdx` with a LangGraph SDK example, a `<Callout>` about the ignored options, and a link to the Custom Thread List guide for the full adapter contract.
- Adds a smoke test covering adapter preference over the cloud adapter.

## Test plan
- [x] `pnpm --filter @assistant-ui/react-langgraph test` — 97 / 97 pass
- [x] `pnpm lint` — no new warnings introduced
- [ ] Manual: pass a `RemoteThreadListAdapter` backed by `client.threads.search()`, confirm pre-existing LangGraph threads render in the thread picker and switching loads the correct state via `load(externalId)`
- [ ] Manual: confirm omitting `unstable_threadListAdapter` keeps current cloud / in-memory behaviour unchanged