### PR TITLE
fix(core): drop phantom siblings when external store swaps message id

### DIFF
--- a/.changeset/fix-external-store-phantom-sibling.md
+++ b/.changeset/fix-external-store-phantom-sibling.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: `useExternalStoreRuntime` no longer leaves phantom assistant siblings when the external store swaps a message id between syncs (e.g. AI SDK v6 `useChat` replacing a client-generated id with a server-provided id mid-stream, surfacing as `BranchPicker` showing `2/2` on a turn the user never branched). The `messages`-array sync path now diffs against the previous sync and removes ids that disappeared, matching the `messageRepository` path's snapshot semantics. Closes #4037.

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -53,6 +53,7 @@ export class ExternalStoreThreadRuntimeCore
   implements ThreadRuntimeCore
 {
   private _assistantOptimisticId: string | null = null;
+  private _lastSyncedMessageIds = new Set<string>();
 
   private _capabilities: RuntimeCapabilities = {
     switchToBranch: false,
@@ -170,6 +171,7 @@ export class ExternalStoreThreadRuntimeCore
       // Clear and import the message repository
       this.repository.clear();
       this._assistantOptimisticId = null;
+      this._lastSyncedMessageIds = new Set();
       this.repository.import(store.messageRepository);
 
       messages = this.repository.getMessages();
@@ -221,6 +223,12 @@ export class ExternalStoreThreadRuntimeCore
             bindExternalStoreMessage(newMessage, m);
             return newMessage;
           });
+
+      const nextIds = new Set(messages.map((m) => m.id));
+      for (const prevId of this._lastSyncedMessageIds) {
+        if (!nextIds.has(prevId)) this.repository.deleteMessage(prevId);
+      }
+      this._lastSyncedMessageIds = nextIds;
 
       for (let i = 0; i < messages.length; i++) {
         const message = messages[i]!;
@@ -336,6 +344,7 @@ export class ExternalStoreThreadRuntimeCore
       previousMessage.id === messages.at(-1)?.id // ensure the previous message is a leaf node
     ) {
       this.repository.deleteMessage(previousMessage.id);
+      this._lastSyncedMessageIds.delete(previousMessage.id);
       if (!this.composer.text.trim()) {
         this.composer.setText(getThreadMessageText(previousMessage));
       }
@@ -364,6 +373,7 @@ export class ExternalStoreThreadRuntimeCore
   }
 
   public override reset(initialMessages?: readonly ThreadMessageLike[]) {
+    this._lastSyncedMessageIds = new Set();
     const repo = new MessageRepository();
     repo.import(ExportedMessageRepository.fromArray(initialMessages ?? []));
     this.updateMessages(repo.getMessages());
@@ -371,6 +381,7 @@ export class ExternalStoreThreadRuntimeCore
 
   public override import(data: ExportedMessageRepository) {
     this._assistantOptimisticId = null;
+    this._lastSyncedMessageIds = new Set();
 
     super.import(data);
 

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -150,3 +150,116 @@ describe("ExternalStoreThreadRuntimeCore - state reference stability", () => {
     expect(runtime.capabilities).toBe(capsBefore);
   });
 });
+
+describe("ExternalStoreThreadRuntimeCore - messages reconciliation", () => {
+  const user = { id: "u", role: "user" as const, content: [] };
+
+  it("drops ids that disappear between syncs (same length, swapped assistant id)", () => {
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages: [user, a1] }),
+    );
+
+    runtime.__internal_setAdapter(makeStore({ messages: [user, a2] }));
+
+    const exported = runtime.export();
+    expect(exported.messages.map((m) => m.message.id)).toEqual(["u", "a2"]);
+    const userChildren = exported.messages
+      .filter((m) => m.parentId === "u")
+      .map((m) => m.message.id);
+    expect(userChildren).toEqual(["a2"]);
+  });
+
+  it("keeps prior ids when they remain in the new sync", () => {
+    const a = { id: "a", role: "assistant" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages: [user, a] }),
+    );
+
+    runtime.__internal_setAdapter(makeStore({ messages: [user, a] }));
+
+    expect(runtime.export().messages.map((m) => m.message.id)).toEqual([
+      "u",
+      "a",
+    ]);
+  });
+
+  it("removes trailing messages dropped from the new sync", () => {
+    const a = { id: "a", role: "assistant" as const, content: [] };
+    const u2 = { id: "u2", role: "user" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages: [user, a, u2] }),
+    );
+
+    runtime.__internal_setAdapter(makeStore({ messages: [user, a] }));
+
+    expect(runtime.export().messages.map((m) => m.message.id)).toEqual([
+      "u",
+      "a",
+    ]);
+  });
+
+  it("does not crash on the next sync after cancelRun removes a leaf user", () => {
+    const userWithText = {
+      id: "u",
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "hi" }],
+    };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [userWithText],
+        onCancel: vi.fn(),
+        isRunning: true,
+      }),
+    );
+
+    runtime.cancelRun();
+
+    expect(() => {
+      runtime.__internal_setAdapter(makeStore({ messages: [] }));
+    }).not.toThrow();
+  });
+
+  it("drops phantom sibling when convertMessage swaps the assistant id", () => {
+    type Raw = { id: string; role: "user" | "assistant"; text: string };
+    const rawU: Raw = { id: "u", role: "user", text: "hi" };
+    const rawA1: Raw = { id: "client_id", role: "assistant", text: "" };
+    const rawA2: Raw = { id: "server_id", role: "assistant", text: "" };
+
+    const convertMessage = (m: Raw) => ({
+      id: m.id,
+      role: m.role,
+      content: [{ type: "text" as const, text: m.text }],
+    });
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [rawU, rawA1] as any,
+        convertMessage: convertMessage as any,
+      }),
+    );
+
+    runtime.__internal_setAdapter(
+      makeStore({
+        messages: [rawU, rawA2] as any,
+        convertMessage: convertMessage as any,
+      }),
+    );
+
+    const userChildren = runtime
+      .export()
+      .messages.filter((m) => m.parentId === "u")
+      .map((m) => m.message.id);
+    expect(userChildren).toEqual(["server_id"]);
+  });
+});


### PR DESCRIPTION
closes #4037

## summary

- prevent `BranchPicker` from showing `2/2` on assistant turns the user never branched, in apps where the external store's assistant message id changes between syncs (e.g. AI SDK v6 `useChat` swapping a client-generated id for a server-provided id mid-stream).
- `ExternalStoreThreadRuntimeCore`'s `messages`-array sync path was add-only: once a new id appeared, the old id stayed as a sibling under the same parent, inflating `parent.children.length` (the `branchCount` source).
- the path now diffs incoming ids against a tracked `_lastSyncedMessageIds` set before linking the new graph and removes ids that disappeared, matching the `messageRepository` path's snapshot semantics. the set is reset on `messageRepository` swaps and `import()`.

## test plan

### already verified

- [x] `pnpm vitest run src/tests/external-store-thread-runtime-core.test.ts` in `packages/core` -> 12/12 green. the new "drops ids that disappear between syncs (same length, swapped assistant id)" case asserts only the new id remains under the user parent; it fails on main and passes post-fix.
- [x] reproduced the bug on clean main in `examples/with-ai-sdk-v6` via a mock route emitting a `data-*` chunk followed by a `start{messageId}` chunk: `runtime.thread.export()` showed two assistant siblings under the user message, and `runtime.thread.getMessageById(active).getState().branchCount` was 2, matching the issue.

### reviewer should verify

- [ ] in a real AI SDK v6 app using `useChatRuntime`, send a message and confirm `BranchPicker` reports `1/1` instead of `2/2`.