### PR TITLE
fix: recover composer after dropped compositionend

### DIFF
--- a/packages/react/src/primitives/composer/ComposerInput.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { FC, PropsWithChildren } from "react";
+import { describe, expect, it } from "vitest";
+import type { AssistantRuntime } from "@assistant-ui/core";
+import { AssistantRuntimeProvider } from "../../legacy-runtime/AssistantRuntimeProvider";
+import { useAssistantRuntime } from "../../legacy-runtime/hooks/AssistantContext";
+import { useLocalRuntime } from "../../legacy-runtime/runtime-cores/local/useLocalRuntime";
+import type { ChatModelAdapter } from "../../index";
+import { ComposerPrimitiveInput } from "./ComposerInput";
+
+const noOpAdapter: ChatModelAdapter = {
+  async *run() {},
+};
+
+const RuntimeProvider: FC<PropsWithChildren> = ({ children }) => {
+  const runtime = useLocalRuntime(noOpAdapter);
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+};
+
+const RuntimeCapture: FC<{
+  runtimeRef: { current: AssistantRuntime | null };
+}> = ({ runtimeRef }) => {
+  runtimeRef.current = useAssistantRuntime();
+  return null;
+};
+
+const renderInput = () => {
+  const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+  render(
+    <RuntimeProvider>
+      <ComposerPrimitiveInput aria-label="Message" />
+      <RuntimeCapture runtimeRef={runtimeRef} />
+    </RuntimeProvider>,
+  );
+  return runtimeRef;
+};
+
+const setNativeInputValue = (element: HTMLTextAreaElement, value: string) => {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(element, value);
+};
+
+const input = (
+  element: HTMLTextAreaElement,
+  value: string,
+  init?: { isComposing?: boolean; inputType?: string },
+) => {
+  setNativeInputValue(element, value);
+  fireEvent(
+    element,
+    new InputEvent("input", {
+      bubbles: true,
+      data: value,
+      inputType: init?.inputType ?? "insertText",
+      isComposing: init?.isComposing ?? false,
+    }),
+  );
+};
+
+describe("ComposerPrimitive.Input", () => {
+  it("recovers when compositionend is dropped before the next input", () => {
+    const runtimeRef = renderInput();
+    const textarea = screen.getByRole("textbox", {
+      name: "Message",
+    }) as HTMLTextAreaElement;
+
+    fireEvent.compositionStart(textarea);
+    input(textarea, "`", {
+      isComposing: true,
+      inputType: "insertCompositionText",
+    });
+    expect(runtimeRef.current!.thread.composer.getState().text).toBe("");
+
+    input(textarea, "`a");
+
+    expect(runtimeRef.current!.thread.composer.getState().text).toBe("`a");
+    expect(textarea.value).toBe("`a");
+  });
+
+  it("continues to ignore active composition input", () => {
+    const runtimeRef = renderInput();
+    const textarea = screen.getByRole("textbox", {
+      name: "Message",
+    }) as HTMLTextAreaElement;
+
+    fireEvent.compositionStart(textarea);
+    input(textarea, "あ", {
+      isComposing: true,
+      inputType: "insertCompositionText",
+    });
+
+    expect(runtimeRef.current!.thread.composer.getState().text).toBe("");
+  });
+});

--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -297,10 +297,20 @@ export const ComposerPrimitiveInput = forwardRef<
         onChange,
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
           if (!aui.composer().getState().isEditing) return;
-          const isComposing =
-            (e.nativeEvent as { isComposing?: boolean }).isComposing === true ||
-            compositionRef.current;
-          if (isComposing) return;
+          const nativeEvent = e.nativeEvent as {
+            isComposing?: boolean;
+            inputType?: string;
+          };
+          const isCompositionInput =
+            nativeEvent.isComposing === true ||
+            nativeEvent.inputType === "insertCompositionText";
+
+          if (isCompositionInput) return;
+          // Some browser/keyboard combinations can drop compositionend, leaving
+          // compositionRef stuck forever. The next non-composition input means
+          // composition has ended, so recover and sync the DOM value.
+          compositionRef.current = false;
+
           flushResourcesSync(() => {
             aui.composer().setText(e.target.value);
           });


### PR DESCRIPTION
## Summary

Recover `ComposerPrimitive.Input` when a browser drops `compositionend` by treating the next non-composition input as the end of composition and syncing the textarea value back into composer state.

## Changes

- Detect active composition from the native event (`isComposing` or `insertCompositionText`) instead of permanently trusting the internal composition ref in `onChange`.
- Reset the composition ref on the next non-composition input so dead-key/browser edge cases self-correct.
- Add regression coverage for a dropped `compositionend` and for still ignoring active composition text.

## Testing

- `pnpm exec biome check packages/react/src/primitives/composer/ComposerInput.tsx packages/react/src/primitives/composer/ComposerInput.test.tsx`
- `pnpm --filter @assistant-ui/react test src/primitives/composer/ComposerInput.test.tsx`

Fixes assistant-ui/assistant-ui#3923
