### PR TITLE
docs(reasoning, limits): minor fixes and updates

### DIFF
--- a/apps/docs/constants/model.ts
+++ b/apps/docs/constants/model.ts
@@ -2,14 +2,14 @@ export const MODELS = [
   // OpenAI
   {
     name: "GPT-5.4 Nano",
-    value: "openai/gpt-5.4-nano",
+    value: "gpt-5.4-nano",
     icon: "/icons/openai.svg",
     disabled: false,
     contextWindow: 400_000,
   },
   {
     name: "GPT-5.4 Mini",
-    value: "openai/gpt-5.4-mini",
+    value: "gpt-5.4-mini",
     icon: "/icons/openai.svg",
     disabled: false,
     contextWindow: 400_000,

--- a/apps/docs/content/docs/ui/reasoning.mdx
+++ b/apps/docs/content/docs/ui/reasoning.mdx
@@ -23,22 +23,26 @@ This adds a `/components/assistant-ui/reasoning.tsx` file to your project.
 
 ### Use in your application
 
-Pass the `Reasoning` and `ReasoningGroup` components to the `MessagePrimitive.Parts` component:
+Pass the `Reasoning` and `ReasoningGroup` components to `MessagePrimitive.Parts` via the `components` prop. Using them together is the recommended default — `ReasoningGroup` wraps consecutive reasoning parts in a collapsible container for a smooth out-of-the-box UI.
 
-```tsx title="/app/components/assistant-ui/thread.tsx" {2,10-11}
+```tsx title="/app/components/assistant-ui/thread.tsx"
 import { MessagePrimitive } from "@assistant-ui/react";
-import { Reasoning } from "@/components/assistant-ui/reasoning";
+import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
+import { Reasoning, ReasoningGroup } from "@/components/assistant-ui/reasoning"; // [!code ++]
 
 const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root className="...">
       <div className="...">
-        <MessagePrimitive.Parts>
-          {({ part }) => {
-            if (part.type === "reasoning") return <Reasoning {...part} />;
-            return null;
+        <MessagePrimitive.Parts
+          components={{
+            Text: MarkdownText,
+            Reasoning, // [!code ++]
+            ReasoningGroup, // [!code ++]
+            tools: { Fallback: ToolFallback },
           }}
-        </MessagePrimitive.Parts>
+        />
       </div>
       <AssistantActionBar />
       <BranchPicker className="..." />
@@ -57,7 +61,7 @@ The component consists of two parts:
 1. `Reasoning`: Renders individual reasoning message part content (with markdown support)
 2. `ReasoningGroup`: Wraps consecutive reasoning parts in a collapsible container
 
-Consecutive reasoning parts are automatically grouped together by the `ReasoningGroup` component.
+Consecutive reasoning parts are automatically grouped together by `ReasoningGroup`. We recommend using both together as the default — you can drop `ReasoningGroup` or build your own layout with the composable API below if you need more flexibility.
 
 > When using the composable API, `Reasoning.Text` is a plain container. Add `<MarkdownText />` for markdown rendering.
 

--- a/apps/docs/lib/validate-input.ts
+++ b/apps/docs/lib/validate-input.ts
@@ -14,8 +14,8 @@ interface InputLimits {
 
 const GENERAL_CHAT_LIMITS: InputLimits = {
   maxMessages: 20,
-  maxTotalChars: 24_000, // ~6k tokens
-  maxSingleMessageChars: 4_000,
+  maxTotalChars: 96_000, // ~24k tokens
+  maxSingleMessageChars: 12_000, // ~3k tokens
 };
 
 const DOC_CHAT_LIMITS: InputLimits = {


### PR DESCRIPTION
- **Docs reasoning API**: revert example to `components={{}}` API and restore `ReasoningGroup` + `Reasoning` as the default usage pattern in the thread docs (pending fix of the newer render-prop API).
- **Model ID fix**: drop the `openai/` prefix in docs demo model IDs — with that prefix the `@ai-sdk/openai` client misidentifies the model as non-reasoning (its `startsWith(\"gpt-5\")` check fails); `assistant-billing` resolves the correct provider/model automatically. Reasoning isn't currently enabled in the demo regardless.
- **Chat limits**: raise docs chat limits (too aggressive before) to 24k-token context and 3k-token single-message caps.

### Testing

- [x] Reasoning docs page renders and the thread snippet reflects `components=` usage
- [x] Docs chat demo sends/receives with the updated model id without provider errors
- [x] Long single messages and multi-turn chats stay under the new limits without premature rejection