### PR TITLE
fix(react-google-adk): use ADK session id as remoteId in initialize()

### DIFF
--- a/.changeset/adk-session-adapter-initialize-remote-id.md
+++ b/.changeset/adk-session-adapter-initialize-remote-id.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix(react-google-adk): return the ADK session id as `remoteId` from `createAdkSessionAdapter().initialize()`. Previously the input `threadId` (an internal `__LOCALID_*`) was returned, so later `delete(remoteId)` calls hit `/sessions/__LOCALID_*` and 404'd — masked by the adapter's tolerated 404 on delete.

--- a/packages/react-google-adk/src/AdkSessionAdapter.test.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.test.ts
@@ -126,7 +126,7 @@ describe("createAdkSessionAdapter - initialize", () => {
     });
     expect(JSON.parse(init?.body as string)).toEqual({});
     expect(result).toMatchObject({
-      remoteId: "thread-1",
+      remoteId: "new-session-1",
       externalId: "new-session-1",
     });
   });

--- a/packages/react-google-adk/src/AdkSessionAdapter.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.ts
@@ -111,7 +111,9 @@ export function createAdkSessionAdapter(
       return { threads };
     },
 
-    async initialize(): Promise<RemoteThreadInitializeResponse> {
+    async initialize(
+      _threadId: string,
+    ): Promise<RemoteThreadInitializeResponse> {
       const headers = await getHeaders();
       const res = await fetch(baseUrl, {
         method: "POST",

--- a/packages/react-google-adk/src/AdkSessionAdapter.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.ts
@@ -111,9 +111,7 @@ export function createAdkSessionAdapter(
       return { threads };
     },
 
-    async initialize(
-      threadId: string,
-    ): Promise<RemoteThreadInitializeResponse> {
+    async initialize(): Promise<RemoteThreadInitializeResponse> {
       const headers = await getHeaders();
       const res = await fetch(baseUrl, {
         method: "POST",
@@ -124,7 +122,7 @@ export function createAdkSessionAdapter(
         throw new Error(`Failed to create session: ${res.status}`);
       }
       const session = (await res.json()) as { id: string };
-      return { remoteId: threadId, externalId: session.id };
+      return { remoteId: session.id, externalId: session.id };
     },
 
     async delete(remoteId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- `createAdkSessionAdapter().initialize()` now returns `{ remoteId: session.id, externalId: session.id }` instead of `{ remoteId: threadId, externalId: session.id }`.
- The input `threadId` is an internal `__LOCALID_*` generated by the runtime, so returning it as `remoteId` meant later `delete(remoteId)` calls hit `/sessions/__LOCALID_*` and 404'd — silently tolerated by the adapter's `status !== 404` guard but left orphaned sessions on the ADK server.
- Matches the behaviour of `useCloudThreadListAdapter` and the Custom Thread List guide, and aligns with the reference example in `runtimes/langgraph/index.mdx`.
- Test assertion updated to reflect the corrected `remoteId`.

## Test plan
- [x] `pnpm --filter @assistant-ui/react-google-adk test` — 163 / 163 pass
- [ ] Manual: create a new thread via the runtime, then delete it — verify the `DELETE /sessions/{id}` request uses the ADK session id (not `__LOCALID_*`) and the session is actually removed on the ADK server
- [ ] Manual: confirm existing sessions in `list()` still switch/delete correctly (no regression on the already-correct `list()` path)