### PR TITLE
fix(react-ag-ui): adopt server messageId as assistant message id

### DIFF
--- a/.changeset/feat-react-ag-ui-propagate-server-message-id.md
+++ b/.changeset/feat-react-ag-ui-propagate-server-message-id.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix(react-ag-ui): adopt `TEXT_MESSAGE_START.messageId` as the assistant `ThreadMessage.id`
+
+`AgUiThreadRuntimeCore` now inserts the assistant placeholder under an optimistic id (`generateOptimisticId`), then atomically reassigns the message id to the server-supplied `messageId` the first time `RunAggregator` observes one (on `TEXT_MESSAGE_START`, `TEXT_MESSAGE_CONTENT`, `TEXT_MESSAGE_END`, or `TOOL_CALL_START.parentMessageId`). `assistantHistoryParents` and `recordedHistoryIds` migrate with the id, so `persistAssistantHistory`, `addToolResult`, and downstream lookups keep working and resolve to the canonical AG-UI id. This brings the streaming path in line with `MESSAGES_SNAPSHOT` imports, which were already keyed on the server id.
+
+`TOOL_CALL_RESULT.messageId` is now surfaced as `unstable_toolMessageId` on the tool-call part, so tool messages round-trip back to AG-UI with their original id instead of a synthetic `${toolCallId}:tool` value.

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -1,6 +1,11 @@
 "use client";
 
-import { generateId, fromThreadMessageLike } from "@assistant-ui/core/internal";
+import {
+  generateId,
+  generateOptimisticId,
+  isOptimisticId,
+  fromThreadMessageLike,
+} from "@assistant-ui/core/internal";
 import type {
   AddToolResultOptions,
   AppendMessage,
@@ -464,7 +469,18 @@ export class AgUiThreadRuntimeCore {
     const aggregator = new RunAggregator({
       showThinking: this.showThinking,
       logger: this.logger,
-      emit: (update) => this.updateAssistantMessage(ensureAssistant(), update),
+      emit: (update) => {
+        const resolved = this.updateAssistantMessage(ensureAssistant(), update);
+        if (resolved !== assistantMessageId) {
+          assistantMessageId = resolved;
+        }
+      },
+      onServerMessageId: (serverId) => {
+        const placeholder = ensureAssistant();
+        if (placeholder === serverId) return;
+        this.reassignAssistantId(placeholder, serverId);
+        assistantMessageId = serverId;
+      },
     });
     const dispatch = (event: AgUiEvent) => this.handleEvent(aggregator, event);
 
@@ -585,7 +601,7 @@ export class AgUiThreadRuntimeCore {
   }
 
   private insertAssistantPlaceholder(): string {
-    const id = generateId();
+    const id = generateOptimisticId();
     const assistant: ThreadAssistantMessage = {
       id,
       role: "assistant",
@@ -605,10 +621,41 @@ export class AgUiThreadRuntimeCore {
     return id;
   }
 
+  private reassignAssistantId(oldId: string, newId: string): void {
+    if (oldId === newId) return;
+
+    const collidesWithExisting = this.messages.some(
+      (m) => m.id === newId && m.id !== oldId,
+    );
+
+    if (collidesWithExisting) {
+      this.messages = this.messages.filter((m) => m.id !== oldId);
+    } else {
+      this.messages = this.messages.map((m) =>
+        m.id === oldId ? { ...m, id: newId } : m,
+      );
+    }
+
+    const pendingParent = this.assistantHistoryParents.get(oldId);
+    if (pendingParent !== undefined) {
+      this.assistantHistoryParents.delete(oldId);
+      if (!this.assistantHistoryParents.has(newId)) {
+        this.assistantHistoryParents.set(newId, pendingParent);
+      }
+    }
+
+    if (this.recordedHistoryIds.has(oldId)) {
+      this.recordedHistoryIds.delete(oldId);
+      this.recordedHistoryIds.add(newId);
+    }
+
+    this.notifyUpdate();
+  }
+
   private updateAssistantMessage(
     messageId: string,
     update: ChatModelRunResult,
-  ) {
+  ): string {
     let touched = false;
     let latestStatus: MessageStatus | undefined;
     this.messages = this.messages.map((message) => {
@@ -628,12 +675,20 @@ export class AgUiThreadRuntimeCore {
         metadata,
       };
     });
-    if (touched) {
+    if (!touched) return messageId;
+
+    let resolvedMessageId = messageId;
+    if (this.isPersistableStatus(latestStatus) && isOptimisticId(messageId)) {
+      const stableId = generateId();
+      this.reassignAssistantId(messageId, stableId);
+      resolvedMessageId = stableId;
+    } else {
       this.notifyUpdate();
-      if (this.isPersistableStatus(latestStatus)) {
-        this.persistAssistantHistory(messageId);
-      }
     }
+    if (this.isPersistableStatus(latestStatus)) {
+      this.persistAssistantHistory(resolvedMessageId);
+    }
+    return resolvedMessageId;
   }
 
   private mergeAssistantMetadata(

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -624,11 +624,13 @@ export class AgUiThreadRuntimeCore {
   private reassignAssistantId(oldId: string, newId: string): void {
     if (oldId === newId) return;
 
-    const collidesWithExisting = this.messages.some(
-      (m) => m.id === newId && m.id !== oldId,
-    );
+    const collidesWithExisting = this.messages.some((m) => m.id === newId);
 
     if (collidesWithExisting) {
+      this.logger.debug?.(
+        "[agui] reassignAssistantId: server id already present in messages, dropping placeholder",
+        { oldId, newId },
+      );
       this.messages = this.messages.filter((m) => m.id !== oldId);
     } else {
       this.messages = this.messages.map((m) =>
@@ -678,7 +680,9 @@ export class AgUiThreadRuntimeCore {
     if (!touched) return messageId;
 
     let resolvedMessageId = messageId;
-    if (this.isPersistableStatus(latestStatus) && isOptimisticId(messageId)) {
+    const isSettled =
+      latestStatus !== undefined && latestStatus.type !== "running";
+    if (isSettled && isOptimisticId(messageId)) {
       const stableId = generateId();
       this.reassignAssistantId(messageId, stableId);
       resolvedMessageId = stableId;

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -24,12 +24,14 @@ type ToolCallState = {
   result: unknown;
   isError: boolean | undefined;
   parentMessageId?: string;
+  toolMessageId?: string;
 };
 
 export type RunAggregatorOptions = {
   showThinking: boolean;
   logger: Logger;
   emit: Emit;
+  onServerMessageId?: (messageId: string) => void;
 };
 
 /**
@@ -42,6 +44,7 @@ export class RunAggregator {
   private readonly emitUpdate: Emit;
   private readonly showThinking: boolean;
   private readonly logger: Logger;
+  private readonly onServerMessageId: ((messageId: string) => void) | undefined;
 
   private status: ChatModelRunResult["status"] | undefined;
   private interrupts: AgUiInterrupt[] | undefined;
@@ -60,11 +63,13 @@ export class RunAggregator {
   )[] = [];
   private hasReasoningPart = false;
   private textPartCounter = 0;
+  private serverMessageIdReported = false;
 
   constructor(options: RunAggregatorOptions) {
     this.emitUpdate = options.emit;
     this.showThinking = options.showThinking;
     this.logger = options.logger;
+    this.onServerMessageId = options.onServerMessageId;
   }
 
   handle(event: AgUiEvent): void {
@@ -79,6 +84,7 @@ export class RunAggregator {
         this.textPartCounter = 0;
         this.activeTextMessageId = undefined;
         this.interrupts = undefined;
+        this.serverMessageIdReported = false;
         this.status = { type: "running" };
         this.emit();
         break;
@@ -119,6 +125,7 @@ export class RunAggregator {
       }
 
       case "TEXT_MESSAGE_START": {
+        this.reportServerMessageId(event.messageId);
         const id = this.startTextMessage(event.messageId);
         if (id) {
           this.markTextPartTouched(id);
@@ -128,15 +135,16 @@ export class RunAggregator {
       }
       case "TEXT_MESSAGE_CONTENT":
       case "TEXT_MESSAGE_CHUNK": {
+        const incomingId = "messageId" in event ? event.messageId : undefined;
+        this.reportServerMessageId(incomingId);
         if (!event.delta) break;
-        const id = this.resolveTextMessageId(
-          "messageId" in event ? event.messageId : undefined,
-        );
+        const id = this.resolveTextMessageId(incomingId);
         this.appendText(id, event.delta);
         this.emit();
         break;
       }
       case "TEXT_MESSAGE_END": {
+        this.reportServerMessageId(event.messageId);
         if (event.messageId && this.activeTextMessageId === event.messageId) {
           this.activeTextMessageId = undefined;
         }
@@ -162,6 +170,7 @@ export class RunAggregator {
         break;
 
       case "TOOL_CALL_START": {
+        this.reportServerMessageId(event.parentMessageId);
         this.startToolCall(
           event.toolCallId,
           event.toolCallName,
@@ -172,6 +181,9 @@ export class RunAggregator {
       }
       case "TOOL_CALL_ARGS":
       case "TOOL_CALL_CHUNK": {
+        if (event.type === "TOOL_CALL_CHUNK") {
+          this.reportServerMessageId(event.parentMessageId);
+        }
         if (!event.delta) break;
         this.appendToolArgs(event.toolCallId, event.delta);
         this.emit();
@@ -186,6 +198,7 @@ export class RunAggregator {
           event.toolCallId,
           event.content ?? "",
           event.role === "tool" ? false : undefined,
+          event.messageId,
         );
         this.emit();
         break;
@@ -195,6 +208,12 @@ export class RunAggregator {
         this.logger.debug?.("[agui] aggregator ignored event", event);
       }
     }
+  }
+
+  private reportServerMessageId(messageId: string | undefined): void {
+    if (this.serverMessageIdReported || !messageId) return;
+    this.serverMessageIdReported = true;
+    this.onServerMessageId?.(messageId);
   }
 
   private clearTextParts(): void {
@@ -298,7 +317,12 @@ export class RunAggregator {
     }
   }
 
-  private finishToolCall(id: string, content: string, isError?: boolean) {
+  private finishToolCall(
+    id: string,
+    content: string,
+    isError?: boolean,
+    toolMessageId?: string,
+  ) {
     if (!id) return;
     let entry = this.toolCalls.get(id);
     if (!entry) {
@@ -321,6 +345,9 @@ export class RunAggregator {
     }
     entry.result = this.tryParseJSON(content);
     entry.isError = isError;
+    if (toolMessageId) {
+      entry.toolMessageId = toolMessageId;
+    }
   }
 
   private tryParseJSON(value: string): unknown {
@@ -368,6 +395,9 @@ export class RunAggregator {
         ...(entry.result !== undefined ? { result: entry.result } : {}),
         ...(entry.isError !== undefined ? { isError: entry.isError } : {}),
         ...(entry.parentMessageId ? { parentId: entry.parentMessageId } : {}),
+        ...(entry.toolMessageId
+          ? { unstable_toolMessageId: entry.toolMessageId }
+          : {}),
       } as ToolCallMessagePart;
       snapshot.push(toolPart);
     }

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -398,7 +398,7 @@ export class RunAggregator {
         ...(entry.toolMessageId
           ? { unstable_toolMessageId: entry.toolMessageId }
           : {}),
-      } as ToolCallMessagePart;
+      } as ToolCallMessagePart & { unstable_toolMessageId?: string };
       snapshot.push(toolPart);
     }
 

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1080,4 +1080,172 @@ describe("AGUIThreadRuntimeCore", () => {
 
     expect(stateAtRun).toEqual({ initial: false, snapshot: 42 });
   });
+
+  it("adopts TEXT_MESSAGE_START.messageId as the ThreadAssistantMessage.id", async () => {
+    const serverId = "11111111-1111-1111-1111-111111111111";
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onTextMessageStartEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_START",
+            messageId: serverId,
+            role: "assistant",
+          },
+        });
+        subscriber.onTextMessageContentEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_CONTENT",
+            messageId: serverId,
+            delta: "Hello",
+          },
+        });
+        subscriber.onTextMessageEndEvent?.({
+          event: { type: "TEXT_MESSAGE_END", messageId: serverId },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.role).toBe("assistant");
+    expect(assistant.id).toBe(serverId);
+    expect(assistant.content[0]).toMatchObject({ type: "text", text: "Hello" });
+  });
+
+  it("persists assistant history under the server id, not the placeholder", async () => {
+    const serverId = "srv-msg-42";
+    const append = vi.fn(async () => {});
+    const history: ThreadHistoryAdapter = {
+      load: async () => null,
+      append,
+    } as unknown as ThreadHistoryAdapter;
+
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onTextMessageStartEvent?.({
+          event: { type: "TEXT_MESSAGE_START", messageId: serverId },
+        });
+        subscriber.onTextMessageContentEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_CONTENT",
+            messageId: serverId,
+            delta: "hi",
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent, { history });
+    await core.append(createAppendMessage());
+
+    const assistantAppendCall = append.mock.calls.find(
+      ([entry]: [{ message: ThreadMessage }]) =>
+        entry.message.role === "assistant",
+    );
+    expect(assistantAppendCall).toBeDefined();
+    expect(assistantAppendCall![0].message.id).toBe(serverId);
+  });
+
+  it("stabilizes the assistant id before history.append fires", async () => {
+    const append = vi.fn(async () => {});
+    const history: ThreadHistoryAdapter = {
+      load: async () => null,
+      append,
+    } as unknown as ThreadHistoryAdapter;
+
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onTextMessageContentEvent?.({
+          event: { type: "TEXT_MESSAGE_CONTENT", delta: "ok" },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent, { history });
+    await core.append(createAppendMessage());
+
+    const assistantAppendCall = append.mock.calls.find(
+      ([entry]: [{ message: ThreadMessage }]) =>
+        entry.message.role === "assistant",
+    );
+    expect(assistantAppendCall).toBeDefined();
+    expect(
+      assistantAppendCall![0].message.id.startsWith("__optimistic__"),
+    ).toBe(false);
+  });
+
+  it("stabilizes the assistant id at terminal state when no server messageId is provided", async () => {
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onTextMessageContentEvent?.({
+          event: { type: "TEXT_MESSAGE_CONTENT", delta: "ok" },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.id.startsWith("__optimistic__")).toBe(false);
+    expect(assistant.id.length).toBeGreaterThan(0);
+    expect(assistant.status).toMatchObject({ type: "complete" });
+  });
+
+  it("routes addToolResult through the server id after id reassignment", async () => {
+    const serverId = "srv-with-tools";
+    let resumeCalls = 0;
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        resumeCalls += 1;
+        if (resumeCalls === 1) {
+          subscriber.onTextMessageStartEvent?.({
+            event: { type: "TEXT_MESSAGE_START", messageId: serverId },
+          });
+          subscriber.onToolCallStartEvent?.({
+            event: {
+              type: "TOOL_CALL_START",
+              toolCallId: "tc-9",
+              toolCallName: "lookup",
+              parentMessageId: serverId,
+            },
+          });
+          subscriber.onToolCallEndEvent?.({
+            event: { type: "TOOL_CALL_END", toolCallId: "tc-9" },
+          });
+        }
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const assistantBeforeResult = core
+      .getMessages()
+      .find((m) => m.id === serverId) as ThreadAssistantMessage | undefined;
+    expect(assistantBeforeResult?.id).toBe(serverId);
+
+    core.addToolResult({
+      messageId: serverId,
+      toolCallId: "tc-9",
+      toolName: "lookup",
+      result: { ok: true },
+      isError: false,
+    });
+
+    const updatedAssistant = core
+      .getMessages()
+      .find((m) => m.id === serverId) as ThreadAssistantMessage;
+    const toolPart = updatedAssistant.content.find(
+      (part) => part.type === "tool-call",
+    ) as any;
+    expect(toolPart.result).toEqual({ ok: true });
+  });
 });

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1248,4 +1248,100 @@ describe("AGUIThreadRuntimeCore", () => {
     ) as any;
     expect(toolPart.result).toEqual({ ok: true });
   });
+
+  it("stabilizes the assistant id before addToolResult forwards to history", async () => {
+    const append = vi.fn(async () => {});
+    const history: ThreadHistoryAdapter = {
+      load: async () => null,
+      append,
+    } as unknown as ThreadHistoryAdapter;
+
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "tc-leaky",
+            toolCallName: "lookup",
+          },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: { type: "TOOL_CALL_END", toolCallId: "tc-leaky" },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent, { history });
+    await core.append(createAppendMessage());
+
+    const assistant = core
+      .getMessages()
+      .findLast((m) => m.role === "assistant") as ThreadAssistantMessage;
+    expect(assistant.id.startsWith("__optimistic__")).toBe(false);
+
+    core.addToolResult({
+      messageId: assistant.id,
+      toolCallId: "tc-leaky",
+      toolName: "lookup",
+      result: { ok: true },
+      isError: false,
+    });
+
+    const assistantAppendCall = append.mock.calls.find(
+      ([entry]: [{ message: ThreadMessage }]) =>
+        entry.message.role === "assistant",
+    );
+    expect(assistantAppendCall).toBeDefined();
+    expect(
+      assistantAppendCall![0].message.id.startsWith("__optimistic__"),
+    ).toBe(false);
+  });
+
+  it("drops the optimistic placeholder when the server id collides with an existing message", async () => {
+    const serverId = "srv-collision";
+    const existingMessage: ThreadAssistantMessage = {
+      id: serverId,
+      role: "assistant",
+      createdAt: new Date(),
+      status: { type: "complete", reason: "unknown" },
+      content: [{ type: "text", text: "from history" }],
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+    };
+
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onTextMessageStartEvent?.({
+          event: { type: "TEXT_MESSAGE_START", messageId: serverId },
+        });
+        subscriber.onTextMessageContentEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_CONTENT",
+            messageId: serverId,
+            delta: "streaming",
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    core.applyExternalMessages([existingMessage as ThreadMessage]);
+    await core.append(createAppendMessage());
+
+    const collidedMessages = core
+      .getMessages()
+      .filter((m) => m.id === serverId);
+    expect(collidedMessages).toHaveLength(1);
+    const optimisticLingerers = core
+      .getMessages()
+      .filter((m) => m.id.startsWith("__optimistic__"));
+    expect(optimisticLingerers).toHaveLength(0);
+  });
 });

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { ChatModelRunResult } from "@assistant-ui/core";
 import { RunAggregator } from "../src/runtime/adapter/run-aggregator";
 import type { AgUiEvent } from "../src/runtime/types";
@@ -17,11 +17,15 @@ describe("RunAggregator", () => {
     results = [];
   });
 
-  const createAggregator = (showThinking: boolean) =>
+  const createAggregator = (
+    showThinking: boolean,
+    onServerMessageId?: (id: string) => void,
+  ) =>
     new RunAggregator({
       showThinking,
       logger: makeLogger(),
       emit: (update) => results.push(update),
+      ...(onServerMessageId ? { onServerMessageId } : {}),
     });
 
   it("streams text content", () => {
@@ -418,5 +422,142 @@ describe("RunAggregator", () => {
     expect(toolPart.toolName).toBe("tool");
     expect(toolPart.result).toEqual({ ok: true });
     expect(toolPart.isError).toBe(false);
+  });
+
+  it("reports the first TEXT_MESSAGE_START.messageId exactly once per run", () => {
+    const onServerMessageId = vi.fn();
+    const aggregator = createAggregator(false, onServerMessageId);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      messageId: "srv-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "srv-1",
+      delta: "hi",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_END",
+      messageId: "srv-1",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    expect(onServerMessageId).toHaveBeenCalledTimes(1);
+    expect(onServerMessageId).toHaveBeenCalledWith("srv-1");
+  });
+
+  it("ignores subsequent server messageIds within the same run", () => {
+    const onServerMessageId = vi.fn();
+    const aggregator = createAggregator(false, onServerMessageId);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      messageId: "srv-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_END",
+      messageId: "srv-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      messageId: "srv-2",
+    } as AgUiEvent);
+
+    expect(onServerMessageId).toHaveBeenCalledTimes(1);
+    expect(onServerMessageId).toHaveBeenCalledWith("srv-1");
+  });
+
+  it("re-arms server messageId reporting across runs", () => {
+    const onServerMessageId = vi.fn();
+    const aggregator = createAggregator(false, onServerMessageId);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      messageId: "srv-1",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({ type: "RUN_STARTED", runId: "r2" } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      messageId: "srv-2",
+    } as AgUiEvent);
+
+    expect(onServerMessageId).toHaveBeenCalledTimes(2);
+    expect(onServerMessageId.mock.calls[0]?.[0]).toBe("srv-1");
+    expect(onServerMessageId.mock.calls[1]?.[0]).toBe("srv-2");
+  });
+
+  it("falls back to TEXT_MESSAGE_CONTENT.messageId when START omits it", () => {
+    const onServerMessageId = vi.fn();
+    const aggregator = createAggregator(false, onServerMessageId);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "srv-3",
+      delta: "hi",
+    } as AgUiEvent);
+
+    expect(onServerMessageId).toHaveBeenCalledWith("srv-3");
+  });
+
+  it("reports TOOL_CALL_START.parentMessageId for tool-only runs", () => {
+    const onServerMessageId = vi.fn();
+    const aggregator = createAggregator(false, onServerMessageId);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tc-1",
+      toolCallName: "search",
+      parentMessageId: "srv-parent",
+    } as AgUiEvent);
+
+    expect(onServerMessageId).toHaveBeenCalledWith("srv-parent");
+  });
+
+  it("does not fire when no event carries a messageId", () => {
+    const onServerMessageId = vi.fn();
+    const aggregator = createAggregator(false, onServerMessageId);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({ type: "TEXT_MESSAGE_START" } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "hi",
+    } as AgUiEvent);
+
+    expect(onServerMessageId).not.toHaveBeenCalled();
+  });
+
+  it("surfaces TOOL_CALL_RESULT.messageId as unstable_toolMessageId", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tc-1",
+      toolCallName: "lookup",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tc-1",
+      messageId: "tool-msg-7",
+      content: '{"ok":true}',
+      role: "tool",
+    } as AgUiEvent);
+
+    const last = results.at(-1);
+    const toolPart = last?.content?.find(
+      (part) => part.type === "tool-call",
+    ) as any;
+    expect(toolPart).toMatchObject({
+      toolCallId: "tc-1",
+      unstable_toolMessageId: "tool-msg-7",
+    });
   });
 });


### PR DESCRIPTION
closes #4016

## summary

- `ThreadAssistantMessage.id` now matches `TEXT_MESSAGE_START.messageId` from the AG-UI stream when the agent provides one, so callers can correlate assistant rows with backend records by id (previously the id was a local random string disconnected from any server identity).
- `TOOL_CALL_RESULT.messageId` is surfaced as `unstable_toolMessageId` on the corresponding `tool-call` part, populating the field that `conversions.ts` already consumed for tool message round-trip but no one was filling.
- under the hood: `RunAggregator` gains an `onServerMessageId` callback that fires once on the first observed messageId (across `TEXT_MESSAGE_START`, `TEXT_MESSAGE_CONTENT`, `TEXT_MESSAGE_END`, `TOOL_CALL_START.parentMessageId`); `AgUiThreadRuntimeCore` inserts the placeholder under an optimistic id and atomically reassigns to the server id, migrating `assistantHistoryParents` and `recordedHistoryIds` so `persistAssistantHistory` / `addToolResult` lookups keep resolving.
- harden: when the agent never emits a server messageId, the optimistic placeholder is stabilized to a regular `generateId()` at terminal state, so the `__optimistic__` prefix never leaks into history.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ag-ui test` -> 5 files / 93 tests green (11 new assertions covering the propagation path)
- [x] `pnpm --filter @assistant-ui/react-ag-ui build` -> 9 dist files emitted, no errors
- [x] reverted runtime files to HEAD and re-ran the new tests to confirm 9 of them fail on the buggy code, then restored the fix and confirmed all green again

### reviewer should verify

- [ ] with a real AG-UI agent that emits `TEXT_MESSAGE_START.messageId`, `thread.getState().messages.at(-1).id` after the stream completes equals the messageId emitted by the agent
- [ ] thread history adapter (`history.append`) receives `{ message: { id: <serverMessageId>, ... } }` rather than a local random id
- [ ] `MESSAGES_SNAPSHOT` replay of the same conversation does not duplicate the assistant row (snapshot path was already keyed on server id; streaming path is now aligned)

## notes

- the change preserves backward compatibility for agents that do not emit `messageId`: such runs end with a plain `generateId()` id, matching the previous shape exactly.
- the only observable change for non-conforming agents is during streaming: between placeholder insertion and the first event, `m.id` carries an `__optimistic__` prefix. this matches the in-flight behavior of `ExternalStoreThreadRuntimeCore` / langgraph / ai-sdk adapters, which already use optimistic ids during runs.
- followups not in scope: applying the same id-propagation pattern to `REASONING_MESSAGE_START.messageId` and to a multi-assistant-message run (currently collapsed into one assistant message), and lifting `unstable_toolMessageId` into the core `ToolCallMessagePart` type so the cast in `run-aggregator.ts` can be dropped.