### PR TITLE
ci: add pypi-publish workflow with trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -150,19 +150,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          version=$(awk -F'"' '/^version[[:space:]]*=/ {print $2; exit}' "$PYTHON_PACKAGE_DIR/pyproject.toml")
-          if [ -z "$version" ]; then
-            echo "Failed to parse version from $PYTHON_PACKAGE_DIR/pyproject.toml" >&2
+          version=$(python3 - <<'PY' "$PYTHON_PACKAGE_DIR/pyproject.toml"
+          import sys, tomllib
+          with open(sys.argv[1], "rb") as f:
+              data = tomllib.load(f)
+          v = data.get("project", {}).get("version")
+          if not v:
+              sys.exit("[project].version missing from pyproject.toml")
+          print(v)
+          PY
+          )
+
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Refusing to publish non-stable version: $version" >&2
             exit 1
           fi
-
-          # Reject prereleases on default-branch publishes.
-          case "$version" in
-            *[!0-9.]*)
-              echo "Refusing to publish non-stable version: $version" >&2
-              exit 1
-              ;;
-          esac
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
@@ -221,7 +223,7 @@ jobs:
       - name: Checkout code repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ env.RELEASE_SHA }}
 
       - name: Install uv
@@ -239,15 +241,14 @@ jobs:
         working-directory: ${{ env.PYTHON_PACKAGE_DIR }}
         run: |
           set -euo pipefail
-          expected_wheel="dist/${PYTHON_PACKAGE_NAME//-/_}-${VERSION}-py3-none-any.whl"
-          expected_sdist="dist/${PYTHON_PACKAGE_NAME//-/_}-${VERSION}.tar.gz"
-          for f in "$expected_wheel" "$expected_sdist"; do
-            if [ ! -f "$f" ]; then
-              echo "Expected build artifact missing: $f" >&2
-              ls dist >&2 || true
-              exit 1
-            fi
-          done
+          dist_name="${PYTHON_PACKAGE_NAME//-/_}-${VERSION}"
+          shopt -s nullglob
+          wheels=( "dist/${dist_name}"-*.whl )
+          if [ "${#wheels[@]}" -eq 0 ] || [ ! -f "dist/${dist_name}.tar.gz" ]; then
+            echo "Expected build artifacts for ${dist_name} are missing." >&2
+            ls dist >&2 || true
+            exit 1
+          fi
 
       - name: Publish to PyPI via OIDC
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.13.0

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -139,9 +139,11 @@ jobs:
           fi
 
           git fetch origin "$DEFAULT_BRANCH"
+          origin_default_sha=$(git rev-parse "origin/$DEFAULT_BRANCH")
           if ! git merge-base --is-ancestor "$RELEASE_SHA" "origin/$DEFAULT_BRANCH"; then
             echo "releaseSha is not an ancestor of origin/$DEFAULT_BRANCH; refusing to publish" >&2
             echo "releaseSha=$RELEASE_SHA" >&2
+            echo "origin/$DEFAULT_BRANCH SHA=$origin_default_sha" >&2
             exit 1
           fi
 
@@ -168,7 +170,7 @@ jobs:
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-          status=$(curl -s -o /dev/null -w "%{http_code}" \
+          status=$(curl -s --max-time 30 -o /dev/null -w "%{http_code}" \
             "https://pypi.org/pypi/$PYTHON_PACKAGE_NAME/$version/json")
 
           case "$status" in

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1,0 +1,263 @@
+name: PyPI Publish
+
+# Publishes `assistant-stream` to PyPI via OIDC trusted publishing — no
+# secrets required. The PyPI project's trusted-publisher config must point
+# at this workflow file (`pypi-publish.yaml`) and the `pypi publish`
+# environment used below.
+#
+# Triggered by:
+#   - workflow_dispatch (manual; optionally pin a release SHA)
+#   - repository_dispatch with type `pypi-publish` and an optional
+#     `releaseSha` field on the client_payload (chains from another job)
+
+on:
+  repository_dispatch:
+    types: [pypi-publish]
+  workflow_dispatch:
+    inputs:
+      releaseSha:
+        description: "Release commit SHA to publish (defaults to latest default-branch commit)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  CI: true
+  PYTHON_PACKAGE_DIR: python/assistant-stream
+  PYTHON_PACKAGE_NAME: assistant-stream
+
+jobs:
+  approve:
+    name: Resolve release SHA
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: pypi-publish-approval
+      cancel-in-progress: true
+    outputs:
+      release_sha: ${{ steps.release-sha.outputs.value }}
+      default_branch: ${{ steps.release-sha.outputs.default_branch }}
+    steps:
+      - name: Resolve release commit SHA
+        id: release-sha
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const dispatchReleaseShaRaw = context.payload?.client_payload?.releaseSha;
+            const manualReleaseShaRaw = context.payload?.inputs?.releaseSha;
+            const payloadDefaultBranchRaw =
+              context.payload?.repository?.default_branch;
+            const dispatchReleaseSha =
+              typeof dispatchReleaseShaRaw === "string"
+                ? dispatchReleaseShaRaw.trim()
+                : "";
+            const manualReleaseSha =
+              typeof manualReleaseShaRaw === "string"
+                ? manualReleaseShaRaw.trim()
+                : "";
+            const payloadDefaultBranch =
+              typeof payloadDefaultBranchRaw === "string"
+                ? payloadDefaultBranchRaw.trim()
+                : "";
+
+            let releaseSha = dispatchReleaseSha || manualReleaseSha;
+            let defaultBranch = payloadDefaultBranch;
+
+            if (!defaultBranch) {
+              const repoInfo = await github.rest.repos.get(context.repo);
+              defaultBranch = repoInfo.data.default_branch;
+            }
+
+            if (!defaultBranch) {
+              core.setFailed("Unable to determine repository default branch");
+              return;
+            }
+
+            if (!releaseSha) {
+              if (context.eventName === "repository_dispatch") {
+                core.setFailed("repository_dispatch payload is missing releaseSha");
+                return;
+              }
+
+              const ref = await github.rest.git.getRef({
+                ...context.repo,
+                ref: `heads/${defaultBranch}`,
+              });
+
+              releaseSha = ref.data.object.sha;
+              core.info(
+                `No release SHA provided; using ${defaultBranch} HEAD ${releaseSha}`,
+              );
+            }
+
+            if (!/^[0-9a-f]{40}$/i.test(releaseSha)) {
+              core.setFailed(
+                `releaseSha must be a full 40-character commit SHA: ${releaseSha}`,
+              );
+              return;
+            }
+
+            core.setOutput("value", releaseSha);
+            core.setOutput("default_branch", defaultBranch);
+
+  summary:
+    name: Resolve publish target
+    needs: approve
+    runs-on: ubuntu-24.04
+    outputs:
+      should_publish: ${{ steps.target.outputs.shouldPublish }}
+      version: ${{ steps.target.outputs.version }}
+    env:
+      RELEASE_SHA: ${{ needs.approve.outputs.release_sha }}
+      DEFAULT_BRANCH: ${{ needs.approve.outputs.default_branch }}
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ env.RELEASE_SHA }}
+
+      - name: Validate release commit is on default branch
+        run: |
+          if [ -z "$RELEASE_SHA" ]; then
+            echo "Missing releaseSha" >&2
+            exit 1
+          fi
+
+          if [ -z "$DEFAULT_BRANCH" ]; then
+            echo "Missing default branch" >&2
+            exit 1
+          fi
+
+          head_sha=$(git rev-parse HEAD)
+          if [ "$head_sha" != "$RELEASE_SHA" ]; then
+            echo "Checked out commit does not match releaseSha payload" >&2
+            echo "HEAD=$head_sha" >&2
+            echo "releaseSha=$RELEASE_SHA" >&2
+            exit 1
+          fi
+
+          git fetch origin "$DEFAULT_BRANCH"
+          if ! git merge-base --is-ancestor "$RELEASE_SHA" "origin/$DEFAULT_BRANCH"; then
+            echo "releaseSha is not an ancestor of origin/$DEFAULT_BRANCH; refusing to publish" >&2
+            echo "releaseSha=$RELEASE_SHA" >&2
+            exit 1
+          fi
+
+      - name: Resolve target version + PyPI status
+        id: target
+        run: |
+          set -euo pipefail
+
+          version=$(awk -F'"' '/^version[[:space:]]*=/ {print $2; exit}' "$PYTHON_PACKAGE_DIR/pyproject.toml")
+          if [ -z "$version" ]; then
+            echo "Failed to parse version from $PYTHON_PACKAGE_DIR/pyproject.toml" >&2
+            exit 1
+          fi
+
+          # Reject prereleases on default-branch publishes.
+          case "$version" in
+            *[!0-9.]*)
+              echo "Refusing to publish non-stable version: $version" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          status=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://pypi.org/pypi/$PYTHON_PACKAGE_NAME/$version/json")
+
+          case "$status" in
+            200)
+              echo "$PYTHON_PACKAGE_NAME@$version already on PyPI; skipping publish."
+              echo "shouldPublish=false" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "$PYTHON_PACKAGE_NAME@$version not yet on PyPI; will publish."
+              echo "shouldPublish=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unexpected PyPI status $status for $PYTHON_PACKAGE_NAME@$version" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Write release summary
+        if: steps.target.outputs.shouldPublish == 'true'
+        run: |
+          {
+            echo "## PyPI Release Summary"
+            echo
+            echo "**Release SHA:** \`${RELEASE_SHA:0:12}\`"
+            echo "**Package:** \`$PYTHON_PACKAGE_NAME\`"
+            echo "**Version:** **${{ steps.target.outputs.version }}**"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: No targets
+        if: steps.target.outputs.shouldPublish == 'false'
+        run: echo "$PYTHON_PACKAGE_NAME@${{ steps.target.outputs.version }} is already published; nothing to do."
+
+  publish:
+    name: Publish to PyPI
+    needs:
+      - approve
+      - summary
+    if: needs.summary.outputs.should_publish == 'true'
+    environment: pypi publish
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      # Required for PyPI trusted publishing (OIDC).
+      id-token: write
+    concurrency:
+      group: pypi-publish-exec
+      cancel-in-progress: false
+    env:
+      RELEASE_SHA: ${{ needs.approve.outputs.release_sha }}
+      VERSION: ${{ needs.summary.outputs.version }}
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ env.RELEASE_SHA }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cb5e2bb1f6e4a3caf6dd3bb691baad1d8b9ea98e # v6.10.0
+
+      - name: Build sdist + wheel
+        working-directory: ${{ env.PYTHON_PACKAGE_DIR }}
+        run: |
+          set -euo pipefail
+          rm -rf dist
+          uv build
+          ls -la dist
+
+      - name: Verify built version matches target
+        working-directory: ${{ env.PYTHON_PACKAGE_DIR }}
+        run: |
+          set -euo pipefail
+          expected_wheel="dist/${PYTHON_PACKAGE_NAME//-/_}-${VERSION}-py3-none-any.whl"
+          expected_sdist="dist/${PYTHON_PACKAGE_NAME//-/_}-${VERSION}.tar.gz"
+          for f in "$expected_wheel" "$expected_sdist"; do
+            if [ ! -f "$f" ]; then
+              echo "Expected build artifact missing: $f" >&2
+              ls dist >&2 || true
+              exit 1
+            fi
+          done
+
+      - name: Publish to PyPI via OIDC
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.13.0
+        with:
+          packages-dir: ${{ env.PYTHON_PACKAGE_DIR }}/dist
+          # No `password` — the action uses GitHub OIDC + the trusted-publisher
+          # configuration on PyPI to mint a short-lived token at publish time.
+
+      - name: Recovery guidance
+        if: failure()
+        run: |
+          echo "::error::Publish failed for $PYTHON_PACKAGE_NAME@${VERSION} on release SHA ${RELEASE_SHA}."
+          echo "::error::Rerun this workflow run, or workflow_dispatch with releaseSha=${RELEASE_SHA}."


### PR DESCRIPTION
## Summary

Add a credential-free `pypi-publish.yaml` workflow that publishes the `assistant-stream` Python package using PyPI's OIDC trusted-publisher feature. The PyPI project is already configured to trust this workflow file + the `pypi publish` environment, so no API token / secret is needed — the action mints a short-lived upload token at runtime.

## Structure

Mirrors the existing `npm-publish.yaml` flow:

| Job | What |
| --- | --- |
| `approve` | Resolve a 40-char release SHA from `workflow_dispatch.inputs.releaseSha`, the `repository_dispatch` `client_payload.releaseSha`, or default-branch HEAD. Validate format. |
| `summary` | Check out at the release SHA, refuse if it isn't an ancestor of `origin/<default-branch>`, parse the version from `python/assistant-stream/pyproject.toml`, hit `https://pypi.org/pypi/assistant-stream/<version>/json` to decide whether the version is already published, and emit a job summary. Refuses pre-release / non-stable versions. |
| `publish` | Gated by `environment: pypi publish` so it goes through the org's review/wait policy. Builds sdist + wheel with `uv build`, verifies the expected artifacts exist, and publishes via `pypa/gh-action-pypi-publish` (no password). |

Permissions: `id-token: write` only on `publish`. Default `contents: read` everywhere else.

## Triggers

- `workflow_dispatch` — manual, optional `releaseSha` input.
- `repository_dispatch` with type `pypi-publish` — chains from another workflow (e.g. release tagging).

## Test plan

- [x] YAML parses
- [ ] CI Actions: workflow file picked up, syntax valid on GitHub
- [ ] Manual `workflow_dispatch` once merged to verify the OIDC handshake against PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)