### PR TITLE
ci: Change version of '@assistant-ui/react' to minor

### DIFF
--- a/.changeset/robust-top-turn-anchoring.md
+++ b/.changeset/robust-top-turn-anchoring.md
@@ -1,5 +1,5 @@
 ---
-"@assistant-ui/react": patch
+"@assistant-ui/react": minor
 ---
 
 fix: robust top-turn anchoring with viewport-owned reserve


### PR DESCRIPTION
Updated the version of '@assistant-ui/react' from patch to minor to reflect changes in robust top-turn anchoring.