### PR TITLE
fix(composer): accept highlighted trigger popover item on Tab

### DIFF
--- a/.changeset/trigger-popover-tab-select.md
+++ b/.changeset/trigger-popover-tab-select.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(composer): select highlighted item on Tab in trigger popover
+
+`ComposerPrimitive.Unstable_TriggerPopover` only accepted the highlighted entry on Enter. Tab fell through to the underlying textarea, moving focus out of the composer or inserting a tab character. This diverged from the autocomplete convention used in CLIs, IDEs, command palettes, GitHub, Slack, Discord, and Notion, where Tab accepts the highlighted suggestion.
+
+Tab now mirrors Enter and selects the highlighted item or category. Shift+Tab still passes through so native focus traversal keeps working.

--- a/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.test.ts
+++ b/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import { createResourceRoot } from "@assistant-ui/tap";
+import type {
+  Unstable_TriggerCategory,
+  Unstable_TriggerItem,
+} from "@assistant-ui/core";
+import { TriggerKeyboardResource } from "./triggerKeyboardResource";
+
+const item = (id: string): Unstable_TriggerItem => ({
+  id,
+  type: "command",
+  label: id,
+});
+
+const category = (id: string): Unstable_TriggerCategory => ({
+  id,
+  label: id,
+});
+
+const makeKeyEvent = (key: string, shiftKey = false) => ({
+  key,
+  shiftKey,
+  preventDefault: vi.fn(),
+});
+
+const render = (
+  overrides: Partial<Parameters<typeof TriggerKeyboardResource>[0]> = {},
+) => {
+  const props = {
+    navigableList: [item("a"), item("b"), item("c")],
+    isSearchMode: false,
+    activeCategoryId: null as string | null,
+    query: "",
+    popoverId: "popover",
+    open: true,
+    selectItem: vi.fn(),
+    selectCategory: vi.fn(),
+    goBack: vi.fn(),
+    close: vi.fn(),
+    ...overrides,
+  };
+  const root = createResourceRoot();
+  const sub = root.render(TriggerKeyboardResource(props));
+  return { sub, props };
+};
+
+describe("TriggerKeyboardResource", () => {
+  it("selects highlighted item on Tab", () => {
+    const { sub, props } = render();
+    const e = makeKeyEvent("Tab");
+
+    const consumed = sub.getValue().handleKeyDown(e);
+
+    expect(consumed).toBe(true);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(props.selectItem).toHaveBeenCalledWith(props.navigableList[0]);
+    expect(props.selectCategory).not.toHaveBeenCalled();
+  });
+
+  it("selects category on Tab when entry is a category", () => {
+    const { sub, props } = render({
+      navigableList: [category("cat-1"), item("b")],
+    });
+
+    const consumed = sub.getValue().handleKeyDown(makeKeyEvent("Tab"));
+
+    expect(consumed).toBe(true);
+    expect(props.selectCategory).toHaveBeenCalledWith("cat-1");
+    expect(props.selectItem).not.toHaveBeenCalled();
+  });
+
+  it("lets Shift+Tab pass through for native focus traversal", () => {
+    const { sub, props } = render();
+    const e = makeKeyEvent("Tab", true);
+
+    const consumed = sub.getValue().handleKeyDown(e);
+
+    expect(consumed).toBe(false);
+    expect(e.preventDefault).not.toHaveBeenCalled();
+    expect(props.selectItem).not.toHaveBeenCalled();
+  });
+
+  it("swallows Tab when the navigable list is empty", () => {
+    const { sub, props } = render({ navigableList: [] });
+    const e = makeKeyEvent("Tab");
+
+    const consumed = sub.getValue().handleKeyDown(e);
+
+    expect(consumed).toBe(true);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(props.selectItem).not.toHaveBeenCalled();
+    expect(props.selectCategory).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the popover is closed", () => {
+    const { sub, props } = render({ open: false });
+    const e = makeKeyEvent("Tab");
+
+    const consumed = sub.getValue().handleKeyDown(e);
+
+    expect(consumed).toBe(false);
+    expect(e.preventDefault).not.toHaveBeenCalled();
+    expect(props.selectItem).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.ts
+++ b/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.ts
@@ -103,7 +103,8 @@ export const TriggerKeyboardResource = resource(
             });
             return true;
           }
-          case "Enter": {
+          case "Enter":
+          case "Tab": {
             if (e.shiftKey) return false;
             e.preventDefault();
             const item = navigableList[highlightedIndex];


### PR DESCRIPTION
## Problem

`ComposerPrimitive.Unstable_TriggerPopover` only binds <kbd>Enter</kbd> for selection. <kbd>Tab</kbd> falls through to the underlying textarea, so focus moves out of the composer or a tab character is inserted depending on the host, instead of accepting the highlighted entry.

This diverges from the autocomplete convention used in CLIs, IDEs, command palettes, GitHub's `@`/`#` pickers, Slack, Discord, and Notion mentions, where <kbd>Tab</kbd> accepts the highlighted suggestion. Users coming from any of those flows reach for Tab and the popover feels half-built.

Closes #4018.

## Solution

In `triggerKeyboardResource.ts`, the `handleKeyDown` switch now handles `Tab` alongside `Enter`. Both keys accept the highlighted item or drill into the highlighted category. <kbd>Shift+Tab</kbd> still passes through (`return false`) so native focus traversal keeps working, and an empty `navigableList` still swallows Tab so focus doesn't escape while the popover is open.

## Testing

Added `triggerKeyboardResource.test.ts` covering:

- Tab selects the highlighted item
- Tab selects a highlighted category (drill-in)
- Shift+Tab is not consumed
- Empty navigable list still consumes Tab without calling selectors
- Tab is ignored when the popover is closed

```bash
pnpm --filter @assistant-ui/react exec vitest run src/primitives/composer/trigger
# Test Files  2 passed (2)
# Tests       24 passed (24)
```

Includes a patch changeset for `@assistant-ui/react`.