### PR TITLE
docs(claude): expand tap skill — store coverage + useAui resolution rule

### DIFF
--- a/.claude/skills/tap/SKILL.md
+++ b/.claude/skills/tap/SKILL.md
@@ -1,184 +1,146 @@
 ---
 name: tap
-description: Use this skill whenever you write or review code that uses `@assistant-ui/tap` or `@assistant-ui/store` in the assistant-ui monorepo — including resource factories, `tapState`/`tapEffect`/`tapMemo`, `tapClientResource`/`tapClientLookup`/`tapClientList`, `useAui`/`useAuiState`, scope registration via `ScopeRegistry`, or any new package that exposes a store scope. Read this before writing tap or store code to avoid common naming/lifecycle mistakes.
+description: Use this skill whenever you write or review code that uses `@assistant-ui/tap` or `@assistant-ui/store` in the assistant-ui monorepo — tap hooks, resource factories, `tapClientResource`/`tapClientLookup`/`tapClientList`, `useAui`/`useAuiState`/`useAuiEvent`, `ScopeRegistry`, `Derived` child scopes, `attachTransformScopes`, `tapAssistantClientRef`/`tapAssistantEmit`, or any new package exposing a store scope. Read first to avoid the recurring mistakes catalogued below.
 ---
 
-# tap & store conventions
+# tap & store cheat sheet
 
-`@assistant-ui/tap` is the reactive primitives library. `@assistant-ui/store` bridges tap to React with named, type-safe scopes.
+Authoritative docs: `apps/docs/content/tap-docs/` (and `.../store/`). This is a working summary, not a replacement.
 
-Authoritative docs live in `apps/docs/content/tap-docs/`. This skill is a working summary — read the docs when in doubt.
+## Naming
 
-## Naming conventions (the easy-to-break ones)
+- **`tap*`** = a hook called inside a resource body, follows rules of hooks. Examples: `tapState`, `tapEffect`, `tapMemo`, `tapCallback`, `tapRef`, `tapConst`, `tapEffectEvent`, `tapReducer`, `tapReducerWithDerivedState`, `tapResource`, `tapResources`, `tapResourceRoot`, `tapClientResource`, `tapClientLookup`, `tapClientList`, `tapAssistantClientRef`, `tapAssistantEmit`, `tap` (context reader).
+- **`*Resource` / `Foo`** = resource factory produced by `resource(fn)`, called *outside* resource bodies (`SpanResource`, `CounterResource`, `MCPManagerResource`). Never name a factory `tapFoo` — that signals "hook".
+- Plain utilities have no prefix (`defineConnector`, `createOAuthProvider`).
 
-- **`tap*` is the hook prefix.** Reserve it for functions that are called **inside a resource body** and follow the rules of hooks: `tapState`, `tapEffect`, `tapMemo`, `tapCallback`, `tapRef`, `tapConst`, `tapEffectEvent`, `tapReducer`, `tapResource`, `tapResources`, `tapResourceRoot`, `tapClientResource`, `tapClientLookup`, `tapClientList`.
-- **Resource factories use `*Resource` or a plain noun.** Examples in the codebase: `SpanResource`, `CounterResource`, `MCPManagerResource`. They're created by `resource(fn)` and called from outside resource bodies to produce `ResourceElement`s. **Never** name a resource factory `tapFoo` — that signals "hook" and is wrong.
-- **Plain utility functions stay plain.** `defineConnector`, `createOAuthProvider`, `buildHeaders`. No `tap` prefix.
-
-If you find yourself writing `export const tapFoo = resource(...)`, stop — rename to `Foo` or `FooResource`.
-
-## Resources, ResourceElements, instances
+## Resources
 
 ```ts
 import { resource, tapState } from "@assistant-ui/tap";
 
-// 1. Factory (defined once, at module scope)
-const Counter = resource(({ initial = 0 }: { initial?: number }) => {
+const Counter = resource(({ initial = 0 }) => {
   const [count, setCount] = tapState(initial);
   return { count, increment: () => setCount((c) => c + 1) };
 });
 
-// 2. ResourceElement (call the factory — inert description, no state yet)
-const element = Counter({ initial: 10 });
-
-// 3. Instance — one of:
-//    - useResource(element) inside React
-//    - tapResource(element) inside another resource body
-//    - createResourceRoot().render(element) imperatively
-//    - useAui({ scope: element }) to mount as a store scope
+const element = Counter({ initial: 10 });   // ResourceElement = { type, props, key? }, inert
 ```
 
-A `ResourceElement` is `{ type, props, key? }`. It's just a description; nothing runs until it's instantiated.
+Instantiate via: `useResource(element)` in React, `tapResource(element)` inside another resource body, `createResourceRoot().render(element)` imperatively, or `useAui({ scope: element })` as a store scope.
 
-## Rules of tap hooks
+## Hook rules
 
-Same rules as React hooks. Specifically:
+- Top level of resource body or a custom `tap*` helper only.
+- Not in conditions, loops, nested functions, event handlers, `try/catch`, or callbacks passed to `tapState`/`tapMemo`/`tapEffect`.
+- **`setState` during render throws** (unlike React). For derive-from-props use `tapReducerWithDerivedState`.
 
-- Call hooks at the **top level** of a resource body, or at the top level of a custom `tap*` helper.
-- **Don't** call in conditions, loops, nested functions, `try/catch`, event handlers, or inside callbacks passed to `tapState`/`tapMemo`/`tapEffect`.
-- **Setting state during render throws** (unlike React). If you need to derive state from props, use `tapReducerWithDerivedState`.
+## Trees & re-renders
 
-## State, effects, refs
+`tapResource` returns child values to the parent, so **the entire tree re-renders from the root** when any resource updates. `tapResourceRoot` breaks the chain (subtree boundary, used inside Store). Tap batches updates via microtasks; >50 update flushes throws.
 
-```ts
-const [val, setVal] = tapState(initial);       // setter is stable; setVal in render throws
-tapEffect(() => {                              // runs after commit; cleanup on dep change / unmount
-  const handle = subscribe();
-  return () => handle.close();
-}, [deps]);
-const sorted = tapMemo(() => sort(items), [items]);
-const ref = tapRef<HTMLElement>();             // mutable across renders
-const id = tapConst(() => crypto.randomUUID(), []);  // computed once, [] required
-const onMsg = tapEffectEvent((m) => setVal(m)); // stable, always sees latest closure
-```
+Effects run in **call order** (not children-first like React). Cleanups run FIFO on unmount.
 
-Effects run in **call order**, not children-first like React. You can place `tapEffect` calls before or after `tapResource` and they fire in source order. Cleanups run in the same FIFO order on unmount.
+# `@assistant-ui/store`
 
-## Composition
+A **scope** = named slot with typed methods (+ optional state + events). Multiple scopes compose under `<AuiProvider>`.
 
-```ts
-const child = tapResource(Child());            // single child; returns child's value directly
-const items = tapResources(
-  () => list.map((x) => withKey(x.id, Item({ data: x }))),
-  [list],
-);                                              // dynamic list; every element needs withKey
-const handle = tapResourceRoot(Child());        // returns { getValue, subscribe }, no parent re-render
-```
-
-`withKey(key, element)` is required for `tapResources`. Same identity rules as React's `key`.
-
-## Store scopes
-
-A scope is a named slot with typed methods. Register via module augmentation:
+## Registering & implementing
 
 ```ts
 import "@assistant-ui/store";
-
 declare module "@assistant-ui/store" {
   interface ScopeRegistry {
     counter: {
-      methods: {
-        getState: () => { count: number };
-        increment: () => void;
-      };
-      // optional:
-      meta?: { source: "counterList"; query: { index: number } | { key: string } };
-      events?: { "counter.reset": { reason: string } };
+      methods: { getState: () => { count: number }; increment: () => void };
+      meta?: { source: "counterList"; query: { id: string } };   // for derived child scopes
+      events?: { "counter.reset": { reason: string } };           // typed events
     };
   }
 }
 ```
 
-`methods` MUST include `getState()` if the scope exposes state via `useAuiState`. `meta` declares this scope is *derived* from another scope by a query. `events` declares the events the scope can emit.
-
-## Resource → scope binding
-
-A resource fills a scope by returning a value matching the scope's `methods` type. Use `ClientOutput<"name">` for the return type:
-
 ```ts
 import type { ClientOutput } from "@assistant-ui/store";
 
-export const CounterResource = resource(
-  ({ initial = 0 }: { initial?: number }): ClientOutput<"counter"> => {
-    const [count, setCount] = tapState(initial);
-    const state = tapMemo(() => ({ count }), [count]);
-    return {
-      getState: () => state,
-      increment: () => setCount((c) => c + 1),
-    };
-  },
-);
+export const CounterResource = resource((): ClientOutput<"counter"> => {
+  const [count, setCount] = tapState(0);
+  const state = tapMemo(() => ({ count }), [count]);    // ✅ stabilize identity
+  return { getState: () => state, increment: () => setCount((c) => c + 1) };
+});
 ```
 
-`tapMemo` the state object so identity is stable when nothing changes — `useAuiState` selectors run on every emit and benefit from referential equality.
+Always `tapMemo` the `getState` object — Store detects changes via `Object.is`, an inline literal looks new every render.
 
-## Bringing it into React
+## `useAui()` — the resolution rule
+
+`useAui()` returns a stable `AssistantClient`; it does **not** subscribe. `aui.counter` is an *accessor*; calling `aui.counter()` resolves to the scope's methods.
+
+**Never resolve scope methods during render.** A snapshot taken in the render body goes stale when a derived scope retargets. The pattern is always:
 
 ```tsx
-import { useAui, useAuiState, AuiProvider } from "@assistant-ui/store";
-
-function App() {
-  const aui = useAui({ counter: CounterResource({ initial: 0 }) });
-  return (
-    <AuiProvider value={aui}>
-      <CounterDisplay />
-    </AuiProvider>
-  );
+function MessageActions() {
+  const aui = useAui();                                       // ✅ in body
+  return <button onClick={() => aui.counter().increment()} />; // ✅ resolved in callback
 }
 
-function CounterDisplay() {
-  const count = useAuiState((s) => s.counter.count);          // granular subscription
-  const aui = useAui();
-  return <button onClick={() => aui.counter().increment()}>{count}</button>;
+// ❌ Don't do these:
+// const count = aui.counter().getState().count;     (read during render)
+// const counter = aui.counter();                    (cached scope during render)
+// <button onClick={() => counter.increment()}>      (uses the stale cache)
+```
+
+For render-time state reads, use `useAuiState` (which subscribes). For imperative reads in effects/handlers, `aui.counter().getState()` is fine.
+
+Check existence with `aui.counter.source !== null` (it's `null` when no ancestor provides the scope; calling `aui.counter()` then throws).
+
+## `useAuiState` — render-time reads
+
+```tsx
+const count = useAuiState((s) => s.counter.count);
+```
+
+- `s.counter` = that scope's `getState()` return.
+- Return is compared by `Object.is`. **Never return a fresh object/array** from the selector — infinite re-render. Use one `useAuiState` call per leaf value.
+- Selecting wide state slices re-renders on any field change. Select the leaf you actually use.
+- Selecting on a missing scope throws — gate with `aui.foo.source !== null` if conditional.
+
+## React composition
+
+```tsx
+function App() {
+  const aui = useAui({ counter: CounterResource({ initial: 0 }) });
+  return <AuiProvider value={aui}><CounterDisplay /></AuiProvider>;
 }
 ```
 
-- `useAui({ scope: element })` extends the parent store; the new scope is available to children via `AuiProvider`.
-- `useAuiState(selector)` re-renders only when the selected slice changes. **The selector must return a primitive or stable value** — returning the proxy itself throws.
-- `aui.counter()` returns the methods object (proxied; always calls the latest impl). `aui.counter().increment()` is the standard call form.
+Each level can extend with another `useAui({ ... })`; children see the merged store.
 
-## Lists & lookups inside resources
-
-When a resource owns many sub-clients:
+## Lists inside a resource
 
 ```ts
-// Static or recomputed-from-array list — no add/remove
+// Recomputed from an array — no add/remove
 const lookup = tapClientLookup(
   () => items.map((it) => withKey(it.id, ItemResource({ data: it }))),
   [items],
 );
-// lookup.state: ItemState[]
-// lookup.get({ key }) or lookup.get({ index }) -> methods (throws on miss)
+// lookup.state: ItemState[]; lookup.get({key} | {index}) -> methods (throws on miss)
 
 // Dynamic, owns mutation
 const list = tapClientList({
   initialValues: initialItems,
   getKey: (it) => it.id,
   resource: ({ key, getInitialData, remove }) => ItemResource({ ... }),
-});
-// list.state, list.get(...), list.add(data) — duplicate add() throws
+});  // list.state, list.get, list.add — duplicate key throws
 ```
 
-`tapClientResource(element)` wraps a single sub-resource and exposes `{ state, methods, key }` — used when you have a 1:1 mapping and want event scoping.
+`tapClientResource(element)` is the single-child variant: `{ state, methods, key }`, adds to event-scoping stack.
 
-## Derived scopes
-
-When a child scope is "scope X queried by Y from parent scope Z":
+## Derived child scopes
 
 ```ts
 import { Derived } from "@assistant-ui/store";
 
-const aui = useAui({
+useAui({
   message: Derived({
     source: "thread",
     query: { index },
@@ -187,22 +149,93 @@ const aui = useAui({
 });
 ```
 
-The scope's `meta: { source, query }` declaration must match. `get` is called via `tapEffectEvent` internally, so always sees the latest parent.
+The scope's `meta: { source, query }` must match. `get` is wrapped in `tapEffectEvent` internally — always sees the latest parent.
 
-## Common pitfalls
+## Rendering lists in React
 
-- Naming a resource factory `tapFoo` (looks like a hook). Use `FooResource` or `Foo`.
-- Calling `setState` inside a `tapState` initializer or during render — throws.
-- Forgetting `withKey` in `tapResources` — throws.
-- Returning the proxy from `useAuiState((s) => s.foo)` — throws. Select a leaf value: `useAuiState((s) => s.foo.bar)`.
-- Function calls in dep arrays (e.g. `[a.getState()]`) — biome lints against this. Extract to a variable first.
-- Treating storage / adapter resources as needing tap hooks. Resources without reactive state are still valid — `resource()` is just the factory wrapper; the body can be pure.
+Three-step pattern (used by every assistant-ui list primitive). Subscribe to **length**, memoize the array, defer per-item reads with `RenderChildrenWithAccessor`:
 
-## Reference paths in this repo
+```tsx
+import { useAuiState, RenderChildrenWithAccessor } from "@assistant-ui/store";
 
-- Tap hook source: `packages/tap/src/`
-- Store source: `packages/store/src/`
-- Store spec: `packages/store/SPEC.md`
-- Tap docs: `apps/docs/content/tap-docs/`
-- Store docs: `apps/docs/content/tap-docs/store/`
-- Real-world resource example: `packages/react-o11y/src/resources/SpanResource.tsx`
+const length = useAuiState((s) => s.todoList.todos.length);
+return useMemo(() => Array.from({ length }, (_, index) => (
+  <TodoProvider key={index} index={index}>
+    <RenderChildrenWithAccessor
+      getItemState={(aui) => aui.todoList().todo({ index }).getState()}
+    >
+      {(getItem) => children({ get todo() { return getItem(); } })}
+    </RenderChildrenWithAccessor>
+  </TodoProvider>
+)), [length, children]);
+```
+
+Length-only subscription = re-render on add/remove only. Lazy `getItem` = no subscription if consumer doesn't read. Propless-component children get auto-memoized.
+
+## Events
+
+```ts
+// declare on the scope
+events: { "counter.incremented": { newCount: number }; "counter.reset": undefined };
+
+// emit (in a resource)
+const emit = tapAssistantEmit();
+emit("counter.incremented", { newCount });   // delivered via microtask
+
+// subscribe (in a component)
+useAuiEvent("counter.incremented", ({ newCount }) => toast(`Count: ${newCount}`));
+```
+
+Scoping selectors:
+
+| Listen for… | Selector |
+| --- | --- |
+| Events from your own scope | `"scope.event"` |
+| Events from any child below | `{ scope: "yourScope", event: "child.event" }` |
+| Events from a sibling | Listen at a mutual parent + filter by payload |
+| Events from anywhere | `{ scope: "*", event: "scope.event" }` |
+| All events (debugging) | `"*"` (payload becomes `{ event, payload }`) |
+
+`{ scope }` must be in your context, else throws.
+
+## Sibling scopes
+
+Two patterns, often paired:
+
+```ts
+// Runtime access to a sibling (in effects/methods — NOT in render body)
+const clientRef = tapAssistantClientRef();
+tapEffect(() => {
+  const unsub = clientRef.current!.modelContext().register({ ... });
+  return () => unsub();
+}, [clientRef]);
+
+// Guarantee the sibling exists at mount
+attachTransformScopes(ToolsResource, (scopes, parent) => {
+  if (!scopes.modelContext && parent.modelContext.source === null) {
+    scopes.modelContext = ModelContextResource();   // only add if not provided above
+  }
+});
+```
+
+Transforms apply iteratively; new root scopes trigger their own transforms. One transform per resource (duplicate attach throws).
+
+## Recurring pitfalls
+
+- **Resolving scope during render** (`aui.x().getState()` in body, caching `const x = aui.x()`). The pattern is `const aui = useAui();` + `aui.x()` *inside* the callback. Bug shows up when a derived scope retargets.
+- **`useAuiState` selector returns fresh object/array** → infinite re-render. One call per leaf value.
+- **Naming a resource factory `tapFoo`** — signals "hook", is wrong.
+- **`setState` in `tapState` initializer or during render** — throws.
+- **Forgetting `withKey`** in `tapResources` / `tapClientLookup` / `tapClientList` — throws.
+- **Function calls in dep arrays** (`[a.getState()]`). Biome lints; extract first.
+- **Wide `useAuiState` selectors** (`(s) => s.foo`) — re-renders on every field change.
+- **Reading `tapAssistantClientRef().current` during render** — null until siblings mount. Use in effects only.
+- **Forgetting `tapMemo` on the `getState` object** — every consumer re-renders every emit.
+- **Treating stateless adapter resources as needing tap hooks** — `resource()` body can be pure; that's fine.
+
+## Pointers
+
+- Tap hooks: `packages/tap/src/`
+- Store: `packages/store/src/`, spec at `packages/store/SPEC.md`
+- Docs: `apps/docs/content/tap-docs/` (+ `/store/`)
+- Real example: `packages/react-o11y/src/resources/SpanResource.tsx`


### PR DESCRIPTION
## Summary

Follow-up to the initial tap skill (#4026, merged). Expands it to cover `@assistant-ui/store` properly and adds the resolution rule for `useAui()` that I keep getting wrong in this repo.

**Most important addition** — the `useAui()` resolution rule:

> Never call `aui.x()` during render. The pattern is always:
> ```tsx
> const aui = useAui();                                       // ✅ stable, in body
> // ❌ const counter = aui.counter();                         (cached scope during render)
> // ❌ const count = aui.counter().getState().count;          (read during render)
> return <button onClick={() => aui.counter().increment()} />; // ✅ resolved in callback
> ```
> For render-time state reads, use `useAuiState`. The bug shows up when a derived scope retargets to a different item and the cached scope still points at the old methods.

Other store coverage now in the skill:

- `useAuiState` selector pitfalls (fresh-object returns → infinite re-render; one call per leaf value).
- Scope registration + `ClientOutput<"name">` return-type binding + `tapMemo` on `getState`.
- Derived child scopes with `Derived({ source, query, get })`.
- The `RenderChildrenWithAccessor` list pattern (length-only subscription, lazy `getItem`, propless memoization).
- Events: `tapAssistantEmit` + `useAuiEvent` scoping table (own scope, child, sibling, wildcard).
- Sibling scopes: `tapAssistantClientRef` runtime access (effects only — `current` is null in render body) and `attachTransformScopes` to guarantee sibling mounting.

Prose trimmed throughout to keep the file dense and code-first while preserving every pitfall. Net diff: +157 / -124.

## Test plan

- [x] Diff parses (frontmatter intact, structure preserved).
- [ ] Next session in this repo lists `tap` in available skills with the expanded description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)