### PR TITLE
docs: trim redundant "AI Chat" prefix from hub page titles

### DIFF
--- a/apps/docs/content/docs/(docs)/index.mdx
+++ b/apps/docs/content/docs/(docs)/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: React AI Chat Documentation
+title: Documentation
 description: Build production-grade AI chat experiences in React with assistant-ui — components, runtimes, and primitives for ChatGPT-style UIs, copilots, and agents.
 platforms: ["react"]
 ---

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI Chat Integrations
+title: Integrations
 description: Adapters for Vercel AI SDK, LangChain, LangGraph, Mastra, plus auth, persistence, observability, and tool services — drop into a React chat UI built with assistant-ui.
 ---
 

--- a/apps/docs/content/examples/index.mdx
+++ b/apps/docs/content/examples/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: React AI Chat Examples
+title: Examples
 description: Production-ready examples of AI chat in React — ChatGPT clones, copilots, generative UI, artifacts, multimodal, and more, all built with assistant-ui.
 ---
 


### PR DESCRIPTION
## Summary

Replaces the closed #3990. (That one's branch landed in a borked GitButler-rebase state with empty commits; cleaner to redo from a fresh base.)

Follow-up to review feedback from @Yonom on #3986: "AI Chat Guides" → "Guides" because the layout template already appends `— assistant-ui (React Chat UI for AI)` to every page. Same principle applies to the other hub titles I added in #3985:

- `apps/docs/content/docs/(docs)/index.mdx` — `React AI Chat Documentation` → `Documentation`
- `apps/docs/content/examples/index.mdx` — `React AI Chat Examples` → `Examples`
- `apps/docs/content/docs/integrations/index.mdx` — `AI Chat Integrations` → `Integrations`

Descriptions unchanged — those go into `<meta>` tags only, not into navigation chrome, so they keep the intent phrasing.

`@assistant-ui/docs` is private (no changeset).

## Test plan

- [x] Diff is exactly 3 single-word title changes; no other files touched.
- [ ] Quick eyeball after merge to confirm rendered titles read `Documentation — assistant-ui (React Chat UI for AI)` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)