### PR TITLE
docs(streamdown): document tailwind @source and CSS setup

### DIFF
--- a/apps/docs/content/docs/ui/streamdown.mdx
+++ b/apps/docs/content/docs/ui/streamdown.mdx
@@ -26,6 +26,36 @@ For additional features, install the optional plugins:
 
 <PackageManagerTabs packages={["@streamdown/code", "@streamdown/math", "@streamdown/mermaid", "@streamdown/cjk"]} />
 
+## CSS setup
+
+Streamdown's controls (code-block copy/download buttons, mermaid fullscreen overlay) and the streaming caret are written as Tailwind utility classes. Tailwind v4 does not scan `node_modules` by default, so add a `@source` directive for Streamdown (and one per installed plugin) to the same global stylesheet that imports Tailwind:
+
+```css
+@import "tailwindcss";
+
+@source "../node_modules/streamdown/dist/*.js";
+@source "../node_modules/@streamdown/code/dist/*.js";
+@source "../node_modules/@streamdown/math/dist/*.js";
+@source "../node_modules/@streamdown/mermaid/dist/*.js";
+@source "../node_modules/@streamdown/cjk/dist/*.js";
+```
+
+Adjust the relative path to wherever your project's `node_modules` lives. In a pnpm or Turbo monorepo with hoisted dependencies, you typically need more `../` segments to reach the workspace root. Only include the plugin lines for packages you actually installed.
+
+Without these directives, the copy/download/fullscreen buttons render with no padding or cursor styling (and look broken), and the `caret` indicator stays invisible.
+
+<Callout type="info">
+  Streamdown's components assume the shadcn/ui design tokens (`--background`, `--muted-foreground`, `--border`, etc.). If you are not on shadcn/ui, copy the minimum variable set from the [Streamdown README](https://github.com/vercel/streamdown#css-custom-properties-design-tokens).
+</Callout>
+
+If you opt into the `animated` prop or use `createAnimatePlugin` for word-level fade-in, also import the keyframes once at your app entry:
+
+```ts
+import "streamdown/styles.css";
+```
+
+The bare `caret` prop does **not** require this import; only the word-level animation does.
+
 ## Basic Usage
 
 ```tsx
@@ -172,6 +202,8 @@ Display a caret indicator during streaming:
 <StreamdownTextPrimitive caret="block" />  // ▋
 <StreamdownTextPrimitive caret="circle" /> // ●
 ```
+
+The caret is implemented as a Tailwind `::after` utility on the wrapper, so it only appears if your Tailwind setup includes the `@source` directive from [CSS setup](#css-setup).
 
 ### Link Safety
 

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -12,6 +12,7 @@
 @plugin "tailwind-scrollbar";
 
 @source "../../../packages/ui/src";
+@source "../node_modules/streamdown/dist/*.js";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/packages/react-streamdown/README.md
+++ b/packages/react-streamdown/README.md
@@ -22,6 +22,32 @@ For optional features:
 npm install @streamdown/code @streamdown/math @streamdown/mermaid @streamdown/cjk
 ```
 
+## CSS setup
+
+Streamdown ships its control buttons (code-block toolbar, mermaid fullscreen) and the streaming caret as Tailwind utility classes. Tailwind v4 does not scan `node_modules` by default, so add a `@source` directive for Streamdown (and one per installed plugin) to the same stylesheet that imports Tailwind:
+
+```css
+@import "tailwindcss";
+
+@source "../node_modules/streamdown/dist/*.js";
+@source "../node_modules/@streamdown/code/dist/*.js";
+@source "../node_modules/@streamdown/math/dist/*.js";
+@source "../node_modules/@streamdown/mermaid/dist/*.js";
+@source "../node_modules/@streamdown/cjk/dist/*.js";
+```
+
+Adjust the relative path to your project's `node_modules`. In a pnpm or Turbo monorepo with hoisted dependencies, you typically need more `../` segments to reach the workspace root. Only keep the plugin lines for packages you actually installed.
+
+Without these directives, the copy, download, and fullscreen buttons render unstyled, and the `caret` indicator stays invisible.
+
+If you use the `animated` prop or `createAnimatePlugin` for word-level fade-in, also import the keyframes once at your app entry:
+
+```ts
+import "streamdown/styles.css";
+```
+
+For details on the shadcn/ui design tokens Streamdown expects, see the [Streamdown README](https://github.com/vercel/streamdown#css-custom-properties-design-tokens).
+
 ## Usage
 
 ```tsx


### PR DESCRIPTION
closes #4036

## summary

- documents that streamdown needs a Tailwind v4 `@source "../node_modules/streamdown/dist/*.js"` directive (plus one per installed `@streamdown/*` plugin), without which the code-block copy/download buttons, the mermaid fullscreen overlay, and the streaming `caret` indicator render unstyled or invisible. adds the section to both the docs page and the `@assistant-ui/react-streamdown` README.
- clarifies that `import "streamdown/styles.css"` is only required when opting into `animated` / `createAnimatePlugin` for word-level fade-in, since the bare `caret` prop is implemented as a Tailwind `::after` utility on the wrapper, not as a CSS keyframe in `styles.css`.
- adds the missing `@source` line to the docs site's own `globals.css` so the live `<StreamdownSample />` on assistant-ui.com picks up streamdown's utilities going forward.

no test plan, docs only