### PR TITLE
fix(react-ai-sdk): resolve MCP app metadata from output _meta

### DIFF
--- a/.changeset/fix-mcp-app-output-meta.md
+++ b/.changeset/fix-mcp-app-output-meta.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix(react-ai-sdk): resolve MCP app metadata from tool output `_meta["ui/resourceUri"]` as a fallback when it isn't present in `callProviderMetadata.mcp.app`. MCP-UI tools (e.g. xmcp) surface the UI pointer in the call result, so the renderer previously never picked it up.

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
@@ -596,6 +596,34 @@ describe("AISDKMessageConverter", () => {
     });
   });
 
+  it("extracts MCP app metadata from output._meta['ui/resourceUri']", () => {
+    const converted = AISDKMessageConverter.toThreadMessages([
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-hello_ui",
+            toolCallId: "tc-1",
+            state: "output-available",
+            input: {},
+            output: {
+              _meta: { "ui/resourceUri": "ui://app/hello_ui.html" },
+              content: [{ type: "text", text: "" }],
+            },
+          },
+        ],
+      } as any,
+    ]);
+
+    const call = converted[0]?.content.find(
+      (part): part is any => part.type === "tool-call",
+    );
+    expect(call?.mcp?.app).toEqual({
+      resourceUri: "ui://app/hello_ui.html",
+    });
+  });
+
   it("memoizes MCP app metadata across conversions by resourceUri", () => {
     const metadata = {
       mcpAppMetadataCache: new Map(),

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -37,7 +37,6 @@ function extractMcpAppMetadata(
   cache: Map<string, McpAppMetadata> | undefined,
 ): McpAppMetadata | undefined {
   if (!part || typeof part !== "object") return undefined;
-  let a: Record<string, unknown> | undefined;
   const meta = (part as { callProviderMetadata?: unknown })
     .callProviderMetadata;
   const mcp =
@@ -46,6 +45,7 @@ function extractMcpAppMetadata(
       : undefined;
   const app =
     mcp && typeof mcp === "object" ? (mcp as { app?: unknown }).app : undefined;
+  let a: Record<string, unknown>;
   if (app && typeof app === "object") {
     a = app as Record<string, unknown>;
   } else {

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -37,14 +37,32 @@ function extractMcpAppMetadata(
   cache: Map<string, McpAppMetadata> | undefined,
 ): McpAppMetadata | undefined {
   if (!part || typeof part !== "object") return undefined;
+  let a: Record<string, unknown> | undefined;
   const meta = (part as { callProviderMetadata?: unknown })
     .callProviderMetadata;
-  if (!meta || typeof meta !== "object") return undefined;
-  const mcp = (meta as { mcp?: unknown }).mcp;
-  if (!mcp || typeof mcp !== "object") return undefined;
-  const app = (mcp as { app?: unknown }).app;
-  if (!app || typeof app !== "object") return undefined;
-  const a = app as Record<string, unknown>;
+  const mcp =
+    meta && typeof meta === "object"
+      ? (meta as { mcp?: unknown }).mcp
+      : undefined;
+  const app =
+    mcp && typeof mcp === "object" ? (mcp as { app?: unknown }).app : undefined;
+  if (app && typeof app === "object") {
+    a = app as Record<string, unknown>;
+  } else {
+    // MCP-UI tools (e.g. xmcp) surface the UI pointer as
+    // result._meta["ui/resourceUri"] rather than in callProviderMetadata.
+    const output = (part as { output?: unknown }).output;
+    const outMeta =
+      output && typeof output === "object"
+        ? (output as { _meta?: unknown })._meta
+        : undefined;
+    const uiResourceUri =
+      outMeta && typeof outMeta === "object"
+        ? (outMeta as Record<string, unknown>)["ui/resourceUri"]
+        : undefined;
+    if (typeof uiResourceUri !== "string") return undefined;
+    a = { resourceUri: uiResourceUri };
+  }
   if (typeof a["resourceUri"] !== "string") return undefined;
   if (!isMcpAppUri(a["resourceUri"])) return undefined;
   const cached = cache?.get(a["resourceUri"]);


### PR DESCRIPTION
## Summary

`extractMcpAppMetadata` only read the UI pointer from `part.callProviderMetadata.mcp.app.resourceUri`. Tools that follow the MCP-UI convention used by xmcp surface the pointer in the call result instead (`result._meta["ui/resourceUri"]`), with no provider metadata. As a result `McpAppRenderer` never saw an app and rendered nothing for those tools.

This adds an output-side fallback: when `callProviderMetadata.mcp.app` is absent, look at `output._meta["ui/resourceUri"]`.

## Repro

1. Run any xmcp server exposing a `.tsx` tool (auto-generates `_meta.ui.resourceUri`).
2. Wire it through the assistant-ui starter-mcp template.
3. Call the tool — before this fix the result renders as raw JSON; after, the MCP-UI widget renders.

## Test plan

- [x] New unit test in `convertMessage.test.ts` covering the `output._meta["ui/resourceUri"]` path
- [x] `pnpm test` in `packages/react-ai-sdk` (44 passed)
- [x] `pnpm build` in `packages/react-ai-sdk`
- [ ] Verified end-to-end with an xmcp server + assistant-ui-starter-mcp frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)