### PR TITLE
feat(react-ink): add ComposerPrimitive.Quote parity

### DIFF
--- a/.changeset/react-ink-composer-quote.md
+++ b/.changeset/react-ink-composer-quote.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+feat(react-ink): add ComposerPrimitive.Quote, QuoteText, and QuoteDismiss for terminal composer quote parity with `@assistant-ui/react`

--- a/apps/docs/content/docs/ink/primitives.mdx
+++ b/apps/docs/content/docs/ink/primitives.mdx
@@ -273,6 +273,56 @@ Triggers attachment addition.
 </ComposerPrimitive.AddAttachment>
 ```
 
+### Quote
+
+Renders the active composer quote preview. Children are only rendered while `s.composer.quote` is set, so this acts as both a container and a gate.
+
+```tsx
+<ComposerPrimitive.Quote>
+  <Box>
+    <Text dimColor>Quoting:</Text>
+    <ComposerPrimitive.QuoteText color="gray" />
+    <ComposerPrimitive.QuoteDismiss>
+      <Text color="red">[x]</Text>
+    </ComposerPrimitive.QuoteDismiss>
+  </Box>
+</ComposerPrimitive.Quote>
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `children` | `ReactNode` | Quote preview content; only rendered when a quote is set |
+| `...rest` | `BoxProps` | Standard Ink Box props |
+
+### QuoteText
+
+Renders the quoted text from `s.composer.quote?.text`. Pass `children` to override the displayed value.
+
+```tsx
+<ComposerPrimitive.QuoteText color="gray" />
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `children` | `ReactNode` | Override content; defaults to `s.composer.quote?.text` |
+| `...rest` | `TextProps` | Standard Ink Text props |
+
+### QuoteDismiss
+
+Pressable that clears the active quote by calling `aui.composer().setQuote(undefined)`.
+
+```tsx
+<ComposerPrimitive.QuoteDismiss>
+  <Text color="red">[x]</Text>
+</ComposerPrimitive.QuoteDismiss>
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `children` | `ReactNode` | Button content |
+| `disabled` | `boolean` | Disable Enter activation and focus |
+| `...rest` | `BoxProps` | Standard Ink Box props |
+
 ### Conditional Rendering (Composer)
 
 Use `AuiIf` for conditional rendering based on composer state:

--- a/packages/react-ink/src/primitives/composer.ts
+++ b/packages/react-ink/src/primitives/composer.ts
@@ -22,4 +22,16 @@ export {
   ComposerAddAttachment as AddAttachment,
   type ComposerAddAttachmentProps as AddAttachmentProps,
 } from "./composer/ComposerAddAttachment";
+export {
+  ComposerQuote as Quote,
+  type ComposerQuoteProps as QuoteProps,
+} from "./composer/ComposerQuote";
+export {
+  ComposerQuoteText as QuoteText,
+  type ComposerQuoteTextProps as QuoteTextProps,
+} from "./composer/ComposerQuoteText";
+export {
+  ComposerQuoteDismiss as QuoteDismiss,
+  type ComposerQuoteDismissProps as QuoteDismissProps,
+} from "./composer/ComposerQuoteDismiss";
 export { ComposerIf as If } from "./composer/ComposerIf";

--- a/packages/react-ink/src/primitives/composer/ComposerQuote.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerQuote.tsx
@@ -10,7 +10,7 @@ export const ComposerQuote = ({
   children,
   ...boxProps
 }: ComposerQuoteProps) => {
-  const quote = useAuiState((s) => s.composer.quote);
-  if (!quote) return null;
+  const hasQuote = useAuiState((s) => s.composer.quote !== undefined);
+  if (!hasQuote) return null;
   return <Box {...boxProps}>{children}</Box>;
 };

--- a/packages/react-ink/src/primitives/composer/ComposerQuote.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerQuote.tsx
@@ -1,0 +1,16 @@
+import type { ComponentProps, ReactNode } from "react";
+import { Box } from "ink";
+import { useAuiState } from "@assistant-ui/store";
+
+export type ComposerQuoteProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+};
+
+export const ComposerQuote = ({
+  children,
+  ...boxProps
+}: ComposerQuoteProps) => {
+  const quote = useAuiState((s) => s.composer.quote);
+  if (!quote) return null;
+  return <Box {...boxProps}>{children}</Box>;
+};

--- a/packages/react-ink/src/primitives/composer/ComposerQuoteDismiss.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerQuoteDismiss.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+import { useCallback } from "react";
+import { useAui } from "@assistant-ui/store";
+import { Pressable, type PressableProps } from "../internal/Pressable";
+
+export type ComposerQuoteDismissProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+export const ComposerQuoteDismiss = ({
+  children,
+  ...pressableProps
+}: ComposerQuoteDismissProps) => {
+  const aui = useAui();
+
+  const handleDismiss = useCallback(() => {
+    aui.composer().setQuote(undefined);
+  }, [aui]);
+
+  return (
+    <Pressable onPress={handleDismiss} {...pressableProps}>
+      {children}
+    </Pressable>
+  );
+};

--- a/packages/react-ink/src/primitives/composer/ComposerQuoteText.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerQuoteText.tsx
@@ -1,0 +1,16 @@
+import type { ComponentProps, ReactNode } from "react";
+import { Text } from "ink";
+import { useAuiState } from "@assistant-ui/store";
+
+export type ComposerQuoteTextProps = ComponentProps<typeof Text> & {
+  children?: ReactNode;
+};
+
+export const ComposerQuoteText = ({
+  children,
+  ...textProps
+}: ComposerQuoteTextProps) => {
+  const text = useAuiState((s) => s.composer.quote?.text);
+  if (!text) return null;
+  return <Text {...textProps}>{children ?? text}</Text>;
+};

--- a/packages/react-ink/src/primitives/composer/ComposerQuoteText.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerQuoteText.tsx
@@ -11,6 +11,6 @@ export const ComposerQuoteText = ({
   ...textProps
 }: ComposerQuoteTextProps) => {
   const text = useAuiState((s) => s.composer.quote?.text);
-  if (!text) return null;
+  if (text === undefined) return null;
   return <Text {...textProps}>{children ?? text}</Text>;
 };

--- a/packages/react-ink/src/tests/ComposerQuote.test.tsx
+++ b/packages/react-ink/src/tests/ComposerQuote.test.tsx
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "ink-testing-library";
+import { Text } from "ink";
+
+const setQuote = vi.fn();
+
+const mockUseAui = vi.fn(() => ({
+  composer: () => ({ setQuote }),
+}));
+const mockUseAuiState = vi.fn();
+
+type InputHandler = (
+  input: string,
+  key: { return?: boolean; ctrl?: boolean; shift?: boolean; meta?: boolean },
+) => void;
+
+let inputHandlers: InputHandler[] = [];
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  return {
+    ...actual,
+    useAui: () => mockUseAui(),
+    useAuiState: (selector: (s: unknown) => unknown) =>
+      mockUseAuiState(selector),
+  };
+});
+
+vi.mock("ink", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ink")>();
+  return {
+    ...actual,
+    useFocus: () => ({ isFocused: true }),
+    useInput: (handler: InputHandler, opts?: { isActive?: boolean }) => {
+      if (opts?.isActive !== false) inputHandlers.push(handler);
+    },
+  };
+});
+
+import { ComposerQuote } from "../primitives/composer/ComposerQuote";
+import { ComposerQuoteText } from "../primitives/composer/ComposerQuoteText";
+import { ComposerQuoteDismiss } from "../primitives/composer/ComposerQuoteDismiss";
+
+const pressEnter = () => {
+  for (const handler of inputHandlers) handler("", { return: true });
+};
+
+const stateWithQuote = (text: string | undefined) => ({
+  composer: { quote: text === undefined ? undefined : { text } },
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  inputHandlers = [];
+});
+
+describe("ComposerPrimitive.Quote", () => {
+  it("renders nothing when no quote is set", () => {
+    mockUseAuiState.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector(stateWithQuote(undefined)),
+    );
+    const { lastFrame } = render(
+      <ComposerQuote>
+        <Text>inner</Text>
+      </ComposerQuote>,
+    );
+    expect(lastFrame()).not.toContain("inner");
+  });
+
+  it("renders children when a quote is set", () => {
+    mockUseAuiState.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector(stateWithQuote("hello")),
+    );
+    const { lastFrame } = render(
+      <ComposerQuote>
+        <Text>inner</Text>
+      </ComposerQuote>,
+    );
+    expect(lastFrame()).toContain("inner");
+  });
+});
+
+describe("ComposerPrimitive.QuoteText", () => {
+  it("renders the quote text from state", () => {
+    mockUseAuiState.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector(stateWithQuote("quoted body")),
+    );
+    const { lastFrame } = render(<ComposerQuoteText />);
+    expect(lastFrame()).toContain("quoted body");
+  });
+
+  it("renders children when provided (override)", () => {
+    mockUseAuiState.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector(stateWithQuote("quoted body")),
+    );
+    const { lastFrame } = render(
+      <ComposerQuoteText>override</ComposerQuoteText>,
+    );
+    expect(lastFrame()).toContain("override");
+    expect(lastFrame()).not.toContain("quoted body");
+  });
+
+  it("renders nothing when there is no quote text, even with children", () => {
+    mockUseAuiState.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector(stateWithQuote(undefined)),
+    );
+    const { lastFrame } = render(
+      <ComposerQuoteText>fallback</ComposerQuoteText>,
+    );
+    expect(lastFrame()?.trim() ?? "").toBe("");
+  });
+
+  it("forwards Ink Text props", () => {
+    mockUseAuiState.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector(stateWithQuote("colored")),
+    );
+    const { lastFrame } = render(<ComposerQuoteText color="cyan" />);
+    expect(lastFrame()).toContain("colored");
+  });
+});
+
+describe("ComposerPrimitive.QuoteDismiss", () => {
+  it("calls aui.composer().setQuote(undefined) on Enter", () => {
+    render(
+      <ComposerQuoteDismiss>
+        <Text>[x]</Text>
+      </ComposerQuoteDismiss>,
+    );
+    pressEnter();
+    expect(setQuote).toHaveBeenCalledTimes(1);
+    expect(setQuote).toHaveBeenCalledWith(undefined);
+  });
+
+  it("does not call setQuote when disabled", () => {
+    render(
+      <ComposerQuoteDismiss disabled>
+        <Text>[x]</Text>
+      </ComposerQuoteDismiss>,
+    );
+    pressEnter();
+    expect(setQuote).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-ink/src/tests/ComposerQuote.test.tsx
+++ b/packages/react-ink/src/tests/ComposerQuote.test.tsx
@@ -121,6 +121,14 @@ describe("ComposerPrimitive.QuoteText", () => {
     expect(lastFrame()).toContain("override");
   });
 
+  it("renders an empty Text when quote text is an empty string and no children are provided", () => {
+    mockUseAuiState.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector(stateWithQuote("")),
+    );
+    const { lastFrame } = render(<ComposerQuoteText />);
+    expect(lastFrame()?.trim() ?? "").toBe("");
+  });
+
   it("forwards Ink Text props", () => {
     mockUseAuiState.mockImplementation((selector: (s: unknown) => unknown) =>
       selector(stateWithQuote("colored")),

--- a/packages/react-ink/src/tests/ComposerQuote.test.tsx
+++ b/packages/react-ink/src/tests/ComposerQuote.test.tsx
@@ -111,6 +111,16 @@ describe("ComposerPrimitive.QuoteText", () => {
     expect(lastFrame()?.trim() ?? "").toBe("");
   });
 
+  it("renders children override when quote text is an empty string", () => {
+    mockUseAuiState.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector(stateWithQuote("")),
+    );
+    const { lastFrame } = render(
+      <ComposerQuoteText>override</ComposerQuoteText>,
+    );
+    expect(lastFrame()).toContain("override");
+  });
+
   it("forwards Ink Text props", () => {
     mockUseAuiState.mockImplementation((selector: (s: unknown) => unknown) =>
       selector(stateWithQuote("colored")),


### PR DESCRIPTION
 ## Summary               
  Adds `ComposerPrimitive.Quote`, `ComposerPrimitive.QuoteText`, and `ComposerPrimitive.QuoteDismiss` to `@assistant-ui/react-ink`, matching the web surface in `@assistant-ui/react`.                                                                                                                                                     
                                                                                                                                                                             
  - `Quote` — gates rendering of children on `s.composer.quote`; renders an Ink `Box` when set.                                                                              
  - `QuoteText` — renders `s.composer.quote?.text` with a `children` override (matches web semantics: returns `null` when no quote text is set).                             
  - `QuoteDismiss` — `Pressable` button that calls `aui.composer().setQuote(undefined)` on Enter.                                               
                                                                                                                                                                             
  Backed by existing core state (`s.composer.quote`) and the existing `setQuote(undefined)` action — no `@assistant-ui/core` or `@assistant-ui/react` changes. Out of scope: 
  quote selection/capture UI, message-side quote display, quote runtime behavior.                                                                                            
                                                                                                                                                                             
  ```tsx                                                                                                                                                                     
  <ComposerPrimitive.Quote>                                                                                                                                                  
    <Box>                                
      <Text dimColor>Quoting:</Text>                                                                                                                                         
      <ComposerPrimitive.QuoteText color="gray" />                                      
      <ComposerPrimitive.QuoteDismiss>                                                                                                                                       
        <Text color="red">[x]</Text>     
      </ComposerPrimitive.QuoteDismiss>                                                                                                                                      
    </Box>                                                                                                                                                                   
  </ComposerPrimitive.Quote>                                                                                                                                                 
  ```                                                                                                                                                                        
                                                                                        
  ## Test plan                           
                                         
  - [ ] `pnpm --filter @assistant-ui/react-ink test` passes (8 new cases + existing suites)
  - [ ] `pnpm --filter @assistant-ui/react-ink build` passes; `dist/index.d.ts` exposes `Quote`, `QuoteText`, `QuoteDismiss` under `ComposerPrimitive`  