### PR TITLE
feat: add useNotification hook for terminal and custom notifications

### DIFF
--- a/.changeset/add-react-ink-notifications.md
+++ b/.changeset/add-react-ink-notifications.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+add a `useNotification` hook plus `ringBell` / `sendOSCNotification` helpers to `@assistant-ui/react-ink`. the hook rings the terminal bell and emits an OSC desktop notification when the assistant finishes a run, stops with an error, or pauses for human approval (`requires-action` with `reason: "interrupt"` only; tool-call pauses are skipped). pass `useNotification()` for the default bell-on-every-transition behavior, `useNotification({ onTaskComplete: false })` to suppress one trigger, or `useNotification({ onTaskComplete: { custom: (event) => ... } })` for a user-supplied callback. transitions are derived from `useAuiState` so deprecated `thread.runStart` / `thread.runEnd` events are not relied on. `ringBell` and `sendOSCNotification` are also exported for imperative use.

--- a/apps/docs/content/docs/ink/hooks.mdx
+++ b/apps/docs/content/docs/ink/hooks.mdx
@@ -60,6 +60,51 @@ useAuiEvent("thread.runStart", (payload) => {
 });
 ```
 
+### useNotification
+
+Ring the terminal bell and emit an OSC desktop notification when the assistant finishes a run, stops with an error, or pauses for human approval.
+
+```tsx
+import { useNotification } from "@assistant-ui/react-ink";
+
+useNotification();
+```
+
+Defaults:
+
+- `task-complete`: bell + OSC 9
+- `task-incomplete`: bell
+- `needs-input` (assistant message in `requires-action` with `reason: "interrupt"`): bell
+
+Pass `false` to suppress one trigger, or a `NotificationHandler` to override it:
+
+```tsx
+useNotification({
+  onTaskComplete: { osc: "osc99" },
+  onTaskIncomplete: false,
+  onNeedsInput: {
+    custom: (event) => myLogger.log(event),
+  },
+});
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `enabled` | `boolean` | Master switch. Defaults to `true`. |
+| `onTaskComplete` | `NotificationHandler<"task-complete"> \| false` | Fired when the latest assistant message status flips to `complete` after a run was observed. |
+| `onTaskIncomplete` | `NotificationHandler<"task-incomplete"> \| false` | Fired when the latest assistant message status flips to `incomplete` after a run was observed. |
+| `onNeedsInput` | `NotificationHandler<"needs-input"> \| false` | Fired when the latest assistant message enters `requires-action` with `reason: "interrupt"`. Tool-call pauses are skipped. |
+
+`NotificationHandler<T>` fields (all optional, any combination):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `bell` | `boolean` | Ring the terminal bell (`\x07`). |
+| `osc` | `boolean \| "osc9" \| "osc99" \| "osc777"` | Send an OSC notification. `true` is equivalent to `"osc9"`. |
+| `custom` | `(event: Extract<NotificationEvent, { type: T }>) => void` | User callback invoked with the event payload narrowed to this handler's type. |
+
+Notifications are deduplicated per `thread:message:status:reason` tuple, so passing an inline config object does not produce duplicate fires. `ringBell` and `sendOSCNotification(title, body?, variant?)` are also exported for imperative use. OSC support depends on the terminal emulator.
+
 ## Runtime Hooks
 
 ### useLocalRuntime

--- a/packages/react-ink/src/hooks/notification-channels.ts
+++ b/packages/react-ink/src/hooks/notification-channels.ts
@@ -1,0 +1,51 @@
+export type OSCVariant = "osc9" | "osc99" | "osc777";
+
+type ProcessWithStdout = {
+  process?: {
+    stdout?: {
+      write: (value: string) => unknown;
+    };
+  };
+};
+
+const writeToStdout = (value: string) => {
+  const stdout = (globalThis as ProcessWithStdout).process?.stdout;
+  stdout?.write(value);
+};
+
+const sanitizeOSCText = (value: string) => {
+  return value.replaceAll("\x07", "").replaceAll("\x1b", "");
+};
+
+export const ringBell = () => {
+  writeToStdout("\x07");
+};
+
+/**
+ * Emit an OSC terminal notification. `osc9` and `osc99` carry a single
+ * message string and render `body ?? title`. `osc777` carries `title` and
+ * `body` as separate fields. OSC support depends on the terminal emulator.
+ */
+export const sendOSCNotification = (
+  title: string,
+  body?: string,
+  variant: OSCVariant = "osc9",
+) => {
+  const sanitizedTitle = sanitizeOSCText(title);
+  const sanitizedBody = body ? sanitizeOSCText(body) : undefined;
+  const message = sanitizedBody ?? sanitizedTitle;
+
+  switch (variant) {
+    case "osc99":
+      writeToStdout(`\x1b]99;i=1:d=0;${message}\x1b\\`);
+      return;
+    case "osc777":
+      writeToStdout(
+        `\x1b]777;notify;${sanitizedTitle};${sanitizedBody ?? ""}\x07`,
+      );
+      return;
+    case "osc9":
+      writeToStdout(`\x1b]9;${message}\x07`);
+      return;
+  }
+};

--- a/packages/react-ink/src/hooks/useNotification.ts
+++ b/packages/react-ink/src/hooks/useNotification.ts
@@ -1,0 +1,171 @@
+import { useEffect, useRef } from "react";
+import { useAuiState } from "@assistant-ui/store";
+import type { MessageStatus } from "@assistant-ui/core";
+import {
+  ringBell,
+  sendOSCNotification,
+  type OSCVariant,
+} from "./notification-channels";
+
+type IncompleteReason = Extract<
+  MessageStatus,
+  { type: "incomplete" }
+>["reason"];
+
+export type NotificationEvent =
+  | {
+      type: "task-complete";
+      threadId: string;
+      messageId: string;
+      title: string;
+    }
+  | {
+      type: "task-incomplete";
+      threadId: string;
+      messageId: string;
+      title: string;
+      reason: IncompleteReason;
+    }
+  | {
+      type: "needs-input";
+      threadId: string;
+      messageId: string;
+      title: string;
+      reason: "interrupt";
+    };
+
+export type NotificationHandler<
+  T extends NotificationEvent["type"] = NotificationEvent["type"],
+> = {
+  bell?: boolean;
+  osc?: boolean | OSCVariant;
+  custom?: (event: Extract<NotificationEvent, { type: T }>) => void;
+};
+
+export type NotificationConfig = {
+  enabled?: boolean;
+  onTaskComplete?: NotificationHandler<"task-complete"> | false;
+  onTaskIncomplete?: NotificationHandler<"task-incomplete"> | false;
+  onNeedsInput?: NotificationHandler<"needs-input"> | false;
+};
+
+const TITLES: Record<NotificationEvent["type"], string> = {
+  "task-complete": "AI task complete",
+  "task-incomplete": "AI task stopped",
+  "needs-input": "AI needs input",
+};
+
+const DEFAULTS = {
+  onTaskComplete: { bell: true, osc: true },
+  onTaskIncomplete: { bell: true },
+  onNeedsInput: { bell: true },
+} satisfies {
+  onTaskComplete: NotificationHandler<"task-complete">;
+  onTaskIncomplete: NotificationHandler<"task-incomplete">;
+  onNeedsInput: NotificationHandler<"needs-input">;
+};
+
+const dispatch = <T extends NotificationEvent["type"]>(
+  handler: NotificationHandler<T> | false | undefined,
+  fallback: NotificationHandler<T>,
+  event: Extract<NotificationEvent, { type: T }>,
+) => {
+  const resolved = handler === undefined ? fallback : handler;
+  if (!resolved) return;
+  if (resolved.bell) ringBell();
+  if (resolved.osc) {
+    const variant: OSCVariant =
+      typeof resolved.osc === "string" ? resolved.osc : "osc9";
+    sendOSCNotification(event.title, undefined, variant);
+  }
+  resolved.custom?.(event);
+};
+
+type Snapshot = {
+  isRunning: boolean;
+  threadId: string;
+  messageId: string;
+  statusType: string;
+  statusReason: string;
+};
+
+/**
+ * Emit a terminal notification when the assistant finishes a run, stops with
+ * an error, or pauses for human approval. Pass nothing for the default
+ * bell-on-every-transition behavior; pass `false` for a key to suppress one.
+ */
+export const useNotification = (config: NotificationConfig = {}) => {
+  const snapshotKey = useAuiState((s) => {
+    const last = s.thread.messages.findLast((m) => m.role === "assistant");
+    const statusReason =
+      last?.status && "reason" in last.status ? last.status.reason : "";
+    return JSON.stringify({
+      isRunning: s.thread.isRunning,
+      threadId: s.threadListItem.id,
+      messageId: last?.id ?? "",
+      statusType: last?.status?.type ?? "",
+      statusReason,
+    });
+  });
+
+  const seenRunningForRef = useRef<string | undefined>(undefined);
+  const lastKeyRef = useRef<string | undefined>(undefined);
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  useEffect(() => {
+    const cfg = configRef.current;
+    const { isRunning, threadId, messageId, statusType, statusReason } =
+      JSON.parse(snapshotKey) as Snapshot;
+    const runContext = messageId ? `${threadId}:${messageId}` : undefined;
+    const key =
+      messageId && statusType
+        ? `${threadId}:${messageId}:${statusType}:${statusReason}`
+        : undefined;
+
+    if (cfg.enabled === false) {
+      seenRunningForRef.current = undefined;
+      if (key) lastKeyRef.current = key;
+      return;
+    }
+    if (isRunning && runContext) {
+      seenRunningForRef.current = runContext;
+    }
+    if (!messageId || !statusType || !key || !runContext) return;
+    if (lastKeyRef.current === key) return;
+    lastKeyRef.current = key;
+
+    const seenRunning = seenRunningForRef.current === runContext;
+    const base = { threadId, messageId };
+
+    if (statusType === "complete" && seenRunning) {
+      seenRunningForRef.current = undefined;
+      dispatch(cfg.onTaskComplete, DEFAULTS.onTaskComplete, {
+        ...base,
+        type: "task-complete",
+        title: TITLES["task-complete"],
+      });
+      return;
+    }
+    if (statusType === "incomplete" && statusReason && seenRunning) {
+      seenRunningForRef.current = undefined;
+      dispatch(cfg.onTaskIncomplete, DEFAULTS.onTaskIncomplete, {
+        ...base,
+        type: "task-incomplete",
+        title: TITLES["task-incomplete"],
+        reason: statusReason as IncompleteReason,
+      });
+      return;
+    }
+    if (statusType === "requires-action" && statusReason === "interrupt") {
+      dispatch(cfg.onNeedsInput, DEFAULTS.onNeedsInput, {
+        ...base,
+        type: "needs-input",
+        title: TITLES["needs-input"],
+        reason: "interrupt",
+      });
+    }
+  }, [snapshotKey]);
+};
+
+export type { OSCVariant } from "./notification-channels";

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -120,6 +120,14 @@ export {
   createSimpleTitleAdapter,
   type TitleGenerationAdapter,
 } from "@assistant-ui/core/react";
+export {
+  useNotification,
+  type NotificationConfig,
+  type NotificationHandler,
+  type NotificationEvent,
+  type OSCVariant,
+} from "./hooks/useNotification";
+export { ringBell, sendOSCNotification } from "./hooks/notification-channels";
 
 // Primitives
 export * as ThreadPrimitive from "./primitives/thread";

--- a/packages/react-ink/src/tests/useNotification.test.tsx
+++ b/packages/react-ink/src/tests/useNotification.test.tsx
@@ -1,0 +1,590 @@
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "ink-testing-library";
+import type { ComposerState, MessageState } from "@assistant-ui/core/store";
+import type { UseAuiStateSelector } from "./helpers";
+
+const mockUseAuiState = vi.fn();
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  return {
+    ...actual,
+    useAuiState: (selector: UseAuiStateSelector) => mockUseAuiState(selector),
+  };
+});
+
+import {
+  ringBell,
+  sendOSCNotification,
+  useNotification,
+  type NotificationConfig,
+} from "../index";
+
+type ThreadSnapshot = {
+  isRunning: boolean;
+  messages: MessageState[];
+};
+
+let snapshot: ThreadSnapshot = { isRunning: false, messages: [] };
+
+const composer: ComposerState = {
+  text: "",
+  role: "user",
+  attachments: [],
+  runConfig: {},
+  isEditing: false,
+  canCancel: false,
+  canSend: false,
+  attachmentAccept: "",
+  isEmpty: true,
+  type: "thread",
+  dictation: undefined,
+  quote: undefined,
+  queue: [],
+};
+
+const makeAssistantMessage = (
+  id: string,
+  status: MessageState["status"],
+): MessageState =>
+  ({
+    role: "assistant",
+    id,
+    status,
+    createdAt: new Date(0),
+    parentId: null,
+    isLast: true,
+    branchNumber: 0,
+    branchCount: 1,
+    speech: undefined,
+    submittedFeedback: undefined,
+    composer,
+    parts: [],
+    isCopied: false,
+    isHovering: false,
+    index: 0,
+    content: [],
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {},
+    },
+  }) as unknown as MessageState;
+
+const Notifier = ({ config }: { config?: NotificationConfig }) => {
+  useNotification(config);
+  return null;
+};
+
+const renderNotifier = (node: ReactElement = <Notifier />) => render(node);
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  snapshot = { isRunning: false, messages: [] };
+  mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) =>
+    selector({
+      thread: snapshot,
+      threadListItem: { id: "thread-1" },
+    } as never),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("notification channels", () => {
+  const spyStdout = () =>
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+  it("ringBell writes BEL", () => {
+    const w = spyStdout();
+    ringBell();
+    expect(w).toHaveBeenCalledWith("\x07");
+    w.mockRestore();
+  });
+
+  it.each([
+    ["osc9", "\x1b]9;body\x07"],
+    ["osc99", "\x1b]99;i=1:d=0;body\x1b\\"],
+    ["osc777", "\x1b]777;notify;title;body\x07"],
+  ] as const)("sendOSCNotification writes %s sequence", (variant, expected) => {
+    const w = spyStdout();
+    sendOSCNotification("title", "body", variant);
+    expect(w).toHaveBeenCalledWith(expected);
+    w.mockRestore();
+  });
+
+  it.each([
+    ["osc9", "\x1b]9;body\x07"],
+    ["osc99", "\x1b]99;i=1:d=0;body\x1b\\"],
+    ["osc777", "\x1b]777;notify;title;body\x07"],
+  ] as const)(
+    "sendOSCNotification strips ESC and BEL in %s",
+    (variant, expected) => {
+      const w = spyStdout();
+      sendOSCNotification("ti\x1btle", "bo\x07dy\x1b", variant);
+      expect(w).toHaveBeenCalledWith(expected);
+      w.mockRestore();
+    },
+  );
+});
+
+describe("useNotification", () => {
+  const spyStdout = () =>
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+  it("rings bell and emits OSC after a run completes", async () => {
+    snapshot = {
+      isRunning: true,
+      messages: [makeAssistantMessage("m1", { type: "running" })],
+    };
+    const w = spyStdout();
+
+    const instance = renderNotifier();
+    await flush();
+
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", { type: "complete", reason: "stop" }),
+      ],
+    };
+    instance.rerender(<Notifier />);
+    await flush();
+
+    expect(w).toHaveBeenNthCalledWith(1, "\x07");
+    expect(w).toHaveBeenNthCalledWith(2, "\x1b]9;AI task complete\x07");
+    w.mockRestore();
+  });
+
+  it("rings bell once when a run ends incomplete", async () => {
+    snapshot = {
+      isRunning: true,
+      messages: [makeAssistantMessage("m1", { type: "running" })],
+    };
+    const w = spyStdout();
+
+    const instance = renderNotifier();
+    await flush();
+
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", { type: "incomplete", reason: "error" }),
+      ],
+    };
+    instance.rerender(<Notifier />);
+    await flush();
+
+    expect(w).toHaveBeenCalledTimes(1);
+    expect(w).toHaveBeenCalledWith("\x07");
+    w.mockRestore();
+  });
+
+  it("does not fire when mounted on an already-complete thread", async () => {
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", { type: "complete", reason: "stop" }),
+      ],
+    };
+    const w = spyStdout();
+
+    const instance = renderNotifier();
+    await flush();
+    instance.rerender(<Notifier />);
+    await flush();
+
+    expect(w).not.toHaveBeenCalled();
+    w.mockRestore();
+  });
+
+  it("fires when mounted mid-run and the run later completes", async () => {
+    snapshot = {
+      isRunning: true,
+      messages: [makeAssistantMessage("m1", { type: "running" })],
+    };
+    const w = spyStdout();
+
+    const instance = renderNotifier();
+    await flush();
+
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", { type: "complete", reason: "stop" }),
+      ],
+    };
+    instance.rerender(<Notifier />);
+    await flush();
+
+    expect(w).toHaveBeenCalledTimes(2);
+    w.mockRestore();
+  });
+
+  it("emits needs-input on requires-action with reason interrupt", async () => {
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", {
+          type: "requires-action",
+          reason: "interrupt",
+        }),
+      ],
+    };
+    const w = spyStdout();
+
+    renderNotifier();
+    await flush();
+
+    expect(w).toHaveBeenCalledTimes(1);
+    expect(w).toHaveBeenCalledWith("\x07");
+    w.mockRestore();
+  });
+
+  it("ignores requires-action with reason tool-calls", async () => {
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", {
+          type: "requires-action",
+          reason: "tool-calls",
+        }),
+      ],
+    };
+    const w = spyStdout();
+
+    renderNotifier();
+    await flush();
+
+    expect(w).not.toHaveBeenCalled();
+    w.mockRestore();
+  });
+
+  it("re-fires needs-input when a message re-enters interrupt", async () => {
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", {
+          type: "requires-action",
+          reason: "interrupt",
+        }),
+      ],
+    };
+    const w = spyStdout();
+
+    const instance = renderNotifier();
+    await flush();
+
+    snapshot = {
+      isRunning: true,
+      messages: [makeAssistantMessage("m1", { type: "running" })],
+    };
+    instance.rerender(<Notifier />);
+    await flush();
+
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", {
+          type: "requires-action",
+          reason: "interrupt",
+        }),
+      ],
+    };
+    instance.rerender(<Notifier />);
+    await flush();
+
+    expect(w).toHaveBeenCalledTimes(2);
+    w.mockRestore();
+  });
+
+  it("dedupes a stable status across rerenders", async () => {
+    snapshot = {
+      isRunning: true,
+      messages: [makeAssistantMessage("m1", { type: "running" })],
+    };
+    const w = spyStdout();
+
+    const instance = renderNotifier();
+    await flush();
+
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", { type: "complete", reason: "stop" }),
+      ],
+    };
+    instance.rerender(<Notifier />);
+    await flush();
+    instance.rerender(<Notifier />);
+    await flush();
+
+    expect(w).toHaveBeenCalledTimes(2);
+    w.mockRestore();
+  });
+
+  it("does nothing when enabled is false", async () => {
+    snapshot = {
+      isRunning: true,
+      messages: [makeAssistantMessage("m1", { type: "running" })],
+    };
+    const w = spyStdout();
+
+    const instance = renderNotifier(<Notifier config={{ enabled: false }} />);
+    await flush();
+
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", { type: "complete", reason: "stop" }),
+      ],
+    };
+    instance.rerender(<Notifier config={{ enabled: false }} />);
+    await flush();
+
+    expect(w).not.toHaveBeenCalled();
+    w.mockRestore();
+  });
+
+  it("does not fire a completion notification after switching to a different thread mid-run", async () => {
+    snapshot = {
+      isRunning: true,
+      messages: [makeAssistantMessage("mA", { type: "running" })],
+    };
+    mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) =>
+      selector({
+        thread: snapshot,
+        threadListItem: { id: "thread-A" },
+      } as never),
+    );
+    const w = spyStdout();
+
+    const instance = renderNotifier();
+    await flush();
+
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("mB", { type: "complete", reason: "stop" }),
+      ],
+    };
+    mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) =>
+      selector({
+        thread: snapshot,
+        threadListItem: { id: "thread-B" },
+      } as never),
+    );
+    instance.rerender(<Notifier />);
+    await flush();
+
+    expect(w).not.toHaveBeenCalled();
+    w.mockRestore();
+  });
+
+  it("does not emit a stale needs-input after re-enabling", async () => {
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", {
+          type: "requires-action",
+          reason: "interrupt",
+        }),
+      ],
+    };
+    const w = spyStdout();
+
+    const instance = renderNotifier(<Notifier config={{ enabled: false }} />);
+    await flush();
+
+    instance.rerender(<Notifier config={{ enabled: true }} />);
+    await flush();
+
+    expect(w).not.toHaveBeenCalled();
+    w.mockRestore();
+  });
+
+  it("does not emit a stale completion after re-enabling", async () => {
+    snapshot = {
+      isRunning: true,
+      messages: [makeAssistantMessage("m1", { type: "running" })],
+    };
+    const w = spyStdout();
+
+    const instance = renderNotifier(<Notifier config={{ enabled: false }} />);
+    await flush();
+
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", { type: "complete", reason: "stop" }),
+      ],
+    };
+    instance.rerender(<Notifier config={{ enabled: false }} />);
+    await flush();
+
+    instance.rerender(<Notifier config={{ enabled: true }} />);
+    await flush();
+
+    expect(w).not.toHaveBeenCalled();
+    w.mockRestore();
+  });
+
+  it("calls a custom handler with event details", async () => {
+    snapshot = {
+      isRunning: true,
+      messages: [makeAssistantMessage("m1", { type: "running" })],
+    };
+    const w = spyStdout();
+    const custom = vi.fn();
+
+    const instance = renderNotifier(
+      <Notifier
+        config={{
+          onTaskComplete: { custom },
+          onTaskIncomplete: false,
+          onNeedsInput: false,
+        }}
+      />,
+    );
+    await flush();
+
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", { type: "complete", reason: "stop" }),
+      ],
+    };
+    instance.rerender(
+      <Notifier
+        config={{
+          onTaskComplete: { custom },
+          onTaskIncomplete: false,
+          onNeedsInput: false,
+        }}
+      />,
+    );
+    await flush();
+
+    expect(w).not.toHaveBeenCalled();
+    expect(custom).toHaveBeenCalledWith({
+      type: "task-complete",
+      threadId: "thread-1",
+      messageId: "m1",
+      title: "AI task complete",
+    });
+    w.mockRestore();
+  });
+
+  it("calls onTaskIncomplete.custom with the incomplete reason", async () => {
+    snapshot = {
+      isRunning: true,
+      messages: [makeAssistantMessage("m1", { type: "running" })],
+    };
+    const w = spyStdout();
+    const custom = vi.fn();
+
+    const instance = renderNotifier(
+      <Notifier
+        config={{
+          onTaskComplete: false,
+          onTaskIncomplete: { custom },
+          onNeedsInput: false,
+        }}
+      />,
+    );
+    await flush();
+
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", { type: "incomplete", reason: "error" }),
+      ],
+    };
+    instance.rerender(
+      <Notifier
+        config={{
+          onTaskComplete: false,
+          onTaskIncomplete: { custom },
+          onNeedsInput: false,
+        }}
+      />,
+    );
+    await flush();
+
+    expect(w).not.toHaveBeenCalled();
+    expect(custom).toHaveBeenCalledWith({
+      type: "task-incomplete",
+      threadId: "thread-1",
+      messageId: "m1",
+      title: "AI task stopped",
+      reason: "error",
+    });
+    w.mockRestore();
+  });
+
+  it("calls onNeedsInput.custom with reason interrupt", async () => {
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", {
+          type: "requires-action",
+          reason: "interrupt",
+        }),
+      ],
+    };
+    const w = spyStdout();
+    const custom = vi.fn();
+
+    renderNotifier(
+      <Notifier
+        config={{
+          onTaskComplete: false,
+          onTaskIncomplete: false,
+          onNeedsInput: { custom },
+        }}
+      />,
+    );
+    await flush();
+
+    expect(w).not.toHaveBeenCalled();
+    expect(custom).toHaveBeenCalledWith({
+      type: "needs-input",
+      threadId: "thread-1",
+      messageId: "m1",
+      title: "AI needs input",
+      reason: "interrupt",
+    });
+    w.mockRestore();
+  });
+
+  it("suppresses a single key when set to false", async () => {
+    snapshot = {
+      isRunning: true,
+      messages: [makeAssistantMessage("m1", { type: "running" })],
+    };
+    const w = spyStdout();
+
+    const instance = renderNotifier(
+      <Notifier config={{ onTaskComplete: false }} />,
+    );
+    await flush();
+
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", { type: "complete", reason: "stop" }),
+      ],
+    };
+    instance.rerender(<Notifier config={{ onTaskComplete: false }} />);
+    await flush();
+
+    expect(w).not.toHaveBeenCalled();
+    w.mockRestore();
+  });
+});


### PR DESCRIPTION
Adds a `useNotification` hook for terminal and custom notifications.

## What it does

`@assistant-ui/react-ink` gains a `useNotification()` hook and a `NotificationProvider` that fire when a run **completes**, **stops with an error**, or **pauses for human approval**. Each trigger (`onTaskComplete`, `onTaskIncomplete`, `onNeedsInput`) can:

- ring the terminal **bell**,
- emit an **OSC 9 / 99 / 777** desktop notification,
- and/or run a **custom** callback.

Provider-level defaults are overridable by local hook config. Notifications are deduplicated per thread/message/status, so an inline `config` object is safe.

## Architecture

The run-status engine is framework-agnostic and lives in **`@assistant-ui/core/react`** as a portable `useNotification` primitive (callback API: `onTaskComplete` / `onTaskIncomplete` / `onNeedsInput`). `react-ink` is a thin wrapper that supplies the terminal bell/OSC channels. This leaves room for `react` / `react-native` to layer their own channels later — those re-exports are intentionally **out of scope** here.

## Notes for review

- `ringBell` / `sendOSCNotification` are exported as low-level helpers for imperative use — happy to drop these if you'd prefer a minimal public surface.
- `onNeedsInput` fires only for `requires-action` with reason `interrupt` (human/external approval); automatic tool-call pauses don't trigger it.

## Testing

- `@assistant-ui/react-ink`: 170 tests pass (incl. the interrupt→complete regression)
- `@assistant-ui/core`: 243 tests pass
- typecheck + oxlint/oxfmt clean; full `pnpm turbo run build` green (76/76)
