### PR TITLE
ci(traction): install sharp in isolated dir to avoid pnpm workspace conflict

### DIFF
--- a/.github/workflows/traction.yaml
+++ b/.github/workflows/traction.yaml
@@ -24,11 +24,16 @@ jobs:
                   node-version: "lts/*"
 
             - name: Install dependencies
-              run: npm install sharp
+              run: |
+                  mkdir -p /tmp/sharp-deps
+                  cd /tmp/sharp-deps
+                  npm init -y > /dev/null
+                  npm install sharp
 
             - name: Generate chart
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NODE_PATH: /tmp/sharp-deps/node_modules
               run: |
                   node << 'SCRIPT'
                   const sharp = require('sharp');


### PR DESCRIPTION
## Summary
- The weekly `Update README Traction Chart` workflow has been failing because `npm install sharp` is run at the repo root, where `package.json` contains `"@assistant-ui/x-changelog": "workspace:*"`. npm doesn't understand the `workspace:` protocol and bails with `EUNSUPPORTEDPROTOCOL`.
- Fix: install sharp in `/tmp/sharp-deps` (an isolated dir, away from the workspace) and set `NODE_PATH` so the chart-generation script's `require('sharp')` resolves.

Failing run: https://github.com/assistant-ui/assistant-ui/actions/runs/25234591761/job/73997841050

## Test plan
- [ ] Trigger the workflow via `workflow_dispatch` after merge and confirm the chart is regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)