### PR TITLE
docs: standardize package READMEs to a tier convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://www.assistant-ui.com">Product</a> ·
   <a href="https://www.assistant-ui.com/docs">Documentation</a> ·
   <a href="https://www.assistant-ui.com/examples">Examples</a> ·
-  <a href="https://discord.gg/S9dwgCNEFs">Discord Community</a> ·
+  <a href="https://discord.gg/S9dwgCNEFs">Discord</a> ·
   <a href="https://cal.com/simon-farshid/assistant-ui">Contact Sales</a>
 </p>
 
@@ -15,63 +15,74 @@
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/assistant-ui/assistant-ui)
 [![Weave Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fapp.workweave.ai%2Fapi%2Frepository%2Fbadge%2Forg_GhSIrtWo37b5B3Mv0At3wQ1Q%2F722184017&cacheSeconds=3600)](https://app.workweave.ai/reports/repository/org_GhSIrtWo37b5B3Mv0At3wQ1Q/722184017)
 ![GitHub License](https://img.shields.io/github/license/assistant-ui/assistant-ui)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
 ![Backed by Y Combinator](https://img.shields.io/badge/Backed_by-Y_Combinator-orange)
-<!-- [![Manta Graph badge](https://getmanta.ai/api/badges?text=Manta%20Graph&link=assistant-ui)](https://getmanta.ai/assistant-ui) -->
-
-[⭐️ Star us on GitHub](https://github.com/assistant-ui/assistant-ui)
 
 ## The UX of ChatGPT in your React app 💬🚀
 
-**assistant-ui** is an open source TypeScript/React library to build production-grade AI chat experiences fast.
+**assistant-ui** is an open-source TypeScript/React library to build production-grade AI chat experiences fast.
 
-- Handles streaming, auto-scrolling, accessibility, and real-time updates for you
-- Fully composable primitives inspired by shadcn/ui and cmdk — customize every pixel
-- Works with your stack: AI SDK, LangGraph, Mastra, or any custom backend
-- Broad model support out of the box (OpenAI, Anthropic, Mistral, Perplexity, AWS Bedrock, Azure, Google Gemini, Hugging Face, Fireworks, Cohere, Replicate, Ollama) with easy extension to custom APIs
+## Installation
 
-## Why assistant-ui
-
-- **Fast to production**: battle-tested primitives, built-in streaming and attachments
-- **Designed for customization**: composable pieces instead of a monolithic widget
-- **Great DX**: sensible defaults, keyboard shortcuts, a11y, and strong TypeScript
-- **Enterprise-ready**: optional chat history and analytics via Assistant Cloud
-
-## Getting Started
-
-Run one of the following in your terminal:
+The fastest path is the CLI, which scaffolds a Next.js app or adds the styled components to an existing project:
 
 ```bash
-npx assistant-ui create   # new project
-npx assistant-ui init     # add to existing project
+npx assistant-ui@latest create   # new project
+npx assistant-ui@latest init     # add to existing project
 ```
+
+Or install the package directly:
+
+```bash
+npm install @assistant-ui/react
+```
+
+## Usage
+
+```tsx
+"use client";
+
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { Thread } from "@/components/assistant-ui/thread";
+
+export function Chat() {
+  const runtime = useChatRuntime();
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+`useChatRuntime` connects to the Vercel AI SDK out of the box. Swap it for `useLangGraphRuntime`, `useDataStreamRuntime`, or any custom runtime to integrate with your own backend.
 
 [![assistant-ui starter template](https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/assistant-ui-starter.gif)](https://youtu.be/k6Dc8URmLjk)
 
-## Features
+## What you get
 
-- **Build**: composable primitives to create any chat UX (message list, input, thread, toolbar) and a polished shadcn/ui theme you can fully customize.
-
-- **Ship**: production-ready UX out of the box — streaming, auto-scroll, retries, attachments, markdown, code highlighting, and voice input (dictation) — plus keyboard shortcuts and accessibility by default.
-
-- **Generate**: render tool calls and JSON as components, collect human approvals inline, and enable safe frontend actions.
-
-- **Integrate**: works with AI SDK, LangGraph, Mastra, or custom backends; broad provider support; optional chat history and analytics via Assistant Cloud (single env var).
+- **Composable primitives**: build any chat UX from `Thread`, `Message`, `Composer`, `ThreadList`, `ActionBar`, and friends. Style every pixel yourself, or start from a polished shadcn/ui theme that the CLI copies into your project.
+- **Production UX out of the box**: streaming, auto-scroll, retries, attachments, markdown, code highlighting, voice dictation, keyboard shortcuts, and accessibility.
+- **Generative UI**: render tool calls and JSON as React components, collect inline human approvals, and expose safe frontend actions to the model.
+- **Strong TypeScript**: typed runtime APIs, tool schemas, message parts, and adapters end to end.
 
 ## Backends
 
-- **Assistant Cloud**: managed chat persistence and analytics. Deploy with the Cloud Starter template; bring any model/provider.
+| Integration                            | Package                                                          |
+| -------------------------------------- | ---------------------------------------------------------------- |
+| Vercel AI SDK                          | `@assistant-ui/react-ai-sdk`                                     |
+| LangGraph / LangChain                  | `@assistant-ui/react-langgraph`, `@assistant-ui/react-langchain` |
+| AG-UI / A2A protocols                  | `@assistant-ui/react-ag-ui`, `@assistant-ui/react-a2a`           |
+| Google ADK / OpenCode                  | `@assistant-ui/react-google-adk`, `@assistant-ui/react-opencode` |
+| Custom data-stream backend             | `@assistant-ui/react-data-stream`                                |
+| Managed thread history, telemetry, and file storage | `assistant-cloud`                                       |
 
-- **AI SDK**: integration with Vercel AI SDK; connect to any supported provider.
-
-- **LangGraph**: integration with LangGraph and LangGraph Cloud; connect via LangChain providers.
-
-- **Mastra**: integration with Mastra agents/workflows/RAG; model routing via Vercel AI SDK; optional Mastra Cloud.
-
-- **Custom**: use assistant-ui on top of your own backend/streaming protocol.
+Broad model support out of the box (OpenAI, Anthropic, Google Gemini, Mistral, Perplexity, AWS Bedrock, Azure, Fireworks, Ollama) plus community providers via the AI SDK, and easy extension to any custom HTTP backend.
 
 ## Customization
 
-assistant-ui takes a Radix-style approach: instead of a single monolithic chat component, you compose primitives and bring your own styles. We provide a great starter config; you control everything else.
+Radix-style: instead of a single monolithic chat component, you compose primitives and bring your own styles. The CLI ships a great starter; you control everything else.
 
 ![Overview of components](https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/components.png)
 
@@ -79,11 +90,9 @@ Sample customization to make a Perplexity lookalike:
 
 ![Perplexity clone created with assistant-ui](https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/perplexity.gif)
 
-## Traction
+## Used in production by
 
-assistant-ui is the most popular UI library for building AI chat.
-
-Hundreds of companies and projects use assistant-ui to build in-app AI assistants, including <a href="https://mastra.ai/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Mastra.svg" height="20" alt="Mastra"></a>, <a href="https://langchain.com/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/LangChain.svg" height="20" alt="LangChain"></a>, <a href="https://athenaintelligence.ai/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Athena-Intelligence.svg" height="20" alt="Athena Intelligence"></a>, <a href="https://browser-use.com/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Browser-Use.svg" height="20" alt="Browser Use"></a>, <a href="https://stack-ai.com/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Stack.svg" height="20" alt="Stack"></a>, <a href="https://inconvo.com/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Inconvo.svg" height="20" alt="Inconvo"></a>, <a href="https://iterable.com/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Iterable.svg" height="20" alt="Iterable"></a>, <a href="https://helicone.ai/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/helicone.svg" height="20" alt="Helicone"></a>, <a href="https://getgram.ai/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/gram.svg" height="20" alt="Gram"></a>, <a href="https://coreviz.io/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Coreviz.svg" height="20" alt="Coreviz"></a>, and more.
+<a href="https://mastra.ai/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Mastra.svg" height="20" alt="Mastra"></a>, <a href="https://langchain.com/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/LangChain.svg" height="20" alt="LangChain"></a>, <a href="https://athenaintelligence.ai/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Athena-Intelligence.svg" height="20" alt="Athena Intelligence"></a>, <a href="https://browser-use.com/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Browser-Use.svg" height="20" alt="Browser Use"></a>, <a href="https://stack-ai.com/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Stack.svg" height="20" alt="Stack"></a>, <a href="https://inconvo.com/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Inconvo.svg" height="20" alt="Inconvo"></a>, <a href="https://iterable.com/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Iterable.svg" height="20" alt="Iterable"></a>, <a href="https://helicone.ai/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/helicone.svg" height="20" alt="Helicone"></a>, <a href="https://getgram.ai/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/gram.svg" height="20" alt="Gram"></a>, <a href="https://coreviz.io/?ref=assistant-ui" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/logos/Coreviz.svg" height="20" alt="Coreviz"></a>, and many more.
 
 ![Chart of assistant-ui's traction](https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/traction.png)
 
@@ -106,11 +115,18 @@ Hundreds of companies and projects use assistant-ui to build in-app AI assistant
 
 ## Community & Support
 
-- [Check out example demos](https://www.assistant-ui.com/)
-- [Read the docs](https://www.assistant-ui.com/docs/)
-- [Join our Discord](https://discord.com/invite/S9dwgCNEFs)
+- [Examples](https://www.assistant-ui.com/examples)
+- [Documentation](https://www.assistant-ui.com/docs/)
+- [Discord](https://discord.com/invite/S9dwgCNEFs)
 - [Book a sales call](https://cal.com/simon-farshid/assistant-ui)
 
----
+## For other platforms
 
-Backed by Y Combinator. Building something with assistant-ui? We’d love to hear from you.
+- React Native: [`@assistant-ui/react-native`](https://www.npmjs.com/package/@assistant-ui/react-native)
+- Terminal (Ink): [`@assistant-ui/react-ink`](https://www.npmjs.com/package/@assistant-ui/react-ink)
+
+## License
+
+MIT, with optional Assistant Cloud for managed thread persistence and analytics.
+
+Backed by Y Combinator.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ npx assistant-ui@latest create   # new project
 npx assistant-ui@latest init     # add to existing project
 ```
 
-Or install the package directly:
+Or install the packages directly:
 
 ```bash
-npm install @assistant-ui/react
+npm install @assistant-ui/react @assistant-ui/react-ai-sdk
 ```
 
 ## Usage

--- a/packages/agent-launcher/README.md
+++ b/packages/agent-launcher/README.md
@@ -1,0 +1,28 @@
+# `@assistant-ui/agent-launcher`
+
+Spawn the [Claude Code](https://www.anthropic.com/claude-code) CLI with a chosen plugin directory, skill, and prompt.
+
+Used internally by the `assistant-ui` CLI's `agent` command. Call it directly when wiring up your own integration that bundles Claude Code plugins or skills.
+
+## Installation
+
+```bash
+npm install @assistant-ui/agent-launcher
+```
+
+The `claude` CLI must be available on `PATH`. If it is missing, `launch` prints an install hint and exits with code 1.
+
+## Usage
+
+```typescript
+import { launch } from "@assistant-ui/agent-launcher";
+
+launch({
+  pluginDir: "/absolute/path/to/plugins", // forwarded as --plugin-dir
+  skillName: "assistant-ui",              // optional; sends /<skill> <prompt>
+  prompt: "Add a thread component to this project.",
+  dry: false,                              // print command without spawning
+});
+```
+
+The child process inherits `stdio`, so output streams directly to the parent terminal. `launch` exits the parent with the child's status code on non-zero exit.

--- a/packages/agent-launcher/package.json
+++ b/packages/agent-launcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@assistant-ui/agent-launcher",
   "version": "0.1.4",
-  "description": "Launch Claude Code with bundled plugins and skills",
+  "description": "Spawn the Claude Code CLI with a chosen plugin directory, skill, and prompt",
   "keywords": [
     "claude",
     "claude-code",

--- a/packages/assistant-stream/README.md
+++ b/packages/assistant-stream/README.md
@@ -1,0 +1,39 @@
+# `assistant-stream`
+
+[![npm version](https://img.shields.io/npm/v/assistant-stream)](https://www.npmjs.com/package/assistant-stream)
+[![npm downloads](https://img.shields.io/npm/dm/assistant-stream)](https://www.npmjs.com/package/assistant-stream)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/assistant-stream)](https://bundlephobia.com/package/assistant-stream)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
+
+Framework-agnostic streaming primitives for AI assistant backends. Defines a chunked stream of typed events (text, tool calls, tool results, data parts, message metadata), encoders/decoders for several wire formats, and a server-side tool execution pipeline. Runs in any standard JavaScript runtime; no React or DOM dependencies.
+
+Most apps reach `assistant-stream` indirectly through `@assistant-ui/react-ai-sdk` or `@assistant-ui/react-data-stream`, which handle the wire format for you. Install it directly when you are building a custom backend or a new integration package.
+
+## Installation
+
+```bash
+npm install assistant-stream
+```
+
+## Usage
+
+```typescript
+import { createAssistantStreamResponse } from "assistant-stream";
+
+export async function POST(request: Request) {
+  return createAssistantStreamResponse(async (controller) => {
+    const text = controller.appendText();
+    text.append("Hello, ");
+    text.append("world!");
+    text.close();
+  });
+}
+```
+
+For tool execution, pipe through `ToolExecutionStream`; for resumable streams (clients can reconnect and replay), import from the `assistant-stream/resumable` sub-path with a `redis` or `ioredis` adapter.
+
+## Sub-paths
+
+`.`, `./utils`, `./resumable`, `./resumable/redis`, `./resumable/ioredis`. The two Redis adapters are optional peer dependencies; install whichever client your stack already uses.
+
+Full reference for encoders, tool execution, message conversion, and resumable streams at [assistant-ui.com/docs/architecture](https://www.assistant-ui.com/docs/architecture).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,141 +1,50 @@
 # `assistant-ui` CLI
 
-The `assistant-ui` CLI for adding components and dependencies to your project.
+[![npm version](https://img.shields.io/npm/v/assistant-ui)](https://www.npmjs.com/package/assistant-ui)
+[![npm downloads](https://img.shields.io/npm/dm/assistant-ui)](https://www.npmjs.com/package/assistant-ui)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
 
-## Usage
+Command-line tool for adding shadcn-style components to your project, scaffolding a new app, and keeping your assistant-ui packages up to date.
 
-Use the `init` command to initialize assistant-ui in an existing project.
+## Installation
 
-The `init` command installs dependencies, adds components, and configures your project for assistant-ui.
+Run via your package manager of choice; nothing to install globally:
 
 ```bash
+npx assistant-ui@latest <command>
+pnpm dlx assistant-ui@latest <command>
+yarn dlx assistant-ui@latest <command>
+bunx assistant-ui@latest <command>
+```
+
+## Common tasks
+
+```bash
+# scaffold a new Next.js project
+npx assistant-ui@latest create my-app
+
+# add assistant-ui to an existing project
 npx assistant-ui@latest init
-npx assistant-ui@latest init --yes  # non-interactive / CI / agent mode
-```
 
-If no existing project is found (no `package.json`), `init` forwards to `create`.
-Passing `--preset` to `init` also forwards to `create` for compatibility.
-
-## create
-
-Use the `create` command to scaffold a new Next.js project with assistant-ui.
-
-The `create` command scaffolds a project from assistant-ui starter templates or examples.
-
-```bash
-npx assistant-ui@latest create my-app
-```
-
-You can choose from multiple templates:
-
-```bash
-# Default template with Vercel AI SDK
-npx assistant-ui@latest create my-app
-
-# Minimal starter
-npx assistant-ui@latest create my-app -t minimal
-
-# With Assistant Cloud for persistence
-npx assistant-ui@latest create my-app -t cloud
-
-# With Assistant Cloud + Clerk auth
-npx assistant-ui@latest create my-app -t cloud-clerk
-
-# With LangGraph starter template
-npx assistant-ui@latest create my-app -t langgraph
-
-# With MCP starter template
-npx assistant-ui@latest create my-app -t mcp
-
-# With playground preset configuration
-npx assistant-ui@latest create my-app --preset "https://www.assistant-ui.com/playground/init?preset=chatgpt"
-```
-
-## add
-
-Use the `add` command to add components to your project.
-
-The `add` command adds a component to your project and installs all required dependencies.
-
-```bash
-npx assistant-ui@latest add [component]
-```
-
-### Example
-
-```bash
+# add a component
 npx assistant-ui@latest add thread
-```
 
-You can also add multiple components at once:
-
-```bash
-npx assistant-ui@latest add thread thread-list assistant-modal
-```
-
-## update
-
-Use the `update` command to update all assistant-ui packages to their latest versions.
-
-```bash
+# update all @assistant-ui/* and assistant-* packages
 npx assistant-ui@latest update
-```
 
-## upgrade
-
-Use the `upgrade` command to automatically migrate your codebase when upgrading to a new major version.
-
-The `upgrade` command runs codemods to transform your code and prompts to install new dependencies.
-
-```bash
+# run codemods after a major version bump
 npx assistant-ui@latest upgrade
-```
 
-## info
-
-Use the `info` command to print your environment and package versions for bug reports.
-
-```bash
+# print env + version info for a bug report
 npx assistant-ui info
 ```
 
-This command collects and prints:
-- OS, Node.js version, package manager, and framework
-- All installed `@assistant-ui/*` and `assistant-*` package versions
-- Key ecosystem dependency versions (React, Next.js, AI SDK, etc.)
-- Peer dependency warnings if any mismatches are detected
+`init` falls back to `create` when no `package.json` is found, so a single command works for both new and existing projects. `init` is non-interactive with `--yes` for CI and agent usage.
 
-**Example output:**
+## Templates
 
-```
-Environment:
-  OS:               macOS 15.3 (arm64)
-  Node.js:          v22.14.0
-  Package Manager:  pnpm 10.32.1
-  Framework:        Next.js 15.3.1
-
-Packages:
-  @assistant-ui/react            0.12.15
-  @assistant-ui/react-ai-sdk     1.3.12
-  @assistant-ui/react-markdown   0.3.8
-  assistant-stream                0.2.14
-
-Ecosystem:
-  react      19.1.0
-  react-dom  19.1.0
-  next       15.3.1
-  ai         6.0.120
-```
-
-The output includes a copy-pasteable markdown block that you can paste directly into a bug report.
-
-**Options:**
-- `-c, --cwd <cwd>` - the working directory. defaults to the current directory.
+`create` scaffolds from named templates: `default` (AI SDK), `minimal`, `cloud`, `cloud-clerk`, `langgraph`, `mcp`. Pass `-t <name>`, or pass `--preset <url>` to scaffold from an `assistant-ui.com` playground link.
 
 ## Documentation
 
-Visit https://assistant-ui.com/docs/cli to view the full documentation.
-
-## License
-
-Licensed under the [MIT license](https://github.com/assistant-ui/assistant-ui/blob/main/LICENSE).
+Full command reference, flags, and template details at [assistant-ui.com/docs/cli](https://www.assistant-ui.com/docs/cli).

--- a/packages/cloud-ai-sdk/README.md
+++ b/packages/cloud-ai-sdk/README.md
@@ -1,42 +1,35 @@
-# @assistant-ui/cloud-ai-sdk
+# `@assistant-ui/cloud-ai-sdk`
 
-Standalone AI SDK hooks for `assistant-cloud` persistence. No runtime surface — just hooks.
+Standalone [Vercel AI SDK](https://sdk.vercel.ai) hooks backed by [Assistant Cloud](https://cloud.assistant-ui.com) persistence. Use this when you want managed thread history, auto-titling, and thread CRUD for an AI SDK chat app without pulling in `@assistant-ui/react`.
 
-## What this package provides
+If you are already using `@assistant-ui/react`, install `@assistant-ui/react-ai-sdk` and pass an `AssistantCloud` instance instead.
 
-- **`useCloudChat`** — Chat + thread persistence with optional auto-title generation.
-- **`useThreads`** — Thread CRUD, selection, and title generation.
+## Installation
 
-## Internal Architecture
+```bash
+npm install @assistant-ui/cloud-ai-sdk assistant-cloud ai @ai-sdk/react
+```
 
-`useCloudChat` is organized around three layers:
+## Usage
 
-1. **`useChatRegistry`**
-   Tracks active `Chat` instances by thread/session and reuses them across switches.
+```tsx
+"use client";
 
-2. **`useCloudChatCore`** — React lifecycle wrapper that creates, syncs, and manages the `CloudChatCore` instance.
+import { useCloudChat } from "@assistant-ui/cloud-ai-sdk";
 
-3. **Thread loading** (`useThreadMessageLoader` helper in `useCloudChat`)
-   Loads thread history when a thread is selected; delegates to `CloudChatCore.loadThreadMessages`.
+export function Chat() {
+  const { messages, sendMessage, threadId } = useCloudChat();
+  return (
+    <div>
+      {messages.map((m) => (
+        <div key={m.id}>{m.content}</div>
+      ))}
+      <button onClick={() => sendMessage({ text: "Hello" })}>Send</button>
+    </div>
+  );
+}
+```
 
-Supporting internals:
+Set `NEXT_PUBLIC_ASSISTANT_BASE_URL` for zero-config, or pass an explicit `cloud` instance: `useCloudChat({ cloud })`. Pair with `useThreads` for thread CRUD and selection.
 
-- **`CloudChatCore`** — Orchestrates persistence (`MessagePersistence`), thread creation (`ThreadSessionManager`), and title generation (`TitlePolicy`).
-- **`MessagePersistence`** — Encodes/decodes `UIMessage` to cloud format.
-- **`ThreadSessionManager`** — Deduplicates concurrent thread creation.
-- **`TitlePolicy`** — One-time auto-title generation for new threads.
-
-## Package boundary
-
-This package is standalone. It depends on:
-
-- `assistant-cloud` — Persistence and auth API client.
-- `@ai-sdk/react` / `ai` — Peer dependencies for Chat and transport types.
-
-It does **not** depend on `@assistant-ui/react` or `@assistant-ui/react-ai-sdk`.
-
-## Configuration
-
-- **Zero-config:** Set `NEXT_PUBLIC_ASSISTANT_BASE_URL`.
-- **Explicit cloud:** `useCloudChat({ cloud })`.
-- **External thread store:** `useCloudChat({ threads })` with a `useThreads` result.
+Full reference at [assistant-ui.com/docs/cloud/ai-sdk](https://www.assistant-ui.com/docs/cloud/ai-sdk).

--- a/packages/cloud-ai-sdk/package.json
+++ b/packages/cloud-ai-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@assistant-ui/cloud-ai-sdk",
   "version": "0.1.14",
-  "description": "AI SDK hooks for assistant-cloud persistence",
+  "description": "Standalone Vercel AI SDK hooks backed by Assistant Cloud persistence",
   "keywords": [
     "assistant",
     "cloud",

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -1,0 +1,42 @@
+# `assistant-cloud`
+
+[![npm version](https://img.shields.io/npm/v/assistant-cloud)](https://www.npmjs.com/package/assistant-cloud)
+[![npm downloads](https://img.shields.io/npm/dm/assistant-cloud)](https://www.npmjs.com/package/assistant-cloud)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
+
+Server- and client-side SDK for [Assistant Cloud](https://cloud.assistant-ui.com), the managed thread-history, telemetry, and file-storage backend for `@assistant-ui/react`.
+
+## Installation
+
+```bash
+npm install assistant-cloud
+```
+
+## Usage
+
+Pass an `AssistantCloud` instance to your runtime hook (typically `useChatRuntime` from `@assistant-ui/react-ai-sdk`):
+
+```tsx
+import { AssistantCloud, AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+
+const cloud = new AssistantCloud({
+  baseUrl: process.env.NEXT_PUBLIC_ASSISTANT_BASE_URL!,
+  anonymous: true,
+});
+
+export function Provider({ children }: { children: React.ReactNode }) {
+  const runtime = useChatRuntime({ cloud });
+  return <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>;
+}
+```
+
+## Authentication
+
+| Mode             | Required fields                                         | Use case                              |
+| ---------------- | ------------------------------------------------------- | ------------------------------------- |
+| Anonymous        | `baseUrl`, `anonymous: true`                            | Demos and unauthenticated playgrounds.|
+| JWT              | `baseUrl`, `authToken: () => Promise<string \| null>`   | Browser apps with their own auth.     |
+| API key (server) | `apiKey`, `userId`, `workspaceId`                       | Server-side admin and data-plane jobs.|
+
+For advanced persistence adapters and MCP sampling instrumentation, see the [docs](https://www.assistant-ui.com/docs/cloud).

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -9,7 +9,7 @@ Server- and client-side SDK for [Assistant Cloud](https://cloud.assistant-ui.com
 ## Installation
 
 ```bash
-npm install assistant-cloud
+npm install @assistant-ui/react @assistant-ui/react-ai-sdk assistant-cloud
 ```
 
 ## Usage

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,45 @@
+# `@assistant-ui/core`
+
+[![npm version](https://img.shields.io/npm/v/@assistant-ui/core)](https://www.npmjs.com/package/@assistant-ui/core)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
+
+The framework-agnostic core of assistant-ui. Defines the shared types, runtime interfaces, adapter contracts, and React bindings that the distribution packages re-export.
+
+Most users do not install `@assistant-ui/core` directly. Reach for the distribution that matches your target:
+
+| Distribution                  | Use this for          |
+| ----------------------------- | --------------------- |
+| `@assistant-ui/react`         | Web applications.     |
+| `@assistant-ui/react-native`  | React Native apps.    |
+| `@assistant-ui/react-ink`     | Terminal/Ink apps.    |
+
+`core` is published so that integration libraries (for example `@assistant-ui/react-ag-ui`) can depend on the runtime types without pulling in DOM or native primitives.
+
+## Installation
+
+```bash
+npm install @assistant-ui/core
+```
+
+## Usage
+
+```ts
+import { tool, ModelContextRegistry } from "@assistant-ui/core";
+import { z } from "zod";
+
+const registry = new ModelContextRegistry();
+
+registry.registerTool({
+  name: "getWeather",
+  ...tool({
+    parameters: z.object({ city: z.string() }),
+    execute: async ({ city }) => fetchWeather(city),
+  }),
+});
+```
+
+## Sub-paths
+
+`@assistant-ui/core` exposes `.`, `./react`, `./store`, and `./internal` sub-paths. The `./react` sub-path holds the React hooks and providers consumed by `@assistant-ui/react` and `@assistant-ui/react-native`.
+
+Full reference for message types, runtime interfaces, and adapter contracts at [assistant-ui.com/docs/architecture](https://www.assistant-ui.com/docs/architecture).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -29,8 +29,8 @@ import { z } from "zod";
 
 const registry = new ModelContextRegistry();
 
-registry.registerTool({
-  name: "getWeather",
+registry.addTool({
+  toolName: "getWeather",
   ...tool({
     parameters: z.object({ city: z.string() }),
     execute: async ({ city }) => fetchWeather(city),

--- a/packages/create-assistant-ui/README.md
+++ b/packages/create-assistant-ui/README.md
@@ -1,9 +1,33 @@
 # `create-assistant-ui`
 
-This package contains the command line interface for `create-assistant-ui`.
+[![npm version](https://img.shields.io/npm/v/create-assistant-ui)](https://www.npmjs.com/package/create-assistant-ui)
+[![npm downloads](https://img.shields.io/npm/dm/create-assistant-ui)](https://www.npmjs.com/package/create-assistant-ui)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
+
+Scaffold a new assistant-ui project from a chosen template (default AI SDK, minimal, cloud, langgraph, MCP, and more).
 
 ## Usage
 
-```sh
-npm create assistant-ui
+```bash
+npm create assistant-ui my-app
+pnpm create assistant-ui my-app
+yarn create assistant-ui my-app
+bunx create-assistant-ui my-app
 ```
+
+This wraps the `assistant-ui create` command from the [`assistant-ui` CLI](https://www.npmjs.com/package/assistant-ui). Pass `-t <template>` to pick a starter, or `--preset <url>` to scaffold from an `assistant-ui.com` playground link.
+
+## Templates
+
+| Name           | Description                                                |
+| -------------- | ---------------------------------------------------------- |
+| `default`      | Next.js + Vercel AI SDK (the recommended starting point).  |
+| `minimal`      | Smallest possible Next.js + assistant-ui setup.            |
+| `cloud`        | Default template plus Assistant Cloud thread persistence.  |
+| `cloud-clerk`  | Cloud template with Clerk authentication.                  |
+| `langgraph`    | Next.js + LangGraph agent backend.                         |
+| `mcp`          | Next.js + an MCP server integration.                       |
+
+## Documentation
+
+Full template list and flag reference at [assistant-ui.com/docs/cli](https://www.assistant-ui.com/docs/cli).

--- a/packages/heat-graph/README.md
+++ b/packages/heat-graph/README.md
@@ -1,0 +1,51 @@
+# `heat-graph`
+
+[![npm version](https://img.shields.io/npm/v/heat-graph)](https://www.npmjs.com/package/heat-graph)
+[![npm downloads](https://img.shields.io/npm/dm/heat-graph)](https://www.npmjs.com/package/heat-graph)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/heat-graph)](https://bundlephobia.com/package/heat-graph)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
+
+Headless, Radix-style React components for rendering GitHub-style activity heatmaps. Ships only the layout, date math, and tooltip wiring; you bring colors, sizing, and labels so the heatmap matches your design system.
+
+## Installation
+
+```bash
+npm install heat-graph
+```
+
+## Usage
+
+```tsx
+import * as HeatGraph from "heat-graph";
+
+const COLORS = ["#ebedf0", "#c6d7f9", "#8fb0f3", "#5888e8", "#2563eb"];
+
+export function ActivityGraph({ data }: { data: HeatGraph.DataPoint[] }) {
+  return (
+    <HeatGraph.Root data={data} weekStart="monday" colorScale={COLORS}>
+      <HeatGraph.Grid>
+        {() => <HeatGraph.Cell />}
+      </HeatGraph.Grid>
+    </HeatGraph.Root>
+  );
+}
+```
+
+Compose `MonthLabels`, `DayLabels`, `Legend` / `LegendLevel`, and `Tooltip` (Radix Popper-backed) inside `Root` for the full GitHub-contributions look.
+
+## Components
+
+| Component                | Purpose                                                                 |
+| ------------------------ | ----------------------------------------------------------------------- |
+| `Root`                   | Holds the data, week-start, and color-scale context.                    |
+| `Grid` / `Cell`          | The week-by-day grid and one cell per day.                              |
+| `MonthLabels`            | Render-prop component yielding month labels with column index.          |
+| `DayLabels`              | Render-prop component yielding weekday labels with row index.           |
+| `Legend` / `LegendLevel` | Color-scale legend bar.                                                 |
+| `Tooltip`                | Tooltip that follows the hovered cell.                                  |
+
+`autoLevels`, `MONTH_SHORT`, `DAY_SHORT`, plus `DataPoint`, `CellData`, and other types are exported for layout work.
+
+## Documentation
+
+Live demo and full reference at [assistant-ui.com/heat-graph](https://www.assistant-ui.com/heat-graph).

--- a/packages/mcp-app-studio/README.md
+++ b/packages/mcp-app-studio/README.md
@@ -1,17 +1,6 @@
-# MCP App Studio
+# `mcp-app-studio`
 
-**Build interactive apps for MCP Apps hosts (ChatGPT, Claude Desktop, etc.).**
-
-ChatGPT is an **MCP Apps host**. This SDK is MCP-first: it uses the standard
-`ui/*` bridge everywhere, and treats `window.openai` as **optional ChatGPT-only
-extensions** layered on top.
-
-## What You Get
-
-- **Local workbench** — Preview widgets without deploying
-- **Universal SDK** — Single API works across MCP Apps hosts
-- **Optional ChatGPT extensions** — Feature-detected `window.openai` helpers
-- **One-command export** — Generate production bundle + MCP server
+Build interactive widgets for [MCP Apps](https://modelcontextprotocol.io/specification/) hosts (ChatGPT, Claude Desktop, and others). Ships a local workbench, a universal SDK that works across hosts, and a one-command export to a static widget bundle plus an optional MCP server.
 
 ## Quick Start
 
@@ -22,11 +11,11 @@ npm install
 npm run dev
 ```
 
-Open http://localhost:3002 — you're in the workbench.
+Open http://localhost:3002 to land in the workbench.
 
 ## Universal SDK
 
-The SDK provides React hooks that work identically across platforms:
+Hooks that work identically across MCP Apps hosts. Optional `window.openai` extensions are feature-detected on top:
 
 ```tsx
 import {
@@ -40,24 +29,17 @@ import {
 } from "mcp-app-studio";
 
 function MyWidget() {
-  const platform = usePlatform(); // "mcp" | "unknown"
+  const platform = usePlatform();
   const input = useToolInput<{ query: string }>();
   const callTool = useCallTool();
   const theme = useTheme();
 
-  // Optional ChatGPT extensions (window.openai)
-  const hasWidgetState = useFeature("widgetState");
-  const canUseOpenAIExtensions = hasChatGPTExtensions();
+  const canPersistState = useFeature("widgetState");
 
-  return (
-    <div className={theme === 'dark' ? 'bg-gray-900' : 'bg-white'}>
-      {/* Your widget */}
-    </div>
-  );
+  return <div className={theme === "dark" ? "bg-gray-900" : "bg-white"}>{/* ... */}</div>;
 }
 
-// Wrap your app
-function App() {
+export default function App() {
   return (
     <UniversalProvider>
       <MyWidget />
@@ -66,135 +48,16 @@ function App() {
 }
 ```
 
-## Migrating from 0.5.x
-
-### Platform detection
-
-`detectPlatform()` now reports host family (`"mcp"` or `"unknown"`). It no
-longer returns `"chatgpt"` directly.
-
-```tsx
-// Before (0.5.x)
-import { detectPlatform } from "mcp-app-studio";
-
-if (detectPlatform() === "chatgpt") {
-  // ChatGPT-specific behavior
-}
-
-// After (MCP-first)
-import { hasChatGPTExtensions, useFeature } from "mcp-app-studio";
-
-if (hasChatGPTExtensions()) {
-  // ChatGPT extension layer is available (window.openai)
-}
-
-const hasWidgetState = useFeature("widgetState");
-```
-
-### Provider imports
-
-Use `UniversalProvider` from the main package export. The
-`mcp-app-studio/chatgpt` entrypoint is removed.
-
-```tsx
-// Before (0.5.x)
-import { ChatGPTProvider } from "mcp-app-studio/chatgpt";
-
-// After (MCP-first)
-import { UniversalProvider } from "mcp-app-studio";
-```
-
-## Platform Capabilities
-
-| Feature | MCP Apps bridge | ChatGPT extensions (`window.openai`) |
-|---------|----------------|-------------------------------------|
-| `callTool` | ✅ | ✅ (`callTool`) |
-| `openLink` | ✅ | ✅ (`openExternal`) |
-| `sendMessage` | ✅ | ✅ (`sendFollowUpMessage`) |
-| `modelContext` (`ui/update-model-context`) | ✅ | — |
-| `widgetState` (persistence) | — | ✅ |
-| `fileUpload` / `fileDownload` | — | ✅ |
-| `requestModal` | — | ✅ |
-| `partialToolInput` (streaming) | Host-dependent | — |
-
-## Workflow
-
-```
-1. DEVELOP     npm run dev       Edit widgets, test with mock tools
-2. EXPORT      npm run export    Generate widget bundle + manifest
-3. DEPLOY      Your choice       Vercel, Netlify, any static host
-4. REGISTER    Platform dashboard  Connect your app
-```
-
-## Generated Project
-
-```
-my-app/
-├── app/                    Next.js app
-├── components/
-│   └── examples/           Example widgets
-├── lib/
-│   ├── workbench/          Dev environment + React hooks
-│   └── export/             Production bundler
-└── server/                 MCP server (if selected)
-```
-
-## Export Output
+## Export
 
 ```bash
 npm run export
 ```
 
-Generates:
+Produces a self-contained widget bundle, app manifest, and deployment instructions in `export/`.
 
-```
-export/
-├── widget/
-│   └── index.html      Self-contained widget (deploy to static host)
-├── manifest.json       App manifest
-└── README.md           Deployment instructions
-```
+## Documentation
 
-## Debugging
-
-Enable debug mode to troubleshoot platform detection:
-
-```ts
-import { enableDebugMode, detectPlatformDetailed } from "mcp-app-studio";
-
-// In browser console or before app init
-enableDebugMode();
-
-// Get detailed detection info
-const result = detectPlatformDetailed();
-console.log('Platform:', result.platform);
-console.log('Detected by:', result.detectedBy);
-console.log('Checks:', result.checks);
-```
-
-## Tool metadata (`_meta.ui.resourceUri`)
-
-For tools that render UI, OpenAI recommends using `_meta.ui.resourceUri` (with
-legacy support for `_meta["openai/outputTemplate"]`). See the starter template
-and MCP server generator for a working example.
-
-## MCP Server
-
-If you selected "Include MCP server" during setup:
-
-```bash
-cd server
-npm install
-npm run dev          # http://localhost:3001/mcp
-npm run inspect      # Test with MCP Inspector
-```
-
-## Learn More
-
-- [MCP Apps Specification](https://modelcontextprotocol.io/specification/)
+- [MCP Apps specification](https://modelcontextprotocol.io/specification/)
 - [ChatGPT Apps SDK](https://developers.openai.com/apps-sdk/)
-- [assistant-ui](https://www.assistant-ui.com/)
-
-## License
-
-MIT
+- [assistant-ui.com/mcp-app-studio](https://www.assistant-ui.com/mcp-app-studio) for the platform capability matrix and migration guide

--- a/packages/mcp-docs-server/README.md
+++ b/packages/mcp-docs-server/README.md
@@ -1,28 +1,23 @@
-# Assistant-UI MCP Docs Server
+# `@assistant-ui/mcp-docs-server`
 
-A Model Context Protocol (MCP) server that provides AI assistants with direct access to assistant-ui's documentation and examples.
+Model Context Protocol (MCP) server that gives AI assistants direct access to assistant-ui's documentation and example projects. Exposes `assistantUIDocs` (retrieve documentation by path) and `assistantUIExamples` (access complete example projects).
 
-> **📖 Full Documentation**
-> For detailed installation instructions, troubleshooting, and advanced usage, visit the [complete documentation](https://www.assistant-ui.com/docs/llm#mcp).
+> [!NOTE]
+> Detailed installation, troubleshooting, and advanced usage at [assistant-ui.com/docs/llm#mcp](https://www.assistant-ui.com/docs/llm#mcp).
 
 ## Installation
 
 ### Claude Code
 
 ```bash
-# Add to current project
 claude mcp add assistant-ui -- npx -y @assistant-ui/mcp-docs-server
-
-# Or add globally for all projects
+# or globally for all projects
 claude mcp add --scope user assistant-ui -- npx -y @assistant-ui/mcp-docs-server
 ```
 
 ### Claude Desktop
 
-Add to your Claude Desktop configuration:
-
-- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 
 ```json
 {
@@ -35,39 +30,13 @@ Add to your Claude Desktop configuration:
 }
 ```
 
-### Cursor
+### Cursor / Windsurf
 
-Add to `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global):
+Add to `.cursor/mcp.json` (or `~/.cursor/mcp.json`) for Cursor, or `~/.codeium/windsurf/mcp_config.json` for Windsurf, using the same `mcpServers` block as above.
 
-```json
-{
-  "mcpServers": {
-    "assistant-ui": {
-      "command": "npx",
-      "args": ["-y", "@assistant-ui/mcp-docs-server"]
-    }
-  }
-}
-```
+### VS Code
 
-### Windsurf
-
-Add to `~/.codeium/windsurf/mcp_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "assistant-ui": {
-      "command": "npx",
-      "args": ["-y", "@assistant-ui/mcp-docs-server"]
-    }
-  }
-}
-```
-
-### VSCode
-
-Add to `.vscode/mcp.json` in your project:
+Add to `.vscode/mcp.json`:
 
 ```json
 {
@@ -83,7 +52,7 @@ Add to `.vscode/mcp.json` in your project:
 
 ### Zed
 
-Add to `settings.json` (open via `cmd+,` or `zed: open settings`):
+Add to `settings.json`:
 
 ```json
 {
@@ -91,38 +60,11 @@ Add to `settings.json` (open via `cmd+,` or `zed: open settings`):
     "assistant-ui": {
       "command": {
         "path": "npx",
-        "args": ["-y", "@assistant-ui/mcp-docs-server"],
-        "env": {}
-      },
-      "settings": {}
+        "args": ["-y", "@assistant-ui/mcp-docs-server"]
+      }
     }
   }
 }
 ```
 
-## Tools
-
-- **assistantUIDocs** - Retrieve documentation by path
-- **assistantUIExamples** - Access complete example projects
-
-## Managing the Server
-
-### Claude Code
-
-```bash
-# View configured servers
-claude mcp list
-
-# Get server details
-claude mcp get assistant-ui
-
-# Remove the server
-claude mcp remove assistant-ui
-
-# Restart the server
-claude mcp restart assistant-ui
-```
-
-## License
-
-MIT
+To list, get, or remove the server, use your editor's MCP management commands.

--- a/packages/react-a2a/README.md
+++ b/packages/react-a2a/README.md
@@ -1,23 +1,22 @@
 # `@assistant-ui/react-a2a`
 
-[A2A (Agent-to-Agent) v1.0](https://github.com/a2aproject/A2A) protocol adapter for [assistant-ui](https://www.assistant-ui.com/).
+[A2A (Agent-to-Agent) v1.0](https://github.com/a2aproject/A2A) protocol integration for `@assistant-ui/react`. Built-in HTTP client with SSE streaming, agent-card discovery, multi-tenancy, and structured error handling.
 
 ## Installation
 
-```sh
+```bash
 npm install @assistant-ui/react @assistant-ui/react-a2a
 ```
 
-## Quick Start
+## Usage
 
 ```tsx
-import { AssistantRuntimeProvider, Thread } from "@assistant-ui/react";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { useA2ARuntime } from "@assistant-ui/react-a2a";
+import { Thread } from "@/components/assistant-ui/thread";
 
-function App() {
-  const runtime = useA2ARuntime({
-    baseUrl: "http://localhost:9999",
-  });
+export function App() {
+  const runtime = useA2ARuntime({ baseUrl: "http://localhost:9999" });
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
@@ -27,23 +26,11 @@ function App() {
 }
 ```
 
-## Documentation
+Supports all 9 A2A task states (including `input_required` and `auth_required`), artifact streaming, push-notification config, extension negotiation, and streaming/non-streaming auto-fallback.
 
-Full documentation is available at [assistant-ui.com/docs/runtimes/a2a](https://www.assistant-ui.com/docs/runtimes/a2a).
+## See also
 
-## Features
+- `@assistant-ui/react-ag-ui` for the AG-UI protocol.
+- `@assistant-ui/react-langgraph` for LangGraph agents.
 
-- Full A2A v1.0 protocol support
-- Built-in HTTP client with SSE streaming
-- All 9 task states (including `input_required`, `auth_required`)
-- Artifact streaming with append/lastChunk support
-- Agent card discovery
-- Multi-tenancy
-- Structured error handling (google.rpc.Status)
-- Push notification config CRUD
-- Extension negotiation
-- Streaming/non-streaming auto-fallback
-
-## License
-
-MIT
+Full reference at [assistant-ui.com/docs/runtimes/a2a](https://www.assistant-ui.com/docs/runtimes/a2a).

--- a/packages/react-ag-ui/README.md
+++ b/packages/react-ag-ui/README.md
@@ -1,0 +1,39 @@
+# `@assistant-ui/react-ag-ui`
+
+[AG-UI protocol](https://github.com/ag-ui-protocol/ag-ui) integration for `@assistant-ui/react`. Wraps an `@ag-ui/client` agent in an assistant-ui runtime so any AG-UI-compatible backend (CopilotKit, custom Python/Go/TS agents) can drive the standard assistant-ui components.
+
+## Installation
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-ag-ui @ag-ui/client
+```
+
+## Usage
+
+```tsx
+"use client";
+
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { HttpAgent } from "@ag-ui/client";
+import { useAgUiRuntime } from "@assistant-ui/react-ag-ui";
+
+export function Provider({ children }: { children: React.ReactNode }) {
+  const agent = new HttpAgent({
+    url: process.env.NEXT_PUBLIC_AGUI_AGENT_URL!,
+  });
+  const runtime = useAgUiRuntime({ agent });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+## See also
+
+- `@assistant-ui/react-a2a` for the A2A v1.0 protocol.
+- `@assistant-ui/react-langgraph` for LangGraph SDK agents.
+
+Full API reference, multi-thread setup, and interrupt handling at [assistant-ui.com/docs/runtimes/ag-ui](https://www.assistant-ui.com/docs/runtimes/ag-ui). See [`examples/with-ag-ui`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-ag-ui) for a complete app.

--- a/packages/react-ag-ui/README.md
+++ b/packages/react-ag-ui/README.md
@@ -13,14 +13,16 @@ npm install @assistant-ui/react @assistant-ui/react-ag-ui @ag-ui/client
 ```tsx
 "use client";
 
+import { useMemo } from "react";
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { HttpAgent } from "@ag-ui/client";
 import { useAgUiRuntime } from "@assistant-ui/react-ag-ui";
 
 export function Provider({ children }: { children: React.ReactNode }) {
-  const agent = new HttpAgent({
-    url: process.env.NEXT_PUBLIC_AGUI_AGENT_URL!,
-  });
+  const agent = useMemo(
+    () => new HttpAgent({ url: process.env.NEXT_PUBLIC_AGUI_AGENT_URL! }),
+    [],
+  );
   const runtime = useAgUiRuntime({ agent });
 
   return (

--- a/packages/react-ai-sdk/README.md
+++ b/packages/react-ai-sdk/README.md
@@ -1,58 +1,32 @@
 # `@assistant-ui/react-ai-sdk`
 
-Vercel AI SDK integration for `@assistant-ui/react`.
+[Vercel AI SDK](https://sdk.vercel.ai) v6 integration for `@assistant-ui/react`. Wraps the AI SDK chat in an assistant-ui runtime and forwards system messages and frontend tools through `AssistantChatTransport`.
 
-## Features
+## Installation
 
-- Seamless integration with Vercel AI SDK v6
-- Automatic system message and frontend tools forwarding via `AssistantChatTransport`
-- Support for custom transport configuration
+```bash
+npm install @assistant-ui/react @assistant-ui/react-ai-sdk
+```
 
 ## Usage
 
-### Basic Setup
+```tsx
+"use client";
 
-```typescript
-import { useChatRuntime } from '@assistant-ui/react-ai-sdk';
-import { AssistantRuntimeProvider } from '@assistant-ui/react';
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { Thread } from "@/components/assistant-ui/thread";
 
-function App() {
-  // By default, uses AssistantChatTransport which forwards system messages and tools
+export function Chat() {
   const runtime = useChatRuntime();
-
   return (
     <AssistantRuntimeProvider runtime={runtime}>
-      {/* Your assistant-ui components */}
+      <Thread />
     </AssistantRuntimeProvider>
   );
 }
 ```
 
-### Custom Transport
+`useChatRuntime` defaults to `AssistantChatTransport`, which forwards frontend system messages and tool definitions to your backend. To customize the API URL, the cache, or other transport settings, pass a configured `AssistantChatTransport` to keep that forwarding behavior; pass `DefaultChatTransport` to opt out.
 
-When you need to customize the transport configuration:
-
-```typescript
-import { DefaultChatTransport } from "ai";
-import { AssistantChatTransport } from "@assistant-ui/react-ai-sdk";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
-
-// Custom API URL while keeping system/tools forwarding
-const runtime = useChatRuntime({
-  transport: new AssistantChatTransport({
-    api: "/my-custom-api/chat",
-  }),
-});
-
-// Or disable system/tools forwarding entirely
-const runtime = useChatRuntime({
-  transport: new DefaultChatTransport(),
-});
-```
-
-**Important:** When customizing the API URL, you must explicitly use `AssistantChatTransport` to keep frontend system messages and tools forwarding.
-
-## AssistantChatTransport vs DefaultChatTransport
-
-- **AssistantChatTransport** (default): Automatically forwards system messages and frontend tools from the assistant-ui context to your backend API
-- **DefaultChatTransport**: Standard AI SDK transport without automatic forwarding
+Full reference at [assistant-ui.com/docs/runtimes/ai-sdk](https://www.assistant-ui.com/docs/runtimes/ai-sdk).

--- a/packages/react-data-stream/README.md
+++ b/packages/react-data-stream/README.md
@@ -1,3 +1,35 @@
 # `@assistant-ui/react-data-stream`
 
-Data Stream protocol integration for `@assistant-ui/react`.
+Data Stream protocol integration for `@assistant-ui/react`. Connects an assistant-ui runtime to any backend that speaks the AI SDK data-stream or UI-message-stream wire format.
+
+## Installation
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-data-stream
+```
+
+## Usage
+
+```tsx
+"use client";
+
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useDataStreamRuntime } from "@assistant-ui/react-data-stream";
+
+export function Provider({ children }: { children: React.ReactNode }) {
+  const runtime = useDataStreamRuntime({ api: "/api/chat" });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+## See also
+
+- `@assistant-ui/react-ai-sdk` for direct Vercel AI SDK integration with frontend tool forwarding.
+- `useCloudRuntime` (also exported from this package) for managed thread persistence backed by `assistant-cloud`.
+
+Full API reference at [assistant-ui.com/docs/api-reference/integrations/react-data-stream](https://www.assistant-ui.com/docs/api-reference/integrations/react-data-stream).

--- a/packages/react-devtools/README.md
+++ b/packages/react-devtools/README.md
@@ -1,65 +1,29 @@
-# @assistant-ui/react-devtools
+# `@assistant-ui/react-devtools`
 
-React-first development tools for assistant-ui components. This package ships the reusable React helpers, runtime adapters, and UI necessary to embed the DevTools experience in any host application.
-
-## Features
-
-- **Component Library**: React components for debugging assistant-ui experiences
-- **Event Logging**: Track and inspect assistant-ui events and state changes
-- **Context Viewer**: View Assistant API context and state in real-time
-- **Embeddable Host**: Frame bridges that power custom hosts, including the Chrome extension
+React DevTools UI for `@assistant-ui/react`. Embed an event log, context viewer, and runtime inspector in any host application.
 
 ## Installation
-
-### As React Component Library
 
 ```bash
 npm install @assistant-ui/react-devtools
 ```
 
-### As Chrome Extension
-
-See `apps/devtools-extension` for the standalone Chrome extension source and build scripts (`pnpm --filter @assistant-ui/devtools-extension run build`).
-
 ## Usage
 
-### React Components
-
 ```tsx
-import { DevToolsUI, DevToolsModal } from '@assistant-ui/react-devtools';
+import { DevToolsModal, DevToolsFrame } from "@assistant-ui/react-devtools";
 
-// Use the full DevTools UI
-<DevToolsUI />
+// render as a modal overlay
+<DevToolsModal />;
 
-// Or use as a modal overlay
-<DevToolsModal />
+// or embed inline as a frame
+<DevToolsFrame />;
 ```
 
-### Chrome Extension
+## Chrome extension
 
-The Chrome extension now lives under `apps/devtools-extension` as a separate workspace app. It consumes this package at build time to reuse the shared runtime and UI.
+A standalone Chrome extension consuming this package lives at [`apps/devtools-extension`](https://github.com/assistant-ui/assistant-ui/tree/main/apps/devtools-extension).
 
-## Build Scripts
+## Documentation
 
-- `npm run build` - Build the React component library
-- `npm run build:lib` - Alias for `build`
-- `npm run dev` - Development build with watch mode
-
-## Package Structure
-
-```
-packages/react-devtools/
-├── src/                     # React component library source
-│   ├── DevToolsHooks.ts     # Core devtools functionality
-│   ├── DevToolsModal.tsx    # Modal wrapper component (iframe host)
-│   └── index.ts             # Main exports
-└── scripts/                 # Build scripts
-```
-
-## Development
-
-The devtools package builds with `@assistant-ui/x-buildutils` to transpile the TypeScript sources that power the React helpers and adapters consumed across the workspace.
-
-## License
-
-MIT
+Full reference at [assistant-ui.com/docs/devtools](https://www.assistant-ui.com/docs/devtools).

--- a/packages/react-google-adk/README.md
+++ b/packages/react-google-adk/README.md
@@ -1,36 +1,31 @@
-# @assistant-ui/react-google-adk
+# `@assistant-ui/react-google-adk`
 
-Google ADK (Agent Development Kit) adapter for [assistant-ui](https://www.assistant-ui.com/).
-
-Connects Google ADK JS agents to assistant-ui's React runtime with streaming, tool calls, multi-agent support, tool confirmations, auth flows, and session state management.
+[Google ADK](https://github.com/google/adk-js) (Agent Development Kit) integration for `@assistant-ui/react`. Connects ADK JS agents to the assistant-ui runtime with streaming, tool calls, multi-agent support, tool confirmations, auth flows, and session-state management.
 
 ## Installation
 
-```sh
-npm install @assistant-ui/react @assistant-ui/react-google-adk
+```bash
+npm install @assistant-ui/react @assistant-ui/react-google-adk @google/adk
 ```
 
-## Quick Start
+## Usage
 
-### Proxy Mode (with a Next.js API Route)
+The recommended setup proxies through your own API route:
 
-**Server** (`app/api/adk/route.ts`):
-
-```typescript
+```ts
+// app/api/adk/route.ts
 import { createAdkApiRoute } from "@assistant-ui/react-google-adk/server";
 import { runner } from "./agent";
 
 export const POST = createAdkApiRoute({
   runner,
   userId: "default-user",
-  sessionId: (req) =>
-    new URL(req.url).searchParams.get("sessionId") ?? "default",
+  sessionId: (req) => new URL(req.url).searchParams.get("sessionId") ?? "default",
 });
 ```
 
-**Client:**
-
 ```tsx
+// client component
 import { useAdkRuntime, createAdkStream } from "@assistant-ui/react-google-adk";
 
 const runtime = useAdkRuntime({
@@ -38,119 +33,11 @@ const runtime = useAdkRuntime({
 });
 ```
 
-### Direct Mode (connecting to an ADK server)
+Or connect directly to an ADK server with `createAdkSessionAdapter`; see the docs for the full setup and option reference.
 
-```tsx
-import {
-  useAdkRuntime,
-  createAdkStream,
-  createAdkSessionAdapter,
-} from "@assistant-ui/react-google-adk";
+## See also
 
-const { adapter, load } = createAdkSessionAdapter({
-  apiUrl: "http://localhost:8000",
-  appName: "my-app",
-  userId: "user-1",
-});
+- `@assistant-ui/react-langgraph` for LangGraph SDK agents.
+- `@assistant-ui/react-ag-ui` for the AG-UI protocol.
 
-const runtime = useAdkRuntime({
-  stream: createAdkStream({
-    api: "http://localhost:8000",
-    appName: "my-app",
-    userId: "user-1",
-  }),
-  sessionAdapter: adapter,
-  load,
-});
-```
-
-## API Reference
-
-### Client Exports
-
-#### `createAdkStream(options)`
-
-Creates an `AdkStreamCallback` that connects to an ADK endpoint via SSE.
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `api` | `string` | URL to POST to (proxy route or ADK server base URL) |
-| `appName` | `string?` | ADK app name (enables direct mode when set) |
-| `userId` | `string?` | ADK user ID (required with `appName`) |
-| `headers` | `Record<string, string> \| (() => ...)` | Static or dynamic request headers |
-
-#### `createAdkSessionAdapter(options)`
-
-Creates a `RemoteThreadListAdapter` backed by ADK's session REST API.
-
-Returns `{ adapter, load }` where `load` reconstructs messages from session events.
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `apiUrl` | `string` | ADK server base URL |
-| `appName` | `string` | ADK app name |
-| `userId` | `string` | ADK user ID |
-| `headers` | `Record<string, string> \| (() => ...)` | Static or dynamic request headers |
-
-#### `useAdkRuntime(options)`
-
-Main hook that creates a full `AssistantRuntime`.
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `stream` | `AdkStreamCallback` | Stream callback (use `createAdkStream`) |
-| `sessionAdapter` | `RemoteThreadListAdapter?` | Alternative to `cloud` for thread persistence |
-| `cloud` | `AssistantCloud?` | Cloud adapter for thread persistence |
-| `load` | `(threadId: string) => Promise<{messages}>` | Load thread history |
-| `autoCancelPendingToolCalls` | `boolean?` | Auto-cancel pending tools on new message (default: true) |
-| `unstable_allowCancellation` | `boolean?` | Enable stream cancellation |
-| `getCheckpointId` | `(threadId, messages) => Promise<string?>` | Enable edit/reload |
-| `adapters` | `{attachments?, speech?, feedback?}` | Optional adapters |
-| `eventHandlers` | `{onError?, onCustomEvent?, onAgentTransfer?}` | Event callbacks |
-
-### Hooks
-
-| Hook | Description |
-|------|-------------|
-| `useAdkAgentInfo()` | Current agent name and branch path |
-| `useAdkSessionState()` | Accumulated session state delta |
-| `useAdkSend()` | Send raw ADK messages |
-| `useAdkLongRunningToolIds()` | Pending tool IDs awaiting input |
-| `useAdkToolConfirmations()` | Tool confirmation requests |
-| `useAdkAuthRequests()` | Auth credential requests |
-| `useAdkArtifacts()` | Artifact delta (filename → version) |
-| `useAdkEscalation()` | Escalation flag |
-| `useAdkMessageMetadata()` | Per-message grounding/citation/usage |
-
-### Server Exports (`/server`)
-
-#### `createAdkApiRoute(options)`
-
-One-liner API route handler combining request parsing and SSE streaming.
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `runner` | `AdkRunner` | ADK Runner instance |
-| `userId` | `string \| (req) => string` | Static or dynamic user ID |
-| `sessionId` | `string \| (req) => string` | Static or dynamic session ID |
-| `onError` | `(error) => void` | Error handler |
-
-#### `adkEventStream(events, options?)`
-
-Converts an ADK event async generator into an SSE `Response`.
-
-#### `parseAdkRequest(request)`
-
-Parses an incoming HTTP request into a structured ADK request.
-
-#### `toAdkContent(parsed)`
-
-Converts a parsed request into a Google GenAI `Content` object.
-
-## Documentation
-
-See the [full documentation](https://www.assistant-ui.com/docs/runtimes/google-adk) for setup guides, advanced APIs, and examples.
-
-## License
-
-MIT
+Full reference for client hooks (`useAdkAgentInfo`, `useAdkSessionState`, `useAdkToolConfirmations`, `useAdkAuthRequests`, etc.), server exports, and direct mode at [assistant-ui.com/docs/runtimes/google-adk](https://www.assistant-ui.com/docs/runtimes/google-adk).

--- a/packages/react-hook-form/README.md
+++ b/packages/react-hook-form/README.md
@@ -1,5 +1,39 @@
 # `@assistant-ui/react-hook-form`
 
-React Hook Form integration for `@assistant-ui/react`.
+[React Hook Form](https://react-hook-form.com) integration for `@assistant-ui/react`. Replace `useForm` with `useAssistantForm` to give the assistant the ability to read and fill your form fields through tool calls.
 
-Simply replace `useForm` with `useAssistantForm` to give the chatbot the ability to interact with your form.
+## Installation
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-hook-form react-hook-form
+```
+
+## Usage
+
+```tsx
+"use client";
+
+import { useAssistantForm } from "@assistant-ui/react-hook-form";
+
+export function SignupForm() {
+  const form = useAssistantForm({
+    defaultValues: { firstName: "", lastName: "", email: "" },
+    assistant: {
+      tools: {
+        set_form_field: { render: () => <FieldUpdated /> },
+        submit_form: { render: () => <FormSubmitted /> },
+      },
+    },
+  });
+
+  return <form onSubmit={form.handleSubmit(onSubmit)}>{/* fields */}</form>;
+}
+```
+
+The assistant gets two built-in tools: `set_form_field` to write values into fields and `submit_form` to call your submit handler.
+
+## See also
+
+- `@assistant-ui/react-lexical` if you also want a rich-text composer with `@`-mention support inside the same chat.
+
+Full API reference at [assistant-ui.com/docs/api-reference/integrations/react-hook-form](https://www.assistant-ui.com/docs/api-reference/integrations/react-hook-form). See [`examples/with-react-hook-form`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-react-hook-form) for a complete app.

--- a/packages/react-ink-markdown/README.md
+++ b/packages/react-ink-markdown/README.md
@@ -1,59 +1,28 @@
-# @assistant-ui/react-ink-markdown
+# `@assistant-ui/react-ink-markdown`
 
-Terminal markdown rendering for [`@assistant-ui/react-ink`](https://www.assistant-ui.com/). Wraps [markdansi](https://github.com/steipete/Markdansi) to render formatted headings, code blocks, tables, lists, and more in the terminal.
+Terminal markdown rendering for [`@assistant-ui/react-ink`](https://www.npmjs.com/package/@assistant-ui/react-ink). Wraps [`markdansi`](https://github.com/steipete/Markdansi) to render formatted headings, code blocks, tables, lists, and more in the terminal, with Shiki syntax highlighting.
 
 ## Installation
 
 ```bash
-npm install @assistant-ui/react-ink-markdown
-```
-
-For syntax highlighting in code blocks, also install Shiki (optional):
-
-```bash
-npm install shiki
+npm install @assistant-ui/react-ink @assistant-ui/react-ink-markdown ink react shiki
 ```
 
 ## Usage
 
-```tsx
-import { MarkdownText } from "@assistant-ui/react-ink-markdown";
-
-// Standalone — pass text directly
-<MarkdownText text="# Hello **world**" />
-
-// With MessageContent's renderText slot
-<MessageContent
-  renderText={({ part }) => <MarkdownText text={part.text} />}
-/>
-```
-
-### With syntax highlighting
+Inside `MessagePrimitive.Parts`, use `MarkdownTextPrimitive` to read text and status from the runtime context automatically:
 
 ```tsx
-import { MarkdownText, useShikiHighlighter } from "@assistant-ui/react-ink-markdown";
-
-const App = ({ text }: { text: string }) => {
-  const highlighter = useShikiHighlighter({ theme: "github-dark" });
-  return <MarkdownText text={text} highlighter={highlighter} />;
-};
-```
-
-### Auto-wired primitive
-
-Use `MarkdownTextPrimitive` inside `MessagePrimitive.Parts` — it reads text and status from the runtime context automatically:
-
-```tsx
+import { MessagePrimitive } from "@assistant-ui/react-ink";
 import { MarkdownTextPrimitive } from "@assistant-ui/react-ink-markdown";
 
 <MessagePrimitive.Parts>
-  {({ part }) => {
-    if (part.type === "text") return <MarkdownTextPrimitive />;
-    return null;
-  }}
-</MessagePrimitive.Parts>
+  {({ part }) => (part.type === "text" ? <MarkdownTextPrimitive /> : null)}
+</MessagePrimitive.Parts>;
 ```
 
-## API
+For standalone use or to attach a custom Shiki highlighter, see the Documentation section below.
 
-See the [assistant-ui docs](https://www.assistant-ui.com/) for full API reference.
+## Documentation
+
+Full reference at [assistant-ui.com/docs/ink](https://www.assistant-ui.com/docs/ink).

--- a/packages/react-ink/README.md
+++ b/packages/react-ink/README.md
@@ -1,73 +1,71 @@
-# @assistant-ui/react-ink
+# `@assistant-ui/react-ink`
 
-React Ink (terminal UI) bindings for [assistant-ui](https://www.assistant-ui.com/).
+[![npm version](https://img.shields.io/npm/v/@assistant-ui/react-ink)](https://www.npmjs.com/package/@assistant-ui/react-ink)
+[![npm downloads](https://img.shields.io/npm/dm/@assistant-ui/react-ink)](https://www.npmjs.com/package/@assistant-ui/react-ink)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
+![License](https://img.shields.io/npm/l/@assistant-ui/react-ink)
 
-Build AI chat interfaces for the terminal using [Ink](https://github.com/vadimdemedes/ink) — React for CLIs — powered by the same runtime as assistant-ui.
+[Ink](https://github.com/vadimdemedes/ink) bindings for assistant-ui. Composable, unstyled terminal primitives that share the same runtime, adapters, and tools as `@assistant-ui/react`, so you can ship a CLI chat UI without rewriting your backend code.
 
 ## Installation
 
-```sh
+Requires React 19 and ink 6 or newer.
+
+```bash
 npm install @assistant-ui/react-ink ink react
 ```
 
-## Quick Start
+For markdown rendering with syntax highlighting, also install [`@assistant-ui/react-ink-markdown`](https://www.npmjs.com/package/@assistant-ui/react-ink-markdown).
+
+## Usage
 
 ```tsx
-import { render } from "ink";
-import { Box, Text } from "ink";
+import { render, Box, Text } from "ink";
 import {
-  AssistantProvider,
+  AssistantRuntimeProvider,
   useLocalRuntime,
-  ThreadRoot,
-  ThreadMessages,
-  ComposerInput,
+  ThreadPrimitive,
+  ComposerPrimitive,
+  useAuiState,
   type ChatModelAdapter,
 } from "@assistant-ui/react-ink";
 
-const myAdapter: ChatModelAdapter = {
+const adapter: ChatModelAdapter = {
   async *run({ messages }) {
-    // your AI backend here
     yield { content: [{ type: "text", text: "Hello from AI!" }] };
   },
 };
 
-function App() {
-  const runtime = useLocalRuntime(myAdapter);
-
+const Message = () => {
+  const message = useAuiState((s) => s.message);
+  const text = message.content.find((p) => p.type === "text")?.text ?? "";
   return (
-    <AssistantProvider runtime={runtime}>
-      <ThreadRoot>
-        <ThreadMessages
-          renderMessage={({ message }) => (
-            <Box marginBottom={1}>
-              <Text>
-                {message.content
-                  .filter((p) => p.type === "text")
-                  .map((p) => p.text)
-                  .join("")}
-              </Text>
-            </Box>
-          )}
-        />
-        <ComposerInput submitOnEnter placeholder="Message..." autoFocus />
-      </ThreadRoot>
-    </AssistantProvider>
+    <Box marginBottom={1}>
+      <Text color={message.role === "user" ? "green" : "blue"}>
+        {message.role === "user" ? "You: " : "AI: "}
+      </Text>
+      <Text>{text}</Text>
+    </Box>
   );
-}
+};
+
+const App = () => {
+  const runtime = useLocalRuntime(adapter);
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ThreadPrimitive.Root>
+        <ThreadPrimitive.Messages>{() => <Message />}</ThreadPrimitive.Messages>
+        <Box borderStyle="round" paddingX={1}>
+          <Text>{"> "}</Text>
+          <ComposerPrimitive.Input submitOnEnter placeholder="Message..." autoFocus />
+        </Box>
+      </ThreadPrimitive.Root>
+    </AssistantRuntimeProvider>
+  );
+};
 
 render(<App />);
 ```
-
-## Features
-
-- Composable, unstyled primitives (Thread, Composer, Message, ActionBar, etc.)
-- Streaming responses with real-time updates
-- Tool call support with built-in ToolFallback component
-- Diff rendering with DiffPrimitive components and DiffView for unified diffs and file comparisons in the terminal
-- Message branching and editing
-- Multi-thread support with thread list management
-- Markdown rendering via `@assistant-ui/react-ink-markdown`
-- Same runtime as `@assistant-ui/react` — share adapters, tools, and backend code
 
 ## Documentation
 
@@ -76,12 +74,7 @@ render(<App />);
 - [Primitives](https://www.assistant-ui.com/docs/ink/primitives)
 - [Hooks](https://www.assistant-ui.com/docs/ink/hooks)
 
-## Related Packages
+## For other platforms
 
-- [`@assistant-ui/react-ink-markdown`](https://www.npmjs.com/package/@assistant-ui/react-ink-markdown) — Terminal markdown rendering with syntax highlighting
-- [`@assistant-ui/react`](https://www.npmjs.com/package/@assistant-ui/react) — Web (React) bindings
-- [`@assistant-ui/react-native`](https://www.npmjs.com/package/@assistant-ui/react-native) — React Native bindings
-
-## License
-
-MIT
+- Web: [`@assistant-ui/react`](https://www.npmjs.com/package/@assistant-ui/react)
+- React Native: [`@assistant-ui/react-native`](https://www.npmjs.com/package/@assistant-ui/react-native)

--- a/packages/react-langchain/README.md
+++ b/packages/react-langchain/README.md
@@ -1,17 +1,10 @@
-## `@assistant-ui/react-langchain`
+# `@assistant-ui/react-langchain`
 
-Adapter that wraps [`useStream`](https://docs.langchain.com/oss/javascript/langgraph-sdk/react-stream) from `@langchain/react` and exposes it as an assistant-ui runtime, with hooks for reading interrupts, submitting raw state updates, and reading arbitrary LangGraph custom state keys.
+Adapter that wraps [`useStream`](https://docs.langchain.com/oss/javascript/langgraph-sdk/react-stream) from `@langchain/react` and exposes it as an assistant-ui runtime. Bridges LangChain's `useStream` to an `AssistantRuntime` with hooks for interrupts, raw state submission, and reading custom LangGraph state keys.
 
-> assistant-ui also ships [`@assistant-ui/react-langgraph`](https://www.npmjs.com/package/@assistant-ui/react-langgraph), which integrates with `@langchain/langgraph-sdk` directly and has a broader feature set (subgraph events, UI messages, message metadata, cancellation). The two packages are independent adapters targeting different upstream libraries — pick whichever matches your upstream choice. See the [comparison](https://www.assistant-ui.com/docs/runtimes/langchain/comparison).
+## When to use this
 
-## Features
-
-- Bridges LangChain's `useStream` to an assistant-ui `AssistantRuntime`
-- Tool invocations flow through assistant-ui's `useToolInvocations`
-- `useLangChainInterruptState` — read the current LangGraph interrupt
-- `useLangChainSubmit` — submit raw state updates (e.g. resume commands)
-- `useLangChainState<T>(key)` — read custom state keys like `todos` / `files` reactively
-- Optional assistant-cloud thread persistence
+assistant-ui also ships `@assistant-ui/react-langgraph`, which integrates with `@langchain/langgraph-sdk` directly and has a broader feature set (subgraph events, UI messages, message metadata, cancellation). The two packages are independent adapters targeting different upstream libraries; pick whichever matches the SDK you already use.
 
 ## Installation
 
@@ -21,13 +14,12 @@ npm install @assistant-ui/react @assistant-ui/react-langchain @langchain/react
 
 ## Usage
 
-### Basic setup
-
 ```tsx
 import { useStreamRuntime } from "@assistant-ui/react-langchain";
-import { AssistantRuntimeProvider, Thread } from "@assistant-ui/react";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { Thread } from "@/components/assistant-ui/thread";
 
-function App() {
+export function App() {
   const runtime = useStreamRuntime({
     assistantId: "agent",
     apiUrl: "http://localhost:2024",
@@ -41,71 +33,6 @@ function App() {
 }
 ```
 
-`useStreamRuntime` accepts every option `useStream` from `@langchain/react` does, plus:
+`useStreamRuntime` accepts every option `@langchain/react`'s `useStream` does, plus `cloud` for thread persistence, an `adapters` bag, and a `messagesKey` override.
 
-- `cloud` — an `AssistantCloud` instance for persisting threads
-- `adapters` — `{ attachments, speech, feedback }`
-- `messagesKey` — the state key that holds messages (default `"messages"`)
-
-### Reading custom state keys
-
-LangGraph agents often expose structured state beyond messages (plans, todos, scratch files, generative-UI artifacts). Read them directly with `useLangChainState` — mirrors `useStream().values[key]` upstream and updates when the stream emits new state.
-
-```tsx
-import { useLangChainState } from "@assistant-ui/react-langchain";
-
-type Todo = { id: string; title: string; done: boolean };
-
-function TodoList() {
-  const todos = useLangChainState<Todo[]>("todos", []);
-
-  return (
-    <ul>
-      {todos.map((t) => (
-        <li key={t.id}>{t.title}</li>
-      ))}
-    </ul>
-  );
-}
-```
-
-Signatures:
-
-```ts
-useLangChainState<T>(key: string): T | undefined;
-useLangChainState<T>(key: string, defaultValue: T): T;
-```
-
-### Interrupts
-
-```tsx
-import {
-  useLangChainInterruptState,
-  useLangChainSubmit,
-} from "@assistant-ui/react-langchain";
-import { Command } from "@langchain/langgraph-sdk";
-
-function InterruptPrompt() {
-  const interrupt = useLangChainInterruptState();
-  const submit = useLangChainSubmit();
-
-  if (!interrupt) return null;
-
-  return (
-    <div>
-      <pre>{JSON.stringify(interrupt.value, null, 2)}</pre>
-      <button onClick={() => submit(null, { command: new Command({ resume: "yes" }) })}>
-        Approve
-      </button>
-    </div>
-  );
-}
-```
-
-### Message conversion
-
-The adapter ships `convertLangChainBaseMessage` for cases where you want to reuse the internal converter directly (e.g. when building a custom `ExternalStoreAdapter`).
-
-```ts
-import { convertLangChainBaseMessage } from "@assistant-ui/react-langchain";
-```
+Full reference for `useLangChainState`, `useLangChainInterruptState`, `useLangChainSubmit`, and `convertLangChainBaseMessage` at [assistant-ui.com/docs/runtimes/langchain](https://www.assistant-ui.com/docs/runtimes/langchain).

--- a/packages/react-langgraph/README.md
+++ b/packages/react-langgraph/README.md
@@ -1,3 +1,48 @@
 # `@assistant-ui/react-langgraph`
 
-LangGraph integration for `@assistant-ui/react`.
+[LangGraph](https://langchain-ai.github.io/langgraph/) integration for `@assistant-ui/react`. Wraps a LangGraph stream in an assistant-ui runtime with thread persistence, interrupts, and message-tuple events.
+
+## Installation
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-langgraph @langchain/langgraph-sdk
+```
+
+## Usage
+
+```tsx
+"use client";
+
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useLangGraphRuntime } from "@assistant-ui/react-langgraph";
+import { createThread, sendMessage, getThreadState } from "@/lib/chatApi";
+
+export function Provider({ children }: { children: React.ReactNode }) {
+  const runtime = useLangGraphRuntime({
+    stream: async function* (messages, { initialize, ...config }) {
+      const { externalId } = await initialize();
+      yield* sendMessage({ threadId: externalId!, messages, config });
+    },
+    create: async () => {
+      const { thread_id } = await createThread();
+      return { externalId: thread_id };
+    },
+    load: async (externalId) => {
+      const state = await getThreadState(externalId);
+      return { messages: state.values.messages ?? [], interrupts: [] };
+    },
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+## See also
+
+- `@assistant-ui/react-langchain` targets `@langchain/react`'s `useStream`; pick it if that's the SDK you already use.
+
+Full API reference at [assistant-ui.com/docs/runtimes/langgraph](https://www.assistant-ui.com/docs/runtimes/langgraph). See [`examples/with-langgraph`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-langgraph) for a complete app.

--- a/packages/react-lexical/README.md
+++ b/packages/react-lexical/README.md
@@ -1,0 +1,33 @@
+# `@assistant-ui/react-lexical`
+
+[Lexical](https://lexical.dev) rich-text composer for `@assistant-ui/react`, with first-class support for `@`-mention directive chips. Drop `LexicalComposerInput` in place of the default plain-text composer to render mentions and slash commands as inline chips while keeping the underlying message format clean.
+
+## Installation
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-lexical
+```
+
+## Usage
+
+```tsx
+import { ComposerPrimitive } from "@assistant-ui/react";
+import { LexicalComposerInput } from "@assistant-ui/react-lexical";
+
+export function Composer() {
+  return (
+    <ComposerPrimitive.Root>
+      <LexicalComposerInput placeholder="Ask anything..." />
+      <ComposerPrimitive.Send />
+    </ComposerPrimitive.Root>
+  );
+}
+```
+
+For custom chip rendering, pass a `directiveChip` render prop. Directives (e.g. `@user`, `/command`) survive cursor navigation, selection, and copy/paste as a single unit.
+
+## See also
+
+- `@assistant-ui/react-hook-form` for binding the composer to a form whose fields the assistant can read and fill.
+
+Full reference at [assistant-ui.com/docs](https://www.assistant-ui.com/docs).

--- a/packages/react-markdown/README.md
+++ b/packages/react-markdown/README.md
@@ -13,7 +13,7 @@
 ## Installation
 
 ```bash
-npm install @assistant-ui/react @assistant-ui/react-markdown react-markdown
+npm install @assistant-ui/react @assistant-ui/react-markdown react-markdown remark-gfm
 ```
 
 ## Usage

--- a/packages/react-markdown/README.md
+++ b/packages/react-markdown/README.md
@@ -1,3 +1,32 @@
 # `@assistant-ui/react-markdown`
 
-`react-markdown` integration for `@assistant-ui/react`.
+[`react-markdown`](https://github.com/remarkjs/react-markdown) integration for `@assistant-ui/react`. Renders the assistant's markdown output as React components inside `MessagePrimitive.Parts`.
+
+## When to use this
+
+| Package                                  | Best for                                                          |
+| ---------------------------------------- | ----------------------------------------------------------------- |
+| `@assistant-ui/react-markdown`           | Lightweight rendering; bring your own syntax highlighter.         |
+| `@assistant-ui/react-streamdown`         | Feature-rich with built-in Shiki, KaTeX, and Mermaid.             |
+| `@assistant-ui/react-syntax-highlighter` | Pair with `react-markdown` when you only need code-block highlighting. |
+
+## Installation
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-markdown react-markdown
+```
+
+## Usage
+
+```tsx
+import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
+import remarkGfm from "remark-gfm";
+
+export const MarkdownText = () => (
+  <MarkdownTextPrimitive remarkPlugins={[remarkGfm]} className="aui-md" />
+);
+```
+
+Plug `<MarkdownText />` into `MessagePrimitive.Parts` as the `Text` component to render markdown for every text part.
+
+Full reference at [assistant-ui.com/docs/ui/markdown](https://www.assistant-ui.com/docs/ui/markdown).

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -17,7 +17,7 @@ npm install @assistant-ui/react-native
 
 ```tsx
 import {
-  AssistantProvider,
+  AssistantRuntimeProvider,
   useLocalRuntime,
   type ChatModelAdapter,
 } from "@assistant-ui/react-native";
@@ -31,9 +31,9 @@ const adapter: ChatModelAdapter = {
 export function App() {
   const runtime = useLocalRuntime(adapter);
   return (
-    <AssistantProvider runtime={runtime}>
+    <AssistantRuntimeProvider runtime={runtime}>
       {/* Thread, Composer, Message primitives */}
-    </AssistantProvider>
+    </AssistantRuntimeProvider>
   );
 }
 ```

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -1,25 +1,48 @@
 # `@assistant-ui/react-native`
 
-React Native bindings for assistant-ui.
+[![npm version](https://img.shields.io/npm/v/@assistant-ui/react-native)](https://www.npmjs.com/package/@assistant-ui/react-native)
+[![npm downloads](https://img.shields.io/npm/dm/@assistant-ui/react-native)](https://www.npmjs.com/package/@assistant-ui/react-native)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
+![License](https://img.shields.io/npm/l/@assistant-ui/react-native)
 
-## Features
+React Native bindings for assistant-ui. Native primitives for `Thread`, `Composer`, `Message`, and `ThreadList` that share the same runtime and adapters as `@assistant-ui/react`.
 
-- Native React Native primitives (Thread, Composer, Message, ThreadList)
-- Multi-thread support with in-memory thread list
-- Compatible with `@assistant-ui/core` runtime system
+## Installation
+
+```bash
+npm install @assistant-ui/react-native
+```
 
 ## Usage
 
-```typescript
-import { useLocalRuntime, AssistantProvider } from '@assistant-ui/react-native';
+```tsx
+import {
+  AssistantProvider,
+  useLocalRuntime,
+  type ChatModelAdapter,
+} from "@assistant-ui/react-native";
 
-function App() {
-  const runtime = useLocalRuntime(chatModelAdapter);
+const adapter: ChatModelAdapter = {
+  async *run({ messages }) {
+    yield { content: [{ type: "text", text: "Hello!" }] };
+  },
+};
 
+export function App() {
+  const runtime = useLocalRuntime(adapter);
   return (
     <AssistantProvider runtime={runtime}>
-      {/* Your chat UI */}
+      {/* Thread, Composer, Message primitives */}
     </AssistantProvider>
   );
 }
 ```
+
+## Documentation
+
+Full primitives, hooks, and adapter reference at [assistant-ui.com/docs/react-native](https://www.assistant-ui.com/docs/react-native).
+
+## For other platforms
+
+- Web: [`@assistant-ui/react`](https://www.npmjs.com/package/@assistant-ui/react)
+- Terminal (Ink): [`@assistant-ui/react-ink`](https://www.npmjs.com/package/@assistant-ui/react-ink)

--- a/packages/react-o11y/README.md
+++ b/packages/react-o11y/README.md
@@ -1,0 +1,36 @@
+# `@assistant-ui/react-o11y`
+
+Headless React primitives for rendering span and trace UIs (waterfalls, timelines, run inspectors) on top of `@assistant-ui/store`. Ships a tap-based `SpanResource` that owns the data and a set of unstyled `SpanPrimitive.*` components for laying it out.
+
+## Installation
+
+```bash
+npm install @assistant-ui/react-o11y
+```
+
+## Usage
+
+```tsx
+"use client";
+
+import { AuiProvider, useAui } from "@assistant-ui/store";
+import { SpanResource } from "@assistant-ui/react-o11y";
+
+const spans = [
+  { id: "a", parentSpanId: null, name: "request", type: "http", status: "completed", startedAt: 0, endedAt: 120, latencyMs: 120 },
+  { id: "b", parentSpanId: "a", name: "db query", type: "db", status: "completed", startedAt: 10, endedAt: 80, latencyMs: 70 },
+];
+
+export function Waterfall() {
+  const aui = useAui({ span: SpanResource({ spans }) });
+  return (
+    <AuiProvider value={aui}>
+      <Timeline />
+    </AuiProvider>
+  );
+}
+```
+
+Compose `SpanPrimitive.*` components inside `<Timeline>` to render rows, indentation, names, status, and the collapse toggle.
+
+See [`examples/waterfall`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/waterfall) for a complete waterfall implementation.

--- a/packages/react-o11y/README.md
+++ b/packages/react-o11y/README.md
@@ -25,12 +25,12 @@ export function Waterfall() {
   const aui = useAui({ span: SpanResource({ spans }) });
   return (
     <AuiProvider value={aui}>
-      <Timeline />
+      {/* compose SpanPrimitive.* components here — see examples/waterfall for a full layout */}
     </AuiProvider>
   );
 }
 ```
 
-Compose `SpanPrimitive.*` components inside `<Timeline>` to render rows, indentation, names, status, and the collapse toggle.
+`SpanPrimitive.*` components rendered inside `<AuiProvider>` cover rows, indentation, names, status, and the collapse toggle.
 
 See [`examples/waterfall`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/waterfall) for a complete waterfall implementation.

--- a/packages/react-opencode/README.md
+++ b/packages/react-opencode/README.md
@@ -1,7 +1,39 @@
-# @assistant-ui/react-opencode
+# `@assistant-ui/react-opencode`
 
-> [!NOTE] This integration is experimental, there may be bugs or issues.
+[OpenCode](https://opencode.ai) runtime adapter for `@assistant-ui/react`. Maps OpenCode activity onto the standard assistant-ui message primitives so an OpenCode session can drive a Thread UI.
 
-OpenCode runtime adapter for assistant-ui.
+> [!NOTE]
+> This integration is experimental. APIs may change between minor versions.
 
-This package projects OpenCode activity into existing assistant-ui message primitives.
+## Installation
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-opencode
+```
+
+## Usage
+
+```tsx
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useOpenCodeRuntime } from "@assistant-ui/react-opencode";
+import { Thread } from "@/components/assistant-ui/thread";
+
+export function App() {
+  const runtime = useOpenCodeRuntime({
+    apiUrl: "http://localhost:4096",
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+## See also
+
+- `@assistant-ui/react-ai-sdk` for general-purpose Vercel AI SDK integration.
+- `@assistant-ui/react-langgraph` for LangGraph agents.
+
+Full reference at [assistant-ui.com/docs/runtimes/opencode](https://www.assistant-ui.com/docs/runtimes/opencode).

--- a/packages/react-streamdown/README.md
+++ b/packages/react-streamdown/README.md
@@ -1,38 +1,28 @@
-# @assistant-ui/react-streamdown
+# `@assistant-ui/react-streamdown`
 
-Streamdown-based markdown rendering for assistant-ui. An alternative to `@assistant-ui/react-markdown` with built-in syntax highlighting, math, and diagram support.
+[Streamdown](https://github.com/vercel/streamdown)-based markdown rendering for `@assistant-ui/react`. Drop-in replacement for `@assistant-ui/react-markdown` with built-in Shiki, KaTeX, and Mermaid support, optimized for AI streaming output.
 
-## When to Use
+## When to use this
 
-| Package | Best For |
-|---------|----------|
-| `@assistant-ui/react-markdown` | Lightweight, bring-your-own syntax highlighter |
-| `@assistant-ui/react-streamdown` | Feature-rich with built-in Shiki, KaTeX, Mermaid |
+| Package                                  | Best for                                                          |
+| ---------------------------------------- | ----------------------------------------------------------------- |
+| `@assistant-ui/react-markdown`           | Lightweight rendering; bring your own syntax highlighter.         |
+| `@assistant-ui/react-streamdown`         | Feature-rich with built-in Shiki, KaTeX, and Mermaid.             |
+| `@assistant-ui/react-syntax-highlighter` | Pair with `react-markdown` when you only need code-block highlighting. |
 
 ## Installation
 
 ```bash
-npm install @assistant-ui/react-streamdown streamdown
+npm install @assistant-ui/react @assistant-ui/react-streamdown
 ```
 
-For additional features, install the optional plugins:
+For optional features:
 
 ```bash
 npm install @streamdown/code @streamdown/math @streamdown/mermaid @streamdown/cjk
 ```
 
 ## Usage
-
-### Basic
-
-```tsx
-import { StreamdownTextPrimitive } from "@assistant-ui/react-streamdown";
-
-// Inside a MessagePartText component
-<StreamdownTextPrimitive />
-```
-
-### With Plugins (Recommended)
 
 ```tsx
 import { StreamdownTextPrimitive } from "@assistant-ui/react-streamdown";
@@ -41,123 +31,12 @@ import { math } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
 import "katex/dist/katex.min.css";
 
-<StreamdownTextPrimitive
-  plugins={{ code, math, mermaid }}
-  shikiTheme={["github-light", "github-dark"]}
-/>
+export const MarkdownText = () => (
+  <StreamdownTextPrimitive
+    plugins={{ code, math, mermaid }}
+    shikiTheme={["github-light", "github-dark"]}
+  />
+);
 ```
 
-### Migration from react-markdown
-
-If you're migrating from `@assistant-ui/react-markdown`, you can use the compatibility API:
-
-```tsx
-import { StreamdownTextPrimitive } from "@assistant-ui/react-streamdown";
-
-// Your existing SyntaxHighlighter component still works
-<StreamdownTextPrimitive
-  components={{
-    SyntaxHighlighter: MySyntaxHighlighter,
-    CodeHeader: MyCodeHeader,
-  }}
-  componentsByLanguage={{
-    mermaid: { SyntaxHighlighter: MermaidRenderer }
-  }}
-/>
-```
-
-## Props
-
-| Prop | Type | Description |
-|------|------|-------------|
-| `mode` | `"streaming" \| "static"` | Rendering mode. Default: `"streaming"` |
-| `plugins` | `PluginConfig` | Streamdown plugins (code, math, mermaid, cjk) |
-| `shikiTheme` | `[string, string]` | Light and dark theme for Shiki |
-| `components` | `object` | Custom components including `SyntaxHighlighter` and `CodeHeader` |
-| `componentsByLanguage` | `object` | Language-specific component overrides |
-| `preprocess` | `(text: string) => string` | Text preprocessing function |
-| `controls` | `boolean \| object` | Enable/disable UI controls for code blocks and tables |
-| `containerProps` | `object` | Props for the container div |
-| `containerClassName` | `string` | Class name for the container |
-| `remarkRehypeOptions` | `object` | Options passed to remark-rehype during processing |
-| `BlockComponent` | `React.ComponentType` | Custom component for rendering blocks |
-| `parseMarkdownIntoBlocksFn` | `(md: string) => string[]` | Custom block parsing function |
-| `remend` | `object` | Incomplete markdown auto-completion config |
-| `linkSafety` | `object` | Link safety confirmation config |
-| `mermaid` | `object` | Mermaid diagram rendering config |
-| `allowedTags` | `object` | HTML tags whitelist |
-
-## Differences from react-markdown
-
-1. **Streaming optimization**: Uses block-based rendering and `remend` for better streaming performance
-2. **Built-in highlighting**: Shiki is integrated via `@streamdown/code` plugin
-3. **No smooth prop**: Streaming animation is handled by streamdown's `mode` and `isAnimating`
-4. **Auto isAnimating**: Automatically detects streaming state from message context
-
-## Advanced Usage
-
-### Custom Block Rendering
-
-Use `BlockComponent` to customize how individual markdown blocks are rendered:
-
-```tsx
-<StreamdownTextPrimitive
-  BlockComponent={({ content, index }) => (
-    <div key={index} className="my-block">
-      {/* Custom block rendering */}
-    </div>
-  )}
-/>
-```
-
-### Custom Block Parsing
-
-Override the default block splitting logic:
-
-```tsx
-<StreamdownTextPrimitive
-  parseMarkdownIntoBlocksFn={(markdown) => markdown.split(/\n{2,}/)}
-/>
-```
-
-### Using Hooks
-
-```tsx
-import {
-  useIsStreamdownCodeBlock,
-  useStreamdownPreProps,
-} from "@assistant-ui/react-streamdown";
-
-// Inside a code component
-function MyCodeComponent() {
-  const isCodeBlock = useIsStreamdownCodeBlock();
-  const preProps = useStreamdownPreProps();
-
-  if (!isCodeBlock) {
-    return <code className="inline-code">...</code>;
-  }
-
-  return <pre {...preProps}>...</pre>;
-}
-```
-
-## Performance Best Practices
-
-1. **Use memoized components**: Custom `SyntaxHighlighter` and `CodeHeader` components should be memoized to avoid unnecessary re-renders.
-
-2. **Avoid inline function props**: Define `preprocess`, `parseMarkdownIntoBlocksFn`, and other callbacks outside the render function or wrap them in `useCallback`.
-
-3. **Plugin configuration**: Pass plugin objects by reference (not inline) to prevent recreation on each render.
-
-```tsx
-// Good
-const plugins = useMemo(() => ({ code, math }), []);
-<StreamdownTextPrimitive plugins={plugins} />
-
-// Avoid
-<StreamdownTextPrimitive plugins={{ code, math }} />
-```
-
-## License
-
-MIT
+Full prop reference, plugin docs, performance guide, and `react-markdown` migration notes at [assistant-ui.com/docs/ui/streamdown](https://www.assistant-ui.com/docs/ui/streamdown).

--- a/packages/react-syntax-highlighter/README.md
+++ b/packages/react-syntax-highlighter/README.md
@@ -1,3 +1,36 @@
 # `@assistant-ui/react-syntax-highlighter`
 
-`react-syntax-highlighter` integration for `@assistant-ui/react`.
+Code-block syntax highlighting for `@assistant-ui/react-markdown`, powered by [`react-syntax-highlighter`](https://github.com/react-syntax-highlighter/react-syntax-highlighter). Use the light or async builds to keep your bundle size small.
+
+## When to use this
+
+Pair this with `@assistant-ui/react-markdown` when you want syntax-highlighted code blocks. If you want a batteries-included setup with Shiki built in, use `@assistant-ui/react-streamdown` instead.
+
+## Installation
+
+```bash
+npm install @assistant-ui/react @assistant-ui/react-markdown @assistant-ui/react-syntax-highlighter react-syntax-highlighter
+```
+
+## Usage
+
+```tsx
+import { makeLightSyntaxHighlighter } from "@assistant-ui/react-syntax-highlighter";
+import { coldarkDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import js from "react-syntax-highlighter/dist/cjs/languages/hljs/javascript";
+import ts from "react-syntax-highlighter/dist/cjs/languages/hljs/typescript";
+
+export const SyntaxHighlighter = makeLightSyntaxHighlighter({
+  style: coldarkDark,
+  languages: { javascript: js, typescript: ts },
+});
+```
+
+Pass the resulting component as the `SyntaxHighlighter` override to `MarkdownTextPrimitive`.
+
+## Builds
+
+- `makeLightSyntaxHighlighter` / `makeLightAsyncSyntaxHighlighter`: hljs grammars.
+- `makePrismLightSyntaxHighlighter` / `makePrismAsyncLightSyntaxHighlighter`: Prism grammars.
+
+Full reference at [assistant-ui.com/docs/ui/syntax-highlighting](https://www.assistant-ui.com/docs/ui/syntax-highlighting).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@assistant-ui/react",
   "version": "0.14.0",
-  "description": "TypeScript/React library for AI Chat",
+  "description": "Open-source TypeScript/React library for building production-grade AI chat experiences",
   "keywords": [
     "radix-ui",
     "nextjs",

--- a/packages/safe-content-frame/README.md
+++ b/packages/safe-content-frame/README.md
@@ -1,0 +1,70 @@
+# `safe-content-frame`
+
+[![npm version](https://img.shields.io/npm/v/safe-content-frame)](https://www.npmjs.com/package/safe-content-frame)
+[![npm downloads](https://img.shields.io/npm/dm/safe-content-frame)](https://www.npmjs.com/package/safe-content-frame)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/safe-content-frame)](https://bundlephobia.com/package/safe-content-frame)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
+
+Render untrusted HTML, PDF, or arbitrary `Blob` content inside a sandboxed iframe whose origin is hashed per-content. The frame is hosted on `scf.auiusercontent.com`, a separate eTLD+1 from your app, so model-generated scripts cannot reach `document.cookie`, `localStorage`, or the parent window even if `allow-scripts` is set.
+
+`safe-content-frame` is framework-agnostic vanilla JS. There is no React or DOM-framework dependency.
+
+## Installation
+
+```bash
+npm install safe-content-frame
+```
+
+## Usage
+
+```ts
+import { SafeContentFrame } from "safe-content-frame";
+
+const frame = new SafeContentFrame("my-app");
+
+const container = document.getElementById("preview")!;
+const rendered = await frame.renderHtml(modelGeneratedHtml, container);
+
+await rendered.fullyLoadedPromiseWithTimeout(5000);
+
+rendered.sendMessage({ type: "theme", value: "dark" });
+
+// later
+rendered.dispose();
+```
+
+The first argument to `SafeContentFrame` is your product identifier; it scopes the hashed origin so different products on the same domain do not collide.
+
+## Methods
+
+| Method                                                        | Purpose                                          |
+| ------------------------------------------------------------- | ------------------------------------------------ |
+| `renderHtml(html, container, opts?)`                          | Render an HTML string.                           |
+| `renderRaw(content, mimeType, container)`                     | Render any MIME type from a string or `Uint8Array`. |
+| `renderPdf(content, container)`                               | Render a PDF document.                           |
+
+Each renderer returns a `RenderedFrame`:
+
+| Property/Method                      | Description                                                                |
+| ------------------------------------ | -------------------------------------------------------------------------- |
+| `iframe`                             | The created `<iframe>` element.                                            |
+| `origin`                             | The hashed origin the frame was loaded from.                               |
+| `sendMessage(data, transfer?)`       | `postMessage` to the frame, scoped to its origin.                          |
+| `fullyLoadedPromiseWithTimeout(ms)`  | Resolves once the frame signals it is fully loaded; rejects on timeout.    |
+| `dispose()`                          | Remove the iframe from the DOM.                                            |
+
+## Options
+
+| Option                 | Default                                      | Effect                                                                                              |
+| ---------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `useShadowDom`         | `false`                                      | Mount the iframe inside a closed shadow root.                                                       |
+| `enableBrowserCaching` | `false`                                      | Derive the salt from the content hash so repeated renders reuse the same origin and HTTP cache.     |
+| `sandbox`              | `["allow-same-origin", "allow-scripts"]`     | Extra `iframe[sandbox]` permissions to grant. The two defaults are always added.                    |
+| `salt`                 | random per render                            | Override the salt explicitly (useful for tests or stable-origin embeds).                            |
+
+## Sub-paths
+
+- `safe-content-frame`: the main `SafeContentFrame` class above.
+- `safe-content-frame/shadow_dom`: shadow-DOM rendering variant for embedding inside a custom element.
+
+See the [docs page](https://www.assistant-ui.com/safe-content-frame) for the threat model and a live demo.

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -1,30 +1,55 @@
-# @assistant-ui/store
+# `@assistant-ui/store`
 
-Tap-based state management with React Context integration.
+[![npm version](https://img.shields.io/npm/v/@assistant-ui/store)](https://www.npmjs.com/package/@assistant-ui/store)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
 
-## Quick Start
+Tap-based state container with React Context integration. Bridges `@assistant-ui/tap` resources into React via `useAui`, `useAuiState`, and `<AuiProvider>`.
+
+`store` powers the runtime layer of assistant-ui. Most users do not install it directly; reach for `@assistant-ui/react` instead.
+
+## Installation
+
+```bash
+npm install @assistant-ui/store @assistant-ui/tap
+```
+
+## Usage
 
 ```typescript
 import { resource, tapState } from "@assistant-ui/tap";
-import { useAui, useAuiState, AuiProvider, type ClientOutput } from "@assistant-ui/store";
+import {
+  useAui,
+  useAuiState,
+  AuiProvider,
+  type ClientOutput,
+} from "@assistant-ui/store";
 
-// 1. Define client type
 declare module "@assistant-ui/store" {
   interface ScopeRegistry {
-    counter: { methods: { getState: () => { count: number }; increment: () => void } };
+    counter: {
+      methods: {
+        getState: () => { count: number };
+        increment: () => void;
+      };
+    };
   }
 }
 
-// 2. Create resource
 const CounterClient = resource((): ClientOutput<"counter"> => {
   const [state, setState] = tapState({ count: 0 });
-  return { getState: () => state, increment: () => setState({ count: state.count + 1 }) };
+  return {
+    getState: () => state,
+    increment: () => setState({ count: state.count + 1 }),
+  };
 });
 
-// 3. Use in React
 function App() {
   const aui = useAui({ counter: CounterClient() });
-  return <AuiProvider value={aui}><Counter /></AuiProvider>;
+  return (
+    <AuiProvider value={aui}>
+      <Counter />
+    </AuiProvider>
+  );
 }
 
 function Counter() {
@@ -34,58 +59,4 @@ function Counter() {
 }
 ```
 
-## Concepts
-
-**Clients**: Named state containers registered via module augmentation.
-```typescript
-declare module "@assistant-ui/store" {
-  interface ScopeRegistry {
-    myClient: {
-      methods: MyMethods; // must include getState(): MyState
-      meta?: { source: "parent"; query: { id: string } };
-      events?: { "myClient.updated": { id: string } };
-    };
-  }
-}
-```
-
-**Derived Clients**: Access nested clients from parents.
-```typescript
-useAui({
-  item: Derived({ source: "list", query: { index: 0 }, get: (aui) => aui.list().item({ index: 0 }) }),
-});
-```
-
-**Events**:
-```typescript
-const emit = tapAssistantEmit();
-emit("myClient.updated", { id: "123" });
-
-useAuiEvent("myClient.updated", (p) => console.log(p.id));
-```
-
-## API
-
-| Hook/Component | Description |
-|----------------|-------------|
-| `useAui()` | Get client from context |
-| `useAui(clients)` | Create/extend client |
-| `useAuiState(selector)` | Subscribe to state |
-| `useAuiEvent(event, cb)` | Subscribe to events |
-| `AuiProvider` | Provide client to tree |
-| `AuiIf` | Conditional rendering |
-
-| Tap Utility | Description |
-|-------------|-------------|
-| `tapAssistantClientRef()` | Access client ref in resources |
-| `tapAssistantEmit()` | Emit events from resources |
-| `tapClientResource(element)` | Wrap resource for event scoping (1:1 mappings) |
-| `tapClientLookup(map, fn, deps)` | Lookup by `{index}` or `{key}` |
-| `tapClientList(config)` | Dynamic list with add/remove |
-| `attachTransformScopes(resource, fn)` | Attach scope transform |
-
-| Type | Description |
-|------|-------------|
-| `ClientOutput<K>` | Resource return type (methods object) |
-| `ScopeRegistry` | Module augmentation interface |
-| `AssistantClient` | Full client type |
+Full API reference (clients, derived clients, events, `tapClientLookup`, `tapClientList`) at [assistant-ui.com/tap/docs/store/quickstart](https://www.assistant-ui.com/tap/docs/store/quickstart).

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -48,7 +48,7 @@ In React, use the `useResource` hook from the `/react` sub-path:
 ```tsx
 import { useResource } from "@assistant-ui/tap/react";
 
-function Counter() {
+function CounterButton() {
   const { count, increment } = useResource(Counter({ incrementBy: 1 }));
   return <button onClick={increment}>{count}</button>;
 }

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -1,6 +1,13 @@
-# @assistant-ui/tap
+# `@assistant-ui/tap`
 
-**tap** (Reactive Resources) is a zero-dependency reactive state management library that brings **React's hooks mental model to state management outside of React components**.
+[![npm version](https://img.shields.io/npm/v/@assistant-ui/tap)](https://www.npmjs.com/package/@assistant-ui/tap)
+[![npm downloads](https://img.shields.io/npm/dm/@assistant-ui/tap)](https://www.npmjs.com/package/@assistant-ui/tap)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/@assistant-ui/tap)](https://bundlephobia.com/package/@assistant-ui/tap)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
+
+Reactive primitives that bring React's hook mental model outside of components. The core has zero runtime dependencies and works in vanilla JS, on a server, or in React via the optional `/react` sub-path. Define self-contained units of state and effects (Resources) using `tapState`, `tapEffect`, `tapMemo`, and friends, and consume them via `useResource`.
+
+`tap` powers the runtime layer of assistant-ui. Most users do not install it directly; reach for `@assistant-ui/react` instead.
 
 ## Installation
 
@@ -8,400 +15,50 @@
 npm install @assistant-ui/tap
 ```
 
-## What is tap?
-
-Instead of limiting hooks to React components, tap lets you use the same familiar hooks pattern (`useState`, `useEffect`, `useMemo`, etc.) to create self-contained, reusable units of reactive state and logic called **Resources** that can be used anywhere - in vanilla JavaScript, servers, or outside of React.
-
-## Philosophy
-
-- **Unified mental model**: Use the same hooks pattern everywhere
-- **Framework agnostic**: Zero dependencies, works with or without React
-- **Lifecycle management**: Resources handle their own cleanup automatically
-- **Type-safe**: Full TypeScript support with proper type inference
-
-## How It Works
-
-tap implements a **render-commit pattern** similar to React:
-
-### Render Phase
-
-1. Each resource instance has a "fiber" that tracks state and effects
-2. When a resource function runs, hooks record their data in the fiber
-3. The library maintains an execution context to track which fiber's hooks are being called
-4. Each hook stores its data in cells indexed by call order (enforcing React's rules)
-
-### Commit Phase
-
-1. After render, collected effect tasks are processed
-2. Effects check if dependencies changed using shallow equality
-3. Old effects are cleaned up before new ones run
-4. Updates are batched using microtasks to prevent excessive re-renders
-
-## Core Concepts
-
-### Resources
-
-Resources are self-contained units of reactive state and logic. They follow the same rules as React hooks:
-
-- **Hook Order**: Hooks must be called in the same order in every render
-- **No Conditional Hooks**: Can't call hooks inside conditionals or loops
-- **No Async Hooks**: Hooks must be called synchronously during render
-- Resources automatically handle cleanup and lifecycle
-
-### Creating Resources
+## Usage
 
 ```typescript
-import { createResourceRoot, tapState, tapEffect } from "@assistant-ui/tap";
+import { resource, tapState, tapEffect, createResourceRoot } from "@assistant-ui/tap";
 
-// Define a resource using familiar hook patterns
 const Counter = resource(({ incrementBy = 1 }: { incrementBy?: number }) => {
   const [count, setCount] = tapState(0);
 
   tapEffect(() => {
-    console.log(`Count is now: ${count}`);
+    console.log("count:", count);
   }, [count]);
 
   return {
     count,
     increment: () => setCount((c) => c + incrementBy),
-    decrement: () => setCount((c) => c - incrementBy),
   };
 });
 
-// Create an instance
 const root = createResourceRoot();
 const counter = root.render(Counter({ incrementBy: 2 }));
 
-// Subscribe to changes
 const unsubscribe = counter.subscribe(() => {
-  console.log("Counter value:", counter.getValue().count);
+  console.log("counter updated:", counter.getValue().count);
 });
 
-// Use the resource
 counter.getValue().increment();
 ```
 
-## `resource`
+In React, use the `useResource` hook from the `/react` sub-path:
 
-Creates a resource element factory. Resource elements are plain objects of the type `{ type: ResourceFn<R, P>, props: P, key?: string | number }`.
-
-```typescript
-const Counter = resource(({ incrementBy = 1 }: { incrementBy?: number }) => {
-  const [count, setCount] = tapState(0);
-});
-
-// create a Counter element
-const counterEl = Counter({ incrementBy: 2 });
-
-// create a Counter instance
-const root = createResourceRoot();
-root.render(counterEl);
-root.unmount();
-```
-
-## Hook APIs
-
-### `tapState`
-
-Manages local state within a resource, exactly like React's `useState`.
-
-```typescript
-const [value, setValue] = tapState(initialValue);
-const [value, setValue] = tapState(() => computeInitialValue());
-```
-
-### `tapEffect`
-
-Runs side effects with automatic cleanup, exactly like React's `useEffect`.
-
-```typescript
-tapEffect(() => {
-  // Effect logic
-  return () => {
-    // Cleanup logic
-  };
-}, [dependencies]);
-```
-
-### `tapMemo`
-
-Memoizes expensive computations, exactly like React's `useMemo`.
-
-```typescript
-const expensiveValue = tapMemo(() => {
-  return computeExpensiveValue(dep1, dep2);
-}, [dep1, dep2]);
-```
-
-### `tapCallback`
-
-Memoizes callbacks to prevent unnecessary re-renders, exactly like React's `useCallback`.
-
-```typescript
-const stableCallback = tapCallback(() => {
-  doSomething(value);
-}, [value]);
-```
-
-### `tapRef`
-
-Creates a mutable reference that persists across renders, exactly like React's `useRef`.
-
-```typescript
-// With initial value
-const ref = tapRef(initialValue);
-ref.current = newValue;
-
-// Without initial value
-const ref = tapRef<string>(); // ref.current is undefined
-ref.current = "hello";
-```
-
-### `tapResource`
-
-Composes resources together - resources can render other resources.
-
-```typescript
-const Timer = resource(() => {
-  const counter = tapResource({ type: Counter, props: { incrementBy: 1 } });
-
-  tapEffect(() => {
-    const interval = setInterval(() => {
-      counter.increment();
-    }, 1000);
-    return () => clearInterval(interval);
-  }, []);
-
-  return counter.count;
-});
-```
-
-### `tapResources`
-
-Renders multiple resources from an array, similar to React's list rendering. Returns an array with each resource's result.
-
-```typescript
-tapResources<E extends ResourceElement<any, any>>(
-  getElements: () => readonly E[],
-  getElementsDeps: readonly any[]
-): ExtractResourceReturnType<E>[]
-```
-
-**Parameters:**
-- `getElements`: A function that returns an array of ResourceElements
-- `getElementsDeps`: Dependency array for memoizing the getElements function
-
-**Example:**
-
-```typescript
-const TodoItem = resource((props: { text: string }) => {
-  const [completed, setCompleted] = tapState(false);
-  return { text: props.text, completed, setCompleted };
-});
-
-const TodoList = resource(() => {
-  const todos = tapMemo(
-    () => [
-      { id: "1", text: "Learn tap" },
-      { id: "2", text: "Build something awesome" },
-    ],
-    [],
-  );
-
-  // Returns Array<{ text, completed, setCompleted }>
-  const todoItems = tapResources(
-    () => todos.map((todo) => TodoItem({ text: todo.text })),
-    [todos]
-  );
-
-  return todoItems;
-});
-```
-
-**Key features:**
-- Resource instances are preserved when keys remain the same (use `withKey()` to provide stable keys)
-- Automatically cleans up resources when removed from the array
-- Handles resource type changes (recreates fiber if type changes)
-
-### `tap` and Context Support
-
-Create and use context to pass values through resource boundaries without prop drilling.
-
-```typescript
-import {
-  createResourceContext,
-  tap,
-  withContextProvider,
-} from "@assistant-ui/tap";
-
-const MyContext = createResourceContext(defaultValue);
-
-// Provide context
-withContextProvider(MyContext, value, () => {
-  // Inside this function, tap can access the value
-});
-
-// Access context in a resource
-const value = tap(MyContext);
-```
-
-## Resource Management
-
-### `createResourceRoot`
-
-Create an instance of a resource. Call `render()` with a resource element to render it and mount effects. Returns a `SubscribableResource` with `getValue()` and `subscribe()`.
-
-```typescript
-import { createResourceRoot } from "@assistant-ui/tap";
-
-const root = createResourceRoot();
-const counter = root.render(Counter({ incrementBy: 1 }));
-
-// Access current value
-console.log(counter.getValue().count);
-
-// Subscribe to changes
-const unsubscribe = counter.subscribe(() => {
-  console.log("Counter updated:", counter.getValue());
-});
-
-// Update props by calling render again
-root.render(Counter({ incrementBy: 2 }));
-
-// Cleanup
-root.unmount();
-unsubscribe();
-```
-
-## React Integration
-
-Use resources directly in React components with the `useResource` hook:
-
-```typescript
+```tsx
 import { useResource } from "@assistant-ui/tap/react";
 
-function MyComponent() {
-  const state = useResource(new Counter({ incrementBy: 1 }));
-  return (
-    <div>
-      <p>Count: {state.count}</p>
-      <button onClick={state.increment}>Increment</button>
-    </div>
-  );
+function Counter() {
+  const { count, increment } = useResource(Counter({ incrementBy: 1 }));
+  return <button onClick={increment}>{count}</button>;
 }
 ```
 
-## Design Patterns
+## Hooks
 
-### Automatic Cleanup
+`tapState`, `tapEffect`, `tapMemo`, `tapCallback`, `tapRef` mirror their React counterparts. Additional primitives include `tapResource` and `tapResources` for composition, plus `createResourceContext` / `tap` / `withContextProvider` for context.
 
-Resources automatically clean up after themselves when unmounted:
-
-```typescript
-const WebSocketResource = resource(() => {
-  const [messages, setMessages] = tapState<string[]>([]);
-
-  tapEffect(() => {
-    const ws = new WebSocket("ws://localhost:8080");
-
-    ws.onmessage = (event) => {
-      setMessages((prev) => [...prev, event.data]);
-    };
-
-    // Cleanup happens automatically when resource unmounts
-    return () => ws.close();
-  }, []);
-
-  return messages;
-});
-```
-
-### API Wrapper Pattern
-
-A common pattern in assistant-ui is to wrap resource state in a stable API object:
-
-```typescript
-export const tapApi = <TApi extends ApiObject & { getState: () => any }>(
-  api: TApi,
-) => {
-  const ref = tapRef(api);
-
-  tapEffect(() => {
-    ref.current = api;
-  });
-
-  const apiProxy = tapMemo(
-    () =>
-      new Proxy<TApi>({} as TApi, new ReadonlyApiHandler(() => ref.current)),
-    [],
-  );
-
-  return tapMemo(
-    () => ({
-      state: api.getState(),
-      api: apiProxy,
-    }),
-    [api.getState()],
-  );
-};
-```
-
-## Use Cases
-
-tap is used throughout assistant-ui for:
-
-1. **State Management**: Application-wide state without Redux/Zustand
-2. **Event Handling**: Managing event subscriptions and cleanup
-3. **Resource Lifecycle**: Auto-cleanup of WebSockets, timers, subscriptions
-4. **Composition**: Nested resource management (threads, messages, tools)
-5. **Context Injection**: Passing values through resource boundaries without prop drilling
-6. **API Wrapping**: Creating reactive API objects with `getState()` and `subscribe()`
-
-### Example: Tools Management
-
-```typescript
-export const Tools = resource(({ toolkit }: { toolkit?: Toolkit }) => {
-  const [state, setState] = tapState<ToolsState>(() => ({
-    tools: {},
-  }));
-
-  const modelContext = tapModelContext();
-
-  tapEffect(() => {
-    if (!toolkit) return;
-
-    // Register tools and setup subscriptions
-    const unsubscribes: (() => void)[] = [];
-    // ... registration logic
-
-    return () => unsubscribes.forEach((fn) => fn());
-  }, [toolkit, modelContext]);
-
-  return tapApi<ToolsApi>({
-    getState: () => state,
-    setToolUI,
-  });
-});
-```
-
-## Why tap?
-
-- **Reuse React knowledge**: Developers already familiar with hooks can immediately work with tap
-- **Framework flexibility**: Core logic can work outside React components
-- **Automatic cleanup**: No memory leaks from forgotten unsubscribes
-- **Composability**: Resources can nest and combine naturally
-- **Type safety**: Full TypeScript inference for state and APIs
-- **Zero dependencies**: Lightweight and portable
-
-## Comparison with React Hooks
-
-| React Hook    | Reactive Resource | Behavior  |
-| ------------- | ----------------- | --------- |
-| `useState`    | `tapState`        | Identical |
-| `useEffect`   | `tapEffect`       | Identical |
-| `useMemo`     | `tapMemo`         | Identical |
-| `useCallback` | `tapCallback`     | Identical |
-| `useRef`      | `tapRef`          | Identical |
+Full API reference at [assistant-ui.com/tap/docs](https://www.assistant-ui.com/tap/docs).
 
 ## License
 

--- a/packages/tw-glass/README.md
+++ b/packages/tw-glass/README.md
@@ -1,18 +1,16 @@
-# tw-glass
+# `tw-glass`
 
-Tailwind CSS v4 plugin for glass refraction effects. Pure CSS, no JavaScript.
+[![npm version](https://img.shields.io/npm/v/tw-glass)](https://www.npmjs.com/package/tw-glass)
+[![npm downloads](https://img.shields.io/npm/dm/tw-glass)](https://www.npmjs.com/package/tw-glass)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
 
-Uses inline SVG displacement maps with `filterUnits="objectBoundingBox"` so refraction scales with element size automatically.
-
-[Live demo & docs](https://www.assistant-ui.com/tw-glass)
+Tailwind CSS v4 plugin for glass refraction effects. Pure CSS, no JavaScript. Uses inline SVG displacement maps with `filterUnits="objectBoundingBox"` so refraction scales with element size automatically.
 
 ## Installation
 
-```sh
+```bash
 npm install tw-glass
 ```
-
-Import in your CSS:
 
 ```css
 @import "tw-glass";
@@ -22,89 +20,34 @@ Requires Tailwind CSS v4+.
 
 ## Usage
 
-### Glass refraction
-
-Add `glass` to any element with content behind it:
-
 ```html
-<div class="glass rounded-xl p-6">
-  Content with refracted backdrop
-</div>
-```
-
-Pair with `glass-surface` for a frosted panel look:
-
-```html
-<div class="glass glass-surface rounded-xl p-6">
-  Frosted glass panel
-</div>
-```
-
-### Refraction strength
-
-Control displacement intensity:
-
-```html
-<div class="glass glass-strength-5">Subtle</div>
-<div class="glass glass-strength-20">Default</div>
-<div class="glass glass-strength-50">Heavy</div>
-```
-
-Available: `glass-strength-5`, `10`, `20`, `30`, `40`, `50`.
-
-### Chromatic aberration
-
-Split RGB channels for a prism effect:
-
-```html
-<div class="glass glass-chromatic-10">Prismatic</div>
-```
-
-Available: `glass-chromatic-5`, `10`, `20`, `30`, `40`, `50`.
-
-### Backdrop tuning
-
-Fine-tune blur, saturation, and brightness:
-
-```html
-<div class="glass glass-blur-4 glass-saturation-150 glass-brightness-110">
-  Custom backdrop
-</div>
-```
-
-- `glass-blur-{n}` -- blur in px (default: 2)
-- `glass-saturation-{n}` -- percentage (default: 120)
-- `glass-brightness-{n}` -- percentage (default: 105)
-
-### Surface opacity
-
-Control the frosted surface background opacity:
-
-```html
-<div class="glass glass-surface glass-bg-12">
-  12% white overlay
-</div>
-```
-
-`glass-bg-{n}` sets opacity as percentage (default: 8).
-
-### Glass text
-
-Clip a background image to the text shape:
-
-```html
-<h1
-  class="glass-text"
-  style="background-image: url(photo.jpg); background-attachment: fixed"
->
+<div class="glass rounded-xl p-6">Refracted backdrop</div>
+<div class="glass glass-surface glass-strength-30 rounded-xl p-6">Frosted panel</div>
+<h1 class="glass-text" style="background-image: url(photo.jpg); background-attachment: fixed">
   Glass heading
 </h1>
 ```
+
+Pair `glass` with `glass-surface` for a frosted-panel look, or layer on strength, chromatic, and backdrop utilities for stronger effects.
+
+## Utilities
+
+| Utility                                     | Effect                                                                  |
+| ------------------------------------------- | ----------------------------------------------------------------------- |
+| `glass`                                     | Base refraction. Apply to any element with content behind it.           |
+| `glass-surface`                             | Adds a frosted-panel background tint.                                   |
+| `glass-strength-{5,10,20,30,40,50}`         | Displacement intensity.                                                 |
+| `glass-chromatic-{5,10,20,30,40,50}`        | RGB channel split for a prism effect.                                   |
+| `glass-blur-{n}`                            | Backdrop blur in px (default 2).                                        |
+| `glass-saturation-{n}`                      | Backdrop saturation in % (default 120).                                 |
+| `glass-brightness-{n}`                      | Backdrop brightness in % (default 105).                                 |
+| `glass-bg-{n}`                              | Frosted-surface overlay opacity in % (default 8).                       |
+| `glass-text`                                | Clip a background image to the text shape.                              |
 
 ## Browser support
 
 Works in all browsers that support `backdrop-filter` with SVG filter references (Chrome, Edge, Safari, Firefox).
 
-## License
+## Documentation
 
-MIT
+Live demo and full reference at [assistant-ui.com/tw-glass](https://www.assistant-ui.com/tw-glass).

--- a/packages/tw-shimmer/README.md
+++ b/packages/tw-shimmer/README.md
@@ -1,22 +1,10 @@
-# tw-shimmer
+# `tw-shimmer`
 
-Tailwind CSS v4 plugin for shimmer effects.
+[![npm version](https://img.shields.io/npm/v/tw-shimmer)](https://www.npmjs.com/package/tw-shimmer)
+[![npm downloads](https://img.shields.io/npm/dm/tw-shimmer)](https://www.npmjs.com/package/tw-shimmer)
+[![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
 
-## Features
-
-- Zero-dependency, CSS-only shimmer effects
-- **Sine-eased gradients** for buttery-smooth highlights with no banding
-- OKLCH color space for perceptually uniform color mixing
-- Text shimmer and skeleton/background shimmer variants
-- Fully customizable speed, spread, angle, and colors
-
-## Why Sine-Eased Gradients?
-
-Most shimmer effects use simple linear gradients that create visible "banding" - harsh edges where the highlight meets the background. We use [eased gradients](https://www.joshwcomeau.com/css/make-beautiful-gradients/) with **13-17 carefully calculated stops** following a sine ease-in-out curve.
-
-This produces gradual transitions at both the center (peak brightness) and edges (fade to transparent), eliminating the banding that plagues typical shimmer implementations. The result is a shimmer that feels organic and polished.
-
-Any performance impact is negligible given the gradient is rendered and accelerated as a texture on the GPU.
+Tailwind CSS v4 plugin for shimmer effects. Zero-dependency, CSS-only, with sine-eased gradients for buttery-smooth highlights and OKLCH color space for perceptually uniform color mixing. Provides text-shimmer and skeleton/background-shimmer variants with customizable speed, spread, angle, and colors.
 
 ## Installation
 
@@ -32,305 +20,34 @@ npm install tw-shimmer
 
 ## Usage
 
-The shimmer effect uses `background-clip: text`, so you need to set a text color for the base text:
+The text shimmer uses `background-clip: text`, so set a text color (typically with low opacity) on the base element:
 
 ```html
 <span class="shimmer text-foreground/40">Loading...</span>
-```
 
-Use opacity (`/40`, `/50`, etc.) to make the shimmer effect visible.
-
-## API
-
-> [!NOTE]
-> All values are unitless numbers with units auto-appended. For example, `shimmer-speed-50` applies 50px/s.
-
-### `shimmer`
-
-Base utility. Apply to any element with a text color.
-
-```html
-<span class="shimmer text-foreground/40">Loading...</span>
-```
-
-### `shimmer-speed-{value}`
-
-Animation speed in pixels per second. Default: `150`px/s for text, `1000`px/s for background.
-
-`--shimmer-speed` is inheritable:
-
-- If you set `--shimmer-speed` (or use `shimmer-speed-{value}`) on a parent container, both `shimmer` and `shimmer-bg` children will use that value unless they override it.
-- If no value is set anywhere, text shimmer falls back to `150` and background shimmer falls back to `1000`.
-
-> **How speed is calculated:** For text shimmer, duration is `(2 × width) / speed`, where width is the shimmer track width in pixels (from `--shimmer-width`). For background shimmer we use the same idea but include an angle-aware overshoot so the stripe starts and ends fully off-screen at shallow angles. At 90deg this reduces to the same `(2 × width) / speed` formula; at more extreme angles the pass time is slightly longer to account for the extra travel. Spread does not affect timing; it only controls how thick the highlight appears.
-
-When `shimmer-bg` is used inside a `shimmer-container`, the plugin derives `--shimmer-speed` automatically from the container width so that each shimmer pass takes roughly 1.1–1.6 seconds, depending on container size. Smaller containers run slightly faster, larger containers slightly slower, which feels more consistent than a perfectly flat duration. Text shimmer in containers uses a slightly slower multiplier (~2.2–3.2 second passes) for a more subtle effect. You can still override this by setting `--shimmer-speed` (or using `shimmer-speed-{value}`) on any ancestor or the element itself.
-
-```html
-<span class="shimmer shimmer-speed-200 text-foreground/40">Fast (200px/s)</span>
-```
-
-### `shimmer-width-{value}`
-
-Container width in pixels for animation timing. Default: `200`px for text shimmer, `800`px for background shimmer.
-
-`--shimmer-width` is inheritable:
-
-- If you set `--shimmer-width` (or use `shimmer-width-{value}`) on a parent container, both `shimmer` and `shimmer-bg` children will use that value unless they override it.
-- If no value is set anywhere, text shimmer falls back to `200` and background shimmer falls back to `800`.
-
-Set this to match your container width for consistent animation speed across different element sizes.
-
-When used inside `shimmer-container`, the plugin sets an auto track width based on the container's width; this auto value is used only if you haven't explicitly set `--shimmer-width` yourself. Any explicit `--shimmer-width` (or `shimmer-width-{value}`) still wins and will be used to compute timing.
-
-```tsx
-<span class="shimmer shimmer-width-300 text-foreground/40">Wide container</span>
-```
-
-Or set via CSS variable at runtime:
-
-```tsx
-<span class="shimmer" style={{ ["--shimmer-width" as string]: "300" }}>
-  Wide container
-</span>
-```
-
-#### CSS-only Auto-Width with `shimmer-container`
-
-In modern browsers that support CSS container queries and container units (Chrome 111+, Safari 16.4+, Firefox 110+), you can use the `shimmer-container` helper class to automatically set `--shimmer-width` based on the container's width:
-
-```html
-<div class="shimmer-container flex gap-3">
-  <div class="shimmer-bg bg-muted size-10 rounded-full" />
-  <div class="flex-1 space-y-2">
-    <div class="shimmer-bg bg-muted h-4 w-24 rounded" />
-    <div class="shimmer-bg bg-muted h-4 w-full rounded" />
-  </div>
+<div class="shimmer-container space-y-2">
+  <div class="shimmer-bg h-4 w-full rounded"></div>
+  <div class="shimmer-bg h-4 w-3/4 rounded"></div>
 </div>
 ```
 
-Inside `shimmer-container`, tw-shimmer automatically:
+Inside a `shimmer-container`, the plugin derives speed and width from the container size automatically.
 
-- Sets the shimmer track width based on the container width (`--shimmer-width` auto).
-- Derives the animation speed from the container width so that one shimmer pass takes roughly 1.1–1.6 seconds, depending on container size. Small containers feel snappier, larger containers a bit slower, while keeping the motion perceptually consistent.
-- For `shimmer-bg`, adjusts the highlight spread based on the container width, clamping it between a sensible minimum (about 200px, or the track width if smaller) and maximum (about 300px) so it looks good at any size.
+## Utilities
 
-These container-based values act as smart defaults. Any explicit `--shimmer-width`, `--shimmer-speed`, or `--shimmer-bg-spread` that you set (for example via `shimmer-width-*`, `shimmer-speed-*`, or `shimmer-bg-spread-*`) will override them, even inside `shimmer-container`.
+| Utility                  | Effect                                                                        |
+| ------------------------ | ----------------------------------------------------------------------------- |
+| `shimmer`                | Base text shimmer. Pair with a low-opacity text color.                        |
+| `shimmer-bg`             | Background shimmer (skeleton placeholders).                                   |
+| `shimmer-container`      | Parent container that auto-derives speed and width for children.              |
+| `shimmer-speed-{value}`  | Animation speed in px per second (text: 150, background: 1000 by default).    |
+| `shimmer-width-{value}`  | Animation track width in px (text: 200, background: 800 by default).          |
+| `shimmer-spread-{value}` | Highlight thickness.                                                          |
+| `shimmer-angle-{value}`  | Highlight angle in degrees.                                                   |
+| `shimmer-color-{color}`  | Highlight color from your Tailwind palette.                                   |
 
-This is primarily useful for **skeleton/background shimmer layouts** where the container already has a stable width defined by its parent or layout context.
+Variables are inheritable; set them on any ancestor element and descendants pick them up unless they override.
 
-> **Note:** `shimmer-container` sets `container-type: inline-size`, which prevents the container from sizing based on its contents. This means it's **not recommended for text-only containers** that rely on shrink-to-fit behavior. For those cases, continue using JS or the `shimmer-width-*` utility.
+## Documentation
 
-In older browsers, `shimmer-container` has no effect and shimmers fall back to their default widths or manually configured values.
-
-### `shimmer-color-{color}`
-
-Shimmer highlight color. Default: `black` for text (white in dark mode), `white` for bg.
-
-`--shimmer-color` is shared and inheritable:
-
-- If you set `--shimmer-color` (or use `shimmer-color-{color}`) on a parent container, any `shimmer` or `shimmer-bg` elements inside will use that color unless they define their own.
-- If no value is set anywhere, text shimmer falls back to black in light mode (and white in dark mode), and background shimmer falls back to white (with a subtler default in dark mode).
-
-Uses the Tailwind color palette.
-
-```html
-<span class="shimmer shimmer-color-blue-500 text-blue-500/40"
-  >Blue highlight</span
->
-```
-
-### `shimmer-spread-{spacing}`
-
-Width of the shimmer highlight for text shimmer. Default: `6`ch.
-
-`--shimmer-spread` is inheritable:
-
-- If you set `--shimmer-spread` (or use `shimmer-spread-{spacing}`) on a parent container, any `shimmer` elements inside will use that value unless they override it.
-- If no value is set anywhere, text shimmer falls back to `6ch`.
-
-Uses the Tailwind spacing scale.
-
-```html
-<span class="shimmer shimmer-spread-24 text-foreground/40">Wide highlight</span>
-```
-
-### `shimmer-angle-{degrees}`
-
-Shimmer direction. Default: `90`deg. Shared with `shimmer-bg`.
-
-`--shimmer-angle` is inheritable:
-
-- If you set `--shimmer-angle` (or use `shimmer-angle-{degrees}`) on a parent container, any `shimmer` or `shimmer-bg` elements inside will use that angle unless they define their own.
-- If no value is set anywhere, both text and background shimmer fall back to `90deg`.
-
-> **Note on angle values:** Avoid exactly `0deg` and `180deg`, as these create extreme values in the animation delay formula (which uses tangent). For diagonal sweeps, use angles in a "safe" range such as 15–75° or 105–165°. Extreme angles can cause very large delays and may visually desync the animation.
-
-```html
-<span class="shimmer shimmer-angle-45 text-foreground/40"
-  >Diagonal (45deg)</span
->
-```
-
-## Background Shimmer (Skeletons)
-
-For skeleton loaders and non-text elements, use `shimmer-bg` instead:
-
-### `shimmer-bg`
-
-Background shimmer for skeleton loaders and non-text elements. Use standard Tailwind `bg-*` for base color. Standalone default: 800px width, 1000px/s speed.
-
-```html
-<div class="shimmer-bg bg-muted h-4 w-48 rounded" />
-```
-
-### Skeleton Example
-
-To sync shimmer timing across all skeleton children, you have two options:
-
-**Option 1: CSS-only with `shimmer-container` (recommended for modern browsers)**
-
-Wrap skeleton elements in `shimmer-container` for consistent timing. The container auto-derives speed so each pass takes roughly 1.1–1.6 seconds depending on width, and clamps the highlight spread to a width-aware band (roughly 200–300px, or the track width if smaller). All `shimmer-bg` children sync to the same animation. Older browsers fall back to standalone defaults.
-
-```html
-<div class="shimmer-container flex gap-3">
-  <div class="shimmer-bg bg-muted size-10 rounded-full" />
-  <div class="flex-1 space-y-2">
-    <div class="shimmer-bg bg-muted h-4 w-24 rounded" />
-    <div class="shimmer-bg bg-muted h-4 w-full rounded" />
-    <div class="shimmer-bg bg-muted h-4 w-4/5 rounded" />
-  </div>
-</div>
-```
-
-**Option 2: Manual width with CSS variable or JS**
-
-Set `--shimmer-width` on the container manually. Any `shimmer-bg` or `shimmer` elements inside will inherit this width unless they define their own `shimmer-width-{value}`:
-
-```tsx
-<div class="flex gap-3" style={{ ["--shimmer-width" as string]: "600" }}>
-  <div class="shimmer-bg bg-muted size-10 rounded-full" />
-  <div class="flex-1 space-y-2">
-    <div class="shimmer-bg bg-muted h-4 w-24 rounded" />
-    <div class="shimmer-bg bg-muted h-4 w-full rounded" />
-    <div class="shimmer-bg bg-muted h-4 w-4/5 rounded" />
-  </div>
-</div>
-```
-
-You can also set `--shimmer-speed`, `--shimmer-angle`, and `--shimmer-color` on the same container to keep both text shimmer and background shimmer moving in the same direction, at the same speed, and with the same highlight color. You can also use `shimmer-bg-spread-*` or set `--shimmer-bg-spread` on the container (or individual skeleton elements) to override the container's auto spread and manually control the background highlight band width.
-
-### `shimmer-color-{color}` (with shimmer-bg)
-
-The same `shimmer-color-*` utility works for both text and bg shimmer:
-
-```html
-<div class="shimmer-bg shimmer-color-blue-100 h-4 w-48 rounded bg-blue-300" />
-```
-
-### Angled Skeleton Shimmer
-
-Use `shimmer-angle-{degrees}` (shared with text shimmer) for diagonal sweeps. This works with both `shimmer-container` and manual width configuration:
-
-```html
-<div class="shimmer-container shimmer-angle-15 flex gap-3">
-  <div class="shimmer-bg bg-muted size-10 rounded-full" />
-  <div class="shimmer-bg bg-muted h-4 w-full rounded" />
-</div>
-```
-
-## Advanced: Position-Based Sync
-
-> **Note:** These utilities are **optional** and only relevant for angled shimmers (`shimmer-angle-*` ≠ 90°). Most users can skip this section.
-
-### `shimmer-x-{value}` / `shimmer-y-{value}`
-
-Manual position hints for syncing angled shimmer animations across multiple elements. When using diagonal shimmers on layouts with multiple skeleton elements (e.g., avatar + text lines), the highlights may appear slightly out of sync because each element animates independently.
-
-These utilities let you specify each element's approximate position (in pixels) relative to a shared container. The plugin uses these values to calculate animation delays, aligning the diagonal sweep across elements.
-
-- `shimmer-x-*`: Horizontal offset from container left (unitless, interpreted as pixels)
-- `shimmer-y-*`: Vertical offset from container top (unitless, interpreted as pixels)
-
-**How it works:** The x/y values feed into an animation-delay formula that accounts for the shimmer angle. This creates the illusion of a single diagonal highlight passing through all elements.
-
-> **Tip:** For larger or rounded elements (like avatars), use the element's approximate center rather than its top-left corner. The sync math treats each element as a single reference point, so using the center better matches where the shimmer visually "passes through" the element. Finding good offsets may still require some trial and error.
->
-> For example, a 40×40 avatar at the left edge of the container would often look better with `shimmer-x-20 shimmer-y-20` than `shimmer-x-0 shimmer-y-0`.
-
-> **Angle caveat:** Position sync works best with moderate angles (15–75° or 105–165°). Avoid exactly 0° and 180° as these cause extreme delay values. See the `shimmer-angle-*` section for details.
-
-```html
-<div class="shimmer-container shimmer-angle-15">
-  <div
-    class="shimmer-bg shimmer-x-20 shimmer-y-20 bg-muted size-10 rounded-full"
-  />
-  <div class="shimmer-bg shimmer-x-52 shimmer-y-0 bg-muted h-4 w-24 rounded" />
-  <div
-    class="shimmer-bg shimmer-x-52 shimmer-y-24 bg-muted h-4 w-full rounded"
-  />
-</div>
-```
-
-### Advanced: Offscreen Overshoot (background shimmer)
-
-For angled background shimmers (`shimmer-bg` with `shimmer-angle-*`), the plugin automatically adjusts how far the shimmer stripe starts and ends off-screen based on the angle. This helps avoid the highlight being visible at the left edge at the very start of the animation, especially at shallow angles (e.g. 15–30°).
-
-Internally, this uses an angle-aware overshoot multiplier:
-
-- Steep angles (~90°) → multiplier ≈ 1 (no extra overshoot)
-- Moderate angles (e.g. 45°) → multiplier ≈ 1.3
-- Shallow angles (e.g. 15° or 165°) → multiplier up to ≈ 3 (clamped)
-
-You can override this behavior per element or per container using the CSS variable:
-
-```css
---shimmer-offscreen-multiplier: 1.5; /* or any positive value */
-```
-
-For example:
-
-```html
-<div
-  class="shimmer-container"
-  style="--shimmer-angle: 20deg; --shimmer-offscreen-multiplier: 2;"
->
-  <div class="shimmer-bg bg-muted h-4 w-full rounded"></div>
-</div>
-```
-
-Most users never need to set this manually; it exists for power users who are tuning very shallow angles or unusual aspect ratios.
-
-## Browser Support & Accessibility
-
-### Modern CSS Requirements
-
-`tw-shimmer` uses modern CSS features for the best visual quality:
-
-- `oklch` and `color-mix` for perceptually uniform color mixing
-- `translate` as an independent transform property
-- `overflow: clip` for precise clipping (with `overflow: hidden` fallback)
-
-These features are supported in all modern browsers (Chrome 111+, Firefox 113+, Safari 16.4+). Older browsers will degrade gracefully but may not render the full effect.
-
-## Limitations
-
-`tw-shimmer` is intentionally **zero-dependency and CSS-only**. This keeps it lightweight and framework-agnostic, but it comes with trade-offs:
-
-- **`shimmer-container` auto-width/auto-speed/auto-spread are progressive enhancements:** The `shimmer-container` helper uses modern CSS container units (`cqw`) and is gated by `@supports (width: 1cqw)`. In unsupported browsers, `shimmer-container` has no effect and shimmer elements fall back to their default widths or manually configured values.
-
-- **`shimmer-container` prevents shrink-to-fit sizing:** Because it sets `container-type: inline-size`, the container cannot size itself based on its contents. This makes it unsuitable for text-only containers that rely on intrinsic sizing.
-
-- **No automatic layout detection:** CSS cannot access runtime element positions, so perfectly unified diagonal shimmer across arbitrarily positioned elements cannot be fully automated.
-
-- **Vertical shimmers just work:** For `shimmer-angle-90` (the default), all elements naturally sync without any extra configuration.
-
-- **Angled shimmers are best-effort:** The `shimmer-x-*` / `shimmer-y-*` utilities enable manual sync tuning, but some minor desync or visual artifacts may still occur—especially at shallow angles or with large rounded shapes.
-
-- **Complex layouts may need JavaScript:** If your application requires truly "physically correct" shimmer alignment across a complex layout, that would require measuring element positions at runtime and setting CSS variables via JavaScript. `tw-shimmer` intentionally does not do this.
-
-For most skeleton loaders and text shimmer use cases, the defaults work well. The advanced position utilities are there for power users who want fine-grained control over angled animations.
-
-## License
-
-MIT
+Full utility reference, accessibility notes, and the technical details of the sine-eased gradient pipeline at [assistant-ui.com/tw-shimmer](https://www.assistant-ui.com/tw-shimmer).

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,27 @@
+# `@assistant-ui/ui`
+
+Internal monorepo-only package. **Not published to npm.**
+
+This is the source of truth for the styled, shadcn-style components that ship to user projects via the `assistant-ui` CLI:
+
+```bash
+npx assistant-ui@latest add thread
+npx assistant-ui@latest add thread-list assistant-modal
+```
+
+The CLI fetches each component from the shadcn registry served at [`r.assistant-ui.com`](https://r.assistant-ui.com) (built from `apps/registry`), which in turn reads its inputs from this package's `src/components/`. Inside the monorepo, the docs site and registry build also depend on this package directly so we avoid maintaining two copies.
+
+## Layout
+
+| Path                              | Contents                                                                 |
+| --------------------------------- | ------------------------------------------------------------------------ |
+| `src/components/assistant-ui/*`   | Assistant-specific components (thread, message, composer, attachment, etc.). |
+| `src/components/ui/*`             | shadcn-style base components (button, dialog, sheet, etc.).              |
+| `src/hooks/*`                     | Shared hooks consumed by the components above.                           |
+| `src/lib/*`                       | Utility helpers (`cn`, formatters, etc.).                                |
+
+Exports use direct file paths (no barrel) so the CLI can copy individual files cleanly.
+
+## Editing
+
+When you change a component here, the change reaches end users only after the registry rebuilds and a new version of the `assistant-ui` CLI is published. See `apps/registry` for the build pipeline.

--- a/packages/x-buildutils/README.md
+++ b/packages/x-buildutils/README.md
@@ -1,0 +1,35 @@
+# `@assistant-ui/x-buildutils`
+
+This package is an internal dependency of assistant-ui and does not follow semantic versioning. If you are not working inside this monorepo, you should use your own build pipeline instead.
+
+## What it provides
+
+- **`aui-build` CLI**: invoked as `"build": "aui-build"` from every package's `package.json`. Compiles TypeScript with our shared strict config, validates that imports resolve to declared `exports` sub-paths, and rewrites `.ts` import specifiers to `.js` so the emitted ESM works at runtime.
+- **`ts/`**: shared `tsconfig` fragments (`base.json`, `base-node.json`, `next.json`).
+- **`types/`**: shared ambient types (e.g. `browser-process`).
+
+## Usage inside the monorepo
+
+```jsonc
+// packages/example/package.json
+{
+  "scripts": {
+    "build": "aui-build"
+  },
+  "devDependencies": {
+    "@assistant-ui/x-buildutils": "workspace:*"
+  }
+}
+```
+
+```jsonc
+// packages/example/tsconfig.json
+{
+  "extends": "@assistant-ui/x-buildutils/ts/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}
+```

--- a/packages/x-buildutils/package.json
+++ b/packages/x-buildutils/package.json
@@ -16,7 +16,8 @@
     "bin",
     "src",
     "ts",
-    "types"
+    "types",
+    "README.md"
   ],
   "bin": {
     "aui-build": "./bin/aui-build.js"

--- a/packages/x-changelog/README.md
+++ b/packages/x-changelog/README.md
@@ -1,0 +1,23 @@
+# `@assistant-ui/x-changelog`
+
+Internal monorepo-only changesets changelog generator. **Not published to npm.**
+
+A small fork of [`@changesets/changelog-github`](https://github.com/changesets/changesets/tree/main/packages/changelog-github) with two tweaks:
+
+- Author credit moves from `" Thanks @user!"` before the summary to `" (@user)"` at the end of the first line, so changelog entries read more like commit messages.
+- Inline `#123` issue references in changeset summaries are linkified to their GitHub issue URLs.
+
+## How it is used
+
+Wired into the root `.changeset/config.json`:
+
+```jsonc
+{
+  "changelog": [
+    "@assistant-ui/x-changelog",
+    { "repo": "assistant-ui/assistant-ui" }
+  ]
+}
+```
+
+When `changeset version` runs, this package's `getReleaseLine` and `getDependencyReleaseLine` produce the per-package `CHANGELOG.md` entries.


### PR DESCRIPTION
## Summary

- adds READMEs to 12 packages that had none (`agent-launcher`, `assistant-stream`, `cloud`, `core`, `heat-graph`, `react-ag-ui`, `react-lexical`, `react-o11y`, `safe-content-frame`, `ui`, `x-buildutils`, `x-changelog`).
- rewrites 25 existing READMEs to match a single tiered template (flagship / foundational / integration shim / standalone / CLI / tooling / internal); over-documented files like `tap` (408 → 65 lines), `tw-shimmer` (336 → 53), `mcp-app-studio` (200 → 63), `react-streamdown` (163 → 42), and `react-google-adk` (156 → 43) get trimmed back to install + usage + docs link.
- fixes the bugs surfaced by pre-publish audits: wrong `Thread` import in 6 READMEs, broken `react-ink` primitive names, missing `DevToolsModal`/`DevToolsFrame`, missing peer-dep packages in install commands (`@google/adk`, `@langchain/langgraph-sdk`, `ink`/`shiki`, etc.), mismatched link text vs href, and stale provider claims (Hugging Face/Cohere/Replicate were never first-party AI SDK).
- adds badges (npm version, downloads, optional bundle size, GitHub stars) to flagship, foundational, and standalone packages; integration shims and internal tooling stay terse.
- aligns `package.json`: tighter descriptions on `@assistant-ui/react`, `@assistant-ui/cloud-ai-sdk`, `@assistant-ui/agent-launcher`; adds `README.md` to `@assistant-ui/x-buildutils`'s `files` array so the README actually ships.

## Test plan

- [ ] `gh pr view --web` and skim every changed README on GitHub to check rendering.
- [ ] for each user-facing package, check the npm preview (`https://www.npmjs.com/package/<name>`) when CI publishes or via `npm pack` locally; the README should be present in the tarball for every public package.
- [ ] verify the `packages/react/README.md` symlink still resolves to the root README.
- [ ] spot-check 3 to 5 docs links (`assistant-ui.com/docs/*`) actually resolve.
- [ ] confirm `cloud.assistant-ui.com` and `r.assistant-ui.com` are the right product/registry subdomains.
- [ ] run `npm install` for one of the integration packages (e.g. `react-google-adk`) following the README; no missing-peer warnings.