### PR TITLE
feat(assistant-stream): add resumable stream primitives

### DIFF
--- a/.changeset/feat-assistant-stream-resumable.md
+++ b/.changeset/feat-assistant-stream-resumable.md
@@ -1,0 +1,15 @@
+---
+"assistant-stream": patch
+---
+
+feat(assistant-stream): add resumable stream primitives
+
+new `assistant-stream/resumable` entrypoint for persisting an in-flight `AssistantStream` and replaying it after a disconnect or reload.
+
+`createResumableStreamContext({ store, ttlMs?, waitUntil?, onAcquire?, onAppend?, onFinalize?, onError? })` returns `{ run, resume, requireResume, status, delete }`.
+
+`createResumableAssistantStreamResponse` and `createResumeAssistantStreamResponse` bridge `AssistantStreamController` callbacks to any `AssistantStreamEncoder`.
+
+`createInMemoryResumableStreamStore` covers dev and tests; Redis adapters live at `assistant-stream/resumable/redis` and `assistant-stream/resumable/ioredis` (peer deps), with pipelined appends and binary chunk values.
+
+typed errors via `ResumableStreamError` with codes `"missing" | "exists" | "finalized" | "invalid-id"`.

--- a/.changeset/feat-react-ai-sdk-resumable.md
+++ b/.changeset/feat-react-ai-sdk-resumable.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+feat(react-ai-sdk): native resumable stream client integration
+
+`AssistantChatTransport` accepts a `resumable: { storage, resumeApi, isFinishEvent? }` option that captures the stream id from the response header, watches the SSE body for the AI SDK `finish` marker so the stored id is cleared on natural completion (cancellation leaves it intact for the next mount), and redirects `chat.resumeStream()` reconnects to `resumeApi`. `createResumableSessionStorage` is the default `sessionStorage`-backed `ResumableClientStorage`. `useChatRuntime` auto-fires `chat.resumeStream()` once on mount when storage already has an id, so adopters drop the manual `useEffect`.

--- a/apps/docs/content/docs/(docs)/cli.mdx
+++ b/apps/docs/content/docs/(docs)/cli.mdx
@@ -71,6 +71,7 @@ Use `--example` to create a project from one of the monorepo examples with full 
 | `with-cloud` | Assistant Cloud persistence | `npx assistant-ui create my-app -e with-cloud` |
 | `with-ag-ui` | [AG-UI protocol](/docs/runtimes/ag-ui) integration | `npx assistant-ui create my-app -e with-ag-ui` |
 | `with-assistant-transport` | Custom backend via Assistant Transport | `npx assistant-ui create my-app -e with-assistant-transport` |
+| `with-resumable-stream` | Resumable LLM stream that survives reload mid-response | `npx assistant-ui create my-app -e with-resumable-stream` |
 | `with-chain-of-thought` | Chain-of-thought with JS execution | `npx assistant-ui create my-app -e with-chain-of-thought` |
 | `with-external-store` | External message store | `npx assistant-ui create my-app -e with-external-store` |
 | `with-custom-thread-list` | Custom thread list UI | `npx assistant-ui create my-app -e with-custom-thread-list` |

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -29,6 +29,10 @@
     "voice",
     "speech",
     "---Programmatic---",
-    "context-api"
+    "context-api",
+    "---Resilience---",
+    "resumable-streams",
+    "resumable-stream-stores",
+    "resumable-stream-deployment"
   ]
 }

--- a/apps/docs/content/docs/guides/resumable-stream-deployment.mdx
+++ b/apps/docs/content/docs/guides/resumable-stream-deployment.mdx
@@ -1,0 +1,212 @@
+---
+title: Resumable Stream Deployment
+description: Production hardening for resumable streams. Authorization, serverless lifetimes, TTLs, key isolation, observability, resource limits, and incident response.
+platforms: ["react"]
+---
+
+This guide assumes you have the basic wiring from [Resumable Streams](/docs/guides/resumable-streams) in place and focuses on what to add before serving production traffic.
+
+## Authentication and authorization
+
+The default resume endpoint serves any caller that knows the `streamId`. Treat the id as opaque, not as a credential. Bind every newly created `streamId` to the requesting user at acquire time and verify the binding on every resume.
+
+Store the binding next to the rest of your session state, or in Redis under a separate key. The example below uses a parallel `<keyPrefix>:owner:<streamId>` entry that mirrors the TTL of the underlying stream.
+
+```ts title="/lib/resumable-context.ts"
+import { createResumableStreamContext } from "assistant-stream/resumable";
+import { redis } from "@/lib/redis";
+import { store } from "@/lib/resumable-store";
+
+const OWNER_PREFIX = "aui:resumable:owner";
+const OWNER_TTL_SEC = 24 * 60 * 60;
+
+export const resumableContext = createResumableStreamContext({ store });
+
+export async function bindStreamToUser(streamId: string, userId: string) {
+  await redis.set(`${OWNER_PREFIX}:${streamId}`, userId, { EX: OWNER_TTL_SEC });
+}
+
+export async function assertStreamOwner(streamId: string, userId: string) {
+  const owner = await redis.get(`${OWNER_PREFIX}:${streamId}`);
+  if (owner !== userId) {
+    throw new Response("Not Found", { status: 404 });
+  }
+}
+```
+
+Wrap `resume` with the ownership check. Returning 404 (not 403) avoids confirming the existence of a stream the caller does not own.
+
+```ts title="/app/api/chat/resume/[streamId]/route.ts"
+import { assertStreamOwner, resumableContext } from "@/lib/resumable-context";
+import { getSessionUserId } from "@/lib/auth";
+
+export async function GET(
+  req: Request,
+  ctx: { params: Promise<{ streamId: string }> },
+) {
+  const userId = await getSessionUserId(req);
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const { streamId } = await ctx.params;
+  await assertStreamOwner(streamId, userId);
+
+  const stream = await resumableContext.resume(streamId);
+  if (!stream) return new Response("Not Found", { status: 404 });
+
+  return new Response(stream, {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+```
+
+## `waitUntil` on serverless
+
+On Vercel and Cloudflare the request handler is torn down once the response is returned, taking the producer task with it. Without a `waitUntil` hook the persisted stream stops growing the moment the originating request unwinds, so reconnects only see the bytes that happened to land before the response flushed.
+
+On Vercel, pass `after` from `next/server`:
+
+```ts title="/lib/resumable-context.ts"
+import { after } from "next/server";
+import { createResumableStreamContext } from "assistant-stream/resumable";
+import { store } from "@/lib/resumable-store";
+
+export const resumableContext = createResumableStreamContext({
+  store,
+  waitUntil: after,
+});
+```
+
+On Cloudflare Workers, take the `ExecutionContext` from your handler and forward `ctx.waitUntil`:
+
+```ts title="/src/worker.ts"
+import { createResumableStreamContext } from "assistant-stream/resumable";
+import { store } from "./resumable-store";
+
+export default {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext) {
+    const resumableContext = createResumableStreamContext({
+      store,
+      waitUntil: (promise) => ctx.waitUntil(promise),
+    });
+    return handle(req, resumableContext);
+  },
+};
+```
+
+In long-lived Node servers (a custom Express app, a container) `waitUntil` can be omitted; the producer task runs on the same event loop as the handler and is not preempted.
+
+## TTL strategy
+
+Streams expire 24 hours after the last write. The default suits typical chat workloads where a user might reload after lunch, but every deployment should pick a number deliberately.
+
+- Shorten when chunks contain sensitive payloads (PII, drafts, internal documents). A 5 to 30 minute window usually covers reload survival without leaving recoverable bytes around.
+- Extend for long-running agent tasks that may legitimately stretch past a day. Set the TTL above the worst-case task duration so the producer can still finalize.
+- Match TTLs across layers. The store TTL, the owner-binding TTL, and any signed cookie that references `streamId` should expire together; otherwise one outlives the other and either leaks or 404s unexpectedly.
+
+Configure on the store for the global default and on the context for a per-deployment override:
+
+```ts
+import {
+  createInMemoryResumableStreamStore,
+  createResumableStreamContext,
+} from "assistant-stream/resumable";
+
+const store = createInMemoryResumableStreamStore({
+  defaultTtlMs: 30 * 60 * 1000,
+});
+
+export const resumableContext = createResumableStreamContext({
+  store,
+  ttlMs: 30 * 60 * 1000,
+});
+```
+
+The Redis adapters accept the same `defaultTtlMs` option.
+
+## Multi-tenant key isolation
+
+When multiple apps or tenants share a Redis instance, set `keyPrefix` per environment so a misconfigured stream in one tenant cannot collide with, or be deleted alongside, another's. The prefix becomes the leading segment of every meta and data key.
+
+```ts title="/lib/resumable-store.ts"
+import { createClient } from "redis";
+import { createRedisResumableStreamStore } from "assistant-stream/resumable/redis";
+
+const client = createClient({ url: process.env.REDIS_URL });
+await client.connect();
+
+export const store = createRedisResumableStreamStore(client, {
+  keyPrefix: `aui:${process.env.APP_NAME}:${process.env.TENANT_ID}`,
+});
+```
+
+Per-tenant prefixes also make incident response cheaper. A `SCAN MATCH aui:app:tenant-42:*` lets you audit or purge a single tenant without touching the rest.
+
+## Observability hooks
+
+`ResumableStreamContextOptions` exposes lifecycle hooks for structured logging, metrics, and tracing. Each hook is invoked synchronously around the underlying store call; throwing inside a hook surfaces as a producer error.
+
+```ts title="/lib/resumable-context.ts"
+import { createResumableStreamContext } from "assistant-stream/resumable";
+import { logger, metrics } from "@/lib/observability";
+import { store } from "@/lib/resumable-store";
+
+export const resumableContext = createResumableStreamContext({
+  store,
+  onAcquire: (streamId, role) => {
+    metrics.increment("resumable.acquire", { role });
+    logger.info("resumable.acquire", { streamId, role });
+  },
+  onAppend: (streamId, byteLength) => {
+    metrics.histogram("resumable.append.bytes", byteLength);
+  },
+  onFinalize: (streamId, status, error) => {
+    metrics.increment("resumable.finalize", { status });
+    logger.info("resumable.finalize", { streamId, status, error });
+  },
+  onError: (streamId, error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error("resumable.error", { streamId, error: message });
+  },
+});
+```
+
+Keep hook bodies cheap. They run on the producer's hot path and any latency they add becomes streaming latency seen by the client.
+
+## Resource limits
+
+The in-memory store enforces three caps that the Redis adapters intentionally leave to the underlying database. Set them whenever your process can be reached by untrusted callers.
+
+```ts
+import { createInMemoryResumableStreamStore } from "assistant-stream/resumable";
+
+const store = createInMemoryResumableStreamStore({
+  maxChunkBytes: 64 * 1024,
+  maxEntriesPerStream: 5000,
+  maxStreams: 10_000,
+});
+```
+
+- `maxChunkBytes` rejects oversized writes from a misbehaving producer (a runaway tool result, a base64 blob accidentally piped through). The producer task fails fast instead of pinning memory.
+- `maxEntriesPerStream` caps the per-stream entry count. This bounds how much any single stream can grow before it starts erroring; pair it with TTLs so finalized streams clear quickly.
+- `maxStreams` caps total live streams. Useful as a backstop in shared development environments and in single-tenant containers; in serverless deployments the platform already constrains concurrency.
+
+These limits exist on the in-memory store. For Redis, configure `maxmemory` and an eviction policy on the server, and rely on application-level rate limiting upstream.
+
+## Incident response
+
+The streamId leaks through response headers, browser session storage, server access logs, and (in some setups) error reports. If you suspect any of those channels were compromised, treat all in-flight stream ids as exposed.
+
+What to log up front, so you have it when you need it:
+
+- The acquiring user id, request id, and IP for every `acquire` call (via `onAcquire`).
+- The finalize status (and any error) for every stream (via `onFinalize`).
+- The owner-binding writes and reads, with the user id and the streamId.
+
+What to rotate or invalidate during an incident:
+
+- Bump `keyPrefix` on the store. Existing streams become unreachable and new ones land under the rotated namespace.
+- Invalidate signed session cookies that reference any cached streamId.
+- Drop the owner-binding keys for affected users (`DEL aui:resumable:owner:*` scoped by user) so resumes are forced through a fresh acquire.
+- Shorten `defaultTtlMs` temporarily so any orphaned stream rolls off quickly.
+
+After rotation, reissue stream ids server-side and redirect clients through a fresh acquire; do not trust any streamId the client already holds.

--- a/apps/docs/content/docs/guides/resumable-stream-stores.mdx
+++ b/apps/docs/content/docs/guides/resumable-stream-stores.mdx
@@ -1,0 +1,152 @@
+---
+title: Custom Resumable Stream Stores
+description: Implement the ResumableStreamStore interface to back resumable streams with Postgres, Cloudflare Durable Objects, Upstash REST, InstantDB, or any other backend.
+platforms: ["react"]
+---
+
+The built-in InMemory and Redis adapters cover most deployments. Write your own `ResumableStreamStore` when you need a backend you already operate (Postgres, MySQL), an edge-native primitive (Cloudflare Durable Objects, Workers KV), an HTTP-only key-value service (Upstash REST), or a realtime database (InstantDB). The contract is six async methods over an opaque `streamId` and a monotonic byte log.
+
+## Interface walkthrough
+
+The full interface lives in `assistant-stream/resumable`:
+
+```ts title="packages/assistant-stream/src/resumable/types.ts"
+export interface ResumableStreamStore {
+  acquire(
+    streamId: string,
+    options?: ResumableStreamAcquireOptions,
+  ): Promise<ResumableStreamRole>;
+  append(streamId: string, chunk: Uint8Array): Promise<void>;
+  finalize(
+    streamId: string,
+    status: "done" | "error",
+    error?: string,
+  ): Promise<void>;
+  read(
+    streamId: string,
+    cursor: string,
+    signal: AbortSignal,
+  ): AsyncIterable<ResumableStreamEntry>;
+  status(streamId: string): Promise<ResumableStreamStatus>;
+  delete(streamId: string): Promise<void>;
+}
+```
+
+`acquire(streamId, options?)` arbitrates ownership. The first caller for a given `streamId` resolves to `"producer"`; every later caller, including those arriving after `finalize`, resolves to `"consumer"`. Implementations must perform the check and the insert atomically (see below). `options.ttlMs` overrides the store default for this stream; honor it when you set the expiration timestamp.
+
+`append(streamId, chunk)` adds a `Uint8Array` to the log under a fresh, monotonically increasing cursor. Callers expect the chunk to be observable to `read` before the promise resolves. Implementations should refresh the TTL on each call so a stream that is still actively producing does not expire mid-flight, and should reject when the stream is missing or already finalized.
+
+`finalize(streamId, status, error?)` flips the stream into a terminal state. Pending and future `read` iterables drain buffered entries and then either complete (`"done"`) or throw with `error` (`"error"`). Implementations must make `finalize` idempotent: a duplicate call with the same status is a no-op, and the producer task may retry on transient errors.
+
+`read(streamId, cursor, signal)` is the only streaming method. It yields every entry whose cursor sorts strictly after the supplied `cursor`, then waits for new appends, then completes when the stream finalizes. Aborting `signal` resolves the iterable cleanly without throwing. Networked stores typically combine a bounded fetch loop with pub/sub, long-poll, or notify wakeups; do not busy-loop.
+
+`status(streamId)` returns one of `"streaming" | "done" | "error" | "missing"` synchronously with respect to the underlying store. It exists so the context can decide whether to start a new producer or attach a consumer without holding a `read` iterator open.
+
+`delete(streamId)` removes all state for the stream. It must be a no-op when the stream does not exist, and it should cause active `read` iterables to terminate (treat outstanding readers as if the stream finalized).
+
+## Acquire semantics
+
+`acquire` is the only method that requires linearizability across processes. Two route handlers that race to start the same `streamId` must see exactly one `"producer"` result; the loser becomes a `"consumer"` and replays the winner's bytes. A single-process store can guard a `Map` with a synchronous `if (!map.has(id)) map.set(id, ...)`. Networked stores need a primitive that does the check and the insert in one round trip:
+
+- Redis: `SET key value NX EX ttl`, or `INCR` against a per-stream counter.
+- Postgres: `INSERT ... ON CONFLICT (stream_id) DO NOTHING RETURNING ...`.
+- Durable Objects: a single object instance per `streamId` plus a boolean field.
+- Upstash REST: `set` with `nx=true`.
+
+If your backend cannot offer atomicity, do not paper over it with read-then-write; you will silently produce two writers for the same stream under contention, and consumers will observe interleaved bytes.
+
+## The cursor contract
+
+Cursors are opaque strings. Callers never inspect them; the store assigns them, the context echoes them back on the next `read` call, and the store uses them to resume from the correct position. Two rules:
+
+- Cursors must be strictly monotonic per stream. Whatever scheme you pick (sequence number, ULID, Postgres `bigserial`, Redis stream id), entry N+1 sorts after entry N.
+- The empty string means start from the beginning. `read(streamId, "", signal)` yields every entry the store has, oldest first.
+
+You do not need cross-stream ordering. You do need a deterministic mapping from cursor back to position so that `read` can resume a consumer that disconnected mid-replay.
+
+## A worked example
+
+A `Map`-backed implementation suitable for a single-process server. It is deliberately small and skips TTL eviction; treat it as a starting point for a custom backend rather than a replacement for `createInMemoryResumableStreamStore`.
+
+```ts title="/lib/map-resumable-store.ts"
+import type { ResumableStreamStore } from "assistant-stream/resumable";
+
+type State = {
+  entries: { cursor: string; chunk: Uint8Array }[];
+  seq: number;
+  final?: { status: "done" | "error"; error?: string };
+  waiters: Array<() => void>;
+};
+
+export function createMapResumableStreamStore(): ResumableStreamStore {
+  const streams = new Map<string, State>();
+  const wake = (s: State) => s.waiters.splice(0).forEach((fn) => fn());
+  return {
+    async acquire(id) {
+      if (streams.has(id)) return "consumer";
+      streams.set(id, { entries: [], seq: 0, waiters: [] });
+      return "producer";
+    },
+    async append(id, chunk) {
+      const s = streams.get(id);
+      if (!s || s.final) throw new Error(`Cannot append: ${id}`);
+      s.entries.push({ cursor: (++s.seq).toString(36), chunk });
+      wake(s);
+    },
+    async finalize(id, status, error) {
+      const s = streams.get(id);
+      if (!s || s.final) return;
+      s.final = { status, error };
+      wake(s);
+    },
+    async *read(id, cursor, signal) {
+      const s = streams.get(id);
+      if (!s) throw new Error(`Stream not found: ${id}`);
+      let i = cursor === "" ? 0 : Number.parseInt(cursor, 36);
+      while (!signal.aborted) {
+        while (i < s.entries.length) yield s.entries[i++]!;
+        if (s.final) {
+          if (s.final.status === "error") throw new Error(s.final.error);
+          return;
+        }
+        await new Promise<void>((r) => {
+          s.waiters.push(r);
+          signal.addEventListener("abort", () => r(), { once: true });
+        });
+      }
+    },
+    async status(id) {
+      const s = streams.get(id);
+      return !s ? "missing" : s.final ? s.final.status : "streaming";
+    },
+    async delete(id) {
+      const s = streams.get(id);
+      if (!s) return;
+      streams.delete(id);
+      s.final ??= { status: "done" };
+      wake(s);
+    },
+  };
+}
+```
+
+## TTL and eviction
+
+`acquire` receives `options.ttlMs`; if absent, fall back to a store-level default (the built-in stores use 24 hours). Refresh the expiration on every `append` and on `finalize` so a stream that finishes near the deadline still has time to be consumed. Persist the TTL alongside the entries so a worker reading the stream much later can decide whether the data is still valid.
+
+When a stream expires, treat it the same as `finalize(streamId, "error", "Stream expired")`: any active `read` iterable must throw or terminate, and `status` must transition to `"missing"` once the eviction has run. Stores backed by Redis or a similar TTL-aware engine can lean on the engine's own expiration; SQL-backed stores need a periodic sweep, and Durable Objects can use `setAlarm`.
+
+## Wiring it up
+
+`createResumableStreamContext` takes any object that satisfies `ResumableStreamStore`. There is no registry and no extra configuration; pass your instance as `store`:
+
+```ts title="/lib/resumable-context.ts"
+import { createResumableStreamContext } from "assistant-stream/resumable";
+import { createMapResumableStreamStore } from "@/lib/map-resumable-store";
+
+export const resumableContext = createResumableStreamContext({
+  store: createMapResumableStreamStore(),
+});
+```
+
+From this point the route handlers in [Resumable Streams](/docs/guides/resumable-streams) work unchanged: `resumableContext.run(streamId, makeStream)` calls your `acquire`, `append`, and `finalize`, and `resumableContext.resume(streamId)` calls your `read`.

--- a/apps/docs/content/docs/guides/resumable-streams.mdx
+++ b/apps/docs/content/docs/guides/resumable-streams.mdx
@@ -1,0 +1,210 @@
+---
+title: "Resumable Streams"
+description: Persist an in-flight LLM response on the server so the client can reload, lose its connection, or open a new tab and pick up the same stream.
+platforms: ["react"]
+---
+
+`assistant-stream/resumable` lets you continue a streaming LLM response across client reconnects. The server keeps writing to a store while the original request is in flight; if the browser reloads or loses its connection, a follow-up request replays the persisted bytes plus any new ones until the producer finalizes.
+
+It works with any encoder that already ships in `assistant-stream` (the AI SDK UI message stream, the data stream protocol, the assistant transport SSE format, or your own), because persistence happens at the byte level after encoding.
+
+## What it solves
+
+A user sends a long prompt, walks away, and reloads the tab. Without resumable streams the LLM call is wasted; with them the client picks up where it left off. The same flow handles dropped mobile connections and lets a stream started on one device be read on another, gated by an opaque stream id.
+
+If your responses are short or you do not care about reload survival, the standard `streamText().toUIMessageStreamResponse()` path is enough.
+
+## Server side: minimum wiring
+
+Construct a `ResumableStreamContext` once per process and reuse it across requests. The context is the seam between your route handlers and the storage backend.
+
+```ts title="/lib/resumable-context.ts"
+import {
+  createInMemoryResumableStreamStore,
+  createResumableStreamContext,
+} from "assistant-stream/resumable";
+
+const store = createInMemoryResumableStreamStore();
+export const resumableContext = createResumableStreamContext({ store });
+```
+
+In your chat route, wrap the response body in `ctx.run(streamId, makeStream)`. The first caller for `streamId` becomes the producer (your `makeStream` callback runs); later callers and reconnects become consumers that replay the persisted bytes.
+
+```ts title="/app/api/chat/route.ts"
+import { streamText } from "ai";
+import { RESUMABLE_STREAM_ID_HEADER } from "assistant-stream/resumable";
+import { resumableContext } from "@/lib/resumable-context";
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const streamId = crypto.randomUUID();
+
+  const result = streamText({ /* model, messages, tools, ... */ });
+  const sourceBody = result.toUIMessageStreamResponse().body!;
+
+  const stream = await resumableContext.run(streamId, () => sourceBody);
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      [RESUMABLE_STREAM_ID_HEADER]: streamId,
+    },
+  });
+}
+```
+
+A separate GET endpoint replays the persisted bytes for reconnecting clients. `ctx.resume(streamId)` returns `null` when no stream exists; use `ctx.requireResume(streamId)` if you prefer to surface a `ResumableStreamError` with code `"missing"` instead.
+
+```ts title="/app/api/chat/resume/[streamId]/route.ts"
+import { RESUMABLE_STREAM_ID_HEADER } from "assistant-stream/resumable";
+import { resumableContext } from "@/lib/resumable-context";
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ streamId: string }> },
+) {
+  const { streamId } = await ctx.params;
+  const stream = await resumableContext.resume(streamId);
+  if (!stream) {
+    return new Response(JSON.stringify({ error: "stream not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      [RESUMABLE_STREAM_ID_HEADER]: streamId,
+    },
+  });
+}
+```
+
+The context exposes two more verbs: `ctx.status(streamId)` returns `"streaming" | "done" | "error" | "missing"`, and `ctx.delete(streamId)` removes all persisted state for a stream and terminates active readers. The remaining options on `createResumableStreamContext` (`onAcquire`, `onAppend`, `onFinalize`, `onError`) are observability hooks covered in [Resumable Stream Deployment](/docs/guides/resumable-stream-deployment).
+
+## Client side: native integration
+
+`@assistant-ui/react-ai-sdk` ships a `resumable` option on `AssistantChatTransport`. It captures the stream id from the response header, redirects `chat.resumeStream()` reconnects to your resume route, and clears the stored id when the response finishes naturally. Pair it with `useChatRuntime`, which fires `chat.resumeStream()` on mount whenever a pending id is present in storage.
+
+```tsx title="/app/page.tsx"
+"use client";
+
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import {
+  AssistantChatTransport,
+  createResumableSessionStorage,
+  useChatRuntime,
+} from "@assistant-ui/react-ai-sdk";
+import { useMemo } from "react";
+import { Thread } from "@/components/assistant-ui/thread";
+
+const storage = createResumableSessionStorage();
+
+export default function Page() {
+  const transport = useMemo(
+    () =>
+      new AssistantChatTransport({
+        api: "/api/chat",
+        resumable: {
+          storage,
+          resumeApi: (streamId) => `/api/chat/resume/${streamId}`,
+        },
+      }),
+    [],
+  );
+  const runtime = useChatRuntime({ transport });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+`createResumableSessionStorage` returns a `ResumableClientStorage` backed by `window.sessionStorage`. Pass `{ key }` to namespace per route or per chat surface, or supply your own implementation of the three methods (`getStreamId`, `setStreamId`, `clear`). If you are running on a transport that already wraps `fetch` or `prepareReconnectToStreamRequest`, the `resumable` option composes with your existing handlers.
+
+The default finish detector scans the SSE body for the AI SDK `"type":"finish"` marker. Override `isFinishEvent` on the `resumable` option when you ship a custom encoder.
+
+## Storage choices
+
+The core package ships `createInMemoryResumableStreamStore` for development and tests. State lives in a process-local `Map`, so it does not survive a server restart. Useful options include `defaultTtlMs`, `maxChunkBytes`, `maxEntriesPerStream`, `maxStreams`, and `gcIntervalMs` for periodic eviction.
+
+For production, use one of the optional Redis adapters via the `assistant-stream/resumable/redis` (node-redis v5) or `assistant-stream/resumable/ioredis` sub-paths. Both adapters batch the per-append `XADD` and TTL refresh into a single pipelined round trip, store chunk values as binary, and accept the same `keyPrefix`, `defaultTtlMs`, `pollIntervalMs`, and `maxChunkBytes` options. Cluster routing works because each stream's keys share a `{streamId}` hash tag.
+
+```ts title="/lib/resumable-context.ts"
+import {
+  createResumableStreamContext,
+  type ResumableStreamStore,
+} from "assistant-stream/resumable";
+
+async function createStore(): Promise<ResumableStreamStore> {
+  if (!process.env.REDIS_URL) {
+    const { createInMemoryResumableStreamStore } = await import(
+      "assistant-stream/resumable"
+    );
+    return createInMemoryResumableStreamStore();
+  }
+  const { createClient } = await import("redis");
+  const { createRedisResumableStreamStore } = await import(
+    "assistant-stream/resumable/redis"
+  );
+  const client = createClient({ url: process.env.REDIS_URL });
+  await client.connect();
+  return createRedisResumableStreamStore(client);
+}
+
+export const resumableContext = createResumableStreamContext({
+  store: await createStore(),
+});
+```
+
+For Postgres, Cloudflare Durable Objects, Upstash REST, or any other backend, implement the `ResumableStreamStore` interface directly. See [Custom Resumable Stream Stores](/docs/guides/resumable-stream-stores) for the contract walkthrough and a worked example.
+
+## Production checklist
+
+- **Auth.** The resume route in the snippets above will serve any caller that knows the stream id. Bind `streamId` to the requesting user at acquire time and verify the binding inside the resume handler. Treat the id as opaque, not as a credential; it leaks via response headers, `sessionStorage`, browser history, and access logs.
+- **`waitUntil` on serverless.** On Vercel and Cloudflare the request handler is killed once the response returns, which interrupts the producer task. Pass `after` from `next/server` (or your platform's `ctx.waitUntil`) when constructing the context so the task survives past the response: `createResumableStreamContext({ store, waitUntil: after })`.
+- **TTL.** Streams expire 24 hours after the last write by default. Configure with `defaultTtlMs` on the store, or override per deployment via `ttlMs` on the context. Match TTLs across the store, any owner-binding key, and any signed cookie that references a `streamId`.
+- **Stream id format.** The Redis adapters validate `streamId` against `/^[A-Za-z0-9_.:-]{1,256}$/` to keep keys well-formed. UUIDv4 is fine.
+
+For the full treatment of authorization, multi-tenant key prefixes, observability hooks, resource limits, and incident response, see [Resumable Stream Deployment](/docs/guides/resumable-stream-deployment).
+
+A new `ResumableStreamError` class is exported from `assistant-stream/resumable` with codes `"missing" | "exists" | "finalized" | "invalid-id"`; catch it in the resume route to distinguish "stream gone" from other failures.
+
+## Helpers for `AssistantStreamController` callbacks
+
+If you produce streams via `createAssistantStream` rather than the AI SDK, the package ships two helpers that bridge the controller-callback style and any encoder to the store:
+
+```ts
+import {
+  createResumableAssistantStreamResponse,
+  createResumeAssistantStreamResponse,
+} from "assistant-stream/resumable";
+import { resumableContext } from "@/lib/resumable-context";
+
+// POST handler
+return createResumableAssistantStreamResponse({
+  context: resumableContext,
+  streamId,
+  callback: (controller) => {
+    /* same shape as createAssistantStreamResponse */
+  },
+});
+
+// GET resume handler
+return createResumeAssistantStreamResponse({
+  context: resumableContext,
+  streamId,
+});
+```
+
+Both helpers default to the data-stream encoder; pass `encoder: () => new AssistantTransportEncoder()` (or any custom encoder) to override. They set the `x-resumable-stream-id` response header automatically, which is what `AssistantChatTransport`'s `resumable` adapter looks for.
+
+## Example app
+
+[`examples/with-resumable-stream`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-resumable-stream) is a runnable Next.js app that uses `useChat`, the `resumable` transport option, and `useChatRuntime`. It falls back to a built-in mock when `OPENAI_API_KEY` is unset, and switches the store from in-memory to Redis when `REDIS_URL` is set.
+
+```sh
+npx assistant-ui create my-app -e with-resumable-stream
+```

--- a/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
@@ -491,6 +491,8 @@ const runtime = useAISDKRuntime(chat);
 
 [`examples/with-ai-sdk-v6`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-ai-sdk-v6) shows a complete reference implementation.
 
+For responses that should survive a page reload mid-stream, see [Resumable streams](/docs/guides/resumable-streams), which wraps the same v6 byte stream in `assistant-stream/resumable`.
+
 ## Next
 
 <Cards>
@@ -503,5 +505,10 @@ const runtime = useAISDKRuntime(chat);
     title="Threads"
     description="Single-thread, AssistantCloud, custom thread list."
     href="/docs/runtimes/concepts/threads"
+  />
+  <Card
+    title="Resumable streams"
+    description="Survive page reloads and connection drops mid-response."
+    href="/docs/guides/resumable-streams"
   />
 </Cards>

--- a/examples/with-resumable-stream/.env.example
+++ b/examples/with-resumable-stream/.env.example
@@ -1,0 +1,11 @@
+# Set to use the real OpenAI model. Leave unset to demo with a built-in mock
+# response that streams slowly enough to interrupt for the resume flow.
+OPENAI_API_KEY=
+
+# Optional. When set, the example uses the redis-backed
+# `assistant-stream/resumable/redis` adapter so resumable state survives
+# server restarts. Leave unset to use the in-memory store.
+#
+# Quick local Redis:
+#   docker run -d --name redis -p 6379:6379 redis:7-alpine
+REDIS_URL=

--- a/examples/with-resumable-stream/README.md
+++ b/examples/with-resumable-stream/README.md
@@ -1,0 +1,81 @@
+# with-resumable-stream
+
+Demonstrates `assistant-stream/resumable`: persist an in-flight LLM response on the server so the client can reload or lose its connection mid-stream and pick up where it left off.
+
+## How it works
+
+1. Each `POST /api/chat` mints a new UUIDv4 `streamId` server-side and returns it in the `x-resumable-stream-id` header. `AssistantChatTransport` reads that header on the browser and stores the latest pending id in `sessionStorage`.
+2. The route runs `streamText`, then pipes the byte body through `context.run(streamId, () => uiMessageStreamBody)`. The bytes are persisted in the configured store while being streamed to the client.
+3. If the client disconnects mid-stream, the server-side producer task keeps running and continues to append bytes to the store.
+4. On page load, if `sessionStorage` still has a stream id, the client calls `chat.resumeStream()`. The transport's `resumable` adapter rewrites the AI SDK reconnect request to `GET /api/chat/resume/[streamId]`, which calls `context.resume(streamId)` and replays the persisted bytes (plus any new ones) to the reconnecting client.
+5. When the response stream closes naturally, the transport detects the AI SDK `finish` SSE event in the body and clears the stored id. Cancellation does not clear the id, so a reload mid-stream still finds it on next mount.
+
+## Quick start
+
+```sh
+cp .env.example .env.local
+# Optional: put your OPENAI_API_KEY in .env.local for the real model. Without
+# it, the example falls back to a slow built-in mock so you can demo resume.
+pnpm install
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000), send a prompt, then reload the page mid-response. The same answer keeps filling in.
+
+## Client integration
+
+The browser side is wired through two helpers from `@assistant-ui/react-ai-sdk`:
+
+- `createResumableSessionStorage()` returns a small `sessionStorage`-backed storage object for the pending stream id. Pass `{ key }` to namespace per route. Use `localStorage` instead if you want a stream that survives full browser restarts (and accept the cross-tab race that comes with it).
+- `AssistantChatTransport` accepts a `resumable` option. When set, the transport captures the `x-resumable-stream-id` response header, watches the SSE body for the `finish` event so the stored id is cleared on natural completion (cancellation leaves it intact), and redirects `chat.resumeStream()` reconnects to the configured `resumeApi`.
+
+The example fires `chat.resumeStream()` from a one-shot `useEffect` when storage already has an id at mount time. If you switch to `useChatRuntime`, that resume call is wired automatically.
+
+## Server methods
+
+The `ResumableStreamContext` returned by `createResumableStreamContext` exposes:
+
+- `run(streamId, makeStream)`: producer-or-consumer entrypoint. Auto-elects the role via the store, so concurrent callers with the same id share the persisted output.
+- `resume(streamId)`: strict consumer; returns `null` when the stream does not exist.
+- `requireResume(streamId)`: same as `resume`, but throws `ResumableStreamError("missing")` instead of returning `null`.
+- `status(streamId)`: probe the lifecycle state without opening a reader.
+- `delete(streamId)`: remove all state for a stream.
+
+## Storage
+
+By default the example uses `createInMemoryResumableStreamStore` from `assistant-stream/resumable`. The store is memoized on `globalThis` via `Symbol.for`, so it survives Next.js hot reload but not full server restart. Default TTL is 24h; configure with `defaultTtlMs` if you want shorter eviction.
+
+To use Redis instead, set `REDIS_URL` in `.env.local`:
+
+```sh
+REDIS_URL=redis://localhost:6379
+OPENAI_API_KEY=your-api-key-here
+```
+
+The example will use the `assistant-stream/resumable/redis` adapter automatically. With Redis, resumable state survives server restarts (until the per-stream TTL expires; default 24h).
+
+You can run a local Redis quickly with Docker:
+
+```sh
+docker run -d --name redis -p 6379:6379 redis:7-alpine
+```
+
+## Production checklist
+
+`GET /api/chat/resume/[streamId]` in this example serves any caller who knows the stream id. UUIDv4 is unguessable in practice, but the id leaks into response headers, `sessionStorage`, browser history, and access logs. Before deploying:
+
+- Gate the resume endpoint with the same auth your chat endpoint uses.
+- Bind `streamId` to the requesting user at creation time and reject mismatches before calling `context.resume`.
+- On serverless platforms that kill the request handler when the response returns (Vercel, Cloudflare), pass `waitUntil` from `next/server` (`after`) when constructing the context. Otherwise the producer task is interrupted and resume cannot recover the rest of the stream.
+
+## Files of interest
+
+- `lib/resumable-context.ts`: picks the store based on `REDIS_URL` and memoizes a single `ResumableStreamContext` across module reloads.
+- `app/api/chat/route.ts`: POST endpoint that mints a fresh `streamId`, runs `streamText` (or a mock), and wraps the response body in `context.run`.
+- `app/api/chat/resume/[streamId]/route.ts`: GET endpoint that calls `context.resume` and replays the persisted bytes.
+- `app/page.tsx`: wires `useChat` with `AssistantChatTransport`'s `resumable` adapter and triggers `chat.resumeStream()` on mount when a pending id exists.
+
+## Related documentation
+
+- [assistant-ui documentation](https://www.assistant-ui.com/docs)
+- [AI SDK reconnect API](https://sdk.vercel.ai/docs)

--- a/examples/with-resumable-stream/app/api/chat/resume/[streamId]/route.ts
+++ b/examples/with-resumable-stream/app/api/chat/resume/[streamId]/route.ts
@@ -1,0 +1,28 @@
+import { UI_MESSAGE_STREAM_HEADERS } from "ai";
+import { RESUMABLE_STREAM_ID_HEADER } from "assistant-stream/resumable";
+import { getResumableStreamContext } from "@/lib/resumable-context";
+
+export const maxDuration = 60;
+
+export async function GET(
+  _req: Request,
+  context: { params: Promise<{ streamId: string }> },
+) {
+  const { streamId } = await context.params;
+  const ctx = await getResumableStreamContext();
+  const stream = await ctx.resume(streamId);
+
+  if (!stream) {
+    return new Response(JSON.stringify({ error: "stream not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(stream, {
+    headers: {
+      ...UI_MESSAGE_STREAM_HEADERS,
+      [RESUMABLE_STREAM_ID_HEADER]: streamId,
+    },
+  });
+}

--- a/examples/with-resumable-stream/app/api/chat/route.ts
+++ b/examples/with-resumable-stream/app/api/chat/route.ts
@@ -1,0 +1,169 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import {
+  type JSONSchema7,
+  streamText,
+  convertToModelMessages,
+  createUIMessageStream,
+  JsonToSseTransformStream,
+  type UIMessage,
+  tool,
+  stepCountIs,
+  zodSchema,
+} from "ai";
+import { RESUMABLE_STREAM_ID_HEADER } from "assistant-stream/resumable";
+import { z } from "zod";
+import { getResumableStreamContext } from "@/lib/resumable-context";
+
+export const maxDuration = 60;
+
+export async function POST(req: Request) {
+  const {
+    messages,
+    system,
+    tools,
+  }: {
+    id?: string;
+    messages: UIMessage[];
+    system?: string;
+    tools?: Record<string, { description?: string; parameters: JSONSchema7 }>;
+  } = await req.json();
+
+  const streamId = crypto.randomUUID();
+
+  const sourceBody = process.env["OPENAI_API_KEY"]
+    ? await buildOpenAIBody({
+        messages,
+        ...(system && { system }),
+        ...(tools && { tools }),
+      })
+    : buildMockBody({ messages });
+
+  const context = await getResumableStreamContext();
+  const stream = await context.run(streamId, () => sourceBody);
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      [RESUMABLE_STREAM_ID_HEADER]: streamId,
+    },
+  });
+}
+
+function convertFrontendTools(
+  tools: Record<string, { description?: string; parameters: JSONSchema7 }>,
+): Record<string, ReturnType<typeof tool>> {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, t]) => [
+      name,
+      tool({
+        ...(t.description ? { description: t.description } : {}),
+        inputSchema: t.parameters as never,
+      }),
+    ]),
+  );
+}
+
+async function buildOpenAIBody({
+  messages,
+  system,
+  tools,
+}: {
+  messages: UIMessage[];
+  system?: string;
+  tools?: Record<string, { description?: string; parameters: JSONSchema7 }>;
+}): Promise<ReadableStream<Uint8Array>> {
+  const openai = createOpenAI({
+    apiKey: process.env["OPENAI_API_KEY"]!,
+    ...(process.env["OPENAI_BASE_URL"] && {
+      baseURL: process.env["OPENAI_BASE_URL"],
+    }),
+  });
+  const result = streamText({
+    model: openai("gpt-4o"),
+    messages: await convertToModelMessages(messages),
+    ...(system ? { system } : {}),
+    stopWhen: stepCountIs(10),
+    tools: {
+      ...convertFrontendTools(tools ?? {}),
+      get_current_weather: tool({
+        description: "Get the current weather",
+        inputSchema: zodSchema(z.object({ city: z.string() })),
+        execute: async ({ city }) => `The weather in ${city} is sunny`,
+      }),
+      slow_count: tool({
+        description: "Count slowly to N",
+        inputSchema: zodSchema(
+          z.object({ to: z.number().int().min(1).max(50) }),
+        ),
+        execute: async ({ to }) => {
+          await new Promise((r) => setTimeout(r, to * 200));
+          return `counted to ${to}`;
+        },
+      }),
+    },
+  });
+
+  const response = result.toUIMessageStreamResponse();
+  if (!response.body) throw new Error("expected response body");
+  return response.body;
+}
+
+function buildMockBody({
+  messages,
+}: {
+  messages: UIMessage[];
+}): ReadableStream<Uint8Array> {
+  const lastUserText =
+    messages
+      .filter((m) => m.role === "user")
+      .at(-1)
+      ?.parts.flatMap((p) =>
+        p.type === "text" ? [(p as { type: "text"; text: string }).text] : [],
+      )
+      .join(" ") ?? "your message";
+
+  const text =
+    `(mock response. set OPENAI_API_KEY for the real model)\n\n` +
+    `you said: ${lastUserText}\n\n` +
+    `here is a slow stream you can interrupt mid-flight by reloading the page. ` +
+    `the resumable layer keeps the producer running on the server, so when ` +
+    `the browser reconnects it continues right where it left off, with no ` +
+    `wasted tokens and no lost progress. ` +
+    `lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod ` +
+    `tempor incididunt ut labore et dolore magna aliqua. ut enim ad minim ` +
+    `veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea ` +
+    `commodo consequat. duis aute irure dolor in reprehenderit in voluptate ` +
+    `velit esse cillum dolore eu fugiat nulla pariatur. excepteur sint ` +
+    `occaecat cupidatat non proident, sunt in culpa qui officia deserunt ` +
+    `mollit anim id est laborum.\n\n` +
+    `done.`;
+
+  const messageId = `msg-${crypto.randomUUID()}`;
+  const textPartId = `text-${crypto.randomUUID()}`;
+  const tokens = text.match(/\S+\s*|\s+/g) ?? [text];
+
+  const uiStream = createUIMessageStream({
+    execute: async ({ writer }) => {
+      writer.write({ type: "start", messageId });
+      writer.write({ type: "start-step" });
+      writer.write({ type: "text-start", id: textPartId });
+      for (const tok of tokens) {
+        await new Promise((r) => setTimeout(r, 250));
+        writer.write({
+          type: "text-delta",
+          id: textPartId,
+          delta: tok,
+        });
+      }
+      writer.write({ type: "text-end", id: textPartId });
+      writer.write({ type: "finish-step" });
+      writer.write({ type: "finish" });
+    },
+  });
+
+  return uiStream
+    .pipeThrough(new JsonToSseTransformStream())
+    .pipeThrough(new TextEncoderStream());
+}

--- a/examples/with-resumable-stream/app/globals.css
+++ b/examples/with-resumable-stream/app/globals.css
@@ -1,0 +1,122 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@source "../../../packages/ui/src";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.141 0.005 285.823);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.141 0.005 285.823);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.141 0.005 285.823);
+  --primary: oklch(0.21 0.006 285.885);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.552 0.016 285.938);
+  --accent: oklch(0.967 0.001 286.375);
+  --accent-foreground: oklch(0.21 0.006 285.885);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.92 0.004 286.32);
+  --input: oklch(0.92 0.004 286.32);
+  --ring: oklch(0.705 0.015 286.067);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.141 0.005 285.823);
+  --sidebar-primary: oklch(0.21 0.006 285.885);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.967 0.001 286.375);
+  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
+  --sidebar-border: oklch(0.92 0.004 286.32);
+  --sidebar-ring: oklch(0.705 0.015 286.067);
+}
+
+.dark {
+  --background: oklch(0.141 0.005 285.823);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.21 0.006 285.885);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.21 0.006 285.885);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.92 0.004 286.32);
+  --primary-foreground: oklch(0.21 0.006 285.885);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.274 0.006 286.033);
+  --muted-foreground: oklch(0.705 0.015 286.067);
+  --accent: oklch(0.274 0.006 286.033);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.552 0.016 285.938);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.21 0.006 285.885);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.274 0.006 286.033);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.552 0.016 285.938);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/examples/with-resumable-stream/app/layout.tsx
+++ b/examples/with-resumable-stream/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Resumable Stream Example",
+  description:
+    "Demonstrates assistant-stream/resumable: persist an in-flight LLM response so the client can reload mid-stream and pick up where it left off.",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body className="h-dvh">{children}</body>
+    </html>
+  );
+}

--- a/examples/with-resumable-stream/app/page.tsx
+++ b/examples/with-resumable-stream/app/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { useChat } from "@ai-sdk/react";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import {
+  AssistantChatTransport,
+  createResumableSessionStorage,
+  useAISDKRuntime,
+} from "@assistant-ui/react-ai-sdk";
+import { Thread } from "@/components/assistant-ui/thread";
+
+const storage = createResumableSessionStorage();
+
+function ChatRuntime() {
+  const transport = useMemo(
+    () =>
+      new AssistantChatTransport({
+        api: "/api/chat",
+        resumable: {
+          storage,
+          resumeApi: (streamId) => `/api/chat/resume/${streamId}`,
+        },
+      }),
+    [],
+  );
+
+  const chat = useChat({ transport });
+  const runtime = useAISDKRuntime(chat);
+
+  const resumedOnceRef = useRef(false);
+  const resumeStream = chat.resumeStream;
+  useEffect(() => {
+    if (resumedOnceRef.current) return;
+    if (!storage.getStreamId()) return;
+    resumedOnceRef.current = true;
+    resumeStream().catch((err: unknown) => {
+      console.warn("[resumable] resume failed; clearing stale id", err);
+      storage.clear();
+    });
+  }, [resumeStream]);
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <div className="h-full">
+        <Thread />
+      </div>
+    </AssistantRuntimeProvider>
+  );
+}
+
+export default function Home() {
+  return <ChatRuntime />;
+}

--- a/examples/with-resumable-stream/app/page.tsx
+++ b/examples/with-resumable-stream/app/page.tsx
@@ -1,18 +1,17 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
-import { useChat } from "@ai-sdk/react";
+import { useMemo } from "react";
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import {
   AssistantChatTransport,
   createResumableSessionStorage,
-  useAISDKRuntime,
+  useChatRuntime,
 } from "@assistant-ui/react-ai-sdk";
 import { Thread } from "@/components/assistant-ui/thread";
 
 const storage = createResumableSessionStorage();
 
-function ChatRuntime() {
+export default function Home() {
   const transport = useMemo(
     () =>
       new AssistantChatTransport({
@@ -25,20 +24,7 @@ function ChatRuntime() {
     [],
   );
 
-  const chat = useChat({ transport });
-  const runtime = useAISDKRuntime(chat);
-
-  const resumedOnceRef = useRef(false);
-  const resumeStream = chat.resumeStream;
-  useEffect(() => {
-    if (resumedOnceRef.current) return;
-    if (!storage.getStreamId()) return;
-    resumedOnceRef.current = true;
-    resumeStream().catch((err: unknown) => {
-      console.warn("[resumable] resume failed; clearing stale id", err);
-      storage.clear();
-    });
-  }, [resumeStream]);
+  const runtime = useChatRuntime({ transport });
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
@@ -47,8 +33,4 @@ function ChatRuntime() {
       </div>
     </AssistantRuntimeProvider>
   );
-}
-
-export default function Home() {
-  return <ChatRuntime />;
 }

--- a/examples/with-resumable-stream/components.json
+++ b/examples/with-resumable-stream/components.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "app/globals.css",
+    "baseColor": "zinc",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide",
+  "registries": {
+    "@assistant-ui": "https://r.assistant-ui.com/{name}.json"
+  }
+}

--- a/examples/with-resumable-stream/lib/resumable-context.ts
+++ b/examples/with-resumable-stream/lib/resumable-context.ts
@@ -1,0 +1,49 @@
+import {
+  createInMemoryResumableStreamStore,
+  createResumableStreamContext,
+  type ResumableStreamContext,
+  type ResumableStreamStore,
+} from "assistant-stream/resumable";
+
+const GLOBAL_KEY = Symbol.for("assistant-ui.example.resumable-context");
+
+type GlobalSlot = typeof globalThis & {
+  [GLOBAL_KEY]?: Promise<ResumableStreamContext>;
+};
+
+const slot = globalThis as GlobalSlot;
+
+export function getResumableStreamContext(): Promise<ResumableStreamContext> {
+  if (slot[GLOBAL_KEY]) return slot[GLOBAL_KEY];
+  const promise = (async () => {
+    const store = await createStore();
+    return createResumableStreamContext({ store });
+  })();
+  // clear the cache on rejection so the next request retries connecting.
+  promise.catch(() => {
+    if (slot[GLOBAL_KEY] === promise) {
+      delete slot[GLOBAL_KEY];
+    }
+  });
+  slot[GLOBAL_KEY] = promise;
+  return promise;
+}
+
+async function createStore(): Promise<ResumableStreamStore> {
+  const url = process.env["REDIS_URL"];
+  if (!url) {
+    return createInMemoryResumableStreamStore();
+  }
+
+  const { createClient } = await import("redis");
+  const { createRedisResumableStreamStore } = await import(
+    "assistant-stream/resumable/redis"
+  );
+
+  const client = createClient({ url });
+  client.on("error", (err) => {
+    console.error("[resumable-stream] redis client error:", err);
+  });
+  await client.connect();
+  return createRedisResumableStreamStore(client);
+}

--- a/examples/with-resumable-stream/next.config.js
+++ b/examples/with-resumable-stream/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/examples/with-resumable-stream/package.json
+++ b/examples/with-resumable-stream/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "with-resumable-stream",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev --webpack",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^3.0.61",
+    "@ai-sdk/react": "^3.0.45",
+    "@assistant-ui/react": "workspace:*",
+    "@assistant-ui/react-ai-sdk": "workspace:*",
+    "@assistant-ui/react-markdown": "workspace:*",
+    "@assistant-ui/store": "workspace:*",
+    "@assistant-ui/tap": "workspace:*",
+    "@assistant-ui/ui": "workspace:*",
+    "ai": "^6.0.175",
+    "assistant-stream": "workspace:*",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.14.0",
+    "next": "^16.2.4",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "redis": "^5.12.1",
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@assistant-ui/x-buildutils": "workspace:*",
+    "@tailwindcss/postcss": "^4.2.4",
+    "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "postcss": "^8.5.14",
+    "tailwindcss": "^4.2.4",
+    "tw-animate-css": "^1.4.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/with-resumable-stream/postcss.config.mjs
+++ b/examples/with-resumable-stream/postcss.config.mjs
@@ -1,0 +1,6 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+export default config;

--- a/examples/with-resumable-stream/tsconfig.json
+++ b/examples/with-resumable-stream/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@assistant-ui/x-buildutils/ts/next",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./*"],
+      "@/components/assistant-ui/*": [
+        "../../packages/ui/src/components/assistant-ui/*"
+      ],
+      "@/components/ui/*": ["../../packages/ui/src/components/ui/*"],
+      "@/lib/utils": ["../../packages/ui/src/lib/utils"],
+      "@assistant-ui/ui/*": ["../../packages/ui/src/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/assistant-stream/package.json
+++ b/packages/assistant-stream/package.json
@@ -22,6 +22,18 @@
     "./utils": {
       "types": "./dist/utils.d.ts",
       "default": "./dist/utils.js"
+    },
+    "./resumable": {
+      "types": "./dist/resumable/index.d.ts",
+      "default": "./dist/resumable/index.js"
+    },
+    "./resumable/redis": {
+      "types": "./dist/resumable/stores/redis.d.ts",
+      "default": "./dist/resumable/stores/redis.js"
+    },
+    "./resumable/ioredis": {
+      "types": "./dist/resumable/stores/ioredis.d.ts",
+      "default": "./dist/resumable/stores/ioredis.js"
     }
   },
   "main": "./dist/index.js",
@@ -43,9 +55,23 @@
     "nanoid": "^5.1.11",
     "secure-json-parse": "^4.1.0"
   },
+  "peerDependencies": {
+    "ioredis": "^5.10.1",
+    "redis": "^5.12.1"
+  },
+  "peerDependenciesMeta": {
+    "ioredis": {
+      "optional": true
+    },
+    "redis": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
     "@types/json-schema": "^7.0.15",
+    "ioredis": "^5.10.1",
+    "redis": "^5.12.1",
     "vitest": "^4.1.5"
   },
   "publishConfig": {

--- a/packages/assistant-stream/src/resumable/ResumableStreamContext.test.ts
+++ b/packages/assistant-stream/src/resumable/ResumableStreamContext.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import { createResumableStreamContext } from "./ResumableStreamContext";
+import { ResumableStreamError } from "./errors";
+import { createInMemoryResumableStreamStore } from "./stores/InMemoryResumableStreamStore";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+const bytes = (s: string): Uint8Array => enc.encode(s);
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  let out = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return out;
+      out += dec.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function makeStringStream(parts: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      for (const part of parts) {
+        controller.enqueue(bytes(part));
+        await Promise.resolve();
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("createResumableStreamContext", () => {
+  it("producer caller receives full byte stream", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    const stream = await ctx.run("a", () =>
+      makeStringStream(["hello ", "world"]),
+    );
+    expect(await collect(stream)).toBe("hello world");
+  });
+
+  it("second caller becomes consumer and receives identical bytes", async () => {
+    const store = createInMemoryResumableStreamStore();
+    const ctx = createResumableStreamContext({ store });
+
+    const producerStream = await ctx.run("a", () =>
+      makeStringStream(["one ", "two ", "three"]),
+    );
+    const consumerStream = await ctx.run("a", () =>
+      makeStringStream(["should-not-run"]),
+    );
+
+    const [a, b] = await Promise.all([
+      collect(producerStream),
+      collect(consumerStream),
+    ]);
+    expect(a).toBe("one two three");
+    expect(b).toBe("one two three");
+  });
+
+  it("late consumer after done replays via resume", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    const producer = await ctx.run("a", () =>
+      makeStringStream(["alpha", "beta", "gamma"]),
+    );
+    expect(await collect(producer)).toBe("alphabetagamma");
+
+    const replay = await ctx.resume("a");
+    expect(replay).not.toBeNull();
+    expect(await collect(replay!)).toBe("alphabetagamma");
+  });
+
+  it("resume returns null for missing streams", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    expect(await ctx.resume("nope")).toBeNull();
+  });
+
+  it("requireResume throws ResumableStreamError for missing streams", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    await expect(ctx.requireResume("nope")).rejects.toBeInstanceOf(
+      ResumableStreamError,
+    );
+    await expect(ctx.requireResume("nope")).rejects.toMatchObject({
+      code: "missing",
+    });
+  });
+
+  it("requireResume returns the replay stream when it exists", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    const producer = await ctx.run("a", () => makeStringStream(["hi"]));
+    expect(await collect(producer)).toBe("hi");
+
+    const replay = await ctx.requireResume("a");
+    expect(await collect(replay)).toBe("hi");
+  });
+
+  it("status tracks lifecycle", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    expect(await ctx.status("a")).toBe("missing");
+    const stream = await ctx.run("a", () => makeStringStream(["x"]));
+    await collect(stream);
+    expect(await ctx.status("a")).toBe("done");
+  });
+
+  it("delete removes stream state", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    const stream = await ctx.run("a", () => makeStringStream(["x"]));
+    await collect(stream);
+    expect(await ctx.status("a")).toBe("done");
+    await ctx.delete("a");
+    expect(await ctx.status("a")).toBe("missing");
+  });
+
+  it("producer keeps writing after the local consumer cancels", async () => {
+    const store = createInMemoryResumableStreamStore();
+    const ctx = createResumableStreamContext({ store });
+
+    let producerEmitted = 0;
+    const slowStream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        for (let i = 0; i < 5; i++) {
+          await new Promise((r) => setTimeout(r, 5));
+          controller.enqueue(bytes(`chunk${i};`));
+          producerEmitted += 1;
+        }
+        controller.close();
+      },
+    });
+
+    const stream = await ctx.run("a", () => slowStream);
+    const reader = stream.getReader();
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+    await reader.cancel();
+
+    while (producerEmitted < 5) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    while ((await ctx.status("a")) === "streaming") {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    const replay = await ctx.resume("a");
+    expect(replay).not.toBeNull();
+    expect(await collect(replay!)).toBe("chunk0;chunk1;chunk2;chunk3;chunk4;");
+  });
+
+  it("propagates producer errors to consumers", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    const failing = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes("partial;"));
+        controller.error(new Error("oops"));
+      },
+    });
+    const stream = await ctx.run("a", () => failing);
+    await expect(collect(stream)).rejects.toThrow("oops");
+    expect(await ctx.status("a")).toBe("error");
+  });
+
+  it("waitUntil receives the producer task promise", async () => {
+    const promises: Promise<unknown>[] = [];
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+      waitUntil: (p) => promises.push(p),
+    });
+    const stream = await ctx.run("a", () => makeStringStream(["x"]));
+    expect(await collect(stream)).toBe("x");
+    expect(promises.length).toBe(1);
+    await Promise.all(promises);
+  });
+
+  it("onAcquire fires for both producer and consumer roles", async () => {
+    const calls: Array<{ id: string; role: string }> = [];
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+      onAcquire: (id, role) => calls.push({ id, role }),
+    });
+    const producer = await ctx.run("a", () => makeStringStream(["x"]));
+    const consumer = await ctx.run("a", () => makeStringStream(["unused"]));
+    await Promise.all([collect(producer), collect(consumer)]);
+    expect(calls).toEqual([
+      { id: "a", role: "producer" },
+      { id: "a", role: "consumer" },
+    ]);
+  });
+
+  it("onAppend fires per appended chunk with byteLength", async () => {
+    const calls: Array<{ id: string; byteLength: number }> = [];
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+      onAppend: (id, byteLength) => calls.push({ id, byteLength }),
+    });
+    const stream = await ctx.run("a", () => makeStringStream(["ab", "cde"]));
+    expect(await collect(stream)).toBe("abcde");
+    expect(calls).toEqual([
+      { id: "a", byteLength: 2 },
+      { id: "a", byteLength: 3 },
+    ]);
+  });
+
+  it("onFinalize fires on successful completion", async () => {
+    const calls: Array<{
+      id: string;
+      status: "done" | "error";
+      error: string | undefined;
+    }> = [];
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+      onFinalize: (id, status, error) => calls.push({ id, status, error }),
+    });
+    const stream = await ctx.run("a", () => makeStringStream(["x"]));
+    await collect(stream);
+    expect(calls).toEqual([{ id: "a", status: "done", error: undefined }]);
+  });
+
+  it("onFinalize fires with error status when producer fails", async () => {
+    const calls: Array<{
+      id: string;
+      status: "done" | "error";
+      error: string | undefined;
+    }> = [];
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+      onFinalize: (id, status, error) => calls.push({ id, status, error }),
+    });
+    const failing = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error("boom"));
+      },
+    });
+    const stream = await ctx.run("a", () => failing);
+    await expect(collect(stream)).rejects.toThrow("boom");
+    expect(calls).toEqual([{ id: "a", status: "error", error: "boom" }]);
+  });
+
+  it("onError fires when the producer task throws", async () => {
+    const errors: Array<{ id: string; error: unknown }> = [];
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+      onError: (id, error) => errors.push({ id, error }),
+    });
+    const failing = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error("boom"));
+      },
+    });
+    const stream = await ctx.run("a", () => failing);
+    await expect(collect(stream)).rejects.toThrow("boom");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.id).toBe("a");
+    expect((errors[0]!.error as Error).message).toBe("boom");
+  });
+});

--- a/packages/assistant-stream/src/resumable/ResumableStreamContext.ts
+++ b/packages/assistant-stream/src/resumable/ResumableStreamContext.ts
@@ -1,0 +1,187 @@
+import { ResumableStreamError } from "./errors";
+import type {
+  ResumableStreamRole,
+  ResumableStreamStatus,
+  ResumableStreamStore,
+} from "./types";
+
+export type ResumableStreamContextOptions = {
+  readonly store: ResumableStreamStore;
+  readonly ttlMs?: number;
+  /**
+   * Required on serverless runtimes that terminate background work when the
+   * request handler returns (Vercel, Cloudflare). Pass `after` from
+   * `next/server` so the producer task outlives the response.
+   */
+  readonly waitUntil?: (promise: Promise<unknown>) => void;
+  readonly onAcquire?: (streamId: string, role: ResumableStreamRole) => void;
+  readonly onAppend?: (streamId: string, byteLength: number) => void;
+  readonly onFinalize?: (
+    streamId: string,
+    status: "done" | "error",
+    error?: string,
+  ) => void;
+  readonly onError?: (streamId: string, error: unknown) => void;
+};
+
+export interface ResumableStreamContext {
+  /** Producer or consumer entrypoint. Atomically elects the role. */
+  run(
+    streamId: string,
+    makeStream: () => ReadableStream<Uint8Array>,
+  ): Promise<ReadableStream<Uint8Array>>;
+
+  /** Returns `null` when the stream does not exist. */
+  resume(streamId: string): Promise<ReadableStream<Uint8Array> | null>;
+
+  /** Throws `ResumableStreamError("missing")` when the stream does not exist. */
+  requireResume(streamId: string): Promise<ReadableStream<Uint8Array>>;
+
+  status(streamId: string): Promise<ResumableStreamStatus>;
+
+  delete(streamId: string): Promise<void>;
+}
+
+export function createResumableStreamContext(
+  options: ResumableStreamContextOptions,
+): ResumableStreamContext {
+  const { store, waitUntil, onAcquire, onAppend, onFinalize, onError } =
+    options;
+  const acquireOptions =
+    options.ttlMs !== undefined ? { ttlMs: options.ttlMs } : undefined;
+
+  return {
+    async run(streamId, makeStream) {
+      const role = await store.acquire(streamId, acquireOptions);
+      onAcquire?.(streamId, role);
+      if (role === "producer") {
+        startProducerTask(store, streamId, makeStream, {
+          waitUntil,
+          onAppend,
+          onFinalize,
+          onError,
+        });
+      }
+      return readFromStore(store, streamId);
+    },
+
+    async resume(streamId) {
+      const status = await store.status(streamId);
+      if (status === "missing") return null;
+      return readFromStore(store, streamId);
+    },
+
+    async requireResume(streamId) {
+      const status = await store.status(streamId);
+      if (status === "missing") {
+        throw new ResumableStreamError(
+          "missing",
+          `resumable stream not found: ${streamId}`,
+        );
+      }
+      return readFromStore(store, streamId);
+    },
+
+    async status(streamId) {
+      return store.status(streamId);
+    },
+
+    async delete(streamId) {
+      await store.delete(streamId);
+    },
+  };
+}
+
+type ProducerHooks = {
+  readonly waitUntil: ((promise: Promise<unknown>) => void) | undefined;
+  readonly onAppend:
+    | ((streamId: string, byteLength: number) => void)
+    | undefined;
+  readonly onFinalize:
+    | ((streamId: string, status: "done" | "error", error?: string) => void)
+    | undefined;
+  readonly onError: ((streamId: string, error: unknown) => void) | undefined;
+};
+
+function startProducerTask(
+  store: ResumableStreamStore,
+  streamId: string,
+  makeStream: () => ReadableStream<Uint8Array>,
+  hooks: ProducerHooks,
+): void {
+  const { waitUntil, onAppend, onFinalize, onError } = hooks;
+  const task = (async () => {
+    let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+    let cancelled = false;
+    try {
+      reader = makeStream().getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        await store.append(streamId, value);
+        onAppend?.(streamId, value.byteLength);
+      }
+      await store.finalize(streamId, "done");
+      onFinalize?.(streamId, "done");
+    } catch (err) {
+      cancelled = true;
+      onError?.(streamId, err);
+      const message = err instanceof Error ? err.message : String(err);
+      try {
+        await reader?.cancel(err);
+      } catch (cancelErr) {
+        console.error("resumable stream reader cancel failed:", cancelErr);
+      }
+      try {
+        await store.finalize(streamId, "error", message);
+        onFinalize?.(streamId, "error", message);
+      } catch (finalizeErr) {
+        console.error("resumable stream finalize failed:", finalizeErr);
+      }
+    } finally {
+      if (!cancelled) reader?.releaseLock();
+    }
+  })();
+
+  if (waitUntil) waitUntil(task);
+  task.catch((err) => {
+    console.error("resumable producer task failed:", err);
+  });
+}
+
+function readFromStore(
+  store: ResumableStreamStore,
+  streamId: string,
+): ReadableStream<Uint8Array> {
+  const ac = new AbortController();
+  let iterator: AsyncIterator<{ chunk: Uint8Array }> | undefined;
+
+  return new ReadableStream<Uint8Array>({
+    start() {
+      iterator = store.read(streamId, "", ac.signal)[Symbol.asyncIterator]();
+    },
+    async pull(controller) {
+      try {
+        if (!iterator) return;
+        const { done, value } = await iterator.next();
+        if (done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(value.chunk);
+      } catch (err) {
+        // the platform never calls cancel() on errored streams, so unwind
+        // the store iterator and abort the signal explicitly.
+        ac.abort();
+        try {
+          await iterator?.return?.();
+        } catch {}
+        controller.error(err);
+      }
+    },
+    cancel() {
+      ac.abort();
+      iterator?.return?.().catch(() => {});
+    },
+  });
+}

--- a/packages/assistant-stream/src/resumable/__tests__/integration.test.ts
+++ b/packages/assistant-stream/src/resumable/__tests__/integration.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  RESUMABLE_STREAM_ID_HEADER,
+  createResumableAssistantStreamResponse,
+  createResumeAssistantStreamResponse,
+} from "../createResumableAssistantStreamResponse";
+import { createResumableStreamContext } from "../ResumableStreamContext";
+import { createInMemoryResumableStreamStore } from "../stores/InMemoryResumableStreamStore";
+import {
+  AssistantTransportDecoder,
+  AssistantTransportEncoder,
+} from "../../core/serialization/assistant-transport/AssistantTransport";
+import { DataStreamDecoder } from "../../core/serialization/data-stream/DataStream";
+import { AssistantMessageAccumulator } from "../../core/accumulators/assistant-message-accumulator";
+import type { AssistantStreamChunk } from "../../core/AssistantStreamChunk";
+import type { AssistantMessage } from "../../core/utils/types";
+
+async function decodeViaDataStream(body: ReadableStream<Uint8Array>) {
+  const stream = body.pipeThrough(new DataStreamDecoder());
+  const out: string[] = [];
+  for await (const chunk of stream) {
+    if (chunk.type === "text-delta") out.push(chunk.textDelta);
+  }
+  return out.join("");
+}
+
+async function accumulate(
+  body: ReadableStream<Uint8Array>,
+  decoder: TransformStream<Uint8Array, AssistantStreamChunk>,
+): Promise<AssistantMessage> {
+  const messages = body
+    .pipeThrough(decoder)
+    .pipeThrough(new AssistantMessageAccumulator());
+  let last: AssistantMessage | undefined;
+  for await (const msg of messages) last = msg;
+  if (!last) throw new Error("accumulator yielded no messages");
+  return last;
+}
+
+describe("resumable integration", () => {
+  it("ten concurrent consumers see identical bytes for a 50 chunk stream", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+
+    const producer = await createResumableAssistantStreamResponse({
+      context: ctx,
+      streamId: "fanout",
+      callback: async (controller) => {
+        for (let i = 0; i < 50; i++) {
+          controller.appendText(`chunk-${i}`);
+          await Promise.resolve();
+        }
+      },
+    });
+
+    const consumers = await Promise.all(
+      Array.from({ length: 10 }, async () => {
+        const r = await ctx.resume("fanout");
+        if (!r) throw new Error("resume returned null");
+        return new Response(r).arrayBuffer();
+      }),
+    );
+    const producerBytes = await new Response(producer.body).arrayBuffer();
+
+    const expected = new Uint8Array(producerBytes);
+    for (const c of consumers) {
+      expect(new Uint8Array(c)).toEqual(expected);
+    }
+
+    const text = await decodeViaDataStream(
+      new Response(new Uint8Array(producerBytes)).body!,
+    );
+    expect(text).toBe(
+      Array.from({ length: 50 }, (_, i) => `chunk-${i}`).join(""),
+    );
+  });
+
+  it("non-ASCII payload round-trips byte-for-byte through resume", async () => {
+    const allCodePoints = Array.from({ length: 256 }, (_, i) =>
+      String.fromCodePoint(i),
+    ).join("");
+    const emoji = "hello 🌍 🚀 ✨";
+    const payload = allCodePoints + emoji;
+
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    const producer = await createResumableAssistantStreamResponse({
+      context: ctx,
+      streamId: "binary",
+      callback: (controller) => controller.appendText(payload),
+    });
+    const producerBytes = new Uint8Array(
+      await new Response(producer.body).arrayBuffer(),
+    );
+
+    const replay = await createResumeAssistantStreamResponse({
+      context: ctx,
+      streamId: "binary",
+    });
+    const replayBytes = new Uint8Array(
+      await new Response(replay.body).arrayBuffer(),
+    );
+    expect(replayBytes).toEqual(producerBytes);
+    expect(replay.headers.get(RESUMABLE_STREAM_ID_HEADER)).toBe("binary");
+
+    const decoded = await decodeViaDataStream(new Response(replayBytes).body!);
+    expect(decoded).toBe(payload);
+  });
+
+  it("AssistantTransportEncoder round-trips through resume into an identical message", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    const producer = await createResumableAssistantStreamResponse({
+      context: ctx,
+      streamId: "transport",
+      encoder: () => new AssistantTransportEncoder(),
+      callback: (controller) => {
+        controller.appendText("processing... ");
+        const tool = controller.addToolCallPart({
+          toolName: "lookup",
+          toolCallId: "tool-1",
+          args: { query: "weather" },
+          response: { result: { temperature: 72 } },
+        });
+        tool.close();
+        controller.appendText("done");
+      },
+    });
+    const producerMessage = await accumulate(
+      producer.body!,
+      new AssistantTransportDecoder(),
+    );
+
+    const replay = await createResumeAssistantStreamResponse({
+      context: ctx,
+      streamId: "transport",
+      encoder: () => new AssistantTransportEncoder(),
+    });
+    expect(replay.headers.get("content-type")).toBe("text/event-stream");
+    const replayMessage = await accumulate(
+      replay.body!,
+      new AssistantTransportDecoder(),
+    );
+
+    expect(replayMessage.parts).toEqual(producerMessage.parts);
+    expect(replayMessage.status).toEqual(producerMessage.status);
+    const toolPart = replayMessage.parts.find((p) => p.type === "tool-call");
+    expect(toolPart).toBeDefined();
+    expect(toolPart).toMatchObject({
+      toolName: "lookup",
+      toolCallId: "tool-1",
+      args: { query: "weather" },
+      result: { temperature: 72 },
+    });
+  });
+});

--- a/packages/assistant-stream/src/resumable/constants.ts
+++ b/packages/assistant-stream/src/resumable/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;

--- a/packages/assistant-stream/src/resumable/createResumableAssistantStreamResponse.test.ts
+++ b/packages/assistant-stream/src/resumable/createResumableAssistantStreamResponse.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  RESUMABLE_STREAM_ID_HEADER,
+  createResumableAssistantStreamResponse,
+  createResumeAssistantStreamResponse,
+} from "./createResumableAssistantStreamResponse";
+import { createResumableStreamContext } from "./ResumableStreamContext";
+import { ResumableStreamError } from "./errors";
+import { createInMemoryResumableStreamStore } from "./stores/InMemoryResumableStreamStore";
+import { DataStreamDecoder } from "../core/serialization/data-stream/DataStream";
+import { AssistantTransportEncoder } from "../core/serialization/assistant-transport/AssistantTransport";
+import { AssistantMessageAccumulator } from "../core/accumulators/assistant-message-accumulator";
+import type { AssistantStreamChunk } from "../core/AssistantStreamChunk";
+
+async function decodeAssistantText(response: Response): Promise<string> {
+  const chunks: AssistantStreamChunk[] = [];
+  const stream = response.body!.pipeThrough(new DataStreamDecoder());
+  for await (const chunk of stream) chunks.push(chunk);
+
+  const acc = new AssistantMessageAccumulator();
+  const messageStream = new ReadableStream<AssistantStreamChunk>({
+    start(c) {
+      for (const ch of chunks) c.enqueue(ch);
+      c.close();
+    },
+  }).pipeThrough(acc);
+
+  const reader = messageStream.getReader();
+  let last:
+    | { parts: ReadonlyArray<{ type: string; text?: string }> }
+    | undefined;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    last = value;
+  }
+  return (
+    last?.parts
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("") ?? ""
+  );
+}
+
+describe("createResumableAssistantStreamResponse", () => {
+  it("produces a response that decodes through DataStreamDecoder", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    const response = await createResumableAssistantStreamResponse({
+      context: ctx,
+      streamId: "s1",
+      callback: (controller) => {
+        controller.appendText("hello ");
+        controller.appendText("world");
+      },
+    });
+
+    expect(response.headers.get(RESUMABLE_STREAM_ID_HEADER)).toBe("s1");
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    expect(await decodeAssistantText(response)).toBe("hello world");
+  });
+
+  it("resume endpoint replays the same payload byte-for-byte", async () => {
+    const store = createInMemoryResumableStreamStore();
+    const ctx = createResumableStreamContext({ store });
+
+    const first = await createResumableAssistantStreamResponse({
+      context: ctx,
+      streamId: "s1",
+      callback: (controller) => {
+        controller.appendText("alpha");
+        const tool = controller.addToolCallPart({
+          toolName: "echo",
+          toolCallId: "t1",
+          args: { v: 1 },
+          response: { result: { ok: true } },
+        });
+        tool.close();
+      },
+    });
+    const firstBytes = await new Response(first.body).arrayBuffer();
+
+    const second = await createResumeAssistantStreamResponse({
+      context: ctx,
+      streamId: "s1",
+    });
+    const secondBytes = await new Response(second.body).arrayBuffer();
+
+    expect(new Uint8Array(secondBytes)).toEqual(new Uint8Array(firstBytes));
+    expect(second.headers.get(RESUMABLE_STREAM_ID_HEADER)).toBe("s1");
+  });
+
+  it("resume returns 404 when streamId is unknown", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    const response = await createResumeAssistantStreamResponse({
+      context: ctx,
+      streamId: "missing",
+    });
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body).toEqual({ error: "stream not found" });
+  });
+
+  it("custom encoder factory survives across producer + consumer", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    const response = await createResumableAssistantStreamResponse({
+      context: ctx,
+      streamId: "s1",
+      encoder: () => new AssistantTransportEncoder(),
+      callback: (controller) => controller.appendText("hi"),
+    });
+
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    const text = await new Response(response.body).text();
+    expect(text).toContain("text-delta");
+    expect(text).toContain("[DONE]");
+  });
+
+  it("user headers override encoder defaults but not the stream id header", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    const response = await createResumableAssistantStreamResponse({
+      context: ctx,
+      streamId: "s1",
+      headers: {
+        "Cache-Control": "private, max-age=0",
+        [RESUMABLE_STREAM_ID_HEADER]: "spoofed",
+      },
+      callback: (controller) => controller.appendText("hi"),
+    });
+    expect(response.headers.get("cache-control")).toBe("private, max-age=0");
+    expect(response.headers.get(RESUMABLE_STREAM_ID_HEADER)).toBe("s1");
+    await response.body!.cancel();
+  });
+
+  describe("producer crash", () => {
+    let suppressed: unknown[];
+    let original: NodeJS.UnhandledRejectionListener[];
+    const swallow: NodeJS.UnhandledRejectionListener = (reason) => {
+      suppressed.push(reason);
+    };
+
+    beforeEach(() => {
+      suppressed = [];
+      original = process.listeners("unhandledRejection");
+      for (const l of original) process.off("unhandledRejection", l);
+      process.on("unhandledRejection", swallow);
+    });
+
+    afterEach(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+      process.off("unhandledRejection", swallow);
+      for (const l of original) process.on("unhandledRejection", l);
+    });
+
+    it("synchronous callback throw is encoded into the body and finalizes the stream", async () => {
+      const ctx = createResumableStreamContext({
+        store: createInMemoryResumableStreamStore(),
+      });
+      const response = await createResumableAssistantStreamResponse({
+        context: ctx,
+        streamId: "s1",
+        callback: () => {
+          throw new Error("boom");
+        },
+      });
+      expect(response.status).toBe(200);
+
+      const firstBytes = await new Response(response.body).arrayBuffer();
+      expect(new TextDecoder().decode(firstBytes)).toContain("Error: boom");
+
+      while ((await ctx.status("s1")) === "streaming") {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      expect(await ctx.status("s1")).toBe("done");
+
+      const replay = await ctx.resume("s1");
+      expect(replay).not.toBeNull();
+      const replayBytes = await new Response(replay).arrayBuffer();
+      expect(new Uint8Array(replayBytes)).toEqual(new Uint8Array(firstBytes));
+
+      while (suppressed.length === 0) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      expect(suppressed.map((e) => (e as Error).message)).toContain("boom");
+    });
+  });
+
+  it("requireResume rejects with ResumableStreamError(missing) for unknown ids", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+    let captured: unknown;
+    try {
+      await ctx.requireResume("nonexistent");
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(ResumableStreamError);
+    expect((captured as ResumableStreamError).code).toBe("missing");
+  });
+
+  it("mid-stream consumer joins active production and receives every chunk in order", async () => {
+    const ctx = createResumableStreamContext({
+      store: createInMemoryResumableStreamStore(),
+    });
+
+    let emitted = 0;
+    const producerDone = createResumableAssistantStreamResponse({
+      context: ctx,
+      streamId: "s1",
+      callback: async (controller) => {
+        for (let i = 0; i < 5; i++) {
+          await new Promise((r) => setTimeout(r, 5));
+          controller.appendText(`chunk${i};`);
+          emitted += 1;
+        }
+      },
+    });
+
+    const producer = await producerDone;
+
+    while (emitted < 2) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+
+    const replay = await ctx.resume("s1");
+    expect(replay).not.toBeNull();
+
+    const [producerBody, replayText] = await Promise.all([
+      new Response(producer.body).arrayBuffer(),
+      decodeAssistantText(new Response(replay)),
+    ]);
+    expect(producerBody.byteLength).toBeGreaterThan(0);
+    expect(replayText).toBe("chunk0;chunk1;chunk2;chunk3;chunk4;");
+  });
+});

--- a/packages/assistant-stream/src/resumable/createResumableAssistantStreamResponse.ts
+++ b/packages/assistant-stream/src/resumable/createResumableAssistantStreamResponse.ts
@@ -22,20 +22,15 @@ export type CreateResumableAssistantStreamResponseOptions = {
 export async function createResumableAssistantStreamResponse(
   options: CreateResumableAssistantStreamResponseOptions,
 ): Promise<Response> {
-  const encoderFactory = options.encoder ?? (() => new DataStreamEncoder());
-  const headerEncoder = encoderFactory();
+  const encoder = (options.encoder ?? (() => new DataStreamEncoder()))();
 
   const stream = await options.context.run(options.streamId, () => {
     const aStream = createAssistantStream(options.callback);
-    return aStream.pipeThrough(encoderFactory());
+    return aStream.pipeThrough(encoder);
   });
 
   return new Response(stream, {
-    headers: mergeHeaders(
-      headerEncoder.headers,
-      options.headers,
-      options.streamId,
-    ),
+    headers: mergeHeaders(encoder.headers, options.headers, options.streamId),
   });
 }
 
@@ -56,14 +51,9 @@ export async function createResumeAssistantStreamResponse(
   if (!stream) {
     return options.missingResponse?.() ?? defaultMissingResponse();
   }
-  const encoderFactory = options.encoder ?? (() => new DataStreamEncoder());
-  const headerEncoder = encoderFactory();
+  const encoder = (options.encoder ?? (() => new DataStreamEncoder()))();
   return new Response(stream, {
-    headers: mergeHeaders(
-      headerEncoder.headers,
-      options.headers,
-      options.streamId,
-    ),
+    headers: mergeHeaders(encoder.headers, options.headers, options.streamId),
   });
 }
 

--- a/packages/assistant-stream/src/resumable/createResumableAssistantStreamResponse.ts
+++ b/packages/assistant-stream/src/resumable/createResumableAssistantStreamResponse.ts
@@ -1,0 +1,90 @@
+import type { AssistantStreamEncoder } from "../core/AssistantStream";
+import {
+  createAssistantStream,
+  type AssistantStreamController,
+} from "../core/modules/assistant-stream";
+import { DataStreamEncoder } from "../core/serialization/data-stream/DataStream";
+import type { ResumableStreamContext } from "./ResumableStreamContext";
+
+export const RESUMABLE_STREAM_ID_HEADER = "x-resumable-stream-id";
+
+export type CreateResumableAssistantStreamResponseOptions = {
+  readonly context: ResumableStreamContext;
+  readonly streamId: string;
+  readonly callback: (
+    controller: AssistantStreamController,
+  ) => PromiseLike<void> | void;
+  /** Defaults to `DataStreamEncoder`. Also consulted for response headers. */
+  readonly encoder?: () => AssistantStreamEncoder;
+  readonly headers?: HeadersInit;
+};
+
+export async function createResumableAssistantStreamResponse(
+  options: CreateResumableAssistantStreamResponseOptions,
+): Promise<Response> {
+  const encoderFactory = options.encoder ?? (() => new DataStreamEncoder());
+  const headerEncoder = encoderFactory();
+
+  const stream = await options.context.run(options.streamId, () => {
+    const aStream = createAssistantStream(options.callback);
+    return aStream.pipeThrough(encoderFactory());
+  });
+
+  return new Response(stream, {
+    headers: mergeHeaders(
+      headerEncoder.headers,
+      options.headers,
+      options.streamId,
+    ),
+  });
+}
+
+export type CreateResumeAssistantStreamResponseOptions = {
+  readonly context: ResumableStreamContext;
+  readonly streamId: string;
+  /** Read for `headers` only; the encoder transform is not invoked on resume. */
+  readonly encoder?: () => AssistantStreamEncoder;
+  readonly headers?: HeadersInit;
+  /** Defaults to a 404 JSON response. */
+  readonly missingResponse?: () => Response;
+};
+
+export async function createResumeAssistantStreamResponse(
+  options: CreateResumeAssistantStreamResponseOptions,
+): Promise<Response> {
+  const stream = await options.context.resume(options.streamId);
+  if (!stream) {
+    return options.missingResponse?.() ?? defaultMissingResponse();
+  }
+  const encoderFactory = options.encoder ?? (() => new DataStreamEncoder());
+  const headerEncoder = encoderFactory();
+  return new Response(stream, {
+    headers: mergeHeaders(
+      headerEncoder.headers,
+      options.headers,
+      options.streamId,
+    ),
+  });
+}
+
+function defaultMissingResponse(): Response {
+  return new Response(JSON.stringify({ error: "stream not found" }), {
+    status: 404,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function mergeHeaders(
+  encoderHeaders: Headers | undefined,
+  extra: HeadersInit | undefined,
+  streamId: string,
+): Headers {
+  const merged = new Headers(encoderHeaders ?? {});
+  if (extra) {
+    for (const [key, value] of new Headers(extra)) {
+      merged.set(key, value);
+    }
+  }
+  merged.set(RESUMABLE_STREAM_ID_HEADER, streamId);
+  return merged;
+}

--- a/packages/assistant-stream/src/resumable/errors.ts
+++ b/packages/assistant-stream/src/resumable/errors.ts
@@ -1,0 +1,26 @@
+export type ResumableStreamErrorCode =
+  | "missing"
+  | "exists"
+  | "finalized"
+  | "invalid-id";
+
+export class ResumableStreamError extends Error {
+  readonly code: ResumableStreamErrorCode;
+
+  constructor(code: ResumableStreamErrorCode, message: string) {
+    super(message);
+    this.name = "ResumableStreamError";
+    this.code = code;
+  }
+}
+
+const STREAM_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,256}$/;
+
+export function validateStreamId(streamId: string): void {
+  if (!STREAM_ID_PATTERN.test(streamId)) {
+    throw new ResumableStreamError(
+      "invalid-id",
+      `Invalid streamId: ${streamId} (must match ${STREAM_ID_PATTERN})`,
+    );
+  }
+}

--- a/packages/assistant-stream/src/resumable/index.ts
+++ b/packages/assistant-stream/src/resumable/index.ts
@@ -1,0 +1,36 @@
+export type {
+  ResumableStreamStore,
+  ResumableStreamRole,
+  ResumableStreamStatus,
+  ResumableStreamEntry,
+  ResumableStreamAcquireOptions,
+} from "./types";
+
+export {
+  ResumableStreamError,
+  type ResumableStreamErrorCode,
+} from "./errors";
+
+export {
+  createResumableStreamContext,
+  type ResumableStreamContext,
+  type ResumableStreamContextOptions,
+} from "./ResumableStreamContext";
+
+export {
+  createResumableAssistantStreamResponse,
+  createResumeAssistantStreamResponse,
+  RESUMABLE_STREAM_ID_HEADER,
+  type CreateResumableAssistantStreamResponseOptions,
+  type CreateResumeAssistantStreamResponseOptions,
+} from "./createResumableAssistantStreamResponse";
+
+export {
+  createInMemoryResumableStreamStore,
+  type InMemoryResumableStreamStoreOptions,
+} from "./stores/InMemoryResumableStreamStore";
+
+export type {
+  RedisLikeClient,
+  RedisResumableStreamStoreOptions,
+} from "./stores/redis-impl";

--- a/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.test.ts
+++ b/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it, vi } from "vitest";
+import { createInMemoryResumableStreamStore } from "./InMemoryResumableStreamStore";
+import type { ResumableStreamEntry } from "../types";
+
+const bytes = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+const decode = (chunk: Uint8Array): string => new TextDecoder().decode(chunk);
+
+async function drain(
+  iter: AsyncIterable<ResumableStreamEntry>,
+): Promise<string[]> {
+  const out: string[] = [];
+  for await (const entry of iter) out.push(decode(entry.chunk));
+  return out;
+}
+
+describe("InMemoryResumableStreamStore", () => {
+  it("elects exactly one producer per stream id", async () => {
+    const store = createInMemoryResumableStreamStore();
+    const first = await store.acquire("a");
+    const second = await store.acquire("a");
+    const third = await store.acquire("a");
+    expect(first).toBe("producer");
+    expect(second).toBe("consumer");
+    expect(third).toBe("consumer");
+  });
+
+  it("isolates streams by id", async () => {
+    const store = createInMemoryResumableStreamStore();
+    expect(await store.acquire("a")).toBe("producer");
+    expect(await store.acquire("b")).toBe("producer");
+  });
+
+  it("replays buffered entries and tails new ones until finalize", async () => {
+    const store = createInMemoryResumableStreamStore();
+    await store.acquire("a");
+    await store.append("a", bytes("hello "));
+    await store.append("a", bytes("world"));
+
+    const ac = new AbortController();
+    const collected: string[] = [];
+    const reading = (async () => {
+      for await (const entry of store.read("a", "", ac.signal)) {
+        collected.push(decode(entry.chunk));
+        if (collected.length === 3) {
+          await store.finalize("a", "done");
+        }
+      }
+    })();
+
+    await store.append("a", bytes("!"));
+    await reading;
+    expect(collected).toEqual(["hello ", "world", "!"]);
+  });
+
+  it("status transitions: missing → streaming → done", async () => {
+    const store = createInMemoryResumableStreamStore();
+    expect(await store.status("a")).toBe("missing");
+    await store.acquire("a");
+    expect(await store.status("a")).toBe("streaming");
+    await store.finalize("a", "done");
+    expect(await store.status("a")).toBe("done");
+  });
+
+  it("status reports error after error finalize", async () => {
+    const store = createInMemoryResumableStreamStore();
+    await store.acquire("a");
+    await store.finalize("a", "error", "boom");
+    expect(await store.status("a")).toBe("error");
+  });
+
+  it("read throws on the next iteration after error finalize", async () => {
+    const store = createInMemoryResumableStreamStore();
+    await store.acquire("a");
+    await store.append("a", bytes("partial"));
+    await store.finalize("a", "error", "boom");
+
+    const ac = new AbortController();
+    const seen: string[] = [];
+    await expect(async () => {
+      for await (const entry of store.read("a", "", ac.signal)) {
+        seen.push(decode(entry.chunk));
+      }
+    }).rejects.toThrow("boom");
+    expect(seen).toEqual(["partial"]);
+  });
+
+  it("a consumer joining after done replays everything", async () => {
+    const store = createInMemoryResumableStreamStore();
+    await store.acquire("a");
+    await store.append("a", bytes("a"));
+    await store.append("a", bytes("b"));
+    await store.append("a", bytes("c"));
+    await store.finalize("a", "done");
+
+    const ac = new AbortController();
+    expect(await drain(store.read("a", "", ac.signal))).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("cursor advances and skips already-seen entries", async () => {
+    const store = createInMemoryResumableStreamStore();
+    await store.acquire("a");
+    await store.append("a", bytes("1"));
+    await store.append("a", bytes("2"));
+    await store.append("a", bytes("3"));
+    await store.finalize("a", "done");
+
+    const ac = new AbortController();
+    const seen: { cursor: string; text: string }[] = [];
+    for await (const entry of store.read("a", "", ac.signal)) {
+      seen.push({ cursor: entry.cursor, text: decode(entry.chunk) });
+    }
+    expect(seen.map((s) => s.text)).toEqual(["1", "2", "3"]);
+
+    const afterFirst = seen[0]!.cursor;
+    expect(await drain(store.read("a", afterFirst, ac.signal))).toEqual([
+      "2",
+      "3",
+    ]);
+  });
+
+  it("aborting the read signal terminates without throwing", async () => {
+    const store = createInMemoryResumableStreamStore();
+    await store.acquire("a");
+    const ac = new AbortController();
+    const collected: string[] = [];
+    const reading = (async () => {
+      for await (const entry of store.read("a", "", ac.signal)) {
+        collected.push(decode(entry.chunk));
+      }
+    })();
+    await store.append("a", bytes("x"));
+    await new Promise((r) => setTimeout(r, 5));
+    ac.abort();
+    await reading;
+    expect(collected).toEqual(["x"]);
+  });
+
+  it("multiple consumers can read concurrently", async () => {
+    const store = createInMemoryResumableStreamStore();
+    await store.acquire("a");
+    const ac = new AbortController();
+    const a = drain(store.read("a", "", ac.signal));
+    const b = drain(store.read("a", "", ac.signal));
+    await store.append("a", bytes("x"));
+    await store.append("a", bytes("y"));
+    await store.finalize("a", "done");
+    expect(await a).toEqual(["x", "y"]);
+    expect(await b).toEqual(["x", "y"]);
+  });
+
+  it("delete prevents further reads and ends in-flight reads", async () => {
+    const store = createInMemoryResumableStreamStore();
+    await store.acquire("a");
+    const ac = new AbortController();
+    const reading = drain(store.read("a", "", ac.signal));
+    await store.append("a", bytes("x"));
+    await new Promise((r) => setTimeout(r, 0));
+    await store.delete("a");
+    expect(await reading).toEqual(["x"]);
+    expect(await store.status("a")).toBe("missing");
+  });
+
+  it("expired streams are evicted on next access", async () => {
+    let now = 1_000;
+    const store = createInMemoryResumableStreamStore({
+      defaultTtlMs: 100,
+      now: () => now,
+    });
+    await store.acquire("a");
+    await store.append("a", bytes("hi"));
+    expect(await store.status("a")).toBe("streaming");
+    now += 200;
+    expect(await store.status("a")).toBe("missing");
+  });
+
+  it("appending refreshes TTL", async () => {
+    let now = 1_000;
+    const store = createInMemoryResumableStreamStore({
+      defaultTtlMs: 100,
+      now: () => now,
+    });
+    await store.acquire("a");
+    now += 80;
+    await store.append("a", bytes("x"));
+    now += 80;
+    expect(await store.status("a")).toBe("streaming");
+  });
+
+  it("rejects append on finalized stream", async () => {
+    const store = createInMemoryResumableStreamStore();
+    await store.acquire("a");
+    await store.finalize("a", "done");
+    await expect(store.append("a", bytes("late"))).rejects.toThrow(
+      /already finalized/,
+    );
+  });
+
+  it("rejects append on missing stream", async () => {
+    const store = createInMemoryResumableStreamStore();
+    await expect(store.append("a", bytes("x"))).rejects.toThrow(
+      /Stream not found/,
+    );
+  });
+
+  it("finalize is idempotent", async () => {
+    const store = createInMemoryResumableStreamStore();
+    await store.acquire("a");
+    await store.finalize("a", "done");
+    await store.finalize("a", "done");
+    expect(await store.status("a")).toBe("done");
+  });
+
+  it("rejects append when chunk exceeds maxChunkBytes", async () => {
+    const store = createInMemoryResumableStreamStore({ maxChunkBytes: 4 });
+    await store.acquire("a");
+    await expect(store.append("a", bytes("hello"))).rejects.toThrow(
+      /Chunk exceeds maxChunkBytes: 5/,
+    );
+    await store.append("a", bytes("ok"));
+    expect(await store.status("a")).toBe("streaming");
+  });
+
+  it("rejects append when stream reaches maxEntriesPerStream", async () => {
+    const store = createInMemoryResumableStreamStore({
+      maxEntriesPerStream: 2,
+    });
+    await store.acquire("a");
+    await store.append("a", bytes("1"));
+    await store.append("a", bytes("2"));
+    await expect(store.append("a", bytes("3"))).rejects.toThrow(
+      /Stream exceeded maxEntriesPerStream: a/,
+    );
+  });
+
+  it("rejects acquire when active stream count exceeds maxStreams", async () => {
+    const store = createInMemoryResumableStreamStore({ maxStreams: 2 });
+    await store.acquire("a");
+    await store.acquire("b");
+    await expect(store.acquire("c")).rejects.toThrow(/maxStreams exceeded/);
+    expect(await store.acquire("a")).toBe("consumer");
+  });
+
+  it("gc sweeper evicts expired streams without explicit access", async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 1_000;
+      const store = createInMemoryResumableStreamStore({
+        defaultTtlMs: 100,
+        gcIntervalMs: 50,
+        now: () => now,
+      });
+      await store.acquire("a");
+      await store.append("a", bytes("hi"));
+      now += 200;
+      vi.advanceTimersByTime(50);
+      expect(await store.status("a")).toBe("missing");
+      store.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dispose clears the gc interval", async () => {
+    vi.useFakeTimers();
+    try {
+      const clearSpy = vi.spyOn(globalThis, "clearInterval");
+      const store = createInMemoryResumableStreamStore({ gcIntervalMs: 50 });
+      store.dispose();
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      clearSpy.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dispose is a no-op when gcIntervalMs is undefined", () => {
+    const store = createInMemoryResumableStreamStore();
+    expect(() => store.dispose()).not.toThrow();
+  });
+});

--- a/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.ts
+++ b/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.ts
@@ -1,0 +1,235 @@
+import { validateStreamId } from "../errors";
+import type {
+  ResumableStreamEntry,
+  ResumableStreamStatus,
+  ResumableStreamStore,
+} from "../types";
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+type FinalizeMarker = { kind: "done" } | { kind: "error"; error: string };
+
+type StreamState = {
+  entries: ResumableStreamEntry[];
+  nextSeq: number;
+  expiresAt: number;
+  ttlMs: number;
+  final: FinalizeMarker | undefined;
+  waiters: Array<() => void>;
+};
+
+const cursorOf = (seq: number): string => seq.toString(36);
+const seqFromCursor = (cursor: string): number => {
+  if (cursor === "") return 0;
+  const parsed = Number.parseInt(cursor, 36);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+export type InMemoryResumableStreamStoreOptions = {
+  readonly defaultTtlMs?: number;
+  readonly now?: () => number;
+  readonly maxChunkBytes?: number;
+  readonly maxEntriesPerStream?: number;
+  readonly maxStreams?: number;
+  readonly gcIntervalMs?: number;
+};
+
+export function createInMemoryResumableStreamStore(
+  options: InMemoryResumableStreamStoreOptions = {},
+): ResumableStreamStore & { dispose: () => void } {
+  const streams = new Map<string, StreamState>();
+  const defaultTtlMs = options.defaultTtlMs ?? DEFAULT_TTL_MS;
+  const now = options.now ?? Date.now;
+  const maxChunkBytes = options.maxChunkBytes;
+  const maxEntriesPerStream = options.maxEntriesPerStream;
+  const maxStreams = options.maxStreams;
+
+  const evictExpired = (): void => {
+    const t = now();
+    for (const [id, state] of streams) {
+      if (state.expiresAt > t) continue;
+      streams.delete(id);
+      state.final ??= { kind: "error", error: "Stream expired" };
+      notify(state);
+    }
+  };
+
+  const notify = (state: StreamState): void => {
+    const waiters = state.waiters;
+    state.waiters = [];
+    for (const wake of waiters) wake();
+  };
+
+  const findStartIndex = (state: StreamState, cursor: string): number => {
+    if (cursor === "") return 0;
+    const after = seqFromCursor(cursor);
+    let lo = 0;
+    let hi = state.entries.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      const seq = seqFromCursor(state.entries[mid]!.cursor);
+      if (seq <= after) lo = mid + 1;
+      else hi = mid;
+    }
+    return lo;
+  };
+
+  const waitForUpdate = (
+    state: StreamState,
+    signal: AbortSignal,
+    wakeBy?: number,
+  ): Promise<void> =>
+    new Promise<void>((resolve) => {
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const wake = () => {
+        if (settled) return;
+        settled = true;
+        if (timer !== undefined) clearTimeout(timer);
+        signal.removeEventListener("abort", wake);
+        const idx = state.waiters.indexOf(wake);
+        if (idx !== -1) state.waiters.splice(idx, 1);
+        resolve();
+      };
+      if (signal.aborted) {
+        wake();
+        return;
+      }
+      state.waiters.push(wake);
+      signal.addEventListener("abort", wake, { once: true });
+      if (wakeBy !== undefined) {
+        if (wakeBy > 0) {
+          timer = setTimeout(wake, wakeBy);
+        } else {
+          // already past the deadline; resolve so the caller can re-check
+          // expiration without waiting for an external notify.
+          wake();
+        }
+      }
+    });
+
+  const requireActive = (streamId: string): StreamState => {
+    evictExpired();
+    const state = streams.get(streamId);
+    if (!state) throw new Error(`Stream not found: ${streamId}`);
+    if (state.final) {
+      throw new Error(`Stream already finalized: ${streamId}`);
+    }
+    return state;
+  };
+
+  const gcTimer =
+    options.gcIntervalMs !== undefined
+      ? setInterval(evictExpired, options.gcIntervalMs)
+      : undefined;
+  gcTimer?.unref?.();
+
+  return {
+    async acquire(streamId, acquireOptions) {
+      validateStreamId(streamId);
+      evictExpired();
+      const existing = streams.get(streamId);
+      if (existing) return "consumer";
+
+      if (maxStreams !== undefined && streams.size >= maxStreams) {
+        throw new Error("maxStreams exceeded");
+      }
+
+      const ttlMs = acquireOptions?.ttlMs ?? defaultTtlMs;
+      streams.set(streamId, {
+        entries: [],
+        nextSeq: 1,
+        expiresAt: now() + ttlMs,
+        ttlMs,
+        final: undefined,
+        waiters: [],
+      });
+      return "producer";
+    },
+
+    async append(streamId, chunk) {
+      validateStreamId(streamId);
+      if (maxChunkBytes !== undefined && chunk.byteLength > maxChunkBytes) {
+        throw new Error(`Chunk exceeds maxChunkBytes: ${chunk.byteLength}`);
+      }
+      const state = requireActive(streamId);
+      if (
+        maxEntriesPerStream !== undefined &&
+        state.entries.length >= maxEntriesPerStream
+      ) {
+        throw new Error(`Stream exceeded maxEntriesPerStream: ${streamId}`);
+      }
+      const seq = state.nextSeq;
+      state.nextSeq += 1;
+      state.entries.push({ cursor: cursorOf(seq), chunk });
+      state.expiresAt = now() + state.ttlMs;
+      notify(state);
+    },
+
+    async finalize(streamId, status, error) {
+      validateStreamId(streamId);
+      evictExpired();
+      const state = streams.get(streamId);
+      if (!state) throw new Error(`Stream not found: ${streamId}`);
+      if (state.final) return;
+      state.final =
+        status === "done"
+          ? { kind: "done" }
+          : { kind: "error", error: error ?? "Stream errored" };
+      state.expiresAt = now() + state.ttlMs;
+      notify(state);
+    },
+
+    async *read(streamId, cursor, signal) {
+      validateStreamId(streamId);
+      evictExpired();
+      const state = streams.get(streamId);
+      if (!state) throw new Error(`Stream not found: ${streamId}`);
+
+      let idx = findStartIndex(state, cursor);
+
+      while (true) {
+        if (signal.aborted) return;
+
+        while (idx < state.entries.length) {
+          if (signal.aborted) return;
+          yield state.entries[idx]!;
+          idx += 1;
+        }
+
+        if (state.final) {
+          if (state.final.kind === "error") {
+            throw new Error(state.final.error);
+          }
+          return;
+        }
+
+        const wakeBy = state.expiresAt - now();
+        await waitForUpdate(state, signal, wakeBy);
+        evictExpired();
+      }
+    },
+
+    async status(streamId): Promise<ResumableStreamStatus> {
+      validateStreamId(streamId);
+      evictExpired();
+      const state = streams.get(streamId);
+      if (!state) return "missing";
+      if (!state.final) return "streaming";
+      return state.final.kind === "error" ? "error" : "done";
+    },
+
+    async delete(streamId) {
+      validateStreamId(streamId);
+      const state = streams.get(streamId);
+      if (!state) return;
+      streams.delete(streamId);
+      state.final ??= { kind: "done" };
+      notify(state);
+    },
+
+    dispose() {
+      if (gcTimer !== undefined) clearInterval(gcTimer);
+    },
+  };
+}

--- a/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.ts
+++ b/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.ts
@@ -1,11 +1,10 @@
+import { DEFAULT_TTL_MS } from "../constants";
 import { ResumableStreamError, validateStreamId } from "../errors";
 import type {
   ResumableStreamEntry,
   ResumableStreamStatus,
   ResumableStreamStore,
 } from "../types";
-
-const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
 
 type FinalizeMarker = { kind: "done" } | { kind: "error"; error: string };
 

--- a/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.ts
+++ b/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.ts
@@ -1,4 +1,4 @@
-import { validateStreamId } from "../errors";
+import { ResumableStreamError, validateStreamId } from "../errors";
 import type {
   ResumableStreamEntry,
   ResumableStreamStatus,
@@ -113,7 +113,10 @@ export function createInMemoryResumableStreamStore(
     const state = streams.get(streamId);
     if (!state) throw new Error(`Stream not found: ${streamId}`);
     if (state.final) {
-      throw new Error(`Stream already finalized: ${streamId}`);
+      throw new ResumableStreamError(
+        "finalized",
+        `Stream already finalized: ${streamId}`,
+      );
     }
     return state;
   };

--- a/packages/assistant-stream/src/resumable/stores/ioredis.ts
+++ b/packages/assistant-stream/src/resumable/stores/ioredis.ts
@@ -1,0 +1,123 @@
+import type {
+  ChainableCommander,
+  Cluster as IoRedisCluster,
+  Redis as IoRedis,
+} from "ioredis";
+import {
+  RedisResumableStreamStore,
+  type PipelineCommand,
+  type RedisLikeClient,
+  type RedisResumableStreamStoreOptions,
+} from "./redis-impl";
+import type { ResumableStreamStore } from "../types";
+
+export type IoRedisLike = IoRedis | IoRedisCluster;
+
+/**
+ * Resumable stream store backed by [`ioredis`](https://www.npmjs.com/package/ioredis)
+ * v5. Accepts a `Redis` or `Cluster` instance.
+ */
+export function createIoredisResumableStreamStore(
+  client: IoRedisLike,
+  options?: RedisResumableStreamStoreOptions,
+): ResumableStreamStore {
+  return new RedisResumableStreamStore(adapt(client), options);
+}
+
+function adapt(client: IoRedisLike): RedisLikeClient {
+  return {
+    async setNX(key, value, ttlSec) {
+      const result = await client.set(key, value, "EX", ttlSec, "NX");
+      return result === "OK";
+    },
+    async set(key, value, ttlSec) {
+      await client.set(key, value, "EX", ttlSec);
+    },
+    async get(key) {
+      return client.get(key);
+    },
+    async expire(key, ttlSec) {
+      await client.expire(key, ttlSec);
+    },
+    async exists(key) {
+      const result = await client.exists(key);
+      return result > 0;
+    },
+    async del(keys) {
+      if (keys.length === 0) return;
+      await client.del(...keys);
+    },
+    async xAdd(key, fields) {
+      const id = await client.xadd(key, "*", ...toFieldArgs(fields));
+      return id ?? "";
+    },
+    async xRange(key, start, end) {
+      const entries = await client.xrangeBuffer(key, start, end);
+      return entries.map(([idBuf, fieldArray]) => ({
+        id: idBuf.toString("utf8"),
+        fields: bufferFieldsToRecord(fieldArray),
+      }));
+    },
+    async pipeline(commands) {
+      if (commands.length === 0) return;
+      const pipe = client.pipeline();
+      for (const cmd of commands) {
+        applyPipelineCommand(pipe, cmd);
+      }
+      const results = (await pipe.exec()) ?? [];
+      for (const [err] of results) {
+        if (err) throw err;
+      }
+    },
+  };
+}
+
+function applyPipelineCommand(
+  pipe: ChainableCommander,
+  cmd: PipelineCommand,
+): void {
+  switch (cmd.type) {
+    case "xAdd":
+      pipe.xadd(cmd.key, "*", ...toFieldArgs(cmd.fields));
+      return;
+    case "expire":
+      pipe.expire(cmd.key, cmd.ttlSec);
+      return;
+    case "set":
+      pipe.set(cmd.key, cmd.value, "EX", cmd.ttlSec);
+      return;
+  }
+}
+
+function toFieldArgs(
+  fields: Record<string, string | Uint8Array>,
+): Array<string | Buffer> {
+  const args: Array<string | Buffer> = [];
+  for (const [k, v] of Object.entries(fields)) {
+    args.push(k, typeof v === "string" ? v : toBuffer(v));
+  }
+  return args;
+}
+
+function toBuffer(bytes: Uint8Array): Buffer {
+  if (Buffer.isBuffer(bytes)) return bytes;
+  return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function bufferFieldsToRecord(
+  fields: Buffer[],
+): Record<string, string | Uint8Array> {
+  const out: Record<string, string | Uint8Array> = {};
+  for (let i = 0; i + 1 < fields.length; i += 2) {
+    const key = fields[i]?.toString("utf8");
+    const value = fields[i + 1];
+    if (key !== undefined && value !== undefined) {
+      out[key] = new Uint8Array(
+        value.buffer,
+        value.byteOffset,
+        value.byteLength,
+      );
+    }
+  }
+  return out;
+}

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_TTL_MS } from "../constants";
 import { ResumableStreamError, validateStreamId } from "../errors";
 import type {
   ResumableStreamAcquireOptions,
@@ -7,7 +8,6 @@ import type {
   ResumableStreamStore,
 } from "../types";
 
-const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_POLL_INTERVAL_MS = 100;
 const DEFAULT_KEY_PREFIX = "aui:resumable";
 
@@ -287,15 +287,18 @@ function sleep(ms: number, signal: AbortSignal): Promise<void> {
   });
 }
 
+const SHARED_DECODER = new TextDecoder();
+const SHARED_ENCODER = new TextEncoder();
+
 function readString(
   value: string | Uint8Array | undefined,
 ): string | undefined {
   if (value === undefined) return undefined;
   if (typeof value === "string") return value;
-  return new TextDecoder().decode(value);
+  return SHARED_DECODER.decode(value);
 }
 
 function toBytes(value: string | Uint8Array): Uint8Array {
   if (value instanceof Uint8Array) return value;
-  return new TextEncoder().encode(value);
+  return SHARED_ENCODER.encode(value);
 }

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.ts
@@ -1,0 +1,301 @@
+import { ResumableStreamError, validateStreamId } from "../errors";
+import type {
+  ResumableStreamAcquireOptions,
+  ResumableStreamEntry,
+  ResumableStreamRole,
+  ResumableStreamStatus,
+  ResumableStreamStore,
+} from "../types";
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_POLL_INTERVAL_MS = 100;
+const DEFAULT_KEY_PREFIX = "aui:resumable";
+
+const FIELD_CHUNK = "c";
+const FIELD_FIN = "fin";
+const FIELD_ERROR = "error";
+
+const FIN_DONE = "done";
+const FIN_ERROR = "error";
+
+const STREAM_START_ID = "0-0";
+
+export type PipelineCommand =
+  | {
+      readonly type: "xAdd";
+      readonly key: string;
+      readonly fields: Record<string, string | Uint8Array>;
+    }
+  | { readonly type: "expire"; readonly key: string; readonly ttlSec: number }
+  | {
+      readonly type: "set";
+      readonly key: string;
+      readonly value: string;
+      readonly ttlSec: number;
+    };
+
+/**
+ * Structural Redis-client interface. The bundled `redis` and `ioredis`
+ * adapters wrap their respective clients to satisfy it; custom or proxied
+ * clients can implement it directly.
+ */
+export interface RedisLikeClient {
+  setNX(key: string, value: string, ttlSec: number): Promise<boolean>;
+  set(key: string, value: string, ttlSec: number): Promise<void>;
+  get(key: string): Promise<string | null>;
+  expire(key: string, ttlSec: number): Promise<void>;
+  exists(key: string): Promise<boolean>;
+  del(keys: string[]): Promise<void>;
+  xAdd(
+    key: string,
+    fields: Record<string, string | Uint8Array>,
+  ): Promise<string>;
+  xRange(
+    key: string,
+    start: string,
+    end: string,
+  ): Promise<
+    Array<{ id: string; fields: Record<string, string | Uint8Array> }>
+  >;
+  /** Executes the commands as a single pipeline batch (one round trip). */
+  pipeline(commands: readonly PipelineCommand[]): Promise<void>;
+}
+
+export type RedisResumableStreamStoreOptions = {
+  readonly keyPrefix?: string;
+  readonly defaultTtlMs?: number;
+  /** Defaults to 100ms. Lower values reduce read latency, raise traffic. */
+  readonly pollIntervalMs?: number;
+  readonly maxChunkBytes?: number;
+};
+
+export class RedisResumableStreamStore implements ResumableStreamStore {
+  private readonly client: RedisLikeClient;
+  private readonly keyPrefix: string;
+  private readonly defaultTtlMs: number;
+  private readonly pollIntervalMs: number;
+  private readonly maxChunkBytes: number | undefined;
+
+  constructor(
+    client: RedisLikeClient,
+    options: RedisResumableStreamStoreOptions = {},
+  ) {
+    this.client = client;
+    this.keyPrefix = options.keyPrefix ?? DEFAULT_KEY_PREFIX;
+    this.defaultTtlMs = options.defaultTtlMs ?? DEFAULT_TTL_MS;
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.maxChunkBytes = options.maxChunkBytes;
+  }
+
+  async acquire(
+    streamId: string,
+    options?: ResumableStreamAcquireOptions,
+  ): Promise<ResumableStreamRole> {
+    validateStreamId(streamId);
+    const ttlSec = msToSec(options?.ttlMs ?? this.defaultTtlMs);
+    const meta = JSON.stringify({ status: "streaming", ttlSec });
+    const acquired = await this.client.setNX(
+      this.metaKey(streamId),
+      meta,
+      ttlSec,
+    );
+    if (acquired) {
+      // a prior producer's data key may outlive its expired meta key.
+      await this.client.del([this.dataKey(streamId)]);
+      return "producer";
+    }
+    return "consumer";
+  }
+
+  async append(streamId: string, chunk: Uint8Array): Promise<void> {
+    validateStreamId(streamId);
+    if (
+      this.maxChunkBytes !== undefined &&
+      chunk.byteLength > this.maxChunkBytes
+    ) {
+      throw new Error(
+        `Chunk exceeds maxChunkBytes (${chunk.byteLength} > ${this.maxChunkBytes})`,
+      );
+    }
+    const dataKey = this.dataKey(streamId);
+    const metaKey = this.metaKey(streamId);
+    const meta = await this.readMeta(streamId);
+    if (!meta) {
+      throw new Error(`Stream not found: ${streamId}`);
+    }
+    if (meta.status !== "streaming") {
+      throw new ResumableStreamError(
+        "finalized",
+        `Stream already finalized: ${streamId}`,
+      );
+    }
+    const ttlSec = meta.ttlSec ?? msToSec(this.defaultTtlMs);
+    await this.client.pipeline([
+      { type: "xAdd", key: dataKey, fields: { [FIELD_CHUNK]: chunk } },
+      { type: "expire", key: dataKey, ttlSec },
+      { type: "expire", key: metaKey, ttlSec },
+    ]);
+  }
+
+  async finalize(
+    streamId: string,
+    status: "done" | "error",
+    error?: string,
+  ): Promise<void> {
+    validateStreamId(streamId);
+    const dataKey = this.dataKey(streamId);
+    const metaKey = this.metaKey(streamId);
+    const existing = await this.readMeta(streamId);
+    if (!existing) {
+      throw new Error(`Stream not found: ${streamId}`);
+    }
+    // a second finalize must not append a duplicate FIN entry.
+    if (existing.status !== "streaming") return;
+    const ttlSec = existing.ttlSec ?? msToSec(this.defaultTtlMs);
+    const meta = JSON.stringify(
+      status === "error"
+        ? { status: "error", error: error ?? "Stream errored", ttlSec }
+        : { status: "done", ttlSec },
+    );
+    const fields: Record<string, string> = {
+      [FIELD_FIN]: status === "error" ? FIN_ERROR : FIN_DONE,
+    };
+    if (status === "error") {
+      fields[FIELD_ERROR] = error ?? "Stream errored";
+    }
+    await this.client.pipeline([
+      { type: "set", key: metaKey, value: meta, ttlSec },
+      { type: "xAdd", key: dataKey, fields },
+      { type: "expire", key: dataKey, ttlSec },
+    ]);
+  }
+
+  async *read(
+    streamId: string,
+    cursor: string,
+    signal: AbortSignal,
+  ): AsyncIterable<ResumableStreamEntry> {
+    validateStreamId(streamId);
+    const dataKey = this.dataKey(streamId);
+    const metaKey = this.metaKey(streamId);
+    const initialMeta = await this.client.get(metaKey);
+    if (initialMeta === null) {
+      throw new Error(`Stream not found: ${streamId}`);
+    }
+
+    let lastId = cursor === "" ? STREAM_START_ID : cursor;
+
+    while (true) {
+      if (signal.aborted) return;
+
+      const start = lastId === STREAM_START_ID ? "-" : `(${lastId}`;
+      const entries = await this.client.xRange(dataKey, start, "+");
+
+      for (const entry of entries) {
+        if (signal.aborted) return;
+        lastId = entry.id;
+
+        const fin = readString(entry.fields[FIELD_FIN]);
+        if (fin === FIN_DONE) return;
+        if (fin === FIN_ERROR) {
+          throw new Error(
+            readString(entry.fields[FIELD_ERROR]) ?? "Stream errored",
+          );
+        }
+
+        const raw = entry.fields[FIELD_CHUNK];
+        if (raw === undefined) continue;
+        yield { cursor: entry.id, chunk: toBytes(raw) };
+      }
+
+      if (entries.length > 0) continue;
+
+      const stillExists = await this.client.exists(metaKey);
+      if (!stillExists) return;
+
+      await sleep(this.pollIntervalMs, signal);
+    }
+  }
+
+  async status(streamId: string): Promise<ResumableStreamStatus> {
+    validateStreamId(streamId);
+    const meta = await this.client.get(this.metaKey(streamId));
+    if (meta === null) return "missing";
+    const parsed = parseMeta(meta);
+    if (parsed?.status === "streaming") return "streaming";
+    if (parsed?.status === "done") return "done";
+    if (parsed?.status === "error") return "error";
+    return "missing";
+  }
+
+  async delete(streamId: string): Promise<void> {
+    validateStreamId(streamId);
+    await this.client.del([this.metaKey(streamId), this.dataKey(streamId)]);
+  }
+
+  private async readMeta(streamId: string): Promise<ParsedMeta | undefined> {
+    const raw = await this.client.get(this.metaKey(streamId));
+    if (raw === null) return undefined;
+    return parseMeta(raw);
+  }
+
+  // {streamId} is a Redis Cluster hash tag so both keys live on the same
+  // shard; multi-key DEL and same-stream pipelines stay single-slot.
+  private metaKey(streamId: string): string {
+    return `${this.keyPrefix}:{${streamId}}:meta`;
+  }
+
+  private dataKey(streamId: string): string {
+    return `${this.keyPrefix}:{${streamId}}:data`;
+  }
+}
+
+type ParsedMeta = {
+  status?: string;
+  error?: string;
+  ttlSec?: number;
+};
+
+function parseMeta(value: string): ParsedMeta | undefined {
+  try {
+    const parsed = JSON.parse(value) as ParsedMeta;
+    return parsed && typeof parsed === "object" ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function msToSec(ms: number): number {
+  return Math.max(1, Math.ceil(ms / 1000));
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function readString(
+  value: string | Uint8Array | undefined,
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") return value;
+  return new TextDecoder().decode(value);
+}
+
+function toBytes(value: string | Uint8Array): Uint8Array {
+  if (value instanceof Uint8Array) return value;
+  return new TextEncoder().encode(value);
+}

--- a/packages/assistant-stream/src/resumable/stores/redis.test.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis.test.ts
@@ -1,0 +1,265 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createClient, type RedisClientType } from "redis";
+import IoRedis from "ioredis";
+import { createRedisResumableStreamStore } from "./redis";
+import { createIoredisResumableStreamStore } from "./ioredis";
+import type { ResumableStreamStore } from "../types";
+
+// Redis adapter tests are skipped unless a reachable Redis is signaled via
+// REDIS_URL or REDIS_TESTS=1. CI without a redis service is the default.
+const REDIS_URL = process.env["REDIS_URL"] ?? "redis://127.0.0.1:6379";
+const REDIS_TESTS_DISABLED =
+  process.env["REDIS_URL"] === undefined && process.env["REDIS_TESTS"] !== "1";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+const bytes = (s: string): Uint8Array => enc.encode(s);
+const text = (b: Uint8Array): string => dec.decode(b);
+
+const KEY_PREFIX_BASE = `aui:resumable:test:${Date.now()}`;
+let suiteCounter = 0;
+
+type Adapter = {
+  name: string;
+  setup: () => Promise<{
+    store: ResumableStreamStore;
+    keyPrefix: string;
+    makeStore: (
+      overrides?: Partial<{
+        maxChunkBytes: number;
+      }>,
+    ) => ResumableStreamStore;
+    cleanup: () => Promise<void>;
+  }>;
+};
+
+const adapters: Adapter[] = [
+  {
+    name: "node-redis",
+    setup: async () => {
+      const client: RedisClientType = createClient({ url: REDIS_URL });
+      client.on("error", () => {});
+      await client.connect();
+      const keyPrefix = `${KEY_PREFIX_BASE}:nr:${suiteCounter++}`;
+      const makeStore = (overrides?: { maxChunkBytes?: number }) =>
+        createRedisResumableStreamStore(client, {
+          keyPrefix,
+          pollIntervalMs: 25,
+          ...overrides,
+        });
+      return {
+        store: makeStore(),
+        keyPrefix,
+        makeStore,
+        cleanup: async () => {
+          const keys = await client.keys(`${keyPrefix}:*`);
+          if (keys.length > 0) await client.del(keys);
+          await client.quit();
+        },
+      };
+    },
+  },
+  {
+    name: "ioredis",
+    setup: async () => {
+      const client = new IoRedis(REDIS_URL, { lazyConnect: true });
+      await client.connect();
+      const keyPrefix = `${KEY_PREFIX_BASE}:io:${suiteCounter++}`;
+      const makeStore = (overrides?: { maxChunkBytes?: number }) =>
+        createIoredisResumableStreamStore(client, {
+          keyPrefix,
+          pollIntervalMs: 25,
+          ...overrides,
+        });
+      return {
+        store: makeStore(),
+        keyPrefix,
+        makeStore,
+        cleanup: async () => {
+          const keys = await client.keys(`${keyPrefix}:*`);
+          if (keys.length > 0) await client.del(...keys);
+          await client.quit();
+        },
+      };
+    },
+  },
+];
+
+for (const adapter of adapters) {
+  describe.skipIf(REDIS_TESTS_DISABLED)(
+    `Redis adapter: ${adapter.name}`,
+    () => {
+      let store: ResumableStreamStore;
+      let makeStore: (overrides?: {
+        maxChunkBytes?: number;
+      }) => ResumableStreamStore;
+      let cleanup: () => Promise<void>;
+
+      beforeAll(async () => {
+        const ctx = await adapter.setup();
+        store = ctx.store;
+        makeStore = ctx.makeStore;
+        cleanup = ctx.cleanup;
+      });
+
+      afterAll(async () => {
+        await cleanup();
+      });
+
+      it("elects exactly one producer per id", async () => {
+        const id = `id-${Math.random()}`;
+        const first = await store.acquire(id);
+        const second = await store.acquire(id);
+        expect(first).toBe("producer");
+        expect(second).toBe("consumer");
+      });
+
+      it("replays buffered chunks and tails until done", async () => {
+        const id = `id-${Math.random()}`;
+        await store.acquire(id);
+        await store.append(id, bytes("hello"));
+        await store.append(id, bytes(" world"));
+
+        const ac = new AbortController();
+        const collected: string[] = [];
+        const reading = (async () => {
+          for await (const entry of store.read(id, "", ac.signal)) {
+            collected.push(text(entry.chunk));
+            if (collected.length === 3) {
+              await store.finalize(id, "done");
+            }
+          }
+        })();
+
+        await new Promise((r) => setTimeout(r, 50));
+        await store.append(id, bytes("!"));
+        await reading;
+        expect(collected.join("")).toBe("hello world!");
+      });
+
+      it("status: missing → streaming → done", async () => {
+        const id = `id-${Math.random()}`;
+        expect(await store.status(id)).toBe("missing");
+        await store.acquire(id);
+        expect(await store.status(id)).toBe("streaming");
+        await store.finalize(id, "done");
+        expect(await store.status(id)).toBe("done");
+      });
+
+      it("status: error finalize", async () => {
+        const id = `id-${Math.random()}`;
+        await store.acquire(id);
+        await store.finalize(id, "error", "boom");
+        expect(await store.status(id)).toBe("error");
+      });
+
+      it("read throws on error finalize after draining buffered entries", async () => {
+        const id = `id-${Math.random()}`;
+        await store.acquire(id);
+        await store.append(id, bytes("partial"));
+        await store.finalize(id, "error", "boom");
+
+        const ac = new AbortController();
+        const seen: string[] = [];
+        await expect(async () => {
+          for await (const entry of store.read(id, "", ac.signal)) {
+            seen.push(text(entry.chunk));
+          }
+        }).rejects.toThrow("boom");
+        expect(seen).toEqual(["partial"]);
+      });
+
+      it("late consumer replays after done", async () => {
+        const id = `id-${Math.random()}`;
+        await store.acquire(id);
+        await store.append(id, bytes("a"));
+        await store.append(id, bytes("b"));
+        await store.append(id, bytes("c"));
+        await store.finalize(id, "done");
+
+        const ac = new AbortController();
+        const out: string[] = [];
+        for await (const entry of store.read(id, "", ac.signal)) {
+          out.push(text(entry.chunk));
+        }
+        expect(out).toEqual(["a", "b", "c"]);
+      });
+
+      it("cursor advances and skips already-seen entries", async () => {
+        const id = `id-${Math.random()}`;
+        await store.acquire(id);
+        await store.append(id, bytes("1"));
+        await store.append(id, bytes("2"));
+        await store.append(id, bytes("3"));
+        await store.finalize(id, "done");
+
+        const ac = new AbortController();
+        const seen: { cursor: string; text: string }[] = [];
+        for await (const entry of store.read(id, "", ac.signal)) {
+          seen.push({ cursor: entry.cursor, text: text(entry.chunk) });
+        }
+        expect(seen.map((s) => s.text)).toEqual(["1", "2", "3"]);
+
+        const out: string[] = [];
+        for await (const entry of store.read(id, seen[0]!.cursor, ac.signal)) {
+          out.push(text(entry.chunk));
+        }
+        expect(out).toEqual(["2", "3"]);
+      });
+
+      it("delete removes a stream", async () => {
+        const id = `id-${Math.random()}`;
+        await store.acquire(id);
+        await store.append(id, bytes("x"));
+        expect(await store.status(id)).toBe("streaming");
+        await store.delete(id);
+        expect(await store.status(id)).toBe("missing");
+      });
+
+      it("preserves arbitrary binary bytes through pipelined append", async () => {
+        const id = `id-${Math.random()}`;
+        await store.acquire(id);
+
+        const producer = new Uint8Array(512);
+        for (let i = 0; i < producer.length; i++) producer[i] = i & 0xff;
+        const half = producer.length / 2;
+        await store.append(id, producer.slice(0, half));
+        await store.append(id, producer.slice(half));
+        await store.finalize(id, "done");
+
+        const ac = new AbortController();
+        const replayed: Uint8Array[] = [];
+        for await (const entry of store.read(id, "", ac.signal)) {
+          replayed.push(entry.chunk);
+        }
+        const total = replayed.reduce((n, c) => n + c.byteLength, 0);
+        const flat = new Uint8Array(total);
+        let offset = 0;
+        for (const c of replayed) {
+          flat.set(c, offset);
+          offset += c.byteLength;
+        }
+        expect(flat.byteLength).toBe(producer.byteLength);
+        expect(Array.from(flat)).toEqual(Array.from(producer));
+      });
+
+      it("rejects appends larger than maxChunkBytes", async () => {
+        const limited = makeStore({ maxChunkBytes: 4 });
+        const id = `id-${Math.random()}`;
+        await limited.acquire(id);
+        await expect(limited.append(id, bytes("12345"))).rejects.toThrow(
+          /maxChunkBytes/,
+        );
+        await limited.append(id, bytes("ok"));
+        await limited.finalize(id, "done");
+
+        const ac = new AbortController();
+        const out: string[] = [];
+        for await (const entry of limited.read(id, "", ac.signal)) {
+          out.push(text(entry.chunk));
+        }
+        expect(out).toEqual(["ok"]);
+      });
+    },
+  );
+}

--- a/packages/assistant-stream/src/resumable/stores/redis.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis.ts
@@ -1,0 +1,171 @@
+import {
+  RedisResumableStreamStore,
+  type PipelineCommand,
+  type RedisLikeClient,
+  type RedisResumableStreamStoreOptions,
+} from "./redis-impl";
+import type { ResumableStreamStore } from "../types";
+
+const RESP_BLOB_STRING = 36;
+
+type NodeRedisFields = Record<string, string | Buffer>;
+
+interface NodeRedisMultiCommand {
+  xAdd(key: string, id: string, fields: NodeRedisFields): NodeRedisMultiCommand;
+  expire(key: string, seconds: number): NodeRedisMultiCommand;
+  set(
+    key: string,
+    value: string,
+    options: { EX: number },
+  ): NodeRedisMultiCommand;
+  execAsPipeline(): Promise<unknown>;
+  exec(): Promise<unknown>;
+}
+
+/** Structural subset of node-redis v5 used by the adapter. */
+export interface NodeRedisLike {
+  set(
+    key: string,
+    value: string,
+    options: { NX: true; EX: number },
+  ): Promise<string | null>;
+  set(
+    key: string,
+    value: string,
+    options: { EX: number },
+  ): Promise<string | null>;
+  get(key: string): Promise<string | null>;
+  expire(key: string, seconds: number): Promise<unknown>;
+  exists(key: string): Promise<number>;
+  del(keys: string | string[]): Promise<unknown>;
+  xAdd(key: string, id: string, fields: NodeRedisFields): Promise<string>;
+  sendCommand<T = unknown>(
+    args: ReadonlyArray<string | Buffer>,
+    options?: { typeMapping?: Record<number, unknown> },
+  ): Promise<T>;
+  multi(): NodeRedisMultiCommand;
+}
+
+/**
+ * Resumable stream store backed by [`redis`](https://www.npmjs.com/package/redis)
+ * v5. Expects a connected client; cluster routing relies on the shared
+ * `{streamId}` hash tag baked into the key scheme.
+ */
+export function createRedisResumableStreamStore(
+  client: NodeRedisLike,
+  options?: RedisResumableStreamStoreOptions,
+): ResumableStreamStore {
+  return new RedisResumableStreamStore(adapt(client), options);
+}
+
+function adapt(client: NodeRedisLike): RedisLikeClient {
+  return {
+    async setNX(key, value, ttlSec) {
+      const result = await client.set(key, value, { NX: true, EX: ttlSec });
+      return result === "OK";
+    },
+    async set(key, value, ttlSec) {
+      await client.set(key, value, { EX: ttlSec });
+    },
+    async get(key) {
+      return client.get(key);
+    },
+    async expire(key, ttlSec) {
+      await client.expire(key, ttlSec);
+    },
+    async exists(key) {
+      const result = await client.exists(key);
+      return result > 0;
+    },
+    async del(keys) {
+      if (keys.length === 0) return;
+      await client.del(keys.length === 1 ? keys[0]! : keys);
+    },
+    async xAdd(key, fields) {
+      return client.xAdd(key, "*", toNodeFields(fields));
+    },
+    async xRange(key, start, end) {
+      const reply = await client.sendCommand<unknown>(
+        ["XRANGE", key, start, end],
+        { typeMapping: { [RESP_BLOB_STRING]: Buffer } },
+      );
+      return parseXRangeReply(reply);
+    },
+    async pipeline(commands) {
+      if (commands.length === 0) return;
+      let chain = client.multi();
+      for (const cmd of commands) {
+        chain = applyPipelineCommand(chain, cmd);
+      }
+      await chain.execAsPipeline();
+    },
+  };
+}
+
+function applyPipelineCommand(
+  chain: NodeRedisMultiCommand,
+  cmd: PipelineCommand,
+): NodeRedisMultiCommand {
+  switch (cmd.type) {
+    case "xAdd":
+      return chain.xAdd(cmd.key, "*", toNodeFields(cmd.fields));
+    case "expire":
+      return chain.expire(cmd.key, cmd.ttlSec);
+    case "set":
+      return chain.set(cmd.key, cmd.value, { EX: cmd.ttlSec });
+  }
+}
+
+function toNodeFields(
+  fields: Record<string, string | Uint8Array>,
+): NodeRedisFields {
+  const out: NodeRedisFields = {};
+  for (const [k, v] of Object.entries(fields)) {
+    out[k] = typeof v === "string" ? v : toBuffer(v);
+  }
+  return out;
+}
+
+function toBuffer(bytes: Uint8Array): Buffer {
+  if (Buffer.isBuffer(bytes)) return bytes;
+  return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function parseXRangeReply(
+  reply: unknown,
+): Array<{ id: string; fields: Record<string, string | Uint8Array> }> {
+  if (!Array.isArray(reply)) return [];
+  const out: Array<{
+    id: string;
+    fields: Record<string, string | Uint8Array>;
+  }> = [];
+  for (const entry of reply) {
+    if (!Array.isArray(entry) || entry.length < 2) continue;
+    const [rawId, rawFields] = entry as [unknown, unknown];
+    const id = bufferOrStringToString(rawId);
+    if (id === undefined || !Array.isArray(rawFields)) continue;
+    const fields: Record<string, string | Uint8Array> = {};
+    for (let i = 0; i + 1 < rawFields.length; i += 2) {
+      const fieldKey = bufferOrStringToString(rawFields[i]);
+      const fieldValue = rawFields[i + 1];
+      if (fieldKey === undefined || fieldValue === undefined) continue;
+      fields[fieldKey] = bufferOrStringToBytes(fieldValue);
+    }
+    out.push({ id, fields });
+  }
+  return out;
+}
+
+function bufferOrStringToString(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (Buffer.isBuffer(value)) return value.toString("utf8");
+  return undefined;
+}
+
+function bufferOrStringToBytes(value: unknown): string | Uint8Array {
+  if (typeof value === "string") return value;
+  if (Buffer.isBuffer(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  return "";
+}

--- a/packages/assistant-stream/src/resumable/types.ts
+++ b/packages/assistant-stream/src/resumable/types.ts
@@ -1,0 +1,49 @@
+export type ResumableStreamRole = "producer" | "consumer";
+
+export type ResumableStreamStatus = "streaming" | "done" | "error" | "missing";
+
+export type ResumableStreamEntry = {
+  readonly cursor: string;
+  readonly chunk: Uint8Array;
+};
+
+export type ResumableStreamAcquireOptions = {
+  readonly ttlMs?: number;
+};
+
+export interface ResumableStreamStore {
+  /**
+   * Atomic election. The first caller for a given `streamId` observes
+   * `"producer"`; every later caller observes `"consumer"`, including those
+   * arriving after `finalize`.
+   */
+  acquire(
+    streamId: string,
+    options?: ResumableStreamAcquireOptions,
+  ): Promise<ResumableStreamRole>;
+
+  /** Implementations should refresh the TTL on each call. */
+  append(streamId: string, chunk: Uint8Array): Promise<void>;
+
+  finalize(
+    streamId: string,
+    status: "done" | "error",
+    error?: string,
+  ): Promise<void>;
+
+  /**
+   * Yields persisted entries strictly after `cursor` (`""` starts from the
+   * beginning), then waits for new ones until the stream is finalized.
+   * Aborting `signal` resolves the iterable without throwing.
+   */
+  read(
+    streamId: string,
+    cursor: string,
+    signal: AbortSignal,
+  ): AsyncIterable<ResumableStreamEntry>;
+
+  status(streamId: string): Promise<ResumableStreamStatus>;
+
+  /** Active readers terminate. No-op when the stream does not exist. */
+  delete(streamId: string): Promise<void>;
+}

--- a/packages/react-ai-sdk/src/index.ts
+++ b/packages/react-ai-sdk/src/index.ts
@@ -5,6 +5,14 @@ export { useAISDKRuntime } from "./ui/use-chat/useAISDKRuntime";
 export { useChatRuntime } from "./ui/use-chat/useChatRuntime";
 export type { UseChatRuntimeOptions } from "./ui/use-chat/useChatRuntime";
 export { AssistantChatTransport } from "./ui/use-chat/AssistantChatTransport";
+export {
+  RESUMABLE_STREAM_ID_HEADER,
+  createResumableSessionStorage,
+} from "./ui/resumable";
+export type {
+  AssistantChatResumableOptions,
+  ResumableClientStorage,
+} from "./ui/resumable";
 export { frontendTools } from "./frontendTools";
 export { injectQuoteContext } from "./injectQuoteContext";
 export type { ThreadTokenUsage, TokenUsageExtractableMessage } from "./usage";

--- a/packages/react-ai-sdk/src/ui/resumable.ts
+++ b/packages/react-ai-sdk/src/ui/resumable.ts
@@ -1,0 +1,42 @@
+"use client";
+
+export const RESUMABLE_STREAM_ID_HEADER = "x-resumable-stream-id";
+
+const DEFAULT_STORAGE_KEY = "aui-resumable-stream-id";
+
+export type ResumableClientStorage = {
+  getStreamId(): string | null;
+  setStreamId(id: string): void;
+  clear(): void;
+};
+
+/** `sessionStorage`-backed storage for the pending resumable stream id. */
+export function createResumableSessionStorage(options?: {
+  key?: string;
+}): ResumableClientStorage {
+  const key = options?.key ?? DEFAULT_STORAGE_KEY;
+  return {
+    getStreamId() {
+      if (typeof window === "undefined") return null;
+      return window.sessionStorage.getItem(key);
+    },
+    setStreamId(id) {
+      if (typeof window === "undefined") return;
+      window.sessionStorage.setItem(key, id);
+    },
+    clear() {
+      if (typeof window === "undefined") return;
+      window.sessionStorage.removeItem(key);
+    },
+  };
+}
+
+export type AssistantChatResumableOptions = {
+  storage: ResumableClientStorage;
+  resumeApi: string | ((streamId: string) => string);
+  /**
+   * Defaults to scanning for the AI SDK UIMessageStream `finish` marker.
+   * Cancellation never invokes this callback, only natural completion does.
+   */
+  isFinishEvent?: (chunk: Uint8Array, accumulator: string) => boolean;
+};

--- a/packages/react-ai-sdk/src/ui/resumable.ts
+++ b/packages/react-ai-sdk/src/ui/resumable.ts
@@ -1,6 +1,6 @@
 "use client";
 
-export const RESUMABLE_STREAM_ID_HEADER = "x-resumable-stream-id";
+export { RESUMABLE_STREAM_ID_HEADER } from "assistant-stream/resumable";
 
 const DEFAULT_STORAGE_KEY = "aui-resumable-stream-id";
 

--- a/packages/react-ai-sdk/src/ui/use-chat/AssistantChatTransport.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/AssistantChatTransport.ts
@@ -8,8 +8,21 @@ import {
   type UIMessage,
 } from "ai";
 import { toToolsJSONSchema } from "assistant-stream";
+import {
+  RESUMABLE_STREAM_ID_HEADER,
+  type AssistantChatResumableOptions,
+} from "../resumable";
 
 type InitializableThreadListItem = Pick<ThreadListItemRuntime, "initialize">;
+
+const FINISH_MARKER = '"type":"finish"';
+const FINISH_BUFFER_LIMIT = 4096;
+const FINISH_BUFFER_TAIL = 1024;
+
+export type AssistantChatTransportInitOptions<UI_MESSAGE extends UIMessage> =
+  HttpChatTransportInitOptions<UI_MESSAGE> & {
+    resumable?: AssistantChatResumableOptions;
+  };
 
 export class AssistantChatTransport<
   UI_MESSAGE extends UIMessage,
@@ -18,9 +31,22 @@ export class AssistantChatTransport<
   private getThreadListItem:
     | (() => InitializableThreadListItem | undefined)
     | undefined;
-  constructor(initOptions?: HttpChatTransportInitOptions<UI_MESSAGE>) {
+  private readonly resumable: AssistantChatResumableOptions | undefined;
+
+  constructor(initOptions?: AssistantChatTransportInitOptions<UI_MESSAGE>) {
+    const { resumable, ...rest } = initOptions ?? {};
+    const userFetch = rest.fetch;
+    const userPrepareReconnect = rest.prepareReconnectToStreamRequest;
+
     super({
-      ...initOptions,
+      ...rest,
+      ...(resumable && {
+        fetch: wrapFetchWithResumable(resumable, userFetch),
+        prepareReconnectToStreamRequest: wrapPrepareReconnect(
+          resumable,
+          userPrepareReconnect,
+        ),
+      }),
       prepareSendMessagesRequest: async (options) => {
         const context = this.runtime?.thread.getModelContext();
         const threadListItem =
@@ -38,7 +64,7 @@ export class AssistantChatTransport<
           },
         };
         const preparedRequest =
-          await initOptions?.prepareSendMessagesRequest?.(optionsEx);
+          await rest.prepareSendMessagesRequest?.(optionsEx);
 
         return {
           ...preparedRequest,
@@ -53,10 +79,16 @@ export class AssistantChatTransport<
         };
       },
     });
+
+    this.resumable = resumable;
   }
 
   setRuntime(runtime: AssistantRuntime) {
     this.runtime = runtime;
+  }
+
+  getResumableAdapter(): AssistantChatResumableOptions | undefined {
+    return this.resumable;
   }
 
   __internal_setGetThreadListItem(
@@ -64,4 +96,73 @@ export class AssistantChatTransport<
   ) {
     this.getThreadListItem = getter;
   }
+}
+
+function wrapFetchWithResumable(
+  resumable: AssistantChatResumableOptions,
+  userFetch: HttpChatTransportInitOptions<UIMessage>["fetch"],
+): NonNullable<HttpChatTransportInitOptions<UIMessage>["fetch"]> {
+  const baseFetch: typeof globalThis.fetch = userFetch
+    ? (input, init) => userFetch(input as RequestInfo | URL, init)
+    : globalThis.fetch.bind(globalThis);
+
+  return async (input, init) => {
+    const res = await baseFetch(input, init);
+    const id = res.headers.get(RESUMABLE_STREAM_ID_HEADER);
+    if (id) resumable.storage.setStreamId(id);
+    if (!res.body) return res;
+
+    const detectFinish = resumable.isFinishEvent ?? defaultIsFinishEvent;
+    // a single decoder is required so multi-byte sequences split across
+    // chunks buffer via stream: true rather than getting dropped.
+    const decoder = new TextDecoder();
+    let accumulator = "";
+    const tap = new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        controller.enqueue(chunk);
+        accumulator += decoder.decode(chunk, { stream: true });
+        if (detectFinish(chunk, accumulator)) {
+          resumable.storage.clear();
+          accumulator = "";
+        } else if (accumulator.length > FINISH_BUFFER_LIMIT) {
+          accumulator = accumulator.slice(-FINISH_BUFFER_TAIL);
+        }
+      },
+    });
+
+    return new Response(res.body.pipeThrough(tap), {
+      status: res.status,
+      statusText: res.statusText,
+      headers: res.headers,
+    });
+  };
+}
+
+function defaultIsFinishEvent(_chunk: Uint8Array, accumulator: string) {
+  return accumulator.includes(FINISH_MARKER);
+}
+
+function wrapPrepareReconnect(
+  resumable: AssistantChatResumableOptions,
+  userPrepareReconnect: HttpChatTransportInitOptions<UIMessage>["prepareReconnectToStreamRequest"],
+): NonNullable<
+  HttpChatTransportInitOptions<UIMessage>["prepareReconnectToStreamRequest"]
+> {
+  return async (options) => {
+    const streamId = resumable.storage.getStreamId();
+    if (!streamId) {
+      throw new Error(
+        "AssistantChatTransport: no resumable stream id available; nothing to resume",
+      );
+    }
+    const api =
+      typeof resumable.resumeApi === "function"
+        ? resumable.resumeApi(streamId)
+        : resumable.resumeApi;
+    const userPrepared = await userPrepareReconnect?.({ ...options, api });
+    return {
+      ...userPrepared,
+      api: userPrepared?.api ?? api,
+    };
+  };
 }

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -15,6 +15,7 @@ import {
 } from "./useAISDKRuntime";
 import type { ChatInit, ChatTransport } from "ai";
 import { AssistantChatTransport } from "./AssistantChatTransport";
+import type { AssistantChatResumableOptions } from "../resumable";
 import { useEffect, useMemo, useRef } from "react";
 
 export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
@@ -48,6 +49,18 @@ const useDynamicChatTransport = <UI_MESSAGE extends UIMessage = UIMessage>(
     [],
   );
   return dynamicTransport;
+};
+
+const getResumableAdapter = <UI_MESSAGE extends UIMessage>(
+  transport: ChatTransport<UI_MESSAGE>,
+): AssistantChatResumableOptions | undefined => {
+  if (transport instanceof AssistantChatTransport) {
+    return transport.getResumableAdapter();
+  }
+  const candidate = (transport as { getResumableAdapter?: () => unknown })
+    .getResumableAdapter;
+  if (typeof candidate !== "function") return undefined;
+  return candidate.call(transport) as AssistantChatResumableOptions | undefined;
 };
 
 const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
@@ -88,6 +101,25 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       aui.threadListItem.source ? aui.threadListItem() : undefined,
     );
   }
+
+  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
+  const resumeFiredRef = useRef(false);
+  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
+  useEffect(() => {
+    if (resumeFiredRef.current) return;
+    const adapter = getResumableAdapter(transport);
+    if (!adapter) return;
+    const pending = adapter.storage.getStreamId();
+    if (!pending) return;
+    resumeFiredRef.current = true;
+    chat.resumeStream().catch((err: unknown) => {
+      console.warn(
+        "[assistant-ui] resumable: resume failed; clearing stored stream id",
+        err,
+      );
+      adapter.storage.clear();
+    });
+  }, [transport, chat]);
 
   return runtime;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1374,7 +1374,7 @@ importers:
         version: 55.0.15(expo@55.0.23)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       expo-router:
         specifier: ~55.0.14
-        version: 55.0.14(zbpmibvzuia5zrux4jh2mfo6ry)
+        version: 55.0.14(ac54ed7c559efcf393f9bd4fdbf5e823)
       expo-server:
         specifier: ~55.0.9
         version: 55.0.9
@@ -1654,7 +1654,7 @@ importers:
         version: link:../../packages/ui
       '@google/adk':
         specifier: ^1.1.0
-        version: 1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.3)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.6.0)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+        version: 1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.3)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.6.0)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1666,7 +1666,7 @@ importers:
         version: 1.14.0(react@19.2.5)
       next:
         specifier: ^16.2.4
-        version: 16.2.4(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.4(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -2357,6 +2357,94 @@ importers:
         specifier: ^6.1.1
         version: 6.1.1(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
 
+  examples/with-resumable-stream:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: ^3.0.61
+        version: 3.0.61(zod@4.4.3)
+      '@ai-sdk/react':
+        specifier: ^3.0.45
+        version: 3.0.177(react@19.2.5)(zod@4.4.3)
+      '@assistant-ui/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      '@assistant-ui/react-ai-sdk':
+        specifier: workspace:*
+        version: link:../../packages/react-ai-sdk
+      '@assistant-ui/react-markdown':
+        specifier: workspace:*
+        version: link:../../packages/react-markdown
+      '@assistant-ui/store':
+        specifier: workspace:*
+        version: link:../../packages/store
+      '@assistant-ui/tap':
+        specifier: workspace:*
+        version: link:../../packages/tap
+      '@assistant-ui/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      ai:
+        specifier: ^6.0.175
+        version: 6.0.175(zod@4.4.3)
+      assistant-stream:
+        specifier: workspace:*
+        version: link:../../packages/assistant-stream
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^1.14.0
+        version: 1.14.0(react@19.2.5)
+      next:
+        specifier: ^16.2.4
+        version: 16.2.4(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      redis:
+        specifier: ^5.12.1
+        version: 5.12.1(@opentelemetry/api@1.9.1)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@assistant-ui/x-buildutils':
+        specifier: workspace:*
+        version: link:../../packages/x-buildutils
+      '@tailwindcss/postcss':
+        specifier: ^4.2.4
+        version: 4.2.4
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      postcss:
+        specifier: ^8.5.14
+        version: 8.5.14
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.2.4
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   examples/with-store:
     dependencies:
       '@assistant-ui/store':
@@ -2431,7 +2519,7 @@ importers:
         version: 1.14.0(react@19.2.5)
       nitro:
         specifier: ^3.0.260311-beta
-        version: 3.0.260311-beta(@azure/identity@4.13.1)(@upstash/redis@1.38.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(lru-cache@11.3.6)(mysql2@3.20.0(@types/node@25.6.0))(rollup@4.60.3)(sqlite3@5.1.7)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 3.0.260311-beta(@azure/identity@4.13.1)(@upstash/redis@1.38.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.3.6)(mysql2@3.20.0(@types/node@25.6.0))(rollup@4.60.3)(sqlite3@5.1.7)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       openai:
         specifier: ^6.36.0
         version: 6.36.0(ws@8.20.0)(zod@4.4.3)
@@ -2571,6 +2659,12 @@ importers:
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
+      ioredis:
+        specifier: ^5.10.1
+        version: 5.10.1
+      redis:
+        specifier: ^5.12.1
+        version: 5.12.1(@opentelemetry/api@1.9.1)
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
@@ -4148,7 +4242,7 @@ importers:
         version: 1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       '@langchain/langgraph-cli':
         specifier: ^1.2.1
-        version: 1.2.1(3dir7xyd3ls2faw6t26cbydfbm)
+        version: 1.2.1(cfe2b9e7cb576b5147714d5eaa3842ca)
       '@tailwindcss/postcss':
         specifier: ^4.2.4
         version: 4.2.4
@@ -5152,24 +5246,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.14':
     resolution: {integrity: sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.14':
     resolution: {integrity: sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.14':
     resolution: {integrity: sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.14':
     resolution: {integrity: sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==}
@@ -6230,89 +6328,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -6345,6 +6459,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -6746,24 +6863,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.4':
     resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.4':
     resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.4':
     resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.4':
     resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
@@ -8094,6 +8215,42 @@ packages:
     peerDependencies:
       react-router: 7.15.0
 
+  '@redis/bloom@5.12.1':
+    resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/client@5.12.1':
+    resolution: {integrity: sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@5.12.1':
+    resolution: {integrity: sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/search@5.12.1':
+    resolution: {integrity: sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/time-series@5.12.1':
+    resolution: {integrity: sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
     peerDependencies:
@@ -8143,24 +8300,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -8249,72 +8410,84 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -8408,66 +8581,79 @@ packages:
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.3':
     resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
@@ -8661,24 +8847,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -9930,6 +10120,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
 
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
@@ -11899,6 +12093,10 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
@@ -12375,24 +12573,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -12452,8 +12654,14 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
@@ -14252,6 +14460,18 @@ packages:
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
+  redis@5.12.1:
+    resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
+    engines: {node: '>= 18.19.0'}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -14789,6 +15009,9 @@ packages:
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
@@ -17620,7 +17843,7 @@ snapshots:
       ws: 8.20.0
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.14(zbpmibvzuia5zrux4jh2mfo6ry)
+      expo-router: 55.0.14(ac54ed7c559efcf393f9bd4fdbf5e823)
       react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -17875,7 +18098,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.23)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
-      expo-router: 55.0.14(zbpmibvzuia5zrux4jh2mfo6ry)
+      expo-router: 55.0.14(ac54ed7c559efcf393f9bd4fdbf5e823)
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -17945,20 +18168,6 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
-  '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
-    dependencies:
-      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
-      '@google-cloud/precise-date': 4.0.0
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      googleapis: 137.1.0(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
       '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -17973,20 +18182,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
-    dependencies:
-      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
-      '@grpc/grpc-js': 1.14.3
-      '@grpc/proto-loader': 0.8.0
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-      google-auth-library: 9.15.1(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
       '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -17997,16 +18192,6 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
       google-auth-library: 9.15.1(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  '@google-cloud/opentelemetry-resource-util@3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
-    dependencies:
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      gcp-metadata: 6.1.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -18052,50 +18237,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  '@google/adk@1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.3)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.6.0)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
-    dependencies:
-      '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.12.0)(@grpc/grpc-js@1.14.3)(express@4.22.1)
-      '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
-      '@google-cloud/opentelemetry-cloud-trace-exporter': 3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
-      '@google-cloud/storage': 7.19.0(encoding@0.1.13)
-      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
-      '@mikro-orm/core': 6.6.14
-      '@mikro-orm/mariadb': 6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0)
-      '@mikro-orm/mssql': 6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0)
-      '@mikro-orm/mysql': 6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.6.0)(mariadb@3.4.5)(pg@8.20.0)
-      '@mikro-orm/postgresql': 6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)
-      '@mikro-orm/reflection': 6.6.14(@mikro-orm/core@6.6.14)
-      '@mikro-orm/sqlite': 6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0)
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.205.0
-      '@opentelemetry/exporter-logs-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resource-detector-gcp': 0.40.3(@opentelemetry/api@1.9.0)(encoding@0.1.13)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.0)
-      express: 4.22.1
-      google-auth-library: 10.6.2
-      js-yaml: 4.1.1
-      jsonpath-plus: 10.4.0
-      lodash-es: 4.18.1
-      winston: 3.19.0
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - '@bufbuild/protobuf'
-      - '@cfworker/json-schema'
-      - '@grpc/grpc-js'
-      - '@opentelemetry/core'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
 
   '@google/adk@1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.3)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.6.0)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)':
     dependencies:
@@ -18301,6 +18442,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
+  '@ioredis/commands@1.5.1': {}
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
@@ -18449,7 +18592,7 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-api@1.2.1(3dir7xyd3ls2faw6t26cbydfbm)':
+  '@langchain/langgraph-api@1.2.1(cfe2b9e7cb576b5147714d5eaa3842ca)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@hono/node-server': 1.19.14(hono@4.12.17)
@@ -18495,11 +18638,11 @@ snapshots:
       '@langchain/core': 1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.36.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       uuid: 10.0.0
 
-  '@langchain/langgraph-cli@1.2.1(3dir7xyd3ls2faw6t26cbydfbm)':
+  '@langchain/langgraph-cli@1.2.1(cfe2b9e7cb576b5147714d5eaa3842ca)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@commander-js/extra-typings': 13.1.0(commander@13.1.0)
-      '@langchain/langgraph-api': 1.2.1(3dir7xyd3ls2faw6t26cbydfbm)
+      '@langchain/langgraph-api': 1.2.1(cfe2b9e7cb576b5147714d5eaa3842ca)
       chokidar: 4.0.3
       commander: 13.1.0
       create-langgraph: 1.1.5
@@ -20849,6 +20992,28 @@ snapshots:
       - supports-color
       - typescript
 
+  '@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
+  '@redis/client@5.12.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      cluster-key-slot: 1.1.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@redis/json@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
+  '@redis/search@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
+  '@redis/time-series@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -22733,6 +22898,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
@@ -23737,7 +23904,7 @@ snapshots:
     optionalDependencies:
       react-native-worklets: 0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
 
-  expo-router@55.0.14(zbpmibvzuia5zrux4jh2mfo6ry):
+  expo-router@55.0.14(ac54ed7c559efcf393f9bd4fdbf5e823):
     dependencies:
       '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.23)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.23)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -24961,6 +25128,20 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ip-address@10.1.0: {}
 
   ip-address@10.2.0:
@@ -25595,7 +25776,11 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
+  lodash.defaults@4.2.0: {}
+
   lodash.includes@4.3.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.isboolean@3.0.3: {}
 
@@ -26821,32 +27006,6 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  next@16.2.4(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      '@next/env': 16.2.4
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.27
-      caniuse-lite: 1.0.30001791
-      postcss: 8.4.31
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      styled-jsx: 5.1.6(react@19.2.5)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.4
-      '@next/swc-darwin-x64': 16.2.4
-      '@next/swc-linux-arm64-gnu': 16.2.4
-      '@next/swc-linux-arm64-musl': 16.2.4
-      '@next/swc-linux-x64-gnu': 16.2.4
-      '@next/swc-linux-x64-musl': 16.2.4
-      '@next/swc-win32-arm64-msvc': 16.2.4
-      '@next/swc-win32-x64-msvc': 16.2.4
-      '@opentelemetry/api': 1.9.0
-      babel-plugin-react-compiler: 1.0.0
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   next@16.2.4(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.2.4
@@ -26875,7 +27034,7 @@ snapshots:
 
   nf3@0.3.16: {}
 
-  nitro@3.0.260311-beta(@azure/identity@4.13.1)(@upstash/redis@1.38.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(lru-cache@11.3.6)(mysql2@3.20.0(@types/node@25.6.0))(rollup@4.60.3)(sqlite3@5.1.7)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)):
+  nitro@3.0.260311-beta(@azure/identity@4.13.1)(@upstash/redis@1.38.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.7.0)(lru-cache@11.3.6)(mysql2@3.20.0(@types/node@25.6.0))(rollup@4.60.3)(sqlite3@5.1.7)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.5(srvx@0.11.15)
@@ -26890,7 +27049,7 @@ snapshots:
       rolldown: 1.0.0-rc.18
       srvx: 0.11.15
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(@azure/identity@4.13.1)(@upstash/redis@1.38.0)(chokidar@5.0.0)(db0@0.3.4(mysql2@3.20.0(@types/node@25.6.0))(sqlite3@5.1.7))(lru-cache@11.3.6)(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(@azure/identity@4.13.1)(@upstash/redis@1.38.0)(chokidar@5.0.0)(db0@0.3.4(mysql2@3.20.0(@types/node@25.6.0))(sqlite3@5.1.7))(ioredis@5.10.1)(lru-cache@11.3.6)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.4.2
       giget: 3.2.0
@@ -28177,6 +28336,23 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
+  redis@5.12.1(@opentelemetry/api@1.9.1):
+    dependencies:
+      '@redis/bloom': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+      '@redis/json': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/search': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/time-series': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
+
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
@@ -28889,6 +29065,8 @@ snapshots:
     dependencies:
       type-fest: 0.7.1
 
+  standard-as-callback@2.1.0: {}
+
   standardwebhooks@1.0.0:
     dependencies:
       '@stablelib/base64': 1.0.1
@@ -29419,12 +29597,13 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unstorage@2.0.0-alpha.7(@azure/identity@4.13.1)(@upstash/redis@1.38.0)(chokidar@5.0.0)(db0@0.3.4(mysql2@3.20.0(@types/node@25.6.0))(sqlite3@5.1.7))(lru-cache@11.3.6)(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(@azure/identity@4.13.1)(@upstash/redis@1.38.0)(chokidar@5.0.0)(db0@0.3.4(mysql2@3.20.0(@types/node@25.6.0))(sqlite3@5.1.7))(ioredis@5.10.1)(lru-cache@11.3.6)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       '@azure/identity': 4.13.1
       '@upstash/redis': 1.38.0
       chokidar: 5.0.0
       db0: 0.3.4(mysql2@3.20.0(@types/node@25.6.0))(sqlite3@5.1.7)
+      ioredis: 5.10.1
       lru-cache: 11.3.6
       ofetch: 2.0.0-alpha.3
 


### PR DESCRIPTION
## Summary

- new `assistant-stream/resumable` module: `createResumableStreamContext` exposing `resumableStream` / `createNewResumableStream` / `resumeExistingStream` / `hasExistingStream`, plus `createResumableAssistantStreamResponse` and `createResumeAssistantStreamResponse` helpers that bridge any encoder to the store at the byte level (post-encoder, so existing encoders work unmodified)
- pluggable storage via `ResumableStreamStore`: ships `createInMemoryResumableStreamStore` for dev / tests, optional Redis adapters at `assistant-stream/resumable/redis` (node-redis) and `assistant-stream/resumable/ioredis`. cluster-safe via `{streamId}` hash-tag keys; `redis` and `ioredis` are optional peer dependencies
- example app `examples/with-resumable-stream`: Next.js + `@ai-sdk/react` `useChat` with custom transport that captures `X-Stream-Id`, redirects `chat.resumeStream()` to `/api/chat/resume/[streamId]`, falls back to a slow built-in mock when `OPENAI_API_KEY` is unset
- vitest coverage across the in-memory store, the context API, the response helpers, and a parameterized adapter suite that runs both Redis adapters against a live Redis (gated by `REDIS_TESTS=0`)
- new guide page `docs/guides/resumable-streams`, a CLI table row for `-e with-resumable-stream`, and a cross-link card on the AI SDK v6 runtime page

## Test plan

- [ ] `pnpm --filter assistant-stream test` (all 215 unit + integration tests pass; Redis suites need `docker run -d -p 6379:6379 redis:7-alpine` or set `REDIS_TESTS=0` to skip)
- [ ] `pnpm --filter assistant-stream build` emits `dist/resumable/{index,types,...}.js` and `dist/resumable/stores/{InMemory*,redis,ioredis,redis-impl}.js`
- [ ] `cd examples/with-resumable-stream && pnpm dev` then send a long prompt and reload the tab mid-response: same answer keeps filling in
- [ ] flip storage by setting `REDIS_URL=redis://localhost:6379` in `.env.local` and verify keys appear as `aui:resumable:{<id>}:meta` / `:data` and `meta` ends as `{"status":"done","ttlSec":86400}`
- [ ] open the new docs page locally (`apps/docs`) and confirm the `Resilience` section renders, the AI SDK v6 page shows the cross-link card, and the CLI example list includes the `with-resumable-stream` row