### PR TITLE
fix(docs): dark-mode type colors and SafeContentFrame CSP

### DIFF
--- a/apps/docs/components/docs/primitives-type-table.tsx
+++ b/apps/docs/components/docs/primitives-type-table.tsx
@@ -42,6 +42,7 @@ async function highlightType(type: string): Promise<ReactNode> {
   return highlight(type, {
     lang: "typescript",
     themes: { light: "github-light", dark: "github-dark" },
+    defaultColor: false,
   });
 }
 

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -6,7 +6,7 @@ const isDev = process.env.NODE_ENV === "development";
 const cspHeader = `
     default-src 'self';
     connect-src *;
-    frame-src *;
+    frame-src * blob:;
     script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'${isDev ? " 'unsafe-eval'" : ""};
     style-src 'self' 'unsafe-inline';
     img-src * blob: data:;


### PR DESCRIPTION
## Summary
- Pass `defaultColor: false` to fumadocs-core `highlight` in `PrimitivesTypeTable` so Shiki emits `--shiki-light`/`--shiki-dark` CSS vars instead of an inline `color: var(--shiki-light)` that defeats the global dark-mode selector — type tokens were rendering near-gray in dark mode
- Add `blob:` to the `frame-src` CSP directive in `next.config.ts`; CSP 3 `*` only matches network schemes, so the `safe-content-frame` shim's blob iframe was blocked ("Framing '' violates frame-src *. The scheme 'blob:' must be added explicitly.") and Chrome showed the generic "Content blocked" error page

## Test plan
- [ ] `/docs/primitives/composer`: switch to dark mode, confirm type cells (e.g. `boolean`, `"enter" | "ctrlEnter" | "none"`) render with GitHub-dark highlighting instead of gray
- [ ] `/docs/primitives/composer`: switch back to light mode, confirm highlighting still uses GitHub-light colors (no regression)
- [ ] `/safe-content-frame`: click **XSS Demo** → **Render Content**, confirm sandboxed blocks still behave as documented
- [ ] Dev server must be restarted after the `next.config.ts` change for CSP headers to reload