### PR TITLE
feat(react-ai-sdk): expose onResume on useAISDKRuntime

### DIFF
--- a/.changeset/feat-react-ai-sdk-on-resume.md
+++ b/.changeset/feat-react-ai-sdk-on-resume.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+feat(react-ai-sdk): expose `onResume` on `useAISDKRuntime` and `useChatRuntime`
+
+`AISDKRuntimeAdapter` and `UseChatRuntimeOptions` now accept `onResume`, which is forwarded to the underlying `useExternalStoreRuntime` adapter. `runtime.thread.resumeRun(config)` previously threw `"Runtime does not support resuming runs."` because the inner adapter literal omitted the field; consumers had to monkey-patch `runtime.thread.__internal_threadBinding.getState().resumeRun` to bridge their own replay channels (e.g. SSE reconnect endpoints keyed by turn id). This is a thin pass-through; the existing transport-level resume on `AssistantChatTransport` (auto-fired by `useChatRuntime` on mount) is unchanged and complementary.

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
@@ -266,6 +266,56 @@ describe("useAISDKRuntime", () => {
     );
   });
 
+  it("forwards onResume so runtime.thread.resumeRun is delivered to the adapter", async () => {
+    const chat = createChatHelpers([
+      { id: "u1", role: "user", parts: [{ type: "text", text: "first" }] },
+    ]);
+    const onResume = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useAISDKRuntime(chat, { onResume }));
+
+    await waitFor(() => {
+      expect(result.current.thread.getState().messages.length).toBe(1);
+    });
+
+    act(() => {
+      result.current.thread.resumeRun({
+        parentId: "u1",
+        runConfig: { custom: { turnId: "t-42" } },
+      });
+    });
+
+    await waitFor(() => {
+      expect(onResume).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onResume).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentId: "u1",
+        sourceId: null,
+        runConfig: { custom: { turnId: "t-42" } },
+      }),
+    );
+  });
+
+  it("rejects when resumeRun is called without an onResume adapter", async () => {
+    const chat = createChatHelpers([
+      { id: "u1", role: "user", parts: [{ type: "text", text: "first" }] },
+    ]);
+
+    const { result } = renderHook(() => useAISDKRuntime(chat));
+
+    await waitFor(() => {
+      expect(result.current.thread.getState().messages.length).toBe(1);
+    });
+
+    await expect(
+      result.current.thread.resumeRun({
+        parentId: "u1",
+      }) as unknown as Promise<void>,
+    ).rejects.toThrow("Runtime does not support resuming runs.");
+  });
+
   it("reload slices history and regenerates with metadata", async () => {
     const chat = createChatHelpers([
       { id: "u1", role: "user", parts: [{ type: "text", text: "first" }] },

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -68,6 +68,14 @@ export type AISDKRuntimeAdapter = {
    * @default true
    */
   cancelPendingToolCallsOnSend?: boolean | undefined;
+  /**
+   * Called when `runtime.thread.resumeRun(config)` is invoked.
+   *
+   * When omitted, `resumeRun` throws `"Runtime does not support resuming runs."`.
+   * Provide this to bridge resume invocations into a custom replay channel
+   * (for example, an SSE reconnect endpoint keyed by turn id).
+   */
+  onResume?: ExternalStoreAdapter["onResume"];
 };
 
 export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
@@ -76,6 +84,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     adapters,
     toCreateMessage: customToCreateMessage,
     cancelPendingToolCallsOnSend = true,
+    onResume,
   }: AISDKRuntimeAdapter = {},
 ) => {
   const contextAdapters = useRuntimeAdapters();
@@ -319,6 +328,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     },
     onResumeToolCall: (options) =>
       toolInvocations.resume(options.toolCallId, options.payload),
+    ...(onResume && { onResume }),
     adapters: {
       attachments: vercelAttachmentAdapter,
       ...contextAdapters,

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -23,6 +23,7 @@ export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
     cloud?: AssistantCloud | undefined;
     adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
     toCreateMessage?: CustomToCreateMessageFunction;
+    onResume?: AISDKRuntimeAdapter["onResume"];
   };
 
 const useDynamicChatTransport = <UI_MESSAGE extends UIMessage = UIMessage>(
@@ -70,6 +71,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     adapters,
     transport: transportOptions,
     toCreateMessage,
+    onResume,
     ...chatOptions
   } = options ?? {};
 
@@ -93,6 +95,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const runtime = useAISDKRuntime(chat, {
     adapters,
     ...(toCreateMessage && { toCreateMessage }),
+    ...(onResume && { onResume }),
   });
 
   if (transport instanceof AssistantChatTransport) {


### PR DESCRIPTION
## Summary

- forward `onResume` from `AISDKRuntimeAdapter` (and `UseChatRuntimeOptions`) into the inner `useExternalStoreRuntime` adapter, so `runtime.thread.resumeRun(config)` actually delivers to a consumer-supplied callback instead of throwing `"Runtime does not support resuming runs."`
- thin pass-through: when `onResume` is omitted the field is not added to the adapter literal, so existing throw behavior (and its test in `ExternalStoreThreadRuntimeCore.test.ts`) is unchanged
- complementary to the existing `AssistantChatTransport.resumable` transport-level resume that `useChatRuntime` auto-fires on mount; the two cover different cases (transport-level reconnect vs. programmatic per-turn replay with a custom `stream` factory)
- new tests in `useAISDKRuntime.test.ts`: positive (callback receives the `ResumeRunConfig` with `parentId` / `runConfig`) and negative (rejects with the canonical error when no adapter)
- patch changeset

closes #3998

## Test plan

- [ ] `pnpm vitest run` in `packages/react-ai-sdk` (30/30, including 2 new)
- [ ] `pnpm tsc --noEmit -p packages/react-ai-sdk` (only pre-existing `convertMessage.test.ts` errors on main remain)
- [ ] `pnpm biome check` on the three changed source files
- [ ] manual: a consumer passing `onResume` to `useAISDKRuntime`/`useChatRuntime` and calling `runtime.thread.resumeRun({ parentId, stream })` should see their callback invoked with the canonicalized `ResumeRunConfig`