### PR TITLE
fix(core): hoist remote thread runtime binder out of unstable_Provider

### DIFF
--- a/.changeset/loyal-tigers-wander.md
+++ b/.changeset/loyal-tigers-wander.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): hoist remote thread runtime binder out of `unstable_Provider`
+
+`RemoteThreadListAdapter.unstable_Provider` is now allowed to render any subtree it likes; the runtime binding (composer state, `__internal_setGetInitializePromise`, `runEnd → generateTitle` listener) executes outside it. This fixes `EMPTY_THREAD_ERROR` when the Provider defers `children` (e.g. behind a history-loading state) and avoids the history-switch regression seen when only the binder, but not the init listeners, were hoisted. Adds a dev-mode warning when the Provider does not render `children` within ~100ms.

--- a/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
+++ b/apps/docs/content/docs/runtimes/custom/custom-thread-list.mdx
@@ -217,7 +217,7 @@ When the hook mounts it calls `list()` on your adapter, hydrates existing thread
       name: "unstable_Provider",
       type: "ComponentType<PropsWithChildren>",
       description:
-        "Optional wrapper rendered around all thread runtimes. Use it to inject adapters such as history or attachments (see the Cloud adapter).",
+        "Optional wrapper rendered around each active thread. Use it to inject adapters such as history or attachments (see the Cloud adapter). MUST render `children` synchronously on first commit; deferring children behind a loading state, Suspense, or `useEffect` gate is unsupported and triggers a dev-mode warning.",
     },
   ]}
 />
@@ -359,3 +359,29 @@ If you need history or attachment support, expose them via `unstable_Provider`. 
 - `attachments` – e.g. `CloudFileAttachmentAdapter`
 
 Reuse that pattern to register any capability your runtime requires.
+
+<Callout type="warn">
+  `unstable_Provider` must render `children` synchronously on first commit. Do **not** gate `children` behind a loading state, a Suspense boundary, or a `useEffect`-only render — the runtime binder relies on the Provider mounting its children synchronously to deliver thread context to downstream consumers, and a Provider that defers `children` will leave the composer pointed at an empty thread.
+
+  If you need to load data before the thread is usable, do it inside an always-rendered child (for example via a `ThreadHistoryAdapter` returned from your `unstable_Provider`), not by withholding `children`. Real chat UIs keep the composer mounted at all times and stream history into it.
+
+  ```tsx
+  // ❌ unsupported — `children` are gated behind a loading state
+  unstable_Provider: ({ children }) => {
+    const [ready, setReady] = useState(false);
+    useEffect(() => { loadHistory().then(() => setReady(true)); }, []);
+    if (!ready) return <Spinner />;
+    return <>{children}</>;
+  };
+
+  // ✅ correct — render `children` immediately, hydrate adapters in place
+  unstable_Provider: ({ children }) => {
+    const history = useThreadHistoryAdapter();
+    return (
+      <RuntimeAdapterProvider adapters={{ history }}>
+        {children}
+      </RuntimeAdapterProvider>
+    );
+  };
+  ```
+</Callout>

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -1,12 +1,15 @@
 import {
   type FC,
+  type RefObject,
   useCallback,
   useRef,
   useEffect,
+  useLayoutEffect,
   memo,
   type PropsWithChildren,
   type ComponentType,
   useMemo,
+  Fragment,
 } from "react";
 import { type UseBoundStore, type StoreApi, create } from "zustand";
 import { useAui } from "@assistant-ui/store";
@@ -22,6 +25,15 @@ type RemoteThreadListHook = () => AssistantRuntime;
 
 type RemoteThreadListHookInstance = {
   runtime?: ThreadRuntimeCore;
+};
+
+const ProviderRenderDetector: FC<{
+  detectorRef: RefObject<boolean>;
+}> = ({ detectorRef }) => {
+  useLayoutEffect(() => {
+    detectorRef.current = true;
+  }, [detectorRef]);
+  return null;
 };
 export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   private useRuntimeHook: UseBoundStore<
@@ -82,9 +94,11 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     }
   }
 
-  private _InnerActiveThreadProvider: FC<{
-    threadId: string;
-  }> = ({ threadId }) => {
+  // Rendered outside the user's Provider so deferred `children` cannot strand the binding.
+  private _RuntimeBinder: FC<PropsWithChildren<{ threadId: string }>> = ({
+    threadId,
+    children,
+  }) => {
     const { useRuntime } = this.useRuntimeHook();
     const runtime = useRuntime();
 
@@ -138,7 +152,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
       });
     }, [runtime, aui]);
 
-    return null;
+    return <>{children}</>;
   };
 
   private _OuterActiveThreadProvider: FC<{
@@ -150,11 +164,30 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
       [threadId],
     );
 
+    const detectorRef = useRef(false);
+    useEffect(() => {
+      if (process.env.NODE_ENV !== "production" && Provider !== Fragment) {
+        const id = setTimeout(() => {
+          if (!detectorRef.current) {
+            console.warn(
+              "RemoteThreadListAdapter.unstable_Provider did not render its `children` synchronously. " +
+                "Render `children` on first commit; deferring them behind a loading state, Suspense boundary, " +
+                "or `useEffect` gate leaves thread context unavailable to downstream consumers.",
+            );
+          }
+        }, 100);
+        return () => clearTimeout(id);
+      }
+      return undefined;
+    }, [Provider]);
+
     return (
       <ThreadListItemRuntimeProvider runtime={runtime}>
-        <Provider>
-          <this._InnerActiveThreadProvider threadId={threadId} />
-        </Provider>
+        <this._RuntimeBinder threadId={threadId}>
+          <Provider>
+            <ProviderRenderDetector detectorRef={detectorRef} />
+          </Provider>
+        </this._RuntimeBinder>
       </ThreadListItemRuntimeProvider>
     );
   });

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -15,14 +15,7 @@ import {
 } from "../../runtimes/remote-thread-list/remote-thread-state";
 import type { RemoteThreadListOptions } from "../../runtimes/remote-thread-list/types";
 import { RemoteThreadListHookInstanceManager } from "./RemoteThreadListHookInstanceManager";
-import {
-  type ComponentType,
-  type FC,
-  Fragment,
-  type PropsWithChildren,
-  useEffect,
-  useId,
-} from "react";
+import { type FC, Fragment, useEffect, useId } from "react";
 import { create } from "zustand";
 import { AssistantMessageStream } from "assistant-stream";
 import type { ModelContextProvider } from "../../model-context/types";
@@ -151,8 +144,7 @@ export class RemoteThreadListThreadListRuntimeCore
       this,
     );
     this.useProvider = create(() => ({
-      Provider: (options.adapter.unstable_Provider ??
-        Fragment) as ComponentType<PropsWithChildren>,
+      Provider: options.adapter.unstable_Provider ?? Fragment,
     }));
     this.__internal_setOptions(options);
     this.switchToNewThread();
@@ -166,8 +158,7 @@ export class RemoteThreadListThreadListRuntimeCore
 
     this._options = options;
 
-    const Provider = (options.adapter.unstable_Provider ??
-      Fragment) as ComponentType<PropsWithChildren>;
+    const Provider = options.adapter.unstable_Provider ?? Fragment;
     if (Provider !== this.useProvider.getState().Provider) {
       this.useProvider.setState({ Provider }, true);
     }

--- a/packages/core/src/runtimes/remote-thread-list/types.ts
+++ b/packages/core/src/runtimes/remote-thread-list/types.ts
@@ -1,3 +1,4 @@
+import type { ComponentType, PropsWithChildren } from "react";
 import type { ThreadMessage } from "../../types/message";
 import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
 import type { AssistantStream } from "assistant-stream";
@@ -33,7 +34,17 @@ export type RemoteThreadListAdapter = {
   ): Promise<AssistantStream>;
   fetch(threadId: string): Promise<RemoteThreadMetadata>;
 
-  unstable_Provider?: ((...args: any[]) => unknown) | undefined;
+  /**
+   * Optional React component wrapped around each active thread. Use it to
+   * inject per-thread context such as a history or attachments adapter (see
+   * `useCloudThreadListAdapter` for the canonical shape).
+   *
+   * The Provider must render `children` on its first commit; deferring them
+   * behind a loading state, a Suspense boundary, or a `useEffect`-gated render
+   * is unsupported and leaves thread context unavailable to downstream
+   * consumers. Load data inside an always-mounted child instead.
+   */
+  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
 };
 
 export type RemoteThreadListOptions = {

--- a/packages/react/src/tests/RemoteThreadListRuntime.deferredProvider.test.tsx
+++ b/packages/react/src/tests/RemoteThreadListRuntime.deferredProvider.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { render } from "@testing-library/react";
+import { type FC, type PropsWithChildren, useState } from "react";
+import { describe, expect, it } from "vitest";
+import { useRemoteThreadListRuntime } from "@assistant-ui/core/react";
+import { makeAdapter } from "@assistant-ui/core/tests/remote-thread-list-test-helpers";
+import type { AssistantRuntime } from "@assistant-ui/core";
+import { AssistantRuntimeProvider } from "../context";
+import { useLocalRuntime } from "../legacy-runtime/runtime-cores/local/useLocalRuntime";
+import { useAssistantRuntime } from "../legacy-runtime/hooks/AssistantContext";
+import type { ChatModelAdapter, RemoteThreadListAdapter } from "../index";
+
+const noOpAdapter: ChatModelAdapter = {
+  async *run() {},
+};
+
+const useTestRuntimeHook = () => useLocalRuntime(noOpAdapter);
+
+const RuntimeProvider: FC<
+  PropsWithChildren<{ adapter: RemoteThreadListAdapter }>
+> = ({ children, adapter }) => {
+  const runtime = useRemoteThreadListRuntime({
+    runtimeHook: useTestRuntimeHook,
+    adapter,
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+};
+
+const RuntimeCapture: FC<{
+  runtimeRef: { current: AssistantRuntime | null };
+}> = ({ runtimeRef }) => {
+  const runtime = useAssistantRuntime();
+  runtimeRef.current = runtime;
+  return null;
+};
+
+// regression for #3678: deferred unstable_Provider must not strand the runtime binder.
+describe("useRemoteThreadListRuntime with a deferred unstable_Provider", () => {
+  it("composer.setText does not throw EMPTY_THREAD_ERROR when unstable_Provider defers children", () => {
+    const Provider: FC<PropsWithChildren> = ({ children }) => {
+      const [ready] = useState(false);
+      if (!ready) return null;
+      return <>{children}</>;
+    };
+    const adapter = makeAdapter({ unstable_Provider: Provider });
+
+    const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+    render(
+      <RuntimeProvider adapter={adapter}>
+        <RuntimeCapture runtimeRef={runtimeRef} />
+      </RuntimeProvider>,
+    );
+
+    const runtime = runtimeRef.current;
+    expect(runtime).toBeTruthy();
+    expect(() => runtime!.thread.composer.setText("hello")).not.toThrow();
+  });
+
+  it("composer.setText still works when unstable_Provider renders children unconditionally", () => {
+    const Provider: FC<PropsWithChildren> = ({ children }) => <>{children}</>;
+    const adapter = makeAdapter({ unstable_Provider: Provider });
+
+    const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+    render(
+      <RuntimeProvider adapter={adapter}>
+        <RuntimeCapture runtimeRef={runtimeRef} />
+      </RuntimeProvider>,
+    );
+
+    const runtime = runtimeRef.current;
+    expect(runtime).toBeTruthy();
+    expect(() => runtime!.thread.composer.setText("hello")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- closes #3678. when the user-supplied `unstable_Provider` defers `children` (e.g. behind a history-loading state), the runtime binder used to live inside it via `_InnerActiveThreadProvider`, so `instance.runtime` never got set, `getMainThreadRuntimeCore()` fell back to `EMPTY_THREAD_CORE`, and typing into the composer threw `EMPTY_THREAD_ERROR`.
- consolidate all four binder responsibilities (runtime hook + `updateRuntime`, `__internal_setGetInitializePromise`, the `unstable_on("initialize") → runEnd → generateTitle` listener) into a single `_RuntimeBinder` rendered outside the user's Provider. avoids the history-switch regression seen in the earlier split-only attempt where init listeners registered late.
- document the synchronous-`children` contract on `RemoteThreadListAdapter.unstable_Provider` and add a dev-mode warning when the Provider has not rendered `children` ~100ms after mount.
- add a regression test in `@assistant-ui/react` exercising `composer.setText` under a Provider that withholds `children`.
- update the custom-thread-list docs with a `Callout` showing the contract plus an anti-pattern / correct-pattern example.

## Test plan

- [x] `pnpm --filter='@assistant-ui/core' test` — 151 tests pass
- [x] `pnpm --filter='@assistant-ui/react' test` — 235 tests pass (incl. 2 new regression tests in `RemoteThreadListRuntime.deferredProvider.test.tsx`)
- [x] `pnpm biome check` clean on changed files
- [x] manual repro in `examples/with-custom-thread-list` with a `HistoryProvider` that gates children behind a `useState`: pre-fix emits 5× `EMPTY_THREAD_ERROR` when typing; post-fix the composer accepts text, the dev warning fires once, no errors.
- [ ] verify behaviour when switching to an existing thread under a deferred Provider (covered indirectly by keeping `unstable_on("initialize")` in `_RuntimeBinder`; reviewer to spot-check)
- [ ] confirm `unstable_Provider` shipped by `useCloudThreadListAdapter` and `LocalStorageThreadListAdapter` continues to work (both already render `children` unconditionally)