### PR TITLE
feat(examples): GitHub MCP showcase with OAuth + MCP Apps

### DIFF
--- a/.changeset/react-mcp-initial.md
+++ b/.changeset/react-mcp-initial.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+feat: new package — MCP server configuration and OAuth primitives. Unstyled Radix-style primitives (`McpManagerPrimitive`, `McpServerPrimitive`, `McpAddFormPrimitive`), a tap-backed manager + per-server resource, OAuth (PKCE + DCR) / bearer / none auth modes, and pluggable persistence via `MCPLocalStorage` / `MCPMemoryStorage` / `MCPCustomStorage`.

--- a/apps/docs/content/docs/integrations/tools/meta.json
+++ b/apps/docs/content/docs/integrations/tools/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Tools",
-  "pages": ["mcp"]
+  "pages": ["mcp", "react-mcp"]
 }

--- a/apps/docs/content/docs/integrations/tools/react-mcp.mdx
+++ b/apps/docs/content/docs/integrations/tools/react-mcp.mdx
@@ -1,0 +1,336 @@
+---
+title: User-managed MCP servers
+description: Let end users add and authenticate MCP servers from the browser with @assistant-ui/react-mcp.
+---
+
+[`@assistant-ui/react-mcp`](https://npmjs.com/package/@assistant-ui/react-mcp) is the user-facing layer for MCP. Where the [server-side MCP guide](/docs/integrations/tools/mcp) wires a single fixed set of MCP servers into your API route, this package lets *end users* see a list of connectors, sign in via OAuth, paste a custom server URL, and have the resulting tool catalog flow into the chat.
+
+Two ways a server reaches the user:
+
+- **Connector** — a preset declared by the app developer with `defineConnector(...)`. The user just clicks Connect (and completes auth).
+- **Custom server** — the user supplies the URL, name, and auth in `<McpAddFormPrimitive>`. Disable with `canAddCustom={false}`.
+
+Both flow through one connection lifecycle and one persisted state surface.
+
+## How it works
+
+```
+<MCPProvider>
+  │
+  ├─ tap manager resource owns server list + connection lifecycle
+  │
+  ├─ for each server:  StreamableHTTPClientTransport (MCP SDK)
+  │                    + OAuth provider backed by MCPStorage
+  │
+  └─ tools surface via useMcpTools() → your chat runtime
+```
+
+OAuth, bearer, and "no auth" are all first-class. OAuth handles PKCE, RFC 7591 dynamic client registration, and token refresh through the official MCP SDK; this package only mediates persistence and the redirect step.
+
+## Setup
+
+<Steps>
+<Step>
+
+### Install
+
+<InstallCommand npm={["@assistant-ui/react-mcp"]} />
+
+</Step>
+<Step>
+
+### Mount the provider
+
+Wrap the part of your tree that should see the MCP state:
+
+```tsx title="app/providers.tsx"
+"use client";
+
+import { MCPProvider, defineConnector } from "@assistant-ui/react-mcp";
+
+const connectors = [
+  defineConnector({
+    id: "linear",
+    name: "Linear",
+    url: "https://mcp.linear.app",
+    auth: { type: "oauth", scopes: ["read"] },
+    icon: "/icons/linear.svg",
+  }),
+  defineConnector({
+    id: "internal-docs",
+    name: "Internal Docs",
+    url: "https://docs.mycorp.internal/mcp",
+    auth: { type: "bearer" }, // user pastes token in the add form
+  }),
+];
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <MCPProvider
+      connectors={connectors}
+      oauthRedirectUri={
+        typeof window !== "undefined"
+          ? `${window.location.origin}/mcp/callback`
+          : undefined
+      }
+    >
+      {children}
+    </MCPProvider>
+  );
+}
+```
+
+`MCPProvider` accepts:
+
+- `connectors` — app-declared presets
+- `storage` — see [Storage](#storage). Defaults to `MCPLocalStorage()`
+- `canAddCustom` — gates custom-server creation. Default `true`
+- `oauthRedirectUri` — where OAuth providers redirect back. Default `${origin}/mcp/callback`
+- `autoConnect` — try to connect on mount if usable auth is persisted. Default `true`
+
+</Step>
+<Step>
+
+### Compose the UI from primitives
+
+Three namespaces, all unstyled and `data-*`-driven (same conventions as `@assistant-ui/react-o11y`):
+
+```tsx title="app/mcp/page.tsx"
+"use client";
+
+import {
+  McpManagerPrimitive,
+  McpServerPrimitive,
+  McpAddFormPrimitive,
+} from "@assistant-ui/react-mcp";
+
+export default function McpPage() {
+  return (
+    <McpManagerPrimitive.Root>
+      <h2>Connectors</h2>
+      <McpManagerPrimitive.Connectors>
+        <McpServerPrimitive.Root>
+          <McpServerPrimitive.Icon />
+          <McpServerPrimitive.Name />
+          <McpServerPrimitive.Status />
+          <McpServerPrimitive.ConnectButton>Connect</McpServerPrimitive.ConnectButton>
+          <McpServerPrimitive.DisconnectButton>Disconnect</McpServerPrimitive.DisconnectButton>
+          <McpServerPrimitive.OAuthLink>Authorize ↗</McpServerPrimitive.OAuthLink>
+          <McpServerPrimitive.Error />
+        </McpServerPrimitive.Root>
+      </McpManagerPrimitive.Connectors>
+
+      <h2>Your servers</h2>
+      <McpManagerPrimitive.CustomServers>
+        <McpServerPrimitive.Root>
+          <McpServerPrimitive.Name />
+          <McpServerPrimitive.Status />
+          <McpServerPrimitive.ConnectButton>Connect</McpServerPrimitive.ConnectButton>
+          <McpServerPrimitive.DisconnectButton>Disconnect</McpServerPrimitive.DisconnectButton>
+          <McpServerPrimitive.RemoveButton>Remove</McpServerPrimitive.RemoveButton>
+        </McpServerPrimitive.Root>
+      </McpManagerPrimitive.CustomServers>
+
+      <McpManagerPrimitive.AddCustomTrigger>Add custom server</McpManagerPrimitive.AddCustomTrigger>
+    </McpManagerPrimitive.Root>
+  );
+}
+```
+
+`<Connectors>` and `<CustomServers>` iterate over their respective lists, wrapping each child in an `MCPServerByIdProvider` so the nested `<McpServerPrimitive.*>` reads from the correct scope.
+
+`<ConnectButton>`, `<DisconnectButton>`, and `<RemoveButton>` render only when the server is in a state that allows the action — there's no need to gate them manually. `<OAuthLink>` renders an anchor to the authorization URL only when the server is in `authRequired`.
+
+</Step>
+<Step>
+
+### Add the custom-server form
+
+The form owns its own local state and submits via `mcp.addCustomServer(...)`. Drop it inside your own dialog/sheet:
+
+```tsx
+<McpAddFormPrimitive.Root onSubmitted={() => closeDialog()}>
+  <McpAddFormPrimitive.NameField />
+  <McpAddFormPrimitive.UrlField />
+  <McpAddFormPrimitive.AuthSelect /> {/* none | bearer | oauth */}
+  <McpAddFormPrimitive.AuthFields /> {/* token / scopes input */}
+  <McpAddFormPrimitive.Error />
+  <McpAddFormPrimitive.Submit>Add</McpAddFormPrimitive.Submit>
+  <McpAddFormPrimitive.Cancel>Cancel</McpAddFormPrimitive.Cancel>
+</McpAddFormPrimitive.Root>
+```
+
+`AuthFields` defaults to a bearer-token input or scope input depending on the selected auth type. Pass a render function to fully customize it.
+
+</Step>
+<Step>
+
+### Handle the OAuth callback
+
+Add a callback route — usually `/mcp/callback` — that completes the flow and routes the user back:
+
+```tsx title="app/mcp/callback/page.tsx"
+"use client";
+
+import { McpOAuthCallback } from "@assistant-ui/react-mcp";
+import { useRouter } from "next/navigation";
+import { Providers } from "../../providers";
+
+export default function Callback() {
+  const router = useRouter();
+  return (
+    <Providers>
+      <McpOAuthCallback onComplete={() => router.replace("/mcp")} />
+    </Providers>
+  );
+}
+```
+
+`<McpOAuthCallback>` reads `?state=...&code=...` from `window.location`, derives the target server id from the state parameter (set automatically by the package's OAuth provider), and calls `completeAuth` on the right server.
+
+</Step>
+<Step>
+
+### Pipe tools into your runtime
+
+`useMcpTools()` aggregates the enabled tools across all connected servers, in a shape your chat runtime can adopt directly:
+
+```tsx
+"use client";
+
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import {
+  useMcpTools,
+  mcpRuntimeToolsToAiSdkTools,
+} from "@assistant-ui/react-mcp";
+
+export function Chat() {
+  const { tools } = useMcpTools();
+  const runtime = useChatRuntime({
+    api: "/api/chat",
+    tools: mcpRuntimeToolsToAiSdkTools(tools),
+  });
+  /* … */
+}
+```
+
+Tool names are prefixed `serverId__toolName` to avoid collisions across servers. The hook auto-rebuilds the map when a server connects or disconnects.
+
+The package never auto-registers tools with a runtime — the choice of which servers' tools become available to the model is deliberately yours.
+
+</Step>
+</Steps>
+
+## Storage
+
+All persisted state — custom server records, OAuth tokens, PKCE verifiers, DCR client info — goes through a single `MCPStorage` resource. Three built-ins:
+
+- `MCPLocalStorage()` — default. Stores under the `aui-mcp:` prefix in `window.localStorage`.
+- `MCPMemoryStorage()` — in-process Map. Use for SSR/tests where localStorage is absent.
+- `MCPCustomStorage({ ... })` — bring your own load/save methods. Use for app-controlled backends (e.g. POST to your API).
+
+```tsx
+import { MCPProvider, MCPCustomStorage } from "@assistant-ui/react-mcp";
+
+<MCPProvider
+  storage={MCPCustomStorage({
+    loadCustomServers: async () => fetch("/api/mcp/servers").then((r) => r.json()),
+    saveCustomServers: async (records) =>
+      fetch("/api/mcp/servers", { method: "PUT", body: JSON.stringify(records) }),
+    loadAuthState: async (id) =>
+      fetch(`/api/mcp/auth/${id}`).then((r) => (r.ok ? r.json() : null)),
+    saveAuthState: async (id, state) =>
+      fetch(`/api/mcp/auth/${id}`, { method: "PUT", body: JSON.stringify(state) }),
+    clearAuthState: async (id) =>
+      fetch(`/api/mcp/auth/${id}`, { method: "DELETE" }),
+  })}
+>
+  {/* … */}
+</MCPProvider>
+```
+
+<Callout type="warn">
+`MCPLocalStorage` stores tokens in plain text and is XSS-exposed. For anything beyond local prototyping, use `MCPCustomStorage` against an HTTP-only-cookie-backed endpoint, or wrap localStorage with your own encrypted serializer.
+</Callout>
+
+## Auth
+
+Three modes, declared per-connector or per-custom-record:
+
+```ts
+{ type: "none" }                                    // no auth header
+{ type: "bearer", token?: "…" }                     // Authorization: Bearer …
+{ type: "oauth",                                    // PKCE + DCR + refresh
+  scopes?: ["read"],
+  authorizationEndpoint?: "…",                      // overrides discovery
+  tokenEndpoint?: "…",
+  registrationEndpoint?: "…",
+  clientId?: "…",                                   // skip DCR with a static client
+  clientSecret?: "…",
+}
+```
+
+The OAuth provider:
+
+1. Discovers the authorization server via RFC 8414 (or uses your overrides).
+2. Performs DCR via RFC 7591 if no `clientId` is set, persisting the resulting client info.
+3. Generates PKCE; redirect is exposed as `authorizationUrl` on the server state — the package never auto-navigates. `<McpServerPrimitive.OAuthLink>` renders an anchor; you're free to open it in a popup instead.
+4. After the user returns to the callback page, `completeAuth` exchanges the code for tokens.
+5. The MCP SDK transports refresh tokens automatically on 401. A refresh failure transitions the server to `authRequired`.
+
+The OAuth `state` parameter encodes the server id, so the callback handler knows which server to complete without app-level wiring.
+
+## State & methods
+
+Subscribe with the existing `useAuiState`:
+
+```ts
+import { useAuiState } from "@assistant-ui/store";
+
+const isHydrated = useAuiState((s) => s.mcp.isHydrated);
+const connectionState = useAuiState((s) => s.mcpServer.connectionState);
+//                                          ^ requires McpServerByIdProvider
+```
+
+Or use the imperative accessors:
+
+```ts
+const mcp = useMcpManager();        // === useAui().mcp()
+await mcp.addCustomServer({ name, url, auth: { type: "bearer", token } });
+await mcp.server({ id }).connect();
+await mcp.server({ id }).callTool("echo", { text: "hi" });
+```
+
+The full state shape (`MCPManagerState`, `MCPServerState`, `MCPToolInfo`, `MCPConnectionState`) is exported and inferred from `s.mcp` / `s.mcpServer`.
+
+## v1 scope
+
+What ships:
+
+- Tool listing and invocation
+- OAuth (PKCE + DCR), bearer, none
+- StreamableHTTP transport
+- Manual connect/disconnect
+
+What's deferred:
+
+- Resources, prompts, sampling
+- Auto-reconnect with backoff
+- Per-tool enable/disable persistence
+- Per-tool consent prompts
+- Out-of-the-box token encryption (use `MCPCustomStorage` against a server endpoint)
+
+## Related
+
+<Cards>
+  <Card
+    title="Server-side MCP"
+    description="App-developer-controlled MCP servers wired into the API route."
+    href="/docs/integrations/tools/mcp"
+  />
+  <Card
+    title="Tools and tool UI"
+    description="Build custom renderers for tool calls and approvals."
+    href="/docs/guides/tools"
+  />
+</Cards>

--- a/examples/showcase-github-mcp/.env.example
+++ b/examples/showcase-github-mcp/.env.example
@@ -1,0 +1,15 @@
+# ─── GitHub OAuth app ───────────────────────────────────────────────
+# Create one at https://github.com/settings/applications/new
+#   Homepage URL:                http://localhost:8788
+#   Authorization callback URL:  http://localhost:8788/oauth/github/callback
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# ─── MCP server ─────────────────────────────────────────────────────
+# Public origin of this MCP server. Used for OAuth metadata. Default ok for local dev.
+MCP_SERVER_ORIGIN=http://localhost:8788
+
+# ─── Chat (Next.js) ─────────────────────────────────────────────────
+# Used by /api/chat for the LLM. The chat side is optional — the showcase
+# also works by clicking "Call" buttons on tools directly.
+OPENAI_API_KEY=

--- a/examples/showcase-github-mcp/README.md
+++ b/examples/showcase-github-mcp/README.md
@@ -1,0 +1,94 @@
+# showcase-github-mcp
+
+A working showcase that wires three things together:
+
+1. **An MCP server wrapping a slice of the GitHub REST API**, with OAuth via
+   GitHub login (RFC 7591 dynamic client registration + PKCE on the MCP side,
+   OAuth web flow against GitHub on the upstream side).
+2. **An assistant-ui frontend** that configures this MCP connector through
+   `@assistant-ui/react-mcp` and walks through the OAuth flow.
+3. **Inline MCP App widgets** (language pie chart, 52-week commit heatmap,
+   PR lanes board) returned by the GitHub-API tools and rendered with the
+   native MCP Apps renderer in `@assistant-ui/react`.
+
+> **Note on xmcp**: The original request mentioned xmcp. xmcp's built-in
+> OAuth was deprecated in favor of provider plugins (Auth0 / Clerk / Better
+> Auth / WorkOS), none of which fit a "log in directly with GitHub" demo
+> cleanly. This example instead uses `@modelcontextprotocol/sdk`'s OAuth
+> router directly. The file structure (`server/tools/...`) follows xmcp's
+> filesystem convention so porting later is mechanical.
+
+## Run it
+
+### 1. Register a GitHub OAuth app
+
+[Create a new OAuth app](https://github.com/settings/applications/new):
+
+- **Homepage URL** — `http://localhost:8788`
+- **Authorization callback URL** — `http://localhost:8788/oauth/github/callback`
+
+Generate a client secret. Copy `.env.example` to `.env` at the example root
+and fill in `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`.
+
+### 2. Install and run
+
+```sh
+cd examples/showcase-github-mcp
+pnpm dev
+```
+
+This boots:
+
+- **MCP server** on `http://localhost:8788` (Express + `@modelcontextprotocol/sdk`)
+- **Next.js app** on `http://localhost:3020`
+
+Open the app, click **Connect with GitHub**, then **Authorize on GitHub ↗**.
+After the redirect comes back to `/mcp/callback`, the connector transitions
+to `connected` and you can fire tools.
+
+## Tools
+
+| Tool                  | Result                                        |
+| --------------------- | --------------------------------------------- |
+| `whoami`              | Authenticated GitHub user                     |
+| `list_repos`          | User's accessible repositories (text)         |
+| `repo_languages`      | Byte-level language breakdown → **pie chart** |
+| `commit_activity`     | 52-week commit activity → **heatmap**         |
+| `list_pull_requests`  | Open + draft PRs → **two-lane board**         |
+
+The three visualization tools attach `_meta["ui/resourceUri"]` pointing at
+an inline HTML widget. The Next.js app fetches the widget via the MCP
+client's `resources/read`, mounts it in a sandboxed iframe, and pipes the
+tool's `structuredContent` through to it via the MCP Apps JSON-RPC bridge.
+
+## Architecture
+
+```
+            Next.js app                 MCP server (Express)
+            ───────────                  ────────────────────
+            <MCPProvider>                /.well-known/oauth-authorization-server
+              <MCPAppProvider>           /authorize   ◄──┐
+                <Showcase/>               /token         │   redirects to
+                  │                       /register      │   github.com/login/oauth/authorize
+                  │  callTool /            /oauth/github/callback
+                  │  readResource          /mcp  ── bearerAuth ── McpServer
+                  └─► through ──────────►  │
+                      @assistant-ui/react-mcp                tools call api.github.com
+                                                              with the bound user's token
+```
+
+Tokens minted by the MCP server are opaque and bound (in-memory) to a
+GitHub access token + user. Refreshing the MCP token does **not** refresh
+the GitHub token — for a real deployment, persist both and refresh GitHub
+tokens out-of-band.
+
+## What's intentionally minimal
+
+- **In-memory state** — clients, codes, and tokens vanish on server
+  restart. Drop in any store you like.
+- **No chat / LLM yet** — the showcase fires tools manually so it works
+  without an OpenAI/Anthropic key. The pieces are in place to plug a chat
+  runtime on top: `useMcpTools()` returns the connected server's tools in a
+  runtime-agnostic shape.
+- **No styling library** — plain inline styles, so the moving parts stay
+  visible.

--- a/examples/showcase-github-mcp/app/app/Showcase.tsx
+++ b/examples/showcase-github-mcp/app/app/Showcase.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState } from "react";
+import {
+  McpManagerPrimitive,
+  McpServerPrimitive,
+} from "@assistant-ui/react-mcp";
+import { useAuiState } from "@assistant-ui/store";
+import {
+  MCPAppFrame,
+  type MCPAppMetadata,
+  type MCPAppResource,
+} from "@assistant-ui/react";
+import { MCPAppFromCallButton } from "./ToolButton";
+
+type ToolResult = {
+  toolName: string;
+  args: unknown;
+  raw: {
+    content?: { type: string; text?: string }[];
+    structuredContent?: unknown;
+    _meta?: Record<string, unknown>;
+  };
+  app: MCPAppMetadata | null;
+  resource: MCPAppResource | null;
+};
+
+export function Showcase() {
+  const [result, setResult] = useState<ToolResult | null>(null);
+  const [owner, setOwner] = useState("vercel");
+  const [repo, setRepo] = useState("ai");
+
+  return (
+    <McpManagerPrimitive.Root>
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ marginTop: 0 }}>Connect</h2>
+        <McpManagerPrimitive.Connectors>
+          <ConnectCard />
+        </McpManagerPrimitive.Connectors>
+      </section>
+
+      <McpManagerPrimitive.Connectors>
+        <ConnectedOnly>
+          <section style={{ marginBottom: 24 }}>
+            <h2>Try a tool</h2>
+
+            <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+              <MCPAppFromCallButton
+                toolName="whoami"
+                args={{}}
+                onResult={setResult}
+              >
+                whoami
+              </MCPAppFromCallButton>
+              <MCPAppFromCallButton
+                toolName="list_repos"
+                args={{ limit: 30 }}
+                onResult={setResult}
+              >
+                list_repos
+              </MCPAppFromCallButton>
+            </div>
+
+            <div
+              style={{
+                display: "flex",
+                gap: 8,
+                marginBottom: 8,
+                alignItems: "center",
+              }}
+            >
+              <span style={{ fontSize: 13 }}>Repo:</span>
+              <input
+                value={owner}
+                onChange={(e) => setOwner(e.target.value)}
+                style={input}
+                placeholder="owner"
+                aria-label="owner"
+              />
+              <span>/</span>
+              <input
+                value={repo}
+                onChange={(e) => setRepo(e.target.value)}
+                style={input}
+                placeholder="repo"
+                aria-label="repo"
+              />
+            </div>
+
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              <MCPAppFromCallButton
+                toolName="repo_languages"
+                args={{ owner, repo }}
+                onResult={setResult}
+              >
+                repo_languages
+              </MCPAppFromCallButton>
+              <MCPAppFromCallButton
+                toolName="commit_activity"
+                args={{ owner, repo }}
+                onResult={setResult}
+              >
+                commit_activity
+              </MCPAppFromCallButton>
+              <MCPAppFromCallButton
+                toolName="list_pull_requests"
+                args={{ owner, repo }}
+                onResult={setResult}
+              >
+                list_pull_requests
+              </MCPAppFromCallButton>
+            </div>
+          </section>
+
+          {result && (
+            <section>
+              <h2>
+                Result — <code>{result.toolName}</code>
+              </h2>
+              {result.raw.content?.map(
+                (c, i) =>
+                  c.type === "text" && (
+                    <pre
+                      key={i}
+                      style={{
+                        whiteSpace: "pre-wrap",
+                        wordBreak: "break-all",
+                        background: "#f6f8fa",
+                        padding: 12,
+                        borderRadius: 6,
+                        margin: "0 0 12px",
+                        fontSize: 12,
+                      }}
+                    >
+                      {c.text}
+                    </pre>
+                  ),
+              )}
+
+              {result.app && result.resource && (
+                <MCPAppFrame
+                  app={result.app}
+                  resource={result.resource}
+                  input={result.args}
+                  output={result.raw}
+                  sandbox={{
+                    sandbox: [
+                      "allow-scripts",
+                      "allow-same-origin-disabled-cors",
+                    ],
+                  }}
+                />
+              )}
+            </section>
+          )}
+        </ConnectedOnly>
+      </McpManagerPrimitive.Connectors>
+    </McpManagerPrimitive.Root>
+  );
+}
+
+const input: React.CSSProperties = {
+  padding: "4px 8px",
+  border: "1px solid #d0d7de",
+  borderRadius: 4,
+  fontSize: 13,
+  width: 140,
+};
+
+function ConnectedOnly({ children }: { children: React.ReactNode }) {
+  const state = useAuiState((s) => s.mcpServer.connectionState);
+  if (state !== "connected") return null;
+  return <>{children}</>;
+}
+
+function ConnectCard() {
+  const state = useAuiState((s) => s.mcpServer.connectionState);
+  return (
+    <McpServerPrimitive.Root
+      style={{
+        padding: 16,
+        border: "1px solid #d0d7de",
+        borderRadius: 8,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        background:
+          state === "connected" ? "rgba(46, 160, 67, 0.06)" : "transparent",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <strong>
+          <McpServerPrimitive.Name />
+        </strong>
+        <span
+          style={{
+            padding: "2px 8px",
+            background: "#eef",
+            borderRadius: 4,
+            fontSize: 12,
+          }}
+        >
+          <McpServerPrimitive.Status />
+        </span>
+      </div>
+      <McpServerPrimitive.Error style={{ color: "#cc0000", fontSize: 12 }} />
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <McpServerPrimitive.ConnectButton style={btn}>
+          Connect with GitHub
+        </McpServerPrimitive.ConnectButton>
+        <McpServerPrimitive.OAuthLink style={oauthLink}>
+          Authorize on GitHub ↗
+        </McpServerPrimitive.OAuthLink>
+        <McpServerPrimitive.DisconnectButton style={btn}>
+          Disconnect
+        </McpServerPrimitive.DisconnectButton>
+      </div>
+    </McpServerPrimitive.Root>
+  );
+}
+
+const btn: React.CSSProperties = {
+  padding: "6px 12px",
+  border: "1px solid #d0d7de",
+  borderRadius: 6,
+  background: "#f6f8fa",
+  cursor: "pointer",
+  fontSize: 13,
+};
+
+const oauthLink: React.CSSProperties = {
+  padding: "6px 12px",
+  background: "#1f883d",
+  color: "white",
+  borderRadius: 6,
+  textDecoration: "none",
+  fontSize: 13,
+};

--- a/examples/showcase-github-mcp/app/app/ToolButton.tsx
+++ b/examples/showcase-github-mcp/app/app/ToolButton.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { type ReactNode, useState } from "react";
+import { useMcpManager } from "@assistant-ui/react-mcp";
+import { useMCPAppContext } from "@assistant-ui/react";
+import type { MCPAppMetadata, MCPAppResource } from "@assistant-ui/react";
+
+type ToolResult = {
+  toolName: string;
+  args: unknown;
+  raw: {
+    content?: { type: string; text?: string }[];
+    structuredContent?: unknown;
+    _meta?: Record<string, unknown>;
+  };
+  app: MCPAppMetadata | null;
+  resource: MCPAppResource | null;
+};
+
+function readMcpAppMeta(raw: ToolResult["raw"]): MCPAppMetadata | null {
+  const uri = raw._meta?.["ui/resourceUri"];
+  if (typeof uri !== "string" || !uri.startsWith("ui://")) return null;
+  return { resourceUri: uri };
+}
+
+export function MCPAppFromCallButton({
+  toolName,
+  args,
+  onResult,
+  children,
+}: {
+  toolName: string;
+  args: unknown;
+  onResult: (r: ToolResult) => void;
+  children: ReactNode;
+}) {
+  const mcp = useMcpManager();
+  const ctx = useMCPAppContext();
+  const [pending, setPending] = useState(false);
+
+  const onClick = async () => {
+    setPending(true);
+    try {
+      const raw = (await mcp
+        .server({ id: "aui-github" })
+        .callTool(toolName, args)) as ToolResult["raw"];
+
+      const app = readMcpAppMeta(raw);
+      const resource =
+        app && ctx.loadResource ? await ctx.loadResource(app) : null;
+      onResult({ toolName, args, raw, app, resource });
+    } catch (err) {
+      onResult({
+        toolName,
+        args,
+        raw: {
+          content: [
+            {
+              type: "text",
+              text: err instanceof Error ? err.message : String(err),
+            },
+          ],
+        },
+        app: null,
+        resource: null,
+      });
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={pending}
+      style={{
+        padding: "6px 12px",
+        border: "1px solid #d0d7de",
+        borderRadius: 6,
+        background: pending ? "#eee" : "#fff",
+        cursor: pending ? "default" : "pointer",
+        fontSize: 13,
+        opacity: pending ? 0.6 : 1,
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/examples/showcase-github-mcp/app/app/layout.tsx
+++ b/examples/showcase-github-mcp/app/app/layout.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "GitHub MCP showcase",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          fontFamily:
+            "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+          margin: 0,
+          padding: 24,
+          maxWidth: 980,
+          color: "#111",
+          background: "#fff",
+        }}
+      >
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/examples/showcase-github-mcp/app/app/mcp/callback/page.tsx
+++ b/examples/showcase-github-mcp/app/app/mcp/callback/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { McpOAuthCallback } from "@assistant-ui/react-mcp";
+import { Providers } from "../../providers";
+
+export default function CallbackPage() {
+  const router = useRouter();
+  return (
+    <Providers>
+      <h1>Completing GitHub login…</h1>
+      <McpOAuthCallback
+        onComplete={() => router.replace("/")}
+        onError={(err) => {
+          console.error("OAuth callback failed:", err);
+        }}
+      >
+        {(result) => (
+          <pre>
+            {JSON.stringify(
+              {
+                status: result.status,
+                serverId: result.serverId,
+                error: result.error?.message ?? null,
+              },
+              null,
+              2,
+            )}
+          </pre>
+        )}
+      </McpOAuthCallback>
+    </Providers>
+  );
+}

--- a/examples/showcase-github-mcp/app/app/page.tsx
+++ b/examples/showcase-github-mcp/app/app/page.tsx
@@ -1,0 +1,18 @@
+import { Providers } from "./providers";
+import { Showcase } from "./Showcase";
+
+export default function Home() {
+  return (
+    <Providers>
+      <h1 style={{ marginTop: 0 }}>GitHub MCP showcase</h1>
+      <p>
+        A live MCP server wrapping a slice of the GitHub REST API, with OAuth
+        via GitHub login, served to this app through{" "}
+        <code>@assistant-ui/react-mcp</code>. Tools return inline MCP App
+        widgets (charts and diagrams) rendered via the native MCP Apps renderer
+        in <code>@assistant-ui/react</code>.
+      </p>
+      <Showcase />
+    </Providers>
+  );
+}

--- a/examples/showcase-github-mcp/app/app/providers.tsx
+++ b/examples/showcase-github-mcp/app/app/providers.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { type ReactNode, useCallback, useMemo } from "react";
+import {
+  MCPProvider,
+  defineConnector,
+  useMcpManager,
+} from "@assistant-ui/react-mcp";
+import {
+  MCPAppProvider,
+  type MCPAppBridgeHandlers,
+  type MCPAppMetadata,
+  type MCPAppResource,
+} from "@assistant-ui/react";
+
+const SERVER_ORIGIN =
+  process.env.NEXT_PUBLIC_MCP_ORIGIN ?? "http://localhost:8788";
+
+const connectors = [
+  defineConnector({
+    id: "aui-github",
+    name: "GitHub",
+    url: `${SERVER_ORIGIN}/mcp`,
+    auth: { type: "oauth", scopes: ["mcp", "repo"] },
+  }),
+];
+
+const MIME = "text/html;profile=mcp-app";
+
+function AppProviderInner({ children }: { children: ReactNode }) {
+  const mcp = useMcpManager();
+
+  const loadResource = useCallback(
+    async (app: MCPAppMetadata): Promise<MCPAppResource> => {
+      const out = (await mcp
+        .server({ id: "aui-github" })
+        .readResource(app.resourceUri)) as {
+        contents: { uri: string; mimeType?: string; text?: string }[];
+      };
+      const c =
+        out.contents?.find((x) => x.uri === app.resourceUri) ??
+        out.contents?.[0];
+      return {
+        uri: app.resourceUri,
+        mimeType: MIME,
+        html: c?.text ?? "",
+      };
+    },
+    [mcp],
+  );
+
+  const handlers = useMemo<MCPAppBridgeHandlers>(
+    () => ({
+      callTool: async ({ name, arguments: args }) =>
+        await mcp.server({ id: "aui-github" }).callTool(name, args),
+      openLink: ({ url }) => {
+        if (typeof window !== "undefined") {
+          window.open(url, "_blank", "noopener,noreferrer");
+        }
+      },
+    }),
+    [mcp],
+  );
+
+  return (
+    <MCPAppProvider
+      loadResource={loadResource}
+      handlers={handlers}
+      hostInfo={{ name: "aui-github-showcase", version: "0.1.0" }}
+      hostContext={{ theme: "light" }}
+    >
+      {children}
+    </MCPAppProvider>
+  );
+}
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <MCPProvider
+      connectors={connectors}
+      oauthRedirectUri={
+        typeof window !== "undefined"
+          ? `${window.location.origin}/mcp/callback`
+          : undefined
+      }
+    >
+      <AppProviderInner>{children}</AppProviderInner>
+    </MCPProvider>
+  );
+}

--- a/examples/showcase-github-mcp/app/next.config.ts
+++ b/examples/showcase-github-mcp/app/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/examples/showcase-github-mcp/app/tsconfig.json
+++ b/examples/showcase-github-mcp/app/tsconfig.json
@@ -1,0 +1,42 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"],
+      "@assistant-ui/react": ["../../../packages/react/src"],
+      "@assistant-ui/react/*": ["../../../packages/react/src/*"],
+      "@assistant-ui/react-mcp": ["../../../packages/react-mcp/src"],
+      "@assistant-ui/react-mcp/*": ["../../../packages/react-mcp/src/*"],
+      "@assistant-ui/react-ai-sdk": ["../../../packages/react-ai-sdk/src"],
+      "@assistant-ui/store": ["../../../packages/store/src"],
+      "@assistant-ui/store/*": ["../../../packages/store/src/*"],
+      "@assistant-ui/tap": ["../../../packages/tap/src"],
+      "@assistant-ui/tap/*": ["../../../packages/tap/src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/examples/showcase-github-mcp/package.json
+++ b/examples/showcase-github-mcp/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "showcase-github-mcp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "concurrently -n server,app -c blue,magenta \"pnpm dev:server\" \"pnpm dev:app\"",
+    "dev:server": "tsx watch server/index.ts",
+    "dev:app": "next dev app --port 3020",
+    "build:app": "next build app",
+    "start:server": "tsx server/index.ts"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^2.0.55",
+    "@assistant-ui/react": "workspace:*",
+    "@assistant-ui/react-ai-sdk": "workspace:*",
+    "@assistant-ui/react-markdown": "workspace:*",
+    "@assistant-ui/react-mcp": "workspace:*",
+    "@assistant-ui/store": "workspace:*",
+    "@assistant-ui/tap": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "ai": "^5.0.94",
+    "cors": "^2.8.5",
+    "express": "^4.21.2",
+    "next": "^16.2.4",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^5.0.0",
+    "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "concurrently": "^9.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/showcase-github-mcp/server/github.ts
+++ b/examples/showcase-github-mcp/server/github.ts
@@ -1,0 +1,119 @@
+/**
+ * Thin GitHub REST API client. Uses the bearer token bound to the current
+ * MCP session (extracted in oauth.ts).
+ */
+const UA = "aui-mcp-showcase";
+
+export type GhRepo = {
+  name: string;
+  full_name: string;
+  owner: { login: string };
+  description: string | null;
+  language: string | null;
+  stargazers_count: number;
+  forks_count: number;
+  open_issues_count: number;
+  private: boolean;
+  default_branch: string;
+  pushed_at: string;
+};
+
+export type GhPullRequest = {
+  number: number;
+  title: string;
+  user: { login: string };
+  state: "open" | "closed";
+  draft: boolean;
+  created_at: string;
+  updated_at: string;
+  html_url: string;
+  labels: { name: string; color: string }[];
+};
+
+export type GhCommitActivity = {
+  /** total commits in week */
+  total: number;
+  /** Unix timestamp (seconds) for start of week */
+  week: number;
+  /** Sun..Sat commit counts */
+  days: number[];
+};
+
+async function gh<T>(
+  token: string,
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const r = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": UA,
+      ...init?.headers,
+    },
+  });
+  if (!r.ok) {
+    const text = await r.text().catch(() => "");
+    throw new Error(`GitHub API ${r.status} on ${path}: ${text.slice(0, 200)}`);
+  }
+  return (await r.json()) as T;
+}
+
+export async function listUserRepos(
+  token: string,
+  opts: { sort?: "pushed" | "created" | "full_name"; perPage?: number } = {},
+): Promise<GhRepo[]> {
+  const sort = opts.sort ?? "pushed";
+  const perPage = opts.perPage ?? 30;
+  return gh<GhRepo[]>(
+    token,
+    `/user/repos?sort=${sort}&per_page=${perPage}&affiliation=owner,collaborator,organization_member`,
+  );
+}
+
+export async function getRepoLanguages(
+  token: string,
+  owner: string,
+  repo: string,
+): Promise<Record<string, number>> {
+  return gh(token, `/repos/${owner}/${repo}/languages`);
+}
+
+export async function getCommitActivity(
+  token: string,
+  owner: string,
+  repo: string,
+): Promise<GhCommitActivity[]> {
+  // GitHub computes this on demand; first call may 202 with empty body.
+  const r = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/stats/commit_activity`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": UA,
+      },
+    },
+  );
+  if (r.status === 202) return [];
+  if (!r.ok) {
+    throw new Error(`GitHub API ${r.status} on /stats/commit_activity`);
+  }
+  return (await r.json()) as GhCommitActivity[];
+}
+
+export async function listPullRequests(
+  token: string,
+  owner: string,
+  repo: string,
+  opts: { state?: "open" | "closed" | "all"; perPage?: number } = {},
+): Promise<GhPullRequest[]> {
+  const state = opts.state ?? "open";
+  const perPage = opts.perPage ?? 30;
+  return gh<GhPullRequest[]>(
+    token,
+    `/repos/${owner}/${repo}/pulls?state=${state}&per_page=${perPage}`,
+  );
+}

--- a/examples/showcase-github-mcp/server/index.ts
+++ b/examples/showcase-github-mcp/server/index.ts
@@ -1,0 +1,345 @@
+/**
+ * GitHub MCP showcase server.
+ *
+ * - OAuth proxy to GitHub (PKCE + DCR on the MCP side; OAuth web flow on the
+ *   GitHub side). See ./oauth.ts.
+ * - Tools that wrap a slice of the GitHub REST API and return MCP Apps
+ *   (HTML widgets) for visualization-friendly results.
+ * - Single Express server on PORT (default 8788).
+ */
+import express from "express";
+import cors from "cors";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
+import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import {
+  createGithubOAuthProvider,
+  getGithubAuth,
+  type GithubAuthExtras,
+} from "./oauth";
+import {
+  listUserRepos,
+  getRepoLanguages,
+  getCommitActivity,
+  listPullRequests,
+} from "./github";
+import { LANGUAGE_PIE_HTML } from "./widgets/languagePie";
+import { COMMIT_HEATMAP_HTML } from "./widgets/commitHeatmap";
+import { PR_LANES_HTML } from "./widgets/prLanes";
+
+const PORT = Number(process.env.PORT ?? 8788);
+const ORIGIN = process.env.MCP_SERVER_ORIGIN ?? `http://localhost:${PORT}`;
+const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
+const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET;
+
+if (!GITHUB_CLIENT_ID || !GITHUB_CLIENT_SECRET) {
+  console.error(
+    "GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET must be set. See .env.example.",
+  );
+  process.exit(1);
+}
+
+const provider = createGithubOAuthProvider({
+  githubClientId: GITHUB_CLIENT_ID,
+  githubClientSecret: GITHUB_CLIENT_SECRET,
+  serverOrigin: ORIGIN,
+});
+
+const MIME = "text/html;profile=mcp-app";
+
+const URIS = {
+  languagePie: "ui://aui-github-mcp/language-pie.html",
+  commitHeatmap: "ui://aui-github-mcp/commit-heatmap.html",
+  prLanes: "ui://aui-github-mcp/pr-lanes.html",
+} as const;
+
+const RESOURCE_BODIES: Record<string, string> = {
+  [URIS.languagePie]: LANGUAGE_PIE_HTML,
+  [URIS.commitHeatmap]: COMMIT_HEATMAP_HTML,
+  [URIS.prLanes]: PR_LANES_HTML,
+};
+
+function requireGithub(authInfo: AuthInfo | undefined): GithubAuthExtras {
+  const gh = getGithubAuth(authInfo);
+  if (!gh) {
+    throw new Error("No GitHub session bound to this MCP token");
+  }
+  return gh;
+}
+
+function buildMcpServer(authInfo: AuthInfo | undefined): McpServer {
+  const server = new McpServer({ name: "aui-github-mcp", version: "0.0.1" });
+
+  // ─── Resources (one per widget) ──────────────────────────────────────
+  for (const [uri, html] of Object.entries(RESOURCE_BODIES)) {
+    const name = uri.split("/").pop() ?? uri;
+    server.registerResource(name, uri, { mimeType: MIME }, async () => ({
+      contents: [{ uri, mimeType: MIME, text: html }],
+    }));
+  }
+
+  // ─── whoami ──────────────────────────────────────────────────────────
+  server.registerTool(
+    "whoami",
+    {
+      description: "Return the authenticated GitHub user.",
+      inputSchema: {},
+    },
+    async () => {
+      const gh = requireGithub(authInfo);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Authenticated as @${gh.githubLogin} (id ${gh.githubUserId}).`,
+          },
+        ],
+        structuredContent: { login: gh.githubLogin, id: gh.githubUserId },
+      };
+    },
+  );
+
+  // ─── list_repos ──────────────────────────────────────────────────────
+  server.registerTool(
+    "list_repos",
+    {
+      description:
+        "List the authenticated user's accessible repositories (owner, collaborator, org).",
+      inputSchema: {
+        sort: z
+          .enum(["pushed", "created", "full_name"])
+          .optional()
+          .describe("Sort order. Default: pushed."),
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+    },
+    async ({ sort, limit }) => {
+      const gh = requireGithub(authInfo);
+      const repos = await listUserRepos(gh.githubAccessToken, {
+        ...(sort !== undefined ? { sort } : {}),
+        ...(limit !== undefined ? { perPage: limit } : {}),
+      });
+      const summary = repos
+        .slice(0, 20)
+        .map(
+          (r) =>
+            `${r.full_name}${r.private ? " (private)" : ""} · ★${r.stargazers_count} · ${r.language ?? "—"}${r.description ? ` · ${r.description}` : ""}`,
+        )
+        .join("\n");
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              repos.length === 0
+                ? "No repositories."
+                : `${repos.length} repositories:\n${summary}`,
+          },
+        ],
+        structuredContent: {
+          repos: repos.map((r) => ({
+            full_name: r.full_name,
+            stars: r.stargazers_count,
+            language: r.language,
+            private: r.private,
+            pushed_at: r.pushed_at,
+          })),
+        },
+      };
+    },
+  );
+
+  // ─── repo_languages (with MCP App) ───────────────────────────────────
+  server.registerTool(
+    "repo_languages",
+    {
+      description:
+        "Get the byte-level language breakdown of a repo as a pie chart.",
+      inputSchema: {
+        owner: z.string(),
+        repo: z.string(),
+      },
+      _meta: { "ui/resourceUri": URIS.languagePie },
+    },
+    async ({ owner, repo }) => {
+      const gh = requireGithub(authInfo);
+      const langs = await getRepoLanguages(gh.githubAccessToken, owner, repo);
+      const total = Object.values(langs).reduce((s, v) => s + v, 0);
+      const summary = Object.entries(langs)
+        .sort((a, b) => b[1] - a[1])
+        .map(
+          ([name, bytes]) =>
+            `${name}: ${((bytes / Math.max(1, total)) * 100).toFixed(1)}%`,
+        )
+        .join("\n");
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              total === 0
+                ? `No language data for ${owner}/${repo}.`
+                : `Language breakdown for ${owner}/${repo}:\n${summary}`,
+          },
+        ],
+        structuredContent: { repo: `${owner}/${repo}`, languages: langs },
+        _meta: { "ui/resourceUri": URIS.languagePie },
+      };
+    },
+  );
+
+  // ─── commit_activity (with MCP App) ──────────────────────────────────
+  server.registerTool(
+    "commit_activity",
+    {
+      description:
+        "Return the 52-week commit activity for a repo as a GitHub-style heatmap.",
+      inputSchema: {
+        owner: z.string(),
+        repo: z.string(),
+      },
+      _meta: { "ui/resourceUri": URIS.commitHeatmap },
+    },
+    async ({ owner, repo }) => {
+      const gh = requireGithub(authInfo);
+      const weeks = await getCommitActivity(gh.githubAccessToken, owner, repo);
+      const total = weeks.reduce((s, w) => s + w.total, 0);
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              weeks.length === 0
+                ? `GitHub is computing stats for ${owner}/${repo}; try again in a moment.`
+                : `Commit activity for ${owner}/${repo}: ${total} commits across the last 52 weeks.`,
+          },
+        ],
+        structuredContent: { repo: `${owner}/${repo}`, weeks },
+        _meta: { "ui/resourceUri": URIS.commitHeatmap },
+      };
+    },
+  );
+
+  // ─── list_pull_requests (with MCP App) ───────────────────────────────
+  server.registerTool(
+    "list_pull_requests",
+    {
+      description:
+        "List pull requests for a repo. Returns a two-lane (ready / draft) widget.",
+      inputSchema: {
+        owner: z.string(),
+        repo: z.string(),
+        state: z.enum(["open", "closed", "all"]).optional(),
+      },
+      _meta: { "ui/resourceUri": URIS.prLanes },
+    },
+    async ({ owner, repo, state }) => {
+      const gh = requireGithub(authInfo);
+      const prs = await listPullRequests(gh.githubAccessToken, owner, repo, {
+        ...(state !== undefined ? { state } : {}),
+      });
+      const summary =
+        prs.length === 0
+          ? `No ${state ?? "open"} PRs in ${owner}/${repo}.`
+          : `${prs.length} ${state ?? "open"} PRs:\n` +
+            prs
+              .slice(0, 20)
+              .map(
+                (p) =>
+                  `#${p.number} ${p.draft ? "(draft) " : ""}${p.title} — @${p.user.login}`,
+              )
+              .join("\n");
+      return {
+        content: [{ type: "text", text: summary }],
+        structuredContent: {
+          repo: `${owner}/${repo}`,
+          prs: prs.map((p) => ({
+            number: p.number,
+            title: p.title,
+            draft: p.draft,
+            user: p.user,
+            labels: p.labels,
+            html_url: p.html_url,
+          })),
+        },
+        _meta: { "ui/resourceUri": URIS.prLanes },
+      };
+    },
+  );
+
+  return server;
+}
+
+// ─── Express wiring ─────────────────────────────────────────────────────
+async function main() {
+  const app = express();
+
+  app.use(
+    cors({
+      origin: true,
+      credentials: false,
+      exposedHeaders: ["Mcp-Session-Id", "WWW-Authenticate"],
+      allowedHeaders: [
+        "Authorization",
+        "Content-Type",
+        "Mcp-Session-Id",
+        "Accept",
+        "mcp-protocol-version",
+      ],
+    }),
+  );
+
+  // GitHub callback (pre-registered with the GitHub OAuth app).
+  app.use(
+    (provider as unknown as { _githubCallback: express.Router })
+      ._githubCallback,
+  );
+
+  // MCP-side OAuth endpoints (metadata, /authorize, /token, /register, /revoke).
+  app.use(
+    mcpAuthRouter({
+      provider,
+      issuerUrl: new URL(ORIGIN),
+      scopesSupported: ["mcp", "repo"],
+      resourceName: "aui-github-mcp",
+    }),
+  );
+
+  const bearer = requireBearerAuth({ verifier: provider });
+
+  app.post("/mcp", bearer, async (req, res) => {
+    try {
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined, // stateless
+      });
+      res.on("close", () => transport.close());
+      const server = buildMcpServer(req.auth);
+      await server.connect(transport);
+      await transport.handleRequest(req, res);
+    } catch (err) {
+      console.error("MCP request error:", err);
+      if (!res.headersSent) res.status(500).end();
+    }
+  });
+
+  app.get("/health", (_req, res) => res.json({ ok: true }));
+
+  app.listen(PORT, () => {
+    console.log(`GitHub MCP showcase listening on ${ORIGIN}`);
+    console.log(
+      `  - OAuth metadata: ${ORIGIN}/.well-known/oauth-authorization-server`,
+    );
+    console.log(`  - MCP endpoint:   ${ORIGIN}/mcp`);
+    console.log(
+      `  - GitHub callback: ${ORIGIN}/oauth/github/callback (register this with your GitHub OAuth app)`,
+    );
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/showcase-github-mcp/server/oauth.ts
+++ b/examples/showcase-github-mcp/server/oauth.ts
@@ -1,0 +1,296 @@
+/**
+ * OAuthServerProvider implementation that proxies to GitHub.
+ *
+ * Why a proxy and not just declaring GitHub as the OAuth server?
+ * - GitHub OAuth doesn't support RFC 7591 dynamic client registration. MCP
+ *   clients expect DCR; without it, every client has to be pre-registered.
+ * - GitHub doesn't issue PKCE-bound auth codes for public clients in a way
+ *   that interoperates cleanly with the MCP SDK.
+ * - We need a stable callback URL pre-registered with GitHub. Our server
+ *   uses one fixed callback; the per-client redirect_uri is honored
+ *   internally and applied at the final hop.
+ *
+ * Flow:
+ *   client → /authorize (with PKCE, redirect_uri=client-cb)
+ *           → we save the grant, redirect user to GitHub OAuth
+ *   GitHub → /oauth/github/callback (our pre-registered URL)
+ *           → we look up the grant by `state`, swap GitHub code for GitHub
+ *             token, store it under our own auth code, redirect to the
+ *             client-cb with our auth code
+ *   client → POST /token (with code + verifier)
+ *           → we verify PKCE, mint our own access token bound to the
+ *             stored GitHub user + token, return it
+ *   client → GET /mcp (Authorization: Bearer <our-token>)
+ *           → bearer middleware verifies, we attach GitHub user info to
+ *             req.auth so tools can call api.github.com
+ */
+import { randomBytes, randomUUID } from "node:crypto";
+import type { Request, Response } from "express";
+import express from "express";
+import type { OAuthServerProvider } from "@modelcontextprotocol/sdk/server/auth/provider.js";
+import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
+import type {
+  OAuthClientInformationFull,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+
+export type GithubAuthExtras = {
+  githubUserId: number;
+  githubLogin: string;
+  githubAccessToken: string;
+};
+
+type AuthInfoWithGithub = AuthInfo & { extra: GithubAuthExtras };
+
+type AuthorizationGrant = {
+  clientId: string;
+  clientRedirectUri: string;
+  clientState?: string;
+  codeChallenge: string;
+  scopes: string[];
+  // Once GitHub returns and we mint our auth code, these are filled in:
+  githubUserId?: number;
+  githubLogin?: string;
+  githubAccessToken?: string;
+};
+
+const clientsByGrantState = new Map<string, AuthorizationGrant>(); // state issued to GitHub
+const clientsByOurCode = new Map<string, AuthorizationGrant>(); // code we return to client
+
+const clientsStoreMap = new Map<string, OAuthClientInformationFull>();
+const tokens = new Map<string, AuthInfoWithGithub>();
+const refreshTokens = new Map<
+  string,
+  { clientId: string; scopes: string[]; extras: GithubAuthExtras }
+>();
+
+const clientsStore: OAuthRegisteredClientsStore = {
+  async getClient(clientId) {
+    return clientsStoreMap.get(clientId);
+  },
+  async registerClient(client) {
+    const clientId = `aui_${randomUUID()}`;
+    const full: OAuthClientInformationFull = {
+      ...client,
+      client_id: clientId,
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+    };
+    clientsStoreMap.set(clientId, full);
+    return full;
+  },
+};
+
+type ProviderOptions = {
+  githubClientId: string;
+  githubClientSecret: string;
+  serverOrigin: string;
+};
+
+export function createGithubOAuthProvider(
+  opts: ProviderOptions,
+): OAuthServerProvider {
+  const githubCallback = `${opts.serverOrigin}/oauth/github/callback`;
+
+  const provider: OAuthServerProvider = {
+    get clientsStore() {
+      return clientsStore;
+    },
+
+    async authorize(client, params, res) {
+      const ourState = randomBytes(24).toString("base64url");
+      clientsByGrantState.set(ourState, {
+        clientId: client.client_id,
+        clientRedirectUri: params.redirectUri,
+        codeChallenge: params.codeChallenge,
+        scopes: params.scopes ?? [],
+        ...(params.state !== undefined ? { clientState: params.state } : {}),
+      });
+
+      const ghUrl = new URL("https://github.com/login/oauth/authorize");
+      ghUrl.searchParams.set("client_id", opts.githubClientId);
+      ghUrl.searchParams.set("redirect_uri", githubCallback);
+      // Translate MCP scopes to GitHub scopes. We just need `read:user`
+      // and `repo` for the demo tools (public + private repos read).
+      ghUrl.searchParams.set("scope", "read:user repo");
+      ghUrl.searchParams.set("state", ourState);
+      res.redirect(ghUrl.toString());
+    },
+
+    async challengeForAuthorizationCode(_client, authorizationCode) {
+      const grant = clientsByOurCode.get(authorizationCode);
+      if (!grant) throw new Error("invalid authorization code");
+      return grant.codeChallenge;
+    },
+
+    async exchangeAuthorizationCode(client, code): Promise<OAuthTokens> {
+      const grant = clientsByOurCode.get(code);
+      if (!grant) throw new Error("invalid authorization code");
+      if (grant.clientId !== client.client_id) {
+        throw new Error("authorization code/client mismatch");
+      }
+      if (
+        !grant.githubAccessToken ||
+        !grant.githubLogin ||
+        grant.githubUserId === undefined
+      ) {
+        throw new Error("authorization code has no associated GitHub session");
+      }
+      clientsByOurCode.delete(code);
+
+      return mintTokens(client.client_id, grant.scopes, {
+        githubUserId: grant.githubUserId,
+        githubLogin: grant.githubLogin,
+        githubAccessToken: grant.githubAccessToken,
+      });
+    },
+
+    async exchangeRefreshToken(
+      client,
+      refreshToken,
+      scopes,
+    ): Promise<OAuthTokens> {
+      const entry = refreshTokens.get(refreshToken);
+      if (!entry) throw new Error("invalid refresh token");
+      if (entry.clientId !== client.client_id) {
+        throw new Error("refresh token/client mismatch");
+      }
+      refreshTokens.delete(refreshToken);
+      return mintTokens(client.client_id, scopes ?? entry.scopes, entry.extras);
+    },
+
+    async verifyAccessToken(token): Promise<AuthInfo> {
+      const info = tokens.get(token);
+      if (!info) throw new Error("invalid access token");
+      return info;
+    },
+  };
+
+  // ─── Express handler for the GitHub callback (pre-registered with GitHub) ──
+  const githubCallbackRouter = express.Router();
+  githubCallbackRouter.get(
+    "/oauth/github/callback",
+    async (req: Request, res: Response) => {
+      const state = String(req.query.state ?? "");
+      const ghCode = String(req.query.code ?? "");
+      const error = String(req.query.error ?? "");
+      const grant = clientsByGrantState.get(state);
+      if (!grant) {
+        res.status(400).type("text/plain").send("Unknown OAuth state");
+        return;
+      }
+      clientsByGrantState.delete(state);
+
+      const redirectBack = new URL(grant.clientRedirectUri);
+      if (grant.clientState)
+        redirectBack.searchParams.set("state", grant.clientState);
+
+      if (error) {
+        redirectBack.searchParams.set("error", error);
+        const desc = req.query.error_description;
+        if (typeof desc === "string") {
+          redirectBack.searchParams.set("error_description", desc);
+        }
+        res.redirect(redirectBack.toString());
+        return;
+      }
+
+      try {
+        // Exchange code with GitHub
+        const tokenResp = await fetch(
+          "https://github.com/login/oauth/access_token",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "application/json",
+            },
+            body: JSON.stringify({
+              client_id: opts.githubClientId,
+              client_secret: opts.githubClientSecret,
+              code: ghCode,
+              redirect_uri: githubCallback,
+            }),
+          },
+        );
+        const tokenJson = (await tokenResp.json()) as {
+          access_token?: string;
+          error?: string;
+          error_description?: string;
+        };
+        if (!tokenJson.access_token) {
+          const msg =
+            tokenJson.error_description ??
+            tokenJson.error ??
+            "github exchange failed";
+          redirectBack.searchParams.set("error", "server_error");
+          redirectBack.searchParams.set("error_description", msg);
+          res.redirect(redirectBack.toString());
+          return;
+        }
+
+        // Fetch user info to bind to our token
+        const userResp = await fetch("https://api.github.com/user", {
+          headers: {
+            Authorization: `Bearer ${tokenJson.access_token}`,
+            Accept: "application/vnd.github+json",
+            "User-Agent": "aui-mcp-showcase",
+          },
+        });
+        const user = (await userResp.json()) as { id: number; login: string };
+
+        // Mint our own auth code bound to this GitHub session
+        const ourCode = randomBytes(24).toString("base64url");
+        grant.githubAccessToken = tokenJson.access_token;
+        grant.githubLogin = user.login;
+        grant.githubUserId = user.id;
+        clientsByOurCode.set(ourCode, grant);
+
+        redirectBack.searchParams.set("code", ourCode);
+        res.redirect(redirectBack.toString());
+      } catch (err) {
+        redirectBack.searchParams.set("error", "server_error");
+        redirectBack.searchParams.set(
+          "error_description",
+          err instanceof Error ? err.message : String(err),
+        );
+        res.redirect(redirectBack.toString());
+      }
+    },
+  );
+
+  return Object.assign(provider, { _githubCallback: githubCallbackRouter });
+}
+
+function mintTokens(
+  clientId: string,
+  scopes: string[],
+  extras: GithubAuthExtras,
+): OAuthTokens {
+  const access = randomBytes(32).toString("base64url");
+  const refresh = randomBytes(32).toString("base64url");
+  tokens.set(access, {
+    token: access,
+    clientId,
+    scopes,
+    expiresAt: Math.floor(Date.now() / 1000) + 60 * 60,
+    extra: extras,
+  });
+  refreshTokens.set(refresh, { clientId, scopes, extras });
+  return {
+    access_token: access,
+    refresh_token: refresh,
+    token_type: "Bearer",
+    expires_in: 60 * 60,
+    scope: scopes.join(" "),
+  };
+}
+
+/** Resolves the GitHub session bound to the verified bearer token. */
+export function getGithubAuth(
+  authInfo: AuthInfo | undefined,
+): GithubAuthExtras | null {
+  const extras = authInfo?.extra as GithubAuthExtras | undefined;
+  if (!extras?.githubAccessToken) return null;
+  return extras;
+}

--- a/examples/showcase-github-mcp/server/widgets/commitHeatmap.ts
+++ b/examples/showcase-github-mcp/server/widgets/commitHeatmap.ts
@@ -1,0 +1,84 @@
+import { BRIDGE_BOOTSTRAP, COMMON_CSS } from "./common";
+
+export const COMMIT_HEATMAP_HTML = /* html */ `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Commit activity</title>
+  <style>
+    ${COMMON_CSS}
+    .grid { display: grid; grid-template-columns: repeat(52, 12px); gap: 2px; }
+    .day-col { display: grid; grid-template-rows: repeat(7, 12px); gap: 2px; }
+    .cell { width: 12px; height: 12px; border-radius: 2px; background: #ebedf0; }
+    @media (prefers-color-scheme: dark) {
+      .cell { background: #161b22; }
+    }
+    .legend { display: flex; align-items: center; gap: 6px; margin-top: 10px; font-size: 11px; color: #888; }
+    .legend .scale { display: flex; gap: 2px; }
+    .legend .scale .cell { width: 10px; height: 10px; }
+  </style>
+</head>
+<body>
+  <h2 id="title">Commit activity</h2>
+  <div id="grid" class="grid"></div>
+  <div class="legend">
+    <span>Less</span>
+    <div class="scale" id="scale"></div>
+    <span>More</span>
+    <span class="muted" id="total" style="margin-left:auto"></span>
+  </div>
+  <script>
+    const SHADES = ["#ebedf0", "#9be9a8", "#40c463", "#30a14e", "#216e39"];
+    const DARK_SHADES = ["#161b22", "#0e4429", "#006d32", "#26a641", "#39d353"];
+
+    function shadeFor(count, max) {
+      if (count === 0) return 0;
+      const frac = count / max;
+      if (frac < 0.25) return 1;
+      if (frac < 0.5) return 2;
+      if (frac < 0.75) return 3;
+      return 4;
+    }
+
+    function getShades() {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches ? DARK_SHADES : SHADES;
+    }
+
+    function render(result) {
+      const sc = result?.structuredContent;
+      const repo = sc?.repo || "";
+      const weeks = sc?.weeks || [];
+      document.getElementById("title").textContent =
+        "Commits — " + repo + " (52-week)";
+
+      const grid = document.getElementById("grid");
+      grid.innerHTML = "";
+
+      const max = Math.max(1, ...weeks.flatMap((w) => w.days || []));
+      const shades = getShades();
+      let total = 0;
+
+      weeks.forEach((week) => {
+        const col = document.createElement("div");
+        col.className = "day-col";
+        for (let d = 0; d < 7; d++) {
+          const cell = document.createElement("div");
+          cell.className = "cell";
+          const c = week.days?.[d] ?? 0;
+          total += c;
+          cell.style.background = shades[shadeFor(c, max)];
+          cell.title = c + " commit" + (c === 1 ? "" : "s");
+          col.appendChild(cell);
+        }
+        grid.appendChild(col);
+      });
+
+      const scale = document.getElementById("scale");
+      scale.innerHTML = shades.map((c) => \`<div class="cell" style="background:\${c}"></div>\`).join("");
+      document.getElementById("total").textContent = total + " commits";
+    }
+    window.render = render;
+  </script>
+  ${BRIDGE_BOOTSTRAP}
+</body>
+</html>`;

--- a/examples/showcase-github-mcp/server/widgets/common.ts
+++ b/examples/showcase-github-mcp/server/widgets/common.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared `<script>` snippet that hooks into the MCP App bridge to receive
+ * the tool result and call a per-widget `render(result)` function.
+ */
+export const BRIDGE_BOOTSTRAP = /* html */ `
+<script>
+  (() => {
+    const log = (...a) => console.log("[mcp-widget]", ...a);
+
+    function emit(method, params) {
+      parent.postMessage({ jsonrpc: "2.0", method, params: params ?? {} }, "*");
+    }
+
+    function init() {
+      emit("notifications/initialized");
+      const h = document.documentElement.scrollHeight;
+      emit("notifications/size_changed", { height: h });
+    }
+
+    function handleResult(result) {
+      try {
+        if (typeof window.render === "function") window.render(result);
+      } catch (err) {
+        log("render error", err);
+        emit("notifications/error", { message: String(err) });
+      } finally {
+        const h = document.documentElement.scrollHeight;
+        emit("notifications/size_changed", { height: h });
+      }
+    }
+
+    window.addEventListener("message", (ev) => {
+      const msg = ev.data;
+      if (!msg || msg.jsonrpc !== "2.0") return;
+      if (msg.method === "notifications/tools/call/result") {
+        handleResult(msg.params?.result);
+      }
+    });
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", init);
+    } else {
+      init();
+    }
+  })();
+</script>
+`;
+
+export const COMMON_CSS = /* css */ `
+  :root { color-scheme: light dark; }
+  body {
+    font: 13px/1.4 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    margin: 0;
+    padding: 12px;
+    color: #111;
+    background: #fff;
+  }
+  @media (prefers-color-scheme: dark) {
+    body { color: #eee; background: #0d1117; }
+  }
+  h2 { font-size: 14px; margin: 0 0 8px; font-weight: 600; }
+  .muted { color: #888; font-size: 12px; }
+`;

--- a/examples/showcase-github-mcp/server/widgets/languagePie.ts
+++ b/examples/showcase-github-mcp/server/widgets/languagePie.ts
@@ -1,0 +1,83 @@
+import { BRIDGE_BOOTSTRAP, COMMON_CSS } from "./common";
+
+export const LANGUAGE_PIE_HTML = /* html */ `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Languages</title>
+  <style>
+    ${COMMON_CSS}
+    .row { display: flex; align-items: center; gap: 16px; }
+    svg { flex: 0 0 auto; }
+    ul { list-style: none; padding: 0; margin: 0; flex: 1; }
+    li { display: grid; grid-template-columns: 12px 1fr auto; align-items: center; gap: 8px; padding: 3px 0; }
+    .dot { width: 10px; height: 10px; border-radius: 50%; }
+    .pct { color: #888; font-variant-numeric: tabular-nums; }
+  </style>
+</head>
+<body>
+  <h2 id="title">Languages</h2>
+  <div class="row">
+    <svg id="pie" width="180" height="180" viewBox="-100 -100 200 200"></svg>
+    <ul id="legend"></ul>
+  </div>
+  <script>
+    const PALETTE = [
+      "#3178c6", "#f1e05a", "#e34c26", "#563d7c", "#dea584",
+      "#b07219", "#89e051", "#a270ba", "#dbbd34", "#fa7343",
+      "#2c3e50", "#41b883", "#cc342d", "#178600", "#f34b7d",
+    ];
+
+    function render(result) {
+      const sc = result?.structuredContent;
+      const repo = sc?.repo || "";
+      document.getElementById("title").textContent =
+        "Languages — " + repo;
+
+      const langs = sc?.languages || {};
+      const entries = Object.entries(langs).sort((a, b) => b[1] - a[1]);
+      const total = entries.reduce((s, [, v]) => s + v, 0);
+      if (total === 0) {
+        document.getElementById("legend").innerHTML =
+          '<li class="pct">No language data</li>';
+        return;
+      }
+
+      const svg = document.getElementById("pie");
+      svg.innerHTML = "";
+      let acc = 0;
+      entries.forEach(([name, bytes], i) => {
+        const frac = bytes / total;
+        const start = acc;
+        const end = acc + frac;
+        acc = end;
+        const a0 = start * Math.PI * 2 - Math.PI / 2;
+        const a1 = end * Math.PI * 2 - Math.PI / 2;
+        const r = 90;
+        const x0 = Math.cos(a0) * r, y0 = Math.sin(a0) * r;
+        const x1 = Math.cos(a1) * r, y1 = Math.sin(a1) * r;
+        const large = frac > 0.5 ? 1 : 0;
+        const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        path.setAttribute("d",
+          \`M0 0 L \${x0.toFixed(2)} \${y0.toFixed(2)} A \${r} \${r} 0 \${large} 1 \${x1.toFixed(2)} \${y1.toFixed(2)} Z\`);
+        path.setAttribute("fill", PALETTE[i % PALETTE.length]);
+        svg.appendChild(path);
+      });
+
+      const legend = entries
+        .map(([name, bytes], i) => {
+          const pct = ((bytes / total) * 100).toFixed(1);
+          return \`<li>
+            <span class="dot" style="background:\${PALETTE[i % PALETTE.length]}"></span>
+            <span>\${name}</span>
+            <span class="pct">\${pct}%</span>
+          </li>\`;
+        })
+        .join("");
+      document.getElementById("legend").innerHTML = legend;
+    }
+    window.render = render;
+  </script>
+  ${BRIDGE_BOOTSTRAP}
+</body>
+</html>`;

--- a/examples/showcase-github-mcp/server/widgets/prLanes.ts
+++ b/examples/showcase-github-mcp/server/widgets/prLanes.ts
@@ -1,0 +1,75 @@
+import { BRIDGE_BOOTSTRAP, COMMON_CSS } from "./common";
+
+export const PR_LANES_HTML = /* html */ `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Open pull requests</title>
+  <style>
+    ${COMMON_CSS}
+    .lanes { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .lane h3 { font-size: 12px; margin: 0 0 6px; color: #666; text-transform: uppercase; letter-spacing: 0.04em; }
+    .card { padding: 8px 10px; margin-bottom: 6px; border: 1px solid #d0d7de; border-radius: 6px; background: #fff; }
+    @media (prefers-color-scheme: dark) {
+      .card { background: #161b22; border-color: #30363d; }
+    }
+    .card a { color: inherit; text-decoration: none; font-weight: 500; }
+    .card a:hover { text-decoration: underline; }
+    .row { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; margin-top: 2px; }
+    .num { color: #888; font-size: 11px; }
+    .label { font-size: 10px; padding: 1px 6px; border-radius: 10px; border: 1px solid #d0d7de; }
+    .draft { color: #888; }
+  </style>
+</head>
+<body>
+  <h2 id="title">Open pull requests</h2>
+  <div class="lanes">
+    <div class="lane">
+      <h3>Ready for review</h3>
+      <div id="ready"></div>
+    </div>
+    <div class="lane">
+      <h3>Drafts</h3>
+      <div id="drafts"></div>
+    </div>
+  </div>
+  <script>
+    function escape(s) {
+      return String(s).replace(/[&<>"]/g, (c) => ({"&":"&amp;","<":"&lt;",">":"&gt;","\\"":"&quot;"}[c]));
+    }
+    function labelsHtml(labels) {
+      if (!labels?.length) return "";
+      return labels
+        .map((l) => \`<span class="label" style="border-color:#\${l.color || 'd0d7de'}">\${escape(l.name)}</span>\`)
+        .join("");
+    }
+    function cardHtml(pr) {
+      return \`<div class="card">
+        <a href="\${escape(pr.html_url)}" target="_blank" rel="noopener">\${escape(pr.title)}</a>
+        <div class="row">
+          <span class="num">#\${pr.number} · \${escape(pr.user?.login || "")}</span>
+          \${labelsHtml(pr.labels)}
+        </div>
+      </div>\`;
+    }
+    function render(result) {
+      const sc = result?.structuredContent;
+      const repo = sc?.repo || "";
+      const prs = sc?.prs || [];
+      document.getElementById("title").textContent =
+        "Open pull requests — " + repo;
+
+      const drafts = prs.filter((p) => p.draft);
+      const ready = prs.filter((p) => !p.draft);
+      const renderInto = (id, list) => {
+        const el = document.getElementById(id);
+        el.innerHTML = list.length === 0 ? '<div class="muted">None</div>' : list.map(cardHtml).join("");
+      };
+      renderInto("ready", ready);
+      renderInto("drafts", drafts);
+    }
+    window.render = render;
+  </script>
+  ${BRIDGE_BOOTSTRAP}
+</body>
+</html>`;

--- a/examples/showcase-github-mcp/tsconfig.json
+++ b/examples/showcase-github-mcp/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "paths": {
+      "@/*": ["./app/*"],
+      "@assistant-ui/react": ["../../packages/react/src"],
+      "@assistant-ui/react/*": ["../../packages/react/src/*"],
+      "@assistant-ui/react-mcp": ["../../packages/react-mcp/src"],
+      "@assistant-ui/react-mcp/*": ["../../packages/react-mcp/src/*"],
+      "@assistant-ui/react-ai-sdk": ["../../packages/react-ai-sdk/src"],
+      "@assistant-ui/store": ["../../packages/store/src"],
+      "@assistant-ui/store/*": ["../../packages/store/src/*"],
+      "@assistant-ui/tap": ["../../packages/tap/src"],
+      "@assistant-ui/tap/*": ["../../packages/tap/src/*"]
+    }
+  },
+  "include": [
+    "app/next-env.d.ts",
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    "server/**/*.ts",
+    "app/.next/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/examples/with-mcp/README.md
+++ b/examples/with-mcp/README.md
@@ -1,0 +1,28 @@
+# with-mcp
+
+Minimal harness for `@assistant-ui/react-mcp`. Runs a local MCP server with
+OAuth (PKCE + DCR) under `server/`, and a Next.js client under `app/` that
+uses the package's primitives.
+
+## Run
+
+```sh
+cd examples/with-mcp
+pnpm dev
+```
+
+This starts both the server (`http://localhost:8787`) and the Next.js app
+(`http://localhost:3010`).
+
+Open the app, click **Connect** on the "Local test MCP" connector, then
+**Authorize ↗** to walk through the OAuth flow. After redirect the server
+transitions to `connected` and the `echo` / `fingerprint` tools appear.
+
+## Notes
+
+- The test server is in-memory: tokens, clients, and codes don't persist
+  across restarts.
+- OAuth auto-approves (no consent screen). PKCE verification, DCR, and
+  refresh-token rotation still run end-to-end.
+- This example is intentionally unstyled; primitives are unstyled. See
+  `app/app/McpUI.tsx` for raw composition.

--- a/examples/with-mcp/app/app/McpUI.tsx
+++ b/examples/with-mcp/app/app/McpUI.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useId, useState } from "react";
+import {
+  McpManagerPrimitive,
+  McpServerPrimitive,
+  McpAddFormPrimitive,
+  useMcpTools,
+  useMcpManager,
+} from "@assistant-ui/react-mcp";
+
+export function McpUI() {
+  const [showForm, setShowForm] = useState(false);
+  const nameId = useId();
+  const urlId = useId();
+  const authId = useId();
+
+  return (
+    <McpManagerPrimitive.Root>
+      <section>
+        <h2>Connectors</h2>
+        <McpManagerPrimitive.Connectors>
+          <ServerCard />
+        </McpManagerPrimitive.Connectors>
+      </section>
+
+      <section>
+        <h2>Custom servers</h2>
+        <McpManagerPrimitive.CustomServers>
+          <ServerCard />
+        </McpManagerPrimitive.CustomServers>
+        <McpManagerPrimitive.AddCustomTrigger
+          onClick={() => setShowForm((v) => !v)}
+        >
+          {showForm ? "Hide form" : "Add custom server"}
+        </McpManagerPrimitive.AddCustomTrigger>
+
+        {showForm && (
+          <div style={{ marginTop: 12, padding: 12, border: "1px solid #ccc" }}>
+            <McpAddFormPrimitive.Root onSubmitted={() => setShowForm(false)}>
+              <Row>
+                <label htmlFor={nameId}>Name</label>
+                <McpAddFormPrimitive.NameField id={nameId} style={inputStyle} />
+              </Row>
+              <Row>
+                <label htmlFor={urlId}>URL</label>
+                <McpAddFormPrimitive.UrlField id={urlId} style={inputStyle} />
+              </Row>
+              <Row>
+                <label htmlFor={authId}>Auth</label>
+                <McpAddFormPrimitive.AuthSelect
+                  id={authId}
+                  style={inputStyle}
+                />
+              </Row>
+              <Row>
+                <span>Auth fields</span>
+                <McpAddFormPrimitive.AuthFields />
+              </Row>
+              <McpAddFormPrimitive.Error
+                style={{ color: "red", marginTop: 8 }}
+              />
+              <div style={{ marginTop: 8, display: "flex", gap: 8 }}>
+                <McpAddFormPrimitive.Submit>Add</McpAddFormPrimitive.Submit>
+                <McpAddFormPrimitive.Cancel onClick={() => setShowForm(false)}>
+                  Cancel
+                </McpAddFormPrimitive.Cancel>
+              </div>
+            </McpAddFormPrimitive.Root>
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h2>Tools</h2>
+        <ToolsList />
+      </section>
+    </McpManagerPrimitive.Root>
+  );
+}
+
+const inputStyle = {
+  width: "100%",
+  padding: 6,
+  boxSizing: "border-box" as const,
+};
+
+function Row({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "120px 1fr",
+        alignItems: "center",
+        gap: 8,
+        marginBottom: 6,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ServerCard() {
+  return (
+    <McpServerPrimitive.Root
+      style={{
+        padding: 12,
+        border: "1px solid #ccc",
+        borderRadius: 6,
+        marginBottom: 8,
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <McpServerPrimitive.Icon style={{ width: 24, height: 24 }} />
+        <strong>
+          <McpServerPrimitive.Name />
+        </strong>
+        <span
+          style={{
+            padding: "2px 8px",
+            background: "#eee",
+            borderRadius: 4,
+            fontSize: 12,
+          }}
+        >
+          <McpServerPrimitive.Status />
+        </span>
+      </div>
+      <McpServerPrimitive.Error style={{ color: "red" }} />
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <McpServerPrimitive.ConnectButton>
+          Connect
+        </McpServerPrimitive.ConnectButton>
+        <McpServerPrimitive.OAuthLink
+          style={{
+            display: "inline-block",
+            padding: "4px 10px",
+            background: "#0066ff",
+            color: "white",
+            borderRadius: 4,
+            textDecoration: "none",
+          }}
+        >
+          Authorize ↗
+        </McpServerPrimitive.OAuthLink>
+        <McpServerPrimitive.DisconnectButton>
+          Disconnect
+        </McpServerPrimitive.DisconnectButton>
+        <McpServerPrimitive.RemoveButton>
+          Remove
+        </McpServerPrimitive.RemoveButton>
+      </div>
+      <McpServerPrimitive.Tools>
+        <li>
+          <McpServerPrimitive.ToolName />
+        </li>
+      </McpServerPrimitive.Tools>
+    </McpServerPrimitive.Root>
+  );
+}
+
+function ToolsList() {
+  const { tools } = useMcpTools();
+  const mcp = useMcpManager();
+  const [result, setResult] = useState<string>("");
+
+  const entries = Object.entries(tools);
+  if (entries.length === 0) return <p>(no connected tools)</p>;
+  return (
+    <div>
+      <ul>
+        {entries.map(([key, t]) => (
+          <li key={key}>
+            <code>{key}</code>{" "}
+            <button
+              type="button"
+              onClick={async () => {
+                try {
+                  const out = await mcp
+                    .server({ id: t.serverId })
+                    .callTool(t.name, { text: "hello", input: "hello" });
+                  setResult(JSON.stringify(out, null, 2));
+                } catch (err) {
+                  setResult(String(err));
+                }
+              }}
+            >
+              Call
+            </button>
+          </li>
+        ))}
+      </ul>
+      {result && (
+        <pre
+          style={{
+            background: "#f5f5f5",
+            padding: 8,
+            borderRadius: 4,
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-all",
+          }}
+        >
+          {result}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/examples/with-mcp/app/app/layout.tsx
+++ b/examples/with-mcp/app/app/layout.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "react-mcp test",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          fontFamily:
+            "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+          margin: 0,
+          padding: 24,
+          maxWidth: 880,
+        }}
+      >
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/examples/with-mcp/app/app/mcp/callback/page.tsx
+++ b/examples/with-mcp/app/app/mcp/callback/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { McpOAuthCallback } from "@assistant-ui/react-mcp";
+import { Providers } from "../../providers";
+
+export default function CallbackPage() {
+  const router = useRouter();
+  return (
+    <Providers>
+      <h1>Completing OAuth…</h1>
+      <McpOAuthCallback
+        onComplete={() => router.replace("/")}
+        onError={(err) => {
+          console.error("OAuth callback failed:", err);
+        }}
+      >
+        {(result) => (
+          <pre>
+            {JSON.stringify(
+              {
+                status: result.status,
+                serverId: result.serverId,
+                error: result.error?.message ?? null,
+              },
+              null,
+              2,
+            )}
+          </pre>
+        )}
+      </McpOAuthCallback>
+    </Providers>
+  );
+}

--- a/examples/with-mcp/app/app/page.tsx
+++ b/examples/with-mcp/app/app/page.tsx
@@ -1,0 +1,16 @@
+import { Providers } from "./providers";
+import { McpUI } from "./McpUI";
+
+export default function Home() {
+  return (
+    <Providers>
+      <h1>react-mcp test</h1>
+      <p>
+        A minimal harness for verifying the OAuth flow against a local MCP
+        server. The server runs at <code>http://localhost:8787</code> (started
+        alongside the app by <code>pnpm dev</code>).
+      </p>
+      <McpUI />
+    </Providers>
+  );
+}

--- a/examples/with-mcp/app/app/providers.tsx
+++ b/examples/with-mcp/app/app/providers.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { MCPProvider, defineConnector } from "@assistant-ui/react-mcp";
+
+const connectors = [
+  defineConnector({
+    id: "local-test",
+    name: "Local test MCP",
+    url: "http://localhost:8787/mcp",
+    auth: { type: "oauth", scopes: ["mcp"] },
+  }),
+];
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <MCPProvider
+      connectors={connectors}
+      oauthRedirectUri={
+        typeof window !== "undefined"
+          ? `${window.location.origin}/mcp/callback`
+          : undefined
+      }
+    >
+      {children}
+    </MCPProvider>
+  );
+}

--- a/examples/with-mcp/app/next.config.ts
+++ b/examples/with-mcp/app/next.config.ts
@@ -1,0 +1,11 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  transpilePackages: [
+    "@assistant-ui/react-mcp",
+    "@assistant-ui/store",
+    "@assistant-ui/tap",
+  ],
+};
+
+export default nextConfig;

--- a/examples/with-mcp/app/tsconfig.json
+++ b/examples/with-mcp/app/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "**/*.mts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/examples/with-mcp/package.json
+++ b/examples/with-mcp/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "with-mcp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "concurrently -n server,app -c blue,magenta \"pnpm dev:server\" \"pnpm dev:app\"",
+    "dev:server": "tsx watch server/server.ts",
+    "dev:app": "next dev app --port 3010",
+    "build": "next build app",
+    "start:server": "tsx server/server.ts"
+  },
+  "dependencies": {
+    "@assistant-ui/react-mcp": "workspace:*",
+    "@assistant-ui/store": "workspace:*",
+    "@assistant-ui/tap": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "cors": "^2.8.5",
+    "express": "^4.21.2",
+    "next": "^16.2.4",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^5.0.0",
+    "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "concurrently": "^9.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/with-mcp/server/server.ts
+++ b/examples/with-mcp/server/server.ts
@@ -1,0 +1,255 @@
+/**
+ * Standalone test MCP server with OAuth.
+ *
+ * - OAuth 2.1 authorization server (PKCE + DCR) via @modelcontextprotocol/sdk auth router.
+ * - One MCP tool, `echo`, that returns its input.
+ * - All state in memory; for local development / E2E only.
+ *
+ * Run: `pnpm dev:server` (defaults to http://localhost:8787)
+ */
+import express from "express";
+import cors from "cors";
+import { randomBytes, randomUUID, createHash } from "node:crypto";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
+import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
+import type { OAuthServerProvider } from "@modelcontextprotocol/sdk/server/auth/provider.js";
+import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
+import type {
+  OAuthClientInformationFull,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { z } from "zod";
+
+const PORT = Number(process.env.PORT ?? 8787);
+const ISSUER = process.env.ISSUER ?? `http://localhost:${PORT}`;
+
+// ───────────────────────────────────────────────────────────────────────────
+// In-memory OAuth provider
+// ───────────────────────────────────────────────────────────────────────────
+
+type AuthorizationGrant = {
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  scopes: string[];
+  state?: string;
+};
+
+const clients = new Map<string, OAuthClientInformationFull>();
+const authCodes = new Map<string, AuthorizationGrant>();
+const tokens = new Map<string, AuthInfo>();
+const refreshTokens = new Map<string, { clientId: string; scopes: string[] }>();
+
+const clientsStore: OAuthRegisteredClientsStore = {
+  async getClient(clientId) {
+    return clients.get(clientId);
+  },
+  async registerClient(client) {
+    const clientId = `client_${randomUUID()}`;
+    const full: OAuthClientInformationFull = {
+      ...client,
+      client_id: clientId,
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+    };
+    clients.set(clientId, full);
+    return full;
+  },
+};
+
+const provider: OAuthServerProvider = {
+  get clientsStore() {
+    return clientsStore;
+  },
+
+  async authorize(client, params, res) {
+    // Auto-approve for the test server.
+    const code = randomBytes(24).toString("base64url");
+    authCodes.set(code, {
+      clientId: client.client_id,
+      redirectUri: params.redirectUri,
+      codeChallenge: params.codeChallenge,
+      scopes: params.scopes ?? [],
+      ...(params.state !== undefined ? { state: params.state } : {}),
+    });
+
+    const target = new URL(params.redirectUri);
+    target.searchParams.set("code", code);
+    if (params.state) target.searchParams.set("state", params.state);
+    res.redirect(target.toString());
+  },
+
+  async challengeForAuthorizationCode(_client, authorizationCode) {
+    const grant = authCodes.get(authorizationCode);
+    if (!grant) throw new Error("invalid authorization code");
+    return grant.codeChallenge;
+  },
+
+  async exchangeAuthorizationCode(
+    client,
+    authorizationCode,
+  ): Promise<OAuthTokens> {
+    const grant = authCodes.get(authorizationCode);
+    if (!grant) throw new Error("invalid authorization code");
+    if (grant.clientId !== client.client_id) {
+      throw new Error("authorization code/client mismatch");
+    }
+    authCodes.delete(authorizationCode);
+
+    const accessToken = randomBytes(32).toString("base64url");
+    const refreshToken = randomBytes(32).toString("base64url");
+    tokens.set(accessToken, {
+      token: accessToken,
+      clientId: client.client_id,
+      scopes: grant.scopes,
+      expiresAt: Math.floor(Date.now() / 1000) + 60 * 60,
+    });
+    refreshTokens.set(refreshToken, {
+      clientId: client.client_id,
+      scopes: grant.scopes,
+    });
+    return {
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      token_type: "Bearer",
+      expires_in: 60 * 60,
+      scope: grant.scopes.join(" "),
+    };
+  },
+
+  async exchangeRefreshToken(
+    client,
+    refreshToken,
+    scopes,
+  ): Promise<OAuthTokens> {
+    const grant = refreshTokens.get(refreshToken);
+    if (!grant) throw new Error("invalid refresh token");
+    if (grant.clientId !== client.client_id) {
+      throw new Error("refresh token/client mismatch");
+    }
+    const newAccess = randomBytes(32).toString("base64url");
+    const newRefresh = randomBytes(32).toString("base64url");
+    const effectiveScopes = scopes ?? grant.scopes;
+    refreshTokens.delete(refreshToken);
+    tokens.set(newAccess, {
+      token: newAccess,
+      clientId: client.client_id,
+      scopes: effectiveScopes,
+      expiresAt: Math.floor(Date.now() / 1000) + 60 * 60,
+    });
+    refreshTokens.set(newRefresh, {
+      clientId: client.client_id,
+      scopes: effectiveScopes,
+    });
+    return {
+      access_token: newAccess,
+      refresh_token: newRefresh,
+      token_type: "Bearer",
+      expires_in: 60 * 60,
+      scope: effectiveScopes.join(" "),
+    };
+  },
+
+  async verifyAccessToken(token): Promise<AuthInfo> {
+    const info = tokens.get(token);
+    if (!info) throw new Error("invalid access token");
+    return info;
+  },
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+// MCP server
+// ───────────────────────────────────────────────────────────────────────────
+
+function buildMcpServer(): McpServer {
+  const server = new McpServer({ name: "aui-mcp-test", version: "0.0.1" });
+  server.tool(
+    "echo",
+    "Echo back the provided text.",
+    { text: z.string().describe("Text to echo back") },
+    async ({ text }) => ({
+      content: [{ type: "text" as const, text: `echo: ${text}` }],
+    }),
+  );
+  server.tool(
+    "fingerprint",
+    "Return a deterministic fingerprint of a string (sha256 hex).",
+    { input: z.string() },
+    async ({ input }) => ({
+      content: [
+        {
+          type: "text" as const,
+          text: createHash("sha256").update(input).digest("hex"),
+        },
+      ],
+    }),
+  );
+  return server;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Express wiring
+// ───────────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const app = express();
+
+  app.use(
+    cors({
+      origin: true,
+      credentials: false,
+      // Without these the browser won't expose MCP session/auth headers.
+      exposedHeaders: ["Mcp-Session-Id", "WWW-Authenticate"],
+      allowedHeaders: [
+        "Authorization",
+        "Content-Type",
+        "Mcp-Session-Id",
+        "Accept",
+        "mcp-protocol-version",
+      ],
+    }),
+  );
+
+  app.use(
+    mcpAuthRouter({
+      provider,
+      issuerUrl: new URL(ISSUER),
+      scopesSupported: ["mcp"],
+      resourceName: "aui-mcp-test",
+    }),
+  );
+
+  const bearer = requireBearerAuth({ verifier: provider });
+
+  app.post("/mcp", bearer, async (req, res) => {
+    try {
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+      });
+      res.on("close", () => transport.close());
+      const server = buildMcpServer();
+      await server.connect(transport);
+      await transport.handleRequest(req, res);
+    } catch (err) {
+      console.error("MCP request error:", err);
+      if (!res.headersSent) res.status(500).end();
+    }
+  });
+
+  app.get("/health", (_req, res) => res.json({ ok: true }));
+
+  app.listen(PORT, () => {
+    console.log(`MCP test server listening on ${ISSUER}`);
+    console.log(
+      `  - OAuth metadata: ${ISSUER}/.well-known/oauth-authorization-server`,
+    );
+    console.log(`  - MCP endpoint:   ${ISSUER}/mcp`);
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/with-mcp/tsconfig.json
+++ b/examples/with-mcp/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "paths": {
+      "@/*": ["./app/*"]
+    }
+  },
+  "include": [
+    "app/next-env.d.ts",
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    "server/**/*.ts",
+    "app/.next/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/packages/react-mcp/SPEC.md
+++ b/packages/react-mcp/SPEC.md
@@ -1,0 +1,599 @@
+# @assistant-ui/react-mcp Specification
+
+External API spec for the MCP integration package. Mirrors `@assistant-ui/react-o11y`: scope-augmented store types, tap-backed resources, Radix-style unstyled primitives.
+
+## Scope (v1)
+
+`react-mcp` is the **user-facing** configuration surface for MCP servers in an assistant-ui app. Two ways a server reaches the user:
+
+- **Connector** — A preset declared by the app developer (`defineConnector(...)`). User just connects (and authenticates).
+- **Custom server** — User supplies URL, name, auth, via `<McpAddFormPrimitive.*>`.
+
+Both share one connection lifecycle and one persisted state surface.
+
+**Tools only.** v1 lists and invokes tools. Resources, prompts, sampling, server-pushed list updates, and resumable sessions are deferred.
+
+**Three auth modes only:** OAuth (PKCE + RFC 7591 DCR), Bearer, None.
+
+**No auto-reconnect.** Connect/disconnect is user-driven. A failed connection sets `connectionState: "error"` with `lastError` and stops; the UI surfaces a reconnect button.
+
+## Design principles
+
+- **One source of truth.** All persisted state goes through a `MCPStorage` tap resource. localStorage is the default; swap by passing a different resource element.
+- **Tap-first.** Connection lifecycle and tool lists are tap state. Components read via `useAuiState`.
+- **Unstyled primitives.** `data-*` attributes for styling, no CSS, no business logic in components — matches `SpanPrimitive`.
+- **Token refresh is internal.** Refresh runs inside the OAuth strategy on 401. A failed refresh transitions to `authRequired`.
+
+## Package layout
+
+```
+packages/react-mcp/
+├── src/
+│   ├── mcp-scope.ts                          ScopeRegistry augmentation
+│   ├── connector.ts                          defineConnector()
+│   ├── resources/
+│   │   ├── MCPManagerResource.tsx
+│   │   ├── MCPServerResource.tsx
+│   │   └── storage/
+│   │       ├── MCPLocalStorage.ts
+│   │       ├── MCPMemoryStorage.ts
+│   │       └── MCPCustomStorage.ts
+│   ├── auth/
+│   │   ├── types.ts                          MCPAuthConfig, MCPPersistedAuthState
+│   │   ├── createOAuthProvider.ts            OAuthClientProvider implementation
+│   │   └── buildHeaders.ts                   for bearer / none
+│   ├── context/
+│   │   ├── MCPProvider.tsx
+│   │   └── MCPServerByIdProvider.tsx
+│   ├── primitives/
+│   │   ├── manager.ts                        barrel (McpManagerPrimitive)
+│   │   ├── manager/
+│   │   │   ├── McpManagerRoot.tsx
+│   │   │   ├── McpManagerConnectors.tsx
+│   │   │   ├── McpManagerCustomServers.tsx
+│   │   │   └── McpManagerAddCustomTrigger.tsx
+│   │   ├── server.ts                         barrel (McpServerPrimitive)
+│   │   ├── server/
+│   │   │   ├── McpServerRoot.tsx
+│   │   │   ├── McpServerIcon.tsx
+│   │   │   ├── McpServerName.tsx
+│   │   │   ├── McpServerStatus.tsx
+│   │   │   ├── McpServerError.tsx
+│   │   │   ├── McpServerConnectButton.tsx
+│   │   │   ├── McpServerDisconnectButton.tsx
+│   │   │   ├── McpServerRemoveButton.tsx
+│   │   │   ├── McpServerOAuthLink.tsx
+│   │   │   ├── McpServerTools.tsx
+│   │   │   └── McpServerToolName.tsx
+│   │   ├── addForm.ts                        barrel (McpAddFormPrimitive)
+│   │   └── addForm/
+│   │       ├── McpAddFormRoot.tsx
+│   │       ├── McpAddFormNameField.tsx
+│   │       ├── McpAddFormUrlField.tsx
+│   │       ├── McpAddFormAuthSelect.tsx
+│   │       ├── McpAddFormAuthFields.tsx
+│   │       ├── McpAddFormSubmit.tsx
+│   │       ├── McpAddFormCancel.tsx
+│   │       └── McpAddFormError.tsx
+│   ├── hooks/
+│   │   ├── useMcpManager.ts
+│   │   ├── useMcpTools.ts
+│   │   └── useMcpOAuthCallback.tsx
+│   └── index.ts
+├── package.json
+├── tsconfig.json
+└── SPEC.md
+```
+
+```jsonc
+// package.json
+{
+  "name": "@assistant-ui/react-mcp",
+  "dependencies": {
+    "@assistant-ui/store": "workspace:*",
+    "@assistant-ui/tap": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@radix-ui/react-primitive": "^2.1.4"
+  },
+  "peerDependencies": { "react": "^18 || ^19" }
+}
+```
+
+Single `.` export.
+
+---
+
+## 1. Types
+
+### 1.1 Connector
+
+```ts
+export type MCPConnector = {
+  id: string;
+  name: string;
+  url: string;
+  icon?: string;                       // URL only — keep types primitive
+  auth: MCPAuthConfig;
+};
+
+export function defineConnector(c: MCPConnector): MCPConnector;
+```
+
+### 1.2 Custom server record (persisted)
+
+```ts
+export type MCPCustomServerRecord = {
+  id: string;
+  name: string;
+  url: string;
+  auth: MCPAuthConfig;
+  createdAt: number;
+};
+```
+
+### 1.3 Live state
+
+```ts
+export type MCPServerKind = "connector" | "custom";
+
+export type MCPConnectionState =
+  | "disconnected"
+  | "authRequired"
+  | "authPending"
+  | "connecting"
+  | "connected"
+  | "error";
+
+export type MCPToolInfo = {
+  name: string;
+  description?: string;
+  inputSchema: unknown;
+};
+
+export type MCPServerState = {
+  id: string;
+  kind: MCPServerKind;
+  name: string;
+  url: string;
+  icon?: string;
+  connectionState: MCPConnectionState;
+  lastError: { message: string } | null;
+  tools: MCPToolInfo[];
+  authorizationUrl: string | null;     // set when authRequired
+};
+
+export type MCPManagerState = {
+  servers: MCPServerState[];
+  connectors: MCPServerState[];
+  customServers: MCPServerState[];
+  isHydrated: boolean;
+};
+```
+
+### 1.4 Scopes
+
+```ts
+// mcp-scope.ts
+type MCPManagerMethods = {
+  getState: () => MCPManagerState;
+  server: (lookup: { id: string }) => MCPServerMethods;
+  addCustomServer: (input: {
+    name: string;
+    url: string;
+    auth: MCPAuthConfig;
+  }) => Promise<string>;
+  removeServer: (id: string) => Promise<void>;
+};
+
+type MCPServerMethods = {
+  getState: () => MCPServerState;
+  connect: () => Promise<void>;
+  disconnect: () => Promise<void>;
+  remove: () => Promise<void>;
+  callTool: (name: string, args: unknown) => Promise<unknown>;
+  /** OAuth only: pass full callback URL (window.location.href) */
+  completeAuth: (callbackUrl: string) => Promise<void>;
+};
+
+declare module "@assistant-ui/store" {
+  interface ScopeRegistry {
+    mcp: { methods: MCPManagerMethods };
+    mcpServer: {
+      methods: MCPServerMethods;
+      meta: { source: "mcp"; query: { id: string } };
+    };
+  }
+}
+```
+
+Two scopes. Storage is **not** a registered scope — it's a sub-resource of the manager, configured via `MCPProvider`'s `storage` prop.
+
+---
+
+## 2. Storage
+
+A simple async interface, backed by a tap resource so swappability is uniform.
+
+```ts
+export type MCPStorage = {
+  loadCustomServers: () => Promise<MCPCustomServerRecord[]>;
+  saveCustomServers: (records: MCPCustomServerRecord[]) => Promise<void>;
+  loadAuthState: (serverId: string) => Promise<MCPPersistedAuthState | null>;
+  saveAuthState: (serverId: string, state: MCPPersistedAuthState) => Promise<void>;
+  clearAuthState: (serverId: string) => Promise<void>;
+};
+
+export type MCPPersistedAuthState = {
+  // OAuth
+  tokens?: { access_token: string; refresh_token?: string; expires_in?: number; scope?: string; token_type?: string };
+  clientInformation?: { client_id: string; client_secret?: string; [k: string]: unknown };
+  codeVerifier?: string;
+  // Bearer
+  token?: string;
+};
+
+export const MCPLocalStorage: (opts?: {
+  keyPrefix?: string;                          // default "aui-mcp"
+  storage?: Storage;                           // default globalThis.localStorage
+}) => ResourceElement<{ getState: () => { isHydrated: boolean } } & MCPStorage>;
+
+export const MCPMemoryStorage: () => ResourceElement<{ getState: () => { isHydrated: boolean } } & MCPStorage>;
+
+export const MCPCustomStorage: (impl: MCPStorage) => ResourceElement<{ getState: () => { isHydrated: boolean } } & MCPStorage>;
+```
+
+The localStorage default is fine for prototyping; production apps with security requirements should pass `MCPCustomStorage` backed by a server endpoint. This is documented, not papered over.
+
+---
+
+## 3. Provider
+
+```tsx
+export type MCPProviderProps = {
+  connectors?: MCPConnector[];
+  storage?: ResourceElement<MCPStorage & { getState: () => { isHydrated: boolean } }>;
+  /** If false, addCustomServer rejects and McpManagerPrimitive.AddCustomTrigger is data-disabled. Default true. */
+  canAddCustom?: boolean;
+  /** Where the OAuth server redirects back. Used to construct the redirect_uri. Default: window.location.origin + "/mcp/callback". */
+  oauthRedirectUri?: string;
+  /** Connect on mount if a valid token / DCR registration exists. Default true. */
+  autoConnect?: boolean;
+  children: React.ReactNode;
+};
+
+export const MCPProvider: React.FC<MCPProviderProps>;
+
+export const MCPServerByIdProvider: React.FC<{ id: string; children: React.ReactNode }>;
+```
+
+`MCPProvider` mounts `MCPManagerResource` and re-exposes via `AuiProvider`. Composes safely under an outer `AuiProvider` (adds only the `mcp` scope).
+
+---
+
+## 4. Auth
+
+```ts
+export type MCPAuthConfig =
+  | { type: "none" }
+  | { type: "bearer"; token?: string }    // if absent, user is prompted in the connect flow
+  | {
+      type: "oauth";
+      scopes?: string[];
+      /** Override OAuth metadata discovery. */
+      authorizationEndpoint?: string;
+      tokenEndpoint?: string;
+      registrationEndpoint?: string;
+      /** Static client (skip DCR). */
+      clientId?: string;
+      clientSecret?: string;
+    };
+```
+
+### 4.1 OAuth implementation
+
+`createOAuthProvider(serverId, config, storage, redirectUri)` returns an `OAuthClientProvider` (from `@modelcontextprotocol/sdk/client/auth.js`). The SDK's `StreamableHTTPClientTransport` handles discovery, DCR, PKCE, and code exchange; this provider only implements load/save against `MCPStorage`.
+
+Flow:
+1. `server.connect()` builds the transport with the provider and calls `client.connect(transport)`.
+2. If the SDK needs auth, our `redirectToAuthorization(url)` **does not navigate** — it stores `authorizationUrl` on the server state and transitions to `authRequired`. The UI renders `<McpServerPrimitive.OAuthLink>` (anchor) or the app opens a popup.
+3. The user authorizes and is redirected to `oauthRedirectUri`. The app renders `<McpOAuthCallback>` there, which calls `server.completeAuth(window.location.href)`.
+4. `completeAuth` invokes `transport.finishAuth(code)` (MCP SDK API), retries the connection.
+5. On 401 mid-session, the SDK calls our `tokens()`; if the access token is expired, the SDK refreshes via the token endpoint and saves through `saveTokens()`. A refresh failure transitions to `authRequired`.
+
+### 4.2 Bearer
+
+If `auth.type === "bearer"` and `token` is present, transport is constructed with `requestInit: { headers: { Authorization: `Bearer ${token}` } }`. If `token` is absent on a custom record, the user is prompted via the add form (the form's auth fields include a token input for bearer).
+
+### 4.3 None
+
+No headers added.
+
+---
+
+## 5. Primitives
+
+All follow the `SpanPrimitive` pattern: `forwardRef`, Radix `Primitive.<tag>`, namespaced `Element`/`Props`, data-attribute rendering. Imported as:
+
+```tsx
+import {
+  McpManagerPrimitive,
+  McpServerPrimitive,
+  McpAddFormPrimitive,
+} from "@assistant-ui/react-mcp";
+```
+
+### 5.1 `McpManagerPrimitive.*`
+
+```tsx
+<McpManagerPrimitive.Root>                         {/* data-mcp-hydrated, data-can-add-custom */}
+  <McpManagerPrimitive.Connectors>                 {/* iterates connectors; provides MCPServerByIdProvider per item */}
+    {/* children rendered once per connector */}
+  </McpManagerPrimitive.Connectors>
+  <McpManagerPrimitive.CustomServers>
+    {/* children rendered once per custom server */}
+  </McpManagerPrimitive.CustomServers>
+  <McpManagerPrimitive.AddCustomTrigger />         {/* button; data-disabled when canAddCustom=false */}
+</McpManagerPrimitive.Root>
+```
+
+`Connectors` / `CustomServers` accept children directly (RenderChildrenWithAccessor pattern from store) — each child render is wrapped in `MCPServerByIdProvider` so nested `<McpServerPrimitive.*>` works.
+
+### 5.2 `McpServerPrimitive.*`
+
+```tsx
+<McpServerPrimitive.Root>                          {/* data-server-id, data-kind, data-connection-state */}
+  <McpServerPrimitive.Icon />
+  <McpServerPrimitive.Name />
+  <McpServerPrimitive.Status />                    {/* data-state="<connectionState>" */}
+  <McpServerPrimitive.Error />                     {/* visible only when lastError !== null */}
+
+  <McpServerPrimitive.ConnectButton />             {/* visible when state ∈ {disconnected, error, authRequired} */}
+  <McpServerPrimitive.DisconnectButton />          {/* visible when state ∈ {connected, connecting, authPending} */}
+  <McpServerPrimitive.RemoveButton />              {/* visible only when kind === "custom" */}
+
+  <McpServerPrimitive.OAuthLink />                 {/* anchor to authorizationUrl, visible when authRequired */}
+
+  <McpServerPrimitive.Tools>                       {/* iterates tools */}
+    <McpServerPrimitive.ToolName />                {/* used inside Tools children */}
+  </McpServerPrimitive.Tools>
+</McpServerPrimitive.Root>
+```
+
+No `Description`, no `Resources`, no `ToolToggle` in v1.
+
+### 5.3 `McpAddFormPrimitive.*`
+
+```tsx
+<McpAddFormPrimitive.Root onSubmitted={(id) => ...}>
+  <McpAddFormPrimitive.NameField />
+  <McpAddFormPrimitive.UrlField />
+  <McpAddFormPrimitive.AuthSelect />               {/* none | bearer | oauth */}
+  <McpAddFormPrimitive.AuthFields />               {/* conditionally renders bearer token input */}
+  <McpAddFormPrimitive.Error />
+  <McpAddFormPrimitive.Submit />
+  <McpAddFormPrimitive.Cancel />
+</McpAddFormPrimitive.Root>
+```
+
+`Root` owns local form draft state. Submit calls `mcp.addCustomServer(...)` and calls `onSubmitted(id)`. Apps wrap this in their own dialog/sheet.
+
+---
+
+## 6. Lifecycle
+
+`MCPManagerResource`:
+
+```
+mount
+  → mount storage resource
+  → wait for storage isHydrated
+  → loadCustomServers()
+  → for each (connector | custom):
+       create MCPServerResource (state: disconnected)
+       if autoConnect && hasUsableAuth: server.connect()
+```
+
+`MCPServerResource.connect()`:
+
+```
+state = "connecting"
+authProvider = createAuthForRecord(record, storage, redirectUri)
+transport = new StreamableHTTPClientTransport(url, { authProvider })
+client = new Client({ name: "assistant-ui-mcp", version })
+try {
+  await client.connect(transport)        // throws UnauthorizedError on first OAuth
+  tools = await client.listTools()
+  state = "connected"
+} catch (UnauthorizedError) {
+  // authorizationUrl already set by our redirectToAuthorization
+  state = "authRequired"
+} catch (other) {
+  lastError = { message }
+  state = "error"
+}
+```
+
+`completeAuth(url)`:
+
+```
+state = "authPending"
+code = new URL(url).searchParams.get("code")
+await transport.finishAuth(code)         // SDK exchanges code, saves tokens via our provider
+await client.connect(transport)
+tools = await client.listTools()
+state = "connected"
+```
+
+---
+
+## 7. Hooks
+
+```ts
+/** Imperative accessor. Equivalent to useAui().mcp(). */
+export function useMcpManager(): MCPManagerMethods;
+
+/** Aggregates tools across connected servers; returns a runtime-agnostic shape. */
+export function useMcpTools(opts?: {
+  filter?: (server: MCPServerState) => boolean;
+}): { tools: Record<string, MCPRuntimeTool>; byServer: Record<string, MCPRuntimeTool[]> };
+
+export type MCPRuntimeTool = {
+  serverId: string;
+  name: string;
+  description?: string;
+  parameters: unknown;
+  execute: (args: unknown) => Promise<unknown>;
+};
+
+/** Reads window.location, resolves the target server from state param, calls completeAuth. */
+export function useMcpOAuthCallback(opts?: {
+  url?: string;
+  onComplete?: (serverId: string) => void;
+  onError?: (err: Error) => void;
+}): { status: "idle" | "running" | "done" | "error"; serverId: string | null; error: Error | null };
+
+export const McpOAuthCallback: React.FC<{
+  url?: string;
+  onComplete?: (serverId: string) => void;
+  onError?: (err: Error) => void;
+  children?: (status: ReturnType<typeof useMcpOAuthCallback>) => React.ReactNode;
+}>;
+```
+
+State subscription via existing `useAuiState`. Tool name collision is resolved with `serverId__toolName` prefixing in `useMcpTools` (v1 default; not configurable).
+
+---
+
+## 8. Runtime integration
+
+`react-mcp` does not auto-wire tools into any runtime. The app reads `useMcpTools().tools` and feeds it into its chat runtime — see §11. A small adapter `mcpRuntimeToolsToAiSdkTools(tools)` is exported (zero runtime dependency on `ai`).
+
+---
+
+## 9. Errors
+
+```ts
+export class MCPError extends Error { code: string }
+export class MCPAuthError extends MCPError { serverId: string }
+```
+
+All async methods reject with one of these. `<McpServerPrimitive.Error>` renders `lastError.message`.
+
+---
+
+## 10. SSR
+
+- `MCPLocalStorage` returns `isHydrated: false` during SSR and flips on mount.
+- `McpOAuthCallback` reads `window.location` — must be client-only.
+
+---
+
+## 11. End-to-end example
+
+```tsx
+// app/providers.tsx
+import { MCPProvider, defineConnector } from "@assistant-ui/react-mcp";
+
+const connectors = [
+  defineConnector({
+    id: "linear",
+    name: "Linear",
+    url: "https://mcp.linear.app",
+    auth: { type: "oauth", scopes: ["read"] },
+    icon: "/icons/linear.svg",
+  }),
+];
+
+export function Providers({ children }) {
+  return (
+    <MCPProvider connectors={connectors} oauthRedirectUri="http://localhost:3000/mcp/callback">
+      {children}
+    </MCPProvider>
+  );
+}
+```
+
+```tsx
+// app/mcp/page.tsx
+"use client";
+import { McpManagerPrimitive, McpServerPrimitive, McpAddFormPrimitive } from "@assistant-ui/react-mcp";
+
+export default function McpPage() {
+  return (
+    <McpManagerPrimitive.Root>
+      <h2>Connectors</h2>
+      <McpManagerPrimitive.Connectors>
+        <McpServerPrimitive.Root>
+          <McpServerPrimitive.Icon />
+          <McpServerPrimitive.Name />
+          <McpServerPrimitive.Status />
+          <McpServerPrimitive.ConnectButton>Connect</McpServerPrimitive.ConnectButton>
+          <McpServerPrimitive.DisconnectButton>Disconnect</McpServerPrimitive.DisconnectButton>
+          <McpServerPrimitive.OAuthLink>Authorize</McpServerPrimitive.OAuthLink>
+          <McpServerPrimitive.Error />
+        </McpServerPrimitive.Root>
+      </McpManagerPrimitive.Connectors>
+
+      <h2>Custom servers</h2>
+      <McpManagerPrimitive.CustomServers>
+        <McpServerPrimitive.Root>
+          <McpServerPrimitive.Name />
+          <McpServerPrimitive.Status />
+          <McpServerPrimitive.ConnectButton>Connect</McpServerPrimitive.ConnectButton>
+          <McpServerPrimitive.DisconnectButton />
+          <McpServerPrimitive.RemoveButton>Remove</McpServerPrimitive.RemoveButton>
+        </McpServerPrimitive.Root>
+      </McpManagerPrimitive.CustomServers>
+
+      <McpManagerPrimitive.AddCustomTrigger>Add server</McpManagerPrimitive.AddCustomTrigger>
+      {/* In a dialog elsewhere: */}
+      <McpAddFormPrimitive.Root onSubmitted={() => /* close dialog */ undefined}>
+        <McpAddFormPrimitive.NameField />
+        <McpAddFormPrimitive.UrlField />
+        <McpAddFormPrimitive.AuthSelect />
+        <McpAddFormPrimitive.AuthFields />
+        <McpAddFormPrimitive.Error />
+        <McpAddFormPrimitive.Submit>Add</McpAddFormPrimitive.Submit>
+        <McpAddFormPrimitive.Cancel>Cancel</McpAddFormPrimitive.Cancel>
+      </McpAddFormPrimitive.Root>
+    </McpManagerPrimitive.Root>
+  );
+}
+```
+
+```tsx
+// app/mcp/callback/page.tsx
+"use client";
+import { McpOAuthCallback } from "@assistant-ui/react-mcp";
+import { useRouter } from "next/navigation";
+
+export default function Callback() {
+  const router = useRouter();
+  return <McpOAuthCallback onComplete={() => router.replace("/mcp")} />;
+}
+```
+
+```tsx
+// app/chat/page.tsx
+"use client";
+import { useMcpTools, mcpRuntimeToolsToAiSdkTools } from "@assistant-ui/react-mcp";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+
+export function Chat() {
+  const { tools } = useMcpTools();
+  const runtime = useChatRuntime({ api: "/api/chat", tools: mcpRuntimeToolsToAiSdkTools(tools) });
+  /* … */
+}
+```
+
+---
+
+## 12. Deferred / non-goals
+
+- Resources, prompts, sampling, server-pushed tool list updates
+- Auto-reconnect (manual reconnect only)
+- Tool enable/disable persistence
+- Per-tool consent UI
+- API-key / custom-headers / custom-strategy auth — bearer + headers gets folded in later if asked
+- Default styling (apps theme via `data-*`; shadcn wrappers belong in `@assistant-ui/ui`)
+- Storage encryption out of the box (escape hatch is `MCPCustomStorage` against an app-controlled backend)

--- a/packages/react-mcp/package.json
+++ b/packages/react-mcp/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@assistant-ui/react-mcp",
+  "version": "0.0.0",
+  "description": "MCP server configuration and connection primitives for @assistant-ui",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "oauth",
+    "assistant-ui",
+    "react"
+  ],
+  "author": "AgentbaseAI Inc.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "aui-build"
+  },
+  "dependencies": {
+    "@assistant-ui/store": "workspace:*",
+    "@assistant-ui/tap": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@radix-ui/react-primitive": "^2.1.4"
+  },
+  "peerDependencies": {
+    "@types/react": "*",
+    "react": "^18 || ^19"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@assistant-ui/x-buildutils": "workspace:*",
+    "@types/react": "^19.2.14",
+    "react": "^19.2.5"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://www.assistant-ui.com/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/assistant-ui/assistant-ui.git",
+    "directory": "packages/react-mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/assistant-ui/assistant-ui/issues"
+  }
+}

--- a/packages/react-mcp/src/auth/buildHeaders.ts
+++ b/packages/react-mcp/src/auth/buildHeaders.ts
@@ -1,0 +1,19 @@
+import type { MCPAuthConfig } from "../mcp-scope";
+import type { MCPPersistedAuthState } from "./types";
+
+/**
+ * Build request headers for the bearer/none flows. For bearer, prefer a token
+ * stored at add-form time (persisted), falling back to a static token on the
+ * config (used by connectors that hardcode a token, rare in practice).
+ */
+export function buildHeaders(
+  auth: MCPAuthConfig,
+  persisted: MCPPersistedAuthState | null,
+): Record<string, string> | undefined {
+  if (auth.type === "bearer") {
+    const token = persisted?.token ?? auth.token;
+    if (!token) return undefined;
+    return { Authorization: `Bearer ${token}` };
+  }
+  return undefined;
+}

--- a/packages/react-mcp/src/auth/createOAuthProvider.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.ts
@@ -1,0 +1,159 @@
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthClientInformationFull,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { MCPStorage } from "../resources/storage/types";
+import type { MCPAuthConfig } from "../mcp-scope";
+
+const STATE_PREFIX = "aui-mcp:";
+
+function encodeServerIdInState(serverId: string): string {
+  const b64 = btoa(unescape(encodeURIComponent(serverId)));
+  const urlSafe = b64
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `${STATE_PREFIX}${urlSafe}`;
+}
+
+export function decodeServerIdFromState(state: string): string | null {
+  if (!state.startsWith(STATE_PREFIX)) return null;
+  const dot = state.indexOf(".", STATE_PREFIX.length);
+  const encoded =
+    dot === -1
+      ? state.slice(STATE_PREFIX.length)
+      : state.slice(STATE_PREFIX.length, dot);
+  try {
+    const b64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+    return decodeURIComponent(escape(atob(b64)));
+  } catch {
+    return null;
+  }
+}
+
+export type CreateOAuthProviderOptions = {
+  serverId: string;
+  /** Must be `auth.type === "oauth"`. */
+  config: Extract<MCPAuthConfig, { type: "oauth" }>;
+  storage: MCPStorage;
+  redirectUri: string;
+  /** Called by the SDK to start the authorization redirect. */
+  onAuthorizationUrl: (url: URL) => void;
+};
+
+/**
+ * Builds an OAuthClientProvider for the MCP SDK, backed by MCPStorage.
+ * Token refresh and DCR are handled by the SDK; this provider only mediates
+ * load/save and the redirect step.
+ */
+export function createOAuthProvider(
+  opts: CreateOAuthProviderOptions,
+): OAuthClientProvider {
+  const { serverId, config, storage, redirectUri, onAuthorizationUrl } = opts;
+
+  type Cache = {
+    tokens?: OAuthTokens | undefined;
+    clientInformation?: OAuthClientInformationFull | undefined;
+    codeVerifier?: string | undefined;
+  };
+  let cached: Cache | null = null;
+
+  const loadCache = async (): Promise<Cache> => {
+    if (cached) return cached;
+    const persisted = await storage.loadAuthState(serverId);
+    const initial: Cache = {};
+    if (persisted?.tokens) initial.tokens = persisted.tokens;
+    if (config.clientId) {
+      const ci: OAuthClientInformationFull = {
+        client_id: config.clientId,
+        redirect_uris: [redirectUri],
+      };
+      if (config.clientSecret) ci.client_secret = config.clientSecret;
+      initial.clientInformation = ci;
+    } else if (persisted?.clientInformation) {
+      initial.clientInformation = persisted.clientInformation;
+    }
+    if (persisted?.codeVerifier) initial.codeVerifier = persisted.codeVerifier;
+    cached = initial;
+    return cached;
+  };
+
+  const persist = async () => {
+    const c = cached;
+    if (!c) return;
+    const next: Parameters<typeof storage.saveAuthState>[1] = {};
+    if (c.tokens) next.tokens = c.tokens;
+    if (c.clientInformation) next.clientInformation = c.clientInformation;
+    if (c.codeVerifier) next.codeVerifier = c.codeVerifier;
+    await storage.saveAuthState(serverId, next);
+  };
+
+  const clientMetadata: OAuthClientMetadata = {
+    client_name: "assistant-ui",
+    redirect_uris: [redirectUri],
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+    scope: config.scopes?.join(" "),
+  };
+
+  return {
+    get redirectUrl() {
+      return redirectUri;
+    },
+    get clientMetadata() {
+      return clientMetadata;
+    },
+    state() {
+      // Embed the server id so the callback handler can route it back to the
+      // right MCPServerResource without app-level wiring.
+      const nonce =
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : `${Date.now()}.${Math.random()}`;
+      return `${encodeServerIdInState(serverId)}.${nonce}`;
+    },
+    async clientInformation() {
+      const c = await loadCache();
+      return c.clientInformation;
+    },
+    async saveClientInformation(info) {
+      const c = await loadCache();
+      c.clientInformation = info as OAuthClientInformationFull;
+      await persist();
+    },
+    async tokens() {
+      const c = await loadCache();
+      return c.tokens;
+    },
+    async saveTokens(tokens) {
+      const c = await loadCache();
+      c.tokens = tokens;
+      await persist();
+    },
+    async redirectToAuthorization(url) {
+      onAuthorizationUrl(url);
+    },
+    async saveCodeVerifier(codeVerifier) {
+      const c = await loadCache();
+      c.codeVerifier = codeVerifier;
+      await persist();
+    },
+    async codeVerifier() {
+      const c = await loadCache();
+      if (!c.codeVerifier) {
+        throw new Error("No code verifier saved for this OAuth flow");
+      }
+      return c.codeVerifier;
+    },
+    async invalidateCredentials(scope) {
+      const c = await loadCache();
+      if (scope === "all" || scope === "tokens") delete c.tokens;
+      if (scope === "all" || scope === "client") delete c.clientInformation;
+      if (scope === "all" || scope === "verifier") delete c.codeVerifier;
+      await persist();
+    },
+  };
+}

--- a/packages/react-mcp/src/auth/types.ts
+++ b/packages/react-mcp/src/auth/types.ts
@@ -1,0 +1,12 @@
+import type {
+  OAuthTokens,
+  OAuthClientInformationFull,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+
+export type MCPPersistedAuthState = {
+  tokens?: OAuthTokens;
+  clientInformation?: OAuthClientInformationFull;
+  codeVerifier?: string;
+  /** Bearer token (entered at add-form time). */
+  token?: string;
+};

--- a/packages/react-mcp/src/connector.ts
+++ b/packages/react-mcp/src/connector.ts
@@ -1,0 +1,5 @@
+import type { MCPConnector } from "./mcp-scope";
+
+export function defineConnector(connector: MCPConnector): MCPConnector {
+  return connector;
+}

--- a/packages/react-mcp/src/context/MCPProvider.tsx
+++ b/packages/react-mcp/src/context/MCPProvider.tsx
@@ -1,0 +1,42 @@
+import type { FC, PropsWithChildren } from "react";
+import { useAui, AuiProvider } from "@assistant-ui/store";
+import { MCPManagerResource } from "../resources/MCPManagerResource";
+import type { MCPStorageElement } from "../resources/storage/types";
+import type { MCPConnector } from "../mcp-scope";
+
+export type MCPProviderProps = PropsWithChildren<{
+  connectors?: MCPConnector[] | undefined;
+  storage?: MCPStorageElement | undefined;
+  /** Default true. When false, addCustomServer rejects and the AddCustomTrigger primitive is data-disabled. */
+  canAddCustom?: boolean | undefined;
+  /** Where the OAuth server redirects back. Defaults to `${window.location.origin}/mcp/callback`. */
+  oauthRedirectUri?: string | undefined;
+  /** Connect on mount when usable auth exists. Default true. */
+  autoConnect?: boolean | undefined;
+}>;
+
+function defaultRedirectUri(): string {
+  if (typeof window === "undefined") return "";
+  return `${window.location.origin}/mcp/callback`;
+}
+
+export const MCPProvider: FC<MCPProviderProps> = ({
+  connectors,
+  storage,
+  canAddCustom = true,
+  oauthRedirectUri,
+  autoConnect = true,
+  children,
+}) => {
+  const aui = useAui({
+    mcp: MCPManagerResource({
+      connectors: connectors ?? [],
+      storage,
+      redirectUri: oauthRedirectUri ?? defaultRedirectUri(),
+      autoConnect,
+      canAddCustom,
+    }),
+  });
+
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+};

--- a/packages/react-mcp/src/context/MCPServerByIdProvider.tsx
+++ b/packages/react-mcp/src/context/MCPServerByIdProvider.tsx
@@ -1,0 +1,19 @@
+import type { FC, PropsWithChildren } from "react";
+import { useAui, AuiProvider, Derived } from "@assistant-ui/store";
+
+export const MCPServerByIdProvider: FC<PropsWithChildren<{ id: string }>> = ({
+  id,
+  children,
+}) => {
+  const parentAui = useAui();
+
+  const aui = useAui({
+    mcpServer: Derived({
+      source: "mcp",
+      query: { id },
+      get: () => parentAui.mcp().server({ id }),
+    }),
+  });
+
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+};

--- a/packages/react-mcp/src/hooks/useMcpManager.ts
+++ b/packages/react-mcp/src/hooks/useMcpManager.ts
@@ -1,0 +1,9 @@
+import { useAui } from "@assistant-ui/store";
+import type { MCPManagerMethods } from "../mcp-scope";
+
+/**
+ * Imperative accessor for the MCP manager. Equivalent to `useAui().mcp()`.
+ */
+export function useMcpManager(): MCPManagerMethods {
+  return useAui().mcp();
+}

--- a/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
+++ b/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
@@ -1,0 +1,79 @@
+import { type FC, type ReactNode, useEffect, useState } from "react";
+import { useAui } from "@assistant-ui/store";
+import { decodeServerIdFromState } from "../auth/createOAuthProvider";
+
+export type UseMcpOAuthCallbackOptions = {
+  /** Defaults to `window.location.href`. */
+  url?: string;
+  onComplete?: (serverId: string) => void;
+  onError?: (err: Error) => void;
+};
+
+export type UseMcpOAuthCallbackResult = {
+  status: "idle" | "running" | "done" | "error";
+  serverId: string | null;
+  error: Error | null;
+};
+
+export function useMcpOAuthCallback(
+  opts: UseMcpOAuthCallbackOptions = {},
+): UseMcpOAuthCallbackResult {
+  const aui = useAui();
+  const [result, setResult] = useState<UseMcpOAuthCallbackResult>({
+    status: "idle",
+    serverId: null,
+    error: null,
+  });
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-running on callback identity changes would double-redeem the OAuth code
+  useEffect(() => {
+    const url =
+      opts.url ?? (typeof window !== "undefined" ? window.location.href : null);
+    if (!url) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const parsed = new URL(url);
+        const state = parsed.searchParams.get("state");
+        const error = parsed.searchParams.get("error");
+        if (error) {
+          throw new Error(
+            parsed.searchParams.get("error_description") ?? error,
+          );
+        }
+        if (!state) throw new Error("missing state parameter in callback URL");
+        const serverId = decodeServerIdFromState(state);
+        if (!serverId) {
+          throw new Error("callback state does not match an MCP server");
+        }
+        if (cancelled) return;
+        setResult({ status: "running", serverId, error: null });
+        await aui.mcp().server({ id: serverId }).completeAuth(url);
+        if (cancelled) return;
+        setResult({ status: "done", serverId, error: null });
+        opts.onComplete?.(serverId);
+      } catch (err) {
+        if (cancelled) return;
+        const e = err instanceof Error ? err : new Error(String(err));
+        setResult((prev) => ({ ...prev, status: "error", error: e }));
+        opts.onError?.(e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [aui, opts.url]);
+
+  return result;
+}
+
+export const McpOAuthCallback: FC<
+  UseMcpOAuthCallbackOptions & {
+    children?: (result: UseMcpOAuthCallbackResult) => ReactNode;
+  }
+> = ({ children, ...opts }) => {
+  const result = useMcpOAuthCallback(opts);
+  if (children) return <>{children(result)}</>;
+  return null;
+};

--- a/packages/react-mcp/src/hooks/useMcpTools.ts
+++ b/packages/react-mcp/src/hooks/useMcpTools.ts
@@ -1,0 +1,94 @@
+import { useMemo } from "react";
+import { useAui, useAuiState } from "@assistant-ui/store";
+import type { MCPServerState } from "../mcp-scope";
+
+export type MCPRuntimeTool = {
+  serverId: string;
+  name: string;
+  description?: string | undefined;
+  parameters: unknown;
+  execute: (args: unknown) => Promise<unknown>;
+};
+
+export type UseMcpToolsOptions = {
+  /** Filter which servers contribute tools. Default: all connected servers. */
+  filter?: ((server: MCPServerState) => boolean) | undefined;
+};
+
+export type UseMcpToolsResult = {
+  tools: Record<string, MCPRuntimeTool>;
+  byServer: Record<string, MCPRuntimeTool[]>;
+};
+
+/**
+ * Aggregates enabled tools across MCP servers, returning a runtime-agnostic shape.
+ *
+ * Tool names are prefixed with `serverId__` to avoid collisions across servers.
+ */
+export function useMcpTools(opts: UseMcpToolsOptions = {}): UseMcpToolsResult {
+  const aui = useAui();
+
+  // Subscribe to a primitive signature so we only re-aggregate on real change.
+  const signature = useAuiState((s) => {
+    return s.mcp.servers
+      .map((server) => {
+        if (server.connectionState !== "connected") return null;
+        if (opts.filter && !opts.filter(server)) return null;
+        return `${server.id}|${server.tools.map((t) => t.name).join(",")}`;
+      })
+      .filter(Boolean)
+      .join("||");
+  });
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `signature` is the only change driver
+  return useMemo(() => {
+    const tools: Record<string, MCPRuntimeTool> = {};
+    const byServer: Record<string, MCPRuntimeTool[]> = {};
+    const servers = aui.mcp().getState().servers;
+    for (const server of servers) {
+      if (server.connectionState !== "connected") continue;
+      if (opts.filter && !opts.filter(server)) continue;
+      const serverTools: MCPRuntimeTool[] = [];
+      for (const tool of server.tools) {
+        const runtimeTool: MCPRuntimeTool = {
+          serverId: server.id,
+          name: tool.name,
+          parameters: tool.inputSchema,
+          execute: async (args) =>
+            await aui.mcp().server({ id: server.id }).callTool(tool.name, args),
+        };
+        if (tool.description !== undefined) {
+          runtimeTool.description = tool.description;
+        }
+        tools[`${server.id}__${tool.name}`] = runtimeTool;
+        serverTools.push(runtimeTool);
+      }
+      byServer[server.id] = serverTools;
+    }
+    return { tools, byServer };
+  }, [aui, signature, opts.filter]);
+}
+
+/**
+ * Adapter for Vercel AI SDK tool shape. Zero-dep on `ai` itself.
+ */
+export type AiSdkToolShape = {
+  description?: string | undefined;
+  parameters: unknown;
+  execute: (args: unknown) => Promise<unknown>;
+};
+
+export function mcpRuntimeToolsToAiSdkTools(
+  tools: Record<string, MCPRuntimeTool>,
+): Record<string, AiSdkToolShape> {
+  const out: Record<string, AiSdkToolShape> = {};
+  for (const [key, t] of Object.entries(tools)) {
+    const entry: AiSdkToolShape = {
+      parameters: t.parameters,
+      execute: t.execute,
+    };
+    if (t.description !== undefined) entry.description = t.description;
+    out[key] = entry;
+  }
+  return out;
+}

--- a/packages/react-mcp/src/index.ts
+++ b/packages/react-mcp/src/index.ts
@@ -1,0 +1,69 @@
+// Scope augmentation must be imported for module declaration side-effect.
+import "./mcp-scope";
+
+// Primitives (namespaced)
+export * as McpManagerPrimitive from "./primitives/manager";
+export * as McpServerPrimitive from "./primitives/server";
+export * as McpAddFormPrimitive from "./primitives/addForm";
+
+// Context providers
+export { MCPProvider, type MCPProviderProps } from "./context/MCPProvider";
+export { MCPServerByIdProvider } from "./context/MCPServerByIdProvider";
+
+// Connector helper
+export { defineConnector } from "./connector";
+
+// Hooks
+export { useMcpManager } from "./hooks/useMcpManager";
+export {
+  useMcpTools,
+  mcpRuntimeToolsToAiSdkTools,
+  type UseMcpToolsOptions,
+  type UseMcpToolsResult,
+  type MCPRuntimeTool,
+} from "./hooks/useMcpTools";
+export {
+  useMcpOAuthCallback,
+  McpOAuthCallback,
+  type UseMcpOAuthCallbackOptions,
+  type UseMcpOAuthCallbackResult,
+} from "./hooks/useMcpOAuthCallback";
+
+// Resources (advanced)
+export {
+  MCPManagerResource,
+  type MCPManagerResourceProps,
+} from "./resources/MCPManagerResource";
+export {
+  MCPServerResource,
+  type MCPServerResourceProps,
+} from "./resources/MCPServerResource";
+
+// Storage resources
+export {
+  MCPLocalStorage,
+  type MCPLocalStorageOptions,
+} from "./resources/storage/MCPLocalStorage";
+export { MCPMemoryStorage } from "./resources/storage/MCPMemoryStorage";
+export { MCPCustomStorage } from "./resources/storage/MCPCustomStorage";
+export type {
+  MCPStorage,
+  MCPStorageElement,
+} from "./resources/storage/types";
+
+// Auth helpers
+export type { MCPPersistedAuthState } from "./auth/types";
+
+// Public types
+export type {
+  MCPAuthConfig,
+  MCPConnector,
+  MCPCustomServerRecord,
+  MCPServerKind,
+  MCPConnectionState,
+  MCPToolInfo,
+  MCPServerState,
+  MCPManagerState,
+  MCPServerMethods,
+  MCPManagerMethods,
+} from "./mcp-scope";

--- a/packages/react-mcp/src/mcp-scope.ts
+++ b/packages/react-mcp/src/mcp-scope.ts
@@ -1,0 +1,99 @@
+import "@assistant-ui/store";
+
+export type MCPAuthConfig =
+  | { type: "none" }
+  | { type: "bearer"; token?: string | undefined }
+  | {
+      type: "oauth";
+      scopes?: string[] | undefined;
+      authorizationEndpoint?: string | undefined;
+      tokenEndpoint?: string | undefined;
+      registrationEndpoint?: string | undefined;
+      clientId?: string | undefined;
+      clientSecret?: string | undefined;
+    };
+
+export type MCPConnector = {
+  id: string;
+  name: string;
+  url: string;
+  icon?: string | undefined;
+  auth: MCPAuthConfig;
+};
+
+export type MCPCustomServerRecord = {
+  id: string;
+  name: string;
+  url: string;
+  auth: MCPAuthConfig;
+  createdAt: number;
+};
+
+export type MCPServerKind = "connector" | "custom";
+
+export type MCPConnectionState =
+  | "disconnected"
+  | "authRequired"
+  | "authPending"
+  | "connecting"
+  | "connected"
+  | "error";
+
+export type MCPToolInfo = {
+  name: string;
+  description?: string | undefined;
+  inputSchema: unknown;
+};
+
+export type MCPServerState = {
+  id: string;
+  kind: MCPServerKind;
+  name: string;
+  url: string;
+  icon?: string | undefined;
+  connectionState: MCPConnectionState;
+  lastError: { message: string } | null;
+  tools: MCPToolInfo[];
+  authorizationUrl: string | null;
+};
+
+export type MCPManagerState = {
+  servers: MCPServerState[];
+  connectors: MCPServerState[];
+  customServers: MCPServerState[];
+  isHydrated: boolean;
+  canAddCustom: boolean;
+};
+
+export type MCPServerMethods = {
+  getState: () => MCPServerState;
+  connect: () => Promise<void>;
+  disconnect: () => Promise<void>;
+  remove: () => Promise<void>;
+  callTool: (name: string, args: unknown) => Promise<unknown>;
+  /** OAuth only: pass full callback URL (e.g. window.location.href) */
+  completeAuth: (callbackUrl: string) => Promise<void>;
+};
+
+export type MCPManagerMethods = {
+  getState: () => MCPManagerState;
+  server: (lookup: { id: string }) => MCPServerMethods;
+  addCustomServer: (input: {
+    name: string;
+    url: string;
+    auth: MCPAuthConfig;
+  }) => Promise<string>;
+  removeServer: (id: string) => Promise<void>;
+};
+
+declare module "@assistant-ui/store" {
+  interface ScopeRegistry {
+    mcp: {
+      methods: MCPManagerMethods;
+    };
+    mcpServer: {
+      methods: MCPServerMethods;
+      meta: { source: "mcp"; query: { id: string } };
+    };
+  }
+}

--- a/packages/react-mcp/src/mcp-scope.ts
+++ b/packages/react-mcp/src/mcp-scope.ts
@@ -71,6 +71,8 @@ export type MCPServerMethods = {
   disconnect: () => Promise<void>;
   remove: () => Promise<void>;
   callTool: (name: string, args: unknown) => Promise<unknown>;
+  /** Read a resource by URI. Returns the raw MCP `ReadResourceResult`. */
+  readResource: (uri: string) => Promise<unknown>;
   /** OAuth only: pass full callback URL (e.g. window.location.href) */
   completeAuth: (callbackUrl: string) => Promise<void>;
 };

--- a/packages/react-mcp/src/primitives/addForm.ts
+++ b/packages/react-mcp/src/primitives/addForm.ts
@@ -1,0 +1,8 @@
+export { McpAddFormPrimitiveRoot as Root } from "./addForm/McpAddFormRoot";
+export { McpAddFormPrimitiveNameField as NameField } from "./addForm/McpAddFormNameField";
+export { McpAddFormPrimitiveUrlField as UrlField } from "./addForm/McpAddFormUrlField";
+export { McpAddFormPrimitiveAuthSelect as AuthSelect } from "./addForm/McpAddFormAuthSelect";
+export { McpAddFormPrimitiveAuthFields as AuthFields } from "./addForm/McpAddFormAuthFields";
+export { McpAddFormPrimitiveSubmit as Submit } from "./addForm/McpAddFormSubmit";
+export { McpAddFormPrimitiveCancel as Cancel } from "./addForm/McpAddFormCancel";
+export { McpAddFormPrimitiveError as Error } from "./addForm/McpAddFormError";

--- a/packages/react-mcp/src/primitives/addForm/McpAddFormAuthFields.tsx
+++ b/packages/react-mcp/src/primitives/addForm/McpAddFormAuthFields.tsx
@@ -1,0 +1,51 @@
+import type { FC } from "react";
+import { useAddForm } from "./context";
+
+export namespace McpAddFormPrimitiveAuthFields {
+  export type Props = {
+    /**
+     * Optional render override. Receives the current auth type so apps can render
+     * fully custom inputs. Defaults to a minimal built-in for bearer / oauth.
+     */
+    children?: FC<{ authType: "none" | "bearer" | "oauth" }>;
+  };
+}
+
+export const McpAddFormPrimitiveAuthFields: FC<
+  McpAddFormPrimitiveAuthFields.Props
+> = ({ children }) => {
+  const { state, setField } = useAddForm();
+
+  if (children) {
+    const Render = children;
+    return <Render authType={state.authType} />;
+  }
+
+  if (state.authType === "bearer") {
+    return (
+      <input
+        type="password"
+        placeholder="Bearer token"
+        value={state.bearerToken}
+        onChange={(e) => setField("bearerToken", e.target.value)}
+        data-mcp-auth-field="bearer-token"
+      />
+    );
+  }
+
+  if (state.authType === "oauth") {
+    return (
+      <input
+        type="text"
+        placeholder="Scopes (space-separated, optional)"
+        value={state.scopes}
+        onChange={(e) => setField("scopes", e.target.value)}
+        data-mcp-auth-field="oauth-scopes"
+      />
+    );
+  }
+
+  return null;
+};
+
+McpAddFormPrimitiveAuthFields.displayName = "McpAddFormPrimitive.AuthFields";

--- a/packages/react-mcp/src/primitives/addForm/McpAddFormAuthSelect.tsx
+++ b/packages/react-mcp/src/primitives/addForm/McpAddFormAuthSelect.tsx
@@ -1,0 +1,40 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAddForm, type AddFormAuthType } from "./context";
+
+export namespace McpAddFormPrimitiveAuthSelect {
+  export type Element = ComponentRef<typeof Primitive.select>;
+  export type Props = Omit<
+    ComponentPropsWithoutRef<typeof Primitive.select>,
+    "value" | "onChange"
+  >;
+}
+
+export const McpAddFormPrimitiveAuthSelect = forwardRef<
+  McpAddFormPrimitiveAuthSelect.Element,
+  McpAddFormPrimitiveAuthSelect.Props
+>((props, ref) => {
+  const { state, setField } = useAddForm();
+  return (
+    <Primitive.select
+      {...props}
+      ref={ref}
+      value={state.authType}
+      onChange={(e) => setField("authType", e.target.value as AddFormAuthType)}
+    >
+      {props.children ?? (
+        <>
+          <option value="oauth">OAuth</option>
+          <option value="bearer">Bearer token</option>
+          <option value="none">None</option>
+        </>
+      )}
+    </Primitive.select>
+  );
+});
+
+McpAddFormPrimitiveAuthSelect.displayName = "McpAddFormPrimitive.AuthSelect";

--- a/packages/react-mcp/src/primitives/addForm/McpAddFormCancel.tsx
+++ b/packages/react-mcp/src/primitives/addForm/McpAddFormCancel.tsx
@@ -1,0 +1,33 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAddForm } from "./context";
+
+export namespace McpAddFormPrimitiveCancel {
+  export type Element = ComponentRef<typeof Primitive.button>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+export const McpAddFormPrimitiveCancel = forwardRef<
+  McpAddFormPrimitiveCancel.Element,
+  McpAddFormPrimitiveCancel.Props
+>((props, ref) => {
+  const { cancel } = useAddForm();
+  return (
+    <Primitive.button
+      type="button"
+      {...props}
+      ref={ref}
+      onClick={(e) => {
+        props.onClick?.(e);
+        if (e.defaultPrevented) return;
+        cancel();
+      }}
+    />
+  );
+});
+
+McpAddFormPrimitiveCancel.displayName = "McpAddFormPrimitive.Cancel";

--- a/packages/react-mcp/src/primitives/addForm/McpAddFormError.tsx
+++ b/packages/react-mcp/src/primitives/addForm/McpAddFormError.tsx
@@ -1,0 +1,27 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAddForm } from "./context";
+
+export namespace McpAddFormPrimitiveError {
+  export type Element = ComponentRef<typeof Primitive.div>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
+}
+
+export const McpAddFormPrimitiveError = forwardRef<
+  McpAddFormPrimitiveError.Element,
+  McpAddFormPrimitiveError.Props
+>((props, ref) => {
+  const { state } = useAddForm();
+  if (!state.error) return null;
+  return (
+    <Primitive.div {...props} ref={ref}>
+      {props.children ?? state.error}
+    </Primitive.div>
+  );
+});
+
+McpAddFormPrimitiveError.displayName = "McpAddFormPrimitive.Error";

--- a/packages/react-mcp/src/primitives/addForm/McpAddFormNameField.tsx
+++ b/packages/react-mcp/src/primitives/addForm/McpAddFormNameField.tsx
@@ -1,0 +1,34 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAddForm } from "./context";
+
+export namespace McpAddFormPrimitiveNameField {
+  export type Element = ComponentRef<typeof Primitive.input>;
+  export type Props = Omit<
+    ComponentPropsWithoutRef<typeof Primitive.input>,
+    "value" | "onChange" | "type"
+  >;
+}
+
+export const McpAddFormPrimitiveNameField = forwardRef<
+  McpAddFormPrimitiveNameField.Element,
+  McpAddFormPrimitiveNameField.Props
+>((props, ref) => {
+  const { state, setField } = useAddForm();
+  return (
+    <Primitive.input
+      type="text"
+      placeholder="Name"
+      {...props}
+      ref={ref}
+      value={state.name}
+      onChange={(e) => setField("name", e.target.value)}
+    />
+  );
+});
+
+McpAddFormPrimitiveNameField.displayName = "McpAddFormPrimitive.NameField";

--- a/packages/react-mcp/src/primitives/addForm/McpAddFormRoot.tsx
+++ b/packages/react-mcp/src/primitives/addForm/McpAddFormRoot.tsx
@@ -1,0 +1,143 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  type FormEventHandler,
+  forwardRef,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAui } from "@assistant-ui/store";
+import { AddFormContext, type AddFormState } from "./context";
+import type { MCPAuthConfig, MCPCustomServerRecord } from "../../mcp-scope";
+import type { MCPStorage } from "../../resources/storage/types";
+
+const INITIAL: AddFormState = {
+  name: "",
+  url: "",
+  authType: "oauth",
+  bearerToken: "",
+  scopes: "",
+  submitting: false,
+  error: null,
+};
+
+export namespace McpAddFormPrimitiveRoot {
+  export type Element = ComponentRef<typeof Primitive.form>;
+  export type Props = Omit<
+    ComponentPropsWithoutRef<typeof Primitive.form>,
+    "onSubmit"
+  > & {
+    onSubmitted?: (id: string) => void;
+    onCancel?: () => void;
+    /**
+     * Override how the bearer token is persisted. By default, this is best-effort:
+     * the manager stores the bearer auth config on the record, including the token.
+     * If you don't want plaintext tokens in localStorage, pass a custom impl
+     * that persists to a server endpoint.
+     */
+    persistBearerToken?: (
+      storage: MCPStorage,
+      record: MCPCustomServerRecord,
+      token: string,
+    ) => Promise<void>;
+  };
+}
+
+export const McpAddFormPrimitiveRoot = forwardRef<
+  McpAddFormPrimitiveRoot.Element,
+  McpAddFormPrimitiveRoot.Props
+>(({ onSubmitted, onCancel, persistBearerToken, ...props }, ref) => {
+  const aui = useAui();
+  const [state, setState] = useState<AddFormState>(INITIAL);
+
+  const setField = useCallback(
+    <K extends keyof AddFormState>(key: K, value: AddFormState[K]) => {
+      setState((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const reset = useCallback(() => setState(INITIAL), []);
+
+  const buildAuth = useCallback((): MCPAuthConfig => {
+    switch (state.authType) {
+      case "none":
+        return { type: "none" };
+      case "bearer":
+        return { type: "bearer", token: state.bearerToken || undefined };
+      case "oauth": {
+        const scopeList = state.scopes
+          .split(/[\s,]+/)
+          .map((s) => s.trim())
+          .filter(Boolean);
+        return {
+          type: "oauth",
+          scopes: scopeList.length > 0 ? scopeList : undefined,
+        };
+      }
+    }
+  }, [state.authType, state.bearerToken, state.scopes]);
+
+  const submit = useCallback(async () => {
+    if (state.submitting) return;
+    if (!state.name.trim()) {
+      setState((p) => ({ ...p, error: "Name is required" }));
+      return;
+    }
+    if (!state.url.trim()) {
+      setState((p) => ({ ...p, error: "URL is required" }));
+      return;
+    }
+    try {
+      new URL(state.url);
+    } catch {
+      setState((p) => ({ ...p, error: "Invalid URL" }));
+      return;
+    }
+    setState((p) => ({ ...p, submitting: true, error: null }));
+    try {
+      const id = await aui.mcp().addCustomServer({
+        name: state.name.trim(),
+        url: state.url.trim(),
+        auth: buildAuth(),
+      });
+      setState(INITIAL);
+      onSubmitted?.(id);
+    } catch (err) {
+      setState((p) => ({
+        ...p,
+        submitting: false,
+        error: err instanceof Error ? err.message : String(err),
+      }));
+    }
+  }, [aui, buildAuth, onSubmitted, state]);
+
+  const cancel = useCallback(() => {
+    setState(INITIAL);
+    onCancel?.();
+  }, [onCancel]);
+
+  const value = useMemo(
+    () => ({ state, setField, reset, submit, cancel, buildAuth }),
+    [state, setField, reset, submit, cancel, buildAuth],
+  );
+
+  const onFormSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    void submit();
+  };
+
+  // `persistBearerToken` is currently unused; reserved for an explicit
+  // post-create token write step when a future bearer-out-of-band flow lands.
+  void persistBearerToken;
+
+  return (
+    <AddFormContext.Provider value={value}>
+      <Primitive.form {...props} ref={ref} onSubmit={onFormSubmit} />
+    </AddFormContext.Provider>
+  );
+});
+
+McpAddFormPrimitiveRoot.displayName = "McpAddFormPrimitive.Root";

--- a/packages/react-mcp/src/primitives/addForm/McpAddFormSubmit.tsx
+++ b/packages/react-mcp/src/primitives/addForm/McpAddFormSubmit.tsx
@@ -1,0 +1,30 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAddForm } from "./context";
+
+export namespace McpAddFormPrimitiveSubmit {
+  export type Element = ComponentRef<typeof Primitive.button>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+export const McpAddFormPrimitiveSubmit = forwardRef<
+  McpAddFormPrimitiveSubmit.Element,
+  McpAddFormPrimitiveSubmit.Props
+>((props, ref) => {
+  const { state } = useAddForm();
+  return (
+    <Primitive.button
+      type="submit"
+      {...props}
+      ref={ref}
+      disabled={props.disabled || state.submitting}
+      data-submitting={state.submitting || undefined}
+    />
+  );
+});
+
+McpAddFormPrimitiveSubmit.displayName = "McpAddFormPrimitive.Submit";

--- a/packages/react-mcp/src/primitives/addForm/McpAddFormUrlField.tsx
+++ b/packages/react-mcp/src/primitives/addForm/McpAddFormUrlField.tsx
@@ -1,0 +1,35 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAddForm } from "./context";
+
+export namespace McpAddFormPrimitiveUrlField {
+  export type Element = ComponentRef<typeof Primitive.input>;
+  export type Props = Omit<
+    ComponentPropsWithoutRef<typeof Primitive.input>,
+    "value" | "onChange" | "type"
+  >;
+}
+
+export const McpAddFormPrimitiveUrlField = forwardRef<
+  McpAddFormPrimitiveUrlField.Element,
+  McpAddFormPrimitiveUrlField.Props
+>((props, ref) => {
+  const { state, setField } = useAddForm();
+  return (
+    <Primitive.input
+      type="url"
+      inputMode="url"
+      placeholder="https://example.com/mcp"
+      {...props}
+      ref={ref}
+      value={state.url}
+      onChange={(e) => setField("url", e.target.value)}
+    />
+  );
+});
+
+McpAddFormPrimitiveUrlField.displayName = "McpAddFormPrimitive.UrlField";

--- a/packages/react-mcp/src/primitives/addForm/context.tsx
+++ b/packages/react-mcp/src/primitives/addForm/context.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext } from "react";
+import type { MCPAuthConfig } from "../../mcp-scope";
+
+export type AddFormAuthType = "none" | "bearer" | "oauth";
+
+export type AddFormState = {
+  name: string;
+  url: string;
+  authType: AddFormAuthType;
+  bearerToken: string;
+  scopes: string;
+  submitting: boolean;
+  error: string | null;
+};
+
+export type AddFormContextValue = {
+  state: AddFormState;
+  setField: <K extends keyof AddFormState>(
+    key: K,
+    value: AddFormState[K],
+  ) => void;
+  reset: () => void;
+  submit: () => Promise<void>;
+  cancel: () => void;
+  buildAuth: () => MCPAuthConfig;
+};
+
+export const AddFormContext = createContext<AddFormContextValue | null>(null);
+
+export const useAddForm = (): AddFormContextValue => {
+  const ctx = useContext(AddFormContext);
+  if (!ctx) {
+    throw new Error(
+      "McpAddFormPrimitive.* must be used inside McpAddFormPrimitive.Root",
+    );
+  }
+  return ctx;
+};

--- a/packages/react-mcp/src/primitives/manager.ts
+++ b/packages/react-mcp/src/primitives/manager.ts
@@ -1,0 +1,4 @@
+export { McpManagerPrimitiveRoot as Root } from "./manager/McpManagerRoot";
+export { McpManagerPrimitiveConnectors as Connectors } from "./manager/McpManagerConnectors";
+export { McpManagerPrimitiveCustomServers as CustomServers } from "./manager/McpManagerCustomServers";
+export { McpManagerPrimitiveAddCustomTrigger as AddCustomTrigger } from "./manager/McpManagerAddCustomTrigger";

--- a/packages/react-mcp/src/primitives/manager/McpManagerAddCustomTrigger.tsx
+++ b/packages/react-mcp/src/primitives/manager/McpManagerAddCustomTrigger.tsx
@@ -1,0 +1,31 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAuiState } from "@assistant-ui/store";
+
+export namespace McpManagerPrimitiveAddCustomTrigger {
+  export type Element = ComponentRef<typeof Primitive.button>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+export const McpManagerPrimitiveAddCustomTrigger = forwardRef<
+  McpManagerPrimitiveAddCustomTrigger.Element,
+  McpManagerPrimitiveAddCustomTrigger.Props
+>((props, ref) => {
+  const canAdd = useAuiState((s) => s.mcp.canAddCustom);
+  return (
+    <Primitive.button
+      type="button"
+      {...props}
+      ref={ref}
+      disabled={props.disabled || !canAdd}
+      data-disabled={!canAdd || undefined}
+    />
+  );
+});
+
+McpManagerPrimitiveAddCustomTrigger.displayName =
+  "McpManagerPrimitive.AddCustomTrigger";

--- a/packages/react-mcp/src/primitives/manager/McpManagerConnectors.tsx
+++ b/packages/react-mcp/src/primitives/manager/McpManagerConnectors.tsx
@@ -1,0 +1,29 @@
+import { type FC, type ReactNode, memo, useMemo } from "react";
+import { useAuiState } from "@assistant-ui/store";
+import { MCPServerByIdProvider } from "../../context/MCPServerByIdProvider";
+
+export namespace McpManagerPrimitiveConnectors {
+  export type Props = {
+    children: ReactNode;
+  };
+}
+
+export const McpManagerPrimitiveConnectors: FC<McpManagerPrimitiveConnectors.Props> =
+  memo(({ children }) => {
+    const ids = useAuiState((s) =>
+      s.mcp.connectors.map((c) => c.id).join("\n"),
+    );
+    const idList = useMemo(() => (ids ? ids.split("\n") : []), [ids]);
+
+    return (
+      <>
+        {idList.map((id) => (
+          <MCPServerByIdProvider key={id} id={id}>
+            {children}
+          </MCPServerByIdProvider>
+        ))}
+      </>
+    );
+  });
+
+McpManagerPrimitiveConnectors.displayName = "McpManagerPrimitive.Connectors";

--- a/packages/react-mcp/src/primitives/manager/McpManagerCustomServers.tsx
+++ b/packages/react-mcp/src/primitives/manager/McpManagerCustomServers.tsx
@@ -1,0 +1,30 @@
+import { type FC, type ReactNode, memo, useMemo } from "react";
+import { useAuiState } from "@assistant-ui/store";
+import { MCPServerByIdProvider } from "../../context/MCPServerByIdProvider";
+
+export namespace McpManagerPrimitiveCustomServers {
+  export type Props = {
+    children: ReactNode;
+  };
+}
+
+export const McpManagerPrimitiveCustomServers: FC<McpManagerPrimitiveCustomServers.Props> =
+  memo(({ children }) => {
+    const ids = useAuiState((s) =>
+      s.mcp.customServers.map((c) => c.id).join("\n"),
+    );
+    const idList = useMemo(() => (ids ? ids.split("\n") : []), [ids]);
+
+    return (
+      <>
+        {idList.map((id) => (
+          <MCPServerByIdProvider key={id} id={id}>
+            {children}
+          </MCPServerByIdProvider>
+        ))}
+      </>
+    );
+  });
+
+McpManagerPrimitiveCustomServers.displayName =
+  "McpManagerPrimitive.CustomServers";

--- a/packages/react-mcp/src/primitives/manager/McpManagerRoot.tsx
+++ b/packages/react-mcp/src/primitives/manager/McpManagerRoot.tsx
@@ -1,0 +1,28 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAuiState } from "@assistant-ui/store";
+
+export namespace McpManagerPrimitiveRoot {
+  export type Element = ComponentRef<typeof Primitive.div>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
+}
+
+export const McpManagerPrimitiveRoot = forwardRef<
+  McpManagerPrimitiveRoot.Element,
+  McpManagerPrimitiveRoot.Props
+>((props, ref) => {
+  const isHydrated = useAuiState((s) => s.mcp.isHydrated);
+  return (
+    <Primitive.div
+      {...props}
+      ref={ref}
+      data-mcp-hydrated={isHydrated || undefined}
+    />
+  );
+});
+
+McpManagerPrimitiveRoot.displayName = "McpManagerPrimitive.Root";

--- a/packages/react-mcp/src/primitives/server.ts
+++ b/packages/react-mcp/src/primitives/server.ts
@@ -1,0 +1,14 @@
+export { McpServerPrimitiveRoot as Root } from "./server/McpServerRoot";
+export { McpServerPrimitiveName as Name } from "./server/McpServerName";
+export { McpServerPrimitiveStatus as Status } from "./server/McpServerStatus";
+export { McpServerPrimitiveError as Error } from "./server/McpServerError";
+export { McpServerPrimitiveIcon as Icon } from "./server/McpServerIcon";
+export { McpServerPrimitiveConnectButton as ConnectButton } from "./server/McpServerConnectButton";
+export { McpServerPrimitiveDisconnectButton as DisconnectButton } from "./server/McpServerDisconnectButton";
+export { McpServerPrimitiveRemoveButton as RemoveButton } from "./server/McpServerRemoveButton";
+export { McpServerPrimitiveOAuthLink as OAuthLink } from "./server/McpServerOAuthLink";
+export {
+  McpServerPrimitiveTools as Tools,
+  useMcpServerTool,
+} from "./server/McpServerTools";
+export { McpServerPrimitiveToolName as ToolName } from "./server/McpServerToolName";

--- a/packages/react-mcp/src/primitives/server/McpServerConnectButton.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerConnectButton.tsx
@@ -1,0 +1,39 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAui, useAuiState } from "@assistant-ui/store";
+
+export namespace McpServerPrimitiveConnectButton {
+  export type Element = ComponentRef<typeof Primitive.button>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+const CONNECTABLE = new Set(["disconnected", "error", "authRequired"]);
+
+export const McpServerPrimitiveConnectButton = forwardRef<
+  McpServerPrimitiveConnectButton.Element,
+  McpServerPrimitiveConnectButton.Props
+>((props, ref) => {
+  const state = useAuiState((s) => s.mcpServer.connectionState);
+  const aui = useAui();
+  if (!CONNECTABLE.has(state)) return null;
+  return (
+    <Primitive.button
+      type="button"
+      {...props}
+      ref={ref}
+      data-state-hint={state === "authRequired" ? "auth-required" : undefined}
+      onClick={(e) => {
+        props.onClick?.(e);
+        if (e.defaultPrevented) return;
+        void aui.mcpServer().connect();
+      }}
+    />
+  );
+});
+
+McpServerPrimitiveConnectButton.displayName =
+  "McpServerPrimitive.ConnectButton";

--- a/packages/react-mcp/src/primitives/server/McpServerDisconnectButton.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerDisconnectButton.tsx
@@ -1,0 +1,38 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAui, useAuiState } from "@assistant-ui/store";
+
+export namespace McpServerPrimitiveDisconnectButton {
+  export type Element = ComponentRef<typeof Primitive.button>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+const DISCONNECTABLE = new Set(["connected", "connecting", "authPending"]);
+
+export const McpServerPrimitiveDisconnectButton = forwardRef<
+  McpServerPrimitiveDisconnectButton.Element,
+  McpServerPrimitiveDisconnectButton.Props
+>((props, ref) => {
+  const state = useAuiState((s) => s.mcpServer.connectionState);
+  const aui = useAui();
+  if (!DISCONNECTABLE.has(state)) return null;
+  return (
+    <Primitive.button
+      type="button"
+      {...props}
+      ref={ref}
+      onClick={(e) => {
+        props.onClick?.(e);
+        if (e.defaultPrevented) return;
+        void aui.mcpServer().disconnect();
+      }}
+    />
+  );
+});
+
+McpServerPrimitiveDisconnectButton.displayName =
+  "McpServerPrimitive.DisconnectButton";

--- a/packages/react-mcp/src/primitives/server/McpServerError.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerError.tsx
@@ -1,0 +1,27 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAuiState } from "@assistant-ui/store";
+
+export namespace McpServerPrimitiveError {
+  export type Element = ComponentRef<typeof Primitive.div>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
+}
+
+export const McpServerPrimitiveError = forwardRef<
+  McpServerPrimitiveError.Element,
+  McpServerPrimitiveError.Props
+>((props, ref) => {
+  const message = useAuiState((s) => s.mcpServer.lastError?.message ?? null);
+  if (message === null) return null;
+  return (
+    <Primitive.div {...props} ref={ref}>
+      {props.children ?? message}
+    </Primitive.div>
+  );
+});
+
+McpServerPrimitiveError.displayName = "McpServerPrimitive.Error";

--- a/packages/react-mcp/src/primitives/server/McpServerIcon.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerIcon.tsx
@@ -1,0 +1,35 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAuiState } from "@assistant-ui/store";
+
+export namespace McpServerPrimitiveIcon {
+  export type Element = ComponentRef<typeof Primitive.img>;
+  export type Props = Omit<
+    ComponentPropsWithoutRef<typeof Primitive.img>,
+    "src" | "alt"
+  > & {
+    /** Override the icon URL. Defaults to the server's icon prop. */
+    src?: string;
+    alt?: string;
+  };
+}
+
+export const McpServerPrimitiveIcon = forwardRef<
+  McpServerPrimitiveIcon.Element,
+  McpServerPrimitiveIcon.Props
+>(({ src, alt, ...props }, ref) => {
+  const iconUrl = useAuiState((s) => s.mcpServer.icon ?? null);
+  const name = useAuiState((s) => s.mcpServer.name);
+  const effective = src ?? iconUrl;
+  if (!effective) return null;
+  return (
+    // biome-ignore lint/performance/noImgElement: unstyled primitive — consumers can swap via asChild
+    <Primitive.img {...props} ref={ref} src={effective} alt={alt ?? name} />
+  );
+});
+
+McpServerPrimitiveIcon.displayName = "McpServerPrimitive.Icon";

--- a/packages/react-mcp/src/primitives/server/McpServerName.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerName.tsx
@@ -1,0 +1,26 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAuiState } from "@assistant-ui/store";
+
+export namespace McpServerPrimitiveName {
+  export type Element = ComponentRef<typeof Primitive.span>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
+}
+
+export const McpServerPrimitiveName = forwardRef<
+  McpServerPrimitiveName.Element,
+  McpServerPrimitiveName.Props
+>((props, ref) => {
+  const name = useAuiState((s) => s.mcpServer.name);
+  return (
+    <Primitive.span {...props} ref={ref}>
+      {props.children ?? name}
+    </Primitive.span>
+  );
+});
+
+McpServerPrimitiveName.displayName = "McpServerPrimitive.Name";

--- a/packages/react-mcp/src/primitives/server/McpServerOAuthLink.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerOAuthLink.tsx
@@ -1,0 +1,37 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAuiState } from "@assistant-ui/store";
+
+export namespace McpServerPrimitiveOAuthLink {
+  export type Element = ComponentRef<typeof Primitive.a>;
+  export type Props = Omit<
+    ComponentPropsWithoutRef<typeof Primitive.a>,
+    "href"
+  > & {
+    /** Optional href override; defaults to the server's authorizationUrl. */
+    href?: string;
+  };
+}
+
+export const McpServerPrimitiveOAuthLink = forwardRef<
+  McpServerPrimitiveOAuthLink.Element,
+  McpServerPrimitiveOAuthLink.Props
+>(({ href, ...props }, ref) => {
+  const url = useAuiState((s) => s.mcpServer.authorizationUrl);
+  const effective = href ?? url;
+  if (!effective) return null;
+  return (
+    <Primitive.a
+      {...props}
+      ref={ref}
+      href={effective}
+      rel={props.rel ?? "noopener noreferrer"}
+    />
+  );
+});
+
+McpServerPrimitiveOAuthLink.displayName = "McpServerPrimitive.OAuthLink";

--- a/packages/react-mcp/src/primitives/server/McpServerRemoveButton.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerRemoveButton.tsx
@@ -1,0 +1,35 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAui, useAuiState } from "@assistant-ui/store";
+
+export namespace McpServerPrimitiveRemoveButton {
+  export type Element = ComponentRef<typeof Primitive.button>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+export const McpServerPrimitiveRemoveButton = forwardRef<
+  McpServerPrimitiveRemoveButton.Element,
+  McpServerPrimitiveRemoveButton.Props
+>((props, ref) => {
+  const kind = useAuiState((s) => s.mcpServer.kind);
+  const aui = useAui();
+  if (kind !== "custom") return null;
+  return (
+    <Primitive.button
+      type="button"
+      {...props}
+      ref={ref}
+      onClick={(e) => {
+        props.onClick?.(e);
+        if (e.defaultPrevented) return;
+        void aui.mcpServer().remove();
+      }}
+    />
+  );
+});
+
+McpServerPrimitiveRemoveButton.displayName = "McpServerPrimitive.RemoveButton";

--- a/packages/react-mcp/src/primitives/server/McpServerRoot.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerRoot.tsx
@@ -1,0 +1,35 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAuiState } from "@assistant-ui/store";
+
+export namespace McpServerPrimitiveRoot {
+  export type Element = ComponentRef<typeof Primitive.div>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
+}
+
+export const McpServerPrimitiveRoot = forwardRef<
+  McpServerPrimitiveRoot.Element,
+  McpServerPrimitiveRoot.Props
+>((props, ref) => {
+  const id = useAuiState((s) => s.mcpServer.id);
+  const kind = useAuiState((s) => s.mcpServer.kind);
+  const connectionState = useAuiState((s) => s.mcpServer.connectionState);
+  const hasError = useAuiState((s) => s.mcpServer.lastError !== null);
+
+  return (
+    <Primitive.div
+      {...props}
+      ref={ref}
+      data-server-id={id}
+      data-kind={kind}
+      data-connection-state={connectionState}
+      data-has-error={hasError || undefined}
+    />
+  );
+});
+
+McpServerPrimitiveRoot.displayName = "McpServerPrimitive.Root";

--- a/packages/react-mcp/src/primitives/server/McpServerStatus.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerStatus.tsx
@@ -1,0 +1,26 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAuiState } from "@assistant-ui/store";
+
+export namespace McpServerPrimitiveStatus {
+  export type Element = ComponentRef<typeof Primitive.span>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
+}
+
+export const McpServerPrimitiveStatus = forwardRef<
+  McpServerPrimitiveStatus.Element,
+  McpServerPrimitiveStatus.Props
+>((props, ref) => {
+  const state = useAuiState((s) => s.mcpServer.connectionState);
+  return (
+    <Primitive.span {...props} ref={ref} data-state={state}>
+      {props.children ?? state}
+    </Primitive.span>
+  );
+});
+
+McpServerPrimitiveStatus.displayName = "McpServerPrimitive.Status";

--- a/packages/react-mcp/src/primitives/server/McpServerToolName.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerToolName.tsx
@@ -1,0 +1,26 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useMcpServerTool } from "./McpServerTools";
+
+export namespace McpServerPrimitiveToolName {
+  export type Element = ComponentRef<typeof Primitive.span>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
+}
+
+export const McpServerPrimitiveToolName = forwardRef<
+  McpServerPrimitiveToolName.Element,
+  McpServerPrimitiveToolName.Props
+>((props, ref) => {
+  const tool = useMcpServerTool();
+  return (
+    <Primitive.span {...props} ref={ref} data-tool-name={tool.name}>
+      {props.children ?? tool.name}
+    </Primitive.span>
+  );
+});
+
+McpServerPrimitiveToolName.displayName = "McpServerPrimitive.ToolName";

--- a/packages/react-mcp/src/primitives/server/McpServerTools.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerTools.tsx
@@ -1,0 +1,39 @@
+import { type FC, type ReactNode, createContext, useContext } from "react";
+import { useAuiState } from "@assistant-ui/store";
+import type { MCPToolInfo } from "../../mcp-scope";
+
+const ToolContext = createContext<MCPToolInfo | null>(null);
+
+export const useMcpServerTool = (): MCPToolInfo => {
+  const tool = useContext(ToolContext);
+  if (!tool) {
+    throw new Error(
+      "useMcpServerTool must be used inside <McpServerPrimitive.Tools>",
+    );
+  }
+  return tool;
+};
+
+export namespace McpServerPrimitiveTools {
+  export type Props = {
+    children: ReactNode | ((tool: MCPToolInfo) => ReactNode);
+  };
+}
+
+export const McpServerPrimitiveTools: FC<McpServerPrimitiveTools.Props> = ({
+  children,
+}) => {
+  const tools = useAuiState((s) => s.mcpServer.tools);
+  if (tools.length === 0) return null;
+  return (
+    <>
+      {tools.map((tool) => (
+        <ToolContext.Provider key={tool.name} value={tool}>
+          {typeof children === "function" ? children(tool) : children}
+        </ToolContext.Provider>
+      ))}
+    </>
+  );
+};
+
+McpServerPrimitiveTools.displayName = "McpServerPrimitive.Tools";

--- a/packages/react-mcp/src/resources/MCPManagerResource.ts
+++ b/packages/react-mcp/src/resources/MCPManagerResource.ts
@@ -1,0 +1,167 @@
+import {
+  resource,
+  tapState,
+  tapResource,
+  tapEffect,
+  tapMemo,
+  tapEffectEvent,
+  tapRef,
+  withKey,
+} from "@assistant-ui/tap";
+import { tapClientLookup, type ClientOutput } from "@assistant-ui/store";
+import { MCPServerResource } from "./MCPServerResource";
+import { MCPLocalStorage } from "./storage/MCPLocalStorage";
+import type { MCPStorageElement } from "./storage/types";
+import type {
+  MCPAuthConfig,
+  MCPConnector,
+  MCPCustomServerRecord,
+  MCPManagerState,
+} from "../mcp-scope";
+
+export type MCPManagerResourceProps = {
+  connectors: MCPConnector[];
+  storage?: MCPStorageElement | undefined;
+  redirectUri: string;
+  autoConnect: boolean;
+  canAddCustom: boolean;
+};
+
+export const MCPManagerResource = resource(
+  (props: MCPManagerResourceProps): ClientOutput<"mcp"> => {
+    const storageElement = props.storage ?? MCPLocalStorage();
+    const storage = tapResource(storageElement);
+
+    const [customServers, setCustomServers] = tapState<MCPCustomServerRecord[]>(
+      [],
+    );
+    const [isHydrated, setIsHydrated] = tapState(false);
+
+    // The tap effect ref guards against an initial save before hydration completes.
+    const hydratedRef = tapRef(false);
+
+    const hydrate = tapEffectEvent(async (signal: { cancelled: boolean }) => {
+      try {
+        const records = await storage.loadCustomServers();
+        if (signal.cancelled) return;
+        setCustomServers(records);
+      } finally {
+        if (!signal.cancelled) {
+          hydratedRef.current = true;
+          setIsHydrated(true);
+        }
+      }
+    });
+
+    tapEffect(() => {
+      const signal = { cancelled: false };
+      void hydrate(signal);
+      return () => {
+        signal.cancelled = true;
+      };
+    }, []);
+
+    const persistCustomServers = tapEffectEvent(
+      async (records: MCPCustomServerRecord[]) => {
+        if (!hydratedRef.current) return;
+        await storage.saveCustomServers(records);
+      },
+    );
+
+    // Persist custom server list when it changes (after hydration).
+    tapEffect(() => {
+      void persistCustomServers(customServers);
+    }, [customServers]);
+
+    const removeServerById = tapEffectEvent(async (id: string) => {
+      setCustomServers((prev) => prev.filter((s) => s.id !== id));
+    });
+
+    const serverElements = tapMemo(() => {
+      const connectorElements = props.connectors.map((c) =>
+        withKey(
+          c.id,
+          MCPServerResource({
+            id: c.id,
+            kind: "connector",
+            name: c.name,
+            url: c.url,
+            icon: c.icon,
+            auth: c.auth,
+            storage,
+            redirectUri: props.redirectUri,
+            autoConnect: props.autoConnect,
+            onRemove: async () => {
+              // connectors cannot be removed
+            },
+          }),
+        ),
+      );
+      const customElements = customServers.map((s) =>
+        withKey(
+          s.id,
+          MCPServerResource({
+            id: s.id,
+            kind: "custom",
+            name: s.name,
+            url: s.url,
+            auth: s.auth,
+            storage,
+            redirectUri: props.redirectUri,
+            autoConnect: props.autoConnect,
+            onRemove: async () => {
+              await removeServerById(s.id);
+            },
+          }),
+        ),
+      );
+      return [...connectorElements, ...customElements];
+    }, [
+      props.connectors,
+      customServers,
+      storage,
+      props.redirectUri,
+      props.autoConnect,
+    ]);
+
+    const lookup = tapClientLookup(() => serverElements, [serverElements]);
+
+    const state = tapMemo<MCPManagerState>(() => {
+      const all = lookup.state;
+      return {
+        servers: all,
+        connectors: all.filter((s) => s.kind === "connector"),
+        customServers: all.filter((s) => s.kind === "custom"),
+        isHydrated,
+        canAddCustom: props.canAddCustom,
+      };
+    }, [lookup.state, isHydrated, props.canAddCustom]);
+
+    return {
+      getState: () => state,
+      server: ({ id }) => lookup.get({ key: id }),
+      addCustomServer: async ({ name, url, auth }) => {
+        if (!props.canAddCustom) {
+          throw new Error("Adding custom MCP servers is disabled");
+        }
+        const record: MCPCustomServerRecord = {
+          id:
+            typeof crypto !== "undefined" && "randomUUID" in crypto
+              ? crypto.randomUUID()
+              : `mcp-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+          name,
+          url,
+          auth: auth as MCPAuthConfig,
+          createdAt: Date.now(),
+        };
+        setCustomServers((prev) => [...prev, record]);
+        return record.id;
+      },
+      removeServer: async (id) => {
+        // For connectors we just clear auth state; the entry remains.
+        await storage.clearAuthState(id);
+        setCustomServers((prev) => prev.filter((s) => s.id !== id));
+      },
+    };
+  },
+);

--- a/packages/react-mcp/src/resources/MCPServerResource.ts
+++ b/packages/react-mcp/src/resources/MCPServerResource.ts
@@ -1,0 +1,251 @@
+import {
+  resource,
+  tapState,
+  tapRef,
+  tapEffect,
+  tapMemo,
+  tapEffectEvent,
+} from "@assistant-ui/tap";
+import type { ClientOutput } from "@assistant-ui/store";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  StreamableHTTPClientTransport,
+  type StreamableHTTPClientTransportOptions,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { createOAuthProvider } from "../auth/createOAuthProvider";
+import { buildHeaders } from "../auth/buildHeaders";
+import type { MCPStorage } from "./storage/types";
+import type {
+  MCPAuthConfig,
+  MCPConnectionState,
+  MCPServerKind,
+  MCPServerState,
+  MCPToolInfo,
+} from "../mcp-scope";
+
+export type MCPServerResourceProps = {
+  id: string;
+  kind: MCPServerKind;
+  name: string;
+  url: string;
+  icon?: string | undefined;
+  auth: MCPAuthConfig;
+  storage: MCPStorage;
+  redirectUri: string;
+  autoConnect: boolean;
+  onRemove: () => Promise<void>;
+};
+
+export const MCPServerResource = resource(
+  (props: MCPServerResourceProps): ClientOutput<"mcpServer"> => {
+    const [connectionState, setConnectionState] =
+      tapState<MCPConnectionState>("disconnected");
+    const [tools, setTools] = tapState<MCPToolInfo[]>([]);
+    const [lastError, setLastError] = tapState<{ message: string } | null>(
+      null,
+    );
+    const [authorizationUrl, setAuthorizationUrl] = tapState<string | null>(
+      null,
+    );
+
+    const clientRef = tapRef<Client | null>(null);
+    const transportRef = tapRef<StreamableHTTPClientTransport | null>(null);
+
+    const buildTransport = tapEffectEvent(
+      async (): Promise<StreamableHTTPClientTransport> => {
+        if (props.auth.type === "oauth") {
+          const authProvider = createOAuthProvider({
+            serverId: props.id,
+            config: props.auth,
+            storage: props.storage,
+            redirectUri: props.redirectUri,
+            onAuthorizationUrl: (url) => setAuthorizationUrl(url.toString()),
+          });
+          return new StreamableHTTPClientTransport(new URL(props.url), {
+            authProvider,
+          });
+        }
+        if (props.auth.type === "bearer") {
+          const persisted = await props.storage.loadAuthState(props.id);
+          const headers = buildHeaders(props.auth, persisted);
+          const transportOpts: StreamableHTTPClientTransportOptions = {};
+          if (headers) transportOpts.requestInit = { headers };
+          return new StreamableHTTPClientTransport(
+            new URL(props.url),
+            transportOpts,
+          );
+        }
+        return new StreamableHTTPClientTransport(new URL(props.url));
+      },
+    );
+
+    const finalizeConnect = tapEffectEvent(
+      async (transport: StreamableHTTPClientTransport) => {
+        const client = new Client({
+          name: "assistant-ui-mcp",
+          version: "0.0.0",
+        });
+        // SDK's StreamableHTTPClientTransport.sessionId is `string | undefined`
+        // but Transport.sessionId is declared `string?` — under
+        // exactOptionalPropertyTypes the SDK's own classes don't satisfy its
+        // Transport interface. Cast to bridge the gap.
+        await client.connect(transport as unknown as Transport);
+        clientRef.current = client;
+        transportRef.current = transport;
+        const list = await client.listTools();
+        setTools(
+          list.tools.map((t) => {
+            const info: MCPToolInfo = {
+              name: t.name,
+              inputSchema: t.inputSchema,
+            };
+            if (t.description !== undefined) info.description = t.description;
+            return info;
+          }),
+        );
+        setConnectionState("connected");
+      },
+    );
+
+    const doConnect = tapEffectEvent(async () => {
+      setConnectionState("connecting");
+      setLastError(null);
+      setAuthorizationUrl(null);
+      try {
+        const transport = await buildTransport();
+        transportRef.current = transport;
+        await finalizeConnect(transport);
+      } catch (err) {
+        if (err instanceof UnauthorizedError) {
+          setConnectionState("authRequired");
+        } else {
+          setLastError({
+            message: err instanceof Error ? err.message : String(err),
+          });
+          setConnectionState("error");
+        }
+      }
+    });
+
+    const doDisconnect = tapEffectEvent(async () => {
+      const t = transportRef.current;
+      transportRef.current = null;
+      clientRef.current = null;
+      setTools([]);
+      setAuthorizationUrl(null);
+      setConnectionState("disconnected");
+      if (t) {
+        try {
+          await t.close();
+        } catch {
+          // ignore close errors
+        }
+      }
+    });
+
+    const doCompleteAuth = tapEffectEvent(async (callbackUrl: string) => {
+      setConnectionState("authPending");
+      try {
+        const url = new URL(callbackUrl);
+        const code = url.searchParams.get("code");
+        if (!code)
+          throw new Error("missing authorization code in callback URL");
+        let transport = transportRef.current;
+        if (!transport) {
+          transport = await buildTransport();
+          transportRef.current = transport;
+        }
+        await transport.finishAuth(code);
+        setAuthorizationUrl(null);
+        await finalizeConnect(transport);
+      } catch (err) {
+        setLastError({
+          message: err instanceof Error ? err.message : String(err),
+        });
+        setConnectionState("error");
+      }
+    });
+
+    const tryAutoConnect = tapEffectEvent(
+      async (signal: { cancelled: boolean }) => {
+        if (!props.autoConnect) return;
+        if (props.auth.type === "oauth") {
+          const persisted = await props.storage.loadAuthState(props.id);
+          if (signal.cancelled) return;
+          if (!persisted?.tokens) return;
+          void doConnect();
+        } else if (props.auth.type === "bearer") {
+          const persisted = await props.storage.loadAuthState(props.id);
+          if (signal.cancelled) return;
+          const token = persisted?.token ?? props.auth.token;
+          if (!token) return;
+          void doConnect();
+        } else {
+          void doConnect();
+        }
+      },
+    );
+
+    // Auto-connect on mount when usable auth exists.
+    tapEffect(() => {
+      const signal = { cancelled: false };
+      void tryAutoConnect(signal);
+      return () => {
+        signal.cancelled = true;
+        const t = transportRef.current;
+        transportRef.current = null;
+        clientRef.current = null;
+        if (t) t.close().catch(() => {});
+      };
+    }, []);
+
+    const state = tapMemo<MCPServerState>(
+      () => ({
+        id: props.id,
+        kind: props.kind,
+        name: props.name,
+        url: props.url,
+        icon: props.icon,
+        connectionState,
+        lastError,
+        tools,
+        authorizationUrl,
+      }),
+      [
+        props.id,
+        props.kind,
+        props.name,
+        props.url,
+        props.icon,
+        connectionState,
+        lastError,
+        tools,
+        authorizationUrl,
+      ],
+    );
+
+    return {
+      getState: () => state,
+      connect: doConnect,
+      disconnect: doDisconnect,
+      remove: async () => {
+        await doDisconnect();
+        await props.storage.clearAuthState(props.id);
+        await props.onRemove();
+      },
+      callTool: async (name, args) => {
+        const client = clientRef.current;
+        if (!client) {
+          throw new Error(`MCP server "${props.id}" is not connected`);
+        }
+        return await client.callTool({
+          name,
+          arguments: args as Record<string, unknown> | undefined,
+        });
+      },
+      completeAuth: doCompleteAuth,
+    };
+  },
+);

--- a/packages/react-mcp/src/resources/MCPServerResource.ts
+++ b/packages/react-mcp/src/resources/MCPServerResource.ts
@@ -245,6 +245,13 @@ export const MCPServerResource = resource(
           arguments: args as Record<string, unknown> | undefined,
         });
       },
+      readResource: async (uri) => {
+        const client = clientRef.current;
+        if (!client) {
+          throw new Error(`MCP server "${props.id}" is not connected`);
+        }
+        return await client.readResource({ uri });
+      },
       completeAuth: doCompleteAuth,
     };
   },

--- a/packages/react-mcp/src/resources/storage/MCPCustomStorage.ts
+++ b/packages/react-mcp/src/resources/storage/MCPCustomStorage.ts
@@ -1,0 +1,6 @@
+import { resource } from "@assistant-ui/tap";
+import type { MCPStorage } from "./types";
+
+export const MCPCustomStorage = resource(
+  (impl: MCPStorage): MCPStorage => impl,
+);

--- a/packages/react-mcp/src/resources/storage/MCPLocalStorage.ts
+++ b/packages/react-mcp/src/resources/storage/MCPLocalStorage.ts
@@ -1,0 +1,79 @@
+import { resource } from "@assistant-ui/tap";
+import type { MCPCustomServerRecord } from "../../mcp-scope";
+import type { MCPPersistedAuthState } from "../../auth/types";
+import type { MCPStorage } from "./types";
+
+export type MCPLocalStorageOptions = {
+  /** Namespace prefix for keys. Default "aui-mcp". */
+  keyPrefix?: string;
+  /** Override the underlying Storage. Defaults to globalThis.localStorage. */
+  storage?: Storage;
+};
+
+function getStorage(opts: MCPLocalStorageOptions): Storage | null {
+  if (opts.storage) return opts.storage;
+  if (typeof globalThis !== "undefined" && "localStorage" in globalThis) {
+    try {
+      return (globalThis as { localStorage: Storage }).localStorage;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+export const MCPLocalStorage = resource(
+  (opts: MCPLocalStorageOptions = {}): MCPStorage => {
+    const prefix = opts.keyPrefix ?? "aui-mcp";
+    const customServersKey = `${prefix}:custom-servers`;
+    const authKey = (id: string) => `${prefix}:auth:${id}`;
+
+    const read = <T>(key: string, fallback: T): T => {
+      const s = getStorage(opts);
+      if (!s) return fallback;
+      try {
+        const raw = s.getItem(key);
+        if (raw == null) return fallback;
+        return JSON.parse(raw) as T;
+      } catch {
+        return fallback;
+      }
+    };
+
+    const write = (key: string, value: unknown): void => {
+      const s = getStorage(opts);
+      if (!s) return;
+      try {
+        s.setItem(key, JSON.stringify(value));
+      } catch {
+        // quota or serialization failure — silently drop
+      }
+    };
+
+    const remove = (key: string): void => {
+      const s = getStorage(opts);
+      if (!s) return;
+      try {
+        s.removeItem(key);
+      } catch {
+        // ignore
+      }
+    };
+
+    return {
+      loadCustomServers: async () =>
+        read<MCPCustomServerRecord[]>(customServersKey, []),
+      saveCustomServers: async (records) => {
+        write(customServersKey, records);
+      },
+      loadAuthState: async (id) =>
+        read<MCPPersistedAuthState | null>(authKey(id), null),
+      saveAuthState: async (id, state) => {
+        write(authKey(id), state);
+      },
+      clearAuthState: async (id) => {
+        remove(authKey(id));
+      },
+    };
+  },
+);

--- a/packages/react-mcp/src/resources/storage/MCPMemoryStorage.ts
+++ b/packages/react-mcp/src/resources/storage/MCPMemoryStorage.ts
@@ -1,0 +1,22 @@
+import { resource } from "@assistant-ui/tap";
+import type { MCPCustomServerRecord } from "../../mcp-scope";
+import type { MCPPersistedAuthState } from "../../auth/types";
+import type { MCPStorage } from "./types";
+
+export const MCPMemoryStorage = resource((): MCPStorage => {
+  let servers: MCPCustomServerRecord[] = [];
+  const auth = new Map<string, MCPPersistedAuthState>();
+  return {
+    loadCustomServers: async () => [...servers],
+    saveCustomServers: async (records) => {
+      servers = [...records];
+    },
+    loadAuthState: async (id) => auth.get(id) ?? null,
+    saveAuthState: async (id, state) => {
+      auth.set(id, state);
+    },
+    clearAuthState: async (id) => {
+      auth.delete(id);
+    },
+  };
+});

--- a/packages/react-mcp/src/resources/storage/types.ts
+++ b/packages/react-mcp/src/resources/storage/types.ts
@@ -1,0 +1,16 @@
+import type { ResourceElement } from "@assistant-ui/tap";
+import type { MCPCustomServerRecord } from "../../mcp-scope";
+import type { MCPPersistedAuthState } from "../../auth/types";
+
+export type MCPStorage = {
+  loadCustomServers: () => Promise<MCPCustomServerRecord[]>;
+  saveCustomServers: (records: MCPCustomServerRecord[]) => Promise<void>;
+  loadAuthState: (serverId: string) => Promise<MCPPersistedAuthState | null>;
+  saveAuthState: (
+    serverId: string,
+    state: MCPPersistedAuthState,
+  ) => Promise<void>;
+  clearAuthState: (serverId: string) => Promise<void>;
+};
+
+export type MCPStorageElement = ResourceElement<MCPStorage>;

--- a/packages/react-mcp/tsconfig.json
+++ b/packages/react-mcp/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,6 +509,79 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  examples/showcase-github-mcp:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: ^2.0.55
+        version: 2.0.106(zod@3.25.76)
+      '@assistant-ui/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      '@assistant-ui/react-ai-sdk':
+        specifier: workspace:*
+        version: link:../../packages/react-ai-sdk
+      '@assistant-ui/react-markdown':
+        specifier: workspace:*
+        version: link:../../packages/react-markdown
+      '@assistant-ui/react-mcp':
+        specifier: workspace:*
+        version: link:../../packages/react-mcp
+      '@assistant-ui/store':
+        specifier: workspace:*
+        version: link:../../packages/store
+      '@assistant-ui/tap':
+        specifier: workspace:*
+        version: link:../../packages/tap
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      ai:
+        specifier: ^5.0.94
+        version: 5.0.188(zod@3.25.76)
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.6
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      next:
+        specifier: ^16.2.4
+        version: 16.2.4(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/cors':
+        specifier: ^2.8.17
+        version: 2.8.19
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      concurrently:
+        specifier: ^9.0.0
+        version: 9.2.1
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   examples/waterfall:
     dependencies:
       '@assistant-ui/react-o11y':
@@ -4580,6 +4653,12 @@ packages:
   '@ag-ui/proto@0.0.53':
     resolution: {integrity: sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw==}
 
+  '@ai-sdk/gateway@2.0.89':
+    resolution: {integrity: sha512-oIIsLOTgfuFIg6HGQ3d5gXjUvgx2YKav10T4t+sexnQj1anw6WoMDdSAT24igbfgWrC+Cf2tmlLeRhBUxdsZ9g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.110':
     resolution: {integrity: sha512-sbv8+1L9/BRKydn8dMNwoMQKupA4iLJ9N+yvxgW6wMQ/94UepDf3FeYWMj/dLdzolAHZ6izRUP4s5WqQkmJ2Zg==}
     engines: {node: '>=18'}
@@ -4592,8 +4671,20 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai@2.0.106':
+    resolution: {integrity: sha512-EFC0rpo1wfe4HIz5KZCE72edP2J7fOeR7wPXzjCDljaTRB1wectKDIKRLowpU4F0mbcJ+XScAsoYNPK/Z20aVQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@3.0.61':
     resolution: {integrity: sha512-L5FdlTo+7IBOdXbnTZqVzowRdLGWnxPn01vHe4leLPp0G4ydoXhySu0tp0ttkoO0ZSzPjHo7iiAkYoT0J91Q8Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@3.0.25':
+    resolution: {integrity: sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4603,6 +4694,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@2.0.3':
+    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
@@ -9578,6 +9673,10 @@ packages:
       vue-router:
         optional: true
 
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
@@ -9686,6 +9785,12 @@ packages:
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
+
+  ai@5.0.188:
+    resolution: {integrity: sha512-ABV+wRB1hz3UTZJTTqFIDi85tzUyr9o1ZKO5ZYZluFYlhZgKGOaInWaYv+OnBAb+qLpXWsrTWemd9/XShZJN0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ai@6.0.175:
     resolution: {integrity: sha512-6fFFHzbh6FIZnYc31V6osOxq25ABJYCShfG0O6ajHiA4FB/DgnPi1mP8cO5aAU3HNSbQHiMazdlh9bIsp97mVA==}
@@ -16395,6 +16500,13 @@ snapshots:
       '@bufbuild/protobuf': 2.12.0
       '@protobuf-ts/protoc': 2.11.1
 
+  '@ai-sdk/gateway@2.0.89(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
+      zod: 3.25.76
+
   '@ai-sdk/gateway@3.0.110(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -16409,11 +16521,24 @@ snapshots:
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
+  '@ai-sdk/openai@2.0.106(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(zod@3.25.76)
+      zod: 3.25.76
+
   '@ai-sdk/openai@3.0.61(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.26(zod@4.4.3)
       zod: 4.4.3
+
+  '@ai-sdk/provider-utils@3.0.25(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.26(zod@4.4.3)':
     dependencies:
@@ -16421,6 +16546,10 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.8
       zod: 4.4.3
+
+  '@ai-sdk/provider@2.0.3':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.10':
     dependencies:
@@ -22336,6 +22465,8 @@ snapshots:
       next: 16.2.4(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
+  '@vercel/oidc@3.1.0': {}
+
   '@vercel/oidc@3.2.0': {}
 
   '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
@@ -22456,6 +22587,14 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
     optional: true
+
+  ai@5.0.188(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 2.0.89(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
 
   ai@6.0.175(zod@4.4.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2052,6 +2052,64 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  examples/with-mcp:
+    dependencies:
+      '@assistant-ui/react-mcp':
+        specifier: workspace:*
+        version: link:../../packages/react-mcp
+      '@assistant-ui/store':
+        specifier: workspace:*
+        version: link:../../packages/store
+      '@assistant-ui/tap':
+        specifier: workspace:*
+        version: link:../../packages/tap
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.6
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      next:
+        specifier: ^16.2.4
+        version: 16.2.4(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/cors':
+        specifier: ^2.8.17
+        version: 2.8.19
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      concurrently:
+        specifier: ^9.0.0
+        version: 9.2.1
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   examples/with-opencode:
     dependencies:
       '@assistant-ui/react':
@@ -3503,6 +3561,31 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+
+  packages/react-mcp:
+    dependencies:
+      '@assistant-ui/store':
+        specifier: workspace:*
+        version: link:../store
+      '@assistant-ui/tap':
+        specifier: workspace:*
+        version: link:../tap
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      '@radix-ui/react-primitive':
+        specifier: ^2.1.4
+        version: 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    devDependencies:
+      '@assistant-ui/x-buildutils':
+        specifier: workspace:*
+        version: link:../x-buildutils
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
 
   packages/react-native:
     dependencies:
@@ -9154,6 +9237,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/caseless@0.12.5':
     resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
 
@@ -9165,6 +9251,12 @@ packages:
 
   '@types/cli-progress@3.11.6':
     resolution: {integrity: sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
   '@types/cross-spawn@6.0.6':
     resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
@@ -9277,6 +9369,12 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/filesystem@0.0.36':
     resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
 
@@ -9297,6 +9395,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -9337,6 +9438,12 @@ packages:
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
 
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -9356,6 +9463,12 @@ packages:
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -19184,6 +19297,30 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.17)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.0(express@5.2.1)
+      hono: 4.12.17
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.17)
@@ -21839,6 +21976,11 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 25.6.0
+
   '@types/caseless@0.12.5': {}
 
   '@types/chai@5.2.3':
@@ -21852,6 +21994,14 @@ snapshots:
       '@types/har-format': 1.2.16
 
   '@types/cli-progress@3.11.6':
+    dependencies:
+      '@types/node': 25.6.0
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 25.6.0
+
+  '@types/cors@2.8.19':
     dependencies:
       '@types/node': 25.6.0
 
@@ -21990,6 +22140,19 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 25.6.0
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
   '@types/filesystem@0.0.36':
     dependencies:
       '@types/filewriter': 0.0.33
@@ -22009,6 +22172,8 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -22049,6 +22214,10 @@ snapshots:
 
   '@types/prismjs@1.26.6': {}
 
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -22073,6 +22242,15 @@ snapshots:
       form-data: 2.5.5
 
   '@types/retry@0.12.0': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 25.6.0
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.6.0
 
   '@types/stack-utils@2.0.3': {}
 
@@ -30190,6 +30368,10 @@ snapshots:
   yoctocolors@2.1.2: {}
 
   yoga-layout@3.2.1: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
## Summary

End-to-end demo wiring together `@assistant-ui/react-mcp`, the MCP Apps renderer in `@assistant-ui/react`, and a live MCP server that wraps a slice of the GitHub REST API.

**What's in it**

- `examples/showcase-github-mcp/server` — Express + `@modelcontextprotocol/sdk` MCP server.
  - **OAuth proxy to GitHub** (`oauth.ts`): PKCE + RFC 7591 dynamic client registration on the MCP side; web OAuth flow against github.com on the upstream side. Opaque MCP tokens are bound (in-memory) to a GitHub access token + user.
  - **Tools** (`tools/` via `registerTool`): `whoami`, `list_repos`, `repo_languages`, `commit_activity`, `list_pull_requests`. Visualization tools attach `_meta["ui/resourceUri"]`.
  - **MCP App widgets** (`widgets/*.ts`): three self-contained HTML+SVG widgets — language pie chart, 52-week commit heatmap, PR lanes board. Each listens for `notifications/tools/call/result` over the MCP Apps JSON-RPC bridge and renders.

- `examples/showcase-github-mcp/app` — Next.js client:
  - `MCPProvider` (`@assistant-ui/react-mcp`) for the connector + OAuth callback.
  - `MCPAppProvider` (`@assistant-ui/react`) for the MCP App rendering context (`loadResource`, bridge handlers).
  - `Showcase.tsx` composes `McpManagerPrimitive`/`McpServerPrimitive` for connect/auth and `MCPAppFrame` for the widget output.

## Note on xmcp

The original ask was xmcp-based. xmcp's built-in OAuth was deprecated in favor of provider plugins (Auth0/Clerk/Better Auth/WorkOS), none of which fit a "log in directly with GitHub" demo cleanly. This uses the official MCP SDK's `mcpAuthRouter` directly. The `server/tools/*.ts` and `server/widgets/*.ts` layout follows xmcp's filesystem convention, so porting later is mechanical.

## Dependencies

- Depends on `@assistant-ui/react-mcp` from #4025 (this PR adds the `readResource` method needed by the MCP App loader).
- Depends on the unmerged `feat-react-mcp-apps` work in `@assistant-ui/react` for `MCPAppProvider` / `MCPAppFrame`. Until that lands, the example won't build against `main`.

## Setup

1. Register a GitHub OAuth app (homepage `http://localhost:8788`, callback `http://localhost:8788/oauth/github/callback`).
2. Copy `.env.example` → `.env`, fill in `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`.
3. `cd examples/showcase-github-mcp && pnpm dev` — boots the MCP server on :8788 and the Next.js app on :3020.

## Test plan

- [x] MCP server boots, `/health` returns 200, `/.well-known/oauth-authorization-server` returns valid metadata
- [x] Next.js app boots and renders the connector card
- [ ] **Known issue**: clicking *Connect with GitHub* in the dev app freezes Next.js Turbopack's HMR/RSC. Suspected interaction between `MCPAppProvider`'s context value identity (depends on `useMcpManager` return) and Turbopack RSC. Needs follow-up — proposed fix: stabilize the `MCPAppProvider` handlers/loadResource references with a ref-based bridge, or fall back to webpack. Server-side code paths verified independently (curl).
- [ ] Manual: full OAuth roundtrip with real GitHub OAuth credentials (run locally; cannot run in CI without secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)