### PR TITLE
fix(react-google-adk): add missing DictationAdapter to UseAdkRuntimeOptions

### DIFF
--- a/.changeset/add-dictation-adapter-adk.md
+++ b/.changeset/add-dictation-adapter-adk.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix(react-google-adk): add missing DictationAdapter to UseAdkRuntimeOptions

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import {
   getExternalStoreMessages,
   type AttachmentAdapter,
+  type DictationAdapter,
   type FeedbackAdapter,
   type SpeechSynthesisAdapter,
   type AppendMessage,
@@ -144,6 +145,7 @@ export type UseAdkRuntimeOptions = {
     | {
         attachments?: AttachmentAdapter;
         speech?: SpeechSynthesisAdapter;
+        dictation?: DictationAdapter;
         feedback?: FeedbackAdapter;
       }
     | undefined;
@@ -164,7 +166,7 @@ export type UseAdkRuntimeOptions = {
 
 const useAdkRuntimeImpl = ({
   autoCancelPendingToolCalls,
-  adapters: { attachments, feedback, speech } = {},
+  adapters: { attachments, dictation, feedback, speech } = {},
   unstable_allowCancellation,
   stream,
   load,
@@ -261,7 +263,7 @@ const useAdkRuntimeImpl = ({
   const runtime = useExternalStoreRuntime({
     isRunning: effectiveIsRunning,
     messages: threadMessages,
-    adapters: { attachments, feedback, speech },
+    adapters: { attachments, dictation, feedback, speech },
     extras: {
       [symbolAdkRuntimeExtras]: true,
       agentInfo,


### PR DESCRIPTION
## Summary
- adds `dictation?: DictationAdapter` to `UseAdkRuntimeOptions.adapters`, aligning the wrapper hook's surface with `ExternalStoreAdapterBase`
- threads the adapter through to `useExternalStoreRuntime` so `startDictation` / `stopDictation` work end-to-end with `useAdkRuntime`
- mirrors the precedent fix for `react-ag-ui` in #3056 (same diff shape: import + type field + destructure + forward)
- patch changeset for `@assistant-ui/react-google-adk`

fixes #3892

## Test plan
- [x] `pnpm --filter @assistant-ui/react-google-adk build` passes
- [x] `pnpm --filter @assistant-ui/react-google-adk test` passes (163/163)
- [ ] manually wire `WebSpeechDictationAdapter` into a `useAdkRuntime` example and confirm composer dictation toggle works