### PR TITLE
feat(react): clamp MCP app auto-resize height to configurable max

### DIFF
--- a/.changeset/mcp-app-max-height.md
+++ b/.changeset/mcp-app-max-height.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat(react): clamp MCP app auto-resize height to a configurable max (default 800px)

--- a/packages/react/src/mcp-apps/McpAppRenderer.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.tsx
@@ -41,6 +41,11 @@ export type McpAppRendererOptions = {
   host: ResourceElement<McpAppsHost>;
   /** Sandbox + container styling. Passes through to SafeContentFrame. */
   sandbox?: McpAppSandboxConfig;
+  /**
+   * Upper bound (in pixels) applied to the widget-driven auto-resize height.
+   * Defaults to 800.
+   */
+  maxHeight?: number;
   /** Identifies the host to the widget in the `ui/initialize` response. */
   hostInfo?: McpAppHostInfo;
   /** Delivered to the widget on initialize and pushed via `notifications/host_context/changed` on change. */
@@ -182,6 +187,7 @@ function InlineRenderer({
       handlers={bridgeHandlers}
       hostInfo={opts.hostInfo}
       hostContext={opts.hostContext}
+      maxHeight={opts.maxHeight}
     />
   );
 }

--- a/packages/react/src/mcp-apps/app-frame.tsx
+++ b/packages/react/src/mcp-apps/app-frame.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type MutableRefObject, useEffect, useRef } from "react";
+import { type MutableRefObject, useEffect, useRef, useState } from "react";
 import { type RenderedFrame, SafeContentFrame } from "safe-content-frame";
 import { type McpAppBridge, createMcpAppBridge } from "./bridge";
 import type {
@@ -11,6 +11,7 @@ import type {
 
 const DEFAULT_PRODUCT = "assistant-ui-mcp-app";
 const INIT_TIMEOUT_MS = 5000;
+const DEFAULT_MAX_HEIGHT = 800;
 
 function useBridgeNotify<T>(
   value: T | undefined,
@@ -97,8 +98,12 @@ export function McpAppFrame({
   handlers,
   hostInfo,
   hostContext,
+  maxHeight = DEFAULT_MAX_HEIGHT,
 }: McpAppFrameProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [contentHeight, setContentHeight] = useState<number | undefined>(
+    undefined,
+  );
   const bridgeRef = useRef<McpAppBridge | null>(null);
   const lastSentInputRef = useRef<unknown>(undefined);
   const lastSentOutputRef = useRef<unknown>(undefined);
@@ -183,6 +188,7 @@ export function McpAppFrame({
             pendingHostContextRef.current = undefined;
           }
         };
+        const liveOnSizeChange = liveHandlers.onSizeChange;
         const wrappedHandlers: McpAppBridgeHandlers = {
           ...liveHandlers,
           onInitialized: () => {
@@ -192,6 +198,12 @@ export function McpAppFrame({
             }
             flushPending();
             liveOnInitialized?.();
+          },
+          onSizeChange: (p) => {
+            if (typeof p.height === "number") {
+              setContentHeight(p.height);
+            }
+            liveOnSizeChange?.(p);
           },
         };
         // Safety net: if the widget never sends notifications/initialized
@@ -238,6 +250,7 @@ export function McpAppFrame({
       pendingInputRef.current = undefined;
       pendingOutputRef.current = undefined;
       pendingHostContextRef.current = undefined;
+      setContentHeight(undefined);
     };
   }, [resourceUri]);
 
@@ -266,11 +279,18 @@ export function McpAppFrame({
     (b, v) => b.notifyHostContextChanged(v),
   );
 
+  const resolvedHeight =
+    contentHeight != null ? Math.min(contentHeight, maxHeight) : undefined;
+  const mergedStyle =
+    resolvedHeight != null
+      ? { ...sandbox?.style, height: resolvedHeight }
+      : sandbox?.style;
+
   return (
     <div
       ref={containerRef}
       className={sandbox?.className}
-      style={sandbox?.style}
+      style={mergedStyle}
       data-mcp-app-resource={app.resourceUri}
       data-mcp-app-prefers-border={
         resource.meta?.prefersBorder ? "" : undefined

--- a/packages/react/src/mcp-apps/app-frame.tsx
+++ b/packages/react/src/mcp-apps/app-frame.tsx
@@ -188,7 +188,6 @@ export function McpAppFrame({
             pendingHostContextRef.current = undefined;
           }
         };
-        const liveOnSizeChange = liveHandlers.onSizeChange;
         const wrappedHandlers: McpAppBridgeHandlers = {
           ...liveHandlers,
           onInitialized: () => {
@@ -200,10 +199,14 @@ export function McpAppFrame({
             liveOnInitialized?.();
           },
           onSizeChange: (p) => {
-            if (typeof p.height === "number") {
+            if (
+              typeof p.height === "number" &&
+              Number.isFinite(p.height) &&
+              p.height > 0
+            ) {
               setContentHeight(p.height);
             }
-            liveOnSizeChange?.(p);
+            liveHandlers.onSizeChange?.(p);
           },
         };
         // Safety net: if the widget never sends notifications/initialized

--- a/packages/react/src/mcp-apps/types.ts
+++ b/packages/react/src/mcp-apps/types.ts
@@ -117,6 +117,11 @@ export type McpAppFrameProps = {
   handlers?: McpAppBridgeHandlers | undefined;
   hostInfo?: McpAppHostInfo | undefined;
   hostContext?: McpAppHostContext | undefined;
+  /**
+   * Upper bound (in pixels) for the auto-resize height driven by the widget's
+   * `notifications/size_changed`. Defaults to 800.
+   */
+  maxHeight?: number | undefined;
 };
 
 export type McpAppJsonRpcRequest = {


### PR DESCRIPTION
## Summary
- Wires the widget's `notifications/size_changed` into the `McpAppFrame` container — the host div now sets `height` from the widget-reported height, clamped to a new `maxHeight` option (default `800`).
- Exposes `maxHeight` on both `McpAppFrame` props and `McpAppRenderer` options.
- Resets the tracked height when the frame remounts (resource URI change).

## Test plan
- [x] `pnpm turbo build --filter=@assistant-ui/react`
- [x] `pnpm --filter @assistant-ui/react test`
- [x] biome lint on changed files
- [ ] Manual: load an MCP app widget that emits `notifications/size_changed`, confirm container resizes and is clamped at 800px (and at custom override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)