### PR TITLE
feat(react-ink): add ThreadPrimitive viewport support

### DIFF
--- a/.changeset/react-ink-thread-viewport.md
+++ b/.changeset/react-ink-thread-viewport.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+feat(react-ink): add thread viewport primitives

--- a/apps/docs/content/docs/ink/index.mdx
+++ b/apps/docs/content/docs/ink/index.mdx
@@ -179,9 +179,11 @@ export const Thread = () => {
         </Box>
       </ThreadPrimitive.Empty>
 
-      <ThreadPrimitive.Messages>
-        {() => <Message />}
-      </ThreadPrimitive.Messages>
+      <ThreadPrimitive.Viewport height={20}>
+        <ThreadPrimitive.Messages>
+          {() => <Message />}
+        </ThreadPrimitive.Messages>
+      </ThreadPrimitive.Viewport>
 
       <StatusIndicator />
 

--- a/apps/docs/content/docs/ink/primitives.mdx
+++ b/apps/docs/content/docs/ink/primitives.mdx
@@ -29,9 +29,107 @@ Container `Box` for the thread area.
 |------|------|-------------|
 | `...rest` | `BoxProps` | Standard Ink Box props |
 
+### Viewport
+
+Bounded terminal viewport for thread history. It keeps the latest messages visible by default, supports PageUp/PageDown/Home/End scrolling, and clips message history to the configured height.
+
+```tsx
+<ThreadPrimitive.Viewport height={20}>
+  <ThreadPrimitive.Messages>
+    {() => <MyMessage />}
+  </ThreadPrimitive.Messages>
+</ThreadPrimitive.Viewport>
+```
+
+When `height` is omitted, the parent Ink layout must constrain the viewport height.
+
+When `ThreadPrimitive.Viewport` creates its own provider, `autoScroll`, `initialScrollToBottom`, and `stickToBottomThreshold` can be passed directly to `Viewport`. In explicit-provider layouts, pass those values to `ThreadPrimitive.ViewportProvider options` instead because the provider owns viewport state.
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `children` | `ReactNode` | Usually `ThreadPrimitive.Messages` |
+| `height` | `number` | Fixed viewport height in terminal rows |
+| `autoScroll` | `boolean` | Whether the viewport initially follows the bottom. Defaults to `true` |
+| `initialScrollToBottom` | `boolean` | Start pinned to the newest messages. Defaults to `true` |
+| `scrollToBottomOnRunStart` | `boolean` | Jump to bottom when a run starts. Defaults to `true` |
+| `scrollToBottomOnInitialize` | `boolean` | Jump to bottom when the thread initializes. Defaults to `true` |
+| `scrollToBottomOnThreadSwitch` | `boolean` | Jump to bottom when switching threads. Defaults to `true` |
+| `stickToBottomThreshold` | `number` | Rows from the bottom that still count as sticky. Defaults to `2` |
+| `keybindings` | `ThreadViewportKeybindings \| false` | Override PageUp/PageDown/Home/End bindings, or disable them |
+| `renderPausedHint` | `(state) => ReactNode \| false` | Customize or disable the paused-scroll hint |
+| `...rest` | `BoxProps` | Standard Ink Box props |
+
+Disable default keybindings when another component owns those keys:
+
+```tsx
+<ThreadPrimitive.Viewport height={12} keybindings={false}>
+  <ThreadPrimitive.Messages>
+    {() => <MyMessage />}
+  </ThreadPrimitive.Messages>
+</ThreadPrimitive.Viewport>
+```
+
+Ink input events are global. If a focused composer or text input should own navigation keys such as Home, End, PageUp, or PageDown, disable viewport keybindings and handle scrolling from your app-level keyboard coordination.
+
+Customize the paused hint:
+
+```tsx
+<ThreadPrimitive.Viewport
+  height={12}
+  renderPausedHint={(state) => (
+    <Text dimColor>{state.messageKeys.length - state.visibleLastIndex - 1} new</Text>
+  )}
+>
+  <ThreadPrimitive.Messages>
+    {() => <MyMessage />}
+  </ThreadPrimitive.Messages>
+</ThreadPrimitive.Viewport>
+```
+
+### ViewportProvider
+
+Advanced composition provider for viewport state. Use it when controls such as `ScrollToBottom` should render outside the clipped message area while observing the same viewport.
+
+```tsx
+<ThreadPrimitive.ViewportProvider>
+  <ThreadPrimitive.Viewport height={20}>
+    <ThreadPrimitive.Messages>
+      {() => <MyMessage />}
+    </ThreadPrimitive.Messages>
+  </ThreadPrimitive.Viewport>
+
+  <ThreadPrimitive.ScrollToBottom>
+    <Text>[Jump to bottom]</Text>
+  </ThreadPrimitive.ScrollToBottom>
+</ThreadPrimitive.ViewportProvider>
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `children` | `ReactNode` | Viewport and controls that share viewport state |
+| `options.autoScroll` | `boolean` | Whether the viewport initially follows the bottom |
+| `options.initialScrollToBottom` | `boolean` | Start pinned to the newest messages |
+| `options.stickToBottomThreshold` | `number` | Rows from the bottom that still count as sticky |
+
+### ScrollToBottom
+
+Action component that renders only when the nearest thread viewport is not at the bottom.
+
+```tsx
+<ThreadPrimitive.ScrollToBottom>
+  <Text>[Jump to bottom]</Text>
+</ThreadPrimitive.ScrollToBottom>
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `children` | `ReactNode` | Content rendered as the action |
+| `behavior` | `"auto" \| "instant"` | Accepted for web parity; both are instant in Ink |
+| `...rest` | `BoxProps` | Standard Ink Box props |
+
 ### Messages
 
-Renders the message list with automatic runtime integration. Each message is wrapped in a scoped context so that `useAuiState((s) => s.message)` works inside the message component.
+Renders the message list with automatic runtime integration. Each message is wrapped in a scoped context so that `useAuiState((s) => s.message)` works inside the message component. Wrap it in `ThreadPrimitive.Viewport` for bounded terminal history.
 
 ```tsx
 <ThreadPrimitive.Messages>
@@ -42,6 +140,8 @@ Renders the message list with automatic runtime integration. Each message is wra
 | Prop | Type | Description |
 |------|------|-------------|
 | `components` | `MessageComponents` | Component map with `Message`, `UserMessage`, `AssistantMessage`, `SystemMessage`, and edit composer variants |
+
+`ThreadPrimitive.ViewportFooter` is intentionally not part of the Ink API. The web footer measures sticky DOM overlap, which does not map cleanly to Ink layout.
 
 ### AuiIf
 

--- a/packages/react-ink/src/primitives/thread.ts
+++ b/packages/react-ink/src/primitives/thread.ts
@@ -3,6 +3,18 @@ export {
   type ThreadRootProps as RootProps,
 } from "./thread/ThreadRoot";
 export {
+  ThreadViewport as Viewport,
+  type ThreadViewportProps as ViewportProps,
+} from "./thread/ThreadViewport";
+export {
+  ThreadViewportProvider as ViewportProvider,
+  type ThreadViewportProviderProps as ViewportProviderProps,
+} from "./thread/ThreadViewportProvider";
+export {
+  ThreadScrollToBottom as ScrollToBottom,
+  type ThreadScrollToBottomProps as ScrollToBottomProps,
+} from "./thread/ThreadScrollToBottom";
+export {
   ThreadMessages as Messages,
   type ThreadMessagesProps as MessagesProps,
 } from "./thread/ThreadMessages";

--- a/packages/react-ink/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadMessages.tsx
@@ -1,8 +1,20 @@
-import { type ComponentType, type FC, type ReactNode, useMemo } from "react";
-import { Box } from "ink";
+import {
+  type ComponentType,
+  type FC,
+  type ReactNode,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
+import { Box, useBoxMetrics, type DOMElement } from "ink";
 import type { ThreadMessage } from "@assistant-ui/core";
 import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
 import { MessageByIndexProvider } from "@assistant-ui/core/react";
+import {
+  useOptionalThreadViewport,
+  type ThreadViewportContextValue,
+} from "./useThreadViewport";
+import type { ThreadMessageKey } from "./useThreadViewportState";
 
 type MessageComponents =
   | {
@@ -103,45 +115,135 @@ const ThreadMessageComponent: FC<{ components: MessageComponents }> = ({
 
 const ThreadMessagesInner: FC<{
   children: (value: { message: ThreadMessage }) => ReactNode;
-}> = ({ children }) => {
+  messageKeys: readonly ThreadMessageKey[];
+  estimatedHeights: readonly number[];
+  setMessageHeight: ThreadViewportContextValue["setMessageHeight"] | undefined;
+}> = ({ children, messageKeys, estimatedHeights, setMessageHeight }) => {
   const messagesLength = useAuiState((s) => s.thread.messages.length);
 
   return useMemo(() => {
     if (messagesLength === 0) return null;
     return Array.from({ length: messagesLength }, (_, index) => (
-      <MessageByIndexProvider key={index} index={index}>
-        <RenderChildrenWithAccessor
-          getItemState={(aui) => aui.thread().message({ index }).getState()}
-        >
-          {(getItem) =>
-            children({
-              get message() {
-                return getItem();
-              },
-            })
-          }
-        </RenderChildrenWithAccessor>
-      </MessageByIndexProvider>
+      <MeasuredThreadMessage
+        key={String(messageKeys[index] ?? index)}
+        messageKey={messageKeys[index] ?? index}
+        estimatedHeight={estimatedHeights[index] ?? 1}
+        setMessageHeight={setMessageHeight}
+      >
+        <MessageByIndexProvider index={index}>
+          <RenderChildrenWithAccessor
+            getItemState={(aui) => aui.thread().message({ index }).getState()}
+          >
+            {(getItem) =>
+              children({
+                get message() {
+                  return getItem();
+                },
+              })
+            }
+          </RenderChildrenWithAccessor>
+        </MessageByIndexProvider>
+      </MeasuredThreadMessage>
     ));
-  }, [messagesLength, children]);
+  }, [
+    messagesLength,
+    messageKeys,
+    estimatedHeights,
+    setMessageHeight,
+    children,
+  ]);
+};
+
+const getMessageKey = (message: ThreadMessage, index: number) =>
+  message.id ?? index;
+
+const getTextHeightEstimate = (message: ThreadMessage, width: number) => {
+  const text = message.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+
+  if (!text) return 1;
+
+  const contentWidth = Math.max(20, width - 4);
+  const textRows = text
+    .split("\n")
+    .reduce(
+      (rows, line) => rows + Math.max(1, Math.ceil(line.length / contentWidth)),
+      0,
+    );
+
+  return textRows + (message.role === "assistant" ? 2 : 1);
+};
+
+const MeasuredThreadMessage: FC<{
+  messageKey: ThreadMessageKey;
+  estimatedHeight: number;
+  setMessageHeight: ThreadViewportContextValue["setMessageHeight"] | undefined;
+  children: ReactNode;
+}> = ({ messageKey, estimatedHeight, setMessageHeight, children }) => {
+  const ref = useRef<DOMElement>(null!);
+  const { height, hasMeasured } = useBoxMetrics(ref);
+
+  useLayoutEffect(() => {
+    if (!setMessageHeight || !hasMeasured) return;
+    setMessageHeight(messageKey, Math.max(height, estimatedHeight));
+  }, [estimatedHeight, height, hasMeasured, messageKey, setMessageHeight]);
+
+  if (!setMessageHeight) return <>{children}</>;
+
+  return (
+    <Box ref={ref} flexShrink={0}>
+      {children}
+    </Box>
+  );
 };
 
 export const ThreadMessages: FC<ThreadMessagesProps> = ({
   components,
   children,
 }) => {
-  if (components) {
-    return (
-      <Box flexDirection="column">
-        <ThreadMessagesInner>
-          {() => <ThreadMessageComponent components={components} />}
-        </ThreadMessagesInner>
-      </Box>
-    );
-  }
+  const viewport = useOptionalThreadViewport();
+  const setMessageKeys = viewport?.setMessageKeys;
+  const setMessageHeight = viewport?.setMessageHeight;
+  const viewportWidth = viewport?.viewportWidth;
+  const scrollOffset = viewport?.state.scrollOffset;
+  const messages = useAuiState((s) => s.thread.messages);
+  const messageKeys = useMemo(
+    () => messages.map((message, index) => getMessageKey(message, index)),
+    [messages],
+  );
+
+  useLayoutEffect(() => {
+    setMessageKeys?.(messageKeys);
+  }, [messageKeys, setMessageKeys]);
+
+  const estimatedHeights = useMemo(
+    () =>
+      messages.map((message) =>
+        getTextHeightEstimate(message, viewportWidth ?? 80),
+      ),
+    [messages, viewportWidth],
+  );
+  const renderMessage = components
+    ? () => <ThreadMessageComponent components={components} />
+    : children;
+
+  const content = (
+    <ThreadMessagesInner
+      messageKeys={messageKeys}
+      estimatedHeights={estimatedHeights}
+      setMessageHeight={setMessageHeight}
+    >
+      {renderMessage}
+    </ThreadMessagesInner>
+  );
+
+  const marginTop = scrollOffset !== undefined ? -scrollOffset : undefined;
+
   return (
-    <Box flexDirection="column">
-      <ThreadMessagesInner>{children}</ThreadMessagesInner>
+    <Box flexDirection="column" marginTop={marginTop} flexShrink={0}>
+      {content}
     </Box>
   );
 };

--- a/packages/react-ink/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadMessages.tsx
@@ -2,6 +2,7 @@ import {
   type ComponentType,
   type FC,
   type ReactNode,
+  useCallback,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -225,9 +226,12 @@ export const ThreadMessages: FC<ThreadMessagesProps> = ({
       ),
     [messages, viewportWidth],
   );
-  const renderMessage = components
-    ? () => <ThreadMessageComponent components={components} />
-    : children;
+  const renderComponentMessage = useCallback(
+    () =>
+      components ? <ThreadMessageComponent components={components} /> : null,
+    [components],
+  );
+  const renderMessage = components ? renderComponentMessage : children;
 
   const content = (
     <ThreadMessagesInner

--- a/packages/react-ink/src/primitives/thread/ThreadScrollToBottom.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadScrollToBottom.tsx
@@ -1,0 +1,31 @@
+import type { ComponentProps, ReactNode } from "react";
+import type { Box } from "ink";
+import { Pressable } from "../internal/Pressable";
+import { useThreadViewport } from "./useThreadViewport";
+
+export type ThreadScrollToBottomProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+  behavior?: "auto" | "instant" | undefined;
+};
+
+export const ThreadScrollToBottom = ({
+  children,
+  behavior: _behavior,
+  ...boxProps
+}: ThreadScrollToBottomProps) => {
+  const viewport = useThreadViewport();
+
+  if (viewport.state.isAtBottom) return null;
+
+  return (
+    <Pressable onPress={viewport.actions.scrollToBottom} {...boxProps}>
+      {children}
+    </Pressable>
+  );
+};
+
+ThreadScrollToBottom.displayName = "ThreadPrimitive.ScrollToBottom";
+
+export namespace ThreadScrollToBottom {
+  export type Props = ThreadScrollToBottomProps;
+}

--- a/packages/react-ink/src/primitives/thread/ThreadViewport.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadViewport.tsx
@@ -1,0 +1,230 @@
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
+import {
+  Box,
+  Text,
+  useBoxMetrics,
+  useInput,
+  type DOMElement,
+  type Key,
+} from "ink";
+import { useAuiEvent } from "@assistant-ui/store";
+import { ThreadViewportProvider } from "./ThreadViewportProvider";
+import {
+  useOptionalThreadViewport,
+  useThreadViewport,
+  type ThreadViewportStateSnapshot,
+} from "./useThreadViewport";
+
+export type ThreadViewportKeybindings = {
+  pageUp?: string | string[] | undefined;
+  pageDown?: string | string[] | undefined;
+  top?: string | string[] | undefined;
+  bottom?: string | string[] | undefined;
+  lineUp?: string | string[] | undefined;
+  lineDown?: string | string[] | undefined;
+};
+
+export type ThreadViewportProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+  height?: number | undefined;
+  autoScroll?: boolean | undefined;
+  initialScrollToBottom?: boolean | undefined;
+  scrollToBottomOnRunStart?: boolean | undefined;
+  scrollToBottomOnInitialize?: boolean | undefined;
+  scrollToBottomOnThreadSwitch?: boolean | undefined;
+  stickToBottomThreshold?: number | undefined;
+  keybindings?: ThreadViewportKeybindings | false | undefined;
+  renderPausedHint?:
+    | ((state: ThreadViewportStateSnapshot) => ReactNode)
+    | false
+    | undefined;
+};
+
+const DEFAULT_KEYBINDINGS: ThreadViewportKeybindings = {
+  pageUp: "pageup",
+  pageDown: "pagedown",
+  top: "home",
+  bottom: "end",
+};
+
+const normalizeBinding = (binding?: string | string[]) => {
+  if (!binding) return [];
+  return Array.isArray(binding) ? binding : [binding];
+};
+
+const matchBinding = (input: string, key: Key, binding?: string | string[]) =>
+  normalizeBinding(binding).some((entry) => {
+    const parts = entry.toLowerCase().split("+");
+    const keyName = parts[parts.length - 1];
+    const wantsCtrl = parts.includes("ctrl");
+    const wantsShift = parts.includes("shift");
+    const wantsMeta = parts.includes("meta");
+
+    const keyRecord = key as Key & {
+      pageup?: boolean;
+      pagedown?: boolean;
+    };
+    const matchedKey =
+      keyName === "pageup"
+        ? key.pageUp || keyRecord.pageup
+        : keyName === "pagedown"
+          ? key.pageDown || keyRecord.pagedown
+          : keyName === "home"
+            ? key.home
+            : keyName === "end"
+              ? key.end
+              : keyName === "uparrow"
+                ? key.upArrow
+                : keyName === "downarrow"
+                  ? key.downArrow
+                  : input.toLowerCase() === keyName;
+
+    return (
+      matchedKey &&
+      Boolean(key.ctrl) === wantsCtrl &&
+      Boolean(key.shift) === wantsShift &&
+      Boolean(key.meta) === wantsMeta
+    );
+  });
+
+const getPausedHintText = (newBelow: number) =>
+  `[paused | End to resume | ${newBelow} new below]`;
+
+const ThreadViewportInner = ({
+  children,
+  height,
+  autoScroll: _autoScroll,
+  initialScrollToBottom: _initialScrollToBottom,
+  scrollToBottomOnRunStart = true,
+  scrollToBottomOnInitialize = true,
+  scrollToBottomOnThreadSwitch = true,
+  stickToBottomThreshold: _stickToBottomThreshold,
+  keybindings,
+  renderPausedHint,
+  ...boxProps
+}: ThreadViewportProps) => {
+  const viewport = useThreadViewport();
+  const viewportRef = useRef<DOMElement>(null!);
+  const viewportMetrics = useBoxMetrics(viewportRef);
+  const effectiveHeight = height ?? viewportMetrics.height ?? 1;
+
+  useLayoutEffect(() => {
+    viewport.setViewportHeight(effectiveHeight > 0 ? effectiveHeight : 1);
+    viewport.setViewportWidth(
+      viewportMetrics.width > 0 ? viewportMetrics.width : 80,
+    );
+  }, [effectiveHeight, viewport, viewportMetrics.width]);
+
+  useAuiEvent("thread.runStart", () => {
+    if (scrollToBottomOnRunStart) viewport.actions.scrollToBottom();
+  });
+  useAuiEvent("thread.initialize", () => {
+    if (scrollToBottomOnInitialize) viewport.actions.scrollToBottom();
+  });
+  useAuiEvent("threadListItem.switchedTo", () => {
+    if (scrollToBottomOnThreadSwitch) viewport.actions.scrollToBottom();
+  });
+
+  const effectiveKeybindings = useMemo(() => {
+    if (keybindings === false) return false;
+    return {
+      ...DEFAULT_KEYBINDINGS,
+      ...keybindings,
+    };
+  }, [keybindings]);
+
+  const handleInput = useCallback(
+    (input: string, key: Key) => {
+      if (!effectiveKeybindings) return;
+      if (matchBinding(input, key, effectiveKeybindings.pageUp)) {
+        viewport.actions.scrollByPage("up");
+        return;
+      }
+      if (matchBinding(input, key, effectiveKeybindings.pageDown)) {
+        viewport.actions.scrollByPage("down");
+        return;
+      }
+      if (matchBinding(input, key, effectiveKeybindings.top)) {
+        viewport.actions.scrollToTop();
+        return;
+      }
+      if (matchBinding(input, key, effectiveKeybindings.bottom)) {
+        viewport.actions.scrollToBottom();
+        return;
+      }
+      if (matchBinding(input, key, effectiveKeybindings.lineUp)) {
+        viewport.actions.scrollBy(-1);
+        return;
+      }
+      if (matchBinding(input, key, effectiveKeybindings.lineDown)) {
+        viewport.actions.scrollBy(1);
+      }
+    },
+    [effectiveKeybindings, viewport.actions],
+  );
+
+  useInput(handleInput, { isActive: effectiveKeybindings !== false });
+
+  const newBelow = Math.max(
+    0,
+    viewport.state.messageKeys.length - viewport.state.visibleLastIndex - 1,
+  );
+  const shouldShowPausedHint =
+    viewport.state.autoScroll === false &&
+    viewport.state.maxScrollOffset > viewport.state.scrollOffset &&
+    newBelow > 0;
+
+  return (
+    <Box flexDirection="column">
+      <Box
+        ref={viewportRef}
+        height={height}
+        minHeight={height === undefined ? 1 : undefined}
+        overflowY="hidden"
+        flexDirection="column"
+        flexGrow={height === undefined ? 1 : undefined}
+        {...boxProps}
+      >
+        {children}
+      </Box>
+      {shouldShowPausedHint && renderPausedHint !== false ? (
+        renderPausedHint ? (
+          renderPausedHint(viewport.state)
+        ) : (
+          <Text>{getPausedHintText(newBelow)}</Text>
+        )
+      ) : null}
+    </Box>
+  );
+};
+
+export const ThreadViewport = (props: ThreadViewportProps) => {
+  const outerViewport = useOptionalThreadViewport();
+
+  if (outerViewport) return <ThreadViewportInner {...props} />;
+
+  return (
+    <ThreadViewportProvider
+      options={{
+        autoScroll: props.autoScroll,
+        initialScrollToBottom: props.initialScrollToBottom,
+        stickToBottomThreshold: props.stickToBottomThreshold,
+      }}
+    >
+      <ThreadViewportInner {...props} />
+    </ThreadViewportProvider>
+  );
+};
+
+ThreadViewport.displayName = "ThreadPrimitive.Viewport";
+
+export namespace ThreadViewport {
+  export type Props = ThreadViewportProps;
+}

--- a/packages/react-ink/src/primitives/thread/ThreadViewport.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadViewport.tsx
@@ -111,16 +111,21 @@ const ThreadViewportInner = ({
   ...boxProps
 }: ThreadViewportProps) => {
   const viewport = useThreadViewport();
+  const setViewportHeight = viewport.setViewportHeight;
+  const setViewportWidth = viewport.setViewportWidth;
   const viewportRef = useRef<DOMElement>(null!);
   const viewportMetrics = useBoxMetrics(viewportRef);
   const effectiveHeight = height ?? viewportMetrics.height ?? 1;
 
   useLayoutEffect(() => {
-    viewport.setViewportHeight(effectiveHeight > 0 ? effectiveHeight : 1);
-    viewport.setViewportWidth(
-      viewportMetrics.width > 0 ? viewportMetrics.width : 80,
-    );
-  }, [effectiveHeight, viewport, viewportMetrics.width]);
+    setViewportHeight(effectiveHeight > 0 ? effectiveHeight : 1);
+    setViewportWidth(viewportMetrics.width > 0 ? viewportMetrics.width : 80);
+  }, [
+    effectiveHeight,
+    setViewportHeight,
+    setViewportWidth,
+    viewportMetrics.width,
+  ]);
 
   useAuiEvent("thread.runStart", () => {
     if (scrollToBottomOnRunStart) viewport.actions.scrollToBottom();

--- a/packages/react-ink/src/primitives/thread/ThreadViewportProvider.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadViewportProvider.tsx
@@ -1,0 +1,105 @@
+import { useCallback, useMemo, useState, type PropsWithChildren } from "react";
+import { ThreadViewportContext } from "./useThreadViewport";
+import {
+  createThreadViewportActions,
+  useThreadViewportState,
+} from "./useThreadViewportState";
+import { useThreadMessageHeights } from "./useThreadMessageHeights";
+
+export type ThreadViewportProviderProps = PropsWithChildren<{
+  options?:
+    | {
+        autoScroll?: boolean | undefined;
+        initialScrollToBottom?: boolean | undefined;
+        stickToBottomThreshold?: number | undefined;
+      }
+    | undefined;
+}>;
+
+export const ThreadViewportProvider = ({
+  children,
+  options,
+}: ThreadViewportProviderProps) => {
+  const [viewportHeight, setViewportHeightState] = useState(0);
+  const [viewportWidth, setViewportWidthState] = useState(80);
+  const initialScrollToBottom =
+    options?.initialScrollToBottom ?? options?.autoScroll ?? true;
+
+  const setViewportHeight = useCallback((height: number) => {
+    setViewportHeightState((previous) => {
+      const next = Math.max(0, height);
+      return previous === next ? previous : next;
+    });
+  }, []);
+
+  const setViewportWidth = useCallback((width: number) => {
+    setViewportWidthState((previous) => {
+      const next = Math.max(1, width);
+      return previous === next ? previous : next;
+    });
+  }, []);
+
+  const { messageHeights, messageKeyOrder, setMessageKeys, setMessageHeight } =
+    useThreadMessageHeights({});
+
+  const { state, derived, dispatchWithDerived } = useThreadViewportState({
+    viewportHeight,
+    messageHeights,
+    messageKeyOrder,
+    stickToBottomThreshold: options?.stickToBottomThreshold,
+    initialScrollToBottom,
+  });
+
+  const actions = useMemo(
+    () => createThreadViewportActions(dispatchWithDerived),
+    [dispatchWithDerived],
+  );
+
+  const value = useMemo(
+    () => ({
+      state: {
+        scrollOffset: state.scrollOffset,
+        autoScroll: state.autoScroll,
+        viewportHeight: state.viewportHeight,
+        stickToBottomThreshold: state.stickToBottomThreshold,
+        contentHeight: derived.contentHeight,
+        maxScrollOffset: derived.maxScrollOffset,
+        visibleFirstIndex: derived.visibleFirstIndex,
+        visibleLastIndex: derived.visibleLastIndex,
+        isAtBottom: derived.isAtBottom,
+        messageOffsets: derived.messageOffsets,
+        messageHeightsInOrder: derived.messageHeightsInOrder,
+        messageKeys: messageKeyOrder,
+      },
+      actions,
+      setViewportHeight,
+      setViewportWidth,
+      setMessageKeys,
+      setMessageHeight,
+      viewportWidth,
+    }),
+    [
+      actions,
+      derived,
+      messageKeyOrder,
+      setMessageHeight,
+      setMessageKeys,
+      setViewportHeight,
+      setViewportWidth,
+      state,
+      viewportWidth,
+    ],
+  );
+
+  return (
+    <ThreadViewportContext.Provider value={value}>
+      {children}
+    </ThreadViewportContext.Provider>
+  );
+};
+
+ThreadViewportProvider.displayName = "ThreadPrimitive.ViewportProvider";
+
+export namespace ThreadViewportProvider {
+  export type Props = ThreadViewportProviderProps;
+}

--- a/packages/react-ink/src/primitives/thread/useThreadMessageHeights.ts
+++ b/packages/react-ink/src/primitives/thread/useThreadMessageHeights.ts
@@ -1,0 +1,92 @@
+import { useCallback, useMemo, useState } from "react";
+import type { ThreadMessageKey } from "./useThreadViewportState";
+import { arraysEqual, mapsEqual } from "./utils";
+
+export type ThreadMessageHeightsState = {
+  heights: Map<ThreadMessageKey, number>;
+  keyOrder: ThreadMessageKey[];
+};
+
+export const createInitialThreadMessageHeights = (
+  keys: readonly ThreadMessageKey[],
+  estimatedHeight: number,
+) => new Map(keys.map((key) => [key, Math.max(1, estimatedHeight)]));
+
+export const reconcileThreadMessageHeights = ({
+  previousHeights,
+  nextKeys,
+  estimatedHeight,
+}: {
+  previousHeights: Map<ThreadMessageKey, number>;
+  nextKeys: readonly ThreadMessageKey[];
+  estimatedHeight: number;
+}): ThreadMessageHeightsState => {
+  const heights = new Map<ThreadMessageKey, number>();
+
+  for (const key of nextKeys) {
+    heights.set(key, previousHeights.get(key) ?? Math.max(1, estimatedHeight));
+  }
+
+  return {
+    heights,
+    keyOrder: [...nextKeys],
+  };
+};
+
+export const useThreadMessageHeights = ({
+  estimatedHeight = 1,
+}: {
+  estimatedHeight?: number | undefined;
+}) => {
+  const [state, setState] = useState<ThreadMessageHeightsState>(() => ({
+    heights: createInitialThreadMessageHeights([], estimatedHeight),
+    keyOrder: [],
+  }));
+
+  const setMessageKeys = useCallback(
+    (messageKeys: readonly ThreadMessageKey[]) => {
+      setState((previous) => {
+        const next = reconcileThreadMessageHeights({
+          previousHeights: previous.heights,
+          nextKeys: messageKeys,
+          estimatedHeight,
+        });
+
+        return mapsEqual(previous.heights, next.heights) &&
+          arraysEqual(previous.keyOrder, next.keyOrder)
+          ? previous
+          : next;
+      });
+    },
+    [estimatedHeight],
+  );
+
+  const setMessageHeight = useCallback(
+    (messageKey: ThreadMessageKey, height: number) => {
+      setState((previous) => {
+        const nextHeight = Math.max(1, height);
+        if (previous.heights.get(messageKey) === nextHeight) {
+          return previous;
+        }
+
+        const heights = new Map(previous.heights);
+        heights.set(messageKey, nextHeight);
+        return {
+          heights,
+          keyOrder: previous.keyOrder,
+        };
+      });
+    },
+    [],
+  );
+
+  return useMemo(
+    () => ({
+      messageHeights: state.heights,
+      messageKeyOrder: state.keyOrder,
+      setMessageKeys,
+      setMessageHeight,
+    }),
+    [state, setMessageKeys, setMessageHeight],
+  );
+};

--- a/packages/react-ink/src/primitives/thread/useThreadViewport.ts
+++ b/packages/react-ink/src/primitives/thread/useThreadViewport.ts
@@ -1,0 +1,41 @@
+import { createContext, useContext } from "react";
+import type { ThreadMessageKey } from "./useThreadViewportState";
+import type {
+  ThreadViewportDerivedState,
+  ThreadViewportState,
+  ThreadViewportStateActions,
+} from "./useThreadViewportState";
+
+export type ThreadViewportStateSnapshot = Pick<
+  ThreadViewportState,
+  "scrollOffset" | "autoScroll" | "viewportHeight" | "stickToBottomThreshold"
+> &
+  ThreadViewportDerivedState & {
+    messageKeys: ThreadMessageKey[];
+  };
+
+export type ThreadViewportContextValue = {
+  state: ThreadViewportStateSnapshot;
+  actions: ThreadViewportStateActions;
+  viewportWidth: number;
+  setViewportHeight: (height: number) => void;
+  setViewportWidth: (width: number) => void;
+  setMessageKeys: (keys: readonly ThreadMessageKey[]) => void;
+  setMessageHeight: (key: ThreadMessageKey, height: number) => void;
+};
+
+export const ThreadViewportContext =
+  createContext<ThreadViewportContextValue | null>(null);
+
+export const useOptionalThreadViewport = () =>
+  useContext(ThreadViewportContext);
+
+export const useThreadViewport = () => {
+  const context = useOptionalThreadViewport();
+  if (!context) {
+    throw new Error(
+      "Thread viewport components must be used inside ThreadPrimitive.ViewportProvider or ThreadPrimitive.Viewport.",
+    );
+  }
+  return context;
+};

--- a/packages/react-ink/src/primitives/thread/useThreadViewportState.ts
+++ b/packages/react-ink/src/primitives/thread/useThreadViewportState.ts
@@ -1,0 +1,402 @@
+import { useCallback, useMemo, useRef, useState, type Dispatch } from "react";
+import { arraysEqual, mapsEqual } from "./utils";
+
+export type ThreadMessageKey = string | number;
+
+export type ThreadViewportState = {
+  scrollOffset: number;
+  autoScroll: boolean;
+  viewportHeight: number;
+  messageHeights: Map<ThreadMessageKey, number>;
+  messageKeyOrder: ThreadMessageKey[];
+  stickToBottomThreshold: number;
+};
+
+export type ThreadViewportDerivedState = {
+  contentHeight: number;
+  maxScrollOffset: number;
+  visibleFirstIndex: number;
+  visibleLastIndex: number;
+  isAtBottom: boolean;
+  messageOffsets: number[];
+  messageHeightsInOrder: number[];
+};
+
+type ThreadViewportReducerAction =
+  | {
+      type: "scrollBy";
+      rows: number;
+      derived: ThreadViewportDerivedState;
+      stickToBottomThreshold: number;
+    }
+  | {
+      type: "scrollByPage";
+      direction: "up" | "down";
+      derived: ThreadViewportDerivedState;
+      stickToBottomThreshold: number;
+    }
+  | {
+      type: "scrollToTop";
+      derived: ThreadViewportDerivedState;
+      stickToBottomThreshold: number;
+    }
+  | {
+      type: "scrollToBottom";
+      derived: ThreadViewportDerivedState;
+      stickToBottomThreshold: number;
+    }
+  | {
+      type: "scrollToMessage";
+      index: number;
+      align?: "top" | "bottom";
+      derived: ThreadViewportDerivedState;
+      stickToBottomThreshold: number;
+    }
+  | {
+      type: "setAutoScroll";
+      enabled: boolean;
+      derived: ThreadViewportDerivedState;
+      stickToBottomThreshold: number;
+    };
+
+export type ThreadViewportStateActions = {
+  scrollBy: (rows: number) => void;
+  scrollByPage: (direction: "up" | "down") => void;
+  scrollToTop: () => void;
+  scrollToBottom: () => void;
+  scrollToMessage: (index: number, align?: "top" | "bottom") => void;
+  setAutoScroll: (enabled: boolean) => void;
+};
+
+type ThreadViewportDispatchAction =
+  | {
+      type: "scrollBy";
+      rows: number;
+    }
+  | {
+      type: "scrollByPage";
+      direction: "up" | "down";
+    }
+  | {
+      type: "scrollToTop";
+    }
+  | {
+      type: "scrollToBottom";
+    }
+  | {
+      type: "scrollToMessage";
+      index: number;
+      align?: "top" | "bottom" | undefined;
+    }
+  | {
+      type: "setAutoScroll";
+      enabled: boolean;
+    };
+
+type InternalThreadViewportState = Pick<
+  ThreadViewportState,
+  "scrollOffset" | "autoScroll"
+>;
+
+type ExternalThreadViewportState = Omit<
+  ThreadViewportState,
+  "scrollOffset" | "autoScroll"
+>;
+
+export const clampThreadViewportScrollOffset = (
+  offset: number,
+  maxScrollOffset: number,
+) => Math.max(0, Math.min(offset, Math.max(0, maxScrollOffset)));
+
+const resolveAutoScroll = (
+  scrollOffset: number,
+  maxScrollOffset: number,
+  stickToBottomThreshold: number,
+) => maxScrollOffset - scrollOffset <= stickToBottomThreshold;
+
+const getStateIfChanged = (
+  previous: ThreadViewportState,
+  next: ThreadViewportState,
+): ThreadViewportState =>
+  previous.scrollOffset === next.scrollOffset &&
+  previous.autoScroll === next.autoScroll &&
+  previous.viewportHeight === next.viewportHeight &&
+  previous.stickToBottomThreshold === next.stickToBottomThreshold &&
+  mapsEqual(previous.messageHeights, next.messageHeights) &&
+  arraysEqual(previous.messageKeyOrder, next.messageKeyOrder)
+    ? previous
+    : next;
+
+const finalizeAgainstDerived = (
+  state: ThreadViewportState,
+  scrollOffset: number,
+  derived: ThreadViewportDerivedState,
+  stickToBottomThreshold: number,
+  forceAutoScroll?: boolean | undefined,
+) => {
+  const clampedOffset = clampThreadViewportScrollOffset(
+    scrollOffset,
+    derived.maxScrollOffset,
+  );
+
+  return getStateIfChanged(state, {
+    ...state,
+    scrollOffset: clampedOffset,
+    autoScroll:
+      forceAutoScroll ??
+      resolveAutoScroll(
+        clampedOffset,
+        derived.maxScrollOffset,
+        stickToBottomThreshold,
+      ),
+  });
+};
+
+export const createInitialThreadViewportState = ({
+  viewportHeight = 0,
+  messageHeights = new Map<ThreadMessageKey, number>(),
+  messageKeyOrder = [],
+  scrollOffset = 0,
+  autoScroll = true,
+  stickToBottomThreshold = 2,
+}: Partial<ThreadViewportState> = {}): ThreadViewportState => ({
+  scrollOffset,
+  autoScroll,
+  viewportHeight,
+  messageHeights,
+  messageKeyOrder,
+  stickToBottomThreshold,
+});
+
+export const deriveThreadViewportState = (
+  state: ThreadViewportState,
+): ThreadViewportDerivedState => {
+  let contentHeight = 0;
+  const messageOffsets: number[] = [];
+  const messageHeightsInOrder = state.messageKeyOrder.map((key) => {
+    const height = Math.max(1, state.messageHeights.get(key) ?? 1);
+    messageOffsets.push(contentHeight);
+    contentHeight += height;
+    return height;
+  });
+
+  const maxScrollOffset = Math.max(0, contentHeight - state.viewportHeight);
+  const viewportBottom = state.scrollOffset + Math.max(0, state.viewportHeight);
+  const messageCount = state.messageKeyOrder.length;
+
+  let visibleFirstIndex = messageCount === 0 ? 0 : messageCount - 1;
+  let visibleLastIndex = messageCount === 0 ? 0 : messageCount - 1;
+
+  if (messageCount > 0) {
+    for (let index = 0; index < messageCount; index++) {
+      const top = messageOffsets[index] ?? 0;
+      const bottom = top + (messageHeightsInOrder[index] ?? 1);
+      if (bottom > state.scrollOffset) {
+        visibleFirstIndex = index;
+        break;
+      }
+    }
+
+    for (let index = visibleFirstIndex; index < messageCount; index++) {
+      const top = messageOffsets[index] ?? 0;
+      if (top >= viewportBottom) {
+        visibleLastIndex = Math.max(visibleFirstIndex, index - 1);
+        break;
+      }
+      visibleLastIndex = index;
+    }
+  }
+
+  return {
+    contentHeight,
+    maxScrollOffset,
+    visibleFirstIndex,
+    visibleLastIndex,
+    isAtBottom: resolveAutoScroll(
+      state.scrollOffset,
+      maxScrollOffset,
+      state.stickToBottomThreshold,
+    ),
+    messageOffsets,
+    messageHeightsInOrder,
+  };
+};
+
+export const threadViewportStateReducer = (
+  state: ThreadViewportState,
+  action: ThreadViewportReducerAction,
+): ThreadViewportState => {
+  switch (action.type) {
+    case "scrollBy":
+      return finalizeAgainstDerived(
+        state,
+        state.scrollOffset + action.rows,
+        action.derived,
+        action.stickToBottomThreshold,
+        action.rows < 0 ? false : undefined,
+      );
+    case "scrollByPage":
+      return finalizeAgainstDerived(
+        state,
+        state.scrollOffset +
+          (action.direction === "down"
+            ? state.viewportHeight
+            : -state.viewportHeight),
+        action.derived,
+        action.stickToBottomThreshold,
+        action.direction === "up" ? false : undefined,
+      );
+    case "scrollToTop":
+      return finalizeAgainstDerived(
+        state,
+        0,
+        action.derived,
+        action.stickToBottomThreshold,
+        false,
+      );
+    case "scrollToBottom":
+      return getStateIfChanged(state, {
+        ...state,
+        scrollOffset: action.derived.maxScrollOffset,
+        autoScroll: true,
+      });
+    case "scrollToMessage": {
+      const messageTop = action.derived.messageOffsets[action.index] ?? 0;
+      const messageHeight =
+        action.derived.messageHeightsInOrder[action.index] ?? 1;
+      const nextOffset =
+        action.align === "bottom"
+          ? messageTop + messageHeight - state.viewportHeight
+          : messageTop;
+
+      return finalizeAgainstDerived(
+        state,
+        nextOffset,
+        action.derived,
+        action.stickToBottomThreshold,
+      );
+    }
+    case "setAutoScroll":
+      return action.enabled
+        ? threadViewportStateReducer(state, {
+            type: "scrollToBottom",
+            derived: action.derived,
+            stickToBottomThreshold: action.stickToBottomThreshold,
+          })
+        : getStateIfChanged(state, { ...state, autoScroll: false });
+    default:
+      return state;
+  }
+};
+
+export const buildEffectiveThreadViewportState = (
+  externalState: ExternalThreadViewportState,
+  internalState: InternalThreadViewportState,
+) => {
+  const rawState: ThreadViewportState = {
+    ...externalState,
+    scrollOffset: internalState.scrollOffset,
+    autoScroll: internalState.autoScroll,
+  };
+  const rawDerived = deriveThreadViewportState(rawState);
+  const fullState: ThreadViewportState = {
+    ...rawState,
+    scrollOffset: internalState.autoScroll
+      ? rawDerived.maxScrollOffset
+      : clampThreadViewportScrollOffset(
+          internalState.scrollOffset,
+          rawDerived.maxScrollOffset,
+        ),
+  };
+
+  return {
+    fullState,
+    derived:
+      fullState.scrollOffset === rawState.scrollOffset
+        ? rawDerived
+        : deriveThreadViewportState(fullState),
+  };
+};
+
+export type UseThreadViewportStateOptions = {
+  viewportHeight: number;
+  messageHeights: Map<ThreadMessageKey, number>;
+  messageKeyOrder: ThreadMessageKey[];
+  stickToBottomThreshold?: number | undefined;
+  initialScrollToBottom?: boolean | undefined;
+};
+
+export const useThreadViewportState = ({
+  viewportHeight,
+  messageHeights,
+  messageKeyOrder,
+  stickToBottomThreshold = 2,
+  initialScrollToBottom = true,
+}: UseThreadViewportStateOptions) => {
+  const [internalState, setInternalState] =
+    useState<InternalThreadViewportState>(() => ({
+      scrollOffset: 0,
+      autoScroll: initialScrollToBottom,
+    }));
+
+  const externalState = useMemo<ExternalThreadViewportState>(
+    () => ({
+      viewportHeight,
+      messageHeights,
+      messageKeyOrder,
+      stickToBottomThreshold,
+    }),
+    [viewportHeight, messageHeights, messageKeyOrder, stickToBottomThreshold],
+  );
+
+  const { fullState, derived } = useMemo(
+    () => buildEffectiveThreadViewportState(externalState, internalState),
+    [externalState, internalState],
+  );
+
+  const latestRef = useRef<ExternalThreadViewportState>(externalState);
+  latestRef.current = externalState;
+
+  const dispatchWithDerived = useCallback(
+    (action: ThreadViewportDispatchAction) => {
+      setInternalState((previous) => {
+        const latest = latestRef.current;
+        const current = buildEffectiveThreadViewportState(latest, previous);
+        const nextState = threadViewportStateReducer(current.fullState, {
+          ...action,
+          derived: current.derived,
+          stickToBottomThreshold: latest.stickToBottomThreshold,
+        } as ThreadViewportReducerAction);
+
+        return previous.scrollOffset === nextState.scrollOffset &&
+          previous.autoScroll === nextState.autoScroll
+          ? previous
+          : {
+              scrollOffset: nextState.scrollOffset,
+              autoScroll: nextState.autoScroll,
+            };
+      });
+    },
+    [],
+  );
+
+  return {
+    state: fullState,
+    derived,
+    dispatchWithDerived,
+  };
+};
+
+export const createThreadViewportActions = (
+  dispatchWithDerived: Dispatch<ThreadViewportDispatchAction>,
+): ThreadViewportStateActions => ({
+  scrollBy: (rows) => dispatchWithDerived({ type: "scrollBy", rows }),
+  scrollByPage: (direction) =>
+    dispatchWithDerived({ type: "scrollByPage", direction }),
+  scrollToTop: () => dispatchWithDerived({ type: "scrollToTop" }),
+  scrollToBottom: () => dispatchWithDerived({ type: "scrollToBottom" }),
+  scrollToMessage: (index, align) =>
+    dispatchWithDerived({ type: "scrollToMessage", index, align }),
+  setAutoScroll: (enabled) =>
+    dispatchWithDerived({ type: "setAutoScroll", enabled }),
+});

--- a/packages/react-ink/src/primitives/thread/utils.ts
+++ b/packages/react-ink/src/primitives/thread/utils.ts
@@ -1,0 +1,11 @@
+export const arraysEqual = <T>(a: readonly T[], b: readonly T[]) =>
+  a.length === b.length &&
+  a.every((value, index) => Object.is(value, b[index]));
+
+export const mapsEqual = <K, V>(a: Map<K, V>, b: Map<K, V>) => {
+  if (a.size !== b.size) return false;
+  for (const [key, value] of a) {
+    if (!Object.is(value, b.get(key))) return false;
+  }
+  return true;
+};

--- a/packages/react-ink/src/tests/ThreadViewport.test.tsx
+++ b/packages/react-ink/src/tests/ThreadViewport.test.tsx
@@ -1,0 +1,344 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "ink-testing-library";
+import { Text } from "ink";
+
+const mockUseAuiState = vi.fn();
+const mockUseAuiEvent = vi.fn();
+const mockUseBoxMetrics = vi.fn();
+
+type UseAuiStateSelector = Parameters<
+  typeof import("@assistant-ui/store")["useAuiState"]
+>[0];
+type InputHandler = Parameters<typeof import("ink")["useInput"]>[0];
+type InputOptions = Parameters<typeof import("ink")["useInput"]>[1];
+
+let state = {
+  thread: {
+    messages: [] as Array<{
+      id: string;
+      role: "user" | "assistant" | "system";
+      content: Array<{ type: "text"; text: string }>;
+      metadata: { custom: Record<string, unknown> };
+    }>,
+  },
+  message: {
+    role: "user",
+    composer: { isEditing: false },
+  },
+};
+const inputHandlers: Array<{
+  handler: InputHandler;
+  options: InputOptions;
+}> = [];
+
+const flush = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const sendInput = async (input: string, key: Parameters<InputHandler>[1]) => {
+  for (const entry of inputHandlers) {
+    if (entry.options?.isActive === false) continue;
+    entry.handler(input, key);
+  }
+  await flush();
+};
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  return {
+    ...actual,
+    useAuiState: (selector: UseAuiStateSelector) => mockUseAuiState(selector),
+    useAuiEvent: (...args: unknown[]) => mockUseAuiEvent(...args),
+    RenderChildrenWithAccessor: ({
+      children,
+      getItemState,
+    }: {
+      children: (getItem: () => unknown) => ReactNode;
+      getItemState: (aui: unknown) => unknown;
+    }) => children(() => getItemState(mockAui)),
+  };
+});
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@assistant-ui/core/react")>();
+  return {
+    ...actual,
+    MessageByIndexProvider: ({ children }: { children: ReactNode }) => (
+      <>{children}</>
+    ),
+  };
+});
+
+vi.mock("ink", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ink")>();
+  return {
+    ...actual,
+    useFocus: () => ({ isFocused: true }),
+    useInput: (handler: InputHandler, options: InputOptions) => {
+      inputHandlers.push({ handler, options });
+    },
+    useBoxMetrics: (...args: unknown[]) => mockUseBoxMetrics(...args),
+  };
+});
+
+const mockAui = {
+  thread: () => ({
+    message: ({ index }: { index: number }) => ({
+      getState: () => state.thread.messages[index],
+    }),
+  }),
+};
+
+import { ThreadPrimitive } from "../index";
+
+const MessageText = ({
+  message,
+}: {
+  message: (typeof state.thread.messages)[number];
+}) => <Text>{message.id}</Text>;
+
+const setMessages = (
+  ids: string[],
+  contentById: Record<string, string> = {},
+) => {
+  state = {
+    ...state,
+    thread: {
+      messages: ids.map((id, index) => ({
+        id,
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: contentById[id]
+          ? [{ type: "text", text: contentById[id] }]
+          : [],
+        metadata: { custom: {} },
+      })),
+    },
+  };
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  inputHandlers.length = 0;
+  mockUseBoxMetrics.mockReturnValue({
+    height: 1,
+    width: 20,
+    hasMeasured: true,
+  });
+  setMessages([]);
+});
+
+describe("ThreadPrimitive.Viewport", () => {
+  beforeEach(() => {
+    mockUseBoxMetrics.mockReturnValue({
+      height: 1,
+      width: 20,
+      hasMeasured: true,
+    });
+    mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) =>
+      selector(state as never),
+    );
+  });
+
+  it("renders current ThreadMessages behavior unchanged outside a viewport", async () => {
+    setMessages(["a", "b", "c"]);
+
+    const instance = render(
+      <ThreadPrimitive.Messages>
+        {({ message }) => <MessageText message={message} />}
+      </ThreadPrimitive.Messages>,
+    );
+    await flush();
+
+    expect(instance.lastFrame()).toContain("a");
+    expect(instance.lastFrame()).toContain("b");
+    expect(instance.lastFrame()).toContain("c");
+  });
+
+  it("renders bounded history inside a viewport and handles page/home/end keys", async () => {
+    setMessages(["a", "b", "c", "d"]);
+
+    const instance = render(
+      <ThreadPrimitive.Viewport height={2}>
+        <ThreadPrimitive.Messages>
+          {({ message }) => <MessageText message={message} />}
+        </ThreadPrimitive.Messages>
+      </ThreadPrimitive.Viewport>,
+    );
+    await flush();
+
+    expect(instance.lastFrame()).not.toContain("a");
+    expect(instance.lastFrame()).toContain("c");
+    expect(instance.lastFrame()).toContain("d");
+
+    await sendInput("", { pageUp: true });
+    expect(instance.lastFrame()).toContain("a");
+    expect(instance.lastFrame()).toContain("b");
+
+    await sendInput("", { end: true });
+    expect(instance.lastFrame()).toContain("c");
+    expect(instance.lastFrame()).toContain("d");
+
+    await sendInput("", { home: true });
+    expect(instance.lastFrame()).toContain("a");
+    expect(instance.lastFrame()).toContain("b");
+
+    await sendInput("", { pageDown: true });
+    expect(instance.lastFrame()).toContain("c");
+    expect(instance.lastFrame()).toContain("d");
+  });
+
+  it("does not bind viewport input when keybindings are disabled", async () => {
+    setMessages(["a", "b", "c", "d"]);
+
+    const instance = render(
+      <ThreadPrimitive.Viewport height={2} keybindings={false}>
+        <ThreadPrimitive.Messages>
+          {({ message }) => <MessageText message={message} />}
+        </ThreadPrimitive.Messages>
+      </ThreadPrimitive.Viewport>,
+    );
+    await flush();
+
+    await sendInput("", { pageUp: true });
+
+    expect(instance.lastFrame()).not.toContain("a");
+    expect(instance.lastFrame()).toContain("c");
+    expect(instance.lastFrame()).toContain("d");
+  });
+
+  it("keeps the bottom rows visible for a single tall message while following bottom", async () => {
+    mockUseBoxMetrics.mockReturnValue({
+      height: 6,
+      width: 20,
+      hasMeasured: true,
+    });
+    setMessages(["tall"]);
+
+    const instance = render(
+      <ThreadPrimitive.Viewport height={2}>
+        <ThreadPrimitive.Messages>
+          {() => (
+            <Text>
+              one{"\n"}two{"\n"}three{"\n"}four{"\n"}five{"\n"}six
+            </Text>
+          )}
+        </ThreadPrimitive.Messages>
+      </ThreadPrimitive.Viewport>,
+    );
+    await flush();
+
+    expect(instance.lastFrame()).not.toContain("one");
+    expect(instance.lastFrame()).toContain("six");
+  });
+
+  it("uses text content as a height fallback when Ink measurement is clipped", async () => {
+    mockUseBoxMetrics.mockReturnValue({
+      height: 1,
+      width: 20,
+      hasMeasured: true,
+    });
+    setMessages(["tall"], {
+      tall: "one\ntwo\nthree\nfour\nfive\nsix",
+    });
+
+    const instance = render(
+      <ThreadPrimitive.Viewport height={2}>
+        <ThreadPrimitive.Messages>
+          {() => (
+            <Text>
+              one{"\n"}two{"\n"}three{"\n"}four{"\n"}five{"\n"}six
+            </Text>
+          )}
+        </ThreadPrimitive.Messages>
+      </ThreadPrimitive.Viewport>,
+    );
+    await flush();
+
+    expect(instance.lastFrame()).not.toContain("one");
+    expect(instance.lastFrame()).toContain("six");
+  });
+
+  it("supports ScrollToBottom outside the clipped viewport with an explicit provider", async () => {
+    setMessages(["a", "b", "c", "d"]);
+
+    const instance = render(
+      <ThreadPrimitive.ViewportProvider options={{ stickToBottomThreshold: 0 }}>
+        <ThreadPrimitive.Viewport height={2}>
+          <ThreadPrimitive.Messages>
+            {({ message }) => <MessageText message={message} />}
+          </ThreadPrimitive.Messages>
+        </ThreadPrimitive.Viewport>
+        <ThreadPrimitive.ScrollToBottom>
+          <Text>Jump to bottom</Text>
+        </ThreadPrimitive.ScrollToBottom>
+      </ThreadPrimitive.ViewportProvider>,
+    );
+    await flush();
+
+    expect(instance.lastFrame()).not.toContain("Jump to bottom");
+
+    await sendInput("", { pageUp: true });
+    expect(instance.lastFrame()).toContain("Jump to bottom");
+
+    await sendInput("", { return: true });
+    expect(instance.lastFrame()).not.toContain("Jump to bottom");
+    expect(instance.lastFrame()).toContain("c");
+    expect(instance.lastFrame()).toContain("d");
+  });
+
+  it("keeps ScrollToBottom hidden when geometry is already at bottom", async () => {
+    setMessages(["a", "b"]);
+
+    const instance = render(
+      <ThreadPrimitive.ViewportProvider>
+        <ThreadPrimitive.Viewport height={4}>
+          <ThreadPrimitive.Messages>
+            {({ message }) => <MessageText message={message} />}
+          </ThreadPrimitive.Messages>
+        </ThreadPrimitive.Viewport>
+        <ThreadPrimitive.ScrollToBottom>
+          <Text>Jump to bottom</Text>
+        </ThreadPrimitive.ScrollToBottom>
+      </ThreadPrimitive.ViewportProvider>,
+    );
+    await flush();
+    await sendInput("", { pageUp: true });
+
+    expect(instance.lastFrame()).not.toContain("Jump to bottom");
+  });
+
+  it("shows and suppresses the paused hint while newer content exists below", async () => {
+    setMessages(["a", "b", "c", "d"]);
+
+    const instance = render(
+      <ThreadPrimitive.Viewport height={2}>
+        <ThreadPrimitive.Messages>
+          {({ message }) => <MessageText message={message} />}
+        </ThreadPrimitive.Messages>
+      </ThreadPrimitive.Viewport>,
+    );
+    await flush();
+    await sendInput("", { pageUp: true });
+
+    expect(instance.lastFrame()).toContain(
+      "[paused | End to resume | 2 new below]",
+    );
+
+    setMessages(["a", "b", "c", "d", "e"]);
+    instance.rerender(
+      <ThreadPrimitive.Viewport height={2} renderPausedHint={false}>
+        <ThreadPrimitive.Messages>
+          {({ message }) => <MessageText message={message} />}
+        </ThreadPrimitive.Messages>
+      </ThreadPrimitive.Viewport>,
+    );
+    await flush();
+
+    expect(instance.lastFrame()).not.toContain("[paused");
+  });
+});

--- a/packages/react-ink/src/tests/useThreadMessageHeights.test.ts
+++ b/packages/react-ink/src/tests/useThreadMessageHeights.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialThreadMessageHeights,
+  reconcileThreadMessageHeights,
+} from "../primitives/thread/useThreadMessageHeights";
+
+describe("thread message heights", () => {
+  it("initializes unknown message keys with estimated height", () => {
+    const heights = createInitialThreadMessageHeights(["a", "b"], 2);
+
+    expect(heights).toEqual(
+      new Map([
+        ["a", 2],
+        ["b", 2],
+      ]),
+    );
+  });
+
+  it("preserves measured heights stored in previous state", () => {
+    const next = reconcileThreadMessageHeights({
+      previousHeights: new Map([["a", 4]]),
+      nextKeys: ["a"],
+      estimatedHeight: 1,
+    });
+
+    expect(next.heights.get("a")).toBe(4);
+  });
+
+  it("preserves surviving message heights across message replacement", () => {
+    const next = reconcileThreadMessageHeights({
+      previousHeights: new Map([
+        ["a", 2],
+        ["b", 5],
+      ]),
+      nextKeys: ["b", "c"],
+      estimatedHeight: 1,
+    });
+
+    expect(next.heights).toEqual(
+      new Map([
+        ["b", 5],
+        ["c", 1],
+      ]),
+    );
+    expect(next.keyOrder).toEqual(["b", "c"]);
+  });
+
+  it("evicts removed message keys", () => {
+    const next = reconcileThreadMessageHeights({
+      previousHeights: new Map([
+        ["a", 2],
+        ["b", 5],
+      ]),
+      nextKeys: ["b"],
+      estimatedHeight: 1,
+    });
+
+    expect(next.heights).toEqual(new Map([["b", 5]]));
+  });
+
+  it("updates height for an existing streaming message key", () => {
+    const next = reconcileThreadMessageHeights({
+      previousHeights: new Map([["assistant-1", 7]]),
+      nextKeys: ["assistant-1"],
+      estimatedHeight: 1,
+    });
+
+    expect(next.heights.get("assistant-1")).toBe(7);
+  });
+});

--- a/packages/react-ink/src/tests/useThreadViewportState.test.ts
+++ b/packages/react-ink/src/tests/useThreadViewportState.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEffectiveThreadViewportState,
+  clampThreadViewportScrollOffset,
+  createInitialThreadViewportState,
+  deriveThreadViewportState,
+  threadViewportStateReducer,
+  type ThreadViewportDerivedState,
+  type ThreadViewportState,
+} from "../primitives/thread/useThreadViewportState";
+
+const createDerived = (
+  state: ThreadViewportState,
+  overrides: Partial<ThreadViewportDerivedState> = {},
+): ThreadViewportDerivedState => ({
+  contentHeight: 9,
+  maxScrollOffset: 5,
+  visibleFirstIndex: 0,
+  visibleLastIndex: 2,
+  isAtBottom: state.scrollOffset >= 3,
+  messageOffsets: [],
+  messageHeightsInOrder: [],
+  ...overrides,
+});
+
+describe("thread viewport state", () => {
+  it("clamps negative and too-large scroll offsets", () => {
+    expect(clampThreadViewportScrollOffset(-2, 5)).toBe(0);
+    expect(clampThreadViewportScrollOffset(3, 5)).toBe(3);
+    expect(clampThreadViewportScrollOffset(8, 5)).toBe(5);
+  });
+
+  it("derives content height, visible indexes, max offset, and bottom state", () => {
+    const derived = deriveThreadViewportState({
+      scrollOffset: 2,
+      autoScroll: false,
+      viewportHeight: 3,
+      messageHeights: new Map([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ]),
+      messageKeyOrder: ["a", "b", "c"],
+      stickToBottomThreshold: 1,
+    });
+
+    expect(derived.contentHeight).toBe(6);
+    expect(derived.maxScrollOffset).toBe(3);
+    expect(derived.visibleFirstIndex).toBe(1);
+    expect(derived.visibleLastIndex).toBe(2);
+    expect(derived.isAtBottom).toBe(true);
+  });
+
+  it("scrollByPage moves by viewport height", () => {
+    const state = createInitialThreadViewportState({
+      viewportHeight: 3,
+      messageKeyOrder: ["a", "b", "c", "d"],
+      scrollOffset: 2,
+      autoScroll: false,
+    });
+
+    const down = threadViewportStateReducer(state, {
+      type: "scrollByPage",
+      direction: "down",
+      derived: createDerived(state, { maxScrollOffset: 8 }),
+      stickToBottomThreshold: 1,
+    });
+    const up = threadViewportStateReducer(down, {
+      type: "scrollByPage",
+      direction: "up",
+      derived: createDerived(down, { maxScrollOffset: 8 }),
+      stickToBottomThreshold: 1,
+    });
+
+    expect(down.scrollOffset).toBe(5);
+    expect(up.scrollOffset).toBe(2);
+  });
+
+  it("scrollToBottom pins to max offset and enables auto-scroll", () => {
+    const state = createInitialThreadViewportState({
+      viewportHeight: 3,
+      messageKeyOrder: ["a", "b", "c"],
+      scrollOffset: 0,
+      autoScroll: false,
+    });
+
+    const next = threadViewportStateReducer(state, {
+      type: "scrollToBottom",
+      derived: createDerived(state, { maxScrollOffset: 7 }),
+      stickToBottomThreshold: 1,
+    });
+
+    expect(next.scrollOffset).toBe(7);
+    expect(next.autoScroll).toBe(true);
+  });
+
+  it("scrolling up beyond the threshold disables auto-scroll", () => {
+    const state = createInitialThreadViewportState({
+      viewportHeight: 4,
+      messageKeyOrder: ["a", "b", "c"],
+      scrollOffset: 6,
+      autoScroll: true,
+    });
+
+    const next = threadViewportStateReducer(state, {
+      type: "scrollBy",
+      rows: -4,
+      derived: createDerived(state, { maxScrollOffset: 6 }),
+      stickToBottomThreshold: 1,
+    });
+
+    expect(next.scrollOffset).toBe(2);
+    expect(next.autoScroll).toBe(false);
+  });
+
+  it("content growth while auto-scroll is enabled keeps the viewport pinned to bottom", () => {
+    const externalState = {
+      viewportHeight: 4,
+      messageHeights: new Map([
+        ["a", 1],
+        ["b", 1],
+      ]),
+      messageKeyOrder: ["a", "b"],
+      stickToBottomThreshold: 1,
+    };
+
+    const grown = buildEffectiveThreadViewportState(
+      {
+        ...externalState,
+        messageHeights: new Map([
+          ["a", 1],
+          ["b", 10],
+        ]),
+      },
+      {
+        scrollOffset: 0,
+        autoScroll: true,
+      },
+    );
+
+    expect(grown.fullState.scrollOffset).toBe(7);
+    expect(grown.fullState.autoScroll).toBe(true);
+  });
+
+  it("content growth while auto-scroll is paused preserves current offset", () => {
+    const grown = buildEffectiveThreadViewportState(
+      {
+        viewportHeight: 4,
+        messageHeights: new Map([
+          ["a", 3],
+          ["b", 8],
+        ]),
+        messageKeyOrder: ["a", "b"],
+        stickToBottomThreshold: 1,
+      },
+      {
+        scrollOffset: 1,
+        autoScroll: false,
+      },
+    );
+
+    expect(grown.fullState.scrollOffset).toBe(1);
+    expect(grown.fullState.autoScroll).toBe(false);
+  });
+
+  it("empty message lists report sensible zero state", () => {
+    const derived = deriveThreadViewportState(
+      createInitialThreadViewportState({ viewportHeight: 4 }),
+    );
+
+    expect(derived.contentHeight).toBe(0);
+    expect(derived.maxScrollOffset).toBe(0);
+    expect(derived.visibleFirstIndex).toBe(0);
+    expect(derived.visibleLastIndex).toBe(0);
+    expect(derived.isAtBottom).toBe(true);
+  });
+});


### PR DESCRIPTION
  ## Summary

  - Add `ThreadPrimitive.Viewport`, `ViewportProvider`, and `ScrollToBottom` for bounded terminal thread history
  - Integrate `ThreadPrimitive.Messages` with viewport state while preserving unbounded behavior outside a viewport
  - Add Ink docs, tests, and a patch changeset for `@assistant-ui/react-ink`
