### PR TITLE
feat(docs): platform URL params, changelog UX, traction forecast

### DIFF
--- a/apps/docs/app/(home)/changelog/changelog-list.tsx
+++ b/apps/docs/app/(home)/changelog/changelog-list.tsx
@@ -16,7 +16,6 @@ import {
 import { cn } from "@/lib/utils";
 
 const PAGE_SIZE = 10;
-const COLLAPSE_BODY_THRESHOLD = 240;
 
 function formatDate(date: string): string {
   return new Date(date).toLocaleDateString("en-US", {
@@ -189,8 +188,6 @@ function MetaLine({ item }: { item: ParsedBullet }) {
 function BulletItem({ item }: { item: ParsedBullet }) {
   const [expanded, setExpanded] = useState(false);
   const hasBody = item.body.length > 0;
-  const isLong = hasBody && item.body.length > COLLAPSE_BODY_THRESHOLD;
-  const showFull = expanded || !isLong;
 
   return (
     <div className="flex flex-col gap-1.5">
@@ -205,19 +202,19 @@ function BulletItem({ item }: { item: ParsedBullet }) {
       <MetaLine item={item} />
       {hasBody ? (
         <div className="text-muted-foreground text-sm">
-          <div className={cn(!showFull && "line-clamp-2")}>
-            <ReactMarkdown components={bodyMarkdownComponents}>
-              {item.body}
-            </ReactMarkdown>
-          </div>
-          {isLong ? (
-            <button
-              type="button"
-              onClick={() => setExpanded((e) => !e)}
-              className="mt-1 text-muted-foreground/70 text-xs transition-colors hover:text-foreground"
-            >
-              {expanded ? "Show less" : "Show more"}
-            </button>
+          <button
+            type="button"
+            onClick={() => setExpanded((e) => !e)}
+            className="text-muted-foreground/70 text-xs transition-colors hover:text-foreground"
+          >
+            {expanded ? "Hide description" : "Show description"}
+          </button>
+          {expanded ? (
+            <div className="mt-2">
+              <ReactMarkdown components={bodyMarkdownComponents}>
+                {item.body}
+              </ReactMarkdown>
+            </div>
           ) : null}
         </div>
       ) : null}
@@ -257,7 +254,7 @@ function ReleaseEntry({ release }: { release: PackageRelease }) {
   const groups = useMemo(() => groupByType(parsed.bullets), [parsed.bullets]);
 
   return (
-    <details className="group/release">
+    <details className="group/release" open>
       <summary className="flex cursor-pointer list-none items-center gap-2 py-1 [&::-webkit-details-marker]:hidden">
         <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-transform group-open/release:rotate-90" />
         <span className="font-medium font-mono text-foreground/80 text-sm transition-colors group-hover/release:text-foreground">

--- a/apps/docs/app/examples/layout.tsx
+++ b/apps/docs/app/examples/layout.tsx
@@ -4,17 +4,14 @@ import { DocsHeader } from "@/components/docs/layout/docs-header";
 import { DocsSidebarProvider } from "@/components/docs/contexts/sidebar";
 import { ExamplesShell } from "@/components/docs/layout/examples-shell";
 import { AssistantPanelProvider } from "@/components/docs/assistant/context";
-import { PlatformProvider } from "@/components/docs/contexts/platform";
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <PlatformProvider>
-      <AssistantPanelProvider>
-        <DocsSidebarProvider>
-          <DocsHeader section="Examples" sectionHref="/examples" />
-          <ExamplesShell tree={examples.pageTree}>{children}</ExamplesShell>
-        </DocsSidebarProvider>
-      </AssistantPanelProvider>
-    </PlatformProvider>
+    <AssistantPanelProvider>
+      <DocsSidebarProvider>
+        <DocsHeader section="Examples" sectionHref="/examples" />
+        <ExamplesShell tree={examples.pageTree}>{children}</ExamplesShell>
+      </DocsSidebarProvider>
+    </AssistantPanelProvider>
   );
 }

--- a/apps/docs/components/docs/contexts/platform.tsx
+++ b/apps/docs/components/docs/contexts/platform.tsx
@@ -4,9 +4,11 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useSyncExternalStore,
   type ReactNode,
 } from "react";
+import { usePathname } from "next/navigation";
 
 export const PLATFORMS = ["react", "rn", "ink"] as const;
 export type Platform = (typeof PLATFORMS)[number];
@@ -18,6 +20,7 @@ export const PLATFORM_LABELS: Record<Platform, string> = {
 };
 
 const STORAGE_KEY = "assistant-ui::docs:platform";
+const URL_PARAM = "platform";
 const DEFAULT_PLATFORM: Platform = "react";
 
 interface PlatformContextValue {
@@ -35,7 +38,6 @@ export function usePlatform() {
   return ctx;
 }
 
-// Non-throwing variant for shared MDX components that may render outside a provider.
 export function usePlatformOrDefault(): Platform {
   return useContext(PlatformContext)?.platform ?? DEFAULT_PLATFORM;
 }
@@ -46,13 +48,51 @@ function isPlatform(value: string | null): value is Platform {
 
 const isBrowser = () => typeof window !== "undefined";
 
-/**
- * Singleton store fronting localStorage for the platform selection. Backs
- * useSyncExternalStore so SSR renders the default deterministically, the
- * client reads localStorage synchronously on hydration (no flash), and
- * setting the value broadcasts to other tabs via the standard `storage`
- * event plus same-tab listeners.
- */
+// Avoid useSearchParams so the docs layout isn't opted out of static rendering.
+function readUrlPlatform(): Platform | null {
+  if (!isBrowser()) return null;
+  try {
+    const value = new URLSearchParams(window.location.search).get(URL_PARAM);
+    return isPlatform(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+// replaceState (not router.replace) so URL fixups don't pollute back/forward
+// history and Next.js doesn't treat the param change as a refetch trigger.
+function writeUrlPlatform(next: Platform): void {
+  if (!isBrowser()) return;
+  try {
+    const url = new URL(window.location.href);
+    if (next === DEFAULT_PLATFORM) {
+      if (!url.searchParams.has(URL_PARAM)) return;
+      url.searchParams.delete(URL_PARAM);
+    } else {
+      if (url.searchParams.get(URL_PARAM) === next) return;
+      url.searchParams.set(URL_PARAM, next);
+    }
+    window.history.replaceState(window.history.state, "", url.toString());
+  } catch {}
+}
+
+function syncUrlAndStore(): void {
+  if (!isBrowser()) return;
+  const fromUrl = readUrlPlatform();
+  if (fromUrl) {
+    if (fromUrl !== platformStore.getSnapshot()) {
+      platformStore.setValue(fromUrl);
+    }
+    if (fromUrl === DEFAULT_PLATFORM) {
+      writeUrlPlatform(DEFAULT_PLATFORM);
+    }
+    return;
+  }
+  writeUrlPlatform(platformStore.getSnapshot());
+}
+
+// SSR-safe localStorage backing for useSyncExternalStore, with cross-tab sync
+// via the storage event.
 class PlatformStore {
   private listeners = new Set<() => void>();
 
@@ -98,23 +138,38 @@ class PlatformStore {
     try {
       window.localStorage.setItem(STORAGE_KEY, next);
       this.notify();
-    } catch {
-      // ignore write errors
-    }
+    } catch {}
   };
 }
 
 const platformStore = new PlatformStore();
 
 export function PlatformProvider({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+
   const platform = useSyncExternalStore(
     platformStore.subscribe,
     platformStore.getSnapshot,
     platformStore.getServerSnapshot,
   );
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the only intended trigger
+  useEffect(() => {
+    syncUrlAndStore();
+  }, [pathname]);
+
+  // popstate covers search-only changes (back/forward to a different
+  // ?platform=) which usePathname doesn't fire for.
+  useEffect(() => {
+    window.addEventListener("popstate", syncUrlAndStore);
+    return () => {
+      window.removeEventListener("popstate", syncUrlAndStore);
+    };
+  }, []);
+
   const setPlatform = useCallback((next: Platform) => {
     platformStore.setValue(next);
+    writeUrlPlatform(next);
   }, []);
 
   return (
@@ -124,10 +179,6 @@ export function PlatformProvider({ children }: { children: ReactNode }) {
   );
 }
 
-/**
- * Returns true when an entry with optional `platforms` allowlist is visible
- * for the given platform. No allowlist (undefined or empty) means universal.
- */
 export function isVisibleForPlatform(
   platforms: readonly string[] | undefined,
   active: Platform,

--- a/apps/docs/components/docs/platform-aware-code.tsx
+++ b/apps/docs/components/docs/platform-aware-code.tsx
@@ -1,13 +1,18 @@
 "use client";
 
-import { cloneElement, isValidElement, useMemo, type ReactNode } from "react";
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useMemo,
+  type ReactNode,
+} from "react";
 import {
   usePlatformOrDefault,
   type Platform,
 } from "@/components/docs/contexts/platform";
 
-// Negative lookahead avoids rewriting sibling packages like react-langgraph
-// or names where `react` is a prefix (e.g. `reactive`).
+// Negative lookahead avoids matching siblings like `@assistant-ui/react-langgraph`.
 const PACKAGE_PATTERN = /@assistant-ui\/react(?![-\w])/g;
 
 const PLATFORM_PACKAGE: Record<Platform, string> = {
@@ -21,7 +26,8 @@ function rewrite(node: ReactNode, replacement: string): ReactNode {
     return node.replace(PACKAGE_PATTERN, replacement);
   }
   if (Array.isArray(node)) {
-    return node.map((child) => rewrite(child, replacement));
+    // Children.map auto-keys the siblings; bare Array.map would warn on Shiki spans.
+    return Children.map(node, (child) => rewrite(child, replacement));
   }
   if (isValidElement<{ children?: ReactNode }>(node)) {
     const { children } = node.props;

--- a/apps/docs/components/traction/star-history-chart.tsx
+++ b/apps/docs/components/traction/star-history-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId } from "react";
+import { useId, useMemo } from "react";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import {
   ChartContainer,
@@ -11,13 +11,25 @@ import {
 import { formatCompact } from "@/lib/format";
 
 type Point = { date: string; value: number };
+type ChartPoint = {
+  date: string;
+  value: number | null;
+  forecast: number | null;
+};
 
 const config = {
   stars: {
     label: "Stars",
     color: "var(--chart-1)",
   },
+  forecast: {
+    label: "Projected",
+    color: "var(--chart-1)",
+  },
 } satisfies ChartConfig;
+
+const FORECAST_WINDOW_DAYS = 90;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const formatTick = (iso: string) => {
   const d = new Date(iso);
@@ -31,8 +43,61 @@ const formatTooltipLabel = (iso: string) =>
     year: "numeric",
   });
 
+function buildChartData(data: Point[]): ChartPoint[] {
+  const base: ChartPoint[] = data.map((p) => ({
+    date: p.date,
+    value: p.value,
+    forecast: null,
+  }));
+  if (data.length < 2) return base;
+
+  const last = data[data.length - 1]!;
+  const lastMs = new Date(last.date).getTime();
+
+  const cutoff = lastMs - FORECAST_WINDOW_DAYS * DAY_MS;
+  let anchor = data[0]!;
+  for (let i = data.length - 1; i >= 0; i--) {
+    if (new Date(data[i]!.date).getTime() <= cutoff) {
+      anchor = data[i]!;
+      break;
+    }
+  }
+  const anchorMs = new Date(anchor.date).getTime();
+  if (anchorMs >= lastMs) return base;
+
+  const slope = (last.value - anchor.value) / (lastMs - anchorMs);
+
+  const now = new Date();
+  const monthEnd = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth() + 1,
+    0,
+    23,
+    59,
+    59,
+  );
+  if (monthEnd <= lastMs) return base;
+
+  const projected = Math.max(
+    last.value,
+    Math.round(last.value + slope * (monthEnd - lastMs)),
+  );
+
+  // Stamp the last real point with both keys so the dashed forecast line
+  // connects continuously to the solid history line.
+  base[base.length - 1] = { ...base[base.length - 1]!, forecast: last.value };
+  base.push({
+    date: new Date(monthEnd).toISOString(),
+    value: null,
+    forecast: projected,
+  });
+  return base;
+}
+
 export function StarHistoryChart({ data }: { data: Point[] }) {
   const gradientId = useId();
+  const chartData = useMemo(() => buildChartData(data), [data]);
+
   if (data.length < 2) {
     return (
       <div className="flex h-[260px] items-center justify-center rounded-lg border border-border border-dashed text-muted-foreground text-sm md:h-[360px]">
@@ -46,7 +111,10 @@ export function StarHistoryChart({ data }: { data: Point[] }) {
       config={config}
       className="aspect-auto h-[260px] w-full md:h-[360px]"
     >
-      <AreaChart data={data} margin={{ left: 8, right: 16, top: 8, bottom: 0 }}>
+      <AreaChart
+        data={chartData}
+        margin={{ left: 8, right: 16, top: 8, bottom: 0 }}
+      >
         <defs>
           <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
             <stop
@@ -70,27 +138,44 @@ export function StarHistoryChart({ data }: { data: Point[] }) {
           minTickGap={48}
         />
         <YAxis
-          dataKey="value"
           tickFormatter={(v) => formatCompact(v as number)}
           tickLine={false}
           axisLine={false}
           width={36}
+          // 'auto' overshoots (10.5k → 12k); pad 5% and round up to 500 instead.
+          domain={[0, (max: number) => Math.ceil((max * 1.05) / 500) * 500]}
         />
         <ChartTooltip
           cursor={{ stroke: "var(--border)" }}
-          content={
-            <ChartTooltipContent
-              labelFormatter={(_, payload) => {
-                const iso = payload?.[0]?.payload?.date as string | undefined;
-                return iso ? formatTooltipLabel(iso) : "";
-              }}
-              formatter={(value) => [
-                `${formatCompact(value as number)} stars`,
-                "",
-              ]}
-              hideIndicator
-            />
-          }
+          content={({ active, payload, label }) => {
+            // Drop the forecast row at the bridge point so today's tooltip
+            // doesn't show the same value twice.
+            const filtered = payload?.filter(
+              (e) =>
+                !(
+                  e.dataKey === "forecast" &&
+                  (e.payload as { value?: number | null } | undefined)?.value !=
+                    null
+                ),
+            );
+            if (!active || !filtered || filtered.length === 0) return null;
+            return (
+              <ChartTooltipContent
+                active={active}
+                payload={filtered}
+                label={label}
+                labelFormatter={(_, p) => {
+                  const iso = p?.[0]?.payload?.date as string | undefined;
+                  return iso ? formatTooltipLabel(iso) : "";
+                }}
+                formatter={(value, name) => [
+                  `${formatCompact(value as number)} stars${name === "forecast" ? " (projected)" : ""}`,
+                  "",
+                ]}
+                hideIndicator
+              />
+            );
+          }}
         />
         <Area
           dataKey="value"
@@ -98,6 +183,18 @@ export function StarHistoryChart({ data }: { data: Point[] }) {
           stroke="var(--color-stars)"
           strokeWidth={2}
           fill={`url(#${gradientId})`}
+          connectNulls={false}
+          isAnimationActive={false}
+        />
+        <Area
+          dataKey="forecast"
+          type="monotone"
+          stroke="var(--color-forecast)"
+          strokeWidth={2}
+          strokeDasharray="4 4"
+          fill="transparent"
+          connectNulls={false}
+          isAnimationActive={false}
         />
       </AreaChart>
     </ChartContainer>

--- a/apps/docs/content/examples/index.mdx
+++ b/apps/docs/content/examples/index.mdx
@@ -6,10 +6,10 @@ description: Explore interactive examples and implementations of assistant-ui
 import { ExampleCard } from "@/components/docs/example-card";
 import { INTERNAL_EXAMPLES, COMMUNITY_EXAMPLES } from "@/lib/examples";
 
-<header className="text-center">
+<header className="mt-12 mb-16 text-center md:mt-20">
 <h1 className="mb-4 font-medium text-4xl">Examples</h1>
 
-<span className="mb-16 block text-muted-foreground">
+<span className="block text-muted-foreground">
   Explore our collection of examples that demonstrate different ways to integrate assistant-ui into your applications.
 </span>
 </header>


### PR DESCRIPTION
## Summary
- sync the active docs platform via `?platform=rn` / `?platform=ink` (react = no param) with bogus value cleanup, and drop the unused `PlatformProvider` from the examples route so its URL stays clean
- fix a latent missing-key warning in `PlatformAwareCode` by switching `Array.map` to `Children.map` when rewriting MDX code blocks per platform
- changelog releases now expand by default and bullet descriptions sit behind a show/hide toggle, so the page reads as a scannable list instead of a wall of prose
- traction stars chart projects from today to month-end as a dashed area, dedupes the bridge tooltip, and tightens the y-axis (10.5k no longer rounds up to 12k)
- give the examples index hero proper top spacing so the centered title matches showcase

## Test plan
- [ ] visit `/docs`, switch platform: URL gains `?platform=rn` / `?platform=ink`, switching back to react strips it
- [ ] open `/docs?platform=foo` or `?platform=react`: URL is normalized (param dropped or replaced from localStorage)
- [ ] navigate from `/docs?platform=ink` to `/examples`: examples URL stays clean
- [ ] open a docs page on a non-default platform: no react `key` warning in console
- [ ] visit `/changelog`: each release is expanded; bullets show `[type] description (#PR · hash · @author)` plus a "Show description" button when the body is non-empty
- [ ] visit `/traction`: stars chart shows a dashed forecast line from today to month-end, y-axis tops out near the data, hover tooltip on today shows a single row
- [ ] visit `/examples`: hero title has proper breathing room from the page header