### PR TITLE
chore: fix accuracy of existing .env.example files

### DIFF
--- a/examples/with-ag-ui/.env.example
+++ b/examples/with-ag-ui/.env.example
@@ -1,1 +1,5 @@
+# Frontend AG-UI agent endpoint.
 NEXT_PUBLIC_AGUI_AGENT_URL=http://localhost:8000/agent
+
+# Optional. Used by server/agent.py. When unset the agent replies in echo mode.
+OPENAI_API_KEY=

--- a/examples/with-expo/.env.example
+++ b/examples/with-expo/.env.example
@@ -1,1 +1,3 @@
-EXPO_PUBLIC_OPENAI_API_KEY=
+# Optional. Defaults to /api/chat (the bundled Next.js route).
+# Override to point the Expo app at a separately hosted chat backend.
+EXPO_PUBLIC_CHAT_ENDPOINT_URL=

--- a/examples/with-langgraph/.env.example
+++ b/examples/with-langgraph/.env.example
@@ -6,3 +6,7 @@ LANGCHAIN_API_KEY=
 
 # Graph id. Must match a key under "graphs" in your langgraph.json.
 NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID=stockbroker
+
+# Optional. Bypasses the /api proxy and lets the browser hit LangGraph directly.
+# Leave unset to route everything through the Next.js proxy on the current host.
+NEXT_PUBLIC_LANGGRAPH_API_URL=

--- a/examples/with-langgraph/.env.example
+++ b/examples/with-langgraph/.env.example
@@ -1,2 +1,8 @@
-NEXT_PUBLIC_API_URL=...
+# LangGraph deployment URL. Used by the Next.js proxy at /api/[..._path].
+LANGGRAPH_API_URL=http://localhost:2024
+
+# Forwarded as `x-api-key`. Leave blank for an unauthenticated dev server.
+LANGCHAIN_API_KEY=
+
+# Graph id. Must match a key under "graphs" in your langgraph.json.
 NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID=stockbroker

--- a/examples/with-langgraph/README.md
+++ b/examples/with-langgraph/README.md
@@ -18,9 +18,12 @@ cd my-app
 Create `.env.local`:
 
 ```
-NEXT_PUBLIC_API_URL=https://stockbrokeragent-bracesprouls-projects.vercel.app/api
+LANGGRAPH_API_URL=http://localhost:2024
+LANGCHAIN_API_KEY=
 NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID=stockbroker
 ```
+
+`LANGGRAPH_API_URL` is the LangGraph deployment URL the bundled `/api/[..._path]` proxy fetches from. `LANGCHAIN_API_KEY` is forwarded as `x-api-key` and can be blank for an unauthenticated dev server. `NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID` is the graph id (a key under `graphs` in your `langgraph.json`).
 
 ### Run
 

--- a/templates/cloud/.env.example
+++ b/templates/cloud/.env.example
@@ -1,7 +1,7 @@
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# Assistant Cloud API URL -- sign up on cloud.assistant-ui.com
-# NEXT_PUBLIC_ASSISTANT_BASE_URL=
+# Assistant Cloud API URL. Sign up on cloud.assistant-ui.com.
+NEXT_PUBLIC_ASSISTANT_BASE_URL=
 
-# Assistant Cloud API Key
+# Optional. Only set this when using authenticated (non-anonymous) cloud.
 # ASSISTANT_API_KEY=

--- a/templates/langgraph/.env.example
+++ b/templates/langgraph/.env.example
@@ -14,3 +14,6 @@ LANGGRAPH_API_URL=http://localhost:2024
 LANGCHAIN_API_KEY=
 # Graph id. Must match a key under "graphs" in langgraph.json.
 NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID=agent
+# Optional. Bypasses the /api proxy and lets the browser hit LangGraph directly.
+# Leave unset to route everything through the Next.js proxy on the current host.
+NEXT_PUBLIC_LANGGRAPH_API_URL=


### PR DESCRIPTION
## Summary
follow-up audit of every existing `.env.example` against the env vars its code actually reads. five files had real gaps. SDK-internal reads (e.g. `OPENAI_API_KEY` consumed by `@ai-sdk/openai`, `CLERK_*` consumed by Clerk, `ASSISTANT_API_KEY` consumed by assistant-cloud) are intentionally kept and not flagged.

- `examples/with-langgraph` — `.env.example` and the `README` referenced `NEXT_PUBLIC_API_URL`, but the proxy at `app/api/[..._path]/route.ts` and `lib/chatApi.ts` actually use `LANGGRAPH_API_URL`, `LANGCHAIN_API_KEY`, and `NEXT_PUBLIC_LANGGRAPH_API_URL`. copying the old example would not run.
- `examples/with-expo` — only listed `EXPO_PUBLIC_OPENAI_API_KEY`, which no source file reads. `hooks/use-app-runtime.ts` reads `EXPO_PUBLIC_CHAT_ENDPOINT_URL`. swapped to that (optional, defaults to `/api/chat`).
- `examples/with-ag-ui` — `server/agent.py` reads `OPENAI_API_KEY` (echo mode without it). added as optional.
- `templates/cloud` — `app/assistant.tsx` non-null-asserts `NEXT_PUBLIC_ASSISTANT_BASE_URL`, but `.env.example` only mentioned it as a commented-out option. uncommented so it shows up as required.
- `templates/langgraph` — `lib/chatApi.ts` reads `NEXT_PUBLIC_LANGGRAPH_API_URL`. added as documented optional override.

## Test plan
- [ ] `examples/with-langgraph`: copy `.env.example` to `.env.local`, point `LANGGRAPH_API_URL` at a running LangGraph deployment, app boots without runtime undefined errors
- [ ] `examples/with-expo`: app starts using bundled `/api/chat` without setting any env var
- [ ] `examples/with-ag-ui`: python agent boots, prints `OpenAI API Key: not set (using echo mode)` when `OPENAI_API_KEY` is unset
- [ ] `templates/cloud`: setting only `OPENAI_API_KEY` no longer makes `assistant.tsx` crash silently; copying `.env.example` makes the required cloud URL obvious
- [ ] `templates/langgraph`: example unchanged in default behavior, optional client-side override is now discoverable