### PR TITLE
fix(core): enforce adapter.accept for external CreateAttachment

### DIFF
--- a/.changeset/external-attachment-accept.md
+++ b/.changeset/external-attachment-accept.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): respect `adapter.accept` when adding external `CreateAttachment`
+
+`composer.addAttachment` previously bypassed the configured `AttachmentAdapter` for `CreateAttachment` descriptors, including the `adapter.accept` content-type check. It now validates the descriptor's `contentType` (or filename extension) against `adapter.accept` when an adapter is configured, throwing and emitting `composer.attachmentAddError` on mismatch. Without an adapter, external attachments are still added as-is, preserving the existing "no adapter required" guarantee for external sources.

--- a/apps/docs/content/docs/(docs)/guides/attachments.mdx
+++ b/apps/docs/content/docs/(docs)/guides/attachments.mdx
@@ -490,9 +490,13 @@ class ValidatedImageAdapter implements AttachmentAdapter {
 }
 ```
 
-To surface failures in the UI, subscribe to `composer.attachmentAddError`. It fires whenever `addAttachment` rejects, including when no adapter is configured, when the file type does not match `accept`, and when the adapter's `add` throws or yields an attachment with `status.reason === "error"`.
+To surface failures in the UI, subscribe to `composer.attachmentAddError`. It fires whenever an add operation produces a failure, in either of two ways:
+
+1. `addAttachment()` rejects: no adapter is configured, the file type does not match `accept`, or the adapter's `add()` throws.
+2. `addAttachment()` resolves but the adapter yielded an attachment whose `status.reason === "error"` (the promise resolves successfully, yet the event still fires so the UI can react).
 
 ```tsx
+import { toast } from "sonner"; // or your toast library of choice
 import { useAuiEvent } from "@assistant-ui/react";
 
 function AttachmentErrorToast() {
@@ -507,7 +511,7 @@ function AttachmentErrorToast() {
 }
 ```
 
-`attachmentId` is omitted when the failure happens before an attachment is registered (e.g. unsupported file type), so consumers should treat it as optional.
+`attachmentId` is best-effort and should always be treated as optional. It is resolved by scanning the composer's current attachment list for the most recently registered errored attachment, so it is `undefined` for failures that happen before any attachment is registered (e.g. unsupported file type) only when no prior errored attachment is still present.
 
 ### External Source Attachments
 
@@ -532,7 +536,7 @@ await aui.composer().addAttachment({
 });
 ```
 
-External attachments are added as complete attachments directly — they skip the `AttachmentAdapter` entirely and can be removed without one.
+External attachments are added as complete attachments directly. They bypass the `AttachmentAdapter`'s `add()` step (no upload), but `adapter.accept` is still enforced when an `AttachmentAdapter` is configured: a `CreateAttachment` whose `contentType` does not match `adapter.accept` is rejected and emits `composer.attachmentAddError`. If `contentType` is omitted, the descriptor's filename extension is matched against `adapter.accept` only when `accept` itself contains explicit extension entries (e.g. `.png,.pdf`); MIME-wildcard `accept` strings such as `image/*` always require a matching `contentType`. When no `AttachmentAdapter` is configured, external attachments are added without any content-type check, and they can be removed without an adapter.
 
 ### Multiple File Selection
 

--- a/packages/core/src/runtime/api/composer-runtime.ts
+++ b/packages/core/src/runtime/api/composer-runtime.ts
@@ -136,8 +136,10 @@ export type ComposerRuntime = {
   /**
    * Add an attachment to the composer. Accepts either a standard File object
    * (processed through the AttachmentAdapter) or a CreateAttachment descriptor
-   * for external-source attachments (URLs, API data, CMS references) that
-   * bypasses the adapter entirely.
+   * for external-source attachments (URLs, API data, CMS references). External
+   * descriptors bypass the adapter's `add()` step but still respect
+   * `adapter.accept` when an adapter is configured; without an adapter they
+   * are added as-is.
    * @param fileOrAttachment The file or attachment descriptor to add.
    */
   addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -204,17 +204,42 @@ export abstract class BaseComposerRuntimeCore
 
   async addAttachment(fileOrAttachment: File | CreateAttachment) {
     if (!(fileOrAttachment instanceof File)) {
-      const a: CompleteAttachment = {
-        id: fileOrAttachment.id ?? generateId(),
-        type: fileOrAttachment.type ?? "document",
-        name: fileOrAttachment.name,
-        contentType: fileOrAttachment.contentType,
-        content: fileOrAttachment.content,
-        status: { type: "complete" },
-      };
-      this._attachments = [...this._attachments, a];
+      try {
+        const adapter = this.getAttachmentAdapter();
+        if (
+          adapter &&
+          !fileMatchesAccept(
+            {
+              name: fileOrAttachment.name,
+              type: fileOrAttachment.contentType ?? "",
+            },
+            adapter.accept,
+          )
+        ) {
+          throw new Error(
+            `File type ${fileOrAttachment.contentType || "unknown"} is not accepted. Accepted types: ${adapter.accept}`,
+          );
+        }
+
+        const a: CompleteAttachment = {
+          id: fileOrAttachment.id ?? generateId(),
+          type: fileOrAttachment.type ?? "document",
+          name: fileOrAttachment.name,
+          contentType: fileOrAttachment.contentType,
+          content: fileOrAttachment.content,
+          status: { type: "complete" },
+        };
+        this._attachments = [...this._attachments, a];
+        this._notifySubscribers();
+      } catch (e) {
+        try {
+          this._notifyEventSubscribers("attachmentAddError");
+        } catch {
+          // prevent subscriber errors from masking the original error
+        }
+        throw e;
+      }
       this._notifyEventSubscribers("attachmentAdd");
-      this._notifySubscribers();
       return;
     }
 

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -204,41 +204,37 @@ export abstract class BaseComposerRuntimeCore
 
   async addAttachment(fileOrAttachment: File | CreateAttachment) {
     if (!(fileOrAttachment instanceof File)) {
-      try {
-        const adapter = this.getAttachmentAdapter();
-        if (
-          adapter &&
-          !fileMatchesAccept(
-            {
-              name: fileOrAttachment.name,
-              type: fileOrAttachment.contentType ?? "",
-            },
-            adapter.accept,
-          )
-        ) {
-          throw new Error(
-            `File type ${fileOrAttachment.contentType || "unknown"} is not accepted. Accepted types: ${adapter.accept}`,
-          );
-        }
-
-        const a: CompleteAttachment = {
-          id: fileOrAttachment.id ?? generateId(),
-          type: fileOrAttachment.type ?? "document",
-          name: fileOrAttachment.name,
-          contentType: fileOrAttachment.contentType,
-          content: fileOrAttachment.content,
-          status: { type: "complete" },
-        };
-        this._attachments = [...this._attachments, a];
-        this._notifySubscribers();
-      } catch (e) {
+      const adapter = this.getAttachmentAdapter();
+      if (
+        adapter &&
+        !fileMatchesAccept(
+          {
+            name: fileOrAttachment.name,
+            type: fileOrAttachment.contentType ?? "",
+          },
+          adapter.accept,
+        )
+      ) {
         try {
           this._notifyEventSubscribers("attachmentAddError");
         } catch {
           // prevent subscriber errors from masking the original error
         }
-        throw e;
+        throw new Error(
+          `File type ${fileOrAttachment.contentType || "unknown"} is not accepted. Accepted types: ${adapter.accept}`,
+        );
       }
+
+      const a: CompleteAttachment = {
+        id: fileOrAttachment.id ?? generateId(),
+        type: fileOrAttachment.type ?? "document",
+        name: fileOrAttachment.name,
+        contentType: fileOrAttachment.contentType,
+        content: fileOrAttachment.content,
+        status: { type: "complete" },
+      };
+      this._attachments = [...this._attachments, a];
+      this._notifySubscribers();
       this._notifyEventSubscribers("attachmentAdd");
       return;
     }

--- a/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
@@ -52,7 +52,7 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
   });
 
   it("emits attachmentAddError when file type is rejected by adapter.accept", async () => {
-    const composer = makeComposer(makeAdapter({ accept: "image/*" }));
+    const composer = makeComposer(makeAdapter());
     const onError = vi.fn();
     const onAdd = vi.fn();
     composer.unstable_on("attachmentAddError", onError);
@@ -103,7 +103,7 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
   });
 
   it("does not let subscriber errors mask the original throw", async () => {
-    const composer = makeComposer(makeAdapter({ accept: "image/*" }));
+    const composer = makeComposer(makeAdapter());
     composer.unstable_on("attachmentAddError", () => {
       throw new Error("subscriber boom");
     });
@@ -111,5 +111,44 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
     await expect(
       composer.addAttachment(new File(["x"], "f.txt", { type: "text/plain" })),
     ).rejects.toThrow(/File type text\/plain is not accepted/);
+  });
+
+  it("emits attachmentAddError when async generator adapter throws mid-iteration", async () => {
+    const composer = makeComposer(
+      makeAdapter({
+        async *add({ file }: { file: File }) {
+          yield {
+            id: "att-1",
+            type: "image" as const,
+            name: file.name,
+            contentType: file.type,
+            file,
+            status: {
+              type: "running" as const,
+              reason: "uploading" as const,
+              progress: 0,
+            },
+          };
+          throw new Error("network error");
+        },
+      }),
+    );
+    const onError = vi.fn();
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAddError", onError);
+    composer.unstable_on("attachmentAdd", onAdd);
+
+    await expect(
+      composer.addAttachment(new File(["x"], "f.png", { type: "image/png" })),
+    ).rejects.toThrow("network error");
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onAdd).not.toHaveBeenCalled();
+    expect(composer.attachments).toHaveLength(1);
+    const att = composer.attachments[0]!;
+    expect(att.status.type).toBe("incomplete");
+    if (att.status.type === "incomplete") {
+      expect(att.status.reason).toBe("error");
+    }
   });
 });

--- a/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
+++ b/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
@@ -547,6 +547,27 @@ describe("BaseComposerRuntimeCore", () => {
         expect(composer.attachments).toHaveLength(1);
         expect(onError).not.toHaveBeenCalled();
       });
+
+      it("does not fire attachmentAddError when a state subscriber throws on add", async () => {
+        composer.setAttachmentAdapter(makeImageAdapter());
+        const onError = vi.fn();
+        composer.subscribe(() => {
+          throw new Error("state subscriber boom");
+        });
+        composer.unstable_on("attachmentAddError", onError);
+
+        await expect(
+          composer.addAttachment(
+            makeCreateAttachment({
+              name: "photo.png",
+              contentType: "image/png",
+            }),
+          ),
+        ).rejects.toThrow("state subscriber boom");
+
+        expect(composer.attachments).toHaveLength(1);
+        expect(onError).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
+++ b/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
@@ -426,6 +426,128 @@ describe("BaseComposerRuntimeCore", () => {
       // Pending was sent through adapter
       expect(adapter.send).toHaveBeenCalledTimes(1);
     });
+
+    describe("adapter.accept enforcement", () => {
+      const makeImageAdapter = (): AttachmentAdapter => ({
+        accept: "image/*",
+        add: vi.fn(),
+        remove: vi.fn(),
+        send: vi.fn(),
+      });
+
+      it("rejects external attachment with contentType not matching adapter.accept", async () => {
+        composer.setAttachmentAdapter(makeImageAdapter());
+        const onError = vi.fn();
+        const onAdd = vi.fn();
+        composer.unstable_on("attachmentAddError", onError);
+        composer.unstable_on("attachmentAdd", onAdd);
+
+        await expect(
+          composer.addAttachment(
+            makeCreateAttachment({
+              name: "doc.pdf",
+              contentType: "application/pdf",
+            }),
+          ),
+        ).rejects.toThrow(/File type application\/pdf is not accepted/);
+
+        expect(composer.attachments).toHaveLength(0);
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onAdd).not.toHaveBeenCalled();
+      });
+
+      it("accepts external attachment with contentType matching adapter.accept", async () => {
+        composer.setAttachmentAdapter(makeImageAdapter());
+        const onError = vi.fn();
+
+        composer.unstable_on("attachmentAddError", onError);
+        await composer.addAttachment(
+          makeCreateAttachment({
+            name: "photo.png",
+            contentType: "image/png",
+          }),
+        );
+
+        expect(composer.attachments).toHaveLength(1);
+        expect(onError).not.toHaveBeenCalled();
+      });
+
+      it("accepts external attachment when only filename extension matches adapter.accept", async () => {
+        composer.setAttachmentAdapter({
+          accept: ".pdf",
+          add: vi.fn(),
+          remove: vi.fn(),
+          send: vi.fn(),
+        });
+
+        await composer.addAttachment(
+          makeCreateAttachment({ name: "report.pdf" }),
+        );
+
+        expect(composer.attachments).toHaveLength(1);
+      });
+
+      it("rejects external attachment when contentType missing and extension does not match", async () => {
+        composer.setAttachmentAdapter(makeImageAdapter());
+        const onError = vi.fn();
+        composer.unstable_on("attachmentAddError", onError);
+
+        await expect(
+          composer.addAttachment(makeCreateAttachment({ name: "notes.txt" })),
+        ).rejects.toThrow(/is not accepted/);
+
+        expect(onError).toHaveBeenCalledTimes(1);
+      });
+
+      it("adds external attachment without check when no adapter is configured", async () => {
+        // No adapter — preserves the original "no adapter required" guarantee
+        await composer.addAttachment(
+          makeCreateAttachment({
+            name: "anything.xyz",
+            contentType: "application/x-anything",
+          }),
+        );
+
+        expect(composer.attachments).toHaveLength(1);
+      });
+
+      it("does not let subscriber errors mask the original throw", async () => {
+        composer.setAttachmentAdapter(makeImageAdapter());
+        composer.unstable_on("attachmentAddError", () => {
+          throw new Error("subscriber boom");
+        });
+
+        await expect(
+          composer.addAttachment(
+            makeCreateAttachment({
+              name: "doc.pdf",
+              contentType: "application/pdf",
+            }),
+          ),
+        ).rejects.toThrow(/is not accepted/);
+      });
+
+      it("does not fire attachmentAddError when an attachmentAdd subscriber throws", async () => {
+        composer.setAttachmentAdapter(makeImageAdapter());
+        const onError = vi.fn();
+        composer.unstable_on("attachmentAdd", () => {
+          throw new Error("add subscriber boom");
+        });
+        composer.unstable_on("attachmentAddError", onError);
+
+        await expect(
+          composer.addAttachment(
+            makeCreateAttachment({
+              name: "photo.png",
+              contentType: "image/png",
+            }),
+          ),
+        ).rejects.toThrow("add subscriber boom");
+
+        expect(composer.attachments).toHaveLength(1);
+        expect(onError).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("send options", () => {


### PR DESCRIPTION
closes #3893

## Summary

Primary fix (closes #3893):

- `composer.addAttachment(CreateAttachment)` now enforces `adapter.accept` when an `AttachmentAdapter` is configured, instead of unconditionally bypassing the adapter for external descriptors.
- Validation runs `name` + `contentType ?? ""` through the existing `fileMatchesAccept` helper. When `contentType` is omitted, the filename extension is honored only if `adapter.accept` itself contains explicit `.ext` entries; MIME-wildcard `accept` strings such as `image/*` still require a matching `contentType`.
- Failures throw the same `File type … is not accepted` error as the `File` branch and route through `_notifyEventSubscribers("attachmentAddError")` (the event added in #3895).
- The success-side `attachmentAdd` event fires outside the validation try/catch so a throwing `attachmentAdd` subscriber does not spuriously trigger `attachmentAddError`, matching the File-branch ordering.
- Without an adapter, external descriptors are still added as-is, preserving the "no adapter required for external sources" contract from #3393.
- Updates the `addAttachment` JSDoc and the External Source Attachments section of the attachments guide so they no longer claim the adapter is bypassed entirely, and call out the MIME-wildcard limitation explicitly.

Follow-ups picked up from review on #3895 (same area, no additional public surface):

- Splits the `attachmentAddError` fire-conditions paragraph into the two real cases (`addAttachment` rejecting vs resolving with an attachment whose `status.reason === "error"`); the prior wording conflated them.
- Reframes `attachmentId` as best-effort and explains that it is resolved by scanning the current attachment list, so a prior errored attachment can still populate the field on a pre-registration failure.
- Adds a `toast` library import comment to the docs example so readers know `toast.error` is not built in.
- Drops the redundant `accept: "image/*"` overrides on the existing core test fixtures (`makeAdapter()` already defaults to `image/*`).
- Adds a core test that exercises the async-generator-mid-iteration-throw branch in `addAttachment`, asserting `attachmentAddError` fires and the last yielded attachment is upserted with status `incomplete` / reason `error`.

## Test plan

- [x] `pnpm --filter @assistant-ui/core test` passes (157 tests, includes the new async-generator throw case)
- [x] `pnpm --filter @assistant-ui/react test` passes (242 tests, includes 7 new external-`CreateAttachment` cases)
- [x] `pnpm exec biome check` clean on changed files
- [ ] Manually verify: with an `image/*` adapter, programmatically calling `aui.composer().addAttachment({ name: "doc.pdf", contentType: "application/pdf", content: [...] })` rejects and fires `attachmentAddError`
- [ ] Manually verify: with the same adapter, an `image/png` external descriptor is accepted
- [ ] Manually verify: with a `.pdf` adapter, an external descriptor with no `contentType` but `name: "report.pdf"` is accepted (extension fallback)
- [ ] Manually verify: with an `image/*` adapter, an external descriptor with no `contentType` but `name: "photo.png"` is rejected (extension fallback does NOT apply to MIME-wildcard accept)
- [ ] Manually verify: without any adapter configured, external descriptors are still added (regression check on #3393's guarantee)
- [ ] Manually verify: a throwing `attachmentAdd` subscriber on a successful external add propagates the throw but does not fire `attachmentAddError`