### PR TITLE
fix(core): restore adapter context flow through RemoteThreadListAdapter.unstable_Provider

### DIFF
--- a/.changeset/remote-thread-list-adapter-provider.md
+++ b/.changeset/remote-thread-list-adapter-provider.md
@@ -1,0 +1,11 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(core): restore adapter context flow through RemoteThreadListAdapter.unstable_Provider
+
+PR #3891 hoisted the runtime binder out of `RemoteThreadListAdapter.unstable_Provider` so that user-supplied loading / Suspense wrappers no longer strand the runtime binding. as a side effect, any `RuntimeAdapterProvider` mounted inside `unstable_Provider` (history, attachments — what `useCloudThreadListAdapter` and `LocalStorageThreadListAdapter` both do) ended up below the binder in the render tree. `useRuntimeAdapters()` reads context from above, so the runtime hook saw `null` and `useExternalHistory` early-returned.
+
+for `useChatRuntime({ cloud })` setups this silently disabled message persistence (`POST /v1/threads/:id/messages`), thread history loading, run telemetry (`POST /v1/runs`), and forced cloud attachments to fall back to `vercelAttachmentAdapter`'s base64 inlining. the same regression hits `useA2ARuntime`, `useAgUiRuntime`, and `useLocalRuntime` whenever they are wrapped by `useRemoteThreadListRuntime` with a similar adapter.
+
+restore the pre-#3891 layering: the binder once again renders inside `unstable_Provider`, so the runtime hook reads any context the Provider injects. the `ProviderRenderDetector` warning introduced by #3891 is kept and now fires whenever Provider gates `children` behind suspense, loading state, or `useEffect` (the original #3678 case), pointing the user at the synchronous-children rule. no API surface changes; first-party adapters keep working unchanged.

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -94,7 +94,8 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     }
   }
 
-  // Rendered outside the user's Provider so deferred `children` cannot strand the binding.
+  // Rendered as a child of the user's Provider so the runtime hook can
+  // read context the Provider injects (e.g. RuntimeAdapterProvider).
   private _RuntimeBinder: FC<PropsWithChildren<{ threadId: string }>> = ({
     threadId,
     children,
@@ -172,7 +173,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
             console.warn(
               "RemoteThreadListAdapter.unstable_Provider did not render its `children` synchronously. " +
                 "Render `children` on first commit; deferring them behind a loading state, Suspense boundary, " +
-                "or `useEffect` gate leaves thread context unavailable to downstream consumers.",
+                "or `useEffect` gate strands the runtime binder and leaves the thread without context.",
             );
           }
         }, 100);
@@ -183,11 +184,11 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
 
     return (
       <ThreadListItemRuntimeProvider runtime={runtime}>
-        <this._RuntimeBinder threadId={threadId}>
-          <Provider>
+        <Provider>
+          <this._RuntimeBinder threadId={threadId}>
             <ProviderRenderDetector detectorRef={detectorRef} />
-          </Provider>
-        </this._RuntimeBinder>
+          </this._RuntimeBinder>
+        </Provider>
       </ThreadListItemRuntimeProvider>
     );
   });

--- a/packages/react/src/tests/RemoteThreadListRuntime.adapterProvider.test.tsx
+++ b/packages/react/src/tests/RemoteThreadListRuntime.adapterProvider.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+import { act, render, waitFor } from "@testing-library/react";
+import type { FC, PropsWithChildren } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  RuntimeAdapterProvider,
+  useRemoteThreadListRuntime,
+  useRuntimeAdapters,
+} from "@assistant-ui/core/react";
+import { makeAdapter } from "./remote-thread-list-test-helpers";
+import { useLocalRuntime } from "../legacy-runtime/runtime-cores/local/useLocalRuntime";
+import { AssistantRuntimeProvider } from "../context";
+import type { ChatModelAdapter, RemoteThreadListAdapter } from "../index";
+import type {
+  RuntimeAdapters as RuntimeAdaptersShape,
+  ThreadHistoryAdapter,
+} from "@assistant-ui/core";
+
+type CapturedAdapters = RuntimeAdaptersShape | null;
+
+const noOpAdapter: ChatModelAdapter = {
+  async *run() {},
+};
+
+const dummyHistory: ThreadHistoryAdapter = {
+  load: async () => ({ messages: [] }),
+  append: async () => {},
+};
+
+const makeRuntimeHook = (capture: { adapters: CapturedAdapters }) =>
+  function useTestRuntimeHook() {
+    capture.adapters = useRuntimeAdapters();
+    return useLocalRuntime(noOpAdapter);
+  };
+
+async function renderAndWaitForBinder(
+  adapter: RemoteThreadListAdapter,
+  capture: { adapters: CapturedAdapters },
+) {
+  const Inner: FC = () => {
+    const runtime = useRemoteThreadListRuntime({
+      runtimeHook: makeRuntimeHook(capture),
+      adapter,
+    });
+    return (
+      <AssistantRuntimeProvider runtime={runtime}>
+        {null}
+      </AssistantRuntimeProvider>
+    );
+  };
+
+  // first thread instance arrives asynchronously via switchToNewThread.
+  await act(async () => {
+    render(<Inner />);
+  });
+  await waitFor(() => expect(capture.adapters).not.toBeNull());
+}
+
+const wrapInRuntimeAdapterProvider = (
+  history: ThreadHistoryAdapter,
+): FC<PropsWithChildren> =>
+  function Provider({ children }) {
+    return (
+      <RuntimeAdapterProvider adapters={{ history }}>
+        {children}
+      </RuntimeAdapterProvider>
+    );
+  };
+
+describe("RemoteThreadListAdapter.unstable_Provider", () => {
+  it("makes RuntimeAdapterProvider context visible to the runtime hook", async () => {
+    const capture: { adapters: CapturedAdapters } = { adapters: null };
+    const adapter = makeAdapter({
+      unstable_Provider: wrapInRuntimeAdapterProvider(dummyHistory),
+    });
+    await renderAndWaitForBinder(adapter, capture);
+
+    expect(capture.adapters?.history).toBe(dummyHistory);
+  });
+
+  it("preserves modelContext from the outer runtime-core RuntimeAdapterProvider", async () => {
+    const capture: { adapters: CapturedAdapters } = { adapters: null };
+    const adapter = makeAdapter({
+      unstable_Provider: wrapInRuntimeAdapterProvider(dummyHistory),
+    });
+    await renderAndWaitForBinder(adapter, capture);
+
+    expect(capture.adapters?.history).toBe(dummyHistory);
+    expect(capture.adapters?.modelContext).toBeDefined();
+  });
+
+  it("returns no history when no Provider is supplied", async () => {
+    const capture: { adapters: CapturedAdapters } = { adapters: null };
+    const adapter = makeAdapter();
+    await renderAndWaitForBinder(adapter, capture);
+
+    expect(capture.adapters?.history).toBeUndefined();
+  });
+
+  it("picks up a swapped Provider on re-render", async () => {
+    const capture: { adapters: CapturedAdapters } = { adapters: null };
+    const firstHistory: ThreadHistoryAdapter = {
+      load: async () => ({ messages: [] }),
+      append: async () => {},
+    };
+    const secondHistory: ThreadHistoryAdapter = {
+      load: async () => ({ messages: [] }),
+      append: async () => {},
+    };
+
+    const Inner: FC<{ history: ThreadHistoryAdapter }> = ({ history }) => {
+      const adapter = makeAdapter({
+        unstable_Provider: wrapInRuntimeAdapterProvider(history),
+      });
+      const runtime = useRemoteThreadListRuntime({
+        runtimeHook: makeRuntimeHook(capture),
+        adapter,
+      });
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {null}
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(<Inner history={firstHistory} />);
+    });
+    await waitFor(() => expect(capture.adapters?.history).toBe(firstHistory));
+
+    await act(async () => {
+      result!.rerender(<Inner history={secondHistory} />);
+    });
+    await waitFor(() => expect(capture.adapters?.history).toBe(secondHistory));
+  });
+});

--- a/packages/react/src/tests/RemoteThreadListRuntime.deferredProvider.test.tsx
+++ b/packages/react/src/tests/RemoteThreadListRuntime.deferredProvider.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { type FC, type PropsWithChildren, useState } from "react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useRemoteThreadListRuntime } from "@assistant-ui/core/react";
 import { makeAdapter } from "./remote-thread-list-test-helpers";
 import type { AssistantRuntime } from "@assistant-ui/core";
@@ -39,14 +39,13 @@ const RuntimeCapture: FC<{
   return null;
 };
 
-// regression for #3678: deferred unstable_Provider must not strand the runtime binder.
-describe("useRemoteThreadListRuntime with a deferred unstable_Provider", () => {
-  it("composer.setText does not throw EMPTY_THREAD_ERROR when unstable_Provider defers children", () => {
-    const Provider: FC<PropsWithChildren> = ({ children }) => {
-      const [ready] = useState(false);
-      if (!ready) return null;
-      return <>{children}</>;
-    };
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useRemoteThreadListRuntime with unstable_Provider", () => {
+  it("composer.setText works when unstable_Provider renders children unconditionally", () => {
+    const Provider: FC<PropsWithChildren> = ({ children }) => <>{children}</>;
     const adapter = makeAdapter({ unstable_Provider: Provider });
 
     const runtimeRef: { current: AssistantRuntime | null } = { current: null };
@@ -61,19 +60,31 @@ describe("useRemoteThreadListRuntime with a deferred unstable_Provider", () => {
     expect(() => runtime!.thread.composer.setText("hello")).not.toThrow();
   });
 
-  it("composer.setText still works when unstable_Provider renders children unconditionally", () => {
-    const Provider: FC<PropsWithChildren> = ({ children }) => <>{children}</>;
+  it("warns in dev when unstable_Provider defers children", () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const Provider: FC<PropsWithChildren> = ({ children }) => {
+      const [ready] = useState(false);
+      if (!ready) return null;
+      return <>{children}</>;
+    };
     const adapter = makeAdapter({ unstable_Provider: Provider });
 
-    const runtimeRef: { current: AssistantRuntime | null } = { current: null };
     render(
       <RuntimeProvider adapter={adapter}>
-        <RuntimeCapture runtimeRef={runtimeRef} />
+        <div />
       </RuntimeProvider>,
     );
 
-    const runtime = runtimeRef.current;
-    expect(runtime).toBeTruthy();
-    expect(() => runtime!.thread.composer.setText("hello")).not.toThrow();
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("did not render its `children` synchronously"),
+    );
+
+    warn.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- restore the pre-#3891 layering so the runtime binder once again renders inside `RemoteThreadListAdapter.unstable_Provider`. context the Provider injects (e.g. `RuntimeAdapterProvider`) is now visible to the runtime hook again, recovering message persistence (`POST /v1/threads/:id/messages`), thread history loading, run telemetry (`POST /v1/runs`), and cloud attachments for every `useChatRuntime({ cloud })` / `useA2ARuntime` / `useAgUiRuntime` / `useLocalRuntime` setup
- keep the `ProviderRenderDetector` warning from #3891. it now fires whenever the Provider gates `children` behind suspense, a loading state, or `useEffect`, pointing users at the synchronous-children rule that recovers the original #3678 case
- no API surface changes. first-party adapters (`useCloudThreadListAdapter`, `LocalStorageThreadListAdapter`) and existing third-party adapters keep working unchanged
- new regression test (`adapterProvider.test.tsx`) covers adapter visibility, modelContext merge, no-Provider default, and Provider swap; the existing deferred-Provider test now asserts the dev warning instead of the runtime no-throw

## Test plan

- [x] `pnpm test` in `packages/core` and `packages/react` (170 + 259 tests pass)
- [x] `pnpm build` clean across the monorepo
- [x] `pnpm lint` clean (0 errors)
- [x] live verification with chrome-devtools against `apps/docs` pointing at `proj_0ltyjcuaxpv1.assistant-api.com`: `POST /v1/runs` and `POST /v1/threads/:id/messages` both fire on chat completion
- [x] verified the resulting run lands in Neon (`runs` table) for the docs project
- [ ] `pnpm changeset` describes this as a `patch` for `@assistant-ui/react`