### PR TITLE
fix(ui): make sources favicon provider configurable, default to DuckDuckGo

### DIFF
--- a/apps/docs/content/docs/ui/sources.mdx
+++ b/apps/docs/content/docs/ui/sources.mdx
@@ -122,6 +122,22 @@ Displays the favicon for the given URL. Falls back to the domain initial inside 
 | `faviconUrl` | `(domain: string) => string` | DuckDuckGo's `ip3` endpoint | Override the favicon source — useful in environments where the default service is unreachable |
 | `className` | `string` | — | Additional CSS classes applied to the `<img>` or fallback `<span>` |
 
+#### Customizing the favicon provider
+
+The default `<Sources>` component renders `<SourceIcon>` without forwarding `faviconUrl`, so the prop only applies when you compose `Sources.Icon` directly:
+
+```tsx
+<Sources.Root href={url}>
+  <Sources.Icon
+    url={url}
+    faviconUrl={(domain) => `https://my-favicon-proxy.example.com/${domain}.ico`}
+  />
+  <Sources.Title>{title}</Sources.Title>
+</Sources.Root>
+```
+
+To change the default for every source in your app, edit the `defaultFaviconUrl` constant at the top of your copied `sources.tsx` — that is the single source of truth used by `<Sources>`.
+
 ### `SourceTitle`
 
 Truncated title text rendered as a `<span>`.

--- a/apps/docs/content/docs/ui/sources.mdx
+++ b/apps/docs/content/docs/ui/sources.mdx
@@ -119,6 +119,7 @@ Displays the favicon for the given URL. Falls back to the domain initial inside 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `url` | `string` | — | URL used to derive the favicon and fallback initial |
+| `faviconUrl` | `(domain: string) => string` | DuckDuckGo's `ip3` endpoint | Override the favicon source — useful in environments where the default service is unreachable |
 | `className` | `string` | — | Additional CSS classes applied to the `<img>` or fallback `<span>` |
 
 ### `SourceTitle`

--- a/packages/ui/src/components/assistant-ui/sources.tsx
+++ b/packages/ui/src/components/assistant-ui/sources.tsx
@@ -28,12 +28,8 @@ function SourceIcon({
 }) {
   const domain = extractDomain(url);
   const src = faviconUrl(domain);
-  const [prevSrc, setPrevSrc] = useState(src);
-  const [hasError, setHasError] = useState(false);
-  if (prevSrc !== src) {
-    setPrevSrc(src);
-    setHasError(false);
-  }
+  const [errorSrc, setErrorSrc] = useState<string | undefined>(undefined);
+  const hasError = errorSrc === src;
 
   if (hasError) {
     return (
@@ -56,7 +52,7 @@ function SourceIcon({
       src={src}
       alt=""
       className={cn("size-3 shrink-0 rounded-sm", className)}
-      onError={() => setHasError(true)}
+      onError={() => setErrorSrc(src)}
       {...(props as ComponentProps<"img">)}
     />
   );

--- a/packages/ui/src/components/assistant-ui/sources.tsx
+++ b/packages/ui/src/components/assistant-ui/sources.tsx
@@ -14,11 +14,6 @@ const extractDomain = (url: string): string => {
   }
 };
 
-const getDomainInitial = (url: string): string => {
-  const domain = extractDomain(url);
-  return domain.charAt(0).toUpperCase() || "?";
-};
-
 const defaultFaviconUrl = (domain: string) =>
   `https://icons.duckduckgo.com/ip3/${domain}.ico`;
 
@@ -31,8 +26,14 @@ function SourceIcon({
   url: string;
   faviconUrl?: (domain: string) => string;
 }) {
-  const [hasError, setHasError] = useState(false);
   const domain = extractDomain(url);
+  const src = faviconUrl(domain);
+  const [prevSrc, setPrevSrc] = useState(src);
+  const [hasError, setHasError] = useState(false);
+  if (prevSrc !== src) {
+    setPrevSrc(src);
+    setHasError(false);
+  }
 
   if (hasError) {
     return (
@@ -44,7 +45,7 @@ function SourceIcon({
         )}
         {...props}
       >
-        {getDomainInitial(url)}
+        {domain.charAt(0).toUpperCase() || "?"}
       </span>
     );
   }
@@ -52,7 +53,7 @@ function SourceIcon({
   return (
     <img
       data-slot="source-icon"
-      src={faviconUrl(domain)}
+      src={src}
       alt=""
       className={cn("size-3 shrink-0 rounded-sm", className)}
       onError={() => setHasError(true)}

--- a/packages/ui/src/components/assistant-ui/sources.tsx
+++ b/packages/ui/src/components/assistant-ui/sources.tsx
@@ -16,14 +16,21 @@ const extractDomain = (url: string): string => {
 
 const getDomainInitial = (url: string): string => {
   const domain = extractDomain(url);
-  return domain.charAt(0).toUpperCase();
+  return domain.charAt(0).toUpperCase() || "?";
 };
+
+const defaultFaviconUrl = (domain: string) =>
+  `https://icons.duckduckgo.com/ip3/${domain}.ico`;
 
 function SourceIcon({
   url,
   className,
+  faviconUrl = defaultFaviconUrl,
   ...props
-}: ComponentProps<"span"> & { url: string }) {
+}: ComponentProps<"span"> & {
+  url: string;
+  faviconUrl?: (domain: string) => string;
+}) {
   const [hasError, setHasError] = useState(false);
   const domain = extractDomain(url);
 
@@ -45,7 +52,7 @@ function SourceIcon({
   return (
     <img
       data-slot="source-icon"
-      src={`https://www.google.com/s2/favicons?domain=${domain}&sz=32`}
+      src={faviconUrl(domain)}
       alt=""
       className={cn("size-3 shrink-0 rounded-sm", className)}
       onError={() => setHasError(true)}


### PR DESCRIPTION
## Summary
- `SourceIcon` favicon was hardcoded to `google.com/s2/favicons`, which breaks in regions where Google is unreachable. The `onError` fallback still degraded to a domain-initial badge, but real favicons disappeared.
- Switch default to DuckDuckGo's `https://icons.duckduckgo.com/ip3/${domain}.ico` — same normalizer behavior, reachable from Google-blocked regions.
- Add an optional `faviconUrl?: (domain: string) => string` prop on `SourceIcon` so consumers can plug in any favicon service without rewriting the component.
- Minor: `getDomainInitial` now returns `"?"` instead of an empty string for an empty hostname.

Closes #4035.

## Test plan
- [ ] Verify default favicon renders for common sites (`example.com`, `github.com`)
- [ ] Verify custom `faviconUrl` prop overrides the source
- [ ] Verify fallback badge appears when the favicon URL returns an error
- [ ] Visual regression check in docs sample