### PR TITLE
feat(docs): traction revamp + new /packages page

### DIFF
--- a/apps/docs/app/(home)/packages/page.tsx
+++ b/apps/docs/app/(home)/packages/page.tsx
@@ -1,0 +1,300 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  ArrowUpRight,
+  Download,
+  Layers,
+  Package,
+} from "lucide-react";
+import {
+  PACKAGES,
+  PACKAGE_CATEGORIES,
+  fetchNpmDownloads,
+  formatCompact,
+  formatNumber,
+  type PackageCategory,
+  type PackageInfo,
+} from "@/lib/traction";
+import { Sparkline } from "@/components/traction/sparkline";
+import { TopPackagesBar } from "@/components/traction/top-packages-bar";
+import { createOgMetadata } from "@/lib/og";
+
+const title = "Packages";
+const description =
+  "Every assistant-ui package on npm, grouped by surface area and ranked by weekly downloads.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  ...createOgMetadata(title, description),
+};
+
+const HERO_STAT_ICONS = {
+  Package,
+  Layers,
+  Download,
+};
+
+export default async function PackagesPage() {
+  const npm = await fetchNpmDownloads();
+
+  const topPackages = [...PACKAGES]
+    .map((pkg) => ({
+      name: pkg.name,
+      weekly: npm.perPackage[pkg.name]?.weekly ?? 0,
+    }))
+    .filter((row) => row.weekly > 0)
+    .sort((a, b) => b.weekly - a.weekly)
+    .slice(0, 12);
+
+  const grouped = groupByCategory(PACKAGES);
+  const visibleCategories = (
+    Object.keys(PACKAGE_CATEGORIES) as PackageCategory[]
+  ).filter((c) => (grouped[c]?.length ?? 0) > 0);
+
+  const totalWeekly = Object.values(npm.perPackage).reduce(
+    (sum, p) => sum + (p?.weekly ?? 0),
+    0,
+  );
+
+  const heroStats = [
+    {
+      icon: HERO_STAT_ICONS.Package,
+      value: PACKAGES.length.toString(),
+      label: "Packages",
+      caption: "across the ecosystem",
+    },
+    {
+      icon: HERO_STAT_ICONS.Layers,
+      value: visibleCategories.length.toString(),
+      label: "Surfaces",
+      caption: "categories shipped",
+    },
+    {
+      icon: HERO_STAT_ICONS.Download,
+      value: totalWeekly > 0 ? formatCompact(totalWeekly) : "—",
+      label: "Weekly downloads",
+      caption: "combined across npm",
+    },
+  ];
+
+  return (
+    <main className="mx-auto w-full max-w-7xl px-4 pt-14 pb-16 md:pb-24">
+      <header className="mb-12 max-w-3xl">
+        <Link
+          href="/traction"
+          className="mb-3 inline-flex items-center gap-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="size-3.5" />
+          Back to traction
+        </Link>
+        <h1 className="font-medium text-3xl tracking-tight md:text-4xl">
+          Every distribution, in one place.
+        </h1>
+        <p className="mt-3 text-muted-foreground md:text-lg">
+          {PACKAGES.length} packages on npm, grouped by surface area. Pick the
+          one that fits your stack.
+        </p>
+      </header>
+
+      <section className="mb-12">
+        <div className="grid grid-cols-1 gap-px overflow-hidden rounded-xl border border-border bg-border md:grid-cols-3">
+          {heroStats.map((stat) => {
+            const Icon = stat.icon;
+            return (
+              <div
+                key={stat.label}
+                className="flex flex-col gap-3 bg-background p-6"
+              >
+                <Icon className="size-4 text-muted-foreground" />
+                <div className="font-medium text-3xl tabular-nums tracking-tight md:text-4xl">
+                  {stat.value}
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-sm">{stat.label}</span>
+                  <span className="text-muted-foreground text-xs">
+                    {stat.caption}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {topPackages.length > 0 ? (
+        <section className="mb-12 rounded-xl border border-border p-4 md:p-6">
+          <div className="mb-4 flex items-end justify-between gap-3">
+            <div className="flex flex-col gap-0.5">
+              <h2 className="font-medium text-sm">
+                Top packages by weekly downloads
+              </h2>
+              <p className="text-muted-foreground text-xs">
+                Last 7 days, npm registry.
+              </p>
+            </div>
+          </div>
+          <TopPackagesBar rows={topPackages} />
+        </section>
+      ) : null}
+
+      <nav
+        aria-label="Package categories"
+        className="sticky top-12 z-10 -mx-4 mb-12 border-border border-y bg-background/85 px-4 py-3 backdrop-blur"
+      >
+        <ul className="flex flex-wrap gap-1.5">
+          {visibleCategories.map((category) => {
+            const meta = PACKAGE_CATEGORIES[category];
+            const count = grouped[category]?.length ?? 0;
+            return (
+              <li key={category}>
+                <a
+                  href={`#${category}`}
+                  className="flex items-center gap-1.5 rounded-md border border-transparent bg-muted/40 px-2.5 py-1 text-muted-foreground text-xs transition-colors hover:border-border hover:bg-muted hover:text-foreground"
+                >
+                  {meta.label}
+                  <span className="text-muted-foreground/70 tabular-nums">
+                    {count}
+                  </span>
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+
+      <section className="flex flex-col gap-12">
+        {visibleCategories.map((category) => {
+          const items = grouped[category]!;
+          const meta = PACKAGE_CATEGORIES[category];
+          return (
+            <div
+              key={category}
+              id={category}
+              className="flex scroll-mt-28 flex-col gap-4"
+            >
+              <div className="flex items-end justify-between gap-4 border-border border-b pb-3">
+                <div className="flex flex-col gap-0.5">
+                  <h3 className="font-medium text-sm">{meta.label}</h3>
+                  <p className="text-muted-foreground text-xs">
+                    {meta.description}
+                  </p>
+                </div>
+                <span className="text-muted-foreground text-xs tabular-nums">
+                  {items.length}
+                </span>
+              </div>
+              <div className="grid gap-3 md:grid-cols-2">
+                {items.map((pkg) => {
+                  const stats = npm.perPackage[pkg.name];
+                  return (
+                    <PackageRow
+                      key={pkg.name}
+                      pkg={pkg}
+                      weekly={stats?.weekly ?? 0}
+                      series={stats?.series ?? []}
+                      monthly={stats?.monthly ?? 0}
+                      prevMonthly={stats?.prevMonthly ?? 0}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </section>
+    </main>
+  );
+}
+
+type MoMBadge = {
+  label: string;
+  tone: "up" | "down" | "flat";
+};
+
+function computeMoM(monthly: number, prevMonthly: number): MoMBadge | null {
+  if (prevMonthly < 100 || monthly === 0) return null;
+  const change = ((monthly - prevMonthly) / prevMonthly) * 100;
+  if (!Number.isFinite(change)) return null;
+  const capped = Math.max(-99, Math.min(999, change));
+  const sign = capped > 0 ? "+" : "";
+  const rounded = Math.round(capped);
+  let tone: MoMBadge["tone"] = "flat";
+  if (rounded >= 5) tone = "up";
+  else if (rounded <= -5) tone = "down";
+  return { label: `${sign}${rounded}%`, tone };
+}
+
+const MOM_TONE: Record<MoMBadge["tone"], string> = {
+  up: "text-emerald-600 dark:text-emerald-400",
+  down: "text-rose-600 dark:text-rose-400",
+  flat: "text-muted-foreground",
+};
+
+function PackageRow({
+  pkg,
+  weekly,
+  series,
+  monthly,
+  prevMonthly,
+}: {
+  pkg: PackageInfo;
+  weekly: number;
+  series: number[];
+  monthly: number;
+  prevMonthly: number;
+}) {
+  const npmHref = `https://www.npmjs.com/package/${pkg.name}`;
+  const mom = computeMoM(monthly, prevMonthly);
+  return (
+    <a
+      href={npmHref}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex flex-col gap-1.5 rounded-lg border border-border p-4 transition-colors hover:border-foreground/30 hover:bg-muted/40"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="truncate font-medium font-mono text-sm">
+          {pkg.name}
+        </span>
+        <ArrowUpRight className="size-3.5 flex-shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+      </div>
+      <p className="text-muted-foreground text-sm leading-relaxed">
+        {pkg.description}
+      </p>
+      {weekly > 0 ? (
+        <div className="mt-1 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-xs tabular-nums">
+            <span className="text-muted-foreground">
+              {formatNumber(weekly)} / week
+            </span>
+            {mom ? (
+              <span
+                className={`font-medium ${MOM_TONE[mom.tone]}`}
+                title="Past 30 days vs prior 30 days"
+              >
+                {mom.label}
+              </span>
+            ) : null}
+          </div>
+          {series.length > 1 ? (
+            <Sparkline values={series} className="text-foreground/50" />
+          ) : null}
+        </div>
+      ) : null}
+    </a>
+  );
+}
+
+function groupByCategory(
+  packages: PackageInfo[],
+): Record<PackageCategory, PackageInfo[]> {
+  const result = {} as Record<PackageCategory, PackageInfo[]>;
+  for (const pkg of packages) {
+    const list = result[pkg.category] ?? [];
+    list.push(pkg);
+    result[pkg.category] = list;
+  }
+  return result;
+}

--- a/apps/docs/app/(home)/traction/page.tsx
+++ b/apps/docs/app/(home)/traction/page.tsx
@@ -5,6 +5,7 @@ import {
   ArrowUpRight,
   GitFork,
   GitCommit,
+  Network,
   Package,
   Star,
   Users,
@@ -14,24 +15,21 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { GitHubIcon } from "@/components/icons/github";
 import { createOgMetadata } from "@/lib/og";
 import {
-  PACKAGES,
-  PACKAGE_CATEGORIES,
   PROJECT_FACTS,
   TIMELINE_PACKAGES,
   daysSince,
+  fetchContributors,
+  fetchDependents,
   fetchNpmDownloads,
   fetchRepoStats,
   fetchStarHistory,
   fetchTimelineSeries,
   formatCompact,
   formatNumber,
-  type PackageCategory,
-  type PackageInfo,
 } from "@/lib/traction";
 import { DownloadsChart } from "@/components/traction/downloads-chart";
-import { Sparkline } from "@/components/traction/sparkline";
 import { StarHistoryChart } from "@/components/traction/star-history-chart";
-import { TopPackagesBar } from "@/components/traction/top-packages-bar";
+import { WeeklyDownloadsStat } from "@/components/traction/weekly-downloads-stat";
 
 const title = "Traction";
 const description =
@@ -57,23 +55,17 @@ const FLAGSHIP_PACKAGE = "@assistant-ui/react";
 export default async function TractionPage() {
   const repo = await fetchRepoStats();
 
-  const [npm, starHistory, downloadsTimeline] = await Promise.all([
-    fetchNpmDownloads(),
-    fetchStarHistory(repo.stars),
-    fetchTimelineSeries(TIMELINE_PACKAGES),
-  ]);
+  const [npm, starHistory, downloadsTimeline, contributors, dependents] =
+    await Promise.all([
+      fetchNpmDownloads(),
+      fetchStarHistory(repo.stars),
+      fetchTimelineSeries(TIMELINE_PACKAGES),
+      fetchContributors(),
+      fetchDependents(),
+    ]);
 
   const days = daysSince(PROJECT_FACTS.firstCommitDate);
   const flagshipWeekly = npm.perPackage[FLAGSHIP_PACKAGE]?.weekly ?? 0;
-
-  const topPackages = [...PACKAGES]
-    .map((pkg) => ({
-      name: pkg.name,
-      weekly: npm.perPackage[pkg.name]?.weekly ?? 0,
-    }))
-    .filter((row) => row.weekly > 0)
-    .sort((a, b) => b.weekly - a.weekly)
-    .slice(0, 12);
 
   const heroStats: HeroStat[] = [
     {
@@ -96,7 +88,10 @@ export default async function TractionPage() {
     },
     {
       label: "Contributors",
-      value: `${PROJECT_FACTS.uniqueAuthors}+`,
+      value:
+        contributors.length > 0
+          ? contributors.length.toString()
+          : `${PROJECT_FACTS.uniqueAuthors}+`,
       caption: "from the community",
       icon: Users,
     },
@@ -118,27 +113,19 @@ export default async function TractionPage() {
       value: days.toLocaleString(),
       icon: Sparkles,
     },
-    {
-      label: "Production examples",
-      value: PROJECT_FACTS.examples.toString(),
-      icon: Package,
-    },
-    {
-      label: "Showcased apps",
-      value: PROJECT_FACTS.showcased.toString(),
-      icon: Star,
-    },
-    {
-      label: "Open issues",
-      value: repo.openIssues.toString(),
-      icon: GitCommit,
-    },
+    ...(dependents && dependents.repos > 0
+      ? [
+          {
+            label: "Public dependents",
+            value: formatNumber(dependents.repos),
+            icon: Network,
+          },
+        ]
+      : []),
   ];
 
-  const grouped = groupByCategory(PACKAGES);
-
   return (
-    <main className="mx-auto w-full max-w-6xl px-4 py-16 md:py-24">
+    <main className="mx-auto w-full max-w-7xl px-4 pt-14 pb-16 md:pb-24">
       <header className="mb-16 max-w-3xl">
         <p className="mb-3 text-muted-foreground text-sm">Traction</p>
         <h1 className="font-medium text-3xl tracking-tight md:text-4xl">
@@ -169,6 +156,21 @@ export default async function TractionPage() {
       <section className="mb-20">
         <div className="grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border md:grid-cols-4">
           {heroStats.map((stat) => {
+            if (stat.label === "Weekly downloads") {
+              return (
+                <WeeklyDownloadsStat
+                  key={stat.label}
+                  flagship={{
+                    value: flagshipWeekly,
+                    caption: FLAGSHIP_PACKAGE,
+                  }}
+                  total={{
+                    value: npm.totalWeekly,
+                    caption: "across all packages",
+                  }}
+                />
+              );
+            }
             const Icon = stat.icon;
             return (
               <div
@@ -188,6 +190,15 @@ export default async function TractionPage() {
               </div>
             );
           })}
+        </div>
+        <div className="mt-6 flex justify-center">
+          <Link
+            href="/packages"
+            className={buttonVariants({ variant: "outline" })}
+          >
+            See packages detail
+            <ArrowRight />
+          </Link>
         </div>
       </section>
 
@@ -226,7 +237,7 @@ export default async function TractionPage() {
             Live from the assistant-ui/assistant-ui GitHub repository.
           </p>
         </div>
-        <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
           {detailStats.map((stat) => {
             const Icon = stat.icon;
             return (
@@ -249,73 +260,40 @@ export default async function TractionPage() {
         </div>
       </section>
 
-      <section className="mb-20">
-        <div className="mb-8 flex flex-col gap-1">
-          <h2 className="font-medium text-xl tracking-tight">
-            {PACKAGES.length} public packages
-          </h2>
-          <p className="text-muted-foreground text-sm">
-            One ecosystem, every distribution. Pick the surface that fits your
-            stack.
-          </p>
-        </div>
-
-        {topPackages.length > 0 ? (
-          <div className="mb-12 rounded-xl border border-border p-4 md:p-6">
-            <div className="mb-4 flex items-end justify-between gap-3">
-              <div className="flex flex-col gap-0.5">
-                <h3 className="font-medium text-sm">
-                  Top packages by weekly downloads
-                </h3>
-                <p className="text-muted-foreground text-xs">
-                  Last 7 days, npm registry.
-                </p>
-              </div>
-            </div>
-            <TopPackagesBar rows={topPackages} />
+      {contributors.length > 0 ? (
+        <section className="mb-20">
+          <div className="mb-8 flex flex-col gap-1">
+            <h2 className="font-medium text-xl tracking-tight">
+              Built by {contributors.length} contributors
+            </h2>
+            <p className="text-muted-foreground text-sm">
+              Thanks to everyone who has shipped code to assistant-ui.
+            </p>
           </div>
-        ) : null}
-
-        <div className="flex flex-col gap-12">
-          {(Object.keys(PACKAGE_CATEGORIES) as PackageCategory[]).map(
-            (category) => {
-              const items = grouped[category];
-              if (!items || items.length === 0) return null;
-              const meta = PACKAGE_CATEGORIES[category];
-              return (
-                <div key={category} className="flex flex-col gap-4">
-                  <div className="flex items-end justify-between gap-4 border-border border-b pb-3">
-                    <div className="flex flex-col gap-0.5">
-                      <h3 className="font-medium text-sm">{meta.label}</h3>
-                      <p className="text-muted-foreground text-xs">
-                        {meta.description}
-                      </p>
-                    </div>
-                    <span className="text-muted-foreground text-xs tabular-nums">
-                      {items.length}
-                    </span>
-                  </div>
-                  <div className="grid gap-3 md:grid-cols-2">
-                    {items.map((pkg) => {
-                      const stats = npm.perPackage[pkg.name];
-                      return (
-                        <PackageRow
-                          key={pkg.name}
-                          pkg={pkg}
-                          weekly={stats?.weekly ?? 0}
-                          series={stats?.series ?? []}
-                          monthly={stats?.monthly ?? 0}
-                          prevMonthly={stats?.prevMonthly ?? 0}
-                        />
-                      );
-                    })}
-                  </div>
-                </div>
-              );
-            },
-          )}
-        </div>
-      </section>
+          <div className="flex flex-wrap gap-2">
+            {contributors.map((c) => (
+              <a
+                key={c.login}
+                href={c.htmlUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={`${c.login} · ${c.contributions.toLocaleString()} commit${c.contributions === 1 ? "" : "s"}`}
+                className="block transition-transform hover:scale-110"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={c.avatarUrl}
+                  alt={c.login}
+                  width={32}
+                  height={32}
+                  loading="lazy"
+                  className="size-8 rounded-full border border-border"
+                />
+              </a>
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       <section className="mb-20 rounded-xl border border-border p-8 md:p-12">
         <div className="grid gap-8 md:grid-cols-[1fr_auto] md:items-center">
@@ -368,95 +346,4 @@ export default async function TractionPage() {
       </section>
     </main>
   );
-}
-
-type MoMBadge = {
-  label: string;
-  tone: "up" | "down" | "flat";
-};
-
-function computeMoM(monthly: number, prevMonthly: number): MoMBadge | null {
-  if (prevMonthly < 100 || monthly === 0) return null;
-  const change = ((monthly - prevMonthly) / prevMonthly) * 100;
-  if (!Number.isFinite(change)) return null;
-  const capped = Math.max(-99, Math.min(999, change));
-  const sign = capped > 0 ? "+" : "";
-  const rounded = Math.round(capped);
-  let tone: MoMBadge["tone"] = "flat";
-  if (rounded >= 5) tone = "up";
-  else if (rounded <= -5) tone = "down";
-  return { label: `${sign}${rounded}%`, tone };
-}
-
-const MOM_TONE: Record<MoMBadge["tone"], string> = {
-  up: "text-emerald-600 dark:text-emerald-400",
-  down: "text-rose-600 dark:text-rose-400",
-  flat: "text-muted-foreground",
-};
-
-function PackageRow({
-  pkg,
-  weekly,
-  series,
-  monthly,
-  prevMonthly,
-}: {
-  pkg: PackageInfo;
-  weekly: number;
-  series: number[];
-  monthly: number;
-  prevMonthly: number;
-}) {
-  const npmHref = `https://www.npmjs.com/package/${pkg.name}`;
-  const mom = computeMoM(monthly, prevMonthly);
-  return (
-    <a
-      href={npmHref}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="group flex flex-col gap-1.5 rounded-lg border border-border p-4 transition-colors hover:border-foreground/30 hover:bg-muted/40"
-    >
-      <div className="flex items-center justify-between gap-3">
-        <span className="truncate font-medium font-mono text-sm">
-          {pkg.name}
-        </span>
-        <ArrowUpRight className="size-3.5 flex-shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
-      </div>
-      <p className="text-muted-foreground text-sm leading-relaxed">
-        {pkg.description}
-      </p>
-      {weekly > 0 ? (
-        <div className="mt-1 flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2 text-xs tabular-nums">
-            <span className="text-muted-foreground">
-              {formatNumber(weekly)} / week
-            </span>
-            {mom ? (
-              <span
-                className={`font-medium ${MOM_TONE[mom.tone]}`}
-                title="Past 30 days vs prior 30 days"
-              >
-                {mom.label}
-              </span>
-            ) : null}
-          </div>
-          {series.length > 1 ? (
-            <Sparkline values={series} className="text-foreground/50" />
-          ) : null}
-        </div>
-      ) : null}
-    </a>
-  );
-}
-
-function groupByCategory(
-  packages: PackageInfo[],
-): Record<PackageCategory, PackageInfo[]> {
-  const result = {} as Record<PackageCategory, PackageInfo[]>;
-  for (const pkg of packages) {
-    const list = result[pkg.category] ?? [];
-    list.push(pkg);
-    result[pkg.category] = list;
-  }
-  return result;
 }

--- a/apps/docs/components/docs/layout/docs-header.tsx
+++ b/apps/docs/components/docs/layout/docs-header.tsx
@@ -110,7 +110,7 @@ export function DocsHeader({
 
   return (
     <header className="sticky top-0 z-50 w-full">
-      <div className="mask-[linear-gradient(to_bottom,black_50%,transparent)] dark:mask-[linear-gradient(to_bottom,black_40%,transparent)] pointer-events-none absolute inset-x-0 top-0 h-16 bg-linear-to-b from-background via-60% via-background/80 to-transparent backdrop-blur-xl md:h-24 dark:via-50%" />
+      <div className="mask-[linear-gradient(to_bottom,black_75%,transparent)] pointer-events-none absolute inset-x-0 top-0 h-14 bg-linear-to-b from-background to-transparent backdrop-blur-xl" />
       <div className="relative flex h-12 w-full items-center px-4">
         <div className="flex shrink-0 items-center">
           <Link href="/" className="flex shrink-0 items-center gap-2">

--- a/apps/docs/components/docs/layout/sidebar-content.tsx
+++ b/apps/docs/components/docs/layout/sidebar-content.tsx
@@ -13,6 +13,8 @@ import {
   usePlatform,
   type Platform,
 } from "@/components/docs/contexts/platform";
+import { GitHubIcon } from "@/components/icons/github";
+import { DiscordIcon } from "@/components/icons/discord";
 import { analytics } from "@/lib/analytics";
 
 /**
@@ -142,8 +144,8 @@ function SectionItem({
             className={cn(
               "flex items-center gap-2 rounded-md px-2 py-1.5 text-[13px] transition-colors duration-150",
               isActive
-                ? "bg-accent/40 font-medium text-foreground"
-                : "text-muted-foreground hover:bg-accent/40 hover:text-foreground/90",
+                ? "bg-accent/20 font-medium text-foreground dark:bg-accent/50"
+                : "text-muted-foreground hover:bg-accent/30 hover:text-foreground/90 dark:hover:bg-accent/40",
             )}
           >
             {item.icon}
@@ -156,7 +158,7 @@ function SectionItem({
           </p>
         )}
         {hasChildren && (containsActive || !item.index) && (
-          <div className="ml-2 border-border/50 border-l pl-2">
+          <div className="ml-2 flex flex-col gap-0.5 border-border/50 border-l pl-2">
             {item.children.map((child) => (
               <SectionItem
                 key={child.$id}
@@ -184,8 +186,8 @@ function SectionItem({
       className={cn(
         "flex items-center gap-2 rounded-md px-2 py-1.5 text-[13px] transition-colors duration-150",
         isActive
-          ? "bg-accent/40 font-medium text-foreground"
-          : "text-muted-foreground hover:bg-accent/40 hover:text-foreground/90",
+          ? "bg-accent/20 font-medium text-foreground dark:bg-accent/50"
+          : "text-muted-foreground hover:bg-accent/30 hover:text-foreground/90 dark:hover:bg-accent/40",
       )}
     >
       {item.icon}
@@ -219,7 +221,7 @@ function SidebarSection({
         onClick={onToggle}
         aria-expanded={isOpen}
         className={cn(
-          "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-[13px] transition-colors duration-150 hover:bg-accent/40",
+          "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-[13px] transition-colors duration-150 hover:bg-accent/30 dark:hover:bg-accent/40",
           isActive || isOpen
             ? "font-medium text-foreground"
             : "text-muted-foreground/90",
@@ -245,7 +247,7 @@ function SidebarSection({
             transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
             className="overflow-hidden"
           >
-            <div className="mt-0.5 mb-1 ml-3 border-border/50 border-l pl-2">
+            <div className="mt-0.5 mb-1 ml-3 flex flex-col gap-0.5 border-border/50 border-l pl-2">
               {folder.children.map((child) => (
                 <SectionItem
                   key={child.$id}
@@ -373,24 +375,46 @@ export function SidebarContent({ tree }: SidebarContentProps) {
   const onNavigate = () => setSidebarOpen(false);
 
   return (
-    <nav
-      ref={navRef}
-      className="sidebar-tree-content flex h-full flex-col gap-0.5 overflow-y-auto px-3 pt-4 pb-12"
-    >
-      {sections.map((section) => (
-        <SidebarSection
-          key={section.$id}
-          folder={section}
-          isOpen={openSectionId === section.$id}
-          onToggle={() => {
-            const id = section.$id ?? null;
-            const willOpen = openSectionId !== id;
-            analytics.docs.folderToggled(String(section.name), willOpen, 0);
-            setOpenSectionId(willOpen ? id : null);
-          }}
-          onNavigate={onNavigate}
-        />
-      ))}
-    </nav>
+    <div className="flex h-full flex-col">
+      <nav
+        ref={navRef}
+        className="sidebar-tree-content flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-4 pb-4"
+      >
+        {sections.map((section) => (
+          <SidebarSection
+            key={section.$id}
+            folder={section}
+            isOpen={openSectionId === section.$id}
+            onToggle={() => {
+              const id = section.$id ?? null;
+              const willOpen = openSectionId !== id;
+              analytics.docs.folderToggled(String(section.name), willOpen, 0);
+              setOpenSectionId(willOpen ? id : null);
+            }}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </nav>
+      <div className="flex shrink-0 items-center gap-1 border-border/50 border-t px-3 py-2">
+        <a
+          href="https://github.com/assistant-ui/assistant-ui"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground dark:hover:bg-accent/40"
+          aria-label="GitHub"
+        >
+          <GitHubIcon className="size-4" />
+        </a>
+        <a
+          href="https://discord.gg/S9dwgCNEFs"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground dark:hover:bg-accent/40"
+          aria-label="Discord"
+        >
+          <DiscordIcon className="size-4" />
+        </a>
+      </div>
+    </div>
   );
 }

--- a/apps/docs/components/shared/footer.tsx
+++ b/apps/docs/components/shared/footer.tsx
@@ -31,6 +31,7 @@ const FOOTER_LINKS: Record<string, FooterLinkItem[]> = {
     { label: "Examples", href: "/examples" },
     { label: "Showcase", href: "/showcase" },
     { label: "Traction", href: "/traction" },
+    { label: "Packages", href: "/packages" },
     { label: "Blog", href: "/blog" },
   ],
   Company: [

--- a/apps/docs/components/shared/header.tsx
+++ b/apps/docs/components/shared/header.tsx
@@ -83,7 +83,7 @@ export function Header() {
 
   return (
     <header className="sticky top-0 z-50 w-full">
-      <div className="mask-[linear-gradient(to_bottom,black_50%,transparent)] dark:mask-[linear-gradient(to_bottom,black_40%,transparent)] pointer-events-none absolute inset-x-0 top-0 h-16 bg-linear-to-b from-background via-60% via-background/80 to-transparent backdrop-blur-xl md:h-24 dark:via-50%" />
+      <div className="mask-[linear-gradient(to_bottom,black_75%,transparent)] pointer-events-none absolute inset-x-0 top-0 h-14 bg-linear-to-b from-background to-transparent backdrop-blur-xl" />
       <div className="relative mx-auto flex h-12 w-full max-w-7xl items-center justify-between px-4">
         <Link href="/" className="flex items-center gap-2">
           <Image

--- a/apps/docs/components/shared/sub-project-layout.tsx
+++ b/apps/docs/components/shared/sub-project-layout.tsx
@@ -67,7 +67,7 @@ export function SubProjectLayout({
         className={cn("z-50 w-full shrink-0", !fullHeight && "sticky top-0")}
       >
         {!fullHeight && (
-          <div className="mask-[linear-gradient(to_bottom,black_50%,transparent)] dark:mask-[linear-gradient(to_bottom,black_40%,transparent)] pointer-events-none absolute inset-x-0 top-0 h-16 bg-linear-to-b from-background via-60% via-background/80 to-transparent backdrop-blur-xl md:h-24 dark:via-50%" />
+          <div className="mask-[linear-gradient(to_bottom,black_75%,transparent)] pointer-events-none absolute inset-x-0 top-0 h-14 bg-linear-to-b from-background to-transparent backdrop-blur-xl" />
         )}
         <div
           className={cn(

--- a/apps/docs/components/traction/downloads-chart.tsx
+++ b/apps/docs/components/traction/downloads-chart.tsx
@@ -1,15 +1,23 @@
 "use client";
 
-import { useId } from "react";
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import { useId, useState } from "react";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Line,
+  ReferenceLine,
+  XAxis,
+  YAxis,
+} from "recharts";
 import {
   ChartContainer,
   type ChartConfig,
   ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import { cn } from "@/lib/utils";
 import { formatCompact, type TimelineSeries } from "@/lib/traction";
 
 const MONTH_NAMES = [
@@ -41,6 +49,7 @@ const formatTooltipLabel = (yearMonth: string) => {
 
 export function DownloadsChart({ timeline }: { timeline: TimelineSeries }) {
   const gradientPrefix = useId();
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
 
   if (timeline.data.length < 2 || timeline.series.length === 0) {
     return (
@@ -57,6 +66,15 @@ export function DownloadsChart({ timeline }: { timeline: TimelineSeries }) {
       color: `var(--chart-${s.chartIndex})`,
     };
   }
+
+  const toggle = (key: string) => {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
 
   return (
     <ChartContainer
@@ -106,51 +124,155 @@ export function DownloadsChart({ timeline }: { timeline: TimelineSeries }) {
         />
         <ChartTooltip
           cursor={{ stroke: "var(--border)" }}
-          content={
-            <ChartTooltipContent
-              labelFormatter={(_, payload) => {
-                const ym = payload?.[0]?.payload?.date as string | undefined;
-                return ym ? formatTooltipLabel(ym) : "";
-              }}
-              formatter={(value, name, item) => {
-                const series = timeline.series.find((s) => s.key === name);
-                const color =
-                  (item as { color?: string } | undefined)?.color ??
-                  (item?.payload as { fill?: string } | undefined)?.fill;
-                return (
-                  <>
-                    <div
-                      className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
-                      style={{ backgroundColor: color }}
-                    />
-                    <div className="flex flex-1 items-center justify-between gap-3 leading-none">
-                      <span className="text-muted-foreground">
-                        {series?.label ?? String(name)}
-                      </span>
-                      <span className="font-medium font-mono text-foreground tabular-nums">
-                        {formatCompact(value as number)}
-                      </span>
-                    </div>
-                  </>
-                );
-              }}
-              indicator="dot"
-            />
-          }
+          content={(tooltipProps) => {
+            // hide _proj entries when their raw counterpart has a value (avoids empty rows on the bridging month).
+            const filtered = (
+              tooltipProps.payload as
+                | Array<{
+                    dataKey?: string | number;
+                    payload?: Record<string, number | undefined>;
+                  }>
+                | undefined
+            )?.filter((entry) => {
+              const key = String(entry?.dataKey ?? "");
+              if (!key.endsWith("_proj")) return true;
+              const baseKey = key.slice(0, -5);
+              return entry.payload?.[baseKey] === undefined;
+            });
+            return (
+              <ChartTooltipContent
+                {...(tooltipProps as Record<string, unknown>)}
+                payload={filtered}
+                labelFormatter={(_, p) => {
+                  const ym = p?.[0]?.payload?.date as string | undefined;
+                  return ym ? formatTooltipLabel(ym) : "";
+                }}
+                formatter={(value, name, item) => {
+                  const rawName = String(name);
+                  const isProjEntry = rawName.endsWith("_proj");
+                  const baseKey = isProjEntry ? rawName.slice(0, -5) : rawName;
+                  const series = timeline.series.find((s) => s.key === baseKey);
+                  let displayValue = value as number;
+                  const rowPayload = item?.payload as
+                    | Record<string, number | undefined>
+                    | undefined;
+                  if (isProjEntry && rowPayload) {
+                    const idx = timeline.series.findIndex(
+                      (s) => s.key === baseKey,
+                    );
+                    const prev = idx > 0 ? timeline.series[idx - 1]! : null;
+                    const prevCum = prev
+                      ? (rowPayload[`${prev.key}_proj`] ?? 0)
+                      : 0;
+                    displayValue = (value as number) - prevCum;
+                  }
+                  const color =
+                    (item as { color?: string } | undefined)?.color ??
+                    (item?.payload as { fill?: string } | undefined)?.fill;
+                  return (
+                    <>
+                      <div
+                        className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                        style={{ backgroundColor: color }}
+                      />
+                      <div className="flex flex-1 items-center justify-between gap-3 leading-none">
+                        <span className="text-muted-foreground">
+                          {series?.label ?? rawName}
+                        </span>
+                        <span className="font-medium font-mono text-foreground tabular-nums">
+                          {formatCompact(displayValue)}
+                        </span>
+                      </div>
+                    </>
+                  );
+                }}
+                indicator="dot"
+              />
+            );
+          }}
         />
-        {timeline.series.map((s) => (
-          <Area
-            key={s.key}
-            dataKey={s.key}
-            stackId="downloads"
-            type="monotone"
-            stroke={`var(--color-${s.key})`}
-            strokeWidth={1.5}
-            fill={`url(#${gradientPrefix}-${s.key})`}
-          />
-        ))}
+        {timeline.series.map((s) => {
+          const isHidden = hidden.has(s.key);
+          return (
+            <Area
+              key={s.key}
+              dataKey={s.key}
+              stackId="downloads"
+              type="monotone"
+              // hide via transparent stroke/fill so toggled series keep their stack slot and siblings don't shift.
+              stroke={isHidden ? "transparent" : `var(--color-${s.key})`}
+              strokeWidth={1.5}
+              fill={
+                isHidden ? "transparent" : `url(#${gradientPrefix}-${s.key})`
+              }
+              isAnimationActive={false}
+            />
+          );
+        })}
+        {timeline.projectedMonth ? (
+          <>
+            <ReferenceLine
+              x={timeline.projectedMonth}
+              stroke="var(--muted-foreground)"
+              strokeDasharray="3 3"
+              strokeOpacity={0.4}
+            />
+            {timeline.series.map((s) => {
+              const isHidden = hidden.has(s.key);
+              return (
+                <Line
+                  key={`${s.key}-proj`}
+                  dataKey={`${s.key}_proj`}
+                  stroke={isHidden ? "transparent" : `var(--color-${s.key})`}
+                  strokeWidth={1.5}
+                  strokeDasharray="5 4"
+                  type="monotone"
+                  dot={false}
+                  activeDot={false}
+                  connectNulls={false}
+                  isAnimationActive={false}
+                  legendType="none"
+                />
+              );
+            })}
+          </>
+        ) : null}
         <ChartLegend
-          content={<ChartLegendContent className="flex-wrap gap-x-4 gap-y-1" />}
+          content={({ payload }) => (
+            <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 pt-3">
+              {(
+                payload as
+                  | Array<{
+                      dataKey?: string | number;
+                      value?: string;
+                      color?: string;
+                    }>
+                  | undefined
+              )?.map((item) => {
+                const key = String(item.dataKey ?? item.value ?? "");
+                const series = timeline.series.find((s) => s.key === key);
+                if (!series) return null;
+                const isHidden = hidden.has(key);
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => toggle(key)}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-1.5 rounded-sm text-muted-foreground text-xs outline-none transition-opacity hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50",
+                      isHidden && "opacity-40",
+                    )}
+                  >
+                    <div
+                      className="h-2 w-2 shrink-0 rounded-[2px]"
+                      style={{ backgroundColor: `var(--color-${key})` }}
+                    />
+                    <span>{series.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
         />
       </AreaChart>
     </ChartContainer>

--- a/apps/docs/components/traction/downloads-chart.tsx
+++ b/apps/docs/components/traction/downloads-chart.tsx
@@ -126,18 +126,14 @@ export function DownloadsChart({ timeline }: { timeline: TimelineSeries }) {
           cursor={{ stroke: "var(--border)" }}
           content={(tooltipProps) => {
             // hide _proj entries when their raw counterpart has a value (avoids empty rows on the bridging month).
-            const filtered = (
-              tooltipProps.payload as
-                | Array<{
-                    dataKey?: string | number;
-                    payload?: Record<string, number | undefined>;
-                  }>
-                | undefined
-            )?.filter((entry) => {
+            const filtered = tooltipProps.payload?.filter((entry) => {
               const key = String(entry?.dataKey ?? "");
               if (!key.endsWith("_proj")) return true;
               const baseKey = key.slice(0, -5);
-              return entry.payload?.[baseKey] === undefined;
+              const rowPayload = entry.payload as
+                | Record<string, number | undefined>
+                | undefined;
+              return rowPayload?.[baseKey] === undefined;
             });
             return (
               <ChartTooltipContent

--- a/apps/docs/components/traction/weekly-downloads-stat.tsx
+++ b/apps/docs/components/traction/weekly-downloads-stat.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowLeftRight, ArrowUpRight } from "lucide-react";
+import { formatCompact } from "@/lib/traction";
+
+type Mode = { value: number; caption: string };
+
+export function WeeklyDownloadsStat({
+  flagship,
+  total,
+}: {
+  flagship: Mode;
+  total: Mode;
+}) {
+  const [showTotal, setShowTotal] = useState(false);
+  const current = showTotal ? total : flagship;
+  return (
+    <div className="flex flex-col gap-3 bg-background p-6">
+      <ArrowUpRight className="size-4 text-muted-foreground" />
+      <div className="font-medium text-3xl tabular-nums tracking-tight md:text-4xl">
+        {current.value > 0 ? formatCompact(current.value) : "—"}
+      </div>
+      <div className="flex flex-col gap-0.5">
+        <span className="text-sm">Weekly downloads</span>
+        <button
+          type="button"
+          onClick={() => setShowTotal((v) => !v)}
+          className="flex w-fit cursor-pointer items-center gap-1 rounded-sm text-left text-muted-foreground text-xs outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+          aria-label="Toggle between flagship package and ecosystem total"
+        >
+          <span>{current.caption}</span>
+          <ArrowLeftRight className="size-3 opacity-60" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/lib/constants.ts
+++ b/apps/docs/lib/constants.ts
@@ -114,7 +114,13 @@ export const NAV_ITEMS: NavItem[] = [
       {
         label: "Traction",
         href: "/traction",
-        description: "Packages, stars, and adoption",
+        description: "Stars, downloads, and adoption",
+        external: false,
+      },
+      {
+        label: "Packages",
+        href: "/packages",
+        description: "Every distribution on npm",
         external: false,
       },
       {

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -421,13 +421,6 @@ function currentMonthKey(): string {
   return new Date().toISOString().slice(0, 7);
 }
 
-function startOfCurrentMonthISO(): string {
-  const now = new Date();
-  return new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
-  ).toISOString();
-}
-
 export const TIMELINE_PACKAGES = [
   "@assistant-ui/react",
   "@assistant-ui/react-ai-sdk",
@@ -503,7 +496,7 @@ export async function fetchTimelineSeries(
   return {
     series,
     data,
-    projectedMonth: projectedIndex >= 0 ? cutoff : undefined,
+    ...(projectedIndex >= 0 ? { projectedMonth: cutoff } : {}),
   };
 }
 

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -271,6 +271,73 @@ const REPO_FALLBACK: RepoStats = {
   watchers: 80,
 };
 
+export type Contributor = {
+  login: string;
+  avatarUrl: string;
+  htmlUrl: string;
+  contributions: number;
+};
+
+export async function fetchDependents(): Promise<{
+  repos: number;
+  packages: number;
+} | null> {
+  try {
+    const res = await fetch(
+      "https://github.com/assistant-ui/assistant-ui/network/dependents",
+      {
+        headers: { "User-Agent": "Mozilla/5.0 (assistant-ui-traction)" },
+        next: { revalidate: 21600 },
+      },
+    );
+    if (!res.ok) return null;
+    const html = await res.text();
+    const reposMatch = html.match(/([\d,]+)\s+Repositories\b/);
+    const packagesMatch = html.match(/([\d,]+)\s+Packages\b/);
+    if (!reposMatch && !packagesMatch) return null;
+    return {
+      repos: reposMatch ? Number(reposMatch[1]!.replace(/,/g, "")) : 0,
+      packages: packagesMatch ? Number(packagesMatch[1]!.replace(/,/g, "")) : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchContributors(): Promise<Contributor[]> {
+  try {
+    const all: Contributor[] = [];
+    for (let page = 1; page <= 5; page++) {
+      const res = await fetch(
+        `https://api.github.com/repos/assistant-ui/assistant-ui/contributors?per_page=100&page=${page}`,
+        { headers: githubHeaders(), next: { revalidate: 21600 } },
+      );
+      if (!res.ok) break;
+      const data = (await res.json()) as Array<{
+        login: string;
+        avatar_url: string;
+        html_url: string;
+        contributions: number;
+        type?: string;
+      }>;
+      if (data.length === 0) break;
+      for (const c of data) {
+        if (c.type === "Bot" || /\[bot\]$/i.test(c.login)) continue;
+        all.push({
+          login: c.login,
+          avatarUrl: c.avatar_url,
+          htmlUrl: c.html_url,
+          contributions: c.contributions,
+        });
+      }
+      if (data.length < 100) break;
+    }
+    return all;
+  } catch {
+    return [];
+  }
+}
+
 export async function fetchRepoStats(): Promise<RepoStats> {
   try {
     const res = await fetch(
@@ -377,6 +444,7 @@ export type TimelineSeries = {
     chartIndex: number;
   }[];
   data: { date: string; [key: string]: number | string }[];
+  projectedMonth?: string;
 };
 
 export async function fetchTimelineSeries(
@@ -398,14 +466,32 @@ export async function fetchTimelineSeries(
   }
   const months = Array.from(monthsSet).sort();
 
+  const cutoff = currentMonthKey();
   const data = months.map((date) => {
+    const isProjected = date === cutoff;
     const row: { date: string; [key: string]: number | string } = { date };
     for (const { key, points } of fetched) {
       const point = points.find((p) => p.date === date);
-      row[key] = point?.value ?? 0;
+      const value = point?.value ?? 0;
+      // omit projected month so its stacked area renders no fill; the per-series _proj line bridges that gap instead.
+      if (!isProjected) row[key] = value;
     }
     return row;
   });
+
+  const projectedIndex = data.findIndex((r) => r.date === cutoff);
+  if (projectedIndex >= 1) {
+    for (let idx = projectedIndex - 1; idx <= projectedIndex; idx++) {
+      const row = data[idx]!;
+      const rowDate = row.date as string;
+      let cum = 0;
+      for (const { key, points } of fetched) {
+        const val = points.find((p) => p.date === rowDate)?.value ?? 0;
+        cum += val;
+        row[`${key}_proj`] = cum;
+      }
+    }
+  }
 
   const series = fetched.map(({ key, pkg, label, chartIndex }) => ({
     key,
@@ -414,7 +500,11 @@ export async function fetchTimelineSeries(
     chartIndex,
   }));
 
-  return { series, data };
+  return {
+    series,
+    data,
+    projectedMonth: projectedIndex >= 0 ? cutoff : undefined,
+  };
 }
 
 export async function fetchDownloadsTimeline(
@@ -431,18 +521,85 @@ export async function fetchDownloadsTimeline(
     };
     if (!data.downloads?.length) return [];
     const cutoff = currentMonthKey();
-    const byMonth = new Map<string, number>();
+    type MonthBucket = {
+      sum: number;
+      dailies: { day: string; downloads: number }[];
+    };
+    const byMonth = new Map<string, MonthBucket>();
     for (const point of data.downloads) {
       const month = point.day.slice(0, 7);
-      if (month >= cutoff) continue;
-      byMonth.set(month, (byMonth.get(month) ?? 0) + point.downloads);
+      const entry = byMonth.get(month) ?? { sum: 0, dailies: [] };
+      entry.sum += point.downloads;
+      entry.dailies.push({ day: point.day, downloads: point.downloads });
+      byMonth.set(month, entry);
     }
-    return Array.from(byMonth.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([date, value]) => ({ date, value }));
+    const sorted = Array.from(byMonth.entries()).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    const fullMonths = sorted.filter(([k]) => k !== cutoff);
+    const lastFullMonth = fullMonths[fullMonths.length - 1];
+    const priorFullMonth = fullMonths[fullMonths.length - 2];
+
+    return sorted.map(([date, bucket]) => {
+      if (date !== cutoff || bucket.dailies.length === 0) {
+        return { date, value: bucket.sum };
+      }
+      return {
+        date,
+        value: projectInflightMonth(
+          date,
+          bucket,
+          lastFullMonth?.[1].sum,
+          priorFullMonth?.[1].sum,
+        ),
+      };
+    });
   } catch {
     return [];
   }
+}
+
+function projectInflightMonth(
+  date: string,
+  bucket: { sum: number; dailies: { day: string; downloads: number }[] },
+  lastFullMonthSum: number | undefined,
+  priorFullMonthSum: number | undefined,
+): number {
+  // npm aggregation lags 1-2 days; trailing days under-report and would drag the daily average down.
+  const TRAILING_LAG_DAYS = 2;
+  const dailies = [...bucket.dailies].sort((a, b) =>
+    a.day.localeCompare(b.day),
+  );
+  const stable = dailies.slice(
+    0,
+    Math.max(1, dailies.length - TRAILING_LAG_DAYS),
+  );
+  const stableSum = stable.reduce((s, d) => s + d.downloads, 0);
+  const stableDays = stable.length;
+
+  const totalDays = new Date(
+    Number(date.slice(0, 4)),
+    Number(date.slice(5, 7)),
+    0,
+  ).getDate();
+
+  const linear = (stableSum / stableDays) * totalDays;
+
+  if (!lastFullMonthSum || !priorFullMonthSum || priorFullMonthSum === 0) {
+    return Math.round(linear);
+  }
+
+  // cap growth so an outlier month doesn't produce a runaway projection.
+  const growth = Math.max(
+    -0.3,
+    Math.min(1.0, lastFullMonthSum / priorFullMonthSum - 1),
+  );
+  const trend = lastFullMonthSum * (1 + growth);
+  // early in the month trust the trend (little data); late, trust observed.
+  const elapsedFraction = stableDays / totalDays;
+  const blended = elapsedFraction * linear + (1 - elapsedFraction) * trend;
+
+  return Math.round(blended);
 }
 
 function githubHeaders(): HeadersInit {
@@ -483,7 +640,7 @@ export async function fetchStarHistory(
       Math.max(1, Math.ceil(totalStars / 100));
 
     const samples = new Set<number>([1, lastPage]);
-    const target = 8;
+    const target = 24;
     if (lastPage > 2) {
       const step = (lastPage - 1) / (target - 1);
       for (let i = 1; i < target - 1; i++) {
@@ -506,22 +663,77 @@ export async function fetchStarHistory(
       }),
     );
 
-    const points: TimelinePoint[] = fetched
+    const anchors: TimelinePoint[] = fetched
       .filter(({ data }) => data.length > 0)
       .map(({ page, data }) => ({
         date: data[0]!.starred_at,
         value: (page - 1) * 100 + 1,
-      }));
-
-    const cutoff = startOfCurrentMonthISO();
-
-    return points
-      .filter((p) => p.date < cutoff)
+      }))
       .sort((a, b) => a.date.localeCompare(b.date))
       .filter((p, i, arr) => i === 0 || p.value > arr[i - 1]!.value);
+
+    // page sampling stops at the first star on the last page; append (now, totalStars) so the chart reaches today.
+    const now = new Date().toISOString();
+    const lastAnchor = anchors[anchors.length - 1];
+    if (
+      !lastAnchor ||
+      (totalStars > lastAnchor.value && now > lastAnchor.date)
+    ) {
+      anchors.push({ date: now, value: totalStars });
+    }
+
+    if (anchors.length < 2) return anchors;
+
+    return resampleMonthly(anchors);
   } catch {
     return [];
   }
+}
+
+// page-based sampling clusters unevenly in time; resample on a monthly grid so the chart shows real acceleration, not straight segments.
+function resampleMonthly(anchors: TimelinePoint[]): TimelinePoint[] {
+  const startMs = new Date(anchors[0]!.date).getTime();
+  const endAnchor = anchors[anchors.length - 1]!;
+  const endMs = new Date(endAnchor.date).getTime();
+
+  const startDate = new Date(startMs);
+  const cursor = new Date(
+    Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth() + 1, 1),
+  );
+
+  const out: TimelinePoint[] = [
+    { date: anchors[0]!.date, value: anchors[0]!.value },
+  ];
+
+  let i = 0;
+  while (cursor.getTime() <= endMs) {
+    const t = cursor.getTime();
+    while (
+      i < anchors.length - 1 &&
+      new Date(anchors[i + 1]!.date).getTime() < t
+    ) {
+      i++;
+    }
+    const a = anchors[i]!;
+    const b = anchors[Math.min(i + 1, anchors.length - 1)]!;
+    const aT = new Date(a.date).getTime();
+    const bT = new Date(b.date).getTime();
+    const ratio =
+      bT === aT ? 0 : Math.min(1, Math.max(0, (t - aT) / (bT - aT)));
+    const value = Math.round(a.value + (b.value - a.value) * ratio);
+    out.push({ date: cursor.toISOString(), value });
+    cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+  }
+
+  // tail point so the line reaches today instead of the latest crossed month boundary.
+  const tailExisting = out[out.length - 1]!;
+  if (
+    new Date(endAnchor.date).getTime() > new Date(tailExisting.date).getTime()
+  ) {
+    out.push(endAnchor);
+  }
+
+  return out;
 }
 
 export function formatNumber(value: number): string {

--- a/apps/docs/styles/fumadocs.css
+++ b/apps/docs/styles/fumadocs.css
@@ -39,7 +39,7 @@ html:has(#nd-docs-layout) {
 
 #nd-page {
   padding-inline: 1rem !important;
-  padding-top: 1.5rem !important;
+  padding-top: 1rem !important;
   padding-bottom: 1.5rem !important;
 }
 
@@ -50,14 +50,8 @@ html:has(#nd-docs-layout) {
   }
 }
 
-@media (min-width: 768px) {
-  #nd-page {
-    padding-top: 2.5rem !important;
-  }
-}
-
 #nd-toc > .sticky {
-  top: calc(var(--docs-header-height) + 2rem) !important;
+  top: calc(var(--docs-header-height) + 1rem) !important;
 }
 
 #nd-sidebar {


### PR DESCRIPTION
## Summary

- **New `/packages` page** split off from traction — ecosystem totals, top-12 weekly downloads bar, sticky category quick-nav, and per-package cards (sparkline + mom badge). Discoverable via Resources dropdown and footer.
- **Traction page expanded** — live contributor avatars and public-dependents count from github, in-flight month projection on the downloads chart with per-series dashed continuations (npm-lag and mom corrections applied), clickable hero stat that toggles weekly downloads between flagship `@assistant-ui/react` and ecosystem total, and stars-over-time extended through today via monthly resampling.
- **Sidebar polish** — github and discord icons pinned at the bottom (lost when sidebar tabs were removed), softer active item background (`bg-accent/20` light, `bg-accent/50` dark), and first nav item aligned with the page h1 + table of contents.
- **Header backdrop unified** — compressed from `h-16/md:h-24` with split light/dark masks down to a single `h-14` with a tighter 75% fade across docs-header, shared header, and sub-project layout.

## Test plan

- [ ] visit `/traction` — verify hero stats load, weekly-downloads stat toggles between flagship/total, contributors render, charts render correctly in light + dark mode
- [ ] hover the ecosystem downloads chart — tooltip should show package names with raw values, no empty rows on the bridging month
- [ ] click legend entries — toggled series should fade out without other series shifting position
- [ ] visit `/packages` — sticky category nav should stay pinned while scrolling, anchor links jump to correct sections, "Back to traction" returns to `/traction`
- [ ] visit `/docs` — sidebar github/discord buttons render, active state is subtle in light mode, top nav item aligns with the page h1