### PR TITLE
fix(react): sync pointer hover with keyboard highlight in TriggerPopover

### DIFF
--- a/.changeset/fix-trigger-popover-hover-keyboard-sync.md
+++ b/.changeset/fix-trigger-popover-hover-keyboard-sync.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(composer): sync mouse hover with keyboard highlight in `TriggerPopover`. Items and categories now update `highlightedIndex` on mouse move, keeping `data-highlighted`, `aria-selected`, and `aria-activedescendant` consistent with the hovered element. A new `highlightIndex(index)` method is exposed on the popover scope. Closes #3868.

--- a/packages/react/src/primitives/composer/trigger/TriggerPopoverCategories.tsx
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopoverCategories.tsx
@@ -64,9 +64,10 @@ export namespace ComposerPrimitiveTriggerPopoverCategoryItem {
 export const ComposerPrimitiveTriggerPopoverCategoryItem = forwardRef<
   ComposerPrimitiveTriggerPopoverCategoryItem.Element,
   ComposerPrimitiveTriggerPopoverCategoryItem.Props
->(({ categoryId, onClick, ...props }, forwardedRef) => {
+>(({ categoryId, onClick, onMouseMove, ...props }, forwardedRef) => {
   const {
     selectCategory,
+    highlightIndex,
     categories,
     highlightedIndex,
     activeCategoryId,
@@ -78,10 +79,13 @@ export const ComposerPrimitiveTriggerPopoverCategoryItem = forwardRef<
     selectCategory(categoryId);
   }, [selectCategory, categoryId]);
 
+  const categoryIndex = categories.findIndex((c) => c.id === categoryId);
   const isHighlighted =
-    !activeCategoryId &&
-    !isSearchMode &&
-    categories.findIndex((c) => c.id === categoryId) === highlightedIndex;
+    !activeCategoryId && !isSearchMode && categoryIndex === highlightedIndex;
+
+  const handleMouseMove = useCallback(() => {
+    highlightIndex(categoryIndex);
+  }, [highlightIndex, categoryIndex]);
 
   return (
     <Primitive.button
@@ -93,6 +97,7 @@ export const ComposerPrimitiveTriggerPopoverCategoryItem = forwardRef<
       {...props}
       ref={forwardedRef}
       onClick={composeEventHandlers(onClick, handleClick)}
+      onMouseMove={composeEventHandlers(onMouseMove, handleMouseMove)}
     />
   );
 });

--- a/packages/react/src/primitives/composer/trigger/TriggerPopoverItems.tsx
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopoverItems.tsx
@@ -65,38 +65,49 @@ export namespace ComposerPrimitiveTriggerPopoverItem {
 export const ComposerPrimitiveTriggerPopoverItem = forwardRef<
   ComposerPrimitiveTriggerPopoverItem.Element,
   ComposerPrimitiveTriggerPopoverItem.Props
->(({ item, index: indexProp, onClick, ...props }, forwardedRef) => {
-  const {
-    selectItem,
-    items,
-    highlightedIndex,
-    activeCategoryId,
-    isSearchMode,
-    popoverId,
-  } = useTriggerPopoverScopeContext();
+>(
+  (
+    { item, index: indexProp, onClick, onMouseMove, ...props },
+    forwardedRef,
+  ) => {
+    const {
+      selectItem,
+      highlightIndex,
+      items,
+      highlightedIndex,
+      activeCategoryId,
+      isSearchMode,
+      popoverId,
+    } = useTriggerPopoverScopeContext();
 
-  const handleClick = useCallback(() => {
-    selectItem(item);
-  }, [selectItem, item]);
+    const handleClick = useCallback(() => {
+      selectItem(item);
+    }, [selectItem, item]);
 
-  const itemIndex = indexProp ?? items.findIndex((i) => i.id === item.id);
-  const isHighlighted =
-    (isSearchMode || activeCategoryId !== null) &&
-    itemIndex === highlightedIndex;
+    const itemIndex = indexProp ?? items.findIndex((i) => i.id === item.id);
+    const isHighlighted =
+      (isSearchMode || activeCategoryId !== null) &&
+      itemIndex === highlightedIndex;
 
-  return (
-    <Primitive.button
-      type="button"
-      role="option"
-      id={`${popoverId}-option-${item.id}`}
-      aria-selected={isHighlighted}
-      data-highlighted={isHighlighted ? "" : undefined}
-      {...props}
-      ref={forwardedRef}
-      onClick={composeEventHandlers(onClick, handleClick)}
-    />
-  );
-});
+    const handleMouseMove = useCallback(() => {
+      highlightIndex(itemIndex);
+    }, [highlightIndex, itemIndex]);
+
+    return (
+      <Primitive.button
+        type="button"
+        role="option"
+        id={`${popoverId}-option-${item.id}`}
+        aria-selected={isHighlighted}
+        data-highlighted={isHighlighted ? "" : undefined}
+        {...props}
+        ref={forwardedRef}
+        onClick={composeEventHandlers(onClick, handleClick)}
+        onMouseMove={composeEventHandlers(onMouseMove, handleMouseMove)}
+      />
+    );
+  },
+);
 
 ComposerPrimitiveTriggerPopoverItem.displayName =
   "ComposerPrimitive.TriggerPopoverItem";

--- a/packages/react/src/primitives/composer/trigger/TriggerPopoverResource.ts
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopoverResource.ts
@@ -37,6 +37,8 @@ export type TriggerPopoverResourceOutput = {
   goBack(): void;
   selectItem(item: Unstable_TriggerItem): void;
   close(): void;
+  /** Move the highlight to an entry index (e.g. from pointer hover). Out-of-range values are ignored. */
+  highlightIndex(index: number): void;
   handleKeyDown(e: {
     readonly key: string;
     readonly shiftKey: boolean;
@@ -126,6 +128,7 @@ export const TriggerPopoverResource = resource(
       goBack: navigation.goBack,
       selectItem: selection.selectItem,
       close: selection.close,
+      highlightIndex: keyboard.highlightIndex,
       handleKeyDown: keyboard.handleKeyDown,
       setCursorPosition: detection.setCursorPosition,
       registerSelectItemOverride: selection.registerSelectItemOverride,

--- a/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.ts
+++ b/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.ts
@@ -28,6 +28,8 @@ export type TriggerKeyboardResourceOutput = {
   readonly highlightedIndex: number;
   /** ID of the currently highlighted item (for `aria-activedescendant`). */
   readonly highlightedItemId: string | undefined;
+  /** Move the highlight to an entry index (e.g. from pointer hover). Out-of-range values are ignored. */
+  highlightIndex(index: number): void;
   /** Handle a key event; returns `true` if it was consumed. */
   handleKeyDown(e: TriggerPopoverKeyEvent): boolean;
 };
@@ -71,6 +73,12 @@ export const TriggerKeyboardResource = resource(
     tapEffect(() => {
       setHighlightedIndex(0);
     }, [isSearchMode, activeCategoryId]);
+
+    const highlightIndex = tapEffectEvent((index: number) => {
+      if (index < 0 || index >= navigableList.length) return;
+      if (index === highlightedIndex) return;
+      setHighlightedIndex(index);
+    });
 
     const handleKeyDown = tapEffectEvent(
       (e: TriggerPopoverKeyEvent): boolean => {
@@ -136,6 +144,7 @@ export const TriggerKeyboardResource = resource(
     return {
       highlightedIndex,
       highlightedItemId,
+      highlightIndex,
       handleKeyDown,
     };
   },


### PR DESCRIPTION
## Summary
- Items and categories in `Unstable_TriggerPopover` now update `highlightedIndex` on `pointermove`, so `data-highlighted`, `aria-selected`, and `aria-activedescendant` follow the hovered element.
- Eliminates three symptoms of the old dual-state bug: simultaneous CSS `:hover` + `data-highlighted` on different items, Enter selecting a different item than the mouse click, and screen readers disagreeing with visual hover.
- Exposes a new `highlightIndex(index)` method on the popover scope resource (returned by `unstable_useTriggerPopoverScopeContext`) for custom consumers; out-of-range values are ignored.
- Closes #3868.

## Test plan
- [ ] Open the mention/slash demo (`apps/docs/components/docs/samples/composer-trigger-popover.tsx`) and confirm hovering an item updates the highlighted entry and Enter selects the hovered item.
- [ ] Keyboard-navigate to item N, then mouse-hover item M; press Enter — the hovered (M) item is selected.
- [ ] Verify only one element carries `data-highlighted` at a time when moving between mouse and arrow keys.
- [ ] With a screen reader, confirm `aria-activedescendant` follows the pointer.
- [ ] Verify existing arrow-key/Enter/Escape/Backspace keyboard flows still behave as before.
- [ ] Confirm the shadcn `composer-trigger-popover.tsx` copy automatically picks up the fix without changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)