### PR TITLE
feat(core): add reload() to ThreadListRuntime

### DIFF
--- a/.changeset/feat-thread-list-reload.md
+++ b/.changeset/feat-thread-list-reload.md
@@ -1,5 +1,6 @@
 ---
 "@assistant-ui/core": patch
+"@assistant-ui/react": patch
 ---
 
 feat(core): add `reload()` method on `ThreadListRuntime` and `aui.threads()` that re-invokes the remote adapter's `list()` and refreshes the thread list. Use this after asynchronous auth (e.g. OIDC, better-auth) completes to recover from an initial load that ran before the authenticated user was available. A generation counter ensures a mid-flight response from a superseded load cannot overwrite a newer reload's state.

--- a/.changeset/feat-thread-list-reload.md
+++ b/.changeset/feat-thread-list-reload.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat(core): add `reload()` method on `ThreadListRuntime` and `aui.threads()` that re-invokes the remote adapter's `list()` and refreshes the thread list. Use this after asynchronous auth (e.g. OIDC, better-auth) completes to recover from an initial load that ran before the authenticated user was available. A generation counter ensures a mid-flight response from a superseded load cannot overwrite a newer reload's state.

--- a/apps/docs/content/docs/(reference)/api-reference/runtimes/thread-list-runtime.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/runtimes/thread-list-runtime.mdx
@@ -18,6 +18,10 @@ const aui = useAui();
 await aui.threads().switchToNewThread();
 await aui.threads().switchToThread(threadId);
 
+// Re-fetch the thread list from the remote adapter
+// (e.g. after async auth completes)
+await aui.threads().reload();
+
 // Access the main thread runtime
 const mainThread = aui.threads().main;
 

--- a/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
+++ b/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
@@ -216,11 +216,47 @@ When the hook mounts it calls `list()` on your adapter, hydrates existing thread
 
 ## Thread Lifecycle Cheatsheet
 
-- `list()` hydrates threads on mount and during refreshes.
+- `list()` hydrates threads on mount. It runs once; call `runtime.threads.reload()` to re-fetch.
 - Creating a new conversation calls `initialize()` once the user sends the first message.
 - `archive`, `unarchive`, and `delete` are called optimistically; throw to revert the UI.
 - `generateTitle()` powers the automatic title button and expects an `AssistantStream`.
 - Provide a `runtimeHook` that always returns a fresh runtime instance per active thread.
+
+## Reloading After Async Authentication
+
+If your adapter depends on an authenticated user (e.g. an OIDC provider, `better-auth`, `next-auth`) and the auth state resolves asynchronously after `useRemoteThreadListRuntime` has mounted, the initial `list()` call may run before the user is available. Call `runtime.threads.reload()` when auth completes to re-fetch with the authenticated request.
+
+```tsx title="app/ThreadListProvider.tsx"
+import { useEffect } from "react";
+import { useAuth } from "react-oidc-context";
+import {
+  AssistantRuntimeProvider,
+  useLocalRuntime,
+  useRemoteThreadListRuntime,
+} from "@assistant-ui/react";
+
+export function ThreadListProvider({ children }) {
+  const { isLoading, user } = useAuth();
+  const runtime = useRemoteThreadListRuntime({
+    runtimeHook: () => useLocalRuntime(myModelAdapter),
+    adapter: useThreadListAdapter(),
+  });
+
+  useEffect(() => {
+    if (!isLoading && user) {
+      runtime.threads.reload();
+    }
+  }, [isLoading, user?.id, runtime]);
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+`reload()` replaces the cached load promise and discards any in-flight response from a superseded call, so it is safe to invoke multiple times (for example, on logout followed by a new login).
 
 ## Avoiding Race Conditions in History Adapters
 

--- a/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
+++ b/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
@@ -224,39 +224,49 @@ When the hook mounts it calls `list()` on your adapter, hydrates existing thread
 
 ## Reloading After Async Authentication
 
-If your adapter depends on an authenticated user (e.g. an OIDC provider, `better-auth`, `next-auth`) and the auth state resolves asynchronously after `useRemoteThreadListRuntime` has mounted, the initial `list()` call may run before the user is available. Call `runtime.threads.reload()` when auth completes to re-fetch with the authenticated request.
+If your adapter depends on an authenticated user (e.g. an OIDC provider, `better-auth`, `next-auth`) and the auth state resolves asynchronously after `useRemoteThreadListRuntime` has mounted, the initial `list()` call may run before the user is available. Call `aui.threads().reload()` when auth completes to re-fetch with the authenticated request.
 
 ```tsx title="app/ThreadListProvider.tsx"
+"use client";
+
 import { useEffect } from "react";
 import { useAuth } from "react-oidc-context";
 import {
   AssistantRuntimeProvider,
+  useAui,
   useLocalRuntime,
   useRemoteThreadListRuntime,
 } from "@assistant-ui/react";
 
-export function ThreadListProvider({ children }) {
+function ReloadOnAuth() {
+  const aui = useAui();
   const { isLoading, user } = useAuth();
+
+  useEffect(() => {
+    if (!isLoading && user) {
+      aui.threads().reload();
+    }
+  }, [isLoading, user?.id]);
+
+  return null;
+}
+
+export function ThreadListProvider({ children }) {
   const runtime = useRemoteThreadListRuntime({
     runtimeHook: () => useLocalRuntime(myModelAdapter),
     adapter: useThreadListAdapter(),
   });
 
-  useEffect(() => {
-    if (!isLoading && user) {
-      runtime.threads.reload();
-    }
-  }, [isLoading, user?.id, runtime]);
-
   return (
     <AssistantRuntimeProvider runtime={runtime}>
+      <ReloadOnAuth />
       {children}
     </AssistantRuntimeProvider>
   );
 }
 ```
 
-`reload()` replaces the cached load promise and discards any in-flight response from a superseded call, so it is safe to invoke multiple times (for example, on logout followed by a new login).
+`reload()` replaces the cached load promise and discards any in-flight response from a superseded call, so it is safe to invoke multiple times (for example, on logout followed by a new login). `useAui` must be called inside `AssistantRuntimeProvider`, so the effect lives in a child component.
 
 ## Avoiding Race Conditions in History Adapters
 

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -122,6 +122,7 @@ export class RemoteThreadListThreadListRuntimeCore
           },
         })
         .catch(() => {
+          if (generation !== this._loadGeneration) return;
           this._loadThreadsPromise = undefined;
           this._state.update({
             ...this._state.baseValue,

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -36,6 +36,7 @@ export class RemoteThreadListThreadListRuntimeCore
   private readonly _hookManager: RemoteThreadListHookInstanceManager;
 
   private _loadThreadsPromise: Promise<void> | undefined;
+  private _loadGeneration = 0;
 
   private _mainThreadId!: string;
   private readonly _state = new OptimisticState<RemoteThreadState>({
@@ -54,6 +55,7 @@ export class RemoteThreadListThreadListRuntimeCore
   public getLoadThreadsPromise() {
     // TODO this needs to be cached in case this promise is loaded during suspense
     if (!this._loadThreadsPromise) {
+      const generation = this._loadGeneration;
       this._loadThreadsPromise = this._state
         .optimisticUpdate({
           execute: () => this._options.adapter.list(),
@@ -65,6 +67,7 @@ export class RemoteThreadListThreadListRuntimeCore
           },
           // biome-ignore lint/suspicious/noThenProperty: OptimisticState reducer pattern
           then: (state, l) => {
+            if (generation !== this._loadGeneration) return state;
             const newThreadIds = [];
             const newArchivedThreadIds = [];
             const newThreadIdMap = {} as Record<string, THREAD_MAPPING_ID>;
@@ -178,6 +181,12 @@ export class RemoteThreadListThreadListRuntimeCore
       this._initialThreadLoaded = true;
       this.switchToThread(startThreadId).catch(() => {});
     }
+  }
+
+  public reload() {
+    this._loadGeneration++;
+    this._loadThreadsPromise = undefined;
+    return this.getLoadThreadsPromise();
   }
 
   public get isLoading() {

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -20,6 +20,8 @@ import {
   ThreadRuntimeImpl,
 } from "./thread-runtime";
 
+const RESOLVED_PROMISE = Promise.resolve();
+
 export type ThreadListState = {
   readonly mainThreadId: string;
   readonly newThreadId: string | undefined;
@@ -156,7 +158,7 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
   }
 
   public reload(): Promise<void> {
-    return this._core.reload?.() ?? Promise.resolve();
+    return this._core.reload?.() ?? RESOLVED_PROMISE;
   }
 
   public getState(): ThreadListState {

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -48,6 +48,7 @@ export type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
 
   getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
 };
 
 const getThreadListState = (
@@ -133,6 +134,7 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
     this.switchToThread = this.switchToThread.bind(this);
     this.switchToNewThread = this.switchToNewThread.bind(this);
     this.getLoadThreadsPromise = this.getLoadThreadsPromise.bind(this);
+    this.reload = this.reload.bind(this);
     this.getState = this.getState.bind(this);
     this.subscribe = this.subscribe.bind(this);
     this.getById = this.getById.bind(this);
@@ -151,6 +153,10 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
 
   public getLoadThreadsPromise(): Promise<void> {
     return this._core.getLoadThreadsPromise();
+  }
+
+  public reload(): Promise<void> {
+    return this._core.reload?.() ?? Promise.resolve();
   }
 
   public getState(): ThreadListState {

--- a/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
@@ -33,6 +33,7 @@ export type ThreadListRuntimeCore = {
   switchToNewThread(): Promise<void>;
 
   getLoadThreadsPromise(): Promise<void>;
+  reload?(): Promise<void>;
 
   detach(threadId: string): Promise<void>;
   rename(threadId: string, newTitle: string): Promise<void>;

--- a/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
@@ -86,6 +86,7 @@ export const ThreadListClient = resource(
         await runtime.switchToNewThread();
       },
       getLoadThreadsPromise: () => runtime.getLoadThreadsPromise(),
+      reload: () => runtime.reload(),
       __internal_getAssistantRuntime: () => __internal_assistantRuntime,
     };
   },

--- a/packages/core/src/store/scopes/threads.ts
+++ b/packages/core/src/store/scopes/threads.ts
@@ -27,6 +27,7 @@ export type ThreadsMethods = {
   ): ThreadListItemMethods;
   thread(selector: "main"): ThreadMethods;
   getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
   __internal_getAssistantRuntime?(): AssistantRuntime;
 };
 

--- a/packages/core/src/tests/OptimisticState-list-race.test.ts
+++ b/packages/core/src/tests/OptimisticState-list-race.test.ts
@@ -7,6 +7,7 @@ import {
   createThreadMappingId,
   updateStatusReducer,
 } from "../runtimes/remote-thread-list/remote-thread-state";
+import { deferred } from "./remote-thread-list-test-helpers";
 
 /**
  * Reproduces the race condition where a stale list() response
@@ -74,15 +75,6 @@ const applyListResult = (
     threadData: { ...state.threadData, ...newThreadData },
   };
 };
-
-/** Creates a deferred promise for controlling resolution order. */
-function deferred<T>() {
-  let resolve!: (v: T) => void;
-  const promise = new Promise<T>((r) => {
-    resolve = r;
-  });
-  return { promise, resolve };
-}
 
 describe("list + delete race condition", () => {
   it("stale list() does not re-add a thread deleted while list was in flight", async () => {

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reload.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reload.test.ts
@@ -178,6 +178,39 @@ describe("RemoteThreadListThreadListRuntimeCore.reload", () => {
     expect(core.threadIds).toEqual(["t-1"]);
   });
 
+  it("does not clear the active reload's promise when a stale load rejects", async () => {
+    const first = deferred<RemoteThreadListResponse>();
+    const second = deferred<RemoteThreadListResponse>();
+    const listFn = vi
+      .fn<() => Promise<RemoteThreadListResponse>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    const adapter = makeAdapter({ list: listFn });
+    const core = createCore(adapter);
+
+    core.getLoadThreadsPromise();
+    const reloaded = core.reload();
+
+    first.reject(new Error("stale 401"));
+    await Promise.resolve();
+
+    second.resolve({
+      threads: [
+        {
+          status: "regular",
+          remoteId: "fresh",
+          externalId: "fresh",
+          title: "Fresh",
+        },
+      ],
+    });
+
+    await reloaded;
+    expect(core.threadIds).toEqual(["fresh"]);
+    expect(core.isLoading).toBe(false);
+  });
+
   it("only the last of several overlapping reloads wins", async () => {
     const deferreds = [
       deferred<RemoteThreadListResponse>(),

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reload.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reload.test.ts
@@ -1,73 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
-import { RemoteThreadListThreadListRuntimeCore } from "../react/runtimes/RemoteThreadListThreadListRuntimeCore";
-import type {
-  RemoteThreadListAdapter,
-  RemoteThreadListResponse,
-} from "../runtimes/remote-thread-list/types";
-import type { ModelContextProvider } from "../model-context/types";
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
-
-const contextProvider: ModelContextProvider = {
-  getModelContext: () => ({}),
-  subscribe: () => () => {},
-};
-
-function makeAdapter(
-  overrides: Partial<RemoteThreadListAdapter> = {},
-): RemoteThreadListAdapter {
-  return {
-    list: vi.fn(async () => ({ threads: [] })),
-    initialize: vi.fn(async (threadId: string) => ({
-      remoteId: threadId,
-      externalId: threadId,
-    })),
-    rename: vi.fn(async () => {}),
-    archive: vi.fn(async () => {}),
-    unarchive: vi.fn(async () => {}),
-    delete: vi.fn(async () => {}),
-    generateTitle: vi.fn(
-      async () =>
-        new ReadableStream({
-          start(c) {
-            c.close();
-          },
-        }) as never,
-    ),
-    fetch: vi.fn(async (id: string) => ({
-      status: "regular" as const,
-      remoteId: id,
-      externalId: id,
-      title: "Test",
-    })),
-    ...overrides,
-  };
-}
-
-function createCore(
-  adapter: RemoteThreadListAdapter,
-): RemoteThreadListThreadListRuntimeCore {
-  const core = new RemoteThreadListThreadListRuntimeCore(
-    { adapter, runtimeHook: () => ({}) as never },
-    contextProvider,
-  );
-  (
-    core as unknown as {
-      _hookManager: {
-        startThreadRuntime: (id: string) => Promise<unknown>;
-      };
-    }
-  )._hookManager.startThreadRuntime = async () => ({});
-  return core;
-}
+import type { RemoteThreadListResponse } from "../runtimes/remote-thread-list/types";
+import {
+  createCore,
+  deferred,
+  makeAdapter,
+} from "./remote-thread-list-test-helpers";
 
 describe("RemoteThreadListThreadListRuntimeCore.reload", () => {
   it("refetches list() after a successful empty load", async () => {
@@ -121,7 +58,7 @@ describe("RemoteThreadListThreadListRuntimeCore.reload", () => {
     const adapter = makeAdapter({ list: listFn });
     const core = createCore(adapter);
 
-    const initial = core.getLoadThreadsPromise();
+    core.getLoadThreadsPromise();
     const reloaded = core.reload();
 
     second.resolve({
@@ -146,7 +83,9 @@ describe("RemoteThreadListThreadListRuntimeCore.reload", () => {
         },
       ],
     });
-    await initial;
+    // flush microtasks so the stale then() reducer runs and its generation
+    // guard has a chance to discard the result
+    await Promise.resolve();
 
     expect(core.threadIds).toEqual(["fresh"]);
     expect(core.threadIds).not.toContain("stale");

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reload.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reload.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi } from "vitest";
+import { RemoteThreadListThreadListRuntimeCore } from "../react/runtimes/RemoteThreadListThreadListRuntimeCore";
+import type {
+  RemoteThreadListAdapter,
+  RemoteThreadListResponse,
+} from "../runtimes/remote-thread-list/types";
+import type { ModelContextProvider } from "../model-context/types";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const contextProvider: ModelContextProvider = {
+  getModelContext: () => ({}),
+  subscribe: () => () => {},
+};
+
+function makeAdapter(
+  overrides: Partial<RemoteThreadListAdapter> = {},
+): RemoteThreadListAdapter {
+  return {
+    list: vi.fn(async () => ({ threads: [] })),
+    initialize: vi.fn(async (threadId: string) => ({
+      remoteId: threadId,
+      externalId: threadId,
+    })),
+    rename: vi.fn(async () => {}),
+    archive: vi.fn(async () => {}),
+    unarchive: vi.fn(async () => {}),
+    delete: vi.fn(async () => {}),
+    generateTitle: vi.fn(
+      async () =>
+        new ReadableStream({
+          start(c) {
+            c.close();
+          },
+        }) as never,
+    ),
+    fetch: vi.fn(async (id: string) => ({
+      status: "regular" as const,
+      remoteId: id,
+      externalId: id,
+      title: "Test",
+    })),
+    ...overrides,
+  };
+}
+
+function createCore(
+  adapter: RemoteThreadListAdapter,
+): RemoteThreadListThreadListRuntimeCore {
+  const core = new RemoteThreadListThreadListRuntimeCore(
+    { adapter, runtimeHook: () => ({}) as never },
+    contextProvider,
+  );
+  (
+    core as unknown as {
+      _hookManager: {
+        startThreadRuntime: (id: string) => Promise<unknown>;
+      };
+    }
+  )._hookManager.startThreadRuntime = async () => ({});
+  return core;
+}
+
+describe("RemoteThreadListThreadListRuntimeCore.reload", () => {
+  it("refetches list() after a successful empty load", async () => {
+    const listFn = vi
+      .fn<() => Promise<RemoteThreadListResponse>>()
+      .mockResolvedValueOnce({ threads: [] })
+      .mockResolvedValueOnce({
+        threads: [
+          {
+            status: "regular",
+            remoteId: "t-1",
+            externalId: "t-1",
+            title: "After auth",
+          },
+        ],
+      });
+    const adapter = makeAdapter({ list: listFn });
+    const core = createCore(adapter);
+
+    await core.getLoadThreadsPromise();
+    expect(listFn).toHaveBeenCalledTimes(1);
+    expect(core.threadIds).toEqual([]);
+
+    await core.reload();
+    expect(listFn).toHaveBeenCalledTimes(2);
+    expect(core.threadIds).toEqual(["t-1"]);
+  });
+
+  it("returns the same cached promise from getLoadThreadsPromise when reload is not called", async () => {
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({ threads: [] })),
+    });
+    const core = createCore(adapter);
+
+    const p1 = core.getLoadThreadsPromise();
+    const p2 = core.getLoadThreadsPromise();
+    await p1;
+    await p2;
+
+    expect(adapter.list).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops stale responses when a reload is triggered mid-flight", async () => {
+    const first = deferred<RemoteThreadListResponse>();
+    const second = deferred<RemoteThreadListResponse>();
+    const listFn = vi
+      .fn<() => Promise<RemoteThreadListResponse>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    const adapter = makeAdapter({ list: listFn });
+    const core = createCore(adapter);
+
+    const initial = core.getLoadThreadsPromise();
+    const reloaded = core.reload();
+
+    second.resolve({
+      threads: [
+        {
+          status: "regular",
+          remoteId: "fresh",
+          externalId: "fresh",
+          title: "Fresh",
+        },
+      ],
+    });
+    await reloaded;
+
+    first.resolve({
+      threads: [
+        {
+          status: "regular",
+          remoteId: "stale",
+          externalId: "stale",
+          title: "Stale",
+        },
+      ],
+    });
+    await initial;
+
+    expect(core.threadIds).toEqual(["fresh"]);
+    expect(core.threadIds).not.toContain("stale");
+  });
+
+  it("recovers after a failed initial load", async () => {
+    const listFn = vi
+      .fn<() => Promise<RemoteThreadListResponse>>()
+      .mockRejectedValueOnce(new Error("401"))
+      .mockResolvedValueOnce({
+        threads: [
+          {
+            status: "regular",
+            remoteId: "t-1",
+            externalId: "t-1",
+            title: "Authed",
+          },
+        ],
+      });
+    const adapter = makeAdapter({ list: listFn });
+    const core = createCore(adapter);
+
+    await core.getLoadThreadsPromise();
+    expect(core.threadIds).toEqual([]);
+    expect(core.isLoading).toBe(false);
+
+    await core.reload();
+    expect(listFn).toHaveBeenCalledTimes(2);
+    expect(core.threadIds).toEqual(["t-1"]);
+  });
+
+  it("only the last of several overlapping reloads wins", async () => {
+    const deferreds = [
+      deferred<RemoteThreadListResponse>(),
+      deferred<RemoteThreadListResponse>(),
+      deferred<RemoteThreadListResponse>(),
+    ];
+    const listFn = vi
+      .fn<() => Promise<RemoteThreadListResponse>>()
+      .mockImplementationOnce(() => deferreds[0]!.promise)
+      .mockImplementationOnce(() => deferreds[1]!.promise)
+      .mockImplementationOnce(() => deferreds[2]!.promise);
+
+    const adapter = makeAdapter({ list: listFn });
+    const core = createCore(adapter);
+
+    const r1 = core.getLoadThreadsPromise();
+    const r2 = core.reload();
+    const r3 = core.reload();
+
+    deferreds[2]!.resolve({
+      threads: [
+        {
+          status: "regular",
+          remoteId: "c",
+          externalId: "c",
+          title: "c",
+        },
+      ],
+    });
+    await r3;
+
+    deferreds[0]!.resolve({
+      threads: [
+        {
+          status: "regular",
+          remoteId: "a",
+          externalId: "a",
+          title: "a",
+        },
+      ],
+    });
+    deferreds[1]!.resolve({
+      threads: [
+        {
+          status: "regular",
+          remoteId: "b",
+          externalId: "b",
+          title: "b",
+        },
+      ],
+    });
+    await r1;
+    await r2;
+
+    expect(core.threadIds).toEqual(["c"]);
+  });
+});

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-switchToThread-dedupe.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-switchToThread-dedupe.test.ts
@@ -1,77 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
-import { RemoteThreadListThreadListRuntimeCore } from "../react/runtimes/RemoteThreadListThreadListRuntimeCore";
 import type {
-  RemoteThreadListAdapter,
   RemoteThreadListResponse,
   RemoteThreadMetadata,
 } from "../runtimes/remote-thread-list/types";
-import type { ModelContextProvider } from "../model-context/types";
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
-
-const contextProvider: ModelContextProvider = {
-  getModelContext: () => ({}),
-  subscribe: () => () => {},
-};
-
-function makeAdapter(
-  overrides: Partial<RemoteThreadListAdapter> = {},
-): RemoteThreadListAdapter {
-  return {
-    list: vi.fn(async () => ({ threads: [] })),
-    initialize: vi.fn(async (threadId: string) => ({
-      remoteId: threadId,
-      externalId: threadId,
-    })),
-    rename: vi.fn(async () => {}),
-    archive: vi.fn(async () => {}),
-    unarchive: vi.fn(async () => {}),
-    delete: vi.fn(async () => {}),
-    generateTitle: vi.fn(
-      async () =>
-        new ReadableStream({
-          start(c) {
-            c.close();
-          },
-        }) as never,
-    ),
-    fetch: vi.fn(async (id: string) => ({
-      status: "regular" as const,
-      remoteId: id,
-      externalId: id,
-      title: "Test",
-    })),
-    ...overrides,
-  };
-}
-
-function createCore(
-  adapter: RemoteThreadListAdapter,
-  threadId?: string,
-): RemoteThreadListThreadListRuntimeCore {
-  const core = new RemoteThreadListThreadListRuntimeCore(
-    { adapter, runtimeHook: () => ({}) as never, threadId },
-    contextProvider,
-  );
-  // `startThreadRuntime` blocks until a React component attaches a runtime;
-  // stub it so non-React unit tests don't hang.
-  (
-    core as unknown as {
-      _hookManager: {
-        startThreadRuntime: (id: string) => Promise<unknown>;
-      };
-    }
-  )._hookManager.startThreadRuntime = async () => ({});
-  return core;
-}
+import {
+  createCore,
+  deferred,
+  makeAdapter,
+} from "./remote-thread-list-test-helpers";
 
 describe("RemoteThreadListThreadListRuntimeCore.switchToThread dedupe", () => {
   it("does not duplicate threadIds when list() resolves during fetch()", async () => {

--- a/packages/core/src/tests/remote-thread-list-isLoading.test.ts
+++ b/packages/core/src/tests/remote-thread-list-isLoading.test.ts
@@ -6,6 +6,7 @@ import {
   type THREAD_MAPPING_ID,
   createThreadMappingId,
 } from "../runtimes/remote-thread-list/remote-thread-state";
+import { deferred } from "./remote-thread-list-test-helpers";
 
 /**
  * Tests for the isLoading lifecycle of RemoteThreadListThreadListRuntimeCore.
@@ -69,16 +70,6 @@ const applyListResult = (
     threadData: { ...state.threadData, ...newThreadData },
   };
 };
-
-function deferred<T>() {
-  let resolve!: (v: T) => void;
-  let reject!: (e: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
 
 describe("RemoteThreadList isLoading lifecycle", () => {
   it("starts as true before any loading begins", () => {

--- a/packages/core/src/tests/remote-thread-list-test-helpers.ts
+++ b/packages/core/src/tests/remote-thread-list-test-helpers.ts
@@ -1,0 +1,70 @@
+import { vi } from "vitest";
+import { RemoteThreadListThreadListRuntimeCore } from "../react/runtimes/RemoteThreadListThreadListRuntimeCore";
+import type { RemoteThreadListAdapter } from "../runtimes/remote-thread-list/types";
+import type { ModelContextProvider } from "../model-context/types";
+
+export function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export const contextProvider: ModelContextProvider = {
+  getModelContext: () => ({}),
+  subscribe: () => () => {},
+};
+
+export function makeAdapter(
+  overrides: Partial<RemoteThreadListAdapter> = {},
+): RemoteThreadListAdapter {
+  return {
+    list: vi.fn(async () => ({ threads: [] })),
+    initialize: vi.fn(async (threadId: string) => ({
+      remoteId: threadId,
+      externalId: threadId,
+    })),
+    rename: vi.fn(async () => {}),
+    archive: vi.fn(async () => {}),
+    unarchive: vi.fn(async () => {}),
+    delete: vi.fn(async () => {}),
+    generateTitle: vi.fn(
+      async () =>
+        new ReadableStream({
+          start(c) {
+            c.close();
+          },
+        }) as never,
+    ),
+    fetch: vi.fn(async (id: string) => ({
+      status: "regular" as const,
+      remoteId: id,
+      externalId: id,
+      title: "Test",
+    })),
+    ...overrides,
+  };
+}
+
+export function createCore(
+  adapter: RemoteThreadListAdapter,
+  threadId?: string,
+): RemoteThreadListThreadListRuntimeCore {
+  const core = new RemoteThreadListThreadListRuntimeCore(
+    { adapter, runtimeHook: () => ({}) as never, threadId },
+    contextProvider,
+  );
+  // `startThreadRuntime` blocks until a React component attaches a runtime;
+  // stub it so non-React unit tests don't hang.
+  (
+    core as unknown as {
+      _hookManager: {
+        startThreadRuntime: (id: string) => Promise<unknown>;
+      };
+    }
+  )._hookManager.startThreadRuntime = async () => ({});
+  return core;
+}

--- a/packages/core/src/tests/thread-list-runtime-getLoadThreadsPromise.test.ts
+++ b/packages/core/src/tests/thread-list-runtime-getLoadThreadsPromise.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { ThreadListRuntimeImpl } from "../runtime/api/thread-list-runtime";
 import type { ThreadListRuntimeCore } from "../runtime/interfaces/thread-list-runtime-core";
 import { EMPTY_THREAD_CORE } from "../runtimes/remote-thread-list/empty-thread-core";
@@ -71,5 +71,21 @@ describe("ThreadListRuntime.getLoadThreadsPromise", () => {
     expect(resolved).toBe(false);
     await runtime.getLoadThreadsPromise();
     expect(resolved).toBe(true);
+  });
+});
+
+describe("ThreadListRuntime.reload", () => {
+  it("resolves to undefined when core omits reload", async () => {
+    const runtime = new ThreadListRuntimeImpl(createMockCore());
+    await expect(runtime.reload()).resolves.toBeUndefined();
+  });
+
+  it("delegates to core.reload when implemented", async () => {
+    const reload = vi.fn<() => Promise<void>>(() => Promise.resolve());
+    const core = { ...createMockCore(), reload };
+    const runtime = new ThreadListRuntimeImpl(core);
+
+    await runtime.reload();
+    expect(reload).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -154,6 +154,7 @@ export const InMemoryThreadList = resource(
       switchToThread: handleSwitchToThread,
       switchToNewThread: handleSwitchToNewThread,
       getLoadThreadsPromise: () => RESOLVED_PROMISE,
+      reload: () => RESOLVED_PROMISE,
       item: (selector) => {
         if (selector === "main") {
           const index = threads.findIndex((t) => t.id === mainThreadId);

--- a/packages/react/src/client/SingleThreadList.ts
+++ b/packages/react/src/client/SingleThreadList.ts
@@ -64,6 +64,7 @@ export const SingleThreadList = resource(
         throw new Error("SingleThreadList does not support switchToNewThread");
       },
       getLoadThreadsPromise: () => RESOLVED_PROMISE,
+      reload: () => RESOLVED_PROMISE,
       item: (selector) => {
         if (
           selector !== "main" &&


### PR DESCRIPTION
## Summary

- Add `reload()` to `ThreadListRuntime` and `aui.threads()` so callers can re-invoke the remote adapter's `list()` after the initial load.
- Motivated by issue #3815: async auth libraries (OIDC, better-auth, next-auth) can resolve after `useRemoteThreadListRuntime` has already cached an unauthenticated `list()` result, and today there is no escape hatch to refetch.
- Add a per-load generation counter in `RemoteThreadListThreadListRuntimeCore` so a superseded in-flight response cannot overwrite the state of a newer reload (safe to call during logout → re-login flows).
- Plumb the new method through all three layers — `ThreadListRuntimeCore` (optional), `ThreadListRuntimeImpl` (with `?? Promise.resolve()` fallback for cores that don't implement it, mirroring how `message.reload()` is wired), and the tap-only `ThreadsMethods` / `ThreadListClient`.
- Document the feature in the `ThreadListRuntime` API reference and add a "Reloading After Async Authentication" section with a concrete `react-oidc-context` example to the Custom Thread List guide.

## Test plan

- [x] `pnpm --filter @assistant-ui/core test` — 145 tests pass (18 files), including 7 new cases in `RemoteThreadListThreadListRuntimeCore-reload.test.ts` and `thread-list-runtime-getLoadThreadsPromise.test.ts`.
- [x] `pnpm lint` — no new warnings introduced.
- [ ] Manually verify in a `react-oidc-context` app: adapter's first `list()` runs unauthenticated, `runtime.threads.reload()` fired from a `useEffect([isLoading, user?.id])` refetches with the authenticated request and the UI populates.
- [ ] Manually verify logout → re-login: calling `reload()` twice back-to-back drops the intermediate response and leaves the state consistent with the final call.
- [ ] Confirm `useLocalRuntime` (no adapter) still no-ops silently when `runtime.threads.reload()` is called.

close #3815