### PR TITLE
docs: document runtime driven suggestions

### DIFF
--- a/apps/docs/content/docs/guides/suggestions.mdx
+++ b/apps/docs/content/docs/guides/suggestions.mdx
@@ -136,9 +136,83 @@ Suggestions dismiss automatically once the user sends a message because `thread.
 
 The primitives available for rendering suggestions are `ThreadPrimitive.Suggestions`, `ThreadPrimitive.SuggestionByIndex`, `SuggestionPrimitive.Title`, `SuggestionPrimitive.Description`, and `SuggestionPrimitive.Trigger`. `ThreadPrimitive.SuggestionByIndex` is useful when you need layout control over a specific suggestion slot rather than iterating all of them. For the full prop reference and usage patterns, see the [Suggestion primitive docs](/docs/primitives/suggestion).
 
-## Dynamic Suggestions
+## Runtime driven suggestions
 
-You can dynamically change suggestions based on your application state:
+The static `Suggestions(...)` API covers welcome screens. For follow up prompts that depend on the conversation, a tool result, or your backend, push suggestions through the runtime itself. They land on `thread.suggestions` rather than the static `suggestions` scope, so they render through a different component.
+
+### Local runtime: `SuggestionAdapter`
+
+Pass a `suggestion` adapter to `useLocalRuntime`. Its `generate` function runs after every assistant turn and may return a promise or an async generator for streaming updates.
+
+```tsx
+import { useLocalRuntime, type SuggestionAdapter } from "@assistant-ui/react";
+
+const suggestionAdapter: SuggestionAdapter = {
+  async generate({ messages }) {
+    const response = await fetch("/api/follow-ups", {
+      method: "POST",
+      body: JSON.stringify({ messages }),
+    });
+    const data: { prompt: string }[] = await response.json();
+    return data;
+  },
+};
+
+const runtime = useLocalRuntime(myChatModel, {
+  adapters: { suggestion: suggestionAdapter },
+});
+```
+
+### External store runtime
+
+`useExternalStoreRuntime` exposes a `suggestions` field, so you can drive follow ups straight from your application state.
+
+```tsx
+const [suggestions, setSuggestions] = useState<ThreadSuggestion[]>([]);
+
+const runtime = useExternalStoreRuntime({
+  messages,
+  onNew,
+  suggestions,
+});
+
+// Push a follow up after a tool result, a stream chunk, or any app event.
+setSuggestions([{ prompt: "Summarize this case" }]);
+```
+
+The local runtime clears its suggestions when a new run starts. External stores keep whatever state you push, so you control the lifetime.
+
+### Rendering runtime suggestions
+
+Static suggestions go through `ThreadPrimitive.Suggestions`; runtime suggestions go through `thread.suggestions`. The shadcn registry ships `ThreadFollowupSuggestions` for the common single line pill layout. For a custom layout, read the array yourself:
+
+```tsx
+import { useAuiState, ThreadPrimitive, AuiIf } from "@assistant-ui/react";
+
+function FollowUps() {
+  const suggestions = useAuiState((s) => s.thread.suggestions);
+  return (
+    <AuiIf condition={(s) => !s.thread.isEmpty && !s.thread.isRunning}>
+      <div className="flex gap-2">
+        {suggestions.map((s, i) => (
+          <ThreadPrimitive.Suggestion
+            key={i}
+            prompt={s.prompt}
+            method="replace"
+            autoSend
+          >
+            {s.prompt}
+          </ThreadPrimitive.Suggestion>
+        ))}
+      </div>
+    </AuiIf>
+  );
+}
+```
+
+## Reacting to application state
+
+You can dynamically change the static suggestion list based on your application state:
 
 ```tsx
 import { useMemo } from "react";

--- a/apps/docs/content/docs/primitives/suggestion.mdx
+++ b/apps/docs/content/docs/primitives/suggestion.mdx
@@ -128,6 +128,15 @@ When `send={false}`, the `clearComposer` prop controls whether the suggestion re
 - **`clearComposer={true}`** (default): replaces the current composer text
 - **`clearComposer={false}`**: appends the suggestion to the existing text
 
+### Static configuration vs. runtime suggestions
+
+There are two separate data flows for suggestions:
+
+- **Static configuration** flows through the `suggestions` scope. Pass an array to `Suggestions(...)` in your runtime provider; render it with `ThreadPrimitive.Suggestions`. Best for welcome screen prompts.
+- **Runtime / dynamic suggestions** flow through `thread.suggestions`. Populate it via `SuggestionAdapter` (local runtime) or the `suggestions` field on `useExternalStoreRuntime`; render it with the shadcn `ThreadFollowupSuggestions` component or your own component reading `useAuiState((s) => s.thread.suggestions)`. Best for follow up prompts after a turn.
+
+See [Suggested Prompts](/docs/guides/suggestions) for end to end examples.
+
 ### ThreadPrimitive.Suggestion (Legacy)
 
 `ThreadPrimitive.Suggestion` is a self-contained button that takes a `prompt` prop directly. The newer pattern (`ThreadPrimitive.Suggestions` + `SuggestionPrimitive` parts) is preferred for structured suggestions with title and description:


### PR DESCRIPTION
## Summary
- adds a "Runtime driven suggestions" section to the suggestions guide covering the `SuggestionAdapter` (local runtime) and `useExternalStoreRuntime` `suggestions` field paths.
- clarifies on the suggestion primitive page that there are two separate data flows: static configs via `Suggestions(...)` render through `ThreadPrimitive.Suggestions`, while runtime / dynamic suggestions render through `thread.suggestions`.
- shows a small custom render example for users who want their own runtime suggestion layout instead of the shadcn `ThreadFollowupSuggestions`.
- responds to #3997: the capability the issue requested is already supported by the existing API; only the docs were missing.

## Test plan
- [ ] build the docs site locally and confirm both mdx pages render without errors.
- [ ] verify the code samples typecheck against the current public types (`SuggestionAdapter`, `ThreadSuggestion`, `useExternalStoreRuntime`).
- [ ] spot check the existing static suggestions guide content still reads correctly alongside the new section.