### PR TITLE
fix(react): recover ComposerPrimitive.Input from stuck IME composition state

### DIFF
--- a/.changeset/composer-input-ime-react19.md
+++ b/.changeset/composer-input-ime-react19.md
@@ -2,12 +2,6 @@
 "@assistant-ui/react": patch
 ---
 
-fix(react): keep CJK IME input alive on React 19 and recover stuck `compositionRef`
+fix(react): recover ComposerPrimitive.Input from dropped compositionend
 
-Two related fixes inside `ComposerPrimitive.Input` for users on React 19 with CJK (Korean, Japanese, Chinese) input methods:
-
-1. **React 19 controlled input regression.** During an IME composition the `onChange` handler was returning early before calling `setText`, leaving the controlled `value` stale. React 19 reconciles controlled inputs more aggressively than 18 and would reset the textarea to the stale value mid-composition, causing in-progress characters to disappear (e.g. typing `가` showed nothing). The fix calls `setText` on every change so the controlled value tracks the DOM value, even while composing. Plugin cursor tracking still skips composing events, where the selection position is unstable.
-
-2. **Stuck `compositionRef` recovery.** If `compositionend` was dropped by the browser (dead-key layouts, tab unfocus mid-composition, etc.), the internal `compositionRef` stayed `true` forever and silently swallowed every subsequent `onChange`, freezing the input. The handler now resets the ref whenever the native event reports `isComposing === false`, allowing the input to self-heal.
-
-Fixes #3923.
+reset `compositionRef` when the next change event reports `isComposing: false` so a dropped `compositionend` (chromium dead-key layouts, mid-composition focus loss) can no longer freeze the input. additionally call `setText` during composition so React 19's stricter controlled-input reconciliation does not reset the textarea mid-IME. fixes #3923.

--- a/.changeset/composer-input-ime-react19.md
+++ b/.changeset/composer-input-ime-react19.md
@@ -1,0 +1,13 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): keep CJK IME input alive on React 19 and recover stuck `compositionRef`
+
+Two related fixes inside `ComposerPrimitive.Input` for users on React 19 with CJK (Korean, Japanese, Chinese) input methods:
+
+1. **React 19 controlled input regression.** During an IME composition the `onChange` handler was returning early before calling `setText`, leaving the controlled `value` stale. React 19 reconciles controlled inputs more aggressively than 18 and would reset the textarea to the stale value mid-composition, causing in-progress characters to disappear (e.g. typing `가` showed nothing). The fix calls `setText` on every change so the controlled value tracks the DOM value, even while composing. Plugin cursor tracking still skips composing events, where the selection position is unstable.
+
+2. **Stuck `compositionRef` recovery.** If `compositionend` was dropped by the browser (dead-key layouts, tab unfocus mid-composition, etc.), the internal `compositionRef` stayed `true` forever and silently swallowed every subsequent `onChange`, freezing the input. The handler now resets the ref whenever the native event reports `isComposing === false`, allowing the input to self-heal.
+
+Fixes #3923.

--- a/packages/react/src/primitives/composer/ComposerInput.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComposerPrimitiveInput } from "./ComposerInput";
+
+const setText = vi.fn<(text: string) => void>();
+
+const composerState = {
+  isEditing: true,
+  text: "",
+  type: "thread" as const,
+  isEmpty: true,
+  canCancel: false,
+  dictation: undefined as undefined | { inputDisabled: boolean },
+};
+
+const threadState = {
+  isDisabled: false,
+  isRunning: false,
+  capabilities: { queue: false, attachments: false },
+};
+
+const setCursorPosition = vi.fn<(pos: number) => void>();
+const plugin = {
+  handleKeyDown: () => false,
+  setCursorPosition,
+};
+
+let pluginRegistry: { getPlugins: () => (typeof plugin)[] } | null = null;
+
+vi.mock("@assistant-ui/store", () => {
+  const aui = {
+    composer: () => ({
+      setText,
+      getState: () => composerState,
+      cancel: () => {},
+      send: () => {},
+      addAttachment: async () => {},
+    }),
+    thread: () => ({
+      getState: () => threadState,
+    }),
+    on: () => () => {},
+  };
+  type Selector<T> = (s: {
+    composer: typeof composerState;
+    thread: typeof threadState;
+  }) => T;
+  return {
+    useAui: () => aui,
+    useAuiState: <T,>(selector: Selector<T>) =>
+      selector({ composer: composerState, thread: threadState }),
+  };
+});
+
+vi.mock("@assistant-ui/tap", () => ({
+  flushResourcesSync: (fn: () => void) => fn(),
+}));
+
+vi.mock("./ComposerInputPluginContext", () => ({
+  useComposerInputPluginRegistryOptional: () => pluginRegistry,
+}));
+
+vi.mock("@radix-ui/react-use-escape-keydown", () => ({
+  useEscapeKeydown: () => {},
+}));
+
+vi.mock("../../utils/hooks/useOnScrollToBottom", () => ({
+  useOnScrollToBottom: () => {},
+}));
+
+const fireInput = (
+  textarea: HTMLTextAreaElement,
+  value: string,
+  isComposing: boolean,
+) => {
+  // fireEvent.change uses the prototype value setter so React 19 detects
+  // the change. We override isComposing on the synthetic native event so
+  // the IME branch in onChange is exercised correctly.
+  fireEvent.input(textarea, {
+    target: { value },
+    isComposing,
+  });
+};
+
+describe("ComposerPrimitiveInput", () => {
+  let textarea: HTMLTextAreaElement;
+
+  beforeEach(() => {
+    setText.mockReset();
+    setCursorPosition.mockReset();
+    composerState.isEditing = true;
+    composerState.text = "";
+    composerState.isEmpty = true;
+    composerState.dictation = undefined;
+    threadState.isDisabled = false;
+    threadState.isRunning = false;
+    threadState.capabilities = { queue: false, attachments: false };
+    pluginRegistry = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const renderInput = () => {
+    const { container } = render(
+      <ComposerPrimitiveInput data-testid="input" />,
+    );
+    textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+  };
+
+  describe("IME composition", () => {
+    it("calls setText during active composition so React 19 cannot reset the textarea value", () => {
+      renderInput();
+
+      // Korean IME starts composing
+      fireEvent.compositionStart(textarea);
+
+      // While composing, the input event reports isComposing=true.
+      // Previously this skipped setText and the controlled value stayed
+      // stale, letting React 19's reconciliation wipe the textarea.
+      fireInput(textarea, "ㄱ", true);
+      expect(setText).toHaveBeenCalledWith("ㄱ");
+
+      fireInput(textarea, "가", true);
+      expect(setText).toHaveBeenLastCalledWith("가");
+    });
+
+    it("commits the final value on compositionend", () => {
+      renderInput();
+
+      fireEvent.compositionStart(textarea);
+      fireInput(textarea, "가", true);
+      fireEvent.compositionEnd(textarea, { target: { value: "가" } });
+
+      expect(setText).toHaveBeenLastCalledWith("가");
+    });
+
+    it("recovers from a stuck composition state when compositionend is dropped", () => {
+      renderInput();
+
+      // Some browsers and dead-key layouts drop compositionend, leaving
+      // compositionRef stuck at true and freezing the input. Once the next
+      // input event arrives without isComposing, the ref must self-heal.
+      fireEvent.compositionStart(textarea);
+
+      // No compositionend fires here.
+
+      // A regular keystroke now arrives with isComposing=false.
+      fireInput(textarea, "hello", false);
+      expect(setText).toHaveBeenCalledWith("hello");
+
+      // A subsequent regular input continues to work, proving the ref reset.
+      fireInput(textarea, "hello!", false);
+      expect(setText).toHaveBeenLastCalledWith("hello!");
+    });
+
+    it("skips plugin cursor tracking during composition but resumes after", () => {
+      pluginRegistry = { getPlugins: () => [plugin] };
+      renderInput();
+
+      fireEvent.compositionStart(textarea);
+      fireInput(textarea, "ㄱ", true);
+
+      expect(setText).toHaveBeenCalledWith("ㄱ");
+      // Cursor should NOT be tracked while composing — the selection
+      // position is unstable until the composition resolves.
+      expect(setCursorPosition).not.toHaveBeenCalled();
+
+      fireEvent.compositionEnd(textarea, { target: { value: "가" } });
+      // After compositionend the plugin gets the final cursor position.
+      expect(setCursorPosition).toHaveBeenCalled();
+    });
+  });
+
+  describe("non-composition input", () => {
+    it("calls setText and tracks plugin cursor for normal keystrokes", () => {
+      pluginRegistry = { getPlugins: () => [plugin] };
+      renderInput();
+
+      fireInput(textarea, "abc", false);
+
+      expect(setText).toHaveBeenCalledWith("abc");
+      expect(setCursorPosition).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/src/primitives/composer/ComposerInput.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.test.tsx
@@ -1,11 +1,13 @@
 /**
  * @vitest-environment jsdom
  */
-import { fireEvent, render } from "@testing-library/react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ComposerPrimitiveInput } from "./ComposerInput";
 
 const setText = vi.fn<(text: string) => void>();
+const setCursorPosition = vi.fn<(pos: number) => void>();
 
 const composerState = {
   isEditing: true,
@@ -22,13 +24,14 @@ const threadState = {
   capabilities: { queue: false, attachments: false },
 };
 
-const setCursorPosition = vi.fn<(pos: number) => void>();
 const plugin = {
   handleKeyDown: () => false,
   setCursorPosition,
 };
 
 let pluginRegistry: { getPlugins: () => (typeof plugin)[] } | null = null;
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 vi.mock("@assistant-ui/store", () => {
   const aui = {
@@ -71,22 +74,41 @@ vi.mock("../../utils/hooks/useOnScrollToBottom", () => ({
   useOnScrollToBottom: () => {},
 }));
 
+const setNativeValue = (textarea: HTMLTextAreaElement, value: string) => {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(textarea, value);
+};
+
 const fireInput = (
   textarea: HTMLTextAreaElement,
   value: string,
   isComposing: boolean,
 ) => {
-  // fireEvent.change uses the prototype value setter so React 19 detects
-  // the change. We override isComposing on the synthetic native event so
-  // the IME branch in onChange is exercised correctly.
-  fireEvent.input(textarea, {
-    target: { value },
-    isComposing,
-  });
+  setNativeValue(textarea, value);
+  textarea.dispatchEvent(
+    new InputEvent("input", { bubbles: true, isComposing }),
+  );
+};
+
+const fireCompositionStart = (textarea: HTMLTextAreaElement) => {
+  textarea.dispatchEvent(
+    new CompositionEvent("compositionstart", { bubbles: true }),
+  );
+};
+
+const fireCompositionEnd = (textarea: HTMLTextAreaElement, value: string) => {
+  setNativeValue(textarea, value);
+  textarea.dispatchEvent(
+    new CompositionEvent("compositionend", { bubbles: true }),
+  );
 };
 
 describe("ComposerPrimitiveInput", () => {
-  let textarea: HTMLTextAreaElement;
+  let container: HTMLDivElement;
+  let root: Root;
 
   beforeEach(() => {
     setText.mockReset();
@@ -99,93 +121,112 @@ describe("ComposerPrimitiveInput", () => {
     threadState.isRunning = false;
     threadState.capabilities = { queue: false, attachments: false };
     pluginRegistry = null;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
     vi.restoreAllMocks();
   });
 
-  const renderInput = () => {
-    const { container } = render(
-      <ComposerPrimitiveInput data-testid="input" />,
-    );
-    textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+  const mount = async () => {
+    await act(async () => {
+      root.render(<ComposerPrimitiveInput data-testid="input" />);
+    });
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
     expect(textarea).not.toBeNull();
+    return textarea;
   };
 
-  describe("IME composition", () => {
-    it("calls setText during active composition so React 19 cannot reset the textarea value", () => {
-      renderInput();
+  it("syncs setText during active composition so React 19 cannot reset the textarea", async () => {
+    const textarea = await mount();
 
-      // Korean IME starts composing
-      fireEvent.compositionStart(textarea);
-
-      // While composing, the input event reports isComposing=true.
-      // Previously this skipped setText and the controlled value stayed
-      // stale, letting React 19's reconciliation wipe the textarea.
+    await act(async () => {
+      fireCompositionStart(textarea);
       fireInput(textarea, "ㄱ", true);
-      expect(setText).toHaveBeenCalledWith("ㄱ");
+    });
+    expect(setText).toHaveBeenCalledWith("ㄱ");
 
+    await act(async () => {
       fireInput(textarea, "가", true);
-      expect(setText).toHaveBeenLastCalledWith("가");
     });
-
-    it("commits the final value on compositionend", () => {
-      renderInput();
-
-      fireEvent.compositionStart(textarea);
-      fireInput(textarea, "가", true);
-      fireEvent.compositionEnd(textarea, { target: { value: "가" } });
-
-      expect(setText).toHaveBeenLastCalledWith("가");
-    });
-
-    it("recovers from a stuck composition state when compositionend is dropped", () => {
-      renderInput();
-
-      // Some browsers and dead-key layouts drop compositionend, leaving
-      // compositionRef stuck at true and freezing the input. Once the next
-      // input event arrives without isComposing, the ref must self-heal.
-      fireEvent.compositionStart(textarea);
-
-      // No compositionend fires here.
-
-      // A regular keystroke now arrives with isComposing=false.
-      fireInput(textarea, "hello", false);
-      expect(setText).toHaveBeenCalledWith("hello");
-
-      // A subsequent regular input continues to work, proving the ref reset.
-      fireInput(textarea, "hello!", false);
-      expect(setText).toHaveBeenLastCalledWith("hello!");
-    });
-
-    it("skips plugin cursor tracking during composition but resumes after", () => {
-      pluginRegistry = { getPlugins: () => [plugin] };
-      renderInput();
-
-      fireEvent.compositionStart(textarea);
-      fireInput(textarea, "ㄱ", true);
-
-      expect(setText).toHaveBeenCalledWith("ㄱ");
-      // Cursor should NOT be tracked while composing — the selection
-      // position is unstable until the composition resolves.
-      expect(setCursorPosition).not.toHaveBeenCalled();
-
-      fireEvent.compositionEnd(textarea, { target: { value: "가" } });
-      // After compositionend the plugin gets the final cursor position.
-      expect(setCursorPosition).toHaveBeenCalled();
-    });
+    expect(setText).toHaveBeenLastCalledWith("가");
   });
 
-  describe("non-composition input", () => {
-    it("calls setText and tracks plugin cursor for normal keystrokes", () => {
-      pluginRegistry = { getPlugins: () => [plugin] };
-      renderInput();
+  it("commits the final value on compositionend", async () => {
+    const textarea = await mount();
 
-      fireInput(textarea, "abc", false);
-
-      expect(setText).toHaveBeenCalledWith("abc");
-      expect(setCursorPosition).toHaveBeenCalled();
+    await act(async () => {
+      fireCompositionStart(textarea);
+      fireInput(textarea, "가", true);
     });
+    expect(setText).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      fireCompositionEnd(textarea, "가");
+    });
+    expect(setText).toHaveBeenCalledTimes(2);
+    expect(setText).toHaveBeenLastCalledWith("가");
+  });
+
+  it("recovers when compositionend is dropped before the next input", async () => {
+    const textarea = await mount();
+
+    await act(async () => {
+      fireCompositionStart(textarea);
+      fireInput(textarea, "hello", false);
+    });
+    expect(setText).toHaveBeenCalledWith("hello");
+
+    await act(async () => {
+      fireInput(textarea, "hello!", false);
+    });
+    expect(setText).toHaveBeenLastCalledWith("hello!");
+  });
+
+  it("skips plugin cursor tracking during composition but resumes after", async () => {
+    pluginRegistry = { getPlugins: () => [plugin] };
+    const textarea = await mount();
+
+    await act(async () => {
+      fireCompositionStart(textarea);
+      fireInput(textarea, "ㄱ", true);
+    });
+    expect(setText).toHaveBeenCalledWith("ㄱ");
+    expect(setCursorPosition).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireCompositionEnd(textarea, "가");
+    });
+    expect(setCursorPosition).toHaveBeenCalled();
+  });
+
+  it("tracks plugin cursor for non-composition input", async () => {
+    pluginRegistry = { getPlugins: () => [plugin] };
+    const textarea = await mount();
+
+    await act(async () => {
+      fireInput(textarea, "abc", false);
+    });
+    expect(setText).toHaveBeenCalledWith("abc");
+    expect(setCursorPosition).toHaveBeenCalled();
+  });
+
+  it("ignores input and compositionend when the composer is not editing", async () => {
+    composerState.isEditing = false;
+    const textarea = await mount();
+
+    await act(async () => {
+      fireInput(textarea, "abc", false);
+      fireCompositionStart(textarea);
+      fireCompositionEnd(textarea, "가");
+    });
+    expect(setText).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -297,13 +297,28 @@ export const ComposerPrimitiveInput = forwardRef<
         onChange,
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
           if (!aui.composer().getState().isEditing) return;
-          const isComposing =
-            (e.nativeEvent as { isComposing?: boolean }).isComposing === true ||
-            compositionRef.current;
-          if (isComposing) return;
+          const nativeIsComposing =
+            (e.nativeEvent as { isComposing?: boolean }).isComposing === true;
+          // Recover from a stuck composition: if compositionEnd was dropped
+          // (e.g. dead-key layouts, unfocus during composition, browser
+          // quirks), the ref can stay true forever and silently swallow input.
+          // When the native event reports no active composition, reset the
+          // ref so subsequent events are processed normally.
+          if (compositionRef.current && !nativeIsComposing) {
+            compositionRef.current = false;
+          }
+          const isComposing = nativeIsComposing || compositionRef.current;
+          // Always sync the controlled value to the DOM value, even mid-IME.
+          // React 19 reconciles controlled inputs more aggressively than 18
+          // and will reset the textarea to the stale `value` prop while a CJK
+          // IME composition is in progress, causing characters to disappear.
+          // Keeping the controlled value in sync prevents that reset.
           flushResourcesSync(() => {
             aui.composer().setText(e.target.value);
           });
+          // Skip plugin cursor tracking during composition — the selection
+          // position is unreliable until the composition resolves.
+          if (isComposing) return;
           const pos = e.target.selectionStart ?? e.target.value.length;
           if (pluginRegistry) {
             for (const plugin of pluginRegistry.getPlugins()) {

--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -299,25 +299,15 @@ export const ComposerPrimitiveInput = forwardRef<
           if (!aui.composer().getState().isEditing) return;
           const nativeIsComposing =
             (e.nativeEvent as { isComposing?: boolean }).isComposing === true;
-          // Recover from a stuck composition: if compositionEnd was dropped
-          // (e.g. dead-key layouts, unfocus during composition, browser
-          // quirks), the ref can stay true forever and silently swallow input.
-          // When the native event reports no active composition, reset the
-          // ref so subsequent events are processed normally.
+          // recover stuck compositionRef when the browser drops compositionend
           if (compositionRef.current && !nativeIsComposing) {
             compositionRef.current = false;
           }
           const isComposing = nativeIsComposing || compositionRef.current;
-          // Always sync the controlled value to the DOM value, even mid-IME.
-          // React 19 reconciles controlled inputs more aggressively than 18
-          // and will reset the textarea to the stale `value` prop while a CJK
-          // IME composition is in progress, causing characters to disappear.
-          // Keeping the controlled value in sync prevents that reset.
+          // keep controlled value in sync mid-IME so react does not reset the textarea to a stale value
           flushResourcesSync(() => {
             aui.composer().setText(e.target.value);
           });
-          // Skip plugin cursor tracking during composition — the selection
-          // position is unreliable until the composition resolves.
           if (isComposing) return;
           const pos = e.target.selectionStart ?? e.target.value.length;
           if (pluginRegistry) {


### PR DESCRIPTION
## summary

- recover `ComposerPrimitive.Input` when `compositionend` is dropped (chromium dead-key layouts, focus loss mid-composition) by resetting `compositionRef` whenever the next change event reports `isComposing: false`. the textarea is no longer permanently frozen on the next input.
- always call `setText(e.target.value)` during composition so the controlled `value` prop tracks the DOM value. without this, React 19's stricter controlled-input reconciliation resets the textarea to the stale `value` prop mid-IME and in-progress CJK characters disappear (e.g. typing `가` shows nothing).
- plugin cursor tracking remains gated on `isComposing` since the selection position is unreliable during composition.
- closes #3923.

## test plan

- [ ] on a dead-key keyboard layout (German ISO, U.S. International), type `` ` `` then any letter; the input keeps responding and characters render.
- [ ] on Korean, Japanese, and Chinese IME under React 19, type a multi-keystroke character; intermediate characters render and the final commit is correct.
- [ ] `@`-mention and `/`-slash command popovers behave normally during and after IME input.
- [ ] `pnpm --filter @assistant-ui/react test` passes (249 tests, 6 new in `ComposerInput.test.tsx`).
- [ ] `pnpm exec biome check packages/react/src/primitives/composer/ComposerInput.tsx packages/react/src/primitives/composer/ComposerInput.test.tsx` passes.