### PR TITLE
chore(docs): refresh model picker

### DIFF
--- a/apps/docs/constants/model.ts
+++ b/apps/docs/constants/model.ts
@@ -14,50 +14,42 @@ export const MODELS = [
     disabled: false,
     contextWindow: 400_000,
   },
-  // Anthropic
-  {
-    name: "Claude Haiku 4.5",
-    value: "anthropic/claude-haiku-4-5",
-    icon: "/icons/anthropic.svg",
-    disabled: true,
-    contextWindow: 200_000,
-  },
   // Google
   {
-    name: "Gemini 3 Flash",
-    value: "google-ai-studio/gemini-3-flash",
+    name: "Gemini 3.1 Flash Lite",
+    value: "google-ai-studio/gemini-3.1-flash-lite-preview",
     icon: "/icons/google.svg",
-    disabled: true,
-    contextWindow: 1_000_000,
+    disabled: false,
+    contextWindow: 1_048_576,
   },
   // xAI
   {
     name: "Grok 4.1 Fast",
     value: "grok/grok-4-1-fast",
     icon: "/icons/xai.svg",
-    disabled: true,
-    contextWindow: 131_072,
+    disabled: false,
+    contextWindow: 2_000_000,
   },
   {
-    name: "Grok 3 Mini Fast",
-    value: "grok/grok-3-mini-fast",
+    name: "Grok 3 Mini",
+    value: "grok/grok-3-mini",
     icon: "/icons/xai.svg",
-    disabled: true,
+    disabled: false,
     contextWindow: 131_072,
   },
   // Groq
   {
-    name: "Llama 3.3 70B",
-    value: "groq/llama-3.3-70b-versatile",
+    name: "Llama 4 Scout 17B",
+    value: "groq/meta-llama/llama-4-scout-17b-16e-instruct",
     icon: "/icons/meta.svg",
-    disabled: true,
+    disabled: false,
     contextWindow: 131_072,
   },
   {
     name: "Qwen3 32B",
     value: "groq/qwen/qwen3-32b",
     icon: "/icons/groq.svg",
-    disabled: true,
+    disabled: false,
     contextWindow: 131_072,
   },
 ] as const;


### PR DESCRIPTION
## Summary
- replace `gemini-3-flash` with `gemini-3.1-flash-lite-preview` (newer family, 1.048M ctx, $0.25/$1.50 per 1M)
- replace `llama-3.3-70b-versatile` with `meta-llama/llama-4-scout-17b-16e-instruct` (newer family and cheaper, $0.11/$0.34)
- rename `grok-3-mini-fast` → `grok-3-mini` to match the gateway's actual model id
- fix `grok-4-1-fast` context window 131072 → 2000000 to reflect upstream
- enable all entries (`disabled: false`) after verifying every id routes successfully through the assistant-billing gateway
- drop the unused disabled anthropic placeholder

## Test plan
- [ ] each entry's `value` returns 200 from `https://gateway.assistant-billing.dev/v1/chat/completions` with a real chat completion (verified manually for all 7 ids)
- [ ] docs model picker renders all 7 options with correct icons
- [ ] selecting any model in the docs assistant produces a streamed reply
- [ ] `getContextWindow` returns the updated values for the changed ids