### PR TITLE
fix(core): edit composer respects attachment changes

### DIFF
--- a/.changeset/edit-composer-lift-nontext-parts.md
+++ b/.changeset/edit-composer-lift-nontext-parts.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): edit composer no longer re-injects original file parts when user message attachments are modified. Non-text content parts on user messages are lifted into `_attachments` so attachment removals take effect and files aren't duplicated on resend; non-user messages keep the existing content pass-through.

--- a/packages/core/src/adapters/attachment.ts
+++ b/packages/core/src/adapters/attachment.ts
@@ -3,11 +3,7 @@ import type {
   PendingAttachment,
   CompleteAttachment,
 } from "../types/attachment";
-import type {
-  ImageMessagePart,
-  ThreadMessage,
-  ThreadUserMessagePart,
-} from "../types/message";
+import type { ThreadUserMessagePart } from "../types/message";
 import { generateId } from "../utils/id";
 
 export type AttachmentAdapter = {
@@ -147,17 +143,12 @@ export function attachmentsEqual(
   return a.every((att, i) => att.id === b[i]!.id);
 }
 
-type NonTextUserMessagePart = Exclude<ThreadUserMessagePart, { type: "text" }>;
-
-const isImagePart = (part: NonTextUserMessagePart): part is ImageMessagePart =>
-  part.type === "image";
-
 export function partToCompleteAttachment(
-  part: NonTextUserMessagePart,
+  part: Exclude<ThreadUserMessagePart, { type: "text" }>,
 ): CompleteAttachment {
   const id = generateId();
 
-  if (isImagePart(part)) {
+  if (part.type === "image") {
     return {
       id,
       type: "image",
@@ -199,16 +190,11 @@ export function partToCompleteAttachment(
 }
 
 export function liftNonTextParts(
-  content: ThreadMessage["content"],
+  content: readonly ThreadUserMessagePart[],
 ): CompleteAttachment[] {
   const result: CompleteAttachment[] = [];
   for (const part of content) {
-    if (
-      part.type === "image" ||
-      part.type === "file" ||
-      part.type === "data" ||
-      part.type === "audio"
-    ) {
+    if (part.type !== "text") {
       result.push(partToCompleteAttachment(part));
     }
   }

--- a/packages/core/src/adapters/attachment.ts
+++ b/packages/core/src/adapters/attachment.ts
@@ -3,6 +3,12 @@ import type {
   PendingAttachment,
   CompleteAttachment,
 } from "../types/attachment";
+import type {
+  ImageMessagePart,
+  ThreadMessage,
+  ThreadUserMessagePart,
+} from "../types/message";
+import { generateId } from "../utils/id";
 
 export type AttachmentAdapter = {
   accept: string;
@@ -131,6 +137,82 @@ export function fileMatchesAccept(
   }
 
   return false;
+}
+
+export function attachmentsEqual(
+  a: readonly CompleteAttachment[],
+  b: readonly CompleteAttachment[],
+): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((att, i) => att.id === b[i]!.id);
+}
+
+type NonTextUserMessagePart = Exclude<ThreadUserMessagePart, { type: "text" }>;
+
+const isImagePart = (part: NonTextUserMessagePart): part is ImageMessagePart =>
+  part.type === "image";
+
+export function partToCompleteAttachment(
+  part: NonTextUserMessagePart,
+): CompleteAttachment {
+  const id = generateId();
+
+  if (isImagePart(part)) {
+    return {
+      id,
+      type: "image",
+      name: part.filename ?? "image",
+      content: [part],
+      status: { type: "complete" },
+    };
+  }
+
+  if (part.type === "file") {
+    return {
+      id,
+      type: "document",
+      name: part.filename ?? "document",
+      contentType: part.mimeType,
+      content: [part],
+      status: { type: "complete" },
+    };
+  }
+
+  if (part.type === "audio") {
+    return {
+      id,
+      type: "audio",
+      name: `audio.${part.audio.format}`,
+      contentType: `audio/${part.audio.format}`,
+      content: [part],
+      status: { type: "complete" },
+    };
+  }
+
+  return {
+    id,
+    type: "data",
+    name: part.name,
+    content: [part],
+    status: { type: "complete" },
+  };
+}
+
+export function liftNonTextParts(
+  content: ThreadMessage["content"],
+): CompleteAttachment[] {
+  const result: CompleteAttachment[] = [];
+  for (const part of content) {
+    if (
+      part.type === "image" ||
+      part.type === "file" ||
+      part.type === "data" ||
+      part.type === "audio"
+    ) {
+      result.push(partToCompleteAttachment(part));
+    }
+  }
+  return result;
 }
 
 export class CompositeAttachmentAdapter implements AttachmentAdapter {

--- a/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
@@ -1,5 +1,7 @@
 import type { AppendMessage, ThreadMessage } from "../../types/message";
+import type { CompleteAttachment } from "../../types/attachment";
 import { getThreadMessageText } from "../../utils/text";
+import { attachmentsEqual, liftNonTextParts } from "../../adapters/attachment";
 import type { AttachmentAdapter } from "../../adapters/attachment";
 import type { DictationAdapter } from "../../adapters/speech";
 import type { SendOptions } from "../interfaces/composer-runtime-core";
@@ -19,8 +21,9 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
     return this.runtime.adapters?.dictation;
   }
 
-  private _nonTextParts;
   private _previousText;
+  private _previousAttachments: readonly CompleteAttachment[];
+  private _nonTextPassthrough: readonly ThreadMessage["content"][number][];
   private _parentId: string | null;
   private _sourceId: string | null;
   constructor(
@@ -42,9 +45,20 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
     this.setText(this._previousText);
 
     this.setRole(message.role);
-    this.setAttachments(message.attachments ?? []);
 
-    this._nonTextParts = message.content.filter((part) => part.type !== "text");
+    if (message.role === "user") {
+      this._previousAttachments = [
+        ...(message.attachments ?? []),
+        ...liftNonTextParts(message.content),
+      ];
+      this._nonTextPassthrough = [];
+    } else {
+      this._previousAttachments = message.attachments ?? [];
+      this._nonTextPassthrough = message.content.filter(
+        (p) => p.type !== "text",
+      );
+    }
+    this.setAttachments(this._previousAttachments);
 
     this.setRunConfig({ ...runtime.composer.runConfig });
   }
@@ -62,10 +76,26 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
     options?: SendOptions,
   ) {
     const text = getThreadMessageText(message as AppendMessage);
-    if (text !== this._previousText || options?.startRun) {
+    const attachmentsChanged = !attachmentsEqual(
+      message.attachments ?? [],
+      this._previousAttachments,
+    );
+
+    if (
+      text !== this._previousText ||
+      attachmentsChanged ||
+      options?.startRun
+    ) {
+      const content =
+        this._nonTextPassthrough.length > 0
+          ? ([
+              ...message.content,
+              ...this._nonTextPassthrough,
+            ] as AppendMessage["content"])
+          : message.content;
       this.runtime.append({
         ...message,
-        content: [...message.content, ...this._nonTextParts] as any,
+        content,
         parentId: this._parentId,
         sourceId: this._sourceId,
         startRun: options?.startRun,

--- a/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
@@ -1,4 +1,8 @@
-import type { AppendMessage, ThreadMessage } from "../../types/message";
+import type {
+  AppendMessage,
+  ThreadAssistantMessagePart,
+  ThreadMessage,
+} from "../../types/message";
 import type { CompleteAttachment } from "../../types/attachment";
 import { getThreadMessageText } from "../../utils/text";
 import { attachmentsEqual, liftNonTextParts } from "../../adapters/attachment";
@@ -23,7 +27,7 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
 
   private _previousText;
   private _previousAttachments: readonly CompleteAttachment[];
-  private _nonTextPassthrough: readonly ThreadMessage["content"][number][];
+  private _nonTextPassthrough: readonly ThreadAssistantMessagePart[];
   private _parentId: string | null;
   private _sourceId: string | null;
   constructor(
@@ -56,7 +60,7 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
       this._previousAttachments = message.attachments ?? [];
       this._nonTextPassthrough = message.content.filter(
         (p) => p.type !== "text",
-      );
+      ) as ThreadAssistantMessagePart[];
     }
     this.setAttachments(this._previousAttachments);
 

--- a/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
@@ -1,8 +1,4 @@
-import type {
-  AppendMessage,
-  ThreadAssistantMessagePart,
-  ThreadMessage,
-} from "../../types/message";
+import type { AppendMessage, ThreadMessage } from "../../types/message";
 import type { CompleteAttachment } from "../../types/attachment";
 import { getThreadMessageText } from "../../utils/text";
 import { attachmentsEqual, liftNonTextParts } from "../../adapters/attachment";
@@ -27,7 +23,7 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
 
   private _previousText;
   private _previousAttachments: readonly CompleteAttachment[];
-  private _nonTextPassthrough: readonly ThreadAssistantMessagePart[];
+  private _nonTextPassthrough: readonly ThreadMessage["content"][number][];
   private _parentId: string | null;
   private _sourceId: string | null;
   constructor(
@@ -60,7 +56,7 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
       this._previousAttachments = message.attachments ?? [];
       this._nonTextPassthrough = message.content.filter(
         (p) => p.type !== "text",
-      ) as ThreadAssistantMessagePart[];
+      );
     }
     this.setAttachments(this._previousAttachments);
 

--- a/packages/core/src/tests/attachment.test.ts
+++ b/packages/core/src/tests/attachment.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import {
+  attachmentsEqual,
+  liftNonTextParts,
+  partToCompleteAttachment,
+} from "../adapters/attachment";
+import type { CompleteAttachment } from "../types/attachment";
+
+const makeAttachment = (id: string): CompleteAttachment => ({
+  id,
+  type: "document",
+  name: "file.pdf",
+  content: [
+    { type: "file", data: "data", mimeType: "application/pdf", filename: id },
+  ],
+  status: { type: "complete" },
+});
+
+describe("attachmentsEqual", () => {
+  it("returns true for two empty arrays", () => {
+    expect(attachmentsEqual([], [])).toBe(true);
+  });
+
+  it("returns false when lengths differ", () => {
+    expect(attachmentsEqual([makeAttachment("a")], [])).toBe(false);
+  });
+
+  it("returns true when all ids match in order", () => {
+    const a = makeAttachment("a");
+    const b = makeAttachment("b");
+    expect(attachmentsEqual([a, b], [a, b])).toBe(true);
+  });
+
+  it("returns false when ids differ at the same length", () => {
+    expect(attachmentsEqual([makeAttachment("a")], [makeAttachment("b")])).toBe(
+      false,
+    );
+  });
+});
+
+describe("partToCompleteAttachment", () => {
+  it("converts an image part using the filename as name", () => {
+    const result = partToCompleteAttachment({
+      type: "image",
+      image: "https://example.com/x.png",
+      filename: "x.png",
+    });
+    expect(result).toMatchObject({
+      type: "image",
+      name: "x.png",
+      status: { type: "complete" },
+    });
+    expect(result.content).toEqual([
+      {
+        type: "image",
+        image: "https://example.com/x.png",
+        filename: "x.png",
+      },
+    ]);
+  });
+
+  it("falls back to 'image' when the image part has no filename", () => {
+    const result = partToCompleteAttachment({
+      type: "image",
+      image: "blob",
+    });
+    expect(result.name).toBe("image");
+  });
+
+  it("converts a file part to a document attachment with contentType", () => {
+    const result = partToCompleteAttachment({
+      type: "file",
+      data: "blob",
+      mimeType: "application/pdf",
+      filename: "report.pdf",
+    });
+    expect(result).toMatchObject({
+      type: "document",
+      name: "report.pdf",
+      contentType: "application/pdf",
+    });
+  });
+
+  it("falls back to 'document' when the file part has no filename", () => {
+    const result = partToCompleteAttachment({
+      type: "file",
+      data: "blob",
+      mimeType: "application/pdf",
+    });
+    expect(result.name).toBe("document");
+  });
+
+  it("converts an audio part with derived name and contentType", () => {
+    const mp3 = partToCompleteAttachment({
+      type: "audio",
+      audio: { data: "blob", format: "mp3" },
+    });
+    expect(mp3).toMatchObject({
+      type: "audio",
+      name: "audio.mp3",
+      contentType: "audio/mp3",
+    });
+
+    const wav = partToCompleteAttachment({
+      type: "audio",
+      audio: { data: "blob", format: "wav" },
+    });
+    expect(wav.name).toBe("audio.wav");
+    expect(wav.contentType).toBe("audio/wav");
+  });
+
+  it("converts a data part using its name", () => {
+    const result = partToCompleteAttachment({
+      type: "data",
+      name: "weather-widget",
+      data: { temp: 20 },
+    });
+    expect(result).toMatchObject({
+      type: "data",
+      name: "weather-widget",
+    });
+    expect(result.contentType).toBeUndefined();
+  });
+
+  it("generates a unique id for each call", () => {
+    const a = partToCompleteAttachment({
+      type: "file",
+      data: "x",
+      mimeType: "application/pdf",
+    });
+    const b = partToCompleteAttachment({
+      type: "file",
+      data: "x",
+      mimeType: "application/pdf",
+    });
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe("liftNonTextParts", () => {
+  it("returns an empty array for content of only text parts", () => {
+    expect(
+      liftNonTextParts([
+        { type: "text", text: "hello" },
+        { type: "text", text: "world" },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("lifts mixed non-text types preserving order", () => {
+    const result = liftNonTextParts([
+      { type: "text", text: "mix" },
+      {
+        type: "image",
+        image: "url",
+        filename: "pic.png",
+      },
+      {
+        type: "file",
+        data: "d",
+        mimeType: "application/pdf",
+        filename: "doc.pdf",
+      },
+      { type: "audio", audio: { data: "a", format: "mp3" } },
+      { type: "data", name: "widget", data: {} },
+    ]);
+    expect(result.map((a) => a.type)).toEqual([
+      "image",
+      "document",
+      "audio",
+      "data",
+    ]);
+    expect(result.map((a) => a.name)).toEqual([
+      "pic.png",
+      "doc.pdf",
+      "audio.mp3",
+      "widget",
+    ]);
+  });
+});

--- a/packages/core/src/tests/default-edit-composer-runtime-core.test.ts
+++ b/packages/core/src/tests/default-edit-composer-runtime-core.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it, vi } from "vitest";
+import { DefaultEditComposerRuntimeCore } from "../runtime/base/default-edit-composer-runtime-core";
+import type { AppendMessage, ThreadMessage } from "../types/message";
+import type { CompleteAttachment } from "../types/attachment";
+import type { ThreadRuntimeCore } from "../runtime/interfaces/thread-runtime-core";
+
+const makeRuntime = () => {
+  const append = vi.fn();
+  const runtime = {
+    append,
+    composer: { runConfig: {} },
+  } as unknown as ThreadRuntimeCore & { adapters?: undefined };
+  return { runtime, append };
+};
+
+const makeUserMessage = (overrides?: Partial<ThreadMessage>): ThreadMessage =>
+  ({
+    id: "msg-1",
+    role: "user",
+    createdAt: new Date(),
+    content: [{ type: "text", text: "hello" }],
+    attachments: [],
+    metadata: { custom: {} },
+    ...overrides,
+  }) as ThreadMessage;
+
+const makeCompleteAttachment = (
+  id: string,
+  name = "file.pdf",
+): CompleteAttachment => ({
+  id,
+  type: "document",
+  name,
+  contentType: "application/pdf",
+  content: [
+    { type: "file", data: "blob", mimeType: "application/pdf", filename: name },
+  ],
+  status: { type: "complete" },
+});
+
+describe("DefaultEditComposerRuntimeCore", () => {
+  describe("construction", () => {
+    it("seeds composer text from the edited message", () => {
+      const { runtime } = makeRuntime();
+      const composer = new DefaultEditComposerRuntimeCore(runtime, () => {}, {
+        parentId: null,
+        message: makeUserMessage({
+          content: [{ type: "text", text: "original" }],
+        }),
+      });
+      expect(composer.text).toBe("original");
+    });
+
+    it("seeds attachments from message.attachments", () => {
+      const { runtime } = makeRuntime();
+      const attachment = makeCompleteAttachment("att-1");
+      const composer = new DefaultEditComposerRuntimeCore(runtime, () => {}, {
+        parentId: null,
+        message: makeUserMessage({ attachments: [attachment] }),
+      });
+      expect(composer.attachments).toEqual([attachment]);
+    });
+
+    it("lifts non-text content parts into attachments", () => {
+      const { runtime } = makeRuntime();
+      const composer = new DefaultEditComposerRuntimeCore(runtime, () => {}, {
+        parentId: null,
+        message: makeUserMessage({
+          content: [
+            { type: "text", text: "here is a file" },
+            {
+              type: "file",
+              data: "blob",
+              mimeType: "application/pdf",
+              filename: "report.pdf",
+            },
+          ],
+        }),
+      });
+      expect(composer.attachments).toHaveLength(1);
+      expect(composer.attachments[0]).toMatchObject({
+        type: "document",
+        name: "report.pdf",
+        contentType: "application/pdf",
+        status: { type: "complete" },
+      });
+    });
+
+    it("merges message.attachments with lifted content parts", () => {
+      const { runtime } = makeRuntime();
+      const attachment = makeCompleteAttachment("att-1", "existing.pdf");
+      const composer = new DefaultEditComposerRuntimeCore(runtime, () => {}, {
+        parentId: null,
+        message: makeUserMessage({
+          attachments: [attachment],
+          content: [
+            { type: "text", text: "x" },
+            {
+              type: "file",
+              data: "b",
+              mimeType: "application/pdf",
+              filename: "inline.pdf",
+            },
+          ],
+        }),
+      });
+      expect(composer.attachments).toHaveLength(2);
+      expect(composer.attachments[0]).toBe(attachment);
+      expect(composer.attachments[1]).toMatchObject({ name: "inline.pdf" });
+    });
+
+    it("exposes parentId and sourceId", () => {
+      const { runtime } = makeRuntime();
+      const composer = new DefaultEditComposerRuntimeCore(runtime, () => {}, {
+        parentId: "parent-7",
+        message: makeUserMessage(),
+      });
+      expect(composer.parentId).toBe("parent-7");
+      expect(composer.sourceId).toBe("msg-1");
+    });
+  });
+
+  describe("send behavior", () => {
+    it("does not call append when nothing changed", async () => {
+      const { runtime, append } = makeRuntime();
+      const composer = new DefaultEditComposerRuntimeCore(runtime, () => {}, {
+        parentId: "p1",
+        message: makeUserMessage({
+          content: [{ type: "text", text: "same" }],
+        }),
+      });
+      await composer.send();
+      expect(append).not.toHaveBeenCalled();
+    });
+
+    it("calls append when text changes", async () => {
+      const { runtime, append } = makeRuntime();
+      const composer = new DefaultEditComposerRuntimeCore(runtime, () => {}, {
+        parentId: "p1",
+        message: makeUserMessage({
+          content: [{ type: "text", text: "old" }],
+        }),
+      });
+      composer.setText("new");
+      await composer.send();
+      expect(append).toHaveBeenCalledTimes(1);
+      const appended = append.mock.calls[0]![0] as AppendMessage;
+      expect(appended.content).toEqual([{ type: "text", text: "new" }]);
+      expect(appended.parentId).toBe("p1");
+      expect(appended.sourceId).toBe("msg-1");
+    });
+
+    it("drops a removed attachment from the sent message", async () => {
+      const { runtime, append } = makeRuntime();
+      const composer = new DefaultEditComposerRuntimeCore(runtime, () => {}, {
+        parentId: null,
+        message: makeUserMessage({
+          content: [
+            { type: "text", text: "original" },
+            {
+              type: "file",
+              data: "blob",
+              mimeType: "application/pdf",
+              filename: "doc.pdf",
+            },
+          ],
+        }),
+      });
+      expect(composer.attachments).toHaveLength(1);
+      await composer.removeAttachment(composer.attachments[0]!.id);
+      await composer.send();
+      expect(append).toHaveBeenCalledTimes(1);
+      const appended = append.mock.calls[0]![0] as AppendMessage;
+      expect(appended.attachments).toHaveLength(0);
+      expect(appended.content).toEqual([{ type: "text", text: "original" }]);
+    });
+
+    it("preserves the attachment without duplicating it when only text changes", async () => {
+      const { runtime, append } = makeRuntime();
+      const composer = new DefaultEditComposerRuntimeCore(runtime, () => {}, {
+        parentId: null,
+        message: makeUserMessage({
+          content: [
+            { type: "text", text: "old" },
+            {
+              type: "file",
+              data: "blob",
+              mimeType: "application/pdf",
+              filename: "doc.pdf",
+            },
+          ],
+        }),
+      });
+      composer.setText("new text");
+      await composer.send();
+      const appended = append.mock.calls[0]![0] as AppendMessage;
+      expect(appended.content).toEqual([{ type: "text", text: "new text" }]);
+      expect(appended.attachments).toHaveLength(1);
+      expect(appended.attachments![0]).toMatchObject({ name: "doc.pdf" });
+    });
+
+    it("forwards startRun even when text and attachments are unchanged", async () => {
+      const { runtime, append } = makeRuntime();
+      const composer = new DefaultEditComposerRuntimeCore(runtime, () => {}, {
+        parentId: null,
+        message: makeUserMessage({
+          content: [{ type: "text", text: "same" }],
+        }),
+      });
+      await composer.send({ startRun: true });
+      expect(append).toHaveBeenCalledTimes(1);
+      const appended = append.mock.calls[0]![0] as AppendMessage;
+      expect(appended.startRun).toBe(true);
+    });
+  });
+
+  describe("non-user messages", () => {
+    it("does not lift non-text parts for assistant messages", () => {
+      const { runtime } = makeRuntime();
+      const composer = new DefaultEditComposerRuntimeCore(runtime, () => {}, {
+        parentId: null,
+        message: {
+          id: "msg-a",
+          role: "assistant",
+          createdAt: new Date(),
+          content: [
+            { type: "text", text: "answer" },
+            {
+              type: "file",
+              data: "blob",
+              mimeType: "application/pdf",
+              filename: "doc.pdf",
+            },
+          ],
+          status: { type: "complete", reason: "stop" },
+          metadata: {
+            unstable_state: null,
+            unstable_annotations: [],
+            unstable_data: [],
+            steps: [],
+            custom: {},
+          },
+        } as ThreadMessage,
+      });
+      expect(composer.attachments).toHaveLength(0);
+    });
+
+    it("preserves non-text content parts of assistant messages on send", async () => {
+      const { runtime, append } = makeRuntime();
+      const fileParts = [
+        {
+          type: "file" as const,
+          data: "blob",
+          mimeType: "application/pdf",
+          filename: "doc.pdf",
+        },
+        { type: "reasoning" as const, text: "chain of thought" },
+      ];
+      const composer = new DefaultEditComposerRuntimeCore(runtime, () => {}, {
+        parentId: null,
+        message: {
+          id: "msg-a",
+          role: "assistant",
+          createdAt: new Date(),
+          content: [{ type: "text", text: "old answer" }, ...fileParts],
+          status: { type: "complete", reason: "stop" },
+          metadata: {
+            unstable_state: null,
+            unstable_annotations: [],
+            unstable_data: [],
+            steps: [],
+            custom: {},
+          },
+        } as ThreadMessage,
+      });
+      composer.setText("new answer");
+      await composer.send();
+      expect(append).toHaveBeenCalledTimes(1);
+      const appended = append.mock.calls[0]![0] as AppendMessage;
+      expect(appended.content).toEqual([
+        { type: "text", text: "new answer" },
+        ...fileParts,
+      ]);
+      expect(appended.attachments ?? []).toHaveLength(0);
+    });
+  });
+
+  describe("lifecycle", () => {
+    it("invokes endEditCallback after send", async () => {
+      const endEdit = vi.fn();
+      const { runtime } = makeRuntime();
+      const composer = new DefaultEditComposerRuntimeCore(runtime, endEdit, {
+        parentId: null,
+        message: makeUserMessage(),
+      });
+      composer.setText("changed");
+      await composer.send();
+      expect(endEdit).toHaveBeenCalledTimes(1);
+    });
+
+    it("invokes endEditCallback on cancel", () => {
+      const endEdit = vi.fn();
+      const { runtime } = makeRuntime();
+      const composer = new DefaultEditComposerRuntimeCore(runtime, endEdit, {
+        parentId: null,
+        message: makeUserMessage(),
+      });
+      composer.cancel();
+      expect(endEdit).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #3476 — edit composer no longer re-injects original file parts when a user-edited message's attachments are modified, so removals take effect and file content isn't duplicated on resend (Bedrock/LangGraph "duplicate document names" error).
- **User messages**: non-text content parts (e.g. `FileMessagePart` from backend round-trip) are lifted into `_attachments` during construction — single source of truth, mirroring `DefaultThreadComposerRuntimeCore`.
- **Non-user messages**: non-text content parts kept as pass-through since assistant/system roles don't support attachments (`fromThreadMessageLike` rejects them).
- `append` now fires when attachments change, not only when text changes.
- Adds `attachmentsEqual`, `partToCompleteAttachment`, `liftNonTextParts` helpers in `adapters/attachment.ts` alongside the existing `fileMatchesAccept`.

## Test plan
- [x] editing a user message with a file and changing only text does not duplicate the file downstream
- [x] removing an attachment in the edit composer actually removes it from the sent message
- [x] editing an assistant message with `file`/`reasoning` parts does not crash `fromThreadMessageLike` and preserves non-text parts
- [x] `startRun: true` without text/attachment changes still fires `append`
- [x] 131 unit tests pass (`pnpm --filter @assistant-ui/core test`)
- [x] 822 cross-package tests pass (`pnpm test`)
- [x] `pnpm build` succeeds (71/71 tasks)