### PR TITLE
chore(butflow): codify no-review-narration rule for comments

### DIFF
--- a/.claude/commands/butflow.md
+++ b/.claude/commands/butflow.md
@@ -28,6 +28,8 @@ Every unresolved thread must get a reply and a resolve:
 
 Use judgment on bot nits. Common-sense suggestions that just duplicate what a competent agent already knows aren't worth a fix commit — reply-and-resolve those. Scope creep from a long bot-feedback loop is a signal to cut and merge.
 
+**No comments / changeset prose that only exist to acknowledge review feedback.** Test: would you write it if no reviewer had flagged the code? If no, drop it — orphan noise on `main`. Catches subtle "why" comments, not just blatant "addresses review" ones.
+
 ```
 gh api /repos/assistant-ui/assistant-ui/pulls/<n>/comments/<databaseId>/replies -f body='...'
 gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id=<threadId>


### PR DESCRIPTION
## Summary

Adds a one-line rule + concrete test to the butflow playbook for source comments and changeset prose written during review iteration:

> **Test**: would you write it if no reviewer had flagged the code? If no, drop it.

The motivation is that comments born during a PR review thread don't carry their context to `main` — readers there see "Stable reference: keeps tree memo from busting per render" and have no idea why the comment exists at all. The rule is meant to catch the *subtle* cases (defensive "why" comments that look ordinary) in addition to the blatant "addresses review feedback" ones.

`.claude/commands/butflow.md` only — no published-package change, no changeset.

## Test plan

- [x] Diff is one paragraph in `.claude/commands/butflow.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)