### PR TITLE
fix(store): suppress zombie-child throws in useAuiState

### DIFF
--- a/.changeset/fix-zombie-child-tapclient-lookup.md
+++ b/.changeset/fix-zombie-child-tapclient-lookup.md
@@ -1,0 +1,20 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix(store): suppress zombie-child throws in `useAuiState`
+
+`useAuiState` now caches the last successful slice and returns it when a
+selector throws after the initial render. This is the same pattern
+react-redux uses for the zombie-child problem.
+
+Fixes the recurring `tapClientLookup: Index N out of bounds (length: M)`
+runtime error reported on thread switches and history reloads (e.g.
+issues #3968, #3652). The throw originates in a stale message child
+whose selector reads through the proxy into `tapClientLookup.get` after
+the parent has already shrunk the indexed list, but before React has
+unmounted the child. Returning the previously-observed slice keeps
+reconciliation moving so the zombie unmounts cleanly.
+
+The first selector call is never suppressed — real bugs surfaced on the
+initial render still propagate.

--- a/packages/store/src/__tests__/hooks.test.tsx
+++ b/packages/store/src/__tests__/hooks.test.tsx
@@ -92,6 +92,65 @@ describe("store hooks", () => {
     );
   });
 
+  it("useAuiState returns last-good slice when a zombie selector throws after a notify", () => {
+    // Simulates the tapClientLookup out-of-bounds throw that surfaces when a
+    // parent state change has shrunk an indexed list before React has had a
+    // chance to unmount the children subscribed to the old indices.
+    const testClient = createTestAuiClient({ counter: 1 });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AuiProvider value={testClient.client as never}>{children}</AuiProvider>
+    );
+
+    let shouldThrow = false;
+    const selector = (s: any) => {
+      if (shouldThrow) {
+        throw new Error("tapClientLookup: Index 5 out of bounds (length: 4)");
+      }
+      return s.counter;
+    };
+
+    const { result } = renderHook(() => useAuiState(selector), { wrapper });
+    expect(result.current).toBe(1);
+
+    expect(() => {
+      act(() => {
+        shouldThrow = true;
+        testClient.notify();
+      });
+    }).not.toThrow();
+
+    // Stale slice is preserved until React unmounts the zombie subscriber.
+    expect(result.current).toBe(1);
+
+    // Recovery: once the selector stops throwing, fresh values flow again.
+    act(() => {
+      shouldThrow = false;
+      testClient.state.counter = 7;
+      testClient.notify();
+    });
+    expect(result.current).toBe(7);
+  });
+
+  it("useAuiState propagates selector errors raised on the very first call", () => {
+    // The zombie-child guard only suppresses errors after a value has been
+    // observed at least once. Real bugs surfaced on the initial render still
+    // propagate so they are not silently swallowed.
+    const testClient = createTestAuiClient({ counter: 1 });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AuiProvider value={testClient.client as never}>{children}</AuiProvider>
+    );
+
+    expect(() => {
+      renderHook(
+        () =>
+          useAuiState(() => {
+            throw new Error("boom");
+          }),
+        { wrapper },
+      );
+    }).toThrow("boom");
+  });
+
   it("useAuiEvent subscribes with normalized selector and invokes latest callback", () => {
     const testClient = createTestAuiClient({ counter: 1 });
     const wrapper = ({ children }: { children: ReactNode }) => (

--- a/packages/store/src/useAuiState.ts
+++ b/packages/store/src/useAuiState.ts
@@ -29,7 +29,9 @@ export const useAuiState = <T>(selector: (state: AssistantState) => T): T => {
   // before unmount runs. Returning the last successful slice keeps React's
   // reconciliation moving so the stale child is unmounted by its parent
   // instead of crashing the tree (matches react-redux's `useSelector`
-  // pattern). The first selector call is never suppressed.
+  // pattern). Only applied to the client snapshot — the zombie scenario is
+  // browser-only, and server snapshots must never mask a real selector
+  // failure on the initial client render.
   const lastSliceRef = useRef<{ value: T } | null>(null);
 
   const slice = useSyncExternalStore(
@@ -44,16 +46,7 @@ export const useAuiState = <T>(selector: (state: AssistantState) => T): T => {
         return lastSliceRef.current.value;
       }
     },
-    () => {
-      try {
-        const value = selector(proxiedState);
-        lastSliceRef.current = { value };
-        return value;
-      } catch (err) {
-        if (lastSliceRef.current === null) throw err;
-        return lastSliceRef.current.value;
-      }
-    },
+    () => selector(proxiedState),
   );
 
   if (slice === proxiedState) {

--- a/packages/store/src/useAuiState.ts
+++ b/packages/store/src/useAuiState.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore, useDebugValue } from "react";
+import { useSyncExternalStore, useDebugValue, useRef } from "react";
 import type { AssistantState } from "./types/client";
 import { useAui } from "./useAui";
 import { getProxiedAssistantState } from "./utils/proxied-assistant-state";
@@ -22,10 +22,38 @@ export const useAuiState = <T>(selector: (state: AssistantState) => T): T => {
   const aui = useAui();
   const proxiedState = getProxiedAssistantState(aui);
 
+  // Zombie-child guard: a parent state change (e.g. thread switch, history
+  // reload) can shrink an indexed list before React unmounts the children
+  // that subscribed to its old indices. Their selectors then read through
+  // the proxy into `tapClientLookup.get({ index })` and throw out-of-bounds
+  // before unmount runs. Returning the last successful slice keeps React's
+  // reconciliation moving so the stale child is unmounted by its parent
+  // instead of crashing the tree (matches react-redux's `useSelector`
+  // pattern). The first selector call is never suppressed.
+  const lastSliceRef = useRef<{ value: T } | null>(null);
+
   const slice = useSyncExternalStore(
     aui.subscribe,
-    () => selector(proxiedState),
-    () => selector(proxiedState),
+    () => {
+      try {
+        const value = selector(proxiedState);
+        lastSliceRef.current = { value };
+        return value;
+      } catch (err) {
+        if (lastSliceRef.current === null) throw err;
+        return lastSliceRef.current.value;
+      }
+    },
+    () => {
+      try {
+        const value = selector(proxiedState);
+        lastSliceRef.current = { value };
+        return value;
+      } catch (err) {
+        if (lastSliceRef.current === null) throw err;
+        return lastSliceRef.current.value;
+      }
+    },
   );
 
   if (slice === proxiedState) {


### PR DESCRIPTION
## Summary

- `useAuiState` now caches the last successful slice and returns it when a selector throws after the initial render.
- Mirrors react-redux's `useSelector` pattern for the same problem.
- First-call throws still propagate so real bugs are not silently swallowed.

## Why

Fixes the recurring `tapClientLookup: Index N out of bounds (length: M)` runtime error users hit on thread switches and history reloads — see #3968 (filed today, React 19 + Next 16) and #3652 (open since March, React 18 legacy mode).

The throw originates in a stale message child whose selector reads through the proxy into `tapClientLookup.get({ index })` after the parent has already shrunk the indexed list — but before React has unmounted the child. React 18 concurrent mode dodges it via root-first re-render; legacy mode and some React 19 paths still surface the throw because `useSyncExternalStore`'s second `getSnapshot` call (post-`forceStoreRerender`) is uncaught.

This is the classic **zombie-child** problem and the fix shape is well-known: cache the last good snapshot, return it on selector throw, let reconciliation finish, and the zombie unmounts cleanly. react-redux applies the same pattern in `useSelector`.

## Scope

Defensive fix in the consumer hook only. The deeper root-cause fix discussed in #3652 (scope-isolated subscriptions, per @ShobhitPatra's analysis) would touch the core subscription path across multiple files and is intentionally out of scope here — this PR exists so users stop hitting the crash today.

## Test plan

- [x] New unit test simulates a notify-time selector throw and asserts the hook returns the last-good slice rather than propagating the error.
- [x] New unit test asserts a first-call throw still propagates (no silent failures on real bugs).
- [x] Recovery path tested — once the selector stops throwing, fresh values flow again.
- [x] Existing `@assistant-ui/store` tests still pass (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)