### PR TITLE
feat: add chat-test-kit (v1)

### DIFF
--- a/.changeset/chat-test-kit-core.md
+++ b/.changeset/chat-test-kit-core.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/chat-test-kit-core": patch
+---
+
+feat: add chat-test-kit-core package
+
+Adds the transcript format (v0 grammar, 12 verbs), the `transcript()` DSL, canonical JSON + JSON Schema, parser, replayer state machine, virtual clock, failure injection (cancel, interrupt, transportError, disconnect, abortAndRestart), `RuntimeAdapter` interface, and headless reference adapter.

--- a/.changeset/chat-test-kit-react-initial.md
+++ b/.changeset/chat-test-kit-react-initial.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/chat-test-kit-react": patch
+---
+
+feat: initial release of chat-test-kit-react (M2).
+
+Adds `createChatTestHarness` (A-tier `waitForIdle/cancel` and C-tier `advanceChunk/advanceToolCall/inject.*`), the seven chat-aware matchers (`thread().on(harness).toHaveAssistantText`, `thread().toShowError`, `message(n).toHaveText`, `message(n).on(harness).toStreamCompletely`, `message(n).on(harness).toBeInterrupted`, `toolCall(name).toRenderResult`, `toolCall(name).on(harness).toHaveReceivedArgs`), and `setupChatTestKit()` for zero-config matcher registration. Drives a real `useLocalRuntime` via `@assistant-ui/react` public exports, and re-exports core transcript APIs so consumers only need to install `@assistant-ui/chat-test-kit-react`.

--- a/.changeset/chat-test-kit-react.md
+++ b/.changeset/chat-test-kit-react.md
@@ -2,6 +2,6 @@
 "@assistant-ui/chat-test-kit-react": patch
 ---
 
-feat: initial release of chat-test-kit-react (M2).
+feat: add chat-test-kit-react package
 
 Adds `createChatTestHarness` (A-tier `waitForIdle/cancel` and C-tier `advanceChunk/advanceToolCall/inject.*`), the seven chat-aware matchers (`thread().on(harness).toHaveAssistantText`, `thread().toShowError`, `message(n).toHaveText`, `message(n).on(harness).toStreamCompletely`, `message(n).on(harness).toBeInterrupted`, `toolCall(name).toRenderResult`, `toolCall(name).on(harness).toHaveReceivedArgs`), and `setupChatTestKit()` for zero-config matcher registration. Drives a real `useLocalRuntime` via `@assistant-ui/react` public exports, and re-exports core transcript APIs so consumers only need to install `@assistant-ui/chat-test-kit-react`.

--- a/apps/docs/content/docs/(docs)/guides/chat-test-kit-quickstart.mdx
+++ b/apps/docs/content/docs/(docs)/guides/chat-test-kit-quickstart.mdx
@@ -1,0 +1,118 @@
+---
+title: Chat Test Kit Quickstart
+description: Write deterministic transcript-driven tests for assistant-ui chat flows.
+---
+
+`@assistant-ui/chat-test-kit-react` is for UI behavior tests in chat apps: streaming text, tool call rendering, cancellation, and transport failures.
+
+It is not an eval framework for model-answer correctness.
+
+## Install
+
+```bash
+pnpm add -D @assistant-ui/chat-test-kit-react @testing-library/react @testing-library/user-event vitest jsdom
+```
+
+## Test Runner Setup
+
+`vitest.setup.ts`
+
+```ts
+import { setupChatTestKit } from "@assistant-ui/chat-test-kit-react";
+
+setupChatTestKit();
+```
+
+`vitest.config.ts`
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+  },
+});
+```
+
+## First Test
+
+```tsx
+import {
+  createChatTestHarness,
+  message,
+  thread,
+  transcript,
+} from "@assistant-ui/chat-test-kit-react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import Home from "../page";
+
+describe("chat", () => {
+  it("replays streamed assistant text", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .user("Check AAPL")
+        .assistantStream("AAPL is at $212.44.", {
+          chunks: ["AAPL is ", "at $212.44."],
+          interChunkDelayMs: 20,
+          finish: { reason: "stop" },
+        })
+        .toJSON(),
+    });
+
+    const user = userEvent.setup();
+    render(<Home />, { wrapper: harness.wrapper });
+
+    await user.type(screen.getByRole("textbox"), "Check AAPL");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await harness.waitForIdle();
+
+    expect(thread().on(harness)).toHaveAssistantText(/AAPL is at/);
+    expect(message(1).on(harness)).toStreamCompletely();
+  });
+});
+```
+
+## Common Pitfalls
+
+### jsdom Gaps
+
+Some full UI trees rely on browser APIs that jsdom does not implement fully (`ResizeObserver`, scroll behavior).
+
+Use a setup shim:
+
+```ts
+class ResizeObserverMock {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+}
+
+if (!Element.prototype.scrollTo) {
+  Element.prototype.scrollTo = () => {};
+}
+```
+
+### Full Page vs Primitive-First Harness
+
+When full app composition is brittle in tests (for example, CSS/plugin or runtime constraints), use a minimal primitive-first harness to isolate the behavior under test.
+
+### Keep Tests Offline
+
+Do not use live network paths in these tests. Drive all behavior from transcript replay so test timing and outcomes stay deterministic.
+
+## Next Steps
+
+- [Transcript format reference](/docs/chat-test-kit-transcript-format)
+- [Core package README](https://github.com/assistant-ui/assistant-ui/blob/main/packages/chat-test-kit-core/README.md)
+- [React package README](https://github.com/assistant-ui/assistant-ui/blob/main/packages/chat-test-kit-react/README.md)
+- [AI SDK example test](https://github.com/assistant-ui/assistant-ui/blob/main/examples/with-ai-sdk-v6/app/__tests__/chat-stream.test.tsx)
+- [LangGraph example test](https://github.com/assistant-ui/assistant-ui/blob/main/examples/with-langgraph/app/__tests__/tool-calls.test.tsx)
+- [Assistant transport example test](https://github.com/assistant-ui/assistant-ui/blob/main/examples/with-assistant-transport/app/__tests__/transport-and-cancel.test.tsx)

--- a/apps/docs/content/docs/(docs)/guides/meta.json
+++ b/apps/docs/content/docs/(docs)/guides/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "attachments",
     "branching",
+    "chat-test-kit-quickstart",
     "chain-of-thought",
     "context-api",
     "dictation",

--- a/apps/docs/content/docs/(reference)/chat-test-kit-transcript-format.mdx
+++ b/apps/docs/content/docs/(reference)/chat-test-kit-transcript-format.mdx
@@ -1,14 +1,9 @@
-# @assistant-ui/chat-test-kit-core
+---
+title: Chat Test Kit Transcript Format
+description: Canonical transcript grammar and JSON contract for chat-test-kit.
+---
 
-Transcript-driven testing for AI chat UIs: format spec, replayer, runtime adapter interface.
-
-This package defines a portable transcript format for AI chat conversations and a runtime-agnostic replayer that drives any adapter implementing `RuntimeAdapter`
-
-## Install
-
-```bash
-pnpm add -D @assistant-ui/chat-test-kit-core
-```
+This page documents the transcript contract shipped by `@assistant-ui/chat-test-kit-core`.
 
 ## Grammar
 
@@ -41,7 +36,11 @@ pnpm add -D @assistant-ui/chat-test-kit-core
       "args": { "ticker": "AAPL" },
       "argsText": "{\"ticker\":\"AAPL\"}"
     },
-    { "kind": "toolResult", "toolCallId": "tc_1", "value": { "price": 212.44 } },
+    {
+      "kind": "toolResult",
+      "toolCallId": "tc_1",
+      "value": { "price": 212.44 }
+    },
     {
       "kind": "assistantStream",
       "text": "AAPL is at $212.44.",
@@ -50,15 +49,15 @@ pnpm add -D @assistant-ui/chat-test-kit-core
       "finish": { "reason": "stop" }
     }
   ],
-  "injections": [
-    { "kind": "disconnect", "at": { "turnIndex": 3, "afterChunk": 1 } }
-  ]
+  "injections": [{ "kind": "disconnect", "at": { "turnIndex": 3, "afterChunk": 1 } }]
 }
 ```
 
-JSON Schema is published at `@assistant-ui/chat-test-kit-core/schema/transcript.schema.json`.
+Schema location:
 
-## RuntimeAdapter
+`@assistant-ui/chat-test-kit-core/schema/transcript.schema.json`
+
+## Runtime Adapter Contract
 
 ```ts
 interface RuntimeAdapter {
@@ -69,22 +68,23 @@ interface RuntimeAdapter {
 }
 ```
 
-## Replayer
+## Replayer Contract
 
 ```ts
-const r = new Replayer({ transcript, adapter, clock: new VirtualClock() });
-await r.tick();
-await r.advanceToNextTurn();
-await r.advanceToIdle();
-await r.cancel();
-r.state;
+const replayer = new Replayer({ transcript, adapter, clock: new VirtualClock() });
+
+await replayer.tick();
+await replayer.advanceToNextTurn();
+await replayer.advanceToIdle();
+await replayer.cancel();
+
+replayer.state;
 ```
 
-## Format Version
+`VirtualClock` ensures deterministic replay of stream timing (including inter-chunk delays) without wall-clock waiting.
 
-`version` is the grammar version, independent of the package version. Today it is `"0"`. While in `0.x`, breaking format changes are allowed; they bump `version` and are documented here.
+## Versioning Policy
 
-## Documentation
+`version` in transcript JSON is the grammar version, independent from npm package version.
 
-- Quickstart guide: `/docs/guides/chat-test-kit-quickstart`
-- Transcript format reference: `/docs/chat-test-kit-transcript-format`
+Current grammar version is `"0"`. If a breaking grammar change is introduced while packages are still in `0.x`, transcript `version` must be bumped and documented.

--- a/apps/docs/content/docs/(reference)/meta.json
+++ b/apps/docs/content/docs/(reference)/meta.json
@@ -2,5 +2,10 @@
   "title": "API Reference",
   "icon": "FileCode",
   "root": true,
-  "pages": ["...api-reference", "...migrations", "react-compatibility"]
+  "pages": [
+    "...api-reference",
+    "...migrations",
+    "chat-test-kit-transcript-format",
+    "react-compatibility"
+  ]
 }

--- a/examples/with-ai-sdk-v6/app/__tests__/chat-stream.test.tsx
+++ b/examples/with-ai-sdk-v6/app/__tests__/chat-stream.test.tsx
@@ -1,0 +1,45 @@
+import {
+  createChatTestHarness,
+  message,
+  setupChatTestKit,
+  thread,
+  transcript,
+} from "@assistant-ui/chat-test-kit-react";
+import { useAssistantRuntime } from "@assistant-ui/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import Home from "../page";
+
+vi.mock("@assistant-ui/react-ai-sdk", () => {
+  return {
+    useChatRuntime: () => useAssistantRuntime(),
+  };
+});
+
+setupChatTestKit();
+
+describe("with-ai-sdk-v6 chat-test-kit dogfood", () => {
+  it("replays a streamed assistant response", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .user("Check AAPL")
+        .assistantStream("AAPL is at $212.44.", {
+          chunks: ["AAPL is ", "at $212.44."],
+          interChunkDelayMs: 20,
+          finish: { reason: "stop" },
+        })
+        .toJSON(),
+    });
+
+    const user = userEvent.setup();
+    render(<Home />, { wrapper: harness.wrapper });
+
+    await user.type(screen.getByRole("textbox"), "Check AAPL");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await harness.waitForIdle();
+
+    expect(thread().on(harness)).toHaveAssistantText(/AAPL is at/);
+    expect(message(1).on(harness)).toStreamCompletely();
+  });
+});

--- a/examples/with-ai-sdk-v6/app/__tests__/matchers.d.ts
+++ b/examples/with-ai-sdk-v6/app/__tests__/matchers.d.ts
@@ -1,0 +1,23 @@
+import "vitest";
+
+declare module "vitest" {
+  interface Assertion<T = any> {
+    toHaveAssistantText(expected: string | RegExp): T;
+    toShowError(match?: string | RegExp): T;
+    toHaveText(expected: string): T;
+    toStreamCompletely(): T;
+    toBeInterrupted(): T;
+    toRenderResult(): T;
+    toHaveReceivedArgs(expected: Record<string, unknown>): T;
+  }
+
+  interface AsymmetricMatchersContaining {
+    toHaveAssistantText(expected: string | RegExp): void;
+    toShowError(match?: string | RegExp): void;
+    toHaveText(expected: string): void;
+    toStreamCompletely(): void;
+    toBeInterrupted(): void;
+    toRenderResult(): void;
+    toHaveReceivedArgs(expected: Record<string, unknown>): void;
+  }
+}

--- a/examples/with-ai-sdk-v6/app/page.tsx
+++ b/examples/with-ai-sdk-v6/app/page.tsx
@@ -9,7 +9,7 @@ import {
 } from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 
-function ThreadWithSuggestions() {
+export function ThreadWithSuggestions() {
   const aui = useAui({
     suggestions: Suggestions([
       {

--- a/examples/with-ai-sdk-v6/package.json
+++ b/examples/with-ai-sdk-v6/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.53",
@@ -25,14 +27,19 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@assistant-ui/chat-test-kit-react": "workspace:*",
     "@assistant-ui/x-buildutils": "workspace:*",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.5.2",
     "@tailwindcss/postcss": "^4.2.4",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.0.2",
     "postcss": "^8.5.10",
     "tailwindcss": "^4.2.4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/examples/with-ai-sdk-v6/vitest.config.ts
+++ b/examples/with-ai-sdk-v6/vitest.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@/components/assistant-ui/": new URL(
+        "../../packages/ui/src/components/assistant-ui/",
+        import.meta.url,
+      ).pathname,
+      "@/components/ui/": new URL(
+        "../../packages/ui/src/components/ui/",
+        import.meta.url,
+      ).pathname,
+      "@/lib/utils": new URL(
+        "../../packages/ui/src/lib/utils.ts",
+        import.meta.url,
+      ).pathname,
+      "@": new URL("./", import.meta.url).pathname,
+    },
+  },
+  css: {
+    postcss: {
+      plugins: [],
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["app/**/*.test.{ts,tsx}"],
+  },
+});

--- a/examples/with-ai-sdk-v6/vitest.setup.ts
+++ b/examples/with-ai-sdk-v6/vitest.setup.ts
@@ -1,0 +1,13 @@
+class ResizeObserverMock {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+}
+
+if (!Element.prototype.scrollTo) {
+  Element.prototype.scrollTo = () => {};
+}

--- a/examples/with-assistant-transport/app/__tests__/matchers.d.ts
+++ b/examples/with-assistant-transport/app/__tests__/matchers.d.ts
@@ -1,0 +1,23 @@
+import "vitest";
+
+declare module "vitest" {
+  interface Assertion<T = any> {
+    toHaveAssistantText(expected: string | RegExp): T;
+    toShowError(match?: string | RegExp): T;
+    toHaveText(expected: string): T;
+    toStreamCompletely(): T;
+    toBeInterrupted(): T;
+    toRenderResult(): T;
+    toHaveReceivedArgs(expected: Record<string, unknown>): T;
+  }
+
+  interface AsymmetricMatchersContaining {
+    toHaveAssistantText(expected: string | RegExp): void;
+    toShowError(match?: string | RegExp): void;
+    toHaveText(expected: string): void;
+    toStreamCompletely(): void;
+    toBeInterrupted(): void;
+    toRenderResult(): void;
+    toHaveReceivedArgs(expected: Record<string, unknown>): void;
+  }
+}

--- a/examples/with-assistant-transport/app/__tests__/transport-and-cancel.test.tsx
+++ b/examples/with-assistant-transport/app/__tests__/transport-and-cancel.test.tsx
@@ -1,0 +1,134 @@
+import {
+  createChatTestHarness,
+  message,
+  setupChatTestKit,
+  thread,
+  transcript,
+  type ChatTestHarness,
+} from "@assistant-ui/chat-test-kit-react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect, useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import Home from "../page";
+
+vi.mock("../MyRuntimeProvider", () => {
+  return {
+    MyRuntimeProvider: ({ children }: { children: React.ReactNode }) =>
+      children,
+  };
+});
+
+function ErrorSurface({ harness }: { harness: ChatTestHarness }) {
+  const [errorText, setErrorText] = useState<string | null>(null);
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      const state = harness.getReplayState();
+      if (state.phase === "error" && state.lastError) {
+        setErrorText(state.lastError.message);
+      }
+    }, 10);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [harness]);
+
+  if (!errorText) return null;
+
+  return <div data-testid="aui-error">{errorText}</div>;
+}
+
+setupChatTestKit();
+
+describe("with-assistant-transport chat-test-kit dogfood", () => {
+  it("marks a message interrupted when cancelled mid-stream", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .user("Weather in SF")
+        .assistantStream("Checking weather...", {
+          chunks: ["Checking ", "weather..."],
+          interChunkDelayMs: 20,
+        })
+        .toJSON(),
+      autoAdvance: false,
+    });
+
+    const user = userEvent.setup();
+    render(
+      <>
+        <Home />
+        <ErrorSurface harness={harness} />
+      </>,
+      { wrapper: harness.wrapper },
+    );
+
+    await user.type(screen.getByRole("textbox"), "Weather in SF");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    await harness.advanceToolCall();
+    await harness.advanceChunk();
+    await harness.cancel();
+
+    expect(message(1).on(harness)).toBeInterrupted();
+  });
+
+  it("surfaces disconnect and transport failures", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .user("Weather in SF")
+        .assistantStream("Let me check that", {
+          chunks: ["Let me ", "check that"],
+        })
+        .inject.disconnect({ afterChunk: 1 })
+        .toJSON(),
+    });
+
+    const user = userEvent.setup();
+    render(
+      <>
+        <Home />
+        <ErrorSurface harness={harness} />
+      </>,
+      { wrapper: harness.wrapper },
+    );
+
+    await user.type(screen.getByRole("textbox"), "Weather in SF");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await harness.waitForIdle();
+
+    expect(message(1).on(harness)).toBeInterrupted();
+
+    await waitFor(() => {
+      expect(thread()).toShowError(/disconnected/i);
+    });
+  });
+
+  it("surfaces transport error code/message", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .user("Weather in SF")
+        .assistantStream("Let me check that")
+        .inject.transportError({ code: 500, message: "transport down" })
+        .toJSON(),
+    });
+
+    const user = userEvent.setup();
+    render(
+      <>
+        <Home />
+        <ErrorSurface harness={harness} />
+      </>,
+      { wrapper: harness.wrapper },
+    );
+
+    await user.type(screen.getByRole("textbox"), "Weather in SF");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await harness.waitForIdle();
+
+    await waitFor(() => {
+      expect(thread()).toShowError(/transport down/i);
+    });
+  });
+});

--- a/examples/with-assistant-transport/package.json
+++ b/examples/with-assistant-transport/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@assistant-ui/react": "workspace:*",
@@ -23,14 +25,19 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@assistant-ui/chat-test-kit-react": "workspace:*",
     "@assistant-ui/x-buildutils": "workspace:*",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.5.2",
     "@tailwindcss/postcss": "^4.2.4",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.0.2",
     "postcss": "^8.5.10",
     "tailwindcss": "^4.2.4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/examples/with-assistant-transport/vitest.config.ts
+++ b/examples/with-assistant-transport/vitest.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@/components/assistant-ui/": new URL(
+        "../../packages/ui/src/components/assistant-ui/",
+        import.meta.url,
+      ).pathname,
+      "@/components/ui/": new URL(
+        "../../packages/ui/src/components/ui/",
+        import.meta.url,
+      ).pathname,
+      "@/lib/utils": new URL(
+        "../../packages/ui/src/lib/utils.ts",
+        import.meta.url,
+      ).pathname,
+      "@": new URL("./", import.meta.url).pathname,
+    },
+  },
+  css: {
+    postcss: {
+      plugins: [],
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["app/**/*.test.{ts,tsx}"],
+  },
+});

--- a/examples/with-assistant-transport/vitest.setup.ts
+++ b/examples/with-assistant-transport/vitest.setup.ts
@@ -1,0 +1,13 @@
+class ResizeObserverMock {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+}
+
+if (!Element.prototype.scrollTo) {
+  Element.prototype.scrollTo = () => {};
+}

--- a/examples/with-langgraph/app/__tests__/matchers.d.ts
+++ b/examples/with-langgraph/app/__tests__/matchers.d.ts
@@ -1,0 +1,23 @@
+import "vitest";
+
+declare module "vitest" {
+  interface Assertion<T = any> {
+    toHaveAssistantText(expected: string | RegExp): T;
+    toShowError(match?: string | RegExp): T;
+    toHaveText(expected: string): T;
+    toStreamCompletely(): T;
+    toBeInterrupted(): T;
+    toRenderResult(): T;
+    toHaveReceivedArgs(expected: Record<string, unknown>): T;
+  }
+
+  interface AsymmetricMatchersContaining {
+    toHaveAssistantText(expected: string | RegExp): void;
+    toShowError(match?: string | RegExp): void;
+    toHaveText(expected: string): void;
+    toStreamCompletely(): void;
+    toBeInterrupted(): void;
+    toRenderResult(): void;
+    toHaveReceivedArgs(expected: Record<string, unknown>): void;
+  }
+}

--- a/examples/with-langgraph/app/__tests__/tool-calls.test.tsx
+++ b/examples/with-langgraph/app/__tests__/tool-calls.test.tsx
@@ -1,0 +1,80 @@
+import {
+  createChatTestHarness,
+  setupChatTestKit,
+  thread,
+  toolCall,
+  transcript,
+} from "@assistant-ui/chat-test-kit-react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import Home from "../page";
+
+setupChatTestKit();
+
+function priceSnapshotTranscript() {
+  return transcript()
+    .user("What is AAPL?")
+    .assistantToolCall(
+      "price_snapshot",
+      { ticker: "AAPL" },
+      { toolCallId: "tc_1" },
+    )
+    .toolResult(
+      JSON.stringify({
+        snapshot: {
+          price: 212.44,
+          day_change: 1.2,
+          day_change_percent: 0.57,
+          time: "2026-04-25T10:00:00.000Z",
+        },
+      }),
+    )
+    .assistantStream("AAPL is $212.44.", {
+      chunks: ["AAPL is ", "$212.44."],
+      finish: { reason: "stop" },
+    })
+    .toJSON();
+}
+
+describe("with-langgraph chat-test-kit dogfood", () => {
+  it("replays tool call args and rendered result", async () => {
+    const harness = createChatTestHarness({
+      transcript: priceSnapshotTranscript(),
+    });
+
+    const user = userEvent.setup();
+    render(<Home />, { wrapper: harness.wrapper });
+
+    await user.type(screen.getByRole("textbox"), "What is AAPL?");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await harness.waitForIdle();
+
+    expect(toolCall("price_snapshot").on(harness)).toHaveReceivedArgs({
+      ticker: "AAPL",
+    });
+    expect(toolCall("price_snapshot")).toRenderResult();
+  });
+
+  it("supports C-tier step progression through tool and stream phases", async () => {
+    const harness = createChatTestHarness({
+      transcript: priceSnapshotTranscript(),
+      autoAdvance: false,
+    });
+
+    const user = userEvent.setup();
+    render(<Home />, { wrapper: harness.wrapper });
+
+    await user.type(screen.getByRole("textbox"), "What is AAPL?");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    await harness.advanceToolCall();
+    await harness.advanceToolCall();
+    await harness.advanceToolCall();
+    await harness.advanceChunk();
+
+    expect(thread().on(harness)).toHaveAssistantText("AAPL is ");
+
+    await harness.waitForIdle();
+  });
+});

--- a/examples/with-langgraph/components/tools/price-snapshot/PriceSnapshotTool.tsx
+++ b/examples/with-langgraph/components/tools/price-snapshot/PriceSnapshotTool.tsx
@@ -25,7 +25,10 @@ export const PriceSnapshotTool = makeAssistantToolUI<
       : undefined;
 
     return (
-      <div className="mb-4 flex flex-col items-center gap-2">
+      <div
+        data-tool-name="price_snapshot"
+        className="mb-4 flex flex-col items-center gap-2"
+      >
         <pre className="whitespace-pre-wrap">price_snapshot({argsText})</pre>
         {resultObj && (
           <PriceSnapshot ticker={args.ticker} {...resultObj.snapshot} />

--- a/examples/with-langgraph/package.json
+++ b/examples/with-langgraph/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@assistant-ui/react": "workspace:*",
@@ -23,14 +25,19 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@assistant-ui/chat-test-kit-react": "workspace:*",
     "@assistant-ui/x-buildutils": "workspace:*",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.5.2",
     "@tailwindcss/postcss": "^4.2.4",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.0.2",
     "postcss": "^8.5.10",
     "tailwindcss": "^4.2.4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/examples/with-langgraph/vitest.config.ts
+++ b/examples/with-langgraph/vitest.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@/components/assistant-ui/": new URL(
+        "../../packages/ui/src/components/assistant-ui/",
+        import.meta.url,
+      ).pathname,
+      "@/components/ui/": new URL(
+        "../../packages/ui/src/components/ui/",
+        import.meta.url,
+      ).pathname,
+      "@/lib/utils": new URL(
+        "../../packages/ui/src/lib/utils.ts",
+        import.meta.url,
+      ).pathname,
+      "@": new URL("./", import.meta.url).pathname,
+    },
+  },
+  css: {
+    postcss: {
+      plugins: [],
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["app/**/*.test.{ts,tsx}"],
+  },
+});

--- a/examples/with-langgraph/vitest.setup.ts
+++ b/examples/with-langgraph/vitest.setup.ts
@@ -1,0 +1,13 @@
+class ResizeObserverMock {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+}
+
+if (!Element.prototype.scrollTo) {
+  Element.prototype.scrollTo = () => {};
+}

--- a/packages/chat-test-kit-core/README.md
+++ b/packages/chat-test-kit-core/README.md
@@ -1,0 +1,85 @@
+# @assistant-ui/chat-test-kit-core
+
+Transcript-driven testing for AI chat UIs: format spec, replayer, runtime adapter interface.
+
+This package defines a portable transcript format for AI chat conversations and a runtime-agnostic replayer that drives any adapter implementing `RuntimeAdapter`. It does not depend on React or any `@assistant-ui/*` package.
+
+## Install
+
+```bash
+pnpm add -D @assistant-ui/chat-test-kit-core
+```
+
+## Grammar
+
+| Category | Verb | Purpose |
+|---|---|---|
+| Turn | `user(content)` | A user message |
+| Turn | `assistantStream(text, { chunks, interChunkDelayMs, finish })` | A streamed assistant text reply |
+| Turn | `assistantToolCall(name, args, { toolCallId? })` | Assistant emits a tool call |
+| Turn | `toolResult(value)` | The result of the most recent tool call |
+| Failure | `inject.cancel()` | Simulate user pressing stop |
+| Failure | `inject.interrupt(reason?)` | Generic interrupt |
+| Failure | `inject.transportError({ code?, message })` | Transport layer error |
+| Failure | `inject.disconnect({ afterChunk })` | Drop the connection mid-stream |
+| Failure | `inject.abortAndRestart()` | Abort and restart the transcript |
+| Timing | `delayMs(ms)` | Advance the virtual clock |
+| Timing | implicit chunk boundary | Each entry of `chunks[]` is a boundary |
+| Meta | `metadata(data)` | Arbitrary JSON object attached to the turn list |
+
+## Canonical JSON
+
+```json
+{
+  "version": "0",
+  "turns": [
+    { "kind": "user", "content": [{ "type": "text", "text": "Check AAPL" }] },
+    {
+      "kind": "assistantToolCall",
+      "toolCallId": "tc_1",
+      "name": "get_stock_price",
+      "args": { "ticker": "AAPL" },
+      "argsText": "{\"ticker\":\"AAPL\"}"
+    },
+    { "kind": "toolResult", "toolCallId": "tc_1", "value": { "price": 212.44 } },
+    {
+      "kind": "assistantStream",
+      "text": "AAPL is at $212.44.",
+      "chunks": ["AAPL is ", "at $212.44."],
+      "interChunkDelayMs": 20,
+      "finish": { "reason": "stop" }
+    }
+  ],
+  "injections": [
+    { "kind": "disconnect", "at": { "turnIndex": 3, "afterChunk": 1 } }
+  ]
+}
+```
+
+JSON Schema is published at `@assistant-ui/chat-test-kit-core/schema/transcript.schema.json`.
+
+## RuntimeAdapter
+
+```ts
+interface RuntimeAdapter {
+  sendUserMessage(content: ContentPart[]): Promise<void>;
+  emit(event: AssistantEvent): Promise<void>;
+  getSnapshot(): RuntimeSnapshot;
+  abort(): Promise<void>;
+}
+```
+
+## Replayer
+
+```ts
+const r = new Replayer({ transcript, adapter, clock: new VirtualClock() });
+await r.tick();
+await r.advanceToNextTurn();
+await r.advanceToIdle();
+await r.cancel();
+r.state;
+```
+
+## Format Version
+
+`version` is the grammar version, independent of the package version. Today it is `"0"`. While in `0.x`, breaking format changes are allowed; they bump `version` and are documented here.

--- a/packages/chat-test-kit-core/package.json
+++ b/packages/chat-test-kit-core/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@assistant-ui/chat-test-kit-core",
+  "version": "0.0.0",
+  "description": "Transcript-driven testing for AI chat UIs - format, replayer, runtime adapter interface.",
+  "keywords": [
+    "assistant-ui",
+    "testing",
+    "chat",
+    "transcript",
+    "replay"
+  ],
+  "author": "AgentbaseAI Inc.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./schema/transcript.schema.json": "./schema/transcript.schema.json"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "schema",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "aui-build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@assistant-ui/x-buildutils": "workspace:*",
+    "@types/node": "^25.6.0",
+    "ajv": "^8.17.1",
+    "vitest": "^4.1.5"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://www.assistant-ui.com/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/assistant-ui/assistant-ui.git",
+    "directory": "packages/chat-test-kit-core"
+  },
+  "bugs": {
+    "url": "https://github.com/assistant-ui/assistant-ui/issues"
+  }
+}

--- a/packages/chat-test-kit-core/schema/transcript.schema.json
+++ b/packages/chat-test-kit-core/schema/transcript.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assistant-ui.com/schema/chat-test-kit/transcript-v0.json",
+  "title": "Transcript v0",
+  "type": "object",
+  "required": ["version", "turns", "injections"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "const": "0" },
+    "turns": { "type": "array", "items": { "$ref": "#/$defs/Turn" } },
+    "injections": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Injection" }
+    }
+  },
+  "$defs": {
+    "ContentPart": {
+      "oneOf": [
+        { "$ref": "#/$defs/TextPart" },
+        { "$ref": "#/$defs/ToolCallPart" }
+      ]
+    },
+    "TextPart": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "text"],
+      "properties": {
+        "type": { "const": "text" },
+        "text": { "type": "string" }
+      }
+    },
+    "ToolCallPart": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "toolCallId", "toolName", "args", "argsText"],
+      "properties": {
+        "type": { "const": "tool-call" },
+        "toolCallId": { "type": "string" },
+        "toolName": { "type": "string" },
+        "args": { "type": "object" },
+        "argsText": { "type": "string" }
+      }
+    },
+    "Turn": {
+      "oneOf": [
+        { "$ref": "#/$defs/UserTurn" },
+        { "$ref": "#/$defs/AssistantStreamTurn" },
+        { "$ref": "#/$defs/AssistantToolCallTurn" },
+        { "$ref": "#/$defs/ToolResultTurn" },
+        { "$ref": "#/$defs/DelayTurn" },
+        { "$ref": "#/$defs/MetadataTurn" }
+      ]
+    },
+    "UserTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "content"],
+      "properties": {
+        "kind": { "const": "user" },
+        "content": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ContentPart" }
+        }
+      }
+    },
+    "AssistantStreamTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "text", "chunks"],
+      "properties": {
+        "kind": { "const": "assistantStream" },
+        "text": { "type": "string" },
+        "chunks": { "type": "array", "items": { "type": "string" } },
+        "interChunkDelayMs": { "type": "integer", "minimum": 0 },
+        "finish": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["reason"],
+          "properties": {
+            "reason": { "enum": ["stop", "abort", "error"] }
+          }
+        }
+      }
+    },
+    "AssistantToolCallTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "toolCallId", "name", "args", "argsText"],
+      "properties": {
+        "kind": { "const": "assistantToolCall" },
+        "toolCallId": { "type": "string" },
+        "name": { "type": "string" },
+        "args": { "type": "object" },
+        "argsText": { "type": "string" }
+      }
+    },
+    "ToolResultTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "toolCallId", "value"],
+      "properties": {
+        "kind": { "const": "toolResult" },
+        "toolCallId": { "type": "string" },
+        "value": {}
+      }
+    },
+    "DelayTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "ms"],
+      "properties": {
+        "kind": { "const": "delay" },
+        "ms": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "MetadataTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "data"],
+      "properties": {
+        "kind": { "const": "metadata" },
+        "data": { "type": "object" }
+      }
+    },
+    "InjectionPosition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["turnIndex"],
+      "properties": {
+        "turnIndex": { "type": "integer", "minimum": 0 },
+        "afterChunk": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "Injection": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "at"],
+          "properties": {
+            "kind": { "enum": ["cancel", "abortAndRestart"] },
+            "at": { "$ref": "#/$defs/InjectionPosition" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "at"],
+          "properties": {
+            "kind": { "const": "interrupt" },
+            "at": { "$ref": "#/$defs/InjectionPosition" },
+            "reason": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "at", "message"],
+          "properties": {
+            "kind": { "const": "transportError" },
+            "at": { "$ref": "#/$defs/InjectionPosition" },
+            "code": { "type": "integer" },
+            "message": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "at"],
+          "properties": {
+            "kind": { "const": "disconnect" },
+            "at": {
+              "allOf": [
+                { "$ref": "#/$defs/InjectionPosition" },
+                { "type": "object", "required": ["afterChunk"] }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/packages/chat-test-kit-core/src/__tests__/adapter-types.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/adapter-types.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  AssistantEvent,
+  RuntimeAdapter,
+  RuntimeSnapshot,
+} from "../adapter/types";
+import type { ContentPart } from "../transcript/types";
+
+describe("adapter types", () => {
+  it("AssistantEvent variants", () => {
+    const events: AssistantEvent[] = [
+      { type: "text-delta", delta: "hi" },
+      {
+        type: "tool-call",
+        toolCallId: "tc_1",
+        toolName: "x",
+        args: {},
+        argsText: "{}",
+      },
+      { type: "tool-result", toolCallId: "tc_1", value: 1 },
+      { type: "finish", reason: "stop" },
+      { type: "transport-error", message: "boom" },
+      { type: "disconnect" },
+    ];
+    expect(events).toHaveLength(6);
+  });
+
+  it("RuntimeAdapter interface is implementable", () => {
+    const adapter: RuntimeAdapter = {
+      async sendUserMessage(_content: ContentPart[]) {},
+      async emit(_event: AssistantEvent) {},
+      getSnapshot(): RuntimeSnapshot {
+        return { events: [], abortCount: 0, userMessages: [] };
+      },
+      async abort() {},
+    };
+    expect(typeof adapter.emit).toBe("function");
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/builder-assistant-stream.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/builder-assistant-stream.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { transcript } from "../transcript/builder";
+
+describe("transcript().assistantStream()", () => {
+  it("text-only defaults to a single chunk equal to text", () => {
+    expect(
+      transcript().assistantStream("hello world").toJSON().turns[0],
+    ).toEqual({
+      kind: "assistantStream",
+      text: "hello world",
+      chunks: ["hello world"],
+    });
+  });
+
+  it("explicit chunks must concatenate to text", () => {
+    expect(() =>
+      transcript().assistantStream("hello world", {
+        chunks: ["hel", "lo"],
+      }),
+    ).toThrow(/chunks.*concatenate/i);
+  });
+
+  it("interChunkDelayMs is preserved", () => {
+    const turn = transcript()
+      .assistantStream("hi", { chunks: ["h", "i"], interChunkDelayMs: 25 })
+      .toJSON().turns[0];
+    expect(turn).toMatchObject({ interChunkDelayMs: 25 });
+  });
+
+  it("finish defaults to undefined; explicit finish is preserved", () => {
+    const turn = transcript()
+      .assistantStream("hi", { finish: { reason: "stop" } })
+      .toJSON().turns[0];
+    expect(turn).toMatchObject({ finish: { reason: "stop" } });
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/builder-inject.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/builder-inject.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { transcript } from "../transcript/builder";
+
+describe("transcript().inject", () => {
+  it("cancel records at the most recent turn", () => {
+    expect(transcript().user("hi").inject.cancel().toJSON().injections).toEqual(
+      [{ kind: "cancel", at: { turnIndex: 0 } }],
+    );
+  });
+
+  it("interrupt with reason", () => {
+    expect(
+      transcript().user("hi").inject.interrupt("user-pressed-stop").toJSON()
+        .injections[0],
+    ).toEqual({
+      kind: "interrupt",
+      at: { turnIndex: 0 },
+      reason: "user-pressed-stop",
+    });
+  });
+
+  it("transportError with code and message", () => {
+    expect(
+      transcript()
+        .user("hi")
+        .inject.transportError({ code: 500, message: "boom" })
+        .toJSON().injections[0],
+    ).toEqual({
+      kind: "transportError",
+      at: { turnIndex: 0 },
+      code: 500,
+      message: "boom",
+    });
+  });
+
+  it("abortAndRestart", () => {
+    expect(
+      transcript().user("hi").inject.abortAndRestart().toJSON().injections[0],
+    ).toEqual({
+      kind: "abortAndRestart",
+      at: { turnIndex: 0 },
+    });
+  });
+
+  it("inject before any turn throws", () => {
+    expect(() => transcript().inject.cancel()).toThrow(/at least one turn/i);
+  });
+
+  it("returns a ReadyBuilder so chaining continues", () => {
+    const t = transcript().user("hi").inject.cancel().user("retry").toJSON();
+    expect(t.turns).toHaveLength(2);
+    expect(t.injections).toHaveLength(1);
+  });
+});
+
+describe("inject.disconnect", () => {
+  it("targets the most recent assistantStream turn with afterChunk", () => {
+    const t = transcript()
+      .user("q")
+      .assistantStream("hello world", { chunks: ["hello ", "world"] })
+      .inject.disconnect({ afterChunk: 1 })
+      .toJSON();
+
+    expect(t.injections).toEqual([
+      { kind: "disconnect", at: { turnIndex: 1, afterChunk: 1 } },
+    ]);
+  });
+
+  it("disconnect is not on the inject namespace before a stream", () => {
+    const ready = transcript().user("hi");
+    expect(() => {
+      // @ts-expect-error disconnect requires an immediately-prior assistantStream.
+      ready.inject.disconnect({ afterChunk: 0 });
+    }).toThrow();
+  });
+
+  it("disconnect afterChunk out of range throws", () => {
+    expect(() =>
+      transcript()
+        .assistantStream("hi", { chunks: ["h", "i"] })
+        .inject.disconnect({ afterChunk: 5 }),
+    ).toThrow(/afterChunk/i);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/builder-meta-timing.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/builder-meta-timing.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { transcript } from "../transcript/builder";
+
+describe("transcript().metadata() / delayMs()", () => {
+  it("metadata appends a metadata turn", () => {
+    expect(transcript().metadata({ runId: "r1" }).toJSON().turns[0]).toEqual({
+      kind: "metadata",
+      data: { runId: "r1" },
+    });
+  });
+
+  it("delayMs appends a delay turn", () => {
+    expect(transcript().delayMs(50).toJSON().turns[0]).toEqual({
+      kind: "delay",
+      ms: 50,
+    });
+  });
+
+  it("delayMs rejects negative values", () => {
+    expect(() => transcript().delayMs(-1)).toThrow(/non-negative/i);
+  });
+
+  it("metadata is callable from any ready state and chains as Ready", () => {
+    const t = transcript()
+      .user("hi")
+      .metadata({ tag: "before-stream" })
+      .assistantStream("hello")
+      .metadata({ tag: "after-stream" })
+      .toJSON();
+    expect(t.turns.map((turn) => turn.kind)).toEqual([
+      "user",
+      "metadata",
+      "assistantStream",
+      "metadata",
+    ]);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/builder-tool-call.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/builder-tool-call.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { transcript } from "../transcript/builder";
+
+describe("transcript().assistantToolCall() / toolResult()", () => {
+  it("auto-generates a toolCallId and serializes args to argsText", () => {
+    const t = transcript()
+      .assistantToolCall("get_stock_price", { ticker: "AAPL" })
+      .toolResult({ price: 212.44 })
+      .toJSON();
+
+    expect(t.turns).toHaveLength(2);
+    expect(t.turns[0]).toMatchObject({
+      kind: "assistantToolCall",
+      toolCallId: "tc_1",
+      name: "get_stock_price",
+      args: { ticker: "AAPL" },
+      argsText: '{"ticker":"AAPL"}',
+    });
+    expect(t.turns[1]).toEqual({
+      kind: "toolResult",
+      toolCallId: "tc_1",
+      value: { price: 212.44 },
+    });
+  });
+
+  it("explicit toolCallId is honored", () => {
+    const t = transcript()
+      .assistantToolCall("x", {}, { toolCallId: "tc_custom" })
+      .toolResult(1)
+      .toJSON();
+    expect(t.turns[0]).toMatchObject({ toolCallId: "tc_custom" });
+    expect(t.turns[1]).toMatchObject({ toolCallId: "tc_custom" });
+  });
+
+  it("toolResult is not callable on a Ready builder", () => {
+    const ready = transcript();
+    expect(() => {
+      // @ts-expect-error toolResult only exists after assistantToolCall.
+      ready.toolResult(1);
+    }).toThrow(/assistantToolCall/);
+    expect(() =>
+      (
+        transcript() as unknown as { toolResult: (v: unknown) => unknown }
+      ).toolResult(1),
+    ).toThrow(/assistantToolCall/);
+  });
+
+  it("two consecutive tool calls chain through toolResult", () => {
+    const t = transcript()
+      .assistantToolCall("a", {})
+      .toolResult(1)
+      .assistantToolCall("b", {})
+      .toolResult(2)
+      .toJSON();
+    expect(t.turns).toHaveLength(4);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/builder-user.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/builder-user.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { transcript } from "../transcript/builder";
+
+describe("transcript().user()", () => {
+  it("string content becomes a single text part", () => {
+    expect(transcript().user("hello").toJSON()).toEqual({
+      version: "0",
+      turns: [{ kind: "user", content: [{ type: "text", text: "hello" }] }],
+      injections: [],
+    });
+  });
+
+  it("array content is preserved as-is", () => {
+    const t = transcript()
+      .user([
+        { type: "text", text: "see file" },
+        { type: "text", text: "now" },
+      ])
+      .toJSON();
+
+    expect(t.turns[0]).toEqual({
+      kind: "user",
+      content: [
+        { type: "text", text: "see file" },
+        { type: "text", text: "now" },
+      ],
+    });
+  });
+
+  it("multiple user turns chain", () => {
+    expect(transcript().user("a").user("b").toJSON().turns).toHaveLength(2);
+  });
+
+  it("returned JSON is a fresh object on each call", () => {
+    const builder = transcript().user("a");
+    const first = builder.toJSON();
+    const second = builder.toJSON();
+    expect(first).not.toBe(second);
+    expect(first).toEqual(second);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/conformance.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/conformance.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createHeadlessAdapter,
+  Replayer,
+  transcript,
+  Transcript,
+  VirtualClock,
+} from "../index";
+
+describe("format conformance via headless adapter", () => {
+  it("happy path: user to tool-call to tool-result to stream to finish", async () => {
+    const parsed = Transcript.fromJSON(
+      transcript()
+        .user("Check AAPL")
+        .assistantToolCall("get_stock_price", { ticker: "AAPL" })
+        .toolResult({ price: 212.44 })
+        .assistantStream("AAPL is at $212.44.", {
+          chunks: ["AAPL is ", "at $212.44."],
+          interChunkDelayMs: 20,
+          finish: { reason: "stop" },
+        })
+        .toJSON(),
+    );
+    const adapter = createHeadlessAdapter();
+    const clock = new VirtualClock();
+    const r = new Replayer({ transcript: parsed, adapter, clock });
+
+    await r.advanceToIdle();
+
+    expect(r.state.phase).toBe("complete");
+    expect(clock.now()).toBe(20);
+    expect(adapter.getSnapshot().events.map((event) => event.type)).toEqual([
+      "tool-call",
+      "tool-result",
+      "text-delta",
+      "text-delta",
+      "finish",
+    ]);
+  });
+
+  it("disconnect mid-stream", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: Transcript.fromJSON(
+        transcript()
+          .assistantStream("ab", { chunks: ["a", "b"] })
+          .inject.disconnect({ afterChunk: 0 })
+          .toJSON(),
+      ),
+      adapter,
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+    expect(r.state.phase).toBe("error");
+    expect(adapter.getSnapshot().events.map((event) => event.type)).toEqual([
+      "text-delta",
+      "disconnect",
+    ]);
+  });
+
+  it("transport error before stream", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: Transcript.fromJSON(
+        transcript()
+          .user("hi")
+          .assistantStream("never")
+          .inject.transportError({ code: 503, message: "unavailable" })
+          .toJSON(),
+      ),
+      adapter,
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+    expect(r.state.phase).toBe("error");
+    expect(r.state.lastError).toEqual({ code: 503, message: "unavailable" });
+  });
+
+  it("cancel injection at a turn", async () => {
+    const r = new Replayer({
+      transcript: Transcript.fromJSON(
+        transcript()
+          .user("hi")
+          .assistantStream("hello")
+          .inject.cancel()
+          .toJSON(),
+      ),
+      adapter: createHeadlessAdapter(),
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+    expect(r.state.phase).toBe("cancelled");
+  });
+
+  it("abortAndRestart re-runs the transcript once", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: Transcript.fromJSON(
+        transcript()
+          .user("hi")
+          .assistantStream("nope", { chunks: ["no", "pe"] })
+          .inject.abortAndRestart()
+          .toJSON(),
+      ),
+      adapter,
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+    expect(adapter.getSnapshot().abortCount).toBe(1);
+    expect(adapter.getSnapshot().userMessages).toHaveLength(2);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/headless-adapter.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/headless-adapter.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { createHeadlessAdapter } from "../adapter/headless";
+
+describe("createHeadlessAdapter", () => {
+  it("records sent user messages and emitted events in order", async () => {
+    const adapter = createHeadlessAdapter();
+
+    await adapter.sendUserMessage([{ type: "text", text: "hi" }]);
+    await adapter.emit({ type: "text-delta", delta: "Hel" });
+    await adapter.emit({ type: "text-delta", delta: "lo" });
+    await adapter.emit({ type: "finish", reason: "stop" });
+
+    expect(adapter.getSnapshot()).toEqual({
+      userMessages: [[{ type: "text", text: "hi" }]],
+      events: [
+        { type: "text-delta", delta: "Hel" },
+        { type: "text-delta", delta: "lo" },
+        { type: "finish", reason: "stop" },
+      ],
+      abortCount: 0,
+    });
+  });
+
+  it("abort() increments abortCount", async () => {
+    const adapter = createHeadlessAdapter();
+    await adapter.abort();
+    await adapter.abort();
+    expect(adapter.getSnapshot().abortCount).toBe(2);
+  });
+
+  it("getSnapshot returns a defensive copy", async () => {
+    const adapter = createHeadlessAdapter();
+    await adapter.emit({ type: "disconnect" });
+    const first = adapter.getSnapshot();
+    await adapter.emit({ type: "finish", reason: "abort" });
+    const second = adapter.getSnapshot();
+    expect(first.events).toHaveLength(1);
+    expect(second.events).toHaveLength(2);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/parse.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/parse.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { transcript } from "../transcript/builder";
+import { Transcript } from "../transcript/parse";
+
+describe("Transcript.fromJSON", () => {
+  it("accepts a builder-produced transcript and returns it as-is shape", () => {
+    const built = transcript().user("hi").toJSON();
+    expect(Transcript.fromJSON(built)).toEqual(built);
+  });
+
+  it("rejects a malformed transcript with a descriptive error", () => {
+    expect(() =>
+      Transcript.fromJSON({ version: "9", turns: [], injections: [] }),
+    ).toThrow(/version/i);
+  });
+
+  it("rejects a non-object input", () => {
+    expect(() => Transcript.fromJSON(null)).toThrow();
+    expect(() => Transcript.fromJSON("x")).toThrow();
+  });
+
+  it("rejects mismatched chunks vs text", () => {
+    expect(() =>
+      Transcript.fromJSON({
+        version: "0",
+        turns: [
+          { kind: "assistantStream", text: "hello", chunks: ["he", "X"] },
+        ],
+        injections: [],
+      }),
+    ).toThrow(/chunks.*concatenate/i);
+  });
+
+  it("rejects toolResult that does not match an open tool call", () => {
+    expect(() =>
+      Transcript.fromJSON({
+        version: "0",
+        turns: [{ kind: "toolResult", toolCallId: "tc_missing", value: 1 }],
+        injections: [],
+      }),
+    ).toThrow(/toolResult.*tc_missing/i);
+  });
+
+  it("rejects disconnect injection whose target is not an assistantStream", () => {
+    expect(() =>
+      Transcript.fromJSON({
+        version: "0",
+        turns: [{ kind: "user", content: [] }],
+        injections: [
+          { kind: "disconnect", at: { turnIndex: 0, afterChunk: 0 } },
+        ],
+      }),
+    ).toThrow(/disconnect.*assistantStream/i);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/public-api.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/public-api.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import * as api from "../index";
+
+describe("public API surface", () => {
+  it("exports the documented value identifiers", () => {
+    expect(typeof api.transcript).toBe("function");
+    expect(typeof api.Transcript.fromJSON).toBe("function");
+    expect(typeof api.createHeadlessAdapter).toBe("function");
+    expect(typeof api.Replayer).toBe("function");
+    expect(typeof api.VirtualClock).toBe("function");
+    expect(api.TRANSCRIPT_VERSION).toBe("0");
+    expect(typeof api.transcriptSchema).toBe("object");
+  });
+
+  it("module export keys are stable", () => {
+    expect(Object.keys(api).sort()).toEqual([
+      "Replayer",
+      "TRANSCRIPT_VERSION",
+      "Transcript",
+      "VirtualClock",
+      "createHeadlessAdapter",
+      "transcript",
+      "transcriptSchema",
+    ]);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/replayer-cancel.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/replayer-cancel.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { createHeadlessAdapter } from "../adapter/headless";
+import { VirtualClock } from "../replayer/clock";
+import { Replayer } from "../replayer/replayer";
+import { transcript } from "../transcript/builder";
+
+describe("Replayer cancel", () => {
+  it("explicit cancel() sets phase to cancelled and calls adapter.abort once", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript()
+        .user("hi")
+        .assistantStream("hello", { chunks: ["he", "llo"] })
+        .toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+
+    await r.tick();
+    await r.tick();
+    await r.cancel();
+
+    expect(r.state.phase).toBe("cancelled");
+    expect(adapter.getSnapshot().abortCount).toBe(1);
+  });
+
+  it("cancel injection at a turn triggers cancel before that turn runs", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript()
+        .user("hi")
+        .assistantStream("hello", { chunks: ["he", "llo"] })
+        .inject.cancel()
+        .toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+
+    await r.advanceToIdle();
+    expect(r.state.phase).toBe("cancelled");
+    expect(adapter.getSnapshot().userMessages).toHaveLength(1);
+    expect(adapter.getSnapshot().events).toHaveLength(0);
+    expect(adapter.getSnapshot().abortCount).toBe(1);
+  });
+
+  it("further ticks after cancel are no-ops", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript().user("hi").user("two").toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+    await r.cancel();
+    await r.tick();
+    await r.advanceToIdle();
+    expect(adapter.getSnapshot().userMessages).toHaveLength(0);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/replayer-control.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/replayer-control.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import { createHeadlessAdapter } from "../adapter/headless";
+import { VirtualClock } from "../replayer/clock";
+import { Replayer } from "../replayer/replayer";
+import { transcript } from "../transcript/builder";
+
+describe("Replayer construction", () => {
+  it("starts idle at turn 0 with no errors and no pending tool calls", () => {
+    const r = new Replayer({
+      transcript: transcript().user("hi").toJSON(),
+      adapter: createHeadlessAdapter(),
+      clock: new VirtualClock(),
+    });
+
+    expect(r.state).toEqual({
+      phase: "idle",
+      currentTurnIndex: 0,
+      currentChunkIndex: null,
+      pendingToolCalls: [],
+      lastError: null,
+    });
+  });
+
+  it("an empty transcript completes immediately on advanceToIdle", async () => {
+    const r = new Replayer({
+      transcript: transcript().toJSON(),
+      adapter: createHeadlessAdapter(),
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+    expect(r.state.phase).toBe("complete");
+  });
+});
+
+describe("Replayer control surface", () => {
+  it("tick() advances one observable step (one chunk per tick, cleanup folded)", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript()
+        .assistantStream("ab", { chunks: ["a", "b"] })
+        .toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+
+    await r.tick();
+    expect(adapter.getSnapshot().events).toHaveLength(1);
+    expect(r.state.currentTurnIndex).toBe(0);
+    expect(r.state.currentChunkIndex).toBe(0);
+
+    await r.tick();
+    expect(adapter.getSnapshot().events).toHaveLength(2);
+    expect(r.state.currentTurnIndex).toBe(1);
+    expect(r.state.currentChunkIndex).toBeNull();
+  });
+
+  it("tick() emits finish as its own step before cleaning up", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript()
+        .assistantStream("a", { chunks: ["a"], finish: { reason: "stop" } })
+        .toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+
+    await r.tick();
+    expect(adapter.getSnapshot().events.map((e) => e.type)).toEqual([
+      "text-delta",
+    ]);
+    expect(r.state.currentTurnIndex).toBe(0);
+
+    await r.tick();
+    expect(adapter.getSnapshot().events.map((e) => e.type)).toEqual([
+      "text-delta",
+      "finish",
+    ]);
+    expect(r.state.currentTurnIndex).toBe(1);
+    expect(r.state.currentChunkIndex).toBeNull();
+  });
+
+  it("advanceToNextTurn() runs exactly one turn", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript().user("a").user("b").toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+
+    await r.advanceToNextTurn();
+    expect(adapter.getSnapshot().userMessages).toHaveLength(1);
+    expect(r.state.currentTurnIndex).toBe(1);
+  });
+
+  it("advanceToIdle() runs all remaining turns", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript().user("a").user("b").user("c").toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+
+    await r.advanceToIdle();
+    expect(r.state.phase).toBe("complete");
+    expect(adapter.getSnapshot().userMessages).toHaveLength(3);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/replayer-disconnect.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/replayer-disconnect.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { createHeadlessAdapter } from "../adapter/headless";
+import { VirtualClock } from "../replayer/clock";
+import { Replayer } from "../replayer/replayer";
+import { transcript } from "../transcript/builder";
+
+describe("Replayer disconnect injection", () => {
+  it("emits disconnect event after the configured chunk and stops the stream", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript()
+        .assistantStream("hello world", { chunks: ["hello ", "world"] })
+        .inject.disconnect({ afterChunk: 0 })
+        .toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+
+    expect(adapter.getSnapshot().events.map((event) => event.type)).toEqual([
+      "text-delta",
+      "disconnect",
+    ]);
+    expect(r.state.phase).toBe("error");
+    expect(r.state.lastError?.message).toMatch(/disconnected/i);
+  });
+
+  it("disconnect after the last chunk still emits disconnect and ends in error", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript()
+        .assistantStream("ab", { chunks: ["a", "b"] })
+        .inject.disconnect({ afterChunk: 1 })
+        .toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+    expect(adapter.getSnapshot().events.map((event) => event.type)).toEqual([
+      "text-delta",
+      "text-delta",
+      "disconnect",
+    ]);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/replayer-interrupt.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/replayer-interrupt.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { createHeadlessAdapter } from "../adapter/headless";
+import { VirtualClock } from "../replayer/clock";
+import { Replayer } from "../replayer/replayer";
+import { transcript } from "../transcript/builder";
+
+describe("Replayer interrupt", () => {
+  it("interrupt aborts and ends in cancelled with the reason", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript()
+        .user("hi")
+        .assistantStream("a")
+        .inject.interrupt("user-pressed-stop")
+        .toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+    expect(r.state.phase).toBe("cancelled");
+    expect(r.state.lastError).toEqual({ message: "user-pressed-stop" });
+    expect(adapter.getSnapshot().abortCount).toBe(1);
+  });
+});
+
+describe("Replayer abortAndRestart", () => {
+  it("calls abort then resets to turn 0 and continues", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript()
+        .user("hi")
+        .assistantStream("nope", { chunks: ["no", "pe"] })
+        .inject.abortAndRestart()
+        .user("retry")
+        .toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+    expect(adapter.getSnapshot().abortCount).toBe(1);
+    expect(adapter.getSnapshot().userMessages.map((m) => m[0]?.text)).toEqual([
+      "hi",
+      "hi",
+      "retry",
+    ]);
+    expect(adapter.getSnapshot().events).toHaveLength(0);
+    expect(r.state.phase).toBe("complete");
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/replayer-stream.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/replayer-stream.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { createHeadlessAdapter } from "../adapter/headless";
+import { VirtualClock } from "../replayer/clock";
+import { Replayer } from "../replayer/replayer";
+import { transcript } from "../transcript/builder";
+
+describe("Replayer assistantStream", () => {
+  it("emits one text-delta per chunk in order", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript()
+        .user("q")
+        .assistantStream("hello world", { chunks: ["hello ", "world"] })
+        .toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+    expect(adapter.getSnapshot().events).toEqual([
+      { type: "text-delta", delta: "hello " },
+      { type: "text-delta", delta: "world" },
+    ]);
+  });
+
+  it("consumes interChunkDelayMs from the virtual clock between chunks", async () => {
+    const clock = new VirtualClock();
+    const r = new Replayer({
+      transcript: transcript()
+        .assistantStream("ab", { chunks: ["a", "b"], interChunkDelayMs: 50 })
+        .toJSON(),
+      adapter: createHeadlessAdapter(),
+      clock,
+    });
+    await r.advanceToIdle();
+    expect(clock.now()).toBe(50);
+  });
+
+  it("emits a finish event when the turn declares finish", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript()
+        .assistantStream("hi", { finish: { reason: "stop" } })
+        .toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+    expect(adapter.getSnapshot().events.map((event) => event.type)).toEqual([
+      "text-delta",
+      "finish",
+    ]);
+  });
+
+  it("does not emit finish when finish is omitted", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript().assistantStream("hi").toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+    expect(adapter.getSnapshot().events.map((event) => event.type)).toEqual([
+      "text-delta",
+    ]);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/replayer-tool-call.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/replayer-tool-call.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { createHeadlessAdapter } from "../adapter/headless";
+import { VirtualClock } from "../replayer/clock";
+import { Replayer } from "../replayer/replayer";
+import { transcript } from "../transcript/builder";
+
+describe("Replayer tool calls", () => {
+  it("emits tool-call event and tracks pendingToolCalls", async () => {
+    const t = transcript()
+      .assistantToolCall("get_stock_price", { ticker: "AAPL" })
+      .toolResult({ price: 212.44 })
+      .toJSON();
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: t,
+      adapter,
+      clock: new VirtualClock(),
+    });
+
+    await r.advanceToNextTurn();
+    expect(r.state.pendingToolCalls).toEqual(["tc_1"]);
+
+    await r.advanceToIdle();
+    expect(r.state.pendingToolCalls).toEqual([]);
+    expect(adapter.getSnapshot().events.map((event) => event.type)).toEqual([
+      "tool-call",
+      "tool-result",
+    ]);
+  });
+
+  it("at idle with an unmatched tool call, replayer ends in error", async () => {
+    const r = new Replayer({
+      transcript: transcript().assistantToolCall("never_resolves", {}).toJSON(),
+      adapter: createHeadlessAdapter(),
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+    expect(r.state.phase).toBe("error");
+    expect(r.state.lastError?.message).toMatch(/unresolved tool call/i);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/replayer-transport-error.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/replayer-transport-error.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { createHeadlessAdapter } from "../adapter/headless";
+import { VirtualClock } from "../replayer/clock";
+import { Replayer } from "../replayer/replayer";
+import { transcript } from "../transcript/builder";
+
+describe("Replayer transportError injection", () => {
+  it("emits transport-error event and ends in error before target turn runs", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript()
+        .user("hi")
+        .assistantStream("hello", { chunks: ["he", "llo"] })
+        .inject.transportError({ code: 500, message: "boom" })
+        .toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+    await r.advanceToIdle();
+
+    expect(adapter.getSnapshot().events.map((event) => event.type)).toEqual([
+      "transport-error",
+    ]);
+    expect(r.state.phase).toBe("error");
+    expect(r.state.lastError).toEqual({ code: 500, message: "boom" });
+    expect(adapter.getSnapshot().userMessages).toHaveLength(1);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/replayer-user.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/replayer-user.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { createHeadlessAdapter } from "../adapter/headless";
+import { VirtualClock } from "../replayer/clock";
+import { Replayer } from "../replayer/replayer";
+import { transcript } from "../transcript/builder";
+
+describe("Replayer user turns", () => {
+  it("forwards user content to adapter.sendUserMessage", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript().user("hi").toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+
+    await r.advanceToIdle();
+
+    expect(adapter.getSnapshot().userMessages).toEqual([
+      [{ type: "text", text: "hi" }],
+    ]);
+    expect(r.state.phase).toBe("complete");
+    expect(r.state.currentTurnIndex).toBe(1);
+  });
+
+  it("forwards multiple user turns in order", async () => {
+    const adapter = createHeadlessAdapter();
+    const r = new Replayer({
+      transcript: transcript().user("a").user("b").toJSON(),
+      adapter,
+      clock: new VirtualClock(),
+    });
+
+    await r.advanceToIdle();
+
+    expect(adapter.getSnapshot().userMessages.map((m) => m[0]?.text)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/round-trip.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/round-trip.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { transcript } from "../transcript/builder";
+import { Transcript } from "../transcript/parse";
+
+describe("DSL to JSON to fromJSON round trip", () => {
+  it("preserves a complex transcript exactly", () => {
+    const original = transcript()
+      .user("Check AAPL")
+      .assistantToolCall("get_stock_price", { ticker: "AAPL" })
+      .toolResult({ price: 212.44 })
+      .assistantStream("AAPL is at $212.44.", {
+        chunks: ["AAPL is ", "at $212.44."],
+        interChunkDelayMs: 20,
+        finish: { reason: "stop" },
+      })
+      .inject.disconnect({ afterChunk: 1 })
+      .metadata({ runId: "r1" })
+      .delayMs(50)
+      .inject.transportError({ code: 500, message: "boom" })
+      .toJSON();
+
+    const reparsed = Transcript.fromJSON(JSON.parse(JSON.stringify(original)));
+    expect(reparsed).toEqual(original);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/schema-sync.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/schema-sync.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { transcriptSchema } from "../transcript/schema";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const schemaPath = resolve(here, "../../schema/transcript.schema.json");
+
+describe("transcript schema sync", () => {
+  it("schema.ts mirrors schema/transcript.schema.json byte-for-byte after JSON normalization", () => {
+    const fileContents = readFileSync(schemaPath, "utf-8");
+    const fromFile = JSON.parse(fileContents);
+    expect(transcriptSchema).toEqual(fromFile);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/schema-validation.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/schema-validation.test.ts
@@ -1,0 +1,52 @@
+import Ajv2020 from "ajv/dist/2020";
+import { describe, expect, it } from "vitest";
+
+import { transcript } from "../transcript/builder";
+import { transcriptSchema } from "../transcript/schema";
+
+const ajv = new Ajv2020({ strict: true, allErrors: true });
+const validate = ajv.compile(transcriptSchema);
+
+describe("transcript schema", () => {
+  it("validates an empty transcript", () => {
+    expect(validate(transcript().toJSON())).toBe(true);
+  });
+
+  it("validates a full-grammar transcript", () => {
+    const t = transcript()
+      .user("Check AAPL")
+      .assistantToolCall("get_stock_price", { ticker: "AAPL" })
+      .toolResult({ price: 212.44 })
+      .assistantStream("AAPL is at $212.44.", {
+        chunks: ["AAPL is ", "at $212.44."],
+        interChunkDelayMs: 20,
+        finish: { reason: "stop" },
+      })
+      .inject.disconnect({ afterChunk: 1 })
+      .metadata({ runId: "r" })
+      .delayMs(100)
+      .toJSON();
+
+    expect(validate(t)).toBe(true);
+  });
+
+  it("rejects an unknown turn kind", () => {
+    expect(
+      validate({ version: "0", turns: [{ kind: "unknown" }], injections: [] }),
+    ).toBe(false);
+  });
+
+  it("rejects version other than '0'", () => {
+    expect(validate({ version: "1", turns: [], injections: [] })).toBe(false);
+  });
+
+  it("rejects disconnect injection without afterChunk", () => {
+    expect(
+      validate({
+        version: "0",
+        turns: [{ kind: "assistantStream", text: "x", chunks: ["x"] }],
+        injections: [{ kind: "disconnect", at: { turnIndex: 0 } }],
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/types-compile.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/types-compile.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  AbortAndRestartInjection,
+  AssistantStreamTurn,
+  AssistantToolCallTurn,
+  CancelInjection,
+  ContentPart,
+  DelayTurn,
+  DisconnectInjection,
+  Injection,
+  InterruptInjection,
+  MetadataTurn,
+  TextPart,
+  ToolCallPart,
+  ToolResultTurn,
+  Transcript,
+  TransportErrorInjection,
+  Turn,
+  UserTurn,
+} from "../transcript/types";
+import { TRANSCRIPT_VERSION } from "../transcript/version";
+
+describe("transcript types", () => {
+  it("TRANSCRIPT_VERSION is the string literal '0'", () => {
+    expect(TRANSCRIPT_VERSION).toBe("0");
+  });
+
+  it("content part variants assign to ContentPart", () => {
+    const text: TextPart = { type: "text", text: "hi" };
+    const tool: ToolCallPart = {
+      type: "tool-call",
+      toolCallId: "tc_1",
+      toolName: "x",
+      args: { a: 1 },
+      argsText: '{"a":1}',
+    };
+    const parts: ContentPart[] = [text, tool];
+    expect(parts).toHaveLength(2);
+  });
+
+  it("each turn shape is a valid Turn", () => {
+    const turns: Turn[] = [
+      {
+        kind: "user",
+        content: [{ type: "text", text: "hi" }],
+      } satisfies UserTurn,
+      {
+        kind: "assistantStream",
+        text: "Hello",
+        chunks: ["Hel", "lo"],
+      } satisfies AssistantStreamTurn,
+      {
+        kind: "assistantToolCall",
+        toolCallId: "tc_1",
+        name: "x",
+        args: {},
+        argsText: "{}",
+      } satisfies AssistantToolCallTurn,
+      {
+        kind: "toolResult",
+        toolCallId: "tc_1",
+        value: 1,
+      } satisfies ToolResultTurn,
+      { kind: "delay", ms: 10 } satisfies DelayTurn,
+      { kind: "metadata", data: {} } satisfies MetadataTurn,
+    ];
+    expect(turns).toHaveLength(6);
+  });
+
+  it("each injection variant assigns to Injection", () => {
+    const injections: Injection[] = [
+      { kind: "cancel", at: { turnIndex: 0 } } satisfies CancelInjection,
+      {
+        kind: "interrupt",
+        at: { turnIndex: 0 },
+        reason: "x",
+      } satisfies InterruptInjection,
+      {
+        kind: "transportError",
+        at: { turnIndex: 0 },
+        message: "boom",
+      } satisfies TransportErrorInjection,
+      {
+        kind: "disconnect",
+        at: { turnIndex: 0, afterChunk: 1 },
+      } satisfies DisconnectInjection,
+      {
+        kind: "abortAndRestart",
+        at: { turnIndex: 0 },
+      } satisfies AbortAndRestartInjection,
+    ];
+    expect(injections).toHaveLength(5);
+  });
+
+  it("Transcript root requires version, turns, injections", () => {
+    const t: Transcript = { version: "0", turns: [], injections: [] };
+    expect(t.version).toBe("0");
+  });
+});

--- a/packages/chat-test-kit-core/src/__tests__/virtual-clock.test.ts
+++ b/packages/chat-test-kit-core/src/__tests__/virtual-clock.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { VirtualClock } from "../replayer/clock";
+
+describe("VirtualClock", () => {
+  it("starts at 0", () => {
+    expect(new VirtualClock().now()).toBe(0);
+  });
+
+  it("advance() moves time forward and runs due timers in fire order", () => {
+    const clock = new VirtualClock();
+    const events: string[] = [];
+    clock.setTimeout(() => events.push("a@10"), 10);
+    clock.setTimeout(() => events.push("b@5"), 5);
+    clock.setTimeout(() => events.push("c@10"), 10);
+
+    clock.advance(10);
+    expect(events).toEqual(["b@5", "a@10", "c@10"]);
+    expect(clock.now()).toBe(10);
+  });
+
+  it("clearTimeout cancels a pending timer", () => {
+    const clock = new VirtualClock();
+    const events: string[] = [];
+    const handle = clock.setTimeout(() => events.push("nope"), 5);
+    clock.clearTimeout(handle);
+    clock.advance(10);
+    expect(events).toEqual([]);
+  });
+
+  it("a timer scheduled inside another timer fires within the same advance call", () => {
+    const clock = new VirtualClock();
+    const events: string[] = [];
+    clock.setTimeout(() => {
+      events.push("first");
+      clock.setTimeout(() => events.push("nested"), 1);
+    }, 1);
+    clock.advance(2);
+    expect(events).toEqual(["first", "nested"]);
+    expect(clock.now()).toBe(2);
+  });
+
+  it("advance(0) drains 0-delay timers", () => {
+    const clock = new VirtualClock();
+    const events: string[] = [];
+    clock.setTimeout(() => events.push("now"), 0);
+    clock.advance(0);
+    expect(events).toEqual(["now"]);
+  });
+});

--- a/packages/chat-test-kit-core/src/adapter/headless.ts
+++ b/packages/chat-test-kit-core/src/adapter/headless.ts
@@ -1,0 +1,27 @@
+import type { AssistantEvent, RuntimeAdapter, RuntimeSnapshot } from "./types";
+import type { ContentPart } from "../transcript/types";
+
+export function createHeadlessAdapter(): RuntimeAdapter {
+  const events: AssistantEvent[] = [];
+  const userMessages: ContentPart[][] = [];
+  let abortCount = 0;
+
+  return {
+    async sendUserMessage(content) {
+      userMessages.push([...content]);
+    },
+    async emit(event) {
+      events.push(event);
+    },
+    getSnapshot(): RuntimeSnapshot {
+      return {
+        events: [...events],
+        abortCount,
+        userMessages: userMessages.map((message) => [...message]),
+      };
+    },
+    async abort() {
+      abortCount += 1;
+    },
+  };
+}

--- a/packages/chat-test-kit-core/src/adapter/types.ts
+++ b/packages/chat-test-kit-core/src/adapter/types.ts
@@ -1,0 +1,28 @@
+import type { ContentPart, JsonObject, JsonValue } from "../transcript/types";
+
+export type AssistantEvent =
+  | { type: "text-delta"; delta: string }
+  | {
+      type: "tool-call";
+      toolCallId: string;
+      toolName: string;
+      args: JsonObject;
+      argsText: string;
+    }
+  | { type: "tool-result"; toolCallId: string; value: JsonValue }
+  | { type: "finish"; reason: "stop" | "abort" | "error" }
+  | { type: "transport-error"; code?: number; message: string }
+  | { type: "disconnect" };
+
+export type RuntimeSnapshot = {
+  events: AssistantEvent[];
+  abortCount: number;
+  userMessages: ContentPart[][];
+};
+
+export type RuntimeAdapter = {
+  sendUserMessage(content: ContentPart[]): Promise<void>;
+  emit(event: AssistantEvent): Promise<void>;
+  getSnapshot(): RuntimeSnapshot;
+  abort(): Promise<void>;
+};

--- a/packages/chat-test-kit-core/src/index.ts
+++ b/packages/chat-test-kit-core/src/index.ts
@@ -1,0 +1,37 @@
+export { createHeadlessAdapter } from "./adapter/headless";
+export type {
+  AssistantEvent,
+  RuntimeAdapter,
+  RuntimeSnapshot,
+} from "./adapter/types";
+export { Replayer } from "./replayer/replayer";
+export type { ReplayerOptions } from "./replayer/replayer";
+export { VirtualClock } from "./replayer/clock";
+export type { ReplayerPhase, ReplayerState } from "./replayer/state";
+export { transcript } from "./transcript/builder";
+export type { AssistantStreamOptions } from "./transcript/builder";
+export { Transcript } from "./transcript/parse";
+export { transcriptSchema } from "./transcript/schema";
+export type {
+  AbortAndRestartInjection,
+  AssistantStreamTurn,
+  AssistantToolCallTurn,
+  CancelInjection,
+  ContentPart,
+  DelayTurn,
+  DisconnectInjection,
+  Injection,
+  InjectionPosition,
+  InterruptInjection,
+  JsonObject,
+  JsonValue,
+  MetadataTurn,
+  TextPart,
+  ToolCallPart,
+  ToolResultTurn,
+  Transcript as TranscriptType,
+  TransportErrorInjection,
+  Turn,
+  UserTurn,
+} from "./transcript/types";
+export { TRANSCRIPT_VERSION } from "./transcript/version";

--- a/packages/chat-test-kit-core/src/replayer/clock.ts
+++ b/packages/chat-test-kit-core/src/replayer/clock.ts
@@ -1,0 +1,43 @@
+type Timer = {
+  id: number;
+  due: number;
+  fire: () => void;
+};
+
+export class VirtualClock {
+  private current = 0;
+  private nextId = 1;
+  private timers: Timer[] = [];
+
+  now(): number {
+    return this.current;
+  }
+
+  setTimeout(fire: () => void, delayMs: number): number {
+    const id = this.nextId++;
+    this.timers.push({ id, due: this.current + Math.max(0, delayMs), fire });
+    return id;
+  }
+
+  clearTimeout(id: number): void {
+    this.timers = this.timers.filter((timer) => timer.id !== id);
+  }
+
+  advance(ms: number): void {
+    if (ms < 0) throw new Error("VirtualClock.advance: ms must be >= 0");
+
+    const target = this.current + ms;
+    for (;;) {
+      const due = this.timers
+        .filter((timer) => timer.due <= target)
+        .sort((a, b) => a.due - b.due || a.id - b.id);
+      const next = due[0];
+      if (!next) break;
+
+      this.current = next.due;
+      this.timers = this.timers.filter((timer) => timer.id !== next.id);
+      next.fire();
+    }
+    this.current = target;
+  }
+}

--- a/packages/chat-test-kit-core/src/replayer/injection.ts
+++ b/packages/chat-test-kit-core/src/replayer/injection.ts
@@ -1,0 +1,24 @@
+import type { Injection, Transcript } from "../transcript/types";
+
+export function findInjectionsAtTurn(
+  transcript: Transcript,
+  turnIndex: number,
+): Injection[] {
+  return transcript.injections.filter(
+    (injection) =>
+      injection.at.turnIndex === turnIndex &&
+      injection.at.afterChunk === undefined,
+  );
+}
+
+export function findInjectionAtChunk(
+  transcript: Transcript,
+  turnIndex: number,
+  chunkIndex: number,
+): Injection | undefined {
+  return transcript.injections.find(
+    (injection) =>
+      injection.at.turnIndex === turnIndex &&
+      injection.at.afterChunk === chunkIndex,
+  );
+}

--- a/packages/chat-test-kit-core/src/replayer/replayer.ts
+++ b/packages/chat-test-kit-core/src/replayer/replayer.ts
@@ -1,0 +1,310 @@
+import type { RuntimeAdapter } from "../adapter/types";
+import type {
+  AssistantStreamTurn,
+  Injection,
+  Transcript,
+  Turn,
+} from "../transcript/types";
+import type { VirtualClock } from "./clock";
+import { findInjectionAtChunk, findInjectionsAtTurn } from "./injection";
+import { type ReplayerState, initialReplayerState } from "./state";
+
+export type ReplayerOptions = {
+  transcript: Transcript;
+  adapter: RuntimeAdapter;
+  clock: VirtualClock;
+};
+
+type StreamCursor = {
+  turn: AssistantStreamTurn;
+  nextChunkIndex: number;
+  finishEmitted: boolean;
+};
+
+export class Replayer {
+  state: ReplayerState = initialReplayerState();
+  private readonly transcript: Transcript;
+  private readonly adapter: RuntimeAdapter;
+  private readonly clock: VirtualClock;
+  private streamCursor: StreamCursor | null = null;
+  private consumedInjections = new WeakSet<Injection>();
+  // why: abortAndRestart restarts the prefix but skips the turn that triggered
+  // the abort, so retries do not re-execute the failed turn. Without this set,
+  // restart would re-run the aborted stream/tool-call after the injection is
+  // consumed, producing an unintended success on the second pass.
+  private consumedTurnIndices = new Set<number>();
+
+  constructor(options: ReplayerOptions) {
+    this.transcript = options.transcript;
+    this.adapter = options.adapter;
+    this.clock = options.clock;
+  }
+
+  async tick(): Promise<void> {
+    if (this.isFinished()) return;
+    this.state = { ...this.state, phase: "running" };
+
+    if (this.streamCursor) {
+      await this.tickStream();
+      return;
+    }
+
+    if (this.state.currentTurnIndex >= this.transcript.turns.length) {
+      this.finalize();
+      return;
+    }
+
+    const turn = this.transcript.turns[this.state.currentTurnIndex];
+    if (!turn) {
+      this.finalize();
+      return;
+    }
+
+    if (this.consumedTurnIndices.has(this.state.currentTurnIndex)) {
+      this.state = {
+        ...this.state,
+        currentTurnIndex: this.state.currentTurnIndex + 1,
+      };
+      return;
+    }
+
+    const turnIndex = this.state.currentTurnIndex;
+    const turnInjections = findInjectionsAtTurn(
+      this.transcript,
+      turnIndex,
+    ).filter((injection) => !this.consumedInjections.has(injection));
+
+    for (const injection of turnInjections) {
+      await this.applyInjection(injection);
+      if (this.isFinished()) return;
+      if (this.state.currentTurnIndex !== turnIndex) return;
+    }
+
+    if (turn.kind === "assistantStream") {
+      this.streamCursor = {
+        turn,
+        nextChunkIndex: 0,
+        finishEmitted: false,
+      };
+      await this.tickStream();
+      return;
+    }
+
+    await this.runTurn(turn);
+    if (this.isFinished()) return;
+    this.state = {
+      ...this.state,
+      currentTurnIndex: this.state.currentTurnIndex + 1,
+    };
+  }
+
+  async advanceToNextTurn(): Promise<void> {
+    const start = this.state.currentTurnIndex;
+    while (this.state.currentTurnIndex === start) {
+      if (this.isFinished()) return;
+      await this.tick();
+    }
+  }
+
+  async advanceToIdle(): Promise<void> {
+    while (!this.isFinished()) {
+      await this.tick();
+    }
+    this.finalize();
+  }
+
+  async cancel(): Promise<void> {
+    if (this.isFinished()) return;
+    await this.adapter.abort();
+    this.streamCursor = null;
+    this.state = {
+      ...this.state,
+      phase: "cancelled",
+      currentChunkIndex: null,
+    };
+  }
+
+  private async runTurn(turn: Turn): Promise<void> {
+    switch (turn.kind) {
+      case "user":
+        await this.adapter.sendUserMessage(turn.content);
+        return;
+      case "metadata":
+        return;
+      case "delay":
+        this.clock.advance(turn.ms);
+        return;
+      case "assistantToolCall":
+        await this.adapter.emit({
+          type: "tool-call",
+          toolCallId: turn.toolCallId,
+          toolName: turn.name,
+          args: turn.args,
+          argsText: turn.argsText,
+        });
+        this.state = {
+          ...this.state,
+          pendingToolCalls: [...this.state.pendingToolCalls, turn.toolCallId],
+        };
+        return;
+      case "toolResult":
+        await this.adapter.emit({
+          type: "tool-result",
+          toolCallId: turn.toolCallId,
+          value: turn.value,
+        });
+        this.state = {
+          ...this.state,
+          pendingToolCalls: this.state.pendingToolCalls.filter(
+            (id) => id !== turn.toolCallId,
+          ),
+        };
+        return;
+      case "assistantStream":
+        return;
+    }
+  }
+
+  private async tickStream(): Promise<void> {
+    const cursor = this.streamCursor;
+    if (!cursor) return;
+
+    if (cursor.nextChunkIndex < cursor.turn.chunks.length) {
+      if (
+        cursor.nextChunkIndex > 0 &&
+        cursor.turn.interChunkDelayMs !== undefined
+      ) {
+        this.clock.advance(cursor.turn.interChunkDelayMs);
+      }
+
+      this.state = {
+        ...this.state,
+        currentChunkIndex: cursor.nextChunkIndex,
+      };
+      await this.adapter.emit({
+        type: "text-delta",
+        delta: cursor.turn.chunks[cursor.nextChunkIndex] ?? "",
+      });
+
+      const injection = findInjectionAtChunk(
+        this.transcript,
+        this.state.currentTurnIndex,
+        cursor.nextChunkIndex,
+      );
+      cursor.nextChunkIndex += 1;
+      if (injection && !this.consumedInjections.has(injection)) {
+        await this.applyInjection(injection);
+        return;
+      }
+
+      if (
+        cursor.nextChunkIndex >= cursor.turn.chunks.length &&
+        !cursor.turn.finish
+      ) {
+        this.completeStream();
+      }
+      return;
+    }
+
+    if (cursor.turn.finish && !cursor.finishEmitted) {
+      await this.adapter.emit({
+        type: "finish",
+        reason: cursor.turn.finish.reason,
+      });
+      cursor.finishEmitted = true;
+      this.completeStream();
+      return;
+    }
+
+    this.completeStream();
+  }
+
+  private completeStream(): void {
+    this.streamCursor = null;
+    this.state = {
+      ...this.state,
+      currentChunkIndex: null,
+      currentTurnIndex: this.state.currentTurnIndex + 1,
+    };
+  }
+
+  private async applyInjection(injection: Injection): Promise<void> {
+    switch (injection.kind) {
+      case "cancel":
+        await this.cancel();
+        return;
+      case "disconnect":
+        await this.adapter.emit({ type: "disconnect" });
+        this.streamCursor = null;
+        this.state = {
+          ...this.state,
+          phase: "error",
+          currentChunkIndex: null,
+          lastError: { message: "Replayer: stream disconnected" },
+        };
+        return;
+      case "transportError":
+        await this.adapter.emit({
+          type: "transport-error",
+          ...(injection.code !== undefined ? { code: injection.code } : {}),
+          message: injection.message,
+        });
+        this.state = {
+          ...this.state,
+          phase: "error",
+          lastError: {
+            ...(injection.code !== undefined ? { code: injection.code } : {}),
+            message: injection.message,
+          },
+        };
+        return;
+      case "interrupt":
+        await this.adapter.abort();
+        this.streamCursor = null;
+        this.state = {
+          ...this.state,
+          phase: "cancelled",
+          currentChunkIndex: null,
+          lastError: { message: injection.reason ?? "interrupted" },
+        };
+        return;
+      case "abortAndRestart":
+        await this.adapter.abort();
+        this.streamCursor = null;
+        this.consumedInjections.add(injection);
+        this.consumedTurnIndices.add(injection.at.turnIndex);
+        this.state = {
+          ...this.state,
+          currentTurnIndex: 0,
+          currentChunkIndex: null,
+          pendingToolCalls: [],
+          phase: "running",
+          lastError: null,
+        };
+        return;
+    }
+  }
+
+  private isFinished(): boolean {
+    return (
+      this.state.phase === "complete" ||
+      this.state.phase === "error" ||
+      this.state.phase === "cancelled"
+    );
+  }
+
+  private finalize(): void {
+    if (this.isFinished()) return;
+    if (this.state.pendingToolCalls.length > 0) {
+      this.state = {
+        ...this.state,
+        phase: "error",
+        lastError: {
+          message: `Replayer: ${this.state.pendingToolCalls.length} unresolved tool call(s) at end of transcript`,
+        },
+      };
+      return;
+    }
+    this.state = { ...this.state, phase: "complete" };
+  }
+}

--- a/packages/chat-test-kit-core/src/replayer/state.ts
+++ b/packages/chat-test-kit-core/src/replayer/state.ts
@@ -1,0 +1,24 @@
+export type ReplayerPhase =
+  | "idle"
+  | "running"
+  | "complete"
+  | "error"
+  | "cancelled";
+
+export type ReplayerState = {
+  phase: ReplayerPhase;
+  currentTurnIndex: number;
+  currentChunkIndex: number | null;
+  pendingToolCalls: string[];
+  lastError: { code?: number; message: string } | null;
+};
+
+export function initialReplayerState(): ReplayerState {
+  return {
+    phase: "idle",
+    currentTurnIndex: 0,
+    currentChunkIndex: null,
+    pendingToolCalls: [],
+    lastError: null,
+  };
+}

--- a/packages/chat-test-kit-core/src/transcript/builder.ts
+++ b/packages/chat-test-kit-core/src/transcript/builder.ts
@@ -1,0 +1,271 @@
+import type {
+  ContentPart,
+  Injection,
+  InjectionPosition,
+  JsonObject,
+  JsonValue,
+  Transcript,
+  Turn,
+} from "./types";
+import { TRANSCRIPT_VERSION } from "./version";
+
+export type AssistantStreamOptions = {
+  chunks?: string[];
+  interChunkDelayMs?: number;
+  finish?: { reason: "stop" | "abort" | "error" };
+};
+
+type InjectNamespace<R> = {
+  cancel(): R;
+  interrupt(reason?: string): R;
+  transportError(options: { code?: number; message: string }): R;
+  abortAndRestart(): R;
+};
+
+type ReadyBuilder = {
+  inject: InjectNamespace<ReadyBuilder>;
+  user(content: string | ContentPart[]): ReadyBuilder;
+  assistantStream(
+    text: string,
+    options?: AssistantStreamOptions,
+  ): AfterStreamBuilder;
+  assistantToolCall(
+    name: string,
+    args: JsonObject,
+    options?: { toolCallId?: string },
+  ): OpenToolBuilder;
+  metadata(data: JsonObject): ReadyBuilder;
+  delayMs(ms: number): ReadyBuilder;
+  toJSON(): Transcript;
+};
+
+type OpenToolBuilder = {
+  toolResult(value: JsonValue): ReadyBuilder;
+  toJSON(): Transcript;
+};
+
+type AfterStreamInject = InjectNamespace<ReadyBuilder> & {
+  disconnect(options: { afterChunk: number }): ReadyBuilder;
+};
+
+type AfterStreamBuilder = Omit<ReadyBuilder, "inject"> & {
+  inject: AfterStreamInject;
+};
+
+const cloneTranscript = (
+  turns: Turn[],
+  injections: Injection[],
+): Transcript => ({
+  version: TRANSCRIPT_VERSION,
+  turns: [...turns],
+  injections: [...injections],
+});
+
+function makeBuilder(
+  turns: Turn[],
+  injections: Injection[],
+  nextId: () => string,
+): ReadyBuilder {
+  const builder = {
+    inject: buildInject(turns, injections, nextId),
+    user(content: string | ContentPart[]) {
+      const parts =
+        typeof content === "string"
+          ? [{ type: "text" as const, text: content }]
+          : content;
+      return makeBuilder(
+        [...turns, { kind: "user", content: parts }],
+        injections,
+        nextId,
+      );
+    },
+    assistantStream(text: string, options: AssistantStreamOptions = {}) {
+      const chunks = options.chunks ?? [text];
+      const joined = chunks.join("");
+      if (joined !== text) {
+        throw new Error(
+          `assistantStream: chunks must concatenate to text. Got chunks="${joined}", text="${text}".`,
+        );
+      }
+      const turn: Turn = {
+        kind: "assistantStream",
+        text,
+        chunks,
+        ...(options.interChunkDelayMs !== undefined
+          ? { interChunkDelayMs: options.interChunkDelayMs }
+          : {}),
+        ...(options.finish !== undefined ? { finish: options.finish } : {}),
+      };
+      const nextTurns = [...turns, turn];
+      const ready = makeBuilder(nextTurns, injections, nextId);
+      return {
+        ...ready,
+        inject: buildAfterStreamInject(
+          nextTurns,
+          injections,
+          nextId,
+          nextTurns.length - 1,
+        ),
+      };
+    },
+    assistantToolCall(
+      name: string,
+      args: JsonObject,
+      options: { toolCallId?: string } = {},
+    ) {
+      const toolCallId = options.toolCallId ?? nextId();
+      return makeOpenToolBuilder(
+        [
+          ...turns,
+          {
+            kind: "assistantToolCall",
+            toolCallId,
+            name,
+            args,
+            argsText: JSON.stringify(args),
+          },
+        ],
+        injections,
+        nextId,
+        toolCallId,
+      );
+    },
+    metadata(data: JsonObject) {
+      return makeBuilder(
+        [...turns, { kind: "metadata", data }],
+        injections,
+        nextId,
+      );
+    },
+    delayMs(ms: number) {
+      if (ms < 0) {
+        throw new Error("delayMs requires a non-negative ms value");
+      }
+      return makeBuilder([...turns, { kind: "delay", ms }], injections, nextId);
+    },
+    toolResult() {
+      throw new Error(
+        "toolResult() can only be called immediately after assistantToolCall()",
+      );
+    },
+    toJSON() {
+      return cloneTranscript(turns, injections);
+    },
+  };
+
+  return builder;
+}
+
+function makeOpenToolBuilder(
+  turns: Turn[],
+  injections: Injection[],
+  nextId: () => string,
+  openToolCallId: string,
+): OpenToolBuilder {
+  return {
+    toolResult(value) {
+      return makeBuilder(
+        [...turns, { kind: "toolResult", toolCallId: openToolCallId, value }],
+        injections,
+        nextId,
+      );
+    },
+    toJSON() {
+      return cloneTranscript(turns, injections);
+    },
+  };
+}
+
+function buildInject(
+  turns: Turn[],
+  injections: Injection[],
+  nextId: () => string,
+): InjectNamespace<ReadyBuilder> {
+  const at = (): InjectionPosition => {
+    if (turns.length === 0) {
+      throw new Error("inject requires at least one turn before it");
+    }
+    return { turnIndex: turns.length - 1 };
+  };
+
+  return {
+    cancel: () =>
+      makeBuilder(turns, [...injections, { kind: "cancel", at: at() }], nextId),
+    interrupt: (reason) =>
+      makeBuilder(
+        turns,
+        [
+          ...injections,
+          {
+            kind: "interrupt",
+            at: at(),
+            ...(reason !== undefined ? { reason } : {}),
+          },
+        ],
+        nextId,
+      ),
+    transportError: ({ code, message }) =>
+      makeBuilder(
+        turns,
+        [
+          ...injections,
+          {
+            kind: "transportError",
+            at: at(),
+            ...(code !== undefined ? { code } : {}),
+            message,
+          },
+        ],
+        nextId,
+      ),
+    abortAndRestart: () =>
+      makeBuilder(
+        turns,
+        [...injections, { kind: "abortAndRestart", at: at() }],
+        nextId,
+      ),
+  };
+}
+
+function buildAfterStreamInject(
+  turns: Turn[],
+  injections: Injection[],
+  nextId: () => string,
+  streamTurnIndex: number,
+): AfterStreamInject {
+  const base = buildInject(turns, injections, nextId);
+  const stream = turns[streamTurnIndex];
+  if (!stream || stream.kind !== "assistantStream") {
+    throw new Error(
+      "buildAfterStreamInject called without a prior assistantStream",
+    );
+  }
+
+  return {
+    ...base,
+    disconnect({ afterChunk }) {
+      if (afterChunk < 0 || afterChunk >= stream.chunks.length) {
+        throw new Error(
+          `disconnect: afterChunk ${afterChunk} is out of range (0..${stream.chunks.length - 1})`,
+        );
+      }
+      return makeBuilder(
+        turns,
+        [
+          ...injections,
+          {
+            kind: "disconnect",
+            at: { turnIndex: streamTurnIndex, afterChunk },
+          },
+        ],
+        nextId,
+      );
+    },
+  };
+}
+
+export function transcript(): ReadyBuilder {
+  let counter = 0;
+  const nextId = () => `tc_${++counter}`;
+  return makeBuilder([], [], nextId);
+}

--- a/packages/chat-test-kit-core/src/transcript/parse.ts
+++ b/packages/chat-test-kit-core/src/transcript/parse.ts
@@ -1,0 +1,85 @@
+import Ajv2020 from "ajv/dist/2020";
+
+import type { Injection, Transcript as TranscriptType, Turn } from "./types";
+import { transcriptSchema } from "./schema";
+
+const ajv = new Ajv2020({ strict: true, allErrors: true });
+const validate = ajv.compile(transcriptSchema);
+
+function ensureSchema(input: unknown): asserts input is TranscriptType {
+  if (typeof input !== "object" || input === null) {
+    throw new Error("Transcript.fromJSON: input must be an object");
+  }
+
+  if (!validate(input)) {
+    throw new Error(`Transcript.fromJSON: ${ajv.errorsText(validate.errors)}`);
+  }
+}
+
+function ensureTurnSemantics(turns: Turn[]): void {
+  const openToolCalls = new Set<string>();
+
+  turns.forEach((turn, index) => {
+    if (turn.kind === "assistantStream" && turn.chunks.join("") !== turn.text) {
+      throw new Error(
+        `Transcript.fromJSON: turns[${index}] chunks must concatenate to text`,
+      );
+    }
+
+    if (turn.kind === "assistantToolCall") {
+      openToolCalls.add(turn.toolCallId);
+      return;
+    }
+
+    if (turn.kind === "toolResult") {
+      if (!openToolCalls.has(turn.toolCallId)) {
+        throw new Error(
+          `Transcript.fromJSON: turns[${index}] toolResult references unknown toolCallId ${turn.toolCallId}`,
+        );
+      }
+      openToolCalls.delete(turn.toolCallId);
+    }
+  });
+}
+
+function ensureInjectionSemantics(
+  turns: Turn[],
+  injections: Injection[],
+): void {
+  injections.forEach((injection, index) => {
+    const target = turns[injection.at.turnIndex];
+    if (!target) {
+      throw new Error(
+        `Transcript.fromJSON: injections[${index}] turnIndex out of range`,
+      );
+    }
+
+    if (injection.kind !== "disconnect") return;
+
+    if (target.kind !== "assistantStream") {
+      throw new Error(
+        `Transcript.fromJSON: injections[${index}] disconnect target must be assistantStream`,
+      );
+    }
+
+    const afterChunk = injection.at.afterChunk;
+    if (
+      afterChunk === undefined ||
+      afterChunk < 0 ||
+      afterChunk >= target.chunks.length
+    ) {
+      throw new Error(
+        `Transcript.fromJSON: injections[${index}] afterChunk out of range`,
+      );
+    }
+  });
+}
+
+export const Transcript = {
+  fromJSON(input: unknown): TranscriptType {
+    ensureSchema(input);
+    ensureTurnSemantics(input.turns);
+    ensureInjectionSemantics(input.turns, input.injections);
+    return input;
+  },
+};

--- a/packages/chat-test-kit-core/src/transcript/schema.ts
+++ b/packages/chat-test-kit-core/src/transcript/schema.ts
@@ -1,0 +1,183 @@
+export const transcriptSchema = JSON.parse(`{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assistant-ui.com/schema/chat-test-kit/transcript-v0.json",
+  "title": "Transcript v0",
+  "type": "object",
+  "required": ["version", "turns", "injections"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "const": "0" },
+    "turns": { "type": "array", "items": { "$ref": "#/$defs/Turn" } },
+    "injections": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Injection" }
+    }
+  },
+  "$defs": {
+    "ContentPart": {
+      "oneOf": [
+        { "$ref": "#/$defs/TextPart" },
+        { "$ref": "#/$defs/ToolCallPart" }
+      ]
+    },
+    "TextPart": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "text"],
+      "properties": {
+        "type": { "const": "text" },
+        "text": { "type": "string" }
+      }
+    },
+    "ToolCallPart": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "toolCallId", "toolName", "args", "argsText"],
+      "properties": {
+        "type": { "const": "tool-call" },
+        "toolCallId": { "type": "string" },
+        "toolName": { "type": "string" },
+        "args": { "type": "object" },
+        "argsText": { "type": "string" }
+      }
+    },
+    "Turn": {
+      "oneOf": [
+        { "$ref": "#/$defs/UserTurn" },
+        { "$ref": "#/$defs/AssistantStreamTurn" },
+        { "$ref": "#/$defs/AssistantToolCallTurn" },
+        { "$ref": "#/$defs/ToolResultTurn" },
+        { "$ref": "#/$defs/DelayTurn" },
+        { "$ref": "#/$defs/MetadataTurn" }
+      ]
+    },
+    "UserTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "content"],
+      "properties": {
+        "kind": { "const": "user" },
+        "content": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ContentPart" }
+        }
+      }
+    },
+    "AssistantStreamTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "text", "chunks"],
+      "properties": {
+        "kind": { "const": "assistantStream" },
+        "text": { "type": "string" },
+        "chunks": { "type": "array", "items": { "type": "string" } },
+        "interChunkDelayMs": { "type": "integer", "minimum": 0 },
+        "finish": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["reason"],
+          "properties": {
+            "reason": { "enum": ["stop", "abort", "error"] }
+          }
+        }
+      }
+    },
+    "AssistantToolCallTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "toolCallId", "name", "args", "argsText"],
+      "properties": {
+        "kind": { "const": "assistantToolCall" },
+        "toolCallId": { "type": "string" },
+        "name": { "type": "string" },
+        "args": { "type": "object" },
+        "argsText": { "type": "string" }
+      }
+    },
+    "ToolResultTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "toolCallId", "value"],
+      "properties": {
+        "kind": { "const": "toolResult" },
+        "toolCallId": { "type": "string" },
+        "value": {}
+      }
+    },
+    "DelayTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "ms"],
+      "properties": {
+        "kind": { "const": "delay" },
+        "ms": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "MetadataTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "data"],
+      "properties": {
+        "kind": { "const": "metadata" },
+        "data": { "type": "object" }
+      }
+    },
+    "InjectionPosition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["turnIndex"],
+      "properties": {
+        "turnIndex": { "type": "integer", "minimum": 0 },
+        "afterChunk": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "Injection": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "at"],
+          "properties": {
+            "kind": { "enum": ["cancel", "abortAndRestart"] },
+            "at": { "$ref": "#/$defs/InjectionPosition" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "at"],
+          "properties": {
+            "kind": { "const": "interrupt" },
+            "at": { "$ref": "#/$defs/InjectionPosition" },
+            "reason": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "at", "message"],
+          "properties": {
+            "kind": { "const": "transportError" },
+            "at": { "$ref": "#/$defs/InjectionPosition" },
+            "code": { "type": "integer" },
+            "message": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "at"],
+          "properties": {
+            "kind": { "const": "disconnect" },
+            "at": {
+              "allOf": [
+                { "$ref": "#/$defs/InjectionPosition" },
+                { "type": "object", "required": ["afterChunk"] }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}`);

--- a/packages/chat-test-kit-core/src/transcript/types.ts
+++ b/packages/chat-test-kit-core/src/transcript/types.ts
@@ -1,0 +1,117 @@
+import type { TranscriptVersion } from "./version";
+
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type JsonObject = { [key: string]: JsonValue };
+
+export type TextPart = {
+  type: "text";
+  text: string;
+};
+
+export type ToolCallPart = {
+  type: "tool-call";
+  toolCallId: string;
+  toolName: string;
+  args: JsonObject;
+  argsText: string;
+};
+
+export type ContentPart = TextPart | ToolCallPart;
+
+export type UserTurn = {
+  kind: "user";
+  content: ContentPart[];
+};
+
+export type AssistantStreamTurn = {
+  kind: "assistantStream";
+  text: string;
+  chunks: string[];
+  interChunkDelayMs?: number;
+  finish?: { reason: "stop" | "abort" | "error" };
+};
+
+export type AssistantToolCallTurn = {
+  kind: "assistantToolCall";
+  toolCallId: string;
+  name: string;
+  args: JsonObject;
+  argsText: string;
+};
+
+export type ToolResultTurn = {
+  kind: "toolResult";
+  toolCallId: string;
+  value: JsonValue;
+};
+
+export type DelayTurn = {
+  kind: "delay";
+  ms: number;
+};
+
+export type MetadataTurn = {
+  kind: "metadata";
+  data: JsonObject;
+};
+
+export type Turn =
+  | UserTurn
+  | AssistantStreamTurn
+  | AssistantToolCallTurn
+  | ToolResultTurn
+  | DelayTurn
+  | MetadataTurn;
+
+export type InjectionPosition = {
+  turnIndex: number;
+  afterChunk?: number;
+};
+
+export type CancelInjection = {
+  kind: "cancel";
+  at: InjectionPosition;
+};
+
+export type InterruptInjection = {
+  kind: "interrupt";
+  at: InjectionPosition;
+  reason?: string;
+};
+
+export type TransportErrorInjection = {
+  kind: "transportError";
+  at: InjectionPosition;
+  code?: number;
+  message: string;
+};
+
+export type DisconnectInjection = {
+  kind: "disconnect";
+  at: InjectionPosition;
+};
+
+export type AbortAndRestartInjection = {
+  kind: "abortAndRestart";
+  at: InjectionPosition;
+};
+
+export type Injection =
+  | CancelInjection
+  | InterruptInjection
+  | TransportErrorInjection
+  | DisconnectInjection
+  | AbortAndRestartInjection;
+
+export type Transcript = {
+  version: TranscriptVersion;
+  turns: Turn[];
+  injections: Injection[];
+};

--- a/packages/chat-test-kit-core/src/transcript/version.ts
+++ b/packages/chat-test-kit-core/src/transcript/version.ts
@@ -1,0 +1,2 @@
+export const TRANSCRIPT_VERSION = "0" as const;
+export type TranscriptVersion = typeof TRANSCRIPT_VERSION;

--- a/packages/chat-test-kit-core/tsconfig.json
+++ b/packages/chat-test-kit-core/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "include": ["src"]
+}

--- a/packages/chat-test-kit-core/vitest.config.ts
+++ b/packages/chat-test-kit-core/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.{ts,tsx}"],
+    globals: true,
+  },
+});

--- a/packages/chat-test-kit-react/README.md
+++ b/packages/chat-test-kit-react/README.md
@@ -1,0 +1,94 @@
+# @assistant-ui/chat-test-kit-react
+
+React harness and chat-aware matchers for transcript-driven AI chat UI tests,
+with [@assistant-ui/chat-test-kit-core](../chat-test-kit-core/README.md)
+re-exported from this package.
+
+## Install
+
+```bash
+pnpm add -D @assistant-ui/chat-test-kit-react
+```
+
+## Setup
+
+```ts
+// vitest.setup.ts
+import { setupChatTestKit } from "@assistant-ui/chat-test-kit-react";
+
+setupChatTestKit();
+```
+
+`setupChatTestKit()` registers seven matchers on Vitest's global `expect`.
+Calling it more than once is a no-op.
+
+## A-tier example
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  createChatTestHarness,
+  message,
+  transcript,
+  thread,
+} from "@assistant-ui/chat-test-kit-react";
+
+const t = transcript()
+  .user("Check AAPL")
+  .assistantStream("AAPL is at $212.44.", {
+    chunks: ["AAPL is ", "at $212.44."],
+    finish: { reason: "stop" },
+  })
+  .toJSON();
+
+const harness = createChatTestHarness({ transcript: t });
+const user = userEvent.setup();
+
+render(<MyChatApp />, { wrapper: harness.wrapper });
+await user.type(screen.getByRole("textbox"), "Check AAPL");
+await user.click(screen.getByRole("button", { name: /send/i }));
+await harness.waitForIdle();
+
+expect(thread().on(harness)).toHaveAssistantText(/AAPL is at/);
+expect(message(1).on(harness)).toStreamCompletely();
+```
+
+## C-tier (escape hatches)
+
+```ts
+await harness.advanceChunk();
+await harness.advanceToolCall();
+await harness.inject.disconnect();
+await harness.inject.transportError({ code: 500, message: "boom" });
+await harness.cancel();
+```
+
+## Diagnostics
+
+```ts
+harness.getReplayState();
+harness.timeline();
+harness.getRuntimeSnapshot();
+harness.getRuntime();
+```
+
+## Matchers
+
+| Target | Matcher | Notes |
+|---|---|---|
+| `thread().on(harness)` | `toHaveAssistantText(text \| RegExp)` | Cumulative assistant text |
+| `thread()` | `toShowError(match?)` | Asserts an error surface |
+| `message(n)` | `toHaveText(string)` | n is 0-indexed across rendered messages |
+| `message(n).on(harness)` | `toStreamCompletely()` | Stream reached complete |
+| `message(n).on(harness)` | `toBeInterrupted()` | Stream was interrupted/error/cancelled |
+| `toolCall(name)` | `toRenderResult()` | Tool UI rendered a result |
+| `toolCall(name).on(harness)` | `toHaveReceivedArgs(args)` | Args seen by runtime |
+
+## Notes
+
+- Tool results are delivered through yielded `tool-call` content parts with
+  `result` populated, bypassing `useAssistantTool({ execute })`.
+- `harness.cancel()` aborts the in-flight run via the runtime cancel API.
+- The harness uses `@assistant-ui/chat-test-kit-core`'s `VirtualClock` for
+  deterministic transcript replay.

--- a/packages/chat-test-kit-react/README.md
+++ b/packages/chat-test-kit-react/README.md
@@ -85,6 +85,35 @@ harness.getRuntime();
 | `toolCall(name)` | `toRenderResult()` | Tool UI rendered a result |
 | `toolCall(name).on(harness)` | `toHaveReceivedArgs(args)` | Args seen by runtime |
 
+## Matcher DOM Contracts
+
+- `toolCall(name).toRenderResult()` looks for `[data-tool-name="<name>"]`.
+- `thread().toShowError()` looks for `[data-testid="aui-error"]`.
+
+If your app uses different attributes, render equivalent test-only wrappers so these matchers can resolve deterministic targets.
+
+## jsdom Caveats
+
+Some UI trees require browser APIs that jsdom does not fully emulate. Add these shims in your test setup when needed:
+
+```ts
+class ResizeObserverMock {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+}
+
+if (!Element.prototype.scrollTo) {
+  Element.prototype.scrollTo = () => {};
+}
+```
+
+When full page composition is brittle under jsdom, prefer a minimal primitive-first harness that isolates only the behavior you are asserting.
+
 ## Notes
 
 - Tool results are delivered through yielded `tool-call` content parts with

--- a/packages/chat-test-kit-react/package.json
+++ b/packages/chat-test-kit-react/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@assistant-ui/chat-test-kit-react",
+  "version": "0.0.0",
+  "description": "React harness and chat-aware matchers for transcript-driven AI chat UI tests.",
+  "keywords": [
+    "assistant-ui",
+    "testing",
+    "chat",
+    "react",
+    "vitest",
+    "jest"
+  ],
+  "author": "AgentbaseAI Inc.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "aui-build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@assistant-ui/react": "workspace:*",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "*",
+    "react": "^18 || ^19"
+  },
+  "dependencies": {
+    "@assistant-ui/chat-test-kit-core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@assistant-ui/react": "workspace:*",
+    "@assistant-ui/x-buildutils": "workspace:*",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.0.2",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "vitest": "^4.1.5"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://www.assistant-ui.com/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/assistant-ui/assistant-ui.git",
+    "directory": "packages/chat-test-kit-react"
+  },
+  "bugs": {
+    "url": "https://github.com/assistant-ui/assistant-ui/issues"
+  }
+}

--- a/packages/chat-test-kit-react/src/__tests__/adapter.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/adapter.test.tsx
@@ -1,0 +1,61 @@
+import type {
+  AssistantEvent,
+  ContentPart,
+} from "@assistant-ui/chat-test-kit-core";
+import { describe, expect, it } from "vitest";
+import { createAssistantUIAdapter } from "../harness/adapter";
+import { EventBridge } from "../harness/bridge";
+
+describe("createAssistantUIAdapter", () => {
+  it("records sendUserMessage in snapshot.userMessages and timeline", async () => {
+    const bridge = new EventBridge();
+    const adapter = createAssistantUIAdapter({ bridge });
+    const content: ContentPart[] = [{ type: "text", text: "hi" }];
+
+    await adapter.sendUserMessage(content);
+
+    expect(adapter.getSnapshot().userMessages).toEqual([content]);
+    expect(adapter.timeline()).toEqual([
+      { kind: "user-submit", at: expect.any(Number), content: "hi" },
+    ]);
+  });
+
+  it("forwards emitted events to the bridge AND records them in snapshot/timeline", async () => {
+    const bridge = new EventBridge();
+    const adapter = createAssistantUIAdapter({ bridge });
+
+    const event: AssistantEvent = { type: "text-delta", delta: "Hel" };
+    await adapter.emit(event);
+
+    expect(adapter.getSnapshot().events).toEqual([event]);
+    expect(adapter.timeline()[0]).toMatchObject({ kind: "event", event });
+  });
+
+  it("abort calls onAbort once and increments abortCount", async () => {
+    const bridge = new EventBridge();
+    let aborts = 0;
+    const adapter = createAssistantUIAdapter({
+      bridge,
+      onAbort: () => {
+        aborts += 1;
+      },
+    });
+
+    await adapter.abort();
+    await adapter.abort();
+
+    expect(aborts).toBe(2);
+    expect(adapter.getSnapshot().abortCount).toBe(2);
+  });
+
+  it("ending the bridge after a finish event is the adapter's responsibility", async () => {
+    const bridge = new EventBridge();
+    const adapter = createAssistantUIAdapter({ bridge });
+
+    await adapter.emit({ type: "finish", reason: "stop" });
+
+    const out = [];
+    for await (const event of bridge.consume()) out.push(event);
+    expect(out).toEqual([{ type: "finish", reason: "stop" }]);
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/bridge.test.ts
+++ b/packages/chat-test-kit-react/src/__tests__/bridge.test.ts
@@ -1,0 +1,59 @@
+import type { AssistantEvent } from "@assistant-ui/chat-test-kit-core";
+import { describe, expect, it } from "vitest";
+import { EventBridge } from "../harness/bridge";
+
+describe("EventBridge", () => {
+  it("delivers pushed events to a consumer in order", async () => {
+    const bridge = new EventBridge();
+    const events: AssistantEvent[] = [
+      { type: "text-delta", delta: "Hel" },
+      { type: "text-delta", delta: "lo" },
+      { type: "finish", reason: "stop" },
+    ];
+
+    const consumer = (async () => {
+      const out: AssistantEvent[] = [];
+      for await (const event of bridge.consume()) out.push(event);
+      return out;
+    })();
+
+    for (const event of events) bridge.push(event);
+    bridge.end();
+
+    expect(await consumer).toEqual(events);
+  });
+
+  it("buffers events pushed before consume() starts", async () => {
+    const bridge = new EventBridge();
+    bridge.push({ type: "text-delta", delta: "early" });
+    bridge.end();
+
+    const out: AssistantEvent[] = [];
+    for await (const event of bridge.consume()) out.push(event);
+
+    expect(out).toEqual([{ type: "text-delta", delta: "early" }]);
+  });
+
+  it("can be reset for a new run", async () => {
+    const bridge = new EventBridge();
+    bridge.push({ type: "text-delta", delta: "a" });
+    bridge.end();
+
+    const first: AssistantEvent[] = [];
+    for await (const event of bridge.consume()) first.push(event);
+
+    bridge.reset();
+    bridge.push({ type: "text-delta", delta: "b" });
+    bridge.end();
+
+    const second: AssistantEvent[] = [];
+    for await (const event of bridge.consume()) second.push(event);
+
+    expect(first.map((event) => (event as { delta: string }).delta)).toEqual([
+      "a",
+    ]);
+    expect(second.map((event) => (event as { delta: string }).delta)).toEqual([
+      "b",
+    ]);
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/chat-model-adapter.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/chat-model-adapter.test.tsx
@@ -1,0 +1,101 @@
+import type { ChatModelAdapter } from "@assistant-ui/react";
+import { describe, expect, it } from "vitest";
+import { EventBridge } from "../harness/bridge";
+import { buildChatModelAdapter } from "../harness/chat-model-adapter";
+
+function fakeOptions(): Parameters<ChatModelAdapter["run"]>[0] {
+  return {} as unknown as Parameters<ChatModelAdapter["run"]>[0];
+}
+
+describe("buildChatModelAdapter", () => {
+  it("accumulates text-delta into cumulative content", async () => {
+    const bridge = new EventBridge();
+    const adapter = buildChatModelAdapter({ bridge });
+
+    bridge.push({ type: "text-delta", delta: "Hel" });
+    bridge.push({ type: "text-delta", delta: "lo" });
+    bridge.push({ type: "finish", reason: "stop" });
+    bridge.end();
+
+    const yields = [];
+    const gen = adapter.run(fakeOptions()) as AsyncGenerator<{
+      content?: ReadonlyArray<{ type: string; text?: string }>;
+      status?: unknown;
+    }>;
+    for await (const update of gen) yields.push(update);
+
+    const texts = yields.map(
+      (y) => y.content?.find((part) => part.type === "text")?.text ?? "",
+    );
+    expect(texts).toEqual(["Hel", "Hello", "Hello"]);
+    expect(yields.at(-1)?.status).toEqual({ type: "complete", reason: "stop" });
+  });
+
+  it("yields tool-call without result, then with result on tool-result event", async () => {
+    const bridge = new EventBridge();
+    const adapter = buildChatModelAdapter({ bridge });
+
+    bridge.push({
+      type: "tool-call",
+      toolCallId: "tc_1",
+      toolName: "x",
+      args: { a: 1 },
+      argsText: '{"a":1}',
+    });
+    bridge.push({
+      type: "tool-result",
+      toolCallId: "tc_1",
+      value: { ok: true },
+    });
+    bridge.push({ type: "finish", reason: "stop" });
+    bridge.end();
+
+    const yields: Array<{
+      content?: ReadonlyArray<{ type: string; result?: unknown }>;
+    }> = [];
+    const gen = adapter.run(fakeOptions()) as AsyncGenerator<{
+      content?: ReadonlyArray<{ type: string; result?: unknown }>;
+    }>;
+    for await (const update of gen) yields.push(update);
+
+    const toolParts = yields.map((y) =>
+      y.content?.find((part) => part.type === "tool-call"),
+    );
+    expect(toolParts[0]).toMatchObject({
+      type: "tool-call",
+      toolCallId: "tc_1",
+      toolName: "x",
+    });
+    expect(toolParts[1]).toMatchObject({ result: { ok: true } });
+  });
+
+  it("transport-error event terminates the run with status reason 'error'", async () => {
+    const bridge = new EventBridge();
+    const adapter = buildChatModelAdapter({ bridge });
+
+    bridge.push({ type: "transport-error", code: 500, message: "boom" });
+
+    const yields = [] as Array<{ status?: { reason?: string } }>;
+    const gen = adapter.run(fakeOptions()) as AsyncGenerator<{
+      status?: { reason?: string };
+    }>;
+    for await (const update of gen) yields.push(update);
+
+    expect(yields.at(-1)?.status?.reason).toBe("error");
+  });
+
+  it("disconnect event terminates the run with status reason 'error'", async () => {
+    const bridge = new EventBridge();
+    const adapter = buildChatModelAdapter({ bridge });
+
+    bridge.push({ type: "disconnect" });
+
+    const yields = [] as Array<{ status?: { reason?: string } }>;
+    const gen = adapter.run(fakeOptions()) as AsyncGenerator<{
+      status?: { reason?: string };
+    }>;
+    for await (const update of gen) yields.push(update);
+
+    expect(yields.at(-1)?.status?.reason).toBe("error");
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/harness-auto-advance.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/harness-auto-advance.test.tsx
@@ -1,0 +1,41 @@
+import { transcript } from "@assistant-ui/chat-test-kit-core";
+import { MessagePrimitive, ThreadPrimitive } from "@assistant-ui/react";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createChatTestHarness } from "../harness/harness";
+
+describe("auto-advance on user submit", () => {
+  it("drives the replayer to idle after yields a streamed reply", async () => {
+    const t = transcript()
+      .user("hi")
+      .assistantStream("hello world", {
+        chunks: ["hello ", "world"],
+        finish: { reason: "stop" },
+      })
+      .toJSON();
+    const harness = createChatTestHarness({ transcript: t });
+
+    function App() {
+      return (
+        <ThreadPrimitive.Root>
+          <ThreadPrimitive.Messages>
+            {() => (
+              <MessagePrimitive.Root>
+                <MessagePrimitive.Parts />
+              </MessagePrimitive.Root>
+            )}
+          </ThreadPrimitive.Messages>
+        </ThreadPrimitive.Root>
+      );
+    }
+
+    render(<App />, { wrapper: harness.wrapper });
+
+    await harness.waitForIdle();
+
+    expect(harness.getReplayState().phase).toBe("complete");
+    expect(
+      harness.getRuntimeSnapshot().events.map((event) => event.type),
+    ).toEqual(["text-delta", "text-delta", "finish"]);
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/harness-c-tier.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/harness-c-tier.test.tsx
@@ -1,0 +1,39 @@
+import { transcript } from "@assistant-ui/chat-test-kit-core";
+import { describe, expect, it } from "vitest";
+import { createChatTestHarness } from "../harness/harness";
+
+describe("C-tier", () => {
+  it("advanceChunk emits one chunk per call", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .assistantStream("ab", { chunks: ["a", "b"] })
+        .toJSON(),
+    });
+
+    await harness.advanceChunk();
+    expect(
+      harness.getRuntimeSnapshot().events.map((event) => event.type),
+    ).toEqual(["text-delta"]);
+
+    await harness.advanceChunk();
+    expect(
+      harness.getRuntimeSnapshot().events.map((event) => event.type),
+    ).toEqual(["text-delta", "text-delta"]);
+  });
+
+  it("advanceToolCall runs to the next turn", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .assistantToolCall("get", { ticker: "AAPL" })
+        .toolResult({ price: 1 })
+        .assistantStream("done", { finish: { reason: "stop" } })
+        .toJSON(),
+    });
+
+    await harness.advanceToolCall();
+    const types = harness
+      .getRuntimeSnapshot()
+      .events.map((event) => event.type);
+    expect(types).toEqual(["tool-call"]);
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/harness-cancel.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/harness-cancel.test.tsx
@@ -1,0 +1,44 @@
+import { transcript } from "@assistant-ui/chat-test-kit-core";
+import { describe, expect, it } from "vitest";
+import { createChatTestHarness } from "../harness/harness";
+
+describe("C-tier injections", () => {
+  it("inject.disconnect emits a disconnect event", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript().toJSON(),
+    });
+
+    await harness.inject.disconnect();
+
+    expect(
+      harness.getRuntimeSnapshot().events.map((event) => event.type),
+    ).toContain("disconnect");
+  });
+
+  it("inject.transportError emits a transport-error event with code+message", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript().toJSON(),
+    });
+
+    await harness.inject.transportError({ code: 503, message: "unavailable" });
+
+    const event = harness
+      .getRuntimeSnapshot()
+      .events.find((item) => item.type === "transport-error");
+    expect(event).toMatchObject({ code: 503, message: "unavailable" });
+  });
+
+  it("cancel transitions replayer to cancelled phase", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .assistantStream("hello", { chunks: ["he", "llo"] })
+        .toJSON(),
+    });
+
+    await harness.advanceChunk();
+    await harness.cancel();
+
+    expect(harness.getReplayState().phase).toBe("cancelled");
+    expect(harness.getRuntimeSnapshot().abortCount).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/harness-render.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/harness-render.test.tsx
@@ -1,0 +1,49 @@
+import { transcript } from "@assistant-ui/chat-test-kit-core";
+import { MessagePrimitive, ThreadPrimitive } from "@assistant-ui/react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createChatTestHarness } from "../harness/harness";
+
+function MinimalApp() {
+  return (
+    <ThreadPrimitive.Root>
+      <ThreadPrimitive.Messages>
+        {() => (
+          <MessagePrimitive.Root>
+            <MessagePrimitive.Parts />
+          </MessagePrimitive.Root>
+        )}
+      </ThreadPrimitive.Messages>
+    </ThreadPrimitive.Root>
+  );
+}
+
+describe("createChatTestHarness — render", () => {
+  it("renders a runtime-backed app via wrapper without throwing", () => {
+    const harness = createChatTestHarness({
+      transcript: transcript().user("hi").toJSON(),
+    });
+
+    render(<MinimalApp />, { wrapper: harness.wrapper });
+
+    expect(screen.queryByText("hi")).toBeNull();
+  });
+
+  it("exposes the documented harness shape", () => {
+    const harness = createChatTestHarness({
+      transcript: transcript().toJSON(),
+    });
+
+    expect(typeof harness.wrapper).toBe("function");
+    expect(typeof harness.waitForIdle).toBe("function");
+    expect(typeof harness.cancel).toBe("function");
+    expect(typeof harness.advanceChunk).toBe("function");
+    expect(typeof harness.advanceToolCall).toBe("function");
+    expect(typeof harness.inject.disconnect).toBe("function");
+    expect(typeof harness.inject.transportError).toBe("function");
+    expect(typeof harness.getReplayState).toBe("function");
+    expect(typeof harness.timeline).toBe("function");
+    expect(typeof harness.getRuntimeSnapshot).toBe("function");
+    expect(typeof harness.getRuntime).toBe("function");
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/harness-wait-for-idle.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/harness-wait-for-idle.test.tsx
@@ -1,0 +1,41 @@
+import { transcript } from "@assistant-ui/chat-test-kit-core";
+import { describe, expect, it } from "vitest";
+import { createChatTestHarness } from "../harness/harness";
+
+describe("waitForIdle", () => {
+  it("returns when phase is complete", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .assistantStream("a", { chunks: ["a"], finish: { reason: "stop" } })
+        .toJSON(),
+    });
+    await harness.waitForIdle();
+    expect(harness.getReplayState().phase).toBe("complete");
+  });
+
+  it("returns when phase is error (transport error injected)", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .assistantStream("a")
+        .inject.transportError({ code: 500, message: "boom" })
+        .toJSON(),
+    });
+    await harness.waitForIdle();
+    expect(harness.getReplayState().phase).toBe("error");
+    expect(harness.getReplayState().lastError).toEqual({
+      code: 500,
+      message: "boom",
+    });
+  });
+
+  it("is idempotent — calling twice is safe", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .assistantStream("a", { chunks: ["a"], finish: { reason: "stop" } })
+        .toJSON(),
+    });
+    await harness.waitForIdle();
+    await harness.waitForIdle();
+    expect(harness.getReplayState().phase).toBe("complete");
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/integration.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/integration.test.tsx
@@ -1,0 +1,59 @@
+import { transcript } from "@assistant-ui/chat-test-kit-core";
+import {
+  ComposerPrimitive,
+  MessagePrimitive,
+  ThreadPrimitive,
+} from "@assistant-ui/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { createChatTestHarness } from "../harness/harness";
+import { message, thread } from "../matchers/targets";
+import { setupChatTestKit } from "../setup";
+
+setupChatTestKit();
+
+function ChatApp() {
+  return (
+    <ThreadPrimitive.Root>
+      <ThreadPrimitive.Messages>
+        {() => (
+          <MessagePrimitive.Root>
+            <MessagePrimitive.Parts />
+          </MessagePrimitive.Root>
+        )}
+      </ThreadPrimitive.Messages>
+      <ComposerPrimitive.Root>
+        <ComposerPrimitive.Input aria-label="message" />
+        <ComposerPrimitive.Send>send</ComposerPrimitive.Send>
+      </ComposerPrimitive.Root>
+    </ThreadPrimitive.Root>
+  );
+}
+
+describe("integration — A-tier example from v1 roadmap", () => {
+  it("renders a streamed assistant reply in response to a user submission", async () => {
+    const t = transcript()
+      .user("Check AAPL")
+      .assistantStream("AAPL is at $212.44.", {
+        chunks: ["AAPL is ", "at $212.44."],
+        interChunkDelayMs: 20,
+        finish: { reason: "stop" },
+      })
+      .toJSON();
+    const harness = createChatTestHarness({ transcript: t });
+
+    const user = userEvent.setup();
+    render(<ChatApp />, { wrapper: harness.wrapper });
+
+    await user.type(
+      screen.getByRole("textbox", { name: "message" }),
+      "Check AAPL",
+    );
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await harness.waitForIdle();
+
+    expect(thread().on(harness)).toHaveAssistantText(/AAPL is at/);
+    expect(message(1).on(harness)).toStreamCompletely();
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/matchers-message.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/matchers-message.test.tsx
@@ -1,0 +1,93 @@
+import { transcript } from "@assistant-ui/chat-test-kit-core";
+import {
+  ComposerPrimitive,
+  MessagePrimitive,
+  ThreadPrimitive,
+} from "@assistant-ui/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { createChatTestHarness } from "../harness/harness";
+import { message } from "../matchers/targets";
+import { setupChatTestKit } from "../setup";
+
+setupChatTestKit();
+
+function App() {
+  return (
+    <ThreadPrimitive.Root>
+      <ThreadPrimitive.Messages>
+        {() => (
+          <MessagePrimitive.Root>
+            <MessagePrimitive.Parts />
+          </MessagePrimitive.Root>
+        )}
+      </ThreadPrimitive.Messages>
+      <ComposerPrimitive.Root>
+        <ComposerPrimitive.Input aria-label="message" />
+        <ComposerPrimitive.Send>send</ComposerPrimitive.Send>
+      </ComposerPrimitive.Root>
+    </ThreadPrimitive.Root>
+  );
+}
+
+describe("message(n) matchers", () => {
+  it("toHaveText reads the n-th message text", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .user("hi there")
+        .assistantStream("hello world", { finish: { reason: "stop" } })
+        .toJSON(),
+    });
+
+    const user = userEvent.setup();
+    render(<App />, { wrapper: harness.wrapper });
+
+    await user.type(
+      screen.getByRole("textbox", { name: "message" }),
+      "hi there",
+    );
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await harness.waitForIdle();
+
+    expect(message(0)).toHaveText("hi there");
+    expect(message(1)).toHaveText("hello world");
+  });
+
+  it("toStreamCompletely passes when replay reaches complete", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .user("go")
+        .assistantStream("done", { finish: { reason: "stop" } })
+        .toJSON(),
+    });
+
+    const user = userEvent.setup();
+    render(<App />, { wrapper: harness.wrapper });
+
+    await user.type(screen.getByRole("textbox", { name: "message" }), "go");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await harness.waitForIdle();
+
+    expect(message(1).on(harness)).toStreamCompletely();
+  });
+
+  it("toBeInterrupted passes when interrupt was injected", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .user("go")
+        .assistantStream("x")
+        .inject.interrupt("user-stop")
+        .toJSON(),
+    });
+
+    const user = userEvent.setup();
+    render(<App />, { wrapper: harness.wrapper });
+
+    await user.type(screen.getByRole("textbox", { name: "message" }), "go");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await harness.waitForIdle();
+
+    expect(message(1).on(harness)).toBeInterrupted();
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/matchers-targets.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/matchers-targets.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { message, thread, toolCall } from "../matchers/targets";
+
+describe("matcher targets", () => {
+  it("thread() returns a tagged object", () => {
+    expect(thread()).toMatchObject({ __kind: "thread" });
+    expect(typeof thread().on).toBe("function");
+  });
+
+  it("message(n) returns a tagged object with index", () => {
+    expect(message(2)).toMatchObject({ __kind: "message", index: 2 });
+    expect(typeof message(2).on).toBe("function");
+  });
+
+  it("toolCall(name) returns a tagged object with name", () => {
+    expect(toolCall("get_stock_price")).toMatchObject({
+      __kind: "toolCall",
+      name: "get_stock_price",
+    });
+    expect(typeof toolCall("get_stock_price").on).toBe("function");
+  });
+
+  it("message rejects negative index at construction time", () => {
+    expect(() => message(-1)).toThrow(/non-negative/i);
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/matchers-thread.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/matchers-thread.test.tsx
@@ -1,0 +1,75 @@
+import { transcript } from "@assistant-ui/chat-test-kit-core";
+import {
+  ComposerPrimitive,
+  MessagePrimitive,
+  ThreadPrimitive,
+} from "@assistant-ui/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { createChatTestHarness } from "../harness/harness";
+import { thread } from "../matchers/targets";
+import { setupChatTestKit } from "../setup";
+
+setupChatTestKit();
+
+function App() {
+  return (
+    <ThreadPrimitive.Root>
+      <ThreadPrimitive.Messages>
+        {() => (
+          <MessagePrimitive.Root>
+            <MessagePrimitive.Parts />
+          </MessagePrimitive.Root>
+        )}
+      </ThreadPrimitive.Messages>
+      <ComposerPrimitive.Root>
+        <ComposerPrimitive.Input aria-label="message" />
+        <ComposerPrimitive.Send>send</ComposerPrimitive.Send>
+      </ComposerPrimitive.Root>
+    </ThreadPrimitive.Root>
+  );
+}
+
+describe("thread() matchers", () => {
+  it("toHaveAssistantText matches cumulative assistant text", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .user("q")
+        .assistantStream("AAPL is at $212.44.", {
+          finish: { reason: "stop" },
+        })
+        .toJSON(),
+    });
+
+    const user = userEvent.setup();
+    render(<App />, { wrapper: harness.wrapper });
+
+    await user.type(screen.getByRole("textbox", { name: "message" }), "q");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await harness.waitForIdle();
+
+    expect(thread().on(harness)).toHaveAssistantText(/AAPL is at/);
+  });
+
+  it("toShowError fails when only harness state has an error", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .user("q")
+        .assistantStream("x")
+        .inject.transportError({ code: 500, message: "boom" })
+        .toJSON(),
+    });
+
+    const user = userEvent.setup();
+    render(<App />, { wrapper: harness.wrapper });
+
+    await user.type(screen.getByRole("textbox", { name: "message" }), "q");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await harness.waitForIdle();
+
+    expect(() => expect(thread().on(harness)).toShowError(/boom/)).toThrow(
+      /error surface/i,
+    );
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/matchers-tool-call.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/matchers-tool-call.test.tsx
@@ -1,0 +1,96 @@
+import { transcript } from "@assistant-ui/chat-test-kit-core";
+import {
+  ComposerPrimitive,
+  MessagePrimitive,
+  ThreadPrimitive,
+  useAssistantTool,
+} from "@assistant-ui/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { createChatTestHarness } from "../harness/harness";
+import { setupChatTestKit } from "../setup";
+import { toolCall } from "../matchers/targets";
+
+setupChatTestKit();
+
+function ToolApp() {
+  useAssistantTool({
+    toolName: "get_stock_price",
+    description: "x",
+    parameters: { type: "object", properties: { ticker: { type: "string" } } },
+    execute: async () => ({ price: 0 }),
+    render: (part) => (
+      <div data-tool-name="get_stock_price">
+        {part.result ? JSON.stringify(part.result) : "pending"}
+      </div>
+    ),
+  });
+
+  return (
+    <ThreadPrimitive.Root>
+      <ThreadPrimitive.Messages>
+        {() => (
+          <MessagePrimitive.Root>
+            <MessagePrimitive.Parts />
+          </MessagePrimitive.Root>
+        )}
+      </ThreadPrimitive.Messages>
+      <ComposerPrimitive.Root>
+        <ComposerPrimitive.Input aria-label="message" />
+        <ComposerPrimitive.Send>send</ComposerPrimitive.Send>
+      </ComposerPrimitive.Root>
+    </ThreadPrimitive.Root>
+  );
+}
+
+describe("toolCall(name) matchers", () => {
+  it("toRenderResult passes when the tool result is in the DOM", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .user("Check AAPL")
+        .assistantToolCall("get_stock_price", { ticker: "AAPL" })
+        .toolResult({ price: 212.44 })
+        .assistantStream("done", { finish: { reason: "stop" } })
+        .toJSON(),
+    });
+
+    const user = userEvent.setup();
+    render(<ToolApp />, { wrapper: harness.wrapper });
+
+    await user.type(
+      screen.getByRole("textbox", { name: "message" }),
+      "Check AAPL",
+    );
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await harness.waitForIdle();
+
+    expect(toolCall("get_stock_price")).toRenderResult();
+    expect(screen.getByText(/212\.44/)).toBeTruthy();
+  });
+
+  it("toHaveReceivedArgs reads from the runtime snapshot via .on(harness)", async () => {
+    const harness = createChatTestHarness({
+      transcript: transcript()
+        .user("Check AAPL")
+        .assistantToolCall("get_stock_price", { ticker: "AAPL" })
+        .toolResult({ price: 1 })
+        .assistantStream("done", { finish: { reason: "stop" } })
+        .toJSON(),
+    });
+
+    const user = userEvent.setup();
+    render(<ToolApp />, { wrapper: harness.wrapper });
+
+    await user.type(
+      screen.getByRole("textbox", { name: "message" }),
+      "Check AAPL",
+    );
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await harness.waitForIdle();
+
+    expect(toolCall("get_stock_price").on(harness)).toHaveReceivedArgs({
+      ticker: "AAPL",
+    });
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/public-api.test.ts
+++ b/packages/chat-test-kit-react/src/__tests__/public-api.test.ts
@@ -1,0 +1,31 @@
+import * as api from "../index";
+import { describe, expect, it } from "vitest";
+
+describe("public API surface", () => {
+  it("exports the documented value identifiers", () => {
+    expect(typeof api.transcript).toBe("function");
+    expect(typeof api.Transcript).toBe("object");
+    expect(typeof api.TRANSCRIPT_VERSION).toBe("string");
+    expect(typeof api.createChatTestHarness).toBe("function");
+    expect(typeof api.setupChatTestKit).toBe("function");
+    expect(typeof api.thread).toBe("function");
+    expect(typeof api.message).toBe("function");
+    expect(typeof api.toolCall).toBe("function");
+  });
+
+  it("module export keys are stable", () => {
+    const keys = Object.keys(api).sort();
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        "TRANSCRIPT_VERSION",
+        "Transcript",
+        "createChatTestHarness",
+        "message",
+        "setupChatTestKit",
+        "thread",
+        "toolCall",
+        "transcript",
+      ]),
+    );
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/setup.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/setup.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { thread } from "../matchers/targets";
+
+describe("setupChatTestKit", () => {
+  it("registers matchers on the global expect", async () => {
+    vi.resetModules();
+    const originalExpect = (globalThis as { expect?: unknown }).expect;
+    const fakeExpect = { extend: vi.fn() };
+    (globalThis as { expect?: unknown }).expect = fakeExpect;
+
+    const { setupChatTestKit } = await import("../setup");
+    setupChatTestKit();
+
+    expect(fakeExpect.extend).toHaveBeenCalledOnce();
+
+    (globalThis as { expect?: unknown }).expect = originalExpect;
+  });
+
+  it("can be called multiple times without throwing", async () => {
+    vi.resetModules();
+    const { setupChatTestKit } = await import("../setup");
+    setupChatTestKit();
+    setupChatTestKit();
+    setupChatTestKit();
+    expect(
+      typeof (expect(thread()) as { toHaveAssistantText?: unknown })
+        .toHaveAssistantText,
+    ).toBe("function");
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/smoke.test.ts
+++ b/packages/chat-test-kit-react/src/__tests__/smoke.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+
+describe("chat-test-kit-react", () => {
+  it("loads under jsdom", () => {
+    expect(typeof document).toBe("object");
+    expect(typeof window).toBe("object");
+  });
+});

--- a/packages/chat-test-kit-react/src/__tests__/tool-call-execution-spike.test.tsx
+++ b/packages/chat-test-kit-react/src/__tests__/tool-call-execution-spike.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import {
+  AssistantRuntimeProvider,
+  MessagePrimitive,
+  ThreadPrimitive,
+  useAssistantTool,
+  useLocalRuntime,
+  type AssistantRuntime,
+  type ChatModelAdapter,
+} from "@assistant-ui/react";
+import { describe, expect, it, vi } from "vitest";
+
+function MinimalAppWithTool({
+  adapter,
+  runtimeRef,
+  executeSpy,
+}: {
+  adapter: ChatModelAdapter;
+  runtimeRef: { current: AssistantRuntime | null };
+  executeSpy: ReturnType<typeof vi.fn>;
+}) {
+  const runtime = useLocalRuntime(adapter);
+  runtimeRef.current = runtime;
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ToolRegistration executeSpy={executeSpy} />
+      <ThreadPrimitive.Root>
+        <ThreadPrimitive.Messages>
+          {() => (
+            <MessagePrimitive.Root>
+              <MessagePrimitive.Parts />
+            </MessagePrimitive.Root>
+          )}
+        </ThreadPrimitive.Messages>
+      </ThreadPrimitive.Root>
+    </AssistantRuntimeProvider>
+  );
+}
+
+function ToolRegistration({
+  executeSpy,
+}: {
+  executeSpy: ReturnType<typeof vi.fn>;
+}) {
+  useAssistantTool({
+    toolName: "get_stock_price",
+    description: "Get a stock price",
+    parameters: { type: "object", properties: { ticker: { type: "string" } } },
+    execute: executeSpy as unknown as (args: unknown) => Promise<unknown>,
+    render: (part) => (
+      <div data-testid="tool-render">
+        result={JSON.stringify(part.result ?? null)}
+      </div>
+    ),
+  });
+  return null;
+}
+
+describe("tool-call delivery via yielded content with result", () => {
+  it("renders tool result without invoking useAssistantTool execute", async () => {
+    const executeSpy = vi.fn();
+
+    const adapter: ChatModelAdapter = {
+      run: async function* () {
+        yield {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "tc_1",
+              toolName: "get_stock_price",
+              args: { ticker: "AAPL" },
+              argsText: '{"ticker":"AAPL"}',
+            },
+          ],
+        };
+        yield {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "tc_1",
+              toolName: "get_stock_price",
+              args: { ticker: "AAPL" },
+              argsText: '{"ticker":"AAPL"}',
+              result: { price: 212.44 },
+            },
+          ],
+          status: { type: "complete", reason: "stop" },
+        };
+      },
+    };
+
+    const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+    render(
+      <MinimalAppWithTool
+        adapter={adapter}
+        runtimeRef={runtimeRef}
+        executeSpy={executeSpy}
+      />,
+    );
+
+    await act(async () => {
+      runtimeRef.current!.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "Check AAPL" }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tool-render").textContent).toContain(
+        '"price":212.44',
+      );
+    });
+
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/chat-test-kit-react/src/harness/adapter.ts
+++ b/packages/chat-test-kit-react/src/harness/adapter.ts
@@ -1,0 +1,66 @@
+import type {
+  AssistantEvent,
+  ContentPart,
+  RuntimeAdapter,
+  RuntimeSnapshot,
+} from "@assistant-ui/chat-test-kit-core";
+import type { EventBridge } from "./bridge";
+import type { TimelineEntry } from "./types";
+
+export type AssistantUIAdapterOptions = {
+  bridge: EventBridge;
+  onAbort?: () => void;
+};
+
+export type AssistantUIAdapter = RuntimeAdapter & {
+  timeline(): TimelineEntry[];
+};
+
+export function createAssistantUIAdapter(
+  options: AssistantUIAdapterOptions,
+): AssistantUIAdapter {
+  const events: AssistantEvent[] = [];
+  const userMessages: ContentPart[][] = [];
+  const timelineEntries: TimelineEntry[] = [];
+  let abortCount = 0;
+
+  function pushTimeline(entry: TimelineEntry): void {
+    timelineEntries.push(entry);
+  }
+
+  return {
+    async sendUserMessage(content) {
+      const copy = [...content];
+      userMessages.push(copy);
+      const text = copy
+        .map((part) => (part.type === "text" ? part.text : ""))
+        .join("");
+      pushTimeline({ kind: "user-submit", at: Date.now(), content: text });
+    },
+    async emit(event) {
+      events.push(event);
+      pushTimeline({ kind: "event", at: Date.now(), event });
+      options.bridge.push(event);
+      const isTerminal =
+        event.type === "finish" ||
+        event.type === "transport-error" ||
+        event.type === "disconnect";
+      if (isTerminal) options.bridge.end();
+    },
+    getSnapshot(): RuntimeSnapshot {
+      return {
+        events: [...events],
+        abortCount,
+        userMessages: userMessages.map((m) => [...m]),
+      };
+    },
+    async abort() {
+      abortCount += 1;
+      options.onAbort?.();
+      options.bridge.end();
+    },
+    timeline() {
+      return [...timelineEntries];
+    },
+  };
+}

--- a/packages/chat-test-kit-react/src/harness/bridge.ts
+++ b/packages/chat-test-kit-react/src/harness/bridge.ts
@@ -1,0 +1,53 @@
+import type { AssistantEvent } from "@assistant-ui/chat-test-kit-core";
+
+type Resolver = (value: AssistantEvent | "end") => void;
+
+export class EventBridge {
+  private queue: AssistantEvent[] = [];
+  private ended = false;
+  private waiting: Resolver | null = null;
+
+  push(event: AssistantEvent): void {
+    if (this.ended) {
+      throw new Error("EventBridge: push() after end()");
+    }
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      resolve(event);
+      return;
+    }
+    this.queue.push(event);
+  }
+
+  end(): void {
+    if (this.ended) return;
+    this.ended = true;
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      resolve("end");
+    }
+  }
+
+  reset(): void {
+    this.queue = [];
+    this.ended = false;
+    this.waiting = null;
+  }
+
+  async *consume(): AsyncGenerator<AssistantEvent, void> {
+    for (;;) {
+      if (this.queue.length > 0) {
+        yield this.queue.shift()!;
+        continue;
+      }
+      if (this.ended) return;
+      const next = await new Promise<AssistantEvent | "end">((resolve) => {
+        this.waiting = resolve;
+      });
+      if (next === "end") return;
+      yield next;
+    }
+  }
+}

--- a/packages/chat-test-kit-react/src/harness/chat-model-adapter.ts
+++ b/packages/chat-test-kit-react/src/harness/chat-model-adapter.ts
@@ -1,0 +1,125 @@
+import type {
+  ChatModelAdapter,
+  ChatModelRunResult,
+  MessageStatus,
+  ToolCallMessagePart,
+} from "@assistant-ui/react";
+import type { EventBridge } from "./bridge";
+
+export type ChatModelAdapterOptions = {
+  bridge: EventBridge;
+  onRunStart?: () => void;
+};
+
+type Part =
+  | { type: "text"; text: string }
+  | {
+      type: "tool-call";
+      toolCallId: string;
+      toolName: string;
+      args: Record<string, unknown>;
+      argsText: string;
+      result?: unknown;
+    };
+
+function finishStatus(reason: "stop" | "abort" | "error"): MessageStatus {
+  if (reason === "stop") {
+    return { type: "complete", reason: "stop" };
+  }
+  if (reason === "abort") {
+    return { type: "incomplete", reason: "cancelled" };
+  }
+  return { type: "incomplete", reason: "error" };
+}
+
+export function buildChatModelAdapter(
+  options: ChatModelAdapterOptions,
+): ChatModelAdapter {
+  return {
+    run: async function* (): AsyncGenerator<ChatModelRunResult, void> {
+      options.onRunStart?.();
+
+      const parts: Part[] = [];
+      let textIndex: number | null = null;
+
+      for await (const event of options.bridge.consume()) {
+        switch (event.type) {
+          case "text-delta": {
+            if (textIndex === null) {
+              parts.push({ type: "text", text: event.delta });
+              textIndex = parts.length - 1;
+            } else {
+              const current = parts[textIndex] as {
+                type: "text";
+                text: string;
+              };
+              parts[textIndex] = {
+                type: "text",
+                text: current.text + event.delta,
+              };
+            }
+            yield { content: snapshot(parts) };
+            break;
+          }
+          case "tool-call": {
+            parts.push({
+              type: "tool-call",
+              toolCallId: event.toolCallId,
+              toolName: event.toolName,
+              args: event.args,
+              argsText: event.argsText,
+            });
+            textIndex = null;
+            yield { content: snapshot(parts) };
+            break;
+          }
+          case "tool-result": {
+            const idx = parts.findIndex(
+              (p): p is Extract<Part, { type: "tool-call" }> =>
+                p.type === "tool-call" && p.toolCallId === event.toolCallId,
+            );
+            if (idx !== -1) {
+              const tc = parts[idx] as Extract<Part, { type: "tool-call" }>;
+              parts[idx] = { ...tc, result: event.value };
+              yield { content: snapshot(parts) };
+            }
+            break;
+          }
+          case "finish": {
+            yield {
+              content: snapshot(parts),
+              status: finishStatus(event.reason),
+            };
+            return;
+          }
+          case "transport-error":
+          case "disconnect": {
+            yield {
+              content: snapshot(parts),
+              status: { type: "incomplete", reason: "error" },
+            };
+            return;
+          }
+        }
+      }
+
+      yield { content: snapshot(parts) };
+    },
+  };
+}
+
+function snapshot(parts: Part[]): ChatModelRunResult["content"] {
+  return parts.map((part) => {
+    if (part.type === "text") {
+      return { type: "text", text: part.text } as const;
+    }
+    return {
+      type: "tool-call",
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      args: part.args as ToolCallMessagePart["args"],
+      argsText: part.argsText,
+      ...(part.result !== undefined ? { result: part.result } : {}),
+    } satisfies ToolCallMessagePart;
+  });
+}

--- a/packages/chat-test-kit-react/src/harness/harness.ts
+++ b/packages/chat-test-kit-react/src/harness/harness.ts
@@ -1,0 +1,95 @@
+import {
+  Replayer,
+  VirtualClock,
+  type TranscriptType,
+} from "@assistant-ui/chat-test-kit-core";
+import type { AssistantRuntime } from "@assistant-ui/react";
+import { createAssistantUIAdapter } from "./adapter";
+import { EventBridge } from "./bridge";
+import { buildChatModelAdapter } from "./chat-model-adapter";
+import type { ChatTestHarness, HarnessOptions } from "./types";
+import { createWrapper } from "./wrapper";
+
+export function createChatTestHarness(
+  options: HarnessOptions,
+): ChatTestHarness {
+  const transcript: TranscriptType = options.transcript;
+  const autoAdvance = options.autoAdvance ?? true;
+
+  const bridge = new EventBridge();
+  const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+
+  let autoAdvancePromise: Promise<void> | null = null;
+  const adapter = createAssistantUIAdapter({
+    bridge,
+    onAbort: () => {
+      runtimeRef.current?.thread.cancelRun?.();
+    },
+  });
+  const clock = new VirtualClock();
+  const replayer = new Replayer({ transcript, adapter, clock });
+
+  const kickAutoAdvance = () => {
+    if (!autoAdvance) return;
+    if (autoAdvancePromise) return;
+    autoAdvancePromise = (async () => {
+      try {
+        await replayer.advanceToIdle();
+      } finally {
+        bridge.end();
+        autoAdvancePromise = null;
+      }
+    })();
+  };
+
+  const chatModelAdapter = buildChatModelAdapter({
+    bridge,
+    onRunStart: kickAutoAdvance,
+  });
+  const wrapper = createWrapper({ chatModelAdapter, runtimeRef });
+
+  const harness: ChatTestHarness = {
+    wrapper,
+    async waitForIdle() {
+      await replayer.advanceToIdle();
+      bridge.end();
+      await Promise.resolve();
+    },
+    async cancel() {
+      await replayer.cancel();
+      bridge.end();
+    },
+    async advanceChunk() {
+      await replayer.tick();
+    },
+    async advanceToolCall() {
+      await replayer.advanceToNextTurn();
+    },
+    inject: {
+      async disconnect() {
+        await adapter.emit({ type: "disconnect" });
+      },
+      async transportError({ code, message }) {
+        await adapter.emit({
+          type: "transport-error",
+          ...(code !== undefined ? { code } : {}),
+          message,
+        });
+      },
+    },
+    getReplayState() {
+      return replayer.state;
+    },
+    timeline() {
+      return adapter.timeline();
+    },
+    getRuntimeSnapshot() {
+      return adapter.getSnapshot();
+    },
+    getRuntime() {
+      return runtimeRef.current;
+    },
+  };
+
+  return harness;
+}

--- a/packages/chat-test-kit-react/src/harness/types.ts
+++ b/packages/chat-test-kit-react/src/harness/types.ts
@@ -1,0 +1,36 @@
+import type {
+  AssistantEvent,
+  ReplayerState,
+  RuntimeSnapshot,
+  TranscriptType,
+} from "@assistant-ui/chat-test-kit-core";
+import type { AssistantRuntime } from "@assistant-ui/react";
+import type { FC, ReactNode } from "react";
+
+export type HarnessOptions = {
+  transcript: TranscriptType;
+  autoAdvance?: boolean;
+};
+
+export type TimelineEntry =
+  | { kind: "user-submit"; at: number; content: string }
+  | { kind: "event"; at: number; event: AssistantEvent };
+
+export type ChatTestHarness = {
+  wrapper: FC<{ children: ReactNode }>;
+
+  waitForIdle(): Promise<void>;
+  cancel(): Promise<void>;
+
+  advanceChunk(): Promise<void>;
+  advanceToolCall(): Promise<void>;
+  inject: {
+    disconnect(opts?: { afterChunk?: number }): Promise<void>;
+    transportError(opts: { code?: number; message: string }): Promise<void>;
+  };
+
+  getReplayState(): ReplayerState;
+  timeline(): TimelineEntry[];
+  getRuntimeSnapshot(): RuntimeSnapshot;
+  getRuntime(): AssistantRuntime | null;
+};

--- a/packages/chat-test-kit-react/src/harness/wrapper.tsx
+++ b/packages/chat-test-kit-react/src/harness/wrapper.tsx
@@ -1,0 +1,31 @@
+import { type FC, type ReactNode, useRef } from "react";
+import {
+  AssistantRuntimeProvider,
+  useLocalRuntime,
+  type AssistantRuntime,
+  type ChatModelAdapter,
+} from "@assistant-ui/react";
+
+export type WrapperOptions = {
+  chatModelAdapter: ChatModelAdapter;
+  runtimeRef: { current: AssistantRuntime | null };
+};
+
+export function createWrapper(
+  options: WrapperOptions,
+): FC<{ children: ReactNode }> {
+  const { chatModelAdapter, runtimeRef } = options;
+  return function HarnessWrapper({ children }) {
+    const runtime = useLocalRuntime(chatModelAdapter);
+    const captured = useRef(false);
+    if (!captured.current) {
+      runtimeRef.current = runtime;
+      captured.current = true;
+    }
+    return (
+      <AssistantRuntimeProvider runtime={runtime}>
+        {children}
+      </AssistantRuntimeProvider>
+    );
+  };
+}

--- a/packages/chat-test-kit-react/src/index.ts
+++ b/packages/chat-test-kit-react/src/index.ts
@@ -1,0 +1,55 @@
+import "./matchers/augment";
+
+export {
+  createHeadlessAdapter,
+  Replayer,
+  Transcript,
+  TRANSCRIPT_VERSION,
+  VirtualClock,
+  transcript,
+  transcriptSchema,
+} from "@assistant-ui/chat-test-kit-core";
+export type {
+  AbortAndRestartInjection,
+  AssistantEvent,
+  AssistantStreamOptions,
+  AssistantStreamTurn,
+  AssistantToolCallTurn,
+  CancelInjection,
+  ContentPart,
+  DelayTurn,
+  DisconnectInjection,
+  Injection,
+  InjectionPosition,
+  InterruptInjection,
+  JsonObject,
+  JsonValue,
+  MetadataTurn,
+  ReplayerOptions,
+  ReplayerPhase,
+  ReplayerState,
+  RuntimeAdapter,
+  RuntimeSnapshot,
+  TextPart,
+  ToolCallPart,
+  ToolResultTurn,
+  TranscriptType,
+  TransportErrorInjection,
+  Turn,
+  UserTurn,
+} from "@assistant-ui/chat-test-kit-core";
+
+export { createChatTestHarness } from "./harness/harness";
+export { setupChatTestKit } from "./setup";
+export { message, thread, toolCall } from "./matchers/targets";
+
+export type {
+  ChatTestHarness,
+  HarnessOptions,
+  TimelineEntry,
+} from "./harness/types";
+export type {
+  MessageTarget,
+  ThreadTarget,
+  ToolCallTarget,
+} from "./matchers/types";

--- a/packages/chat-test-kit-react/src/matchers/augment.ts
+++ b/packages/chat-test-kit-react/src/matchers/augment.ts
@@ -1,0 +1,16 @@
+interface ChatTestKitMatchers<R = unknown> {
+  toHaveAssistantText(expected: string | RegExp): R;
+  toShowError(match?: string | RegExp): R;
+  toHaveText(expected: string): R;
+  toStreamCompletely(): R;
+  toBeInterrupted(): R;
+  toRenderResult(): R;
+  toHaveReceivedArgs(expected: Record<string, unknown>): R;
+}
+
+declare module "vitest" {
+  interface Assertion<T = any> extends ChatTestKitMatchers<T> {}
+  interface AsymmetricMatchersContaining extends ChatTestKitMatchers {}
+}
+
+export {};

--- a/packages/chat-test-kit-react/src/matchers/message.ts
+++ b/packages/chat-test-kit-react/src/matchers/message.ts
@@ -1,0 +1,101 @@
+import type { MatcherResult, MessageTarget } from "./types";
+import type { ChatTestHarness } from "../harness/types";
+
+type HarnessAwareMessageTarget = MessageTarget & {
+  __harness: ChatTestHarness;
+};
+
+function getMessageElements(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>("[data-message-id]"),
+  );
+}
+
+function getNthMessage(index: number): HTMLElement | null {
+  return getMessageElements()[index] ?? null;
+}
+
+export function toHaveText(
+  this: unknown,
+  target: MessageTarget,
+  expected: string,
+): MatcherResult {
+  if (target.__kind !== "message") {
+    return {
+      pass: false,
+      message: () => "toHaveText expects a message() target",
+    };
+  }
+
+  const element = getNthMessage(target.index);
+  if (!element) {
+    return {
+      pass: false,
+      message: () => `message(${target.index}) not found in DOM`,
+    };
+  }
+
+  const text = element.textContent ?? "";
+  const pass = text.includes(expected);
+  return {
+    pass,
+    message: () =>
+      pass
+        ? `expected message(${target.index}) NOT to contain ${JSON.stringify(expected)}`
+        : `expected message(${target.index}) to contain ${JSON.stringify(expected)} but got ${JSON.stringify(text)}`,
+  };
+}
+
+export function toStreamCompletely(
+  this: unknown,
+  target: HarnessAwareMessageTarget,
+): MatcherResult {
+  if (target.__kind !== "message" || !("__harness" in target)) {
+    return {
+      pass: false,
+      message: () =>
+        "toStreamCompletely requires message(n).on(harness) as the target",
+    };
+  }
+
+  const element = getNthMessage(target.index);
+  if (!element) {
+    return { pass: false, message: () => `message(${target.index}) not found` };
+  }
+
+  const replayState = target.__harness.getReplayState();
+  const pass = replayState?.phase === "complete";
+  return {
+    pass,
+    message: () =>
+      `expected message(${target.index}) to be completed, got replay phase ${JSON.stringify(replayState?.phase ?? null)}`,
+  };
+}
+
+export function toBeInterrupted(
+  this: unknown,
+  target: HarnessAwareMessageTarget,
+): MatcherResult {
+  if (target.__kind !== "message" || !("__harness" in target)) {
+    return {
+      pass: false,
+      message: () =>
+        "toBeInterrupted requires message(n).on(harness) as the target",
+    };
+  }
+
+  const element = getNthMessage(target.index);
+  if (!element) {
+    return { pass: false, message: () => `message(${target.index}) not found` };
+  }
+
+  const replayState = target.__harness.getReplayState();
+  const pass =
+    replayState?.phase === "error" || replayState?.phase === "cancelled";
+
+  return {
+    pass,
+    message: () =>
+      `expected message(${target.index}) to be interrupted, got replay phase ${JSON.stringify(replayState?.phase ?? null)}`,
+  };
+}

--- a/packages/chat-test-kit-react/src/matchers/register.ts
+++ b/packages/chat-test-kit-react/src/matchers/register.ts
@@ -1,0 +1,26 @@
+import { expect as vitestExpect } from "vitest";
+import { toBeInterrupted, toHaveText, toStreamCompletely } from "./message";
+import { toHaveAssistantText, toShowError } from "./thread";
+import { toHaveReceivedArgs, toRenderResult } from "./tool-call";
+
+let registered = false;
+
+export function registerMatchers(): void {
+  if (registered) return;
+
+  const expectInstance = (globalThis as { expect?: typeof vitestExpect })
+    .expect;
+  const matcherExpect = expectInstance ?? vitestExpect;
+
+  matcherExpect.extend({
+    toHaveAssistantText: toHaveAssistantText as never,
+    toShowError: toShowError as never,
+    toHaveText: toHaveText as never,
+    toStreamCompletely: toStreamCompletely as never,
+    toBeInterrupted: toBeInterrupted as never,
+    toRenderResult: toRenderResult as never,
+    toHaveReceivedArgs: toHaveReceivedArgs as never,
+  });
+
+  registered = true;
+}

--- a/packages/chat-test-kit-react/src/matchers/targets.ts
+++ b/packages/chat-test-kit-react/src/matchers/targets.ts
@@ -1,0 +1,34 @@
+import type { ChatTestHarness } from "../harness/types";
+import type { MessageTarget, ThreadTarget, ToolCallTarget } from "./types";
+
+export function thread(): ThreadTarget {
+  return {
+    __kind: "thread",
+    on(harness: ChatTestHarness) {
+      return { ...this, __harness: harness };
+    },
+  };
+}
+
+export function message(index: number): MessageTarget {
+  if (index < 0 || !Number.isInteger(index)) {
+    throw new Error("message(n): n must be a non-negative integer");
+  }
+  return {
+    __kind: "message",
+    index,
+    on(harness: ChatTestHarness) {
+      return { ...this, __harness: harness };
+    },
+  };
+}
+
+export function toolCall(name: string): ToolCallTarget {
+  return {
+    __kind: "toolCall",
+    name,
+    on(harness: ChatTestHarness) {
+      return { ...this, __harness: harness };
+    },
+  };
+}

--- a/packages/chat-test-kit-react/src/matchers/thread.ts
+++ b/packages/chat-test-kit-react/src/matchers/thread.ts
@@ -1,0 +1,80 @@
+import type { ChatTestHarness } from "../harness/types";
+import type { MatcherResult, ThreadTarget } from "./types";
+
+type HarnessAwareThreadTarget = ThreadTarget & {
+  __harness: ChatTestHarness;
+};
+
+export function toHaveAssistantText(
+  this: unknown,
+  target: HarnessAwareThreadTarget,
+  expected: string | RegExp,
+): MatcherResult {
+  if (target.__kind !== "thread" || !("__harness" in target)) {
+    return {
+      pass: false,
+      message: () =>
+        "toHaveAssistantText requires thread().on(harness) as the target",
+    };
+  }
+
+  const actual = target.__harness
+    .getRuntimeSnapshot()
+    .events.filter((event) => event.type === "text-delta")
+    .map((event) => event.delta)
+    .join("");
+  const pass =
+    expected instanceof RegExp
+      ? expected.test(actual)
+      : actual.includes(expected);
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? `expected assistant text NOT to match ${String(expected)} but got ${JSON.stringify(actual)}`
+        : `expected assistant text to match ${String(expected)} but got ${JSON.stringify(actual)}`,
+  };
+}
+
+export function toShowError(
+  this: unknown,
+  target: ThreadTarget,
+  match?: string | RegExp,
+): MatcherResult {
+  if (target.__kind !== "thread") {
+    return {
+      pass: false,
+      message: () => "toShowError expects a thread() target",
+    };
+  }
+
+  const domError =
+    document.querySelector<HTMLElement>("[data-testid='aui-error']")
+      ?.textContent ?? "";
+  const text = domError;
+
+  if (!text) {
+    return {
+      pass: false,
+      message: () => "expected an error surface in the DOM, found none",
+    };
+  }
+
+  if (match === undefined) {
+    return {
+      pass: true,
+      message: () => "expected no error surface in the DOM",
+    };
+  }
+
+  const pass =
+    match instanceof RegExp ? match.test(text) : text.includes(match);
+  return {
+    pass,
+    message: () =>
+      pass
+        ? `expected error text NOT to match ${String(match)} but got ${JSON.stringify(text)}`
+        : `expected error text to match ${String(match)} but got ${JSON.stringify(text)}`,
+  };
+}

--- a/packages/chat-test-kit-react/src/matchers/tool-call.ts
+++ b/packages/chat-test-kit-react/src/matchers/tool-call.ts
@@ -1,0 +1,74 @@
+import type { ChatTestHarness } from "../harness/types";
+import type { MatcherResult, ToolCallTarget } from "./types";
+
+export type HarnessAwareToolCallTarget = ToolCallTarget & {
+  __harness: ChatTestHarness;
+};
+
+export function toRenderResult(
+  this: unknown,
+  target: ToolCallTarget,
+): MatcherResult {
+  if (target.__kind !== "toolCall") {
+    return {
+      pass: false,
+      message: () => "toRenderResult expects a toolCall() target",
+    };
+  }
+
+  const el = document.querySelector<HTMLElement>(
+    `[data-tool-name="${target.name}"]`,
+  );
+  if (!el) {
+    return {
+      pass: false,
+      message: () =>
+        `expected tool '${target.name}' to be rendered (looked for [data-tool-name="${target.name}"])`,
+    };
+  }
+
+  const text = el.textContent ?? "";
+  const pass = text.length > 0 && text !== "pending";
+  return {
+    pass,
+    message: () =>
+      pass
+        ? `expected tool '${target.name}' NOT to render a result`
+        : `expected tool '${target.name}' to render a result, got ${JSON.stringify(text)}`,
+  };
+}
+
+export function toHaveReceivedArgs(
+  this: unknown,
+  target: HarnessAwareToolCallTarget,
+  expected: Record<string, unknown>,
+): MatcherResult {
+  if (target.__kind !== "toolCall" || !("__harness" in target)) {
+    return {
+      pass: false,
+      message: () =>
+        "toHaveReceivedArgs requires toolCall(name).on(harness) — pass the harness reference",
+    };
+  }
+
+  const events = target.__harness.getRuntimeSnapshot().events;
+  const event = events.find(
+    (item) => item.type === "tool-call" && item.toolName === target.name,
+  );
+
+  if (!event || event.type !== "tool-call") {
+    return {
+      pass: false,
+      message: () => `tool '${target.name}' was never called`,
+    };
+  }
+
+  const pass = JSON.stringify(event.args) === JSON.stringify(expected);
+  return {
+    pass,
+    message: () =>
+      pass
+        ? `expected tool '${target.name}' NOT to have received ${JSON.stringify(expected)}`
+        : `expected tool '${target.name}' to have received ${JSON.stringify(expected)} but got ${JSON.stringify(event.args)}`,
+  };
+}

--- a/packages/chat-test-kit-react/src/matchers/types.ts
+++ b/packages/chat-test-kit-react/src/matchers/types.ts
@@ -1,0 +1,20 @@
+import type { ChatTestHarness } from "../harness/types";
+
+export type ThreadTarget = {
+  __kind: "thread";
+  on(harness: ChatTestHarness): ThreadTarget & { __harness: ChatTestHarness };
+};
+
+export type MessageTarget = {
+  __kind: "message";
+  index: number;
+  on(harness: ChatTestHarness): MessageTarget & { __harness: ChatTestHarness };
+};
+
+export type ToolCallTarget = {
+  __kind: "toolCall";
+  name: string;
+  on(harness: ChatTestHarness): ToolCallTarget & { __harness: ChatTestHarness };
+};
+
+export type MatcherResult = { pass: boolean; message: () => string };

--- a/packages/chat-test-kit-react/src/setup.ts
+++ b/packages/chat-test-kit-react/src/setup.ts
@@ -1,0 +1,7 @@
+import { registerMatchers } from "./matchers/register";
+
+export type SetupOptions = unknown;
+
+export function setupChatTestKit(_options?: SetupOptions): void {
+  registerMatchers();
+}

--- a/packages/chat-test-kit-react/tsconfig.json
+++ b/packages/chat-test-kit-react/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "include": ["src"]
+}

--- a/packages/chat-test-kit-react/vitest.config.ts
+++ b/packages/chat-test-kit-react/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    include: ["src/**/*.test.{ts,tsx}"],
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2593,6 +2593,49 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/chat-test-kit-react:
+    dependencies:
+      '@assistant-ui/chat-test-kit-core':
+        specifier: workspace:*
+        version: link:../chat-test-kit-core
+    devDependencies:
+      '@assistant-ui/react':
+        specifier: workspace:*
+        version: link:../react
+      '@assistant-ui/x-buildutils':
+        specifier: workspace:*
+        version: link:../x-buildutils
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/cli:
     dependencies:
       '@assistant-ui/agent-launcher':
@@ -8852,6 +8895,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@theguild/remark-mermaid@0.3.0':
     resolution: {integrity: sha512-Fy1J4FSj8totuHsHFpaeWyWRaRSIvpzGTRoEfnNJc1JmLV9uV70sYE3zcT+Jj5Yw20Xq4iCsiT+3Ho49BBZcBQ==}
@@ -21335,6 +21384,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@theguild/remark-mermaid@0.3.0(react@19.2.5)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -722,12 +722,21 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@assistant-ui/chat-test-kit-react':
+        specifier: workspace:*
+        version: link:../../packages/chat-test-kit-react
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../../packages/x-buildutils
       '@tailwindcss/postcss':
         specifier: ^4.2.4
         version: 4.2.4
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -737,6 +746,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
@@ -749,6 +761,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/with-artifacts:
     dependencies:
@@ -862,12 +877,21 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@assistant-ui/chat-test-kit-react':
+        specifier: workspace:*
+        version: link:../../packages/chat-test-kit-react
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../../packages/x-buildutils
       '@tailwindcss/postcss':
         specifier: ^4.2.4
         version: 4.2.4
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -877,6 +901,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
@@ -889,6 +916,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/with-chain-of-thought:
     dependencies:
@@ -1930,12 +1960,21 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0
     devDependencies:
+      '@assistant-ui/chat-test-kit-react':
+        specifier: workspace:*
+        version: link:../../packages/chat-test-kit-react
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../../packages/x-buildutils
       '@tailwindcss/postcss':
         specifier: ^4.2.4
         version: 4.2.4
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -1945,6 +1984,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
@@ -1957,6 +1999,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   examples/with-livekit:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2578,6 +2578,21 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/chat-test-kit-core:
+    devDependencies:
+      '@assistant-ui/x-buildutils':
+        specifier: workspace:*
+        version: link:../x-buildutils
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/cli:
     dependencies:
       '@assistant-ui/agent-launcher':


### PR DESCRIPTION
## Summary

This PR adds Chat Test Kit: a transcript-driven testing framework for assistant-ui chat applications.

The goal is to make chat UI tests deterministic. Instead of depending on live model calls, network timing, or hand-rolled mocks, tests define a conversation transcript and replay it through an assistant-ui runtime. This lets app developers assert streaming text, tool calls, cancellation, transport failures, and rendered UI states with repeatable timing.

This is not an eval framework for judging model quality. It is for UI behavior tests: “given this user message and this assistant/tool timeline, did the app render and behave correctly?”

This PR contains the initial v1 scope for the package pair.

  ## What This Adds

  - `@assistant-ui/chat-test-kit-core`
    - Portable transcript format and chainable `transcript()` DSL
    - Canonical JSON format with published JSON Schema
    - Runtime-agnostic replayer state machine
    - Virtual clock for deterministic stream timing
    - Failure injections for cancel, disconnect, transport error, interrupt, and abort/restart
    - `RuntimeAdapter` interface and headless reference adapter

  - `@assistant-ui/chat-test-kit-react`
    - React harness via `createChatTestHarness`
    - assistant-ui adapter built on public runtime APIs
    - A-tier testing API for normal test flows
    - C-tier controls for stepping chunks, tool calls, and failures
    - Seven chat-aware matchers for thread/message/tool-call assertions
    - `setupChatTestKit()` matcher registration helper
    - Core transcript APIs re-exported for single-package installs

  - Dogfood tests in examples
    - `examples/with-ai-sdk-v6`
    - `examples/with-langgraph`
    - `examples/with-assistant-transport`

  - Documentation
    - Quickstart guide in the docs app
    - Transcript format reference in the docs app
    - Package READMEs for core and react packages
    - Changesets for both published packages

  ## Testing

  - `pnpm --filter @assistant-ui/chat-test-kit-core test`
  - `pnpm --filter @assistant-ui/chat-test-kit-react test`
  - `pnpm --filter with-ai-sdk-v6 test`
  - `pnpm --filter with-langgraph test`
  - `pnpm --filter with-assistant-transport test`