### PR TITLE
fix(react-ink): followups to #3966 (memo deps, clamp, tests, bench runner)

### DIFF
--- a/.changeset/perf-react-ink-virtualization.md
+++ b/.changeset/perf-react-ink-virtualization.md
@@ -2,36 +2,6 @@
 "@assistant-ui/react-ink": patch
 ---
 
-perf: virtualized message list and diff-aware reconciler for long ink threads
+perf: Virtualize message list and memoize per-message render in long ink threads
 
-Two internal changes that drop per-frame work in long ink threads. No public
-API change — all new knobs are optional and backward-compatible.
-
-- `ThreadPrimitive.Messages` now accepts `windowSize` / `windowOverscan`. When
-  set, only the most recent `windowSize + windowOverscan` messages stay
-  mounted and subscribed; messages above the live region graduate into Ink's
-  `<Static>`, which writes them to stdout exactly once and lets the terminal
-  commit them to scrollback before unmounting the React subtree. Per-token
-  reconciliation work is bounded by the window size regardless of thread
-  length, while scrolled-past output remains in the terminal backbuffer for
-  native scroll. Defaults preserve legacy behavior (render all dynamically).
-- Each rendered message is wrapped in a memoized boundary keyed by `(index,
-  render)`. Re-renders triggered by streaming a single message no longer
-  walk every other message's subtree. With a stable render callback, this
-  collapses an O(n) reconcile per token into O(1).
-
-Microbenchmark (`benchmarks/long-thread.bench.tsx`, 1000-message thread,
-~5 s of streaming at 62 tokens/sec, append-and-mutate per token, two
-trials each, averaged):
-
-| mode          | mean ms/frame | peak ms/frame |
-|---------------|---------------|---------------|
-| legacy        | 231           | 608           |
-| memo only     | 189 (-18%)    | 476 (-22%)    |
-| windowed (50) | 110 (-53%)    | 252 (-59%)    |
-
-Memo alone collapses the per-token reconcile cost on unchanged messages.
-Windowing layers on top by removing the bulk of the live tree from each
-flush. Peak frame time is the user-visible "stutter" metric; cutting it
-~2.4× is what eliminates the flicker reported in adjacent ink-on-terminal
-projects.
+`ThreadPrimitive.Messages` now accepts optional `windowSize` / `windowOverscan`. When set, the live render region keeps the last `windowSize + windowOverscan` messages; older ones graduate through Ink's `<Static>` into terminal scrollback. Each rendered message is wrapped in a memoized boundary keyed by `(index, render)`, so streaming a single message no longer reconciles the full list. Defaults preserve legacy behavior; negative values clamp to 0.

--- a/packages/react-ink/benchmarks/long-thread.bench.tsx
+++ b/packages/react-ink/benchmarks/long-thread.bench.tsx
@@ -1,26 +1,8 @@
 /**
- * Long-thread microbenchmark for `@assistant-ui/react-ink`.
+ * Long-thread microbenchmark: streams against a 1000-message thread and
+ * compares legacy, memo, and windowed modes by ms/frame.
  *
- * Renders a 1000-message thread, then drives a simulated 60+ tokens/sec
- * stream against the most recent message. Compares three rendering modes
- * to attribute the per-frame cost to memo vs windowing:
- *
- *   - legacy   : every message inline, no MemoMessage boundary (pre-PR)
- *   - memo     : MemoMessage per index, no windowing
- *   - windowed : MemoMessage + windowSize=50, prefix flushed via <Static>
- *
- * Reports frame count, mean ms/frame, and peak ms/frame for each mode plus
- * percentage deltas. Frame counting reads `ink-testing-library`'s in-memory
- * `stdout.frames` array — every committed Ink flush is one entry.
- *
- * The harness mounts the readonly thread runtime once and drives streaming
- * by calling `core.setMessages(...)` directly. We deliberately bypass
- * `ReadonlyThreadProvider`'s `messages`-prop-driven update path so the
- * provider tree does not re-render on every token; otherwise per-token
- * provider re-render cost dominates and masks the rendering-mode delta.
- *
- * Run:
- *   pnpm --filter @assistant-ui/react-ink exec tsx benchmarks/long-thread.bench.tsx
+ * Run: `pnpm --filter @assistant-ui/react-ink benchmark`
  */
 import { performance } from "node:perf_hooks";
 import type React from "react";
@@ -45,10 +27,6 @@ import { ThreadClient } from "@assistant-ui/core/store/internal";
 import type { ThreadMessage } from "@assistant-ui/core";
 import { ThreadPrimitive } from "../src/index";
 
-/* ------------------------------------------------------------------ */
-/*                       Bench harness (provider)                       */
-/* ------------------------------------------------------------------ */
-
 const READONLY_THREAD_PATH = Object.freeze({
   ref: "readonly-thread",
   threadSelector: { type: "main" as const },
@@ -71,11 +49,9 @@ const READONLY_THREAD_LIST_ITEM_BINDING: ThreadListItemRuntimeBinding =
   });
 
 /**
- * Mirrors `ReadonlyThreadProvider` but exposes the underlying
- * `ReadonlyThreadRuntimeCore` to the test driver via `coreRef`. The provider
- * mounts once with the initial messages and then never re-renders — the
- * driver pushes streaming updates straight into `core.setMessages`, which
- * notifies subscribers exactly the same way the production provider does.
+ * Mounts once and exposes the core via `coreRef` so the driver can push
+ * `setMessages` updates without re-rendering the provider tree, matching
+ * the production update path under streaming load.
  */
 const BenchProvider: React.FC<{
   initialMessages: readonly ThreadMessage[];
@@ -88,7 +64,6 @@ const BenchProvider: React.FC<{
     return c;
   });
 
-  // Stash for the driver. Stable for the lifetime of the harness.
   coreRef.current = core;
 
   const threadRuntime = useMemo(() => {
@@ -116,18 +91,10 @@ const BenchProvider: React.FC<{
   return <AuiProvider value={aui}>{children}</AuiProvider>;
 };
 
-/* ------------------------------------------------------------------ */
-/*                            App under test                           */
-/* ------------------------------------------------------------------ */
-
 /**
- * Each rendered message subscribes to its own first-part text length. Per-
- * token mutations to the streaming message therefore flow through the
- * message-level selector and produce a visibly different render output —
- * exactly the production behavior the perf changes target. Without this,
- * `parts[0]` reference changes but the rendered DOM is identical and Ink
- * skips the commit, so `stdout.frames` doesn't grow and the bench
- * measures nothing.
+ * Subscribes to the streaming message's text length so per-token mutations
+ * actually change the rendered DOM. Without this, Ink skips the commit and
+ * `stdout.frames` stops growing.
  */
 const Message = () => {
   const len = useAuiState((s) => {
@@ -141,11 +108,7 @@ const Message = () => {
   );
 };
 
-/**
- * Pre-PR baseline: render every message inline without the `MemoMessage`
- * boundary. Mirrors `ThreadMessages` before this PR so the perf contribution
- * of the memo change can be isolated from windowing.
- */
+/** Pre-memo baseline: every message rendered inline, no MemoMessage. */
 const LegacyThreadMessages: React.FC = () => {
   const messagesLength = useAuiState((s) => s.thread.messages.length);
   if (messagesLength === 0) return null;
@@ -186,13 +149,9 @@ const App: React.FC<{
   </BenchProvider>
 );
 
-/* ------------------------------------------------------------------ */
-/*                                 Run                                 */
-/* ------------------------------------------------------------------ */
-
 const N_MESSAGES = 1000;
-const N_TOKENS = 300; // ≈5 seconds of streaming at 60 tok/s
-const TOKEN_INTERVAL_MS = 16; // 62.5 tok/s
+const N_TOKENS = 300;
+const TOKEN_INTERVAL_MS = 16;
 const N_TRIALS = 2;
 
 const userMsg = (i: number): ThreadMessage =>
@@ -259,10 +218,8 @@ const run = async (
     .stdout;
   let lastSeen = stdout.frames.length;
 
-  // Distribute elapsed wall time evenly across new frames if multiple flushed
-  // between sample ticks. Keeps `frames` honest and the per-entry delta close
-  // to the true per-frame interval; the burst's actual frame timing is not
-  // observable through `stdout.frames.length` alone.
+  // `stdout.frames.length` exposes flush count but not per-frame timestamps,
+  // so we distribute elapsed wall time evenly across new frames per tick.
   const sample = () => {
     const newFrames = stdout.frames.length - lastSeen;
     if (newFrames <= 0) return;
@@ -273,7 +230,6 @@ const run = async (
     lastSeen = stdout.frames.length;
   };
 
-  // Initial mount frames have settled.
   await new Promise((r) => setTimeout(r, 100));
   sample();
   frameTimes.length = 0;
@@ -282,24 +238,16 @@ const run = async (
   const core = coreRef.current;
   if (!core) throw new Error("BenchProvider did not capture core");
 
-  // Drive streaming via the captured core handle. No React prop changes —
-  // the provider does not re-render. Every update is `core.setMessages(...)
-  // → notifySubscribers`, exactly the production update path under load.
-  //
-  // Each token both (a) mutates the trailing streaming message's text and
-  // (b) appends a new message to the thread. (a) exercises the message-
-  // level subscriber on the streaming entry; (b) makes the parent length
-  // selector tick every token, which is what triggers the per-token parent
-  // re-render that the memo + windowing changes optimize. Without (b), the
-  // parent would only re-render on new turns and the bench would primarily
-  // measure ink-flush cost rather than reconciliation cost.
+  // Mutation exercises the per-message subscriber; the append ticks the
+  // parent length selector, which is what memo+windowing actually targets.
+  // Without the append the bench would measure flush cost, not reconcile.
   let acc = "";
   let cur: ThreadMessage[] = [...initialMessages];
   for (let t = 0; t < N_TOKENS; t++) {
     acc += "x";
     const streamingIdx = cur.length - 1;
     const updatedStreaming = assistantMsg(streamingIdx, acc);
-    const newTail = userMsg(cur.length); // index = previous length
+    const newTail = userMsg(cur.length);
     const next: ThreadMessage[] = [
       ...cur.slice(0, -1),
       updatedStreaming,
@@ -331,7 +279,6 @@ const main = async () => {
     `\n=== long-thread.bench (${N_MESSAGES} messages, ${(N_TOKENS * TOKEN_INTERVAL_MS) / 1000}s @ ${(1000 / TOKEN_INTERVAL_MS).toFixed(0)} tok/s, ${N_TRIALS} trials each) ===\n`,
   );
 
-  // Warm-up.
   console.log("warmup...");
   await run("warmup", "windowed", 50);
 

--- a/packages/react-ink/benchmarks/run.ts
+++ b/packages/react-ink/benchmarks/run.ts
@@ -1,0 +1,23 @@
+import { spawnSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const benchDir = dirname(fileURLToPath(import.meta.url));
+const files = readdirSync(benchDir)
+  .filter((f) => /\.bench\.tsx?$/.test(f))
+  .sort();
+
+if (files.length === 0) {
+  console.log("no bench files found");
+  process.exit(0);
+}
+
+let exitCode = 0;
+for (const f of files) {
+  console.log(`\n=== ${f} ===`);
+  const r = spawnSync("tsx", [join(benchDir, f)], { stdio: "inherit" });
+  if (r.status !== 0 && exitCode === 0) exitCode = r.status ?? 1;
+}
+
+process.exit(exitCode);

--- a/packages/react-ink/package.json
+++ b/packages/react-ink/package.json
@@ -34,7 +34,8 @@
   "scripts": {
     "build": "aui-build",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "benchmark": "tsx benchmarks/run.ts"
   },
   "dependencies": {
     "@assistant-ui/core": "^0.2.0",
@@ -62,6 +63,7 @@
     "ink": "^7.0.2",
     "ink-testing-library": "^4.0.0",
     "react": "^19.2.5",
+    "tsx": "^4.21.0",
     "vitest": "^4.1.5"
   },
   "publishConfig": {

--- a/packages/react-ink/src/primitives/internal/MemoMessage.tsx
+++ b/packages/react-ink/src/primitives/internal/MemoMessage.tsx
@@ -8,19 +8,6 @@ type MemoMessageProps = {
   render: (value: { message: ThreadMessage }) => ReactNode;
 };
 
-/**
- * Stable per-index message boundary.
- *
- * Wrapping each message render in `React.memo` lets the reconciler skip
- * subtrees whose `(index, render)` pair hasn't changed across a parent
- * re-render. With a stable `render` callback (the common case) and a stable
- * index, only the messages whose own `useAuiState` slices change actually
- * re-render — even though `ThreadMessages` itself re-runs on every length
- * change. In a 1000-message thread under streaming, this collapses an O(n)
- * walk into O(1) per token.
- *
- * Internal component. Not exported from the public surface.
- */
 const MemoMessageImpl = ({ index, render }: MemoMessageProps) => {
   return (
     <MessageByIndexProvider index={index}>
@@ -38,6 +25,8 @@ const MemoMessageImpl = ({ index, render }: MemoMessageProps) => {
     </MessageByIndexProvider>
   );
 };
+
+MemoMessageImpl.displayName = "ThreadPrimitive.Messages.MemoItem";
 
 export const MemoMessage = memo(
   MemoMessageImpl,

--- a/packages/react-ink/src/primitives/thread/ThreadMessages.test.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadMessages.test.tsx
@@ -1,0 +1,220 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "ink-testing-library";
+import { Text } from "ink";
+
+const hoisted = vi.hoisted(() => ({
+  state: { messagesLength: 0 },
+  capturedIndices: [] as number[],
+  staticItemCounts: [] as number[],
+  tailItemCounts: [] as number[],
+}));
+
+vi.mock("ink", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ink")>();
+  return {
+    ...actual,
+    Static: <T,>({
+      items,
+      children,
+    }: {
+      items: readonly T[];
+      children: (item: T, index: number) => ReactNode;
+    }) => {
+      hoisted.staticItemCounts.push(items.length);
+      return <>{items.map((item, i) => children(item, i))}</>;
+    },
+  };
+});
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  return {
+    ...actual,
+    useAuiState: (selector: (s: unknown) => unknown) => {
+      const state = {
+        thread: { messages: { length: hoisted.state.messagesLength } },
+        message: {
+          role: "user" as const,
+          composer: { isEditing: false },
+          parts: [],
+        },
+      };
+      return selector(state);
+    },
+    RenderChildrenWithAccessor: ({
+      children,
+    }: {
+      children: (getItem: () => unknown) => ReactNode;
+    }) => <>{children(() => ({}))}</>,
+  };
+});
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@assistant-ui/core/react")>();
+  return {
+    ...actual,
+    MessageByIndexProvider: ({
+      index,
+      children,
+    }: {
+      index: number;
+      children: ReactNode;
+    }) => {
+      hoisted.capturedIndices.push(index);
+      return <>{children}</>;
+    },
+  };
+});
+
+import { ThreadPrimitive } from "../../index";
+
+beforeEach(() => {
+  hoisted.state.messagesLength = 0;
+  hoisted.capturedIndices = [];
+  hoisted.staticItemCounts = [];
+  hoisted.tailItemCounts = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ThreadPrimitive.Messages", () => {
+  it("renders every message when windowSize is undefined", () => {
+    hoisted.state.messagesLength = 5;
+
+    render(
+      <ThreadPrimitive.Messages>
+        {() => <Text>m</Text>}
+      </ThreadPrimitive.Messages>,
+    );
+
+    expect(hoisted.capturedIndices).toEqual([0, 1, 2, 3, 4]);
+    expect(hoisted.staticItemCounts).toEqual([]);
+  });
+
+  it("renders nothing when there are no messages", () => {
+    hoisted.state.messagesLength = 0;
+
+    render(
+      <ThreadPrimitive.Messages>
+        {() => <Text>m</Text>}
+      </ThreadPrimitive.Messages>,
+    );
+
+    expect(hoisted.capturedIndices).toEqual([]);
+    expect(hoisted.staticItemCounts).toEqual([]);
+  });
+
+  it("keeps every message live when total fits within windowSize + windowOverscan", () => {
+    hoisted.state.messagesLength = 5;
+
+    render(
+      <ThreadPrimitive.Messages windowSize={3} windowOverscan={4}>
+        {() => <Text>m</Text>}
+      </ThreadPrimitive.Messages>,
+    );
+
+    expect(hoisted.capturedIndices).toEqual([0, 1, 2, 3, 4]);
+    expect(hoisted.staticItemCounts).toEqual([]);
+  });
+
+  it("splits long threads into a Static prefix plus live tail covering windowSize + windowOverscan", () => {
+    hoisted.state.messagesLength = 20;
+
+    render(
+      <ThreadPrimitive.Messages windowSize={3} windowOverscan={4}>
+        {() => <Text>m</Text>}
+      </ThreadPrimitive.Messages>,
+    );
+
+    expect(hoisted.staticItemCounts.at(-1)).toBe(13);
+    expect(hoisted.capturedIndices).toHaveLength(20);
+    expect(hoisted.capturedIndices.slice(0, 13)).toEqual(
+      Array.from({ length: 13 }, (_, i) => i),
+    );
+    expect(hoisted.capturedIndices.slice(13)).toEqual([
+      13, 14, 15, 16, 17, 18, 19,
+    ]);
+  });
+
+  it("defaults windowOverscan to 4", () => {
+    hoisted.state.messagesLength = 7;
+
+    render(
+      <ThreadPrimitive.Messages windowSize={2}>
+        {() => <Text>m</Text>}
+      </ThreadPrimitive.Messages>,
+    );
+
+    expect(hoisted.staticItemCounts.at(-1)).toBe(1);
+    expect(hoisted.capturedIndices).toHaveLength(7);
+  });
+
+  it("clamps negative windowSize and windowOverscan to 0", () => {
+    hoisted.state.messagesLength = 6;
+
+    render(
+      <ThreadPrimitive.Messages windowSize={-5} windowOverscan={-2}>
+        {() => <Text>m</Text>}
+      </ThreadPrimitive.Messages>,
+    );
+
+    expect(hoisted.staticItemCounts.at(-1)).toBe(6);
+    expect(hoisted.capturedIndices).toHaveLength(6);
+  });
+
+  it("with windowSize=0 keeps only windowOverscan messages live", () => {
+    hoisted.state.messagesLength = 10;
+
+    render(
+      <ThreadPrimitive.Messages windowSize={0} windowOverscan={4}>
+        {() => <Text>m</Text>}
+      </ThreadPrimitive.Messages>,
+    );
+
+    expect(hoisted.staticItemCounts.at(-1)).toBe(6);
+    expect(hoisted.capturedIndices).toHaveLength(10);
+  });
+
+  it("does not re-render messages on parent rerender with a stable render fn", () => {
+    hoisted.state.messagesLength = 3;
+    const stableRender = () => <Text>m</Text>;
+
+    const instance = render(
+      <ThreadPrimitive.Messages>{stableRender}</ThreadPrimitive.Messages>,
+    );
+    expect(hoisted.capturedIndices).toEqual([0, 1, 2]);
+
+    instance.rerender(
+      <ThreadPrimitive.Messages>{stableRender}</ThreadPrimitive.Messages>,
+    );
+    expect(hoisted.capturedIndices).toEqual([0, 1, 2]);
+  });
+
+  it("supports the components API alongside windowing", () => {
+    hoisted.state.messagesLength = 4;
+    const Message = () => <Text>m</Text>;
+
+    render(
+      <ThreadPrimitive.Messages windowSize={2} components={{ Message }} />,
+    );
+
+    expect(hoisted.capturedIndices).toEqual([0, 1, 2, 3]);
+  });
+
+  it("does not re-render messages when an inline components literal is passed", () => {
+    hoisted.state.messagesLength = 3;
+    const Message = () => <Text>m</Text>;
+
+    const App = () => <ThreadPrimitive.Messages components={{ Message }} />;
+
+    const instance = render(<App />);
+    expect(hoisted.capturedIndices).toEqual([0, 1, 2]);
+
+    instance.rerender(<App />);
+    expect(hoisted.capturedIndices).toEqual([0, 1, 2]);
+  });
+});

--- a/packages/react-ink/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadMessages.tsx
@@ -33,34 +33,18 @@ type MessageComponents =
     };
 
 /**
- * Optional virtualization config.
+ * Live render region keeps the last `windowSize + windowOverscan` messages;
+ * older messages graduate through Ink's `<Static>` into terminal scrollback
+ * and stop repainting. Defaults to no windowing.
  *
- * Terminals scroll their own backbuffer; rendering messages that have already
- * scrolled past the visible region is wasted work and (during streaming) also
- * wasted store subscriptions. When `windowSize` is set, only the last
- * `windowSize + windowOverscan` messages are kept in the live render region.
- * Messages above the window are emitted exactly once through Ink's `<Static>`
- * — Ink writes them to stdout, the terminal commits them to scrollback, and
- * the React subtree is then unmounted. As new messages arrive, older entries
- * graduate from the live tail into `<Static>` automatically.
- *
- * Trade-off: messages that have graduated into `<Static>` are read-only from
- * the renderer's perspective. Edits to messages outside the window won't
- * repaint until the user re-opens the thread. This matches terminal
- * scrollback semantics — scrolled-past output is committed history.
- *
- * Defaults to no windowing for backward compatibility.
+ * Per-message memoization only engages when the render callback is
+ * referentially stable. The `components` API handles stability internally;
+ * with the children render-fn API, hoist or memoize the function.
  */
 type WindowingProps = {
-  /**
-   * Maximum number of recent messages to keep in the live render region.
-   * When unset, all messages render dynamically (legacy behavior).
-   */
+  /** Recent messages kept live. Unset renders all dynamically. Negative clamped to 0. */
   windowSize?: number | undefined;
-  /**
-   * Extra messages above the window kept in the live region to absorb
-   * remount churn at the boundary during streaming. Defaults to 4.
-   */
+  /** Extra live messages above the window to absorb boundary churn. Defaults to 4. Negative clamped to 0. */
   windowOverscan?: number | undefined;
 };
 
@@ -146,17 +130,16 @@ const ThreadMessagesInner: FC<{
 }> = ({ children, windowSize, windowOverscan = 4 }) => {
   const messagesLength = useAuiState((s) => s.thread.messages.length);
 
-  // [tailStart, messagesLength) is the live region; [0, tailStart) is the
-  // committed prefix rendered through <Static>. With no windowing, tailStart
-  // is 0 — all messages stay live (legacy behavior).
   const tailStart =
     windowSize !== undefined
-      ? Math.max(0, messagesLength - windowSize - windowOverscan)
+      ? Math.max(
+          0,
+          messagesLength -
+            Math.max(0, windowSize) -
+            Math.max(0, windowOverscan),
+        )
       : 0;
 
-  // <Static> only renders newly-added items: it reads `items.slice(committed)`
-  // each render and bumps the committed cursor in a layout effect. Identity-
-  // stable indices let the slice short-circuit cleanly when the array grows.
   const prefixIndices = useMemo(
     () => Array.from({ length: tailStart }, (_, i) => i),
     [tailStart],
@@ -189,10 +172,6 @@ export const ThreadMessages: FC<ThreadMessagesProps> = ({
   windowSize,
   windowOverscan,
 }) => {
-  // Field-level destructure so inline `components={{ Message: MyMessage }}`
-  // doesn't bust the memo on every parent render. As long as the individual
-  // component refs are stable, `stableComponents` keeps a stable identity
-  // and `MemoMessage` can short-circuit unchanged subtrees.
   const Message = components?.Message;
   const EditComposer = components?.EditComposer;
   const UserEditComposer = components?.UserEditComposer;
@@ -202,6 +181,7 @@ export const ThreadMessages: FC<ThreadMessagesProps> = ({
   const AssistantMessage = components?.AssistantMessage;
   const SystemMessage = components?.SystemMessage;
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `components` excluded so inline literals do not bust the memo; per-field deps cover real changes.
   const stableComponents = useMemo<MessageComponents | undefined>(() => {
     if (!components) return undefined;
     return {
@@ -215,7 +195,6 @@ export const ThreadMessages: FC<ThreadMessagesProps> = ({
       SystemMessage,
     } as MessageComponents;
   }, [
-    components,
     Message,
     EditComposer,
     UserEditComposer,

--- a/packages/react-ink/tsconfig.json
+++ b/packages/react-ink/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "@assistant-ui/x-buildutils/ts/base",
-  "include": ["src"]
+  "include": ["src", "benchmarks"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3282,6 +3282,9 @@ importers:
       react:
         specifier: ^19.2.5
         version: 19.2.5
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))


### PR DESCRIPTION
follow-up to #3966 (which merged before these landed). all five commits target what was already in that PR; nothing new architecturally.

## what's here

- **fix**: drop `components` from the `stableComponents` `useMemo` deps so inline `components={{ Message: X }}` literals stop busting the per-message memo (the regression cubic + greptile both flagged on #3966). also clamp negative `windowSize`/`windowOverscan` to 0, and document on `WindowingProps` that the children render-fn API requires a stable callback.
- **test**: new `ThreadMessages.test.tsx` with 8 cases covering windowing math, default overscan, the static-prefix split, the negative clamp, `windowSize=0`, the memo short-circuit on rerender, and the inline-components stability path.
- **chore**: `pnpm benchmark` script + `benchmarks/run.ts` that walks the directory and runs every `*.bench.{ts,tsx}` through `tsx`. `benchmarks/` is included in `tsconfig` so files type-check; `files` whitelist still excludes the directory from the published tarball.
- **refactor**: trim verbose JSDoc and inline comments in `MemoMessage` (drop entirely, internal) and `long-thread.bench.tsx` (keep only WHY-comments and the run instruction). add `displayName` on the memo boundary for devtools parity with `ThreadPrimitive.MessageByIndex` in core.
- **docs**: collapse the changeset to a single paragraph; drop the (machine-dependent) microbenchmark table.

## test plan

- [x] `pnpm --filter @assistant-ui/react-ink test` (56/56)
- [x] `pnpm --filter @assistant-ui/react-ink exec tsc --noEmit`
- [x] `pnpm --filter @assistant-ui/react-ink build`
- [x] `pnpm exec biome check packages/react-ink/src packages/react-ink/benchmarks`
- [x] `pnpm --filter @assistant-ui/react-ink benchmark` (full 3-mode run, 2 trials each)
- [x] `npm pack --dry-run` confirms `benchmarks/` excluded

## bench attribution (this machine)

| mode          | mean  | peak  |
|---------------|-------|-------|
| legacy        | 96ms  | 205ms |
| memo only     | 74ms (-23%) | 170ms (-17%) |
| windowed 50   | 23ms (-76%) | 55ms (-73%)  |

memo alone gets ~20% off both metrics; the rest of the peak-frame win is from windowing. shape matches the original PR's table; absolute ms vary by machine.