### PR TITLE
fix(core): emit attachmentAddError on add validation failures

### DIFF
--- a/.changeset/attachment-add-error-validation.md
+++ b/.changeset/attachment-add-error-validation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): emit attachmentAddError when no adapter is configured or file type is rejected

--- a/apps/docs/content/docs/(docs)/guides/attachments.mdx
+++ b/apps/docs/content/docs/(docs)/guides/attachments.mdx
@@ -490,6 +490,25 @@ class ValidatedImageAdapter implements AttachmentAdapter {
 }
 ```
 
+To surface failures in the UI, subscribe to `composer.attachmentAddError`. It fires whenever `addAttachment` rejects, including when no adapter is configured, when the file type does not match `accept`, and when the adapter's `add` throws or yields an attachment with `status.reason === "error"`.
+
+```tsx
+import { useAuiEvent } from "@assistant-ui/react";
+
+function AttachmentErrorToast() {
+  useAuiEvent("composer.attachmentAddError", ({ attachmentId }) => {
+    toast.error(
+      attachmentId
+        ? "Attachment failed to upload."
+        : "This file could not be added.",
+    );
+  });
+  return null;
+}
+```
+
+`attachmentId` is omitted when the failure happens before an attachment is registered (e.g. unsupported file type), so consumers should treat it as optional.
+
 ### External Source Attachments
 
 Add attachments from external sources (URLs, API data, CMS references) without needing a `File` object or an `AttachmentAdapter`:

--- a/apps/docs/content/docs/(docs)/guides/context-api.mdx
+++ b/apps/docs/content/docs/(docs)/guides/context-api.mdx
@@ -528,6 +528,7 @@ const isRunning = useAuiState((s) => s.thread.isRunning);
 | `thread.modelContextUpdate`   | Model context is updated      |
 | `composer.send`               | Message is sent               |
 | `composer.attachmentAdd`      | Attachment added to composer  |
+| `composer.attachmentAddError` | Attachment add failed         |
 | `threadListItem.switchedTo`   | Switched to a thread          |
 | `threadListItem.switchedAway` | Switched away from a thread   |
 

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -218,20 +218,6 @@ export abstract class BaseComposerRuntimeCore
       return;
     }
 
-    const adapter = this.getAttachmentAdapter();
-    if (!adapter) throw new Error("Attachments are not supported");
-
-    if (
-      !fileMatchesAccept(
-        { name: fileOrAttachment.name, type: fileOrAttachment.type },
-        adapter.accept,
-      )
-    ) {
-      throw new Error(
-        `File type ${fileOrAttachment.type || "unknown"} is not accepted. Accepted types: ${adapter.accept}`,
-      );
-    }
-
     const upsertAttachment = (a: PendingAttachment) => {
       const idx = this._attachments.findIndex(
         (attachment) => attachment.id === a.id,
@@ -251,6 +237,20 @@ export abstract class BaseComposerRuntimeCore
 
     let lastAttachment: PendingAttachment | undefined;
     try {
+      const adapter = this.getAttachmentAdapter();
+      if (!adapter) throw new Error("Attachments are not supported");
+
+      if (
+        !fileMatchesAccept(
+          { name: fileOrAttachment.name, type: fileOrAttachment.type },
+          adapter.accept,
+        )
+      ) {
+        throw new Error(
+          `File type ${fileOrAttachment.type || "unknown"} is not accepted. Accepted types: ${adapter.accept}`,
+        );
+      }
+
       const promiseOrGenerator = adapter.add({ file: fileOrAttachment });
       if (Symbol.asyncIterator in promiseOrGenerator) {
         for await (const r of promiseOrGenerator) {
@@ -271,7 +271,7 @@ export abstract class BaseComposerRuntimeCore
       try {
         this._notifyEventSubscribers("attachmentAddError");
       } catch {
-        // prevent subscriber errors from masking the adapter error
+        // prevent subscriber errors from masking the original error
       }
       throw e;
     }

--- a/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { DefaultThreadComposerRuntimeCore } from "../runtime/base/default-thread-composer-runtime-core";
+import type { AttachmentAdapter } from "../adapters/attachment";
+import type { ThreadRuntimeCore } from "../runtime/interfaces/thread-runtime-core";
+import type { PendingAttachment } from "../types/attachment";
+
+const makeAdapter = (
+  overrides: Partial<AttachmentAdapter> = {},
+): AttachmentAdapter => ({
+  accept: "image/*",
+  add: async ({ file }: { file: File }): Promise<PendingAttachment> => ({
+    id: "att-1",
+    type: "image",
+    name: file.name,
+    contentType: file.type,
+    file,
+    status: { type: "running", reason: "uploading", progress: 0 },
+  }),
+  remove: async () => {},
+  send: async (a) => ({ ...a, status: { type: "complete" }, content: [] }),
+  ...overrides,
+});
+
+const makeComposer = (adapter?: AttachmentAdapter) => {
+  const runtime = {
+    append: vi.fn(),
+    cancelRun: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
+    capabilities: { cancel: false },
+    messages: [],
+    adapters: adapter ? { attachments: adapter } : undefined,
+  } as unknown as Omit<ThreadRuntimeCore, "composer"> & {
+    adapters?: { attachments?: AttachmentAdapter };
+  };
+  return new DefaultThreadComposerRuntimeCore(runtime);
+};
+
+describe("BaseComposerRuntimeCore.addAttachment error events", () => {
+  it("emits attachmentAddError when no adapter is configured", async () => {
+    const composer = makeComposer();
+    const onError = vi.fn();
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAddError", onError);
+    composer.unstable_on("attachmentAdd", onAdd);
+
+    await expect(
+      composer.addAttachment(new File(["x"], "f.txt", { type: "text/plain" })),
+    ).rejects.toThrow("Attachments are not supported");
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it("emits attachmentAddError when file type is rejected by adapter.accept", async () => {
+    const composer = makeComposer(makeAdapter({ accept: "image/*" }));
+    const onError = vi.fn();
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAddError", onError);
+    composer.unstable_on("attachmentAdd", onAdd);
+
+    await expect(
+      composer.addAttachment(new File(["x"], "f.txt", { type: "text/plain" })),
+    ).rejects.toThrow(/File type text\/plain is not accepted/);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it("emits attachmentAddError when adapter.add throws", async () => {
+    const composer = makeComposer(
+      makeAdapter({
+        add: async () => {
+          throw new Error("upload failed");
+        },
+      }),
+    );
+    const onError = vi.fn();
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAddError", onError);
+    composer.unstable_on("attachmentAdd", onAdd);
+
+    await expect(
+      composer.addAttachment(new File(["x"], "f.png", { type: "image/png" })),
+    ).rejects.toThrow("upload failed");
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it("emits attachmentAdd on successful add", async () => {
+    const composer = makeComposer(makeAdapter());
+    const onError = vi.fn();
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAddError", onError);
+    composer.unstable_on("attachmentAdd", onAdd);
+
+    await composer.addAttachment(
+      new File(["x"], "f.png", { type: "image/png" }),
+    );
+
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("does not let subscriber errors mask the original throw", async () => {
+    const composer = makeComposer(makeAdapter({ accept: "image/*" }));
+    composer.unstable_on("attachmentAddError", () => {
+      throw new Error("subscriber boom");
+    });
+
+    await expect(
+      composer.addAttachment(new File(["x"], "f.txt", { type: "text/plain" })),
+    ).rejects.toThrow(/File type text\/plain is not accepted/);
+  });
+});


### PR DESCRIPTION
## Summary

- closes #3599 — the `composer.attachmentAddError` event added in #3600 only fired from inside `adapter.add()`'s catch block, missing the two pre-checks (`!adapter` and `fileMatchesAccept` rejection) that throw before the try/catch
- move both validations inside the existing try block so a single catch funnels every add-error path through `_notifyEventSubscribers("attachmentAddError")`; preserves the existing `try { notify } catch {}` safety wrapper that prevents subscriber errors from masking the original throw
- add `DefaultThreadComposerRuntimeCore`-based unit tests covering missing adapter, rejected file type, adapter `add` throwing, success path, and subscriber-error isolation
- document `composer.attachmentAddError` in the context-api Common Events table and in the attachments guide's Validation and Error Handling section, noting that `attachmentId` is omitted when the failure happens before an attachment is registered

## Test plan

- [ ] `pnpm --filter @assistant-ui/core test` passes (5 new tests + existing 151)
- [ ] manually attach an unsupported file type in an example with a restrictive `accept` and confirm a `useAuiEvent("composer.attachmentAddError", ...)` listener fires
- [ ] manually call `addAttachment` without configuring an attachment adapter and confirm the listener fires
- [ ] confirm the success path still emits `composer.attachmentAdd` (no double-fire)