### PR TITLE
fix(composer): wire WAI-ARIA combobox attributes into trigger popover

### DIFF
--- a/.changeset/trigger-popover-aria-combobox.md
+++ b/.changeset/trigger-popover-aria-combobox.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(composer): apply WAI-ARIA combobox attributes to the textarea while a trigger popover is open
+
+`Unstable_TriggerPopover` rendered the listbox half of the WAI-ARIA editable combobox pattern, but the focused element (the textarea) lacked the corresponding combobox attributes. screen readers had no way to announce that an autocomplete was open or which item was highlighted.
+
+`ComposerPrimitive.Input` now reads the active popover descriptor from `TriggerPopoverRoot` and applies `aria-controls`, `aria-expanded`, `aria-haspopup="listbox"`, and `aria-activedescendant` to the textarea while a popover is open. attributes are removed when the popover closes. consumers using `ComposerPrimitive.Input` outside a `TriggerPopoverRoot` are unaffected.

--- a/apps/docs/content/docs/ui/composer-trigger-popover.mdx
+++ b/apps/docs/content/docs/ui/composer-trigger-popover.mdx
@@ -159,6 +159,7 @@ const commandHandlers: Record<string, () => void> = {
 | <Kbd>ArrowDown</Kbd> | Highlight next item |
 | <Kbd>ArrowUp</Kbd> | Highlight previous item |
 | <Kbd>Enter</Kbd> / <Kbd>Tab</Kbd> | Select highlighted item / drill into category |
+| <Kbd>Shift + Enter</Kbd> | Insert newline (popover stays open) |
 | <Kbd>Shift + Tab</Kbd> | Pass through (native focus traversal) |
 | <Kbd>Escape</Kbd> | Close popover |
 | <Kbd>Backspace</Kbd> | Go back to categories (when query is empty) |

--- a/apps/docs/content/docs/ui/composer-trigger-popover.mdx
+++ b/apps/docs/content/docs/ui/composer-trigger-popover.mdx
@@ -158,9 +158,18 @@ const commandHandlers: Record<string, () => void> = {
 | --- | --- |
 | <Kbd>ArrowDown</Kbd> | Highlight next item |
 | <Kbd>ArrowUp</Kbd> | Highlight previous item |
-| <Kbd>Enter</Kbd> | Select highlighted item / drill into category |
+| <Kbd>Enter</Kbd> / <Kbd>Tab</Kbd> | Select highlighted item / drill into category |
+| <Kbd>Shift + Tab</Kbd> | Pass through (native focus traversal) |
 | <Kbd>Escape</Kbd> | Close popover |
 | <Kbd>Backspace</Kbd> | Go back to categories (when query is empty) |
+
+## Accessibility
+
+The popover implements the WAI-ARIA editable combobox pattern.
+
+- The listbox container has `role="listbox"` and each item has `role="option"` plus `aria-selected`.
+- When a popover is open, `ComposerPrimitive.Input` (the underlying `<textarea>`) automatically receives `aria-controls`, `aria-expanded="true"`, `aria-haspopup="listbox"`, and `aria-activedescendant` pointing at the highlighted option. Attributes are removed when the popover closes.
+- When `ComposerPrimitive.Input` is rendered outside a `TriggerPopoverRoot`, no ARIA attributes are added.
 
 ## API Reference
 

--- a/packages/react/src/primitives/composer/ComposerInput.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.test.tsx
@@ -66,6 +66,15 @@ vi.mock("./ComposerInputPluginContext", () => ({
   useComposerInputPluginRegistryOptional: () => pluginRegistry,
 }));
 
+let activeAria: {
+  popoverId: string;
+  highlightedItemId: string | undefined;
+} | null = null;
+
+vi.mock("./trigger/TriggerPopoverRootContext", () => ({
+  useTriggerPopoverActiveAriaOptional: () => activeAria,
+}));
+
 vi.mock("@radix-ui/react-use-escape-keydown", () => ({
   useEscapeKeydown: () => {},
 }));
@@ -121,6 +130,7 @@ describe("ComposerPrimitiveInput", () => {
     threadState.isRunning = false;
     threadState.capabilities = { queue: false, attachments: false };
     pluginRegistry = null;
+    activeAria = null;
 
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -228,5 +238,43 @@ describe("ComposerPrimitiveInput", () => {
       fireCompositionEnd(textarea, "가");
     });
     expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("does not apply ARIA combobox attributes when no trigger popover is open", async () => {
+    activeAria = null;
+    const textarea = await mount();
+
+    expect(textarea.getAttribute("aria-controls")).toBeNull();
+    expect(textarea.getAttribute("aria-expanded")).toBeNull();
+    expect(textarea.getAttribute("aria-haspopup")).toBeNull();
+    expect(textarea.getAttribute("aria-activedescendant")).toBeNull();
+  });
+
+  it("applies ARIA combobox attributes when a trigger popover is open", async () => {
+    activeAria = {
+      popoverId: "popover-1",
+      highlightedItemId: "popover-1-option-foo",
+    };
+    const textarea = await mount();
+
+    expect(textarea.getAttribute("aria-controls")).toBe("popover-1");
+    expect(textarea.getAttribute("aria-expanded")).toBe("true");
+    expect(textarea.getAttribute("aria-haspopup")).toBe("listbox");
+    expect(textarea.getAttribute("aria-activedescendant")).toBe(
+      "popover-1-option-foo",
+    );
+  });
+
+  it("omits aria-activedescendant when no item is highlighted", async () => {
+    activeAria = {
+      popoverId: "popover-1",
+      highlightedItemId: undefined,
+    };
+    const textarea = await mount();
+
+    expect(textarea.getAttribute("aria-controls")).toBe("popover-1");
+    expect(textarea.getAttribute("aria-expanded")).toBe("true");
+    expect(textarea.getAttribute("aria-haspopup")).toBe("listbox");
+    expect(textarea.getAttribute("aria-activedescendant")).toBeNull();
   });
 });

--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -101,6 +101,12 @@ export namespace ComposerPrimitiveInput {
  * keyboard shortcuts, file paste support, and intelligent focus management.
  * It integrates with the composer context to manage message state and submission.
  *
+ * When rendered inside `Unstable_TriggerPopoverRoot` and a popover is open, the
+ * underlying `<textarea>` automatically receives `aria-controls`,
+ * `aria-expanded`, `aria-haspopup`, and `aria-activedescendant` for the
+ * combobox relationship. These computed attributes override user-provided
+ * values for those four ARIA props while the popover is open.
+ *
  * @example
  * ```tsx
  * // Ctrl/Cmd+Enter to submit (plain Enter inserts newline)

--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -23,6 +23,7 @@ import { useOnScrollToBottom } from "../../utils/hooks/useOnScrollToBottom";
 import { useAuiState, useAui } from "@assistant-ui/store";
 import { flushResourcesSync } from "@assistant-ui/tap";
 import { useComposerInputPluginRegistryOptional } from "./ComposerInputPluginContext";
+import { useTriggerPopoverActiveAriaOptional } from "./trigger/TriggerPopoverRootContext";
 
 export namespace ComposerPrimitiveInput {
   export type Element = HTMLTextAreaElement;
@@ -142,6 +143,7 @@ export const ComposerPrimitiveInput = forwardRef<
   ) => {
     const aui = useAui();
     const pluginRegistry = useComposerInputPluginRegistryOptional();
+    const activeAria = useTriggerPopoverActiveAriaOptional();
 
     const effectiveSubmitMode =
       submitMode ?? (submitOnEnter === false ? "none" : "enter");
@@ -287,10 +289,20 @@ export const ComposerPrimitiveInput = forwardRef<
       return aui.on("threadListItem.switchedTo", focus);
     }, [unstable_focusOnThreadSwitched, focus, aui]);
 
+    const ariaComboboxProps = activeAria
+      ? {
+          "aria-controls": activeAria.popoverId,
+          "aria-expanded": true as const,
+          "aria-haspopup": "listbox" as const,
+          "aria-activedescendant": activeAria.highlightedItemId,
+        }
+      : {};
+
     const inputProps = {
       name: "input" as const,
       value,
       ...rest,
+      ...ariaComboboxProps,
       ref: ref as React.ForwardedRef<HTMLTextAreaElement>,
       disabled: isDisabled,
       onChange: composeEventHandlers(

--- a/packages/react/src/primitives/composer/trigger/TriggerPopover.tsx
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopover.tsx
@@ -23,7 +23,10 @@ import {
   type TriggerPopoverResourceOutput,
 } from "./TriggerPopoverResource";
 import type { TriggerBehavior } from "./triggerSelectionResource";
-import { useTriggerPopoverRootContext } from "./TriggerPopoverRootContext";
+import {
+  useTriggerPopoverAriaPublish,
+  useTriggerPopoverRootContext,
+} from "./TriggerPopoverRootContext";
 
 const TriggerPopoverScopeContext =
   createContext<TriggerPopoverResourceOutput | null>(null);
@@ -179,19 +182,22 @@ export const ComposerPrimitiveTriggerPopover = forwardRef<
 
     const open = behavior !== null && resource.open;
 
+    const aria = useTriggerPopoverAriaPublish();
+
     useEffect(() => {
-      if (!open) {
-        root.setActiveAria(char, null);
-        return undefined;
-      }
-      root.setActiveAria(char, {
+      if (!open) return undefined;
+      return () => {
+        aria.setActiveAria(char, null);
+      };
+    }, [aria, char, open]);
+
+    useEffect(() => {
+      if (!open) return;
+      aria.setActiveAria(char, {
         popoverId,
         highlightedItemId: resource.highlightedItemId,
       });
-      return () => {
-        root.setActiveAria(char, null);
-      };
-    }, [root, char, popoverId, open, resource.highlightedItemId]);
+    }, [aria, char, popoverId, open, resource.highlightedItemId]);
 
     return (
       <TriggerBehaviorRegistrationContext.Provider value={registration}>

--- a/packages/react/src/primitives/composer/trigger/TriggerPopover.tsx
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopover.tsx
@@ -179,6 +179,20 @@ export const ComposerPrimitiveTriggerPopover = forwardRef<
 
     const open = behavior !== null && resource.open;
 
+    useEffect(() => {
+      if (!open) {
+        root.setActiveAria(char, null);
+        return undefined;
+      }
+      root.setActiveAria(char, {
+        popoverId,
+        highlightedItemId: resource.highlightedItemId,
+      });
+      return () => {
+        root.setActiveAria(char, null);
+      };
+    }, [root, char, popoverId, open, resource.highlightedItemId]);
+
     return (
       <TriggerBehaviorRegistrationContext.Provider value={registration}>
         <TriggerPopoverScopeContext.Provider value={resource}>

--- a/packages/react/src/primitives/composer/trigger/TriggerPopoverRootContext.test.tsx
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopoverRootContext.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, type FC } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ComposerPrimitiveTriggerPopoverRoot,
+  type TriggerPopoverActiveAria,
+  type TriggerPopoverRootContextValue,
+  useTriggerPopoverActiveAriaOptional,
+  useTriggerPopoverRootContext,
+} from "./TriggerPopoverRootContext";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("TriggerPopoverRootContext active ARIA", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const renderWithRoot = async () => {
+    const ctxRef = { current: null as TriggerPopoverRootContextValue | null };
+    const ariaRef = { current: null as TriggerPopoverActiveAria | null };
+
+    const Probe: FC = () => {
+      ctxRef.current = useTriggerPopoverRootContext();
+      ariaRef.current = useTriggerPopoverActiveAriaOptional();
+      return null;
+    };
+
+    await act(async () => {
+      root.render(
+        <ComposerPrimitiveTriggerPopoverRoot>
+          <Probe />
+        </ComposerPrimitiveTriggerPopoverRoot>,
+      );
+    });
+
+    return {
+      ctx: () => ctxRef.current as TriggerPopoverRootContextValue,
+      aria: () => ariaRef.current,
+    };
+  };
+
+  it("returns null initially inside a root", async () => {
+    const { aria } = await renderWithRoot();
+    expect(aria()).toBeNull();
+  });
+
+  it("publishes a descriptor and surfaces it via the hook", async () => {
+    const { ctx, aria } = await renderWithRoot();
+
+    await act(async () => {
+      ctx().setActiveAria("@", {
+        popoverId: "popover-mention",
+        highlightedItemId: "popover-mention-option-a",
+      });
+    });
+
+    expect(aria()).toEqual({
+      popoverId: "popover-mention",
+      highlightedItemId: "popover-mention-option-a",
+    });
+  });
+
+  it("clears the descriptor when the owning char releases it", async () => {
+    const { ctx, aria } = await renderWithRoot();
+
+    await act(async () => {
+      ctx().setActiveAria("@", {
+        popoverId: "popover-mention",
+        highlightedItemId: undefined,
+      });
+    });
+    expect(aria()).not.toBeNull();
+
+    await act(async () => {
+      ctx().setActiveAria("@", null);
+    });
+    expect(aria()).toBeNull();
+  });
+
+  it("ignores a clear call from a non-owning char", async () => {
+    const { ctx, aria } = await renderWithRoot();
+
+    await act(async () => {
+      ctx().setActiveAria("@", {
+        popoverId: "popover-mention",
+        highlightedItemId: undefined,
+      });
+    });
+
+    await act(async () => {
+      ctx().setActiveAria("/", null);
+    });
+
+    expect(aria()).toEqual({
+      popoverId: "popover-mention",
+      highlightedItemId: undefined,
+    });
+  });
+
+  it("replaces the descriptor when a different char takes over", async () => {
+    const { ctx, aria } = await renderWithRoot();
+
+    await act(async () => {
+      ctx().setActiveAria("@", {
+        popoverId: "popover-mention",
+        highlightedItemId: "popover-mention-option-a",
+      });
+    });
+    await act(async () => {
+      ctx().setActiveAria("/", {
+        popoverId: "popover-slash",
+        highlightedItemId: "popover-slash-option-x",
+      });
+    });
+
+    expect(aria()).toEqual({
+      popoverId: "popover-slash",
+      highlightedItemId: "popover-slash-option-x",
+    });
+  });
+
+  it("returns null when the consumer is rendered outside a root", async () => {
+    const ariaRef = { current: null as TriggerPopoverActiveAria | null };
+    const Solo: FC = () => {
+      ariaRef.current = useTriggerPopoverActiveAriaOptional();
+      return null;
+    };
+
+    await act(async () => {
+      root.render(<Solo />);
+    });
+
+    expect(ariaRef.current).toBeNull();
+  });
+});

--- a/packages/react/src/primitives/composer/trigger/TriggerPopoverRootContext.test.tsx
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopoverRootContext.test.tsx
@@ -7,12 +7,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   ComposerPrimitiveTriggerPopoverRoot,
   type TriggerPopoverActiveAria,
-  type TriggerPopoverRootContextValue,
   useTriggerPopoverActiveAriaOptional,
-  useTriggerPopoverRootContext,
+  useTriggerPopoverAriaPublish,
 } from "./TriggerPopoverRootContext";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+type PublishHandle = ReturnType<typeof useTriggerPopoverAriaPublish>;
 
 describe("TriggerPopoverRootContext active ARIA", () => {
   let container: HTMLDivElement;
@@ -32,11 +33,11 @@ describe("TriggerPopoverRootContext active ARIA", () => {
   });
 
   const renderWithRoot = async () => {
-    const ctxRef = { current: null as TriggerPopoverRootContextValue | null };
+    const publishRef = { current: null as PublishHandle | null };
     const ariaRef = { current: null as TriggerPopoverActiveAria | null };
 
     const Probe: FC = () => {
-      ctxRef.current = useTriggerPopoverRootContext();
+      publishRef.current = useTriggerPopoverAriaPublish();
       ariaRef.current = useTriggerPopoverActiveAriaOptional();
       return null;
     };
@@ -50,7 +51,7 @@ describe("TriggerPopoverRootContext active ARIA", () => {
     });
 
     return {
-      ctx: () => ctxRef.current as TriggerPopoverRootContextValue,
+      publish: () => publishRef.current as PublishHandle,
       aria: () => ariaRef.current,
     };
   };
@@ -61,10 +62,10 @@ describe("TriggerPopoverRootContext active ARIA", () => {
   });
 
   it("publishes a descriptor and surfaces it via the hook", async () => {
-    const { ctx, aria } = await renderWithRoot();
+    const { publish, aria } = await renderWithRoot();
 
     await act(async () => {
-      ctx().setActiveAria("@", {
+      publish().setActiveAria("@", {
         popoverId: "popover-mention",
         highlightedItemId: "popover-mention-option-a",
       });
@@ -77,10 +78,10 @@ describe("TriggerPopoverRootContext active ARIA", () => {
   });
 
   it("clears the descriptor when the owning char releases it", async () => {
-    const { ctx, aria } = await renderWithRoot();
+    const { publish, aria } = await renderWithRoot();
 
     await act(async () => {
-      ctx().setActiveAria("@", {
+      publish().setActiveAria("@", {
         popoverId: "popover-mention",
         highlightedItemId: undefined,
       });
@@ -88,23 +89,23 @@ describe("TriggerPopoverRootContext active ARIA", () => {
     expect(aria()).not.toBeNull();
 
     await act(async () => {
-      ctx().setActiveAria("@", null);
+      publish().setActiveAria("@", null);
     });
     expect(aria()).toBeNull();
   });
 
   it("ignores a clear call from a non-owning char", async () => {
-    const { ctx, aria } = await renderWithRoot();
+    const { publish, aria } = await renderWithRoot();
 
     await act(async () => {
-      ctx().setActiveAria("@", {
+      publish().setActiveAria("@", {
         popoverId: "popover-mention",
         highlightedItemId: undefined,
       });
     });
 
     await act(async () => {
-      ctx().setActiveAria("/", null);
+      publish().setActiveAria("/", null);
     });
 
     expect(aria()).toEqual({
@@ -114,16 +115,16 @@ describe("TriggerPopoverRootContext active ARIA", () => {
   });
 
   it("replaces the descriptor when a different char takes over", async () => {
-    const { ctx, aria } = await renderWithRoot();
+    const { publish, aria } = await renderWithRoot();
 
     await act(async () => {
-      ctx().setActiveAria("@", {
+      publish().setActiveAria("@", {
         popoverId: "popover-mention",
         highlightedItemId: "popover-mention-option-a",
       });
     });
     await act(async () => {
-      ctx().setActiveAria("/", {
+      publish().setActiveAria("/", {
         popoverId: "popover-slash",
         highlightedItemId: "popover-slash-option-x",
       });

--- a/packages/react/src/primitives/composer/trigger/TriggerPopoverRootContext.tsx
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopoverRootContext.tsx
@@ -49,15 +49,22 @@ export type TriggerPopoverRootContextValue = {
   getActiveAria(): TriggerPopoverActiveAria | null;
   /** Subscribe to changes in the active ARIA descriptor. */
   subscribeAria(listener: () => void): () => void;
-  /**
-   * Internal: TriggerPopover children publish their open / highlight state
-   * here. Pass `null` to clear when the popover closes.
-   */
+};
+
+/**
+ * Write-side of the ARIA descriptor, scoped to `TriggerPopover` children of a
+ * `TriggerPopoverRoot`. Intentionally not exposed on the public root context
+ * value: external consumers can read ARIA state but cannot publish or clear it.
+ */
+type TriggerPopoverAriaPublish = {
   setActiveAria(char: string, aria: TriggerPopoverActiveAria | null): void;
 };
 
 const TriggerPopoverRootContext =
   createContext<TriggerPopoverRootContextValue | null>(null);
+
+const TriggerPopoverAriaPublishContext =
+  createContext<TriggerPopoverAriaPublish | null>(null);
 
 export const useTriggerPopoverRootContext = () => {
   const ctx = useContext(TriggerPopoverRootContext);
@@ -70,6 +77,19 @@ export const useTriggerPopoverRootContext = () => {
 
 export const useTriggerPopoverRootContextOptional = () =>
   useContext(TriggerPopoverRootContext);
+
+/**
+ * Internal hook used by `TriggerPopover` children to publish their open and
+ * highlight state. Not exported from the trigger module.
+ */
+export const useTriggerPopoverAriaPublish = (): TriggerPopoverAriaPublish => {
+  const ctx = useContext(TriggerPopoverAriaPublishContext);
+  if (!ctx)
+    throw new Error(
+      "useTriggerPopoverAriaPublish must be used within ComposerPrimitive.TriggerPopoverRoot",
+    );
+  return ctx;
+};
 
 /**
  * Live map of registered triggers, re-rendering on change. Prefer
@@ -117,18 +137,34 @@ export namespace ComposerPrimitiveTriggerPopoverRoot {
   };
 }
 
+/**
+ * Local helper for the simple "notify-all listeners" subscribable pattern.
+ * Used twice in this file (trigger registry, active ARIA); kept inline to
+ * avoid pulling a single-use abstraction into the wider tree.
+ */
+function useSimpleSubscribable() {
+  const listenersRef = useRef<Set<() => void>>(new Set());
+  const notify = useCallback(() => {
+    for (const listener of listenersRef.current) listener();
+  }, []);
+  const subscribe = useCallback((listener: () => void) => {
+    listenersRef.current.add(listener);
+    return () => {
+      listenersRef.current.delete(listener);
+    };
+  }, []);
+  return { notify, subscribe };
+}
+
 const TriggerPopoverRootInner: FC<
   ComposerPrimitiveTriggerPopoverRoot.Props
 > = ({ children }) => {
   const triggersRef = useRef<ReadonlyMap<string, RegisteredTrigger>>(new Map());
-  const listenersRef = useRef<Set<() => void>>(new Set());
   const lifecycleListenersRef = useRef<Set<TriggerPopoverLifecycleListener>>(
     new Set(),
   );
 
-  const notify = useCallback(() => {
-    for (const listener of listenersRef.current) listener();
-  }, []);
+  const { notify, subscribe } = useSimpleSubscribable();
 
   const register = useCallback<TriggerPopoverRootContextValue["register"]>(
     (trigger) => {
@@ -173,16 +209,6 @@ const TriggerPopoverRootInner: FC<
     TriggerPopoverRootContextValue["getTriggers"]
   >(() => triggersRef.current, []);
 
-  const subscribe = useCallback<TriggerPopoverRootContextValue["subscribe"]>(
-    (listener) => {
-      listenersRef.current.add(listener);
-      return () => {
-        listenersRef.current.delete(listener);
-      };
-    },
-    [],
-  );
-
   const subscribeLifecycle = useCallback<
     TriggerPopoverRootContextValue["subscribeLifecycle"]
   >((listener) => {
@@ -194,15 +220,10 @@ const TriggerPopoverRootInner: FC<
 
   const activeAriaRef = useRef<TriggerPopoverActiveAria | null>(null);
   const activeAriaCharRef = useRef<string | null>(null);
-  const ariaListenersRef = useRef<Set<() => void>>(new Set());
+  const { notify: notifyAria, subscribe: subscribeAria } =
+    useSimpleSubscribable();
 
-  const notifyAria = useCallback(() => {
-    for (const listener of ariaListenersRef.current) listener();
-  }, []);
-
-  const setActiveAria = useCallback<
-    TriggerPopoverRootContextValue["setActiveAria"]
-  >(
+  const setActiveAria = useCallback<TriggerPopoverAriaPublish["setActiveAria"]>(
     (char, aria) => {
       if (aria === null) {
         if (activeAriaCharRef.current !== char) return;
@@ -231,15 +252,6 @@ const TriggerPopoverRootInner: FC<
     TriggerPopoverRootContextValue["getActiveAria"]
   >(() => activeAriaRef.current, []);
 
-  const subscribeAria = useCallback<
-    TriggerPopoverRootContextValue["subscribeAria"]
-  >((listener) => {
-    ariaListenersRef.current.add(listener);
-    return () => {
-      ariaListenersRef.current.delete(listener);
-    };
-  }, []);
-
   const value = useMemo<TriggerPopoverRootContextValue>(
     () => ({
       register,
@@ -248,7 +260,6 @@ const TriggerPopoverRootInner: FC<
       subscribeLifecycle,
       getActiveAria,
       subscribeAria,
-      setActiveAria,
     }),
     [
       register,
@@ -257,13 +268,19 @@ const TriggerPopoverRootInner: FC<
       subscribeLifecycle,
       getActiveAria,
       subscribeAria,
-      setActiveAria,
     ],
+  );
+
+  const ariaPublishValue = useMemo<TriggerPopoverAriaPublish>(
+    () => ({ setActiveAria }),
+    [setActiveAria],
   );
 
   return (
     <TriggerPopoverRootContext.Provider value={value}>
-      {children}
+      <TriggerPopoverAriaPublishContext.Provider value={ariaPublishValue}>
+        {children}
+      </TriggerPopoverAriaPublishContext.Provider>
     </TriggerPopoverRootContext.Provider>
   );
 };

--- a/packages/react/src/primitives/composer/trigger/TriggerPopoverRootContext.tsx
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopoverRootContext.tsx
@@ -29,12 +29,31 @@ export type TriggerPopoverLifecycleListener = {
   removed(char: string): void;
 };
 
+/**
+ * ARIA descriptor of the popover that is currently open. Consumed by the
+ * focused element (typically the composer textarea) so it can advertise the
+ * combobox relationship per the WAI-ARIA editable combobox pattern.
+ */
+export type TriggerPopoverActiveAria = {
+  popoverId: string;
+  highlightedItemId: string | undefined;
+};
+
 export type TriggerPopoverRootContextValue = {
   register(trigger: RegisteredTrigger): () => void;
   getTriggers(): ReadonlyMap<string, RegisteredTrigger>;
   subscribe(listener: () => void): () => void;
   /** Subscribe to per-trigger add/remove events. */
   subscribeLifecycle(listener: TriggerPopoverLifecycleListener): () => void;
+  /** ARIA descriptor of the open popover, or null if none is open. */
+  getActiveAria(): TriggerPopoverActiveAria | null;
+  /** Subscribe to changes in the active ARIA descriptor. */
+  subscribeAria(listener: () => void): () => void;
+  /**
+   * Internal: TriggerPopover children publish their open / highlight state
+   * here. Pass `null` to clear when the popover closes.
+   */
+  setActiveAria(char: string, aria: TriggerPopoverActiveAria | null): void;
 };
 
 const TriggerPopoverRootContext =
@@ -74,6 +93,23 @@ export const useTriggerPopoverTriggersOptional = () => {
     ctx ? ctx.getTriggers : getEmptyTriggers,
   );
 };
+
+const getNullAria = () => null;
+
+/**
+ * Returns the ARIA descriptor of the currently open trigger popover, or
+ * `null` if none is open or the consumer is rendered outside a
+ * `TriggerPopoverRoot`.
+ */
+export const useTriggerPopoverActiveAriaOptional =
+  (): TriggerPopoverActiveAria | null => {
+    const ctx = useTriggerPopoverRootContextOptional();
+    return useSyncExternalStore(
+      ctx ? ctx.subscribeAria : noopSubscribe,
+      ctx ? ctx.getActiveAria : getNullAria,
+      ctx ? ctx.getActiveAria : getNullAria,
+    );
+  };
 
 export namespace ComposerPrimitiveTriggerPopoverRoot {
   export type Props = {
@@ -156,9 +192,73 @@ const TriggerPopoverRootInner: FC<
     };
   }, []);
 
+  const activeAriaRef = useRef<TriggerPopoverActiveAria | null>(null);
+  const activeAriaCharRef = useRef<string | null>(null);
+  const ariaListenersRef = useRef<Set<() => void>>(new Set());
+
+  const notifyAria = useCallback(() => {
+    for (const listener of ariaListenersRef.current) listener();
+  }, []);
+
+  const setActiveAria = useCallback<
+    TriggerPopoverRootContextValue["setActiveAria"]
+  >(
+    (char, aria) => {
+      if (aria === null) {
+        if (activeAriaCharRef.current !== char) return;
+        activeAriaRef.current = null;
+        activeAriaCharRef.current = null;
+        notifyAria();
+        return;
+      }
+      const prev = activeAriaRef.current;
+      if (
+        activeAriaCharRef.current === char &&
+        prev !== null &&
+        prev.popoverId === aria.popoverId &&
+        prev.highlightedItemId === aria.highlightedItemId
+      ) {
+        return;
+      }
+      activeAriaRef.current = aria;
+      activeAriaCharRef.current = char;
+      notifyAria();
+    },
+    [notifyAria],
+  );
+
+  const getActiveAria = useCallback<
+    TriggerPopoverRootContextValue["getActiveAria"]
+  >(() => activeAriaRef.current, []);
+
+  const subscribeAria = useCallback<
+    TriggerPopoverRootContextValue["subscribeAria"]
+  >((listener) => {
+    ariaListenersRef.current.add(listener);
+    return () => {
+      ariaListenersRef.current.delete(listener);
+    };
+  }, []);
+
   const value = useMemo<TriggerPopoverRootContextValue>(
-    () => ({ register, getTriggers, subscribe, subscribeLifecycle }),
-    [register, getTriggers, subscribe, subscribeLifecycle],
+    () => ({
+      register,
+      getTriggers,
+      subscribe,
+      subscribeLifecycle,
+      getActiveAria,
+      subscribeAria,
+      setActiveAria,
+    }),
+    [
+      register,
+      getTriggers,
+      subscribe,
+      subscribeLifecycle,
+      getActiveAria,
+      subscribeAria,
+      setActiveAria,
+    ],
   );
 
   return (

--- a/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.test.ts
+++ b/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.test.ts
@@ -23,6 +23,8 @@ const makeKeyEvent = (key: string, shiftKey = false) => ({
   preventDefault: vi.fn(),
 });
 
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
 const render = (
   overrides: Partial<Parameters<typeof TriggerKeyboardResource>[0]> = {},
 ) => {
@@ -101,5 +103,134 @@ describe("TriggerKeyboardResource", () => {
     expect(consumed).toBe(false);
     expect(e.preventDefault).not.toHaveBeenCalled();
     expect(props.selectItem).not.toHaveBeenCalled();
+  });
+
+  it("moves the highlight forward on ArrowDown", async () => {
+    const { sub } = render();
+
+    const consumed = sub.getValue().handleKeyDown(makeKeyEvent("ArrowDown"));
+    await tick();
+
+    expect(consumed).toBe(true);
+    expect(sub.getValue().highlightedIndex).toBe(1);
+  });
+
+  it("wraps the highlight to the top on ArrowDown past the last entry", async () => {
+    const { sub } = render();
+    const handle = sub.getValue().handleKeyDown;
+
+    handle(makeKeyEvent("ArrowDown"));
+    handle(makeKeyEvent("ArrowDown"));
+    handle(makeKeyEvent("ArrowDown"));
+    await tick();
+
+    expect(sub.getValue().highlightedIndex).toBe(0);
+  });
+
+  it("moves the highlight backward on ArrowUp", async () => {
+    const { sub } = render();
+    const handle = sub.getValue().handleKeyDown;
+
+    handle(makeKeyEvent("ArrowDown"));
+    await tick();
+    handle(makeKeyEvent("ArrowUp"));
+    await tick();
+
+    expect(sub.getValue().highlightedIndex).toBe(0);
+  });
+
+  it("wraps the highlight to the bottom on ArrowUp from the first entry", async () => {
+    const { sub } = render();
+
+    sub.getValue().handleKeyDown(makeKeyEvent("ArrowUp"));
+    await tick();
+
+    expect(sub.getValue().highlightedIndex).toBe(2);
+  });
+
+  it("keeps the highlight at 0 on ArrowDown when navigableList is empty", async () => {
+    const { sub } = render({ navigableList: [] });
+    const e = makeKeyEvent("ArrowDown");
+
+    const consumed = sub.getValue().handleKeyDown(e);
+    await tick();
+
+    expect(consumed).toBe(true);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(sub.getValue().highlightedIndex).toBe(0);
+  });
+
+  it("selects the highlighted item on Enter", () => {
+    const { sub, props } = render();
+    const e = makeKeyEvent("Enter");
+
+    const consumed = sub.getValue().handleKeyDown(e);
+
+    expect(consumed).toBe(true);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(props.selectItem).toHaveBeenCalledWith(props.navigableList[0]);
+  });
+
+  it("lets Shift+Enter pass through for newline insertion", () => {
+    const { sub, props } = render();
+    const e = makeKeyEvent("Enter", true);
+
+    const consumed = sub.getValue().handleKeyDown(e);
+
+    expect(consumed).toBe(false);
+    expect(e.preventDefault).not.toHaveBeenCalled();
+    expect(props.selectItem).not.toHaveBeenCalled();
+  });
+
+  it("closes the popover on Escape", () => {
+    const { sub, props } = render();
+    const e = makeKeyEvent("Escape");
+
+    const consumed = sub.getValue().handleKeyDown(e);
+
+    expect(consumed).toBe(true);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(props.close).toHaveBeenCalled();
+  });
+
+  it("drills back on Backspace when a category is active and the query is empty", () => {
+    const { sub, props } = render({
+      activeCategoryId: "cat-1",
+      query: "",
+    });
+    const e = makeKeyEvent("Backspace");
+
+    const consumed = sub.getValue().handleKeyDown(e);
+
+    expect(consumed).toBe(true);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(props.goBack).toHaveBeenCalled();
+  });
+
+  it("lets Backspace pass through when the query is non-empty", () => {
+    const { sub, props } = render({
+      activeCategoryId: "cat-1",
+      query: "foo",
+    });
+    const e = makeKeyEvent("Backspace");
+
+    const consumed = sub.getValue().handleKeyDown(e);
+
+    expect(consumed).toBe(false);
+    expect(e.preventDefault).not.toHaveBeenCalled();
+    expect(props.goBack).not.toHaveBeenCalled();
+  });
+
+  it("lets Backspace pass through when no category is active", () => {
+    const { sub, props } = render({
+      activeCategoryId: null,
+      query: "",
+    });
+    const e = makeKeyEvent("Backspace");
+
+    const consumed = sub.getValue().handleKeyDown(e);
+
+    expect(consumed).toBe(false);
+    expect(props.goBack).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## summary

- screen readers now announce the trigger popover as an open combobox. `ComposerPrimitive.Input` automatically receives `aria-controls`, `aria-expanded="true"`, `aria-haspopup="listbox"`, and `aria-activedescendant` while a `TriggerPopover` is open, and the attributes are removed on close.
- `TriggerPopoverRoot` tracks the open popover's aria descriptor via a small subscribe/notify pair (`getActiveAria` / `subscribeAria` / `setActiveAria` on the existing context value). `ComposerInput` reads it via `useSyncExternalStore`. consumers without a `TriggerPopoverRoot` keep their previous behavior; no aria attributes get added.
- backfills test coverage for `triggerKeyboardResource`: 11 cases for ArrowDown, ArrowUp, Enter (including Shift+Enter pass-through), Escape, and Backspace. previously only the Tab path added by #4020 was tested.
- `composer-trigger-popover.mdx` keyboard table now lists Tab next to Enter and adds an explicit Shift+Tab row. a new Accessibility section describes the combobox attributes that get applied automatically.

## test plan

### already verified

- [x] \`pnpm --filter @assistant-ui/react exec vitest run src/primitives/composer\` returned 52/52 green across 5 test files.
- [x] \`pnpm --filter @assistant-ui/react exec tsc --noEmit\` introduces no new errors. the preexisting tsc errors on main are unrelated to this branch.

### reviewer should verify

- [ ] mount \`Unstable_TriggerPopoverRoot\` + \`Unstable_TriggerPopover\` + \`ComposerPrimitive.Input\`, type the trigger char, and inspect the textarea: \`aria-controls\`, \`aria-expanded="true"\`, \`aria-haspopup="listbox"\`, and \`aria-activedescendant\` should appear. clear the textarea so the popover closes; all four should disappear.
- [ ] a \`ComposerPrimitive.Input\` rendered without a \`TriggerPopoverRoot\` should never get those aria attributes.

## notes

- \`role="combobox"\` is deliberately NOT applied to the textarea. WAI-ARIA APG recommends it on the input element, but combobox role on a multiline textarea is unconventional and risks regressing existing textbox semantics. the four aria attributes capture the combobox relationship without changing the role; happy to switch to the stricter pattern if a reviewer prefers.
- the listbox \`<div>\` keeps \`aria-activedescendant\` as well. it is functionally dead now (screen readers only honor the attribute on the focused element) but removing it could break user CSS that selects \`[aria-activedescendant]\`. left in for safety.