### PR TITLE
feat(react-ink): add ScrollPrimitive and ScrollableView

### DIFF
--- a/.changeset/react-ink-scrollable-view.md
+++ b/.changeset/react-ink-scrollable-view.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+feat(react-ink): add ScrollPrimitive and ScrollableView

--- a/apps/docs/content/docs/ink/primitives.mdx
+++ b/apps/docs/content/docs/ink/primitives.mdx
@@ -698,6 +698,159 @@ A built-in component for rendering tool calls with expandable/collapsible output
 | `renderArgs` | `(props: { args, argsText }) => ReactNode` | Custom args renderer |
 | `renderResult` | `(props: { result, isError }) => ReactNode` | Custom result renderer |
 
+## Scroll
+
+```tsx
+import {
+  MessageByIndexProvider,
+  ScrollPrimitive,
+  ScrollableView,
+  useAuiState,
+  useScrollable,
+} from "@assistant-ui/react-ink";
+```
+
+Bounded, sticky-to-bottom scrolling for enumerable terminal content. v1 is generic: you map `thread.messages` yourself and wrap each row with `MessageByIndexProvider`. It does not wrap `ThreadPrimitive.Messages`.
+
+### ScrollableView
+
+Pre-composed `ScrollPrimitive.Root` plus `ScrollPrimitive.Indicator`. The render order is fixed: viewport, paused hint, then the default indicator, followed by any passed `children`.
+
+```tsx
+const messages = useAuiState((s) => s.thread.messages);
+
+<ScrollableView
+  items={messages}
+  height={12}
+  keyExtractor={(message) => message.id}
+  renderItem={(message, index) => (
+    <MessageByIndexProvider key={message.id} index={index}>
+      {message.role === "user" ? <UserMessage /> : <AssistantMessage />}
+    </MessageByIndexProvider>
+  )}
+/>
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `items` | `readonly T[]` | Enumerable items to display |
+| `renderItem` | `(item: T, index: number) => ReactNode` | Row renderer |
+| `keyExtractor` | `(item: T, index: number) => string \| number` | Stable item key; use message ids for thread rows |
+| `height` | `number` | Fixed viewport height; when omitted the root self-measures with Ink box metrics |
+| `stickToBottomThreshold` | `number` | Row threshold for sticky-bottom behavior (default: `2`) |
+| `initialScrollToBottom` | `boolean` | Start pinned to the bottom (default: `true`) |
+| `keybindings` | `ScrollKeybindings \| false` | Override or disable built-in keybindings |
+| `renderPausedHint` | `(() => ReactNode) \| false` | Override or suppress the paused hint |
+| `scrollbar` | `ReactNode` | Optional right-hand scrollbar slot, usually `<ScrollPrimitive.Scrollbar />` |
+
+### Root
+
+Context provider and viewport renderer. Keep custom layouts inside the root so child primitives can read scroll state.
+
+```tsx
+<ScrollPrimitive.Root
+  items={messages}
+  keyExtractor={(message) => message.id}
+  renderItem={(message, index) => (
+    <MessageByIndexProvider key={message.id} index={index}>
+      <MessageRow />
+    </MessageByIndexProvider>
+  )}
+  scrollbar={<ScrollPrimitive.Scrollbar />}
+>
+  <ScrollPrimitive.Indicator />
+</ScrollPrimitive.Root>
+```
+
+Default keybindings are ASCII-safe and non-conflicting with the current composer:
+
+- `PgUp`: scroll up one viewport
+- `PgDn`: scroll down one viewport
+- `Home`: jump to top
+- `End`: jump to bottom and resume sticky mode
+
+Arrow keys are intentionally unset by default. Opt in with `keybindings={{ lineUp: "upArrow", lineDown: "downArrow" }}` if your layout can reserve them.
+
+When scrolling away from the bottom, the root shows:
+
+```text
+[paused | End to resume | N new below]
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `items` | `readonly T[]` | Enumerable items to display |
+| `renderItem` | `(item: T, index: number) => ReactNode` | Row renderer |
+| `keyExtractor` | `(item: T, index: number) => string \| number` | Stable identity for height caching |
+| `height` | `number` | Fixed viewport height |
+| `stickToBottomThreshold` | `number` | Sticky-bottom threshold in rows |
+| `initialScrollToBottom` | `boolean` | Start at bottom on first measurement |
+| `keybindings` | `ScrollKeybindings \| false` | Custom bindings or full disable |
+| `renderPausedHint` | `(() => ReactNode) \| false` | Custom paused-hint renderer |
+| `scrollbar` | `ReactNode` | Optional scrollbar node rendered in a right gutter |
+| `children` | `ReactNode` | Additional content inside the root, typically indicators |
+
+### Indicator
+
+Shows the current visible range. Default output is `[N/M]`.
+
+```tsx
+<ScrollPrimitive.Indicator />
+
+<ScrollPrimitive.Indicator
+  format={({ visibleFirstIndex, visibleLastIndex, itemCount }) =>
+    `${visibleFirstIndex}-${visibleLastIndex} of ${itemCount}`
+  }
+/>
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `format` | `(state) => string` | Custom formatter receiving visible indices, item count, offsets, and bottom-state |
+
+### Scrollbar
+
+ASCII-safe single-column scrollbar for the root gutter slot.
+
+```tsx
+<ScrollPrimitive.Root
+  items={items}
+  renderItem={(item) => <Row item={item} />}
+  scrollbar={<ScrollPrimitive.Scrollbar />}
+>
+  <ScrollPrimitive.Indicator />
+</ScrollPrimitive.Root>
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `char.track` | `string` | Track character (default: `|`) |
+| `char.thumb` | `string` | Thumb character (default: `#`) |
+| `color.track` | `string` | Optional Ink color used when the scrollbar is all track |
+| `color.thumb` | `string` | Optional Ink color for the rendered scrollbar when a thumb is present |
+
+### useScrollable
+
+Hook for custom composition inside `ScrollPrimitive.Root`.
+
+```tsx
+const scroll = useScrollable();
+
+<Text>{`${scroll.visibleFirstIndex}-${scroll.visibleLastIndex}`}</Text>
+```
+
+Returns:
+
+- `scrollOffset`, `maxScrollOffset`, `viewportHeight`, `contentHeight`
+- `itemCount`, `visibleFirstIndex`, `visibleLastIndex`, `isAtBottom`, `autoScroll`
+- `scrollBy()`, `scrollByPage()`, `scrollToTop()`, `scrollToBottom()`, `scrollToItem()`, `setAutoScroll()`
+
+### Limitations
+
+- v1 renders all rows for measurement; true virtualization is planned later.
+- Horizontal scrolling is not supported.
+- On the first measurement pass, content can briefly render with estimated heights before the viewport re-pins.
+
 ## Diff
 
 ```tsx

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -119,7 +119,13 @@ export * as SuggestionPrimitive from "./primitives/suggestion";
 export * as ToolCallPrimitive from "./primitives/toolCall";
 export * as ErrorPrimitive from "./primitives/error";
 export * as DiffPrimitive from "./primitives/diff";
+export * as ScrollPrimitive from "./primitives/scroll";
 export { DiffView, type DiffViewProps } from "./primitives/diff/DiffView";
+export {
+  ScrollableView,
+  type ScrollableViewProps,
+} from "./primitives/scroll/ScrollableView";
+export { useScrollable } from "./primitives/scroll/useScrollable";
 
 // Re-export shared providers from core/react
 export {

--- a/packages/react-ink/src/primitives/scroll.ts
+++ b/packages/react-ink/src/primitives/scroll.ts
@@ -1,0 +1,4 @@
+export { ScrollRoot as Root } from "./scroll/ScrollRoot";
+export { ScrollIndicator as Indicator } from "./scroll/ScrollIndicator";
+export { ScrollScrollbar as Scrollbar } from "./scroll/ScrollScrollbar";
+export { useScrollable } from "./scroll/useScrollable";

--- a/packages/react-ink/src/primitives/scroll/ScrollContext.ts
+++ b/packages/react-ink/src/primitives/scroll/ScrollContext.ts
@@ -1,0 +1,26 @@
+import { createContext, useContext } from "react";
+import type {
+  ScrollDerivedState,
+  ScrollState,
+  ScrollStateActions,
+} from "./useScrollState";
+
+export type ScrollContextValue = {
+  state: ScrollState;
+  derived: ScrollDerivedState;
+  actions: ScrollStateActions;
+};
+
+export const ScrollContext = createContext<ScrollContextValue | null>(null);
+
+export const assertScrollContext = (value: ScrollContextValue | null) => {
+  if (!value) {
+    throw new Error("useScrollable must be used within ScrollPrimitive.Root.");
+  }
+
+  return value;
+};
+
+export const useScrollContext = () => {
+  return assertScrollContext(useContext(ScrollContext));
+};

--- a/packages/react-ink/src/primitives/scroll/ScrollIndicator.tsx
+++ b/packages/react-ink/src/primitives/scroll/ScrollIndicator.tsx
@@ -1,0 +1,63 @@
+import { Text } from "ink";
+import { useScrollable } from "./useScrollable";
+
+export type ScrollIndicatorState = Pick<
+  ReturnType<typeof useScrollable>,
+  | "visibleFirstIndex"
+  | "visibleLastIndex"
+  | "itemCount"
+  | "scrollOffset"
+  | "maxScrollOffset"
+  | "isAtBottom"
+> & {
+  percent: number;
+};
+
+export type ScrollIndicatorProps = {
+  format?: ((state: ScrollIndicatorState) => string) | undefined;
+};
+
+const defaultFormat = ({
+  visibleLastIndex,
+  itemCount,
+}: ScrollIndicatorState) => {
+  return `[${itemCount === 0 ? 0 : visibleLastIndex + 1}/${itemCount}]`;
+};
+
+export const ScrollIndicator = ({
+  format = defaultFormat,
+}: ScrollIndicatorProps) => {
+  const {
+    visibleFirstIndex,
+    visibleLastIndex,
+    itemCount,
+    scrollOffset,
+    maxScrollOffset,
+    isAtBottom,
+  } = useScrollable();
+  const percent =
+    maxScrollOffset === 0
+      ? 100
+      : Math.round((scrollOffset / maxScrollOffset) * 100);
+
+  return (
+    <Text>
+      {format({
+        visibleFirstIndex,
+        visibleLastIndex,
+        itemCount,
+        scrollOffset,
+        maxScrollOffset,
+        percent,
+        isAtBottom,
+      })}
+    </Text>
+  );
+};
+
+ScrollIndicator.displayName = "ScrollPrimitive.Indicator";
+
+export namespace ScrollIndicator {
+  export type Props = ScrollIndicatorProps;
+  export type State = ScrollIndicatorState;
+}

--- a/packages/react-ink/src/primitives/scroll/ScrollRoot.tsx
+++ b/packages/react-ink/src/primitives/scroll/ScrollRoot.tsx
@@ -1,0 +1,303 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  Box,
+  Text,
+  useBoxMetrics,
+  useInput,
+  type DOMElement,
+  type Key,
+} from "ink";
+import { ScrollContext } from "./ScrollContext";
+import { useItemHeights } from "./useItemHeights";
+import {
+  createScrollActions,
+  type ScrollKey,
+  useScrollState,
+} from "./useScrollState";
+
+export type ScrollKeybindings = {
+  pageUp?: string | string[] | undefined;
+  pageDown?: string | string[] | undefined;
+  top?: string | string[] | undefined;
+  bottom?: string | string[] | undefined;
+  lineUp?: string | string[] | undefined;
+  lineDown?: string | string[] | undefined;
+};
+
+export type ScrollRootProps<T> = {
+  items: readonly T[];
+  renderItem: (item: T, index: number) => ReactNode;
+  keyExtractor?: ((item: T, index: number) => ScrollKey) | undefined;
+  height?: number | undefined;
+  stickToBottomThreshold?: number | undefined;
+  initialScrollToBottom?: boolean | undefined;
+  keybindings?: ScrollKeybindings | false | undefined;
+  renderPausedHint?: (() => ReactNode) | false | undefined;
+  scrollbar?: ReactNode;
+  children?: ReactNode;
+};
+
+const DEFAULT_KEYBINDINGS: ScrollKeybindings = {
+  pageUp: "pageup",
+  pageDown: "pagedown",
+  top: "home",
+  bottom: "end",
+};
+
+const normalizeBinding = (binding?: string | string[]) => {
+  if (!binding) return [];
+  return Array.isArray(binding) ? binding : [binding];
+};
+
+const matchBinding = (input: string, key: Key, binding?: string | string[]) => {
+  return normalizeBinding(binding).some((entry) => {
+    const parts = entry.toLowerCase().split("+");
+    const keyName = parts[parts.length - 1];
+    const wantsCtrl = parts.includes("ctrl");
+    const wantsShift = parts.includes("shift");
+    const wantsMeta = parts.includes("meta");
+
+    const matchedKey =
+      keyName === "pageup"
+        ? key.pageUp
+        : keyName === "pagedown"
+          ? key.pageDown
+          : keyName === "home"
+            ? key.home
+            : keyName === "end"
+              ? key.end
+              : keyName === "uparrow"
+                ? key.upArrow
+                : keyName === "downarrow"
+                  ? key.downArrow
+                  : input.toLowerCase() === keyName;
+
+    return (
+      matchedKey &&
+      Boolean(key.ctrl) === wantsCtrl &&
+      Boolean(key.shift) === wantsShift &&
+      Boolean(key.meta) === wantsMeta
+    );
+  });
+};
+
+const getPausedHintText = (newBelow: number) => {
+  return `[paused | End to resume | ${newBelow} new below]`;
+};
+
+const MeasuredScrollItem = ({
+  itemKey,
+  onHeightChange,
+  children,
+}: {
+  itemKey: ScrollKey;
+  onHeightChange: (itemKey: ScrollKey, height: number) => void;
+  children: ReactNode;
+}) => {
+  const ref = useRef<DOMElement>(null!);
+  const { height, hasMeasured } = useBoxMetrics(ref);
+
+  useEffect(() => {
+    if (!hasMeasured) return;
+    onHeightChange(itemKey, height);
+  }, [itemKey, height, hasMeasured, onHeightChange]);
+
+  return <Box ref={ref}>{children}</Box>;
+};
+
+const ScrollInput = ({
+  onInput,
+}: {
+  onInput: (input: string, key: Key) => void;
+}) => {
+  useInput(onInput);
+  return null;
+};
+
+const AutoMeasuredViewport = <T,>({
+  items,
+  itemKeys,
+  renderItem,
+  updateItemHeight,
+  scrollOffset,
+  onViewportHeightChange,
+}: {
+  items: readonly T[];
+  itemKeys: readonly ScrollKey[];
+  renderItem: (item: T, index: number) => ReactNode;
+  updateItemHeight: (itemKey: ScrollKey, height: number) => void;
+  scrollOffset: number;
+  onViewportHeightChange: (height: number) => void;
+}) => {
+  const viewportRef = useRef<DOMElement>(null!);
+  const viewportMetrics = useBoxMetrics(viewportRef);
+
+  useEffect(() => {
+    onViewportHeightChange(viewportMetrics.height);
+  }, [onViewportHeightChange, viewportMetrics.height]);
+
+  return (
+    <Box
+      ref={viewportRef}
+      overflowY="hidden"
+      flexDirection="column"
+      flexGrow={1}
+    >
+      <Box flexDirection="column" marginTop={-scrollOffset}>
+        {items.map((item, index) => (
+          <MeasuredScrollItem
+            key={String(itemKeys[index])}
+            itemKey={itemKeys[index]!}
+            onHeightChange={updateItemHeight}
+          >
+            {renderItem(item, index)}
+          </MeasuredScrollItem>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export const ScrollRoot = <T,>({
+  items,
+  renderItem,
+  keyExtractor,
+  height,
+  stickToBottomThreshold = 2,
+  initialScrollToBottom = true,
+  keybindings,
+  renderPausedHint,
+  scrollbar,
+  children,
+}: ScrollRootProps<T>) => {
+  const [measuredViewportHeight, setMeasuredViewportHeight] = useState(0);
+  const itemKeys = useMemo(
+    () => items.map((item, index) => keyExtractor?.(item, index) ?? index),
+    [items, keyExtractor],
+  );
+
+  const { itemHeights, itemKeyOrder, updateItemHeight } = useItemHeights({
+    itemKeys,
+  });
+
+  const { state, derived, dispatchWithDerived } = useScrollState({
+    viewportHeight: height ?? measuredViewportHeight,
+    itemHeights,
+    itemKeyOrder,
+    itemCount: items.length,
+    stickToBottomThreshold,
+    initialScrollToBottom,
+  });
+
+  const actions = useMemo(
+    () => createScrollActions(dispatchWithDerived),
+    [dispatchWithDerived],
+  );
+
+  const effectiveKeybindings = useMemo(() => {
+    if (keybindings === false) return false;
+    return {
+      ...DEFAULT_KEYBINDINGS,
+      ...keybindings,
+    };
+  }, [keybindings]);
+
+  const handleInput = useCallback(
+    (input: string, key: Key) => {
+      if (!effectiveKeybindings) return;
+      if (matchBinding(input, key, effectiveKeybindings.pageUp)) {
+        actions.scrollByPage("up");
+        return;
+      }
+      if (matchBinding(input, key, effectiveKeybindings.pageDown)) {
+        actions.scrollByPage("down");
+        return;
+      }
+      if (matchBinding(input, key, effectiveKeybindings.top)) {
+        actions.scrollToTop();
+        return;
+      }
+      if (matchBinding(input, key, effectiveKeybindings.bottom)) {
+        actions.scrollToBottom();
+        return;
+      }
+      if (matchBinding(input, key, effectiveKeybindings.lineUp)) {
+        actions.scrollBy(-1);
+        return;
+      }
+      if (matchBinding(input, key, effectiveKeybindings.lineDown)) {
+        actions.scrollBy(1);
+      }
+    },
+    [actions, effectiveKeybindings],
+  );
+
+  const newBelow = Math.max(0, items.length - derived.visibleLastIndex - 1);
+  const shouldShowPausedHint =
+    state.autoScroll === false && derived.maxScrollOffset > state.scrollOffset;
+
+  const contextValue = useMemo(
+    () => ({
+      state,
+      derived,
+      actions,
+    }),
+    [state, derived, actions],
+  );
+
+  return (
+    <ScrollContext.Provider value={contextValue}>
+      <Box flexDirection="column">
+        {effectiveKeybindings ? <ScrollInput onInput={handleInput} /> : null}
+        <Box flexDirection="row">
+          {height !== undefined ? (
+            <Box height={height} overflowY="hidden" flexDirection="column">
+              <Box flexDirection="column" marginTop={-state.scrollOffset}>
+                {items.map((item, index) => (
+                  <MeasuredScrollItem
+                    key={String(itemKeys[index])}
+                    itemKey={itemKeys[index]!}
+                    onHeightChange={updateItemHeight}
+                  >
+                    {renderItem(item, index)}
+                  </MeasuredScrollItem>
+                ))}
+              </Box>
+            </Box>
+          ) : (
+            <AutoMeasuredViewport
+              items={items}
+              itemKeys={itemKeys}
+              renderItem={renderItem}
+              updateItemHeight={updateItemHeight}
+              scrollOffset={state.scrollOffset}
+              onViewportHeightChange={setMeasuredViewportHeight}
+            />
+          )}
+          {scrollbar ? <Box marginLeft={1}>{scrollbar}</Box> : null}
+        </Box>
+        {shouldShowPausedHint &&
+          renderPausedHint !== false &&
+          (renderPausedHint ? (
+            renderPausedHint()
+          ) : (
+            <Text>{getPausedHintText(newBelow)}</Text>
+          ))}
+        {children}
+      </Box>
+    </ScrollContext.Provider>
+  );
+};
+
+ScrollRoot.displayName = "ScrollPrimitive.Root";
+
+export namespace ScrollRoot {
+  export type Props<T> = ScrollRootProps<T>;
+}

--- a/packages/react-ink/src/primitives/scroll/ScrollRoot.tsx
+++ b/packages/react-ink/src/primitives/scroll/ScrollRoot.tsx
@@ -178,6 +178,7 @@ export const ScrollRoot = <T,>({
   children,
 }: ScrollRootProps<T>) => {
   const [measuredViewportHeight, setMeasuredViewportHeight] = useState(0);
+  const hasEverPinnedToBottomRef = useRef(initialScrollToBottom);
   const itemKeys = useMemo(
     () => items.map((item, index) => keyExtractor?.(item, index) ?? index),
     [items, keyExtractor],
@@ -239,9 +240,17 @@ export const ScrollRoot = <T,>({
     [actions, effectiveKeybindings],
   );
 
+  useEffect(() => {
+    if (derived.isAtBottom) {
+      hasEverPinnedToBottomRef.current = true;
+    }
+  }, [derived.isAtBottom]);
+
   const newBelow = Math.max(0, items.length - derived.visibleLastIndex - 1);
   const shouldShowPausedHint =
-    state.autoScroll === false && derived.maxScrollOffset > state.scrollOffset;
+    hasEverPinnedToBottomRef.current &&
+    state.autoScroll === false &&
+    derived.maxScrollOffset > state.scrollOffset;
 
   const contextValue = useMemo(
     () => ({

--- a/packages/react-ink/src/primitives/scroll/ScrollScrollbar.tsx
+++ b/packages/react-ink/src/primitives/scroll/ScrollScrollbar.tsx
@@ -1,0 +1,73 @@
+import { Text } from "ink";
+import { useScrollable } from "./useScrollable";
+
+export type ScrollScrollbarProps = {
+  char?:
+    | {
+        track?: string | undefined;
+        thumb?: string | undefined;
+      }
+    | undefined;
+  color?:
+    | {
+        track?: string | undefined;
+        thumb?: string | undefined;
+      }
+    | undefined;
+};
+
+const repeatRows = (char: string, rows: number) => {
+  return Array.from({ length: rows }, () => char).join("\n");
+};
+
+const renderText = (value: string, textColor?: string) => {
+  return textColor ? (
+    <Text color={textColor}>{value}</Text>
+  ) : (
+    <Text>{value}</Text>
+  );
+};
+
+export const ScrollScrollbar = ({ char, color }: ScrollScrollbarProps) => {
+  const { viewportHeight, contentHeight, scrollOffset, maxScrollOffset } =
+    useScrollable();
+
+  const track = char?.track ?? "|";
+  const thumb = char?.thumb ?? "#";
+  const rows = Math.max(0, viewportHeight);
+
+  if (rows === 0) return null;
+
+  if (contentHeight <= viewportHeight || maxScrollOffset === 0) {
+    return renderText(repeatRows(track, rows), color?.track);
+  }
+
+  const thumbHeight = Math.max(
+    1,
+    Math.round((viewportHeight / contentHeight) * viewportHeight),
+  );
+  const thumbTop = Math.round(
+    (scrollOffset / maxScrollOffset) *
+      Math.max(0, viewportHeight - thumbHeight),
+  );
+
+  const topTrackRows = thumbTop;
+  const bottomTrackRows = Math.max(0, rows - thumbTop - thumbHeight);
+  const topTrack = repeatRows(track, topTrackRows);
+  const thumbOutput = repeatRows(thumb, thumbHeight);
+  const bottomTrack = repeatRows(track, bottomTrackRows);
+
+  return (
+    <>
+      {topTrack ? renderText(`${topTrack}\n`, color?.track) : null}
+      {renderText(`${thumbOutput}${bottomTrack ? "\n" : ""}`, color?.thumb)}
+      {bottomTrack ? renderText(bottomTrack, color?.track) : null}
+    </>
+  );
+};
+
+ScrollScrollbar.displayName = "ScrollPrimitive.Scrollbar";
+
+export namespace ScrollScrollbar {
+  export type Props = ScrollScrollbarProps;
+}

--- a/packages/react-ink/src/primitives/scroll/ScrollScrollbar.tsx
+++ b/packages/react-ink/src/primitives/scroll/ScrollScrollbar.tsx
@@ -51,9 +51,8 @@ export const ScrollScrollbar = ({ char, color }: ScrollScrollbarProps) => {
       Math.max(0, viewportHeight - thumbHeight),
   );
 
-  const topTrackRows = thumbTop;
   const bottomTrackRows = Math.max(0, rows - thumbTop - thumbHeight);
-  const topTrack = repeatRows(track, topTrackRows);
+  const topTrack = repeatRows(track, thumbTop);
   const thumbOutput = repeatRows(thumb, thumbHeight);
   const bottomTrack = repeatRows(track, bottomTrackRows);
 

--- a/packages/react-ink/src/primitives/scroll/ScrollableView.tsx
+++ b/packages/react-ink/src/primitives/scroll/ScrollableView.tsx
@@ -1,0 +1,26 @@
+import { ScrollIndicator } from "./ScrollIndicator";
+import { ScrollRoot, type ScrollRootProps } from "./ScrollRoot";
+
+export type ScrollableViewProps<T> = ScrollRootProps<T>;
+
+/**
+ * Convenience wrapper with a fixed render order:
+ * viewport, paused hint, default indicator.
+ */
+export const ScrollableView = <T,>({
+  children,
+  ...props
+}: ScrollableViewProps<T>) => {
+  return (
+    <ScrollRoot {...props}>
+      <ScrollIndicator />
+      {children}
+    </ScrollRoot>
+  );
+};
+
+ScrollableView.displayName = "ScrollableView";
+
+export namespace ScrollableView {
+  export type Props<T> = ScrollableViewProps<T>;
+}

--- a/packages/react-ink/src/primitives/scroll/useItemHeights.ts
+++ b/packages/react-ink/src/primitives/scroll/useItemHeights.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ScrollKey } from "./useScrollState";
+import { arraysEqual, mapsEqual } from "./utils";
+
+export type ItemHeightsState = {
+  heights: Map<ScrollKey, number>;
+  keyOrder: ScrollKey[];
+};
+
+export const createInitialItemHeights = (
+  keys: readonly ScrollKey[],
+  estimatedHeight: number,
+) => {
+  return new Map(keys.map((key) => [key, estimatedHeight]));
+};
+
+export const reconcileItemHeights = ({
+  previousHeights,
+  nextKeys,
+  estimatedHeight,
+  measuredHeights,
+}: {
+  previousHeights: Map<ScrollKey, number>;
+  nextKeys: readonly ScrollKey[];
+  estimatedHeight: number;
+  measuredHeights: Map<ScrollKey, number>;
+}): ItemHeightsState => {
+  const heights = new Map<ScrollKey, number>();
+
+  for (const key of nextKeys) {
+    heights.set(
+      key,
+      measuredHeights.get(key) ??
+        previousHeights.get(key) ??
+        Math.max(1, estimatedHeight),
+    );
+  }
+
+  return {
+    heights,
+    keyOrder: [...nextKeys],
+  };
+};
+
+export const useItemHeights = ({
+  itemKeys,
+  estimatedHeight = 1,
+}: {
+  itemKeys: readonly ScrollKey[];
+  estimatedHeight?: number;
+}) => {
+  const [measuredHeights, setMeasuredHeights] = useState<
+    Map<ScrollKey, number>
+  >(() => createInitialItemHeights(itemKeys, estimatedHeight));
+  const [state, setState] = useState<ItemHeightsState>(() => ({
+    heights: createInitialItemHeights(itemKeys, estimatedHeight),
+    keyOrder: [...itemKeys],
+  }));
+
+  useEffect(() => {
+    setMeasuredHeights((previous) => {
+      const next = new Map<ScrollKey, number>();
+
+      for (const key of itemKeys) {
+        const value = previous.get(key);
+        if (value !== undefined) {
+          next.set(key, value);
+        }
+      }
+
+      return mapsEqual(previous, next) ? previous : next;
+    });
+  }, [itemKeys]);
+
+  useEffect(() => {
+    setState((previous) => {
+      const next = reconcileItemHeights({
+        previousHeights: previous.heights,
+        nextKeys: itemKeys,
+        estimatedHeight,
+        measuredHeights,
+      });
+
+      return mapsEqual(previous.heights, next.heights) &&
+        arraysEqual(previous.keyOrder, next.keyOrder)
+        ? previous
+        : next;
+    });
+  }, [estimatedHeight, itemKeys, measuredHeights]);
+
+  const updateItemHeight = useCallback((itemKey: ScrollKey, height: number) => {
+    setMeasuredHeights((previous) => {
+      if (previous.get(itemKey) === height) {
+        return previous;
+      }
+      const next = new Map(previous);
+      next.set(itemKey, Math.max(1, height));
+      return next;
+    });
+  }, []);
+
+  return useMemo(
+    () => ({
+      itemHeights: state.heights,
+      itemKeyOrder: state.keyOrder,
+      updateItemHeight,
+    }),
+    [state, updateItemHeight],
+  );
+};

--- a/packages/react-ink/src/primitives/scroll/useScrollState.ts
+++ b/packages/react-ink/src/primitives/scroll/useScrollState.ts
@@ -1,0 +1,414 @@
+import { useCallback, useMemo, useRef, useState, type Dispatch } from "react";
+import { arraysEqual, mapsEqual } from "./utils";
+
+export type ScrollKey = string | number;
+
+export type ScrollState = {
+  scrollOffset: number;
+  autoScroll: boolean;
+  viewportHeight: number;
+  itemHeights: Map<ScrollKey, number>;
+  itemKeyOrder: ScrollKey[];
+  itemCount: number;
+  stickToBottomThreshold: number;
+};
+
+export type ScrollDerivedState = {
+  contentHeight: number;
+  maxScrollOffset: number;
+  visibleFirstIndex: number;
+  visibleLastIndex: number;
+  isAtBottom: boolean;
+  itemOffsets: number[];
+  itemHeightsInOrder: number[];
+};
+
+type ScrollReducerAction =
+  | {
+      type: "scrollBy";
+      rows: number;
+      derived: ScrollDerivedState;
+      stickToBottomThreshold: number;
+    }
+  | {
+      type: "scrollByPage";
+      direction: "up" | "down";
+      derived: ScrollDerivedState;
+      stickToBottomThreshold: number;
+    }
+  | {
+      type: "scrollToTop";
+      derived: ScrollDerivedState;
+      stickToBottomThreshold: number;
+    }
+  | {
+      type: "scrollToBottom";
+      derived: ScrollDerivedState;
+      stickToBottomThreshold: number;
+    }
+  | {
+      type: "scrollToItem";
+      index: number;
+      align?: "top" | "bottom";
+      derived: ScrollDerivedState;
+      stickToBottomThreshold: number;
+    }
+  | {
+      type: "setAutoScroll";
+      enabled: boolean;
+      derived: ScrollDerivedState;
+      stickToBottomThreshold: number;
+    };
+
+export const clampScrollOffset = (offset: number, maxScrollOffset: number) => {
+  return Math.max(0, Math.min(offset, Math.max(0, maxScrollOffset)));
+};
+
+const resolveAutoScroll = (
+  scrollOffset: number,
+  maxScrollOffset: number,
+  stickToBottomThreshold: number,
+) => {
+  return maxScrollOffset - scrollOffset <= stickToBottomThreshold;
+};
+
+export const scrollInputsEqual = (
+  state: ScrollState,
+  next: Pick<
+    ScrollState,
+    "viewportHeight" | "itemHeights" | "itemKeyOrder" | "itemCount"
+  >,
+) => {
+  return (
+    state.viewportHeight === next.viewportHeight &&
+    state.itemCount === next.itemCount &&
+    mapsEqual(state.itemHeights, next.itemHeights) &&
+    arraysEqual(state.itemKeyOrder, next.itemKeyOrder)
+  );
+};
+
+const getStateIfChanged = (
+  previous: ScrollState,
+  next: ScrollState,
+): ScrollState => {
+  return previous.scrollOffset === next.scrollOffset &&
+    previous.autoScroll === next.autoScroll &&
+    previous.viewportHeight === next.viewportHeight &&
+    previous.itemCount === next.itemCount &&
+    previous.stickToBottomThreshold === next.stickToBottomThreshold &&
+    mapsEqual(previous.itemHeights, next.itemHeights) &&
+    arraysEqual(previous.itemKeyOrder, next.itemKeyOrder)
+    ? previous
+    : next;
+};
+
+const finalizeAgainstDerived = (
+  state: ScrollState,
+  scrollOffset: number,
+  derived: ScrollDerivedState,
+  stickToBottomThreshold: number,
+) => {
+  const clampedOffset = clampScrollOffset(
+    scrollOffset,
+    derived.maxScrollOffset,
+  );
+  return getStateIfChanged(state, {
+    ...state,
+    scrollOffset: clampedOffset,
+    autoScroll: resolveAutoScroll(
+      clampedOffset,
+      derived.maxScrollOffset,
+      stickToBottomThreshold,
+    ),
+  });
+};
+
+export const createInitialScrollState = ({
+  viewportHeight = 0,
+  itemHeights = new Map<ScrollKey, number>(),
+  itemKeyOrder = [],
+  itemCount = itemKeyOrder.length,
+  scrollOffset = 0,
+  autoScroll = true,
+  stickToBottomThreshold = 2,
+}: Partial<ScrollState> = {}): ScrollState => {
+  return {
+    scrollOffset,
+    autoScroll,
+    viewportHeight,
+    itemHeights,
+    itemKeyOrder,
+    itemCount,
+    stickToBottomThreshold,
+  };
+};
+
+export const deriveScrollState = (state: ScrollState): ScrollDerivedState => {
+  let contentHeight = 0;
+  const itemOffsets: number[] = [];
+  const itemHeightsInOrder = state.itemKeyOrder.map((key) => {
+    const height = Math.max(1, state.itemHeights.get(key) ?? 1);
+    itemOffsets.push(contentHeight);
+    contentHeight += height;
+    return height;
+  });
+
+  const maxScrollOffset = Math.max(0, contentHeight - state.viewportHeight);
+  const viewportBottom = state.scrollOffset + Math.max(0, state.viewportHeight);
+
+  let visibleFirstIndex = state.itemCount === 0 ? 0 : state.itemCount - 1;
+  let visibleLastIndex = state.itemCount === 0 ? 0 : state.itemCount - 1;
+
+  if (state.itemCount > 0) {
+    for (let index = 0; index < state.itemCount; index++) {
+      const top = itemOffsets[index] ?? 0;
+      const bottom = top + (itemHeightsInOrder[index] ?? 1);
+      if (bottom > state.scrollOffset) {
+        visibleFirstIndex = index;
+        break;
+      }
+    }
+
+    for (let index = visibleFirstIndex; index < state.itemCount; index++) {
+      const top = itemOffsets[index] ?? 0;
+      if (top >= viewportBottom) {
+        visibleLastIndex = Math.max(visibleFirstIndex, index - 1);
+        break;
+      }
+      visibleLastIndex = index;
+    }
+  }
+
+  return {
+    contentHeight,
+    maxScrollOffset,
+    visibleFirstIndex,
+    visibleLastIndex,
+    isAtBottom: resolveAutoScroll(
+      state.scrollOffset,
+      maxScrollOffset,
+      state.stickToBottomThreshold,
+    ),
+    itemOffsets,
+    itemHeightsInOrder,
+  };
+};
+
+export const scrollStateReducer = (
+  state: ScrollState,
+  action: ScrollReducerAction,
+): ScrollState => {
+  switch (action.type) {
+    case "scrollBy":
+      return finalizeAgainstDerived(
+        state,
+        state.scrollOffset + action.rows,
+        action.derived,
+        action.stickToBottomThreshold,
+      );
+    case "scrollByPage":
+      return finalizeAgainstDerived(
+        state,
+        state.scrollOffset +
+          (action.direction === "down"
+            ? state.viewportHeight
+            : -state.viewportHeight),
+        action.derived,
+        action.stickToBottomThreshold,
+      );
+    case "scrollToTop":
+      return finalizeAgainstDerived(
+        state,
+        0,
+        action.derived,
+        action.stickToBottomThreshold,
+      );
+    case "scrollToBottom":
+      return getStateIfChanged(state, {
+        ...state,
+        scrollOffset: action.derived.maxScrollOffset,
+        autoScroll: true,
+      });
+    case "scrollToItem": {
+      const itemTop = action.derived.itemOffsets[action.index] ?? 0;
+      const itemHeight = action.derived.itemHeightsInOrder[action.index] ?? 1;
+      const nextOffset =
+        action.align === "bottom"
+          ? itemTop + itemHeight - state.viewportHeight
+          : itemTop;
+      return finalizeAgainstDerived(
+        state,
+        nextOffset,
+        action.derived,
+        action.stickToBottomThreshold,
+      );
+    }
+    case "setAutoScroll":
+      return action.enabled
+        ? scrollStateReducer(state, {
+            type: "scrollToBottom",
+            derived: action.derived,
+            stickToBottomThreshold: action.stickToBottomThreshold,
+          })
+        : getStateIfChanged(state, { ...state, autoScroll: false });
+    default:
+      return state;
+  }
+};
+
+export type UseScrollStateOptions = {
+  viewportHeight: number;
+  itemHeights: Map<ScrollKey, number>;
+  itemKeyOrder: ScrollKey[];
+  itemCount: number;
+  stickToBottomThreshold?: number;
+  initialScrollToBottom?: boolean;
+};
+
+type InternalScrollState = Pick<ScrollState, "scrollOffset" | "autoScroll">;
+
+type ScrollExternalState = Omit<ScrollState, "scrollOffset" | "autoScroll">;
+
+export const buildEffectiveScrollState = (
+  externalState: ScrollExternalState,
+  internalState: InternalScrollState,
+) => {
+  const rawState: ScrollState = {
+    ...externalState,
+    scrollOffset: internalState.scrollOffset,
+    autoScroll: internalState.autoScroll,
+  };
+  const rawDerived = deriveScrollState(rawState);
+  const fullState: ScrollState = {
+    ...rawState,
+    scrollOffset: internalState.autoScroll
+      ? rawDerived.maxScrollOffset
+      : clampScrollOffset(
+          internalState.scrollOffset,
+          rawDerived.maxScrollOffset,
+        ),
+  };
+
+  return {
+    fullState,
+    derived:
+      fullState.scrollOffset === rawState.scrollOffset
+        ? rawDerived
+        : deriveScrollState(fullState),
+  };
+};
+
+export const useScrollState = ({
+  viewportHeight,
+  itemHeights,
+  itemKeyOrder,
+  itemCount,
+  stickToBottomThreshold = 2,
+  initialScrollToBottom = true,
+}: UseScrollStateOptions) => {
+  const [internalState, setInternalState] = useState(() => ({
+    scrollOffset: 0,
+    autoScroll: initialScrollToBottom,
+  }));
+
+  const externalState = useMemo<ScrollExternalState>(
+    () => ({
+      viewportHeight,
+      itemHeights,
+      itemKeyOrder,
+      itemCount,
+      stickToBottomThreshold,
+    }),
+    [
+      viewportHeight,
+      itemHeights,
+      itemKeyOrder,
+      itemCount,
+      stickToBottomThreshold,
+    ],
+  );
+
+  const { fullState, derived } = useMemo(
+    () => buildEffectiveScrollState(externalState, internalState),
+    [externalState, internalState],
+  );
+
+  const latestRef = useRef<ScrollExternalState>(externalState);
+  latestRef.current = externalState;
+
+  const dispatchWithDerived = useCallback((action: ScrollDispatchAction) => {
+    setInternalState((previous) => {
+      const latest = latestRef.current;
+      const current = buildEffectiveScrollState(latest, previous);
+      const nextState = scrollStateReducer(current.fullState, {
+        ...action,
+        derived: current.derived,
+        stickToBottomThreshold: latest.stickToBottomThreshold,
+      } as ScrollReducerAction);
+
+      return previous.scrollOffset === nextState.scrollOffset &&
+        previous.autoScroll === nextState.autoScroll
+        ? previous
+        : {
+            scrollOffset: nextState.scrollOffset,
+            autoScroll: nextState.autoScroll,
+          };
+    });
+  }, []);
+
+  return {
+    state: fullState,
+    derived,
+    dispatchWithDerived,
+  };
+};
+
+export type ScrollStateActions = {
+  scrollBy: (rows: number) => void;
+  scrollByPage: (direction: "up" | "down") => void;
+  scrollToTop: () => void;
+  scrollToBottom: () => void;
+  scrollToItem: (index: number, align?: "top" | "bottom") => void;
+  setAutoScroll: (enabled: boolean) => void;
+};
+
+type ScrollDispatchAction =
+  | {
+      type: "scrollBy";
+      rows: number;
+    }
+  | {
+      type: "scrollByPage";
+      direction: "up" | "down";
+    }
+  | {
+      type: "scrollToTop";
+    }
+  | {
+      type: "scrollToBottom";
+    }
+  | {
+      type: "scrollToItem";
+      index: number;
+      align?: "top" | "bottom" | undefined;
+    }
+  | {
+      type: "setAutoScroll";
+      enabled: boolean;
+    };
+
+export const createScrollActions = (
+  dispatchWithDerived: Dispatch<ScrollDispatchAction>,
+): ScrollStateActions => {
+  return {
+    scrollBy: (rows) => dispatchWithDerived({ type: "scrollBy", rows }),
+    scrollByPage: (direction) =>
+      dispatchWithDerived({ type: "scrollByPage", direction }),
+    scrollToTop: () => dispatchWithDerived({ type: "scrollToTop" }),
+    scrollToBottom: () => dispatchWithDerived({ type: "scrollToBottom" }),
+    scrollToItem: (index, align) =>
+      dispatchWithDerived({ type: "scrollToItem", index, align }),
+    setAutoScroll: (enabled) =>
+      dispatchWithDerived({ type: "setAutoScroll", enabled }),
+  };
+};

--- a/packages/react-ink/src/primitives/scroll/useScrollState.ts
+++ b/packages/react-ink/src/primitives/scroll/useScrollState.ts
@@ -72,21 +72,6 @@ const resolveAutoScroll = (
   return maxScrollOffset - scrollOffset <= stickToBottomThreshold;
 };
 
-export const scrollInputsEqual = (
-  state: ScrollState,
-  next: Pick<
-    ScrollState,
-    "viewportHeight" | "itemHeights" | "itemKeyOrder" | "itemCount"
-  >,
-) => {
-  return (
-    state.viewportHeight === next.viewportHeight &&
-    state.itemCount === next.itemCount &&
-    mapsEqual(state.itemHeights, next.itemHeights) &&
-    arraysEqual(state.itemKeyOrder, next.itemKeyOrder)
-  );
-};
-
 const getStateIfChanged = (
   previous: ScrollState,
   next: ScrollState,

--- a/packages/react-ink/src/primitives/scroll/useScrollable.ts
+++ b/packages/react-ink/src/primitives/scroll/useScrollable.ts
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+import { useScrollContext } from "./ScrollContext";
+
+export type UseScrollableResult = {
+  scrollOffset: number;
+  maxScrollOffset: number;
+  viewportHeight: number;
+  contentHeight: number;
+  itemCount: number;
+  visibleFirstIndex: number;
+  visibleLastIndex: number;
+  isAtBottom: boolean;
+  autoScroll: boolean;
+  scrollBy: (rows: number) => void;
+  scrollByPage: (direction: "up" | "down") => void;
+  scrollToTop: () => void;
+  scrollToBottom: () => void;
+  scrollToItem: (index: number, align?: "top" | "bottom") => void;
+  setAutoScroll: (enabled: boolean) => void;
+};
+
+export const useScrollable = (): UseScrollableResult => {
+  const { state, derived, actions } = useScrollContext();
+
+  return useMemo(
+    () => ({
+      scrollOffset: state.scrollOffset,
+      maxScrollOffset: derived.maxScrollOffset,
+      viewportHeight: state.viewportHeight,
+      contentHeight: derived.contentHeight,
+      itemCount: state.itemCount,
+      visibleFirstIndex: derived.visibleFirstIndex,
+      visibleLastIndex: derived.visibleLastIndex,
+      isAtBottom: derived.isAtBottom,
+      autoScroll: state.autoScroll,
+      ...actions,
+    }),
+    [actions, derived, state],
+  );
+};

--- a/packages/react-ink/src/primitives/scroll/utils.ts
+++ b/packages/react-ink/src/primitives/scroll/utils.ts
@@ -1,0 +1,26 @@
+import type { ScrollKey } from "./useScrollState";
+
+export const mapsEqual = (
+  left: Map<ScrollKey, number>,
+  right: Map<ScrollKey, number>,
+) => {
+  if (left === right) return true;
+  if (left.size !== right.size) return false;
+
+  for (const [key, value] of left) {
+    if (right.get(key) !== value) return false;
+  }
+
+  return true;
+};
+
+export const arraysEqual = (left: ScrollKey[], right: ScrollKey[]) => {
+  if (left === right) return true;
+  if (left.length !== right.length) return false;
+
+  for (let index = 0; index < left.length; index++) {
+    if (left[index] !== right[index]) return false;
+  }
+
+  return true;
+};

--- a/packages/react-ink/src/tests/ScrollIndicator.test.tsx
+++ b/packages/react-ink/src/tests/ScrollIndicator.test.tsx
@@ -1,0 +1,85 @@
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "ink-testing-library";
+import { Text } from "ink";
+import { ScrollRoot } from "../primitives/scroll/ScrollRoot";
+import { ScrollIndicator } from "../primitives/scroll/ScrollIndicator";
+
+const mockUseBoxMetrics = vi.fn();
+
+vi.mock("ink", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ink")>();
+  return {
+    ...actual,
+    useBoxMetrics: (...args: Parameters<typeof actual.useBoxMetrics>) =>
+      mockUseBoxMetrics(...args),
+  };
+});
+
+const renderFrame = async (node: ReactElement) => {
+  const instance = render(node);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return instance.lastFrame() ?? "";
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ScrollIndicator", () => {
+  it("renders the default [N/M] format", async () => {
+    mockUseBoxMetrics.mockReturnValue({
+      height: 1,
+      width: 10,
+      left: 0,
+      top: 0,
+      hasMeasured: true,
+    });
+
+    const frame = await renderFrame(
+      <ScrollRoot
+        items={["one", "two", "three"]}
+        height={2}
+        initialScrollToBottom={false}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollIndicator />
+      </ScrollRoot>,
+    );
+
+    expect(frame).toContain("[2/3]");
+  });
+
+  it("passes the documented state to a custom formatter", async () => {
+    mockUseBoxMetrics.mockReturnValue({
+      height: 1,
+      width: 10,
+      left: 0,
+      top: 0,
+      hasMeasured: true,
+    });
+
+    const frame = await renderFrame(
+      <ScrollRoot
+        items={["one", "two", "three"]}
+        height={2}
+        initialScrollToBottom={false}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollIndicator
+          format={({
+            visibleFirstIndex,
+            visibleLastIndex,
+            itemCount,
+            percent,
+          }) =>
+            `${visibleFirstIndex}-${visibleLastIndex}-${itemCount}-${percent}`
+          }
+        />
+      </ScrollRoot>,
+    );
+
+    expect(frame).toContain("0-1-3-0");
+  });
+});

--- a/packages/react-ink/src/tests/ScrollRoot.test.tsx
+++ b/packages/react-ink/src/tests/ScrollRoot.test.tsx
@@ -1,0 +1,323 @@
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "ink-testing-library";
+import { Text } from "ink";
+import { ScrollRoot } from "../primitives/scroll/ScrollRoot";
+import { ScrollIndicator } from "../primitives/scroll/ScrollIndicator";
+
+const mockUseInput = vi.fn();
+const mockUseBoxMetrics = vi.fn();
+
+vi.mock("ink", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ink")>();
+  return {
+    ...actual,
+    useInput: (
+      handler: Parameters<typeof actual.useInput>[0],
+      options?: Parameters<typeof actual.useInput>[1],
+    ) => mockUseInput(handler, options),
+    useBoxMetrics: (...args: Parameters<typeof actual.useBoxMetrics>) =>
+      mockUseBoxMetrics(...args),
+  };
+});
+
+const createMetrics = (height: number) => ({
+  height,
+  width: 10,
+  left: 0,
+  top: 0,
+  hasMeasured: true,
+});
+
+const tick = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const renderFrame = async (node: ReactElement) => {
+  const instance = render(node);
+  await tick();
+  return instance;
+};
+
+const getInputHandler = () => {
+  return mockUseInput.mock.calls.at(-1)?.[0] as
+    | ((input: string, key: Record<string, boolean>) => void)
+    | undefined;
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ScrollRoot", () => {
+  it("renders the visible slice for the provided height", async () => {
+    mockUseBoxMetrics.mockReturnValue(createMetrics(1));
+
+    const rendered = await renderFrame(
+      <ScrollRoot
+        items={["one", "two", "three", "four"]}
+        height={3}
+        initialScrollToBottom={false}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollIndicator />
+      </ScrollRoot>,
+    );
+
+    const frame = rendered.lastFrame() ?? "";
+    expect(frame).toContain("one");
+    expect(frame).toContain("two");
+    expect(frame).toContain("[3/4]");
+  });
+
+  it("handles PgDn, PgUp, Home, and End", async () => {
+    mockUseBoxMetrics.mockReturnValue(createMetrics(1));
+
+    const rendered = await renderFrame(
+      <ScrollRoot
+        items={["one", "two", "three", "four", "five", "six"]}
+        height={2}
+        initialScrollToBottom={false}
+        stickToBottomThreshold={0}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollIndicator />
+      </ScrollRoot>,
+    );
+
+    const handler = getInputHandler();
+    expect(handler).toBeTypeOf("function");
+
+    handler?.("", { pageDown: true });
+    await tick();
+    expect(rendered.lastFrame() ?? "").toContain("[4/6]");
+
+    handler?.("", { pageUp: true });
+    await tick();
+    expect(rendered.lastFrame() ?? "").toContain("[2/6]");
+
+    handler?.("", { end: true });
+    await tick();
+    expect(rendered.lastFrame() ?? "").toContain("[6/6]");
+
+    handler?.("", { home: true });
+    await tick();
+    expect(rendered.lastFrame() ?? "").toContain("[2/6]");
+  });
+
+  it("does not bind arrow keys by default", async () => {
+    mockUseBoxMetrics.mockReturnValue(createMetrics(1));
+
+    const rendered = await renderFrame(
+      <ScrollRoot
+        items={["one", "two", "three", "four"]}
+        height={2}
+        initialScrollToBottom={false}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollIndicator />
+      </ScrollRoot>,
+    );
+
+    const handler = getInputHandler();
+    const before = rendered.lastFrame() ?? "";
+
+    handler?.("", { upArrow: true });
+    await tick();
+
+    expect(rendered.lastFrame() ?? "").toBe(before);
+  });
+
+  it("enables arrow keys when line bindings are provided", async () => {
+    mockUseBoxMetrics.mockReturnValue(createMetrics(1));
+
+    const rendered = await renderFrame(
+      <ScrollRoot
+        items={["one", "two", "three", "four", "five", "six"]}
+        height={2}
+        initialScrollToBottom={false}
+        keybindings={{ lineDown: "downArrow", lineUp: "upArrow" }}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollIndicator />
+      </ScrollRoot>,
+    );
+
+    const handler = getInputHandler();
+    handler?.("", { downArrow: true });
+    await tick();
+    expect(rendered.lastFrame() ?? "").toContain("[3/6]");
+
+    handler?.("", { upArrow: true });
+    await tick();
+    expect(rendered.lastFrame() ?? "").toContain("[2/6]");
+  });
+
+  it("does not subscribe to input when keybindings are disabled", async () => {
+    mockUseBoxMetrics.mockReturnValue(createMetrics(1));
+
+    await renderFrame(
+      <ScrollRoot
+        items={["one", "two"]}
+        height={2}
+        keybindings={false}
+        renderItem={(item) => <Text>{item}</Text>}
+      />,
+    );
+
+    expect(mockUseInput).not.toHaveBeenCalled();
+  });
+
+  it("auto-scrolls new items when already at the bottom", async () => {
+    mockUseBoxMetrics.mockReturnValue(createMetrics(1));
+
+    const rendered = await renderFrame(
+      <ScrollRoot
+        items={["one", "two"]}
+        height={2}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollIndicator />
+      </ScrollRoot>,
+    );
+
+    rendered.rerender(
+      <ScrollRoot
+        items={["one", "two", "three"]}
+        height={2}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollIndicator />
+      </ScrollRoot>,
+    );
+
+    await tick();
+
+    const frame = rendered.lastFrame() ?? "";
+    expect(frame).toContain("three");
+    expect(frame).toContain("[3/3]");
+    expect(frame).not.toContain("[paused");
+  });
+
+  it("shows the paused hint when new content arrives while scrolled up", async () => {
+    mockUseBoxMetrics.mockReturnValue(createMetrics(1));
+
+    const rendered = await renderFrame(
+      <ScrollRoot
+        items={["one", "two", "three"]}
+        height={2}
+        initialScrollToBottom={false}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollIndicator />
+      </ScrollRoot>,
+    );
+
+    rendered.rerender(
+      <ScrollRoot
+        items={["one", "two", "three", "four"]}
+        height={2}
+        initialScrollToBottom={false}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollIndicator />
+      </ScrollRoot>,
+    );
+
+    await tick();
+
+    expect(rendered.lastFrame() ?? "").toContain(
+      "[paused | End to resume | 2 new below]",
+    );
+  });
+
+  it("suppresses the paused hint when renderPausedHint is false", async () => {
+    mockUseBoxMetrics.mockReturnValue(createMetrics(1));
+
+    const rendered = await renderFrame(
+      <ScrollRoot
+        items={["one", "two", "three"]}
+        height={2}
+        initialScrollToBottom={false}
+        renderPausedHint={false}
+        renderItem={(item) => <Text>{item}</Text>}
+      />,
+    );
+
+    rendered.rerender(
+      <ScrollRoot
+        items={["one", "two", "three", "four"]}
+        height={2}
+        initialScrollToBottom={false}
+        renderPausedHint={false}
+        renderItem={(item) => <Text>{item}</Text>}
+      />,
+    );
+
+    await tick();
+
+    expect(rendered.lastFrame() ?? "").not.toContain("[paused");
+  });
+
+  it("re-measures streaming growth for an existing key", async () => {
+    let rowHeight = 1;
+    mockUseBoxMetrics.mockImplementation(() => createMetrics(rowHeight));
+
+    const rendered = await renderFrame(
+      <ScrollRoot
+        items={["stream"]}
+        height={2}
+        keyExtractor={(item) => item}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollIndicator
+          format={({ scrollOffset, maxScrollOffset }) =>
+            `${scrollOffset}:${maxScrollOffset}`
+          }
+        />
+      </ScrollRoot>,
+    );
+
+    expect(rendered.lastFrame() ?? "").toContain("0:0");
+
+    rowHeight = 3;
+    rendered.rerender(
+      <ScrollRoot
+        items={["stream"]}
+        height={2}
+        keyExtractor={(item) => item}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollIndicator
+          format={({ scrollOffset, maxScrollOffset }) =>
+            `${scrollOffset}:${maxScrollOffset}`
+          }
+        />
+      </ScrollRoot>,
+    );
+
+    await tick();
+    await tick();
+    await tick();
+    await tick();
+
+    expect(rendered.lastFrame() ?? "").toContain("1:1");
+  });
+
+  it("renders zero items without crashing", async () => {
+    mockUseBoxMetrics.mockReturnValue(createMetrics(1));
+
+    const rendered = await renderFrame(
+      <ScrollRoot
+        items={[]}
+        height={2}
+        renderItem={(item) => <Text>{String(item)}</Text>}
+      >
+        <ScrollIndicator />
+      </ScrollRoot>,
+    );
+
+    expect(rendered.lastFrame() ?? "").toContain("[0/0]");
+  });
+});

--- a/packages/react-ink/src/tests/ScrollRoot.test.tsx
+++ b/packages/react-ink/src/tests/ScrollRoot.test.tsx
@@ -205,16 +205,41 @@ describe("ScrollRoot", () => {
 
     const rendered = await renderFrame(
       <ScrollRoot
-        items={["one", "two", "three"]}
+        items={["one", "two", "three", "four", "five", "six"]}
         height={2}
-        initialScrollToBottom={false}
+        stickToBottomThreshold={0}
         renderItem={(item) => <Text>{item}</Text>}
       >
         <ScrollIndicator />
       </ScrollRoot>,
     );
 
+    const handler = getInputHandler();
+    handler?.("", { pageUp: true });
+    await tick();
+
     rendered.rerender(
+      <ScrollRoot
+        items={["one", "two", "three", "four", "five", "six", "seven"]}
+        height={2}
+        stickToBottomThreshold={0}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollIndicator />
+      </ScrollRoot>,
+    );
+
+    await tick();
+
+    expect(rendered.lastFrame() ?? "").toContain(
+      "[paused | End to resume | 3 new below]",
+    );
+  });
+
+  it("does not show the paused hint on first render when initialScrollToBottom is false", async () => {
+    mockUseBoxMetrics.mockReturnValue(createMetrics(1));
+
+    const rendered = await renderFrame(
       <ScrollRoot
         items={["one", "two", "three", "four"]}
         height={2}
@@ -225,11 +250,7 @@ describe("ScrollRoot", () => {
       </ScrollRoot>,
     );
 
-    await tick();
-
-    expect(rendered.lastFrame() ?? "").toContain(
-      "[paused | End to resume | 2 new below]",
-    );
+    expect(rendered.lastFrame() ?? "").not.toContain("[paused");
   });
 
   it("suppresses the paused hint when renderPausedHint is false", async () => {

--- a/packages/react-ink/src/tests/ScrollScrollbar.test.tsx
+++ b/packages/react-ink/src/tests/ScrollScrollbar.test.tsx
@@ -1,0 +1,76 @@
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "ink-testing-library";
+import { Text } from "ink";
+import { ScrollRoot } from "../primitives/scroll/ScrollRoot";
+import { ScrollScrollbar } from "../primitives/scroll/ScrollScrollbar";
+
+const mockUseBoxMetrics = vi.fn();
+
+vi.mock("ink", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ink")>();
+  return {
+    ...actual,
+    useBoxMetrics: (...args: Parameters<typeof actual.useBoxMetrics>) =>
+      mockUseBoxMetrics(...args),
+  };
+});
+
+const renderFrame = async (node: ReactElement) => {
+  const instance = render(node);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return instance.lastFrame() ?? "";
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ScrollScrollbar", () => {
+  it("renders a thumb and track when content overflows", async () => {
+    mockUseBoxMetrics.mockReturnValue({
+      height: 1,
+      width: 10,
+      left: 0,
+      top: 0,
+      hasMeasured: true,
+    });
+
+    const frame = await renderFrame(
+      <ScrollRoot
+        items={["one", "two", "three", "four"]}
+        height={2}
+        initialScrollToBottom={false}
+        scrollbar={<ScrollScrollbar />}
+        renderItem={(item) => <Text>{item}</Text>}
+      />,
+    );
+
+    expect(frame).toContain("|");
+    expect(frame).toContain("#");
+  });
+
+  it("renders only the track when content fits in the viewport", async () => {
+    mockUseBoxMetrics.mockReturnValue({
+      height: 1,
+      width: 10,
+      left: 0,
+      top: 0,
+      hasMeasured: true,
+    });
+
+    const frame = await renderFrame(
+      <ScrollRoot
+        items={["one", "two"]}
+        height={2}
+        initialScrollToBottom={false}
+        scrollbar={<ScrollScrollbar char={{ track: "." }} />}
+        renderItem={(item) => <Text>{item}</Text>}
+      />,
+    );
+
+    expect(frame).toContain(".");
+    expect(frame).not.toContain("#");
+  });
+});

--- a/packages/react-ink/src/tests/ScrollableView.test.tsx
+++ b/packages/react-ink/src/tests/ScrollableView.test.tsx
@@ -1,0 +1,75 @@
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "ink-testing-library";
+import { Text } from "ink";
+import { ScrollableView } from "../primitives/scroll/ScrollableView";
+
+const mockUseBoxMetrics = vi.fn();
+
+vi.mock("ink", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ink")>();
+  return {
+    ...actual,
+    useBoxMetrics: (...args: Parameters<typeof actual.useBoxMetrics>) =>
+      mockUseBoxMetrics(...args),
+  };
+});
+
+const renderFrame = async (node: ReactElement) => {
+  const instance = render(node);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return instance.lastFrame() ?? "";
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ScrollableView", () => {
+  it("renders the root viewport with the default indicator", async () => {
+    mockUseBoxMetrics.mockReturnValue({
+      height: 1,
+      width: 10,
+      left: 0,
+      top: 0,
+      hasMeasured: true,
+    });
+
+    const frame = await renderFrame(
+      <ScrollableView
+        items={["one", "two", "three"]}
+        height={2}
+        initialScrollToBottom={false}
+        renderItem={(item) => <Text>{item}</Text>}
+      />,
+    );
+
+    expect(frame).toContain("one");
+    expect(frame).toContain("[2/3]");
+  });
+
+  it("renders children after the default indicator", async () => {
+    mockUseBoxMetrics.mockReturnValue({
+      height: 1,
+      width: 10,
+      left: 0,
+      top: 0,
+      hasMeasured: true,
+    });
+
+    const frame = await renderFrame(
+      <ScrollableView
+        items={[]}
+        height={2}
+        initialScrollToBottom={false}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <Text>custom child</Text>
+      </ScrollableView>,
+    );
+
+    expect(frame).toContain("[0/0]");
+    expect(frame).toContain("custom child");
+  });
+});

--- a/packages/react-ink/src/tests/useItemHeights.test.ts
+++ b/packages/react-ink/src/tests/useItemHeights.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialItemHeights,
+  reconcileItemHeights,
+} from "../primitives/scroll/useItemHeights";
+
+describe("useItemHeights", () => {
+  it("initializes new keys with an estimated height", () => {
+    const heights = createInitialItemHeights(["a", "b"], 2);
+
+    expect(heights.get("a")).toBe(2);
+    expect(heights.get("b")).toBe(2);
+  });
+
+  it("replaces estimated heights with measured heights", () => {
+    const next = reconcileItemHeights({
+      previousHeights: createInitialItemHeights(["a"], 1),
+      nextKeys: ["a"],
+      estimatedHeight: 1,
+      measuredHeights: new Map([["a", 4]]),
+    });
+
+    expect(next.heights.get("a")).toBe(4);
+  });
+
+  it("evicts removed keys and preserves surviving ones across replacement", () => {
+    const next = reconcileItemHeights({
+      previousHeights: new Map([
+        ["a", 3],
+        ["b", 2],
+      ]),
+      nextKeys: ["b", "c"],
+      estimatedHeight: 1,
+      measuredHeights: new Map(),
+    });
+
+    expect(next.heights.has("a")).toBe(false);
+    expect(next.heights.get("b")).toBe(2);
+    expect(next.heights.get("c")).toBe(1);
+    expect(next.keyOrder).toEqual(["b", "c"]);
+  });
+
+  it("applies streaming height growth for an existing key", () => {
+    const next = reconcileItemHeights({
+      previousHeights: new Map([["stream", 2]]),
+      nextKeys: ["stream"],
+      estimatedHeight: 1,
+      measuredHeights: new Map([["stream", 5]]),
+    });
+
+    expect(next.heights.get("stream")).toBe(5);
+  });
+});

--- a/packages/react-ink/src/tests/useScrollState.test.ts
+++ b/packages/react-ink/src/tests/useScrollState.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEffectiveScrollState,
+  clampScrollOffset,
+  createInitialScrollState,
+  deriveScrollState,
+  scrollInputsEqual,
+  scrollStateReducer,
+  type ScrollDerivedState,
+  type ScrollState,
+} from "../primitives/scroll/useScrollState";
+
+const createDerived = (
+  state: ScrollState,
+  overrides: Partial<ScrollDerivedState> = {},
+): ScrollDerivedState => {
+  return {
+    contentHeight: 9,
+    maxScrollOffset: 5,
+    visibleFirstIndex: 0,
+    visibleLastIndex: 2,
+    isAtBottom: state.scrollOffset >= 3,
+    itemOffsets: [],
+    itemHeightsInOrder: [],
+    ...overrides,
+  };
+};
+
+describe("useScrollState", () => {
+  it("clamps scroll offsets within the valid range", () => {
+    expect(clampScrollOffset(-2, 5)).toBe(0);
+    expect(clampScrollOffset(3, 5)).toBe(3);
+    expect(clampScrollOffset(8, 5)).toBe(5);
+  });
+
+  it("derives viewport bounds from item heights", () => {
+    const derived = deriveScrollState({
+      scrollOffset: 2,
+      autoScroll: false,
+      viewportHeight: 3,
+      itemHeights: new Map([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ]),
+      itemKeyOrder: ["a", "b", "c"],
+      itemCount: 3,
+      stickToBottomThreshold: 1,
+    });
+
+    expect(derived.contentHeight).toBe(6);
+    expect(derived.maxScrollOffset).toBe(3);
+    expect(derived.visibleFirstIndex).toBe(1);
+    expect(derived.visibleLastIndex).toBe(2);
+    expect(derived.isAtBottom).toBe(true);
+  });
+
+  it("scrolls by a fixed amount and disables auto scroll when leaving the threshold", () => {
+    const initial = createInitialScrollState({
+      viewportHeight: 4,
+      itemKeyOrder: ["a", "b", "c"],
+      itemCount: 3,
+    });
+
+    const next = scrollStateReducer(initial, {
+      type: "scrollBy",
+      rows: -3,
+      derived: createDerived(initial, { maxScrollOffset: 6 }),
+      stickToBottomThreshold: 1,
+    });
+
+    expect(next.scrollOffset).toBe(0);
+    expect(next.autoScroll).toBe(false);
+  });
+
+  it("scrolls by one page using the current viewport height", () => {
+    const state = createInitialScrollState({
+      viewportHeight: 3,
+      itemKeyOrder: ["a", "b", "c", "d"],
+      itemCount: 4,
+      scrollOffset: 2,
+      autoScroll: false,
+    });
+
+    const next = scrollStateReducer(state, {
+      type: "scrollByPage",
+      direction: "down",
+      derived: createDerived(state, { maxScrollOffset: 8 }),
+      stickToBottomThreshold: 1,
+    });
+
+    expect(next.scrollOffset).toBe(5);
+  });
+
+  it("scrolls an item to the top or bottom edge", () => {
+    const state = createInitialScrollState({
+      viewportHeight: 4,
+      itemKeyOrder: ["a", "b", "c"],
+      itemCount: 3,
+      autoScroll: false,
+    });
+
+    const topAligned = scrollStateReducer(state, {
+      type: "scrollToItem",
+      index: 2,
+      align: "top",
+      derived: {
+        ...createDerived(state, { maxScrollOffset: 6 }),
+        itemOffsets: [0, 2, 5],
+        itemHeightsInOrder: [2, 3, 2],
+      },
+      stickToBottomThreshold: 1,
+    });
+
+    const bottomAligned = scrollStateReducer(state, {
+      type: "scrollToItem",
+      index: 2,
+      align: "bottom",
+      derived: {
+        ...createDerived(state, { maxScrollOffset: 6 }),
+        itemOffsets: [0, 2, 5],
+        itemHeightsInOrder: [2, 3, 2],
+      },
+      stickToBottomThreshold: 1,
+    });
+
+    expect(topAligned.scrollOffset).toBe(5);
+    expect(bottomAligned.scrollOffset).toBe(3);
+  });
+
+  it("pins to the new bottom when content grows while auto scroll is enabled", () => {
+    const externalState = {
+      viewportHeight: 4,
+      itemHeights: new Map([
+        ["a", 1],
+        ["b", 1],
+      ]),
+      itemKeyOrder: ["a", "b"],
+      itemCount: 2,
+      stickToBottomThreshold: 1,
+    };
+    const state = createInitialScrollState({
+      ...externalState,
+      scrollOffset: 2,
+      autoScroll: true,
+    });
+
+    const next = buildEffectiveScrollState(externalState, {
+      scrollOffset: state.scrollOffset,
+      autoScroll: state.autoScroll,
+    });
+
+    const grown = buildEffectiveScrollState(
+      {
+        ...externalState,
+        itemHeights: new Map([
+          ["a", 1],
+          ["b", 10],
+        ]),
+      },
+      {
+        scrollOffset: next.fullState.scrollOffset,
+        autoScroll: next.fullState.autoScroll,
+      },
+    );
+
+    expect(grown.fullState.scrollOffset).toBe(7);
+    expect(grown.fullState.autoScroll).toBe(true);
+  });
+
+  it("preserves the current offset when content grows while auto scroll is paused", () => {
+    const externalState = {
+      viewportHeight: 4,
+      itemHeights: new Map([
+        ["a", 3],
+        ["b", 3],
+      ]),
+      itemKeyOrder: ["a", "b"],
+      itemCount: 2,
+      stickToBottomThreshold: 1,
+    };
+    const state = createInitialScrollState({
+      ...externalState,
+      scrollOffset: 1,
+      autoScroll: false,
+    });
+
+    const next = buildEffectiveScrollState(externalState, {
+      scrollOffset: state.scrollOffset,
+      autoScroll: state.autoScroll,
+    });
+
+    const grown = buildEffectiveScrollState(
+      {
+        ...externalState,
+        itemHeights: new Map([
+          ["a", 3],
+          ["b", 8],
+        ]),
+      },
+      {
+        scrollOffset: next.fullState.scrollOffset,
+        autoScroll: next.fullState.autoScroll,
+      },
+    );
+
+    expect(grown.fullState.scrollOffset).toBe(1);
+    expect(grown.fullState.autoScroll).toBe(false);
+  });
+
+  it("returns the same state object for no-op derived syncs", () => {
+    const externalState = {
+      viewportHeight: 4,
+      itemHeights: new Map([
+        ["a", 1],
+        ["b", 1],
+      ]),
+      itemKeyOrder: ["a", "b"],
+      itemCount: 2,
+      stickToBottomThreshold: 2,
+    };
+    const state = createInitialScrollState({
+      ...externalState,
+      scrollOffset: 0,
+      autoScroll: true,
+    });
+
+    const next = buildEffectiveScrollState(externalState, {
+      scrollOffset: state.scrollOffset,
+      autoScroll: state.autoScroll,
+    });
+
+    expect(next.fullState.scrollOffset).toBe(state.scrollOffset);
+    expect(next.fullState.autoScroll).toBe(state.autoScroll);
+  });
+
+  it("treats scroll inputs as equal when maps and key order match by value", () => {
+    const state = createInitialScrollState({
+      viewportHeight: 4,
+      itemKeyOrder: ["a", "b"],
+      itemHeights: new Map([
+        ["a", 2],
+        ["b", 3],
+      ]),
+      itemCount: 2,
+    });
+
+    expect(
+      scrollInputsEqual(state, {
+        viewportHeight: 4,
+        itemHeights: new Map([
+          ["a", 2],
+          ["b", 3],
+        ]),
+        itemKeyOrder: ["a", "b"],
+        itemCount: 2,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/react-ink/src/tests/useScrollState.test.ts
+++ b/packages/react-ink/src/tests/useScrollState.test.ts
@@ -4,7 +4,6 @@ import {
   clampScrollOffset,
   createInitialScrollState,
   deriveScrollState,
-  scrollInputsEqual,
   scrollStateReducer,
   type ScrollDerivedState,
   type ScrollState,
@@ -232,29 +231,5 @@ describe("useScrollState", () => {
 
     expect(next.fullState.scrollOffset).toBe(state.scrollOffset);
     expect(next.fullState.autoScroll).toBe(state.autoScroll);
-  });
-
-  it("treats scroll inputs as equal when maps and key order match by value", () => {
-    const state = createInitialScrollState({
-      viewportHeight: 4,
-      itemKeyOrder: ["a", "b"],
-      itemHeights: new Map([
-        ["a", 2],
-        ["b", 3],
-      ]),
-      itemCount: 2,
-    });
-
-    expect(
-      scrollInputsEqual(state, {
-        viewportHeight: 4,
-        itemHeights: new Map([
-          ["a", 2],
-          ["b", 3],
-        ]),
-        itemKeyOrder: ["a", "b"],
-        itemCount: 2,
-      }),
-    ).toBe(true);
   });
 });

--- a/packages/react-ink/src/tests/useScrollable.test.tsx
+++ b/packages/react-ink/src/tests/useScrollable.test.tsx
@@ -1,0 +1,147 @@
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "ink-testing-library";
+import { Text } from "ink";
+import { assertScrollContext } from "../primitives/scroll/ScrollContext";
+import { ScrollRoot } from "../primitives/scroll/ScrollRoot";
+import { useScrollable } from "../primitives/scroll/useScrollable";
+
+const mockUseBoxMetrics = vi.fn();
+
+vi.mock("ink", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ink")>();
+  return {
+    ...actual,
+    useBoxMetrics: (...args: Parameters<typeof actual.useBoxMetrics>) =>
+      mockUseBoxMetrics(...args),
+  };
+});
+
+const renderFrame = async (node: ReactElement) => {
+  const instance = render(node);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return instance;
+};
+
+const ScrollReader = () => {
+  const scroll = useScrollable();
+  return (
+    <Text>
+      {`${scroll.visibleFirstIndex}-${scroll.visibleLastIndex}-${scroll.itemCount}-${scroll.isAtBottom ? "bottom" : "middle"}`}
+    </Text>
+  );
+};
+
+const ScrollDriver = () => {
+  const scroll = useScrollable();
+  return (
+    <Text>{`${scroll.scrollOffset}:${scroll.maxScrollOffset}:${scroll.autoScroll}`}</Text>
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useScrollable", () => {
+  it("throws outside ScrollPrimitive.Root", () => {
+    expect(() => assertScrollContext(null)).toThrowError(
+      "useScrollable must be used within ScrollPrimitive.Root.",
+    );
+  });
+
+  it("returns derived state inside ScrollPrimitive.Root", async () => {
+    mockUseBoxMetrics.mockReturnValue({
+      height: 1,
+      width: 10,
+      left: 0,
+      top: 0,
+      hasMeasured: true,
+    });
+
+    const rendered = await renderFrame(
+      <ScrollRoot
+        items={["one", "two", "three"]}
+        height={2}
+        initialScrollToBottom={false}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ScrollReader />
+      </ScrollRoot>,
+    );
+
+    expect(rendered.lastFrame() ?? "").toContain("0-1-3-bottom");
+  });
+
+  it("exposes actions that update scroll state", async () => {
+    mockUseBoxMetrics.mockReturnValue({
+      height: 1,
+      width: 10,
+      left: 0,
+      top: 0,
+      hasMeasured: true,
+    });
+
+    let latest: ReturnType<typeof useScrollable> | undefined;
+
+    const ActionProbe = () => {
+      latest = useScrollable();
+      return <ScrollDriver />;
+    };
+
+    const rendered = await renderFrame(
+      <ScrollRoot
+        items={["one", "two", "three", "four"]}
+        height={2}
+        initialScrollToBottom={false}
+        stickToBottomThreshold={0}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ActionProbe />
+      </ScrollRoot>,
+    );
+
+    expect(rendered.lastFrame() ?? "").toContain("0:2:false");
+
+    latest?.scrollToBottom();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(rendered.lastFrame() ?? "").toContain("2:2:true");
+  });
+
+  it("applies back-to-back actions without dropping updates", async () => {
+    mockUseBoxMetrics.mockReturnValue({
+      height: 1,
+      width: 10,
+      left: 0,
+      top: 0,
+      hasMeasured: true,
+    });
+
+    let latest: ReturnType<typeof useScrollable> | undefined;
+
+    const ActionProbe = () => {
+      latest = useScrollable();
+      return <ScrollDriver />;
+    };
+
+    const rendered = await renderFrame(
+      <ScrollRoot
+        items={["one", "two", "three", "four", "five", "six"]}
+        height={2}
+        initialScrollToBottom={false}
+        stickToBottomThreshold={0}
+        renderItem={(item) => <Text>{item}</Text>}
+      >
+        <ActionProbe />
+      </ScrollRoot>,
+    );
+
+    latest?.scrollBy(1);
+    latest?.scrollBy(1);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(rendered.lastFrame() ?? "").toContain("2:4:false");
+  });
+});


### PR DESCRIPTION
 ## Summary

  Adds `ScrollPrimitive` and `ScrollableView` to `@assistant-ui/react-ink` with sticky-bottom scrolling, paused state, indicator, scrollbar, and `useScrollable()`.

  ## Included

  - `ScrollPrimitive.Root`
  - `ScrollPrimitive.Indicator`
  - `ScrollPrimitive.Scrollbar`
  - `ScrollableView`
  - `useScrollable()`
  - docs
  - tests
  - patch changeset

  ## Verification

  - `pnpm test --filter @assistant-ui/react-ink`
  - `pnpm build --filter @assistant-ui/react-ink`