### PR TITLE
feat(core): composer canSend state and isSendDisabled adapter input

### DIFF
--- a/.changeset/feat-composer-can-send.md
+++ b/.changeset/feat-composer-can-send.md
@@ -1,0 +1,11 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat(composer): expose `canSend` state and `isSendDisabled` adapter input
+
+`ComposerState.canSend` (read-only) is now derivable via `useAuiState((s) => s.composer.canSend)` and `<AuiIf condition={(s) => s.composer.canSend}/>`. it reflects whether the composer is in a state where send is permitted; cross-thread gating (`isRunning`, `capabilities.queue`) continues to be layered on top by `useComposerSend`.
+
+`ExternalStoreAdapter.isSendDisabled` is a new optional input alongside `isDisabled`. when `true`, the composer's input remains usable but `send()` becomes a no-op and `canSend` is `false`. use this to gate sending on external React state (e.g. while tool config is loading) without disabling the input itself.
+
+`BaseComposerRuntimeCore.send()` now early-returns when `!canSend`, so the `Cmd/Ctrl+Shift+Enter` steer hotkey, form-`requestSubmit()`, and direct `aui.composer().send()` calls are all gated by the same flag.

--- a/.changeset/feat-composer-can-send.md
+++ b/.changeset/feat-composer-can-send.md
@@ -1,11 +1,12 @@
 ---
 "@assistant-ui/core": patch
+"@assistant-ui/react": patch
 ---
 
 feat(composer): expose `canSend` state and `isSendDisabled` adapter input
 
 `ComposerState.canSend` (read-only) is now derivable via `useAuiState((s) => s.composer.canSend)` and `<AuiIf condition={(s) => s.composer.canSend}/>`. it reflects whether the composer is in a state where send is permitted; cross-thread gating (`isRunning`, `capabilities.queue`) continues to be layered on top by `useComposerSend`.
 
-`ExternalStoreAdapter.isSendDisabled` is a new optional input alongside `isDisabled`. when `true`, the composer's input remains usable but `send()` becomes a no-op and `canSend` is `false`. use this to gate sending on external React state (e.g. while tool config is loading) without disabling the input itself.
+`ExternalStoreAdapter.isSendDisabled` is a new optional input alongside `isDisabled`. when `true`, the thread composer's input remains usable but `send()` becomes a no-op and `canSend` is `false`. use this to gate sending on external React state (e.g. while tool config is loading) without disabling the input itself. edit composers (saving in-progress message edits) intentionally ignore this flag, since it is a thread-scoped gate.
 
-`BaseComposerRuntimeCore.send()` now early-returns when `!canSend`, so the `Cmd/Ctrl+Shift+Enter` steer hotkey, form-`requestSubmit()`, and direct `aui.composer().send()` calls are all gated by the same flag.
+`BaseComposerRuntimeCore.send()` now early-returns when `!canSend`, so the `Cmd/Ctrl+Shift+Enter` steer hotkey, form-`requestSubmit()`, and direct `aui.composer().send()` calls are all gated by the same flag. the same gating is wired through the tap-based `ExternalThread` client via a new `isSendDisabled` prop on `ExternalThreadProps`.

--- a/apps/docs/content/docs/primitives/composer.mdx
+++ b/apps/docs/content/docs/primitives/composer.mdx
@@ -526,6 +526,44 @@ Use `onSubmit` on `Root` to intercept submission:
 </ComposerPrimitive.Root>
 ```
 
+### Gate Sending on External State
+
+Sometimes you want users to type while sending is temporarily blocked, for example while tool configuration, auth, or the first model context is still loading. Disabling the entire thread via `isDisabled` works but also disables the text input, which feels broken.
+
+Use `isSendDisabled` on the runtime adapter to keep the input usable while blocking send:
+
+```tsx
+const runtime = useExternalStoreRuntime({
+  isSendDisabled: !toolsLoaded,
+  onNew,
+  messages,
+  // ...
+});
+```
+
+When `isSendDisabled` is `true`:
+
+- `composer.canSend` becomes `false`
+- `<ComposerPrimitive.Send>` is disabled
+- Enter and the `Cmd/Ctrl+Shift+Enter` steer hotkey become no-ops
+- `aui.composer().send()` short-circuits at the runtime, so direct calls cannot escape the gate
+
+Read the same flag from React with `<AuiIf>` to render hints alongside the input:
+
+```tsx
+<ComposerPrimitive.Root>
+  <ComposerPrimitive.Input placeholder="Ask anything..." />
+  <AuiIf condition={(s) => !s.composer.canSend}>
+    <p className="text-sm text-muted-foreground">Loading tools, hang on...</p>
+  </AuiIf>
+  <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+</ComposerPrimitive.Root>
+```
+
+`canSend` reflects the composer's own willingness to send (editing mode, non-empty content, `isSendDisabled` not set). Cross-thread gating like an in-flight run without queue support is layered on top by `<ComposerPrimitive.Send>` automatically.
+
+For the difference between `isDisabled` and `isSendDisabled`, see the [external store adapter reference](/docs/runtimes/custom/external-store).
+
 ### Ctrl+Enter to Submit
 
 ```tsx

--- a/apps/docs/content/docs/primitives/composer.mdx
+++ b/apps/docs/content/docs/primitives/composer.mdx
@@ -562,6 +562,8 @@ Read the same flag from React with `<AuiIf>` to render hints alongside the input
 
 `canSend` reflects the composer's own willingness to send (editing mode, non-empty content, `isSendDisabled` not set). Cross-thread gating like an in-flight run without queue support is layered on top by `<ComposerPrimitive.Send>` automatically.
 
+`isSendDisabled` only gates the thread composer. Saving an in-progress message edit is unaffected, since it is a per-message action rather than a new send.
+
 For the difference between `isDisabled` and `isSendDisabled`, see the [external store adapter reference](/docs/runtimes/custom/external-store).
 
 ### Ctrl+Enter to Submit

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -627,7 +627,15 @@ useExternalStoreRuntime({
     {
       name: "isDisabled",
       type: "boolean",
-      description: "Whether the chat input should be disabled.",
+      description:
+        "Disables the entire composer, including the text input. For a narrower gate that keeps the input usable but blocks only sending, use isSendDisabled.",
+      default: "false",
+    },
+    {
+      name: "isSendDisabled",
+      type: "boolean",
+      description:
+        "Blocks message sending while leaving the input usable. When true, composer.canSend becomes false, the Send button is disabled, Enter and the steer hotkey are no-ops, and aui.composer().send() short-circuits. Use this to gate sending on external React state (e.g. while tools or auth are still loading).",
       default: "false",
     },
     {

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -635,7 +635,7 @@ useExternalStoreRuntime({
       name: "isSendDisabled",
       type: "boolean",
       description:
-        "Blocks message sending while leaving the input usable. When true, composer.canSend becomes false, the Send button is disabled, Enter and the steer hotkey are no-ops, and aui.composer().send() short-circuits. Use this to gate sending on external React state (e.g. while tools or auth are still loading).",
+        "Blocks new-message sending while leaving the input usable. When true, the thread composer's canSend becomes false, the Send button is disabled, Enter and the steer hotkey are no-ops, and aui.composer().send() short-circuits. Edit composers (saving message edits) ignore this flag. Use this to gate sending on external React state (e.g. while tools or auth are still loading).",
       default: "false",
     },
     {

--- a/packages/core/src/react/primitive-hooks/useComposerSend.ts
+++ b/packages/core/src/react/primitive-hooks/useComposerSend.ts
@@ -6,9 +6,8 @@ export const useComposerSend = () => {
   const aui = useAui();
   const disabled = useAuiState(
     (s) =>
-      (s.thread.isRunning && !s.thread.capabilities.queue) ||
-      !s.composer.isEditing ||
-      s.composer.isEmpty,
+      !s.composer.canSend ||
+      (s.thread.isRunning && !s.thread.capabilities.queue),
   );
 
   const send = useCallback(

--- a/packages/core/src/runtime/api/composer-runtime.ts
+++ b/packages/core/src/runtime/api/composer-runtime.ts
@@ -41,6 +41,7 @@ export type {
 
 type BaseComposerState = {
   readonly canCancel: boolean;
+  readonly canSend: boolean;
   readonly isEditing: boolean;
   readonly isEmpty: boolean;
 
@@ -86,6 +87,7 @@ const getThreadComposerState = (
 
     isEditing: runtime?.isEditing ?? false,
     canCancel: runtime?.canCancel ?? false,
+    canSend: runtime?.canSend ?? false,
     isEmpty: runtime?.isEmpty ?? true,
 
     attachments: runtime?.attachments ?? EMPTY_ARRAY,
@@ -108,6 +110,7 @@ const getEditComposerState = (
 
     isEditing: runtime?.isEditing ?? false,
     canCancel: runtime?.canCancel ?? false,
+    canSend: runtime?.canSend ?? false,
     isEmpty: runtime?.isEmpty ?? true,
 
     text: runtime?.text ?? "",

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -52,6 +52,7 @@ export abstract class BaseComposerRuntimeCore
   }
 
   public abstract get canCancel(): boolean;
+  public abstract get canSend(): boolean;
 
   public get isEmpty() {
     return !this.text.trim() && !this.attachments.length;
@@ -157,7 +158,7 @@ export abstract class BaseComposerRuntimeCore
   }
 
   public async send(options?: SendOptions) {
-    if (this.isEmpty) return;
+    if (!this.canSend) return;
 
     if (this._dictationSession) {
       this._dictationSession.cancel();

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -48,6 +48,7 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   protected readonly repository = new MessageRepository();
   public abstract get adapters(): BaseThreadAdapters | undefined;
   public abstract get isDisabled(): boolean;
+  public abstract get isSendDisabled(): boolean;
   public abstract get isLoading(): boolean;
   public abstract get suggestions(): readonly ThreadSuggestion[];
   public abstract get extras(): unknown;

--- a/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
@@ -14,7 +14,7 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
   }
 
   public get canSend() {
-    return this.isEditing && !this.isEmpty && !this.runtime.isSendDisabled;
+    return this.isEditing && !this.isEmpty;
   }
 
   protected getAttachmentAdapter() {

--- a/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
@@ -14,7 +14,7 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
   }
 
   public get canSend() {
-    return this.isEditing && !this.isEmpty;
+    return !this.isEmpty;
   }
 
   protected getAttachmentAdapter() {

--- a/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
@@ -13,6 +13,10 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
     return true;
   }
 
+  public get canSend() {
+    return this.isEditing && !this.isEmpty && !this.runtime.isSendDisabled;
+  }
+
   protected getAttachmentAdapter() {
     return this.runtime.adapters?.attachments;
   }

--- a/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
@@ -17,6 +17,10 @@ export class DefaultThreadComposerRuntimeCore
     return this._canCancel;
   }
 
+  public get canSend() {
+    return this.isEditing && !this.isEmpty && !this.runtime.isSendDisabled;
+  }
+
   protected getAttachmentAdapter() {
     return this.runtime.adapters?.attachments;
   }
@@ -40,11 +44,18 @@ export class DefaultThreadComposerRuntimeCore
   }
 
   public connect() {
+    let lastIsSendDisabled = this.runtime.isSendDisabled;
     return this.runtime.subscribe(() => {
+      let changed = false;
       if (this.canCancel !== this.runtime.capabilities.cancel) {
         this._canCancel = this.runtime.capabilities.cancel;
-        this._notifySubscribers();
+        changed = true;
       }
+      if (lastIsSendDisabled !== this.runtime.isSendDisabled) {
+        lastIsSendDisabled = this.runtime.isSendDisabled;
+        changed = true;
+      }
+      if (changed) this._notifySubscribers();
     });
   }
 

--- a/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
@@ -18,7 +18,7 @@ export class DefaultThreadComposerRuntimeCore
   }
 
   public get canSend() {
-    return this.isEditing && !this.isEmpty && !this.runtime.isSendDisabled;
+    return !this.isEmpty && !this.runtime.isSendDisabled;
   }
 
   protected getAttachmentAdapter() {

--- a/packages/core/src/runtime/interfaces/composer-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/composer-runtime-core.ts
@@ -51,6 +51,7 @@ export type ComposerRuntimeCore = Readonly<{
   isEditing: boolean;
 
   canCancel: boolean;
+  canSend: boolean;
   isEmpty: boolean;
 
   attachments: readonly Attachment[];

--- a/packages/core/src/runtime/interfaces/thread-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-runtime-core.ts
@@ -158,6 +158,12 @@ export type ThreadRuntimeCore = Readonly<{
 
   capabilities: Readonly<RuntimeCapabilities>;
   isDisabled: boolean;
+  /**
+   * Whether sending from this thread's composer is disabled. Surfaces the
+   * `isSendDisabled` flag from external-store adapters; internal runtimes
+   * default to `false`. Composer state derives `canSend` from this.
+   */
+  isSendDisabled: boolean;
   isLoading: boolean;
   /**
    * Optional explicit thread-level running flag. When provided, takes

--- a/packages/core/src/runtimes/external-store/external-store-adapter.ts
+++ b/packages/core/src/runtimes/external-store/external-store-adapter.ts
@@ -59,7 +59,21 @@ type ExternalStoreMessageConverterAdapter<T> = {
 };
 
 type ExternalStoreAdapterBase<T> = {
+  /**
+   * Whether the entire thread is disabled. When `true`, the composer's input
+   * is also disabled (the user cannot type, attach files, or submit). For a
+   * narrower gate that keeps the input usable but blocks only sending, use
+   * `isSendDisabled`.
+   */
   isDisabled?: boolean | undefined;
+  /**
+   * Whether sending new messages is currently disabled. When `true`, the
+   * composer's input remains usable but `send()` becomes a no-op and
+   * `composer.canSend` is `false`. Use this to gate sending on external
+   * React state (e.g. while tool config is loading) without disabling the
+   * input itself the way `isDisabled` does.
+   */
+  isSendDisabled?: boolean | undefined;
   /**
    * Whether the thread is running. When provided, this value flows directly
    * to `thread.isRunning`, letting the application keep the thread in a

--- a/packages/core/src/runtimes/external-store/external-store-adapter.ts
+++ b/packages/core/src/runtimes/external-store/external-store-adapter.ts
@@ -68,10 +68,11 @@ type ExternalStoreAdapterBase<T> = {
   isDisabled?: boolean | undefined;
   /**
    * Whether sending new messages is currently disabled. When `true`, the
-   * composer's input remains usable but `send()` becomes a no-op and
-   * `composer.canSend` is `false`. Use this to gate sending on external
-   * React state (e.g. while tool config is loading) without disabling the
-   * input itself the way `isDisabled` does.
+   * thread composer's input remains usable but `send()` becomes a no-op
+   * and the thread composer's `canSend` is `false`. Use this to gate
+   * sending on external React state (e.g. while tool config is loading)
+   * without disabling the input itself the way `isDisabled` does. Edit
+   * composers (saving message edits) intentionally ignore this flag.
    */
   isSendDisabled?: boolean | undefined;
   /**

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -75,6 +75,7 @@ export class ExternalStoreThreadRuntimeCore
 
   private _messages!: readonly ThreadMessage[];
   public isDisabled!: boolean;
+  public isSendDisabled!: boolean;
   public get isLoading() {
     return this._store.isLoading ?? false;
   }
@@ -122,6 +123,7 @@ export class ExternalStoreThreadRuntimeCore
 
     const isRunning = store.isRunning ?? false;
     this.isDisabled = store.isDisabled ?? false;
+    this.isSendDisabled = store.isSendDisabled ?? false;
 
     const oldStore = this._store as ExternalStoreAdapter<any> | undefined;
     this._store = store;

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -54,6 +54,7 @@ export class LocalThreadRuntimeCore
   private abortController: AbortController | null = null;
 
   public readonly isDisabled = false;
+  public readonly isSendDisabled = false;
 
   private _isLoading = false;
   public get isLoading() {

--- a/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
+++ b/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
@@ -118,6 +118,7 @@ export class ReadonlyThreadRuntimeCore
 
     isEditing: false as const,
     canCancel: false,
+    canSend: false,
     isEmpty: true,
     text: "",
 
@@ -205,6 +206,7 @@ export class ReadonlyThreadRuntimeCore
   } as const;
 
   isDisabled = false;
+  isSendDisabled = false;
   isLoading = false;
 
   state = null;

--- a/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
+++ b/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
@@ -98,6 +98,7 @@ export const EMPTY_THREAD_CORE: ThreadRuntimeCore = {
     isEditing: true,
 
     canCancel: false,
+    canSend: false,
     isEmpty: true,
 
     text: "",
@@ -186,6 +187,7 @@ export const EMPTY_THREAD_CORE: ThreadRuntimeCore = {
   },
 
   isDisabled: false,
+  isSendDisabled: false,
   isLoading: true,
 
   messages: [],

--- a/packages/core/src/store/clients/no-op-composer-client.ts
+++ b/packages/core/src/store/clients/no-op-composer-client.ts
@@ -14,6 +14,7 @@ export const NoOpComposerClient = resource(
         role: "user",
         runConfig: {},
         canCancel: false,
+        canSend: false,
         type: type,
         dictation: undefined,
         quote: undefined,

--- a/packages/core/src/store/runtime-clients/composer-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/composer-runtime-client.ts
@@ -103,6 +103,7 @@ export const ComposerClient = resource(
         runConfig: runtimeState.runConfig,
         isEditing: runtimeState.isEditing,
         canCancel: runtimeState.canCancel,
+        canSend: runtimeState.canSend,
         attachmentAccept: runtimeState.attachmentAccept,
         isEmpty: runtimeState.isEmpty,
         type: runtimeState.type ?? "thread",

--- a/packages/core/src/store/scopes/composer.ts
+++ b/packages/core/src/store/scopes/composer.ts
@@ -26,6 +26,13 @@ export type ComposerState = {
   readonly runConfig: RunConfig;
   readonly isEditing: boolean;
   readonly canCancel: boolean;
+  /**
+   * Whether the composer is currently willing to send. `true` when the
+   * composer is in editing mode, has non-empty content, and the thread's
+   * `isSendDisabled` flag is not set. Cross-thread gating (running, queue
+   * capability) is layered on top by `useComposerSend`.
+   */
+  readonly canSend: boolean;
   readonly attachmentAccept: string;
   readonly isEmpty: boolean;
   readonly type: "thread" | "edit";

--- a/packages/core/src/store/scopes/composer.ts
+++ b/packages/core/src/store/scopes/composer.ts
@@ -28,9 +28,11 @@ export type ComposerState = {
   readonly canCancel: boolean;
   /**
    * Whether the composer is currently willing to send. `true` when the
-   * composer is in editing mode, has non-empty content, and the thread's
-   * `isSendDisabled` flag is not set. Cross-thread gating (running, queue
-   * capability) is layered on top by `useComposerSend`.
+   * composer is in editing mode and has non-empty content; for thread
+   * composers also requires the thread's `isSendDisabled` flag to be unset.
+   * Edit composers (saving message edits) ignore `isSendDisabled` since it
+   * is a thread-scoped gate. Cross-thread gating (running, queue capability)
+   * is layered on top by `useComposerSend`.
    */
   readonly canSend: boolean;
   readonly attachmentAccept: string;

--- a/packages/core/src/tests/composer-can-send.test.ts
+++ b/packages/core/src/tests/composer-can-send.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import { DefaultThreadComposerRuntimeCore } from "../runtime/base/default-thread-composer-runtime-core";
+import { DefaultEditComposerRuntimeCore } from "../runtime/base/default-edit-composer-runtime-core";
+import type { ThreadRuntimeCore } from "../runtime/interfaces/thread-runtime-core";
+import type { ThreadMessage } from "../types/message";
+
+type ThreadRuntimeStub = Omit<ThreadRuntimeCore, "composer"> & {
+  notify: () => void;
+};
+
+const makeRuntimeStub = (
+  overrides: Partial<ThreadRuntimeCore> = {},
+): ThreadRuntimeStub => {
+  const subscribers = new Set<() => void>();
+  const stub = {
+    append: vi.fn(),
+    cancelRun: vi.fn(),
+    subscribe: (cb: () => void) => {
+      subscribers.add(cb);
+      return () => subscribers.delete(cb);
+    },
+    capabilities: { cancel: false },
+    messages: [],
+    isDisabled: false,
+    isSendDisabled: false,
+    isLoading: false,
+    composer: { runConfig: {} },
+    notify: () => {
+      for (const cb of subscribers) cb();
+    },
+    ...overrides,
+  } as unknown as ThreadRuntimeStub;
+  return stub;
+};
+
+const makeUserMessage = (text = "old"): ThreadMessage =>
+  ({
+    id: "msg-1",
+    role: "user",
+    createdAt: new Date(),
+    content: [{ type: "text", text }],
+    attachments: [],
+    metadata: { custom: {} },
+  }) as ThreadMessage;
+
+describe("DefaultThreadComposerRuntimeCore.canSend", () => {
+  it("is false when the composer is empty", () => {
+    const composer = new DefaultThreadComposerRuntimeCore(makeRuntimeStub());
+    expect(composer.canSend).toBe(false);
+  });
+
+  it("is true when in editing mode with non-empty text", () => {
+    const composer = new DefaultThreadComposerRuntimeCore(makeRuntimeStub());
+    composer.setText("hi");
+    expect(composer.canSend).toBe(true);
+  });
+
+  it("is false when the runtime reports isSendDisabled", () => {
+    const composer = new DefaultThreadComposerRuntimeCore(
+      makeRuntimeStub({ isSendDisabled: true }),
+    );
+    composer.setText("hi");
+    expect(composer.canSend).toBe(false);
+  });
+
+  it("notifies subscribers when isSendDisabled flips", () => {
+    const stub = makeRuntimeStub();
+    const composer = new DefaultThreadComposerRuntimeCore(stub);
+    composer.connect();
+
+    composer.setText("hi");
+    const onChange = vi.fn();
+    composer.subscribe(onChange);
+
+    (stub as { isSendDisabled: boolean }).isSendDisabled = true;
+    stub.notify();
+    expect(onChange).toHaveBeenCalled();
+    expect(composer.canSend).toBe(false);
+  });
+});
+
+describe("BaseComposerRuntimeCore.send", () => {
+  it("is a no-op when canSend is false because of isSendDisabled", async () => {
+    const stub = makeRuntimeStub({ isSendDisabled: true });
+    const composer = new DefaultThreadComposerRuntimeCore(stub);
+    composer.setText("hi");
+
+    await composer.send();
+
+    expect(stub.append).not.toHaveBeenCalled();
+  });
+
+  it("dispatches when canSend is true", async () => {
+    const stub = makeRuntimeStub();
+    const composer = new DefaultThreadComposerRuntimeCore(stub);
+    composer.setText("hi");
+
+    await composer.send();
+
+    expect(stub.append).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DefaultEditComposerRuntimeCore.canSend", () => {
+  it("ignores runtime.isSendDisabled (thread-scoped flag does not block edits)", () => {
+    const stub = makeRuntimeStub({ isSendDisabled: true });
+    const composer = new DefaultEditComposerRuntimeCore(stub, () => {}, {
+      parentId: null,
+      message: makeUserMessage("seed"),
+    });
+
+    expect(composer.canSend).toBe(true);
+  });
+});

--- a/packages/core/src/tests/composer-can-send.test.ts
+++ b/packages/core/src/tests/composer-can-send.test.ts
@@ -66,8 +66,6 @@ describe("DefaultThreadComposerRuntimeCore.canSend", () => {
   it("notifies subscribers when isSendDisabled flips", () => {
     const stub = makeRuntimeStub();
     const composer = new DefaultThreadComposerRuntimeCore(stub);
-    composer.connect();
-
     composer.setText("hi");
     const onChange = vi.fn();
     composer.subscribe(onChange);

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -341,34 +341,35 @@ const ComposerClientResource = resource(
       [queueItems],
     );
 
-    const state = tapMemo(
-      () => ({
+    const state = tapMemo(() => {
+      const isEmpty = !text.trim() && !attachments.length;
+      return {
         text,
         role,
         attachments: attachmentClients.state,
         runConfig,
         isEditing,
         canCancel,
+        canSend: isEditing && !isEmpty,
         attachmentAccept: "*",
-        isEmpty: !text.trim() && !attachments.length,
+        isEmpty,
         type,
         dictation: undefined,
         quote,
         queue: queueItems,
-      }),
-      [
-        text,
-        role,
-        attachmentClients.state,
-        runConfig,
-        isEditing,
-        canCancel,
-        type,
-        attachments.length,
-        quote,
-        queueItems,
-      ],
-    );
+      };
+    }, [
+      text,
+      role,
+      attachmentClients.state,
+      runConfig,
+      isEditing,
+      canCancel,
+      type,
+      attachments.length,
+      quote,
+      queueItems,
+    ]);
 
     return {
       getState: () => state,

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -51,6 +51,13 @@ export type ExternalThreadProps = {
   messages: readonly ExternalThreadMessage[];
   isRunning?: boolean;
   /**
+   * Whether sending new messages is currently disabled. When `true`, the
+   * thread composer's input remains usable but `send()` is a no-op and
+   * `composer.canSend` is `false`. Edit composers (saving message edits)
+   * intentionally ignore this flag.
+   */
+  isSendDisabled?: boolean;
+  /**
    * Callback for new messages (non-queue runtimes).
    * @note Unused when `queue` is provided — new messages are routed through `queue.enqueue` instead.
    */
@@ -241,6 +248,7 @@ type ComposerClientResourceProps = {
   type: "thread" | "edit";
   isEditing: boolean;
   canCancel: boolean;
+  isSendDisabled?: boolean;
   onCancel: () => void;
   onBeginEdit?: () => void;
   onSend?: (message: AppendMessage) => void;
@@ -272,6 +280,7 @@ const ComposerClientResource = resource(
     type,
     isEditing,
     canCancel,
+    isSendDisabled = false,
     onCancel,
     onBeginEdit,
     onSend,
@@ -350,7 +359,7 @@ const ComposerClientResource = resource(
         runConfig,
         isEditing,
         canCancel,
-        canSend: isEditing && !isEmpty,
+        canSend: isEditing && !isEmpty && !isSendDisabled,
         attachmentAccept: "*",
         isEmpty,
         type,
@@ -365,6 +374,7 @@ const ComposerClientResource = resource(
       runConfig,
       isEditing,
       canCancel,
+      isSendDisabled,
       type,
       attachments.length,
       quote,
@@ -417,6 +427,9 @@ const ComposerClientResource = resource(
         setQuote(undefined);
       },
       send: (opts?: ComposerSendOptions) => {
+        const isEmpty = !text.trim() && !attachments.length;
+        if (!isEditing || isEmpty || isSendDisabled) return;
+
         const currentQuote = quote;
         const composedMessage: AppendMessage = {
           role,
@@ -459,6 +472,7 @@ export const ExternalThread = resource(
   ({
     messages,
     isRunning = false,
+    isSendDisabled = false,
     onNew,
     onEdit,
     onReload,
@@ -504,6 +518,7 @@ export const ExternalThread = resource(
         type: "thread",
         isEditing: true,
         canCancel: isRunning,
+        isSendDisabled,
         onCancel: handleCancelRun,
         onSend: handleSendNew,
         queue,

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -427,8 +427,7 @@ const ComposerClientResource = resource(
         setQuote(undefined);
       },
       send: (opts?: ComposerSendOptions) => {
-        const isEmpty = !text.trim() && !attachments.length;
-        if (!isEditing || isEmpty || isSendDisabled) return;
+        if (!state.canSend) return;
 
         const currentQuote = quote;
         const composedMessage: AppendMessage = {

--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -197,13 +197,13 @@ export const ComposerPrimitiveInput = forwardRef<
         const threadState = aui.thread().getState();
         const hasQueue = threadState.capabilities.queue;
 
-        // Steer hotkey: Cmd/Ctrl+Shift+Enter (respects submitMode="none" and isEmpty)
+        // Steer hotkey: Cmd/Ctrl+Shift+Enter (respects submitMode="none" and canSend)
         if (
           e.shiftKey &&
           (e.ctrlKey || e.metaKey) &&
           hasQueue &&
           effectiveSubmitMode !== "none" &&
-          !aui.composer().getState().isEmpty
+          aui.composer().getState().canSend
         ) {
           e.preventDefault();
           aui.composer().send({ steer: true });

--- a/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
+++ b/packages/react/src/tests/BaseComposerRuntimeCore.test.ts
@@ -35,6 +35,10 @@ class TestComposerCore extends BaseComposerRuntimeCore {
     return false;
   }
 
+  get canSend() {
+    return !this.isEmpty;
+  }
+
   protected handleSend(
     message: Omit<AppendMessage, "parentId" | "sourceId">,
     options?: SendOptions,


### PR DESCRIPTION
closes #3981.

## Summary
- new `ComposerState.canSend` (state-derivable; consumable via `useAuiState((s) => s.composer.canSend)` and `<AuiIf condition={(s) => s.composer.canSend}/>`) reflects editing mode + non-empty + the new `isSendDisabled` flag. parallels the existing `canCancel`.
- new `ExternalStoreAdapter.isSendDisabled` adapter input. when `true`, the input stays usable but `send()` is a no-op and `canSend` is `false`. fills the gap that the issue author hit: previously the only way to block sending was `isDisabled`, which also disables typing.
- `BaseComposerRuntimeCore.send()` early-returns on `!canSend`, so the same gate covers the Send button, Enter submit, the `Cmd/Ctrl+Shift+Enter` steer hotkey, and direct `aui.composer().send()` calls.
- docs: new `Gate Sending on External State` recipe in the Composer primitives page; `external-store.mdx` props table gains an `isSendDisabled` row and the `isDisabled` description points to it for the narrower case.
- additive only: every new field is optional with a `false`/`true` default, so existing consumers see no behavior change.

## Test plan
- [x] `pnpm exec turbo test` — 54/54 tasks green (190 core + 262 react + others)
- [x] `pnpm exec tsc --noEmit` in `packages/core` and `packages/react` — zero new TS errors (24 pre-existing in unrelated test mocks)
- [x] biome clean on all touched files
- [x] `pnpm exec next build` in `apps/docs` — MDX builds, the new section renders
- [ ] manual: in an external-store demo, flip `isSendDisabled: true` mid-conversation and confirm: input still typeable, Send button greyed, Enter does nothing, Cmd+Shift+Enter (with queue) does nothing, `aui.composer().send()` from console no-ops
- [ ] manual: confirm `<AuiIf condition={(s) => !s.composer.canSend}>` re-renders when the flag flips