### PR TITLE
fix(docs): only show PlatformSwitcher on /docs route

### DIFF
--- a/apps/docs/components/docs/layout/docs-header.tsx
+++ b/apps/docs/components/docs/layout/docs-header.tsx
@@ -25,6 +25,8 @@ import { cn } from "@/lib/utils";
 interface DocsHeaderProps {
   section: string;
   sectionHref: string;
+  /** When true, render the platform (React/RN/Ink) switcher. Docs route only. */
+  platformSwitcher?: boolean;
 }
 
 function AskAIButton() {
@@ -72,7 +74,11 @@ function HeaderSearch() {
 
 const CONDENSED_HIDDEN = new Set(["Showcase", "Playground", "Pricing"]);
 
-export function DocsHeader({ section, sectionHref }: DocsHeaderProps) {
+export function DocsHeader({
+  section,
+  sectionHref,
+  platformSwitcher = false,
+}: DocsHeaderProps) {
   const { setOpenSearch } = useSearchContext();
   const {
     open: sidebarOpen,
@@ -126,12 +132,16 @@ export function DocsHeader({ section, sectionHref }: DocsHeaderProps) {
           >
             {section}
           </Link>
-          <span className="mx-2 hidden text-muted-foreground/40 sm:inline">
-            ·
-          </span>
-          <div className="hidden sm:block">
-            <PlatformSwitcher />
-          </div>
+          {platformSwitcher && (
+            <>
+              <span className="mx-2 hidden text-muted-foreground/40 sm:inline">
+                ·
+              </span>
+              <div className="hidden sm:block">
+                <PlatformSwitcher />
+              </div>
+            </>
+          )}
         </div>
 
         {/* Mobile controls */}
@@ -215,9 +225,11 @@ export function DocsHeader({ section, sectionHref }: DocsHeaderProps) {
         )}
       >
         <nav className="flex h-full flex-col gap-1 overflow-y-auto px-4 pt-4">
-          <div className="pb-3">
-            <PlatformSwitcher />
-          </div>
+          {platformSwitcher && (
+            <div className="pb-3">
+              <PlatformSwitcher />
+            </div>
+          )}
           {filteredItems.map((item) =>
             item.type === "link" ? (
               item.href.startsWith("http") ? (

--- a/apps/docs/components/docs/layout/docs-root-layout.tsx
+++ b/apps/docs/components/docs/layout/docs-root-layout.tsx
@@ -38,7 +38,11 @@ export function DocsRootLayout({
         <DocsRuntimeProvider>
           <PlatformProvider>
             <DocsSidebarProvider>
-              <DocsHeader section={section} sectionHref={sectionHref} />
+              <DocsHeader
+                section={section}
+                sectionHref={sectionHref}
+                platformSwitcher
+              />
               <DocsContent>
                 <DocsLayout
                   {...sharedDocsOptions}


### PR DESCRIPTION
## Summary

The platform switcher was leaking into `/examples` (and any other route that uses `DocsHeader`) because the switcher was rendered unconditionally inside the header. From the bug report: switching platform on `/examples` did nothing visible (correct — examples aren't platform-tagged), so the dropdown looked broken.

Make `PlatformSwitcher` opt-in via a new `platformSwitcher` prop on `DocsHeader` (default `false`). Only `DocsRootLayout` (the `/docs` route) passes it; `/examples` keeps the same `DocsHeader` minus the switcher.

## Changes

- `apps/docs/components/docs/layout/docs-header.tsx` — add `platformSwitcher?: boolean` prop; conditionally render the switcher (desktop + mobile nav).
- `apps/docs/components/docs/layout/docs-root-layout.tsx` — pass `platformSwitcher`.
- `apps/docs/app/examples/layout.tsx` — unchanged; default-false hides the switcher.

## Test plan

- [x] Local typecheck + biome clean
- [ ] Vercel preview: `/docs` shows the dropdown next to the breadcrumb; `/examples` doesn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)