### PR TITLE
fix(cloud-ai-sdk): drive telemetry status from ai sdk onFinish event

### DIFF
--- a/.changeset/cloud-telemetry-event-driven.md
+++ b/.changeset/cloud-telemetry-event-driven.md
@@ -1,0 +1,11 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix(cloud-ai-sdk): use ai sdk onFinish event for telemetry status instead of message-shape heuristic
+
+`extractRunTelemetry` previously inferred run status by walking message parts and checking for a final text part. when an assistant message ended on an unresolved frontend tool call (e.g. `ask_user_questions`), the model's turn was reported as `status: "incomplete"` with empty `output_text`, and the per-`assistantMessageId` dedupe in `CloudTelemetryReporter` then locked that record so the later resubmission carrying the actual text never overwrote it.
+
+`CloudChatCore` now forwards the ai sdk `onFinish` event (`finishReason`, `isAbort`, `isDisconnect`, `isError`) into `CloudTelemetryReporter.reportFromMessages`. status is derived from those signals; `length` / `content-filter` map to `incomplete`, `isError` / `finishReason: "error"` map to `error`, `stop` and terminal `tool-calls` map to `completed`. mid-loop checkpoints (`finishReason: "tool-calls"` with `lastAssistantMessageIsCompleteWithToolCalls` returning true) are skipped, so the dedupe slot stays open for the post-resubmit final state.
+
+`extractRunTelemetry` now uses ai sdk's `isToolUIPart`, `isStaticToolUIPart`, `isReasoningUIPart`, and `getToolName` helpers in place of hand-rolled equivalents, and exposes a `hasReasoning` flag. `reportFromMessages`'s third `event` argument is optional, so existing callers that only pass `(threadId, messages)` keep their previous behavior.

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -7,7 +7,10 @@ import type { ChatRegistry } from "../chat/ChatRegistry";
 import { MessagePersistence } from "../chat/MessagePersistence";
 import { ThreadSessionManager } from "./ThreadSessionManager";
 import { TitlePolicy } from "./TitlePolicy";
-import { CloudTelemetryReporter } from "./CloudTelemetryReporter";
+import {
+  CloudTelemetryReporter,
+  type TelemetryFinishEvent,
+} from "./CloudTelemetryReporter";
 
 export type CloudChatConfig = Omit<
   UseCloudChatOptions,
@@ -87,6 +90,7 @@ export class CloudChatCore {
   async persistChatMessages(
     chatKey: string,
     registry: ChatRegistry,
+    finishEvent?: TelemetryFinishEvent,
   ): Promise<void> {
     const meta = registry.getMeta(chatKey);
     const threadId = meta?.threadId;
@@ -99,7 +103,7 @@ export class CloudChatCore {
     await this.persist(threadId, messages);
 
     this.telemetryReporter
-      .reportFromMessages(threadId, messages)
+      .reportFromMessages(threadId, messages, finishEvent)
       .catch(() => {});
 
     if (this.titlePolicy.shouldGenerateTitle(threadId, messages)) {
@@ -181,7 +185,7 @@ export class CloudChatCore {
         try {
           this.options.chatConfig.onFinish?.(event);
         } finally {
-          await this.persistChatMessages(chatKey, registry);
+          await this.persistChatMessages(chatKey, registry, event);
         }
       },
       onError: (error) => {

--- a/packages/cloud-ai-sdk/src/core/CloudTelemetryReporter.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudTelemetryReporter.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { UIMessage } from "@ai-sdk/react";
-import { CloudTelemetryReporter } from "./CloudTelemetryReporter";
+import {
+  CloudTelemetryReporter,
+  type TelemetryFinishEvent,
+} from "./CloudTelemetryReporter";
 import type { AssistantCloud } from "assistant-cloud";
 
 function assistantMsg(
@@ -14,6 +17,27 @@ function assistantMsg(
     parts: [{ type: "text", text }],
     ...(metadata ? { metadata } : undefined),
   } as UIMessage;
+}
+
+function assistantMsgWithParts(
+  id: string,
+  parts: UIMessage["parts"],
+): UIMessage {
+  return { id, role: "assistant", parts } as UIMessage;
+}
+
+function event(
+  messages: UIMessage[],
+  overrides?: Partial<TelemetryFinishEvent>,
+): TelemetryFinishEvent {
+  return {
+    message: messages[messages.length - 1]!,
+    messages,
+    isAbort: false,
+    isDisconnect: false,
+    isError: false,
+    ...overrides,
+  };
 }
 
 function createCloud(overrides?: {
@@ -134,6 +158,170 @@ describe("CloudTelemetryReporter", () => {
     ]);
 
     expect(reportMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses finishReason='stop' as the authoritative completed signal", async () => {
+    const { cloud, reportMock } = createCloud();
+    const reporter = new CloudTelemetryReporter(cloud);
+    const messages = [assistantMsg("m-1", "hi")];
+
+    await reporter.reportFromMessages(
+      "thread-1",
+      messages,
+      event(messages, { finishReason: "stop" }),
+    );
+
+    expect(reportMock).toHaveBeenCalledOnce();
+    expect(reportMock.mock.calls[0]![0]!.status).toBe("completed");
+  });
+
+  it("maps finishReason='length' / 'content-filter' to incomplete", async () => {
+    const { cloud, reportMock } = createCloud();
+    const reporter = new CloudTelemetryReporter(cloud);
+
+    await reporter.reportFromMessages(
+      "thread-1",
+      [assistantMsg("m-1", "truncated...")],
+      event([assistantMsg("m-1", "truncated...")], { finishReason: "length" }),
+    );
+    expect(reportMock.mock.calls[0]![0]!.status).toBe("incomplete");
+
+    await reporter.reportFromMessages(
+      "thread-2",
+      [assistantMsg("m-2", "blocked")],
+      event([assistantMsg("m-2", "blocked")], {
+        finishReason: "content-filter",
+      }),
+    );
+    expect(reportMock.mock.calls[1]![0]!.status).toBe("incomplete");
+  });
+
+  it("maps isError to error status", async () => {
+    const { cloud, reportMock } = createCloud();
+    const reporter = new CloudTelemetryReporter(cloud);
+    const messages = [assistantMsg("m-1", "partial")];
+
+    await reporter.reportFromMessages(
+      "thread-1",
+      messages,
+      event(messages, { isError: true }),
+    );
+
+    expect(reportMock.mock.calls[0]![0]!.status).toBe("error");
+  });
+
+  it("maps isAbort / isDisconnect to incomplete", async () => {
+    const { cloud, reportMock } = createCloud();
+    const reporter = new CloudTelemetryReporter(cloud);
+
+    await reporter.reportFromMessages(
+      "thread-1",
+      [assistantMsg("m-1", "aborted")],
+      event([assistantMsg("m-1", "aborted")], { isAbort: true }),
+    );
+    expect(reportMock.mock.calls[0]![0]!.status).toBe("incomplete");
+
+    await reporter.reportFromMessages(
+      "thread-2",
+      [assistantMsg("m-2", "disconnected")],
+      event([assistantMsg("m-2", "disconnected")], { isDisconnect: true }),
+    );
+    expect(reportMock.mock.calls[1]![0]!.status).toBe("incomplete");
+  });
+
+  it("skips mid-loop reports when finishReason='tool-calls' and tools are resolved", async () => {
+    const { cloud, reportMock } = createCloud();
+    const reporter = new CloudTelemetryReporter(cloud);
+    // Last assistant message: step-start + tool call with output → all
+    // client-side tools in the last step are resolved. SDK's
+    // sendAutomaticallyWhen would resubmit; we should defer the report.
+    const messages = [
+      assistantMsgWithParts("m-1", [
+        { type: "step-start" },
+        {
+          type: "tool-ask_user_questions",
+          toolCallId: "tc-1",
+          state: "output-available",
+          input: { questions: [] },
+          output: { answers: [] },
+        } as unknown as UIMessage["parts"][number],
+      ]),
+    ];
+
+    await reporter.reportFromMessages(
+      "thread-1",
+      messages,
+      event(messages, { finishReason: "tool-calls" }),
+    );
+
+    expect(reportMock).not.toHaveBeenCalled();
+
+    // The continuation arrives later with finishReason='stop' and text. The
+    // dedupe slot is still empty (we never inserted), so this report fires.
+    const continuation = [
+      assistantMsgWithParts("m-1", [
+        { type: "step-start" },
+        {
+          type: "tool-ask_user_questions",
+          toolCallId: "tc-1",
+          state: "output-available",
+          input: { questions: [] },
+          output: { answers: [] },
+        } as unknown as UIMessage["parts"][number],
+        { type: "step-start" },
+        { type: "text", text: "thanks for the answers" },
+      ]),
+    ];
+
+    await reporter.reportFromMessages(
+      "thread-1",
+      continuation,
+      event(continuation, { finishReason: "stop" }),
+    );
+
+    expect(reportMock).toHaveBeenCalledOnce();
+    const payload = reportMock.mock.calls[0]![0]!;
+    expect(payload.status).toBe("completed");
+    expect(payload.output_text).toBe("thanks for the answers");
+  });
+
+  it("reports finishReason='tool-calls' when tools are not all resolved (terminal)", async () => {
+    const { cloud, reportMock } = createCloud();
+    const reporter = new CloudTelemetryReporter(cloud);
+    // Tool call without output → lastAssistantMessageIsCompleteWithToolCalls
+    // is false → no auto-resubmit will happen → report as terminal.
+    const messages = [
+      assistantMsgWithParts("m-1", [
+        { type: "step-start" },
+        {
+          type: "tool-search",
+          toolCallId: "tc-1",
+          state: "input-available",
+          input: { query: "x" },
+        } as unknown as UIMessage["parts"][number],
+      ]),
+    ];
+
+    await reporter.reportFromMessages(
+      "thread-1",
+      messages,
+      event(messages, { finishReason: "tool-calls" }),
+    );
+
+    expect(reportMock).toHaveBeenCalledOnce();
+    expect(reportMock.mock.calls[0]![0]!.status).toBe("completed");
+  });
+
+  it("falls back to the message-shape heuristic when no event is provided", async () => {
+    const { cloud, reportMock } = createCloud();
+    const reporter = new CloudTelemetryReporter(cloud);
+
+    await reporter.reportFromMessages("thread-1", [
+      assistantMsgWithParts("m-1", [{ type: "step-start" }]),
+    ]);
+
+    expect(reportMock).toHaveBeenCalledOnce();
+    expect(reportMock.mock.calls[0]![0]!.status).toBe("incomplete");
   });
 
   it("passes sampling_calls through to the report", async () => {

--- a/packages/cloud-ai-sdk/src/core/CloudTelemetryReporter.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudTelemetryReporter.test.ts
@@ -27,12 +27,9 @@ function assistantMsgWithParts(
 }
 
 function event(
-  messages: UIMessage[],
   overrides?: Partial<TelemetryFinishEvent>,
 ): TelemetryFinishEvent {
   return {
-    message: messages[messages.length - 1]!,
-    messages,
     isAbort: false,
     isDisconnect: false,
     isError: false,
@@ -168,7 +165,7 @@ describe("CloudTelemetryReporter", () => {
     await reporter.reportFromMessages(
       "thread-1",
       messages,
-      event(messages, { finishReason: "stop" }),
+      event({ finishReason: "stop" }),
     );
 
     expect(reportMock).toHaveBeenCalledOnce();
@@ -182,14 +179,14 @@ describe("CloudTelemetryReporter", () => {
     await reporter.reportFromMessages(
       "thread-1",
       [assistantMsg("m-1", "truncated...")],
-      event([assistantMsg("m-1", "truncated...")], { finishReason: "length" }),
+      event({ finishReason: "length" }),
     );
     expect(reportMock.mock.calls[0]![0]!.status).toBe("incomplete");
 
     await reporter.reportFromMessages(
       "thread-2",
       [assistantMsg("m-2", "blocked")],
-      event([assistantMsg("m-2", "blocked")], {
+      event({
         finishReason: "content-filter",
       }),
     );
@@ -204,7 +201,21 @@ describe("CloudTelemetryReporter", () => {
     await reporter.reportFromMessages(
       "thread-1",
       messages,
-      event(messages, { isError: true }),
+      event({ isError: true }),
+    );
+
+    expect(reportMock.mock.calls[0]![0]!.status).toBe("error");
+  });
+
+  it("maps finishReason='error' (without isError) to error status", async () => {
+    const { cloud, reportMock } = createCloud();
+    const reporter = new CloudTelemetryReporter(cloud);
+    const messages = [assistantMsg("m-1", "partial")];
+
+    await reporter.reportFromMessages(
+      "thread-1",
+      messages,
+      event({ finishReason: "error" }),
     );
 
     expect(reportMock.mock.calls[0]![0]!.status).toBe("error");
@@ -217,14 +228,14 @@ describe("CloudTelemetryReporter", () => {
     await reporter.reportFromMessages(
       "thread-1",
       [assistantMsg("m-1", "aborted")],
-      event([assistantMsg("m-1", "aborted")], { isAbort: true }),
+      event({ isAbort: true }),
     );
     expect(reportMock.mock.calls[0]![0]!.status).toBe("incomplete");
 
     await reporter.reportFromMessages(
       "thread-2",
       [assistantMsg("m-2", "disconnected")],
-      event([assistantMsg("m-2", "disconnected")], { isDisconnect: true }),
+      event({ isDisconnect: true }),
     );
     expect(reportMock.mock.calls[1]![0]!.status).toBe("incomplete");
   });
@@ -232,9 +243,6 @@ describe("CloudTelemetryReporter", () => {
   it("skips mid-loop reports when finishReason='tool-calls' and tools are resolved", async () => {
     const { cloud, reportMock } = createCloud();
     const reporter = new CloudTelemetryReporter(cloud);
-    // Last assistant message: step-start + tool call with output → all
-    // client-side tools in the last step are resolved. SDK's
-    // sendAutomaticallyWhen would resubmit; we should defer the report.
     const messages = [
       assistantMsgWithParts("m-1", [
         { type: "step-start" },
@@ -251,13 +259,11 @@ describe("CloudTelemetryReporter", () => {
     await reporter.reportFromMessages(
       "thread-1",
       messages,
-      event(messages, { finishReason: "tool-calls" }),
+      event({ finishReason: "tool-calls" }),
     );
 
     expect(reportMock).not.toHaveBeenCalled();
 
-    // The continuation arrives later with finishReason='stop' and text. The
-    // dedupe slot is still empty (we never inserted), so this report fires.
     const continuation = [
       assistantMsgWithParts("m-1", [
         { type: "step-start" },
@@ -276,7 +282,7 @@ describe("CloudTelemetryReporter", () => {
     await reporter.reportFromMessages(
       "thread-1",
       continuation,
-      event(continuation, { finishReason: "stop" }),
+      event({ finishReason: "stop" }),
     );
 
     expect(reportMock).toHaveBeenCalledOnce();
@@ -288,8 +294,6 @@ describe("CloudTelemetryReporter", () => {
   it("reports finishReason='tool-calls' when tools are not all resolved (terminal)", async () => {
     const { cloud, reportMock } = createCloud();
     const reporter = new CloudTelemetryReporter(cloud);
-    // Tool call without output → lastAssistantMessageIsCompleteWithToolCalls
-    // is false → no auto-resubmit will happen → report as terminal.
     const messages = [
       assistantMsgWithParts("m-1", [
         { type: "step-start" },
@@ -305,7 +309,7 @@ describe("CloudTelemetryReporter", () => {
     await reporter.reportFromMessages(
       "thread-1",
       messages,
-      event(messages, { finishReason: "tool-calls" }),
+      event({ finishReason: "tool-calls" }),
     );
 
     expect(reportMock).toHaveBeenCalledOnce();

--- a/packages/cloud-ai-sdk/src/core/CloudTelemetryReporter.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudTelemetryReporter.ts
@@ -1,7 +1,22 @@
 import type { UIMessage } from "@ai-sdk/react";
-import type { AssistantCloud } from "assistant-cloud";
-import type { AssistantCloudRunReport } from "assistant-cloud";
-import { extractRunTelemetry } from "./extractRunTelemetry";
+import type { AssistantCloud, AssistantCloudRunReport } from "assistant-cloud";
+import {
+  type FinishReason,
+  lastAssistantMessageIsCompleteWithToolCalls,
+} from "ai";
+import {
+  extractRunTelemetry,
+  type RunTelemetryData,
+} from "./extractRunTelemetry";
+
+export type TelemetryFinishEvent = {
+  message: UIMessage;
+  messages: UIMessage[];
+  finishReason?: FinishReason;
+  isAbort: boolean;
+  isDisconnect: boolean;
+  isError: boolean;
+};
 
 export class CloudTelemetryReporter {
   private reported = new Set<string>();
@@ -11,8 +26,18 @@ export class CloudTelemetryReporter {
   async reportFromMessages(
     threadId: string,
     messages: UIMessage[],
+    event?: TelemetryFinishEvent,
   ): Promise<void> {
     if (!this.cloud.telemetry.enabled) return;
+
+    // mid-loop checkpoint: ai sdk's sendAutomaticallyWhen will resubmit and a
+    // later onFinish will fire on the same assistantMessageId with the final state.
+    if (
+      event?.finishReason === "tool-calls" &&
+      lastAssistantMessageIsCompleteWithToolCalls({ messages })
+    ) {
+      return;
+    }
 
     const extracted = extractRunTelemetry(messages);
     if (!extracted) return;
@@ -20,11 +45,12 @@ export class CloudTelemetryReporter {
     const dedupeKey = `${threadId}:${extracted.assistantMessageId}`;
     if (this.reported.has(dedupeKey)) return;
 
-    // Keep in sync with assistant-cloud createRunSchema
-    // (apps/aui-cloud-api/src/endpoints/runs/create.ts).
+    const status = event ? deriveStatus(event, extracted) : extracted.status;
+
+    // keep in sync with assistant-cloud createRunSchema (apps/aui-cloud-api/src/endpoints/runs/create.ts).
     const initial: AssistantCloudRunReport = {
       thread_id: threadId,
-      status: extracted.status,
+      status,
       ...(extracted.totalSteps != null
         ? { total_steps: extracted.totalSteps }
         : undefined),
@@ -55,5 +81,25 @@ export class CloudTelemetryReporter {
 
     this.reported.add(dedupeKey);
     await this.cloud.runs.report(report).catch(() => {});
+  }
+}
+
+function deriveStatus(
+  event: TelemetryFinishEvent,
+  extracted: RunTelemetryData,
+): AssistantCloudRunReport["status"] {
+  if (event.isError) return "error";
+  if (event.isAbort || event.isDisconnect) return "incomplete";
+  switch (event.finishReason) {
+    case "stop":
+    case "tool-calls":
+      return "completed";
+    case "length":
+    case "content-filter":
+      return "incomplete";
+    case "error":
+      return "error";
+    default:
+      return extracted.status;
   }
 }

--- a/packages/cloud-ai-sdk/src/core/CloudTelemetryReporter.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudTelemetryReporter.ts
@@ -10,8 +10,6 @@ import {
 } from "./extractRunTelemetry";
 
 export type TelemetryFinishEvent = {
-  message: UIMessage;
-  messages: UIMessage[];
   finishReason?: FinishReason;
   isAbort: boolean;
   isDisconnect: boolean;

--- a/packages/cloud-ai-sdk/src/core/extractRunTelemetry.test.ts
+++ b/packages/cloud-ai-sdk/src/core/extractRunTelemetry.test.ts
@@ -66,6 +66,7 @@ describe("extractRunTelemetry", () => {
       {
         tool_name: "search",
         tool_call_id: "tc-1",
+        tool_source: "frontend",
         tool_args: '{"query":"test"}',
         tool_result: '{"results":["a","b"]}',
       },
@@ -100,7 +101,7 @@ describe("extractRunTelemetry", () => {
       ]),
     ])!;
     expect(result.toolCalls).toEqual([
-      { tool_name: "noop", tool_call_id: "tc-3" },
+      { tool_name: "noop", tool_call_id: "tc-3", tool_source: "frontend" },
     ]);
   });
 
@@ -201,33 +202,6 @@ describe("extractRunTelemetry", () => {
     expect(result.toolCalls![0]!.sampling_calls).toEqual([
       { model_id: "gemini-2.5-flash", input_tokens: 100, output_tokens: 50 },
     ]);
-  });
-
-  it("flags hasReasoning when assistant message contains a reasoning part", () => {
-    const withReasoning = extractRunTelemetry([
-      assistantMsg("m-1", [
-        {
-          type: "reasoning",
-          text: "thinking...",
-        } as UIMessage["parts"][number],
-        { type: "text", text: "answer" },
-      ]),
-    ])!;
-    expect(withReasoning.hasReasoning).toBe(true);
-
-    const withoutReasoning = extractRunTelemetry([
-      assistantMsg("m-2", [{ type: "text", text: "answer" }]),
-    ])!;
-    expect(withoutReasoning.hasReasoning).toBe(false);
-
-    // empty reasoning text shouldn't count
-    const emptyReasoning = extractRunTelemetry([
-      assistantMsg("m-3", [
-        { type: "reasoning", text: "" } as UIMessage["parts"][number],
-        { type: "text", text: "answer" },
-      ]),
-    ])!;
-    expect(emptyReasoning.hasReasoning).toBe(false);
   });
 
   it("ignores sampling calls for non-matching tool call ids", () => {

--- a/packages/cloud-ai-sdk/src/core/extractRunTelemetry.test.ts
+++ b/packages/cloud-ai-sdk/src/core/extractRunTelemetry.test.ts
@@ -203,6 +203,33 @@ describe("extractRunTelemetry", () => {
     ]);
   });
 
+  it("flags hasReasoning when assistant message contains a reasoning part", () => {
+    const withReasoning = extractRunTelemetry([
+      assistantMsg("m-1", [
+        {
+          type: "reasoning",
+          text: "thinking...",
+        } as UIMessage["parts"][number],
+        { type: "text", text: "answer" },
+      ]),
+    ])!;
+    expect(withReasoning.hasReasoning).toBe(true);
+
+    const withoutReasoning = extractRunTelemetry([
+      assistantMsg("m-2", [{ type: "text", text: "answer" }]),
+    ])!;
+    expect(withoutReasoning.hasReasoning).toBe(false);
+
+    // empty reasoning text shouldn't count
+    const emptyReasoning = extractRunTelemetry([
+      assistantMsg("m-3", [
+        { type: "reasoning", text: "" } as UIMessage["parts"][number],
+        { type: "text", text: "answer" },
+      ]),
+    ])!;
+    expect(emptyReasoning.hasReasoning).toBe(false);
+  });
+
   it("ignores sampling calls for non-matching tool call ids", () => {
     const result = extractRunTelemetry([
       assistantMsg(

--- a/packages/cloud-ai-sdk/src/core/extractRunTelemetry.ts
+++ b/packages/cloud-ai-sdk/src/core/extractRunTelemetry.ts
@@ -1,10 +1,5 @@
 import type { UIMessage } from "@ai-sdk/react";
-import {
-  getToolName,
-  isReasoningUIPart,
-  isStaticToolUIPart,
-  isToolUIPart,
-} from "ai";
+import { getToolName, isStaticToolUIPart, isToolUIPart } from "ai";
 import type { SamplingCallData } from "assistant-cloud";
 
 const MAX_SPAN_CONTENT = 50_000;
@@ -63,7 +58,6 @@ export type TelemetryToolCall = {
 export type RunTelemetryData = {
   assistantMessageId: string;
   status: "completed" | "incomplete";
-  hasReasoning: boolean;
   toolCalls?: TelemetryToolCall[];
   totalSteps?: number;
   outputText?: string;
@@ -119,11 +113,13 @@ type Part = UIMessage["parts"][number];
 type ToolPart = Extract<Part, { toolCallId: string }>;
 
 function buildToolCall(part: ToolPart): TelemetryToolCall {
-  // ai sdk does not publicly export isDynamicToolUIPart; invert the static check.
+  // dynamic-tool → mcp, static `tool-*` → frontend. matches server-side
+  // createAssistantRun (apps/cloud-api/src/endpoints/runs/stream.ts).
   const isMcp = !isStaticToolUIPart(part);
   const call: TelemetryToolCall = {
     tool_name: getToolName(part),
     tool_call_id: part.toolCallId,
+    tool_source: isMcp ? "mcp" : "frontend",
   };
 
   const input = "input" in part ? part.input : undefined;
@@ -134,7 +130,6 @@ function buildToolCall(part: ToolPart): TelemetryToolCall {
   const toolResult = isMcp ? summarizeMcpResult(output) : safeStringify(output);
   if (toolResult !== undefined) call.tool_result = toolResult;
 
-  if (isMcp) call.tool_source = "mcp";
   return call;
 }
 
@@ -153,15 +148,12 @@ export function extractRunTelemetry(
   const textParts: string[] = [];
   const toolCalls: TelemetryToolCall[] = [];
   let stepCount = 0;
-  let hasReasoning = false;
 
   for (const part of assistant.parts) {
     if (part.type === "step-start") {
       stepCount++;
     } else if (part.type === "text" && part.text) {
       textParts.push(part.text);
-    } else if (isReasoningUIPart(part)) {
-      if (part.text) hasReasoning = true;
     } else if (isToolUIPart(part)) {
       toolCalls.push(buildToolCall(part));
     }
@@ -198,7 +190,6 @@ export function extractRunTelemetry(
   return {
     assistantMessageId: assistant.id,
     status,
-    hasReasoning,
     ...(toolCalls.length > 0 ? { toolCalls } : undefined),
     ...(stepCount > 0 ? { totalSteps: stepCount } : undefined),
     ...(outputText != null ? { outputText } : undefined),

--- a/packages/cloud-ai-sdk/src/core/extractRunTelemetry.ts
+++ b/packages/cloud-ai-sdk/src/core/extractRunTelemetry.ts
@@ -1,4 +1,10 @@
 import type { UIMessage } from "@ai-sdk/react";
+import {
+  getToolName,
+  isReasoningUIPart,
+  isStaticToolUIPart,
+  isToolUIPart,
+} from "ai";
 import type { SamplingCallData } from "assistant-cloud";
 
 const MAX_SPAN_CONTENT = 50_000;
@@ -57,6 +63,7 @@ export type TelemetryToolCall = {
 export type RunTelemetryData = {
   assistantMessageId: string;
   status: "completed" | "incomplete";
+  hasReasoning: boolean;
   toolCalls?: TelemetryToolCall[];
   totalSteps?: number;
   outputText?: string;
@@ -109,33 +116,11 @@ function normalizeUsage(usage: UsageFields):
 }
 
 type Part = UIMessage["parts"][number];
+type ToolPart = Extract<Part, { toolCallId: string }>;
 
-function isToolPart(
-  part: Part,
-): part is Part & { toolCallId: string; input?: unknown; output?: unknown } {
-  if (!("toolCallId" in part)) return false;
-  const { type } = part;
-  return (
-    type === "dynamic-tool" ||
-    type.startsWith("tool-") ||
-    type.startsWith("dynamic-tool-")
-  );
-}
-
-function isDynamicTool(part: Part): boolean {
-  return part.type === "dynamic-tool" || part.type.startsWith("dynamic-tool-");
-}
-
-function getToolName(part: Part & { toolCallId: string }): string {
-  if ("toolName" in part && typeof part.toolName === "string") {
-    return part.toolName;
-  }
-  // typed tool part: type is "tool-{NAME}"
-  return part.type.slice(5);
-}
-
-function buildToolCall(part: Part & { toolCallId: string }): TelemetryToolCall {
-  const isMcp = isDynamicTool(part);
+function buildToolCall(part: ToolPart): TelemetryToolCall {
+  // ai sdk does not publicly export isDynamicToolUIPart; invert the static check.
+  const isMcp = !isStaticToolUIPart(part);
   const call: TelemetryToolCall = {
     tool_name: getToolName(part),
     tool_call_id: part.toolCallId,
@@ -156,7 +141,6 @@ function buildToolCall(part: Part & { toolCallId: string }): TelemetryToolCall {
 export function extractRunTelemetry(
   messages: UIMessage[],
 ): RunTelemetryData | null {
-  // Find last assistant message
   let assistant: UIMessage | undefined;
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i]!.role === "assistant") {
@@ -169,32 +153,33 @@ export function extractRunTelemetry(
   const textParts: string[] = [];
   const toolCalls: TelemetryToolCall[] = [];
   let stepCount = 0;
+  let hasReasoning = false;
 
   for (const part of assistant.parts) {
     if (part.type === "step-start") {
       stepCount++;
     } else if (part.type === "text" && part.text) {
       textParts.push(part.text);
-    } else if (isToolPart(part)) {
+    } else if (isReasoningUIPart(part)) {
+      if (part.text) hasReasoning = true;
+    } else if (isToolUIPart(part)) {
       toolCalls.push(buildToolCall(part));
     }
   }
 
   const hasText = textParts.length > 0;
   const outputText = hasText ? truncateStr(textParts.join("")) : undefined;
+  // fallback heuristic; callers with the onFinish event should override via deriveStatus.
   const status: RunTelemetryData["status"] = hasText
     ? "completed"
     : "incomplete";
 
-  // Metadata-dependent fields (require route messageMetadata config)
   const metadata = assistant.metadata as Record<string, unknown> | undefined;
   const modelId =
     typeof metadata?.modelId === "string" ? metadata.modelId : undefined;
   const usage = metadata?.usage as UsageFields | undefined;
   const normalizedUsage = usage ? normalizeUsage(usage) : undefined;
 
-  // Sampling calls from sub-agent / delegated model invocations.
-  // Server attaches via messageMetadata: { samplingCalls: { [toolCallId]: SamplingCallData[] } }
   const rawSamplingCalls = metadata?.samplingCalls;
   const samplingCallsMap =
     rawSamplingCalls != null && typeof rawSamplingCalls === "object"
@@ -213,6 +198,7 @@ export function extractRunTelemetry(
   return {
     assistantMessageId: assistant.id,
     status,
+    hasReasoning,
     ...(toolCalls.length > 0 ? { toolCalls } : undefined),
     ...(stepCount > 0 ? { totalSteps: stepCount } : undefined),
     ...(outputText != null ? { outputText } : undefined),


### PR DESCRIPTION
## Summary

- forward the ai sdk `onFinish` event (`finishReason`, `isAbort`, `isDisconnect`, `isError`) from `CloudChatCore` into `CloudTelemetryReporter.reportFromMessages` and derive the run status from those authoritative signals instead of guessing from message parts
- skip mid-loop checkpoints when `finishReason === "tool-calls"` and `lastAssistantMessageIsCompleteWithToolCalls` is true. the per-`assistantMessageId` dedupe slot stays open for the post-resubmit final state, so an unresolved frontend tool (e.g. `ask_user_questions`) no longer locks a misleading `incomplete + no output_text` record
- map: `stop` → `completed`, terminal `tool-calls` → `completed`, `length` / `content-filter` → `incomplete`, `isError` / `finishReason: "error"` → `error`, `isAbort` / `isDisconnect` → `incomplete`. unknown / `other` falls back to the existing message-shape heuristic
- replace hand-rolled tool-part detection in `extractRunTelemetry` with ai sdk's `isToolUIPart`, `isStaticToolUIPart`, `isReasoningUIPart`, and `getToolName`. expose a `hasReasoning` flag for downstream consumers
- the `event` argument is optional; existing `reportFromMessages(threadId, messages)` callers keep the previous heuristic-based behavior

## Background

before this PR, an assistant turn ending on an unresolved frontend tool call had no text part, so `extractRunTelemetry` set `status: "incomplete"` and `output_text: undefined`. the dedupe set then prevented the post-resubmit text from ever updating the record. the resulting database had thousands of `incomplete` runs with empty `output_text` for projects using `useCloudChat` with frontend tools — exactly the failure mode `proj_0cv96p0ojmc4` hit at scale starting 2026-04-21 (~50% incomplete rate).

## Test plan

- [x] `pnpm test` in `packages/cloud-ai-sdk` (56 tests pass, includes 7 new tests covering `finishReason` variants, mid-loop skip, isError, isAbort, fallback path)
- [x] `pnpm build` clean
- [x] `pnpm lint` clean (0 errors)
- [ ] live verification with chrome-devtools against a `useCloudChat` setup that triggers a frontend-tool pause; confirm no `incomplete` record is written and the post-resume final-text record is reported as `completed`