### PR TITLE
fix(react-ai-sdk): require withFormat on ThreadHistoryAdapter

### DIFF
--- a/.changeset/fix-use-external-history-withformat-required.md
+++ b/.changeset/fix-use-external-history-withformat-required.md
@@ -1,5 +1,6 @@
 ---
 "@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/core": patch
 ---
 
-fix: `useAISDKRuntime` now throws when the supplied `ThreadHistoryAdapter` omits `withFormat`, instead of silently dropping all history load/append/update calls. The optional-call chain `historyAdapter.withFormat?.(…).load()` previously short-circuited to `undefined`. The `withFormat`-wrapped adapter is now memoized instead of recomputed on every persist.
+fix: `useAISDKRuntime` now throws when the supplied `ThreadHistoryAdapter` omits `withFormat`, instead of silently dropping all history load/append/update calls. The optional-call chain `historyAdapter.withFormat?.(…).load()` previously short-circuited to `undefined`. The `withFormat`-wrapped adapter is now memoized, and the persist effect short-circuits when no adapter is supplied (avoiding a redundant thread subscription). `ThreadHistoryAdapter.withFormat` gains a JSDoc note clarifying that it is required on the AI SDK path.

--- a/.changeset/fix-use-external-history-withformat-required.md
+++ b/.changeset/fix-use-external-history-withformat-required.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: `useAISDKRuntime` now throws when the supplied `ThreadHistoryAdapter` omits `withFormat`, instead of silently dropping all history load/append/update calls. The optional-call chain `historyAdapter.withFormat?.(…).load()` previously short-circuited to `undefined`. The `withFormat`-wrapped adapter is now memoized instead of recomputed on every persist.

--- a/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
@@ -166,7 +166,7 @@ export default function ChatPage() {
               name: "history",
               type: "ThreadHistoryAdapter",
               description:
-                "Adapter for loading and saving thread history. Used to restore previous messages when switching threads.",
+                "Adapter for loading and saving thread history. Used to restore previous messages when switching threads. The adapter must implement `withFormat` when used with AI SDK — see [Persisting Chat History](/docs/runtimes/ai-sdk/v6#persisting-chat-history).",
             },
           ],
         },

--- a/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
@@ -181,9 +181,7 @@ const historyAdapter: ThreadHistoryAdapter = {
   },
   async append() {},
 
-  // Called once per thread; the returned object handles load / append.
-  // `fmt` is the ai-sdk/v6 format adapter: encode/decode between UIMessage
-  // and a serializable storage row.
+  // `fmt` encodes UIMessage ↔ storage rows (ai-sdk/v6 format).
   withFormat: (fmt) => ({
     async load() {
       const rows = await fetch("/api/history").then((r) => r.json());

--- a/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
@@ -154,6 +154,65 @@ export function TokenCounter() {
   </Step>
 </Steps>
 
+## Persisting Chat History
+
+By default, messages live only in memory and reset on reload. To persist and restore history per thread, provide a `ThreadHistoryAdapter` via `adapters.history`.
+
+<Callout type="warn">
+  The adapter **must** implement `withFormat`. `useChatRuntime` persists history through `withFormat(fmt)` so messages round-trip as AI SDK `UIMessage` objects. An adapter without `withFormat` throws at runtime — `load` / `append` on the top level are unused in the AI SDK path.
+</Callout>
+
+<Callout type="info">
+  For server-side cloud persistence with zero adapter code, see the [AssistantCloud integration](/docs/cloud/ai-sdk-assistant-ui).
+</Callout>
+
+### Example
+
+```tsx
+"use client";
+
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import type { ThreadHistoryAdapter } from "@assistant-ui/react";
+
+const historyAdapter: ThreadHistoryAdapter = {
+  // Required by the type — unused by useChatRuntime.
+  async load() {
+    return { headId: null, messages: [] };
+  },
+  async append() {},
+
+  // Called once per thread; the returned object handles load / append.
+  // `fmt` is the ai-sdk/v6 format adapter: encode/decode between UIMessage
+  // and a serializable storage row.
+  withFormat: (fmt) => ({
+    async load() {
+      const rows = await fetch("/api/history").then((r) => r.json());
+      return { messages: rows.map(fmt.decode) };
+    },
+    async append(item) {
+      await fetch("/api/history", {
+        method: "POST",
+        body: JSON.stringify({
+          id: fmt.getId(item.message),
+          parent_id: item.parentId,
+          format: fmt.format,
+          content: fmt.encode(item),
+        }),
+      });
+    },
+  }),
+};
+
+function Chat() {
+  const runtime = useChatRuntime({
+    adapters: { history: historyAdapter },
+  });
+  // ...
+}
+```
+
+Each persisted row follows `{ id, parent_id, format, content }`; `fmt.encode` produces the `content` payload and `fmt.decode` reverses it, so your backend never needs to know about `UIMessage` internals.
+
 ## Key Changes from v5
 
 | Feature | v5 | v6 |

--- a/packages/core/src/adapters/thread-history.ts
+++ b/packages/core/src/adapters/thread-history.ts
@@ -58,6 +58,7 @@ export type ThreadHistoryAdapter = {
     options: ChatModelRunOptions,
   ): AsyncGenerator<ChatModelRunResult, void, unknown>;
   append(item: ExportedMessageRepositoryItem): Promise<void>;
+  /** Required when used with `useAISDKRuntime` / `useChatRuntime`. */
   withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(
     formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>,
   ): GenericThreadHistoryAdapter<TMessage>;

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AssistantRuntime,
+  MessageFormatAdapter,
+  ThreadHistoryAdapter,
+  ThreadMessage,
+} from "@assistant-ui/core";
+
+vi.mock("@assistant-ui/store", () => ({
+  useAui: () => ({ threadListItem: { source: undefined } }),
+}));
+
+import { useExternalHistory } from "./useExternalHistory";
+
+const noopThread = {
+  subscribe: () => () => {},
+  getState: () => ({ isRunning: false, messages: [] }),
+  import: () => {},
+  export: () => ({ headId: null, messages: [] }),
+} as unknown as AssistantRuntime["thread"];
+
+const runtimeRef = {
+  current: { thread: noopThread } as AssistantRuntime,
+};
+
+const storageFormat: MessageFormatAdapter<unknown, Record<string, unknown>> = {
+  format: "test",
+  encode: (item) => ({ data: item.message }),
+  decode: (stored) => ({
+    parentId: stored.parent_id,
+    message: stored.content,
+  }),
+  getId: () => "id",
+};
+
+const toThreadMessages = (_messages: unknown[]): ThreadMessage[] => [];
+const onSetMessages = () => {};
+
+describe("useExternalHistory withFormat contract", () => {
+  it("throws when the adapter omits withFormat", () => {
+    const adapterWithoutWithFormat: ThreadHistoryAdapter = {
+      load: vi.fn().mockResolvedValue({ headId: null, messages: [] }),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() =>
+      renderHook(() =>
+        useExternalHistory(
+          runtimeRef,
+          adapterWithoutWithFormat,
+          toThreadMessages,
+          storageFormat,
+          onSetMessages,
+        ),
+      ),
+    ).toThrow(/withFormat/);
+
+    errorSpy.mockRestore();
+  });
+
+  it("does not throw when no adapter is supplied", () => {
+    expect(() =>
+      renderHook(() =>
+        useExternalHistory(
+          runtimeRef,
+          undefined,
+          toThreadMessages,
+          storageFormat,
+          onSetMessages,
+        ),
+      ),
+    ).not.toThrow();
+  });
+
+  it("accepts an adapter that implements withFormat", () => {
+    const withFormatResult = {
+      load: vi.fn().mockResolvedValue({ headId: null, messages: [] }),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+    const adapter: ThreadHistoryAdapter = {
+      load: vi.fn(),
+      append: vi.fn(),
+      withFormat: vi.fn().mockReturnValue(withFormatResult),
+    };
+
+    expect(() =>
+      renderHook(() =>
+        useExternalHistory(
+          runtimeRef,
+          adapter,
+          toThreadMessages,
+          storageFormat,
+          onSetMessages,
+        ),
+      ),
+    ).not.toThrow();
+
+    expect(adapter.withFormat).toHaveBeenCalledWith(storageFormat);
+  });
+});

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -10,7 +10,9 @@ import type {
 } from "@assistant-ui/core";
 
 vi.mock("@assistant-ui/store", () => ({
-  useAui: () => ({ threadListItem: { source: undefined } }),
+  useAui: () => ({
+    threadListItem: Object.assign(() => null, { source: undefined }),
+  }),
 }));
 
 import { useExternalHistory } from "./useExternalHistory";

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -17,6 +17,7 @@ import {
   useState,
   type RefObject,
   useCallback,
+  useMemo,
 } from "react";
 
 export const toExportedMessageRepository = <TMessage>(
@@ -59,15 +60,23 @@ export const useExternalHistory = <TMessage>(
     onSetMessagesRef.current = onSetMessages;
   });
 
+  const formatAdapter = useMemo(() => {
+    if (!historyAdapter) return undefined;
+    if (!historyAdapter.withFormat) {
+      throw new Error(
+        "useAISDKRuntime: ThreadHistoryAdapter is missing the required `withFormat` method.",
+      );
+    }
+    return historyAdapter.withFormat<TMessage, any>(storageFormatAdapter);
+  }, [historyAdapter, storageFormatAdapter]);
+
   useEffect(() => {
-    if (!historyAdapter || loadedRef.current) return;
+    if (!formatAdapter || loadedRef.current) return;
 
     const loadHistory = async () => {
       setIsLoading(true);
       try {
-        const repo = await historyAdapter
-          .withFormat?.(storageFormatAdapter)
-          .load();
+        const repo = await formatAdapter.load();
         if (repo && repo.messages.length > 0) {
           const converted = toExportedMessageRepository(toThreadMessages, repo);
           runtimeRef.current.thread.import(converted);
@@ -99,13 +108,7 @@ export const useExternalHistory = <TMessage>(
     }
 
     loadHistory();
-  }, [
-    historyAdapter,
-    storageFormatAdapter,
-    toThreadMessages,
-    runtimeRef,
-    optionalThreadListItem,
-  ]);
+  }, [formatAdapter, toThreadMessages, runtimeRef, optionalThreadListItem]);
 
   const runStartRef = useRef<number | null>(null);
   const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -237,8 +240,6 @@ export const useExternalHistory = <TMessage>(
 
           if (historyIds.current.has(message.id)) {
             if (durationMs !== undefined) {
-              const formatAdapter =
-                historyAdapter?.withFormat?.(storageFormatAdapter);
               let parentId = lastInnerMessageId;
               for (const innerMessage of innerMessages) {
                 try {
@@ -257,9 +258,6 @@ export const useExternalHistory = <TMessage>(
             continue;
           }
           historyIds.current.add(message.id);
-
-          const formatAdapter =
-            historyAdapter?.withFormat?.(storageFormatAdapter);
 
           const batchItems = toBatchItems(innerMessages);
           for (const item of batchItems) {
@@ -281,7 +279,7 @@ export const useExternalHistory = <TMessage>(
         persistTimerRef.current = null;
       }
     };
-  }, [historyAdapter, storageFormatAdapter, runtimeRef]);
+  }, [formatAdapter, storageFormatAdapter, runtimeRef]);
 
   return isLoading;
 };

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -117,6 +117,8 @@ export const useExternalHistory = <TMessage>(
   const toolCallCountRef = useRef(0);
 
   useEffect(() => {
+    if (!formatAdapter) return;
+
     const unsubscribe = runtimeRef.current.thread.subscribe(() => {
       const { isRunning } = runtimeRef.current.thread.getState();
       const wasRunning = wasRunningRef.current;
@@ -243,7 +245,7 @@ export const useExternalHistory = <TMessage>(
               let parentId = lastInnerMessageId;
               for (const innerMessage of innerMessages) {
                 try {
-                  await formatAdapter?.update?.(
+                  await formatAdapter.update?.(
                     { parentId, message: innerMessage },
                     storageFormatAdapter.getId(innerMessage),
                   );
@@ -261,13 +263,13 @@ export const useExternalHistory = <TMessage>(
 
           const batchItems = toBatchItems(innerMessages);
           for (const item of batchItems) {
-            await formatAdapter?.append(item);
+            await formatAdapter.append(item);
           }
 
           lastInnerMessageId =
             getLastInnerId(innerMessages) ?? lastInnerMessageId;
 
-          formatAdapter?.reportTelemetry?.(batchItems, telemetryOptions);
+          formatAdapter.reportTelemetry?.(batchItems, telemetryOptions);
         }
       }, 0);
     });


### PR DESCRIPTION
## Summary

- Fixes #2450. `useExternalHistory` used `historyAdapter.withFormat?.(…).load()`, which silently short-circuits to `undefined` whenever the supplied adapter omits `withFormat` — so `load`, `append`, `update`, and `reportTelemetry` were all dropped without a trace.
- Throw a descriptive error (`useAISDKRuntime: ThreadHistoryAdapter is missing the required withFormat method.`) when `withFormat` is absent, instead of failing silently.
- Memoize the `withFormat`-wrapped adapter in `useMemo` so it is built once per adapter/format pair, not recomputed on every persist tick.
- Add a vitest spec covering the three cases: throws without `withFormat`, no-ops when no adapter is supplied, and invokes `withFormat(storageFormatAdapter)` when provided.
- New "Persisting Chat History" section in the AI SDK v6 runtime guide with a full adapter template using `fmt.encode` / `fmt.decode` / `fmt.getId` / `fmt.format`; cross-linked from the AssistantCloud integration `history` parameter description.

## Test plan

- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` passes (26/26, 3 new)
- [x] `pnpm lint` — no new warnings introduced
- [ ] Verify docs render: `/docs/runtimes/ai-sdk/v6#persisting-chat-history` shows the new section and anchor link from cloud page resolves
- [ ] Sanity-check the error message surfaces in a dev app by passing `{ load, append }` (no `withFormat`) as `adapters.history` to `useChatRuntime`