### PR TITLE
feat(react-ag-ui): tighten interrupt lifecycle

### DIFF
--- a/.changeset/feat-react-ag-ui-interrupt-guards.md
+++ b/.changeset/feat-react-ag-ui-interrupt-guards.md
@@ -1,0 +1,11 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat(react-ag-ui): tighten interrupt lifecycle
+
+`append`, `reload`, and `resume` now refuse to start a new run while interrupts are still pending on the thread; the call throws with a message pointing at `submitInterruptResponses` instead of letting the request hit the wire and rely on the agent to reject it (AG-UI interrupts spec rule 4).
+
+`AgUiInterrupt.reason` is typed as `AgUiInterruptReason` (`"tool_call" | "input_required" | "confirmation" | (string & {})`), so the spec values autocomplete while string extension stays open.
+
+`onRunFinishedEvent` now ignores payloads that parse as a different event type, so a misrouted callback can no longer suppress the `onRunFinalized` fallback.

--- a/packages/react-ag-ui/src/index.ts
+++ b/packages/react-ag-ui/src/index.ts
@@ -2,6 +2,7 @@ export { useAgUiRuntime } from "./useAgUiRuntime";
 export type { AgUiAssistantRuntime } from "./useAgUiRuntime";
 export type {
   AgUiInterrupt,
+  AgUiInterruptReason,
   AgUiResumeEntry,
   AgUiRunFinishedOutcome,
   UseAgUiRuntimeOptions,

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -151,6 +151,7 @@ export class AgUiThreadRuntimeCore {
 
   async append(message: AppendMessage): Promise<void> {
     const startRun = message.startRun ?? message.role === "user";
+    if (startRun) this.assertNoPendingInterrupts();
     if (message.sourceId) {
       this.messages = this.messages.filter(
         (entry) => entry.id !== message.sourceId,
@@ -175,6 +176,7 @@ export class AgUiThreadRuntimeCore {
     parentId: string | null,
     config: { runConfig?: RunConfig } = {},
   ): Promise<void> {
+    this.assertNoPendingInterrupts();
     this.resetHead(parentId);
     this.notifyUpdate();
     await this.startRun(parentId, config.runConfig);
@@ -186,6 +188,7 @@ export class AgUiThreadRuntimeCore {
   }
 
   async resume(config: ResumeRunConfig): Promise<void> {
+    this.assertNoPendingInterrupts();
     if (config.stream) {
       this.logger.debug?.(
         "[agui] resume stream is not supported, falling back to regular run",
@@ -194,6 +197,13 @@ export class AgUiThreadRuntimeCore {
     await this.startRun(
       config.parentId,
       config.runConfig ?? this.lastRunConfig,
+    );
+  }
+
+  private assertNoPendingInterrupts(): void {
+    if (!this.getPendingInterrupts()) return;
+    throw new Error(
+      "[agui] cannot start a new run while interrupts are pending; resolve them with submitInterruptResponses()",
     );
   }
 

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -127,7 +127,7 @@ export const createAgUiSubscriber = (
     onRawEvent: ({ event }) => dispatchIfValid(event, "RAW"),
     onRunFinishedEvent: ({ event }) => {
       const parsed = ensureEvent(event, "RUN_FINISHED", logger);
-      if (!parsed) return;
+      if (!parsed || parsed.type !== "RUN_FINISHED") return;
       runFinishedDispatched = true;
       dispatch(parsed);
     },

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -43,14 +43,18 @@ const ensureEvent = (
   logger?: Logger,
 ): AgUiEvent | null => {
   const parseOptions = logger ? { logger } : undefined;
+  let parsed: AgUiEvent | null;
   if (raw && typeof raw === "object") {
     const payload = raw as Record<string, unknown>;
     if (typeof payload.type === "string") {
-      return parseAgUiEvent(payload, parseOptions);
+      parsed = parseAgUiEvent(payload, parseOptions);
+    } else {
+      parsed = parseAgUiEvent({ type, ...payload }, parseOptions);
     }
-    return parseAgUiEvent({ type, ...payload }, parseOptions);
+  } else {
+    parsed = parseAgUiEvent({ type }, parseOptions);
   }
-  return parseAgUiEvent({ type }, parseOptions);
+  return parsed && parsed.type === type ? parsed : null;
 };
 
 type SubscriberOptions = {
@@ -127,7 +131,7 @@ export const createAgUiSubscriber = (
     onRawEvent: ({ event }) => dispatchIfValid(event, "RAW"),
     onRunFinishedEvent: ({ event }) => {
       const parsed = ensureEvent(event, "RUN_FINISHED", logger);
-      if (!parsed || parsed.type !== "RUN_FINISHED") return;
+      if (!parsed) return;
       runFinishedDispatched = true;
       dispatch(parsed);
     },

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -47,9 +47,15 @@ export type UseAgUiRuntimeOptions = {
   adapters?: UseAgUiRuntimeAdapters;
 };
 
+export type AgUiInterruptReason =
+  | "tool_call"
+  | "input_required"
+  | "confirmation"
+  | (string & {});
+
 export type AgUiInterrupt = {
   id: string;
-  reason: string;
+  reason: AgUiInterruptReason;
   message?: string;
   toolCallId?: string;
   responseSchema?: Record<string, unknown>;

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -962,6 +962,80 @@ describe("AGUIThreadRuntimeCore", () => {
     ]);
   });
 
+  it("blocks append/reload/resume while interrupts are pending", async () => {
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [{ id: "int-1", reason: "tool_call" }],
+          },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+    expect(core.getPendingInterrupts()?.interrupts).toHaveLength(1);
+
+    await expect(
+      core.append(createAppendMessage({ parentId: null })),
+    ).rejects.toThrow(/interrupts are pending/);
+    await expect(core.reload(null)).rejects.toThrow(/interrupts are pending/);
+    await expect(
+      core.resume({
+        parentId: null,
+        sourceId: null,
+        runConfig: {} as TestRunConfig,
+      }),
+    ).rejects.toThrow(/interrupts are pending/);
+
+    expect(runAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows submitInterruptResponses to resume past the pending guard", async () => {
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: {
+              type: "interrupt",
+              interrupts: [{ id: "int-1", reason: "tool_call" }],
+            },
+          },
+        });
+      } else {
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: { type: "success" },
+          },
+        });
+      }
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    await expect(
+      core.submitInterruptResponses([
+        { interruptId: "int-1", status: "resolved" },
+      ]),
+    ).resolves.toBeUndefined();
+    expect(runCount).toBe(2);
+  });
+
   it("syncs runtime state snapshot onto the agent before runAgent", async () => {
     let stateAtRun: unknown;
     const agent = {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -864,6 +864,34 @@ describe("AGUIThreadRuntimeCore", () => {
     ).rejects.toThrow(/expired/);
   });
 
+  it("rejects resume responses with unknown interrupt ids", async () => {
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [{ id: "int-1", reason: "tool_call" }],
+          },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    await expect(
+      core.submitInterruptResponses([
+        { interruptId: "int-1", status: "resolved" },
+        { interruptId: "int-unknown", status: "resolved" },
+      ]),
+    ).rejects.toThrow(/unknown interrupt ids: int-unknown/);
+    expect(runAgent).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects malformed expiresAt strings", async () => {
     const runAgent = vi.fn(async (input: any, subscriber: any) => {
       subscriber.onRunFinishedEvent?.({

--- a/packages/react-ag-ui/test/subscriber.spec.ts
+++ b/packages/react-ag-ui/test/subscriber.spec.ts
@@ -100,6 +100,21 @@ describe("createAgUiSubscriber", () => {
     expect(events).toEqual([{ type: "RUN_FINISHED", runId: "run" }]);
   });
 
+  it("ignores onRunFinishedEvent payloads that parse as a different event type", () => {
+    const events: AgUiEvent[] = [];
+    const subscriber = createAgUiSubscriber({
+      dispatch: (evt) => events.push(evt),
+      runId: "run",
+    });
+
+    subscriber.onRunFinishedEvent?.({
+      event: { type: "TEXT_MESSAGE_CHUNK", delta: "hi" },
+    });
+    subscriber.onRunFinalized?.();
+
+    expect(events).toEqual([{ type: "RUN_FINISHED", runId: "run" }]);
+  });
+
   it("dispatches reasoning handlers without duplication", () => {
     const events: AgUiEvent[] = [];
     const subscriber = createAgUiSubscriber({


### PR DESCRIPTION
## Summary

- `append`, `reload`, and `resume` refuse to start a new run while interrupts are still pending; the call throws with a pointer to `submitInterruptResponses` instead of letting the request hit the wire and rely on the agent to reject it (AG-UI interrupts spec rule 4).
- `AgUiInterrupt.reason` narrows to `AgUiInterruptReason` (`"tool_call" | "input_required" | "confirmation" | (string & {})`), so the spec values autocomplete while string extension stays open.
- `onRunFinishedEvent` ignores payloads that parse as a different event type, so a misrouted callback can no longer suppress the `onRunFinalized` fallback.
- co-authored with @ShobhitPatra; the rule 4 guard pattern, the reason union, and the subscriber narrow originated in #3960.

## Test plan

- [ ] `pnpm --filter @assistant-ui/react-ag-ui test` (80 tests pass; 3 new)
- [ ] `pnpm --filter @assistant-ui/react-ag-ui exec tsc --noEmit`
- [ ] `append` / `reload` / `resume` throw while interrupts are pending; `submitInterruptResponses` still resolves
- [ ] `onRunFinishedEvent` with a `TEXT_MESSAGE_CHUNK` payload does not suppress the `onRunFinalized` fallback

related #3959