### PR TITLE
feat(react-ai-sdk): expose suggestions on AI SDK runtime hooks

### DIFF
--- a/.changeset/feat-ai-sdk-suggestions.md
+++ b/.changeset/feat-ai-sdk-suggestions.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+feat: expose `suggestions` on `useAISDKRuntime` and `useChatRuntime`
+
+both hooks now accept an optional `suggestions: readonly ThreadSuggestion[]` option that is forwarded to the underlying `useExternalStoreRuntime`. this lets AI SDK callers drive follow up suggestions from application state, tool results, or backend responses without dropping down to the raw external store runtime.

--- a/apps/docs/content/docs/guides/suggestions.mdx
+++ b/apps/docs/content/docs/guides/suggestions.mdx
@@ -180,7 +180,17 @@ const runtime = useExternalStoreRuntime({
 setSuggestions([{ prompt: "Summarize this case" }]);
 ```
 
-The local runtime clears its suggestions when a new run starts. External stores keep whatever state you push, so you control the lifetime.
+### AI SDK runtime
+
+`useChatRuntime` and `useAISDKRuntime` accept the same `suggestions` field and forward it to the underlying external store.
+
+```tsx
+const [suggestions, setSuggestions] = useState<ThreadSuggestion[]>([]);
+
+const runtime = useChatRuntime({ suggestions });
+```
+
+The local runtime clears its suggestions when a new run starts. External store and AI SDK runtimes keep whatever state you push, so you control the lifetime.
 
 ### Rendering runtime suggestions
 

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -14,6 +14,7 @@ import type {
   ThreadHistoryAdapter,
   AssistantRuntime,
   ThreadMessage,
+  ThreadSuggestion,
   MessageFormatAdapter,
   MessageFormatItem,
   MessageFormatRepository,
@@ -76,6 +77,13 @@ export type AISDKRuntimeAdapter = {
    * (for example, an SSE reconnect endpoint keyed by turn id).
    */
   onResume?: ExternalStoreAdapter["onResume"];
+  /**
+   * Follow up suggestions to surface on the thread. Use this to drive
+   * dynamic suggestions from application state, tool results, or backend
+   * responses; flows into `thread.suggestions` and is rendered by
+   * components that read it (such as the shadcn `ThreadFollowupSuggestions`).
+   */
+  suggestions?: readonly ThreadSuggestion[] | undefined;
 };
 
 export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
@@ -85,6 +93,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     toCreateMessage: customToCreateMessage,
     cancelPendingToolCallsOnSend = true,
     onResume,
+    suggestions,
   }: AISDKRuntimeAdapter = {},
 ) => {
   const contextAdapters = useRuntimeAdapters();
@@ -329,6 +338,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     onResumeToolCall: (options) =>
       toolInvocations.resume(options.toolCallId, options.payload),
     ...(onResume && { onResume }),
+    ...(suggestions && { suggestions }),
     adapters: {
       attachments: vercelAttachmentAdapter,
       ...contextAdapters,

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -24,6 +24,7 @@ export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
     adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
     toCreateMessage?: CustomToCreateMessageFunction;
     onResume?: AISDKRuntimeAdapter["onResume"];
+    suggestions?: AISDKRuntimeAdapter["suggestions"];
   };
 
 const useDynamicChatTransport = <UI_MESSAGE extends UIMessage = UIMessage>(
@@ -72,6 +73,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     transport: transportOptions,
     toCreateMessage,
     onResume,
+    suggestions,
     ...chatOptions
   } = options ?? {};
 
@@ -96,6 +98,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     adapters,
     ...(toCreateMessage && { toCreateMessage }),
     ...(onResume && { onResume }),
+    ...(suggestions && { suggestions }),
   });
 
   if (transport instanceof AssistantChatTransport) {


### PR DESCRIPTION
## Summary
- adds an optional `suggestions: readonly ThreadSuggestion[]` field to `AISDKRuntimeAdapter` and `UseChatRuntimeOptions`, forwarded to the underlying `useExternalStoreRuntime`.
- AI SDK callers can now drive follow up suggestions from application state, tool results, or backend responses without dropping down to the raw external store runtime.
- updates the runtime driven suggestions guide with an "AI SDK runtime" subsection.
- addresses the follow up reported on #3997: `useChatRuntime` / `useAISDKRuntime` previously had no way to surface dynamic suggestions.

## Test plan
- [ ] build `@assistant-ui/react-ai-sdk` and confirm types compile.
- [ ] in an example app, pass `suggestions` to `useChatRuntime`, mutate via `setSuggestions`, and verify the values appear on `thread.suggestions` and render through `ThreadFollowupSuggestions`.
- [ ] confirm omitting `suggestions` keeps prior behavior unchanged.

closes #3997