### PR TITLE
feat(react|ui): ungroup MCP-app tool calls in chain of thought

### DIFF
--- a/.changeset/mcp-ui-ungroup.md
+++ b/.changeset/mcp-ui-ungroup.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat(react): export `getMcpAppFromToolPart` so hosts can detect MCP-app tool parts

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -382,7 +382,11 @@ export {
 export type { Assistant } from "./augmentations";
 
 // --- mcp-apps ---
-export { McpAppRenderer, McpAppsRemoteHost } from "./mcp-apps";
+export {
+  McpAppRenderer,
+  McpAppsRemoteHost,
+  getMcpAppFromToolPart,
+} from "./mcp-apps";
 export type {
   McpAppRendererOptions,
   McpAppMetadata,

--- a/packages/react/src/mcp-apps/index.ts
+++ b/packages/react/src/mcp-apps/index.ts
@@ -1,5 +1,6 @@
 export { McpAppRenderer, type McpAppRendererOptions } from "./McpAppRenderer";
 export { McpAppsRemoteHost } from "./McpAppsRemoteHost";
+export { getMcpAppFromToolPart } from "./utils";
 export type {
   McpAppMetadata,
   McpAppResource,

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -27,6 +27,7 @@ import {
   BranchPickerPrimitive,
   ComposerPrimitive,
   ErrorPrimitive,
+  getMcpAppFromToolPart,
   MessagePrimitive,
   SuggestionPrimitive,
   ThreadPrimitive,
@@ -243,8 +244,10 @@ const AssistantMessage: FC = () => {
           groupBy={(part) => {
             if (part.type === "reasoning")
               return ["group-chainOfThought", "group-reasoning"];
-            if (part.type === "tool-call")
+            if (part.type === "tool-call") {
+              if (getMcpAppFromToolPart(part)) return null;
               return ["group-chainOfThought", "group-tool"];
+            }
             return null;
           }}
         >

--- a/templates/cloud-clerk/components/assistant-ui/thread.tsx
+++ b/templates/cloud-clerk/components/assistant-ui/thread.tsx
@@ -27,6 +27,7 @@ import {
   BranchPickerPrimitive,
   ComposerPrimitive,
   ErrorPrimitive,
+  getMcpAppFromToolPart,
   MessagePrimitive,
   SuggestionPrimitive,
   ThreadPrimitive,
@@ -243,8 +244,10 @@ const AssistantMessage: FC = () => {
           groupBy={(part) => {
             if (part.type === "reasoning")
               return ["group-chainOfThought", "group-reasoning"];
-            if (part.type === "tool-call")
+            if (part.type === "tool-call") {
+              if (getMcpAppFromToolPart(part)) return null;
               return ["group-chainOfThought", "group-tool"];
+            }
             return null;
           }}
         >

--- a/templates/cloud/components/assistant-ui/thread.tsx
+++ b/templates/cloud/components/assistant-ui/thread.tsx
@@ -27,6 +27,7 @@ import {
   BranchPickerPrimitive,
   ComposerPrimitive,
   ErrorPrimitive,
+  getMcpAppFromToolPart,
   MessagePrimitive,
   SuggestionPrimitive,
   ThreadPrimitive,
@@ -243,8 +244,10 @@ const AssistantMessage: FC = () => {
           groupBy={(part) => {
             if (part.type === "reasoning")
               return ["group-chainOfThought", "group-reasoning"];
-            if (part.type === "tool-call")
+            if (part.type === "tool-call") {
+              if (getMcpAppFromToolPart(part)) return null;
               return ["group-chainOfThought", "group-tool"];
+            }
             return null;
           }}
         >

--- a/templates/default/components/assistant-ui/thread.tsx
+++ b/templates/default/components/assistant-ui/thread.tsx
@@ -27,6 +27,7 @@ import {
   BranchPickerPrimitive,
   ComposerPrimitive,
   ErrorPrimitive,
+  getMcpAppFromToolPart,
   MessagePrimitive,
   SuggestionPrimitive,
   ThreadPrimitive,
@@ -243,8 +244,10 @@ const AssistantMessage: FC = () => {
           groupBy={(part) => {
             if (part.type === "reasoning")
               return ["group-chainOfThought", "group-reasoning"];
-            if (part.type === "tool-call")
+            if (part.type === "tool-call") {
+              if (getMcpAppFromToolPart(part)) return null;
               return ["group-chainOfThought", "group-tool"];
+            }
             return null;
           }}
         >

--- a/templates/langgraph/components/assistant-ui/thread.tsx
+++ b/templates/langgraph/components/assistant-ui/thread.tsx
@@ -27,6 +27,7 @@ import {
   BranchPickerPrimitive,
   ComposerPrimitive,
   ErrorPrimitive,
+  getMcpAppFromToolPart,
   MessagePrimitive,
   SuggestionPrimitive,
   ThreadPrimitive,
@@ -243,8 +244,10 @@ const AssistantMessage: FC = () => {
           groupBy={(part) => {
             if (part.type === "reasoning")
               return ["group-chainOfThought", "group-reasoning"];
-            if (part.type === "tool-call")
+            if (part.type === "tool-call") {
+              if (getMcpAppFromToolPart(part)) return null;
               return ["group-chainOfThought", "group-tool"];
+            }
             return null;
           }}
         >

--- a/templates/mcp/components/assistant-ui/thread.tsx
+++ b/templates/mcp/components/assistant-ui/thread.tsx
@@ -27,6 +27,7 @@ import {
   BranchPickerPrimitive,
   ComposerPrimitive,
   ErrorPrimitive,
+  getMcpAppFromToolPart,
   MessagePrimitive,
   SuggestionPrimitive,
   ThreadPrimitive,
@@ -243,8 +244,10 @@ const AssistantMessage: FC = () => {
           groupBy={(part) => {
             if (part.type === "reasoning")
               return ["group-chainOfThought", "group-reasoning"];
-            if (part.type === "tool-call")
+            if (part.type === "tool-call") {
+              if (getMcpAppFromToolPart(part)) return null;
               return ["group-chainOfThought", "group-tool"];
+            }
             return null;
           }}
         >


### PR DESCRIPTION
## Summary
- Default thread `groupBy` now returns `null` for tool-call parts whose `mcp.app` is an MCP-app URI, so MCP UIs render inline rather than collapsed into the ToolGroup accordion.
- Exports `getMcpAppFromToolPart` from `@assistant-ui/react` so consumers can apply the same check in their own `groupBy`.

## Test plan
- [x] `pnpm turbo build --filter=@assistant-ui/react --filter=@assistant-ui/ui`
- [x] `pnpm --filter @assistant-ui/react test` (302 passing)
- [ ] Manual: a thread with mixed reasoning + non-MCP tool + MCP-app tool — confirm reasoning and non-MCP tool collapse together, MCP-app tool renders inline outside the chain-of-thought block

🤖 Generated with [Claude Code](https://claude.com/claude-code)