### PR TITLE
fix(core): add typesVersions for moduleResolution: node compatibility

### DIFF
--- a/.changeset/fix-core-typesversions-node-resolution.md
+++ b/.changeset/fix-core-typesversions-node-resolution.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: add typesVersions to support moduleResolution: node
+
+Users with `moduleResolution: node` in their tsconfig were seeing `Property 'message' does not exist on type 'AssistantState'` because the `exports` map sub-paths (e.g. `@assistant-ui/core/react`) are ignored by legacy node module resolution. Adding `typesVersions` makes TypeScript resolve sub-path types correctly under all moduleResolution modes.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,22 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "react": [
+        "./dist/react/index.d.ts"
+      ],
+      "internal": [
+        "./dist/internal.d.ts"
+      ],
+      "store": [
+        "./dist/store/index.d.ts"
+      ],
+      "store/internal": [
+        "./dist/store/internal.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist",
     "src",


### PR DESCRIPTION
Adds typesVersions to @assistant-ui/core/package.json so TypeScript can resolve sub-path exports (@assistant-ui/core/react, @assistant-ui/core/store) under legacy moduleResolution: node.

Without this, the ScopeRegistry augmentations never load, causing "Property 'message' does not exist on type 'AssistantState'".

Fixes #3731