### PR TITLE
fix(changesets): move custom changelog into @assistant-ui/x-changelog

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.1/schema.json",
   "changelog": [
-    "./.changeset/changelog.cjs",
+    "@assistant-ui/x-changelog",
     { "repo": "assistant-ui/assistant-ui" }
   ],
   "access": "public",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "deps:update": "npx taze major -f -w -r && cd examples/with-expo && npx expo install --fix && cd ../.. && find . -name node_modules -prune -exec rm -rf {} + && rm -f pnpm-lock.yaml && pnpm install && pnpm dedupe && bash scripts/generate-deps-changeset.sh"
   },
   "devDependencies": {
+    "@assistant-ui/x-changelog": "workspace:*",
     "@biomejs/biome": "^2.4.12",
     "@changesets/cli": "^2.31.0",
-    "@changesets/get-github-info": "^0.8.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "turbo": "^2.9.6",

--- a/packages/x-changelog/index.cjs
+++ b/packages/x-changelog/index.cjs
@@ -28,7 +28,7 @@ const changelogFunctions = {
   ) => {
     if (!options.repo) {
       throw new Error(
-        'Please provide a repo to this changelog generator like this:\n"changelog": ["./.changeset/changelog.cjs", { "repo": "org/repo" }]',
+        'Please provide a repo to this changelog generator like this:\n"changelog": ["@assistant-ui/x-changelog", { "repo": "org/repo" }]',
       );
     }
     if (dependenciesUpdated.length === 0) return "";
@@ -59,7 +59,7 @@ const changelogFunctions = {
     const { GITHUB_SERVER_URL } = readEnv();
     if (!options || !options.repo) {
       throw new Error(
-        'Please provide a repo to this changelog generator like this:\n"changelog": ["./.changeset/changelog.cjs", { "repo": "org/repo" }]',
+        'Please provide a repo to this changelog generator like this:\n"changelog": ["@assistant-ui/x-changelog", { "repo": "org/repo" }]',
       );
     }
 

--- a/packages/x-changelog/package.json
+++ b/packages/x-changelog/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@assistant-ui/x-changelog",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Internal changesets changelog generator for assistant-ui",
+  "main": "./index.cjs",
+  "files": [
+    "index.cjs"
+  ],
+  "dependencies": {
+    "@changesets/get-github-info": "^0.8.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,15 @@ importers:
 
   .:
     devDependencies:
+      '@assistant-ui/x-changelog':
+        specifier: workspace:*
+        version: link:packages/x-changelog
       '@biomejs/biome':
         specifier: ^2.4.12
         version: 2.4.12
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.6.0)
-      '@changesets/get-github-info':
-        specifier: ^0.8.0
-        version: 0.8.0(encoding@0.1.13)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -3773,6 +3773,12 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+
+  packages/x-changelog:
+    dependencies:
+      '@changesets/get-github-info':
+        specifier: ^0.8.0
+        version: 0.8.0(encoding@0.1.13)
 
   templates/cloud:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes the `Create Version PR` workflow failing on main with:

```
🦋  error Error: Cannot find module './.changeset/changelog.cjs'
🦋  error Require stack:
🦋  error - node_modules/.pnpm/@changesets+cli@2.31.0_.../dist/noop.js
```

## Root cause

`@changesets/apply-release-plan` loads the changelog generator with `resolveFrom(contextDir, config.changelog[0])`, where `contextDir` is the CLI's own `__dirname` (`node_modules/.pnpm/@changesets+cli@.../dist/`). Relative paths resolve under that directory, not the repo root — so `./.changeset/changelog.cjs` cannot be found.

Package names work because `resolve-from` walks up looking for `node_modules`, so a workspace-linked package is reachable.

## Fix

- New private workspace package `@assistant-ui/x-changelog` at `packages/x-changelog/` containing the previously-local `changelog.cjs` (renamed to `index.cjs`).
- `.changeset/config.json` points at `@assistant-ui/x-changelog` by name.
- `@changesets/get-github-info` moves from a root devDependency to a dependency of the new package.
- Root `package.json` gains `"@assistant-ui/x-changelog": "workspace:*"` as a devDependency so pnpm symlinks it into the root `node_modules`.

## Test plan

- [x] `pnpm changeset status --since main` loads the config and lists bumped packages (no MODULE_NOT_FOUND)
- [x] `node -e "require('@assistant-ui/x-changelog')"` resolves the package
- [ ] Next `Create Version PR` run completes successfully on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)