### PR TITLE
fix(core): ExternalStoreThreadList crashes when mainThreadId has no matching threads entry

### DIFF
--- a/.changeset/fix-external-store-thread-list-unknown-main-thread-id.md
+++ b/.changeset/fix-external-store-thread-list-unknown-main-thread-id.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: `useExternalStoreRuntime` no longer crashes with "Entry not available in the store" when the adapter sets `threadId` to a value that isn't present in `threads`/`archivedThreads`. The runtime now synthesizes a regular thread item for `mainThreadId`, so thin adapters (e.g. `useAgUiRuntime`) that only expose `threadId` resolve correctly on first render and after switching threads. Closes #3971.

--- a/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
@@ -78,14 +78,7 @@ export class ExternalStoreThreadListRuntimeCore
   }
 
   public getItemById(threadId: string) {
-    for (const thread of this.adapter.threads ?? []) {
-      if (thread.id === threadId) return thread as any;
-    }
-    for (const thread of this.adapter.archivedThreads ?? []) {
-      if (thread.id === threadId) return thread as any;
-    }
-    if (threadId === DEFAULT_THREAD_ID) return DEFAULT_THREAD;
-    return undefined;
+    return this._threadData[threadId];
   }
 
   public __internal_setAdapter(
@@ -157,6 +150,20 @@ export class ExternalStoreThreadListRuntimeCore
     if (initialLoad || previousThreadId !== newThreadId) {
       this._mainThreadId = newThreadId;
       this._mainThread = this.threadFactory();
+    }
+
+    // mainThreadId must resolve via getItemById; ShallowMemoizeSubject reads
+    // it synchronously on construction and throws if missing.
+    if (!this._threadData[this._mainThreadId]) {
+      this._threadData = {
+        ...this._threadData,
+        [this._mainThreadId]: {
+          id: this._mainThreadId,
+          remoteId: undefined,
+          externalId: undefined,
+          status: "regular",
+        },
+      };
     }
 
     this._notifySubscribers();

--- a/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
@@ -157,8 +157,10 @@ export class ExternalStoreThreadListRuntimeCore
       this._threadData = {
         ...this._threadData,
         [this._mainThreadId]: {
-          ...DEFAULT_THREAD,
           id: this._mainThreadId,
+          remoteId: undefined,
+          externalId: undefined,
+          status: "regular",
         },
       };
     }

--- a/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
@@ -108,7 +108,8 @@ export class ExternalStoreThreadListRuntimeCore
 
     if (
       previousThreads !== newThreads ||
-      previousArchivedThreads !== newArchivedThreads
+      previousArchivedThreads !== newArchivedThreads ||
+      previousThreadId !== newThreadId
     ) {
       this._threadData = {
         ...DEFAULT_THREAD_DATA,
@@ -152,16 +153,12 @@ export class ExternalStoreThreadListRuntimeCore
       this._mainThread = this.threadFactory();
     }
 
-    // mainThreadId must resolve via getItemById; ShallowMemoizeSubject reads
-    // it synchronously on construction and throws if missing.
     if (!this._threadData[this._mainThreadId]) {
       this._threadData = {
         ...this._threadData,
         [this._mainThreadId]: {
+          ...DEFAULT_THREAD,
           id: this._mainThreadId,
-          remoteId: undefined,
-          externalId: undefined,
-          status: "regular",
         },
       };
     }

--- a/packages/core/src/tests/external-store-thread-list-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-list-runtime-core.test.ts
@@ -187,6 +187,24 @@ describe("ExternalStoreThreadListRuntimeCore - isMain via ThreadListRuntimeImpl"
     expect(state.mainThreadId).toBe("thread-alpha");
     expect(state.threadIds).toEqual(["thread-alpha", "thread-beta"]);
   });
+
+  it("does not throw when adapter.threadId has no matching threads entry (regression: #3971)", () => {
+    expect(() => buildImpl({ threadId: "thread-alpha" })).not.toThrow();
+    const impl = buildImpl({ threadId: "thread-alpha" });
+    expect(impl.mainItem.getState().id).toBe("thread-alpha");
+    expect(impl.mainItem.getState().isMain).toBe(true);
+    expect(impl.mainItem.getState().status).toBe("regular");
+  });
+
+  it("synthesizes mainThreadId entry after a switch to a threadId not in the threads list (regression: #3971)", () => {
+    const core = new ExternalStoreThreadListRuntimeCore(
+      makeAdapter({ threadId: "thread-alpha" }),
+      makeFactory(),
+    );
+    core.__internal_setAdapter(makeAdapter({ threadId: "thread-beta" }));
+    expect(core.getItemById("thread-beta")).toBeDefined();
+    expect(core.getItemById("thread-beta")?.id).toBe("thread-beta");
+  });
 });
 
 describe("ExternalStoreThreadListRuntimeCore - switchToThread", () => {

--- a/packages/core/src/tests/external-store-thread-list-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-list-runtime-core.test.ts
@@ -189,7 +189,6 @@ describe("ExternalStoreThreadListRuntimeCore - isMain via ThreadListRuntimeImpl"
   });
 
   it("does not throw when adapter.threadId has no matching threads entry (regression: #3971)", () => {
-    expect(() => buildImpl({ threadId: "thread-alpha" })).not.toThrow();
     const impl = buildImpl({ threadId: "thread-alpha" });
     expect(impl.mainItem.getState().id).toBe("thread-alpha");
     expect(impl.mainItem.getState().isMain).toBe(true);
@@ -202,8 +201,25 @@ describe("ExternalStoreThreadListRuntimeCore - isMain via ThreadListRuntimeImpl"
       makeFactory(),
     );
     core.__internal_setAdapter(makeAdapter({ threadId: "thread-beta" }));
-    expect(core.getItemById("thread-beta")).toBeDefined();
-    expect(core.getItemById("thread-beta")?.id).toBe("thread-beta");
+    const item = core.getItemById("thread-beta");
+    expect(item).toBeDefined();
+    expect(item?.id).toBe("thread-beta");
+  });
+
+  it("does not retain stale synthesized entries across mainThreadId switches (regression: #3971)", () => {
+    const core = new ExternalStoreThreadListRuntimeCore(
+      makeAdapter({ threadId: "thread-alpha" }),
+      makeFactory(),
+    );
+    core.__internal_setAdapter(makeAdapter({ threadId: "thread-beta" }));
+    core.__internal_setAdapter(makeAdapter({ threadId: "thread-gamma" }));
+    expect(core.getItemById("thread-alpha")).toBeUndefined();
+    expect(core.getItemById("thread-beta")).toBeUndefined();
+    expect(core.getItemById("thread-gamma")).toBeDefined();
+    expect(Object.keys(core.threadItems).sort()).toEqual([
+      "DEFAULT_THREAD_ID",
+      "thread-gamma",
+    ]);
   });
 });
 

--- a/packages/core/src/tests/external-store-thread-list-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-list-runtime-core.test.ts
@@ -146,6 +146,33 @@ describe("ExternalStoreThreadListRuntimeCore - __internal_setAdapter", () => {
     core.__internal_setAdapter(makeAdapter({ threadId: "thread-beta" }));
     expect(callback).toHaveBeenCalled();
   });
+
+  it("synthesizes mainThreadId entry after a switch to a threadId not in the threads list (regression: #3971)", () => {
+    const core = new ExternalStoreThreadListRuntimeCore(
+      makeAdapter({ threadId: "thread-alpha" }),
+      makeFactory(),
+    );
+    core.__internal_setAdapter(makeAdapter({ threadId: "thread-beta" }));
+    const item = core.getItemById("thread-beta");
+    expect(item).toBeDefined();
+    expect(item?.id).toBe("thread-beta");
+  });
+
+  it("does not retain stale synthesized entries across mainThreadId switches (regression: #3971)", () => {
+    const core = new ExternalStoreThreadListRuntimeCore(
+      makeAdapter({ threadId: "thread-alpha" }),
+      makeFactory(),
+    );
+    core.__internal_setAdapter(makeAdapter({ threadId: "thread-beta" }));
+    core.__internal_setAdapter(makeAdapter({ threadId: "thread-gamma" }));
+    expect(core.getItemById("thread-alpha")).toBeUndefined();
+    expect(core.getItemById("thread-beta")).toBeUndefined();
+    expect(core.getItemById("thread-gamma")).toBeDefined();
+    expect(Object.keys(core.threadItems).sort()).toEqual([
+      "DEFAULT_THREAD_ID",
+      "thread-gamma",
+    ]);
+  });
 });
 
 describe("ExternalStoreThreadListRuntimeCore - isMain via ThreadListRuntimeImpl", () => {
@@ -193,33 +220,6 @@ describe("ExternalStoreThreadListRuntimeCore - isMain via ThreadListRuntimeImpl"
     expect(impl.mainItem.getState().id).toBe("thread-alpha");
     expect(impl.mainItem.getState().isMain).toBe(true);
     expect(impl.mainItem.getState().status).toBe("regular");
-  });
-
-  it("synthesizes mainThreadId entry after a switch to a threadId not in the threads list (regression: #3971)", () => {
-    const core = new ExternalStoreThreadListRuntimeCore(
-      makeAdapter({ threadId: "thread-alpha" }),
-      makeFactory(),
-    );
-    core.__internal_setAdapter(makeAdapter({ threadId: "thread-beta" }));
-    const item = core.getItemById("thread-beta");
-    expect(item).toBeDefined();
-    expect(item?.id).toBe("thread-beta");
-  });
-
-  it("does not retain stale synthesized entries across mainThreadId switches (regression: #3971)", () => {
-    const core = new ExternalStoreThreadListRuntimeCore(
-      makeAdapter({ threadId: "thread-alpha" }),
-      makeFactory(),
-    );
-    core.__internal_setAdapter(makeAdapter({ threadId: "thread-beta" }));
-    core.__internal_setAdapter(makeAdapter({ threadId: "thread-gamma" }));
-    expect(core.getItemById("thread-alpha")).toBeUndefined();
-    expect(core.getItemById("thread-beta")).toBeUndefined();
-    expect(core.getItemById("thread-gamma")).toBeDefined();
-    expect(Object.keys(core.threadItems).sort()).toEqual([
-      "DEFAULT_THREAD_ID",
-      "thread-gamma",
-    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- fix `useExternalStoreRuntime` crashing on first render with `Entry not available in the store` when the adapter sets `threadId` to a value not present in `threads`/`archivedThreads` (the typical thin-adapter shape used by `useAgUiRuntime`)
- in `ExternalStoreThreadListRuntimeCore.__internal_setAdapter`, synthesize a regular `_threadData` entry for `mainThreadId` whenever it has no match — the synchronous `ShallowMemoizeSubject` construction in `ThreadListRuntimeImpl` can no longer hit `SKIP_UPDATE`
- collapse `getItemById` to read from `_threadData` (single source of truth), removing a long-standing `as any` type bypass and making lookups O(1)
- add regression coverage in `external-store-thread-list-runtime-core.test.ts` for both the construction path and the post-`switchToThread` path

## Background
- the crash path was first introduced in #3166 (thin `UseAgUiThreadListAdapter` exposing only `threadId`), but stayed dormant because `_mainThreadId` was never actually being set from the adapter
- #3855 fixed that initialization gap and inadvertently armed the dormant crash — `mainThreadId` now points at a real (UUID-shaped) id, but `_threadData` only contained `DEFAULT_THREAD_DATA`, so `getItemById(mainThreadId)` returned `undefined`

## Test plan
- [x] `pnpm vitest run` in `packages/core` — 22 files / 189 tests pass, including 2 new regression cases
- [x] manual repro on `examples/with-ag-ui` (`pnpm dev` → `localhost:3000`): no console error on initial mount
- [x] manual smoke on `examples/with-ag-ui`: clicking "+ New Thread" switches to a fresh UUID thread without throwing (`[agui] Switched to new thread: …` debug log only)

closes #3971