### PR TITLE
docs: rewrite remaining guide and example titles for organic discovery

### DIFF
--- a/apps/docs/content/docs/guides/context-api.mdx
+++ b/apps/docs/content/docs/guides/context-api.mdx
@@ -1,6 +1,6 @@
 ---
-title: Context API
-description: Read and update assistant state to build custom components.
+title: Assistant Context API
+description: Read and update assistant state to build custom React components in your chat UI — composable context API for thread, message, and runtime data via assistant-ui.
 platforms: ["react"]
 ---
 

--- a/apps/docs/content/docs/guides/editing.mdx
+++ b/apps/docs/content/docs/guides/editing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Message Editing
-description: Allow users to edit their messages with custom editor interfaces.
+description: Let users edit their messages and regenerate AI responses with custom editor interfaces. Edit-and-resubmit patterns for React chat via assistant-ui.
 platforms: ["react"]
 ---
 

--- a/apps/docs/content/docs/guides/interactables.mdx
+++ b/apps/docs/content/docs/guides/interactables.mdx
@@ -1,6 +1,6 @@
 ---
-title: Interactables
-description: Persistent UI whose state can be read and updated by the AI assistant.
+title: Interactable Components
+description: Build persistent UI elements whose state the AI can read and update — copilot interactables in React with assistant-ui for forms, dashboards, and tools.
 platforms: ["react"]
 ---
 

--- a/apps/docs/content/docs/guides/latex.mdx
+++ b/apps/docs/content/docs/guides/latex.mdx
@@ -1,6 +1,6 @@
 ---
-title: LaTeX
-description: Render mathematical expressions in chat messages using KaTeX.
+title: LaTeX in Chat Messages
+description: Render LaTeX math expressions in AI chat messages with KaTeX — drop-in equation support for React chat UIs built on assistant-ui.
 platforms: ["react"]
 ---
 

--- a/apps/docs/content/docs/guides/mentions.mdx
+++ b/apps/docs/content/docs/guides/mentions.mdx
@@ -1,6 +1,6 @@
 ---
-title: Mentions
-description: Let users @-mention tools or custom items in the composer to guide the LLM.
+title: Mentions in Chat
+description: Let users @-mention tools, files, or custom items in the AI chat composer to guide the LLM. Mention picker built into assistant-ui's React composer.
 platforms: ["react"]
 ---
 

--- a/apps/docs/content/docs/guides/mentions.mdx
+++ b/apps/docs/content/docs/guides/mentions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mentions in Chat
-description: Let users @-mention tools, files, or custom items in the AI chat composer to guide the LLM. Mention picker built into assistant-ui's React composer.
+description: Let users @-mention tools or custom items in the AI chat composer to guide the LLM. Mention picker built into assistant-ui's React composer.
 platforms: ["react"]
 ---
 

--- a/apps/docs/content/docs/guides/message-timing.mdx
+++ b/apps/docs/content/docs/guides/message-timing.mdx
@@ -1,6 +1,6 @@
 ---
-title: Message Timing
-description: Display stream timing metadata like duration, tokens per second, and time to first token.
+title: Message Timing & Token Stats
+description: Display stream metadata in AI chat — generation duration, tokens per second, and time to first token, rendered via assistant-ui's React components.
 platforms: ["react"]
 ---
 

--- a/apps/docs/content/docs/guides/quoting.mdx
+++ b/apps/docs/content/docs/guides/quoting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quote Selected Text
-description: Let users select and quote text from messages. Full guide including backend handling and programmatic API.
+description: Let users select text from AI messages and quote it back into the composer. Full quoting flow with backend handling and programmatic API in assistant-ui.
 platforms: ["react"]
 ---
 

--- a/apps/docs/content/docs/guides/speech.mdx
+++ b/apps/docs/content/docs/guides/speech.mdx
@@ -1,6 +1,6 @@
 ---
-title: Text-to-Speech (Speech Synthesis)
-description: Read messages aloud with Web Speech API or a custom TTS adapter.
+title: Text-to-Speech for Chat
+description: Read AI chat messages aloud with the Web Speech API or a custom TTS adapter. Speech synthesis for React chat UIs, integrated with assistant-ui.
 platforms: ["react"]
 ---
 

--- a/apps/docs/content/examples/ai-sdk.mdx
+++ b/apps/docs/content/examples/ai-sdk.mdx
@@ -1,6 +1,6 @@
 ---
-title: AI SDK + Chat Persistence
-description: Chat persistence with AI SDK
+title: AI SDK Chat Persistence
+description: Vercel AI SDK chat with thread persistence — open-source React example combining the AI SDK and assistant-ui Cloud for storage, history, and multi-tenant.
 ---
 
 import { Shadcn } from "@/components/examples/shadcn";

--- a/apps/docs/content/examples/ai-sdk.mdx
+++ b/apps/docs/content/examples/ai-sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: AI SDK Chat Persistence
-description: Vercel AI SDK chat with thread persistence — open-source React example combining the AI SDK and assistant-ui Cloud for storage, history, and multi-tenant.
+description: Vercel AI SDK chat with thread persistence — open-source React example combining the AI SDK and assistant-ui for streaming, thread management, and message history.
 ---
 
 import { Shadcn } from "@/components/examples/shadcn";

--- a/apps/docs/content/examples/form-demo.mdx
+++ b/apps/docs/content/examples/form-demo.mdx
@@ -1,6 +1,6 @@
 ---
-title: Form Filling Co-Pilot
-description: AssistantSidebar copilot which fills forms for the user
+title: Form-Filling AI Copilot
+description: Open-source AI copilot that fills forms for users — sidebar UI, field-aware tool calls, and a working React example built with assistant-ui.
 ---
 
 


### PR DESCRIPTION
## Summary

Round 4 of the SEO frontmatter pass (continuation of #3985, #3986, #3987).

Targets the long-tail guides not yet touched plus two remaining examples:

**Guides** — `Context API`, `Message Editing`, `Interactables`, `LaTeX`, `Mentions`, `Message Timing`, `Quote Selected Text`, `Text-to-Speech (Speech Synthesis)`. All had single-word or short titles competing only on the brand.

**Examples** — `AI SDK + Chat Persistence` (description was just `Chat persistence with AI SDK`) and `Form Filling Co-Pilot` (description: `AssistantSidebar copilot which fills forms for the user`) — both rewritten with intent-bearing descriptions.

After this round every guide and example MDX page in `apps/docs/content` has a search-intent title and an extended description. The `(reference)` API docs are intentionally left alone (those pages serve discovery from inside the app, not search).

`@assistant-ui/docs` is private (no changeset). Pure frontmatter strings.

## Test plan

- [x] `pnpm turbo build --filter=@assistant-ui/docs` — passes (18/18 tasks).
- [ ] Once indexed, monitor whether long-tail terms (`latex chat`, `form filling copilot`, `ai chat speech to text`, `chat mentions`) start appearing in Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)