### PR TITLE
feat(cloud): allow custom baseUrl with API key auth

### DIFF
--- a/.changeset/cloud-api-key-base-url.md
+++ b/.changeset/cloud-api-key-base-url.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+feat(cloud): allow custom `baseUrl` with API key auth. Previously the apiKey config branch hard-coded `https://backend.assistant-api.com`; you can now pass `baseUrl` to point an apiKey-authenticated `AssistantCloud` at a self-hosted or staging backend.

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -71,7 +71,9 @@ export class AssistantCloudAPI {
       this._baseUrl = config.baseUrl;
       this._auth = new AssistantCloudJWTAuthStrategy(config.authToken);
     } else if ("apiKey" in config) {
-      this._baseUrl = config.baseUrl ?? "https://backend.assistant-api.com";
+      this._baseUrl = (
+        config.baseUrl ?? "https://backend.assistant-api.com"
+      ).replace(/\/$/, "");
       this._auth = new AssistantCloudAPIKeyAuthStrategy(
         config.apiKey,
         config.userId,

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -68,7 +68,7 @@ export class AssistantCloudAPI {
 
   constructor(config: AssistantCloudConfig) {
     if ("authToken" in config) {
-      this._baseUrl = config.baseUrl;
+      this._baseUrl = config.baseUrl.replace(/\/$/, "");
       this._auth = new AssistantCloudJWTAuthStrategy(config.authToken);
     } else if ("apiKey" in config) {
       this._baseUrl = (
@@ -80,8 +80,8 @@ export class AssistantCloudAPI {
         config.workspaceId,
       );
     } else if ("anonymous" in config) {
-      this._baseUrl = config.baseUrl;
-      this._auth = new AssistantCloudAnonymousAuthStrategy(config.baseUrl);
+      this._baseUrl = config.baseUrl.replace(/\/$/, "");
+      this._auth = new AssistantCloudAnonymousAuthStrategy(this._baseUrl);
     } else {
       throw new Error(
         "Invalid configuration: Must provide authToken, apiKey, or anonymous configuration",

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -68,7 +68,7 @@ export class AssistantCloudAPI {
 
   constructor(config: AssistantCloudConfig) {
     if ("authToken" in config) {
-      this._baseUrl = config.baseUrl.replace(/\/$/, "");
+      this._baseUrl = config.baseUrl;
       this._auth = new AssistantCloudJWTAuthStrategy(config.authToken);
     } else if ("apiKey" in config) {
       this._baseUrl = (
@@ -80,8 +80,8 @@ export class AssistantCloudAPI {
         config.workspaceId,
       );
     } else if ("anonymous" in config) {
-      this._baseUrl = config.baseUrl.replace(/\/$/, "");
-      this._auth = new AssistantCloudAnonymousAuthStrategy(this._baseUrl);
+      this._baseUrl = config.baseUrl;
+      this._auth = new AssistantCloudAnonymousAuthStrategy(config.baseUrl);
     } else {
       throw new Error(
         "Invalid configuration: Must provide authToken, apiKey, or anonymous configuration",

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -24,6 +24,7 @@ export type AssistantCloudConfig = (
       authToken: () => Promise<string | null>;
     }
   | {
+      baseUrl?: string;
       apiKey: string;
       userId: string;
       workspaceId: string;
@@ -70,7 +71,7 @@ export class AssistantCloudAPI {
       this._baseUrl = config.baseUrl;
       this._auth = new AssistantCloudJWTAuthStrategy(config.authToken);
     } else if ("apiKey" in config) {
-      this._baseUrl = "https://backend.assistant-api.com";
+      this._baseUrl = config.baseUrl ?? "https://backend.assistant-api.com";
       this._auth = new AssistantCloudAPIKeyAuthStrategy(
         config.apiKey,
         config.userId,

--- a/packages/cloud/src/tests/AssistantCloudAPI.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAPI.test.ts
@@ -69,6 +69,27 @@ describe("AssistantCloudAPI", () => {
     expect(url.toString()).toBe("https://custom.example.com/v1/threads");
   });
 
+  it("strips a trailing slash from a custom baseUrl", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: vi.fn().mockResolvedValue({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = new AssistantCloudAPI({
+      baseUrl: "https://custom.example.com/",
+      apiKey: "test-key",
+      userId: "u-1",
+      workspaceId: "w-1",
+    });
+
+    await api.makeRawRequest("/threads");
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url.toString()).toBe("https://custom.example.com/v1/threads");
+  });
+
   it("rejects before fetch when auth token callback returns null", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/cloud/src/tests/AssistantCloudAPI.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAPI.test.ts
@@ -48,6 +48,27 @@ describe("AssistantCloudAPI", () => {
     expect(init.body).toBe(JSON.stringify({ hello: "world" }));
   });
 
+  it("uses custom baseUrl when provided with apiKey config", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: vi.fn().mockResolvedValue({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = new AssistantCloudAPI({
+      baseUrl: "https://custom.example.com",
+      apiKey: "test-key",
+      userId: "u-1",
+      workspaceId: "w-1",
+    });
+
+    await api.makeRawRequest("/threads");
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url.toString()).toBe("https://custom.example.com/v1/threads");
+  });
+
   it("rejects before fetch when auth token callback returns null", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);


### PR DESCRIPTION
## summary

- apiKey-authenticated `AssistantCloud` instances can now point at a self-hosted or staging backend by passing `baseUrl`, instead of being locked to `https://backend.assistant-api.com`.
- the apiKey variant of `AssistantCloudConfig` gains an optional `baseUrl: string`; `AssistantCloudAPI` falls back to the original production URL when it's omitted, so existing callers are unaffected.

## test plan

### already verified

- [x] `pnpm --filter assistant-cloud test` -> 30 passed / 2 skipped, including a new case that constructs an apiKey client with `baseUrl: "https://custom.example.com"` and asserts the fetch URL is rewritten.
- [x] `pnpm exec tsc --noEmit` in `packages/cloud` -> clean.

### reviewer should verify

- [ ] sanity-check the type narrowing: passing `baseUrl` alongside `authToken` or `anonymous` still resolves to the existing branches (the new optional only lives on the apiKey variant of the discriminated union).

## notes

- extracted the uncontroversial slice of #2938. the `AssistantCloudStreams` adapter and the `examples/with-cloud` migration to `useAssistantTransportRuntime` from that PR are left out (separate endpoint family, plus `examples/with-assistant-transport` already covers that pattern).