### PR TITLE
docs: polish all five clone examples to match their real products

### DIFF
--- a/apps/docs/components/examples/chatgpt.tsx
+++ b/apps/docs/components/examples/chatgpt.tsx
@@ -12,7 +12,6 @@ import {
   useAui,
   useAuiState,
 } from "@assistant-ui/react";
-import { Avatar } from "radix-ui";
 import {
   ArrowUpIcon,
   CheckIcon,
@@ -27,68 +26,198 @@ import {
 import { useEffect, useState, type FC } from "react";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { useShallow } from "zustand/shallow";
-import { PlusIcon } from "lucide-react";
+import {
+  AudioLines,
+  Globe,
+  ImageIcon,
+  Lightbulb,
+  Mic,
+  MoreHorizontal,
+  PlusIcon,
+  Share,
+  SlidersHorizontal,
+  Sparkles,
+  Telescope,
+  ThumbsDown,
+  ThumbsUp,
+  Volume2,
+} from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/shared/dropdown-menu";
 
 export const ChatGPT: FC = () => {
   return (
-    <ThreadPrimitive.Root className="flex h-full flex-col items-stretch bg-background px-4 text-foreground dark:bg-[#212121] dark:text-foreground">
-      <ThreadPrimitive.Viewport className="flex grow flex-col gap-8 overflow-y-scroll pt-16">
-        <AuiIf condition={(s) => s.thread.isEmpty}>
-          <div className="flex grow flex-col items-center justify-center">
-            <Avatar.Root className="flex h-12 w-12 items-center justify-center rounded-3xl border shadow dark:border-white/15">
-              <Avatar.AvatarFallback>C</Avatar.AvatarFallback>
-            </Avatar.Root>
-            <p className="mt-4 text-xl dark:text-white">
-              How can I help you today?
+    <ThreadPrimitive.Root className="flex h-full flex-col items-stretch bg-white px-4 text-[#0d0d0d] dark:bg-[#212121] dark:text-[#ececec]">
+      <AuiIf condition={(s) => s.thread.isEmpty}>
+        <EmptyState />
+      </AuiIf>
+
+      <AuiIf condition={(s) => !s.thread.isEmpty}>
+        <ThreadPrimitive.Viewport className="flex grow flex-col gap-8 overflow-y-scroll pt-16">
+          <ThreadPrimitive.Messages>
+            {({ message }) => {
+              if (message.composer.isEditing) return <EditComposer />;
+              if (message.role === "user") return <UserMessage />;
+              return <AssistantMessage />;
+            }}
+          </ThreadPrimitive.Messages>
+
+          <ThreadPrimitive.ViewportFooter className="sticky bottom-0 mx-auto mt-auto flex w-full max-w-3xl flex-col gap-2 overflow-visible rounded-t-3xl bg-white pb-2 dark:bg-[#212121]">
+            <ThreadScrollToBottom />
+            <Composer placeholder="Ask anything" />
+            <p className="text-center text-[#5d5d5d] text-xs dark:text-[#a8a8a8]">
+              ChatGPT can make mistakes. Check important info.
             </p>
-          </div>
-        </AuiIf>
-
-        <ThreadPrimitive.Messages>
-          {({ message }) => {
-            if (message.composer.isEditing) return <EditComposer />;
-            if (message.role === "user") return <UserMessage />;
-            return <AssistantMessage />;
-          }}
-        </ThreadPrimitive.Messages>
-
-        <ThreadPrimitive.ViewportFooter className="sticky bottom-0 mx-auto mt-auto flex w-full max-w-3xl flex-col gap-4 overflow-visible rounded-t-3xl bg-background pb-2 dark:bg-[#212121]">
-          <ThreadScrollToBottom />
-          <ComposerPrimitive.Root className="w-full rounded-3xl border pl-2 dark:border-none dark:bg-white/5">
-            <AuiIf condition={(s) => s.composer.attachments.length > 0}>
-              <div className="flex flex-row flex-wrap gap-2 px-1 py-3">
-                <ComposerPrimitive.Attachments
-                  components={{ Attachment: ChatGPTAttachmentUI }}
-                />
-              </div>
-            </AuiIf>
-            <div className="flex items-center justify-center">
-              <ComposerPrimitive.AddAttachment className="flex size-8 items-center justify-center overflow-hidden rounded-full hover:bg-foreground/5 dark:hover:bg-foreground/15">
-                <PlusIcon size={18} />
-              </ComposerPrimitive.AddAttachment>
-              <ComposerPrimitive.Input
-                placeholder="Ask anything"
-                className="h-12 max-h-40 grow resize-none bg-transparent p-3.5 text-foreground text-sm outline-none placeholder:text-muted-foreground dark:text-white dark:placeholder:text-white/50"
-              />
-              <AuiIf condition={(s) => !s.thread.isRunning}>
-                <ComposerPrimitive.Send className="m-2 flex size-8 items-center justify-center rounded-full bg-primary text-primary-foreground transition-opacity disabled:opacity-10 dark:bg-white dark:text-black">
-                  <ArrowUpIcon className="size-5 dark:[&_path]:stroke-1 dark:[&_path]:stroke-black" />
-                </ComposerPrimitive.Send>
-              </AuiIf>
-              <AuiIf condition={(s) => s.thread.isRunning}>
-                <ComposerPrimitive.Cancel className="m-2 flex size-8 items-center justify-center rounded-full bg-primary text-primary-foreground dark:bg-white">
-                  <div className="size-2.5 bg-background dark:bg-black" />
-                </ComposerPrimitive.Cancel>
-              </AuiIf>
-            </div>
-          </ComposerPrimitive.Root>
-
-          <p className="text-center text-muted-foreground text-xs dark:text-[#cdcdcd]">
-            ChatGPT can make mistakes. Check important info.
-          </p>
-        </ThreadPrimitive.ViewportFooter>
-      </ThreadPrimitive.Viewport>
+          </ThreadPrimitive.ViewportFooter>
+        </ThreadPrimitive.Viewport>
+      </AuiIf>
     </ThreadPrimitive.Root>
+  );
+};
+
+const EmptyState: FC = () => {
+  return (
+    <div className="flex grow flex-col items-center justify-center px-4">
+      <div className="mx-auto flex w-full max-w-3xl flex-col items-stretch gap-6">
+        <h1 className="text-center font-medium text-2xl text-[#0d0d0d] sm:text-3xl dark:text-[#ececec]">
+          Where should we begin?
+        </h1>
+        <Composer placeholder="Ask anything" />
+      </div>
+    </div>
+  );
+};
+
+const Composer: FC<{ placeholder: string }> = ({ placeholder }) => {
+  return (
+    <ComposerPrimitive.Root className="group/composer flex w-full flex-col rounded-[28px] border border-[#e5e5e5] bg-white px-2 py-2 shadow-[0_2px_6px_-2px_rgba(0,0,0,0.05)] focus-within:border-[#d0d0d0] dark:border-transparent dark:bg-[#303030] dark:shadow-none dark:focus-within:border-transparent">
+      <AuiIf condition={(s) => s.composer.attachments.length > 0}>
+        <div className="flex flex-row flex-wrap gap-2 px-1 pt-1 pb-2">
+          <ComposerPrimitive.Attachments
+            components={{ Attachment: ChatGPTAttachmentUI }}
+          />
+        </div>
+      </AuiIf>
+
+      <ComposerPrimitive.Input
+        placeholder={placeholder}
+        rows={1}
+        className="min-h-9 w-full resize-none bg-transparent px-3 pt-2 text-[#0d0d0d] text-base outline-none placeholder:text-[#8e8e8e] dark:text-[#ececec] dark:placeholder:text-[#8e8e8e]"
+      />
+
+      <div className="flex items-center justify-between gap-2 px-1 pt-1">
+        <div className="flex items-center gap-1">
+          <ComposerPrimitive.AddAttachment asChild>
+            <button
+              type="button"
+              className="flex size-9 items-center justify-center rounded-full text-[#5d5d5d] transition-colors hover:bg-[#0d0d0d]/5 hover:text-[#0d0d0d] dark:text-[#cdcdcd] dark:hover:bg-white/10 dark:hover:text-white"
+              aria-label="Add attachment"
+            >
+              <PlusIcon size={18} />
+            </button>
+          </ComposerPrimitive.AddAttachment>
+        </div>
+
+        <div className="flex items-center gap-1">
+          <ChatGPTToolsMenu />
+          <ComposerPrimaryAction />
+        </div>
+      </div>
+    </ComposerPrimitive.Root>
+  );
+};
+
+const CHATGPT_TOOLS = [
+  { id: "search", label: "Search the web", Icon: Globe },
+  { id: "image", label: "Create an image", Icon: ImageIcon },
+  { id: "research", label: "Run deep research", Icon: Telescope },
+  { id: "think", label: "Think longer", Icon: Lightbulb },
+  { id: "study", label: "Study and learn", Icon: Sparkles },
+];
+
+const ChatGPTToolsMenu: FC = () => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="hidden h-9 items-center gap-1.5 rounded-full px-3 text-[#5d5d5d] text-sm transition-colors hover:bg-[#0d0d0d]/5 hover:text-[#0d0d0d] sm:flex dark:text-[#cdcdcd] dark:hover:bg-white/10 dark:hover:text-white">
+        <SlidersHorizontal className="size-4" />
+        <span>Tools</span>
+        <ChevronDownIcon className="size-3.5 opacity-70" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-56">
+        {CHATGPT_TOOLS.map(({ id, label, Icon }) => (
+          <DropdownMenuItem
+            key={id}
+            icon={<Icon className="size-4" />}
+            className="text-foreground text-sm"
+          >
+            {label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+const ComposerPrimaryAction: FC = () => {
+  return (
+    <div className="flex items-center gap-1">
+      <AuiIf condition={(s) => s.thread.isRunning}>
+        <ComposerPrimitive.Cancel className="flex size-9 items-center justify-center rounded-full bg-[#0d0d0d] text-white dark:bg-white dark:text-black">
+          <div className="size-2.5 rounded-[2px] bg-current" />
+        </ComposerPrimitive.Cancel>
+      </AuiIf>
+
+      <AuiIf
+        condition={(s) => !s.thread.isRunning && s.composer.dictation != null}
+      >
+        <ComposerPrimitive.StopDictation
+          className="flex size-9 items-center justify-center rounded-full bg-[#ff5d1f] text-white"
+          aria-label="Stop dictation"
+        >
+          <div className="size-2.5 animate-pulse rounded-[2px] bg-current" />
+        </ComposerPrimitive.StopDictation>
+      </AuiIf>
+
+      <AuiIf
+        condition={(s) =>
+          !s.thread.isRunning &&
+          s.composer.dictation == null &&
+          !s.composer.isEmpty
+        }
+      >
+        <ComposerPrimitive.Send className="flex size-9 items-center justify-center rounded-full bg-[#0d0d0d] text-white transition-opacity disabled:opacity-30 dark:bg-white dark:text-black">
+          <ArrowUpIcon className="size-5" />
+        </ComposerPrimitive.Send>
+      </AuiIf>
+
+      <AuiIf
+        condition={(s) =>
+          !s.thread.isRunning &&
+          s.composer.dictation == null &&
+          s.composer.isEmpty
+        }
+      >
+        <ComposerPrimitive.Dictate
+          className="flex size-9 items-center justify-center rounded-full text-[#5d5d5d] transition-colors hover:bg-[#0d0d0d]/5 hover:text-[#0d0d0d] dark:text-[#cdcdcd] dark:hover:bg-white/10 dark:hover:text-white"
+          aria-label="Dictate"
+        >
+          <Mic className="size-4" />
+        </ComposerPrimitive.Dictate>
+
+        <button
+          type="button"
+          aria-hidden="true"
+          tabIndex={-1}
+          className="flex size-9 items-center justify-center rounded-full bg-[#ff5d1f] text-white"
+        >
+          <AudioLines className="size-4" />
+        </button>
+      </AuiIf>
+    </div>
   );
 };
 
@@ -155,46 +284,53 @@ const EditComposer: FC = () => {
   );
 };
 
+const assistantActionClassName =
+  "flex size-8 items-center justify-center rounded-md text-[#5d5d5d] transition-colors hover:bg-[#0d0d0d]/5 hover:text-[#0d0d0d] dark:text-[#afafaf] dark:hover:bg-white/10 dark:hover:text-white";
+
 const AssistantMessage: FC = () => {
   return (
-    <MessagePrimitive.Root className="relative mx-auto flex w-full max-w-3xl gap-3">
-      <Avatar.Root className="flex size-8 shrink-0 items-center justify-center rounded-3xl border shadow dark:border-white/15">
-        <Avatar.AvatarFallback className="text-foreground text-xs dark:text-white">
-          C
-        </Avatar.AvatarFallback>
-      </Avatar.Root>
+    <MessagePrimitive.Root className="relative mx-auto flex w-full max-w-3xl flex-col">
+      <div className="text-[#0d0d0d] dark:text-[#ececec]">
+        <MessagePrimitive.Parts />
+      </div>
 
-      <div className="pt-1">
-        <div className="text-foreground dark:text-[#eee]">
-          <MessagePrimitive.Parts />
-        </div>
-
-        <div className="flex pt-2">
-          <BranchPicker />
-
-          <ActionBarPrimitive.Root
-            hideWhenRunning
-            autohide="not-last"
-            autohideFloat="single-branch"
-            className="flex items-center gap-1 rounded-lg data-floating:absolute data-floating:border-2 data-floating:p-1"
+      <div className="-ml-2 flex items-center pt-1">
+        <ActionBarPrimitive.Root
+          hideWhenRunning
+          className="flex items-center gap-0.5"
+        >
+          <ActionBarPrimitive.Copy className={assistantActionClassName}>
+            <AuiIf condition={(s) => s.message.isCopied}>
+              <CheckIcon />
+            </AuiIf>
+            <AuiIf condition={(s) => !s.message.isCopied}>
+              <CopyIcon />
+            </AuiIf>
+          </ActionBarPrimitive.Copy>
+          <ActionBarPrimitive.FeedbackPositive
+            className={assistantActionClassName}
           >
-            <ActionBarPrimitive.Reload asChild>
-              <TooltipIconButton tooltip="Reload" className="text-[#b4b4b4]">
-                <ReloadIcon />
-              </TooltipIconButton>
-            </ActionBarPrimitive.Reload>
-            <ActionBarPrimitive.Copy asChild>
-              <TooltipIconButton tooltip="Copy" className="text-[#b4b4b4]">
-                <AuiIf condition={(s) => s.message.isCopied}>
-                  <CheckIcon />
-                </AuiIf>
-                <AuiIf condition={(s) => !s.message.isCopied}>
-                  <CopyIcon />
-                </AuiIf>
-              </TooltipIconButton>
-            </ActionBarPrimitive.Copy>
-          </ActionBarPrimitive.Root>
-        </div>
+            <ThumbsUp className="size-4" />
+          </ActionBarPrimitive.FeedbackPositive>
+          <ActionBarPrimitive.FeedbackNegative
+            className={assistantActionClassName}
+          >
+            <ThumbsDown className="size-4" />
+          </ActionBarPrimitive.FeedbackNegative>
+          <ActionBarPrimitive.Speak className={assistantActionClassName}>
+            <Volume2 className="size-4" />
+          </ActionBarPrimitive.Speak>
+          <button type="button" className={assistantActionClassName}>
+            <Share className="size-4" />
+          </button>
+          <ActionBarPrimitive.Reload className={assistantActionClassName}>
+            <ReloadIcon />
+          </ActionBarPrimitive.Reload>
+          <button type="button" className={assistantActionClassName}>
+            <MoreHorizontal className="size-4" />
+          </button>
+        </ActionBarPrimitive.Root>
+        <BranchPicker className="ml-1" />
       </div>
     </MessagePrimitive.Root>
   );

--- a/apps/docs/components/examples/claude.tsx
+++ b/apps/docs/components/examples/claude.tsx
@@ -9,173 +9,320 @@ import {
   ThreadPrimitive,
   useAuiState,
 } from "@assistant-ui/react";
-import { Avatar } from "radix-ui";
 import {
   ArrowUpIcon,
+  CheckIcon,
   ChevronDownIcon,
   ClipboardIcon,
   Cross2Icon,
-  MixerHorizontalIcon,
   Pencil1Icon,
   PlusIcon,
   ReloadIcon,
 } from "@radix-ui/react-icons";
-import { ThumbsDown, ThumbsUp } from "lucide-react";
+import {
+  AudioLines,
+  Calendar as CalendarIcon,
+  Code as CodeIcon,
+  FolderOpen,
+  GraduationCap,
+  PenLine,
+  Sparkle,
+  ThumbsDown,
+  ThumbsUp,
+} from "lucide-react";
 import { useEffect, useState, type FC } from "react";
 import { useShallow } from "zustand/shallow";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/shared/dropdown-menu";
+
+const messageActionButtonClassName =
+  "flex size-8 items-center justify-center rounded-md text-[#5b5950] transition-colors hover:bg-[#1a1a18]/5 hover:text-[#1a1a18] dark:text-[#a3a098] dark:hover:bg-white/5 dark:hover:text-[#eee]";
 
 export const Claude: FC = () => {
   return (
-    <ThreadPrimitive.Root className="flex h-full flex-col items-stretch bg-[#F5F5F0] p-4 pt-16 font-serif dark:bg-[#2b2a27]">
-      <ThreadPrimitive.Viewport className="flex grow flex-col overflow-y-scroll">
-        <ThreadPrimitive.Messages>
-          {() => <ChatMessage />}
-        </ThreadPrimitive.Messages>
-        <div aria-hidden="true" className="h-4" />
-      </ThreadPrimitive.Viewport>
+    <ThreadPrimitive.Root className="flex h-full flex-col items-stretch bg-[#F0ECE0] font-serif text-[#1a1a18] dark:bg-[#2b2a27] dark:text-[#eee]">
+      <AuiIf condition={(s) => s.thread.isEmpty}>
+        <EmptyState />
+      </AuiIf>
 
-      <ComposerPrimitive.Root className="mx-auto flex w-full max-w-3xl flex-col rounded-2xl border border-transparent bg-white p-0.5 shadow-[0_0.25rem_1.25rem_rgba(0,0,0,0.035),0_0_0_0.5px_rgba(0,0,0,0.08)] transition-shadow duration-200 focus-within:shadow-[0_0.25rem_1.25rem_rgba(0,0,0,0.075),0_0_0_0.5px_rgba(0,0,0,0.15)] hover:shadow-[0_0.25rem_1.25rem_rgba(0,0,0,0.05),0_0_0_0.5px_rgba(0,0,0,0.12)] dark:bg-[#1f1e1b] dark:shadow-[0_0.25rem_1.25rem_rgba(0,0,0,0.4),0_0_0_0.5px_rgba(108,106,96,0.15)] dark:hover:shadow-[0_0.25rem_1.25rem_rgba(0,0,0,0.4),0_0_0_0.5px_rgba(108,106,96,0.3)] dark:focus-within:shadow-[0_0.25rem_1.25rem_rgba(0,0,0,0.5),0_0_0_0.5px_rgba(108,106,96,0.3)]">
-        <div className="m-3.5 flex flex-col gap-3.5">
-          <div className="relative">
-            <div className="wrap-break-word max-h-96 w-full overflow-y-auto">
-              <ComposerPrimitive.Input
-                placeholder="How can I help you today?"
-                className="block min-h-6 w-full resize-none bg-transparent text-[#1a1a18] outline-none placeholder:text-[#9a9893] dark:text-[#eee] dark:placeholder:text-[#9a9893]"
-              />
-            </div>
-          </div>
-          <div className="flex w-full items-center gap-2">
-            <div className="relative flex min-w-0 flex-1 shrink items-center gap-2">
-              <ComposerPrimitive.AddAttachment className="flex h-8 min-w-8 items-center justify-center overflow-hidden rounded-lg border border-[#00000015] bg-transparent px-1.5 text-[#6b6a68] transition-all hover:bg-[#f5f5f0] hover:text-[#1a1a18] active:scale-[0.98] dark:border-[#6c6a6040] dark:text-[#9a9893] dark:hover:bg-[#393937] dark:hover:text-[#eee]">
-                <PlusIcon width={16} height={16} />
-              </ComposerPrimitive.AddAttachment>
-              <button
-                type="button"
-                className="flex h-8 min-w-8 items-center justify-center overflow-hidden rounded-lg border border-[#00000015] bg-transparent px-1.5 text-[#6b6a68] transition-all hover:bg-[#f5f5f0] hover:text-[#1a1a18] active:scale-[0.98] dark:border-[#6c6a6040] dark:text-[#9a9893] dark:hover:bg-[#393937] dark:hover:text-[#eee]"
-                aria-label="Open tools menu"
-              >
-                <MixerHorizontalIcon width={16} height={16} />
-              </button>
-              <button
-                type="button"
-                className="flex h-8 min-w-8 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-[#00000015] bg-transparent px-1.5 text-[#6b6a68] transition-all hover:bg-[#f5f5f0] hover:text-[#1a1a18] active:scale-[0.98] dark:border-[#6c6a6040] dark:text-[#9a9893] dark:hover:bg-[#393937] dark:hover:text-[#eee]"
-                aria-label="Extended thinking"
-              >
-                <ReloadIcon width={16} height={16} />
-              </button>
-            </div>
-            <button
-              type="button"
-              className="flex h-8 min-w-16 items-center justify-center gap-1 whitespace-nowrap rounded-md px-2 pr-2 pl-2.5 text-[#1a1a18] text-xs transition duration-300 ease-[cubic-bezier(0.165,0.85,0.45,1)] hover:bg-[#f5f5f0] active:scale-[0.985] dark:text-[#eee] dark:hover:bg-[#393937]"
-            >
-              <span className="font-serif text-[14px]">Sonnet 4.5</span>
-              <ChevronDownIcon width={20} height={20} className="opacity-75" />
-            </button>
-            <ComposerPrimitive.Send className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#ae5630] transition-colors hover:bg-[#c4633a] active:scale-95 disabled:pointer-events-none disabled:opacity-50 dark:bg-[#ae5630] dark:hover:bg-[#c4633a]">
-              <ArrowUpIcon width={16} height={16} className="text-white" />
-            </ComposerPrimitive.Send>
-          </div>
-        </div>
-        <AuiIf condition={(s) => s.composer.attachments.length > 0}>
-          <div className="overflow-hidden rounded-b-2xl">
-            <div className="overflow-x-auto rounded-b-2xl border-[#00000015] border-t bg-[#f5f5f0] p-3.5 dark:border-[#6c6a6040] dark:bg-[#393937]">
-              <div className="flex flex-row gap-3">
-                <ComposerPrimitive.Attachments>
-                  {() => <ClaudeAttachment />}
-                </ComposerPrimitive.Attachments>
-              </div>
-            </div>
-          </div>
-        </AuiIf>
-      </ComposerPrimitive.Root>
+      <AuiIf condition={(s) => !s.thread.isEmpty}>
+        <ThreadPrimitive.Viewport className="flex grow flex-col overflow-y-auto px-4 pt-12">
+          <ThreadPrimitive.Messages>
+            {() => <ChatMessage />}
+          </ThreadPrimitive.Messages>
+
+          <ThreadPrimitive.ViewportFooter className="sticky bottom-0 mx-auto mt-auto w-full max-w-3xl bg-linear-to-b from-transparent via-[#F0ECE0]/85 to-[#F0ECE0] pt-4 pb-2 dark:via-[#2b2a27]/85 dark:to-[#2b2a27]">
+            <Composer />
+            <p className="pt-2 text-center text-[#8a8780] text-xs dark:text-[#a3a098]">
+              Claude can make mistakes. Please double-check responses.
+            </p>
+          </ThreadPrimitive.ViewportFooter>
+        </ThreadPrimitive.Viewport>
+      </AuiIf>
     </ThreadPrimitive.Root>
+  );
+};
+
+const EmptyState: FC = () => {
+  return (
+    <div className="flex grow flex-col items-center justify-center px-4">
+      <div className="mx-auto flex w-full max-w-2xl flex-col items-stretch gap-5">
+        <h1 className="flex items-center justify-center gap-3 font-serif text-3xl text-[#1a1a18] sm:text-4xl dark:text-[#eee]">
+          <Sparkle className="size-7 fill-[#c96442] text-[#c96442]" />
+          <span>How can I help you today?</span>
+        </h1>
+        <Composer />
+        <ModeTabs />
+      </div>
+    </div>
+  );
+};
+
+const Composer: FC = () => {
+  return (
+    <ComposerPrimitive.Root className="flex w-full flex-col gap-2 rounded-2xl border border-[#E5E0D6] bg-white px-3.5 pt-3 pb-2.5 dark:border-[#3d3a35] dark:bg-[#1f1e1b]">
+      <ComposerPrimitive.Input
+        placeholder="How can I help you today?"
+        rows={1}
+        className="block max-h-72 min-h-6 w-full resize-none bg-transparent text-[#1a1a18] outline-none placeholder:text-[#9a9893] dark:text-[#eee] dark:placeholder:text-[#9a9893]"
+      />
+
+      <div className="flex w-full items-center gap-2">
+        <ComposerPrimitive.AddAttachment
+          aria-label="Add attachment"
+          className="flex size-8 shrink-0 items-center justify-center rounded-md text-[#5b5950] transition-colors hover:bg-[#1a1a18]/5 hover:text-[#1a1a18] dark:text-[#a3a098] dark:hover:bg-white/5 dark:hover:text-[#eee]"
+        >
+          <PlusIcon width={16} height={16} />
+        </ComposerPrimitive.AddAttachment>
+
+        <div className="ml-auto flex items-center gap-1">
+          <ClaudeModelPicker />
+          <ComposerPrimaryAction />
+        </div>
+      </div>
+
+      <AuiIf condition={(s) => s.composer.attachments.length > 0}>
+        <div className="-mx-1 -mb-1 flex flex-row gap-2 overflow-x-auto pt-1">
+          <ComposerPrimitive.Attachments>
+            {() => <ClaudeAttachment />}
+          </ComposerPrimitive.Attachments>
+        </div>
+      </AuiIf>
+    </ComposerPrimitive.Root>
+  );
+};
+
+const ComposerPrimaryAction: FC = () => {
+  return (
+    <>
+      <AuiIf condition={(s) => s.thread.isRunning}>
+        <ComposerPrimitive.Cancel className="flex size-8 items-center justify-center rounded-md bg-[#c96442] text-white transition-colors hover:bg-[#b1573a]">
+          <div className="size-2.5 rounded-[2px] bg-current" />
+        </ComposerPrimitive.Cancel>
+      </AuiIf>
+
+      <AuiIf
+        condition={(s) => !s.thread.isRunning && s.composer.dictation != null}
+      >
+        <ComposerPrimitive.StopDictation
+          className="flex size-8 items-center justify-center rounded-md bg-[#c96442] text-white transition-colors hover:bg-[#b1573a]"
+          aria-label="Stop dictation"
+        >
+          <div className="size-2.5 animate-pulse rounded-[2px] bg-current" />
+        </ComposerPrimitive.StopDictation>
+      </AuiIf>
+
+      <AuiIf
+        condition={(s) =>
+          !s.thread.isRunning &&
+          s.composer.dictation == null &&
+          !s.composer.isEmpty
+        }
+      >
+        <ComposerPrimitive.Send className="flex size-8 items-center justify-center rounded-md bg-[#c96442] text-white transition-colors hover:bg-[#b1573a] disabled:pointer-events-none disabled:opacity-50">
+          <ArrowUpIcon width={16} height={16} />
+        </ComposerPrimitive.Send>
+      </AuiIf>
+
+      <AuiIf
+        condition={(s) =>
+          !s.thread.isRunning &&
+          s.composer.dictation == null &&
+          s.composer.isEmpty
+        }
+      >
+        <ComposerPrimitive.Dictate
+          className="flex size-8 items-center justify-center rounded-md text-[#5b5950] transition-colors hover:bg-[#1a1a18]/5 hover:text-[#1a1a18] dark:text-[#a3a098] dark:hover:bg-white/5 dark:hover:text-[#eee]"
+          aria-label="Use voice mode"
+        >
+          <AudioLines className="size-4" />
+        </ComposerPrimitive.Dictate>
+      </AuiIf>
+    </>
+  );
+};
+
+const CLAUDE_MODELS = [
+  {
+    id: "sonnet-4.5",
+    name: "Sonnet 4.5",
+    description: "Smart, fast, everyday tasks",
+  },
+  {
+    id: "opus-4.7",
+    name: "Opus 4.7",
+    description: "Anthropic's most capable model",
+  },
+  {
+    id: "haiku-4.5",
+    name: "Haiku 4.5",
+    description: "Fastest, most affordable",
+  },
+];
+
+const ClaudeModelPicker: FC = () => {
+  const [model, setModel] = useState(CLAUDE_MODELS[0]!.id);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="flex h-8 items-center gap-1 whitespace-nowrap rounded-md px-2.5 text-[#1a1a18] text-sm transition hover:bg-[#1a1a18]/5 dark:text-[#eee] dark:hover:bg-white/5">
+        <span className="font-serif">
+          {CLAUDE_MODELS.find((m) => m.id === model)?.name}
+        </span>
+        <ChevronDownIcon width={16} height={16} className="opacity-60" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-64">
+        {CLAUDE_MODELS.map((m) => (
+          <DropdownMenuItem
+            key={m.id}
+            onSelect={() => setModel(m.id)}
+            className="flex items-start gap-3"
+          >
+            <span className="mt-0.5 flex size-4 items-center justify-center text-[#c96442]">
+              {m.id === model ? <CheckIcon /> : null}
+            </span>
+            <span className="flex flex-1 flex-col">
+              <span className="font-serif text-foreground text-sm">
+                {m.name}
+              </span>
+              <span className="text-muted-foreground text-xs">
+                {m.description}
+              </span>
+            </span>
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="text-muted-foreground text-sm">
+          More options
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+const ModeTabs: FC = () => {
+  const tabs = [
+    { label: "Write", Icon: PenLine },
+    { label: "Learn", Icon: GraduationCap },
+    { label: "Code", Icon: CodeIcon },
+    { label: "From Drive", Icon: FolderOpen },
+    { label: "From Calendar", Icon: CalendarIcon },
+  ];
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-2">
+      {tabs.map(({ label, Icon }) => (
+        <button
+          key={label}
+          type="button"
+          aria-hidden="true"
+          tabIndex={-1}
+          className="flex h-8 items-center gap-1.5 whitespace-nowrap rounded-lg border border-[#E5E0D6] bg-transparent px-3 text-[#3d3a35] text-sm transition-colors hover:bg-white/60 dark:border-[#3d3a35] dark:text-[#cdc9be] dark:hover:bg-[#1f1e1b]/60"
+        >
+          <Icon className="size-3.5 text-[#8a8780] dark:text-[#a3a098]" />
+          <span className="font-serif">{label}</span>
+        </button>
+      ))}
+    </div>
   );
 };
 
 const ChatMessage: FC = () => {
   return (
-    <MessagePrimitive.Root className="group relative mx-auto mt-1 mb-1 block w-full max-w-3xl">
+    <MessagePrimitive.Root className="group/message relative mx-auto flex w-full max-w-3xl flex-col py-2">
       <AuiIf condition={(s) => s.message.role === "user"}>
-        <div className="group/user wrap-break-word relative inline-flex max-w-[75ch] flex-col gap-2 rounded-xl bg-[#DDD9CE] py-2.5 pr-6 pl-2.5 text-[#1a1a18] transition-all dark:bg-[#393937] dark:text-[#eee]">
-          <div className="relative flex flex-row gap-2">
-            <div className="shrink-0 self-start transition-all duration-300">
-              <Avatar.Root className="flex h-7 w-7 shrink-0 select-none items-center justify-center rounded-full bg-[#1a1a18] font-bold text-[12px] text-white dark:bg-[#eee] dark:text-[#2b2a27]">
-                <Avatar.AvatarFallback>U</Avatar.AvatarFallback>
-              </Avatar.Root>
-            </div>
-            <div className="flex-1">
-              <div className="relative grid grid-cols-1 gap-2 py-0.5">
-                <div className="wrap-break-word whitespace-pre-wrap">
-                  <MessagePrimitive.Parts>
-                    {({ part }) => {
-                      if (part.type === "text") return <MarkdownText />;
-                      return null;
-                    }}
-                  </MessagePrimitive.Parts>
-                </div>
-              </div>
-            </div>
+        <div className="flex flex-col items-end gap-1">
+          <div className="wrap-break-word max-w-[80%] whitespace-pre-wrap rounded-2xl bg-[#E5E0D6] px-4 py-2.5 text-[#1a1a18] dark:bg-[#393937] dark:text-[#eee]">
+            <MessagePrimitive.Parts>
+              {({ part }) => {
+                if (part.type === "text") return <MarkdownText />;
+                return null;
+              }}
+            </MessagePrimitive.Parts>
           </div>
-          <div className="pointer-events-none absolute right-2 bottom-0">
-            <ActionBarPrimitive.Root
-              autohide="not-last"
-              className="pointer-events-auto min-w-max translate-x-1 translate-y-4 rounded-lg border-[#00000015] border-[0.5px] bg-white/80 p-0.5 opacity-0 shadow-sm backdrop-blur-sm transition group-hover/user:translate-x-0.5 group-hover/user:opacity-100 dark:border-[#6c6a6040] dark:bg-[#1f1e1b]/80"
-            >
-              <div className="flex items-center text-[#6b6a68] dark:text-[#9a9893]">
-                <ActionBarPrimitive.Reload className="flex h-8 w-8 items-center justify-center rounded-md transition duration-300 ease-[cubic-bezier(0.165,0.85,0.45,1)] hover:bg-transparent active:scale-95">
-                  <ReloadIcon width={20} height={20} />
-                </ActionBarPrimitive.Reload>
-                <ActionBarPrimitive.Edit className="flex h-8 w-8 items-center justify-center rounded-md transition duration-300 ease-[cubic-bezier(0.165,0.85,0.45,1)] hover:bg-transparent active:scale-95">
-                  <Pencil1Icon width={20} height={20} />
-                </ActionBarPrimitive.Edit>
-              </div>
-            </ActionBarPrimitive.Root>
-          </div>
+          <ActionBarPrimitive.Root
+            hideWhenRunning
+            autohide="not-last"
+            className="-mt-px flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100"
+          >
+            <ActionBarPrimitive.Edit className={messageActionButtonClassName}>
+              <Pencil1Icon width={16} height={16} />
+            </ActionBarPrimitive.Edit>
+            <ActionBarPrimitive.Copy className={messageActionButtonClassName}>
+              <AuiIf condition={(s) => s.message.isCopied}>
+                <CheckIcon />
+              </AuiIf>
+              <AuiIf condition={(s) => !s.message.isCopied}>
+                <ClipboardIcon width={16} height={16} />
+              </AuiIf>
+            </ActionBarPrimitive.Copy>
+          </ActionBarPrimitive.Root>
         </div>
       </AuiIf>
 
       <AuiIf condition={(s) => s.message.role === "assistant"}>
-        <div className="relative mb-12 font-serif">
-          <div className="relative leading-[1.65rem]">
-            <div className="grid grid-cols-1 gap-2.5">
-              <div className="wrap-break-word whitespace-normal pr-8 pl-2 font-serif text-[#1a1a18] dark:text-[#eee]">
-                <MessagePrimitive.Parts>
-                  {({ part }) => {
-                    if (part.type === "text") return <MarkdownText />;
-                    return null;
-                  }}
-                </MessagePrimitive.Parts>
-              </div>
-            </div>
+        <div className="flex flex-col">
+          <div className="prose prose-claude wrap-break-word font-serif text-[#1a1a18] leading-[1.65rem] dark:text-[#eee]">
+            <MessagePrimitive.Parts>
+              {({ part }) => {
+                if (part.type === "text") return <MarkdownText />;
+                return null;
+              }}
+            </MessagePrimitive.Parts>
           </div>
-          <div className="pointer-events-none absolute inset-x-0 bottom-0">
-            <ActionBarPrimitive.Root
-              hideWhenRunning
-              autohide="not-last"
-              className="pointer-events-auto flex w-full translate-y-full flex-col items-end px-2 pt-2 transition"
-            >
-              <div className="flex items-center text-[#6b6a68] dark:text-[#9a9893]">
-                <ActionBarPrimitive.Copy className="flex h-8 w-8 items-center justify-center rounded-md transition duration-300 ease-[cubic-bezier(0.165,0.85,0.45,1)] hover:bg-transparent active:scale-95">
-                  <ClipboardIcon width={20} height={20} />
-                </ActionBarPrimitive.Copy>
-                <ActionBarPrimitive.FeedbackPositive className="flex h-8 w-8 items-center justify-center rounded-md transition duration-300 ease-[cubic-bezier(0.165,0.85,0.45,1)] hover:bg-transparent active:scale-95">
-                  <ThumbsUp width={16} height={16} />
-                </ActionBarPrimitive.FeedbackPositive>
-                <ActionBarPrimitive.FeedbackNegative className="flex h-8 w-8 items-center justify-center rounded-md transition duration-300 ease-[cubic-bezier(0.165,0.85,0.45,1)] hover:bg-transparent active:scale-95">
-                  <ThumbsDown width={16} height={16} />
-                </ActionBarPrimitive.FeedbackNegative>
-                <ActionBarPrimitive.Reload className="flex h-8 w-8 items-center justify-center rounded-md transition duration-300 ease-[cubic-bezier(0.165,0.85,0.45,1)] hover:bg-transparent active:scale-95">
-                  <ReloadIcon width={20} height={20} />
-                </ActionBarPrimitive.Reload>
-              </div>
-              <AuiIf condition={(s) => s.message.isLast}>
-                <p className="mt-2 w-full text-right text-[#8a8985] text-[0.65rem] leading-[0.85rem] opacity-90 sm:text-[0.75rem] dark:text-[#b8b5a9]">
-                  Claude can make mistakes. Please double-check responses.
-                </p>
+          <ActionBarPrimitive.Root
+            hideWhenRunning
+            autohide="not-last"
+            className="mt-2 flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100"
+          >
+            <ActionBarPrimitive.Copy className={messageActionButtonClassName}>
+              <AuiIf condition={(s) => s.message.isCopied}>
+                <CheckIcon />
               </AuiIf>
-            </ActionBarPrimitive.Root>
-          </div>
+              <AuiIf condition={(s) => !s.message.isCopied}>
+                <ClipboardIcon width={16} height={16} />
+              </AuiIf>
+            </ActionBarPrimitive.Copy>
+            <ActionBarPrimitive.FeedbackPositive
+              className={messageActionButtonClassName}
+            >
+              <ThumbsUp className="size-4" />
+            </ActionBarPrimitive.FeedbackPositive>
+            <ActionBarPrimitive.FeedbackNegative
+              className={messageActionButtonClassName}
+            >
+              <ThumbsDown className="size-4" />
+            </ActionBarPrimitive.FeedbackNegative>
+            <ActionBarPrimitive.Reload className={messageActionButtonClassName}>
+              <ReloadIcon width={16} height={16} />
+            </ActionBarPrimitive.Reload>
+          </ActionBarPrimitive.Root>
         </div>
       </AuiIf>
     </MessagePrimitive.Root>
@@ -224,35 +371,24 @@ const ClaudeAttachment: FC = () => {
   return (
     <AttachmentPrimitive.Root className="group/thumbnail relative">
       <div
-        className="can-focus-within overflow-hidden rounded-lg border border-[#00000020] shadow-sm hover:border-[#00000040] hover:shadow-md dark:border-[#6c6a6040] dark:hover:border-[#6c6a6080]"
-        style={{
-          width: "120px",
-          height: "120px",
-          minWidth: "120px",
-          minHeight: "120px",
-        }}
+        className="overflow-hidden rounded-lg border border-[#E5E0D6] dark:border-[#3d3a35]"
+        style={{ width: "80px", height: "80px" }}
       >
-        <button
-          type="button"
-          className="relative bg-white dark:bg-[#2b2a27]"
-          style={{ width: "120px", height: "120px" }}
-        >
-          {isImage && src ? (
-            // biome-ignore lint/performance/noImgElement: example component
-            <img
-              className="h-full w-full object-cover opacity-100 transition duration-400"
-              alt="Attachment"
-              src={src}
-            />
-          ) : (
-            <div className="flex h-full w-full items-center justify-center text-[#6b6a68] dark:text-[#9a9893]">
-              <AttachmentPrimitive.unstable_Thumb className="text-xs" />
-            </div>
-          )}
-        </button>
+        {isImage && src ? (
+          // biome-ignore lint/performance/noImgElement: example component
+          <img
+            className="h-full w-full object-cover"
+            alt="Attachment"
+            src={src}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-white text-[#5b5950] dark:bg-[#2b2a27] dark:text-[#a3a098]">
+            <AttachmentPrimitive.unstable_Thumb className="text-xs" />
+          </div>
+        )}
       </div>
       <AttachmentPrimitive.Remove
-        className="absolute -top-2 -left-2 flex h-5 w-5 items-center justify-center rounded-full border border-[#00000020] bg-white/90 text-[#6b6a68] opacity-0 backdrop-blur-sm transition-all hover:bg-white hover:text-[#1a1a18] group-focus-within/thumbnail:opacity-100 group-hover/thumbnail:opacity-100 dark:border-[#6c6a6040] dark:bg-[#1f1e1b]/90 dark:text-[#9a9893] dark:hover:bg-[#1f1e1b] dark:hover:text-[#eee]"
+        className="absolute -top-1.5 -right-1.5 flex size-5 items-center justify-center rounded-full bg-[#1a1a18] text-white opacity-0 transition-opacity hover:bg-[#3d3a35] group-focus-within/thumbnail:opacity-100 group-hover/thumbnail:opacity-100 dark:bg-white dark:text-[#1a1a18] dark:hover:bg-[#cdc9be]"
         aria-label="Remove attachment"
       >
         <Cross2Icon width={12} height={12} />

--- a/apps/docs/components/examples/gemini.tsx
+++ b/apps/docs/components/examples/gemini.tsx
@@ -11,6 +11,7 @@ import {
 } from "@assistant-ui/react";
 
 import {
+  CheckIcon,
   ChevronDownIcon,
   Cross2Icon,
   MixerHorizontalIcon,
@@ -21,13 +22,16 @@ import {
 import {
   CopyIcon,
   EllipsisVertical,
+  Globe,
   ImageIcon,
   Lightbulb,
   Mic,
+  Music,
   PenLine,
   SendHorizonal,
   Sparkles,
   Square,
+  Telescope,
   ThumbsDown,
   ThumbsUp,
 } from "lucide-react";
@@ -35,19 +39,25 @@ import { type FC, useEffect, useState } from "react";
 import { useShallow } from "zustand/shallow";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import { GeminiIcon } from "@/components/icons/gemini";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/shared/dropdown-menu";
 
 export const Gemini: FC = () => {
   return (
     <ThreadPrimitive.Root className="flex h-full flex-col items-stretch bg-[#f8f9fa] dark:bg-[#131314]">
-      <ThreadPrimitive.Empty>
+      <AuiIf condition={(s) => s.thread.isEmpty}>
         <div className="flex h-full flex-col justify-center px-4">
           <div className="mx-auto w-full max-w-3xl">
             <div className="mb-1 flex items-center gap-3">
-              {/* biome-ignore lint/performance/noImgElement: example component */}
-              <img src="/icons/gemini.svg" alt="" className="size-5" />
-              <p className="text-black text-xl dark:text-white">Hello there</p>
+              <GeminiIcon className="size-5" />
+              <p className="text-black text-xl dark:text-white">Hi there</p>
             </div>
-            <p className="mb-6 bg-clip-text text-4xl text-black dark:text-white">
+            <p className="mb-6 text-3xl text-black sm:text-4xl dark:text-white">
               Where would you like to start?
             </p>
           </div>
@@ -55,6 +65,9 @@ export const Gemini: FC = () => {
           <div className="mx-auto mt-4 flex w-full max-w-3xl flex-wrap justify-center gap-2">
             <SuggestionChip icon={<ImageIcon width={16} height={16} />}>
               Create image
+            </SuggestionChip>
+            <SuggestionChip icon={<Music width={16} height={16} />}>
+              Make music
             </SuggestionChip>
             <SuggestionChip icon={<Lightbulb width={16} height={16} />}>
               Help me learn
@@ -67,15 +80,15 @@ export const Gemini: FC = () => {
             </SuggestionChip>
           </div>
         </div>
-      </ThreadPrimitive.Empty>
+      </AuiIf>
 
-      <AuiIf condition={(s) => s.thread.isEmpty === false}>
+      <AuiIf condition={(s) => !s.thread.isEmpty}>
         <ThreadPrimitive.Viewport className="flex grow flex-col overflow-y-scroll pt-16">
           <ThreadPrimitive.Messages components={{ Message: ChatMessage }} />
         </ThreadPrimitive.Viewport>
-        <div className="space-y-2">
+        <div className="space-y-2 px-4 pb-4">
           <Composer />
-          <p className="my-3 text-center text-[#70757a] text-xs dark:text-[#9aa0a6]">
+          <p className="text-center text-[#70757a] text-xs dark:text-[#9aa0a6]">
             Gemini may display inaccurate info, including about people, so
             double-check its responses.
           </p>
@@ -134,23 +147,11 @@ const Composer: FC = () => {
             <ComposerPrimitive.AddAttachment className="flex size-10 items-center justify-center rounded-full transition-all hover:bg-[#444746]/8 active:scale-[0.98] dark:hover:bg-[#c4c7c5]/8">
               <PlusIcon width={20} height={20} />
             </ComposerPrimitive.AddAttachment>
-            <button
-              type="button"
-              className="flex h-10 items-center justify-center gap-1.5 rounded-full px-3 text-sm transition hover:bg-[#444746]/8 dark:hover:bg-[#c4c7c5]/8"
-            >
-              <MixerHorizontalIcon width={16} height={16} />
-              <span>Tools</span>
-            </button>
+            <GeminiToolsMenu />
           </div>
 
           <div className="flex items-center gap-2">
-            <button
-              type="button"
-              className="flex h-10 items-center justify-center gap-1 whitespace-nowrap rounded-full px-3 text-sm transition hover:bg-[#444746]/8 dark:hover:bg-[#c4c7c5]/8"
-            >
-              <span>Flash</span>
-              <ChevronDownIcon width={20} height={20} className="opacity-60" />
-            </button>
+            <GeminiModelPicker />
             <div className="relative size-10 shrink-0">
               <button
                 type="button"
@@ -170,6 +171,78 @@ const Composer: FC = () => {
         </div>
       </div>
     </ComposerPrimitive.Root>
+  );
+};
+
+const GEMINI_TOOLS = [
+  { id: "research", label: "Deep Research", Icon: Telescope },
+  { id: "image", label: "Create image", Icon: ImageIcon },
+  { id: "search", label: "Search the web", Icon: Globe },
+  { id: "study", label: "Help me learn", Icon: Lightbulb },
+];
+
+const GeminiToolsMenu: FC = () => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="flex h-10 items-center justify-center gap-1.5 rounded-full px-3 text-sm transition hover:bg-[#444746]/8 dark:hover:bg-[#c4c7c5]/8">
+        <MixerHorizontalIcon width={16} height={16} />
+        <span>Tools</span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-56">
+        {GEMINI_TOOLS.map(({ id, label, Icon }) => (
+          <DropdownMenuItem
+            key={id}
+            icon={<Icon className="size-4" />}
+            className="text-foreground text-sm"
+          >
+            {label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+const GEMINI_MODELS = [
+  { id: "fast", name: "Fast", description: "Best for quick chats" },
+  { id: "thinking", name: "Thinking", description: "Best for reasoning" },
+  { id: "pro", name: "Pro", description: "Best for complex tasks" },
+];
+
+const GeminiModelPicker: FC = () => {
+  const [model, setModel] = useState(GEMINI_MODELS[0]!.id);
+  const current = GEMINI_MODELS.find((m) => m.id === model);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="flex h-10 items-center justify-center gap-1 whitespace-nowrap rounded-full px-3 text-sm transition hover:bg-[#444746]/8 dark:hover:bg-[#c4c7c5]/8">
+        <span>{current?.name}</span>
+        <ChevronDownIcon width={20} height={20} className="opacity-60" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-60">
+        {GEMINI_MODELS.map((m) => (
+          <DropdownMenuItem
+            key={m.id}
+            onSelect={() => setModel(m.id)}
+            className="flex items-start gap-3"
+          >
+            <span className="mt-0.5 flex size-4 items-center justify-center text-[#1a73e8] dark:text-[#8ab4f8]">
+              {m.id === model ? <CheckIcon /> : null}
+            </span>
+            <span className="flex flex-1 flex-col">
+              <span className="text-foreground text-sm">{m.name}</span>
+              <span className="text-muted-foreground text-xs">
+                {m.description}
+              </span>
+            </span>
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="text-muted-foreground text-sm">
+          Upgrade to Gemini Advanced
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };
 

--- a/apps/docs/components/examples/grok.tsx
+++ b/apps/docs/components/examples/grok.tsx
@@ -12,6 +12,7 @@ import {
 } from "@assistant-ui/react";
 import {
   ArrowUpIcon,
+  CheckIcon,
   ChevronDownIcon,
   CopyIcon,
   Cross2Icon,
@@ -25,11 +26,19 @@ import {
   Square,
   ThumbsDown,
   ThumbsUp,
+  Zap,
 } from "lucide-react";
 import { useEffect, useState, type FC } from "react";
 import { useShallow } from "zustand/shallow";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import { GrokIcon } from "@/components/icons/grok";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/shared/dropdown-menu";
 
 export const Grok: FC = () => {
   return (
@@ -86,18 +95,7 @@ const Composer: FC = () => {
             className="my-2 h-6 max-h-100 min-w-0 flex-1 resize-none bg-transparent text-[#0d0d0d] text-base leading-6 outline-none placeholder:text-[#9a9a9a] dark:text-white dark:placeholder:text-[#6b6b6b]"
           />
 
-          <button
-            type="button"
-            className="mb-0.5 flex h-9 shrink-0 items-center gap-2 rounded-full px-2.5 text-[#0d0d0d] hover:bg-[#f0f0f0] dark:text-white dark:hover:bg-[#2a2a2a]"
-          >
-            <Moon width={18} height={18} className="shrink-0" />
-            <div className="flex items-center gap-1 overflow-hidden transition-[max-width,opacity] duration-300 group-data-[empty=false]/composer:max-w-0 group-data-[empty=true]/composer:max-w-24 group-data-[empty=false]/composer:opacity-0 group-data-[empty=true]/composer:opacity-100">
-              <span className="whitespace-nowrap font-semibold text-sm">
-                Grok 4.1
-              </span>
-              <ChevronDownIcon width={16} height={16} className="shrink-0" />
-            </div>
-          </button>
+          <GrokModelPicker />
 
           <div className="relative mb-0.5 h-9 w-9 shrink-0 rounded-full bg-[#0d0d0d] text-white dark:bg-white dark:text-[#0d0d0d]">
             <button
@@ -119,6 +117,70 @@ const Composer: FC = () => {
         </div>
       </div>
     </ComposerPrimitive.Root>
+  );
+};
+
+const GROK_MODELS = [
+  {
+    id: "grok-4.1-fast",
+    name: "Fast",
+    description: "Default. Quick responses",
+    Icon: Zap,
+  },
+  {
+    id: "grok-4.1",
+    name: "Grok 4.1",
+    description: "Standard reasoning",
+    Icon: Moon,
+  },
+  {
+    id: "grok-4.1-think",
+    name: "Think",
+    description: "Multi-step reasoning",
+    Icon: Moon,
+  },
+];
+
+const GrokModelPicker: FC = () => {
+  const [model, setModel] = useState(GROK_MODELS[0]!.id);
+  const current = GROK_MODELS.find((m) => m.id === model) ?? GROK_MODELS[0]!;
+  const CurrentIcon = current.Icon;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="mb-0.5 flex h-9 shrink-0 items-center gap-2 rounded-full px-2.5 text-[#0d0d0d] hover:bg-[#f0f0f0] dark:text-white dark:hover:bg-[#2a2a2a]">
+        <CurrentIcon width={18} height={18} className="shrink-0" />
+        <div className="flex items-center gap-1 overflow-hidden transition-[max-width,opacity] duration-300 group-data-[empty=false]/composer:max-w-0 group-data-[empty=true]/composer:max-w-32 group-data-[empty=false]/composer:opacity-0 group-data-[empty=true]/composer:opacity-100">
+          <span className="whitespace-nowrap font-semibold text-sm">
+            {current.name}
+          </span>
+          <ChevronDownIcon width={16} height={16} className="shrink-0" />
+        </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-60">
+        {GROK_MODELS.map(({ id, name, description, Icon }) => (
+          <DropdownMenuItem
+            key={id}
+            onSelect={() => setModel(id)}
+            className="flex items-start gap-3"
+          >
+            <span className="mt-0.5 flex size-4 items-center justify-center text-[#0d0d0d] dark:text-white">
+              {id === model ? <CheckIcon /> : <Icon width={14} height={14} />}
+            </span>
+            <span className="flex flex-1 flex-col">
+              <span className="text-foreground text-sm">{name}</span>
+              <span className="text-muted-foreground text-xs">
+                {description}
+              </span>
+            </span>
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="text-muted-foreground text-sm">
+          Subscribe to SuperGrok
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };
 

--- a/apps/docs/components/examples/perplexity.tsx
+++ b/apps/docs/components/examples/perplexity.tsx
@@ -28,10 +28,18 @@ import {
   FileIcon,
   Plus,
   Search,
+  Sparkles,
   Square,
+  Telescope,
 } from "lucide-react";
 import { type FC, useEffect, useState } from "react";
 import { useShallow } from "zustand/shallow";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/shared/dropdown-menu";
 
 const composerPrimaryActionClassName =
   "absolute inset-0 flex items-center justify-center rounded-full transition-all duration-200 ease-out";
@@ -73,7 +81,7 @@ const EmptyState: FC = () => {
   return (
     <div className="flex h-full flex-col justify-center px-4">
       <div className="mx-auto w-full max-w-(--thread-max-width)">
-        <p className="mb-8 text-center font-display text-[#25211c] text-[3.1rem] leading-none tracking-[-0.06em] dark:text-[#f5f2ed]">
+        <p className="mb-8 text-center font-display text-5xl text-[#25211c] leading-none tracking-[-0.06em] sm:text-[3.1rem] dark:text-[#f5f2ed]">
           perplexity
         </p>
         <Composer placeholder="Ask anything..." />
@@ -99,7 +107,7 @@ const Composer: FC<{ placeholder: string }> = ({ placeholder }) => {
         className="min-h-20 w-full resize-none bg-transparent px-5 pt-4 pb-0 text-[1.05rem] leading-7 outline-none placeholder:text-[#8a8176] dark:placeholder:text-[#918a82]"
       />
 
-      <div className="flex items-center justify-between gap-3 px-3 pt-0.5 pb-3">
+      <div className="flex items-center justify-between gap-2 px-3 pt-0.5 pb-3">
         <div className="flex min-w-0 items-center gap-1.5">
           <ComposerPrimitive.AddAttachment asChild>
             <button
@@ -110,24 +118,11 @@ const Composer: FC<{ placeholder: string }> = ({ placeholder }) => {
               <Plus className="size-4.5" />
             </button>
           </ComposerPrimitive.AddAttachment>
-          <div
-            aria-hidden="true"
-            className="flex h-8 items-center gap-1.5 rounded-full border border-[#e0d8cb] bg-[#f5f1eb] px-3 text-[#3a342d] text-sm dark:border-[#3a342f] dark:bg-[#2a2724] dark:text-[#e6dfd5]"
-          >
-            <Search className="size-3.5" />
-            <span>Search</span>
-            <ChevronDownIcon className="size-3.5 opacity-70" />
-          </div>
+          <SearchModePicker />
         </div>
 
-        <div className="flex items-center gap-2">
-          <div
-            aria-hidden="true"
-            className="flex h-8 items-center gap-1 rounded-full px-2.5 text-[#746c62] text-sm dark:text-[#a19a91]"
-          >
-            <span>Model</span>
-            <ChevronDownIcon className="size-4 opacity-70" />
-          </div>
+        <div className="flex items-center gap-1">
+          <ModelPicker />
           <ComposerPrimaryAction />
         </div>
       </div>
@@ -149,7 +144,26 @@ const ComposerPrimaryAction: FC = () => {
         </ComposerPrimitive.Cancel>
       </AuiIf>
 
-      <AuiIf condition={(s) => !s.thread.isRunning && !s.composer.isEmpty}>
+      <AuiIf
+        condition={(s) => !s.thread.isRunning && s.composer.dictation != null}
+      >
+        <ComposerPrimitive.StopDictation
+          className={cn(
+            composerPrimaryActionClassName,
+            composerPrimaryActionColorsClassName,
+          )}
+        >
+          <Square className="size-3.5 animate-pulse fill-current" />
+        </ComposerPrimitive.StopDictation>
+      </AuiIf>
+
+      <AuiIf
+        condition={(s) =>
+          !s.thread.isRunning &&
+          s.composer.dictation == null &&
+          !s.composer.isEmpty
+        }
+      >
         <ComposerPrimitive.Send
           className={cn(
             composerPrimaryActionClassName,
@@ -163,8 +177,8 @@ const ComposerPrimaryAction: FC = () => {
       <AuiIf
         condition={(s) =>
           !s.thread.isRunning &&
-          s.composer.isEmpty &&
-          s.composer.dictation == null
+          s.composer.dictation == null &&
+          s.composer.isEmpty
         }
       >
         <ComposerPrimitive.Dictate
@@ -176,24 +190,105 @@ const ComposerPrimaryAction: FC = () => {
           <AudioLines className="size-5" />
         </ComposerPrimitive.Dictate>
       </AuiIf>
-
-      <AuiIf
-        condition={(s) =>
-          !s.thread.isRunning &&
-          s.composer.isEmpty &&
-          s.composer.dictation != null
-        }
-      >
-        <ComposerPrimitive.StopDictation
-          className={cn(
-            composerPrimaryActionClassName,
-            composerPrimaryActionColorsClassName,
-          )}
-        >
-          <Square className="size-3.5 animate-pulse fill-current" />
-        </ComposerPrimitive.StopDictation>
-      </AuiIf>
     </div>
+  );
+};
+
+const SEARCH_MODES = [
+  {
+    id: "search",
+    name: "Search",
+    description: "Fast answers to everyday questions",
+    Icon: Search,
+  },
+  {
+    id: "research",
+    name: "Research",
+    description: "In-depth reports on complex topics",
+    Icon: Telescope,
+  },
+  {
+    id: "labs",
+    name: "Labs",
+    description: "Apps, slides, and dashboards",
+    Icon: Sparkles,
+  },
+];
+
+const SearchModePicker: FC = () => {
+  const [mode, setMode] = useState(SEARCH_MODES[0]!.id);
+  const current = SEARCH_MODES.find((m) => m.id === mode) ?? SEARCH_MODES[0]!;
+  const CurrentIcon = current.Icon;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="flex h-8 items-center gap-1.5 rounded-full border border-[#e0d8cb] bg-[#f5f1eb] px-3 text-[#3a342d] text-sm transition-colors hover:bg-[#ede6dd] dark:border-[#3a342f] dark:bg-[#2a2724] dark:text-[#e6dfd5] dark:hover:bg-[#332f2c]">
+        <CurrentIcon className="size-3.5" />
+        <span>{current.name}</span>
+        <ChevronDownIcon className="size-3.5 opacity-70" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-64">
+        {SEARCH_MODES.map(({ id, name, description, Icon }) => (
+          <DropdownMenuItem
+            key={id}
+            onSelect={() => setMode(id)}
+            className="flex items-start gap-3"
+          >
+            <span className="mt-0.5 flex size-4 items-center justify-center text-[#1f1b17] dark:text-[#f5f2ed]">
+              {id === mode ? <CheckIcon /> : <Icon className="size-3.5" />}
+            </span>
+            <span className="flex flex-1 flex-col">
+              <span className="text-foreground text-sm">{name}</span>
+              <span className="text-muted-foreground text-xs">
+                {description}
+              </span>
+            </span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+const PERPLEXITY_MODELS = [
+  { id: "best", name: "Best", description: "Auto-pick the best model" },
+  { id: "sonar", name: "Sonar", description: "Perplexity's fast model" },
+  { id: "claude", name: "Claude 4.5 Sonnet", description: "Anthropic" },
+  { id: "gpt-5", name: "GPT-5", description: "OpenAI" },
+  { id: "gemini", name: "Gemini 3 Pro", description: "Google" },
+];
+
+const ModelPicker: FC = () => {
+  const [model, setModel] = useState(PERPLEXITY_MODELS[0]!.id);
+  const current =
+    PERPLEXITY_MODELS.find((m) => m.id === model) ?? PERPLEXITY_MODELS[0]!;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="hidden h-8 items-center gap-1 rounded-full px-2.5 text-[#746c62] text-sm transition-colors hover:bg-[#f2ede6] hover:text-[#1f1b17] sm:flex dark:text-[#a19a91] dark:hover:bg-[#2b2825] dark:hover:text-[#f5f2ed]">
+        <span>{current.name}</span>
+        <ChevronDownIcon className="size-4 opacity-70" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-60">
+        {PERPLEXITY_MODELS.map((m) => (
+          <DropdownMenuItem
+            key={m.id}
+            onSelect={() => setModel(m.id)}
+            className="flex items-start gap-3"
+          >
+            <span className="mt-0.5 flex size-4 items-center justify-center text-[#1f1b17] dark:text-[#f5f2ed]">
+              {m.id === model ? <CheckIcon /> : null}
+            </span>
+            <span className="flex flex-1 flex-col">
+              <span className="text-foreground text-sm">{m.name}</span>
+              <span className="text-muted-foreground text-xs">
+                {m.description}
+              </span>
+            </span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };
 

--- a/apps/docs/content/examples/chatgpt.mdx
+++ b/apps/docs/content/examples/chatgpt.mdx
@@ -1,6 +1,6 @@
 ---
 title: ChatGPT Clone Example
-description: Open-source ChatGPT clone built in React with assistant-ui — dark theme, rounded composer, streaming responses, and message editing as drop-in components.
+description: Open-source ChatGPT clone built in React with assistant-ui — centered welcome composer, Tools dropdown, four-state primary action, and full assistant action bar.
 ---
 
 import { ChatGPT } from "@/components/examples/chatgpt";
@@ -11,18 +11,17 @@ import { ChatGPT } from "@/components/examples/chatgpt";
 
 ## Overview
 
-The ChatGPT Clone demonstrates how to customize assistant-ui to match OpenAI's ChatGPT interface. This example recreates the characteristic dark theme, rounded input design, and interaction patterns familiar to ChatGPT users.
+The ChatGPT Clone demonstrates how to customize assistant-ui to match OpenAI's ChatGPT interface. This version mirrors the current chatgpt.com layout: a centered welcome composer in the empty state, a Tools dropdown, and an always-visible assistant action bar with thumbs, share, speak, reload, and more.
 
 ## Features
 
-- **Dark Theme**: Authentic `#212121` background with subtle white overlays
-- **Light Mode**: Full light mode support out of the box
-- **Rounded Composer**: ChatGPT-style pill-shaped input with `bg-white/5`
-- **Attachments**: Image and file attachment support with preview thumbnails
-- **Message Layout**: User messages right-aligned, assistant messages with avatar
-- **Action Bar**: Edit, copy, and regenerate buttons on hover
-- **Branch Picker**: Navigate between message variations
-- **Scroll to Bottom**: Auto-hiding button when scrolled up
+- **Theme-Aware**: White light mode (`#ffffff`) and dark mode (`#212121`) with no forced theme
+- **Centered Empty State**: "Where should we begin?" heading + composer rendered together in the middle of the viewport
+- **Functional Tools Dropdown**: `Search the web` / `Create an image` / `Run deep research` / `Think longer` / `Study and learn`
+- **Four-State Primary Action**: Cancel (running), Send (typing), Dictate mic + orange Voice circle (idle), StopDictation (recording)
+- **Assistant Action Bar**: Always visible — Copy, FeedbackPositive, FeedbackNegative, Speak, Share, Reload, More
+- **User Bubble**: Right-aligned `bg-secondary` pill with hover-only Edit action
+- **Sticky Footer**: Composer + "ChatGPT can make mistakes" disclaimer at the bottom of the chat
 
 ## Quick Start
 
@@ -32,78 +31,103 @@ npx assistant-ui add thread
 
 ## Code
 
-The ChatGPT clone uses a dark theme with custom styling:
+The ChatGPT clone splits into an `EmptyState` and a sticky chat layout. The composer is shared by both:
 
 ```tsx
 import {
   AuiIf,
   ThreadPrimitive,
   ComposerPrimitive,
-  MessagePrimitive,
   ActionBarPrimitive,
 } from "@assistant-ui/react";
-import { Avatar } from "radix-ui";
 
-export const ChatGPT = () => {
-  return (
-    <ThreadPrimitive.Root className="dark flex h-full flex-col items-stretch bg-[#212121] px-4 text-foreground">
-      <ThreadPrimitive.Viewport className="flex grow flex-col gap-8 overflow-y-scroll pt-16">
-        <AuiIf condition={(s) => s.thread.isEmpty}>
-          <div className="flex grow flex-col items-center justify-center">
-            <Avatar.Root className="flex h-12 w-12 items-center justify-center rounded-3xl border border-white/15 shadow">
-              <Avatar.AvatarFallback>C</Avatar.AvatarFallback>
-            </Avatar.Root>
-            <p className="mt-4 text-white text-xl">How can I help you today?</p>
-          </div>
-        </AuiIf>
-
-        <ThreadPrimitive.Messages>
-          {({ message }) => {
-            if (message.role === "user") return <UserMessage />;
-            return <AssistantMessage />;
-          }}
-        </ThreadPrimitive.Messages>
-
-        <ThreadPrimitive.ViewportFooter className="sticky bottom-0 mt-auto flex flex-col gap-4 bg-[#212121] pb-2">
-          <ThreadPrimitive.ScrollToBottom className="..." />
-
-          <ComposerPrimitive.Root className="mx-auto flex w-full max-w-3xl items-end rounded-3xl bg-white/5 pl-2">
-            <ComposerPrimitive.Input
-              placeholder="Message ChatGPT"
-              className="h-12 max-h-40 grow resize-none bg-transparent p-3.5 text-sm text-white outline-none placeholder:text-white/50"
-            />
-            <ComposerPrimitive.Send className="m-2 flex size-8 items-center justify-center rounded-full bg-white transition-opacity disabled:opacity-10">
-              <ArrowUpIcon className="size-5 text-black [&_path]:stroke-1 [&_path]:stroke-black" />
-            </ComposerPrimitive.Send>
-          </ComposerPrimitive.Root>
-
-          <p className="text-center text-[#cdcdcd] text-xs">
-            ChatGPT can make mistakes. Check important info.
-          </p>
+export const ChatGPT = () => (
+  <ThreadPrimitive.Root className="bg-white dark:bg-[#212121]">
+    <AuiIf condition={(s) => s.thread.isEmpty}>
+      <EmptyState />
+    </AuiIf>
+    <AuiIf condition={(s) => !s.thread.isEmpty}>
+      <ThreadPrimitive.Viewport>
+        <ThreadPrimitive.Messages />
+        <ThreadPrimitive.ViewportFooter className="sticky bottom-0">
+          <Composer />
+          <p>ChatGPT can make mistakes. Check important info.</p>
         </ThreadPrimitive.ViewportFooter>
       </ThreadPrimitive.Viewport>
-    </ThreadPrimitive.Root>
-  );
-};
+    </AuiIf>
+  </ThreadPrimitive.Root>
+);
+
+const Composer = () => (
+  <ComposerPrimitive.Root className="rounded-[28px] border bg-white dark:bg-[#303030]">
+    <ComposerPrimitive.Input rows={1} placeholder="Ask anything" />
+    <div className="flex items-center justify-between">
+      <ComposerPrimitive.AddAttachment />
+      <div className="flex items-center gap-1">
+        <ToolsMenu />
+        <PrimaryAction />
+      </div>
+    </div>
+  </ComposerPrimitive.Root>
+);
+```
+
+### Four-State Primary Action
+
+```tsx
+<AuiIf condition={(s) => s.thread.isRunning}>
+  <ComposerPrimitive.Cancel />
+</AuiIf>
+<AuiIf condition={(s) => s.composer.dictation != null}>
+  <ComposerPrimitive.StopDictation />
+</AuiIf>
+<AuiIf condition={(s) => s.composer.dictation == null && !s.composer.isEmpty}>
+  <ComposerPrimitive.Send />
+</AuiIf>
+<AuiIf condition={(s) => s.composer.dictation == null && s.composer.isEmpty}>
+  <ComposerPrimitive.Dictate />
+  <button aria-hidden="true" className="bg-[#ff5d1f]"> {/* Voice */}</button>
+</AuiIf>
+```
+
+The conditions are mutually exclusive in priority order (`Cancel > StopDictation > Send > Dictate`) so dictation can be paused even when transcribed text is in the composer.
+
+### Tools Dropdown
+
+```tsx
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/shared/dropdown-menu";
+
+<DropdownMenu>
+  <DropdownMenuTrigger>Tools <ChevronDown /></DropdownMenuTrigger>
+  <DropdownMenuContent>
+    <DropdownMenuItem icon={<Globe />}>Search the web</DropdownMenuItem>
+    <DropdownMenuItem icon={<ImageIcon />}>Create an image</DropdownMenuItem>
+    <DropdownMenuItem icon={<Telescope />}>Run deep research</DropdownMenuItem>
+    <DropdownMenuItem icon={<Lightbulb />}>Think longer</DropdownMenuItem>
+    <DropdownMenuItem icon={<Sparkles />}>Study and learn</DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>
 ```
 
 ### Color Palette
 
-| Element | Color |
-|---------|-------|
-| Background | `#212121` |
-| Input background | `white/5` (5% white overlay) |
-| Text | `#eee` |
-| Muted text | `#cdcdcd`, `#b4b4b4` |
-| Send button | White with black icon |
-| Avatar border | `white/15` |
+| Element | Light | Dark |
+|---------|-------|------|
+| Background | `#ffffff` | `#212121` |
+| Composer surface | `#ffffff` | `#303030` |
+| Composer border | `#e5e5e5` | `transparent` |
+| Primary text | `#0d0d0d` | `#ececec` |
+| Muted text | `#5d5d5d` | `#a8a8a8` |
+| Send button | `#0d0d0d` (white icon) | `#ffffff` (black icon) |
+| Voice button | `#ff5d1f` (orange) | `#ff5d1f` |
 
 ### Styling Details
 
-- **Input**: `rounded-3xl` for pill shape, `max-h-40` for auto-expand
-- **Send button**: Circular with `disabled:opacity-10` for inactive state
-- **Messages**: `max-w-3xl` centered layout
-- **User messages**: Right-aligned with `bg-white/5` bubble
+- **Composer**: `rounded-[28px]` with thin border in light mode, no border in dark mode
+- **Empty Layout**: heading + composer centered together; no avatar
+- **Tools Pill**: `hidden sm:flex` so it collapses on narrow screens; mobile only shows + and primary action
+- **Assistant Action Bar**: always visible, no hover-only behavior
+- **User Bubble**: `rounded-3xl bg-secondary` with hover-only Edit primitive
 
 ## Source
 

--- a/apps/docs/content/examples/claude.mdx
+++ b/apps/docs/content/examples/claude.mdx
@@ -1,6 +1,6 @@
 ---
 title: Claude Clone
-description: Open-source Claude clone in React — soft beige theme, conversation styling, streaming and message editing patterns from Claude.ai built with assistant-ui.
+description: Open-source Claude clone in React — warm cream theme, serif typography, hover-only action bars, and a clean minimal-shadow composer styled after claude.ai.
 ---
 
 import { Claude } from "@/components/examples/claude";
@@ -11,16 +11,18 @@ import { Claude } from "@/components/examples/claude";
 
 ## Overview
 
-The Claude Clone demonstrates how to customize assistant-ui to match Anthropic's Claude interface. This example features Claude's distinctive warm color palette, serif typography, and minimalist design philosophy with careful attention to shadows and spacing.
+The Claude Clone demonstrates how to customize assistant-ui to match Anthropic's Claude interface. The design leans on Claude's signature warm cream background, serif typography, and a deliberately minimal chrome — no shadows, no avatars, just a thin border on the composer and bubbles that fade into the page.
 
 ## Features
 
-- **Warm Color Palette**: Beige backgrounds with orange accent (`#ae5630`)
-- **Serif Typography**: Classic `font-serif` for a refined reading experience
-- **Elegant Shadows**: Multi-layered box shadows for depth
-- **Attachment Support**: Image and file upload with thumbnail previews
-- **Feedback Actions**: Thumbs up/down for response quality feedback
-- **Model Selector**: Dropdown to switch between Claude models
+- **Warm Cream Background**: `#F0ECE0` light, `#2b2a27` dark — a warmer Anthropic-style cream
+- **Serif Throughout**: `font-serif` on every surface for the editorial feel
+- **Sparkle Heading**: Centered "How can I help you today?" with the orange `#c96442` Sparkle icon
+- **Borderless Composer**: Just `border-[#E5E0D6]` and no shadow — matches claude.ai's stripped-down look
+- **Functional Model Picker**: Sonnet 4.5 / Opus 4.7 / Haiku 4.5 dropdown with "More options"
+- **Mode Tabs**: Write / Learn / Code / From Drive / From Calendar — `rounded-lg` chips with thin borders
+- **Hover-only Action Bars**: User Edit/Copy and Assistant Copy/👍/👎/Reload only appear on hover
+- **Four-State Primary Action**: Cancel, StopDictation, Send, Dictate (orange `#c96442` accent)
 
 ## Quick Start
 
@@ -30,63 +32,100 @@ npx assistant-ui add thread
 
 ## Code
 
-The Claude clone features warm tones and serif typography:
+The empty state centers the heading + composer + mode tabs together. The chat state uses a sticky composer with a fade-out gradient over the cream background:
 
 ```tsx
 import {
+  AuiIf,
   ThreadPrimitive,
   ComposerPrimitive,
   MessagePrimitive,
-  AttachmentPrimitive,
+  ActionBarPrimitive,
 } from "@assistant-ui/react";
 
-export const Claude = () => {
-  return (
-    <ThreadPrimitive.Root className="flex h-full flex-col bg-[#F5F5F0] p-4 pt-16 font-serif dark:bg-[#2b2a27]">
-      <ThreadPrimitive.Viewport className="flex grow flex-col overflow-y-scroll">
+export const Claude = () => (
+  <ThreadPrimitive.Root className="bg-[#F0ECE0] font-serif dark:bg-[#2b2a27]">
+    <AuiIf condition={(s) => s.thread.isEmpty}>
+      <EmptyState />
+    </AuiIf>
+    <AuiIf condition={(s) => !s.thread.isEmpty}>
+      <ThreadPrimitive.Viewport>
         <ThreadPrimitive.Messages>
           {() => <ChatMessage />}
         </ThreadPrimitive.Messages>
+        <ThreadPrimitive.ViewportFooter className="sticky bottom-0">
+          <Composer />
+          <p>Claude can make mistakes. Please double-check responses.</p>
+        </ThreadPrimitive.ViewportFooter>
       </ThreadPrimitive.Viewport>
+    </AuiIf>
+  </ThreadPrimitive.Root>
+);
 
-      <ComposerPrimitive.Root className="mx-auto flex w-full max-w-3xl flex-col rounded-2xl bg-white p-0.5 shadow-[0_0.25rem_1.25rem_rgba(0,0,0,0.035)] dark:bg-[#1f1e1b]">
-        <ComposerPrimitive.Input
-          placeholder="How can I help you today?"
-          className="w-full resize-none bg-transparent text-[#1a1a18] outline-none dark:text-[#eee]"
-        />
-        <div className="flex items-center gap-2">
-          <ComposerPrimitive.AddAttachment className="rounded-lg border border-[#00000015] hover:bg-[#f5f5f0]">
-            <PlusIcon />
-          </ComposerPrimitive.AddAttachment>
-          <span className="font-serif">Sonnet 4.5</span>
-          <ComposerPrimitive.Send className="rounded-lg bg-[#ae5630] hover:bg-[#c4633a]">
-            <ArrowUpIcon className="text-white" />
-          </ComposerPrimitive.Send>
-        </div>
-      </ComposerPrimitive.Root>
-    </ThreadPrimitive.Root>
-  );
-};
+const EmptyState = () => (
+  <div className="flex grow flex-col items-center justify-center">
+    <h1 className="flex items-center gap-3 font-serif text-3xl">
+      <Sparkle className="fill-[#c96442] text-[#c96442]" />
+      How can I help you today?
+    </h1>
+    <Composer />
+    <ModeTabs />
+  </div>
+);
+
+const Composer = () => (
+  <ComposerPrimitive.Root className="rounded-2xl border border-[#E5E0D6] bg-white px-3.5 pt-3 pb-2.5 dark:border-[#3d3a35] dark:bg-[#1f1e1b]">
+    <ComposerPrimitive.Input rows={1} placeholder="How can I help you today?" />
+    <div className="flex items-center gap-2">
+      <ComposerPrimitive.AddAttachment />
+      <div className="ml-auto flex items-center gap-1">
+        <ModelPicker />
+        <PrimaryAction />
+      </div>
+    </div>
+  </ComposerPrimitive.Root>
+);
+```
+
+### Hover-only Action Bars
+
+Both user and assistant action bars use opacity + group-hover to stay out of the way:
+
+```tsx
+<MessagePrimitive.Root className="group/message">
+  <div className="rounded-2xl bg-[#E5E0D6] px-4 py-2.5">
+    <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
+  </div>
+  <ActionBarPrimitive.Root
+    hideWhenRunning
+    autohide="not-last"
+    className="opacity-0 transition-opacity group-hover/message:opacity-100"
+  >
+    <ActionBarPrimitive.Edit />
+    <ActionBarPrimitive.Copy />
+  </ActionBarPrimitive.Root>
+</MessagePrimitive.Root>
 ```
 
 ### Color Palette
 
 | Element | Light | Dark |
 |---------|-------|------|
-| Background | `#F5F5F0` | `#2b2a27` |
-| Composer | `white` | `#1f1e1b` |
-| Text | `#1a1a18` | `#eee` |
-| Muted | `#6b6a68` | `#9a9893` |
-| Primary (orange) | `#ae5630` | `#ae5630` |
-| User bubble | `#DDD9CE` | `#393937` |
+| Background | `#F0ECE0` | `#2b2a27` |
+| Composer surface | `white` | `#1f1e1b` |
+| Composer border | `#E5E0D6` | `#3d3a35` |
+| User bubble | `#E5E0D6` | `#393937` |
+| Primary text | `#1a1a18` | `#eee` |
+| Muted text | `#5b5950` | `#a3a098` |
+| Primary action (orange) | `#c96442` | `#c96442` |
 
 ### Styling Details
 
-- **Typography**: `font-serif` throughout for Claude's classic feel
-- **Shadows**: Complex multi-layer shadows for realistic depth
-- **Borders**: Subtle `border-[#00000015]` for soft separation
-- **Transitions**: Smooth `duration-300 ease-[cubic-bezier(0.165,0.85,0.45,1)]`
-- **Active states**: `active:scale-[0.98]` for tactile button feedback
+- **Typography**: `font-serif` everywhere; assistant message uses `leading-[1.65rem]` for a calm reading rhythm
+- **No Shadows**: Composer relies on `border-[#E5E0D6]` only — claude.ai's signature flat surface
+- **User Bubble**: `rounded-2xl bg-[#E5E0D6] max-w-[80%]` right-aligned
+- **Assistant Message**: full-width plain serif, no bubble, no avatar — text sits on the cream background directly
+- **Mode Tabs**: `rounded-lg border border-[#E5E0D6] bg-transparent` so they blend into the cream
 
 ## Source
 

--- a/apps/docs/content/examples/gemini.mdx
+++ b/apps/docs/content/examples/gemini.mdx
@@ -1,6 +1,6 @@
 ---
 title: Gemini Clone
-description: Open-source Gemini clone in React — pastel gradients, rounded composer, streaming responses, and Google-style interaction patterns built with assistant-ui.
+description: Open-source Gemini clone in React — Material Design surface colors, two-line greeting, suggestion chips, functional Tools and Model dropdowns, and a Mic↔Send transition.
 ---
 
 import { Gemini } from "@/components/examples/gemini";
@@ -11,16 +11,17 @@ import { Gemini } from "@/components/examples/gemini";
 
 ## Overview
 
-The Gemini Clone demonstrates how to customize assistant-ui to match Google Gemini's interface. This example features Google's Material Design color system, a distinctive welcome screen with sparkle icon and suggestion chips, and a clean composer with model selector.
+The Gemini Clone demonstrates how to customize assistant-ui to match Google Gemini's interface. The empty state shows a two-line greeting, a centered composer, and a row of suggestion chips. The composer has functional Tools and Model dropdowns, and the trailing slot animates between Mic, Send, and Cancel.
 
 ## Features
 
-- **Material Design Colors**: Google's surface/on-surface color token system
-- **Welcome State**: Gemini sparkle icon, greeting text, and suggestion chips
-- **Composer**: White input with shadow, `+` upload, Tools, model picker, and mic buttons
-- **User Messages**: Right-aligned bubbles with sharp top-right corner (`4px 24px 24px 24px`)
-- **Assistant Messages**: Gemini sparkle avatar on the left with response text
-- **Action Bar**: Thumbs up/down, regenerate, copy, and more menu on hover
+- **Two-line Greeting**: Sparkle icon + "Hi there" + large "Where would you like to start?" headline
+- **Five Suggestion Chips**: Create image, Make music, Help me learn, Write anything, Boost my day
+- **Functional Tools Dropdown**: Deep Research / Create image / Search the web / Help me learn
+- **Functional Model Picker**: Fast / Thinking / Pro with descriptions and "Upgrade to Gemini Advanced"
+- **Animated Send Slot**: Mic when composer is empty, Send circle when typing, Cancel when running (CSS `group-data-[empty]` transitions on `ComposerPrimitive.Root`)
+- **Distinctive User Bubble**: `rounded-3xl rounded-tr` — sharp top-right corner, signature Gemini look
+- **Sparkle Avatar**: Gemini icon on the left of every assistant message
 
 ## Quick Start
 
@@ -30,7 +31,7 @@ npx assistant-ui add thread
 
 ## Code
 
-The Gemini clone uses Google's Material Design surface colors:
+The empty state and chat state share the same `Composer`. The composer carries `data-empty` and `data-running` attributes that drive the Mic↔Send transition:
 
 ```tsx
 import {
@@ -40,38 +41,77 @@ import {
   useAuiState,
 } from "@assistant-ui/react";
 
-export const Gemini = () => {
-  return (
-    <ThreadPrimitive.Root className="flex h-full flex-col bg-[#f8f9fa] dark:bg-[#131314]">
-      <ThreadPrimitive.Empty>
-        {/* Welcome: sparkle + greeting + title + composer + chips */}
-      </ThreadPrimitive.Empty>
-
-      <AuiIf condition={(s) => !s.thread.isEmpty}>
-        <ThreadPrimitive.Viewport>
-          <ThreadPrimitive.Messages components={{ Message: ChatMessage }} />
-        </ThreadPrimitive.Viewport>
-        <Composer />
-      </AuiIf>
-    </ThreadPrimitive.Root>
-  );
-};
+export const Gemini = () => (
+  <ThreadPrimitive.Root className="bg-[#f8f9fa] dark:bg-[#131314]">
+    <AuiIf condition={(s) => s.thread.isEmpty}>
+      <EmptyState />
+    </AuiIf>
+    <AuiIf condition={(s) => !s.thread.isEmpty}>
+      <ThreadPrimitive.Viewport>
+        <ThreadPrimitive.Messages components={{ Message: ChatMessage }} />
+      </ThreadPrimitive.Viewport>
+      <Composer />
+    </AuiIf>
+  </ThreadPrimitive.Root>
+);
 
 const Composer = () => {
+  const isEmpty = useAuiState((s) => s.composer.isEmpty);
+  const isRunning = useAuiState((s) => s.thread.isRunning);
   return (
-    <ComposerPrimitive.Root className="group/composer rounded-4xl bg-white p-3 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-[#1e1f20]">
-      <ComposerPrimitive.Input
-        placeholder="Ask Gemini"
-        className="w-full bg-transparent text-[#1f1f1f] outline-none dark:text-[#e3e3e3]"
-      />
-      <div className="flex items-center text-[#444746] dark:text-[#c4c7c5]">
-        <ComposerPrimitive.AddAttachment>+</ComposerPrimitive.AddAttachment>
-        <button>Tools</button>
-        {/* right side: model picker, send, mic */}
+    <ComposerPrimitive.Root
+      className="group/composer rounded-4xl bg-white p-3 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-[#1e1f20]"
+      data-empty={isEmpty}
+      data-running={isRunning}
+    >
+      <ComposerPrimitive.Input placeholder="Ask Gemini" />
+      <div className="flex items-center">
+        <ComposerPrimitive.AddAttachment />
+        <ToolsMenu />
+        <div className="ml-auto flex items-center gap-2">
+          <ModelPicker />
+          <SendOrMic />
+        </div>
       </div>
     </ComposerPrimitive.Root>
   );
 };
+```
+
+### Mic ↔ Send Transition
+
+The composer passes `isEmpty` and `isRunning` as data attributes; the children animate via `group-data-[empty]` selectors:
+
+```tsx
+<div className="relative size-10 rounded-full">
+  {/* Mic: visible when empty + idle */}
+  <button className="group-data-[empty=false]/composer:scale-0 group-data-[running=true]/composer:scale-0">
+    <Mic />
+  </button>
+  {/* Send: visible when typing + idle */}
+  <ComposerPrimitive.Send className="bg-[#d3e3fd] group-data-[empty=true]/composer:scale-0 group-data-[running=true]/composer:scale-0">
+    <SendHorizonal />
+  </ComposerPrimitive.Send>
+  {/* Cancel: visible while running */}
+  <ComposerPrimitive.Cancel className="bg-[#d3e3fd] group-data-[running=false]/composer:scale-0">
+    <Square />
+  </ComposerPrimitive.Cancel>
+</div>
+```
+
+### Functional Dropdowns
+
+```tsx
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/shared/dropdown-menu";
+
+<DropdownMenu>
+  <DropdownMenuTrigger>Tools</DropdownMenuTrigger>
+  <DropdownMenuContent>
+    <DropdownMenuItem icon={<Telescope />}>Deep Research</DropdownMenuItem>
+    <DropdownMenuItem icon={<ImageIcon />}>Create image</DropdownMenuItem>
+    {/* ... */}
+  </DropdownMenuContent>
+</DropdownMenu>
 ```
 
 ### Color Palette
@@ -79,12 +119,12 @@ const Composer = () => {
 | Element | Light | Dark |
 |---------|-------|------|
 | Background | `#f8f9fa` | `#131314` |
-| Composer bg | `#fff` | `#1e1f20` |
-| Text | `#1f1f1f` | `#e3e3e3` |
+| Composer surface | `#ffffff` | `#1e1f20` |
+| Primary text | `#1f1f1f` | `#e3e3e3` |
 | Muted text | `#444746` | `#c4c7c5` |
 | User bubble | `#e9eef6` | `#282a2c` |
-| Send button | `#d3e3fd` | `#1f3760` |
-| Suggestion chips | `#fff` | `#282a2c` |
+| Send button | `#d3e3fd` (light blue) | `#1f3760` |
+| Suggestion chips | `#ffffff` | `#282a2c` |
 
 ### User Message Bubble
 

--- a/apps/docs/content/examples/grok.mdx
+++ b/apps/docs/content/examples/grok.mdx
@@ -1,6 +1,6 @@
 ---
 title: Grok Clone
-description: Open-source Grok clone in React — black-and-white minimal design with X's chat patterns, streaming responses, and message styling built with assistant-ui.
+description: Open-source Grok clone in React — pill composer with paperclip, animated Mic↔Send, functional model picker dropdown, and message timing tooltip.
 ---
 
 import { Grok } from "@/components/examples/grok";
@@ -11,16 +11,18 @@ import { Grok } from "@/components/examples/grok";
 
 ## Overview
 
-The Grok Clone demonstrates how to customize assistant-ui to match xAI's Grok interface. This example features a clean, minimalist design with smooth animations, inverted color schemes for light/dark modes, and a distinctive welcome screen with the Grok logo.
+The Grok Clone demonstrates how to customize assistant-ui to match xAI's Grok interface. The empty state centers the Grok wordmark above a pill composer with an animated trailing button that swaps between Mic, Send, and Cancel based on composer state. Models are picked from a real dropdown that animates open/collapse along with the composer.
 
 ## Features
 
-- **Minimalist Design**: Clean interface with subtle ring borders
-- **Animated Composer**: Smooth transitions between send, voice, and cancel states
-- **Empty State**: Welcome screen with centered Grok logo
-- **Attachment Thumbnails**: Image preview with hover-to-remove
-- **Inverted Buttons**: Dark button on light mode, light button on dark mode
-- **Model Selector**: Animated expand/collapse on focus
+- **Centered Grok Wordmark**: Empty state shows the SVG wordmark above the composer
+- **Pill Composer**: `rounded-4xl` with thin ring border, paperclip on the leading edge
+- **Functional Model Picker**: Fast / Grok 4.1 / Think dropdown with descriptions, plus "Subscribe to SuperGrok"
+- **Expand/Collapse Model Pill**: When the composer is empty the pill shows the model name; when typing it collapses to just the model icon
+- **Animated Send Slot**: Mic when empty, Send (white-on-dark) when typing, Cancel while running — all via `group-data-[empty]` / `group-data-[running]`
+- **Inverted Primary**: Dark button on light mode, light button on dark mode
+- **Message Timing**: Streaming responses show a hover tooltip with first-token, total time, tokens/sec, chunk count
+- **Hover-only Action Bars**: Edit/Copy on user messages, Reload/Copy/👍/👎 on assistant messages
 
 ## Quick Start
 
@@ -30,7 +32,7 @@ npx assistant-ui add thread
 
 ## Code
 
-The Grok clone uses clean minimalism with smooth animations:
+The composer carries `data-empty` and `data-running` attributes so the trailing button transitions smoothly:
 
 ```tsx
 import {
@@ -40,30 +42,28 @@ import {
   useAuiState,
 } from "@assistant-ui/react";
 
-export const Grok = () => {
-  return (
-    <ThreadPrimitive.Root className="flex h-full flex-col bg-[#fdfdfd] px-4 dark:bg-[#141414]">
-      <AuiIf condition={(s) => s.thread.isEmpty}>
-        <div className="flex h-full flex-col items-center justify-center">
-          <GrokLogo className="mb-6 h-10 text-[#0d0d0d] dark:text-white" />
-          <Composer />
-        </div>
-      </AuiIf>
-
-      <ThreadPrimitive.Viewport className="flex grow flex-col overflow-y-scroll pt-16">
+export const Grok = () => (
+  <ThreadPrimitive.Root className="bg-[#fdfdfd] px-4 dark:bg-[#141414]">
+    <AuiIf condition={(s) => s.thread.isEmpty}>
+      <div className="flex h-full flex-col items-center justify-center">
+        <GrokLogo className="mb-6 h-10 text-[#0d0d0d] dark:text-white" />
+        <Composer />
+      </div>
+    </AuiIf>
+    <AuiIf condition={(s) => !s.thread.isEmpty}>
+      <ThreadPrimitive.Viewport>
         <ThreadPrimitive.Messages>
           {() => <ChatMessage />}
         </ThreadPrimitive.Messages>
       </ThreadPrimitive.Viewport>
       <Composer />
-    </ThreadPrimitive.Root>
-  );
-};
+    </AuiIf>
+  </ThreadPrimitive.Root>
+);
 
 const Composer = () => {
   const isEmpty = useAuiState((s) => s.composer.isEmpty);
   const isRunning = useAuiState((s) => s.thread.isRunning);
-
   return (
     <ComposerPrimitive.Root
       className="group/composer mx-auto mb-3 w-full max-w-3xl"
@@ -71,26 +71,59 @@ const Composer = () => {
       data-running={isRunning}
     >
       <div className="rounded-4xl bg-[#f8f8f8] ring-1 ring-[#e5e5e5] ring-inset dark:bg-[#212121] dark:ring-[#2a2a2a]">
-        <ComposerPrimitive.Input
-          placeholder="What do you want to know?"
-          className="w-full bg-transparent text-[#0d0d0d] outline-none dark:text-white"
-        />
-        {/* Animated button with three states */}
-        <div className="relative h-9 w-9 rounded-full bg-[#0d0d0d] dark:bg-white">
-          <button className="group-data-[empty=false]/composer:scale-0">
-            <Mic /> {/* Voice mode when empty */}
-          </button>
-          <ComposerPrimitive.Send className="group-data-[empty=true]/composer:scale-0">
-            <ArrowUpIcon /> {/* Send when has text */}
-          </ComposerPrimitive.Send>
-          <ComposerPrimitive.Cancel className="group-data-[running=false]/composer:scale-0">
-            <Square /> {/* Stop when running */}
-          </ComposerPrimitive.Cancel>
-        </div>
+        <ComposerPrimitive.AddAttachment><Paperclip /></ComposerPrimitive.AddAttachment>
+        <ComposerPrimitive.Input placeholder="What do you want to know?" />
+        <GrokModelPicker />
+        <SendOrMic />
       </div>
     </ComposerPrimitive.Root>
   );
 };
+```
+
+### Functional Model Picker
+
+```tsx
+const MODELS = [
+  { id: "fast", name: "Fast", description: "Default. Quick responses", Icon: Zap },
+  { id: "grok-4.1", name: "Grok 4.1", description: "Standard reasoning", Icon: Moon },
+  { id: "think", name: "Think", description: "Multi-step reasoning", Icon: Moon },
+];
+
+<DropdownMenu>
+  <DropdownMenuTrigger>
+    <CurrentIcon />
+    {/* Name + chevron collapse to nothing while typing */}
+    <div className="group-data-[empty=false]/composer:max-w-0 group-data-[empty=true]/composer:max-w-32">
+      <span>{current.name}</span>
+      <ChevronDown />
+    </div>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent>
+    {MODELS.map((m) => (
+      <DropdownMenuItem onSelect={() => setModel(m.id)}>
+        {m.id === model ? <Check /> : <m.Icon />}
+        {m.name} — {m.description}
+      </DropdownMenuItem>
+    ))}
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+### Animated Send Slot
+
+```tsx
+<div className="relative h-9 w-9 rounded-full bg-[#0d0d0d] dark:bg-white">
+  <button className="group-data-[empty=false]/composer:scale-0">
+    <Mic /> {/* Voice when empty */}
+  </button>
+  <ComposerPrimitive.Send className="group-data-[empty=true]/composer:scale-0">
+    <ArrowUp /> {/* Send when typing */}
+  </ComposerPrimitive.Send>
+  <ComposerPrimitive.Cancel className="group-data-[running=false]/composer:scale-0">
+    <Square /> {/* Stop while running */}
+  </ComposerPrimitive.Cancel>
+</div>
 ```
 
 ### Color Palette
@@ -98,25 +131,23 @@ const Composer = () => {
 | Element | Light | Dark |
 |---------|-------|------|
 | Background | `#fdfdfd` | `#141414` |
-| Input bg | `#f8f8f8` | `#212121` |
-| Text | `#0d0d0d` | `white` |
-| Muted | `#9a9a9a` | `#6b6b6b` |
+| Composer surface | `#f8f8f8` | `#212121` |
 | Ring border | `#e5e5e5` | `#2a2a2a` |
-| Send button | `#0d0d0d` | `white` |
+| Primary text | `#0d0d0d` | `white` |
+| Muted text | `#9a9a9a` | `#6b6b6b` |
+| Send button (inverted) | `#0d0d0d` | `white` |
 
 ### Animation Technique
 
 The composer uses `data-*` attributes for state-based animations:
 
 ```tsx
-// Container passes state as data attributes
 <ComposerPrimitive.Root data-empty={isEmpty} data-running={isRunning}>
-
-// Children animate based on parent's data attributes
-<button className="group-data-[empty=false]/composer:scale-0 group-data-[empty=false]/composer:opacity-0">
+  <button className="group-data-[empty=false]/composer:scale-0 group-data-[empty=false]/composer:opacity-0" />
+</ComposerPrimitive.Root>
 ```
 
-This creates smooth transitions between voice → send → cancel button states.
+This drives the Mic↔Send transition and the model pill expand/collapse on the same gesture.
 
 ## Source
 

--- a/apps/docs/content/examples/perplexity.mdx
+++ b/apps/docs/content/examples/perplexity.mdx
@@ -1,6 +1,6 @@
 ---
 title: Perplexity Clone
-description: Open-source Perplexity-style chat in React — theme-aware composer, stateful send/dictate/cancel actions, and inline attachment chips built with assistant-ui.
+description: Open-source Perplexity-style chat in React — theme-aware composer, functional Search and Model dropdowns, four-state primary action, and a Search-icon assistant avatar.
 ---
 
 import { Perplexity } from "@/components/examples/perplexity";
@@ -11,16 +11,18 @@ import { Perplexity } from "@/components/examples/perplexity";
 
 ## Overview
 
-The Perplexity Clone demonstrates how to customize assistant-ui to match Perplexity's search-focused interface. This version focuses on a modern composer surface with explicit light and dark theme styling, compact attachment chips, and stateful dictate, send, and cancel actions.
+The Perplexity Clone demonstrates how to customize assistant-ui to match Perplexity's search-focused interface. The empty state centers the `perplexity` wordmark above a multi-line composer with functional Search and Model dropdowns; the chat state keeps the composer pinned as a sticky follow-up footer.
 
 ## Features
 
-- **Theme-Aware Styling**: Separate light and dark palettes instead of a single forced theme
-- **Perplexity-Inspired Composer**: Centered card with a multi-line input and a dedicated bottom action row
-- **Stateful Primary Action**: Dictate when empty, send when typing, cancel while running
-- **Mode + Model Affordances**: Static `Search` pill and `Model` placeholder mirror Perplexity's signature controls
-- **Attachment Chips**: Compact inline previews that sit above the input area
-- **Prompt-First Layout**: Large centered heading with a restrained transcript design
+- **Theme-Aware Styling**: Cream `#f6f2ec` light, espresso `#171615` dark — no forced theme
+- **Hero Wordmark**: Large centered `perplexity` headline that scales down on mobile
+- **Multi-line Composer**: `rows={2}` with `min-h-20` so the input feels as tall as Perplexity's hero
+- **Functional Search Dropdown**: Search / Research / Labs modes, each with an icon and description
+- **Functional Model Dropdown**: Best / Sonar / Claude 4.5 Sonnet / GPT-5 / Gemini 3 Pro (hidden on small screens)
+- **Four-State Primary Action**: Cancel, StopDictation, Send, Dictate — mutually exclusive via priority
+- **Inline Attachment Chips**: Compact previews render above the input
+- **Sticky Follow-up**: Once a chat starts, the composer becomes a pinned footer with a fade-out gradient over the cream background
 
 ## Quick Start
 
@@ -30,7 +32,7 @@ npx assistant-ui add thread
 
 ## Code
 
-The Perplexity clone uses a single shared composer with light and dark theme tokens:
+The empty state and chat state share the same `Composer`. The composer uses `--thread-max-width: 40rem` to stay tighter than the typical max-w-3xl:
 
 ```tsx
 import {
@@ -40,47 +42,88 @@ import {
   AttachmentPrimitive,
 } from "@assistant-ui/react";
 
-export const Thread = () => {
-  return (
-    <ThreadPrimitive.Root className="bg-[#f6f2ec] text-[#1f1b17] dark:bg-[#171615] dark:text-[#f5f2ed]">
-      <AuiIf condition={(s) => s.thread.isEmpty}>
-        <div className="flex h-full items-center justify-center">
-          <div className="w-full max-w-3xl">
-            <p className="mb-8 text-center font-display text-4xl">perplexity</p>
-            <Composer />
-          </div>
-        </div>
-      </AuiIf>
-
+export const Perplexity = () => (
+  <ThreadPrimitive.Root
+    className="bg-[#f6f2ec] dark:bg-[#171615]"
+    style={{ ["--thread-max-width"]: "40rem" }}
+  >
+    <AuiIf condition={(s) => s.thread.isEmpty}>
+      <EmptyState />
+    </AuiIf>
+    <AuiIf condition={(s) => !s.thread.isEmpty}>
       <ThreadPrimitive.Viewport>
         <ThreadPrimitive.Messages />
-        <Composer />
+        <ThreadPrimitive.ViewportFooter className="sticky bottom-0">
+          <Composer placeholder="Ask a follow-up..." />
+        </ThreadPrimitive.ViewportFooter>
       </ThreadPrimitive.Viewport>
-    </ThreadPrimitive.Root>
-  );
-};
+    </AuiIf>
+  </ThreadPrimitive.Root>
+);
 
-const Composer = () => (
+const Composer = ({ placeholder }) => (
   <ComposerPrimitive.Root className="rounded-3xl border border-[#d7d0c5] bg-[#fcfbf8] dark:border-[#4a433b] dark:bg-[#23211f]">
-    <ComposerPrimitive.Attachments components={{ Attachment: ComposerChip }} />
-    <ComposerPrimitive.Input rows={2} placeholder="Ask anything..." />
+    <ComposerPrimitive.Input rows={2} placeholder={placeholder} />
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-1.5">
         <ComposerPrimitive.AddAttachment />
-        <ModePill />
+        <SearchModePicker />
       </div>
-      <div className="flex items-center gap-2">
-        <ModelPlaceholder />
-        <ComposerPrimitive.Dictate />
-        <ComposerPrimitive.Send />
-        <ComposerPrimitive.Cancel />
+      <div className="flex items-center gap-1">
+        <ModelPicker />
+        <ComposerPrimaryAction />
       </div>
     </div>
   </ComposerPrimitive.Root>
 );
-
-const ComposerChip = () => <AttachmentPrimitive.Root />;
 ```
+
+### Functional Search & Model Dropdowns
+
+```tsx
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/shared/dropdown-menu";
+
+const SEARCH_MODES = [
+  { id: "search", name: "Search", description: "Fast answers to everyday questions", Icon: Search },
+  { id: "research", name: "Research", description: "In-depth reports on complex topics", Icon: Telescope },
+  { id: "labs", name: "Labs", description: "Apps, slides, and dashboards", Icon: Sparkles },
+];
+
+<DropdownMenu>
+  <DropdownMenuTrigger className="rounded-full border border-[#e0d8cb] bg-[#f5f1eb] px-3">
+    <CurrentIcon /> {current.name} <ChevronDown />
+  </DropdownMenuTrigger>
+  <DropdownMenuContent>
+    {SEARCH_MODES.map((m) => (
+      <DropdownMenuItem onSelect={() => setMode(m.id)}>
+        {m.id === mode ? <Check /> : <m.Icon />}
+        {m.name} — {m.description}
+      </DropdownMenuItem>
+    ))}
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+The Model picker uses `hidden sm:flex` so it collapses on mobile and the Search pill keeps room.
+
+### Four-State Primary Action
+
+```tsx
+<AuiIf condition={(s) => s.thread.isRunning}>
+  <ComposerPrimitive.Cancel />
+</AuiIf>
+<AuiIf condition={(s) => s.composer.dictation != null}>
+  <ComposerPrimitive.StopDictation />
+</AuiIf>
+<AuiIf condition={(s) => s.composer.dictation == null && !s.composer.isEmpty}>
+  <ComposerPrimitive.Send />
+</AuiIf>
+<AuiIf condition={(s) => s.composer.dictation == null && s.composer.isEmpty}>
+  <ComposerPrimitive.Dictate />
+</AuiIf>
+```
+
+The conditions are mutually exclusive in priority order so dictation can be paused even when transcribed text fills the composer.
 
 ### Color Palette
 
@@ -88,21 +131,20 @@ const ComposerChip = () => <AttachmentPrimitive.Root />;
 |---------|-------|------|
 | Background | `#f6f2ec` | `#171615` |
 | Composer surface | `#fcfbf8` | `#23211f` |
-| Border | `#d7d0c5` | `#4a433b` |
+| Composer border | `#d7d0c5` | `#4a433b` |
 | Primary text | `#1f1b17` | `#f5f2ed` |
 | Muted text | `#7d7468` | `#a19a91` |
 | Primary action | `#25211c` | `#f5f2ed` |
-| Accent detail | `#746c62` | `#a19a91` |
+| Search pill | `#f5f1eb` | `#2a2724` |
 
 ### Styling Details
 
-- **Composer Shell**: Rounded `rounded-3xl` card with a soft layered shadow and explicit light/dark borders
-- **Multi-line Input**: `rows={2}` and a `min-h-20` keeps the composer tall like Perplexity's hero input
-- **Primary Action Swap**: Dictate, send, and cancel share the same trailing action slot via mutually exclusive `AuiIf` branches
-- **Mode + Model Pills**: Static `Search` pill on the leading edge and a `Model` placeholder on the trailing edge mirror Perplexity's chrome
-- **Attachment Row**: Chips render inline above the input instead of as a detached block
-- **Welcome Layout**: Centered wordmark treatment with the composer as the hero element
-- **Transcript Styling**: Simpler messages to keep the composer as the focal point
+- **Composer Shell**: `rounded-3xl` card with a soft layered shadow and explicit light/dark borders
+- **Multi-line Input**: `rows={2}` and `min-h-20` keep the composer tall like Perplexity's hero input
+- **Wordmark**: `text-5xl sm:text-[3.1rem]` so it stays readable on mobile
+- **User Bubble**: `rounded-3xl rounded-tr-md` (chopped top-right corner) with a subtle border
+- **Assistant Avatar**: Search icon on the left of every assistant message
+- **Sticky Footer Gradient**: Fade from `transparent` to the cream background so messages don't sit flush against the composer
 
 ## Source
 


### PR DESCRIPTION
## Summary

- **chatgpt**: centered empty-state composer, removed "C" avatar, functional Tools dropdown, four-state primary action (Cancel / StopDictation / Send / Dictate + Voice), seven-icon assistant action bar
- **claude**: full styling rewrite to match current claude.ai (warmer cream `#F0ECE0`, no composer shadow, hover-only action bars, `#c96442` accent, sparkle heading + five mode tabs, functional model picker)
- **gemini**: two-line greeting, five suggestion chips, functional Tools and Model dropdowns; `ThreadPrimitive.Empty` migrated to `AuiIf`
- **grok**: functional model picker dropdown (Fast / Grok 4.1 / Think + Subscribe to SuperGrok) preserving the empty-state expand/collapse animation
- **perplexity**: functional Search and Model dropdowns, mobile-aware layout (`hidden sm:flex`, responsive wordmark), hover-only user action bar, dictation pause fix (StopDictation now wins over Send)

Every example also gets its mdx refreshed so the description, features, code sample, and color palette reflect the current component.

## Test plan

- [ ] Visit `/examples/chatgpt` empty state in light + dark + mobile; verify Tools dropdown opens and primary action cycles through Voice → Send → Cancel → StopDictation
- [ ] Visit `/examples/claude` empty + chat states; verify hover-only action bars, model picker dropdown, mode tabs render correctly
- [ ] Visit `/examples/gemini` and confirm both Tools and Model dropdowns are interactive; check Mic ↔ Send transition
- [ ] Visit `/examples/grok` and verify model picker dropdown opens; the model name should collapse when typing and reappear when empty
- [ ] Visit `/examples/perplexity` and confirm Search/Model dropdowns work; resize to mobile (≤640px) and verify Model picker hides
- [ ] In any example, start dictation and confirm StopDictation stays visible while transcribed text fills the composer
- [ ] Run `pnpm biome check apps/docs/components/examples apps/docs/content/examples`