### PR TITLE
fix(react-langgraph): prevent duplicate tool cards from empty tool_call ids

### DIFF
--- a/.changeset/fix-langgraph-empty-tool-call-id.md
+++ b/.changeset/fix-langgraph-empty-tool-call-id.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: prevent duplicate "Used tool" cards when LangGraph emits `tool_call_chunks` with an empty `id` followed by a chunk with the real `id` at the same index. `appendLangChainChunk` now also merges by `index` when either side has an empty `id`, and the resulting entry keeps whichever `id` is non-empty. As a defense-in-depth, `convertLangChainMessages` also synthesizes a stable `lc-toolcall-${messageId}-${index}` id when a `tool_call` still arrives at the converter with an empty `id`.

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { appendLangChainChunk } from "./appendLangChainChunk";
+import type { LangChainMessage, LangChainMessageChunk } from "./types";
+
+const aiChunk = (
+  toolCallChunks: LangChainMessageChunk["tool_call_chunks"],
+): LangChainMessageChunk => ({
+  type: "AIMessageChunk",
+  id: "ai-1",
+  content: "",
+  tool_call_chunks: toolCallChunks,
+});
+
+describe("appendLangChainChunk tool_call id merging (regression #3526)", () => {
+  it("merges chunk arriving with real id into entry that started with empty id", () => {
+    let acc: LangChainMessage | undefined;
+    acc = appendLangChainChunk(
+      acc,
+      aiChunk([{ id: "", index: 0, name: "weather", args_json: '{"city":' }]),
+    );
+    acc = appendLangChainChunk(
+      acc,
+      aiChunk([
+        {
+          id: "real-abc",
+          index: 0,
+          name: "weather",
+          args_json: '"Tokyo"}',
+        },
+      ]),
+    );
+
+    expect(acc.tool_calls).toHaveLength(1);
+    expect(acc.tool_calls?.[0]).toMatchObject({
+      id: "real-abc",
+      index: 0,
+      name: "weather",
+      partial_json: '{"city":"Tokyo"}',
+    });
+  });
+
+  it("merges chunk arriving with empty id into entry that started with real id", () => {
+    let acc: LangChainMessage | undefined;
+    acc = appendLangChainChunk(
+      acc,
+      aiChunk([
+        { id: "real-abc", index: 0, name: "weather", args_json: '{"city":' },
+      ]),
+    );
+    acc = appendLangChainChunk(
+      acc,
+      aiChunk([{ id: "", index: 0, name: "weather", args_json: '"Tokyo"}' }]),
+    );
+
+    expect(acc.tool_calls).toHaveLength(1);
+    expect(acc.tool_calls?.[0]).toMatchObject({
+      id: "real-abc",
+      partial_json: '{"city":"Tokyo"}',
+    });
+  });
+
+  it("merges two empty-id chunks at the same index", () => {
+    let acc: LangChainMessage | undefined;
+    acc = appendLangChainChunk(
+      acc,
+      aiChunk([{ id: "", index: 0, name: "weather", args_json: '{"a":' }]),
+    );
+    acc = appendLangChainChunk(
+      acc,
+      aiChunk([{ id: "", index: 0, name: "weather", args_json: "1}" }]),
+    );
+
+    expect(acc.tool_calls).toHaveLength(1);
+    expect(acc.tool_calls?.[0]).toMatchObject({
+      id: "",
+      partial_json: '{"a":1}',
+    });
+  });
+
+  it("does not merge chunks with different real ids at the same index", () => {
+    let acc: LangChainMessage | undefined;
+    acc = appendLangChainChunk(
+      acc,
+      aiChunk([{ id: "id-1", index: 0, name: "a", args_json: "{}" }]),
+    );
+    acc = appendLangChainChunk(
+      acc,
+      aiChunk([{ id: "id-2", index: 0, name: "b", args_json: "{}" }]),
+    );
+
+    expect(acc.tool_calls).toHaveLength(2);
+    expect(acc.tool_calls?.map((t) => t.id)).toEqual(["id-1", "id-2"]);
+  });
+
+  it("keeps chunks at different indices as separate entries", () => {
+    const acc = appendLangChainChunk(
+      undefined,
+      aiChunk([
+        { id: "", index: 0, name: "a", args_json: "{}" },
+        { id: "", index: 1, name: "b", args_json: "{}" },
+      ]),
+    );
+
+    expect(acc.tool_calls).toHaveLength(2);
+    expect(acc.tool_calls?.map((t) => t.index)).toEqual([0, 1]);
+  });
+});

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -76,8 +76,10 @@ export const appendLangChainChunk = (
     let idx = newToolCalls.findIndex(
       (tc) => tc.id != null && tc.id !== "" && tc.id === chunk.id,
     );
-    if (idx === -1 && chunk.id === "" && chunk.index != null) {
-      idx = newToolCalls.findIndex((tc) => tc.index === chunk.index);
+    if (idx === -1 && chunk.index != null) {
+      idx = newToolCalls.findIndex(
+        (tc) => tc.index === chunk.index && (!tc.id || !chunk.id),
+      );
     }
     if (idx === -1) {
       newToolCalls.push(chunkToToolCall(chunk));
@@ -88,6 +90,7 @@ export const appendLangChainChunk = (
       newToolCalls[idx] = {
         ...chunk,
         ...existing,
+        id: existing.id || chunk.id,
         partial_json: partialJson,
         args:
           parsePartialJsonObject(partialJson) ??

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { convertLangChainMessages } from "./convertLangChainMessages";
-import type { UIMessage } from "./types";
+import type { LangChainMessage, UIMessage } from "./types";
 
 describe("convertLangChainMessages metadata", () => {
   it("passes additional_kwargs.metadata to system message", () => {
@@ -466,6 +466,146 @@ describe("convertLangChainMessages UI messages", () => {
     expect(result).toMatchObject({
       role: "assistant",
       content: [{ type: "text", text: "Plain response." }],
+    });
+  });
+});
+
+describe("convertLangChainMessages tool call id stability (regression #3526)", () => {
+  it("synthesizes a stable toolCallId when chunk.id is empty string", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: [
+        { id: "", name: "weather", args: { city: "Tokyo" }, index: 0 },
+      ],
+    });
+
+    if (!("content" in result)) throw new Error("Expected assistant message");
+    const toolCallPart = result.content.find((p) => p.type === "tool-call");
+    expect(toolCallPart).toMatchObject({
+      type: "tool-call",
+      toolName: "weather",
+    });
+    expect((toolCallPart as { toolCallId: string }).toolCallId).not.toBe("");
+    expect((toolCallPart as { toolCallId: string }).toolCallId).toBe(
+      "lc-toolcall-ai-1-0",
+    );
+  });
+
+  it("synthesizes unique ids for multiple empty-id tool_calls in the same message", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: [
+        { id: "", name: "a", args: {}, index: 0 },
+        { id: "", name: "b", args: {}, index: 1 },
+      ],
+    });
+
+    if (!("content" in result)) throw new Error("Expected assistant message");
+    const ids = result.content
+      .filter((p) => p.type === "tool-call")
+      .map((p) => (p as { toolCallId: string }).toolCallId);
+    expect(ids).toEqual(["lc-toolcall-ai-1-0", "lc-toolcall-ai-1-1"]);
+  });
+
+  it("falls back to array index when both chunk.id and chunk.index are missing", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: [
+        { id: "", name: "a", args: {} },
+        { id: "", name: "b", args: {} },
+      ],
+    });
+
+    if (!("content" in result)) throw new Error("Expected assistant message");
+    const ids = result.content
+      .filter((p) => p.type === "tool-call")
+      .map((p) => (p as { toolCallId: string }).toolCallId);
+    expect(ids).toEqual(["lc-toolcall-ai-1-0", "lc-toolcall-ai-1-1"]);
+  });
+
+  it("prefers real chunk.id over synthesized id when present", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: [
+        { id: "call_real_abc", name: "weather", args: {}, index: 0 },
+      ],
+    });
+
+    if (!("content" in result)) throw new Error("Expected assistant message");
+    const toolCallPart = result.content.find((p) => p.type === "tool-call");
+    expect((toolCallPart as { toolCallId: string }).toolCallId).toBe(
+      "call_real_abc",
+    );
+  });
+
+  it("does not collide synthesized id with a real id at a different index", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: [
+        { id: "", name: "a", args: {}, index: 0 },
+        { id: "call_real_abc", name: "b", args: {}, index: 1 },
+      ],
+    });
+
+    if (!("content" in result)) throw new Error("Expected assistant message");
+    const ids = result.content
+      .filter((p) => p.type === "tool-call")
+      .map((p) => (p as { toolCallId: string }).toolCallId);
+    expect(ids).toEqual(["lc-toolcall-ai-1-0", "call_real_abc"]);
+  });
+
+  it("synthesized id is stable across re-renders of the same message", () => {
+    const message: LangChainMessage = {
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: [{ id: "", name: "weather", args: {}, index: 0 }],
+    };
+
+    const r1 = convertLangChainMessages(message);
+    const r2 = convertLangChainMessages(message);
+
+    if (!("content" in r1) || !("content" in r2))
+      throw new Error("Expected assistant messages");
+    const id1 = (
+      r1.content.find((p) => p.type === "tool-call") as { toolCallId: string }
+    ).toolCallId;
+    const id2 = (
+      r2.content.find((p) => p.type === "tool-call") as { toolCallId: string }
+    ).toolCallId;
+    expect(id1).toBe(id2);
+  });
+
+  it("matches tool_call_chunks by index when chunk.id is empty (preserves args_json)", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: [{ id: "", name: "fetch", args: {}, index: 0 }],
+      tool_call_chunks: [
+        {
+          id: "",
+          index: 0,
+          name: "fetch",
+          args_json: '{"url":"https://example.com"}',
+        },
+      ],
+    });
+
+    if (!("content" in result)) throw new Error("Expected assistant message");
+    const toolCallPart = result.content.find((p) => p.type === "tool-call");
+    expect(toolCallPart).toMatchObject({
+      argsText: '{"url":"https://example.com"}',
     });
   });
 });

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -108,13 +108,15 @@ const resolveToolCallArgs = ({
   matchingToolCallChunk,
   messageId,
   toolArgsKeyOrderCache,
+  toolCallId,
 }: {
   chunk: LangChainToolCall;
   matchingToolCallChunk: LangChainToolCallChunk | undefined;
   messageId: string | undefined;
   toolArgsKeyOrderCache: Map<string, Map<string, string[]>> | undefined;
+  toolCallId: string;
 }): Pick<ToolCallMessagePart, "args" | "argsText"> => {
-  const cacheKey = getToolArgsCacheKey(messageId, "tool", chunk.id);
+  const cacheKey = getToolArgsCacheKey(messageId, "tool", toolCallId);
   const providedArgsText =
     chunk.partial_json ??
     matchingToolCallChunk?.args ??
@@ -304,20 +306,25 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
       };
     case "ai": {
       const toolCallParts =
-        message.tool_calls?.map((chunk): ToolCallMessagePart => {
-          const matchingToolCallChunk = message.tool_call_chunks?.find(
-            (c) => c.id === chunk.id,
+        message.tool_calls?.map((chunk, idx): ToolCallMessagePart => {
+          const fallbackIndex = chunk.index ?? idx;
+          const toolCallId = chunk.id
+            ? chunk.id
+            : `lc-toolcall-${message.id ?? "unknown"}-${fallbackIndex}`;
+          const matchingToolCallChunk = message.tool_call_chunks?.find((c) =>
+            chunk.id ? c.id === chunk.id : c.index === fallbackIndex,
           );
           const { args, argsText } = resolveToolCallArgs({
             chunk,
             matchingToolCallChunk,
             messageId: message.id,
             toolArgsKeyOrderCache: metadata.toolArgsKeyOrderCache,
+            toolCallId,
           });
 
           return {
             type: "tool-call",
-            toolCallId: chunk.id,
+            toolCallId,
             toolName: chunk.name,
             args,
             argsText,


### PR DESCRIPTION
## Summary
- Fixes #3526: when LangGraph emits a `tool_call_chunk` with `id: ""` followed by a chunk with the real `id` at the same index, `appendLangChainChunk` previously produced two separate `tool_calls` entries, rendering as two "Used tool" cards.
- `appendLangChainChunk` now falls back to index-matching whenever either side has an empty `id`, and the merged entry preserves the non-empty `id` (`existing.id || chunk.id`).
- `convertLangChainMessages` synthesizes a stable `lc-toolcall-${messageId}-${index}` id when an `ai` snapshot still arrives with an empty `tool_call.id` (defense-in-depth for the no-chunk-accumulation path).
- 5 new tests in `appendLangChainChunk.test.ts` (chunk merging permutations) and 7 new tests in `convertLangChainMessages.test.ts` (synthesized id stability, prefers real id, no collision).

## Test plan
- [ ] `pnpm --filter @assistant-ui/react-langgraph test` passes (126 tests)
- [ ] Manual: run `examples/with-langgraph` against a backend that emits `tool_call_chunks` with empty ids and confirm a single tool card renders
- [ ] Verify no regression in `useToolInvocations` execution semantics (logical `toolCallId` consistency)