### PR TITLE
fix(react-ai-sdk): preserve tool args when AI SDK briefly emits null input

### DIFF
--- a/.changeset/fix-ai-sdk-tool-input-flicker.md
+++ b/.changeset/fix-ai-sdk-tool-input-flicker.md
@@ -1,0 +1,13 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix(react-ai-sdk): preserve tool args when AI SDK briefly emits null input
+
+the AI SDK occasionally emits snapshots of an in-flight tool call where
+`input` is null/undefined, which previously collapsed `argsText` to `"{}"`
+mid-stream and tripped the runtime's append-only invariant (warning + tool
+args stream restart, losing accumulated state). `convertMessage` now caches
+the last good input per `(message.id, toolCallId)` via a new
+`toolLastInputCache` on `AISDKMessageConverterMetadata` and falls back to it
+when a later snapshot drops `input`.

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -22,6 +22,7 @@ import type {
   RunConfig,
 } from "@assistant-ui/core";
 import { getExternalStoreMessages } from "@assistant-ui/core";
+import type { ReadonlyJSONObject } from "assistant-stream/utils";
 import { sliceMessagesUntil } from "../utils/sliceMessagesUntil";
 import { toCreateMessage } from "../utils/toCreateMessage";
 import { vercelAttachmentAdapter } from "../utils/vercelAttachmentAdapter";
@@ -103,6 +104,9 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const toolArgsKeyOrderCacheRef = useRef<Map<string, Map<string, string[]>>>(
     new Map(),
   );
+  const toolLastInputCacheRef = useRef<Map<string, ReadonlyJSONObject>>(
+    new Map(),
+  );
   const lastRunConfigRef = useRef<RunConfig | undefined>(undefined);
 
   const hasExecutingTools = Object.values(toolStatuses).some(
@@ -123,6 +127,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         toolStatuses,
         messageTiming,
         toolArgsKeyOrderCache: toolArgsKeyOrderCacheRef.current,
+        toolLastInputCache: toolLastInputCacheRef.current,
         ...(chatHelpers.error && { error: chatHelpers.error.message }),
       }),
       [toolStatuses, messageTiming, chatHelpers.error],

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { ReadonlyJSONObject } from "assistant-stream/utils";
 import { AISDKMessageConverter } from "./convertMessage";
 
 describe("AISDKMessageConverter", () => {
@@ -399,7 +400,7 @@ describe("AISDKMessageConverter", () => {
   it("preserves last good input when AI SDK briefly emits null input", () => {
     const metadata = {
       toolArgsKeyOrderCache: new Map<string, Map<string, string[]>>(),
-      toolLastInputCache: new Map<string, any>(),
+      toolLastInputCache: new Map<string, ReadonlyJSONObject>(),
     };
 
     const convertWithInput = (input: unknown) =>
@@ -442,7 +443,7 @@ describe("AISDKMessageConverter", () => {
   it("preserves last good input across terminal state transitions", () => {
     const metadata = {
       toolArgsKeyOrderCache: new Map<string, Map<string, string[]>>(),
-      toolLastInputCache: new Map<string, any>(),
+      toolLastInputCache: new Map<string, ReadonlyJSONObject>(),
     };
 
     AISDKMessageConverter.toThreadMessages(

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
@@ -395,4 +395,99 @@ describe("AISDKMessageConverter", () => {
       limit: 5,
     });
   });
+
+  it("preserves last good input when AI SDK briefly emits null input", () => {
+    const metadata = {
+      toolArgsKeyOrderCache: new Map<string, Map<string, string[]>>(),
+      toolLastInputCache: new Map<string, any>(),
+    };
+
+    const convertWithInput = (input: unknown) =>
+      AISDKMessageConverter.toThreadMessages(
+        [
+          {
+            id: "a1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-weather",
+                toolCallId: "tc-1",
+                state: "input-streaming",
+                input,
+              },
+            ],
+          } as any,
+        ],
+        false,
+        metadata,
+      )[0]?.content.find((part): part is any => part.type === "tool-call");
+
+    const first = convertWithInput({ city: "NYC" });
+    expect(first?.argsText).toBe('{"city":"NYC');
+    expect(first?.args).toEqual({ city: "NYC" });
+
+    const dropped = convertWithInput(null);
+    expect(dropped?.argsText).toBe('{"city":"NYC');
+    expect(dropped?.args).toEqual({ city: "NYC" });
+
+    const undef = convertWithInput(undefined);
+    expect(undef?.argsText).toBe('{"city":"NYC');
+    expect(undef?.args).toEqual({ city: "NYC" });
+
+    const grown = convertWithInput({ city: "NYC", units: "F" });
+    expect(grown?.argsText).toBe('{"city":"NYC","units":"F');
+    expect(grown?.args).toEqual({ city: "NYC", units: "F" });
+  });
+
+  it("preserves last good input across terminal state transitions", () => {
+    const metadata = {
+      toolArgsKeyOrderCache: new Map<string, Map<string, string[]>>(),
+      toolLastInputCache: new Map<string, any>(),
+    };
+
+    AISDKMessageConverter.toThreadMessages(
+      [
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-weather",
+              toolCallId: "tc-1",
+              state: "input-available",
+              input: { city: "NYC" },
+            },
+          ],
+        } as any,
+      ],
+      false,
+      metadata,
+    );
+
+    const terminal = AISDKMessageConverter.toThreadMessages(
+      [
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-weather",
+              toolCallId: "tc-1",
+              state: "output-available",
+              input: null,
+              output: { temp: 70 },
+            },
+          ],
+        } as any,
+      ],
+      false,
+      metadata,
+    );
+
+    const call = terminal[0]?.content.find(
+      (part): part is any => part.type === "tool-call",
+    );
+    expect(call?.args).toEqual({ city: "NYC" });
+    expect(call?.result).toEqual({ temp: 70 });
+  });
 });

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -190,6 +190,13 @@ function convertParts(
           argsText = stripClosingDelimiters(argsText);
         } else {
           metadata.toolArgsKeyOrderCache?.delete(argsKeyOrderCacheKey);
+          if (
+            part.state === "output-available" ||
+            part.state === "output-error" ||
+            part.state === "output-denied"
+          ) {
+            metadata.toolLastInputCache?.delete(argsKeyOrderCacheKey);
+          }
         }
 
         const toolStatus = metadata.toolStatuses?.[toolCallId];

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -19,6 +19,7 @@ type MessageMetadata = ThreadMessageLike["metadata"];
 export type AISDKMessageConverterMetadata =
   useExternalMessageConverter.Metadata & {
     toolArgsKeyOrderCache?: Map<string, Map<string, string[]>>;
+    toolLastInputCache?: Map<string, ReadonlyJSONObject>;
   };
 
 function stripClosingDelimiters(json: string): string {
@@ -148,8 +149,19 @@ function convertParts(
         const toolName = getToolName(part);
         const toolCallId = part.toolCallId;
         const argsKeyOrderCacheKey = `${message.id}:${toolCallId}`;
-        const args: ReadonlyJSONObject =
-          (part.input as ReadonlyJSONObject) || {};
+
+        const rawInput = part.input as ReadonlyJSONObject | null | undefined;
+        let args: ReadonlyJSONObject;
+        if (
+          rawInput != null &&
+          typeof rawInput === "object" &&
+          !Array.isArray(rawInput)
+        ) {
+          args = rawInput;
+          metadata.toolLastInputCache?.set(argsKeyOrderCacheKey, args);
+        } else {
+          args = metadata.toolLastInputCache?.get(argsKeyOrderCacheKey) ?? {};
+        }
 
         let result: unknown;
         let isError = false;


### PR DESCRIPTION
## Summary

- supersedes #2775 (closing in favor of this); credits @talglobus as co-author
- AI SDK occasionally emits in-flight tool snapshots where `input` is briefly null/undefined, which collapses `argsText` to `"{}"` mid-stream and trips the runtime's append-only invariant (warning + tool args stream restart, losing accumulated state)
- caches the last good input per `(message.id, toolCallId)` on a new `toolLastInputCache` field of `AISDKMessageConverterMetadata`, falling back to it when a later snapshot drops `input`
- wires the cache through `useAISDKRuntime` via `useRef` so it persists across converter invocations, mirroring the existing `toolArgsKeyOrderCache` pattern
- adds two regression tests covering null input mid-stream and null input across terminal state transitions

## Test plan

- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` (34/34 pass, 2 new cases)
- [x] `pnpm biome check packages/react-ai-sdk/src/`
- [x] `pnpm --filter @assistant-ui/react-ai-sdk build`
- [ ] manually verify a streaming tool call (e.g., streaming table) no longer triggers the "argsText rewrote previous snapshot" warning when AI SDK drops `input` mid-stream