### PR TITLE
feat(react-ink): add intra line highlighting to DiffView

### DIFF
--- a/.changeset/diffview-intra-line-react-ink.md
+++ b/.changeset/diffview-intra-line-react-ink.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+feat(react-ink): add intra-line highlighting to DiffView replacement lines

--- a/apps/docs/content/docs/ink/primitives.mdx
+++ b/apps/docs/content/docs/ink/primitives.mdx
@@ -710,6 +710,8 @@ Components for rendering code diffs in the terminal.
 
 Pre-composed component that combines all diff primitives for easy diff rendering. Accepts either a unified diff patch string or old/new file content for inline comparison.
 
+When a replacement is rendered as an equal-length adjacent `-`/`+` run, `DiffView` also highlights the changed word spans inside those lines. The existing prefixes, line numbers, folding, and primitive API surface stay the same. This intra-line behavior is internal to `DiffView`; `DiffPrimitive.Line` remains a line-level primitive.
+
 ```tsx
 // From a patch string
 <DiffView

--- a/packages/react-ink/src/primitives/diff/DiffView.test.tsx
+++ b/packages/react-ink/src/primitives/diff/DiffView.test.tsx
@@ -1,20 +1,13 @@
 import type { ReactElement } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render } from "ink-testing-library";
-import {
-  parsePatch,
-  computeDiff,
-  foldContext,
-} from "../primitives/diff/diff-utils";
-import { DiffContent } from "../primitives/diff/DiffContent";
-import { DiffHeader } from "../primitives/diff/DiffHeader";
-import {
-  buildIntraLineSegments,
-  buildLinePairMap,
-} from "../primitives/diff/intra-line-utils";
-import { DiffRoot } from "../primitives/diff/DiffRoot";
-import { DiffView } from "../primitives/diff/DiffView";
-import type { ParsedLine } from "../primitives/diff/types";
+import { parsePatch, computeDiff, foldContext } from "./diff-utils";
+import { DiffContent } from "./DiffContent";
+import { DiffHeader } from "./DiffHeader";
+import { buildIntraLineSegments, buildLinePairMap } from "./intra-line-utils";
+import { DiffRoot } from "./DiffRoot";
+import { DiffView } from "./DiffView";
+import type { ParsedLine } from "./types";
 
 const renderFrame = async (node: ReactElement) => {
   const instance = render(node);
@@ -68,14 +61,8 @@ describe("buildLinePairMap", () => {
 
     const pairMap = buildLinePairMap([del, add]);
 
-    expect(pairMap.get(del)).toEqual({
-      role: "del",
-      counterpart: add,
-    });
-    expect(pairMap.get(add)).toEqual({
-      role: "add",
-      counterpart: del,
-    });
+    expect(pairMap.size).toBe(1);
+    expect(pairMap.get(del)).toBe(add);
   });
 
   it("pairs equal-length adjacent delete and add runs in order", () => {
@@ -86,10 +73,8 @@ describe("buildLinePairMap", () => {
 
     const pairMap = buildLinePairMap([del1, del2, add1, add2]);
 
-    expect(pairMap.get(del1)?.counterpart).toBe(add1);
-    expect(pairMap.get(del2)?.counterpart).toBe(add2);
-    expect(pairMap.get(add1)?.counterpart).toBe(del1);
-    expect(pairMap.get(add2)?.counterpart).toBe(del2);
+    expect(pairMap.get(del1)).toBe(add1);
+    expect(pairMap.get(del2)).toBe(add2);
   });
 
   it("pairs equal-length block rewrites of length three", () => {
@@ -102,9 +87,9 @@ describe("buildLinePairMap", () => {
 
     const pairMap = buildLinePairMap([del1, del2, del3, add1, add2, add3]);
 
-    expect(pairMap.get(del1)?.counterpart).toBe(add1);
-    expect(pairMap.get(del2)?.counterpart).toBe(add2);
-    expect(pairMap.get(del3)?.counterpart).toBe(add3);
+    expect(pairMap.get(del1)).toBe(add1);
+    expect(pairMap.get(del2)).toBe(add2);
+    expect(pairMap.get(del3)).toBe(add3);
   });
 
   it("does not pair unequal-length adjacent runs", () => {
@@ -116,7 +101,7 @@ describe("buildLinePairMap", () => {
       makeAddLine("new 3", 3),
     ]);
 
-    expect(pairMap).toHaveLength(0);
+    expect(pairMap.size).toBe(0);
   });
 
   it("does not pair non-adjacent delete and add lines", () => {
@@ -126,7 +111,7 @@ describe("buildLinePairMap", () => {
 
     const pairMap = buildLinePairMap([del, normal, add]);
 
-    expect(pairMap).toHaveLength(0);
+    expect(pairMap.size).toBe(0);
   });
 
   it("does not pair an unpaired add line", () => {
@@ -135,7 +120,7 @@ describe("buildLinePairMap", () => {
       makeAddLine("new value", 2),
     ]);
 
-    expect(pairMap).toHaveLength(0);
+    expect(pairMap.size).toBe(0);
   });
 
   it("does not pair across file boundaries when called per file", () => {
@@ -145,8 +130,8 @@ describe("buildLinePairMap", () => {
     ]);
     const secondFile = buildLinePairMap([makeAddLine("new value", 1)]);
 
-    expect(firstFile).toHaveLength(0);
-    expect(secondFile).toHaveLength(0);
+    expect(firstFile.size).toBe(0);
+    expect(secondFile.size).toBe(0);
   });
 });
 

--- a/packages/react-ink/src/primitives/diff/DiffView.tsx
+++ b/packages/react-ink/src/primitives/diff/DiffView.tsx
@@ -4,6 +4,11 @@ import { DiffContent } from "./DiffContent";
 import { useDiffContext } from "./DiffContext";
 import { DiffRoot } from "./DiffRoot";
 import { computeDiff, parsePatch } from "./diff-utils";
+import {
+  buildIntraLineSegments,
+  buildLinePairMap,
+  type StyledDiffSegment,
+} from "./intra-line-utils";
 import type {
   DiffFileInput,
   FoldedRegion,
@@ -32,14 +37,61 @@ const INDICATOR: Record<string, string> = {
   normal: " ",
 };
 
+const EMPTY_SEGMENT_MAP = new Map<ParsedLine, StyledDiffSegment[]>();
+
 const isDevNull = (n: string | undefined) => !n || n === "/dev/null";
+
+const buildSegmentMap = (lines: ParsedLine[]) => {
+  const pairMap = buildLinePairMap(lines);
+  const segmentMap = new Map<ParsedLine, StyledDiffSegment[]>();
+
+  for (const [line, pairInfo] of pairMap) {
+    if (pairInfo.role !== "del") {
+      continue;
+    }
+
+    const { delSegments, addSegments } = buildIntraLineSegments(
+      line.content,
+      pairInfo.counterpart.content,
+    );
+
+    segmentMap.set(line, delSegments);
+    segmentMap.set(pairInfo.counterpart, addSegments);
+  }
+
+  return segmentMap;
+};
+
+const renderSegmentedLine = (
+  line: ParsedLine,
+  segments: StyledDiffSegment[],
+) => {
+  const color = line.type === "add" ? "green" : "red";
+
+  return (
+    <Text color={color}>
+      {`${INDICATOR[line.type]} `}
+      {segments.map((segment, index) => (
+        <Text
+          key={`${line.type}-${index}`}
+          bold={segment.changed}
+          dimColor={!segment.changed}
+        >
+          {segment.text}
+        </Text>
+      ))}
+    </Text>
+  );
+};
 
 const StyledLine = ({
   line,
   showLineNumbers,
+  segmentMap,
 }: {
   line: ParsedLine;
   showLineNumbers: boolean;
+  segmentMap: Map<ParsedLine, StyledDiffSegment[]>;
 }) => {
   const lineNum =
     line.type === "del"
@@ -49,17 +101,19 @@ const StyledLine = ({
         : line.oldLineNumber;
   const numStr = lineNum !== undefined ? String(lineNum) : "";
   const padded = numStr.padStart(4);
-  const content = `${INDICATOR[line.type]} ${line.content}`;
+  const segments = segmentMap.get(line);
 
   return (
     <Box>
       {showLineNumbers && <Text dimColor>{padded} </Text>}
-      {line.type === "add" ? (
-        <Text color="green">{content}</Text>
+      {segments && line.type !== "normal" ? (
+        renderSegmentedLine(line, segments)
+      ) : line.type === "add" ? (
+        <Text color="green">{`+ ${line.content}`}</Text>
       ) : line.type === "del" ? (
-        <Text color="red">{content}</Text>
+        <Text color="red">{`- ${line.content}`}</Text>
       ) : (
-        <Text>{content}</Text>
+        <Text>{`  ${line.content}`}</Text>
       )}
     </Box>
   );
@@ -76,6 +130,10 @@ const DiffViewInner = ({
 }: DiffViewInnerProps) => {
   const { files } = useDiffContext();
   const shouldShowLineNumbers = showLineNumbers ?? true;
+  const segmentMaps = useMemo(
+    () => files.map((file) => buildSegmentMap(file.lines)),
+    [files],
+  );
 
   if (files.length === 0) {
     return <Text dimColor>No diff content</Text>;
@@ -117,6 +175,7 @@ const DiffViewInner = ({
                 <StyledLine
                   line={line}
                   showLineNumbers={shouldShowLineNumbers}
+                  segmentMap={segmentMaps[i] ?? EMPTY_SEGMENT_MAP}
                 />
               )}
               renderFold={({ region }) => <StyledFold region={region} />}

--- a/packages/react-ink/src/primitives/diff/DiffView.tsx
+++ b/packages/react-ink/src/primitives/diff/DiffView.tsx
@@ -42,21 +42,16 @@ const EMPTY_SEGMENT_MAP = new Map<ParsedLine, StyledDiffSegment[]>();
 const isDevNull = (n: string | undefined) => !n || n === "/dev/null";
 
 const buildSegmentMap = (lines: ParsedLine[]) => {
-  const pairMap = buildLinePairMap(lines);
   const segmentMap = new Map<ParsedLine, StyledDiffSegment[]>();
 
-  for (const [line, pairInfo] of pairMap) {
-    if (pairInfo.role !== "del") {
-      continue;
-    }
-
+  for (const [del, add] of buildLinePairMap(lines)) {
     const { delSegments, addSegments } = buildIntraLineSegments(
-      line.content,
-      pairInfo.counterpart.content,
+      del.content,
+      add.content,
     );
 
-    segmentMap.set(line, delSegments);
-    segmentMap.set(pairInfo.counterpart, addSegments);
+    segmentMap.set(del, delSegments);
+    segmentMap.set(add, addSegments);
   }
 
   return segmentMap;

--- a/packages/react-ink/src/primitives/diff/intra-line-utils.ts
+++ b/packages/react-ink/src/primitives/diff/intra-line-utils.ts
@@ -6,16 +6,6 @@ export type StyledDiffSegment = {
   changed: boolean;
 };
 
-export type PairInfo = {
-  role: "del" | "add";
-  counterpart: ParsedLine;
-};
-
-type LinePair = {
-  del: ParsedLine;
-  add: ParsedLine;
-};
-
 const getRunEnd = (
   lines: ParsedLine[],
   startIndex: number,
@@ -28,31 +18,21 @@ const getRunEnd = (
   return index;
 };
 
-const pushPair = (pairMap: Map<ParsedLine, PairInfo>, pair: LinePair) => {
-  pairMap.set(pair.del, { role: "del", counterpart: pair.add });
-  pairMap.set(pair.add, { role: "add", counterpart: pair.del });
-};
-
 export const buildLinePairMap = (lines: ParsedLine[]) => {
-  const pairMap = new Map<ParsedLine, PairInfo>();
+  const pairMap = new Map<ParsedLine, ParsedLine>();
 
   for (let index = 0; index < lines.length; index++) {
-    const line = lines[index];
-    if (line?.type !== "del") {
+    if (lines[index]?.type !== "del") {
       continue;
     }
 
     const delRunEnd = getRunEnd(lines, index, "del");
     const addRunEnd = getRunEnd(lines, delRunEnd, "add");
-    const delRunLength = delRunEnd - index;
-    const addRunLength = addRunEnd - delRunEnd;
+    const runLength = delRunEnd - index;
 
-    if (addRunLength > 0 && delRunLength === addRunLength) {
-      for (let offset = 0; offset < delRunLength; offset++) {
-        pushPair(pairMap, {
-          del: lines[index + offset]!,
-          add: lines[delRunEnd + offset]!,
-        });
+    if (runLength > 0 && runLength === addRunEnd - delRunEnd) {
+      for (let offset = 0; offset < runLength; offset++) {
+        pairMap.set(lines[index + offset]!, lines[delRunEnd + offset]!);
       }
       index = addRunEnd - 1;
       continue;

--- a/packages/react-ink/src/primitives/diff/intra-line-utils.ts
+++ b/packages/react-ink/src/primitives/diff/intra-line-utils.ts
@@ -1,0 +1,97 @@
+import { diffWordsWithSpace } from "diff";
+import type { ParsedLine } from "./types";
+
+export type StyledDiffSegment = {
+  text: string;
+  changed: boolean;
+};
+
+export type PairInfo = {
+  role: "del" | "add";
+  counterpart: ParsedLine;
+};
+
+type LinePair = {
+  del: ParsedLine;
+  add: ParsedLine;
+};
+
+const getRunEnd = (
+  lines: ParsedLine[],
+  startIndex: number,
+  type: "add" | "del",
+) => {
+  let index = startIndex;
+  while (lines[index]?.type === type) {
+    index++;
+  }
+  return index;
+};
+
+const pushPair = (pairMap: Map<ParsedLine, PairInfo>, pair: LinePair) => {
+  pairMap.set(pair.del, { role: "del", counterpart: pair.add });
+  pairMap.set(pair.add, { role: "add", counterpart: pair.del });
+};
+
+export const buildLinePairMap = (lines: ParsedLine[]) => {
+  const pairMap = new Map<ParsedLine, PairInfo>();
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    if (line?.type !== "del") {
+      continue;
+    }
+
+    const delRunEnd = getRunEnd(lines, index, "del");
+    const addRunEnd = getRunEnd(lines, delRunEnd, "add");
+    const delRunLength = delRunEnd - index;
+    const addRunLength = addRunEnd - delRunEnd;
+
+    if (addRunLength > 0 && delRunLength === addRunLength) {
+      for (let offset = 0; offset < delRunLength; offset++) {
+        pushPair(pairMap, {
+          del: lines[index + offset]!,
+          add: lines[delRunEnd + offset]!,
+        });
+      }
+      index = addRunEnd - 1;
+      continue;
+    }
+
+    index = delRunEnd - 1;
+  }
+
+  return pairMap;
+};
+
+export const buildIntraLineSegments = (
+  delText: string,
+  addText: string,
+): {
+  delSegments: StyledDiffSegment[];
+  addSegments: StyledDiffSegment[];
+} => {
+  const delSegments: StyledDiffSegment[] = [];
+  const addSegments: StyledDiffSegment[] = [];
+
+  for (const part of diffWordsWithSpace(delText, addText)) {
+    if (!part.added) {
+      delSegments.push({
+        text: part.value,
+        changed: Boolean(part.removed),
+      });
+    }
+
+    if (!part.removed) {
+      addSegments.push({
+        text: part.value,
+        changed: Boolean(part.added),
+      });
+    }
+  }
+
+  return {
+    delSegments,
+    addSegments,
+  };
+};

--- a/packages/react-ink/src/tests/DiffView.test.tsx
+++ b/packages/react-ink/src/tests/DiffView.test.tsx
@@ -1,17 +1,49 @@
 import type { ReactElement } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render } from "ink-testing-library";
-import { parsePatch, computeDiff, foldContext } from "./diff-utils";
-import { DiffContent } from "./DiffContent";
-import { DiffHeader } from "./DiffHeader";
-import { DiffRoot } from "./DiffRoot";
-import { DiffView } from "./DiffView";
+import {
+  parsePatch,
+  computeDiff,
+  foldContext,
+} from "../primitives/diff/diff-utils";
+import { DiffContent } from "../primitives/diff/DiffContent";
+import { DiffHeader } from "../primitives/diff/DiffHeader";
+import {
+  buildIntraLineSegments,
+  buildLinePairMap,
+} from "../primitives/diff/intra-line-utils";
+import { DiffRoot } from "../primitives/diff/DiffRoot";
+import { DiffView } from "../primitives/diff/DiffView";
+import type { ParsedLine } from "../primitives/diff/types";
 
 const renderFrame = async (node: ReactElement) => {
   const instance = render(node);
   await new Promise((resolve) => setTimeout(resolve, 0));
   return instance.lastFrame() ?? "";
 };
+
+const makeDelLine = (content: string, oldLineNumber: number): ParsedLine => ({
+  type: "del",
+  content,
+  oldLineNumber,
+});
+
+const makeAddLine = (content: string, newLineNumber: number): ParsedLine => ({
+  type: "add",
+  content,
+  newLineNumber,
+});
+
+const makeNormalLine = (
+  content: string,
+  oldLineNumber: number,
+  newLineNumber: number,
+): ParsedLine => ({
+  type: "normal",
+  content,
+  oldLineNumber,
+  newLineNumber,
+});
 
 afterEach(() => {
   cleanup();
@@ -28,6 +60,131 @@ index 1234567..abcdefg 100644
 +line 2.5 added
  line 3
 `;
+
+describe("buildLinePairMap", () => {
+  it("pairs a single adjacent replacement", () => {
+    const del = makeDelLine("old value", 1);
+    const add = makeAddLine("new value", 1);
+
+    const pairMap = buildLinePairMap([del, add]);
+
+    expect(pairMap.get(del)).toEqual({
+      role: "del",
+      counterpart: add,
+    });
+    expect(pairMap.get(add)).toEqual({
+      role: "add",
+      counterpart: del,
+    });
+  });
+
+  it("pairs equal-length adjacent delete and add runs in order", () => {
+    const del1 = makeDelLine("old alpha", 1);
+    const del2 = makeDelLine("old beta", 2);
+    const add1 = makeAddLine("new alpha", 1);
+    const add2 = makeAddLine("new beta", 2);
+
+    const pairMap = buildLinePairMap([del1, del2, add1, add2]);
+
+    expect(pairMap.get(del1)?.counterpart).toBe(add1);
+    expect(pairMap.get(del2)?.counterpart).toBe(add2);
+    expect(pairMap.get(add1)?.counterpart).toBe(del1);
+    expect(pairMap.get(add2)?.counterpart).toBe(del2);
+  });
+
+  it("pairs equal-length block rewrites of length three", () => {
+    const del1 = makeDelLine("old alpha", 1);
+    const del2 = makeDelLine("old beta", 2);
+    const del3 = makeDelLine("old gamma", 3);
+    const add1 = makeAddLine("new alpha", 1);
+    const add2 = makeAddLine("new beta", 2);
+    const add3 = makeAddLine("new gamma", 3);
+
+    const pairMap = buildLinePairMap([del1, del2, del3, add1, add2, add3]);
+
+    expect(pairMap.get(del1)?.counterpart).toBe(add1);
+    expect(pairMap.get(del2)?.counterpart).toBe(add2);
+    expect(pairMap.get(del3)?.counterpart).toBe(add3);
+  });
+
+  it("does not pair unequal-length adjacent runs", () => {
+    const pairMap = buildLinePairMap([
+      makeDelLine("old 1", 1),
+      makeDelLine("old 2", 2),
+      makeAddLine("new 1", 1),
+      makeAddLine("new 2", 2),
+      makeAddLine("new 3", 3),
+    ]);
+
+    expect(pairMap).toHaveLength(0);
+  });
+
+  it("does not pair non-adjacent delete and add lines", () => {
+    const del = makeDelLine("old value", 1);
+    const normal = makeNormalLine("context", 2, 2);
+    const add = makeAddLine("new value", 3);
+
+    const pairMap = buildLinePairMap([del, normal, add]);
+
+    expect(pairMap).toHaveLength(0);
+  });
+
+  it("does not pair an unpaired add line", () => {
+    const pairMap = buildLinePairMap([
+      makeNormalLine("context", 1, 1),
+      makeAddLine("new value", 2),
+    ]);
+
+    expect(pairMap).toHaveLength(0);
+  });
+
+  it("does not pair across file boundaries when called per file", () => {
+    const firstFile = buildLinePairMap([
+      makeDelLine("old value", 1),
+      makeNormalLine("context", 2, 2),
+    ]);
+    const secondFile = buildLinePairMap([makeAddLine("new value", 1)]);
+
+    expect(firstFile).toHaveLength(0);
+    expect(secondFile).toHaveLength(0);
+  });
+});
+
+describe("buildIntraLineSegments", () => {
+  it("marks only changed whitespace for whitespace-only edits", () => {
+    expect(buildIntraLineSegments("a b", "a  b")).toEqual({
+      delSegments: [
+        { text: "a", changed: false },
+        { text: " ", changed: true },
+        { text: "b", changed: false },
+      ],
+      addSegments: [
+        { text: "a", changed: false },
+        { text: "  ", changed: true },
+        { text: "b", changed: false },
+      ],
+    });
+  });
+
+  it("treats identical paired content as fully unchanged", () => {
+    expect(buildIntraLineSegments("same text", "same text")).toEqual({
+      delSegments: [{ text: "same text", changed: false }],
+      addSegments: [{ text: "same text", changed: false }],
+    });
+  });
+
+  it("handles empty content without throwing", () => {
+    expect(buildIntraLineSegments("", "new")).toEqual({
+      delSegments: [],
+      addSegments: [{ text: "new", changed: true }],
+    });
+
+    expect(buildIntraLineSegments("old", "")).toEqual({
+      delSegments: [{ text: "old", changed: true }],
+      addSegments: [],
+    });
+  });
+});
 
 describe("parsePatch", () => {
   it("parses a unified diff string", () => {
@@ -276,6 +433,41 @@ describe("DiffView", () => {
     expect(frame).toContain("-");
   });
 
+  it("renders paired replacements with visible text preserved", async () => {
+    const frame = await renderFrame(
+      <DiffView
+        oldFile={{ content: "const value = oldName;\n", name: "demo.ts" }}
+        newFile={{ content: "const value = newName;\n", name: "demo.ts" }}
+      />,
+    );
+
+    expect(frame).toContain("- const value = oldName;");
+    expect(frame).toContain("+ const value = newName;");
+  });
+
+  it("falls back to line-level rendering for unpaired runs", async () => {
+    const frame = await renderFrame(
+      <DiffView
+        patch={`diff --git a/demo.ts b/demo.ts
+--- a/demo.ts
++++ b/demo.ts
+@@ -1,2 +1,3 @@
+-old one
+-old two
++new one
++new two
++new three
+`}
+      />,
+    );
+
+    expect(frame).toContain("- old one");
+    expect(frame).toContain("- old two");
+    expect(frame).toContain("+ new one");
+    expect(frame).toContain("+ new two");
+    expect(frame).toContain("+ new three");
+  });
+
   it("hides line numbers when showLineNumbers=false", async () => {
     const withNumbers = await renderFrame(<DiffView patch={SAMPLE_PATCH} />);
     const withoutNumbers = await renderFrame(
@@ -310,13 +502,16 @@ ${manyLines}
 +++ b/ctx.txt
 @@ -1,21 +1,22 @@
 ${normalBefore}
-+inserted
+-old value
++new value
 ${normalAfter}
 `;
     const frame = await renderFrame(
       <DiffView patch={patch} contextLines={2} />,
     );
     expect(frame).toContain("lines hidden");
+    expect(frame).toContain("- old value");
+    expect(frame).toContain("+ new value");
   });
 
   it("renders multi-file patches", async () => {


### PR DESCRIPTION
 ## Summary

Adds intra-line highlighting to `@assistant-ui/react-ink` `DiffView` for paired replacement lines, making changed word spans easier to scan without changing the public API

  ## Included

  - equal-length adjacent delete/add pairing
  - word-level segment rendering via `diffWordsWithSpace()`
  - moved and expanded `DiffView` tests
  - docs update
  - patch changeset
