### PR TITLE
docs: mention TooltipProvider for existing projects

### DIFF
--- a/apps/docs/content/docs/(docs)/installation.mdx
+++ b/apps/docs/content/docs/(docs)/installation.mdx
@@ -47,6 +47,22 @@ npx assistant-ui@latest create -t mcp
 npx assistant-ui@latest init
 ```
 
+When adding assistant-ui to an existing app, make sure your root layout wraps the app with the generated `TooltipProvider`. Components such as `AssistantModal` use tooltip primitives and need this provider to avoid runtime errors.
+
+```tsx title="app/layout.tsx"
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <TooltipProvider>{children}</TooltipProvider>
+      </body>
+    </html>
+  );
+}
+```
+
   </Step>
   <Step>
 


### PR DESCRIPTION
## Summary
- document that existing projects need to wrap their app with the generated `TooltipProvider`
- add a root layout example to avoid the runtime error from tooltip-based assistant-ui components

Fixes #3933

## Validation
- Directly inspected the installation docs change
- `pnpm exec biome check apps/docs/content/docs/(docs)/installation.mdx` could not run because dependencies are not installed in the fresh clone (`biome` not found)