### PR TITLE
feat(composer): enrich attachmentAddError event with typed payload

### DIFF
--- a/.changeset/enrich-attachment-add-error.md
+++ b/.changeset/enrich-attachment-add-error.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat: enrich `composer.attachmentAddError` event with typed payload
+
+The event now carries `{ reason, message, attachmentId?, error? }` so subscribers can branch on the failure mode (`no-adapter` / `not-accepted` / `adapter-error`). The bridge no longer relies on a `findLast` heuristic to recover the failed attachment id.
+
+Several state-derivable events are now annotated `@deprecated` because they duplicate state observation: `composer.send`, `composer.attachmentAdd`, `thread.runStart`, `thread.runEnd`, `thread.initialize`, `threadListItem.switchedTo`, `threadListItem.switchedAway`. They continue to fire for backward compatibility; new code should observe state via `useAuiState` instead.

--- a/apps/docs/content/docs/(docs)/guides/attachments.mdx
+++ b/apps/docs/content/docs/(docs)/guides/attachments.mdx
@@ -494,25 +494,35 @@ class ValidatedImageAdapter implements AttachmentAdapter {
 To surface failures in the UI, subscribe to `composer.attachmentAddError`. It fires whenever an add operation produces a failure, in either of two ways:
 
 1. `addAttachment()` rejects: no adapter is configured, the file type does not match `accept`, or the adapter's `add()` throws.
-2. `addAttachment()` resolves but the adapter yielded an attachment whose `status.reason === "error"` (the promise resolves successfully, yet the event still fires so the UI can react).
+2. `addAttachment()` resolves but the adapter returned (or, for async-iterator adapters, yielded) an attachment whose `status.reason === "error"`. The promise resolves successfully, yet the event still fires so the UI can react.
+
+The event payload carries a `reason` discriminator and a human-readable `message`, so you can branch UI on the failure mode:
+
+| `reason`         | When It Fires                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------ |
+| `no-adapter`     | `addAttachment(File)` was called but no `AttachmentAdapter` is configured.                             |
+| `not-accepted`   | The file's content type (or filename extension) did not match `adapter.accept`.                        |
+| `adapter-error`  | The adapter's `add()` threw, or returned/yielded an attachment with `status.reason === "error"`. If the adapter produced any attachment before failing, the errored attachment is also visible in `composer.attachments`; if it threw before producing one, the event is the only signal. |
 
 ```tsx
 import { toast } from "sonner"; // or your toast library of choice
 import { useAuiEvent } from "@assistant-ui/react";
 
 function AttachmentErrorToast() {
-  useAuiEvent("composer.attachmentAddError", ({ attachmentId }) => {
-    toast.error(
-      attachmentId
-        ? "Attachment failed to upload."
-        : "This file could not be added.",
-    );
+  useAuiEvent("composer.attachmentAddError", ({ reason, message }) => {
+    if (reason === "not-accepted") {
+      toast.error("This file type is not supported.");
+    } else if (reason === "no-adapter") {
+      toast.error("Attachments are not configured for this composer.");
+    } else {
+      toast.error(message || "Attachment failed to upload.");
+    }
   });
   return null;
 }
 ```
 
-`attachmentId` is best-effort and should always be treated as optional. It is resolved by scanning the composer's current attachment list for the most recently registered errored attachment, so it is `undefined` for failures that happen before any attachment is registered (e.g. unsupported file type) only when no prior errored attachment is still present.
+`attachmentId` is included when the failure is associated with an attachment that was registered (typically `adapter-error` cases). It is `undefined` for `no-adapter` and `not-accepted` failures because those reject before any attachment is registered.
 
 ### External Source Attachments
 

--- a/apps/docs/content/docs/(docs)/guides/context-api.mdx
+++ b/apps/docs/content/docs/(docs)/guides/context-api.mdx
@@ -519,19 +519,36 @@ const isRunning = useAuiState((s) => s.thread.isRunning);
 | Suggestion     | `getState()`                                                                                                      | Read individual suggestion data            |
 | ModelContext   | `register(provider)`, `getState()`                                                                                | Register model context providers           |
 
-### Common Events
+### Events vs State Observation
 
-| Event                         | Description                   |
-| ----------------------------- | ----------------------------- |
-| `thread.runStart`             | Assistant starts generating   |
-| `thread.runEnd`               | Assistant finishes generating |
-| `thread.initialize`           | Thread is initialized         |
-| `thread.modelContextUpdate`   | Model context is updated      |
-| `composer.send`               | Message is sent               |
-| `composer.attachmentAdd`      | Attachment added to composer  |
-| `composer.attachmentAddError` | Attachment add failed         |
-| `threadListItem.switchedTo`   | Switched to a thread          |
-| `threadListItem.switchedAway` | Switched away from a thread   |
+`useAuiEvent` is the escape hatch for **transient occurrences that are not derivable from state**. State-derivable transitions (attachment list changing, run progress, thread switching) should be observed with `useAuiState`, not subscribed via events.
+
+The rule of thumb:
+
+1. Can you read the new value from state right now? → use `useAuiState`.
+2. Are you the caller and want immediate feedback? → catch the rejection / read the return value.
+3. Did something happen that has no representation in state at all? → use `useAuiEvent`.
+
+Most existing events are kept for backward compatibility but duplicate state. They are marked `@deprecated` in the type definitions; new code should follow the rule above.
+
+#### Currently Recommended (Truly Transient)
+
+| Event                         | When It Fires                                                                |
+| ----------------------------- | ---------------------------------------------------------------------------- |
+| `composer.attachmentAddError` | An `addAttachment()` call failed. Payload `reason` discriminates `no-adapter` / `not-accepted` / `adapter-error`. `no-adapter` and `not-accepted` are non-state-derivable. `adapter-error` is partially state-derivable: if the adapter produced any attachment before failing, the errored attachment also appears in `composer.attachments` with `status.reason === "error"`. The event additionally surfaces the human-readable `message` and the original `Error`, which are not represented in state. |
+| `thread.modelContextUpdate`   | The model context provider notified a change. The model context lives in a provider, not in thread state, so this event has no state-derivable equivalent. |
+
+#### Legacy (State-Derivable, Prefer `useAuiState`)
+
+These events fire at the same transition you can observe via state. They are kept for backward compatibility but new code should observe state instead.
+
+| Legacy Event                                 | Observe Instead                                                |
+| -------------------------------------------- | -------------------------------------------------------------- |
+| `composer.send`                              | composer `text` clearing                                       |
+| `composer.attachmentAdd`                     | composer `attachments`                                         |
+| `thread.runStart` / `runEnd`                 | thread `isRunning` flipping to `true` / `false`                |
+| `thread.initialize`                          | thread `messages` becoming non-empty (or `isEmpty` flipping)   |
+| `threadListItem.switchedTo` / `switchedAway` | compare `s.threads.mainThreadId` against `s.threadListItem.id` |
 
 ## Troubleshooting
 

--- a/apps/docs/content/docs/(docs)/guides/context-api.mdx
+++ b/apps/docs/content/docs/(docs)/guides/context-api.mdx
@@ -535,7 +535,7 @@ Most existing events are kept for backward compatibility but duplicate state. Th
 
 | Event                         | When It Fires                                                                |
 | ----------------------------- | ---------------------------------------------------------------------------- |
-| `composer.attachmentAddError` | An `addAttachment()` call failed. Payload `reason` discriminates `no-adapter` / `not-accepted` / `adapter-error`. `no-adapter` and `not-accepted` are non-state-derivable. `adapter-error` is partially state-derivable: if the adapter produced any attachment before failing, the errored attachment also appears in `composer.attachments` with `status.reason === "error"`. The event additionally surfaces the human-readable `message` and the original `Error`, which are not represented in state. |
+| `composer.attachmentAddError` | An `addAttachment()` call failed. Payload `reason` discriminates `no-adapter` / `not-accepted` / `adapter-error`. `no-adapter` and `not-accepted` are non-state-derivable. `adapter-error` is partially state-derivable: if the adapter produced any attachment before failing, the errored attachment also appears in `composer.attachments` with `status.reason === "error"`. The event additionally surfaces a human-readable `message` (and the underlying `Error` instance via the low-level `runtime.unstable_on("attachmentAddError")` API; `useAuiEvent` payloads omit it because raw `Error` objects are not store-serializable). |
 | `thread.modelContextUpdate`   | The model context provider notified a change. The model context lives in a provider, not in thread state, so this event has no state-derivable equivalent. |
 
 #### Legacy (State-Derivable, Prefer `useAuiState`)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -143,7 +143,11 @@ export type {
 
 // Runtime Core Interface Types
 export type {
+  AttachmentAddErrorEvent,
+  AttachmentAddErrorReason,
   ComposerRuntimeCore,
+  ComposerRuntimeEventCallback,
+  ComposerRuntimeEventPayload,
   ComposerRuntimeEventType,
   DictationState,
   EditComposerRuntimeCore,
@@ -160,6 +164,8 @@ export type {
   SpeechState,
   VoiceSessionState,
   SubmittedFeedback,
+  ThreadRuntimeEventCallback,
+  ThreadRuntimeEventPayload,
   ThreadRuntimeEventType,
   StartRunConfig,
   ResumeRunConfig,
@@ -191,6 +197,8 @@ export type {
 } from "./runtime/api/thread-list-runtime";
 
 export type {
+  ThreadListItemEventCallback,
+  ThreadListItemEventPayload,
   ThreadListItemEventType,
   ThreadListItemRuntime,
 } from "./runtime/api/thread-list-item-runtime";

--- a/packages/core/src/runtime/api/composer-runtime.ts
+++ b/packages/core/src/runtime/api/composer-runtime.ts
@@ -12,6 +12,7 @@ import {
   SKIP_UPDATE,
 } from "../../subscribable/subscribable";
 import type {
+  ComposerRuntimeEventCallback,
   ComposerRuntimeEventType,
   DictationState,
   EditComposerRuntimeCore,
@@ -222,9 +223,9 @@ export type ComposerRuntime = {
   /**
    * @deprecated This API is still under active development and might change without notice.
    */
-  unstable_on(
-    event: ComposerRuntimeEventType,
-    callback: () => void,
+  unstable_on<E extends ComposerRuntimeEventType>(
+    event: E,
+    callback: ComposerRuntimeEventCallback<E>,
   ): Unsubscribe;
 };
 
@@ -332,19 +333,19 @@ export abstract class ComposerRuntimeImpl implements ComposerRuntime {
     EventSubscriptionSubject<ComposerRuntimeEventType>
   >();
 
-  public unstable_on(
-    event: ComposerRuntimeEventType,
-    callback: () => void,
+  public unstable_on<E extends ComposerRuntimeEventType>(
+    event: E,
+    callback: ComposerRuntimeEventCallback<E>,
   ): Unsubscribe {
     let subject = this._eventSubscriptionSubjects.get(event);
     if (!subject) {
-      subject = new EventSubscriptionSubject({
-        event: event,
+      subject = new EventSubscriptionSubject<ComposerRuntimeEventType>({
+        event,
         binding: this._core,
       });
       this._eventSubscriptionSubjects.set(event, subject);
     }
-    return subject.subscribe(callback);
+    return subject.subscribe(callback as (payload?: unknown) => void);
   }
 
   public abstract getAttachmentByIndex(idx: number): AttachmentRuntime;

--- a/packages/core/src/runtime/api/thread-list-item-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-item-runtime.ts
@@ -3,7 +3,26 @@ import type { SubscribableWithState } from "../../subscribable/subscribable";
 import type { ThreadListItemRuntimePath } from "./paths";
 import type { ThreadListRuntimeCoreBinding } from "./thread-list-runtime";
 
-export type ThreadListItemEventType = "switchedTo" | "switchedAway";
+export type ThreadListItemEventPayload = {
+  /**
+   * @deprecated State-derivable. Compare `s.threads.mainThreadId` against the
+   * item's `s.threadListItem.id` via `useAuiState` instead. Kept for backward
+   * compatibility.
+   */
+  switchedTo: Record<string, never>;
+  /**
+   * @deprecated State-derivable. Compare `s.threads.mainThreadId` against the
+   * item's `s.threadListItem.id` via `useAuiState` instead. Kept for backward
+   * compatibility.
+   */
+  switchedAway: Record<string, never>;
+};
+
+export type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+export type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (
+  payload: ThreadListItemEventPayload[E],
+) => void;
 
 import type { ThreadListItemState } from "./bindings";
 import type { ThreadListItemStatus } from "../interfaces/thread-list-runtime-core";
@@ -27,9 +46,9 @@ export type ThreadListItemRuntime = {
 
   subscribe(callback: () => void): Unsubscribe;
 
-  unstable_on(
-    event: ThreadListItemEventType,
-    callback: () => void,
+  unstable_on<E extends ThreadListItemEventType>(
+    event: E,
+    callback: ThreadListItemEventCallback<E>,
   ): Unsubscribe;
 
   __internal_getRuntime(): ThreadListItemRuntime;
@@ -112,7 +131,10 @@ export class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
     return this._threadListBinding.generateTitle(state.id);
   }
 
-  public unstable_on(event: ThreadListItemEventType, callback: () => void) {
+  public unstable_on<E extends ThreadListItemEventType>(
+    event: E,
+    callback: ThreadListItemEventCallback<E>,
+  ) {
     let prevIsMain = this._core.getState().isMain;
     let prevThreadId = this._core.getState().id;
     return this.subscribe(() => {
@@ -125,7 +147,7 @@ export class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
 
       if (event === "switchedTo" && !newIsMain) return;
       if (event === "switchedAway" && newIsMain) return;
-      callback();
+      (callback as (payload: Record<string, never>) => void)({});
     });
   }
 

--- a/packages/core/src/runtime/api/thread-list-item-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-item-runtime.ts
@@ -147,7 +147,7 @@ export class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
 
       if (event === "switchedTo" && !newIsMain) return;
       if (event === "switchedAway" && newIsMain) return;
-      (callback as (payload: Record<string, never>) => void)({});
+      (callback as (payload?: unknown) => void)({});
     });
   }
 

--- a/packages/core/src/runtime/api/thread-runtime.ts
+++ b/packages/core/src/runtime/api/thread-runtime.ts
@@ -4,6 +4,7 @@ import type {
   ThreadRuntimeCore,
   SpeechState,
   VoiceSessionState,
+  ThreadRuntimeEventCallback,
   ThreadRuntimeEventType,
   StartRunConfig,
   ResumeRunConfig,
@@ -329,7 +330,10 @@ export type ThreadRuntime = {
   muteVoice(): void;
   unmuteVoice(): void;
 
-  unstable_on(event: ThreadRuntimeEventType, callback: () => void): Unsubscribe;
+  unstable_on<E extends ThreadRuntimeEventType>(
+    event: E,
+    callback: ThreadRuntimeEventCallback<E>,
+  ): Unsubscribe;
 };
 
 export class ThreadRuntimeImpl implements ThreadRuntime {
@@ -601,18 +605,18 @@ export class ThreadRuntimeImpl implements ThreadRuntime {
     EventSubscriptionSubject<ThreadRuntimeEventType>
   >();
 
-  public unstable_on(
-    event: ThreadRuntimeEventType,
-    callback: () => void,
+  public unstable_on<E extends ThreadRuntimeEventType>(
+    event: E,
+    callback: ThreadRuntimeEventCallback<E>,
   ): Unsubscribe {
     let subject = this._eventSubscriptionSubjects.get(event);
     if (!subject) {
-      subject = new EventSubscriptionSubject({
-        event: event,
+      subject = new EventSubscriptionSubject<ThreadRuntimeEventType>({
+        event,
         binding: this._threadBinding,
       });
       this._eventSubscriptionSubjects.set(event, subject);
     }
-    return subject.subscribe(callback);
+    return subject.subscribe(callback as (payload?: unknown) => void);
   }
 }

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -335,8 +335,11 @@ export abstract class BaseComposerRuntimeCore
         ...(attachmentId !== undefined && { attachmentId }),
         ...(error !== undefined && { error }),
       });
-    } catch {
-      // prevent subscriber errors from masking the original error
+    } catch (subscriberError) {
+      console.error(
+        "[assistant-ui] attachmentAddError subscriber threw:",
+        subscriberError,
+      );
     }
   }
 

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -14,7 +14,10 @@ import {
   fileMatchesAccept,
 } from "../../adapters/attachment";
 import type {
+  AttachmentAddErrorReason,
   ComposerRuntimeCore,
+  ComposerRuntimeEventCallback,
+  ComposerRuntimeEventPayload,
   ComposerRuntimeEventType,
   DictationState,
   SendOptions,
@@ -189,7 +192,7 @@ export abstract class BaseComposerRuntimeCore
     };
 
     this.handleSend(message, options);
-    this._notifyEventSubscribers("send");
+    this._notifyEventSubscribers("send", {});
   }
 
   public cancel() {
@@ -215,14 +218,15 @@ export abstract class BaseComposerRuntimeCore
           adapter.accept,
         )
       ) {
-        try {
-          this._notifyEventSubscribers("attachmentAddError");
-        } catch {
-          // prevent subscriber errors from masking the original error
-        }
-        throw new Error(
-          `File type ${fileOrAttachment.contentType || "unknown"} is not accepted. Accepted types: ${adapter.accept}`,
+        const message = `File type ${fileOrAttachment.contentType || "unknown"} is not accepted. Accepted types: ${adapter.accept}`;
+        const err = new Error(message);
+        this._safeEmitAttachmentAddError(
+          "not-accepted",
+          message,
+          undefined,
+          err,
         );
+        throw err;
       }
 
       const a: CompleteAttachment = {
@@ -235,7 +239,7 @@ export abstract class BaseComposerRuntimeCore
       };
       this._attachments = [...this._attachments, a];
       this._notifySubscribers();
-      this._notifyEventSubscribers("attachmentAdd");
+      this._notifyEventSubscribers("attachmentAdd", {});
       return;
     }
 
@@ -256,22 +260,28 @@ export abstract class BaseComposerRuntimeCore
       this._notifySubscribers();
     };
 
+    const adapter = this.getAttachmentAdapter();
+    if (!adapter) {
+      const message = "Attachments are not supported";
+      const err = new Error(message);
+      this._safeEmitAttachmentAddError("no-adapter", message, undefined, err);
+      throw err;
+    }
+
+    if (
+      !fileMatchesAccept(
+        { name: fileOrAttachment.name, type: fileOrAttachment.type },
+        adapter.accept,
+      )
+    ) {
+      const message = `File type ${fileOrAttachment.type || "unknown"} is not accepted. Accepted types: ${adapter.accept}`;
+      const err = new Error(message);
+      this._safeEmitAttachmentAddError("not-accepted", message, undefined, err);
+      throw err;
+    }
+
     let lastAttachment: PendingAttachment | undefined;
     try {
-      const adapter = this.getAttachmentAdapter();
-      if (!adapter) throw new Error("Attachments are not supported");
-
-      if (
-        !fileMatchesAccept(
-          { name: fileOrAttachment.name, type: fileOrAttachment.type },
-          adapter.accept,
-        )
-      ) {
-        throw new Error(
-          `File type ${fileOrAttachment.type || "unknown"} is not accepted. Accepted types: ${adapter.accept}`,
-        );
-      }
-
       const promiseOrGenerator = adapter.add({ file: fileOrAttachment });
       if (Symbol.asyncIterator in promiseOrGenerator) {
         for await (const r of promiseOrGenerator) {
@@ -289,20 +299,45 @@ export abstract class BaseComposerRuntimeCore
           status: { type: "incomplete", reason: "error" },
         });
       }
-      try {
-        this._notifyEventSubscribers("attachmentAddError");
-      } catch {
-        // prevent subscriber errors from masking the original error
-      }
+      this._safeEmitAttachmentAddError(
+        "adapter-error",
+        e instanceof Error ? e.message : String(e),
+        lastAttachment?.id,
+        e instanceof Error ? e : undefined,
+      );
       throw e;
     }
 
     const hasError =
       lastAttachment?.status.type === "incomplete" &&
       lastAttachment.status.reason === "error";
-    this._notifyEventSubscribers(
-      hasError ? "attachmentAddError" : "attachmentAdd",
-    );
+    if (hasError) {
+      this._safeEmitAttachmentAddError(
+        "adapter-error",
+        "Attachment upload did not complete successfully.",
+        lastAttachment?.id,
+      );
+    } else {
+      this._notifyEventSubscribers("attachmentAdd", {});
+    }
+  }
+
+  private _safeEmitAttachmentAddError(
+    reason: AttachmentAddErrorReason,
+    message: string,
+    attachmentId?: string,
+    error?: Error,
+  ) {
+    try {
+      this._notifyEventSubscribers("attachmentAddError", {
+        reason,
+        message,
+        ...(attachmentId !== undefined && { attachmentId }),
+        ...(error !== undefined && { error }),
+      });
+    } catch {
+      // prevent subscriber errors from masking the original error
+    }
   }
 
   async removeAttachment(attachmentId: string) {
@@ -471,28 +506,33 @@ export abstract class BaseComposerRuntimeCore
 
   private _eventSubscribers = new Map<
     ComposerRuntimeEventType,
-    Set<() => void>
+    Set<(payload?: unknown) => void>
   >();
 
-  protected _notifyEventSubscribers(event: ComposerRuntimeEventType) {
+  protected _notifyEventSubscribers<E extends ComposerRuntimeEventType>(
+    event: E,
+    payload: ComposerRuntimeEventPayload[E],
+  ) {
     const subscribers = this._eventSubscribers.get(event);
     if (!subscribers) return;
 
-    for (const callback of subscribers) callback();
+    for (const callback of subscribers) callback(payload);
   }
 
-  public unstable_on(event: ComposerRuntimeEventType, callback: () => void) {
-    const subscribers = this._eventSubscribers.get(event);
+  public unstable_on<E extends ComposerRuntimeEventType>(
+    event: E,
+    callback: ComposerRuntimeEventCallback<E>,
+  ) {
+    const wrapped = callback as (payload?: unknown) => void;
+    let subscribers = this._eventSubscribers.get(event);
     if (!subscribers) {
-      this._eventSubscribers.set(event, new Set([callback]));
-    } else {
-      subscribers.add(callback);
+      subscribers = new Set();
+      this._eventSubscribers.set(event, subscribers);
     }
+    subscribers.add(wrapped);
 
     return () => {
-      const subscribers = this._eventSubscribers.get(event);
-      if (!subscribers) return;
-      subscribers.delete(callback);
+      this._eventSubscribers.get(event)?.delete(wrapped);
     };
   }
 }

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -467,19 +467,19 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   ) {
     const wrapped = callback as (payload?: unknown) => void;
     if (event === "modelContextUpdate") {
-      return this._contextProvider.subscribe?.(wrapped) ?? (() => {});
+      // provider.subscribe is `() => void`; pump the typed empty payload to the user callback.
+      return this._contextProvider.subscribe?.(() => wrapped({})) ?? (() => {});
     }
 
-    const subscribers = this._eventSubscribers.get(event);
+    let subscribers = this._eventSubscribers.get(event);
     if (!subscribers) {
-      this._eventSubscribers.set(event, new Set([wrapped]));
-    } else {
-      subscribers.add(wrapped);
+      subscribers = new Set();
+      this._eventSubscribers.set(event, subscribers);
     }
+    subscribers.add(wrapped);
 
     return () => {
-      const subscribers = this._eventSubscribers.get(event)!;
-      subscribers.delete(wrapped);
+      this._eventSubscribers.get(event)?.delete(wrapped);
     };
   }
 }

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -21,6 +21,8 @@ import type {
   SpeechState,
   VoiceSessionState,
   RuntimeCapabilities,
+  ThreadRuntimeEventCallback,
+  ThreadRuntimeEventPayload,
   ThreadRuntimeEventType,
   StartRunConfig,
   ResumeRunConfig,
@@ -168,11 +170,14 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
     for (const callback of this._subscriptions) callback();
   }
 
-  public _notifyEventSubscribers(event: ThreadRuntimeEventType) {
+  public _notifyEventSubscribers<E extends ThreadRuntimeEventType>(
+    event: E,
+    payload: ThreadRuntimeEventPayload[E],
+  ) {
     const subscribers = this._eventSubscribers.get(event);
     if (!subscribers) return;
 
-    for (const callback of subscribers) callback();
+    for (const callback of subscribers) callback(payload);
   }
 
   public subscribe(callback: () => void): Unsubscribe {
@@ -432,7 +437,7 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   protected ensureInitialized() {
     if (!this._isInitialized) {
       this._isInitialized = true;
-      this._notifyEventSubscribers("initialize");
+      this._notifyEventSubscribers("initialize", {});
     }
   }
 
@@ -453,24 +458,28 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
 
   private _eventSubscribers = new Map<
     ThreadRuntimeEventType,
-    Set<() => void>
+    Set<(payload?: unknown) => void>
   >();
 
-  public unstable_on(event: ThreadRuntimeEventType, callback: () => void) {
+  public unstable_on<E extends ThreadRuntimeEventType>(
+    event: E,
+    callback: ThreadRuntimeEventCallback<E>,
+  ) {
+    const wrapped = callback as (payload?: unknown) => void;
     if (event === "modelContextUpdate") {
-      return this._contextProvider.subscribe?.(callback) ?? (() => {});
+      return this._contextProvider.subscribe?.(wrapped) ?? (() => {});
     }
 
     const subscribers = this._eventSubscribers.get(event);
     if (!subscribers) {
-      this._eventSubscribers.set(event, new Set([callback]));
+      this._eventSubscribers.set(event, new Set([wrapped]));
     } else {
-      subscribers.add(callback);
+      subscribers.add(wrapped);
     }
 
     return () => {
       const subscribers = this._eventSubscribers.get(event)!;
-      subscribers.delete(callback);
+      subscribers.delete(wrapped);
     };
   }
 }

--- a/packages/core/src/runtime/interfaces/composer-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/composer-runtime-core.ts
@@ -5,10 +5,37 @@ import type { Unsubscribe } from "../../types/unsubscribe";
 import type { RunConfig } from "../../types/message";
 import type { DictationAdapter } from "../../adapters/speech";
 
-export type ComposerRuntimeEventType =
-  | "send"
-  | "attachmentAdd"
-  | "attachmentAddError";
+export type AttachmentAddErrorReason =
+  | "no-adapter"
+  | "not-accepted"
+  | "adapter-error";
+
+export type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+export type ComposerRuntimeEventPayload = {
+  /**
+   * @deprecated State-derivable. Observe `state.text` clearing via
+   * `subscribe` + `getState` instead. Kept for backward compatibility.
+   */
+  send: Record<string, never>;
+  /**
+   * @deprecated State-derivable. Observe `state.attachments` via `subscribe` +
+   * `getState` instead. Kept for backward compatibility.
+   */
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+export type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+export type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (
+  payload: ComposerRuntimeEventPayload[E],
+) => void;
 
 export type DictationState = {
   readonly status: DictationAdapter.Status;
@@ -56,9 +83,14 @@ export type ComposerRuntimeCore = Readonly<{
 
   subscribe: (callback: () => void) => Unsubscribe;
 
-  unstable_on: (
-    event: ComposerRuntimeEventType,
-    callback: () => void,
+  /**
+   * @deprecated This API is still under active development and might change without notice.
+   * For state-derivable transitions, prefer `subscribe` + `getState`. This channel is the
+   * escape hatch for transient occurrences not represented in state.
+   */
+  unstable_on: <E extends ComposerRuntimeEventType>(
+    event: E,
+    callback: ComposerRuntimeEventCallback<E>,
   ) => Unsubscribe;
 }>;
 

--- a/packages/core/src/runtime/interfaces/thread-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-runtime-core.ts
@@ -69,11 +69,41 @@ export type SubmittedFeedback = {
   readonly type: "negative" | "positive";
 };
 
-export type ThreadRuntimeEventType =
-  | "runStart"
-  | "runEnd"
-  | "initialize"
-  | "modelContextUpdate";
+export type ThreadRuntimeEventPayload = {
+  /**
+   * @deprecated State-derivable. Observe `state.isRunning` flipping to `true`
+   * via `subscribe` + `getState` instead. Note: this event fires at the
+   * transition point and may run before the next subscriber notification.
+   * Kept for backward compatibility.
+   */
+  runStart: Record<string, never>;
+  /**
+   * @deprecated State-derivable. Observe `state.isRunning` flipping to `false`
+   * via `subscribe` + `getState` instead. Note: this event fires at the
+   * transition point and may run before the next subscriber notification.
+   * Kept for backward compatibility.
+   */
+  runEnd: Record<string, never>;
+  /**
+   * @deprecated State-derivable. This event fires at the initialization
+   * transition immediately BEFORE the first message is added, so reading state
+   * inside the handler still sees an empty thread; observe `state.messages`
+   * becoming non-empty via a regular `subscribe` callback instead. Kept for
+   * backward compatibility.
+   */
+  initialize: Record<string, never>;
+  /**
+   * Truly transient. The model context lives in a provider, not in thread
+   * state, so this event has no state-derivable equivalent.
+   */
+  modelContextUpdate: Record<string, never>;
+};
+
+export type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+
+export type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (
+  payload: ThreadRuntimeEventPayload[E],
+) => void;
 
 export type StartRunConfig = {
   parentId: string | null;
@@ -155,7 +185,15 @@ export type ThreadRuntimeCore = Readonly<{
 
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
 
-  unstable_on(event: ThreadRuntimeEventType, callback: () => void): Unsubscribe;
+  /**
+   * @deprecated This API is still under active development and might change without notice.
+   * For state-derivable transitions, prefer `subscribe` + `getState`. This channel is the
+   * escape hatch for transient occurrences not represented in state.
+   */
+  unstable_on<E extends ThreadRuntimeEventType>(
+    event: E,
+    callback: ThreadRuntimeEventCallback<E>,
+  ): Unsubscribe;
 
   /**
    * @deprecated Use importExternalState instead. This method will be removed in 0.12.0.

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -236,9 +236,9 @@ export class ExternalStoreThreadRuntimeCore
 
     if ((oldStore?.isRunning ?? false) !== (store.isRunning ?? false)) {
       if (store.isRunning) {
-        this._notifyEventSubscribers("runStart");
+        this._notifyEventSubscribers("runStart", {});
       } else {
-        this._notifyEventSubscribers("runEnd");
+        this._notifyEventSubscribers("runEnd", {});
       }
     }
 

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -253,7 +253,7 @@ export class LocalThreadRuntimeCore
       createdAt: new Date(),
     };
 
-    this._notifyEventSubscribers("runStart");
+    this._notifyEventSubscribers("runStart", {});
 
     try {
       this._suggestions = [];
@@ -271,7 +271,7 @@ export class LocalThreadRuntimeCore
         runCallback = undefined;
       } while (shouldContinue(message, this._options.unstable_humanToolNames));
     } finally {
-      this._notifyEventSubscribers("runEnd");
+      this._notifyEventSubscribers("runEnd", {});
     }
 
     this._suggestionsController = new AbortController();

--- a/packages/core/src/store/runtime-clients/composer-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/composer-runtime-client.ts
@@ -63,19 +63,14 @@ export const ComposerClient = resource(
         unsubscribers.push(unsubscribe);
       }
 
-      // attachmentAddError carries the failed attachment ID
       unsubscribers.push(
-        runtime.unstable_on("attachmentAddError", () => {
-          const errorAttachment = runtime
-            .getState()
-            .attachments.findLast(
-              (a) =>
-                a.status.type === "incomplete" && a.status.reason === "error",
-            );
+        runtime.unstable_on("attachmentAddError", (payload) => {
           emit("composer.attachmentAddError", {
             threadId: threadIdRef.current,
             ...(messageIdRef && { messageId: messageIdRef.current }),
-            ...(errorAttachment && { attachmentId: errorAttachment.id }),
+            ...(payload.attachmentId && { attachmentId: payload.attachmentId }),
+            reason: payload.reason,
+            message: payload.message,
           });
         }),
       );

--- a/packages/core/src/store/runtime-clients/composer-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/composer-runtime-client.ts
@@ -65,6 +65,7 @@ export const ComposerClient = resource(
 
       unsubscribers.push(
         runtime.unstable_on("attachmentAddError", (payload) => {
+          // payload.error omitted: raw Error is not store-serializable; use runtime.unstable_on for it.
           emit("composer.attachmentAddError", {
             threadId: threadIdRef.current,
             ...(messageIdRef && { messageId: messageIdRef.current }),

--- a/packages/core/src/store/scopes/composer.ts
+++ b/packages/core/src/store/scopes/composer.ts
@@ -4,6 +4,7 @@ import type { QuoteInfo } from "../../types/quote";
 import type { RunConfig } from "../../types/message";
 import type { ComposerRuntime } from "../../runtime/api/composer-runtime";
 import type {
+  AttachmentAddErrorReason,
   DictationState,
   SendOptions,
 } from "../../runtime/interfaces/composer-runtime-core";
@@ -91,12 +92,22 @@ export type ComposerMeta = {
 };
 
 export type ComposerEvents = {
+  /**
+   * @deprecated State-derivable. Observe composer `text` clearing via
+   * `useAuiState` instead. Kept for backward compatibility.
+   */
   "composer.send": { threadId: string; messageId?: string };
+  /**
+   * @deprecated State-derivable. Observe composer `attachments` via
+   * `useAuiState` instead. Kept for backward compatibility.
+   */
   "composer.attachmentAdd": { threadId: string; messageId?: string };
   "composer.attachmentAddError": {
     threadId: string;
     messageId?: string;
     attachmentId?: string;
+    reason: AttachmentAddErrorReason;
+    message: string;
   };
 };
 

--- a/packages/core/src/store/scopes/thread-list-item.ts
+++ b/packages/core/src/store/scopes/thread-list-item.ts
@@ -32,7 +32,17 @@ export type ThreadListItemMeta = {
 };
 
 export type ThreadListItemEvents = {
+  /**
+   * @deprecated State-derivable. Compare `s.threads.mainThreadId` against the
+   * item's `s.threadListItem.id` via `useAuiState` instead. Kept for backward
+   * compatibility.
+   */
   "threadListItem.switchedTo": { threadId: string };
+  /**
+   * @deprecated State-derivable. Compare `s.threads.mainThreadId` against the
+   * item's `s.threadListItem.id` via `useAuiState` instead. Kept for backward
+   * compatibility.
+   */
   "threadListItem.switchedAway": { threadId: string };
 };
 

--- a/packages/core/src/store/scopes/thread.ts
+++ b/packages/core/src/store/scopes/thread.ts
@@ -130,9 +130,26 @@ export type ThreadMeta = {
 };
 
 export type ThreadEvents = {
+  /**
+   * @deprecated State-derivable. Observe `isRunning` flipping to `true` via
+   * `useAuiState` instead. Kept for backward compatibility.
+   */
   "thread.runStart": { threadId: string };
+  /**
+   * @deprecated State-derivable. Observe `isRunning` flipping to `false` via
+   * `useAuiState` instead. Kept for backward compatibility.
+   */
   "thread.runEnd": { threadId: string };
+  /**
+   * @deprecated State-derivable. This event fires before the first message is
+   * added; observe `messages` becoming non-empty via `useAuiState` instead of
+   * reading state inside this event handler. Kept for backward compatibility.
+   */
   "thread.initialize": { threadId: string };
+  /**
+   * Truly transient. Model context lives in a provider, not in thread state,
+   * so this event has no state-derivable equivalent.
+   */
   "thread.modelContextUpdate": { threadId: string };
 };
 

--- a/packages/core/src/subscribable/subscribable.ts
+++ b/packages/core/src/subscribable/subscribable.ts
@@ -21,7 +21,10 @@ export type EventSubscribable<TEvent extends string> = {
   event: TEvent;
   binding: SubscribableWithState<
     | {
-        unstable_on: (event: TEvent, callback: () => void) => Unsubscribe;
+        unstable_on: (
+          event: TEvent,
+          callback: (payload?: unknown) => void,
+        ) => Unsubscribe;
       }
     | undefined,
     unknown
@@ -87,7 +90,7 @@ export class BaseSubscribable {
 
 // lazy connect/disconnect: only opens upstream subscription while it has subscribers
 export abstract class BaseSubject {
-  private _subscriptions = new Set<() => void>();
+  private _subscriptions = new Set<(payload?: unknown) => void>();
   private _connection: Unsubscribe | undefined;
 
   protected get isConnected() {
@@ -96,8 +99,8 @@ export abstract class BaseSubject {
 
   protected abstract _connect(): Unsubscribe;
 
-  protected notifySubscribers() {
-    for (const callback of this._subscriptions) callback();
+  protected notifySubscribers(payload?: unknown) {
+    for (const callback of this._subscriptions) callback(payload);
   }
 
   private _updateConnection() {
@@ -110,7 +113,7 @@ export abstract class BaseSubject {
     }
   }
 
-  public subscribe(callback: () => void) {
+  public subscribe(callback: (payload?: unknown) => void) {
     this._subscriptions.add(callback);
     this._updateConnection();
 
@@ -270,8 +273,8 @@ export class EventSubscriptionSubject<
   }
 
   protected _connect(): Unsubscribe {
-    const callback = () => {
-      this.notifySubscribers();
+    const callback = (payload?: unknown) => {
+      this.notifySubscribers(payload);
     };
 
     let lastState = this.config.binding.getState();

--- a/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
@@ -48,6 +48,12 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
     ).rejects.toThrow("Attachments are not supported");
 
     expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "no-adapter",
+        message: "Attachments are not supported",
+      }),
+    );
     expect(onAdd).not.toHaveBeenCalled();
   });
 
@@ -63,6 +69,14 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
     ).rejects.toThrow(/File type text\/plain is not accepted/);
 
     expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "not-accepted",
+        message: expect.stringContaining(
+          "File type text/plain is not accepted",
+        ),
+      }),
+    );
     expect(onAdd).not.toHaveBeenCalled();
   });
 
@@ -84,6 +98,12 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
     ).rejects.toThrow("upload failed");
 
     expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "adapter-error",
+        message: "upload failed",
+      }),
+    );
     expect(onAdd).not.toHaveBeenCalled();
   });
 
@@ -143,6 +163,13 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
     ).rejects.toThrow("network error");
 
     expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "adapter-error",
+        message: "network error",
+        attachmentId: "att-1",
+      }),
+    );
     expect(onAdd).not.toHaveBeenCalled();
     expect(composer.attachments).toHaveLength(1);
     const att = composer.attachments[0]!;
@@ -150,5 +177,37 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
     if (att.status.type === "incomplete") {
       expect(att.status.reason).toBe("error");
     }
+  });
+
+  it("emits attachmentAddError with attachment id when adapter yields an errored attachment", async () => {
+    const composer = makeComposer(
+      makeAdapter({
+        add: async ({ file }) => ({
+          id: "att-2",
+          type: "image",
+          name: file.name,
+          contentType: file.type,
+          file,
+          status: { type: "incomplete", reason: "error" },
+        }),
+      }),
+    );
+    const onError = vi.fn();
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAddError", onError);
+    composer.unstable_on("attachmentAdd", onAdd);
+
+    await composer.addAttachment(
+      new File(["x"], "f.png", { type: "image/png" }),
+    );
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "adapter-error",
+        attachmentId: "att-2",
+      }),
+    );
+    expect(onAdd).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
@@ -52,6 +52,7 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
       expect.objectContaining({
         reason: "no-adapter",
         message: "Attachments are not supported",
+        error: expect.any(Error),
       }),
     );
     expect(onAdd).not.toHaveBeenCalled();
@@ -75,6 +76,7 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
         message: expect.stringContaining(
           "File type text/plain is not accepted",
         ),
+        error: expect.any(Error),
       }),
     );
     expect(onAdd).not.toHaveBeenCalled();
@@ -102,6 +104,7 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
       expect.objectContaining({
         reason: "adapter-error",
         message: "upload failed",
+        error: expect.any(Error),
       }),
     );
     expect(onAdd).not.toHaveBeenCalled();
@@ -168,6 +171,7 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
         reason: "adapter-error",
         message: "network error",
         attachmentId: "att-1",
+        error: expect.any(Error),
       }),
     );
     expect(onAdd).not.toHaveBeenCalled();

--- a/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
+++ b/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
@@ -459,6 +459,7 @@ describe("BaseComposerRuntimeCore", () => {
             message: expect.stringContaining(
               "File type application/pdf is not accepted",
             ),
+            error: expect.any(Error),
           }),
         );
         expect(onAdd).not.toHaveBeenCalled();

--- a/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
+++ b/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
@@ -453,6 +453,14 @@ describe("BaseComposerRuntimeCore", () => {
 
         expect(composer.attachments).toHaveLength(0);
         expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            reason: "not-accepted",
+            message: expect.stringContaining(
+              "File type application/pdf is not accepted",
+            ),
+          }),
+        );
         expect(onAdd).not.toHaveBeenCalled();
       });
 


### PR DESCRIPTION
## Summary

- `composer.attachmentAddError` now carries `{ reason, message, attachmentId?, error? }` so subscribers can branch on the failure mode (`no-adapter` / `not-accepted` / `adapter-error`); fixes #3912
- Bridge reads the payload directly instead of using a `findLast` heuristic, eliminating a stale-attachment misattribution bug
- `unstable_on` is now generic over the event with a typed payload map across composer, thread, and threadListItem runtime types
- State-derivable events are annotated `@deprecated` (`composer.send`, `composer.attachmentAdd`, `thread.runStart`, `thread.runEnd`, `thread.initialize`, `threadListItem.switchedTo`, `threadListItem.switchedAway`); they continue to fire for backward compatibility, new code should observe state via `useAuiState`
- `thread.modelContextUpdate` is documented as truly transient (model context lives outside thread state)
- Docs updated: attachments guide shows the `reason` discriminator with a per-reason table; context API guide introduces a three-step rule for choosing between state observation, operation result, and event subscription

## Test plan

- [x] `pnpm --filter @assistant-ui/core build` clean (196 files)
- [x] `pnpm --filter @assistant-ui/react --filter @assistant-ui/react-native --filter @assistant-ui/react-ink build` clean
- [x] core tests pass (158/158)
- [x] react tests pass (243/243)
- [x] store tests pass (3/3)
- [x] backward-compat: zero-arg `unstable_on(event, () => {})` callbacks still fire
- [x] chrome end-to-end: all four `addAttachment` failure paths emit the typed payload (no-adapter, not-accepted-File, not-accepted-CreateAttachment, adapter-throw, errored-attachment-yielded)