### PR TITLE
docs: mention TooltipProvider for existing projects

### DIFF
--- a/apps/docs/content/docs/(docs)/installation.mdx
+++ b/apps/docs/content/docs/(docs)/installation.mdx
@@ -47,6 +47,22 @@ npx assistant-ui@latest create -t mcp
 npx assistant-ui@latest init
 ```
 
+If you add assistant-ui to an existing project, make sure your app is wrapped in the generated `TooltipProvider` from `@/components/ui/tooltip`. The starter templates include this in `app/layout.tsx`, but existing apps may need to add it manually:
+
+```tsx title="app/layout.tsx"
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <TooltipProvider>{children}</TooltipProvider>
+      </body>
+    </html>
+  );
+}
+```
+
   </Step>
   <Step>
 


### PR DESCRIPTION
## Summary
- document the `TooltipProvider` wrapper required when adding assistant-ui to an existing app
- show a minimal `app/layout.tsx` example matching the generated templates

Fixes #3933.

## Validation
- inspected the installation MDX and template layout files
- `pnpm lint --filter @assistant-ui/docs` could not run locally because dependencies are not installed and the repo requires Node >=24 (local Node is v22.16.0)
