### PR TITLE
fix(react-streamdown): code adapter crash with custom SyntaxHighlighter

### DIFF
--- a/.changeset/fix-streamdown-code-adapter-memo.md
+++ b/.changeset/fix-streamdown-code-adapter-memo.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: pass memoized code component to streamdown instead of invoking it as a function, and render CodeHeader when no SyntaxHighlighter is configured for a block

--- a/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
+++ b/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
@@ -1,7 +1,12 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { TextMessagePartProvider } from "@assistant-ui/react";
 import { StreamdownTextPrimitive } from "../primitives/StreamdownText";
+import type {
+  StreamdownTextComponents,
+  SyntaxHighlighterProps,
+  CodeHeaderProps,
+} from "../types";
 
 afterEach(cleanup);
 
@@ -52,5 +57,96 @@ describe("StreamdownTextPrimitive", () => {
       ((await screen.findByTitle("Download table")) as HTMLButtonElement)
         .disabled,
     ).toBe(false);
+  });
+
+  describe("code adapter with custom components", () => {
+    const fencedMarkdown = "```ts\nconst x = 1;\n```";
+
+    it("renders without throwing when SyntaxHighlighter is provided", () => {
+      const SyntaxHighlighter = vi.fn(
+        ({ code, language }: SyntaxHighlighterProps) => (
+          <div data-testid="highlighter">{`${language}:${code}`}</div>
+        ),
+      );
+      const components: StreamdownTextComponents = { SyntaxHighlighter };
+
+      expect(() =>
+        render(
+          <TextMessagePartProvider text={fencedMarkdown} isRunning={false}>
+            <StreamdownTextPrimitive components={components} />
+          </TextMessagePartProvider>,
+        ),
+      ).not.toThrow();
+
+      expect(SyntaxHighlighter).toHaveBeenCalled();
+      const callArgs = SyntaxHighlighter.mock.calls[0]![0];
+      expect(callArgs.language).toBe("ts");
+      expect(callArgs.code.trim()).toBe("const x = 1;");
+    });
+
+    it("renders without throwing when only CodeHeader is provided", () => {
+      const CodeHeader = vi.fn(({ language }: CodeHeaderProps) => (
+        <div data-testid="header">{language}</div>
+      ));
+      const components: StreamdownTextComponents = { CodeHeader };
+
+      expect(() =>
+        render(
+          <TextMessagePartProvider text={fencedMarkdown} isRunning={false}>
+            <StreamdownTextPrimitive components={components} />
+          </TextMessagePartProvider>,
+        ),
+      ).not.toThrow();
+
+      expect(CodeHeader).toHaveBeenCalled();
+      expect(screen.getByTestId("header").textContent).toBe("ts");
+    });
+
+    it("renders without throwing when componentsByLanguage is provided for an unmatched language", () => {
+      const PythonHighlighter = vi.fn(() => (
+        <div data-testid="python">python</div>
+      ));
+
+      expect(() =>
+        render(
+          <TextMessagePartProvider text={fencedMarkdown} isRunning={false}>
+            <StreamdownTextPrimitive
+              componentsByLanguage={{
+                python: { SyntaxHighlighter: PythonHighlighter },
+              }}
+            />
+          </TextMessagePartProvider>,
+        ),
+      ).not.toThrow();
+
+      // block is typescript, python config must be ignored and not invoked
+      expect(PythonHighlighter).not.toHaveBeenCalled();
+    });
+
+    it("dispatches to language-specific SyntaxHighlighter", () => {
+      const TsHighlighter = vi.fn(({ code }: SyntaxHighlighterProps) => (
+        <div data-testid="ts-hl">{code}</div>
+      ));
+      const FallbackHighlighter = vi.fn(() => (
+        <div data-testid="fallback-hl">fallback</div>
+      ));
+
+      render(
+        <TextMessagePartProvider text={fencedMarkdown} isRunning={false}>
+          <StreamdownTextPrimitive
+            components={{ SyntaxHighlighter: FallbackHighlighter }}
+            componentsByLanguage={{
+              ts: { SyntaxHighlighter: TsHighlighter },
+            }}
+          />
+        </TextMessagePartProvider>,
+      );
+
+      expect(TsHighlighter).toHaveBeenCalled();
+      expect(FallbackHighlighter).not.toHaveBeenCalled();
+      expect(screen.getByTestId("ts-hl").textContent?.trim()).toBe(
+        "const x = 1;",
+      );
+    });
   });
 });

--- a/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
+++ b/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
@@ -90,16 +90,16 @@ describe("StreamdownTextPrimitive", () => {
       ));
       const components: StreamdownTextComponents = { CodeHeader };
 
-      expect(() =>
-        render(
-          <TextMessagePartProvider text={fencedMarkdown} isRunning={false}>
-            <StreamdownTextPrimitive components={components} />
-          </TextMessagePartProvider>,
-        ),
-      ).not.toThrow();
+      const { container } = render(
+        <TextMessagePartProvider text={fencedMarkdown} isRunning={false}>
+          <StreamdownTextPrimitive components={components} />
+        </TextMessagePartProvider>,
+      );
 
       expect(CodeHeader).toHaveBeenCalled();
       expect(screen.getByTestId("header").textContent).toBe("ts");
+      // Fallback must wrap <code> in <pre> so browsers preserve whitespace.
+      expect(container.querySelector("pre > code")).not.toBeNull();
     });
 
     it("renders without throwing when componentsByLanguage is provided for an unmatched language", () => {
@@ -107,20 +107,19 @@ describe("StreamdownTextPrimitive", () => {
         <div data-testid="python">python</div>
       ));
 
-      expect(() =>
-        render(
-          <TextMessagePartProvider text={fencedMarkdown} isRunning={false}>
-            <StreamdownTextPrimitive
-              componentsByLanguage={{
-                python: { SyntaxHighlighter: PythonHighlighter },
-              }}
-            />
-          </TextMessagePartProvider>,
-        ),
-      ).not.toThrow();
+      const { container } = render(
+        <TextMessagePartProvider text={fencedMarkdown} isRunning={false}>
+          <StreamdownTextPrimitive
+            componentsByLanguage={{
+              python: { SyntaxHighlighter: PythonHighlighter },
+            }}
+          />
+        </TextMessagePartProvider>,
+      );
 
       // block is typescript, python config must be ignored and not invoked
       expect(PythonHighlighter).not.toHaveBeenCalled();
+      expect(container.querySelector("pre > code")).not.toBeNull();
     });
 
     it("dispatches to language-specific SyntaxHighlighter", () => {

--- a/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
+++ b/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
@@ -246,8 +246,8 @@ describe("createCodeAdapter integration", () => {
     });
   });
 
-  describe("null return for streamdown default", () => {
-    it("returns null when no custom SyntaxHighlighter", () => {
+  describe("fallback when no custom SyntaxHighlighter", () => {
+    it("renders a plain block <code> element", () => {
       const AdaptedCode = createCodeAdapter({});
 
       const { container } = render(
@@ -256,7 +256,49 @@ describe("createCodeAdapter integration", () => {
         </AdaptedCode>,
       );
 
-      expect(container.querySelector("code")).toBeNull();
+      const codeElement = container.querySelector("code");
+      expect(codeElement).not.toBeNull();
+      expect(codeElement?.className).toBe("language-js");
+      expect(codeElement?.textContent).toBe("code");
+      expect(codeElement?.className).not.toContain(
+        "aui-streamdown-inline-code",
+      );
+    });
+
+    it("renders CodeHeader above plain block <code> when provided", () => {
+      const MockHeader = vi.fn(({ language }) => (
+        <div data-testid="header">{language}</div>
+      ));
+      const AdaptedCode = createCodeAdapter({ CodeHeader: MockHeader });
+
+      const { container } = render(
+        <AdaptedCode className="language-python" data-block="true">
+          print("hi")
+        </AdaptedCode>,
+      );
+
+      expect(screen.getByTestId("header").textContent).toBe("python");
+      const codeElement = container.querySelector("code");
+      expect(codeElement).not.toBeNull();
+      expect(codeElement?.textContent).toBe('print("hi")');
+    });
+
+    it("renders block <code> for unmatched language in componentsByLanguage", () => {
+      const PythonSyntax = vi.fn(() => <div data-testid="python">py</div>);
+      const AdaptedCode = createCodeAdapter({
+        componentsByLanguage: { python: { SyntaxHighlighter: PythonSyntax } },
+      });
+
+      const { container } = render(
+        <AdaptedCode className="language-javascript" data-block="true">
+          const x = 1;
+        </AdaptedCode>,
+      );
+
+      expect(PythonSyntax).not.toHaveBeenCalled();
+      const codeElement = container.querySelector("code");
+      expect(codeElement).not.toBeNull();
+      expect(codeElement?.textContent).toBe("const x = 1;");
     });
   });
 

--- a/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
+++ b/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
@@ -247,7 +247,7 @@ describe("createCodeAdapter integration", () => {
   });
 
   describe("fallback when no custom SyntaxHighlighter", () => {
-    it("renders a plain block <code> element", () => {
+    it("wraps the fallback <code> in a <pre> to preserve whitespace", () => {
       const AdaptedCode = createCodeAdapter({});
 
       const { container } = render(
@@ -256,7 +256,7 @@ describe("createCodeAdapter integration", () => {
         </AdaptedCode>,
       );
 
-      const codeElement = container.querySelector("code");
+      const codeElement = container.querySelector("pre > code");
       expect(codeElement).not.toBeNull();
       expect(codeElement?.className).toBe("language-js");
       expect(codeElement?.textContent).toBe("code");
@@ -265,7 +265,7 @@ describe("createCodeAdapter integration", () => {
       );
     });
 
-    it("renders CodeHeader above plain block <code> when provided", () => {
+    it("renders CodeHeader above the <pre><code> fallback when provided", () => {
       const MockHeader = vi.fn(({ language }) => (
         <div data-testid="header">{language}</div>
       ));
@@ -278,12 +278,12 @@ describe("createCodeAdapter integration", () => {
       );
 
       expect(screen.getByTestId("header").textContent).toBe("python");
-      const codeElement = container.querySelector("code");
+      const codeElement = container.querySelector("pre > code");
       expect(codeElement).not.toBeNull();
       expect(codeElement?.textContent).toBe('print("hi")');
     });
 
-    it("renders block <code> for unmatched language in componentsByLanguage", () => {
+    it("renders <pre><code> fallback for unmatched language in componentsByLanguage", () => {
       const PythonSyntax = vi.fn(() => <div data-testid="python">py</div>);
       const AdaptedCode = createCodeAdapter({
         componentsByLanguage: { python: { SyntaxHighlighter: PythonSyntax } },
@@ -296,7 +296,7 @@ describe("createCodeAdapter integration", () => {
       );
 
       expect(PythonSyntax).not.toHaveBeenCalled();
-      const codeElement = container.querySelector("code");
+      const codeElement = container.querySelector("pre > code");
       expect(codeElement).not.toBeNull();
       expect(codeElement?.textContent).toBe("const x = 1;");
     });

--- a/packages/react-streamdown/src/__tests__/components-adapter.test.tsx
+++ b/packages/react-streamdown/src/__tests__/components-adapter.test.tsx
@@ -1,7 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, render, renderHook, screen } from "@testing-library/react";
+import { createElement } from "react";
 import { useAdaptedComponents } from "../adapters/components-adapter";
 import type { StreamdownTextComponents } from "../types";
+
+afterEach(cleanup);
 
 describe("useAdaptedComponents", () => {
   describe("basic behavior", () => {
@@ -48,7 +51,47 @@ describe("useAdaptedComponents", () => {
         }),
       );
       expect(result.current).toHaveProperty("code");
-      expect(typeof result.current?.code).toBe("function");
+      // The resolved code is a React.memo exotic — a JSX element type, not a
+      // callable function. Invoking it as `code(props)` throws.
+      const codeComponent = result.current?.code as unknown as {
+        $$typeof?: symbol;
+      };
+      expect(codeComponent).toBeDefined();
+      expect(typeof codeComponent.$$typeof).toBe("symbol");
+    });
+
+    it("the resolved code component renders as JSX without throwing", () => {
+      const MockSyntax = vi.fn(
+        ({ code, language }: { code: string; language: string }) => (
+          <div data-testid="highlighter">{`${language}:${code}`}</div>
+        ),
+      );
+      const { result } = renderHook(() =>
+        useAdaptedComponents({
+          components: { SyntaxHighlighter: MockSyntax },
+        }),
+      );
+      const CodeComponent = result.current?.code;
+      expect(CodeComponent).toBeDefined();
+
+      // Render via createElement — the path streamdown + react-markdown take.
+      // Direct function invocation would crash on the memo exotic.
+      expect(() =>
+        render(
+          createElement(
+            CodeComponent as React.ComponentType<Record<string, unknown>>,
+            {
+              className: "language-ts",
+              "data-block": "true",
+            },
+            "const x = 1;",
+          ),
+        ),
+      ).not.toThrow();
+
+      expect(screen.getByTestId("highlighter").textContent).toBe(
+        "ts:const x = 1;",
+      );
     });
 
     it("creates code adapter when CodeHeader provided", () => {

--- a/packages/react-streamdown/src/__tests__/components-adapter.test.tsx
+++ b/packages/react-streamdown/src/__tests__/components-adapter.test.tsx
@@ -51,13 +51,6 @@ describe("useAdaptedComponents", () => {
         }),
       );
       expect(result.current).toHaveProperty("code");
-      // The resolved code is a React.memo exotic — a JSX element type, not a
-      // callable function. Invoking it as `code(props)` throws.
-      const codeComponent = result.current?.code as unknown as {
-        $$typeof?: symbol;
-      };
-      expect(codeComponent).toBeDefined();
-      expect(typeof codeComponent.$$typeof).toBe("symbol");
     });
 
     it("the resolved code component renders as JSX without throwing", () => {

--- a/packages/react-streamdown/src/__tests__/components-adapter.test.tsx
+++ b/packages/react-streamdown/src/__tests__/components-adapter.test.tsx
@@ -68,19 +68,18 @@ describe("useAdaptedComponents", () => {
       expect(CodeComponent).toBeDefined();
 
       // Render via createElement — the path streamdown + react-markdown take.
-      // Direct function invocation would crash on the memo exotic.
-      expect(() =>
-        render(
-          createElement(
-            CodeComponent as React.ComponentType<Record<string, unknown>>,
-            {
-              className: "language-ts",
-              "data-block": "true",
-            },
-            "const x = 1;",
-          ),
+      // Direct function invocation would crash on the memo exotic; a
+      // render failure here surfaces the TypeError directly.
+      render(
+        createElement(
+          CodeComponent as React.ComponentType<Record<string, unknown>>,
+          {
+            className: "language-ts",
+            "data-block": "true",
+          },
+          "const x = 1;",
         ),
-      ).not.toThrow();
+      );
 
       expect(screen.getByTestId("highlighter").textContent).toBe(
         "ts:const x = 1;",

--- a/packages/react-streamdown/src/adapters/code-adapter.tsx
+++ b/packages/react-streamdown/src/adapters/code-adapter.tsx
@@ -98,13 +98,14 @@ export function createCodeAdapter(options: CodeAdapterOptions) {
     const CodeHeader =
       componentsByLanguage[language]?.CodeHeader ?? UserCodeHeader;
 
-    // If user provided custom SyntaxHighlighter, use it
+    const headerElement = CodeHeader ? (
+      <CodeHeader node={node} language={language} code={code} />
+    ) : null;
+
     if (SyntaxHighlighter) {
       return (
         <>
-          {CodeHeader && (
-            <CodeHeader node={node} language={language} code={code} />
-          )}
+          {headerElement}
           <SyntaxHighlighter
             node={node}
             components={{ Pre: DefaultPre, Code: DefaultCode }}
@@ -115,9 +116,14 @@ export function createCodeAdapter(options: CodeAdapterOptions) {
       );
     }
 
-    // No custom SyntaxHighlighter - return null to let streamdown handle it
-    // This signals to the adapter that we should use streamdown's default
-    return null;
+    return (
+      <>
+        {headerElement}
+        <code className={className} {...props}>
+          {children}
+        </code>
+      </>
+    );
   }
 
   const AdaptedCode = memo(AdaptedCodeInner, (prev, next) => {
@@ -129,6 +135,7 @@ export function createCodeAdapter(options: CodeAdapterOptions) {
       prev.node?.position?.end.line === next.node?.position?.end.line
     );
   });
+  AdaptedCode.displayName = "AdaptedCode";
 
   return AdaptedCode;
 }

--- a/packages/react-streamdown/src/adapters/code-adapter.tsx
+++ b/packages/react-streamdown/src/adapters/code-adapter.tsx
@@ -119,9 +119,11 @@ export function createCodeAdapter(options: CodeAdapterOptions) {
     return (
       <>
         {headerElement}
-        <code className={className} {...props}>
-          {children}
-        </code>
+        <pre>
+          <code className={className} {...props}>
+            {children}
+          </code>
+        </pre>
       </>
     );
   }

--- a/packages/react-streamdown/src/adapters/code-adapter.tsx
+++ b/packages/react-streamdown/src/adapters/code-adapter.tsx
@@ -119,11 +119,11 @@ export function createCodeAdapter(options: CodeAdapterOptions) {
     return (
       <>
         {headerElement}
-        <pre>
+        <DefaultPre node={node}>
           <code className={className} {...props}>
             {children}
           </code>
-        </pre>
+        </DefaultPre>
       </>
     );
   }

--- a/packages/react-streamdown/src/adapters/components-adapter.ts
+++ b/packages/react-streamdown/src/adapters/components-adapter.ts
@@ -45,7 +45,7 @@ export function useAdaptedComponents({
     return {
       ...htmlComponents,
       ...baseComponents,
-      code: (props) => AdaptedCode(props) ?? undefined,
+      code: AdaptedCode,
     };
   }, [components, componentsByLanguage]);
 }


### PR DESCRIPTION
## Summary

- Fix `TypeError: AdaptedCode is not a function` crash when `components.SyntaxHighlighter`, `components.CodeHeader`, or `componentsByLanguage` is passed to `<StreamdownTextPrimitive />` — the adapter was invoking a `React.memo(...)` exotic as a plain function (see #3849).
- Hand the memoized `AdaptedCode` directly to streamdown as a JSX element type instead of wrapping it in `(props) => AdaptedCode(props) ?? undefined`.
- Render `CodeHeader` (plus a plain block `<code>`) when no `SyntaxHighlighter` applies to the block's language, closing a secondary bug where `CodeHeader`-only and unmatched-language configurations silently dropped output.
- Add end-to-end regression coverage through `StreamdownTextPrimitive` — existing tests only rendered `<AdaptedCode>` as JSX and never exercised the plain-function-invocation path.
- Add `displayName` to the memoized component and convert `components-adapter.test.ts` → `.tsx` so it can verify the resolved `code` renders as a React element.

Fixes #3849.

## Test plan

- [x] `pnpm --filter @assistant-ui/react-streamdown test` — 93 passed (6 new)
- [x] `pnpm lint` — clean (no new warnings)
- [ ] Reviewer: mount `<StreamdownTextPrimitive components={{ SyntaxHighlighter }} />` with a fenced code block in a consumer app, confirm no runtime throw and the highlighter renders
- [ ] Reviewer: with `components={{ CodeHeader }}` only (no SyntaxHighlighter), confirm the header renders above a plain code block
- [ ] Reviewer: with `componentsByLanguage={{ python: {...} }}` but a `javascript` block, confirm the block renders without crashing