### PR TITLE
docs: expand public API JSDoc and message part deprecations

### DIFF
--- a/.changeset/docs-assistant-stream-tools-jsdoc.md
+++ b/.changeset/docs-assistant-stream-tools-jsdoc.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+docs: add JSDoc for assistant stream tool definitions

--- a/.changeset/docs-core-assistant-runtime-provider-jsdoc.md
+++ b/.changeset/docs-core-assistant-runtime-provider-jsdoc.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+---
+
+docs: add JSDoc for `AssistantRuntimeProvider`
+
+documents the provider used to mount a runtime built with `useLocalRuntime`, `useExternalStoreRuntime`, `useAssistantTransportRuntime`, etc., including the fact that it installs an `AuiProvider` internally so descendants can use `useAui`/`useAuiState` without extra setup.

--- a/.changeset/docs-core-assistant-runtime-provider-jsdoc.md
+++ b/.changeset/docs-core-assistant-runtime-provider-jsdoc.md
@@ -3,5 +3,3 @@
 ---
 
 docs: add JSDoc for `AssistantRuntimeProvider`
-
-documents the provider used to mount a runtime built with `useLocalRuntime`, `useExternalStoreRuntime`, `useAssistantTransportRuntime`, etc., including the fact that it installs an `AuiProvider` internally so descendants can use `useAui`/`useAuiState` without extra setup.

--- a/.changeset/docs-core-assistant-runtime-provider-jsdoc.md
+++ b/.changeset/docs-core-assistant-runtime-provider-jsdoc.md
@@ -2,4 +2,4 @@
 "@assistant-ui/core": patch
 ---
 
-docs: add JSDoc for `AssistantRuntimeProvider`
+docs: add JSDoc for core runtime and assistant tool APIs

--- a/.changeset/docs-react-deprecate-message-part-hooks.md
+++ b/.changeset/docs-react-deprecate-message-part-hooks.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react": patch
 ---
 
-docs: deprecate `useMessagePart*` primitive hooks
+docs: add React JSDoc and deprecation notices for primitive and tool APIs

--- a/.changeset/docs-react-deprecate-message-part-hooks.md
+++ b/.changeset/docs-react-deprecate-message-part-hooks.md
@@ -3,5 +3,3 @@
 ---
 
 docs: deprecate `useMessagePart*` primitive hooks
-
-adds `@deprecated` JSDoc with `{@link}` migration targets to `useMessagePartText`, `useMessagePartReasoning`, `useMessagePartSource`, `useMessagePartFile`, `useMessagePartImage`, and `useMessagePartData`. these were accidentally skipped when sibling legacy runtime hooks were marked deprecated. they all point to `useAuiState((s) => s.part)` and link to the v0-12 migration guide.

--- a/.changeset/docs-react-deprecate-message-part-hooks.md
+++ b/.changeset/docs-react-deprecate-message-part-hooks.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react": patch
+---
+
+docs: deprecate `useMessagePart*` primitive hooks
+
+adds `@deprecated` JSDoc with `{@link}` migration targets to `useMessagePartText`, `useMessagePartReasoning`, `useMessagePartSource`, `useMessagePartFile`, `useMessagePartImage`, and `useMessagePartData`. these were accidentally skipped when sibling legacy runtime hooks were marked deprecated. they all point to `useAuiState((s) => s.part)` and link to the v0-12 migration guide.

--- a/.changeset/docs-react-deprecated-hooks-link-targets.md
+++ b/.changeset/docs-react-deprecated-hooks-link-targets.md
@@ -3,5 +3,3 @@
 ---
 
 docs: link migration targets and guide URLs in deprecated legacy runtime hooks
-
-converts the `useAui` / `useAuiState` references in `@deprecated` notes across `useAssistantRuntime`, `useThreadRuntime`, `useComposerRuntime`, `useMessageRuntime`, `useMessagePartRuntime`, `useAttachmentRuntime`, `useThreadListItemRuntime`, and their state-hook siblings to use `{@link}`. also wraps the migration guide URL in `{@link}` so IDE hover cards render a clickable link directly to the replacement and the guide.

--- a/.changeset/docs-react-deprecated-hooks-link-targets.md
+++ b/.changeset/docs-react-deprecated-hooks-link-targets.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react": patch
+---
+
+docs: link migration targets and guide URLs in deprecated legacy runtime hooks
+
+converts the `useAui` / `useAuiState` references in `@deprecated` notes across `useAssistantRuntime`, `useThreadRuntime`, `useComposerRuntime`, `useMessageRuntime`, `useMessagePartRuntime`, `useAttachmentRuntime`, `useThreadListItemRuntime`, and their state-hook siblings to use `{@link}`. also wraps the migration guide URL in `{@link}` so IDE hover cards render a clickable link directly to the replacement and the guide.

--- a/.changeset/docs-react-deprecated-hooks-link-targets.md
+++ b/.changeset/docs-react-deprecated-hooks-link-targets.md
@@ -1,5 +1,0 @@
----
-"@assistant-ui/react": patch
----
-
-docs: link migration targets and guide URLs in deprecated legacy runtime hooks

--- a/.changeset/docs-store-aui-jsdoc.md
+++ b/.changeset/docs-store-aui-jsdoc.md
@@ -3,5 +3,3 @@
 ---
 
 docs: add JSDoc for `useAui`, `useAuiState`, `useAuiEvent`, `AuiIf`, and `AuiProvider`
-
-documents the modern core entry points used by application code: usage notes for the no-args `useAui()` shape, the runtime-throw caveat on `useAuiState` selectors, the dotted event-name selector form on `useAuiEvent`, the conditional-render contract on `AuiIf`, and the missing-provider behavior on `AuiProvider`. examples are taken from real call sites in the monorepo.

--- a/.changeset/docs-store-aui-jsdoc.md
+++ b/.changeset/docs-store-aui-jsdoc.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/store": patch
+---
+
+docs: add JSDoc for `useAui`, `useAuiState`, `useAuiEvent`, `AuiIf`, and `AuiProvider`
+
+documents the modern core entry points used by application code: usage notes for the no-args `useAui()` shape, the runtime-throw caveat on `useAuiState` selectors, the dotted event-name selector form on `useAuiEvent`, the conditional-render contract on `AuiIf`, and the missing-provider behavior on `AuiProvider`. examples are taken from real call sites in the monorepo.

--- a/.changeset/docs-tools-jsdoc.md
+++ b/.changeset/docs-tools-jsdoc.md
@@ -1,7 +1,0 @@
----
-"assistant-stream": patch
-"@assistant-ui/core": patch
-"@assistant-ui/react": patch
----
-
-docs: add JSDoc for assistant tool definitions, renderers, and MCP app helpers

--- a/.changeset/docs-tools-jsdoc.md
+++ b/.changeset/docs-tools-jsdoc.md
@@ -1,6 +1,7 @@
 ---
 "assistant-stream": patch
 "@assistant-ui/core": patch
+"@assistant-ui/react": patch
 ---
 
-docs: add JSDoc for assistant tool definitions and renderers
+docs: add JSDoc for assistant tool definitions, renderers, and MCP app helpers

--- a/.changeset/docs-tools-jsdoc.md
+++ b/.changeset/docs-tools-jsdoc.md
@@ -1,0 +1,6 @@
+---
+"assistant-stream": patch
+"@assistant-ui/core": patch
+---
+
+docs: add JSDoc for assistant tool definitions and renderers

--- a/apps/docs/content/docs/(reference)/api-reference/context-providers/assistant-runtime-provider.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/context-providers/assistant-runtime-provider.mdx
@@ -41,7 +41,16 @@ const MyApp = () => {
 
 ### AuiProvider
 
-Provider component for AssistantClient
+Supplies an `AssistantClient` to the React tree.
+
+Place near the root of any subtree that uses [useAui](/docs/api-reference/hooks/state#useaui) or the
+primitives built on it. Components rendered outside an `AuiProvider`
+receive a default client whose scope accessors throw on use, so
+missing-provider mistakes surface at the point of use.
+
+When mounting a runtime built with one of the runtime hooks, use
+[AssistantRuntimeProvider](/docs/api-reference/context-providers/assistant-runtime-provider#assistantruntimeprovider) — it installs an `AuiProvider`
+internally — rather than wiring `AuiProvider` yourself.
 
 <ParametersTable {...AuiProvider} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/external-store/message-conversion.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/external-store/message-conversion.mdx
@@ -38,7 +38,9 @@ const unstable_createMessageConverter: <T extends object>(callback: useExternalM
 
 ### bindExternalStoreMessage
 
-Deprecated: This API is experimental and may change without notice.
+<Callout type="warn">
+<strong>Deprecated.</strong> This API is experimental and may change without notice.
+</Callout>
 
 Attach the original external store message(s) to a ThreadMessage or message part.
 This is a no-op if the target already has a bound message.

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/composer-triggers.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/composer-triggers.mdx
@@ -57,7 +57,9 @@ const unstable_useTriggerPopoverTriggersOptional: () => ReadonlyMap<string, Regi
 
 ### unstable_useMentionAdapter
 
-Deprecated: Under active development and might change without notice.
+<Callout type="warn">
+<strong>Deprecated.</strong> Under active development and might change without notice.
+</Callout>
 
 Creates a spreadable `{ adapter, directive }` bundle for `@` mentions.
 Supports tools registered via `useAssistantTool`, explicit items, or both —
@@ -67,7 +69,9 @@ flat or categorized.
 
 ### unstable_useSlashCommandAdapter
 
-Deprecated: Under active development and may change without notice.
+<Callout type="warn">
+<strong>Deprecated.</strong> Under active development and may change without notice.
+</Callout>
 
 Bundles slash command definitions (with inline `execute` callbacks) into
 `{adapter, action}` that plug directly into `ComposerTriggerPopover`.

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/primitives.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/primitives.mdx
@@ -38,40 +38,6 @@ const useMessageAttachment: { (): { id: string; type: "image" | "document" | "fi
 
 <ParametersTable {...useMessageAttachmentRuntime} />
 
-### useMessagePartData
-
-<ParametersTable {...useMessagePartData} />
-
-### useMessagePartFile
-
-```ts
-const useMessagePartFile: () => FileMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; };
-```
-
-### useMessagePartImage
-
-```ts
-const useMessagePartImage: () => ImageMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; };
-```
-
-### useMessagePartReasoning
-
-```ts
-const useMessagePartReasoning: () => ReasoningMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; };
-```
-
-### useMessagePartSource
-
-```ts
-const useMessagePartSource: () => ({ readonly type: "source"; readonly sourceType: "url"; readonly id: string; readonly url: string; readonly title?: string; readonly providerMetadata?: SourceProviderMetadata; readonly parentId?: string; } & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; }) | ({ readonly type: "source"; readonly sourceType: "document"; readonly id: string; readonly url?: undefined; readonly title: string; readonly mediaType: string; readonly filename?: string; readonly providerMetadata?: SourceProviderMetadata; readonly parentId?: string; } & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; });
-```
-
-### useMessagePartText
-
-```ts
-const useMessagePartText: () => (TextMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; }) | (ReasoningMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; });
-```
-
 ### useMessageQuote
 
 Hook that returns the quote info for the current message, if any.
@@ -146,7 +112,9 @@ const useThreadViewportStore: { (): ReadonlyStore<ThreadViewportState>; (options
 
 ### useAssistantRuntime
 
-Deprecated: Use `useAui()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAui](/docs/api-reference/hooks/state#useaui) instead. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 Hook to access the AssistantRuntime from the current context.
 
@@ -157,7 +125,9 @@ including thread management, tool registration, and configuration.
 
 ### useAttachment
 
-Deprecated: Use `useAuiState((s) => s.attachment)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.attachment)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 ```ts
 const useAttachment: { (): AttachmentState & { source: "message" | "thread-composer" | "edit-composer"; }; <TSelected>(selector: (state: AttachmentState & { source: "message" | "thread-composer" | "edit-composer"; }) => TSelected): TSelected; <TSelected>(selector: ((state: AttachmentState & { source: "message" | "thread-composer" | "edit-composer"; }) => TSelected) | undefined): (AttachmentState & { source: "message" | "thread-composer" | "edit-composer"; }) | TSelected; (options: { optional?: false | undefined; }): AttachmentState & { source: "message" | "thread-composer" | "edit-composer"; }; (options: { optional?: boolean | undefined; }): (AttachmentState & { source: "message" | "thread-composer" | "edit-composer"; }) | null; <TSelected>(options: { optional?: false | undefined; selector: (state: AttachmentState & { source: "message" | "thread-composer" | "edit-composer"; }) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: AttachmentState & { source: "message" | "thread-composer" | "edit-composer"; }) => TSelected) | undefined; }): (AttachmentState & { source: "message" | "thread-composer" | "edit-composer"; }) | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: AttachmentState & { source: "message" | "thread-composer" | "edit-composer"; }) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: AttachmentState & { source: "message" | "thread-composer" | "edit-composer"; }) => TSelected) | undefined; }): (AttachmentState & { source: "message" | "thread-composer" | "edit-composer"; }) | TSelected | null; };
@@ -165,13 +135,17 @@ const useAttachment: { (): AttachmentState & { source: "message" | "thread-compo
 
 ### useAttachmentRuntime
 
-Deprecated: Use `useAui()` with `aui.attachment()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAui](/docs/api-reference/hooks/state#useaui) with `aui.attachment()` instead. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 <ParametersTable {...useAttachmentRuntime} />
 
 ### useComposer
 
-Deprecated: Use `useAuiState((s) => s.composer)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.composer)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 Hook to access the current composer state.
 
@@ -184,7 +158,9 @@ const useComposer: { (): ComposerState; <TSelected>(selector: (state: ComposerSt
 
 ### useComposerRuntime
 
-Deprecated: Use `useAui()` with `aui.composer()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAui](/docs/api-reference/hooks/state#useaui) with `aui.composer()` instead. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 Hook to access the ComposerRuntime from the current context.
 
@@ -197,7 +173,9 @@ the thread's main composer depending on the context.
 
 ### useEditComposer
 
-Deprecated: Use `useAuiState((s) => s.message.composer)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.message.composer)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 ```ts
 const useEditComposer: { (): EditComposerState; <TSelected>(selector: (state: EditComposerState) => TSelected): TSelected; <TSelected>(selector: ((state: EditComposerState) => TSelected) | undefined): EditComposerState | TSelected; (options: { optional?: false | undefined; }): EditComposerState; (options: { optional?: boolean | undefined; }): EditComposerState | null; <TSelected>(options: { optional?: false | undefined; selector: (state: EditComposerState) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: EditComposerState) => TSelected) | undefined; }): EditComposerState | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: EditComposerState) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: EditComposerState) => TSelected) | undefined; }): EditComposerState | TSelected | null; };
@@ -205,7 +183,9 @@ const useEditComposer: { (): EditComposerState; <TSelected>(selector: (state: Ed
 
 ### useMessage
 
-Deprecated: Use `useAuiState((s) => s.message)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.message)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 Hook to access the current message state.
 
@@ -218,21 +198,85 @@ const useMessage: { (): MessageState; <TSelected>(selector: (state: MessageState
 
 ### useMessagePart
 
-Deprecated: Use `useAuiState((s) => s.part)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.part)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 ```ts
 const useMessagePart: { (): MessagePartState; <TSelected>(selector: (state: MessagePartState) => TSelected): TSelected; <TSelected>(selector: ((state: MessagePartState) => TSelected) | undefined): MessagePartState | TSelected; (options: { optional?: false | undefined; }): MessagePartState; (options: { optional?: boolean | undefined; }): MessagePartState | null; <TSelected>(options: { optional?: false | undefined; selector: (state: MessagePartState) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: MessagePartState) => TSelected) | undefined; }): MessagePartState | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: MessagePartState) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: MessagePartState) => TSelected) | undefined; }): MessagePartState | TSelected | null; };
 ```
 
+### useMessagePartData
+
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.part)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
+
+<ParametersTable {...useMessagePartData} />
+
+### useMessagePartFile
+
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.part)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
+
+```ts
+const useMessagePartFile: () => FileMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; };
+```
+
+### useMessagePartImage
+
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.part)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
+
+```ts
+const useMessagePartImage: () => ImageMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; };
+```
+
+### useMessagePartReasoning
+
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.part)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
+
+```ts
+const useMessagePartReasoning: () => ReasoningMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; };
+```
+
 ### useMessagePartRuntime
 
-Deprecated: Use `useAui()` with `aui.part()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAui](/docs/api-reference/hooks/state#useaui) with `aui.part()` instead. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 <ParametersTable {...useMessagePartRuntime} />
 
+### useMessagePartSource
+
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.part)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
+
+```ts
+const useMessagePartSource: () => ({ readonly type: "source"; readonly sourceType: "url"; readonly id: string; readonly url: string; readonly title?: string; readonly providerMetadata?: SourceProviderMetadata; readonly parentId?: string; } & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; }) | ({ readonly type: "source"; readonly sourceType: "document"; readonly id: string; readonly url?: undefined; readonly title: string; readonly mediaType: string; readonly filename?: string; readonly providerMetadata?: SourceProviderMetadata; readonly parentId?: string; } & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; });
+```
+
+### useMessagePartText
+
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.part)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
+
+```ts
+const useMessagePartText: () => (TextMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; }) | (ReasoningMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; });
+```
+
 ### useMessageRuntime
 
-Deprecated: Use `useAui()` with `aui.message()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAui](/docs/api-reference/hooks/state#useaui) with `aui.message()` instead. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 Hook to access the MessageRuntime from the current context.
 
@@ -243,7 +287,9 @@ including message content, status, editing capabilities, and branching.
 
 ### useThread
 
-Deprecated: Use `useAuiState((s) => s.thread)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.thread)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 Hook to access the current thread state.
 
@@ -256,7 +302,9 @@ const useThread: { (): ThreadState; <TSelected>(selector: (state: ThreadState) =
 
 ### useThreadComposer
 
-Deprecated: Use `useAuiState((s) => s.thread.composer)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.thread.composer)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 ```ts
 const useThreadComposer: { (): ThreadComposerState; <TSelected>(selector: (state: ThreadComposerState) => TSelected): TSelected; <TSelected>(selector: ((state: ThreadComposerState) => TSelected) | undefined): ThreadComposerState | TSelected; (options: { optional?: false | undefined; }): ThreadComposerState; (options: { optional?: boolean | undefined; }): ThreadComposerState | null; <TSelected>(options: { optional?: false | undefined; selector: (state: ThreadComposerState) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: ThreadComposerState) => TSelected) | undefined; }): ThreadComposerState | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: ThreadComposerState) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: ThreadComposerState) => TSelected) | undefined; }): ThreadComposerState | TSelected | null; };
@@ -264,7 +312,9 @@ const useThreadComposer: { (): ThreadComposerState; <TSelected>(selector: (state
 
 ### useThreadList
 
-Deprecated: Use `useAuiState((s) => s.threads)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.threads)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 ```ts
 const useThreadList: { (): ThreadListState; <TSelected>(selector: (state: ThreadListState) => TSelected): TSelected; <TSelected>(selector: ((state: ThreadListState) => TSelected) | undefined): ThreadListState | TSelected; (options: { optional?: false | undefined; }): ThreadListState; (options: { optional?: boolean | undefined; }): ThreadListState | null; <TSelected>(options: { optional?: false | undefined; selector: (state: ThreadListState) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: ThreadListState) => TSelected) | undefined; }): ThreadListState | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: ThreadListState) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: ThreadListState) => TSelected) | undefined; }): ThreadListState | TSelected | null; };
@@ -272,7 +322,9 @@ const useThreadList: { (): ThreadListState; <TSelected>(selector: (state: Thread
 
 ### useThreadListItem
 
-Deprecated: Use `useAuiState((s) => s.threadListItem)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.threadListItem)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 ```ts
 const useThreadListItem: { (): ThreadListItemState; <TSelected>(selector: (state: ThreadListItemState) => TSelected): TSelected; <TSelected>(selector: ((state: ThreadListItemState) => TSelected) | undefined): ThreadListItemState | TSelected; (options: { optional?: false | undefined; }): ThreadListItemState; (options: { optional?: boolean | undefined; }): ThreadListItemState | null; <TSelected>(options: { optional?: false | undefined; selector: (state: ThreadListItemState) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: ThreadListItemState) => TSelected) | undefined; }): ThreadListItemState | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: ThreadListItemState) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: ThreadListItemState) => TSelected) | undefined; }): ThreadListItemState | TSelected | null; };
@@ -280,13 +332,17 @@ const useThreadListItem: { (): ThreadListItemState; <TSelected>(selector: (state
 
 ### useThreadListItemRuntime
 
-Deprecated: Use `useAui()` with `aui.threadListItem()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAui](/docs/api-reference/hooks/state#useaui) with `aui.threadListItem()` instead. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 <ParametersTable {...useThreadListItemRuntime} />
 
 ### useThreadRuntime
 
-Deprecated: Use `useAui()` with `aui.thread()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAui](/docs/api-reference/hooks/state#useaui) with `aui.thread()` instead. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 Hook to access the ThreadRuntime from the current context.
 

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/primitives.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/primitives.mdx
@@ -209,7 +209,9 @@ const useMessagePart: { (): MessagePartState; <TSelected>(selector: (state: Mess
 ### useMessagePartData
 
 <Callout type="warn">
-<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.part)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate) to select and narrow `s.part`.
+Return `null` for optional rendering, or throw inside the selector to
+preserve the old hook's strict behavior.
 </Callout>
 
 <ParametersTable {...useMessagePartData} />
@@ -217,7 +219,9 @@ const useMessagePart: { (): MessagePartState; <TSelected>(selector: (state: Mess
 ### useMessagePartFile
 
 <Callout type="warn">
-<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.part)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate) to select and narrow `s.part`.
+Return `null` for optional rendering, or throw inside the selector to
+preserve the old hook's strict behavior.
 </Callout>
 
 ```ts
@@ -227,7 +231,9 @@ const useMessagePartFile: () => FileMessagePart & { readonly status: MessagePart
 ### useMessagePartImage
 
 <Callout type="warn">
-<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.part)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate) to select and narrow `s.part`.
+Return `null` for optional rendering, or throw inside the selector to
+preserve the old hook's strict behavior.
 </Callout>
 
 ```ts
@@ -237,7 +243,9 @@ const useMessagePartImage: () => ImageMessagePart & { readonly status: MessagePa
 ### useMessagePartReasoning
 
 <Callout type="warn">
-<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.part)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate) to select and narrow `s.part`.
+Return `null` for optional rendering, or throw inside the selector to
+preserve the old hook's strict behavior.
 </Callout>
 
 ```ts
@@ -255,7 +263,9 @@ const useMessagePartReasoning: () => ReasoningMessagePart & { readonly status: M
 ### useMessagePartSource
 
 <Callout type="warn">
-<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.part)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate) to select and narrow `s.part`.
+Return `null` for optional rendering, or throw inside the selector to
+preserve the old hook's strict behavior.
 </Callout>
 
 ```ts
@@ -265,7 +275,9 @@ const useMessagePartSource: () => ({ readonly type: "source"; readonly sourceTyp
 ### useMessagePartText
 
 <Callout type="warn">
-<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.part)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate) to select and narrow `s.part`.
+Return `null` for optional rendering, or throw inside the selector to
+preserve the old hook's strict behavior.
 </Callout>
 
 ```ts

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/state.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/state.mdx
@@ -16,6 +16,17 @@ import { useAuiEvent, useAuiState } from "@/generated/typeDocs";
 
 ### useAui
 
+Returns the current `AssistantClient` from context.
+
+Read the client supplied by the nearest [AuiProvider](/docs/api-reference/context-providers/assistant-runtime-provider#auiprovider) or
+[AssistantRuntimeProvider](/docs/api-reference/context-providers/assistant-runtime-provider#assistantruntimeprovider), then access a scope on it —
+`aui.thread()`, `aui.composer()`, `aui.message()`, and so on. Pair
+with [useAuiState](/docs/api-reference/hooks/state#useauistate) to read reactive state and [useAuiEvent](/docs/api-reference/hooks/state#useauievent)
+to subscribe to events.
+
+Rendered outside a provider, the returned client's scope accessors
+throw a descriptive error the first time they are read.
+
 {/* api-example:useAui:start */}
 ```tsx
 import { useAui } from "@assistant-ui/react";
@@ -34,6 +45,13 @@ function useAui(): AssistantClient;
 
 ### useAuiEvent
 
+Subscribes to an assistant event for the lifetime of the component.
+
+The subscription is established on mount and re-established whenever the
+scope or event name changes. The `callback` is wrapped in an effect-event
+shim, so the latest closure is invoked on each emission — you do not
+need to memoize it.
+
 {/* api-example:useAuiEvent:start */}
 ```tsx
 import { useAuiEvent } from "@assistant-ui/react";
@@ -48,7 +66,14 @@ useAuiEvent("thread.runStart", (payload) => {
 
 ### useAuiState
 
-Hook to access a slice of the assistant state with automatic subscription
+Subscribes to a slice of [AssistantState](/docs/api-reference/primitives/assistant-if#assistantstate) and re-renders the
+component whenever that slice changes.
+
+The `selector` is called on every store update; its return value is
+compared by `Object.is`, and the component re-renders only when the
+selected slice changes. Returning the entire state object is not
+supported and throws at runtime — select a specific field instead, or
+compose multiple `useAuiState` calls.
 
 {/* api-example:useAuiState:start */}
 ```tsx

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/state.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/state.mdx
@@ -23,7 +23,8 @@ Read the client supplied by the nearest [AuiProvider](/docs/api-reference/contex
 `aui.thread()`, `aui.composer()`, `aui.message()`, and so on. Pair
 with [useAuiState](/docs/api-reference/hooks/state#useauistate) to read reactive state and [useAuiEvent](/docs/api-reference/hooks/state#useauievent)
 to subscribe to events. The returned client also exposes lower-level
-methods such as `aui.on(...)` and `aui.subscribe(...)`.
+methods such as `aui.on(...)` and `aui.subscribe(...)`; prefer
+`useAuiEvent` for React event subscriptions.
 
 Rendered outside a provider, the returned client's scope accessors
 throw a descriptive error whenever they are called.

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/state.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/state.mdx
@@ -22,10 +22,11 @@ Read the client supplied by the nearest [AuiProvider](/docs/api-reference/contex
 [AssistantRuntimeProvider](/docs/api-reference/context-providers/assistant-runtime-provider#assistantruntimeprovider), then access a scope on it —
 `aui.thread()`, `aui.composer()`, `aui.message()`, and so on. Pair
 with [useAuiState](/docs/api-reference/hooks/state#useauistate) to read reactive state and [useAuiEvent](/docs/api-reference/hooks/state#useauievent)
-to subscribe to events.
+to subscribe to events. The returned client also exposes lower-level
+methods such as `aui.on(...)` and `aui.subscribe(...)`.
 
 Rendered outside a provider, the returned client's scope accessors
-throw a descriptive error the first time they are read.
+throw a descriptive error whenever they are called.
 
 {/* api-example:useAui:start */}
 ```tsx
@@ -56,8 +57,8 @@ need to memoize it.
 ```tsx
 import { useAuiEvent } from "@assistant-ui/react";
 
-useAuiEvent("thread.runStart", (payload) => {
-  console.log("Run started", payload);
+useAuiEvent("thread.modelContextUpdate", ({ threadId }) => {
+  console.log("Model context updated", threadId);
 });
 ```
 {/* api-example:useAuiEvent:end */}
@@ -73,7 +74,10 @@ The `selector` is called on every store update; its return value is
 compared by `Object.is`, and the component re-renders only when the
 selected slice changes. Returning the entire state object is not
 supported and throws at runtime — select a specific field instead, or
-compose multiple `useAuiState` calls.
+compose multiple `useAuiState` calls. Returning a new object or array
+literal, including spreading `s.thread` into a new object, causes a
+re-render on every store update; either select primitives or return a
+memoized reference.
 
 {/* api-example:useAuiState:start */}
 ```tsx

--- a/apps/docs/content/docs/(reference)/api-reference/model-context/context.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/model-context/context.mdx
@@ -44,7 +44,9 @@ const ModelContextClient: () => ResourceElement<ClientOutput<"modelContext">, un
 
 ### useThreadModelContext
 
-Deprecated: Use `useAuiState((s) => s.thread.modelContext)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate): `useAuiState((s) => s.thread.modelContext)`. See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+</Callout>
 
 <ParametersTable {...useThreadModelContext} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/tools/definition.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/definition.mdx
@@ -35,9 +35,10 @@ const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: 
 Defines a model tool with its argument schema, execution behavior, and
 optional model-output conversion.
 
-This helper preserves the inferred argument and result types from the tool
-object, making it convenient to export reusable tool definitions for a
-[Toolkit](/docs/api-reference/tools/definition#toolkit), [Tools](/docs/api-reference/tools/definition#tools), or [useAssistantTool](/docs/api-reference/tools/definition#useassistanttool).
+This helper keeps reusable tool definitions type-checked and convenient to
+export for a [Toolkit](/docs/api-reference/tools/definition#toolkit), [Tools](/docs/api-reference/tools/definition#tools), or [useAssistantTool](/docs/api-reference/tools/definition#useassistanttool).
+Inference from parameter schemas is currently limited, so provide generic
+arguments when you need precise args or result types.
 
 <ParametersTable {...tool} />
 
@@ -45,9 +46,10 @@ object, making it convenient to export reusable tool definitions for a
 
 Tool definition accepted by the React tool registry.
 
-Extends the core tool contract with an optional render component. Frontend
-and human tools require a renderer so users can inspect the call and provide
-results when needed; backend tools may omit one.
+Extends the core tool contract with a render component. Human tools rely on
+the renderer to collect input from the user. Frontend tools execute in the
+browser and require a UI surface for their progress and result. Backend
+tools execute server-side and may omit a renderer.
 
 <ParametersTable {...ToolDefinition} />
 
@@ -80,6 +82,9 @@ mounted.
 If `render` is provided, it is also installed as the renderer for matching
 tool-call message parts. The registration is removed automatically when the
 component unmounts or the tool definition changes.
+
+Pass a referentially stable tool object, such as one declared at module
+scope or memoized with `useMemo`, to avoid re-registering on every render.
 
 <ParametersTable {...useAssistantTool} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/tools/definition.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/definition.mdx
@@ -49,7 +49,8 @@ Tool definition accepted by the React tool registry.
 Extends the core tool contract with a render component. Human tools rely on
 the renderer to collect input from the user. Frontend tools execute in the
 browser and require a UI surface for their progress and result. Backend
-tools execute server-side and may omit a renderer.
+tools execute server-side and may omit a renderer. The `render` component is
+required for frontend and human tools and optional for backend tools.
 
 <ParametersTable {...ToolDefinition} />
 

--- a/apps/docs/content/docs/(reference)/api-reference/tools/definition.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/definition.mdx
@@ -16,8 +16,14 @@ import { ToolDefinition, Tools, tool, useAssistantTool } from "@/generated/typeD
 
 ### makeAssistantTool
 
+Creates a React component that registers an assistant tool when rendered.
+
+Use this when exporting reusable tool modules that can be included in JSX
+rather than calling [useAssistantTool](/docs/api-reference/tools/definition#useassistanttool) directly.
+
 ```ts
 type AssistantToolProps = CoreAssistantToolProps<TArgs, TResult> & {
+  /** Component used to render calls to this tool in assistant messages. */
   render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
 };
 
@@ -26,13 +32,30 @@ const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: 
 
 ### tool
 
+Defines a model tool with its argument schema, execution behavior, and
+optional model-output conversion.
+
+This helper preserves the inferred argument and result types from the tool
+object, making it convenient to export reusable tool definitions for a
+[Toolkit](/docs/api-reference/tools/definition#toolkit), [Tools](/docs/api-reference/tools/definition#tools), or [useAssistantTool](/docs/api-reference/tools/definition#useassistanttool).
+
 <ParametersTable {...tool} />
 
 ### ToolDefinition
 
+Tool definition accepted by the React tool registry.
+
+Extends the core tool contract with an optional render component. Frontend
+and human tools require a renderer so users can inspect the call and provide
+results when needed; backend tools may omit one.
+
 <ParametersTable {...ToolDefinition} />
 
 ### Toolkit
+
+Named collection of tools exposed to the assistant model.
+
+Keys are the tool names the model receives and uses in tool calls.
 
 ```ts
 type Toolkit = Record<string, ToolDefinition<any, any>>;
@@ -40,9 +63,23 @@ type Toolkit = Record<string, ToolDefinition<any, any>>;
 
 ### Tools
 
+Registers tools with model context and installs tool-call renderers.
+
+Mount this resource near an assistant subtree when you want to expose a
+group of tools declaratively. Tool definitions are registered with model
+context, while each tool renderer is registered with the tools scope for
+message rendering.
+
 <ParametersTable {...Tools} />
 
 ### useAssistantTool
+
+Registers a tool with the assistant model context while the component is
+mounted.
+
+If `render` is provided, it is also installed as the renderer for matching
+tool-call message parts. The registration is removed automatically when the
+component unmounts or the tool definition changes.
 
 <ParametersTable {...useAssistantTool} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/tools/rendering.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/rendering.mdx
@@ -16,15 +16,26 @@ import { useAssistantDataUI, useAssistantToolUI } from "@/generated/typeDocs";
 
 ### DataRenderers
 
+Registers renderers for `data` message parts.
+
+Data renderers are looked up by the part's `name` field. Use this resource
+directly for a renderer scope, or prefer [useAssistantDataUI](/docs/api-reference/tools/rendering#useassistantdataui) /
+[makeAssistantDataUI](/docs/api-reference/tools/rendering#makeassistantdataui) when registering from React components.
+
 ```ts
 const DataRenderers: () => ResourceElement<ClientOutput<"dataRenderers">, undefined>;
 ```
 
 ### makeAssistantDataUI
 
+Creates a React component that registers a named data-part renderer when
+rendered.
+
 ```ts
 type AssistantDataUIProps = {
+  /** Data part name this renderer handles. */
   name: string;
+  /** Component rendered for matching data message parts. */
   render: DataMessagePartComponent<T>;
 };
 
@@ -33,9 +44,16 @@ const makeAssistantDataUI: <T = any>(dataUI: AssistantDataUIProps<T>) => Assista
 
 ### makeAssistantToolUI
 
+Creates a React component that registers a tool-call renderer when rendered.
+
+Use this to package reusable display components for tools whose definitions
+are registered elsewhere.
+
 ```ts
 type AssistantToolUIProps = {
+  /** Name of the tool whose calls should use this renderer. */
   toolName: string;
+  /** Component rendered for matching tool-call message parts. */
   render: ToolCallMessagePartComponent<TArgs, TResult>;
 };
 
@@ -44,9 +62,18 @@ const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<TArgs, TR
 
 ### useAssistantDataUI
 
+Registers a renderer for named `data` message parts while the component is
+mounted.
+
 <ParametersTable {...useAssistantDataUI} />
 
 ### useAssistantToolUI
+
+Registers a tool-call renderer while the component is mounted.
+
+This only affects rendering. Pair it with [useAssistantTool](/docs/api-reference/tools/definition#useassistanttool),
+[Tools](/docs/api-reference/tools/definition#tools), or a backend tool registry to expose the actual tool
+definition to the model.
 
 <ParametersTable {...useAssistantToolUI} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/tools/status.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/status.mdx
@@ -16,6 +16,12 @@ description: Read tool arguments, execution status, and result state inside assi
 
 ### useToolArgsStatus
 
+Reads whether each argument field for the current tool-call message part is
+still streaming or complete.
+
+Use inside a tool-call renderer to avoid showing incomplete argument values
+as final.
+
 ```ts
 const useToolArgsStatus: <TArgs extends Record<string, unknown> = Record<string, unknown>>() => ToolArgsStatus<TArgs>;
 ```

--- a/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
@@ -3,7 +3,7 @@ title: Utilities
 description: Miscellaneous @assistant-ui/react utilities for custom rendering, composition, and advanced assistant UI behavior.
 ---
 
-import { AssistantCloud, ChainOfThoughtClient, DevToolsHooks, ExportedMessageRepository, InMemoryThreadList, SingleThreadList } from "@/generated/typeDocs";
+import { AssistantCloud, ChainOfThoughtClient, DevToolsHooks, ExportedMessageRepository, InMemoryThreadList, McpAppRenderer, McpAppsRemoteHost, SingleThreadList, getMcpAppFromToolPart } from "@/generated/typeDocs";
 
 {/* AUTO-GENERATED PAGE by scripts/generate-api-reference.mts */}
 {/* Do not edit manually. */}
@@ -30,6 +30,10 @@ import { AssistantCloud, ChainOfThoughtClient, DevToolsHooks, ExportedMessageRep
 
 <ParametersTable {...ExportedMessageRepository} />
 
+### getMcpAppFromToolPart
+
+<ParametersTable {...getMcpAppFromToolPart} />
+
 ### InMemoryThreadList
 
 <ParametersTable {...InMemoryThreadList} />
@@ -45,6 +49,14 @@ const Interactables: () => ResourceElement<ClientOutput<"interactables">, undefi
 ```ts
 const makeAssistantVisible: <T extends ComponentType<any>>(Component: T, config?: { clickable?: boolean | undefined; editable?: boolean | undefined; }) => T;
 ```
+
+### McpAppRenderer
+
+<ParametersTable {...McpAppRenderer} />
+
+### McpAppsRemoteHost
+
+<ParametersTable {...McpAppsRemoteHost} />
 
 ### SingleThreadList
 

--- a/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
@@ -32,6 +32,12 @@ import { AssistantCloud, ChainOfThoughtClient, DevToolsHooks, ExportedMessageRep
 
 ### getMcpAppFromToolPart
 
+Returns MCP app metadata for a tool-call part that points at a `ui://`
+resource.
+
+Returns `undefined` when the part has no MCP app metadata or the metadata
+does not reference an assistant-ui MCP app resource.
+
 <ParametersTable {...getMcpAppFromToolPart} />
 
 ### InMemoryThreadList
@@ -52,9 +58,22 @@ const makeAssistantVisible: <T extends ComponentType<any>>(Component: T, config?
 
 ### McpAppRenderer
 
+Creates a tool-call renderer for MCP Apps embedded in assistant messages.
+
+Compose this into the `Tools` resource through its `mcpApp` option. When a
+tool-call part carries `mcp.app` metadata for a `ui://` resource, the
+renderer loads that resource from the configured host and displays it in a
+sandboxed frame.
+
 <ParametersTable {...McpAppRenderer} />
 
 ### McpAppsRemoteHost
+
+Creates the default HTTP host for MCP App widgets.
+
+The host POSTs widget requests to the configured route as `{ method,
+params }`, using the method names expected by the assistant-ui MCP Apps
+guide.
 
 <ParametersTable {...McpAppsRemoteHost} />
 

--- a/apps/docs/content/docs/guides/context-api.mdx
+++ b/apps/docs/content/docs/guides/context-api.mdx
@@ -258,8 +258,8 @@ useAuiEvent("composer.send", (event) => {
 });
 
 // Listen to thread events
-useAuiEvent("thread.runStart", (event) => {
-  console.log("Run started in thread:", event.threadId);
+useAuiEvent("thread.modelContextUpdate", (event) => {
+  console.log("Model context updated in thread:", event.threadId);
 });
 
 // Listen to all events of a type across all scopes

--- a/apps/docs/content/docs/ink/hooks.mdx
+++ b/apps/docs/content/docs/ink/hooks.mdx
@@ -55,8 +55,8 @@ Subscribe to events without causing re-renders.
 ```tsx
 import { useAuiEvent } from "@assistant-ui/react-ink";
 
-useAuiEvent("thread.runStart", (payload) => {
-  console.log("Run started:", payload);
+useAuiEvent("thread.modelContextUpdate", ({ threadId }) => {
+  console.log("Model context updated:", threadId);
 });
 ```
 

--- a/apps/docs/content/docs/react-native/hooks.mdx
+++ b/apps/docs/content/docs/react-native/hooks.mdx
@@ -55,8 +55,8 @@ Subscribe to events without causing re-renders.
 ```tsx
 import { useAuiEvent } from "@assistant-ui/react-native";
 
-useAuiEvent("thread.runStart", (payload) => {
-  console.log("Run started:", payload);
+useAuiEvent("thread.modelContextUpdate", ({ threadId }) => {
+  console.log("Model context updated:", threadId);
 });
 ```
 

--- a/packages/assistant-stream/src/core/AssistantStream.ts
+++ b/packages/assistant-stream/src/core/AssistantStream.ts
@@ -1,7 +1,22 @@
 import type { AssistantStreamChunk } from "./AssistantStreamChunk";
 
+/**
+ * Stream of assistant-ui protocol chunks.
+ *
+ * `AssistantStream` is the normalized internal stream format used by
+ * encoders, decoders, accumulators, and tool execution transforms. Use an
+ * encoder such as `DataStreamEncoder` when returning it from an HTTP route,
+ * and the matching decoder when reading it back from a response.
+ */
 export type AssistantStream = ReadableStream<AssistantStreamChunk>;
 
+/**
+ * Encoder that converts an {@link AssistantStream} into bytes suitable for an
+ * HTTP response body.
+ *
+ * Encoders may expose response headers, such as content type or protocol
+ * markers, through `headers`.
+ */
 export type AssistantStreamEncoder = ReadableWritablePair<
   Uint8Array<ArrayBuffer>,
   AssistantStreamChunk
@@ -10,12 +25,26 @@ export type AssistantStreamEncoder = ReadableWritablePair<
 };
 
 export const AssistantStream = {
+  /**
+   * Converts an {@link AssistantStream} into a `Response` using the supplied
+   * encoder.
+   *
+   * The encoder's `headers` are copied onto the response. Pair this with the
+   * decoder for the same wire format when consuming the response.
+   */
   toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder) {
     return new Response(AssistantStream.toByteStream(stream, transformer), {
       headers: transformer.headers ?? {},
     });
   },
 
+  /**
+   * Reads an assistant stream from a `Response` body using the supplied
+   * decoder.
+   *
+   * The response body must be present and encoded with the matching assistant
+   * stream wire format.
+   */
   fromResponse(
     response: Response,
     transformer: ReadableWritablePair<
@@ -26,6 +55,10 @@ export const AssistantStream = {
     return AssistantStream.fromByteStream(response.body!, transformer);
   },
 
+  /**
+   * Pipes an {@link AssistantStream} through an encoder and returns the
+   * resulting byte stream.
+   */
   toByteStream(
     stream: AssistantStream,
     transformer: ReadableWritablePair<
@@ -36,6 +69,10 @@ export const AssistantStream = {
     return stream.pipeThrough(transformer);
   },
 
+  /**
+   * Pipes a byte stream through a decoder and returns normalized
+   * {@link AssistantStreamChunk} values.
+   */
   fromByteStream(
     readable: ReadableStream<Uint8Array<ArrayBuffer>>,
     transformer: ReadableWritablePair<

--- a/packages/assistant-stream/src/core/AssistantStreamChunk.ts
+++ b/packages/assistant-stream/src/core/AssistantStreamChunk.ts
@@ -2,6 +2,12 @@ import type { ReadonlyJSONValue } from "../utils/json/json-value";
 import type { ObjectStreamOperation } from "./object/types";
 import type { ToolModelContentPart } from "./tool/tool-types";
 
+/**
+ * Initial metadata for a stream part.
+ *
+ * A part starts with `part-start`, receives zero or more chunks at the same
+ * path, and ends with `part-finish`.
+ */
 export type PartInit =
   | {
       readonly type: "text" | "reasoning";
@@ -34,34 +40,49 @@ export type PartInit =
       readonly parentId?: string;
     };
 
+/**
+ * Normalized assistant-ui streaming protocol chunk.
+ *
+ * `path` identifies the part or nested position the chunk belongs to. Encoders
+ * may translate these chunks into provider-specific wire formats, while
+ * accumulators consume them to build assistant messages.
+ */
 export type AssistantStreamChunk = { readonly path: readonly number[] } & (
   | {
+      /** Opens a new content part at `path`. */
       readonly type: "part-start";
       readonly part: PartInit;
     }
   | {
+      /** Closes the current part at `path`. */
       readonly type: "part-finish";
     }
   | {
+      /** Marks streamed tool-call argument text as complete. */
       readonly type: "tool-call-args-text-finish";
     }
   | {
+      /** Appends text to a text, reasoning, or tool-call argument part. */
       readonly type: "text-delta";
       readonly textDelta: string;
     }
   | {
+      /** Appends provider or application annotations to the current message. */
       readonly type: "annotations";
       readonly annotations: ReadonlyJSONValue[];
     }
   | {
+      /** Emits application data chunks associated with the current message. */
       readonly type: "data";
       readonly data: ReadonlyJSONValue[];
     }
   | {
+      /** Starts a model generation step. */
       readonly type: "step-start";
       readonly messageId: string;
     }
   | {
+      /** Finishes a model generation step and reports usage for that step. */
       readonly type: "step-finish";
       readonly finishReason:
         | "stop"
@@ -78,6 +99,7 @@ export type AssistantStreamChunk = { readonly path: readonly number[] } & (
       readonly isContinued: boolean;
     }
   | {
+      /** Finishes the assistant message and reports final usage. */
       readonly type: "message-finish";
       readonly finishReason:
         | "stop"
@@ -93,6 +115,12 @@ export type AssistantStreamChunk = { readonly path: readonly number[] } & (
       };
     }
   | {
+      /**
+       * Emits the result for a tool-call part.
+       *
+       * `artifact` is UI-visible metadata, while `modelContent` can override
+       * what is sent back to the model.
+       */
       readonly type: "result";
       readonly artifact?: ReadonlyJSONValue;
       readonly result: ReadonlyJSONValue;
@@ -101,10 +129,12 @@ export type AssistantStreamChunk = { readonly path: readonly number[] } & (
       readonly messages?: ReadonlyJSONValue;
     }
   | {
+      /** Emits a stream-level error message. */
       readonly type: "error";
       readonly error: string;
     }
   | {
+      /** Applies object-stream operations to state carried by this stream. */
       readonly type: "update-state";
       readonly operations: ObjectStreamOperation[];
     }

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -29,18 +29,63 @@ type ToolCallPartInit = {
   response?: ToolResponseLike<ReadonlyJSONValue>;
 };
 
+/**
+ * Imperative writer for constructing an {@link AssistantStream}.
+ *
+ * The controller handles part boundaries for common streaming operations. Use
+ * `appendText` and `appendReasoning` for simple token streams, or open explicit
+ * parts with `addTextPart` and `addToolCallPart` when you need direct control.
+ */
 export type AssistantStreamController = {
+  /** Appends text to the current text part, opening one if needed. */
   appendText(textDelta: string): void;
+  /** Appends reasoning text to the current reasoning part, opening one if needed. */
   appendReasoning(reasoningDelta: string): void;
+  /** Appends a source citation part to the stream. */
   appendSource(options: SourcePart): void;
+  /** Appends a file part to the stream. */
   appendFile(options: FilePart): void;
+  /** Appends a named data part to the stream. */
   appendData(options: DataPart): void;
+  /**
+   * Opens a text part and returns its writer.
+   *
+   * Close the returned controller when the text part is complete. Opening a new
+   * part through this controller closes any implicit text or reasoning append
+   * part first.
+   */
   addTextPart(): TextStreamController;
+  /**
+   * Opens a tool-call part by tool name and returns its writer.
+   *
+   * A tool call id is generated automatically. Use the object overload when the
+   * caller already has an id, initial args, args text, or response.
+   */
   addToolCallPart(options: string): ToolCallStreamController;
+  /**
+   * Opens a tool-call part and returns its writer.
+   *
+   * Use this overload to provide a stable `toolCallId`, initial arguments,
+   * streamed argument text, or an immediate {@link ToolResponseLike}.
+   */
   addToolCallPart(options: ToolCallPartInit): ToolCallStreamController;
+  /** Enqueues a raw protocol chunk. Prefer higher-level helpers when possible. */
   enqueue(chunk: AssistantStreamChunk): void;
+  /**
+   * Merges another assistant stream into this stream.
+   *
+   * Paths from the merged stream are remapped so its parts appear at the next
+   * available position in this controller's output.
+   */
   merge(stream: AssistantStream): void;
+  /** Closes any active part and finishes the stream. */
   close(): void;
+  /**
+   * Returns a controller that writes child parts with `parentId` attached.
+   *
+   * Use this for nested or related parts that should be associated with an
+   * existing message or part in downstream renderers.
+   */
   withParentId(parentId: string): AssistantStreamController;
 };
 

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -271,6 +271,15 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
   }
 }
 
+/**
+ * Creates an {@link AssistantStream} and writes to it with an
+ * {@link AssistantStreamController}.
+ *
+ * The callback may write synchronously or asynchronously. If it throws, an
+ * `error` chunk is emitted before the error is rethrown; when the callback
+ * settles, the stream is closed automatically unless the controller was
+ * already closed.
+ */
 export function createAssistantStream(
   callback: (controller: AssistantStreamController) => PromiseLike<void> | void,
 ): AssistantStream {
@@ -299,6 +308,13 @@ export function createAssistantStream(
   return controller.__internal_getReadable();
 }
 
+/**
+ * Creates an {@link AssistantStream} together with the controller used to
+ * write into it.
+ *
+ * Use this when the stream needs to be returned before all writers are known.
+ * Closing the returned controller finishes the paired stream.
+ */
 export function createAssistantStreamController() {
   const { resolve, promise } = promiseWithResolvers<void>();
   let controller!: AssistantStreamController;
@@ -314,6 +330,13 @@ export function createAssistantStreamController() {
   return [stream, controller] as const;
 }
 
+/**
+ * Creates a `Response` whose body is an encoded {@link AssistantStream}.
+ *
+ * This is the HTTP-route convenience form of {@link createAssistantStream}; it
+ * uses {@link DataStreamEncoder} so the response can be consumed by matching
+ * assistant-ui data stream decoders.
+ */
 export function createAssistantStreamResponse(
   callback: (controller: AssistantStreamController) => PromiseLike<void> | void,
 ) {

--- a/packages/assistant-stream/src/core/tool/ToolResponse.ts
+++ b/packages/assistant-stream/src/core/tool/ToolResponse.ts
@@ -1,16 +1,53 @@
 import type { ReadonlyJSONValue } from "../../utils/json/json-value";
-import type { ToolModelContentPart } from "./tool-types";
+import type {
+  ToolModelContentPart,
+  ToolModelOutputFunction,
+} from "./tool-types";
 
 const TOOL_RESPONSE_SYMBOL = Symbol.for("aui.tool-response");
 
+/**
+ * Shape accepted anywhere a {@link ToolResponse} can be returned.
+ */
 export type ToolResponseLike<TResult> = {
+  /** UI-visible tool result value. */
   result: TResult;
+  /**
+   * Optional UI-only artifact associated with the result.
+   *
+   * Artifacts are useful for large or structured data that should be available
+   * to renderers without necessarily being sent back to the model.
+   */
   artifact?: ReadonlyJSONValue | undefined;
+  /** Marks the tool result as an error result. */
   isError?: boolean | undefined;
+  /**
+   * Explicit model-visible content to send back after the tool call.
+   *
+   * When omitted, assistant-ui derives model output from `result` or a tool's
+   * {@link ToolModelOutputFunction}.
+   */
   modelContent?: readonly ToolModelContentPart[] | undefined;
+  /** Optional provider-specific message payload associated with the tool result. */
   messages?: ReadonlyJSONValue | undefined;
 };
 
+/**
+ * Tool result wrapper for separating UI-visible output from model-visible
+ * output.
+ *
+ * Return `ToolResponse` from a tool when you need to attach an artifact, mark
+ * the result as an error, or control the content sent back to the model.
+ *
+ * @example
+ * ```ts
+ * return new ToolResponse({
+ *   result: { title: "Report ready" },
+ *   artifact: { reportId },
+ *   modelContent: [{ type: "text", text: "The report is ready." }],
+ * });
+ * ```
+ */
 export class ToolResponse<TResult> {
   get [TOOL_RESPONSE_SYMBOL]() {
     return true;
@@ -44,6 +81,13 @@ export class ToolResponse<TResult> {
     );
   }
 
+  /**
+   * Converts a plain tool return value into a {@link ToolResponse}.
+   *
+   * Existing `ToolResponse` instances are returned unchanged. `undefined`
+   * becomes the string `"<no result>"` so downstream protocol chunks always
+   * carry a concrete result.
+   */
   static toResponse(result: any | ToolResponse<any>): ToolResponse<any> {
     if (result instanceof ToolResponse) {
       return result;

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -6,19 +6,35 @@ import type { ToolResponse } from "./ToolResponse";
 
 export type ToolModelContentPart =
   | {
+      /** A text content part returned to the model after a tool call. */
       readonly type: "text";
+      /** Text that should be included in the model-visible tool result. */
       readonly text: string;
     }
   | {
+      /** A file content part returned to the model after a tool call. */
       readonly type: "file";
+      /** File payload encoded as a string. */
       readonly data: string;
+      /** MIME type for the file payload. */
       readonly mediaType: string;
+      /** Optional display filename for the file payload. */
       readonly filename?: string;
     };
 
+/**
+ * Converts a tool's runtime result into content that is sent back to the
+ * model.
+ *
+ * Return this when the value shown in the UI or stored as the tool result
+ * should differ from the model-visible response.
+ */
 export type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  /** Stable identifier for the tool call being converted. */
   toolCallId: string;
+  /** Arguments supplied by the model for this tool call. */
   input: TArgs;
+  /** Value returned by the tool's {@link ToolExecuteFunction}. */
   output: TResult;
 }) =>
   | readonly ToolModelContentPart[]
@@ -90,7 +106,8 @@ export interface ToolCallReader<
   response: ToolCallResponseReader<TResult>;
 
   /**
-   * @deprecated Deprecated. Use `response.get().result` instead.
+   * @deprecated Deprecated. Use {@link ToolCallReader.response} and read
+   * `response.get().result` instead.
    */
   result: {
     get: () => Promise<TResult>;
@@ -98,11 +115,20 @@ export interface ToolCallReader<
 }
 
 export type ToolExecutionContext = {
+  /** Stable identifier for the tool call being executed. */
   toolCallId: string;
+  /** Signal that is aborted when the current run is cancelled. */
   abortSignal: AbortSignal;
+  /**
+   * Requests human input for a {@link Tool} with `type: "human"` and resolves
+   * with the payload supplied by the UI.
+   */
   human: (payload: unknown) => Promise<unknown>;
 };
 
+/**
+ * Function called when assistant-ui executes a frontend tool.
+ */
 export type ToolExecuteFunction<TArgs, TResult> = (
   args: TArgs,
   context: ToolExecutionContext,
@@ -135,13 +161,20 @@ type BackendTool<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
 > = ToolBase<TArgs, TResult> & {
+  /** Tool that is executed by the backend rather than in the browser. */
   type: "backend";
 
+  /** Backend tools are described by the backend model/tool registry. */
   description?: undefined;
+  /** Backend tools receive their parameter schema from the backend. */
   parameters?: undefined;
+  /** Backend tools cannot be disabled from the frontend tool definition. */
   disabled?: undefined;
+  /** Backend tools are not executed by the frontend runtime. */
   execute?: undefined;
+  /** Backend tools do not convert frontend results to model output. */
   toModelOutput?: undefined;
+  /** Backend tools do not run frontend schema validation. */
   experimental_onSchemaValidationError?: undefined;
 };
 
@@ -149,13 +182,20 @@ type FrontendTool<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
 > = ToolBase<TArgs, TResult> & {
+  /** Tool that is executed in the frontend runtime. */
   type: "frontend";
 
+  /** Natural-language description shown to the model when selecting tools. */
   description?: string | undefined;
+  /** Schema for the arguments the model must provide when calling the tool. */
   parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  /** Prevents the tool from being exposed to the model while true. */
   disabled?: boolean;
+  /** Executes the tool after the model provides valid arguments. */
   execute: ToolExecuteFunction<TArgs, TResult>;
+  /** Converts the execution result into model-visible output. */
   toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  /** Handles invalid tool arguments when schema validation fails. */
   experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
 };
 
@@ -163,16 +203,30 @@ type HumanTool<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
 > = ToolBase<TArgs, TResult> & {
+  /** Tool that pauses the run until a user or UI supplies a result. */
   type: "human";
 
+  /** Natural-language description shown to the model when selecting tools. */
   description?: string | undefined;
+  /** Schema for the arguments the model must provide when requesting input. */
   parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  /** Prevents the tool from being exposed to the model while true. */
   disabled?: boolean;
+  /** Human tools are resolved by UI/human input, not direct execution. */
   execute?: undefined;
+  /** Human tool results are sent back as supplied by the UI. */
   toModelOutput?: undefined;
+  /** Human tools do not run frontend schema validation callbacks. */
   experimental_onSchemaValidationError?: undefined;
 };
 
+/**
+ * Definition for a tool that can be exposed to the assistant model.
+ *
+ * Use `type: "frontend"` for tools executed in the browser, `type: "backend"`
+ * for tools handled by your server, and `type: "human"` for flows that pause
+ * until the UI supplies a result.
+ */
 export type Tool<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
@@ -183,7 +237,7 @@ export type Tool<
   | ToolWithoutType<TArgs, TResult>;
 
 /**
- * @deprecated Use `Tool` with an explicit `type` field instead.
+ * @deprecated Use {@link Tool} with an explicit `type` field instead.
  */
 export type ToolWithoutType<
   TArgs extends Record<string, unknown> = Record<string, unknown>,

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -14,7 +14,10 @@ export type ToolModelContentPart =
   | {
       /** A file content part returned to the model after a tool call. */
       readonly type: "file";
-      /** File payload encoded as a string. */
+      /**
+       * File payload encoded as a provider-compatible string, commonly base64
+       * for binary data.
+       */
       readonly data: string;
       /** MIME type for the file payload. */
       readonly mediaType: string;
@@ -27,7 +30,25 @@ export type ToolModelContentPart =
  * model.
  *
  * Return this when the value shown in the UI or stored as the tool result
- * should differ from the model-visible response.
+ * should differ from the model-visible response. When omitted, the successful
+ * tool result is sent back to the model as-is. If a tool returns a
+ * `ToolResponse` with `modelContent`, that explicit content is used instead
+ * of calling this function.
+ *
+ * @example
+ * ```ts
+ * const toModelOutput: ToolModelOutputFunction<
+ *   { documentId: string },
+ *   { summary: string; pdfBase64: string }
+ * > = ({ output }) => [
+ *   { type: "text", text: output.summary },
+ *   {
+ *     type: "file",
+ *     data: output.pdfBase64,
+ *     mediaType: "application/pdf",
+ *   },
+ * ];
+ * ```
  */
 export type ToolModelOutputFunction<TArgs, TResult> = (options: {
   /** Stable identifier for the tool call being converted. */
@@ -120,8 +141,8 @@ export type ToolExecutionContext = {
   /** Signal that is aborted when the current run is cancelled. */
   abortSignal: AbortSignal;
   /**
-   * Requests human input for a {@link Tool} with `type: "human"` and resolves
-   * with the payload supplied by the UI.
+   * From inside a frontend tool's execute function, request human input from
+   * the UI. Resolves with the payload the UI supplies.
    */
   human: (payload: unknown) => Promise<unknown>;
 };
@@ -168,7 +189,7 @@ type BackendTool<
   description?: undefined;
   /** Backend tools receive their parameter schema from the backend. */
   parameters?: undefined;
-  /** Backend tools cannot be disabled from the frontend tool definition. */
+  /** Backend tools are disabled or filtered by the backend tool registry. */
   disabled?: undefined;
   /** Backend tools are not executed by the frontend runtime. */
   execute?: undefined;
@@ -226,6 +247,40 @@ type HumanTool<
  * Use `type: "frontend"` for tools executed in the browser, `type: "backend"`
  * for tools handled by your server, and `type: "human"` for flows that pause
  * until the UI supplies a result.
+ *
+ * @example
+ * ```ts
+ * const frontendTool: Tool<{ city: string }, string> = {
+ *   type: "frontend",
+ *   description: "Get the weather for a city.",
+ *   parameters: {
+ *     type: "object",
+ *     properties: { city: { type: "string" } },
+ *     required: ["city"],
+ *   },
+ *   execute: async ({ city }) => `Sunny in ${city}`,
+ * };
+ * ```
+ *
+ * @example
+ * ```ts
+ * const backendTool: Tool = {
+ *   type: "backend",
+ * };
+ * ```
+ *
+ * @example
+ * ```ts
+ * const humanTool: Tool<{ question: string }, string> = {
+ *   type: "human",
+ *   description: "Ask the user a follow-up question.",
+ *   parameters: {
+ *     type: "object",
+ *     properties: { question: { type: "string" } },
+ *     required: ["question"],
+ *   },
+ * };
+ * ```
  */
 export type Tool<
   TArgs extends Record<string, unknown> = Record<string, unknown>,

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -127,7 +127,7 @@ export interface ToolCallReader<
   response: ToolCallResponseReader<TResult>;
 
   /**
-   * @deprecated Deprecated. Use {@link ToolCallReader.response} and read
+   * @deprecated Use {@link ToolCallReader.response} and read
    * `response.get().result` instead.
    */
   result: {
@@ -185,17 +185,11 @@ type BackendTool<
   /** Tool that is executed by the backend rather than in the browser. */
   type: "backend";
 
-  /** Backend tools are described by the backend model/tool registry. */
   description?: undefined;
-  /** Backend tools receive their parameter schema from the backend. */
   parameters?: undefined;
-  /** Backend tools are disabled or filtered by the backend tool registry. */
   disabled?: undefined;
-  /** Backend tools are not executed by the frontend runtime. */
   execute?: undefined;
-  /** Backend tools do not convert frontend results to model output. */
   toModelOutput?: undefined;
-  /** Backend tools do not run frontend schema validation. */
   experimental_onSchemaValidationError?: undefined;
 };
 
@@ -233,11 +227,8 @@ type HumanTool<
   parameters: StandardSchemaV1<TArgs> | JSONSchema7;
   /** Prevents the tool from being exposed to the model while true. */
   disabled?: boolean;
-  /** Human tools are resolved by UI/human input, not direct execution. */
   execute?: undefined;
-  /** Human tool results are sent back as supplied by the UI. */
   toModelOutput?: undefined;
-  /** Human tools do not run frontend schema validation callbacks. */
   experimental_onSchemaValidationError?: undefined;
 };
 

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -214,10 +214,25 @@ export async function unstable_runPendingTools(
 }
 
 export type ToolResultStreamOptions = {
+  /** Called immediately before a frontend tool's `execute` function runs. */
   onExecutionStart?: (toolCallId: string, toolName: string) => void;
+  /** Called after frontend tool execution finishes or fails. */
   onExecutionEnd?: (toolCallId: string, toolName: string) => void;
 };
 
+/**
+ * Transform stream that executes frontend tools and appends tool results.
+ *
+ * The transform watches streamed tool-call arguments, runs the matching
+ * frontend tool once its arguments are complete, and emits a result chunk for
+ * the tool call. Backend and human tools pass through according to their tool
+ * definition.
+ *
+ * @param tools Tool registry or function returning the current registry.
+ * @param abortSignal Signal, or signal getter, used for the current run.
+ * @param human Callback used to resolve human-tool requests from UI input.
+ * @param options Optional execution lifecycle callbacks.
+ */
 export function toolResultStream(
   tools:
     | Record<string, Tool>

--- a/packages/core/src/model-context/tool.ts
+++ b/packages/core/src/model-context/tool.ts
@@ -2,6 +2,16 @@ import type { Tool } from "assistant-stream";
 
 // TODO re-add the inferrence of the parameters
 
+/**
+ * Defines a model tool with its argument schema, execution behavior, and
+ * optional model-output conversion.
+ *
+ * This helper preserves the inferred argument and result types from the tool
+ * object, making it convenient to export reusable tool definitions for a
+ * {@link Toolkit}, {@link Tools}, or {@link useAssistantTool}.
+ *
+ * @param tool - Tool definition to expose to the assistant model.
+ */
 export function tool<TArgs extends Record<string, unknown>, TResult = any>(
   tool: Tool<TArgs, TResult>,
 ): Tool<TArgs, TResult> {

--- a/packages/core/src/model-context/tool.ts
+++ b/packages/core/src/model-context/tool.ts
@@ -6,11 +6,26 @@ import type { Tool } from "assistant-stream";
  * Defines a model tool with its argument schema, execution behavior, and
  * optional model-output conversion.
  *
- * This helper preserves the inferred argument and result types from the tool
- * object, making it convenient to export reusable tool definitions for a
- * {@link Toolkit}, {@link Tools}, or {@link useAssistantTool}.
+ * This helper keeps reusable tool definitions type-checked and convenient to
+ * export for a {@link Toolkit}, {@link Tools}, or {@link useAssistantTool}.
+ * Inference from parameter schemas is currently limited, so provide generic
+ * arguments when you need precise args or result types.
  *
  * @param tool - Tool definition to expose to the assistant model.
+ *
+ * @example
+ * ```ts
+ * const getWeather = tool<{ city: string }, string>({
+ *   type: "frontend",
+ *   description: "Get the weather for a city.",
+ *   parameters: {
+ *     type: "object",
+ *     properties: { city: { type: "string" } },
+ *     required: ["city"],
+ *   },
+ *   execute: async ({ city }) => `Sunny in ${city}`,
+ * });
+ * ```
  */
 export function tool<TArgs extends Record<string, unknown>, TResult = any>(
   tool: Tool<TArgs, TResult>,

--- a/packages/core/src/react/AssistantRuntimeProvider.tsx
+++ b/packages/core/src/react/AssistantRuntimeProvider.tsx
@@ -15,7 +15,7 @@ import { AssistantProviderBase } from "./AssistantProvider";
  * @example
  * ```tsx
  * function App() {
- *   const runtime = useLocalRuntime({ adapter });
+ *   const runtime = useLocalRuntime(MyModelAdapter);
  *
  *   return (
  *     <AssistantRuntimeProvider runtime={runtime}>
@@ -31,13 +31,17 @@ export const AssistantRuntimeProvider = memo(
     aui,
     children,
   }: {
-    /** The assistant runtime to expose to descendants. */
+    /**
+     * The assistant runtime to expose to descendants. Build one with
+     * `useLocalRuntime`, `useExternalStoreRuntime`, or
+     * `useAssistantTransportRuntime`.
+     */
     runtime: AssistantRuntime;
     /**
-     * Optional pre-built `AssistantClient`. When omitted, the provider
-     * derives a client from `runtime`. Pass an explicit client only when
-     * composing multiple runtimes or extending scopes upstream.
-     * @defaultValue derived from `runtime`
+     * Optional parent `AssistantClient` whose scopes are inherited by the
+     * client created for this runtime. Use this when nesting an
+     * `AssistantRuntimeProvider` inside another assistant context.
+     * @defaultValue null
      */
     aui?: AssistantClient | null;
     children: ReactNode;

--- a/packages/core/src/react/AssistantRuntimeProvider.tsx
+++ b/packages/core/src/react/AssistantRuntimeProvider.tsx
@@ -3,13 +3,42 @@ import type { AssistantClient } from "@assistant-ui/store";
 import type { AssistantRuntime } from "../runtime/api/assistant-runtime";
 import { AssistantProviderBase } from "./AssistantProvider";
 
+/**
+ * Mounts an `AssistantRuntime` into the React tree.
+ *
+ * Accepts the runtime returned by a runtime hook (e.g. `useLocalRuntime`,
+ * `useExternalStoreRuntime`, `useAssistantTransportRuntime`). Internally
+ * installs an {@link AuiProvider}, so descendants can use `useAui`,
+ * `useAuiState`, `useAuiEvent`, and the primitives without any
+ * additional setup.
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   const runtime = useLocalRuntime({ adapter });
+ *
+ *   return (
+ *     <AssistantRuntimeProvider runtime={runtime}>
+ *       <Thread />
+ *     </AssistantRuntimeProvider>
+ *   );
+ * }
+ * ```
+ */
 export const AssistantRuntimeProvider = memo(
   ({
     runtime,
     aui,
     children,
   }: {
+    /** The assistant runtime to expose to descendants. */
     runtime: AssistantRuntime;
+    /**
+     * Optional pre-built `AssistantClient`. When omitted, the provider
+     * derives a client from `runtime`. Pass an explicit client only when
+     * composing multiple runtimes or extending scopes upstream.
+     * @defaultValue derived from `runtime`
+     */
     aui?: AssistantClient | null;
     children: ReactNode;
   }) => {

--- a/packages/core/src/react/client/DataRenderers.ts
+++ b/packages/core/src/react/client/DataRenderers.ts
@@ -3,6 +3,13 @@ import type { ClientOutput } from "@assistant-ui/store";
 import type { DataRenderersState } from "../types/scopes/dataRenderers";
 import type { DataMessagePartComponent } from "../types/MessagePartComponentTypes";
 
+/**
+ * Registers renderers for `data` message parts.
+ *
+ * Data renderers are looked up by the part's `name` field. Use this resource
+ * directly for a renderer scope, or prefer {@link useAssistantDataUI} /
+ * {@link makeAssistantDataUI} when registering from React components.
+ */
 export const DataRenderers = resource((): ClientOutput<"dataRenderers"> => {
   const [state, setState] = tapState<DataRenderersState>(() => ({
     renderers: {},

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -21,12 +21,22 @@ import { ModelContext } from "../../store";
 
 export type { McpAppResourceOutput };
 
+/**
+ * Registers tools with model context and installs tool-call renderers.
+ *
+ * Mount this resource near an assistant subtree when you want to expose a
+ * group of tools declaratively. Tool definitions are registered with model
+ * context, while each tool renderer is registered with the tools scope for
+ * message rendering.
+ */
 export const Tools = resource(
   ({
     toolkit,
     mcpApp,
   }: {
+    /** Tools to expose to the model and optional renderers to install. */
     toolkit?: Toolkit;
+    /** Optional MCP app resource whose tools should be merged into context. */
     mcpApp?: ResourceElement<McpAppResourceOutput> | undefined;
   }): ClientOutput<"tools"> => {
     const mcpAppOutputs = tapResources(

--- a/packages/core/src/react/model-context/makeAssistantDataUI.ts
+++ b/packages/core/src/react/model-context/makeAssistantDataUI.ts
@@ -4,10 +4,23 @@ import {
   useAssistantDataUI,
 } from "./useAssistantDataUI";
 
+/**
+ * Component returned by {@link makeAssistantDataUI}.
+ *
+ * Rendering the component registers a renderer for matching `data` message
+ * parts.
+ */
 export type AssistantDataUI = FC & {
+  /** Data renderer registered by this component. */
   unstable_data: AssistantDataUIProps;
 };
 
+/**
+ * Creates a React component that registers a named data-part renderer when
+ * rendered.
+ *
+ * @param dataUI - Data renderer registration.
+ */
 export const makeAssistantDataUI = <T = any>(
   dataUI: AssistantDataUIProps<T>,
 ) => {

--- a/packages/core/src/react/model-context/makeAssistantTool.ts
+++ b/packages/core/src/react/model-context/makeAssistantTool.ts
@@ -1,10 +1,25 @@
 import type { FC } from "react";
 import { type AssistantToolProps, useAssistantTool } from "./useAssistantTool";
 
+/**
+ * Component returned by {@link makeAssistantTool}.
+ *
+ * Rendering the component registers its tool for the lifetime of that render
+ * subtree.
+ */
 export type AssistantTool = FC & {
+  /** Tool definition registered by this component. */
   unstable_tool: AssistantToolProps<any, any>;
 };
 
+/**
+ * Creates a React component that registers an assistant tool when rendered.
+ *
+ * Use this when exporting reusable tool modules that can be included in JSX
+ * rather than calling {@link useAssistantTool} directly.
+ *
+ * @param tool - Tool definition and name to register.
+ */
 export const makeAssistantTool = <
   TArgs extends Record<string, unknown>,
   TResult,

--- a/packages/core/src/react/model-context/makeAssistantToolUI.ts
+++ b/packages/core/src/react/model-context/makeAssistantToolUI.ts
@@ -4,10 +4,25 @@ import {
   useAssistantToolUI,
 } from "./useAssistantToolUI";
 
+/**
+ * Component returned by {@link makeAssistantToolUI}.
+ *
+ * Rendering the component registers a renderer for matching tool-call message
+ * parts.
+ */
 export type AssistantToolUI = FC & {
+  /** Tool renderer registered by this component. */
   unstable_tool: AssistantToolUIProps<any, any>;
 };
 
+/**
+ * Creates a React component that registers a tool-call renderer when rendered.
+ *
+ * Use this to package reusable display components for tools whose definitions
+ * are registered elsewhere.
+ *
+ * @param tool - Tool renderer registration.
+ */
 export const makeAssistantToolUI = <TArgs, TResult>(
   tool: AssistantToolUIProps<TArgs, TResult>,
 ) => {

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -20,9 +20,10 @@ type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
 /**
  * Tool definition accepted by the React tool registry.
  *
- * Extends the core tool contract with an optional render component. Frontend
- * and human tools require a renderer so users can inspect the call and provide
- * results when needed; backend tools may omit one.
+ * Extends the core tool contract with a render component. Human tools rely on
+ * the renderer to collect input from the user. Frontend tools execute in the
+ * browser and require a UI surface for their progress and result. Backend
+ * tools execute server-side and may omit a renderer.
  */
 export type ToolDefinition<
   TArgs extends Record<string, unknown>,
@@ -33,6 +34,19 @@ export type ToolDefinition<
  * Named collection of tools exposed to the assistant model.
  *
  * Keys are the tool names the model receives and uses in tool calls.
+ *
+ * @example
+ * ```tsx
+ * const toolkit = {
+ *   get_weather: {
+ *     type: "frontend",
+ *     description: "Get the weather for a city.",
+ *     parameters: weatherSchema,
+ *     execute: async ({ city }: { city: string }) => fetchWeather(city),
+ *     render: WeatherToolUI,
+ *   },
+ * } satisfies Toolkit;
+ * ```
  */
 export type Toolkit = Record<string, ToolDefinition<any, any>>;
 

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -1,21 +1,13 @@
 import type { Tool } from "assistant-stream";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
 
-type RequiredToolRenderConfig<TArgs, TResult> = {
-  /** Component used to render calls to this tool in assistant messages. */
-  render: ToolCallMessagePartComponent<TArgs, TResult>;
-};
-
-type OptionalToolRenderConfig<TArgs, TResult> = {
-  /** Optional component used to render calls to this tool in assistant messages. */
-  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
-};
-
 type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
   type: "frontend" | "human";
 }
-  ? T & RequiredToolRenderConfig<TArgs, TResult>
-  : T & OptionalToolRenderConfig<TArgs, TResult>;
+  ? T & { render: ToolCallMessagePartComponent<TArgs, TResult> }
+  : T & {
+      render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
+    };
 
 /**
  * Tool definition accepted by the React tool registry.
@@ -23,7 +15,8 @@ type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
  * Extends the core tool contract with a render component. Human tools rely on
  * the renderer to collect input from the user. Frontend tools execute in the
  * browser and require a UI surface for their progress and result. Backend
- * tools execute server-side and may omit a renderer.
+ * tools execute server-side and may omit a renderer. The `render` component is
+ * required for frontend and human tools and optional for backend tools.
  */
 export type ToolDefinition<
   TArgs extends Record<string, unknown>,

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -1,19 +1,43 @@
 import type { Tool } from "assistant-stream";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
 
+type RequiredToolRenderConfig<TArgs, TResult> = {
+  /** Component used to render calls to this tool in assistant messages. */
+  render: ToolCallMessagePartComponent<TArgs, TResult>;
+};
+
+type OptionalToolRenderConfig<TArgs, TResult> = {
+  /** Optional component used to render calls to this tool in assistant messages. */
+  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
+};
+
 type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
   type: "frontend" | "human";
 }
-  ? T & { render: ToolCallMessagePartComponent<TArgs, TResult> }
-  : T & { render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined };
+  ? T & RequiredToolRenderConfig<TArgs, TResult>
+  : T & OptionalToolRenderConfig<TArgs, TResult>;
 
+/**
+ * Tool definition accepted by the React tool registry.
+ *
+ * Extends the core tool contract with an optional render component. Frontend
+ * and human tools require a renderer so users can inspect the call and provide
+ * results when needed; backend tools may omit one.
+ */
 export type ToolDefinition<
   TArgs extends Record<string, unknown>,
   TResult,
 > = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
 
+/**
+ * Named collection of tools exposed to the assistant model.
+ *
+ * Keys are the tool names the model receives and uses in tool calls.
+ */
 export type Toolkit = Record<string, ToolDefinition<any, any>>;
 
+/** Configuration for the {@link Tools} resource. */
 export type ToolsConfig = {
+  /** Tools to register with model context and, when provided, message renderers. */
   toolkit: Toolkit;
 };

--- a/packages/core/src/react/model-context/useAssistantDataUI.ts
+++ b/packages/core/src/react/model-context/useAssistantDataUI.ts
@@ -2,11 +2,20 @@ import { useEffect } from "react";
 import { useAui } from "@assistant-ui/store";
 import type { DataMessagePartComponent } from "../types/MessagePartComponentTypes";
 
+/** Props used to register a renderer for `data` message parts. */
 export type AssistantDataUIProps<T = any> = {
+  /** Data part name this renderer handles. */
   name: string;
+  /** Component rendered for matching data message parts. */
   render: DataMessagePartComponent<T>;
 };
 
+/**
+ * Registers a renderer for named `data` message parts while the component is
+ * mounted.
+ *
+ * @param dataUI - Data renderer registration, or `null` to skip registration.
+ */
 export const useAssistantDataUI = (dataUI: AssistantDataUIProps | null) => {
   const aui = useAui();
   useEffect(() => {

--- a/packages/core/src/react/model-context/useAssistantTool.ts
+++ b/packages/core/src/react/model-context/useAssistantTool.ts
@@ -3,13 +3,27 @@ import { useAui } from "@assistant-ui/store";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
 import type { AssistantToolProps as CoreAssistantToolProps } from "../..";
 
+/**
+ * Props used to register a tool from React.
+ */
 export type AssistantToolProps<
   TArgs extends Record<string, unknown>,
   TResult,
 > = CoreAssistantToolProps<TArgs, TResult> & {
+  /** Component used to render calls to this tool in assistant messages. */
   render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
 };
 
+/**
+ * Registers a tool with the assistant model context while the component is
+ * mounted.
+ *
+ * If `render` is provided, it is also installed as the renderer for matching
+ * tool-call message parts. The registration is removed automatically when the
+ * component unmounts or the tool definition changes.
+ *
+ * @param tool - Tool definition and name to register.
+ */
 export const useAssistantTool = <
   TArgs extends Record<string, unknown>,
   TResult,

--- a/packages/core/src/react/model-context/useAssistantTool.ts
+++ b/packages/core/src/react/model-context/useAssistantTool.ts
@@ -22,7 +22,27 @@ export type AssistantToolProps<
  * tool-call message parts. The registration is removed automatically when the
  * component unmounts or the tool definition changes.
  *
+ * Pass a referentially stable tool object, such as one declared at module
+ * scope or memoized with `useMemo`, to avoid re-registering on every render.
+ *
  * @param tool - Tool definition and name to register.
+ *
+ * @example
+ * ```tsx
+ * const weatherTool = {
+ *   toolName: "get_weather",
+ *   type: "frontend",
+ *   description: "Get the weather for a city.",
+ *   parameters: weatherSchema,
+ *   execute: async ({ city }: { city: string }) => fetchWeather(city),
+ *   render: WeatherToolUI,
+ * } satisfies AssistantToolProps<{ city: string }, Weather>;
+ *
+ * function WeatherToolRegistration() {
+ *   useAssistantTool(weatherTool);
+ *   return null;
+ * }
+ * ```
  */
 export const useAssistantTool = <
   TArgs extends Record<string, unknown>,

--- a/packages/core/src/react/model-context/useAssistantToolUI.ts
+++ b/packages/core/src/react/model-context/useAssistantToolUI.ts
@@ -2,11 +2,23 @@ import { useEffect } from "react";
 import { useAui } from "@assistant-ui/store";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
 
+/** Props used to register a renderer for tool-call message parts. */
 export type AssistantToolUIProps<TArgs, TResult> = {
+  /** Name of the tool whose calls should use this renderer. */
   toolName: string;
+  /** Component rendered for matching tool-call message parts. */
   render: ToolCallMessagePartComponent<TArgs, TResult>;
 };
 
+/**
+ * Registers a tool-call renderer while the component is mounted.
+ *
+ * This only affects rendering. Pair it with {@link useAssistantTool},
+ * {@link Tools}, or a backend tool registry to expose the actual tool
+ * definition to the model.
+ *
+ * @param tool - Tool renderer registration, or `null` to skip registration.
+ */
 export const useAssistantToolUI = (
   tool: AssistantToolUIProps<any, any> | null,
 ) => {

--- a/packages/core/src/react/model-context/useToolArgsStatus.ts
+++ b/packages/core/src/react/model-context/useToolArgsStatus.ts
@@ -25,6 +25,23 @@ export type ToolArgsStatus<
  *
  * Use inside a tool-call renderer to avoid showing incomplete argument values
  * as final.
+ *
+ * @throws If called outside a tool-call message part.
+ *
+ * @example
+ * ```tsx
+ * function WeatherToolUI({
+ *   args,
+ * }: ToolCallMessagePartProps<{ city: string }>) {
+ *   const { propStatus } = useToolArgsStatus<{ city: string }>();
+ *
+ *   return (
+ *     <span>
+ *       {propStatus.city === "streaming" ? "Reading city..." : args.city}
+ *     </span>
+ *   );
+ * }
+ * ```
  */
 export const useToolArgsStatus = <
   TArgs extends Record<string, unknown> = Record<string, unknown>,

--- a/packages/core/src/react/model-context/useToolArgsStatus.ts
+++ b/packages/core/src/react/model-context/useToolArgsStatus.ts
@@ -7,13 +7,25 @@ import {
 
 type PropFieldStatus = "streaming" | "complete";
 
+/**
+ * Streaming completion status for the arguments of the current tool call.
+ */
 export type ToolArgsStatus<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
 > = {
+  /** Overall lifecycle state of the tool-call part. */
   status: "running" | "complete" | "incomplete" | "requires-action";
+  /** Per-argument status keyed by argument name. */
   propStatus: Partial<Record<keyof TArgs, PropFieldStatus>>;
 };
 
+/**
+ * Reads whether each argument field for the current tool-call message part is
+ * still streaming or complete.
+ *
+ * Use inside a tool-call renderer to avoid showing incomplete argument values
+ * as final.
+ */
 export const useToolArgsStatus = <
   TArgs extends Record<string, unknown> = Record<string, unknown>,
 >(): ToolArgsStatus<TArgs> => {

--- a/packages/core/src/react/runtimes/useToolInvocations.ts
+++ b/packages/core/src/react/runtimes/useToolInvocations.ts
@@ -69,6 +69,12 @@ type UseToolInvocationsParams = {
   ) => void;
 };
 
+/**
+ * Streaming execution state for a frontend tool.
+ *
+ * Custom runtime integrations use this to mirror in-flight tool calls while
+ * `useToolInvocations` executes tools in the browser.
+ */
 export type ToolExecutionStatus =
   | {
       /** The tool's execute function is currently running. */

--- a/packages/core/src/react/runtimes/useToolInvocations.ts
+++ b/packages/core/src/react/runtimes/useToolInvocations.ts
@@ -70,8 +70,16 @@ type UseToolInvocationsParams = {
 };
 
 export type ToolExecutionStatus =
-  | { type: "executing" }
-  | { type: "interrupt"; payload: { type: "human"; payload: unknown } };
+  | {
+      /** The tool's execute function is currently running. */
+      type: "executing";
+    }
+  | {
+      /** The tool is waiting for a human input payload before continuing. */
+      type: "interrupt";
+      /** Human input request emitted by the tool execution context. */
+      payload: { type: "human"; payload: unknown };
+    };
 
 type ToolState = {
   argsText: string;

--- a/packages/core/src/react/types/MessagePartComponentTypes.ts
+++ b/packages/core/src/react/types/MessagePartComponentTypes.ts
@@ -58,13 +58,15 @@ export type ToolCallMessagePartProps<
 > = MessagePartState &
   ToolCallMessagePart<TArgs, TResult> & {
     /**
-     * Adds a result for this tool-call message part and resumes the run when
-     * the tool is waiting for UI input.
+     * Sets the result for this tool-call message part.
+     *
+     * Use when the renderer, rather than a tool `execute` function, is the
+     * source of the result.
      */
     addResult: (result: TResult | ToolResponse<TResult>) => void;
     /**
-     * Supplies the payload requested by a human tool interrupt and resumes the
-     * current tool-call message part.
+     * Supplies the payload requested by `context.human(...)` and resumes the
+     * paused frontend tool execution.
      */
     resume: (payload: unknown) => void;
   };

--- a/packages/core/src/react/types/MessagePartComponentTypes.ts
+++ b/packages/core/src/react/types/MessagePartComponentTypes.ts
@@ -57,10 +57,19 @@ export type ToolCallMessagePartProps<
   TResult = unknown,
 > = MessagePartState &
   ToolCallMessagePart<TArgs, TResult> & {
+    /**
+     * Adds a result for this tool-call message part and resumes the run when
+     * the tool is waiting for UI input.
+     */
     addResult: (result: TResult | ToolResponse<TResult>) => void;
+    /**
+     * Supplies the payload requested by a human tool interrupt and resumes the
+     * current tool-call message part.
+     */
     resume: (payload: unknown) => void;
   };
 
+/** Component used to render a tool-call message part. */
 export type ToolCallMessagePartComponent<
   TArgs = any,
   TResult = any,

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -98,13 +98,17 @@ export type ToolCallMessagePart<
   readonly toolCallId: string;
   /** Name of the tool requested by the model. */
   readonly toolName: string;
-  /** Parsed arguments supplied by the model. */
+  /**
+   * Arguments supplied by the model. During streaming this is a partial parse:
+   * fields may be missing or incomplete. From a tool-call renderer, use
+   * `useToolArgsStatus` to detect which fields are still arriving.
+   */
   readonly args: TArgs;
   /** Result returned by the tool, if it has completed. */
   readonly result?: TResult | undefined;
   /** Whether the result represents a tool execution error. */
   readonly isError?: boolean | undefined;
-  /** Raw argument text streamed by the model. */
+  /** Raw JSON argument text streamed by the model. */
   readonly argsText: string;
   /** UI-only artifact associated with the tool result. */
   readonly artifact?: unknown;
@@ -116,7 +120,10 @@ export type ToolCallMessagePart<
   readonly interrupt?: { type: "human"; payload: unknown };
   /** Parent message-part ID when this part belongs to a nested structure. */
   readonly parentId?: string;
-  /** Messages associated with this tool call, when provided by the runtime. */
+  /**
+   * Nested thread messages produced by this tool call, for example a sub-agent
+   * conversation.
+   */
   readonly messages?: readonly ThreadMessage[];
 };
 

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -92,18 +92,31 @@ export type ToolCallMessagePart<
   TArgs = ReadonlyJSONObject,
   TResult = unknown,
 > = {
+  /** Identifies this part as a tool call. */
   readonly type: "tool-call";
+  /** Stable identifier for this invocation of the tool. */
   readonly toolCallId: string;
+  /** Name of the tool requested by the model. */
   readonly toolName: string;
+  /** Parsed arguments supplied by the model. */
   readonly args: TArgs;
+  /** Result returned by the tool, if it has completed. */
   readonly result?: TResult | undefined;
+  /** Whether the result represents a tool execution error. */
   readonly isError?: boolean | undefined;
+  /** Raw argument text streamed by the model. */
   readonly argsText: string;
+  /** UI-only artifact associated with the tool result. */
   readonly artifact?: unknown;
+  /** MCP app metadata associated with this tool call, when present. */
   readonly mcp?: ToolCallMessagePartMcpMetadata;
+  /** Content returned to the model for this tool result. */
   readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  /** Human-input request that must be resolved before the run can continue. */
   readonly interrupt?: { type: "human"; payload: unknown };
+  /** Parent message-part ID when this part belongs to a nested structure. */
   readonly parentId?: string;
+  /** Messages associated with this tool call, when provided by the runtime. */
   readonly messages?: readonly ThreadMessage[];
 };
 
@@ -143,7 +156,9 @@ export type MessagePartStatus =
 
 export type ToolCallMessagePartStatus =
   | {
+      /** The tool call is waiting for UI or human input before continuing. */
       readonly type: "requires-action";
+      /** Reason the tool call requires action. */
       readonly reason: "interrupt";
     }
   | MessagePartStatus;

--- a/packages/react/src/legacy-runtime/AssistantRuntimeProvider.tsx
+++ b/packages/react/src/legacy-runtime/AssistantRuntimeProvider.tsx
@@ -10,12 +10,17 @@ import { DevToolsProviderApi } from "../devtools/DevToolsHooks";
 export namespace AssistantRuntimeProvider {
   export type Props = PropsWithChildren<{
     /**
-     * The runtime to provide to the rest of your app.
+     * The assistant runtime to expose to descendants. Build one with
+     * `useLocalRuntime`, `useExternalStoreRuntime`, or
+     * `useAssistantTransportRuntime`.
      */
     runtime: AssistantRuntime;
 
     /**
-     * The aui instance to extend. If not provided, a new aui instance will be created.
+     * Optional parent `AssistantClient` whose scopes are inherited by the
+     * client created for this runtime. Use this when nesting an
+     * `AssistantRuntimeProvider` inside another assistant context.
+     * @defaultValue null
      */
     aui?: AssistantClient;
   }>;

--- a/packages/react/src/legacy-runtime/AssistantRuntimeProvider.tsx
+++ b/packages/react/src/legacy-runtime/AssistantRuntimeProvider.tsx
@@ -19,8 +19,9 @@ export namespace AssistantRuntimeProvider {
     /**
      * Optional parent `AssistantClient` whose scopes are inherited by the
      * client created for this runtime. Use this when nesting an
-     * `AssistantRuntimeProvider` inside another assistant context.
-     * @defaultValue null
+     * `AssistantRuntimeProvider` inside another assistant context. Omit this
+     * prop when there is no parent client.
+     * @defaultValue undefined
      */
     aui?: AssistantClient;
   }>;

--- a/packages/react/src/legacy-runtime/hooks/AssistantContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/AssistantContext.ts
@@ -6,7 +6,7 @@ import type { ThreadListRuntime } from "../runtime/ThreadListRuntime";
 import { createStateHookForRuntime } from "../../context/react/utils/createStateHookForRuntime";
 
 /**
- * @deprecated Use `useAui()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAui} instead. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  *
  * Hook to access the AssistantRuntime from the current context.
  *
@@ -62,6 +62,6 @@ const useThreadListRuntime = (opt: {
 }): ThreadListRuntime | null => useAssistantRuntime(opt)?.threads ?? null;
 
 /**
- * @deprecated Use `useAuiState((s) => s.threads)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.threads)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export const useThreadList = createStateHookForRuntime(useThreadListRuntime);

--- a/packages/react/src/legacy-runtime/hooks/AttachmentContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/AttachmentContext.ts
@@ -5,7 +5,7 @@ import { createStateHookForRuntime } from "../../context/react/utils/createState
 import { useAui, useAuiState } from "@assistant-ui/store";
 
 /**
- * @deprecated Use `useAui()` with `aui.attachment()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAui} with `aui.attachment()` instead. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export function useAttachmentRuntime(options?: {
   optional?: false | undefined;
@@ -84,7 +84,7 @@ export function useMessageAttachmentRuntime(options?: {
 }
 
 /**
- * @deprecated Use `useAuiState((s) => s.attachment)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.attachment)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export const useAttachment = createStateHookForRuntime(useAttachmentRuntime);
 

--- a/packages/react/src/legacy-runtime/hooks/ComposerContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/ComposerContext.ts
@@ -5,7 +5,7 @@ import type { ComposerRuntime } from "../runtime/ComposerRuntime";
 import { createStateHookForRuntime } from "../../context/react/utils/createStateHookForRuntime";
 
 /**
- * @deprecated Use `useAui()` with `aui.composer()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAui} with `aui.composer()` instead. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  *
  * Hook to access the ComposerRuntime from the current context.
  *
@@ -87,7 +87,7 @@ export function useComposerRuntime(options?: {
 }
 
 /**
- * @deprecated Use `useAuiState((s) => s.composer)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.composer)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  *
  * Hook to access the current composer state.
  *

--- a/packages/react/src/legacy-runtime/hooks/MessageContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/MessageContext.ts
@@ -6,7 +6,7 @@ import { createStateHookForRuntime } from "../../context/react/utils/createState
 import type { EditComposerRuntime } from "@assistant-ui/core";
 
 /**
- * @deprecated Use `useAui()` with `aui.message()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAui} with `aui.message()` instead. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  *
  * Hook to access the MessageRuntime from the current context.
  *
@@ -76,7 +76,7 @@ export function useMessageRuntime(options?: {
 }
 
 /**
- * @deprecated Use `useAuiState((s) => s.message)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.message)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  *
  * Hook to access the current message state.
  *
@@ -120,7 +120,7 @@ const useEditComposerRuntime = (opt: {
 }): EditComposerRuntime | null => useMessageRuntime(opt)?.composer ?? null;
 
 /**
- * @deprecated Use `useAuiState((s) => s.message.composer)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.message.composer)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export const useEditComposer = createStateHookForRuntime(
   useEditComposerRuntime,

--- a/packages/react/src/legacy-runtime/hooks/MessagePartContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/MessagePartContext.ts
@@ -5,7 +5,7 @@ import { createStateHookForRuntime } from "../../context/react/utils/createState
 import { useAui, useAuiState } from "@assistant-ui/store";
 
 /**
- * @deprecated Use `useAui()` with `aui.part()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAui} with `aui.part()` instead. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export function useMessagePartRuntime(options?: {
   optional?: false | undefined;
@@ -27,6 +27,6 @@ export function useMessagePartRuntime(options?: {
 }
 
 /**
- * @deprecated Use `useAuiState((s) => s.part)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.part)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export const useMessagePart = createStateHookForRuntime(useMessagePartRuntime);

--- a/packages/react/src/legacy-runtime/hooks/ThreadContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/ThreadContext.ts
@@ -8,7 +8,7 @@ import type { ThreadComposerRuntime } from "@assistant-ui/core";
 import { useAui, useAuiEvent, useAuiState } from "@assistant-ui/store";
 
 /**
- * @deprecated Use `useAui()` with `aui.thread()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAui} with `aui.thread()` instead. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  *
  * Hook to access the ThreadRuntime from the current context.
  *
@@ -58,7 +58,7 @@ export function useThreadRuntime(options?: { optional?: boolean | undefined }) {
 }
 
 /**
- * @deprecated Use `useAuiState((s) => s.thread)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.thread)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  *
  * Hook to access the current thread state.
  *
@@ -92,14 +92,14 @@ const useThreadComposerRuntime = (opt: {
 }): ThreadComposerRuntime | null => useThreadRuntime(opt)?.composer ?? null;
 
 /**
- * @deprecated Use `useAuiState((s) => s.thread.composer)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.thread.composer)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export const useThreadComposer = createStateHookForRuntime(
   useThreadComposerRuntime,
 );
 
 /**
- * @deprecated Use `useAuiState((s) => s.thread.modelContext)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.thread.modelContext)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export function useThreadModelContext(options?: {
   optional?: false | undefined;

--- a/packages/react/src/legacy-runtime/hooks/ThreadListItemContext.ts
+++ b/packages/react/src/legacy-runtime/hooks/ThreadListItemContext.ts
@@ -5,7 +5,7 @@ import { createStateHookForRuntime } from "../../context/react/utils/createState
 import { useAui, useAuiState } from "@assistant-ui/store";
 
 /**
- * @deprecated Use `useAui()` with `aui.threadListItem()` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAui} with `aui.threadListItem()` instead. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export function useThreadListItemRuntime(options?: {
   optional?: false | undefined;
@@ -29,7 +29,7 @@ export function useThreadListItemRuntime(options?: {
 }
 
 /**
- * @deprecated Use `useAuiState((s) => s.threadListItem)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.threadListItem)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export const useThreadListItem = createStateHookForRuntime(
   useThreadListItemRuntime,

--- a/packages/react/src/mcp-apps/McpAppRenderer.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.tsx
@@ -192,6 +192,14 @@ function InlineRenderer({
   );
 }
 
+/**
+ * Creates a tool-call renderer for MCP Apps embedded in assistant messages.
+ *
+ * Compose this into the `Tools` resource through its `mcpApp` option. When a
+ * tool-call part carries `mcp.app` metadata for a `ui://` resource, the
+ * renderer loads that resource from the configured host and displays it in a
+ * sandboxed frame.
+ */
 export const McpAppRenderer = resource(
   (
     options: McpAppRendererOptions,

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
@@ -26,6 +26,13 @@ async function postToHost(
   return res.json();
 }
 
+/**
+ * Creates the default HTTP host for MCP App widgets.
+ *
+ * The host POSTs widget requests to the configured route as `{ method,
+ * params }`, using the method names expected by the assistant-ui MCP Apps
+ * guide.
+ */
 export const McpAppsRemoteHost = resource(
   (options: McpAppsRemoteHostOptions): McpAppsHost => {
     const optionsRef = tapRef(options);

--- a/packages/react/src/mcp-apps/utils.ts
+++ b/packages/react/src/mcp-apps/utils.ts
@@ -6,6 +6,13 @@ import {
 
 type ToolPartLike = Pick<ToolCallMessagePart, "mcp">;
 
+/**
+ * Returns MCP app metadata for a tool-call part that points at a `ui://`
+ * resource.
+ *
+ * Returns `undefined` when the part has no MCP app metadata or the metadata
+ * does not reference an assistant-ui MCP app resource.
+ */
 export function getMcpAppFromToolPart(
   part: ToolPartLike,
 ): McpAppMetadata | undefined {

--- a/packages/react/src/primitives/messagePart/useMessagePartData.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartData.ts
@@ -4,7 +4,20 @@ import type { DataMessagePart } from "@assistant-ui/core";
 import { useAuiState } from "@assistant-ui/store";
 
 /**
- * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.part)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
+ * @deprecated Use {@link useAuiState} to select and narrow `s.part`.
+ * Return `null` for optional rendering, or throw inside the selector to
+ * preserve the old hook's strict behavior.
+ *
+ * @example
+ * ```tsx
+ * const part = useAuiState((s) =>
+ *   s.part.type === "data" && (!name || s.part.name === name)
+ *     ? s.part
+ *     : null,
+ * );
+ * ```
+ *
+ * See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export const useMessagePartData = <T = any>(name?: string) => {
   const part = useAuiState((s) => {

--- a/packages/react/src/primitives/messagePart/useMessagePartData.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartData.ts
@@ -3,6 +3,9 @@
 import type { DataMessagePart } from "@assistant-ui/core";
 import { useAuiState } from "@assistant-ui/store";
 
+/**
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.part)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
+ */
 export const useMessagePartData = <T = any>(name?: string) => {
   const part = useAuiState((s) => {
     if (s.part.type !== "data") {

--- a/packages/react/src/primitives/messagePart/useMessagePartFile.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartFile.ts
@@ -3,6 +3,9 @@
 import type { FileMessagePart, MessagePartState } from "@assistant-ui/core";
 import { useAuiState } from "@assistant-ui/store";
 
+/**
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.part)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
+ */
 export const useMessagePartFile = () => {
   const file = useAuiState((s) => {
     if (s.part.type !== "file")

--- a/packages/react/src/primitives/messagePart/useMessagePartFile.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartFile.ts
@@ -4,7 +4,19 @@ import type { FileMessagePart, MessagePartState } from "@assistant-ui/core";
 import { useAuiState } from "@assistant-ui/store";
 
 /**
- * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.part)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
+ * @deprecated Use {@link useAuiState} to select and narrow `s.part`.
+ * Return `null` for optional rendering, or throw inside the selector to
+ * preserve the old hook's strict behavior.
+ *
+ * @example
+ * ```tsx
+ * const file = useAuiState((s) => {
+ *   if (s.part.type !== "file") return null;
+ *   return s.part;
+ * });
+ * ```
+ *
+ * See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export const useMessagePartFile = () => {
   const file = useAuiState((s) => {

--- a/packages/react/src/primitives/messagePart/useMessagePartImage.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartImage.ts
@@ -4,7 +4,19 @@ import type { ImageMessagePart, MessagePartState } from "@assistant-ui/core";
 import { useAuiState } from "@assistant-ui/store";
 
 /**
- * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.part)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
+ * @deprecated Use {@link useAuiState} to select and narrow `s.part`.
+ * Return `null` for optional rendering, or throw inside the selector to
+ * preserve the old hook's strict behavior.
+ *
+ * @example
+ * ```tsx
+ * const image = useAuiState((s) => {
+ *   if (s.part.type !== "image") return null;
+ *   return s.part;
+ * });
+ * ```
+ *
+ * See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export const useMessagePartImage = () => {
   const image = useAuiState((s) => {

--- a/packages/react/src/primitives/messagePart/useMessagePartImage.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartImage.ts
@@ -3,6 +3,9 @@
 import type { ImageMessagePart, MessagePartState } from "@assistant-ui/core";
 import { useAuiState } from "@assistant-ui/store";
 
+/**
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.part)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
+ */
 export const useMessagePartImage = () => {
   const image = useAuiState((s) => {
     if (s.part.type !== "image")

--- a/packages/react/src/primitives/messagePart/useMessagePartReasoning.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartReasoning.ts
@@ -6,6 +6,9 @@ import type {
 } from "@assistant-ui/core";
 import { useAuiState } from "@assistant-ui/store";
 
+/**
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.part)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
+ */
 export const useMessagePartReasoning = () => {
   const text = useAuiState((s) => {
     if (s.part.type !== "reasoning")

--- a/packages/react/src/primitives/messagePart/useMessagePartReasoning.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartReasoning.ts
@@ -7,7 +7,19 @@ import type {
 import { useAuiState } from "@assistant-ui/store";
 
 /**
- * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.part)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
+ * @deprecated Use {@link useAuiState} to select and narrow `s.part`.
+ * Return `null` for optional rendering, or throw inside the selector to
+ * preserve the old hook's strict behavior.
+ *
+ * @example
+ * ```tsx
+ * const reasoning = useAuiState((s) => {
+ *   if (s.part.type !== "reasoning") return null;
+ *   return s.part;
+ * });
+ * ```
+ *
+ * See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export const useMessagePartReasoning = () => {
   const text = useAuiState((s) => {

--- a/packages/react/src/primitives/messagePart/useMessagePartSource.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartSource.ts
@@ -4,7 +4,19 @@ import type { SourceMessagePart, MessagePartState } from "@assistant-ui/core";
 import { useAuiState } from "@assistant-ui/store";
 
 /**
- * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.part)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
+ * @deprecated Use {@link useAuiState} to select and narrow `s.part`.
+ * Return `null` for optional rendering, or throw inside the selector to
+ * preserve the old hook's strict behavior.
+ *
+ * @example
+ * ```tsx
+ * const source = useAuiState((s) => {
+ *   if (s.part.type !== "source") return null;
+ *   return s.part;
+ * });
+ * ```
+ *
+ * See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export const useMessagePartSource = () => {
   const source = useAuiState((s) => {

--- a/packages/react/src/primitives/messagePart/useMessagePartSource.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartSource.ts
@@ -3,6 +3,9 @@
 import type { SourceMessagePart, MessagePartState } from "@assistant-ui/core";
 import { useAuiState } from "@assistant-ui/store";
 
+/**
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.part)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
+ */
 export const useMessagePartSource = () => {
   const source = useAuiState((s) => {
     if (s.part.type !== "source")

--- a/packages/react/src/primitives/messagePart/useMessagePartText.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartText.ts
@@ -7,6 +7,9 @@ import type {
 } from "@assistant-ui/core";
 import { useAuiState } from "@assistant-ui/store";
 
+/**
+ * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.part)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
+ */
 export const useMessagePartText = () => {
   const text = useAuiState((s) => {
     if (s.part.type !== "text" && s.part.type !== "reasoning")

--- a/packages/react/src/primitives/messagePart/useMessagePartText.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartText.ts
@@ -8,7 +8,19 @@ import type {
 import { useAuiState } from "@assistant-ui/store";
 
 /**
- * @deprecated Use {@link useAuiState}: `useAuiState((s) => s.part)`. See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
+ * @deprecated Use {@link useAuiState} to select and narrow `s.part`.
+ * Return `null` for optional rendering, or throw inside the selector to
+ * preserve the old hook's strict behavior.
+ *
+ * @example
+ * ```tsx
+ * const text = useAuiState((s) => {
+ *   if (s.part.type !== "text" && s.part.type !== "reasoning") return null;
+ *   return s.part;
+ * });
+ * ```
+ *
+ * See the {@link https://assistant-ui.com/docs/migrations/v0-12 migration guide}.
  */
 export const useMessagePartText = () => {
   const text = useAuiState((s) => {

--- a/packages/store/src/AuiIf.ts
+++ b/packages/store/src/AuiIf.ts
@@ -5,10 +5,43 @@ import { useAuiState } from "./useAuiState";
 import type { AssistantState } from "./types/client";
 
 export namespace AuiIf {
-  export type Props = PropsWithChildren<{ condition: AuiIf.Condition }>;
+  /** Props for `AuiIf`. */
+  export type Props = PropsWithChildren<{
+    /**
+     * Selector that decides whether to render `children`. Children render
+     * when this returns truthy and unmount when it becomes falsy.
+     */
+    condition: AuiIf.Condition;
+  }>;
+
+  /**
+   * Selector passed to `AuiIf`. Receives the assistant state and must
+   * return a boolean.
+   */
   export type Condition = (state: AssistantState) => boolean;
 }
 
+/**
+ * Conditionally renders children based on a slice of assistant state.
+ *
+ * A thin wrapper around {@link useAuiState} that renders its children
+ * when `condition` returns truthy and unmounts them when it returns
+ * falsy. Keeps render logic declarative without mounting unused subtrees.
+ *
+ * @example
+ * ```tsx
+ * <AuiIf condition={(s) => s.thread.isRunning}>
+ *   <CancelButton />
+ * </AuiIf>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <AuiIf condition={(s) => s.thread.messages.length === 0}>
+ *   <EmptyState />
+ * </AuiIf>
+ * ```
+ */
 export const AuiIf: FC<AuiIf.Props> = ({ children, condition }) => {
   const result = useAuiState(condition);
   return result ? children : null;

--- a/packages/store/src/AuiIf.ts
+++ b/packages/store/src/AuiIf.ts
@@ -9,7 +9,7 @@ export namespace AuiIf {
   export type Props = PropsWithChildren<{
     /**
      * Selector that decides whether to render `children`. Children render
-     * when this returns truthy and unmount when it becomes falsy.
+     * when this returns `true` and unmount when it returns `false`.
      */
     condition: AuiIf.Condition;
   }>;
@@ -25,8 +25,9 @@ export namespace AuiIf {
  * Conditionally renders children based on a slice of assistant state.
  *
  * A thin wrapper around {@link useAuiState} that renders its children
- * when `condition` returns truthy and unmounts them when it returns
- * falsy. Keeps render logic declarative without mounting unused subtrees.
+ * when `condition` returns `true` and unmounts them when it returns
+ * `false`. Keeps render logic declarative without mounting unused
+ * subtrees.
  *
  * @example
  * ```tsx

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -398,12 +398,10 @@ export function useAui(): AssistantClient;
 /**
  * Extends the parent `AssistantClient` with additional scopes.
  *
- * Highly experimental advanced overload used when building primitives or
- * providers — for example, when a custom provider needs to register a
- * `message`, `part`, or other scope onto the client visible to its
- * descendants. This API may change in a minor release. Application code
- * rarely reaches for this; use {@link useAui} with no arguments to read
- * the existing client.
+ * Advanced overload used when building primitives or providers — for example,
+ * when a custom provider needs to register a `message`, `part`, or other scope
+ * onto the client visible to its descendants. Application code rarely reaches
+ * for this; use {@link useAui} with no arguments to read the existing client.
  *
  * @example
  * ```tsx
@@ -417,16 +415,10 @@ export function useAui(): AssistantClient;
  *
  * const role = useAuiState((s) => s.message.role);
  * ```
- *
- * @deprecated This API is highly experimental and may be changed in a
- * minor release.
  */
 export function useAui(clients: useAui.Props): AssistantClient;
 /**
  * Extends an explicit parent `AssistantClient` with additional scopes.
- *
- * @deprecated This API is highly experimental and may be changed in a
- * minor release.
  */
 export function useAui(
   clients: useAui.Props,

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -359,7 +359,49 @@ export namespace useAui {
   };
 }
 
+/**
+ * Returns the current `AssistantClient` from context.
+ *
+ * Read the client supplied by the nearest {@link AuiProvider} or
+ * {@link AssistantRuntimeProvider}, then access a scope on it —
+ * `aui.thread()`, `aui.composer()`, `aui.message()`, and so on. Pair
+ * with {@link useAuiState} to read reactive state and {@link useAuiEvent}
+ * to subscribe to events.
+ *
+ * Rendered outside a provider, the returned client's scope accessors
+ * throw a descriptive error the first time they are read.
+ *
+ * @example
+ * ```tsx
+ * const aui = useAui();
+ *
+ * const onSend = () => aui.composer().send();
+ * const onCancel = () => aui.thread().cancelRun();
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Combine with useAuiState to drive disabled state.
+ * const aui = useAui();
+ * const isRunning = useAuiState((s) => s.thread.isRunning);
+ *
+ * return (
+ *   <button disabled={isRunning} onClick={() => aui.composer().send()}>
+ *     Send
+ *   </button>
+ * );
+ * ```
+ */
 export function useAui(): AssistantClient;
+/**
+ * Extends the parent `AssistantClient` with additional scopes.
+ *
+ * Advanced overload used when building primitives or providers — for
+ * example, when a custom provider needs to register a `message`, `part`,
+ * or other scope onto the client visible to its descendants. Application
+ * code rarely reaches for this; use {@link useAui} with no arguments to
+ * read the existing client.
+ */
 export function useAui(clients: useAui.Props): AssistantClient;
 export function useAui(
   clients: useAui.Props,

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -382,13 +382,11 @@ export namespace useAui {
  *
  * @example
  * ```tsx
+ * // For event subscriptions, prefer useAuiEvent over aui.on() + useEffect.
+ * // Use aui directly for imperative actions:
  * const aui = useAui();
  *
- * useEffect(() => {
- *   return aui.on("thread.modelContextUpdate", () => {
- *     refreshModelContext();
- *   });
- * }, [aui]);
+ * const handleCancel = () => aui.thread().cancelRun();
  * ```
  *
  * @example

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -367,7 +367,8 @@ export namespace useAui {
  * `aui.thread()`, `aui.composer()`, `aui.message()`, and so on. Pair
  * with {@link useAuiState} to read reactive state and {@link useAuiEvent}
  * to subscribe to events. The returned client also exposes lower-level
- * methods such as `aui.on(...)` and `aui.subscribe(...)`.
+ * methods such as `aui.on(...)` and `aui.subscribe(...)`; prefer
+ * `useAuiEvent` for React event subscriptions.
  *
  * Rendered outside a provider, the returned client's scope accessors
  * throw a descriptive error whenever they are called.
@@ -378,15 +379,6 @@ export namespace useAui {
  *
  * const onSend = () => aui.composer().send();
  * const onCancel = () => aui.thread().cancelRun();
- * ```
- *
- * @example
- * ```tsx
- * // For event subscriptions, prefer useAuiEvent over aui.on() + useEffect.
- * // Use aui directly for imperative actions:
- * const aui = useAui();
- *
- * const handleCancel = () => aui.thread().cancelRun();
  * ```
  *
  * @example

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -366,10 +366,11 @@ export namespace useAui {
  * {@link AssistantRuntimeProvider}, then access a scope on it —
  * `aui.thread()`, `aui.composer()`, `aui.message()`, and so on. Pair
  * with {@link useAuiState} to read reactive state and {@link useAuiEvent}
- * to subscribe to events.
+ * to subscribe to events. The returned client also exposes lower-level
+ * methods such as `aui.on(...)` and `aui.subscribe(...)`.
  *
  * Rendered outside a provider, the returned client's scope accessors
- * throw a descriptive error the first time they are read.
+ * throw a descriptive error whenever they are called.
  *
  * @example
  * ```tsx
@@ -377,6 +378,17 @@ export namespace useAui {
  *
  * const onSend = () => aui.composer().send();
  * const onCancel = () => aui.thread().cancelRun();
+ * ```
+ *
+ * @example
+ * ```tsx
+ * const aui = useAui();
+ *
+ * useEffect(() => {
+ *   return aui.on("thread.modelContextUpdate", () => {
+ *     refreshModelContext();
+ *   });
+ * }, [aui]);
  * ```
  *
  * @example
@@ -396,13 +408,36 @@ export function useAui(): AssistantClient;
 /**
  * Extends the parent `AssistantClient` with additional scopes.
  *
- * Advanced overload used when building primitives or providers — for
- * example, when a custom provider needs to register a `message`, `part`,
- * or other scope onto the client visible to its descendants. Application
- * code rarely reaches for this; use {@link useAui} with no arguments to
- * read the existing client.
+ * Highly experimental advanced overload used when building primitives or
+ * providers — for example, when a custom provider needs to register a
+ * `message`, `part`, or other scope onto the client visible to its
+ * descendants. This API may change in a minor release. Application code
+ * rarely reaches for this; use {@link useAui} with no arguments to read
+ * the existing client.
+ *
+ * @example
+ * ```tsx
+ * const aui = useAui({
+ *   message: Derived({
+ *     source: "thread",
+ *     query: { index: 0 },
+ *     get: (aui) => aui.thread().message({ index: 0 }),
+ *   }),
+ * });
+ *
+ * const role = useAuiState((s) => s.message.role);
+ * ```
+ *
+ * @deprecated This API is highly experimental and may be changed in a
+ * minor release.
  */
 export function useAui(clients: useAui.Props): AssistantClient;
+/**
+ * Extends an explicit parent `AssistantClient` with additional scopes.
+ *
+ * @deprecated This API is highly experimental and may be changed in a
+ * minor release.
+ */
 export function useAui(
   clients: useAui.Props,
   config: { parent: null | AssistantClient },

--- a/packages/store/src/useAuiEvent.ts
+++ b/packages/store/src/useAuiEvent.ts
@@ -16,17 +16,20 @@ import { normalizeEventSelector } from "./types/events";
  * shim, so the latest closure is invoked on each emission — you do not
  * need to memoize it.
  *
- * @param selector - Either a dotted event name like `"thread.runStart"`
- *   or an object `{ scope, event }`. Use `scope: "*"` to listen across
- *   every instance of a scope rather than only the one in context.
+ * @param selector - Either a dotted event name like
+ *   `"thread.modelContextUpdate"` or an object `{ scope, event }`. Use
+ *   `scope: "*"` to subscribe at the root client and receive emissions
+ *   from any descendant scope, regardless of which one is in React
+ *   context.
  * @param callback - Invoked with the event payload. The most recent
- *   reference is always called.
+ *   reference is always called. Return values are ignored, async callbacks
+ *   are not awaited, and the callback cannot be called during render.
  *
  * @example
  * ```tsx
- * // Scroll the viewport when the active thread starts a run.
- * useAuiEvent("thread.runStart", () => {
- *   scrollToBottom();
+ * // React to transient model-context changes.
+ * useAuiEvent("thread.modelContextUpdate", ({ threadId }) => {
+ *   analytics.track("model_context_update", { threadId });
  * });
  * ```
  *
@@ -40,9 +43,9 @@ import { normalizeEventSelector } from "./types/events";
  *
  * @example
  * ```tsx
- * // Listen globally across every thread, not just the one in scope.
- * useAuiEvent({ scope: "*", event: "thread.runEnd" }, (payload) => {
- *   analytics.track("run_end", payload);
+ * // Listen from the root client rather than the current React context.
+ * useAuiEvent({ scope: "*", event: "thread.modelContextUpdate" }, (payload) => {
+ *   analytics.track("model_context_update", payload);
  * });
  * ```
  */

--- a/packages/store/src/useAuiEvent.ts
+++ b/packages/store/src/useAuiEvent.ts
@@ -8,6 +8,44 @@ import type {
 } from "./types/events";
 import { normalizeEventSelector } from "./types/events";
 
+/**
+ * Subscribes to an assistant event for the lifetime of the component.
+ *
+ * The subscription is established on mount and re-established whenever the
+ * scope or event name changes. The `callback` is wrapped in an effect-event
+ * shim, so the latest closure is invoked on each emission — you do not
+ * need to memoize it.
+ *
+ * @param selector - Either a dotted event name like `"thread.runStart"`
+ *   or an object `{ scope, event }`. Use `scope: "*"` to listen across
+ *   every instance of a scope rather than only the one in context.
+ * @param callback - Invoked with the event payload. The most recent
+ *   reference is always called.
+ *
+ * @example
+ * ```tsx
+ * // Scroll the viewport when the active thread starts a run.
+ * useAuiEvent("thread.runStart", () => {
+ *   scrollToBottom();
+ * });
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // React to thread switches.
+ * useAuiEvent("threadListItem.switchedTo", () => {
+ *   resetLocalState();
+ * });
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Listen globally across every thread, not just the one in scope.
+ * useAuiEvent({ scope: "*", event: "thread.runEnd" }, (payload) => {
+ *   analytics.track("run_end", payload);
+ * });
+ * ```
+ */
 export const useAuiEvent = <TEvent extends AssistantEventName>(
   selector: AssistantEventSelector<TEvent>,
   callback: AssistantEventCallback<TEvent>,

--- a/packages/store/src/useAuiState.ts
+++ b/packages/store/src/useAuiState.ts
@@ -4,18 +4,32 @@ import { useAui } from "./useAui";
 import { getProxiedAssistantState } from "./utils/proxied-assistant-state";
 
 /**
- * Hook to access a slice of the assistant state with automatic subscription
+ * Subscribes to a slice of {@link AssistantState} and re-renders the
+ * component whenever that slice changes.
  *
- * @param selector - Function to select a slice of the state
- * @returns The selected state slice
+ * The `selector` is called on every store update; its return value is
+ * compared by `Object.is`, and the component re-renders only when the
+ * selected slice changes. Returning the entire state object is not
+ * supported and throws at runtime — select a specific field instead, or
+ * compose multiple `useAuiState` calls.
+ *
+ * @param selector - Pure function that derives a value from the current
+ *   assistant state. Should be cheap and referentially stable for equal
+ *   inputs (plain field reads, primitives, or memoized values).
+ * @returns The currently selected slice.
  *
  * @example
- * ```typescript
- * const aui = useAui({
- *   foo: RootScope({ ... }),
- * });
+ * ```tsx
+ * // Disable a button while a run is in flight.
+ * const isRunning = useAuiState((s) => s.thread.isRunning);
+ * ```
  *
- * const bar = useAuiState((s) => s.foo.bar);
+ * @example
+ * ```tsx
+ * // Prefer multiple selectors over an inline object literal, which would
+ * // create a new reference on every render.
+ * const text = useAuiState((s) => s.composer.text);
+ * const canSend = useAuiState((s) => s.composer.canSend);
  * ```
  */
 export const useAuiState = <T>(selector: (state: AssistantState) => T): T => {

--- a/packages/store/src/useAuiState.ts
+++ b/packages/store/src/useAuiState.ts
@@ -11,7 +11,10 @@ import { getProxiedAssistantState } from "./utils/proxied-assistant-state";
  * compared by `Object.is`, and the component re-renders only when the
  * selected slice changes. Returning the entire state object is not
  * supported and throws at runtime — select a specific field instead, or
- * compose multiple `useAuiState` calls.
+ * compose multiple `useAuiState` calls. Returning a new object or array
+ * literal, including spreading `s.thread` into a new object, causes a
+ * re-render on every store update; either select primitives or return a
+ * memoized reference.
  *
  * @param selector - Pure function that derives a value from the current
  *   assistant state. Should be cheap and referentially stable for equal

--- a/packages/store/src/utils/react-assistant-context.tsx
+++ b/packages/store/src/utils/react-assistant-context.tsx
@@ -98,11 +98,11 @@ export const useAssistantContextValue = (): AssistantClient => {
  *
  * @example
  * ```tsx
- * const client = createAssistantClient({ ... });
+ * function ScopedAssistant({ children, scopes }) {
+ *   const aui = useAui(scopes);
  *
- * <AuiProvider value={client}>
- *   <App />
- * </AuiProvider>
+ *   return <AuiProvider value={aui}>{children}</AuiProvider>;
+ * }
  * ```
  */
 export const AuiProvider = ({

--- a/packages/store/src/utils/react-assistant-context.tsx
+++ b/packages/store/src/utils/react-assistant-context.tsx
@@ -85,12 +85,23 @@ export const useAssistantContextValue = (): AssistantClient => {
 };
 
 /**
- * Provider component for AssistantClient
+ * Supplies an `AssistantClient` to the React tree.
+ *
+ * Place near the root of any subtree that uses {@link useAui} or the
+ * primitives built on it. Components rendered outside an `AuiProvider`
+ * receive a default client whose scope accessors throw on use, so
+ * missing-provider mistakes surface at the point of use.
+ *
+ * When mounting a runtime built with one of the runtime hooks, use
+ * {@link AssistantRuntimeProvider} — it installs an `AuiProvider`
+ * internally — rather than wiring `AuiProvider` yourself.
  *
  * @example
- * ```typescript
- * <AuiProvider value={aui}>
- *   <YourApp />
+ * ```tsx
+ * const client = createAssistantClient({ ... });
+ *
+ * <AuiProvider value={client}>
+ *   <App />
  * </AuiProvider>
  * ```
  */
@@ -98,7 +109,9 @@ export const AuiProvider = ({
   value,
   children,
 }: {
+  /** Assistant client to expose to descendants. */
   value: AssistantClient;
+  /** Subtree that may read from the client. */
   children: React.ReactNode;
 }): React.ReactElement => {
   return (


### PR DESCRIPTION
## Summary

- expand public JSDoc across assistant stream, tool, runtime provider, AUI state/event, and model-context APIs
- add migration-focused `@deprecated` notices for the six `useMessagePart*` hooks
- improve existing legacy deprecation notices with `{@link}` targets so replacements are clickable in IDE/docs output
- regenerate API reference docs from the updated JSDoc

## Notes

This PR is documentation-only. The only newly deprecated public APIs are the `useMessagePart*` hooks; other deprecation changes update prose/link formatting on APIs that were already deprecated.

## Validation

- `pnpm --filter @assistant-ui/docs generate:docs`