### PR TITLE
fix(store): RenderChildrenWithAccessor missed re-renders after access

### DIFF
--- a/.changeset/render-children-accessor-stale-cache.md
+++ b/.changeset/render-children-accessor-stale-cache.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix: `RenderChildrenWithAccessor` no longer misses re-renders when state updates after access
+
+The accessor previously reused a single ref as both an "accessed" sentinel and the cached snapshot. A `useSyncExternalStore` post-commit consistency call could repopulate that cache with the current state, causing later real updates (e.g. `message.composer.isEditing` flipping) to be masked. Access is now tracked with a dedicated flag so children that read item state via the render prop re-render correctly when the underlying state changes.

--- a/apps/docs/components/examples/shadcn.tsx
+++ b/apps/docs/components/examples/shadcn.tsx
@@ -30,7 +30,6 @@ import {
   MessagePrimitive,
   SuggestionPrimitive,
   ThreadPrimitive,
-  useAuiState,
   unstable_useMentionAdapter,
   unstable_useSlashCommandAdapter,
   type Unstable_SlashCommand,
@@ -193,7 +192,11 @@ const Thread: FC = () => {
           className="mb-10 flex flex-col gap-y-8 empty:hidden"
         >
           <ThreadPrimitive.Messages>
-            {() => <ThreadMessage />}
+            {({ message }) => {
+              if (message.composer.isEditing) return <EditComposer />;
+              if (message.role === "user") return <UserMessage />;
+              return <AssistantMessage />;
+            }}
           </ThreadPrimitive.Messages>
         </div>
 
@@ -206,15 +209,6 @@ const Thread: FC = () => {
       <SelectionToolbar />
     </ThreadPrimitive.Root>
   );
-};
-
-const ThreadMessage: FC = () => {
-  const role = useAuiState((s) => s.message.role);
-  const isEditing = useAuiState((s) => s.message.composer.isEditing);
-
-  if (isEditing) return <EditComposer />;
-  if (role === "user") return <UserMessage />;
-  return <AssistantMessage />;
 };
 
 const ThreadScrollToBottom: FC = () => {

--- a/packages/store/src/RenderChildrenWithAccessor.tsx
+++ b/packages/store/src/RenderChildrenWithAccessor.tsx
@@ -10,18 +10,20 @@ export const useGetItemAccessor = <T,>(
 ) => {
   const aui = useAui();
 
-  // if the consumer never accesses the item, do not trigger rerenders
-  const cacheRef = useRef<T | undefined>(undefined);
+  // Track access with a dedicated flag:
+  // useSyncExternalStore may call getSnapshot() after commit (tearing checks),
+  // which would re-cache the current state and mask later real updates.
+  // Use the current state as the pre-access snapshot so the post-commit check
+  // matches getItemState(aui) and doesn't schedule an unnecessary re-render.
+  const accessedRef = useRef(false);
+  const currentValue = accessedRef.current ? null : getItemState(aui);
   useAuiState(() => {
-    if (cacheRef.current === undefined) {
-      cacheRef.current = getItemState(aui);
-    }
-    return cacheRef.current;
+    if (!accessedRef.current) return currentValue;
+    return getItemState(aui);
   });
 
   return () => {
-    cacheRef.current = undefined; // clear the cache (rerender on next state change)
-
+    accessedRef.current = true;
     return getItemState(aui);
   };
 };

--- a/packages/store/src/__tests__/RenderChildrenWithAccessor.test.tsx
+++ b/packages/store/src/__tests__/RenderChildrenWithAccessor.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { act, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuiProvider } from "../utils/react-assistant-context";
+import { RenderChildrenWithAccessor } from "../RenderChildrenWithAccessor";
+import { PROXIED_ASSISTANT_STATE_SYMBOL } from "../utils/proxied-assistant-state";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+type Listener = () => void;
+
+const createTestAuiClient = () => {
+  const listeners = new Set<Listener>();
+  let itemState: { value: number; isEditing: boolean } = {
+    value: 1,
+    isEditing: false,
+  };
+
+  const proxiedState = {
+    item: itemState,
+  };
+
+  const client = {
+    subscribe: (listener: Listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    on: () => () => {},
+    [PROXIED_ASSISTANT_STATE_SYMBOL]: proxiedState,
+  } as const;
+
+  return {
+    client,
+    getItemState: () => itemState,
+    update: (next: Partial<typeof itemState>) => {
+      itemState = { ...itemState, ...next };
+      proxiedState.item = itemState;
+      // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
+      listeners.forEach((listener) => listener());
+    },
+  };
+};
+
+describe("RenderChildrenWithAccessor", () => {
+  it("re-renders when accessed state updates (regression: issue #3838)", () => {
+    const testClient = createTestAuiClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AuiProvider value={testClient.client as never}>{children}</AuiProvider>
+    );
+
+    const { container } = render(
+      <RenderChildrenWithAccessor
+        getItemState={() => testClient.getItemState()}
+      >
+        {(getItem) => {
+          const item = getItem();
+          return <div>{item.isEditing ? "editing" : "viewing"}</div>;
+        }}
+      </RenderChildrenWithAccessor>,
+      { wrapper },
+    );
+
+    expect(container.textContent).toBe("viewing");
+
+    act(() => {
+      testClient.update({ isEditing: true });
+    });
+
+    expect(container.textContent).toBe("editing");
+
+    act(() => {
+      testClient.update({ isEditing: false });
+    });
+
+    expect(container.textContent).toBe("viewing");
+  });
+
+  it("does not schedule an extra render on first access (initial snapshot matches getItemState)", () => {
+    const testClient = createTestAuiClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AuiProvider value={testClient.client as never}>{children}</AuiProvider>
+    );
+
+    const renderSpy = vi.fn();
+
+    render(
+      <RenderChildrenWithAccessor
+        getItemState={() => testClient.getItemState()}
+      >
+        {(getItem) => {
+          renderSpy();
+          const item = getItem();
+          return <div>{item.value}</div>;
+        }}
+      </RenderChildrenWithAccessor>,
+      { wrapper },
+    );
+
+    // first mount accesses the item; useSyncExternalStore's post-commit
+    // tearing check should see a stable snapshot and not force a re-render
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-render when item is never accessed", () => {
+    const testClient = createTestAuiClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AuiProvider value={testClient.client as never}>{children}</AuiProvider>
+    );
+
+    const renderSpy = vi.fn();
+
+    render(
+      <RenderChildrenWithAccessor
+        getItemState={() => testClient.getItemState()}
+      >
+        {() => {
+          renderSpy();
+          return <div>static</div>;
+        }}
+      </RenderChildrenWithAccessor>,
+      { wrapper },
+    );
+
+    const initialRenderCount = renderSpy.mock.calls.length;
+
+    act(() => {
+      testClient.update({ value: 99 });
+    });
+
+    expect(renderSpy.mock.calls.length).toBe(initialRenderCount);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3838.

`useGetItemAccessor` reused a single `cacheRef` as both an "accessed" sentinel (`undefined` = needs fetch) and as the cached snapshot returned by `useSyncExternalStore`. After `getItem()` cleared the ref, `useSyncExternalStore`'s post-commit consistency check would call `getSnapshot()` and repopulate the ref with the *current* state. When state actually changed afterwards (e.g. `message.composer.isEditing` flipping), the selector returned the still-cached snapshot, `Object.is` matched, and no re-render fired — the user-visible bug being that clicking edit on a message did nothing until something else forced a remount.

The fix splits the two concerns:
- a dedicated `accessedRef` boolean tracks whether children invoked `getItem()`,
- the pre-access snapshot is the current state (`getItemState(aui)`) instead of `undefined`, so the post-commit tearing check matches `getItemState(aui)` and doesn't schedule an unnecessary render on first access.

Once `accessedRef` is true, the eager `getItemState(aui)` call is skipped (`null`) since the selector takes the post-access branch and never reads it.

## Test plan

- [x] New regression test in `packages/store/src/__tests__/RenderChildrenWithAccessor.test.tsx` flips state through an accessed `getItem()` and asserts the rendered output updates — fails against the previous code, passes after the fix.
- [x] Additional test asserts no extra render is scheduled on first access (verified to fail with a `return undefined` pre-access snapshot).
- [x] Existing lazy-non-access optimization preserved by a third test.
- [x] `apps/docs/components/examples/shadcn.tsx` reverts the temp `ThreadMessage` workaround from #3839 back to the natural `{({ message }) => ...}` render-prop form.