### PR TITLE
feat(docs): add traction page and restructure changelog list

### DIFF
--- a/apps/docs/app/(home)/changelog/changelog-list.tsx
+++ b/apps/docs/app/(home)/changelog/changelog-list.tsx
@@ -1,13 +1,22 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import { ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { ReleaseGroup, PackageRelease } from "@/lib/releases";
+import {
+  groupByType,
+  parseRelease,
+  TYPE_LABELS,
+  type ChangeType,
+  type ParsedBullet,
+} from "@/lib/changelog-parse";
+import { cn } from "@/lib/utils";
 
 const PAGE_SIZE = 10;
+const COLLAPSE_BODY_THRESHOLD = 240;
 
 function formatDate(date: string): string {
   return new Date(date).toLocaleDateString("en-US", {
@@ -25,53 +34,240 @@ function extractChangeType(
   return match[1]!.toLowerCase() as "major" | "minor" | "patch";
 }
 
-function cleanBody(markdown: string): string {
-  return (
-    markdown
-      // strip known changeset headings only
-      .replace(/^#{1,6}\s+(Patch|Minor|Major)\s+Changes\s*$/gim, "")
-      // strip "Updated dependencies" blocks and their indented deps
-      .replace(/^-\s+Updated dependencies.*(?:\n\s+-.*)*/gm, "")
-      // strip commit hash prefix: "- abc1234: desc" → "- desc"
-      .replace(/^(\s*-\s+)[a-f0-9]{6,10}:\s*/gm, "$1")
-      .trim()
-  );
-}
-
-const changeTypeBadge = {
+const semverBadge = {
   major: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
   minor: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
   patch: "bg-muted text-muted-foreground",
 } as const;
 
-const Heading = ({ children }: { children?: React.ReactNode }) => (
-  <p className="font-medium text-foreground/80">{children}</p>
-);
-
-const markdownComponents = {
-  h1: Heading,
-  h2: Heading,
-  h3: Heading,
-  h4: Heading,
-  h5: Heading,
-  h6: Heading,
+const TYPE_BADGE: Record<ChangeType, string> = {
+  breaking: "bg-red-500/10 text-red-700 ring-red-500/20 dark:text-red-400",
+  feat: "bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:text-emerald-400",
+  fix: "bg-blue-500/10 text-blue-700 ring-blue-500/20 dark:text-blue-400",
+  perf: "bg-amber-500/10 text-amber-700 ring-amber-500/20 dark:text-amber-400",
+  refactor:
+    "bg-violet-500/10 text-violet-700 ring-violet-500/20 dark:text-violet-400",
+  revert: "bg-rose-500/10 text-rose-700 ring-rose-500/20 dark:text-rose-400",
+  docs: "bg-sky-500/10 text-sky-700 ring-sky-500/20 dark:text-sky-400",
+  style: "bg-pink-500/10 text-pink-700 ring-pink-500/20 dark:text-pink-400",
+  test: "bg-teal-500/10 text-teal-700 ring-teal-500/20 dark:text-teal-400",
+  build:
+    "bg-indigo-500/10 text-indigo-700 ring-indigo-500/20 dark:text-indigo-400",
+  ci: "bg-cyan-500/10 text-cyan-700 ring-cyan-500/20 dark:text-cyan-400",
+  chore: "bg-muted text-muted-foreground ring-border",
+  other: "bg-muted text-muted-foreground ring-border",
 };
 
+const TYPE_SHORT_LABEL: Record<ChangeType, string> = {
+  breaking: "BREAKING",
+  feat: "feat",
+  fix: "fix",
+  perf: "perf",
+  refactor: "refactor",
+  revert: "revert",
+  docs: "docs",
+  style: "style",
+  test: "test",
+  build: "build",
+  ci: "ci",
+  chore: "chore",
+  other: "misc",
+};
+
+function TypeBadge({
+  type,
+  scope,
+}: {
+  type: ChangeType;
+  scope?: string | undefined;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-baseline gap-1 rounded-md px-1.5 py-0.5 font-medium font-mono text-[10px] uppercase leading-none tracking-wide ring-1 ring-inset",
+        TYPE_BADGE[type],
+      )}
+    >
+      <span>{TYPE_SHORT_LABEL[type]}</span>
+      {scope ? (
+        <span className="font-normal normal-case opacity-70">· {scope}</span>
+      ) : null}
+    </span>
+  );
+}
+
+const inlineMarkdownComponents: Components = {
+  p: ({ children }) => <>{children}</>,
+  code: ({ children }) => (
+    <code className="rounded bg-foreground/[0.07] px-1 py-0.5 font-mono text-[0.85em] text-foreground ring-1 ring-foreground/10">
+      {children}
+    </code>
+  ),
+  a: ({ children, href }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-foreground/90 underline decoration-foreground/30 underline-offset-2 transition-colors hover:decoration-foreground"
+    >
+      {children}
+    </a>
+  ),
+};
+
+const bodyMarkdownComponents: Components = {
+  ...inlineMarkdownComponents,
+  p: ({ children }) => (
+    <p className="mt-2 leading-relaxed first:mt-0">{children}</p>
+  ),
+  ul: ({ children }) => (
+    <ul className="mt-2 list-disc space-y-1 pl-5 first:mt-0">{children}</ul>
+  ),
+  li: ({ children }) => <li>{children}</li>,
+};
+
+function MetaLine({ item }: { item: ParsedBullet }) {
+  const parts: React.ReactNode[] = [];
+  if (item.pr) {
+    parts.push(
+      <a
+        key="pr"
+        href={item.pr.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-mono transition-colors hover:text-foreground"
+      >
+        #{item.pr.number}
+      </a>,
+    );
+  }
+  if (item.hash) {
+    parts.push(
+      <a
+        key="hash"
+        href={item.hash.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-mono transition-colors hover:text-foreground"
+      >
+        {item.hash.value}
+      </a>,
+    );
+  }
+  if (item.author) {
+    parts.push(
+      <a
+        key="author"
+        href={item.author.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="transition-colors hover:text-foreground"
+      >
+        @{item.author.handle}
+      </a>,
+    );
+  }
+  if (parts.length === 0) return null;
+  const interleaved: React.ReactNode[] = [];
+  parts.forEach((node, i) => {
+    if (i > 0) {
+      interleaved.push(
+        <span key={`sep-${i}`} className="select-none opacity-40">
+          ·
+        </span>,
+      );
+    }
+    interleaved.push(node);
+  });
+  return (
+    <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-muted-foreground/80 text-xs">
+      {interleaved}
+    </div>
+  );
+}
+
+function BulletItem({ item }: { item: ParsedBullet }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasBody = item.body.length > 0;
+  const isLong = hasBody && item.body.length > COLLAPSE_BODY_THRESHOLD;
+  const showFull = expanded || !isLong;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        <TypeBadge type={item.type} scope={item.scope} />
+        <span className="text-foreground text-sm leading-relaxed">
+          <ReactMarkdown components={inlineMarkdownComponents}>
+            {item.description || "(no description)"}
+          </ReactMarkdown>
+        </span>
+      </div>
+      <MetaLine item={item} />
+      {hasBody ? (
+        <div className="text-muted-foreground text-sm">
+          <div className={cn(!showFull && "line-clamp-2")}>
+            <ReactMarkdown components={bodyMarkdownComponents}>
+              {item.body}
+            </ReactMarkdown>
+          </div>
+          {isLong ? (
+            <button
+              type="button"
+              onClick={() => setExpanded((e) => !e)}
+              className="mt-1 text-muted-foreground/70 text-xs transition-colors hover:text-foreground"
+            >
+              {expanded ? "Show less" : "Show more"}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function TypeGroup({
+  type,
+  items,
+}: {
+  type: ChangeType;
+  items: ParsedBullet[];
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-baseline gap-2 border-border/60 border-b pb-1.5">
+        <h4 className="font-medium text-foreground/70 text-xs uppercase tracking-wide">
+          {TYPE_LABELS[type]}
+        </h4>
+        <span className="text-muted-foreground text-xs tabular-nums">
+          {items.length}
+        </span>
+      </div>
+      <div className="flex flex-col gap-4">
+        {items.map((item, i) => (
+          <BulletItem key={i} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function ReleaseEntry({ release }: { release: PackageRelease }) {
-  const changeType = extractChangeType(release.body);
+  const semver = extractChangeType(release.body);
+  const parsed = useMemo(() => parseRelease(release.body), [release.body]);
+  const groups = useMemo(() => groupByType(parsed.bullets), [parsed.bullets]);
 
   return (
     <details className="group/release">
       <summary className="flex cursor-pointer list-none items-center gap-2 py-1 [&::-webkit-details-marker]:hidden">
-        <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open/release:rotate-90" />
+        <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-transform group-open/release:rotate-90" />
         <span className="font-medium font-mono text-foreground/80 text-sm transition-colors group-hover/release:text-foreground">
           {release.pkg}@{release.version}
         </span>
-        {changeType && (
+        {semver && (
           <span
-            className={`shrink-0 rounded-full px-1.5 py-0.5 font-medium text-[10px] leading-none ${changeTypeBadge[changeType]}`}
+            className={`shrink-0 rounded-full px-1.5 py-0.5 font-medium text-[10px] leading-none ${semverBadge[semver]}`}
           >
-            {changeType}
+            {semver}
           </span>
         )}
         <Link
@@ -84,10 +280,20 @@ function ReleaseEntry({ release }: { release: PackageRelease }) {
           GitHub →
         </Link>
       </summary>
-      <div className="py-1 pl-[1.375rem] text-muted-foreground text-sm [&_li]:my-1 [&_p]:my-0 [&_ul]:my-0 [&_ul]:list-disc [&_ul]:pl-4">
-        <ReactMarkdown components={markdownComponents}>
-          {cleanBody(release.body)}
-        </ReactMarkdown>
+      <div className="mt-3 ml-[1.375rem] flex flex-col gap-6 pb-2">
+        {parsed.preamble ? (
+          <div className="text-muted-foreground text-sm">
+            <ReactMarkdown components={bodyMarkdownComponents}>
+              {parsed.preamble}
+            </ReactMarkdown>
+          </div>
+        ) : null}
+        {groups.map(({ type, items }) => (
+          <TypeGroup key={type} type={type} items={items} />
+        ))}
+        {groups.length === 0 && !parsed.preamble ? (
+          <p className="text-muted-foreground text-sm">No notes.</p>
+        ) : null}
       </div>
     </details>
   );

--- a/apps/docs/app/(home)/traction/page.tsx
+++ b/apps/docs/app/(home)/traction/page.tsx
@@ -1,0 +1,462 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  ArrowUpRight,
+  GitFork,
+  GitCommit,
+  Package,
+  Star,
+  Users,
+  Sparkles,
+} from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { GitHubIcon } from "@/components/icons/github";
+import { createOgMetadata } from "@/lib/og";
+import {
+  PACKAGES,
+  PACKAGE_CATEGORIES,
+  PROJECT_FACTS,
+  TIMELINE_PACKAGES,
+  daysSince,
+  fetchNpmDownloads,
+  fetchRepoStats,
+  fetchStarHistory,
+  fetchTimelineSeries,
+  formatCompact,
+  formatNumber,
+  type PackageCategory,
+  type PackageInfo,
+} from "@/lib/traction";
+import { DownloadsChart } from "@/components/traction/downloads-chart";
+import { Sparkline } from "@/components/traction/sparkline";
+import { StarHistoryChart } from "@/components/traction/star-history-chart";
+import { TopPackagesBar } from "@/components/traction/top-packages-bar";
+
+const title = "Traction";
+const description =
+  "GitHub momentum, package coverage, and the numbers behind assistant-ui.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  ...createOgMetadata(title, description),
+};
+
+const REPO_URL = "https://github.com/assistant-ui/assistant-ui";
+
+type HeroStat = {
+  label: string;
+  value: string;
+  caption: string;
+  icon: typeof Star;
+};
+
+const FLAGSHIP_PACKAGE = "@assistant-ui/react";
+
+export default async function TractionPage() {
+  const repo = await fetchRepoStats();
+
+  const [npm, starHistory, downloadsTimeline] = await Promise.all([
+    fetchNpmDownloads(),
+    fetchStarHistory(repo.stars),
+    fetchTimelineSeries(TIMELINE_PACKAGES),
+  ]);
+
+  const days = daysSince(PROJECT_FACTS.firstCommitDate);
+  const flagshipWeekly = npm.perPackage[FLAGSHIP_PACKAGE]?.weekly ?? 0;
+
+  const topPackages = [...PACKAGES]
+    .map((pkg) => ({
+      name: pkg.name,
+      weekly: npm.perPackage[pkg.name]?.weekly ?? 0,
+    }))
+    .filter((row) => row.weekly > 0)
+    .sort((a, b) => b.weekly - a.weekly)
+    .slice(0, 12);
+
+  const heroStats: HeroStat[] = [
+    {
+      label: "GitHub stars",
+      value: formatCompact(repo.stars),
+      caption: "and counting",
+      icon: Star,
+    },
+    {
+      label: "Public packages",
+      value: PROJECT_FACTS.publicPackages.toString(),
+      caption: "shipped on npm",
+      icon: Package,
+    },
+    {
+      label: "Weekly downloads",
+      value: flagshipWeekly > 0 ? formatCompact(flagshipWeekly) : "—",
+      caption: FLAGSHIP_PACKAGE,
+      icon: ArrowUpRight,
+    },
+    {
+      label: "Contributors",
+      value: `${PROJECT_FACTS.uniqueAuthors}+`,
+      caption: "from the community",
+      icon: Users,
+    },
+  ];
+
+  const detailStats = [
+    {
+      label: "Forks",
+      value: formatNumber(repo.forks),
+      icon: GitFork,
+    },
+    {
+      label: "Total commits",
+      value: PROJECT_FACTS.totalCommits.toLocaleString(),
+      icon: GitCommit,
+    },
+    {
+      label: "Days building in the open",
+      value: days.toLocaleString(),
+      icon: Sparkles,
+    },
+    {
+      label: "Production examples",
+      value: PROJECT_FACTS.examples.toString(),
+      icon: Package,
+    },
+    {
+      label: "Showcased apps",
+      value: PROJECT_FACTS.showcased.toString(),
+      icon: Star,
+    },
+    {
+      label: "Open issues",
+      value: repo.openIssues.toString(),
+      icon: GitCommit,
+    },
+  ];
+
+  const grouped = groupByCategory(PACKAGES);
+
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 py-16 md:py-24">
+      <header className="mb-16 max-w-3xl">
+        <p className="mb-3 text-muted-foreground text-sm">Traction</p>
+        <h1 className="font-medium text-3xl tracking-tight md:text-4xl">
+          The receipts behind assistant-ui.
+        </h1>
+        <p className="mt-3 text-muted-foreground md:text-lg">
+          assistant-ui is the open-source UX layer for AI chat. Here are the
+          numbers, the packages, and the teams shipping with it today.
+        </p>
+        <div className="mt-6 flex flex-wrap items-center gap-3">
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={buttonVariants({ variant: "outline" })}
+          >
+            <GitHubIcon className="size-4" />
+            Star on GitHub
+          </a>
+          <Button asChild>
+            <Link href="/docs">
+              Get started <ArrowRight />
+            </Link>
+          </Button>
+        </div>
+      </header>
+
+      <section className="mb-20">
+        <div className="grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border md:grid-cols-4">
+          {heroStats.map((stat) => {
+            const Icon = stat.icon;
+            return (
+              <div
+                key={stat.label}
+                className="flex flex-col gap-3 bg-background p-6"
+              >
+                <Icon className="size-4 text-muted-foreground" />
+                <div className="font-medium text-3xl tabular-nums tracking-tight md:text-4xl">
+                  {stat.value}
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-sm">{stat.label}</span>
+                  <span className="text-muted-foreground text-xs">
+                    {stat.caption}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="mb-20 grid gap-12 lg:grid-cols-2">
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <h2 className="font-medium text-xl tracking-tight">
+              Stars over time
+            </h2>
+            <p className="text-muted-foreground text-sm">
+              Sampled directly from the GitHub stargazers API.
+            </p>
+          </div>
+          <StarHistoryChart data={starHistory} />
+        </div>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <h2 className="font-medium text-xl tracking-tight">
+              Ecosystem downloads
+            </h2>
+            <p className="text-muted-foreground text-sm">
+              Monthly npm downloads, stacked across the{" "}
+              {TIMELINE_PACKAGES.length} core packages.
+            </p>
+          </div>
+          <DownloadsChart timeline={downloadsTimeline} />
+        </div>
+      </section>
+
+      <section className="mb-20">
+        <div className="mb-8 flex flex-col gap-1">
+          <h2 className="font-medium text-xl tracking-tight">
+            Repository momentum
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            Live from the assistant-ui/assistant-ui GitHub repository.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+          {detailStats.map((stat) => {
+            const Icon = stat.icon;
+            return (
+              <div
+                key={stat.label}
+                className="flex items-start gap-4 rounded-lg border border-border p-5"
+              >
+                <Icon className="mt-1 size-4 text-muted-foreground" />
+                <div className="flex flex-col">
+                  <span className="font-medium text-2xl tabular-nums tracking-tight">
+                    {stat.value}
+                  </span>
+                  <span className="text-muted-foreground text-sm">
+                    {stat.label}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="mb-20">
+        <div className="mb-8 flex flex-col gap-1">
+          <h2 className="font-medium text-xl tracking-tight">
+            {PACKAGES.length} public packages
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            One ecosystem, every distribution. Pick the surface that fits your
+            stack.
+          </p>
+        </div>
+
+        {topPackages.length > 0 ? (
+          <div className="mb-12 rounded-xl border border-border p-4 md:p-6">
+            <div className="mb-4 flex items-end justify-between gap-3">
+              <div className="flex flex-col gap-0.5">
+                <h3 className="font-medium text-sm">
+                  Top packages by weekly downloads
+                </h3>
+                <p className="text-muted-foreground text-xs">
+                  Last 7 days, npm registry.
+                </p>
+              </div>
+            </div>
+            <TopPackagesBar rows={topPackages} />
+          </div>
+        ) : null}
+
+        <div className="flex flex-col gap-12">
+          {(Object.keys(PACKAGE_CATEGORIES) as PackageCategory[]).map(
+            (category) => {
+              const items = grouped[category];
+              if (!items || items.length === 0) return null;
+              const meta = PACKAGE_CATEGORIES[category];
+              return (
+                <div key={category} className="flex flex-col gap-4">
+                  <div className="flex items-end justify-between gap-4 border-border border-b pb-3">
+                    <div className="flex flex-col gap-0.5">
+                      <h3 className="font-medium text-sm">{meta.label}</h3>
+                      <p className="text-muted-foreground text-xs">
+                        {meta.description}
+                      </p>
+                    </div>
+                    <span className="text-muted-foreground text-xs tabular-nums">
+                      {items.length}
+                    </span>
+                  </div>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {items.map((pkg) => {
+                      const stats = npm.perPackage[pkg.name];
+                      return (
+                        <PackageRow
+                          key={pkg.name}
+                          pkg={pkg}
+                          weekly={stats?.weekly ?? 0}
+                          series={stats?.series ?? []}
+                          monthly={stats?.monthly ?? 0}
+                          prevMonthly={stats?.prevMonthly ?? 0}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            },
+          )}
+        </div>
+      </section>
+
+      <section className="mb-20 rounded-xl border border-border p-8 md:p-12">
+        <div className="grid gap-8 md:grid-cols-[1fr_auto] md:items-center">
+          <div className="flex flex-col gap-2">
+            <h2 className="font-medium text-xl tracking-tight">
+              Used by teams shipping AI in production.
+            </h2>
+            <p className="text-muted-foreground text-sm">
+              From early-stage startups to LangChain, Mastra, and Y
+              Combinator-backed teams. Browse public deployments in the
+              showcase.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3 md:justify-end">
+            <Link
+              href="/showcase"
+              className={buttonVariants({ variant: "outline" })}
+            >
+              See the showcase
+            </Link>
+            <Button asChild>
+              <Link href="/docs">
+                Read the docs <ArrowRight />
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="flex flex-col items-center gap-6 py-8 text-center">
+        <p className="font-medium text-2xl tracking-tight">
+          Build on a library teams already trust.
+        </p>
+        <div className="flex items-center gap-3">
+          <Button asChild>
+            <Link href="/docs">
+              Get started <ArrowRight />
+            </Link>
+          </Button>
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={buttonVariants({ variant: "outline" })}
+          >
+            <GitHubIcon className="size-4" />
+            {formatCompact(repo.stars)} on GitHub
+          </a>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+type MoMBadge = {
+  label: string;
+  tone: "up" | "down" | "flat";
+};
+
+function computeMoM(monthly: number, prevMonthly: number): MoMBadge | null {
+  if (prevMonthly < 100 || monthly === 0) return null;
+  const change = ((monthly - prevMonthly) / prevMonthly) * 100;
+  if (!Number.isFinite(change)) return null;
+  const capped = Math.max(-99, Math.min(999, change));
+  const sign = capped > 0 ? "+" : "";
+  const rounded = Math.round(capped);
+  let tone: MoMBadge["tone"] = "flat";
+  if (rounded >= 5) tone = "up";
+  else if (rounded <= -5) tone = "down";
+  return { label: `${sign}${rounded}%`, tone };
+}
+
+const MOM_TONE: Record<MoMBadge["tone"], string> = {
+  up: "text-emerald-600 dark:text-emerald-400",
+  down: "text-rose-600 dark:text-rose-400",
+  flat: "text-muted-foreground",
+};
+
+function PackageRow({
+  pkg,
+  weekly,
+  series,
+  monthly,
+  prevMonthly,
+}: {
+  pkg: PackageInfo;
+  weekly: number;
+  series: number[];
+  monthly: number;
+  prevMonthly: number;
+}) {
+  const npmHref = `https://www.npmjs.com/package/${pkg.name}`;
+  const mom = computeMoM(monthly, prevMonthly);
+  return (
+    <a
+      href={npmHref}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex flex-col gap-1.5 rounded-lg border border-border p-4 transition-colors hover:border-foreground/30 hover:bg-muted/40"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="truncate font-medium font-mono text-sm">
+          {pkg.name}
+        </span>
+        <ArrowUpRight className="size-3.5 flex-shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+      </div>
+      <p className="text-muted-foreground text-sm leading-relaxed">
+        {pkg.description}
+      </p>
+      {weekly > 0 ? (
+        <div className="mt-1 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-xs tabular-nums">
+            <span className="text-muted-foreground">
+              {formatNumber(weekly)} / week
+            </span>
+            {mom ? (
+              <span
+                className={`font-medium ${MOM_TONE[mom.tone]}`}
+                title="Past 30 days vs prior 30 days"
+              >
+                {mom.label}
+              </span>
+            ) : null}
+          </div>
+          {series.length > 1 ? (
+            <Sparkline values={series} className="text-foreground/50" />
+          ) : null}
+        </div>
+      ) : null}
+    </a>
+  );
+}
+
+function groupByCategory(
+  packages: PackageInfo[],
+): Record<PackageCategory, PackageInfo[]> {
+  const result = {} as Record<PackageCategory, PackageInfo[]>;
+  for (const pkg of packages) {
+    const list = result[pkg.category] ?? [];
+    list.push(pkg);
+    result[pkg.category] = list;
+  }
+  return result;
+}

--- a/apps/docs/components/home/hero.tsx
+++ b/apps/docs/components/home/hero.tsx
@@ -38,6 +38,14 @@ export function Hero() {
           </Link>
           <span className="hidden size-1 rounded-full bg-muted-foreground/20 sm:block" />
           <Link
+            href="/traction"
+            onClick={() => analytics.cta.clicked("why_us", "hero")}
+            className="font-medium text-foreground/60 transition-colors hover:text-foreground"
+          >
+            Why us?
+          </Link>
+          <span className="hidden size-1 rounded-full bg-muted-foreground/20 sm:block" />
+          <Link
             href="https://cal.com/simon-farshid/assistant-ui"
             onClick={() => analytics.cta.clicked("contact_sales", "hero")}
             className="font-medium text-foreground/60 transition-colors hover:text-foreground"

--- a/apps/docs/components/shared/footer.tsx
+++ b/apps/docs/components/shared/footer.tsx
@@ -30,6 +30,7 @@ const FOOTER_LINKS: Record<string, FooterLinkItem[]> = {
     { label: "Documentation", href: "/docs" },
     { label: "Examples", href: "/examples" },
     { label: "Showcase", href: "/showcase" },
+    { label: "Traction", href: "/traction" },
     { label: "Blog", href: "/blog" },
   ],
   Company: [

--- a/apps/docs/components/traction/downloads-chart.tsx
+++ b/apps/docs/components/traction/downloads-chart.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useId } from "react";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import {
+  ChartContainer,
+  type ChartConfig,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { formatCompact, type TimelineSeries } from "@/lib/traction";
+
+const MONTH_NAMES = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+const formatTick = (yearMonth: string) => {
+  const parts = yearMonth.split("-");
+  const idx = Number(parts[1]) - 1;
+  return MONTH_NAMES[idx] ?? yearMonth;
+};
+
+const formatTooltipLabel = (yearMonth: string) => {
+  const [y, m] = yearMonth.split("-");
+  const date = new Date(Number(y), Number(m) - 1, 1);
+  return date.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+};
+
+export function DownloadsChart({ timeline }: { timeline: TimelineSeries }) {
+  const gradientPrefix = useId();
+
+  if (timeline.data.length < 2 || timeline.series.length === 0) {
+    return (
+      <div className="flex h-[260px] items-center justify-center rounded-lg border border-border border-dashed text-muted-foreground text-sm md:h-[360px]">
+        Download history is currently unavailable.
+      </div>
+    );
+  }
+
+  const config: ChartConfig = {};
+  for (const s of timeline.series) {
+    config[s.key] = {
+      label: s.label,
+      color: `var(--chart-${s.chartIndex})`,
+    };
+  }
+
+  return (
+    <ChartContainer
+      config={config}
+      className="aspect-auto h-[260px] w-full md:h-[360px]"
+    >
+      <AreaChart
+        data={timeline.data}
+        margin={{ left: 8, right: 16, top: 8, bottom: 0 }}
+      >
+        <defs>
+          {timeline.series.map((s) => (
+            <linearGradient
+              key={s.key}
+              id={`${gradientPrefix}-${s.key}`}
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+            >
+              <stop
+                offset="0%"
+                stopColor={`var(--color-${s.key})`}
+                stopOpacity={0.55}
+              />
+              <stop
+                offset="100%"
+                stopColor={`var(--color-${s.key})`}
+                stopOpacity={0.05}
+              />
+            </linearGradient>
+          ))}
+        </defs>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" />
+        <XAxis
+          dataKey="date"
+          tickFormatter={formatTick}
+          tickLine={false}
+          axisLine={false}
+          minTickGap={32}
+        />
+        <YAxis
+          tickFormatter={(v) => formatCompact(v as number)}
+          tickLine={false}
+          axisLine={false}
+          width={42}
+        />
+        <ChartTooltip
+          cursor={{ stroke: "var(--border)" }}
+          content={
+            <ChartTooltipContent
+              labelFormatter={(_, payload) => {
+                const ym = payload?.[0]?.payload?.date as string | undefined;
+                return ym ? formatTooltipLabel(ym) : "";
+              }}
+              formatter={(value, name, item) => {
+                const series = timeline.series.find((s) => s.key === name);
+                const color =
+                  (item as { color?: string } | undefined)?.color ??
+                  (item?.payload as { fill?: string } | undefined)?.fill;
+                return (
+                  <>
+                    <div
+                      className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                      style={{ backgroundColor: color }}
+                    />
+                    <div className="flex flex-1 items-center justify-between gap-3 leading-none">
+                      <span className="text-muted-foreground">
+                        {series?.label ?? String(name)}
+                      </span>
+                      <span className="font-medium font-mono text-foreground tabular-nums">
+                        {formatCompact(value as number)}
+                      </span>
+                    </div>
+                  </>
+                );
+              }}
+              indicator="dot"
+            />
+          }
+        />
+        {timeline.series.map((s) => (
+          <Area
+            key={s.key}
+            dataKey={s.key}
+            stackId="downloads"
+            type="monotone"
+            stroke={`var(--color-${s.key})`}
+            strokeWidth={1.5}
+            fill={`url(#${gradientPrefix}-${s.key})`}
+          />
+        ))}
+        <ChartLegend
+          content={<ChartLegendContent className="flex-wrap gap-x-4 gap-y-1" />}
+        />
+      </AreaChart>
+    </ChartContainer>
+  );
+}

--- a/apps/docs/components/traction/sparkline.tsx
+++ b/apps/docs/components/traction/sparkline.tsx
@@ -1,0 +1,56 @@
+import { cn } from "@/lib/utils";
+
+type Props = {
+  values: number[];
+  className?: string;
+  width?: number;
+  height?: number;
+};
+
+export function Sparkline({
+  values,
+  className,
+  width = 64,
+  height = 18,
+}: Props) {
+  if (values.length < 2) return null;
+
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const range = Math.max(1, max - min);
+
+  const stepX = width / (values.length - 1);
+  const points = values.map((v, i) => {
+    const x = i * stepX;
+    const y = height - ((v - min) / range) * (height - 2) - 1;
+    return [x, y] as const;
+  });
+
+  const linePath = points
+    .map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)}`)
+    .join(" ");
+
+  const areaPath = `${linePath} L${(width).toFixed(2)} ${height} L0 ${height} Z`;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      className={cn("text-foreground/60", className)}
+      role="img"
+    >
+      <title>Weekly downloads trend</title>
+      <path d={areaPath} fill="currentColor" fillOpacity={0.08} />
+      <path
+        d={linePath}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.25}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/apps/docs/components/traction/star-history-chart.tsx
+++ b/apps/docs/components/traction/star-history-chart.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useId } from "react";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import {
+  ChartContainer,
+  type ChartConfig,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { formatCompact } from "@/lib/traction";
+
+type Point = { date: string; value: number };
+
+const config = {
+  stars: {
+    label: "Stars",
+    color: "var(--chart-1)",
+  },
+} satisfies ChartConfig;
+
+const formatTick = (iso: string) => {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", { month: "short", year: "2-digit" });
+};
+
+const formatTooltipLabel = (iso: string) =>
+  new Date(iso).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+
+export function StarHistoryChart({ data }: { data: Point[] }) {
+  const gradientId = useId();
+  if (data.length < 2) {
+    return (
+      <div className="flex h-[260px] items-center justify-center rounded-lg border border-border border-dashed text-muted-foreground text-sm md:h-[360px]">
+        Star history is currently unavailable.
+      </div>
+    );
+  }
+
+  return (
+    <ChartContainer
+      config={config}
+      className="aspect-auto h-[260px] w-full md:h-[360px]"
+    >
+      <AreaChart data={data} margin={{ left: 8, right: 16, top: 8, bottom: 0 }}>
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop
+              offset="0%"
+              stopColor="var(--color-stars)"
+              stopOpacity={0.35}
+            />
+            <stop
+              offset="100%"
+              stopColor="var(--color-stars)"
+              stopOpacity={0}
+            />
+          </linearGradient>
+        </defs>
+        <CartesianGrid vertical={false} strokeDasharray="3 3" />
+        <XAxis
+          dataKey="date"
+          tickFormatter={formatTick}
+          tickLine={false}
+          axisLine={false}
+          minTickGap={48}
+        />
+        <YAxis
+          dataKey="value"
+          tickFormatter={(v) => formatCompact(v as number)}
+          tickLine={false}
+          axisLine={false}
+          width={36}
+        />
+        <ChartTooltip
+          cursor={{ stroke: "var(--border)" }}
+          content={
+            <ChartTooltipContent
+              labelFormatter={(_, payload) => {
+                const iso = payload?.[0]?.payload?.date as string | undefined;
+                return iso ? formatTooltipLabel(iso) : "";
+              }}
+              formatter={(value) => [
+                `${formatCompact(value as number)} stars`,
+                "",
+              ]}
+              hideIndicator
+            />
+          }
+        />
+        <Area
+          dataKey="value"
+          type="monotone"
+          stroke="var(--color-stars)"
+          strokeWidth={2}
+          fill={`url(#${gradientId})`}
+        />
+      </AreaChart>
+    </ChartContainer>
+  );
+}

--- a/apps/docs/components/traction/top-packages-bar.tsx
+++ b/apps/docs/components/traction/top-packages-bar.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
+import {
+  ChartContainer,
+  type ChartConfig,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { formatCompact, formatNumber } from "@/lib/traction";
+
+type Row = { name: string; weekly: number };
+
+const config = {
+  weekly: {
+    label: "Weekly downloads",
+    color: "var(--chart-3)",
+  },
+} satisfies ChartConfig;
+
+const shortenName = (name: string) =>
+  name.replace("@assistant-ui/", "").replace(/^assistant-/, "");
+
+export function TopPackagesBar({ rows }: { rows: Row[] }) {
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const data = rows.map((r) => ({
+    name: r.name,
+    short: shortenName(r.name),
+    weekly: r.weekly,
+  }));
+
+  const height = Math.max(220, data.length * 32 + 40);
+
+  return (
+    <ChartContainer
+      config={config}
+      className="aspect-auto w-full"
+      style={{ height }}
+    >
+      <BarChart
+        data={data}
+        layout="vertical"
+        margin={{ left: 8, right: 16, top: 4, bottom: 4 }}
+      >
+        <XAxis
+          type="number"
+          tickFormatter={(v) => formatCompact(v as number)}
+          tickLine={false}
+          axisLine={false}
+          fontSize={10}
+        />
+        <YAxis
+          dataKey="short"
+          type="category"
+          tickLine={false}
+          axisLine={false}
+          width={110}
+          fontSize={10}
+        />
+        <ChartTooltip
+          cursor={{ fill: "var(--muted)" }}
+          content={
+            <ChartTooltipContent
+              labelFormatter={(_, payload) => {
+                const full = payload?.[0]?.payload?.name as string | undefined;
+                return full ?? "";
+              }}
+              formatter={(value) => [
+                `${formatNumber(value as number)} / week`,
+                "",
+              ]}
+              hideIndicator
+            />
+          }
+        />
+        <Bar dataKey="weekly" radius={[0, 4, 4, 0]}>
+          {data.map((row, i) => (
+            <Cell
+              key={row.name}
+              fill="var(--color-weekly)"
+              fillOpacity={1 - i * 0.05}
+            />
+          ))}
+        </Bar>
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/apps/docs/lib/analytics.ts
+++ b/apps/docs/lib/analytics.ts
@@ -50,8 +50,10 @@ const trackEvent = (event: string, properties?: AnalyticsProperties) => {
 
 export const analytics = {
   cta: {
-    clicked: (cta: "get_started" | "contact_sales", location: string) =>
-      trackEvent("cta_clicked", { cta, location }),
+    clicked: (
+      cta: "get_started" | "contact_sales" | "why_us",
+      location: string,
+    ) => trackEvent("cta_clicked", { cta, location }),
 
     npmCommandCopied: (
       command = "npx assistant-ui init",

--- a/apps/docs/lib/changelog-parse.ts
+++ b/apps/docs/lib/changelog-parse.ts
@@ -1,0 +1,207 @@
+export type ChangeType =
+  | "breaking"
+  | "feat"
+  | "fix"
+  | "perf"
+  | "refactor"
+  | "revert"
+  | "docs"
+  | "style"
+  | "test"
+  | "build"
+  | "ci"
+  | "chore"
+  | "other";
+
+export type ParsedBullet = {
+  pr?: { number: string; url: string };
+  hash?: { value: string; url: string };
+  author?: { handle: string; url: string };
+  type: ChangeType;
+  scope?: string;
+  description: string;
+  body: string;
+};
+
+export type ParsedRelease = {
+  preamble: string;
+  bullets: ParsedBullet[];
+};
+
+const PR_RE = /\[#(\d+)\]\(([^)]+)\)/;
+const HASH_RE_BACKTICK_LINKED = /\[`([a-f0-9]{6,40})`\]\(([^)]+)\)/;
+const HASH_RE_BARE_LINKED = /\[([a-f0-9]{6,40})\]\(([^)]+)\)/;
+const HASH_RE_BACKTICK = /`([a-f0-9]{6,40})`/;
+const AUTHOR_RE = /\(?\[@([\w-]+)\]\(([^)]+)\)\)?/;
+const TYPE_RE =
+  /^\s*(feat|fix|chore|refactor|perf|docs|style|test|build|ci|revert)(?:\(([^)]+)\))?(!?):\s*/i;
+const BREAKING_PREFIX_RE = /^breaking\s+changes?\s*[:-]\s*/i;
+
+function removeMatch(line: string, match: RegExpMatchArray): string {
+  const start = match.index ?? 0;
+  return line.slice(0, start) + line.slice(start + match[0].length);
+}
+
+export function parseRelease(markdown: string): ParsedRelease {
+  const cleaned = markdown
+    .replace(/^#{1,6}\s+(Patch|Minor|Major)\s+Changes\s*$/gim, "")
+    .replace(/^-\s+Updated dependencies[\s\S]*?(?=\n-\s|\n\n|$)/gm, "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  const lines = cleaned.split("\n");
+  const preambleLines: string[] = [];
+  type Chunk = { firstLine: string; bodyLines: string[] };
+  const chunks: Chunk[] = [];
+  let current: Chunk | null = null;
+
+  for (const rawLine of lines) {
+    const isTopBullet = /^-\s+/.test(rawLine);
+    if (isTopBullet) {
+      if (current) chunks.push(current);
+      current = {
+        firstLine: rawLine.replace(/^-\s+/, ""),
+        bodyLines: [],
+      };
+    } else if (current) {
+      current.bodyLines.push(rawLine.replace(/^ {1,4}/, ""));
+    } else if (rawLine.trim().length > 0) {
+      preambleLines.push(rawLine);
+    }
+  }
+  if (current) chunks.push(current);
+
+  const bullets: ParsedBullet[] = chunks.map((chunk) => {
+    let line = chunk.firstLine;
+
+    let pr: { number: string; url: string } | null = null;
+    {
+      const m = line.match(PR_RE);
+      if (m) {
+        pr = { number: m[1]!, url: m[2]! };
+        line = removeMatch(line, m);
+      }
+    }
+
+    let hash: { value: string; url: string } | null = null;
+    {
+      let m = line.match(HASH_RE_BACKTICK_LINKED);
+      if (m) {
+        hash = { value: m[1]!.slice(0, 7), url: m[2]! };
+        line = removeMatch(line, m);
+      } else {
+        m = line.match(HASH_RE_BARE_LINKED);
+        if (m) {
+          hash = { value: m[1]!.slice(0, 7), url: m[2]! };
+          line = removeMatch(line, m);
+        } else {
+          m = line.match(HASH_RE_BACKTICK);
+          if (m) {
+            hash = {
+              value: m[1]!.slice(0, 7),
+              url: `https://github.com/assistant-ui/assistant-ui/commit/${m[1]!}`,
+            };
+            line = removeMatch(line, m);
+          }
+        }
+      }
+    }
+
+    let author: { handle: string; url: string } | null = null;
+    {
+      const m = line.match(AUTHOR_RE);
+      if (m) {
+        author = { handle: m[1]!, url: m[2]! };
+        line = removeMatch(line, m);
+      }
+    }
+
+    line = line
+      .replace(/Thanks\s*!?/i, "")
+      .replace(/\(\s*\)/g, "")
+      .replace(/^\s*[-:]+\s*/, "")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    let type: ChangeType = "other";
+    let scope: string | null = null;
+    let breaking = false;
+
+    const tm = line.match(TYPE_RE);
+    if (tm) {
+      type = tm[1]!.toLowerCase() as ChangeType;
+      scope = tm[2] ?? null;
+      breaking = !!tm[3];
+      line = line.replace(TYPE_RE, "");
+    }
+
+    if (BREAKING_PREFIX_RE.test(line)) {
+      breaking = true;
+      line = line.replace(BREAKING_PREFIX_RE, "");
+    }
+
+    if (breaking) type = "breaking";
+
+    return {
+      ...(pr ? { pr } : {}),
+      ...(hash ? { hash } : {}),
+      ...(author ? { author } : {}),
+      type,
+      ...(scope ? { scope } : {}),
+      description: line.trim(),
+      body: chunk.bodyLines.join("\n").trim(),
+    };
+  });
+
+  return {
+    preamble: preambleLines.join("\n").trim(),
+    bullets,
+  };
+}
+
+export const TYPE_LABELS: Record<ChangeType, string> = {
+  breaking: "Breaking changes",
+  feat: "Features",
+  fix: "Fixes",
+  perf: "Performance",
+  refactor: "Refactors",
+  revert: "Reverts",
+  docs: "Docs",
+  style: "Styles",
+  test: "Tests",
+  build: "Build",
+  ci: "CI",
+  chore: "Chores",
+  other: "Other",
+};
+
+const TYPE_PRIORITY: Record<ChangeType, number> = {
+  breaking: 0,
+  feat: 1,
+  fix: 2,
+  perf: 3,
+  refactor: 4,
+  revert: 5,
+  docs: 6,
+  style: 7,
+  test: 8,
+  build: 9,
+  ci: 10,
+  chore: 11,
+  other: 12,
+};
+
+export function groupByType(
+  bullets: ParsedBullet[],
+): { type: ChangeType; items: ParsedBullet[] }[] {
+  const map = new Map<ChangeType, ParsedBullet[]>();
+  for (const b of bullets) {
+    const list = map.get(b.type) ?? [];
+    list.push(b);
+    map.set(b.type, list);
+  }
+  return Array.from(map.entries())
+    .sort(([a], [b]) => TYPE_PRIORITY[a] - TYPE_PRIORITY[b])
+    .map(([type, items]) => ({ type, items }));
+}

--- a/apps/docs/lib/constants.ts
+++ b/apps/docs/lib/constants.ts
@@ -112,6 +112,12 @@ export const NAV_ITEMS: NavItem[] = [
         external: false,
       },
       {
+        label: "Traction",
+        href: "/traction",
+        description: "Packages, stars, and adoption",
+        external: false,
+      },
+      {
         label: "Changelog",
         href: "/changelog",
         description: "Release notes and version history",

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -1,0 +1,553 @@
+export type PackageInfo = {
+  name: string;
+  description: string;
+  category: PackageCategory;
+};
+
+export type PackageCategory =
+  | "core"
+  | "tooling"
+  | "cloud"
+  | "frameworks"
+  | "protocols"
+  | "platforms"
+  | "ui"
+  | "effects"
+  | "mcp"
+  | "observability";
+
+export const PACKAGE_CATEGORIES: Record<
+  PackageCategory,
+  { label: string; description: string }
+> = {
+  core: {
+    label: "Core",
+    description: "Runtime primitives every distribution shares.",
+  },
+  tooling: {
+    label: "Tooling & CLI",
+    description: "Scaffolding and build tooling.",
+  },
+  cloud: {
+    label: "Cloud & streaming",
+    description: "Hosted persistence and stream transports.",
+  },
+  frameworks: {
+    label: "Framework adapters",
+    description: "Drop-in bindings for popular AI SDKs.",
+  },
+  protocols: {
+    label: "Protocol adapters",
+    description: "Open agent protocols, ready to wire up.",
+  },
+  platforms: {
+    label: "Platform bindings",
+    description: "Run anywhere React runs.",
+  },
+  ui: {
+    label: "UI & rendering",
+    description: "Markdown, rich composers, and devtools.",
+  },
+  effects: {
+    label: "Effects & primitives",
+    description: "Standalone packages we built along the way.",
+  },
+  mcp: {
+    label: "MCP & agents",
+    description: "Tooling for MCP hosts and agent runtimes.",
+  },
+  observability: {
+    label: "Observability",
+    description: "Trace, debug, and measure assistants.",
+  },
+};
+
+export const PACKAGES: PackageInfo[] = [
+  {
+    name: "@assistant-ui/react",
+    description: "TypeScript/React library for AI chat.",
+    category: "core",
+  },
+  {
+    name: "@assistant-ui/core",
+    description: "Framework-agnostic core runtime.",
+    category: "core",
+  },
+  {
+    name: "@assistant-ui/store",
+    description: "Tap-based state management.",
+    category: "core",
+  },
+  {
+    name: "@assistant-ui/tap",
+    description: "Zero-dependency reactive primitives.",
+    category: "core",
+  },
+  {
+    name: "assistant-ui",
+    description: "CLI for assistant-ui.",
+    category: "tooling",
+  },
+  {
+    name: "create-assistant-ui",
+    description: "Scaffold an assistant-ui app in one command.",
+    category: "tooling",
+  },
+  {
+    name: "@assistant-ui/x-buildutils",
+    description: "Shared build utilities for the monorepo.",
+    category: "tooling",
+  },
+  {
+    name: "assistant-cloud",
+    description: "Hosted backend for assistant-ui.",
+    category: "cloud",
+  },
+  {
+    name: "assistant-stream",
+    description: "Streaming utilities for AI assistants.",
+    category: "cloud",
+  },
+  {
+    name: "@assistant-ui/cloud-ai-sdk",
+    description: "AI SDK hooks with assistant-cloud persistence.",
+    category: "cloud",
+  },
+  {
+    name: "@assistant-ui/react-ai-sdk",
+    description: "Vercel AI SDK adapter.",
+    category: "frameworks",
+  },
+  {
+    name: "@assistant-ui/react-langgraph",
+    description: "LangGraph adapter.",
+    category: "frameworks",
+  },
+  {
+    name: "@assistant-ui/react-langchain",
+    description: "LangChain useStream adapter.",
+    category: "frameworks",
+  },
+  {
+    name: "@assistant-ui/react-google-adk",
+    description: "Google ADK adapter.",
+    category: "frameworks",
+  },
+  {
+    name: "@assistant-ui/react-opencode",
+    description: "OpenCode runtime adapter.",
+    category: "frameworks",
+  },
+  {
+    name: "@assistant-ui/react-a2a",
+    description: "A2A v1.0 agent-to-agent protocol adapter.",
+    category: "protocols",
+  },
+  {
+    name: "@assistant-ui/react-ag-ui",
+    description: "AG-UI protocol adapter.",
+    category: "protocols",
+  },
+  {
+    name: "@assistant-ui/react-data-stream",
+    description: "Generic data stream adapter.",
+    category: "protocols",
+  },
+  {
+    name: "@assistant-ui/react-native",
+    description: "React Native bindings.",
+    category: "platforms",
+  },
+  {
+    name: "@assistant-ui/react-ink",
+    description: "Terminal UI bindings via Ink.",
+    category: "platforms",
+  },
+  {
+    name: "@assistant-ui/react-markdown",
+    description: "Streaming-aware markdown renderer.",
+    category: "ui",
+  },
+  {
+    name: "@assistant-ui/react-streamdown",
+    description: "Streamdown-based markdown rendering.",
+    category: "ui",
+  },
+  {
+    name: "@assistant-ui/react-syntax-highlighter",
+    description: "Syntax highlighting for assistant-ui.",
+    category: "ui",
+  },
+  {
+    name: "@assistant-ui/react-ink-markdown",
+    description: "Markdown for the terminal distribution.",
+    category: "ui",
+  },
+  {
+    name: "@assistant-ui/react-lexical",
+    description: "Lexical composer with @-mention support.",
+    category: "ui",
+  },
+  {
+    name: "@assistant-ui/react-hook-form",
+    description: "React Hook Form integration.",
+    category: "ui",
+  },
+  {
+    name: "@assistant-ui/react-devtools",
+    description: "Inspect runtime state in the browser.",
+    category: "ui",
+  },
+  {
+    name: "tw-glass",
+    description: "Tailwind v4 plugin for glass refraction effects.",
+    category: "effects",
+  },
+  {
+    name: "tw-shimmer",
+    description: "Tailwind v4 plugin for shimmer effects.",
+    category: "effects",
+  },
+  {
+    name: "heat-graph",
+    description: "Headless React components for activity heatmaps.",
+    category: "effects",
+  },
+  {
+    name: "safe-content-frame",
+    description: "Secure iframe rendering for untrusted content.",
+    category: "effects",
+  },
+  {
+    name: "mcp-app-studio",
+    description: "Build interactive apps for MCP hosts.",
+    category: "mcp",
+  },
+  {
+    name: "@assistant-ui/mcp-docs-server",
+    description: "MCP server exposing assistant-ui docs.",
+    category: "mcp",
+  },
+  {
+    name: "@assistant-ui/agent-launcher",
+    description: "Launch Claude Code with bundled plugins.",
+    category: "mcp",
+  },
+  {
+    name: "@assistant-ui/react-o11y",
+    description: "Observability primitives for assistants.",
+    category: "observability",
+  },
+];
+
+export type RepoStats = {
+  stars: number;
+  forks: number;
+  openIssues: number;
+  watchers: number;
+};
+
+export type PackageDownloads = {
+  weekly: number;
+  series: number[];
+  monthly: number;
+  prevMonthly: number;
+};
+
+export type NpmDownloads = {
+  totalWeekly: number;
+  perPackage: Record<string, PackageDownloads>;
+};
+
+export type TimelinePoint = {
+  date: string;
+  value: number;
+};
+
+const REPO_FALLBACK: RepoStats = {
+  stars: 9700,
+  forks: 990,
+  openIssues: 60,
+  watchers: 80,
+};
+
+export async function fetchRepoStats(): Promise<RepoStats> {
+  try {
+    const res = await fetch(
+      "https://api.github.com/repos/assistant-ui/assistant-ui",
+      { headers: githubHeaders(), next: { revalidate: 21600 } },
+    );
+    if (!res.ok) return REPO_FALLBACK;
+    const data = await res.json();
+    return {
+      stars: data.stargazers_count ?? REPO_FALLBACK.stars,
+      forks: data.forks_count ?? REPO_FALLBACK.forks,
+      openIssues: data.open_issues_count ?? REPO_FALLBACK.openIssues,
+      watchers: data.subscribers_count ?? REPO_FALLBACK.watchers,
+    };
+  } catch {
+    return REPO_FALLBACK;
+  }
+}
+
+const EMPTY_DOWNLOADS: PackageDownloads = {
+  weekly: 0,
+  series: [],
+  monthly: 0,
+  prevMonthly: 0,
+};
+
+const sum = (arr: number[]) => arr.reduce((acc, n) => acc + n, 0);
+
+async function fetchPackageDownloadRange(
+  name: string,
+): Promise<PackageDownloads> {
+  try {
+    const today = new Date();
+    const end = today.toISOString().slice(0, 10);
+    const start = new Date(today);
+    start.setUTCDate(today.getUTCDate() - 60);
+    const startStr = start.toISOString().slice(0, 10);
+    const url = `https://api.npmjs.org/downloads/range/${startStr}:${end}/${name}`;
+
+    const res = await fetch(url, { next: { revalidate: 3600 } });
+    if (!res.ok) return EMPTY_DOWNLOADS;
+    const data = (await res.json()) as {
+      downloads: { day: string; downloads: number }[];
+    };
+    const all = data.downloads?.map((d) => d.downloads) ?? [];
+    if (all.length === 0) return EMPTY_DOWNLOADS;
+
+    const last60 = all.slice(-60);
+    const last30 = last60.slice(-30);
+    const prior30 = last60.slice(-60, -30);
+    const last7 = last60.slice(-7);
+
+    return {
+      weekly: sum(last7),
+      series: last30,
+      monthly: sum(last30),
+      prevMonthly: sum(prior30),
+    };
+  } catch {
+    return EMPTY_DOWNLOADS;
+  }
+}
+
+export async function fetchNpmDownloads(): Promise<NpmDownloads> {
+  const entries = await Promise.all(
+    PACKAGES.map(
+      async (pkg) =>
+        [pkg.name, await fetchPackageDownloadRange(pkg.name)] as const,
+    ),
+  );
+  const perPackage: Record<string, PackageDownloads> = {};
+  let totalWeekly = 0;
+  for (const [name, downloads] of entries) {
+    perPackage[name] = downloads;
+    totalWeekly += downloads.weekly;
+  }
+  return { totalWeekly, perPackage };
+}
+
+function currentMonthKey(): string {
+  return new Date().toISOString().slice(0, 7);
+}
+
+function startOfCurrentMonthISO(): string {
+  const now = new Date();
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
+  ).toISOString();
+}
+
+export const TIMELINE_PACKAGES = [
+  "@assistant-ui/react",
+  "@assistant-ui/react-ai-sdk",
+  "@assistant-ui/react-markdown",
+  "@assistant-ui/react-langgraph",
+  "assistant-stream",
+] as const;
+
+export type TimelineSeries = {
+  series: {
+    key: string;
+    pkg: string;
+    label: string;
+    chartIndex: number;
+  }[];
+  data: { date: string; [key: string]: number | string }[];
+};
+
+export async function fetchTimelineSeries(
+  packages: readonly string[],
+): Promise<TimelineSeries> {
+  const fetched = await Promise.all(
+    packages.map(async (pkg, idx) => ({
+      key: `s${idx}`,
+      pkg,
+      label: pkg.replace(/^@assistant-ui\//, "").replace(/^assistant-/, ""),
+      chartIndex: (idx % 5) + 1,
+      points: await fetchDownloadsTimeline(pkg),
+    })),
+  );
+
+  const monthsSet = new Set<string>();
+  for (const { points } of fetched) {
+    for (const p of points) monthsSet.add(p.date);
+  }
+  const months = Array.from(monthsSet).sort();
+
+  const data = months.map((date) => {
+    const row: { date: string; [key: string]: number | string } = { date };
+    for (const { key, points } of fetched) {
+      const point = points.find((p) => p.date === date);
+      row[key] = point?.value ?? 0;
+    }
+    return row;
+  });
+
+  const series = fetched.map(({ key, pkg, label, chartIndex }) => ({
+    key,
+    pkg,
+    label,
+    chartIndex,
+  }));
+
+  return { series, data };
+}
+
+export async function fetchDownloadsTimeline(
+  name: string,
+): Promise<TimelinePoint[]> {
+  try {
+    const res = await fetch(
+      `https://api.npmjs.org/downloads/range/last-year/${name}`,
+      { next: { revalidate: 3600 } },
+    );
+    if (!res.ok) return [];
+    const data = (await res.json()) as {
+      downloads: { day: string; downloads: number }[];
+    };
+    if (!data.downloads?.length) return [];
+    const cutoff = currentMonthKey();
+    const byMonth = new Map<string, number>();
+    for (const point of data.downloads) {
+      const month = point.day.slice(0, 7);
+      if (month >= cutoff) continue;
+      byMonth.set(month, (byMonth.get(month) ?? 0) + point.downloads);
+    }
+    return Array.from(byMonth.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, value]) => ({ date, value }));
+  } catch {
+    return [];
+  }
+}
+
+function githubHeaders(): HeadersInit {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  return headers;
+}
+
+function parseLastPage(linkHeader: string | null): number | null {
+  if (!linkHeader) return null;
+  const match = linkHeader.match(/<[^>]*[?&]page=(\d+)[^>]*>;\s*rel="last"/);
+  return match ? Number(match[1]) : null;
+}
+
+export async function fetchStarHistory(
+  totalStars: number,
+): Promise<TimelinePoint[]> {
+  try {
+    const headers = {
+      ...githubHeaders(),
+      Accept: "application/vnd.github.star+json",
+    };
+
+    const firstRes = await fetch(
+      "https://api.github.com/repos/assistant-ui/assistant-ui/stargazers?per_page=100&page=1",
+      { headers, next: { revalidate: 21600 } },
+    );
+    if (!firstRes.ok) return [];
+
+    const firstData = (await firstRes.json()) as { starred_at: string }[];
+    const lastPage =
+      parseLastPage(firstRes.headers.get("Link")) ??
+      Math.max(1, Math.ceil(totalStars / 100));
+
+    const samples = new Set<number>([1, lastPage]);
+    const target = 8;
+    if (lastPage > 2) {
+      const step = (lastPage - 1) / (target - 1);
+      for (let i = 1; i < target - 1; i++) {
+        samples.add(Math.max(2, Math.round(1 + i * step)));
+      }
+    }
+    const pages = Array.from(samples)
+      .filter((p) => p >= 1 && p <= lastPage)
+      .sort((a, b) => a - b);
+
+    const fetched = await Promise.all(
+      pages.map(async (page) => {
+        if (page === 1) return { page, data: firstData };
+        const res = await fetch(
+          `https://api.github.com/repos/assistant-ui/assistant-ui/stargazers?per_page=100&page=${page}`,
+          { headers, next: { revalidate: 21600 } },
+        );
+        if (!res.ok) return { page, data: [] as { starred_at: string }[] };
+        return { page, data: (await res.json()) as { starred_at: string }[] };
+      }),
+    );
+
+    const points: TimelinePoint[] = fetched
+      .filter(({ data }) => data.length > 0)
+      .map(({ page, data }) => ({
+        date: data[0]!.starred_at,
+        value: (page - 1) * 100 + 1,
+      }));
+
+    const cutoff = startOfCurrentMonthISO();
+
+    return points
+      .filter((p) => p.date < cutoff)
+      .sort((a, b) => a.date.localeCompare(b.date))
+      .filter((p, i, arr) => i === 0 || p.value > arr[i - 1]!.value);
+  } catch {
+    return [];
+  }
+}
+
+export function formatNumber(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+  return value.toString();
+}
+
+export function formatCompact(value: number): string {
+  if (value >= 1_000_000) return `${Math.round(value / 100_000) / 10}M`;
+  if (value >= 10_000) return `${Math.round(value / 100) / 10}k`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+  return value.toString();
+}
+
+export const PROJECT_FACTS = {
+  firstCommitDate: "2024-04-21",
+  totalCommits: 3062,
+  uniqueAuthors: 100,
+  publicPackages: PACKAGES.length,
+  examples: 30,
+  showcased: 8,
+} as const;
+
+export function daysSince(isoDate: string): number {
+  const start = new Date(isoDate).getTime();
+  const now = Date.now();
+  return Math.max(0, Math.floor((now - start) / 86_400_000));
+}


### PR DESCRIPTION
## Summary
- adds a new server-rendered `/traction` marketing page with hero stats, sampled GitHub star history (area chart), monthly ecosystem downloads stacked across the 5 core packages, top packages by weekly downloads (horizontal bar), and a directory of all 35 public packages with weekly downloads, MoM growth, and 30-day sparklines
- wires the page into the home hero ("Why us?" inline link), the Resources nav dropdown, and the footer Resources column; extends the analytics CTA enum with `why_us`
- rewrites the changelog list: parses each release bullet into PR / hash / author / type / scope / description / body, groups bullets by conventional commit type (breaking → feat → fix → refactor → chore → ...) with colored badges, linked metadata, styled inline code, and show-more on long bodies
- all data fetchers (GitHub repo stats, sampled stargazers, npm range, monthly timeline) fail soft with placeholder UI; supports optional `GITHUB_TOKEN` env var to bypass the 60/h unauth rate limit
- 6h ISR cache on GitHub fetches, 1h on npm fetches; data filtered to end-of-last-month so partial current month doesn't bias star/download charts

## Test plan
- [ ] visit `/traction`; confirm 4 hero stat cards, star history + ecosystem downloads charts align side by side, top packages bar renders, and every package row shows weekly downloads + MoM badge (green/red/muted) + sparkline
- [ ] hover the downloads chart; verify tooltip shows month label + per-package value (no concatenation glitch)
- [ ] click "Why us?" in the home hero and confirm it lands on `/traction`
- [ ] open the Resources dropdown in the header and the footer; confirm Traction link in both
- [ ] visit `/changelog`; expand a release, confirm bullets grouped by type with colored badges, PR / hash / author links open the right GitHub URLs, long bodies collapse to 2 lines with "Show more"
- [ ] verify mobile layout: charts stack to one column, package rows stack, hero stats 2x2 grid
- [ ] typecheck (`pnpm exec tsc --noEmit`) and lint (`pnpm exec biome check`) pass