### PR TITLE
feat(react-ag-ui): surface AG-UI interrupt-aware run lifecycle

### DIFF
--- a/.changeset/feat-react-ag-ui-interrupt-aware-run-lifecycle.md
+++ b/.changeset/feat-react-ag-ui-interrupt-aware-run-lifecycle.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat(react-ag-ui): surface AG-UI interrupt-aware run lifecycle
+
+`event-parser` reads the optional `outcome` on `RUN_FINISHED` and forwards both `success` and `interrupt` variants; the subscriber subscribes to `onRunFinishedEvent` (with `onRunFinalized` as a fallback for older servers). `RunAggregator` maps `outcome.type === "interrupt"` to `requires-action` with `reason: "interrupt"` and writes the interrupts to `metadata.custom.agui.interrupts`. `useAgUiRuntime` returns an `AgUiAssistantRuntime` augmented with `unstable_getPendingInterrupts` and `unstable_submitInterruptResponses`; the latter validates coverage and expiry on the client, then issues a fresh run with `RunAgentInput.resume` populated. the runtime state snapshot is also synced onto the agent before each run so `state` actually reaches the protocol layer.

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -128,7 +128,7 @@ The runtime parses the AG-UI event stream and maps each event type to assistant-
 | Message editing | Yes |
 | Message reload | Yes |
 | Run resumption | Yes |
-| Interrupts (human-in-the-loop) | Experimental (`unstable_*` API, see below) |
+| Interrupts (human-in-the-loop) | Experimental (`unstable_*` API, see [Interrupts](#interrupts-experimental)) |
 | Multi-thread | Experimental (`adapters.threadList`) |
 | History persistence | Via [history adapter](/docs/runtimes/concepts/adapters#history-adapter) |
 

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -62,13 +62,43 @@ const runtime = useAgUiRuntime({
 });
 ```
 
+## Interrupts (experimental)
+
+<Callout type="warn">
+The interrupt API is experimental and may change without notice.
+</Callout>
+
+When the agent emits `RUN_FINISHED` with `outcome = { type: "interrupt", interrupts: [...] }`, the active assistant message is marked `requires-action` with `reason: "interrupt"` and the `Interrupt[]` payload is written to `metadata.custom.agui.interrupts`. Render an approval / input UI from there.
+
+`useAgUiRuntime` returns an `AgUiAssistantRuntime` with two extra methods:
+
+| Method | Description |
+| --- | --- |
+| `unstable_getPendingInterrupts(): readonly AgUiInterrupt[]` | Snapshot of the open interrupts on the most recent assistant message. |
+| `unstable_submitInterruptResponses(responses: ResumeEntry[]): Promise<void>` | Submits one `ResumeEntry` per open interrupt and resumes the run. |
+
+`responses` must address every open interrupt; missing entries, unknown ids, or expired interrupts (`expiresAt`) reject before any network call. Each entry is `{ interruptId, status: "resolved" | "cancelled", payload? }`. The next `RunAgentInput` carries `resume: ResumeEntry[]`.
+
+```tsx
+const runtime = useAgUiRuntime({ agent });
+const pending = runtime.unstable_getPendingInterrupts();
+
+await runtime.unstable_submitInterruptResponses(
+  pending.map((i) => ({
+    interruptId: i.id,
+    status: "resolved",
+    payload: { approved: true },
+  })),
+);
+```
+
 ## Supported events
 
 The runtime parses the AG-UI event stream and maps each event type to assistant-ui state.
 
 | Event | Effect |
 | --- | --- |
-| `RUN_STARTED` / `RUN_FINISHED` | Toggles thread `isRunning`. |
+| `RUN_STARTED` / `RUN_FINISHED` | Toggles thread `isRunning`. `RUN_FINISHED.outcome` is honored (success / interrupt). |
 | `RUN_CANCELLED` | Marks the in-flight assistant message as cancelled. |
 | `RUN_ERROR` | Marks the message as errored; fires `onError`. |
 | `TEXT_MESSAGE_START` / `_CONTENT` / `_END` | Streams text content into an assistant message. |
@@ -98,6 +128,7 @@ The runtime parses the AG-UI event stream and maps each event type to assistant-
 | Message editing | Yes |
 | Message reload | Yes |
 | Run resumption | Yes |
+| Interrupts (human-in-the-loop) | Experimental (`unstable_*` API, see below) |
 | Multi-thread | Experimental (`adapters.threadList`) |
 | History persistence | Via [history adapter](/docs/runtimes/concepts/adapters#history-adapter) |
 

--- a/packages/react-ag-ui/src/index.ts
+++ b/packages/react-ag-ui/src/index.ts
@@ -1,5 +1,9 @@
 export { useAgUiRuntime } from "./useAgUiRuntime";
+export type { AgUiAssistantRuntime } from "./useAgUiRuntime";
 export type {
+  AgUiInterrupt,
+  AgUiResumeEntry,
+  AgUiRunFinishedOutcome,
   UseAgUiRuntimeOptions,
   UseAgUiRuntimeAdapters,
   UseAgUiThreadListAdapter,

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -13,15 +13,21 @@ import type {
 } from "@assistant-ui/core";
 import type { HttpAgent } from "@ag-ui/client";
 import type { Logger } from "./logger";
-import type { AgUiEvent } from "./types";
+import type { AgUiEvent, AgUiInterrupt, AgUiResumeEntry } from "./types";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
-import { RunAggregator } from "./adapter/run-aggregator";
+import {
+  AG_UI_METADATA_NAMESPACE,
+  type AgUiCustomMetadata,
+  RunAggregator,
+} from "./adapter/run-aggregator";
 import {
   fromAgUiMessages,
   toAgUiMessages,
   toAgUiTools,
 } from "./adapter/conversions";
 import { createAgUiSubscriber } from "./adapter/subscriber";
+
+const symbolResumeShim = Symbol("agui-resume-shim");
 
 type RunConfig = NonNullable<AppendMessage["runConfig"]>;
 type ResumeRunConfig = {
@@ -189,6 +195,117 @@ export class AgUiThreadRuntimeCore {
     );
   }
 
+  getPendingInterrupts(): {
+    messageId: string;
+    interrupts: readonly AgUiInterrupt[];
+  } | null {
+    for (let index = this.messages.length - 1; index >= 0; index--) {
+      const message = this.messages[index];
+      if (!message || message.role !== "assistant") continue;
+      const assistant = message as ThreadAssistantMessage;
+      if (
+        assistant.status?.type !== "requires-action" ||
+        assistant.status.reason !== "interrupt"
+      ) {
+        return null;
+      }
+      const stored = (
+        assistant.metadata.custom[AG_UI_METADATA_NAMESPACE] as
+          | AgUiCustomMetadata
+          | undefined
+      )?.interrupts;
+      if (!stored?.length) return null;
+      return { messageId: assistant.id, interrupts: stored };
+    }
+    return null;
+  }
+
+  async submitInterruptResponses(
+    responses: readonly AgUiResumeEntry[],
+  ): Promise<void> {
+    const pending = this.getPendingInterrupts();
+    if (!pending) {
+      throw new Error(
+        "[agui] submitInterruptResponses: no pending interrupts on this thread",
+      );
+    }
+
+    const responsesById = new Map<string, AgUiResumeEntry>();
+    for (const entry of responses) {
+      if (!entry || typeof entry.interruptId !== "string") {
+        throw new Error(
+          "[agui] submitInterruptResponses: every entry must have an interruptId",
+        );
+      }
+      if (entry.status !== "resolved" && entry.status !== "cancelled") {
+        throw new Error(
+          `[agui] submitInterruptResponses: invalid status "${entry.status}" for interrupt ${entry.interruptId}`,
+        );
+      }
+      responsesById.set(entry.interruptId, entry);
+    }
+
+    const openIds = pending.interrupts.map((i) => i.id);
+    const missing = openIds.filter((id) => !responsesById.has(id));
+    if (missing.length > 0) {
+      throw new Error(
+        `[agui] submitInterruptResponses: missing responses for open interrupts: ${missing.join(", ")}`,
+      );
+    }
+    const known = new Set(openIds);
+    const unknown = [...responsesById.keys()].filter((id) => !known.has(id));
+    if (unknown.length > 0) {
+      throw new Error(
+        `[agui] submitInterruptResponses: unknown interrupt ids: ${unknown.join(", ")}`,
+      );
+    }
+
+    const now = new Date();
+    for (const interrupt of pending.interrupts) {
+      if (!interrupt.expiresAt) continue;
+      if (new Date(interrupt.expiresAt) <= now) {
+        throw new Error(
+          `[agui] submitInterruptResponses: interrupt ${interrupt.id} expired at ${interrupt.expiresAt}`,
+        );
+      }
+    }
+
+    const resume: AgUiResumeEntry[] = openIds.map((id) => {
+      const entry = responsesById.get(id)!;
+      return entry.payload === undefined
+        ? { interruptId: id, status: entry.status }
+        : { interruptId: id, status: entry.status, payload: entry.payload };
+    });
+
+    this.clearPendingInterrupts(pending.messageId);
+    this.persistAssistantHistory(pending.messageId);
+    await this.startRun(pending.messageId, this.lastRunConfig, { resume });
+  }
+
+  private clearPendingInterrupts(messageId: string): void {
+    let touched = false;
+    this.messages = this.messages.map((message) => {
+      if (message.id !== messageId || message.role !== "assistant")
+        return message;
+      const assistant = message as ThreadAssistantMessage;
+      if (
+        assistant.status?.type !== "requires-action" ||
+        assistant.status.reason !== "interrupt"
+      ) {
+        return assistant;
+      }
+      touched = true;
+      const { [AG_UI_METADATA_NAMESPACE]: _drop, ...restCustom } =
+        assistant.metadata.custom;
+      return {
+        ...assistant,
+        status: { type: "complete" as const, reason: "unknown" as const },
+        metadata: { ...assistant.metadata, custom: restCustom },
+      };
+    });
+    if (touched) this.notifyUpdate();
+  }
+
   findMessageIdForToolCall(toolCallId: string): string | undefined {
     let fallbackMessageId: string | undefined;
     for (let index = this.messages.length - 1; index >= 0; index--) {
@@ -288,6 +405,7 @@ export class AgUiThreadRuntimeCore {
   private async startRun(
     parentId: string | null,
     runConfig?: RunConfig,
+    extra?: { resume?: AgUiResumeEntry[] },
   ): Promise<void> {
     const normalizedRunConfig = runConfig ?? {};
     this.lastRunConfig = normalizedRunConfig;
@@ -300,6 +418,7 @@ export class AgUiThreadRuntimeCore {
       runId,
       normalizedRunConfig,
       historicalMessages,
+      extra?.resume,
     );
     const assistantParentId = parentId ?? this.messages.at(-1)?.id ?? null;
     let assistantMessageId: string | undefined;
@@ -348,9 +467,11 @@ export class AgUiThreadRuntimeCore {
       try {
         (this.agent as any).messages = input.messages;
         (this.agent as any).threadId = input.threadId;
+        (this.agent as any).state = input.state ?? null;
       } catch {
         // ignore
       }
+      this.installResumeShim();
       await (this.agent as any).runAgent(input, subscriber, {
         signal: abortSignal,
       });
@@ -376,6 +497,7 @@ export class AgUiThreadRuntimeCore {
     runId: string,
     runConfig: RunConfig | undefined,
     historyMessages: readonly ThreadMessage[] | undefined,
+    resume?: AgUiResumeEntry[],
   ) {
     const threadId = this.agent.threadId || "main";
     const messages = toAgUiMessages(historyMessages ?? this.messages);
@@ -394,7 +516,29 @@ export class AgUiThreadRuntimeCore {
         ...(context?.config ?? {}),
         ...(runConfig?.custom ? { runConfig: runConfig.custom } : {}),
       },
+      ...(resume !== undefined ? { resume } : {}),
     };
+  }
+
+  private installResumeShim(): void {
+    const agent = this.agent as any;
+    if (agent[symbolResumeShim]) return;
+    const onInstance = Object.hasOwn(agent, "prepareRunAgentInput");
+    const original = onInstance
+      ? agent.prepareRunAgentInput
+      : Object.getPrototypeOf(agent)?.prepareRunAgentInput;
+    if (typeof original !== "function") return;
+    agent.prepareRunAgentInput = function (
+      this: unknown,
+      params: { resume?: unknown } | undefined,
+    ) {
+      const input = original.call(this, params);
+      if (params?.resume !== undefined && input && typeof input === "object") {
+        return { ...(input as object), resume: params.resume };
+      }
+      return input;
+    };
+    agent[symbolResumeShim] = true;
   }
 
   private setRunning(running: boolean) {

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -292,7 +292,7 @@ export class AgUiThreadRuntimeCore {
     }
 
     this.clearPendingInterrupts(pending.messageId);
-    await this.startRun(pending.messageId, this.lastRunConfig, { resume });
+    await this.startRun(pending.messageId, this.lastRunConfig, resume);
   }
 
   private clearPendingInterrupts(messageId: string): void {
@@ -426,7 +426,7 @@ export class AgUiThreadRuntimeCore {
   private async startRun(
     parentId: string | null,
     runConfig?: RunConfig,
-    extra?: { resume?: AgUiResumeEntry[] },
+    resume?: AgUiResumeEntry[],
   ): Promise<void> {
     const normalizedRunConfig = runConfig ?? {};
     this.lastRunConfig = normalizedRunConfig;
@@ -439,7 +439,7 @@ export class AgUiThreadRuntimeCore {
       runId,
       normalizedRunConfig,
       historicalMessages,
-      extra?.resume,
+      resume,
     );
     const assistantParentId = parentId ?? this.messages.at(-1)?.id ?? null;
     let assistantMessageId: string | undefined;

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -258,10 +258,10 @@ export class AgUiThreadRuntimeCore {
       );
     }
     const known = new Set(openIds);
-    const unknown = [...responsesById.keys()].filter((id) => !known.has(id));
-    if (unknown.length > 0) {
+    const unknownIds = [...responsesById.keys()].filter((id) => !known.has(id));
+    if (unknownIds.length > 0) {
       throw new Error(
-        `[agui] submitInterruptResponses: unknown interrupt ids: ${unknown.join(", ")}`,
+        `[agui] submitInterruptResponses: unknown interrupt ids: ${unknownIds.join(", ")}`,
       );
     }
 
@@ -292,7 +292,6 @@ export class AgUiThreadRuntimeCore {
     }
 
     this.clearPendingInterrupts(pending.messageId);
-    this.persistAssistantHistory(pending.messageId);
     await this.startRun(pending.messageId, this.lastRunConfig, { resume });
   }
 
@@ -309,12 +308,20 @@ export class AgUiThreadRuntimeCore {
         return assistant;
       }
       touched = true;
-      const { [AG_UI_METADATA_NAMESPACE]: _drop, ...restCustom } =
-        assistant.metadata.custom;
+      const aguiMeta = assistant.metadata.custom[AG_UI_METADATA_NAMESPACE] as
+        | AgUiCustomMetadata
+        | undefined;
+      const { interrupts: _drop, ...restAgui } = aguiMeta ?? {};
+      const newCustom = { ...assistant.metadata.custom };
+      if (Object.keys(restAgui).length > 0) {
+        newCustom[AG_UI_METADATA_NAMESPACE] = restAgui;
+      } else {
+        delete newCustom[AG_UI_METADATA_NAMESPACE];
+      }
       return {
         ...assistant,
         status: { type: "complete" as const, reason: "unknown" as const },
-        metadata: { ...assistant.metadata, custom: restCustom },
+        metadata: { ...assistant.metadata, custom: newCustom },
       };
     });
     if (touched) this.notifyUpdate();
@@ -468,6 +475,7 @@ export class AgUiThreadRuntimeCore {
     const subscriber = createAgUiSubscriber({
       dispatch,
       runId,
+      logger: this.logger,
       onRunFailed: (error) => {
         this.pendingError = error;
         this.onError?.(error);
@@ -536,6 +544,7 @@ export class AgUiThreadRuntimeCore {
   private installResumeShim(): void {
     const agent = this.agent as any;
     if (agent[symbolResumeShim]) return;
+    agent[symbolResumeShim] = true;
     const onInstance = Object.hasOwn(agent, "prepareRunAgentInput");
     const original = onInstance
       ? agent.prepareRunAgentInput
@@ -551,7 +560,6 @@ export class AgUiThreadRuntimeCore {
       }
       return input;
     };
-    agent[symbolResumeShim] = true;
   }
 
   private setRunning(running: boolean) {

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -78,6 +78,7 @@ export class AgUiThreadRuntimeCore {
     this.onCancel = options.onCancel;
     this.history = options.history;
     this.notifyUpdate = options.notifyUpdate;
+    this.installResumeShim();
   }
 
   updateOptions(options: Omit<CoreOptions, "notifyUpdate">) {
@@ -87,6 +88,7 @@ export class AgUiThreadRuntimeCore {
     this.onError = options.onError;
     this.onCancel = options.onCancel;
     this.history = options.history;
+    this.installResumeShim();
   }
 
   attachRuntime(runtime: AssistantRuntime) {
@@ -199,25 +201,23 @@ export class AgUiThreadRuntimeCore {
     messageId: string;
     interrupts: readonly AgUiInterrupt[];
   } | null {
-    for (let index = this.messages.length - 1; index >= 0; index--) {
-      const message = this.messages[index];
-      if (!message || message.role !== "assistant") continue;
-      const assistant = message as ThreadAssistantMessage;
-      if (
-        assistant.status?.type !== "requires-action" ||
-        assistant.status.reason !== "interrupt"
-      ) {
-        return null;
-      }
-      const stored = (
-        assistant.metadata.custom[AG_UI_METADATA_NAMESPACE] as
-          | AgUiCustomMetadata
-          | undefined
-      )?.interrupts;
-      if (!stored?.length) return null;
-      return { messageId: assistant.id, interrupts: stored };
+    const assistant = this.messages.findLast((m) => m.role === "assistant") as
+      | ThreadAssistantMessage
+      | undefined;
+    if (
+      !assistant ||
+      assistant.status?.type !== "requires-action" ||
+      assistant.status.reason !== "interrupt"
+    ) {
+      return null;
     }
-    return null;
+    const stored = (
+      assistant.metadata.custom[AG_UI_METADATA_NAMESPACE] as
+        | AgUiCustomMetadata
+        | undefined
+    )?.interrupts;
+    if (!stored?.length) return null;
+    return { messageId: assistant.id, interrupts: stored };
   }
 
   async submitInterruptResponses(
@@ -242,6 +242,11 @@ export class AgUiThreadRuntimeCore {
           `[agui] submitInterruptResponses: invalid status "${entry.status}" for interrupt ${entry.interruptId}`,
         );
       }
+      if (responsesById.has(entry.interruptId)) {
+        throw new Error(
+          `[agui] submitInterruptResponses: duplicate response for interrupt ${entry.interruptId}`,
+        );
+      }
       responsesById.set(entry.interruptId, entry);
     }
 
@@ -260,22 +265,31 @@ export class AgUiThreadRuntimeCore {
       );
     }
 
-    const now = new Date();
+    const now = Date.now();
     for (const interrupt of pending.interrupts) {
       if (!interrupt.expiresAt) continue;
-      if (new Date(interrupt.expiresAt) <= now) {
+      const expiry = new Date(interrupt.expiresAt).getTime();
+      if (Number.isNaN(expiry)) {
+        throw new Error(
+          `[agui] submitInterruptResponses: interrupt ${interrupt.id} has malformed expiresAt "${interrupt.expiresAt}"`,
+        );
+      }
+      if (expiry <= now) {
         throw new Error(
           `[agui] submitInterruptResponses: interrupt ${interrupt.id} expired at ${interrupt.expiresAt}`,
         );
       }
     }
 
-    const resume: AgUiResumeEntry[] = openIds.map((id) => {
-      const entry = responsesById.get(id)!;
-      return entry.payload === undefined
-        ? { interruptId: id, status: entry.status }
-        : { interruptId: id, status: entry.status, payload: entry.payload };
-    });
+    const resume: AgUiResumeEntry[] = openIds.map(
+      (id) => responsesById.get(id)!,
+    );
+
+    if (this.isRunningFlag) {
+      throw new Error(
+        "[agui] submitInterruptResponses: a run is already in progress",
+      );
+    }
 
     this.clearPendingInterrupts(pending.messageId);
     this.persistAssistantHistory(pending.messageId);
@@ -471,7 +485,6 @@ export class AgUiThreadRuntimeCore {
       } catch {
         // ignore
       }
-      this.installResumeShim();
       await (this.agent as any).runAgent(input, subscriber, {
         signal: abortSignal,
       });
@@ -599,7 +612,7 @@ export class AgUiThreadRuntimeCore {
     });
     if (touched) {
       this.notifyUpdate();
-      if (this.isTerminalStatus(latestStatus)) {
+      if (this.isPersistableStatus(latestStatus)) {
         this.persistAssistantHistory(messageId);
       }
     }
@@ -702,6 +715,11 @@ export class AgUiThreadRuntimeCore {
     return status?.type === "complete" || status?.type === "incomplete";
   }
 
+  private isPersistableStatus(status?: MessageStatus): boolean {
+    if (this.isTerminalStatus(status)) return true;
+    return status?.type === "requires-action" && status.reason === "interrupt";
+  }
+
   private recordHistoryEntry(parentId: string | null, message: ThreadMessage) {
     this.appendHistoryItem(parentId, message);
   }
@@ -720,7 +738,7 @@ export class AgUiThreadRuntimeCore {
     if (parentId === undefined) return;
     const message = this.messages.find((m) => m.id === messageId);
     if (!message || message.role !== "assistant") return;
-    if (!this.isTerminalStatus(message.status)) return;
+    if (!this.isPersistableStatus(message.status)) return;
     this.assistantHistoryParents.delete(messageId);
     this.appendHistoryItem(parentId, message);
   }

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -5,8 +5,14 @@ import type {
   ThreadAssistantMessagePart,
   ToolCallMessagePart,
 } from "@assistant-ui/core";
-import type { AgUiEvent } from "../types";
+import type { AgUiEvent, AgUiInterrupt } from "../types";
 import type { Logger } from "../logger";
+
+export const AG_UI_METADATA_NAMESPACE = "agui";
+
+export type AgUiCustomMetadata = {
+  interrupts?: AgUiInterrupt[];
+};
 
 type Emit = (update: ChatModelRunResult) => void;
 
@@ -38,6 +44,7 @@ export class RunAggregator {
   private readonly logger: Logger;
 
   private status: ChatModelRunResult["status"] | undefined;
+  private interrupts: AgUiInterrupt[] | undefined;
   private readonly textParts = new Map<
     string,
     { buffer: string; touched: boolean }
@@ -71,18 +78,28 @@ export class RunAggregator {
         this.hasReasoningPart = false;
         this.textPartCounter = 0;
         this.activeTextMessageId = undefined;
+        this.interrupts = undefined;
         this.status = { type: "running" };
         this.emit();
         break;
       }
       case "RUN_FINISHED": {
+        if (event.outcome?.type === "interrupt") {
+          this.interrupts = event.outcome.interrupts;
+          this.status = { type: "requires-action", reason: "interrupt" };
+          this.emit();
+          break;
+        }
+
+        this.interrupts = undefined;
         const hasUnresolvedToolCalls = Array.from(this.toolCalls.values()).some(
           (tc) => tc.result === undefined,
         );
 
-        this.status = hasUnresolvedToolCalls
-          ? { type: "requires-action", reason: "tool-calls" }
-          : { type: "complete", reason: "unknown" };
+        this.status =
+          event.outcome?.type === "success" || !hasUnresolvedToolCalls
+            ? { type: "complete", reason: "unknown" }
+            : { type: "requires-action", reason: "tool-calls" };
         this.emit();
         break;
       }
@@ -358,6 +375,17 @@ export class RunAggregator {
     const result: ChatModelRunResult = {
       content: snapshot,
       ...(this.status ? { status: this.status } : undefined),
+      ...(this.interrupts
+        ? {
+            metadata: {
+              custom: {
+                [AG_UI_METADATA_NAMESPACE]: {
+                  interrupts: this.interrupts,
+                } satisfies AgUiCustomMetadata,
+              },
+            },
+          }
+        : undefined),
     };
     this.emitUpdate(result);
   }

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -131,8 +131,10 @@ export const createAgUiSubscriber = (
     onCustomEvent: ({ event }) => dispatchIfValid(dispatch, event, "CUSTOM"),
     onRawEvent: ({ event }) => dispatchIfValid(dispatch, event, "RAW"),
     onRunFinishedEvent: ({ event }) => {
+      const parsed = ensureEvent(event, "RUN_FINISHED");
+      if (!parsed) return;
       runFinishedDispatched = true;
-      dispatchIfValid(dispatch, event, "RUN_FINISHED");
+      dispatch(parsed);
     },
     onRunFinalized: () => {
       if (runFinishedDispatched) return;

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -31,6 +31,7 @@ type Subscriber = {
   onMessagesSnapshotEvent?: (payload: { event: unknown }) => void;
   onCustomEvent?: (payload: { event: unknown }) => void;
   onRawEvent?: (payload: { event: unknown }) => void;
+  onRunFinishedEvent?: (payload: { event: unknown }) => void;
   onRunFinalized?: () => void;
   onRunFailed?: (payload: { error: Error }) => void;
 };
@@ -69,6 +70,7 @@ export const createAgUiSubscriber = (
   options: SubscriberOptions,
 ): Subscriber => {
   const { dispatch, runId, onRunFailed } = options;
+  let runFinishedDispatched = false;
   return {
     onEvent: ({ event }) => {
       const typeCandidate =
@@ -128,7 +130,14 @@ export const createAgUiSubscriber = (
       dispatchIfValid(dispatch, event, "MESSAGES_SNAPSHOT"),
     onCustomEvent: ({ event }) => dispatchIfValid(dispatch, event, "CUSTOM"),
     onRawEvent: ({ event }) => dispatchIfValid(dispatch, event, "RAW"),
-    onRunFinalized: () => dispatch({ type: "RUN_FINISHED", runId }),
+    onRunFinishedEvent: ({ event }) => {
+      runFinishedDispatched = true;
+      dispatchIfValid(dispatch, event, "RUN_FINISHED");
+    },
+    onRunFinalized: () => {
+      if (runFinishedDispatched) return;
+      dispatch({ type: "RUN_FINISHED", runId });
+    },
     onRunFailed: ({ error }) => {
       onRunFailed?.(error);
       const message =

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -2,6 +2,7 @@
 
 import type { AgUiEvent } from "../types";
 import { parseAgUiEvent } from "../event-parser";
+import type { Logger } from "../logger";
 
 type Dispatch = (event: AgUiEvent) => void;
 
@@ -39,38 +40,36 @@ type Subscriber = {
 const ensureEvent = (
   raw: unknown,
   type: AgUiEvent["type"],
+  logger?: Logger,
 ): AgUiEvent | null => {
+  const parseOptions = logger ? { logger } : undefined;
   if (raw && typeof raw === "object") {
     const payload = raw as Record<string, unknown>;
     if (typeof payload.type === "string") {
-      return parseAgUiEvent(payload);
+      return parseAgUiEvent(payload, parseOptions);
     }
-    return parseAgUiEvent({ type, ...payload });
+    return parseAgUiEvent({ type, ...payload }, parseOptions);
   }
-  return parseAgUiEvent({ type });
-};
-
-const dispatchIfValid = (
-  dispatch: Dispatch,
-  raw: unknown,
-  type: AgUiEvent["type"],
-) => {
-  const event = ensureEvent(raw, type);
-  if (!event) return;
-  dispatch(event);
+  return parseAgUiEvent({ type }, parseOptions);
 };
 
 type SubscriberOptions = {
   dispatch: Dispatch;
   runId: string;
+  logger?: Logger;
   onRunFailed?: (error: Error) => void;
 };
 
 export const createAgUiSubscriber = (
   options: SubscriberOptions,
 ): Subscriber => {
-  const { dispatch, runId, onRunFailed } = options;
+  const { dispatch, runId, logger, onRunFailed } = options;
   let runFinishedDispatched = false;
+  const dispatchIfValid = (raw: unknown, type: AgUiEvent["type"]) => {
+    const event = ensureEvent(raw, type, logger);
+    if (!event) return;
+    dispatch(event);
+  };
   return {
     onEvent: ({ event }) => {
       const typeCandidate =
@@ -85,53 +84,49 @@ export const createAgUiSubscriber = (
       if (parsed) dispatch(parsed);
     },
     onTextMessageStartEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "TEXT_MESSAGE_START"),
+      dispatchIfValid(event, "TEXT_MESSAGE_START"),
     onTextMessageContentEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "TEXT_MESSAGE_CONTENT"),
+      dispatchIfValid(event, "TEXT_MESSAGE_CONTENT"),
     onTextMessageEndEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "TEXT_MESSAGE_END"),
+      dispatchIfValid(event, "TEXT_MESSAGE_END"),
     onTextMessageChunkEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "TEXT_MESSAGE_CHUNK"),
+      dispatchIfValid(event, "TEXT_MESSAGE_CHUNK"),
     onThinkingStartEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "THINKING_START"),
-    onThinkingEndEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "THINKING_END"),
+      dispatchIfValid(event, "THINKING_START"),
+    onThinkingEndEvent: ({ event }) => dispatchIfValid(event, "THINKING_END"),
     onThinkingTextMessageStartEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "THINKING_TEXT_MESSAGE_START"),
+      dispatchIfValid(event, "THINKING_TEXT_MESSAGE_START"),
     onThinkingTextMessageContentEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "THINKING_TEXT_MESSAGE_CONTENT"),
+      dispatchIfValid(event, "THINKING_TEXT_MESSAGE_CONTENT"),
     onThinkingTextMessageEndEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "THINKING_TEXT_MESSAGE_END"),
+      dispatchIfValid(event, "THINKING_TEXT_MESSAGE_END"),
     onReasoningStartEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "REASONING_START"),
-    onReasoningEndEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "REASONING_END"),
+      dispatchIfValid(event, "REASONING_START"),
+    onReasoningEndEvent: ({ event }) => dispatchIfValid(event, "REASONING_END"),
     onReasoningMessageStartEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "REASONING_MESSAGE_START"),
+      dispatchIfValid(event, "REASONING_MESSAGE_START"),
     onReasoningMessageContentEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "REASONING_MESSAGE_CONTENT"),
+      dispatchIfValid(event, "REASONING_MESSAGE_CONTENT"),
     onReasoningMessageEndEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "REASONING_MESSAGE_END"),
+      dispatchIfValid(event, "REASONING_MESSAGE_END"),
     onToolCallStartEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "TOOL_CALL_START"),
+      dispatchIfValid(event, "TOOL_CALL_START"),
     onToolCallArgsEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "TOOL_CALL_ARGS"),
-    onToolCallEndEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "TOOL_CALL_END"),
+      dispatchIfValid(event, "TOOL_CALL_ARGS"),
+    onToolCallEndEvent: ({ event }) => dispatchIfValid(event, "TOOL_CALL_END"),
     onToolCallChunkEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "TOOL_CALL_CHUNK"),
+      dispatchIfValid(event, "TOOL_CALL_CHUNK"),
     onToolCallResultEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "TOOL_CALL_RESULT"),
+      dispatchIfValid(event, "TOOL_CALL_RESULT"),
     onStateSnapshotEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "STATE_SNAPSHOT"),
-    onStateDeltaEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "STATE_DELTA"),
+      dispatchIfValid(event, "STATE_SNAPSHOT"),
+    onStateDeltaEvent: ({ event }) => dispatchIfValid(event, "STATE_DELTA"),
     onMessagesSnapshotEvent: ({ event }) =>
-      dispatchIfValid(dispatch, event, "MESSAGES_SNAPSHOT"),
-    onCustomEvent: ({ event }) => dispatchIfValid(dispatch, event, "CUSTOM"),
-    onRawEvent: ({ event }) => dispatchIfValid(dispatch, event, "RAW"),
+      dispatchIfValid(event, "MESSAGES_SNAPSHOT"),
+    onCustomEvent: ({ event }) => dispatchIfValid(event, "CUSTOM"),
+    onRawEvent: ({ event }) => dispatchIfValid(event, "RAW"),
     onRunFinishedEvent: ({ event }) => {
-      const parsed = ensureEvent(event, "RUN_FINISHED");
+      const parsed = ensureEvent(event, "RUN_FINISHED", logger);
       if (!parsed) return;
       runFinishedDispatched = true;
       dispatch(parsed);

--- a/packages/react-ag-ui/src/runtime/event-parser.ts
+++ b/packages/react-ag-ui/src/runtime/event-parser.ts
@@ -1,4 +1,4 @@
-import type { AgUiEvent } from "./types";
+import type { AgUiEvent, AgUiInterrupt, AgUiRunFinishedOutcome } from "./types";
 
 const isString = (value: unknown): value is string => typeof value === "string";
 const isNonEmptyString = (value: unknown): value is string =>
@@ -14,6 +14,44 @@ const withOptional = <T extends object>(
   return definedEntries.length === 0
     ? base
     : ({ ...base, ...Object.fromEntries(definedEntries) } as T);
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === "object" && !Array.isArray(value);
+
+const parseInterrupt = (raw: unknown): AgUiInterrupt | null => {
+  if (!isPlainObject(raw)) return null;
+  const id = raw.id;
+  const reason = raw.reason;
+  if (typeof id !== "string" || typeof reason !== "string") return null;
+  const interrupt: AgUiInterrupt = { id, reason };
+  if (typeof raw.message === "string") interrupt.message = raw.message;
+  if (typeof raw.toolCallId === "string") interrupt.toolCallId = raw.toolCallId;
+  if (typeof raw.expiresAt === "string") interrupt.expiresAt = raw.expiresAt;
+  if (isPlainObject(raw.responseSchema))
+    interrupt.responseSchema = raw.responseSchema;
+  if (isPlainObject(raw.metadata)) interrupt.metadata = raw.metadata;
+  return interrupt;
+};
+
+const parseRunFinishedOutcome = (
+  raw: unknown,
+): AgUiRunFinishedOutcome | undefined => {
+  if (!isPlainObject(raw)) return undefined;
+  if (raw.type === "success") {
+    return raw.result !== undefined
+      ? { type: "success", result: raw.result }
+      : { type: "success" };
+  }
+  if (raw.type === "interrupt") {
+    if (!Array.isArray(raw.interrupts)) return undefined;
+    const parsed = raw.interrupts
+      .map((entry) => parseInterrupt(entry))
+      .filter((entry): entry is AgUiInterrupt => entry !== null);
+    if (parsed.length === 0) return undefined;
+    return { type: "interrupt", interrupts: parsed };
+  }
+  return undefined;
 };
 
 export const parseAgUiEvent = (event: unknown): AgUiEvent | null => {
@@ -32,7 +70,15 @@ export const parseAgUiEvent = (event: unknown): AgUiEvent | null => {
     }
     case "RUN_FINISHED": {
       const runId = getString("runId");
-      return runId ? { type: "RUN_FINISHED", runId } : null;
+      if (!runId) return null;
+      const outcome = parseRunFinishedOutcome(payload.outcome);
+      return withOptional(
+        { type: "RUN_FINISHED" as const, runId },
+        {
+          outcome,
+          result: payload.result,
+        },
+      );
     }
     case "RUN_CANCELLED": {
       const runId = getString("runId");

--- a/packages/react-ag-ui/src/runtime/event-parser.ts
+++ b/packages/react-ag-ui/src/runtime/event-parser.ts
@@ -38,11 +38,7 @@ const parseRunFinishedOutcome = (
   raw: unknown,
 ): AgUiRunFinishedOutcome | undefined => {
   if (!isPlainObject(raw)) return undefined;
-  if (raw.type === "success") {
-    return raw.result !== undefined
-      ? { type: "success", result: raw.result }
-      : { type: "success" };
-  }
+  if (raw.type === "success") return { type: "success" };
   if (raw.type === "interrupt") {
     if (!Array.isArray(raw.interrupts)) return undefined;
     const parsed = raw.interrupts
@@ -71,13 +67,9 @@ export const parseAgUiEvent = (event: unknown): AgUiEvent | null => {
     case "RUN_FINISHED": {
       const runId = getString("runId");
       if (!runId) return null;
-      const outcome = parseRunFinishedOutcome(payload.outcome);
       return withOptional(
         { type: "RUN_FINISHED" as const, runId },
-        {
-          outcome,
-          result: payload.result,
-        },
+        { outcome: parseRunFinishedOutcome(payload.outcome) },
       );
     }
     case "RUN_CANCELLED": {

--- a/packages/react-ag-ui/src/runtime/event-parser.ts
+++ b/packages/react-ag-ui/src/runtime/event-parser.ts
@@ -1,4 +1,9 @@
 import type { AgUiEvent, AgUiInterrupt, AgUiRunFinishedOutcome } from "./types";
+import type { Logger } from "./logger";
+
+export type ParseAgUiEventOptions = {
+  logger?: Logger;
+};
 
 const isString = (value: unknown): value is string => typeof value === "string";
 const isNonEmptyString = (value: unknown): value is string =>
@@ -36,21 +41,37 @@ const parseInterrupt = (raw: unknown): AgUiInterrupt | null => {
 
 const parseRunFinishedOutcome = (
   raw: unknown,
+  logger: Logger | undefined,
 ): AgUiRunFinishedOutcome | undefined => {
   if (!isPlainObject(raw)) return undefined;
   if (raw.type === "success") return { type: "success" };
   if (raw.type === "interrupt") {
-    if (!Array.isArray(raw.interrupts)) return undefined;
+    if (!Array.isArray(raw.interrupts)) {
+      logger?.debug?.(
+        "[agui] RUN_FINISHED interrupt outcome missing interrupts array",
+        raw,
+      );
+      return undefined;
+    }
     const parsed = raw.interrupts
       .map((entry) => parseInterrupt(entry))
       .filter((entry): entry is AgUiInterrupt => entry !== null);
-    if (parsed.length === 0) return undefined;
+    if (parsed.length === 0) {
+      logger?.debug?.(
+        "[agui] RUN_FINISHED interrupt outcome has no valid interrupts",
+        raw.interrupts,
+      );
+      return undefined;
+    }
     return { type: "interrupt", interrupts: parsed };
   }
   return undefined;
 };
 
-export const parseAgUiEvent = (event: unknown): AgUiEvent | null => {
+export const parseAgUiEvent = (
+  event: unknown,
+  options?: ParseAgUiEventOptions,
+): AgUiEvent | null => {
   if (!event || typeof event !== "object") return null;
   const payload = event as Record<string, unknown>;
   const typeValue = payload.type;
@@ -69,7 +90,9 @@ export const parseAgUiEvent = (event: unknown): AgUiEvent | null => {
       if (!runId) return null;
       return withOptional(
         { type: "RUN_FINISHED" as const, runId },
-        { outcome: parseRunFinishedOutcome(payload.outcome) },
+        {
+          outcome: parseRunFinishedOutcome(payload.outcome, options?.logger),
+        },
       );
     }
     case "RUN_CANCELLED": {

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -47,9 +47,34 @@ export type UseAgUiRuntimeOptions = {
   adapters?: UseAgUiRuntimeAdapters;
 };
 
+export type AgUiInterrupt = {
+  id: string;
+  reason: string;
+  message?: string;
+  toolCallId?: string;
+  responseSchema?: Record<string, unknown>;
+  expiresAt?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type AgUiResumeEntry = {
+  interruptId: string;
+  status: "resolved" | "cancelled";
+  payload?: unknown;
+};
+
+export type AgUiRunFinishedOutcome =
+  | { type: "success"; result?: unknown }
+  | { type: "interrupt"; interrupts: AgUiInterrupt[] };
+
 export type AgUiEvent =
   | { type: "RUN_STARTED"; runId: string }
-  | { type: "RUN_FINISHED"; runId: string }
+  | {
+      type: "RUN_FINISHED";
+      runId: string;
+      outcome?: AgUiRunFinishedOutcome;
+      result?: unknown;
+    }
   | { type: "RUN_CANCELLED"; runId?: string }
   | { type: "RUN_ERROR"; message?: string; code?: string }
   | { type: "TEXT_MESSAGE_START"; messageId?: string }

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -64,7 +64,7 @@ export type AgUiResumeEntry = {
 };
 
 export type AgUiRunFinishedOutcome =
-  | { type: "success"; result?: unknown }
+  | { type: "success" }
   | { type: "interrupt"; interrupts: AgUiInterrupt[] };
 
 export type AgUiEvent =
@@ -73,7 +73,6 @@ export type AgUiEvent =
       type: "RUN_FINISHED";
       runId: string;
       outcome?: AgUiRunFinishedOutcome;
-      result?: unknown;
     }
   | { type: "RUN_CANCELLED"; runId?: string }
   | { type: "RUN_ERROR"; message?: string; code?: string }

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -185,21 +185,16 @@ export function useAgUiRuntime(
     [adapterAdapters, core, _version, hasExecutingTools],
   );
 
-  const runtime = useExternalStoreRuntime(store) as AgUiAssistantRuntime;
+  const baseRuntime = useExternalStoreRuntime(store);
 
-  if (!Object.hasOwn(runtime, "unstable_submitInterruptResponses")) {
-    Object.defineProperty(runtime, "unstable_getPendingInterrupts", {
-      configurable: true,
-      enumerable: false,
-      value: () => core.getPendingInterrupts()?.interrupts ?? [],
-    });
-    Object.defineProperty(runtime, "unstable_submitInterruptResponses", {
-      configurable: true,
-      enumerable: false,
-      value: (responses: readonly AgUiResumeEntry[]) =>
-        core.submitInterruptResponses(responses),
-    });
-  }
+  const runtime = useMemo<AgUiAssistantRuntime>(() => {
+    const wrapper = Object.create(baseRuntime) as AgUiAssistantRuntime;
+    wrapper.unstable_getPendingInterrupts = () =>
+      core.getPendingInterrupts()?.interrupts ?? [];
+    wrapper.unstable_submitInterruptResponses = (responses) =>
+      core.submitInterruptResponses(responses);
+    return wrapper;
+  }, [baseRuntime, core]);
 
   useEffect(() => {
     core.attachRuntime(runtime);

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -15,12 +15,23 @@ import type {
 } from "@assistant-ui/core";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import { makeLogger } from "./runtime/logger";
-import type { UseAgUiRuntimeOptions } from "./runtime/types";
+import type {
+  AgUiInterrupt,
+  AgUiResumeEntry,
+  UseAgUiRuntimeOptions,
+} from "./runtime/types";
 import { AgUiThreadRuntimeCore } from "./runtime/AgUiThreadRuntimeCore";
+
+export type AgUiAssistantRuntime = AssistantRuntime & {
+  unstable_getPendingInterrupts: () => readonly AgUiInterrupt[];
+  unstable_submitInterruptResponses: (
+    responses: readonly AgUiResumeEntry[],
+  ) => Promise<void>;
+};
 
 export function useAgUiRuntime(
   options: UseAgUiRuntimeOptions,
-): AssistantRuntime {
+): AgUiAssistantRuntime {
   const logger = useMemo(() => makeLogger(options.logger), [options.logger]);
   const [_version, setVersion] = useState(0);
   const notifyUpdate = useCallback(() => setVersion((v) => v + 1), []);
@@ -174,7 +185,21 @@ export function useAgUiRuntime(
     [adapterAdapters, core, _version, hasExecutingTools],
   );
 
-  const runtime = useExternalStoreRuntime(store);
+  const runtime = useExternalStoreRuntime(store) as AgUiAssistantRuntime;
+
+  if (!Object.hasOwn(runtime, "unstable_submitInterruptResponses")) {
+    Object.defineProperty(runtime, "unstable_getPendingInterrupts", {
+      configurable: true,
+      enumerable: false,
+      value: () => core.getPendingInterrupts()?.interrupts ?? [],
+    });
+    Object.defineProperty(runtime, "unstable_submitInterruptResponses", {
+      configurable: true,
+      enumerable: false,
+      value: (responses: readonly AgUiResumeEntry[]) =>
+        core.submitInterruptResponses(responses),
+    });
+  }
 
   useEffect(() => {
     core.attachRuntime(runtime);

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -732,4 +732,152 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(onError).toHaveBeenCalledWith(expect.any(Error));
     expect(onError.mock.calls[0][0].message).toBe("string error");
   });
+
+  it("captures pending interrupts and resumes via submitInterruptResponses", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+
+      if (runCount === 1) {
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: {
+              type: "interrupt",
+              interrupts: [
+                {
+                  id: "int-1",
+                  reason: "tool_call",
+                  toolCallId: "call-1",
+                  message: "approve?",
+                },
+              ],
+            },
+          },
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onTextMessageContentEvent?.({
+        event: { type: "TEXT_MESSAGE_CONTENT", delta: "Done." },
+      });
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const pending = core.getPendingInterrupts();
+    expect(pending).toBeTruthy();
+    expect(pending?.interrupts).toEqual([
+      expect.objectContaining({ id: "int-1", reason: "tool_call" }),
+    ]);
+
+    await core.submitInterruptResponses([
+      { interruptId: "int-1", status: "resolved", payload: { ok: true } },
+    ]);
+
+    expect(runCount).toBe(2);
+    expect(runInputs[1].resume).toEqual([
+      { interruptId: "int-1", status: "resolved", payload: { ok: true } },
+    ]);
+
+    const assistant = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    expect(assistant.status).toMatchObject({ type: "complete" });
+    expect(assistant.metadata.custom.agui).toBeUndefined();
+  });
+
+  it("rejects interrupt resume that does not cover every open interrupt", async () => {
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [
+              { id: "int-1", reason: "tool_call" },
+              { id: "int-2", reason: "input_required" },
+            ],
+          },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    await expect(
+      core.submitInterruptResponses([
+        { interruptId: "int-1", status: "resolved" },
+      ]),
+    ).rejects.toThrow(/missing responses for open interrupts: int-2/);
+
+    expect(runAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects interrupt resume past expiresAt", async () => {
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [
+              {
+                id: "int-1",
+                reason: "tool_call",
+                expiresAt: new Date(Date.now() - 1000).toISOString(),
+              },
+            ],
+          },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    await expect(
+      core.submitInterruptResponses([
+        { interruptId: "int-1", status: "resolved" },
+      ]),
+    ).rejects.toThrow(/expired/);
+  });
+
+  it("syncs runtime state snapshot onto the agent before runAgent", async () => {
+    let stateAtRun: unknown;
+    const agent = {
+      state: { initial: true },
+      runAgent: vi.fn(async function (this: any, _input: any, subscriber: any) {
+        stateAtRun = this.state;
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    core.loadExternalState({ initial: false, snapshot: 42 } as any);
+    await core.append(createAppendMessage());
+
+    expect(stateAtRun).toEqual({ initial: false, snapshot: 42 });
+  });
 });

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -864,6 +864,104 @@ describe("AGUIThreadRuntimeCore", () => {
     ).rejects.toThrow(/expired/);
   });
 
+  it("rejects malformed expiresAt strings", async () => {
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [
+              { id: "int-1", reason: "tool_call", expiresAt: "not-a-date" },
+            ],
+          },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    await expect(
+      core.submitInterruptResponses([
+        { interruptId: "int-1", status: "resolved" },
+      ]),
+    ).rejects.toThrow(/malformed expiresAt/);
+  });
+
+  it("rejects duplicate interruptId in resume responses", async () => {
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [{ id: "int-1", reason: "tool_call" }],
+          },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    await expect(
+      core.submitInterruptResponses([
+        { interruptId: "int-1", status: "resolved" },
+        { interruptId: "int-1", status: "cancelled" },
+      ]),
+    ).rejects.toThrow(/duplicate response/);
+    expect(runAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists interrupt-state assistant message to history before resolution", async () => {
+    const append = vi.fn(async () => {});
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [{ id: "int-1", reason: "tool_call" }],
+          },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+    const history: ThreadHistoryAdapter = {
+      load: vi.fn().mockResolvedValue(null),
+      append,
+    };
+
+    const core = createCore(agent, { history });
+    await core.append(createAppendMessage());
+    // wait a microtask cycle so the in-flight history append resolves
+    await new Promise((r) => setTimeout(r, 0));
+
+    const persistedRoles = append.mock.calls.map(
+      (call: any[]) => call[0].message.role,
+    );
+    expect(persistedRoles).toEqual(["user", "assistant"]);
+    const persistedAssistant = append.mock.calls.find(
+      (call: any[]) => call[0].message.role === "assistant",
+    )?.[0].message;
+    expect(persistedAssistant.status).toMatchObject({
+      type: "requires-action",
+      reason: "interrupt",
+    });
+    expect(persistedAssistant.metadata.custom.agui.interrupts).toEqual([
+      { id: "int-1", reason: "tool_call" },
+    ]);
+  });
+
   it("syncs runtime state snapshot onto the agent before runAgent", async () => {
     let stateAtRun: unknown;
     const agent = {

--- a/packages/react-ag-ui/test/event-parser.spec.ts
+++ b/packages/react-ag-ui/test/event-parser.spec.ts
@@ -43,4 +43,70 @@ describe("parseAgUiEvent", () => {
       source: "UNKNOWN_EVENT",
     });
   });
+
+  it("passes RUN_FINISHED through with no outcome (legacy)", () => {
+    const event = parseAgUiEvent({ type: "RUN_FINISHED", runId: "r1" });
+    expect(event).toEqual({ type: "RUN_FINISHED", runId: "r1" });
+  });
+
+  it("parses RUN_FINISHED success outcome including result", () => {
+    const event = parseAgUiEvent({
+      type: "RUN_FINISHED",
+      runId: "r1",
+      outcome: { type: "success" },
+      result: { ok: true },
+    });
+    expect(event).toEqual({
+      type: "RUN_FINISHED",
+      runId: "r1",
+      outcome: { type: "success" },
+      result: { ok: true },
+    });
+  });
+
+  it("parses RUN_FINISHED interrupt outcome with interrupts", () => {
+    const event = parseAgUiEvent({
+      type: "RUN_FINISHED",
+      runId: "r1",
+      outcome: {
+        type: "interrupt",
+        interrupts: [
+          {
+            id: "int-1",
+            reason: "tool_call",
+            message: "approve?",
+            toolCallId: "call-1",
+            responseSchema: { type: "object" },
+            metadata: { foo: "bar" },
+          },
+        ],
+      },
+    });
+    expect(event).toMatchObject({
+      type: "RUN_FINISHED",
+      runId: "r1",
+      outcome: {
+        type: "interrupt",
+        interrupts: [
+          {
+            id: "int-1",
+            reason: "tool_call",
+            message: "approve?",
+            toolCallId: "call-1",
+            responseSchema: { type: "object" },
+            metadata: { foo: "bar" },
+          },
+        ],
+      },
+    });
+  });
+
+  it("drops malformed interrupt outcomes (no interrupts)", () => {
+    const event = parseAgUiEvent({
+      type: "RUN_FINISHED",
+      runId: "r1",
+      outcome: { type: "interrupt", interrupts: [] },
+    });
+    expect(event).toEqual({ type: "RUN_FINISHED", runId: "r1" });
+  });
 });

--- a/packages/react-ag-ui/test/event-parser.spec.ts
+++ b/packages/react-ag-ui/test/event-parser.spec.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { parseAgUiEvent } from "../src/runtime/event-parser";
 
 describe("parseAgUiEvent", () => {
@@ -106,5 +106,22 @@ describe("parseAgUiEvent", () => {
       outcome: { type: "interrupt", interrupts: [] },
     });
     expect(event).toEqual({ type: "RUN_FINISHED", runId: "r1" });
+  });
+
+  it("logs a debug entry when interrupt outcome falls back silently", () => {
+    const debug = vi.fn();
+    parseAgUiEvent(
+      {
+        type: "RUN_FINISHED",
+        runId: "r1",
+        outcome: {
+          type: "interrupt",
+          interrupts: [{ id: "" }, { reason: "" }],
+        },
+      },
+      { logger: { debug } as any },
+    );
+    expect(debug).toHaveBeenCalledTimes(1);
+    expect(debug.mock.calls[0][0]).toMatch(/no valid interrupts/);
   });
 });

--- a/packages/react-ag-ui/test/event-parser.spec.ts
+++ b/packages/react-ag-ui/test/event-parser.spec.ts
@@ -49,18 +49,16 @@ describe("parseAgUiEvent", () => {
     expect(event).toEqual({ type: "RUN_FINISHED", runId: "r1" });
   });
 
-  it("parses RUN_FINISHED success outcome including result", () => {
+  it("parses RUN_FINISHED success outcome", () => {
     const event = parseAgUiEvent({
       type: "RUN_FINISHED",
       runId: "r1",
       outcome: { type: "success" },
-      result: { ok: true },
     });
     expect(event).toEqual({
       type: "RUN_FINISHED",
       runId: "r1",
       outcome: { type: "success" },
-      result: { ok: true },
     });
   });
 

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -320,6 +320,85 @@ describe("RunAggregator", () => {
     });
   });
 
+  it("emits requires-action.reason: interrupt with interrupts metadata", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "need approval",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "RUN_FINISHED",
+      runId: "r1",
+      outcome: {
+        type: "interrupt",
+        interrupts: [
+          { id: "int-1", reason: "tool_call", toolCallId: "call-1" },
+        ],
+      },
+    } as AgUiEvent);
+
+    const last = results.at(-1);
+    expect(last?.status).toMatchObject({
+      type: "requires-action",
+      reason: "interrupt",
+    });
+    expect(last?.metadata?.custom).toMatchObject({
+      agui: {
+        interrupts: [
+          { id: "int-1", reason: "tool_call", toolCallId: "call-1" },
+        ],
+      },
+    });
+  });
+
+  it("treats success outcome as complete even with pending tool calls", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool1",
+      toolCallName: "search",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "RUN_FINISHED",
+      runId: "r1",
+      outcome: { type: "success" },
+    } as AgUiEvent);
+
+    const last = results.at(-1);
+    expect(last?.status).toMatchObject({
+      type: "complete",
+      reason: "unknown",
+    });
+  });
+
+  it("clears interrupts metadata when a fresh run starts", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "RUN_FINISHED",
+      runId: "r1",
+      outcome: {
+        type: "interrupt",
+        interrupts: [{ id: "int-1", reason: "tool_call" }],
+      },
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_STARTED", runId: "r2" } as AgUiEvent);
+    aggregator.handle({
+      type: "RUN_FINISHED",
+      runId: "r2",
+      outcome: { type: "success" },
+    } as AgUiEvent);
+
+    const last = results.at(-1);
+    expect(last?.status).toMatchObject({ type: "complete" });
+    expect(last?.metadata).toBeUndefined();
+  });
+
   it("parses tool call results and defaults metadata", () => {
     const aggregator = createAggregator(false);
 

--- a/packages/react-ag-ui/test/subscriber.spec.ts
+++ b/packages/react-ag-ui/test/subscriber.spec.ts
@@ -85,6 +85,21 @@ describe("createAgUiSubscriber", () => {
     expect(events).toEqual([{ type: "RUN_FINISHED", runId: "run" }]);
   });
 
+  it("falls back to onRunFinalized when RunFinishedEvent has no runId", () => {
+    const events: AgUiEvent[] = [];
+    const subscriber = createAgUiSubscriber({
+      dispatch: (evt) => events.push(evt),
+      runId: "run",
+    });
+
+    subscriber.onRunFinishedEvent?.({
+      event: { type: "RUN_FINISHED" },
+    });
+    subscriber.onRunFinalized?.();
+
+    expect(events).toEqual([{ type: "RUN_FINISHED", runId: "run" }]);
+  });
+
   it("dispatches reasoning handlers without duplication", () => {
     const events: AgUiEvent[] = [];
     const subscriber = createAgUiSubscriber({

--- a/packages/react-ag-ui/test/subscriber.spec.ts
+++ b/packages/react-ag-ui/test/subscriber.spec.ts
@@ -41,6 +41,50 @@ describe("createAgUiSubscriber", () => {
     expect(events[0]).toMatchObject({ type: "RUN_ERROR", message: "boom" });
   });
 
+  it("dispatches RUN_FINISHED with outcome from onRunFinishedEvent", () => {
+    const events: AgUiEvent[] = [];
+    const subscriber = createAgUiSubscriber({
+      dispatch: (evt) => events.push(evt),
+      runId: "run",
+    });
+
+    subscriber.onRunFinishedEvent?.({
+      event: {
+        type: "RUN_FINISHED",
+        runId: "run",
+        outcome: {
+          type: "interrupt",
+          interrupts: [{ id: "int-1", reason: "tool_call" }],
+        },
+      },
+    });
+    // onRunFinalized fires after onRunFinishedEvent in real ag-ui flows;
+    // we should not double-dispatch.
+    subscriber.onRunFinalized?.();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "RUN_FINISHED",
+      runId: "run",
+      outcome: {
+        type: "interrupt",
+        interrupts: [{ id: "int-1", reason: "tool_call" }],
+      },
+    });
+  });
+
+  it("falls back to onRunFinalized when no RunFinishedEvent fires", () => {
+    const events: AgUiEvent[] = [];
+    const subscriber = createAgUiSubscriber({
+      dispatch: (evt) => events.push(evt),
+      runId: "run",
+    });
+
+    subscriber.onRunFinalized?.();
+
+    expect(events).toEqual([{ type: "RUN_FINISHED", runId: "run" }]);
+  });
+
   it("dispatches reasoning handlers without duplication", () => {
     const events: AgUiEvent[] = [];
     const subscriber = createAgUiSubscriber({


### PR DESCRIPTION
## Summary

- parse `RUN_FINISHED.outcome` and dispatch typed `success` / `interrupt` variants; `onRunFinishedEvent` is the primary lifecycle hook, `onRunFinalized` stays as a fallback for older AG-UI servers.
- on `outcome.type === "interrupt"`, the active assistant message gets `MessageStatus { type: "requires-action", reason: "interrupt" }` and the `Interrupt[]` is written to `metadata.custom.agui.interrupts`. an explicit `success` outcome wins over the legacy unresolved-tool-call heuristic.
- expose `unstable_getPendingInterrupts` and `unstable_submitInterruptResponses` on the runtime returned by `useAgUiRuntime`. the latter validates coverage and expiry on the client (rules 3 / 7 of the AG-UI interrupts spec) and resumes the run with `RunAgentInput.resume` populated.
- side fix: sync the runtime state snapshot onto the agent before each run so `state` actually reaches the wire (previously dropped by `prepareRunAgentInput`).
- docs: new "Interrupts (experimental)" section in `runtime-options.mdx`; supported events / feature support tables updated.

## Test plan

- [ ] `pnpm --filter @assistant-ui/react-ag-ui test` (72 tests pass)
- [ ] `pnpm --filter @assistant-ui/react-ag-ui exec tsc --noEmit` clean
- [ ] `pnpm --filter @assistant-ui/react-ag-ui build` clean
- [ ] legacy `RUN_FINISHED` (no `outcome`) still settles into `complete: "unknown"`
- [ ] `submitInterruptResponses` rejects on missing / unknown / expired ids before any network call
- [ ] resume run carries `resume: ResumeEntry[]` on the wire even with the published `@ag-ui/client@0.0.53` (instance-level shim)
- [ ] docs build (`pnpm --filter @assistant-ui/docs build`) renders the new section without MDX errors

closes #3959