### PR TITLE
feat(core): allow runtimes to override thread.isRunning

### DIFF
--- a/.changeset/thread-isrunning-app-override.md
+++ b/.changeset/thread-isrunning-app-override.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat(core): let runtimes provide an explicit `isRunning` that overrides the last-message-status heuristic. `ExternalStoreAdapter.isRunning` now flows through to `thread.isRunning` directly, so applications can keep the thread in a running state even after the last assistant message has completed (e.g. while non-message stream chunks like suggestions, step-finish, or metadata updates are still arriving). When a runtime does not provide `isRunning`, the previous last-message-based behavior is preserved.

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -1447,7 +1447,7 @@ The main interface for connecting your state to assistant-ui.
       name: "isRunning",
       type: "boolean",
       description:
-        "Whether the assistant is currently generating a response. When true, shows optimistic assistant message",
+        "Whether the assistant is currently generating a response. When true, shows an optimistic assistant message and flows directly to `thread.isRunning`, so the thread stays in a running state even after the last assistant message has completed (e.g. while suggestions or metadata chunks are still arriving). When omitted, `thread.isRunning` falls back to the last-message-status heuristic.",
       default: "false",
     },
     {

--- a/packages/core/src/runtime/api/thread-runtime.ts
+++ b/packages/core/src/runtime/api/thread-runtime.ts
@@ -204,9 +204,10 @@ export const getThreadState = (
     isDisabled: runtime.isDisabled,
     isLoading: runtime.isLoading,
     isRunning:
-      lastMessage?.role !== "assistant"
+      runtime.isRunning ??
+      (lastMessage?.role !== "assistant"
         ? false
-        : lastMessage.status.type === "running",
+        : lastMessage.status.type === "running"),
     messages: runtime.messages,
     state: runtime.state,
     suggestions: runtime.suggestions,

--- a/packages/core/src/runtime/interfaces/thread-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-runtime-core.ts
@@ -129,6 +129,13 @@ export type ThreadRuntimeCore = Readonly<{
   capabilities: Readonly<RuntimeCapabilities>;
   isDisabled: boolean;
   isLoading: boolean;
+  /**
+   * Optional explicit thread-level running flag. When provided, takes
+   * precedence over the last-message-status heuristic. When omitted, falls
+   * back to the legacy behavior. External-store runtimes surface this via
+   * `ExternalStoreAdapter.isRunning`.
+   */
+  isRunning?: boolean | undefined;
   messages: readonly ThreadMessage[];
   state: ReadonlyJSONValue;
   suggestions: readonly ThreadSuggestion[];

--- a/packages/core/src/runtimes/external-store/external-store-adapter.ts
+++ b/packages/core/src/runtimes/external-store/external-store-adapter.ts
@@ -60,6 +60,14 @@ type ExternalStoreMessageConverterAdapter<T> = {
 
 type ExternalStoreAdapterBase<T> = {
   isDisabled?: boolean | undefined;
+  /**
+   * Whether the thread is running. When provided, this value flows directly
+   * to `thread.isRunning`, letting the application keep the thread in a
+   * running state even after the last assistant message has completed (for
+   * example while non-message stream chunks like suggestions or metadata
+   * updates are still arriving). When omitted, `thread.isRunning` falls back
+   * to the last-message-status heuristic.
+   */
   isRunning?: boolean | undefined;
   isLoading?: boolean | undefined;
   messages?: readonly T[];

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -78,6 +78,10 @@ export class ExternalStoreThreadRuntimeCore
   public get isLoading() {
     return this._store.isLoading ?? false;
   }
+  // Unlike `isLoading`: pass `undefined` through to preserve the `getThreadState` fallback.
+  public get isRunning(): boolean | undefined {
+    return this._store.isRunning;
+  }
 
   protected override _getBaseMessages(): readonly ThreadMessage[] {
     return this._messages;

--- a/packages/core/src/tests/get-thread-state-isRunning.test.ts
+++ b/packages/core/src/tests/get-thread-state-isRunning.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { getThreadState } from "../runtime/api/thread-runtime";
+import type { ThreadRuntimeCore } from "../runtime/interfaces/thread-runtime-core";
+import type { ThreadMessage } from "../types/message";
+import type { ThreadListItemState } from "../runtime/api/thread-list-item-runtime";
+
+const listItem = { id: "t1" } as unknown as ThreadListItemState;
+
+const baseRuntime = (
+  overrides: Partial<ThreadRuntimeCore>,
+): ThreadRuntimeCore =>
+  ({
+    messages: [],
+    isDisabled: false,
+    isLoading: false,
+    capabilities: {} as any,
+    state: null,
+    suggestions: [],
+    extras: undefined,
+    speech: undefined,
+    voice: undefined,
+    ...overrides,
+  }) as unknown as ThreadRuntimeCore;
+
+const userMessage: ThreadMessage = {
+  id: "u1",
+  role: "user",
+  content: [],
+  createdAt: new Date(),
+  attachments: [],
+  metadata: { custom: {} },
+} as unknown as ThreadMessage;
+
+const completeAssistant: ThreadMessage = {
+  id: "a1",
+  role: "assistant",
+  content: [],
+  createdAt: new Date(),
+  status: { type: "complete", reason: "stop" },
+  metadata: { unstable_state: null, custom: {}, steps: [] },
+} as unknown as ThreadMessage;
+
+const runningAssistant: ThreadMessage = {
+  ...completeAssistant,
+  id: "a2",
+  status: { type: "running" },
+} as unknown as ThreadMessage;
+
+describe("getThreadState.isRunning", () => {
+  it("falls back to last-message heuristic when runtime.isRunning is undefined", () => {
+    expect(
+      getThreadState(baseRuntime({ messages: [runningAssistant] }), listItem)
+        .isRunning,
+    ).toBe(true);
+
+    expect(
+      getThreadState(baseRuntime({ messages: [completeAssistant] }), listItem)
+        .isRunning,
+    ).toBe(false);
+
+    expect(
+      getThreadState(baseRuntime({ messages: [userMessage] }), listItem)
+        .isRunning,
+    ).toBe(false);
+  });
+
+  it("prefers explicit runtime.isRunning=true even when last message is complete", () => {
+    expect(
+      getThreadState(
+        baseRuntime({ isRunning: true, messages: [completeAssistant] }),
+        listItem,
+      ).isRunning,
+    ).toBe(true);
+  });
+
+  it("prefers explicit runtime.isRunning=true when last message is a user message", () => {
+    expect(
+      getThreadState(
+        baseRuntime({ isRunning: true, messages: [userMessage] }),
+        listItem,
+      ).isRunning,
+    ).toBe(true);
+  });
+
+  it("prefers explicit runtime.isRunning=false even when last message is running", () => {
+    expect(
+      getThreadState(
+        baseRuntime({ isRunning: false, messages: [runningAssistant] }),
+        listItem,
+      ).isRunning,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add optional `isRunning` field to `ThreadRuntimeCore`; `getThreadState` prefers it and falls back to the legacy last-message-status heuristic when unset.
- Wire `ExternalStoreAdapter.isRunning` through `ExternalStoreThreadRuntimeCore` so adapter-level values flow directly to `thread.isRunning` — keeping the thread running even after the last assistant message has completed.
- Covers the gap described in #3869: non-message stream chunks (suggestions, `step-finish`, metadata updates) can continue arriving after `message-finish`, and apps previously had no way to keep `thread.isRunning` true.
- 100% backward compatible — runtimes that do not provide `isRunning` behave exactly as before.
- New tests pin both the explicit-override precedence and the heuristic fallback; docs updated to reflect the new semantics.

## Test plan

- [x] `pnpm test` in `@assistant-ui/core` — 138 tests pass (including 4 new cases).
- [x] `pnpm -w run lint` — clean (only pre-existing warnings in unrelated files).
- [x] `tsc --noEmit` — no new type errors.
- [ ] Manual: set `isRunning: true` on an `ExternalStoreAdapter` with a completed last assistant message, confirm Send button stays disabled and Stop button stays visible.
- [ ] Manual: omit `isRunning`; confirm legacy last-message-status behavior is unchanged.

Closes #3869