### PR TITLE
feat(react-ink): harden pressable interactions

### DIFF
--- a/.changeset/react-ink-pressable-hardening.md
+++ b/.changeset/react-ink-pressable-hardening.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+feat(react-ink): harden terminal pressable interactions

--- a/packages/react-ink/src/primitives/internal/Pressable.tsx
+++ b/packages/react-ink/src/primitives/internal/Pressable.tsx
@@ -1,8 +1,13 @@
 import type { ComponentProps, ReactNode } from "react";
 import { Box, useFocus, useInput } from "ink";
 
-export type PressableProps = ComponentProps<typeof Box> & {
-  children: ReactNode;
+export type PressableState = {
+  isFocused: boolean;
+  disabled: boolean;
+};
+
+export type PressableProps = Omit<ComponentProps<typeof Box>, "children"> & {
+  children: ReactNode | ((state: PressableState) => ReactNode);
   onPress?: (() => void) | undefined;
   disabled?: boolean | undefined;
 };
@@ -13,16 +18,23 @@ export const Pressable = ({
   disabled,
   ...boxProps
 }: PressableProps) => {
-  const { isFocused } = useFocus({ isActive: !disabled });
+  const isDisabled = !!disabled;
+  const { isFocused } = useFocus({ isActive: !isDisabled });
 
   useInput(
-    (_input, key) => {
-      if (key.return && onPress) {
+    (input, key) => {
+      if ((key.return || input === " ") && onPress) {
         onPress();
       }
     },
-    { isActive: isFocused && !disabled },
+    { isActive: isFocused },
   );
 
-  return <Box {...boxProps}>{children}</Box>;
+  return (
+    <Box {...boxProps}>
+      {typeof children === "function"
+        ? children({ isFocused, disabled: isDisabled })
+        : children}
+    </Box>
+  );
 };

--- a/packages/react-ink/src/tests/Pressable.test.tsx
+++ b/packages/react-ink/src/tests/Pressable.test.tsx
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "ink-testing-library";
+import { Text } from "ink";
+
+const mockUseFocus = vi.fn();
+
+type InputHandler = (
+  input: string,
+  key: {
+    return?: boolean;
+  },
+) => void;
+
+let inputHandler: InputHandler | undefined;
+let inputOptions: { isActive?: boolean } | undefined;
+
+const sendInput = (input: string, key: Parameters<InputHandler>[1]) => {
+  if (!inputHandler) {
+    throw new Error("Pressable test input handler was not registered");
+  }
+  if (inputOptions?.isActive) {
+    inputHandler(input, key);
+  }
+};
+
+vi.mock("ink", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ink")>();
+  return {
+    ...actual,
+    useFocus: (options: { isActive?: boolean }) => mockUseFocus(options),
+    useInput: (handler: InputHandler, options?: { isActive?: boolean }) => {
+      inputHandler = handler;
+      inputOptions = options;
+    },
+  };
+});
+
+import { Pressable } from "../primitives/internal/Pressable";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  inputHandler = undefined;
+  inputOptions = undefined;
+});
+
+describe("Pressable", () => {
+  it("activates on enter when focused", () => {
+    const onPress = vi.fn();
+    mockUseFocus.mockReturnValue({ isFocused: true });
+
+    render(
+      <Pressable onPress={onPress}>
+        <Text>Submit</Text>
+      </Pressable>,
+    );
+
+    expect(inputOptions).toEqual({ isActive: true });
+    sendInput("", { return: true });
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("activates on space when focused", () => {
+    const onPress = vi.fn();
+    mockUseFocus.mockReturnValue({ isFocused: true });
+
+    render(
+      <Pressable onPress={onPress}>
+        <Text>Submit</Text>
+      </Pressable>,
+    );
+
+    expect(inputOptions).toEqual({ isActive: true });
+    sendInput(" ", {});
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not activate when disabled", () => {
+    const onPress = vi.fn();
+    mockUseFocus.mockReturnValue({ isFocused: false });
+
+    render(
+      <Pressable disabled onPress={onPress}>
+        <Text>Submit</Text>
+      </Pressable>,
+    );
+
+    expect(mockUseFocus).toHaveBeenCalledWith({ isActive: false });
+    expect(inputOptions).toEqual({ isActive: false });
+    sendInput("", { return: true });
+    sendInput(" ", {});
+
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("does not activate when unfocused", () => {
+    const onPress = vi.fn();
+    mockUseFocus.mockReturnValue({ isFocused: false });
+
+    render(
+      <Pressable onPress={onPress}>
+        <Text>Submit</Text>
+      </Pressable>,
+    );
+
+    expect(inputOptions).toEqual({ isActive: false });
+    sendInput("", { return: true });
+    sendInput(" ", {});
+
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("passes disabled state to render-prop children", () => {
+    mockUseFocus.mockReturnValue({ isFocused: false });
+
+    const result = render(
+      <Pressable disabled>
+        {({ isFocused, disabled }) => (
+          <Text>{`${isFocused ? "focused" : "blurred"} ${disabled ? "disabled" : "enabled"}`}</Text>
+        )}
+      </Pressable>,
+    );
+
+    expect(result.lastFrame()).toContain("blurred disabled");
+  });
+
+  it("passes focused state to render-prop children when enabled", () => {
+    mockUseFocus.mockReturnValue({ isFocused: true });
+
+    const result = render(
+      <Pressable>
+        {({ isFocused, disabled }) => (
+          <Text>{`${isFocused ? "focused" : "blurred"} ${disabled ? "disabled" : "enabled"}`}</Text>
+        )}
+      </Pressable>,
+    );
+
+    expect(result.lastFrame()).toContain("focused enabled");
+  });
+});


### PR DESCRIPTION
## Summary

  - add Space activation to the internal react-ink `Pressable`
  - support render-prop children with `{ isFocused, disabled }`
  - add focused Pressable tests
  - add a patch changeset for `@assistant-ui/react-ink`
