### PR TITLE
chore: address every review thread before merge

### DIFF
--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -12,39 +12,34 @@ The user has requested butflow mode. Implement features, open PRs via GitButler,
 
 ## Cron cycle
 
-Run every cycle:
 1. `gh pr checks <n>`
-2. Review threads — resolution state, thread node IDs (for the resolve mutation), comment `databaseId`s (REST integers for the reply endpoint), bodies, authors:
+2. Review threads — `id` is the GraphQL node id for the resolve mutation; `databaseId` on each comment is the REST integer for replies:
    ```
-   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { pageInfo { hasNextPage endCursor } nodes { id isResolved isOutdated comments(first:50) { pageInfo { hasNextPage endCursor } nodes { databaseId body author { login } } } } } } } }'
+   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { nodes { id isResolved isOutdated comments(first:50) { nodes { databaseId body author { login } } } } } } } }'
    ```
-3. `gh pr view <n> --json reviews` — check review states and body text for actionable feedback.
+3. `gh pr view <n> --json reviews`
 
-Steps 2 and 3 are independent — run them in parallel.
+## Addressing threads
 
-## Before merging
+Every unresolved thread must get a reply and a resolve:
+- **Valid** → fix in a follow-up commit, reply with the fix SHA, resolve.
+- **Invalid** → reply with a short rationale, resolve.
+- **Outdated** (`isOutdated: true`) → the diff moved; reply noting that and resolve.
 
-Every review thread — human or bot — must be resolved. For each:
-- **Valid** → fix in a follow-up commit (lint/build/test first), reply with the fix commit SHA, then resolve the thread.
-- **Invalid** → reply with a short rationale, then resolve the thread.
+Use judgment on bot nits. Common-sense suggestions that just duplicate what a competent agent already knows aren't worth a fix commit — reply-and-resolve those. Scope creep from a long bot-feedback loop is a signal to cut and merge.
 
-Reply to a specific inline comment (REST; `<comment_id>` is a comment's `databaseId` from step 2):
 ```
-gh api /repos/assistant-ui/assistant-ui/pulls/<n>/comments/<comment_id>/replies -f body='...'
-```
-
-Resolve the thread (GraphQL; `<threadId>` is the thread `id` from step 2, e.g. `PRRT_kw...`):
-```
+gh api /repos/assistant-ui/assistant-ui/pulls/<n>/comments/<databaseId>/replies -f body='...'
 gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id=<threadId>
 ```
 
-Merge once:
+## Merge gate
+
 - All non-cubic CI checks pass.
-- Every thread is resolved (including `isOutdated` threads — diff moved under the comment, so skip re-fixing; still reply + resolve).
-- No non-cubic reviewer's current state is `CHANGES_REQUESTED` (from step 3). If one is, address it and wait for the reviewer to re-approve — don't dismiss or merge around it.
-- The GraphQL query's `pageInfo.hasNextPage` is `false` on both thread and comment pagination. If `true`, re-run with `after:"<endCursor>"` added after `first:100` / `first:50` to fetch the next page — don't silently miss threads.
+- Every thread is resolved.
+- No non-cubic reviewer's current state is `CHANGES_REQUESTED` — address and wait for re-approve, don't dismiss.
 
 ## Gotchas
 
 - Ambiguous `but stage` id → `but status -j`, use the longer form.
-- One branch per change group; stage files to each, commit/push/PR independently.
+- One branch per change group; stage, commit, push, PR independently.

--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -20,6 +20,8 @@ Run every cycle:
    ```
 3. `gh pr view <n> --json reviews`
 
+Steps 2 and 3 are independent — run them in parallel.
+
 ## Before merging
 
 Every review thread — human or bot — must be resolved. For each:

--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -16,7 +16,7 @@ Run every cycle:
 1. `gh pr checks <n>`
 2. Review threads — resolution state, thread node IDs (for the resolve mutation), comment `databaseId`s (REST integers for the reply endpoint), bodies, authors:
    ```
-   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { nodes { id isResolved comments(first:50) { nodes { databaseId body author { login } } } } } } } }'
+   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { nodes { id isResolved isOutdated comments(first:50) { nodes { databaseId body author { login } } } } } } } }'
    ```
 3. `gh pr view <n> --json reviews`
 
@@ -36,7 +36,7 @@ Resolve the thread (GraphQL; `<threadId>` is the thread `id` from step 2, e.g. `
 gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id=<threadId>
 ```
 
-Merge once all non-cubic checks pass, every thread is resolved, and no formal review on the current HEAD is in `CHANGES_REQUESTED` (from step 3). If one is, either address it and wait for the reviewer to re-approve, or dismiss it — don't merge around it.
+Merge once all non-cubic checks pass, every thread is resolved (or `isOutdated` — the diff moved under the comment, so it's effectively obsolete; still reply + resolve), and no non-cubic review on the current HEAD is in `CHANGES_REQUESTED` (from step 3). If one is, either address it and wait for the reviewer to re-approve, or dismiss it — don't merge around it.
 
 ## Gotchas
 

--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -6,7 +6,7 @@ GitButler CI flow. Multiple agents may run concurrently.
 
 ## Flow
 
-1. `but pull` → implement → new branch → stage → commit → push → `gh pr create`.
+1. `but pull` → implement → lint/build/test → new branch → stage → commit → push → `gh pr create`.
 2. Add `.changeset/*.md` (patch) if a published package changed.
 3. Schedule a 2-min cron to monitor. Merge with `gh pr merge <n> --squash --admin`.
 
@@ -14,17 +14,28 @@ GitButler CI flow. Multiple agents may run concurrently.
 
 Run every cycle:
 1. `gh pr checks <n>`
-2. `gh api repos/assistant-ui/assistant-ui/pulls/<n>/comments` — inline comments. For thread ids, GraphQL `reviewThreads { nodes { id isResolved comments { nodes { databaseId body author { login } } } } }`.
-3. `gh pr view <n> --json reviews`
+2. `gh api repos/assistant-ui/assistant-ui/pulls/<n>/comments` — inline comments (returns REST `id` integers).
+3. Thread IDs + resolution state (GraphQL node IDs, needed for the resolve mutation):
+   ```
+   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { nodes { id isResolved comments(first:1) { nodes { databaseId body author { login } } } } } } } }'
+   ```
+4. `gh pr view <n> --json reviews`
 
 ## Before merging
 
 Every review thread — human or bot — must be resolved. For each:
 - **Valid** → fix in a follow-up commit.
-- **Invalid** → reply with a short rationale via `gh api /repos/assistant-ui/assistant-ui/pulls/<n>/comments/<comment_id>/replies -f body=...`, then resolve:
-  ```
-  gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id=<threadId>
-  ```
+- **Invalid** → reply with a short rationale, then resolve.
+
+Reply to a specific inline comment (REST; `<comment_id>` is the integer from step 2):
+```
+gh api /repos/assistant-ui/assistant-ui/pulls/<n>/comments/<comment_id>/replies -f body='...'
+```
+
+Resolve the thread (GraphQL; `<threadId>` is the node ID from step 3, e.g. `PRRT_kw...`):
+```
+gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id=<threadId>
+```
 
 Merge once all non-cubic checks pass and every thread is resolved.
 

--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -16,7 +16,7 @@ Run every cycle:
 1. `gh pr checks <n>`
 2. Review threads — resolution state, thread node IDs (for the resolve mutation), comment `databaseId`s (REST integers for the reply endpoint), bodies, authors:
    ```
-   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { nodes { id isResolved isOutdated comments(first:50) { nodes { databaseId body author { login } } } } } } } }'
+   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { pageInfo { hasNextPage } nodes { id isResolved isOutdated comments(first:50) { pageInfo { hasNextPage } nodes { databaseId body author { login } } } } } } } }'
    ```
 3. `gh pr view <n> --json reviews`
 
@@ -36,7 +36,11 @@ Resolve the thread (GraphQL; `<threadId>` is the thread `id` from step 2, e.g. `
 gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id=<threadId>
 ```
 
-Merge once all non-cubic checks pass, every thread is resolved (or `isOutdated` — the diff moved under the comment, so it's effectively obsolete; still reply + resolve), and no non-cubic review on the current HEAD is in `CHANGES_REQUESTED` (from step 3). If one is, either address it and wait for the reviewer to re-approve, or dismiss it — don't merge around it.
+Merge once:
+- All non-cubic CI checks pass.
+- Every thread is resolved (including `isOutdated` threads — diff moved under the comment, so skip re-fixing; still reply + resolve).
+- No non-cubic review on the current HEAD is in `CHANGES_REQUESTED` (from step 3). If one is, either address it and wait for the reviewer to re-approve, or dismiss it — don't merge around it.
+- The GraphQL query's `pageInfo.hasNextPage` is `false` on both thread and comment pagination (else fetch the next page — don't silently miss threads).
 
 ## Gotchas
 

--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -18,7 +18,7 @@ Run every cycle:
    ```
    gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { pageInfo { hasNextPage endCursor } nodes { id isResolved isOutdated comments(first:50) { pageInfo { hasNextPage endCursor } nodes { databaseId body author { login } } } } } } } }'
    ```
-3. `gh pr view <n> --json reviews`
+3. `gh pr view <n> --json reviews` — check review states and body text for actionable feedback.
 
 Steps 2 and 3 are independent — run them in parallel.
 
@@ -41,8 +41,8 @@ gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$
 Merge once:
 - All non-cubic CI checks pass.
 - Every thread is resolved (including `isOutdated` threads — diff moved under the comment, so skip re-fixing; still reply + resolve).
-- No non-cubic review on the current HEAD is in `CHANGES_REQUESTED` (from step 3). If one is, address it and wait for the reviewer to re-approve — don't dismiss or merge around it.
-- The GraphQL query's `pageInfo.hasNextPage` is `false` on both thread and comment pagination (else fetch the next page — don't silently miss threads).
+- No non-cubic reviewer's current state is `CHANGES_REQUESTED` (from step 3). If one is, address it and wait for the reviewer to re-approve — don't dismiss or merge around it.
+- The GraphQL query's `pageInfo.hasNextPage` is `false` on both thread and comment pagination. If `true`, re-run with `after:"<endCursor>"` added after `first:100` / `first:50` to fetch the next page — don't silently miss threads.
 
 ## Gotchas
 

--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -23,7 +23,7 @@ Run every cycle:
 ## Before merging
 
 Every review thread — human or bot — must be resolved. For each:
-- **Valid** → fix in a follow-up commit, reply with the fix commit SHA, then resolve the thread.
+- **Valid** → fix in a follow-up commit (lint/build/test first), reply with the fix commit SHA, then resolve the thread.
 - **Invalid** → reply with a short rationale, then resolve the thread.
 
 Reply to a specific inline comment (REST; `<comment_id>` is a comment's `databaseId` from step 2):

--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -6,7 +6,7 @@ GitButler CI flow. Multiple agents may run concurrently.
 
 ## Flow
 
-1. `but pull` → implement → lint/build/test → new branch → stage → commit → push → `gh pr create`.
+1. `but pull` → implement → lint/build/test → `but branch` → stage → commit → push → `gh pr create`.
 2. Add `.changeset/*.md` (patch) if a published package changed.
 3. Schedule a 2-min cron to monitor. Merge with `gh pr merge <n> --squash --admin`.
 
@@ -24,8 +24,8 @@ Run every cycle:
 ## Before merging
 
 Every review thread — human or bot — must be resolved. For each:
-- **Valid** → fix in a follow-up commit.
-- **Invalid** → reply with a short rationale, then resolve.
+- **Valid** → fix in a follow-up commit, then resolve the thread.
+- **Invalid** → reply with a short rationale, then resolve the thread.
 
 Reply to a specific inline comment (REST; `<comment_id>` is the integer from step 2):
 ```

--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -14,12 +14,11 @@ The user has requested butflow mode. Implement features, open PRs via GitButler,
 
 Run every cycle:
 1. `gh pr checks <n>`
-2. `gh api repos/assistant-ui/assistant-ui/pulls/<n>/comments` — inline comments (returns REST `id` integers).
-3. Thread IDs + resolution state (GraphQL node IDs, needed for the resolve mutation):
+2. Review threads — resolution state, thread node IDs (for the resolve mutation), comment `databaseId`s (REST integers for the reply endpoint), bodies, authors:
    ```
-   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { nodes { id isResolved comments(first:1) { nodes { databaseId body author { login } } } } } } } }'
+   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { nodes { id isResolved comments(first:5) { nodes { databaseId body author { login } } } } } } } }'
    ```
-4. `gh pr view <n> --json reviews`
+3. `gh pr view <n> --json reviews`
 
 ## Before merging
 
@@ -27,12 +26,12 @@ Every review thread — human or bot — must be resolved. For each:
 - **Valid** → fix in a follow-up commit, then resolve the thread.
 - **Invalid** → reply with a short rationale, then resolve the thread.
 
-Reply to a specific inline comment (REST; `<comment_id>` is the integer from step 2):
+Reply to a specific inline comment (REST; `<comment_id>` is a comment's `databaseId` from step 2):
 ```
 gh api /repos/assistant-ui/assistant-ui/pulls/<n>/comments/<comment_id>/replies -f body='...'
 ```
 
-Resolve the thread (GraphQL; `<threadId>` is the node ID from step 3, e.g. `PRRT_kw...`):
+Resolve the thread (GraphQL; `<threadId>` is the thread `id` from step 2, e.g. `PRRT_kw...`):
 ```
 gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id=<threadId>
 ```

--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -16,7 +16,7 @@ Run every cycle:
 1. `gh pr checks <n>`
 2. Review threads — resolution state, thread node IDs (for the resolve mutation), comment `databaseId`s (REST integers for the reply endpoint), bodies, authors:
    ```
-   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { pageInfo { hasNextPage } nodes { id isResolved isOutdated comments(first:50) { pageInfo { hasNextPage } nodes { databaseId body author { login } } } } } } } }'
+   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { pageInfo { hasNextPage endCursor } nodes { id isResolved isOutdated comments(first:50) { pageInfo { hasNextPage endCursor } nodes { databaseId body author { login } } } } } } } }'
    ```
 3. `gh pr view <n> --json reviews`
 
@@ -39,7 +39,7 @@ gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$
 Merge once:
 - All non-cubic CI checks pass.
 - Every thread is resolved (including `isOutdated` threads — diff moved under the comment, so skip re-fixing; still reply + resolve).
-- No non-cubic review on the current HEAD is in `CHANGES_REQUESTED` (from step 3). If one is, either address it and wait for the reviewer to re-approve, or dismiss it — don't merge around it.
+- No non-cubic review on the current HEAD is in `CHANGES_REQUESTED` (from step 3). If one is, address it and wait for the reviewer to re-approve — don't dismiss or merge around it.
 - The GraphQL query's `pageInfo.hasNextPage` is `false` on both thread and comment pagination (else fetch the next page — don't silently miss threads).
 
 ## Gotchas

--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -1,27 +1,34 @@
 ---
-description: "GitButler CI review flow: implement task, create PR, monitor CI, fix review issues, auto-merge"
+description: "GitButler CI review flow: implement, PR, monitor CI, address reviews, merge"
 ---
 
-The user has requested butflow mode. Implement features, open PRs via GitButler, iterate on CI/review feedback, and merge. Multiple agents may work on the same codebase concurrently.
+GitButler CI flow. Multiple agents may run concurrently.
 
 ## Flow
 
-1. `but pull` → implement → lint/build/test → create GitButler branch → stage → commit → push → `gh pr create`
-2. Add `.changeset/*.md` (patch) if published packages changed.
-3. Set a 2-min cron to monitor CI and AI review comments. Don't wait for cubic (optional). Merge with `gh pr merge <n> --squash --admin`.
+1. `but pull` → implement → new branch → stage → commit → push → `gh pr create`.
+2. Add `.changeset/*.md` (patch) if a published package changed.
+3. Schedule a 2-min cron to monitor. Merge with `gh pr merge <n> --squash --admin`.
 
-## Cron prompt template
+## Cron cycle
 
-The cron prompt MUST run ALL of these commands every cycle before deciding to merge:
+Run every cycle:
+1. `gh pr checks <n>`
+2. `gh api repos/assistant-ui/assistant-ui/pulls/<n>/comments` — inline comments. For thread ids, GraphQL `reviewThreads { nodes { id isResolved comments { nodes { databaseId body author { login } } } } }`.
+3. `gh pr view <n> --json reviews`
 
-```
-1. `gh pr checks <n>` — check CI status
-2. `gh api repos/assistant-ui/assistant-ui/pulls/<n>/comments` — check for new review comments
-3. `gh pr view <n> --json reviews` — check for reviews
-```
+## Before merging
+
+Every review thread — human or bot — must be resolved. For each:
+- **Valid** → fix in a follow-up commit.
+- **Invalid** → reply with a short rationale via `gh api /repos/assistant-ui/assistant-ui/pulls/<n>/comments/<comment_id>/replies -f body=...`, then resolve:
+  ```
+  gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id=<threadId>
+  ```
+
+Merge once all non-cubic checks pass and every thread is resolved.
 
 ## Gotchas
 
-- **Check for PR comments**: Review and address valid AI review bot comments, only auto-merge if all human comments are addressed.
-- **Ambiguous cliIds**: if `but stage` says an ID is ambiguous, re-run `but status -j` and use the longer form.
-- **Multiple PRs**: create one branch per change group, stage files to each, commit/push/PR independently.
+- Ambiguous `but stage` id → `but status -j`, use the longer form.
+- One branch per change group.

--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -2,13 +2,13 @@
 description: "GitButler CI review flow: implement, PR, monitor CI, address reviews, merge"
 ---
 
-GitButler CI flow. Multiple agents may run concurrently.
+The user has requested butflow mode. Implement features, open PRs via GitButler, iterate on CI/review feedback, and merge. Multiple agents may run concurrently.
 
 ## Flow
 
 1. `but pull` → implement → lint/build/test → `but branch` → stage → commit → push → `gh pr create`.
 2. Add `.changeset/*.md` (patch) if a published package changed.
-3. Schedule a 2-min cron to monitor. Merge with `gh pr merge <n> --squash --admin`.
+3. Schedule a 2-min cron to monitor. Merge with `gh pr merge <n> --squash --admin` (cubic is optional — don't wait for it).
 
 ## Cron cycle
 
@@ -42,4 +42,4 @@ Merge once all non-cubic checks pass and every thread is resolved.
 ## Gotchas
 
 - Ambiguous `but stage` id → `but status -j`, use the longer form.
-- One branch per change group.
+- One branch per change group; stage files to each, commit/push/PR independently.

--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -16,14 +16,14 @@ Run every cycle:
 1. `gh pr checks <n>`
 2. Review threads — resolution state, thread node IDs (for the resolve mutation), comment `databaseId`s (REST integers for the reply endpoint), bodies, authors:
    ```
-   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { nodes { id isResolved comments(first:5) { nodes { databaseId body author { login } } } } } } } }'
+   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { nodes { id isResolved comments(first:10) { nodes { databaseId body author { login } } } } } } } }'
    ```
 3. `gh pr view <n> --json reviews`
 
 ## Before merging
 
 Every review thread — human or bot — must be resolved. For each:
-- **Valid** → fix in a follow-up commit, then resolve the thread.
+- **Valid** → fix in a follow-up commit, reply with the fix commit SHA, then resolve the thread.
 - **Invalid** → reply with a short rationale, then resolve the thread.
 
 Reply to a specific inline comment (REST; `<comment_id>` is a comment's `databaseId` from step 2):

--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -16,7 +16,7 @@ Run every cycle:
 1. `gh pr checks <n>`
 2. Review threads — resolution state, thread node IDs (for the resolve mutation), comment `databaseId`s (REST integers for the reply endpoint), bodies, authors:
    ```
-   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { nodes { id isResolved comments(first:10) { nodes { databaseId body author { login } } } } } } } }'
+   gh api graphql -f query='query { repository(owner:"assistant-ui",name:"assistant-ui") { pullRequest(number:<n>) { reviewThreads(first:100) { nodes { id isResolved comments(first:50) { nodes { databaseId body author { login } } } } } } } }'
    ```
 3. `gh pr view <n> --json reviews`
 
@@ -36,7 +36,7 @@ Resolve the thread (GraphQL; `<threadId>` is the thread `id` from step 2, e.g. `
 gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id=<threadId>
 ```
 
-Merge once all non-cubic checks pass and every thread is resolved.
+Merge once all non-cubic checks pass, every thread is resolved, and no formal review on the current HEAD is in `CHANGES_REQUESTED` (from step 3). If one is, either address it and wait for the reviewer to re-approve, or dismiss it — don't merge around it.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Updates `.claude/commands/butflow.md` so the flow requires every review thread — human or bot — to be resolved before merging. Each unresolved thread gets either a fix-in-code follow-up commit or a short "why this is invalid" reply, followed by a GraphQL `resolveReviewThread` mutation. Overall file is tighter.

## Test plan

- [x] Local Claude Code picks up the new command description (visible as `butflow: GitButler CI review flow: implement, PR, monitor CI, address reviews, merge`)
- [ ] Next butflow run resolves all threads before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)