### PR TITLE
ci(npm-publish): disable OIDC pre-flight verification

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -686,6 +686,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Verify npm trusted publishing
+        # Temporarily disabled: npm appears to reject the subsequent CLI OIDC
+        # exchange after this pre-flight call within the same job, causing
+        # "OIDC publish authorize: Invalid token" on every package.
+        if: false
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           TARGETS_JSON: ${{ needs.summary.outputs.targets_json }}


### PR DESCRIPTION
## Summary
- The pre-flight `oidc/token/exchange` call against npm appears to interfere with the npm CLI's own OIDC exchange during the subsequent `pnpm ci:publish`, causing `OIDC publish authorize: Invalid token` for every package despite trusted-publisher configs being correct.
- Disable the verification step via `if: false` (kept in place so we can re-enable once root-caused).

## Test plan
- [ ] Re-run npm Publish workflow; confirm packages publish successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)