### PR TITLE
fix(store): guard useAuiState getSnapshot against zombie-child crashes

### DIFF
--- a/.changeset/fix-zombie-child-tap-client-lookup.md
+++ b/.changeset/fix-zombie-child-tap-client-lookup.md
@@ -1,0 +1,11 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix: guard useAuiState getSnapshot against zombie-child out-of-bounds throws
+
+When the store notifies all subscribers after a thread switch, stale child
+components re-run getSnapshot() before React can unmount them. tapClientLookup
+throws Index N out of bounds for the now-invalid index. Return the last good
+snapshot value instead of throwing so React can cleanly unmount the zombie
+child on the next reconciliation pass. Real errors on first render still propagate.

--- a/packages/store/src/useAuiState.ts
+++ b/packages/store/src/useAuiState.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore, useDebugValue } from "react";
+import { useSyncExternalStore, useDebugValue, useRef } from "react";
 import type { AssistantState } from "./types/client";
 import { useAui } from "./useAui";
 import { getProxiedAssistantState } from "./utils/proxied-assistant-state";
@@ -21,12 +21,20 @@ import { getProxiedAssistantState } from "./utils/proxied-assistant-state";
 export const useAuiState = <T>(selector: (state: AssistantState) => T): T => {
   const aui = useAui();
   const proxiedState = getProxiedAssistantState(aui);
+  const lastSnapshot = useRef<{ value: T } | undefined>(undefined);
 
-  const slice = useSyncExternalStore(
-    aui.subscribe,
-    () => selector(proxiedState),
-    () => selector(proxiedState),
-  );
+  const getSnapshot = () => {
+    try {
+      const value = selector(proxiedState);
+      lastSnapshot.current = { value };
+      return value;
+    } catch (e) {
+      if (lastSnapshot.current !== undefined) return lastSnapshot.current.value;
+      throw e;
+    }
+  };
+
+  const slice = useSyncExternalStore(aui.subscribe, getSnapshot, getSnapshot);
 
   if (slice === proxiedState) {
     throw new Error(


### PR DESCRIPTION
When notifySubscribers() fires outside React's render cycle, stale child components re-run getSnapshot() before React can unmount them. tapClientLookup throws 'Index N out of bounds', crashing the whole tree.