### PR TITLE
fix(core): drop "./*" wildcard export

### DIFF
--- a/.changeset/core-drop-wildcard-export.md
+++ b/.changeset/core-drop-wildcard-export.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/core": patch
+---
+
+chore: drop `./*` wildcard export and surface internal attachment status types
+
+The `./*` wildcard in `exports` was exposing the entire dist tree as importable subpaths, which inadvertently leaked internal modules (e.g. `@assistant-ui/core/tests/*`, `@assistant-ui/core/types/*`) as public API. Removing it.
+
+Two attachment status types that were previously only reachable through the wildcard (`PendingAttachmentStatus`, `CompleteAttachmentStatus`) are now re-exported from the package root so that consumers' inferred types remain portable.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,10 +32,6 @@
     "./react": {
       "types": "./dist/react/index.d.ts",
       "default": "./dist/react/index.js"
-    },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "default": "./dist/*.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,7 +32,9 @@ export type {
 export type {
   Attachment,
   PendingAttachment,
+  PendingAttachmentStatus,
   CompleteAttachment,
+  CompleteAttachmentStatus,
   AttachmentStatus,
   CreateAttachment,
 } from "./types/attachment";

--- a/packages/react/src/tests/RemoteThreadListRuntime.deferredProvider.test.tsx
+++ b/packages/react/src/tests/RemoteThreadListRuntime.deferredProvider.test.tsx
@@ -4,7 +4,7 @@ import { render } from "@testing-library/react";
 import { type FC, type PropsWithChildren, useState } from "react";
 import { describe, expect, it } from "vitest";
 import { useRemoteThreadListRuntime } from "@assistant-ui/core/react";
-import { makeAdapter } from "@assistant-ui/core/tests/remote-thread-list-test-helpers";
+import { makeAdapter } from "./remote-thread-list-test-helpers";
 import type { AssistantRuntime } from "@assistant-ui/core";
 import { AssistantRuntimeProvider } from "../context";
 import { useLocalRuntime } from "../legacy-runtime/runtime-cores/local/useLocalRuntime";

--- a/packages/react/src/tests/remote-thread-list-test-helpers.ts
+++ b/packages/react/src/tests/remote-thread-list-test-helpers.ts
@@ -1,0 +1,33 @@
+import { vi } from "vitest";
+import type { RemoteThreadListAdapter } from "../index";
+
+export function makeAdapter(
+  overrides: Partial<RemoteThreadListAdapter> = {},
+): RemoteThreadListAdapter {
+  return {
+    list: vi.fn(async () => ({ threads: [] })),
+    initialize: vi.fn(async (threadId: string) => ({
+      remoteId: threadId,
+      externalId: threadId,
+    })),
+    rename: vi.fn(async () => {}),
+    archive: vi.fn(async () => {}),
+    unarchive: vi.fn(async () => {}),
+    delete: vi.fn(async () => {}),
+    generateTitle: vi.fn(
+      async () =>
+        new ReadableStream({
+          start(c) {
+            c.close();
+          },
+        }) as never,
+    ),
+    fetch: vi.fn(async (id: string) => ({
+      status: "regular" as const,
+      remoteId: id,
+      externalId: id,
+      title: "Test",
+    })),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

The `"./*"` wildcard in `@assistant-ui/core`'s `exports` field was leaking the entire `dist/` tree as public subpaths — including internal test helpers (`@assistant-ui/core/tests/...`) and internal type files (`@assistant-ui/core/types/...`). Removing it.

- **Drop the wildcard** from `packages/core/package.json`.
- **Re-export `PendingAttachmentStatus` and `CompleteAttachmentStatus`** from `@assistant-ui/core` root. Without this, three hooks in `packages/react/src/legacy-runtime/hooks/AttachmentContext.ts` would emit TS2883 ("inferred type cannot be named without a reference to internal path"). These two types were previously only reachable through the wildcard.
- **Inline `makeAdapter` into a local helper in `packages/react`**. It was the sole external consumer of the now-removed `@assistant-ui/core/tests/remote-thread-list-test-helpers` subpath; the function is small and self-contained, so duplicating it inside the package that needs it is cleaner than exposing test helpers as a public API surface.

## Test plan

- [x] `pnpm turbo build --filter=@assistant-ui/core --filter=@assistant-ui/react --filter=@assistant-ui/react-native --filter=@assistant-ui/react-ink --filter=@assistant-ui/store` — clean (verified in a worktree from main; the workspace had unrelated WIP from another virtual branch).
- [x] `pnpm --filter @assistant-ui/react test` — 17 files / 243 tests pass.
- [x] `pnpm --filter @assistant-ui/core test` — 20 files / 157 tests pass.
- [x] `pnpm lint` — clean.
- [x] Audited every cross-package import of `@assistant-ui/core/<subpath>` in the monorepo. The only wildcard-reliant consumer was the test helper now inlined; all other subpaths are explicit (`./internal`, `./store`, `./store/internal`, `./react`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)