### PR TITLE
fix(ui): make TooltipIconButton self-contained with TooltipProvider

### DIFF
--- a/packages/ui/src/components/assistant-ui/tooltip-icon-button.tsx
+++ b/packages/ui/src/components/assistant-ui/tooltip-icon-button.tsx
@@ -6,6 +6,7 @@ import { Slot } from "radix-ui";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
@@ -21,21 +22,23 @@ export const TooltipIconButton = forwardRef<
   TooltipIconButtonProps
 >(({ children, tooltip, side = "bottom", className, ...rest }, ref) => {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          {...rest}
-          className={cn("aui-button-icon size-6 p-1", className)}
-          ref={ref}
-        >
-          <Slot.Slottable>{children}</Slot.Slottable>
-          <span className="aui-sr-only sr-only">{tooltip}</span>
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side={side}>{tooltip}</TooltipContent>
-    </Tooltip>
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            {...rest}
+            className={cn("aui-button-icon size-6 p-1", className)}
+            ref={ref}
+          >
+            <Slot.Slottable>{children}</Slot.Slottable>
+            <span className="aui-sr-only sr-only">{tooltip}</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side={side}>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 });
 

--- a/templates/cloud-clerk/components/assistant-ui/tooltip-icon-button.tsx
+++ b/templates/cloud-clerk/components/assistant-ui/tooltip-icon-button.tsx
@@ -6,6 +6,7 @@ import { Slot } from "radix-ui";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
@@ -21,21 +22,23 @@ export const TooltipIconButton = forwardRef<
   TooltipIconButtonProps
 >(({ children, tooltip, side = "bottom", className, ...rest }, ref) => {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          {...rest}
-          className={cn("aui-button-icon size-6 p-1", className)}
-          ref={ref}
-        >
-          <Slot.Slottable>{children}</Slot.Slottable>
-          <span className="aui-sr-only sr-only">{tooltip}</span>
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side={side}>{tooltip}</TooltipContent>
-    </Tooltip>
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            {...rest}
+            className={cn("aui-button-icon size-6 p-1", className)}
+            ref={ref}
+          >
+            <Slot.Slottable>{children}</Slot.Slottable>
+            <span className="aui-sr-only sr-only">{tooltip}</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side={side}>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 });
 

--- a/templates/cloud/components/assistant-ui/tooltip-icon-button.tsx
+++ b/templates/cloud/components/assistant-ui/tooltip-icon-button.tsx
@@ -6,6 +6,7 @@ import { Slot } from "radix-ui";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
@@ -21,21 +22,23 @@ export const TooltipIconButton = forwardRef<
   TooltipIconButtonProps
 >(({ children, tooltip, side = "bottom", className, ...rest }, ref) => {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          {...rest}
-          className={cn("aui-button-icon size-6 p-1", className)}
-          ref={ref}
-        >
-          <Slot.Slottable>{children}</Slot.Slottable>
-          <span className="aui-sr-only sr-only">{tooltip}</span>
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side={side}>{tooltip}</TooltipContent>
-    </Tooltip>
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            {...rest}
+            className={cn("aui-button-icon size-6 p-1", className)}
+            ref={ref}
+          >
+            <Slot.Slottable>{children}</Slot.Slottable>
+            <span className="aui-sr-only sr-only">{tooltip}</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side={side}>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 });
 

--- a/templates/default/components/assistant-ui/tooltip-icon-button.tsx
+++ b/templates/default/components/assistant-ui/tooltip-icon-button.tsx
@@ -6,6 +6,7 @@ import { Slot } from "radix-ui";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
@@ -21,21 +22,23 @@ export const TooltipIconButton = forwardRef<
   TooltipIconButtonProps
 >(({ children, tooltip, side = "bottom", className, ...rest }, ref) => {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          {...rest}
-          className={cn("aui-button-icon size-6 p-1", className)}
-          ref={ref}
-        >
-          <Slot.Slottable>{children}</Slot.Slottable>
-          <span className="aui-sr-only sr-only">{tooltip}</span>
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side={side}>{tooltip}</TooltipContent>
-    </Tooltip>
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            {...rest}
+            className={cn("aui-button-icon size-6 p-1", className)}
+            ref={ref}
+          >
+            <Slot.Slottable>{children}</Slot.Slottable>
+            <span className="aui-sr-only sr-only">{tooltip}</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side={side}>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 });
 

--- a/templates/langgraph/components/assistant-ui/tooltip-icon-button.tsx
+++ b/templates/langgraph/components/assistant-ui/tooltip-icon-button.tsx
@@ -6,6 +6,7 @@ import { Slot } from "radix-ui";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
@@ -21,21 +22,23 @@ export const TooltipIconButton = forwardRef<
   TooltipIconButtonProps
 >(({ children, tooltip, side = "bottom", className, ...rest }, ref) => {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          {...rest}
-          className={cn("aui-button-icon size-6 p-1", className)}
-          ref={ref}
-        >
-          <Slot.Slottable>{children}</Slot.Slottable>
-          <span className="aui-sr-only sr-only">{tooltip}</span>
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side={side}>{tooltip}</TooltipContent>
-    </Tooltip>
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            {...rest}
+            className={cn("aui-button-icon size-6 p-1", className)}
+            ref={ref}
+          >
+            <Slot.Slottable>{children}</Slot.Slottable>
+            <span className="aui-sr-only sr-only">{tooltip}</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side={side}>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 });
 

--- a/templates/mcp/components/assistant-ui/tooltip-icon-button.tsx
+++ b/templates/mcp/components/assistant-ui/tooltip-icon-button.tsx
@@ -6,6 +6,7 @@ import { Slot } from "radix-ui";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
@@ -21,21 +22,23 @@ export const TooltipIconButton = forwardRef<
   TooltipIconButtonProps
 >(({ children, tooltip, side = "bottom", className, ...rest }, ref) => {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          {...rest}
-          className={cn("aui-button-icon size-6 p-1", className)}
-          ref={ref}
-        >
-          <Slot.Slottable>{children}</Slot.Slottable>
-          <span className="aui-sr-only sr-only">{tooltip}</span>
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side={side}>{tooltip}</TooltipContent>
-    </Tooltip>
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            {...rest}
+            className={cn("aui-button-icon size-6 p-1", className)}
+            ref={ref}
+          >
+            <Slot.Slottable>{children}</Slot.Slottable>
+            <span className="aui-sr-only sr-only">{tooltip}</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side={side}>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 });
 

--- a/templates/minimal/components/assistant-ui/tooltip-icon-button.tsx
+++ b/templates/minimal/components/assistant-ui/tooltip-icon-button.tsx
@@ -6,6 +6,7 @@ import { Slot } from "radix-ui";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
@@ -21,21 +22,23 @@ export const TooltipIconButton = forwardRef<
   TooltipIconButtonProps
 >(({ children, tooltip, side = "bottom", className, ...rest }, ref) => {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          {...rest}
-          className={cn("aui-button-icon size-6 p-1", className)}
-          ref={ref}
-        >
-          <Slot.Slottable>{children}</Slot.Slottable>
-          <span className="aui-sr-only sr-only">{tooltip}</span>
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side={side}>{tooltip}</TooltipContent>
-    </Tooltip>
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            {...rest}
+            className={cn("aui-button-icon size-6 p-1", className)}
+            ref={ref}
+          >
+            <Slot.Slottable>{children}</Slot.Slottable>
+            <span className="aui-sr-only sr-only">{tooltip}</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side={side}>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 });
 


### PR DESCRIPTION
## Summary
- wrap `TooltipIconButton` with a local `<TooltipProvider delayDuration={0}>` so consumers no longer need a root `TooltipProvider` in `app/layout.tsx`
- aligns with shadcn's own `sidebar.tsx` pattern for complex components that internally consume tooltip; radix providers nest cleanly so existing root-provider setups are unaffected
- propagates the same change to all 6 template snapshots (`templates/{default,minimal,cloud,cloud-clerk,langgraph,mcp}/components/assistant-ui/tooltip-icon-button.tsx`) so `npx assistant-ui create` scaffolds stay identical with the canonical source
- root-cause fix for the runtime error `'Tooltip' must be used within 'TooltipProvider'` that hits anyone running `npx assistant-ui init` against an existing project (upstream shadcn `tooltip` block does not auto-wrap, and the install-time docs hint is easily missed in a long install log)

fixes #3933

## Test plan
- [ ] `npx assistant-ui init` against a fresh Next.js project, render `<AssistantModal />` without adding `TooltipProvider` to `layout.tsx`, page should mount without runtime error
- [ ] `npx assistant-ui create -t minimal` (and other templates), verify tooltip on action buttons still appears on hover with the original 0ms delay
- [ ] existing project that already has `<TooltipProvider>` in `app/layout.tsx`, verify tooltips still render correctly with the nested provider
- [ ] `pnpm --filter @assistant-ui/shadcn-registry build` and inspect `apps/registry/dist/tooltip-icon-button.json`, the inlined `content` should contain the new `<TooltipProvider delayDuration={0}>` wrapper