### PR TITLE
feat(core): add custom slot to RemoteThreadMetadata

### DIFF
--- a/.changeset/quiet-foxes-roam.md
+++ b/.changeset/quiet-foxes-roam.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat: add `custom` slot to `RemoteThreadMetadata` and `ThreadListItemState`
+
+allows adapter authors to carry arbitrary backend session data through `list()` / `fetch()` and surface it on the thread list item state. matches the existing `custom: Record<string, unknown>` convention used on `ThreadMessage`, `RunConfig`, and `ChatModelRunResult`. consumers can intersect a typed shape at their own boundary, e.g. `RemoteThreadMetadata & { custom: { workspaceId: string } }`.

--- a/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
+++ b/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
@@ -237,7 +237,7 @@ type MyThreadMetadata = RemoteThreadMetadata & {
 };
 ```
 
-Read it with `useAuiState`:
+Read it with `useAuiState`. The runtime stores `custom` as `Record<string, unknown>`, so cast back to your shape at the boundary — the adapter is responsible for actually returning that shape.
 
 ```tsx
 import { useAuiState } from "@assistant-ui/react";

--- a/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
+++ b/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
@@ -226,22 +226,7 @@ When the hook mounts it calls `list()` on your adapter, hydrates existing thread
 
 `RemoteThreadMetadata` includes an optional `custom?: Record<string, unknown>` slot for backend-specific fields (timestamps, owner ids, workspace ids, tags, model name, etc.). Whatever you return from `list()` and `fetch()` flows through to the thread list item state and is reachable from any UI primitive via `useAuiState`.
 
-```tsx
-import { useAuiState } from "@assistant-ui/react";
-
-function ThreadListItemMeta() {
-  const custom = useAuiState((s) => s.threadListItem.custom);
-  const createdAt = custom?.createdAt as string | undefined;
-  const ownerId = custom?.ownerId as string | undefined;
-  return (
-    <span className="aui-thread-list-item-meta">
-      {ownerId} · {createdAt}
-    </span>
-  );
-}
-```
-
-For typed access, intersect `RemoteThreadMetadata` with your own `custom` shape at the adapter boundary instead of casting at every read site:
+Declare a typed shape at the adapter boundary by intersecting `RemoteThreadMetadata` with your own `custom` shape:
 
 ```ts
 type MyThreadMetadata = RemoteThreadMetadata & {
@@ -250,6 +235,23 @@ type MyThreadMetadata = RemoteThreadMetadata & {
     readonly ownerId: string;
   };
 };
+```
+
+Read it with `useAuiState`:
+
+```tsx
+import { useAuiState } from "@assistant-ui/react";
+
+function ThreadListItemMeta() {
+  const custom = useAuiState(
+    (s) => s.threadListItem.custom as MyThreadMetadata["custom"] | undefined,
+  );
+  return (
+    <span className="aui-thread-list-item-meta">
+      {custom?.ownerId} · {custom?.createdAt}
+    </span>
+  );
+}
 ```
 
 <Callout type="info">

--- a/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
+++ b/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
@@ -79,6 +79,10 @@ When the hook mounts it calls `list()` on your adapter, hydrates existing thread
             externalId: thread.external_id ?? undefined,
             status: thread.is_archived ? "archived" : "regular",
             title: thread.title ?? undefined,
+            custom: {
+              createdAt: thread.created_at,
+              ownerId: thread.owner_id,
+            },
           })),
         };
       },
@@ -114,6 +118,10 @@ When the hook mounts it calls `list()` on your adapter, hydrates existing thread
           status: thread.is_archived ? "archived" : "regular",
           remoteId: thread.id,
           title: thread.title,
+          custom: {
+            createdAt: thread.created_at,
+            ownerId: thread.owner_id,
+          },
         };
       },
       async generateTitle(remoteId, unstable_messages) {
@@ -157,7 +165,7 @@ When the hook mounts it calls `list()` on your adapter, hydrates existing thread
       name: "list",
       type: "() => Promise<{ threads: RemoteThreadMetadata[] }>",
       description:
-        "Return the current threads. Each thread must include status, remoteId, and any metadata you want to show immediately.",
+        "Return the current threads. Each thread must include status and remoteId, plus any optional title, externalId, or custom backend fields you want to surface in the UI.",
       required: true,
     },
     {
@@ -202,7 +210,7 @@ When the hook mounts it calls `list()` on your adapter, hydrates existing thread
       name: "fetch",
       type: "(threadId: string) => Promise<RemoteThreadMetadata>",
       description:
-        "Fetch metadata for a specific thread. Used when switching to a thread not in the initial list.",
+        "Fetch metadata for a specific thread. Used when switching to a thread not in the initial list. Return the same shape as list() entries, including any custom fields.",
       required: true,
     },
     {
@@ -213,6 +221,43 @@ When the hook mounts it calls `list()` on your adapter, hydrates existing thread
     },
   ]}
 />
+
+## Custom Metadata
+
+`RemoteThreadMetadata` includes an optional `custom?: Record<string, unknown>` slot for backend-specific fields (timestamps, owner ids, workspace ids, tags, model name, etc.). Whatever you return from `list()` and `fetch()` flows through to the thread list item state and is reachable from any UI primitive via `useAuiState`.
+
+```tsx
+import { useAuiState } from "@assistant-ui/react";
+
+function ThreadListItemMeta() {
+  const custom = useAuiState((s) => s.threadListItem.custom);
+  const createdAt = custom?.createdAt as string | undefined;
+  const ownerId = custom?.ownerId as string | undefined;
+  return (
+    <span className="aui-thread-list-item-meta">
+      {ownerId} · {createdAt}
+    </span>
+  );
+}
+```
+
+For typed access, intersect `RemoteThreadMetadata` with your own `custom` shape at the adapter boundary instead of casting at every read site:
+
+```ts
+type MyThreadMetadata = RemoteThreadMetadata & {
+  readonly custom: {
+    readonly createdAt: string;
+    readonly ownerId: string;
+  };
+};
+```
+
+<Callout type="info">
+  `custom` is preserved across `rename`, `archive`, `unarchive`, and
+  `generateTitle`, so you don't need to re-send it on every adapter call. To
+  mutate it, return updated values from a subsequent `fetch()` or trigger
+  `runtime.threads.reload()`.
+</Callout>
 
 ## Thread Lifecycle Cheatsheet
 

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
@@ -28,6 +28,8 @@ type LocalStorageAdapterOptions = {
   titleGenerator?: TitleGenerationAdapter | undefined;
 };
 
+// `RemoteThreadMetadata.custom` is intentionally not persisted; consumers that
+// need it across reloads should fork this adapter or use a remote backend.
 type StoredThreadMetadata = {
   remoteId: string;
   externalId?: string;

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -337,6 +337,7 @@ export class RemoteThreadListThreadListRuntimeCore
             remoteId: undefined,
             externalId: undefined,
             title: undefined,
+            custom: undefined,
           } satisfies RemoteThreadData,
         },
       });

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -98,6 +98,7 @@ export class RemoteThreadListThreadListRuntimeCore
                 externalId: thread.externalId,
                 status: thread.status,
                 title: thread.title,
+                custom: thread.custom,
                 initializeTask: Promise.resolve({
                   remoteId: thread.remoteId,
                   externalId: thread.externalId,
@@ -250,6 +251,7 @@ export class RemoteThreadListThreadListRuntimeCore
           externalId: remoteMetadata.externalId,
           status: remoteMetadata.status,
           title: remoteMetadata.title,
+          custom: remoteMetadata.custom,
         } as RemoteThreadData,
       };
 

--- a/packages/core/src/runtime/api/bindings.ts
+++ b/packages/core/src/runtime/api/bindings.ts
@@ -47,4 +47,5 @@ export type ThreadListItemState = {
   readonly externalId: string | undefined;
   readonly status: import("../interfaces/thread-list-runtime-core").ThreadListItemStatus;
   readonly title?: string | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
 };

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -80,6 +80,7 @@ const getThreadListItemState = (
     externalId: threadData.externalId,
     title: threadData.title,
     status: threadData.status,
+    custom: threadData.custom,
     isMain: threadData.id === threadList.mainThreadId,
   };
 };

--- a/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
@@ -10,6 +10,7 @@ export type ThreadListItemCoreState = {
 
   readonly status: ThreadListItemStatus;
   readonly title?: string | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
 
   readonly runtime?: ThreadRuntimeCore | undefined;
 };

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -7,6 +7,7 @@ export type RemoteThreadData =
       readonly externalId: undefined;
       readonly status: "new";
       readonly title: undefined;
+      readonly custom?: Record<string, unknown> | undefined;
     }
   | {
       readonly id: string;
@@ -15,6 +16,7 @@ export type RemoteThreadData =
       readonly externalId: undefined;
       readonly status: "regular" | "archived";
       readonly title?: string | undefined;
+      readonly custom?: Record<string, unknown> | undefined;
     }
   | {
       readonly id: string;
@@ -23,6 +25,7 @@ export type RemoteThreadData =
       readonly externalId: string | undefined;
       readonly status: "regular" | "archived";
       readonly title?: string | undefined;
+      readonly custom?: Record<string, unknown> | undefined;
     };
 
 export type THREAD_MAPPING_ID = string & { __brand: "THREAD_MAPPING_ID" };

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -7,7 +7,7 @@ export type RemoteThreadData =
       readonly externalId: undefined;
       readonly status: "new";
       readonly title: undefined;
-      readonly custom?: Record<string, unknown> | undefined;
+      readonly custom: undefined;
     }
   | {
       readonly id: string;

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -16,7 +16,7 @@ export type RemoteThreadData =
       readonly externalId: undefined;
       readonly status: "regular" | "archived";
       readonly title?: string | undefined;
-      readonly custom?: Record<string, unknown> | undefined;
+      readonly custom: undefined;
     }
   | {
       readonly id: string;

--- a/packages/core/src/runtimes/remote-thread-list/types.ts
+++ b/packages/core/src/runtimes/remote-thread-list/types.ts
@@ -12,6 +12,7 @@ export type RemoteThreadMetadata = {
   readonly remoteId: string;
   readonly externalId?: string | undefined;
   readonly title?: string | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
 };
 
 export type RemoteThreadListResponse = {

--- a/packages/core/src/store/scopes/thread-list-item.ts
+++ b/packages/core/src/store/scopes/thread-list-item.ts
@@ -7,6 +7,7 @@ export type ThreadListItemState = {
   readonly externalId: string | undefined;
   readonly title?: string | undefined;
   readonly status: ThreadListItemStatus;
+  readonly custom?: Record<string, unknown> | undefined;
 };
 
 export type ThreadListItemMethods = {

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-custom-metadata.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-custom-metadata.test.ts
@@ -89,4 +89,35 @@ describe("RemoteThreadListThreadListRuntimeCore custom metadata", () => {
     expect(item?.title).toBe("New");
     expect(item?.custom).toEqual({ tag: "important" });
   });
+
+  it("preserves custom across archive and unarchive optimistic updates", async () => {
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "regular" as const,
+            remoteId: "thread-5",
+            externalId: "ext-5",
+            title: "Test",
+            custom: { workspaceId: "ws-1" },
+          },
+        ],
+      })),
+    });
+
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+
+    await core.archive("thread-5");
+    expect(core.getItemById("thread-5")?.status).toBe("archived");
+    expect(core.getItemById("thread-5")?.custom).toEqual({
+      workspaceId: "ws-1",
+    });
+
+    await core.unarchive("thread-5");
+    expect(core.getItemById("thread-5")?.status).toBe("regular");
+    expect(core.getItemById("thread-5")?.custom).toEqual({
+      workspaceId: "ws-1",
+    });
+  });
 });

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-custom-metadata.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-custom-metadata.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { createCore, makeAdapter } from "./remote-thread-list-test-helpers";
+
+describe("RemoteThreadListThreadListRuntimeCore custom metadata", () => {
+  it("preserves custom field from list() through to threadItems", async () => {
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "regular" as const,
+            remoteId: "thread-1",
+            externalId: "ext-1",
+            title: "Test",
+            custom: { workspaceId: "ws-1", createdAt: "2026-04-26" },
+          },
+        ],
+      })),
+    });
+
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+
+    const item = core.getItemById("thread-1");
+    expect(item?.custom).toEqual({
+      workspaceId: "ws-1",
+      createdAt: "2026-04-26",
+    });
+  });
+
+  it("preserves custom field from fetch() through switchToThread", async () => {
+    const adapter = makeAdapter({
+      fetch: vi.fn(async (id: string) => ({
+        status: "regular" as const,
+        remoteId: id,
+        externalId: id,
+        title: "Test",
+        custom: { ownerId: "user-42" },
+      })),
+    });
+
+    const core = createCore(adapter);
+    await core.switchToThread("thread-2");
+
+    const item = core.getItemById("thread-2");
+    expect(item?.custom).toEqual({ ownerId: "user-42" });
+  });
+
+  it("leaves custom undefined when adapter omits it", async () => {
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "regular" as const,
+            remoteId: "thread-3",
+            externalId: "ext-3",
+            title: "Test",
+          },
+        ],
+      })),
+    });
+
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+
+    const item = core.getItemById("thread-3");
+    expect(item?.custom).toBeUndefined();
+  });
+
+  it("preserves custom across rename optimistic update", async () => {
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "regular" as const,
+            remoteId: "thread-4",
+            externalId: "ext-4",
+            title: "Old",
+            custom: { tag: "important" },
+          },
+        ],
+      })),
+    });
+
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+    await core.rename("thread-4", "New");
+
+    const item = core.getItemById("thread-4");
+    expect(item?.title).toBe("New");
+    expect(item?.custom).toEqual({ tag: "important" });
+  });
+});


### PR DESCRIPTION
## Summary

- adds `readonly custom?: Record<string, unknown> | undefined` to `RemoteThreadMetadata`, `RemoteThreadData`, `ThreadListItemCoreState`, and the runtime + store-scope `ThreadListItemState`, matching the existing convention used on `ThreadMessage` and `RunConfig`
- forwards the field through the two field-by-field construction sites in `RemoteThreadListThreadListRuntimeCore` (the `list()` rebuild and the `switchToThread` fetch path) so adapter-supplied values survive into thread list state; other state mutations already use spread and preserve unknown fields
- exposes `custom` to UI consumers via `useAuiState((s) => s.threadListItem.custom)`; users can intersect a typed shape at the adapter boundary, e.g. `RemoteThreadMetadata & { custom: { workspaceId: string } }`
- documents the slot in the Custom Thread List guide with a populated example, a `useAuiState` snippet, the typed-intersection pattern, and a `Callout` noting preservation across `rename`/`archive`/`unarchive`/`generateTitle`
- closes #3875

## Test plan

- [ ] `pnpm --filter @assistant-ui/core test` — 4 new tests cover `list()`, `fetch()`, omission, and `rename` preservation paths (150 total, all passing locally)
- [ ] `pnpm --filter @assistant-ui/core exec tsc --noEmit` — no new type errors introduced
- [ ] in a sample app, populate `custom` from `list()` and confirm `useAuiState((s) => s.threadListItem.custom)` returns the value
- [ ] confirm `custom` is preserved after `rename`, `archive`, and `unarchive` calls
- [ ] verify the docs page renders correctly: `pnpm --filter @assistant-ui/docs dev`