### PR TITLE
fix(docs): clean /examples layout and tighten platform filtering

### DIFF
--- a/apps/docs/app/examples/[[...slug]]/page.tsx
+++ b/apps/docs/app/examples/[[...slug]]/page.tsx
@@ -6,7 +6,6 @@ import { notFound } from "next/navigation";
 import { getMDXComponents } from "@/mdx-components";
 import { DocsRuntimeProvider } from "@/contexts/DocsRuntimeProvider";
 import { ExamplesNavbar } from "@/components/docs/examples-navbar";
-import { TableOfContents } from "@/components/docs/layout/table-of-contents";
 import { DocsFooter } from "@/components/docs/layout/docs-footer";
 import { DocsPager } from "@/components/docs/layout/docs-pager";
 import { findNeighbour } from "fumadocs-core/page-tree";
@@ -27,9 +26,7 @@ export default async function Page(props: {
   const page = getPage(params.slug);
   const isIndex = !params.slug || params.slug.length === 0;
 
-  const path = `apps/docs/content/examples/${page.path}`;
   const markdownUrl = `${page.url}.mdx`;
-  const githubEditUrl = `https://github.com/assistant-ui/assistant-ui/edit/main/${path}`;
 
   const neighbours = findNeighbour(examples.pageTree, page.url);
   const footerPrevious = neighbours.previous
@@ -44,14 +41,7 @@ export default async function Page(props: {
       toc={page.data.toc}
       full={true}
       tableOfContent={{
-        enabled: !isIndex,
-        component: !isIndex ? (
-          <TableOfContents
-            items={page.data.toc}
-            githubEditUrl={githubEditUrl}
-            markdownUrl={markdownUrl}
-          />
-        ) : undefined,
+        enabled: false,
       }}
       tableOfContentPopover={{
         enabled: false,

--- a/apps/docs/app/examples/layout.tsx
+++ b/apps/docs/app/examples/layout.tsx
@@ -1,13 +1,8 @@
-import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import type { ReactNode } from "react";
-import { sharedDocsOptions } from "@/lib/layout.shared";
 import { examples } from "@/lib/source";
 import { DocsHeader } from "@/components/docs/layout/docs-header";
-import {
-  DocsSidebarProvider,
-  DocsSidebar,
-} from "@/components/docs/contexts/sidebar";
-import { SidebarContent } from "@/components/docs/layout/sidebar-content";
+import { DocsSidebarProvider } from "@/components/docs/contexts/sidebar";
+import { ExamplesShell } from "@/components/docs/layout/examples-shell";
 import { AssistantPanelProvider } from "@/components/docs/assistant/context";
 import { PlatformProvider } from "@/components/docs/contexts/platform";
 
@@ -17,16 +12,7 @@ export default function Layout({ children }: { children: ReactNode }) {
       <AssistantPanelProvider>
         <DocsSidebarProvider>
           <DocsHeader section="Examples" sectionHref="/examples" />
-          <DocsLayout
-            {...sharedDocsOptions}
-            tree={examples.pageTree}
-            nav={{ enabled: false }}
-          >
-            {children}
-          </DocsLayout>
-          <DocsSidebar>
-            <SidebarContent tree={examples.pageTree} />
-          </DocsSidebar>
+          <ExamplesShell tree={examples.pageTree}>{children}</ExamplesShell>
         </DocsSidebarProvider>
       </AssistantPanelProvider>
     </PlatformProvider>

--- a/apps/docs/components/docs/layout/examples-shell.tsx
+++ b/apps/docs/components/docs/layout/examples-shell.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+import type * as PageTree from "fumadocs-core/page-tree";
+import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import { sharedDocsOptions } from "@/lib/layout.shared";
+
+export function ExamplesShell({
+  tree,
+  children,
+}: {
+  tree: PageTree.Root;
+  children: ReactNode;
+}) {
+  return (
+    <DocsLayout
+      {...sharedDocsOptions}
+      tree={tree}
+      nav={{ enabled: false }}
+      sidebar={{ enabled: false }}
+    >
+      {children}
+    </DocsLayout>
+  );
+}

--- a/apps/docs/content/docs/(docs)/architecture.mdx
+++ b/apps/docs/content/docs/(docs)/architecture.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Architecture"
 description: How components, runtimes, and cloud services fit together.
-platforms: ["react"]
 ---
 
 import { Sparkles, PanelsTopLeft, Database, Terminal } from "lucide-react";

--- a/apps/docs/content/docs/(docs)/llm.mdx
+++ b/apps/docs/content/docs/(docs)/llm.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Agent Skills"
 description: Use AI tools to build with assistant-ui faster. AI-accessible documentation, Claude Code skills, and MCP integration.
-platforms: ["react"]
 ---
 
 import { FileText } from "lucide-react";

--- a/apps/docs/content/docs/(reference)/meta.json
+++ b/apps/docs/content/docs/(reference)/meta.json
@@ -2,5 +2,6 @@
   "title": "API Reference",
   "icon": "FileCode",
   "root": true,
+  "platforms": ["react"],
   "pages": ["...api-reference", "...migrations", "react-compatibility"]
 }

--- a/apps/docs/content/docs/cloud/meta.json
+++ b/apps/docs/content/docs/cloud/meta.json
@@ -3,6 +3,7 @@
   "description": "AssistantCloud services",
   "icon": "Cloud",
   "root": true,
+  "platforms": ["react"],
   "pages": [
     "index",
     "ai-sdk",

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -2,6 +2,7 @@
   "title": "Integrations",
   "icon": "Plug",
   "root": true,
+  "platforms": ["react"],
   "pages": [
     "index",
     "frameworks",

--- a/apps/docs/content/docs/primitives/meta.json
+++ b/apps/docs/content/docs/primitives/meta.json
@@ -3,6 +3,7 @@
   "description": "Unstyled, accessible building blocks for AI chat interfaces",
   "icon": "Blocks",
   "root": true,
+  "platforms": ["react"],
   "pages": [
     "index",
     "composer",

--- a/apps/docs/content/docs/runtimes/meta.json
+++ b/apps/docs/content/docs/runtimes/meta.json
@@ -3,6 +3,7 @@
   "description": "Backend integrations",
   "icon": "Server",
   "root": true,
+  "platforms": ["react"],
   "pages": [
     "pick-a-runtime",
     "concepts",

--- a/apps/docs/content/docs/utilities/react-o11y.mdx
+++ b/apps/docs/content/docs/utilities/react-o11y.mdx
@@ -1,6 +1,7 @@
 ---
 title: react-o11y
 description: Headless primitives for visualizing observability spans (traces, waterfalls).
+platforms: ["react"]
 ---
 
 <Callout type="warn">


### PR DESCRIPTION
## Summary

- Drop the empty sidebar slot and the on-this-page toc from `/examples` (index and slug pages) so the showcase grid and example detail pages render full-width with just the existing `ExamplesNavbar` for navigation.
- Mark the `API Reference`, `Runtimes`, `Integrations`, `Primitives`, and `Cloud` top-level docs sections as `platforms: ["react"]` so RN and Ink tabs no longer leak react-only content into the sidebar.
- Tag `utilities/react-o11y.mdx` as react-only to match `heat-graph` and `tw-shimmer`.
- Drop the `platforms: ["react"]` tag from `architecture.mdx` and `llm.mdx` since those concept pages apply to every distribution and were over-restricted before.

## Test plan

- [ ] visit `/examples` — index renders full-width grid, no left sidebar, no toc
- [ ] visit `/examples/modal` — same: navbar + content full-width, no sidebar/toc
- [ ] open `/docs` on the React tab — all 8 sections still visible (Docs, Primitives, Components, Runtimes, Integrations, Cloud, Utilities, API Reference)
- [ ] switch platform to React Native — only `Docs` shows, with a `Getting Started` group containing `Agent Skills` + `Architecture`, then a `React Native` group with the injected RN content
- [ ] switch to React Ink — same shape as RN but with the Ink section injected