### PR TITLE
docs(tool-ui): document deferred rendering pattern

### DIFF
--- a/apps/docs/content/docs/(reference)/api-reference/primitives/assistant-if.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/assistant-if.mdx
@@ -111,6 +111,13 @@ The condition function receives an `AssistantState` object with the following pr
   <Disclaimer />
 </AuiIf>
 
+// Render content only after the assistant finishes streaming
+<AuiIf condition={(s) =>
+  s.message.role === "assistant" && s.message.status?.type === "complete"
+}>
+  <FollowUpCard />
+</AuiIf>
+
 // Toggle copy icon based on copied state
 <ActionBarPrimitive.Copy>
   <AuiIf condition={(s) => !s.message.isCopied}>

--- a/apps/docs/content/docs/guides/tool-ui.mdx
+++ b/apps/docs/content/docs/guides/tool-ui.mdx
@@ -506,6 +506,10 @@ render: ({ status, args }) => {
 
 ### Deferred Rendering
 
+<Callout type="info">
+This section applies when the model **drives** the component through a tool call (args arrive incrementally and you want to wait for the final shape). If your backend or orchestrator pushes the component instead, prefer [Data-Part Generative UI](#data-part-generative-ui) with `makeAssistantDataUI`. Data parts arrive as terminal events, so the renderer only fires once with the final data, no deferred rendering needed.
+</Callout>
+
 Sometimes you want to capture a tool call's streaming arguments but only render the final UI once the call completes. This is useful when partial args would render misleading or jarring intermediate states (a chart that flashes through half-populated data), when the component is expensive to mount (heavy visualizations, embedded iframes, third-party widgets), or when the model controls *whether* the component appears at all.
 
 #### Inline at the end of streaming
@@ -526,6 +530,8 @@ const ChartToolUI = makeAssistantToolUI<
 ```
 
 The chart mounts once, with the final args, after streaming finishes. No re-renders during the stream.
+
+The same `render` shape works inside the [`Tools()`](/docs/guides/tools) toolkit's `render` field, with `useAssistantToolUI`, and with `MessagePrimitive.Parts`'s inline `tools.by_name` overrides. The deferred-rendering pattern applies regardless of how you registered the tool UI.
 
 #### Below the message body
 
@@ -811,6 +817,13 @@ const WeatherUI = makeAssistantToolUI({
 ## Data-Part Generative UI
 
 Alongside tool-call rendering, assistant-ui supports a second generative UI mechanism based on `DataMessagePart`. Instead of attaching UI to a tool invocation, the backend (or the LangGraph graph) emits named data events that are appended as `{ type: "data", name, data }` parts on the parent assistant message.
+
+**When to choose which:**
+
+- **Tool UI**: the **model** decides what to render by calling a tool whose args become the component's data. Register the renderer via the [`Tools()`](/docs/guides/tools) toolkit's `render` field (recommended), or standalone with `makeAssistantToolUI` / `useAssistantToolUI` when the tool itself is defined elsewhere (backend, MCP, LangGraph). Args stream incrementally, so you observe partial state via `status` / `useToolArgsStatus` and may need [Deferred Rendering](#deferred-rendering) for components that should only mount with final data.
+- **Data UI** (`makeAssistantDataUI`): the **backend or orchestrator** decides what to render and pushes a named data event onto the assistant message. Data parts arrive as terminal events with no streaming partials, so the renderer naturally fires once with the final data.
+
+If you want a component to appear only after the message is complete and you control the backend, Data UI is usually the more direct fit; reach for Tool UI's deferred pattern when the model itself must drive the choice.
 
 Use `makeAssistantDataUI` to register a renderer for a named data part:
 

--- a/apps/docs/content/docs/guides/tool-ui.mdx
+++ b/apps/docs/content/docs/guides/tool-ui.mdx
@@ -504,6 +504,63 @@ render: ({ status, args }) => {
 };
 ```
 
+### Deferred Rendering
+
+Sometimes you want to capture a tool call's streaming arguments but only render the final UI once the call completes. This is useful when partial args would render misleading or jarring intermediate states (a chart that flashes through half-populated data), when the component is expensive to mount (heavy visualizations, embedded iframes, third-party widgets), or when the model controls *whether* the component appears at all.
+
+#### Inline at the end of streaming
+
+Return `null` from the tool UI's `render` until `status.type === "complete"`. The streaming args still arrive in `args` as the model emits them, you just ignore them until the call is done:
+
+```tsx
+const ChartToolUI = makeAssistantToolUI<
+  { title: string; series: number[] },
+  void
+>({
+  toolName: "renderChart",
+  render: ({ args, status }) => {
+    if (status.type !== "complete") return null;
+    return <Chart title={args.title} data={args.series} />;
+  },
+});
+```
+
+The chart mounts once, with the final args, after streaming finishes. No re-renders during the stream.
+
+#### Below the message body
+
+If the component should sit *outside* the message parts (for example, a card attached under the avatar block rather than inline with text), gate at the message level with [`AuiIf`](/docs/api-reference/primitives/assistant-if) and read `s.message.status`:
+
+```tsx
+import { MessagePrimitive, AuiIf, useAuiState } from "@assistant-ui/react";
+
+function PostMessageCard() {
+  const parts = useAuiState((s) => s.message.parts);
+  const chartCall = parts.find(
+    (p) => p.type === "tool-call" && p.toolName === "renderChart",
+  );
+  if (!chartCall) return null;
+  return <Chart {...chartCall.args} />;
+}
+
+<MessagePrimitive.Root>
+  <MessagePrimitive.Parts />
+
+  <AuiIf
+    condition={(s) =>
+      s.message.role === "assistant" &&
+      s.message.status?.type === "complete"
+    }
+  >
+    <PostMessageCard />
+  </AuiIf>
+</MessagePrimitive.Root>;
+```
+
+The `AuiIf` predicate fires whenever the assistant state changes; children mount only when both checks pass. `PostMessageCard` then reads the captured tool-call part from `s.message.parts` and renders from its args.
+
+For the opposite pattern (showing partial data as it streams in), see [Field-Level Streaming State](#field-level-streaming-state) and [Partial Results & Streaming](#partial-results--streaming) below.
+
 ### Field-Level Streaming State
 
 Use `useToolArgsStatus` to react to per-field streaming state. The hook returns a `propStatus` map where each top-level key in the args object resolves from `"streaming"` to `"complete"` as the partial JSON arrives. Call it inside a tool-call message part context:

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -454,6 +454,29 @@ import { ErrorPrimitive, MessagePrimitive } from "@assistant-ui/react";
 
 `ErrorPrimitive.Root` renders a `<div>` container with `role="alert"` and `ErrorPrimitive.Message` renders a `<span>` that displays the error text. `Root` always renders. Only `Message` conditionally returns `null` when there is no error. Wrap in `<MessagePrimitive.Error>` if you want the entire block to be conditional. See the [ErrorPrimitive API Reference](/docs/api-reference/primitives/error) for full details.
 
+### Render After Stream Completes
+
+To render content only once the assistant message has finished streaming (a follow-up card, a feedback prompt, a generated component that should not flicker through partial states), gate it with [`AuiIf`](/docs/api-reference/primitives/assistant-if) on `s.message.status`:
+
+```tsx
+import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
+
+<MessagePrimitive.Root>
+  <MessagePrimitive.Parts />
+
+  <AuiIf
+    condition={(s) =>
+      s.message.role === "assistant" &&
+      s.message.status?.type === "complete"
+    }
+  >
+    <FollowUpCard />
+  </AuiIf>
+</MessagePrimitive.Root>;
+```
+
+`s.message.status` is a discriminated union of `running | requires-action | complete | incomplete`, defined only on assistant messages. The `role === "assistant"` guard keeps the predicate type-safe. For tool-call-driven generative UI that defers rendering inside the part itself, see [Deferred Rendering](/docs/guides/tool-ui#deferred-rendering) in the Generative UI guide.
+
 ### Legacy and Unstable APIs
 
 - `MessagePrimitive.Unstable_PartsGrouped` and `MessagePrimitive.Unstable_PartsGroupedByParentId` are unstable APIs for custom grouping.


### PR DESCRIPTION
## Summary

- add a "deferred rendering" section to the generative UI guide covering two patterns: returning `null` from a tool UI's `render` until `status.type === "complete"`, and gating with `AuiIf` at the message level when content should sit outside the message body
- add a parallel "render after stream completes" pattern to the message primitive doc, showing the generic `AuiIf` + `s.message.status` form for non-tool content
- add a status-based example to the `AuiIf` API reference under "message state conditions" so users entering from the reference page also discover the pattern
- cross-link the three entries so each is reachable from the others
- no code changes, no new APIs; existing primitives already cover the use case but were not documented as a named pattern

## Test plan

- [ ] `pnpm --filter @assistant-ui/docs dev`, navigate to `/docs/guides/tool-ui#deferred-rendering` and confirm the section renders and code blocks highlight correctly
- [ ] confirm `/docs/primitives/message#render-after-stream-completes` renders and its link to `/docs/guides/tool-ui#deferred-rendering` resolves
- [ ] confirm the new example shows up under "message state conditions" on `/docs/api-reference/primitives/assistant-if`
- [ ] verify code samples typecheck mentally against `s.message.status` (only on assistant messages, hence the `role === "assistant"` guard)