### PR TITLE
fix(docs): clarify makeAssistantTool/UI coexist with Tools() api

### DIFF
--- a/apps/docs/content/docs/(docs)/copilots/make-assistant-tool-ui.mdx
+++ b/apps/docs/content/docs/(docs)/copilots/make-assistant-tool-ui.mdx
@@ -4,9 +4,15 @@ description: Register custom UI components to render tool executions and their s
 platforms: ["react"]
 ---
 
-<Callout type="warn">
-  `makeAssistantToolUI` is deprecated. Use the `Tools()` API instead. See the
-  [Tools guide](/docs/guides/tools) for the recommended approach.
+<Callout type="info">
+  Prefer pre-registering tool UIs via the [`Tools()` API](/docs/guides/tools)
+  (set `render` on the tool definition) or by mounting `makeAssistantToolUI`
+  near the root of your tree. A tool UI that is only registered while a
+  specific component is mounted will not appear when chat history is replayed
+  or during server-side rendering, since the registering component may not be
+  mounted at that point. Tool execution can still be registered dynamically
+  via [`makeAssistantTool`](/docs/copilots/make-assistant-tool); this caveat
+  applies specifically to the UI render function.
 </Callout>
 
 The `makeAssistantToolUI` utility is used to register a tool UI component with the Assistant.

--- a/apps/docs/content/docs/(docs)/copilots/make-assistant-tool.mdx
+++ b/apps/docs/content/docs/(docs)/copilots/make-assistant-tool.mdx
@@ -4,9 +4,13 @@ description: Create React components that provide reusable tools to the assistan
 platforms: ["react"]
 ---
 
-<Callout type="warn">
-  `makeAssistantTool` is deprecated. Use the `Tools()` API instead. See the
-  [Tools guide](/docs/guides/tools) for the recommended approach.
+<Callout type="info">
+  For most apps, the [`Tools()` API](/docs/guides/tools) is an easier starting
+  point: tool definitions live in a toolkit object rather than the component
+  tree. `makeAssistantTool` is fully supported and remains a good fit when a
+  tool's availability is tied to a component being mounted, for example a
+  product-specific tool that should only be exposed while that product's UI is
+  on screen (the [intelligent components](/docs/copilots/motivation) pattern).
 </Callout>
 
 `makeAssistantTool` creates a React component that provides a tool to the assistant. This is useful for defining reusable tools that can be composed into your application.

--- a/apps/docs/content/docs/guides/tools.mdx
+++ b/apps/docs/content/docs/guides/tools.mdx
@@ -27,7 +27,7 @@ When tools are executed, you can display custom generative UI components that pr
 
 ## Tools() API
 
-The `Tools()` API is the recommended way to register tools in assistant-ui. It provides centralized tool registration that prevents duplicate registrations and works seamlessly with all runtimes.
+The `Tools()` API is the recommended starting point for registering tools in assistant-ui. It provides centralized tool registration that prevents duplicate registrations and works seamlessly with all runtimes. For tools whose availability depends on a specific part of your UI being mounted, see the [component-based APIs](#component-based-apis) below; both styles are supported and can be mixed in the same app.
 
 ### Quick Start
 
@@ -315,11 +315,20 @@ const SearchToolUI = makeAssistantToolUI<{ query: string; limit: number }, unkno
 
 ## Component-Based APIs
 
-`makeAssistantTool`, `useAssistantTool`, and `makeAssistantToolUI` are component-and-hook-based APIs that coexist with the [`Tools()`](#tools-api) toolkit pattern. They are fully supported and useful when you want tool registration tied to the React tree rather than declared in a toolkit object. The toolkit pattern is generally more ergonomic for larger tool sets; pick whichever fits your codebase.
+`makeAssistantTool`, `useAssistantTool`, and `makeAssistantToolUI` are component-and-hook-based APIs that coexist with the [`Tools()`](#tools-api) toolkit pattern. They are fully supported and the natural fit for the [intelligent components](/docs/copilots/motivation) pattern, where each part of your UI registers the tools it owns when it is mounted, for example a product-specific tool that should only be exposed while that product's screen is open.
 
 <Callout type="info">
   Be careful not to register the same tool from both APIs at once: each API
   registers under `toolName`, and duplicate registrations will be rejected.
+</Callout>
+
+<Callout type="warn">
+  Tool **execution** can be registered dynamically (when a component mounts),
+  but tool **UI** should generally be pre-registered. A `render` function that
+  is only registered while a specific component is mounted will not render
+  when chat history is replayed or during server-side rendering. Either
+  declare the tool's `render` in a `Tools()` toolkit, or mount
+  `makeAssistantToolUI` near the root of your tree.
 </Callout>
 
 ### Using `makeAssistantTool`


### PR DESCRIPTION
## Summary
- addresses #3164 where a user concluded `makeAssistantTool` was being deprecated; per the maintainer's reply, neither it nor `makeAssistantToolUI` is officially deprecated, and both are intended to coexist with the `Tools()` api
- replace the explicit "deprecated" callouts on the `makeAssistantTool` and `makeAssistantToolUI` reference pages with info callouts that explain when each api fits
- on the `makeAssistantToolUI` page, surface the actual concern: dynamic tool ui registration breaks chat history replay and ssr (the render function does not run if the registering component is not mounted at that point)
- in the tools guide, soften "the recommended way" to "the recommended starting point" and acknowledge the [intelligent components](/docs/copilots/motivation) pattern as a legitimate fit for component-based registration
- add a callout in the tools guide drawing the line between tool execution (dynamic is fine) and tool ui (should be pre-registered)

## Test plan
- [ ] visit `/docs/copilots/make-assistant-tool` and confirm the deprecation warning is gone, replaced with the new info callout linking to the intelligent components page
- [ ] visit `/docs/copilots/make-assistant-tool-ui` and confirm the new callout explains the chat history / ssr caveat
- [ ] visit `/docs/guides/tools` and confirm the component-based section calls out the intelligent components pattern and the tool execution vs tool ui distinction
- [ ] click the cross-links to verify they resolve