### PR TITLE
perf: cut per-message overhead in long threads

### DIFF
--- a/.changeset/perf-long-thread-mount.md
+++ b/.changeset/perf-long-thread-mount.md
@@ -1,0 +1,12 @@
+---
+"@assistant-ui/react": patch
+---
+
+perf: cut per-message overhead in long threads
+
+Two changes to `MessagePrimitive.Root` that remove work that scaled with message count:
+
+- Defer the `parseCssLength` call inside the top-anchor target ref to the next animation frame. The synchronous `getComputedStyle` read used to force a full-tree layout during the bulk-mount of a long thread (observed as a 335 ms forced reflow at 100 messages); deferring past first paint lets the browser do that layout naturally.
+- Split the root into a default and a top-anchor path. Threads using the default `turnAnchor="bottom"` no longer subscribe to the top-anchor `useAuiState` selectors per message, eliminating O(messages × 2) selector evaluations on every state change.
+
+Behavior is unchanged. Top-turn anchoring still works the same way; the only observable difference is that the anchor target registration is now async (one frame).

--- a/.changeset/perf-long-thread-mount.md
+++ b/.changeset/perf-long-thread-mount.md
@@ -4,9 +4,11 @@
 
 perf: cut per-message overhead in long threads
 
-Two changes to `MessagePrimitive.Root` that remove work that scaled with message count:
+Two `MessagePrimitive.Root` changes remove work that scaled with message count:
 
-- Defer the `parseCssLength` call inside the top-anchor target ref to the next animation frame. The synchronous `getComputedStyle` read used to force a full-tree layout during the bulk-mount of a long thread (observed as a 335 ms forced reflow at 100 messages); deferring past first paint lets the browser do that layout naturally.
-- Split the root into a default and a top-anchor path. Threads using the default `turnAnchor="bottom"` no longer subscribe to the top-anchor `useAuiState` selectors per message, eliminating O(messages × 2) selector evaluations on every state change.
+- Defer the `parseCssLength` call inside the top-anchor target ref to the next animation frame. The synchronous `getComputedStyle` read previously forced a full-tree layout during the bulk-mount of a long thread (a 335 ms forced reflow at 100 messages in our trace). Deferring past first paint lets the browser do the layout naturally.
+- Split the root into a default and a top-anchor path. Threads using the default `turnAnchor="bottom"` no longer subscribe to the top-anchor `useAuiState` selectors per message.
 
-Behavior is unchanged. Top-turn anchoring still works the same way; the only observable difference is that the anchor target registration is now async (one frame).
+The only observable change is that top-anchor target registration is now async by one frame.
+
+Note: `@assistant-ui/ui` (private, copy-into-project) gains a `content-visibility: auto` default on message wrappers in the same PR. On a cold load with pre-existing history taller than the viewport, the placeholder-based `scrollHeight` can transiently disagree with the at-bottom check until off-screen messages are measured. `useOnResizeContent` resyncs within a frame, and the auto-scroll path uses an explicit "scrolling" flag rather than trusting `isAtBottom` alone, so run-start scrolling is unaffected.

--- a/packages/react/src/primitives/message/MessageRoot.tsx
+++ b/packages/react/src/primitives/message/MessageRoot.tsx
@@ -12,7 +12,7 @@ import { useAui, useAuiState } from "@assistant-ui/store";
 import { useManagedRef } from "../../utils/hooks/useManagedRef";
 import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import { useThreadViewportStore } from "../../context/react/ThreadViewportContext";
-import { parseCssLength } from "../thread/topAnchor/topAnchorUtils";
+import { scheduleAnchorTargetRegistration } from "../thread/topAnchor/scheduleAnchorTargetRegistration";
 
 type ThreadViewportStore = NonNullable<
   ReturnType<typeof useThreadViewportStore>
@@ -51,13 +51,6 @@ const useIsHoveringRef = () => {
   return useManagedRef(callbackRef);
 };
 
-/**
- * Predicate: this user message is the anchor target of an in-flight top-turn
- * (second-to-last message after the first turn, with the last being an
- * assistant response). Only call this when the viewport is in "top" turnAnchor
- * mode; in "bottom" mode the predicate is always false and the selector
- * subscription is pure overhead.
- */
 const useIsTopAnchorUser = () => {
   return useAuiState(
     (s) =>
@@ -68,11 +61,6 @@ const useIsTopAnchorUser = () => {
   );
 };
 
-/**
- * Predicate: this assistant message is the streaming response paired with the
- * preceding user message under top-turn anchoring. Same caller contract as
- * `useIsTopAnchorUser`.
- */
 const useIsTopAnchorTarget = () => {
   return useAuiState(
     (s) =>
@@ -83,7 +71,6 @@ const useIsTopAnchorTarget = () => {
   );
 };
 
-/** Registers the user message as the top-anchor user reference element. */
 const useTopAnchorUserRef = (
   active: boolean,
   threadViewportStore: ThreadViewportStore,
@@ -99,15 +86,6 @@ const useTopAnchorUserRef = (
   return useManagedRef<HTMLElement>(callback);
 };
 
-/**
- * Registers the assistant message as the top-anchor target element. CSS-length
- * clamp config is parsed against the registered element's computed style and
- * stored as numeric pixels.
- *
- * The parse (which calls `getComputedStyle`) is deferred to the next animation
- * frame so it cannot force a synchronous layout during the bulk-mount phase of
- * a long thread.
- */
 const useTopAnchorTargetRef = ({
   active,
   threadViewportStore,
@@ -118,22 +96,7 @@ const useTopAnchorTargetRef = ({
   const targetRefCallback = useCallback(
     (el: HTMLElement) => {
       if (!active) return;
-
-      let unregister: (() => void) | undefined;
-      let frameHandle: number | null = requestAnimationFrame(() => {
-        frameHandle = null;
-        const state = threadViewportStore.getState();
-        const clamp = state.topAnchorMessageClamp;
-        unregister = state.registerAnchorTargetElement(el, {
-          tallerThan: parseCssLength(clamp.tallerThan, el),
-          visibleHeight: parseCssLength(clamp.visibleHeight, el),
-        });
-      });
-
-      return () => {
-        if (frameHandle !== null) cancelAnimationFrame(frameHandle);
-        unregister?.();
-      };
+      return scheduleAnchorTargetRegistration(el, threadViewportStore);
     },
     [active, threadViewportStore],
   );
@@ -209,10 +172,6 @@ const MessagePrimitiveRootTopAnchor = ({
  * message) or as the top-anchor target (when it's the streaming assistant
  * response). No additional component is required.
  *
- * Internally splits into a default path and a top-anchor path so that threads
- * running with the default `turnAnchor="bottom"` do not pay the per-message
- * cost of the top-anchor selector subscriptions.
- *
  * @example
  * ```tsx
  * <MessagePrimitive.Root>
@@ -229,8 +188,7 @@ export const MessagePrimitiveRoot = forwardRef<
   MessagePrimitiveRoot.Props
 >((props, forwardedRef) => {
   const threadViewportStore = useThreadViewportStore();
-  // turnAnchor is an initial viewport option (see ThreadViewportProvider) and
-  // therefore safe to read non-reactively here.
+  // turnAnchor is initial-only viewport config (see ThreadViewportProvider).
   const turnAnchor = threadViewportStore.getState().turnAnchor;
 
   if (turnAnchor === "top") {

--- a/packages/react/src/primitives/message/MessageRoot.tsx
+++ b/packages/react/src/primitives/message/MessageRoot.tsx
@@ -5,6 +5,7 @@ import {
   type ComponentRef,
   forwardRef,
   type ComponentPropsWithoutRef,
+  type ForwardedRef,
   useCallback,
 } from "react";
 import { useAui, useAuiState } from "@assistant-ui/store";
@@ -53,12 +54,13 @@ const useIsHoveringRef = () => {
 /**
  * Predicate: this user message is the anchor target of an in-flight top-turn
  * (second-to-last message after the first turn, with the last being an
- * assistant response).
+ * assistant response). Only call this when the viewport is in "top" turnAnchor
+ * mode; in "bottom" mode the predicate is always false and the selector
+ * subscription is pure overhead.
  */
-const useIsTopAnchorUser = (turnAnchor: "top" | "bottom") => {
+const useIsTopAnchorUser = () => {
   return useAuiState(
     (s) =>
-      turnAnchor === "top" &&
       s.message.role === "user" &&
       s.message.index > 0 &&
       s.message.index === s.thread.messages.length - 2 &&
@@ -68,12 +70,12 @@ const useIsTopAnchorUser = (turnAnchor: "top" | "bottom") => {
 
 /**
  * Predicate: this assistant message is the streaming response paired with the
- * preceding user message under top-turn anchoring.
+ * preceding user message under top-turn anchoring. Same caller contract as
+ * `useIsTopAnchorUser`.
  */
-const useIsTopAnchorTarget = (turnAnchor: "top" | "bottom") => {
+const useIsTopAnchorTarget = () => {
   return useAuiState(
     (s) =>
-      turnAnchor === "top" &&
       s.message.isLast &&
       s.message.role === "assistant" &&
       s.message.index >= 1 &&
@@ -99,8 +101,12 @@ const useTopAnchorUserRef = (
 
 /**
  * Registers the assistant message as the top-anchor target element. CSS-length
- * clamp config is parsed once at register time using the registered element's
- * computed style, then stored as numeric pixels.
+ * clamp config is parsed against the registered element's computed style and
+ * stored as numeric pixels.
+ *
+ * The parse (which calls `getComputedStyle`) is deferred to the next animation
+ * frame so it cannot force a synchronous layout during the bulk-mount phase of
+ * a long thread.
  */
 const useTopAnchorTargetRef = ({
   active,
@@ -112,13 +118,22 @@ const useTopAnchorTargetRef = ({
   const targetRefCallback = useCallback(
     (el: HTMLElement) => {
       if (!active) return;
-      const state = threadViewportStore.getState();
-      const clamp = state.topAnchorMessageClamp;
 
-      return state.registerAnchorTargetElement(el, {
-        tallerThan: parseCssLength(clamp.tallerThan, el),
-        visibleHeight: parseCssLength(clamp.visibleHeight, el),
+      let unregister: (() => void) | undefined;
+      let frameHandle: number | null = requestAnimationFrame(() => {
+        frameHandle = null;
+        const state = threadViewportStore.getState();
+        const clamp = state.topAnchorMessageClamp;
+        unregister = state.registerAnchorTargetElement(el, {
+          tallerThan: parseCssLength(clamp.tallerThan, el),
+          visibleHeight: parseCssLength(clamp.visibleHeight, el),
+        });
       });
+
+      return () => {
+        if (frameHandle !== null) cancelAnimationFrame(frameHandle);
+        unregister?.();
+      };
     },
     [active, threadViewportStore],
   );
@@ -131,6 +146,57 @@ export namespace MessagePrimitiveRoot {
   export type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
 }
 
+type MessagePrimitiveRootInternalProps = MessagePrimitiveRoot.Props & {
+  forwardedRef: ForwardedRef<MessagePrimitiveRoot.Element>;
+};
+
+const MessagePrimitiveRootDefault = ({
+  forwardedRef,
+  ...props
+}: MessagePrimitiveRootInternalProps) => {
+  const isHoveringRef = useIsHoveringRef();
+  const ref = useComposedRefs<HTMLDivElement>(forwardedRef, isHoveringRef);
+  const messageId = useAuiState((s) => s.message.id);
+
+  return <Primitive.div {...props} ref={ref} data-message-id={messageId} />;
+};
+
+const MessagePrimitiveRootTopAnchor = ({
+  forwardedRef,
+  threadViewportStore,
+  ...props
+}: MessagePrimitiveRootInternalProps & {
+  threadViewportStore: ThreadViewportStore;
+}) => {
+  const isHoveringRef = useIsHoveringRef();
+  const isTopAnchorUser = useIsTopAnchorUser();
+  const isTopAnchorTarget = useIsTopAnchorTarget();
+  const topAnchorUserRef = useTopAnchorUserRef(
+    isTopAnchorUser,
+    threadViewportStore,
+  );
+  const topAnchorTargetRef = useTopAnchorTargetRef({
+    active: isTopAnchorTarget,
+    threadViewportStore,
+  });
+  const ref = useComposedRefs<HTMLDivElement>(
+    forwardedRef,
+    isHoveringRef,
+    topAnchorUserRef,
+    topAnchorTargetRef,
+  );
+  const messageId = useAuiState((s) => s.message.id);
+
+  return (
+    <Primitive.div
+      {...props}
+      ref={ref}
+      data-message-id={messageId}
+      data-aui-top-anchor-target={isTopAnchorTarget ? "" : undefined}
+    />
+  );
+};
+
 /**
  * The root container component for a message.
  *
@@ -142,6 +208,10 @@ export namespace MessagePrimitiveRoot {
  * registers itself as the top-anchor user message (when it's the previous user
  * message) or as the top-anchor target (when it's the streaming assistant
  * response). No additional component is required.
+ *
+ * Internally splits into a default path and a top-anchor path so that threads
+ * running with the default `turnAnchor="bottom"` do not pay the per-message
+ * cost of the top-anchor selector subscriptions.
  *
  * @example
  * ```tsx
@@ -157,36 +227,22 @@ export namespace MessagePrimitiveRoot {
 export const MessagePrimitiveRoot = forwardRef<
   MessagePrimitiveRoot.Element,
   MessagePrimitiveRoot.Props
->((props, forwardRef) => {
-  const isHoveringRef = useIsHoveringRef();
+>((props, forwardedRef) => {
   const threadViewportStore = useThreadViewportStore();
+  // turnAnchor is an initial viewport option (see ThreadViewportProvider) and
+  // therefore safe to read non-reactively here.
   const turnAnchor = threadViewportStore.getState().turnAnchor;
-  const isTopAnchorUser = useIsTopAnchorUser(turnAnchor);
-  const isTopAnchorTarget = useIsTopAnchorTarget(turnAnchor);
-  const topAnchorUserRef = useTopAnchorUserRef(
-    isTopAnchorUser,
-    threadViewportStore,
-  );
-  const topAnchorTargetRef = useTopAnchorTargetRef({
-    active: isTopAnchorTarget,
-    threadViewportStore,
-  });
-  const ref = useComposedRefs<HTMLDivElement>(
-    forwardRef,
-    isHoveringRef,
-    topAnchorUserRef,
-    topAnchorTargetRef,
-  );
-  const messageId = useAuiState((s) => s.message.id);
 
-  return (
-    <Primitive.div
-      {...props}
-      ref={ref}
-      data-message-id={messageId}
-      data-aui-top-anchor-target={isTopAnchorTarget ? "" : undefined}
-    />
-  );
+  if (turnAnchor === "top") {
+    return (
+      <MessagePrimitiveRootTopAnchor
+        {...props}
+        forwardedRef={forwardedRef}
+        threadViewportStore={threadViewportStore}
+      />
+    );
+  }
+  return <MessagePrimitiveRootDefault {...props} forwardedRef={forwardedRef} />;
 });
 
 MessagePrimitiveRoot.displayName = "MessagePrimitive.Root";

--- a/packages/react/src/primitives/thread/topAnchor/scheduleAnchorTargetRegistration.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/scheduleAnchorTargetRegistration.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  scheduleAnchorTargetRegistration,
+  type AnchorTargetRegistrationStore,
+} from "./scheduleAnchorTargetRegistration";
+
+const makeStore = () => {
+  const unregister = vi.fn<() => void>();
+  const registerAnchorTargetElement = vi.fn(() => unregister);
+  const store: AnchorTargetRegistrationStore = {
+    getState: () => ({
+      topAnchorMessageClamp: { tallerThan: "10em", visibleHeight: "6em" },
+      registerAnchorTargetElement,
+    }),
+  };
+  return { store, registerAnchorTargetElement, unregister };
+};
+
+describe("scheduleAnchorTargetRegistration", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.replaceChildren();
+  });
+
+  it("registers the element with parsed clamp values on the next animation frame", () => {
+    const el = document.createElement("div");
+    document.body.append(el);
+    const { store, registerAnchorTargetElement } = makeStore();
+
+    scheduleAnchorTargetRegistration(el, store);
+
+    expect(registerAnchorTargetElement).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(20);
+
+    expect(registerAnchorTargetElement).toHaveBeenCalledOnce();
+    const [calledEl, calledConfig] = registerAnchorTargetElement.mock.calls[0]!;
+    expect(calledEl).toBe(el);
+    // jsdom returns empty fontSize, parseCssLength falls back to 16. 10em = 160, 6em = 96.
+    expect(calledConfig).toEqual({ tallerThan: 160, visibleHeight: 96 });
+  });
+
+  it("cancels the pending frame and never registers when cleaned up before the frame fires", () => {
+    const el = document.createElement("div");
+    document.body.append(el);
+    const { store, registerAnchorTargetElement, unregister } = makeStore();
+
+    const cleanup = scheduleAnchorTargetRegistration(el, store);
+    cleanup();
+
+    vi.advanceTimersByTime(50);
+
+    expect(registerAnchorTargetElement).not.toHaveBeenCalled();
+    expect(unregister).not.toHaveBeenCalled();
+  });
+
+  it("unregisters the element when cleaned up after the frame has fired", () => {
+    const el = document.createElement("div");
+    document.body.append(el);
+    const { store, registerAnchorTargetElement, unregister } = makeStore();
+
+    const cleanup = scheduleAnchorTargetRegistration(el, store);
+    vi.advanceTimersByTime(20);
+    expect(registerAnchorTargetElement).toHaveBeenCalledOnce();
+    expect(unregister).not.toHaveBeenCalled();
+
+    cleanup();
+
+    expect(unregister).toHaveBeenCalledOnce();
+  });
+
+  it("does not unregister twice when cleanup is invoked multiple times", () => {
+    const el = document.createElement("div");
+    document.body.append(el);
+    const { store, unregister } = makeStore();
+
+    const cleanup = scheduleAnchorTargetRegistration(el, store);
+    vi.advanceTimersByTime(20);
+    cleanup();
+    cleanup();
+
+    expect(unregister).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react/src/primitives/thread/topAnchor/scheduleAnchorTargetRegistration.ts
+++ b/packages/react/src/primitives/thread/topAnchor/scheduleAnchorTargetRegistration.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { parseCssLength } from "./topAnchorUtils";
+
+export type AnchorTargetRegistrationStore = {
+  getState(): {
+    topAnchorMessageClamp: {
+      tallerThan: string;
+      visibleHeight: string;
+    };
+    registerAnchorTargetElement: (
+      element: HTMLElement | null,
+      config?: { tallerThan: number; visibleHeight: number },
+    ) => () => void;
+  };
+};
+
+// rAF-defers the parseCssLength + register so the synchronous getComputedStyle
+// inside parseCssLength can't force a layout during bulk-mount of a long thread.
+// Returned cleanup is safe before or after the frame fires.
+export const scheduleAnchorTargetRegistration = (
+  element: HTMLElement,
+  store: AnchorTargetRegistrationStore,
+): (() => void) => {
+  let unregister: (() => void) | undefined;
+  let frameHandle: number | null = requestAnimationFrame(() => {
+    frameHandle = null;
+    const state = store.getState();
+    const clamp = state.topAnchorMessageClamp;
+    unregister = state.registerAnchorTargetElement(element, {
+      tallerThan: parseCssLength(clamp.tallerThan, element),
+      visibleHeight: parseCssLength(clamp.visibleHeight, element),
+    });
+  });
+
+  return () => {
+    if (frameHandle !== null) {
+      cancelAnimationFrame(frameHandle);
+      frameHandle = null;
+    }
+    unregister?.();
+    unregister = undefined;
+  };
+};

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -233,7 +233,7 @@ const AssistantMessage: FC = () => {
     <MessagePrimitive.Root
       data-slot="aui_assistant-message-root"
       data-role="assistant"
-      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150"
+      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150 [contain-intrinsic-size:auto_300px] [content-visibility:auto]"
     >
       <div
         data-slot="aui_assistant-message-content"
@@ -350,7 +350,7 @@ const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
       data-slot="aui_user-message-root"
-      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [&:where(>*)]:col-start-2"
+      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [contain-intrinsic-size:auto_60px] [content-visibility:auto] [&:where(>*)]:col-start-2"
       data-role="user"
     >
       <UserMessageAttachments />

--- a/templates/cloud-clerk/components/assistant-ui/thread.tsx
+++ b/templates/cloud-clerk/components/assistant-ui/thread.tsx
@@ -233,7 +233,7 @@ const AssistantMessage: FC = () => {
     <MessagePrimitive.Root
       data-slot="aui_assistant-message-root"
       data-role="assistant"
-      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150"
+      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150 [contain-intrinsic-size:auto_300px] [content-visibility:auto]"
     >
       <div
         data-slot="aui_assistant-message-content"
@@ -350,7 +350,7 @@ const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
       data-slot="aui_user-message-root"
-      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [&:where(>*)]:col-start-2"
+      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [contain-intrinsic-size:auto_60px] [content-visibility:auto] [&:where(>*)]:col-start-2"
       data-role="user"
     >
       <UserMessageAttachments />

--- a/templates/cloud/components/assistant-ui/thread.tsx
+++ b/templates/cloud/components/assistant-ui/thread.tsx
@@ -233,7 +233,7 @@ const AssistantMessage: FC = () => {
     <MessagePrimitive.Root
       data-slot="aui_assistant-message-root"
       data-role="assistant"
-      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150"
+      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150 [contain-intrinsic-size:auto_300px] [content-visibility:auto]"
     >
       <div
         data-slot="aui_assistant-message-content"
@@ -350,7 +350,7 @@ const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
       data-slot="aui_user-message-root"
-      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [&:where(>*)]:col-start-2"
+      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [contain-intrinsic-size:auto_60px] [content-visibility:auto] [&:where(>*)]:col-start-2"
       data-role="user"
     >
       <UserMessageAttachments />

--- a/templates/default/components/assistant-ui/thread.tsx
+++ b/templates/default/components/assistant-ui/thread.tsx
@@ -233,7 +233,7 @@ const AssistantMessage: FC = () => {
     <MessagePrimitive.Root
       data-slot="aui_assistant-message-root"
       data-role="assistant"
-      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150"
+      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150 [contain-intrinsic-size:auto_300px] [content-visibility:auto]"
     >
       <div
         data-slot="aui_assistant-message-content"
@@ -350,7 +350,7 @@ const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
       data-slot="aui_user-message-root"
-      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [&:where(>*)]:col-start-2"
+      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [contain-intrinsic-size:auto_60px] [content-visibility:auto] [&:where(>*)]:col-start-2"
       data-role="user"
     >
       <UserMessageAttachments />

--- a/templates/langgraph/components/assistant-ui/thread.tsx
+++ b/templates/langgraph/components/assistant-ui/thread.tsx
@@ -233,7 +233,7 @@ const AssistantMessage: FC = () => {
     <MessagePrimitive.Root
       data-slot="aui_assistant-message-root"
       data-role="assistant"
-      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150"
+      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150 [contain-intrinsic-size:auto_300px] [content-visibility:auto]"
     >
       <div
         data-slot="aui_assistant-message-content"
@@ -350,7 +350,7 @@ const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
       data-slot="aui_user-message-root"
-      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [&:where(>*)]:col-start-2"
+      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [contain-intrinsic-size:auto_60px] [content-visibility:auto] [&:where(>*)]:col-start-2"
       data-role="user"
     >
       <UserMessageAttachments />

--- a/templates/mcp/components/assistant-ui/thread.tsx
+++ b/templates/mcp/components/assistant-ui/thread.tsx
@@ -233,7 +233,7 @@ const AssistantMessage: FC = () => {
     <MessagePrimitive.Root
       data-slot="aui_assistant-message-root"
       data-role="assistant"
-      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150"
+      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150 [contain-intrinsic-size:auto_300px] [content-visibility:auto]"
     >
       <div
         data-slot="aui_assistant-message-content"
@@ -350,7 +350,7 @@ const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
       data-slot="aui_user-message-root"
-      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [&:where(>*)]:col-start-2"
+      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [contain-intrinsic-size:auto_60px] [content-visibility:auto] [&:where(>*)]:col-start-2"
       data-role="user"
     >
       <UserMessageAttachments />

--- a/templates/minimal/components/assistant-ui/thread.tsx
+++ b/templates/minimal/components/assistant-ui/thread.tsx
@@ -218,7 +218,7 @@ const AssistantMessage: FC = () => {
     <MessagePrimitive.Root
       data-slot="aui_assistant-message-root"
       data-role="assistant"
-      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150"
+      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150 [contain-intrinsic-size:auto_300px] [content-visibility:auto]"
     >
       <div
         data-slot="aui_assistant-message-content"
@@ -298,7 +298,7 @@ const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
       data-slot="aui_user-message-root"
-      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [&:where(>*)]:col-start-2"
+      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [contain-intrinsic-size:auto_60px] [content-visibility:auto] [&:where(>*)]:col-start-2"
       data-role="user"
     >
       <UserMessageAttachments />


### PR DESCRIPTION
## Summary

- defer `parseCssLength` (and the `getComputedStyle` it calls) inside the top-anchor target ref to the next animation frame, so the bulk-mount of a long thread no longer triggers a synchronous layout during ref attach.
- split `MessagePrimitive.Root` into a default and top-anchor path. threads using the default `turnAnchor="bottom"` no longer subscribe per message to the top-anchor `useAuiState` selectors.
- set `content-visibility: auto` + `contain-intrinsic-size` on the assistant (300px) and user (60px) message wrappers in `@assistant-ui/ui`, so the browser skips layout / paint / style for off-screen messages. ctrl+f, a11y, and text selection are unaffected.
- synced the ui change to all 6 templates via `scripts/sync-templates.sh` (minimal patched manually since it's an override).
- patch changeset added for `@assistant-ui/react`. `@assistant-ui/ui` and the templates are private (`"private": true`) so no changesets needed for them.

## Behavior changes

- `MessagePrimitive.Root`: api unchanged. the only observable difference is that top-anchor target registration is now async by one animation frame (~16 ms). on rapid mount/unmount of the streaming assistant message, the reserve element may briefly disappear and re-appear; not visible in normal interaction.
- `turnAnchor="top"` behavior is preserved through `MessagePrimitiveRootTopAnchor`.
- `turnAnchor="bottom"` (default) is functionally identical, just stops calling selectors that always returned false.

## Benchmark

repro: temp `/perf?count=N` route on `examples/with-external-store` seeding N alternating user/assistant messages, each assistant message with markdown and a fenced ts code block, mounted under the standard `Thread`. measured via chrome-devtools mcp, no cpu / network throttling, single fresh-navigation trace.

| messages | LCP before | LCP after | render delay before | render delay after | ForcedReflow / `parseCssLength` |
|---|---|---|---|---|---|
| 10  | 125 ms   | 125 ms   | 87 ms    | 87 ms   | not triggered |
| 100 | 1389 ms  | **144 ms**  | 1354 ms  | **87 ms**   | **335 ms → 52 ms** |
| 500 | n/a      | **116 ms**  | n/a      | 83 ms   | **insight no longer reported** |

caveat: these are dev-mode numbers (next dev + turbopack, react development build). production builds will be faster overall, but the relative gap (cold-mount cost no longer scaling catastrophically with thread length) is the load-bearing result.

what this does **not** fix: the `append-message` long task at count=200 stays around ~80 ms; that one is React reconcile + commit across the full subtree, which only virtualization can break structurally. that's deliberately out of scope here, and should land later as an opt-in `<ThreadPrimitive.Messages>` variant or a docs recipe wiring `@tanstack/react-virtual` + `ThreadPrimitive.MessageByIndex`.

## Test plan

- [ ] `@assistant-ui/react` tests pass (259 cases)
- [ ] `@assistant-ui/core` tests pass (170 cases)
- [ ] `bash scripts/sync-templates.sh` reports no drift
- [ ] `pnpm lint` passes (biome including `useSortedClasses`)
- [ ] manual: top-anchor mode (`templates/default`) — first turn scrolls correctly when streaming begins, despite the one-frame async registration
- [ ] manual: default bottom-anchor mode — long thread (50+ messages) loads, scrolls, and sends new messages without regression
- [ ] manual: ctrl+f finds text inside off-screen messages with `content-visibility: auto` applied
- [ ] visual: scrolling through a 100+ message thread shows no obvious jumps from `contain-intrinsic-size` placeholder mismatch on first scroll