### PR TITLE
chore: custom changelog puts author at end as "(@user)"

### DIFF
--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -1,0 +1,152 @@
+// Forked from @changesets/changelog-github@0.6.0
+// Difference: moves the author credit from " Thanks @user!" before the summary
+// to " (@user)" at the end of the first line.
+// https://github.com/changesets/changesets/blob/main/packages/changelog-github/src/index.ts
+
+const {
+  getInfo,
+  getInfoFromPullRequest,
+} = require("@changesets/get-github-info");
+
+function linkifyIssueRefs(line, { serverUrl, repo }) {
+  return line.replace(/\[.*?\]\(.*?\)|\B#([1-9]\d*)\b/g, (match, issue) =>
+    issue ? `[#${issue}](${serverUrl}/${repo}/issues/${issue})` : match,
+  );
+}
+
+function readEnv() {
+  const GITHUB_SERVER_URL =
+    process.env.GITHUB_SERVER_URL || "https://github.com";
+  return { GITHUB_SERVER_URL };
+}
+
+const changelogFunctions = {
+  getDependencyReleaseLine: async (
+    changesets,
+    dependenciesUpdated,
+    options,
+  ) => {
+    if (!options.repo) {
+      throw new Error(
+        'Please provide a repo to this changelog generator like this:\n"changelog": ["./.changeset/changelog.cjs", { "repo": "org/repo" }]',
+      );
+    }
+    if (dependenciesUpdated.length === 0) return "";
+
+    const changesetLink = `- Updated dependencies [${(
+      await Promise.all(
+        changesets.map(async (cs) => {
+          if (cs.commit) {
+            const { links } = await getInfo({
+              repo: options.repo,
+              commit: cs.commit,
+            });
+            return links.commit;
+          }
+        }),
+      )
+    )
+      .filter((_) => _)
+      .join(", ")}]:`;
+
+    const updatedDependenciesList = dependenciesUpdated.map(
+      (dependency) => `  - ${dependency.name}@${dependency.newVersion}`,
+    );
+
+    return [changesetLink, ...updatedDependenciesList].join("\n");
+  },
+  getReleaseLine: async (changeset, type, options) => {
+    const { GITHUB_SERVER_URL } = readEnv();
+    if (!options || !options.repo) {
+      throw new Error(
+        'Please provide a repo to this changelog generator like this:\n"changelog": ["./.changeset/changelog.cjs", { "repo": "org/repo" }]',
+      );
+    }
+
+    let prFromSummary;
+    let commitFromSummary;
+    const usersFromSummary = [];
+
+    const replacedChangelog = changeset.summary
+      .replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
+        const num = Number(pr);
+        if (!Number.isNaN(num)) prFromSummary = num;
+        return "";
+      })
+      .replace(/^\s*commit:\s*([^\s]+)/im, (_, commit) => {
+        commitFromSummary = commit;
+        return "";
+      })
+      .replace(/^\s*(?:author|user):\s*@?([^\s]+)/gim, (_, user) => {
+        usersFromSummary.push(user);
+        return "";
+      })
+      .trim();
+
+    const [firstLine, ...futureLines] = replacedChangelog
+      .split("\n")
+      .map((l) => l.trimEnd());
+
+    const links = await (async () => {
+      if (prFromSummary !== undefined) {
+        let { links } = await getInfoFromPullRequest({
+          repo: options.repo,
+          pull: prFromSummary,
+        });
+        if (commitFromSummary) {
+          const shortCommitId = commitFromSummary.slice(0, 7);
+          links = {
+            ...links,
+            commit: `[\`${shortCommitId}\`](${GITHUB_SERVER_URL}/${options.repo}/commit/${commitFromSummary})`,
+          };
+        }
+        return links;
+      }
+      const commitToFetchFrom = commitFromSummary || changeset.commit;
+      if (commitToFetchFrom) {
+        const { links } = await getInfo({
+          repo: options.repo,
+          commit: commitToFetchFrom,
+        });
+        return links;
+      }
+      return { commit: null, pull: null, user: null };
+    })();
+
+    const users = usersFromSummary.length
+      ? usersFromSummary
+          .map(
+            (userFromSummary) =>
+              `[@${userFromSummary}](${GITHUB_SERVER_URL}/${userFromSummary})`,
+          )
+          .join(", ")
+      : links.user;
+
+    const prefix = [
+      links.pull === null ? "" : ` ${links.pull}`,
+      links.commit === null ? "" : ` ${links.commit}`,
+    ].join("");
+
+    const suffix = users === null ? "" : ` (${users})`;
+
+    const renderedFirstLine = linkifyIssueRefs(firstLine, {
+      serverUrl: GITHUB_SERVER_URL,
+      repo: options.repo,
+    });
+
+    const renderedFutureLines = futureLines
+      .map(
+        (l) =>
+          `  ${linkifyIssueRefs(l, {
+            serverUrl: GITHUB_SERVER_URL,
+            repo: options.repo,
+          })}`,
+      )
+      .join("\n");
+
+    return `\n\n-${prefix ? `${prefix} -` : ""} ${renderedFirstLine}${suffix}\n${renderedFutureLines}`;
+  },
+};
+
+module.exports = changelogFunctions;
+module.exports.default = changelogFunctions;

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.1/schema.json",
   "changelog": [
-    "@changesets/changelog-github",
+    "./.changeset/changelog.cjs",
     { "repo": "assistant-ui/assistant-ui" }
   ],
   "access": "public",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@biomejs/biome": "^2.4.12",
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.31.0",
+    "@changesets/get-github-info": "^0.8.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "turbo": "^2.9.6",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",
-    "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.31.0",
     "@changesets/get-github-info": "^0.8.0",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.6.0)
+      '@changesets/get-github-info':
+        specifier: ^0.8.0
+        version: 0.8.0(encoding@0.1.13)
       husky:
         specifier: ^9.1.7
         version: 9.1.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.12
         version: 2.4.12
-      '@changesets/changelog-github':
-        specifier: ^0.6.0
-        version: 0.6.0(encoding@0.1.13)
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.6.0)
@@ -5209,9 +5206,6 @@ packages:
 
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
-
-  '@changesets/changelog-github@0.6.0':
-    resolution: {integrity: sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==}
 
   '@changesets/cli@2.31.0':
     resolution: {integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==}
@@ -10514,10 +10508,6 @@ packages:
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
-
-  dotenv@8.6.0:
-    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
-    engines: {node: '>=10'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -16963,14 +16953,6 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/changelog-github@0.6.0(encoding@0.1.13)':
-    dependencies:
-      '@changesets/get-github-info': 0.8.0(encoding@0.1.13)
-      '@changesets/types': 6.1.0
-      dotenv: 8.6.0
-    transitivePeerDependencies:
-      - encoding
-
   '@changesets/cli@2.31.0(@types/node@25.6.0)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
@@ -23152,8 +23134,6 @@ snapshots:
   dotenv@17.3.1: {}
 
   dotenv@17.4.2: {}
-
-  dotenv@8.6.0: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Fork `@changesets/changelog-github@0.6.0` into `.changeset/changelog.cjs`
- Move the author credit from `" Thanks @user!"` before the summary to `" (@user)"` at the end of the first line
- Point `.changeset/config.json` at the local module
- Add `@changesets/get-github-info` as a direct devDependency (the fork imports it; pnpm's strict isolation requires direct declaration)

### Before

```
- [#3881](url) [`80f5d32`](url) Thanks @Yonom! - chore: switch changesets to @changesets/changelog-github
```

### After

```
- [#3881](url) [`80f5d32`](url) - chore: switch changesets to @changesets/changelog-github (@Yonom)
```

## Test plan

- [x] Module loads and exports `getReleaseLine` / `getDependencyReleaseLine` / `default`
- [x] `getDependencyReleaseLine` returns empty string when no deps changed (no network call)
- [ ] Next `changeset version` run produces CHANGELOG entries with `(@user)` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)