### PR TITLE
fix(cli): improve scaffold validation and respect package managers

### DIFF
--- a/.changeset/fix-cli-dx-shortcuts.md
+++ b/.changeset/fix-cli-dx-shortcuts.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: validate create scaffold selector conflicts, respect package managers in add, and refresh CLI README examples

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,8 +23,23 @@ bunx assistant-ui@latest <command>
 # scaffold a new Next.js project
 npx assistant-ui@latest create my-app
 
+# scaffold a minimal project
+npx assistant-ui@latest create my-app --template minimal
+
+# scaffold from a feature example
+npx assistant-ui@latest create my-app --example with-ai-sdk-v6
+
+# scaffold an Expo / React Native project
+npx assistant-ui@latest create my-app --native
+
+# scaffold a React Ink terminal project
+npx assistant-ui@latest create my-app --ink
+
 # add assistant-ui to an existing project
 npx assistant-ui@latest init
+
+# initialize non-interactively for CI or agent flows
+npx assistant-ui@latest init --yes
 
 # add a component
 npx assistant-ui@latest add thread
@@ -39,11 +54,11 @@ npx assistant-ui@latest upgrade
 npx assistant-ui info
 ```
 
-`init` falls back to `create` when no `package.json` is found, so a single command works for both new and existing projects. `init` is non-interactive with `--yes` for CI and agent usage.
+`init` falls back to `create` when no `package.json` is found, so a single command works for both new and existing projects. Use `init --yes` for CI and agent flows where prompts are not available.
 
 ## Templates
 
-`create` scaffolds from named templates: `default` (AI SDK), `minimal`, `cloud`, `cloud-clerk`, `langgraph`, `mcp`. Pass `-t <name>`, or pass `--preset <url>` to scaffold from an `assistant-ui.com` playground link.
+`create` scaffolds from named templates: `default` (AI SDK), `minimal`, `cloud`, `cloud-clerk`, `langgraph`, `mcp`. Pass `-t <name>`, pass `--example <name>` for examples such as `with-ai-sdk-v6`, use `--native` for Expo / React Native, use `--ink` for React Ink, or pass `--preset <url>` to scaffold from an `assistant-ui.com` playground link.
 
 ## Documentation
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -34,6 +34,8 @@ export function createAddComponentsPlan(params: {
   const [command, dlxArgs] = dlxCommand(params.packageManager);
   const args = [...dlxArgs, "shadcn@latest", "add", ...componentsToAdd];
 
+  // For npm, dlxArgs may already include `--yes` for npx auto-install.
+  // This flag is for shadcn's own confirmation prompt.
   if (params.yes) args.push("--yes");
   if (params.overwrite) args.push("--overwrite");
   if (params.cwd) args.push("--cwd", params.cwd);

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,5 +1,4 @@
 import { Command } from "commander";
-import { spawn } from "cross-spawn";
 import { logger } from "../lib/utils/logger";
 import { hasConfig } from "../lib/utils/config";
 import {
@@ -8,6 +7,7 @@ import {
   resolvePackageManagerForCwd,
   type PackageManagerName,
 } from "../lib/create-project";
+import { runSpawn, SpawnExitError } from "../lib/run-spawn";
 
 const REGISTRY_BASE_URL = "https://r.assistant-ui.com";
 
@@ -84,21 +84,17 @@ export const add = new Command()
       path: opts.path,
     });
 
-    const child = spawn(command, args, {
-      stdio: "inherit",
-    });
-
-    child.on("error", (error) => {
-      logger.error(`Failed to add components: ${error.message}`);
-      process.exit(1);
-    });
-
-    child.on("close", (code) => {
-      if (code !== 0) {
-        logger.error(`Process exited with code ${code}`);
-        process.exit(code || 1);
-      } else {
-        logger.success("Components added successfully!");
+    try {
+      await runSpawn(command, args);
+    } catch (error) {
+      if (error instanceof SpawnExitError) {
+        logger.error(`Process exited with code ${error.code}`);
+        process.exit(error.code);
       }
-    });
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Failed to add components: ${message}`);
+      process.exit(1);
+    }
+
+    logger.success("Components added successfully!");
   });

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,14 +1,13 @@
 import { Command } from "commander";
 import { spawn } from "cross-spawn";
-import path from "node:path";
 import { logger } from "../lib/utils/logger";
 import { hasConfig } from "../lib/utils/config";
 import {
   dlxCommand,
-  resolvePackageManagerName,
+  resolvePackageManager,
+  resolvePackageManagerForCwd,
   type PackageManagerName,
 } from "../lib/create-project";
-import { resolvePackageManager } from "./create";
 
 const REGISTRY_BASE_URL = "https://r.assistant-ui.com";
 
@@ -70,8 +69,8 @@ export const add = new Command()
 
     logger.step(`Adding ${components.length} component(s)...`);
 
-    const packageManager = await resolvePackageManagerName(
-      path.join(opts.cwd, "_"),
+    const packageManager = await resolvePackageManagerForCwd(
+      opts.cwd,
       resolvePackageManager(opts),
     );
     const { command, args } = createAddComponentsPlan({

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -85,7 +85,7 @@ export const add = new Command()
     });
 
     try {
-      await runSpawn(command, args);
+      await runSpawn(command, args, opts.cwd);
     } catch (error) {
       if (error instanceof SpawnExitError) {
         logger.error(`Process exited with code ${error.code}`);

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,9 +1,47 @@
 import { Command } from "commander";
 import { spawn } from "cross-spawn";
+import path from "node:path";
 import { logger } from "../lib/utils/logger";
 import { hasConfig } from "../lib/utils/config";
+import {
+  dlxCommand,
+  resolvePackageManagerName,
+  type PackageManagerName,
+} from "../lib/create-project";
+import { resolvePackageManager } from "./create";
 
 const REGISTRY_BASE_URL = "https://r.assistant-ui.com";
+
+export interface AddComponentsPlan {
+  command: string;
+  args: string[];
+}
+
+export function createAddComponentsPlan(params: {
+  components: string[];
+  packageManager: PackageManagerName;
+  yes?: boolean;
+  overwrite?: boolean;
+  cwd?: string;
+  path?: string;
+}): AddComponentsPlan {
+  const componentsToAdd = params.components.map((c) => {
+    if (!/^[a-zA-Z0-9-/]+$/.test(c)) {
+      throw new Error(`Invalid component name: ${c}`);
+    }
+    return `${REGISTRY_BASE_URL}/${encodeURIComponent(c)}.json`;
+  });
+
+  const [command, dlxArgs] = dlxCommand(params.packageManager);
+  const args = [...dlxArgs, "shadcn@latest", "add", ...componentsToAdd];
+
+  if (params.yes) args.push("--yes");
+  if (params.overwrite) args.push("--overwrite");
+  if (params.cwd) args.push("--cwd", params.cwd);
+  if (params.path) args.push("--path", params.path);
+
+  return { command, args };
+}
 
 export const add = new Command()
   .name("add")
@@ -17,7 +55,11 @@ export const add = new Command()
     process.cwd(),
   )
   .option("-p, --path <path>", "the path to add the component to.")
-  .action((components: string[], opts) => {
+  .option("--use-npm", "explicitly use npm")
+  .option("--use-pnpm", "explicitly use pnpm")
+  .option("--use-yarn", "explicitly use yarn")
+  .option("--use-bun", "explicitly use bun")
+  .action(async (components: string[], opts) => {
     // Check if project is initialized
     if (!hasConfig(opts.cwd)) {
       logger.warn(
@@ -26,25 +68,23 @@ export const add = new Command()
       logger.break();
     }
 
-    const componentsToAdd = components.map((c) => {
-      if (!/^[a-zA-Z0-9-/]+$/.test(c)) {
-        throw new Error(`Invalid component name: ${c}`);
-      }
-      return `${REGISTRY_BASE_URL}/${encodeURIComponent(c)}.json`;
-    });
-
     logger.step(`Adding ${components.length} component(s)...`);
 
-    const args = [`shadcn@latest`, "add", ...componentsToAdd];
+    const packageManager = await resolvePackageManagerName(
+      path.join(opts.cwd, "_"),
+      resolvePackageManager(opts),
+    );
+    const { command, args } = createAddComponentsPlan({
+      components,
+      packageManager,
+      yes: opts.yes,
+      overwrite: opts.overwrite,
+      cwd: opts.cwd,
+      path: opts.path,
+    });
 
-    if (opts.yes) args.push("--yes");
-    if (opts.overwrite) args.push("--overwrite");
-    if (opts.cwd) args.push("--cwd", opts.cwd);
-    if (opts.path) args.push("--path", opts.path);
-
-    const child = spawn("npx", args, {
+    const child = spawn(command, args, {
       stdio: "inherit",
-      shell: true,
     });
 
     child.on("error", (error) => {

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -9,9 +9,9 @@ import {
   dlxCommand,
   downloadProject,
   resolveLatestReleaseRef,
-  resolvePackageManagerName,
+  resolvePackageManager,
+  resolvePackageManagerForCwd,
   transformProject,
-  type PackageManagerName,
 } from "../lib/create-project";
 
 export interface ProjectMetadata {
@@ -384,19 +384,6 @@ export function resolveCreateProjectDirectory(params: {
   return undefined;
 }
 
-export function resolvePackageManager(opts: {
-  useNpm?: boolean;
-  usePnpm?: boolean;
-  useYarn?: boolean;
-  useBun?: boolean;
-}): PackageManagerName | undefined {
-  if (opts.useNpm) return "npm";
-  if (opts.usePnpm) return "pnpm";
-  if (opts.useYarn) return "yarn";
-  if (opts.useBun) return "bun";
-  return undefined;
-}
-
 const PLAYGROUND_PRESET_BASE_URL =
   "https://www.assistant-ui.com/playground/init";
 
@@ -415,12 +402,17 @@ export interface ScaffoldSelectorOptions {
   ink?: boolean;
 }
 
+export type ResolvedScaffoldSelector = Pick<
+  ScaffoldSelectorOptions,
+  "template" | "example" | "preset"
+>;
+
 const scaffoldSelectorHelp =
   "Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.";
 
 export function resolveScaffoldSelector(
   opts: ScaffoldSelectorOptions,
-): Pick<ScaffoldSelectorOptions, "template" | "example"> {
+): ResolvedScaffoldSelector {
   const selectors = [
     opts.template ? "--template" : undefined,
     opts.example ? "--example" : undefined,
@@ -437,7 +429,11 @@ export function resolveScaffoldSelector(
 
   if (opts.native) return { example: "with-expo" };
   if (opts.ink) return { example: "with-react-ink" };
-  return { template: opts.template, example: opts.example };
+  return {
+    ...(opts.template !== undefined && { template: opts.template }),
+    ...(opts.example !== undefined && { example: opts.example }),
+    ...(opts.preset !== undefined && { preset: opts.preset }),
+  };
 }
 
 export const create = new Command()
@@ -465,7 +461,7 @@ export const create = new Command()
   .option("--ink", "create a React Ink terminal project")
   .option("--skip-install", "skip installing packages")
   .action(async (projectDirectory, opts) => {
-    let scaffoldSelector: Pick<ScaffoldSelectorOptions, "template" | "example">;
+    let scaffoldSelector: ResolvedScaffoldSelector;
     try {
       scaffoldSelector = resolveScaffoldSelector(opts);
     } catch (error) {
@@ -534,10 +530,7 @@ export const create = new Command()
     }
 
     // 2. Resolve scaffold target
-    const project = await resolveProject({
-      template: scaffoldSelector.template,
-      example: scaffoldSelector.example,
-    });
+    const project = await resolveProject(scaffoldSelector);
     if (!project) {
       p.cancel("Project creation cancelled.");
       process.exit(0);
@@ -546,8 +539,8 @@ export const create = new Command()
     logger.info(`Creating project from ${project.category}: ${project.label}`);
     logger.break();
 
-    const pm = await resolvePackageManagerName(
-      absoluteProjectDir,
+    const pm = await resolvePackageManagerForCwd(
+      path.dirname(absoluteProjectDir),
       resolvePackageManager(opts),
     );
 
@@ -595,8 +588,8 @@ export const create = new Command()
       }
 
       // 6. Apply preset if provided
-      if (opts.preset) {
-        const presetUrl = resolvePresetUrl(opts.preset);
+      if (scaffoldSelector.preset) {
+        const presetUrl = resolvePresetUrl(scaffoldSelector.preset);
         logger.info("Applying preset configuration...");
         logger.break();
         const [dlxCmd, dlxArgs] = dlxCommand(pm);

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { spawn } from "cross-spawn";
 import fs from "node:fs";
 import path from "node:path";
 import * as p from "@clack/prompts";
@@ -13,6 +12,7 @@ import {
   resolvePackageManagerForCwd,
   transformProject,
 } from "../lib/create-project";
+import { runSpawn, SpawnExitError } from "../lib/run-spawn";
 
 export interface ProjectMetadata {
   name: string;
@@ -342,37 +342,6 @@ export async function resolveProject(params: {
   return meta;
 }
 
-class SpawnExitError extends Error {
-  code: number;
-
-  constructor(code: number) {
-    super(`Process exited with code ${code}`);
-    this.code = code;
-  }
-}
-
-async function runSpawn(
-  command: string,
-  args: string[],
-  cwd?: string,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      stdio: "inherit",
-      cwd,
-    });
-
-    child.on("error", (error) => reject(error));
-    child.on("close", (code) => {
-      if (code !== 0) {
-        reject(new SpawnExitError(code || 1));
-      } else {
-        resolve();
-      }
-    });
-  });
-}
-
 export function resolveCreateProjectDirectory(params: {
   projectDirectory?: string;
   stdinIsTTY?: boolean;
@@ -420,7 +389,7 @@ export function resolveScaffoldSelector(
     opts.example !== undefined ? "--example" : undefined,
     opts.native ? "--native" : undefined,
     opts.ink ? "--ink" : undefined,
-  ].filter(Boolean);
+  ].filter((selector): selector is string => selector !== undefined);
 
   if (selectors.length > 1) {
     throw new Error(

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -407,6 +407,39 @@ export function resolvePresetUrl(preset: string): string {
   return `${PLAYGROUND_PRESET_BASE_URL}?preset=${encodeURIComponent(preset)}`;
 }
 
+export interface ScaffoldSelectorOptions {
+  template?: string;
+  example?: string;
+  preset?: string;
+  native?: boolean;
+  ink?: boolean;
+}
+
+const scaffoldSelectorHelp =
+  "Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.";
+
+export function resolveScaffoldSelector(
+  opts: ScaffoldSelectorOptions,
+): Pick<ScaffoldSelectorOptions, "template" | "example"> {
+  const selectors = [
+    opts.template ? "--template" : undefined,
+    opts.example ? "--example" : undefined,
+    opts.preset ? "--preset" : undefined,
+    opts.native ? "--native" : undefined,
+    opts.ink ? "--ink" : undefined,
+  ].filter(Boolean);
+
+  if (selectors.length > 1) {
+    throw new Error(
+      `Only one scaffold selector can be provided (${selectors.join(", ")}). ${scaffoldSelectorHelp}`,
+    );
+  }
+
+  if (opts.native) return { example: "with-expo" };
+  if (opts.ink) return { example: "with-react-ink" };
+  return { template: opts.template, example: opts.example };
+}
+
 export const create = new Command()
   .name("create")
   .description("create a new project")
@@ -432,21 +465,12 @@ export const create = new Command()
   .option("--ink", "create a React Ink terminal project")
   .option("--skip-install", "skip installing packages")
   .action(async (projectDirectory, opts) => {
-    if (opts.native) {
-      opts.example = "with-expo";
-    }
-
-    if (opts.ink) {
-      opts.example = "with-react-ink";
-    }
-
-    if (opts.example && opts.preset) {
-      logger.error("Cannot use --preset with --example.");
-      process.exit(1);
-    }
-
-    if (opts.template && opts.example) {
-      logger.error("Cannot use both --template and --example.");
+    let scaffoldSelector: Pick<ScaffoldSelectorOptions, "template" | "example">;
+    try {
+      scaffoldSelector = resolveScaffoldSelector(opts);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(message);
       process.exit(1);
     }
 
@@ -511,8 +535,8 @@ export const create = new Command()
 
     // 2. Resolve scaffold target
     const project = await resolveProject({
-      template: opts.template,
-      example: opts.example,
+      template: scaffoldSelector.template,
+      example: scaffoldSelector.example,
     });
     if (!project) {
       p.cancel("Project creation cancelled.");

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -276,7 +276,7 @@ export async function resolveProject(params: {
     isCancel = p.isCancel,
   } = params;
 
-  if (template) {
+  if (template !== undefined) {
     const meta = PROJECT_METADATA.find(
       (m) => m.name === template && m.category === "template",
     );
@@ -288,7 +288,7 @@ export async function resolveProject(params: {
     return meta;
   }
 
-  if (example) {
+  if (example !== undefined) {
     const meta = PROJECT_METADATA.find(
       (m) => m.name === example && m.category === "example",
     );
@@ -402,21 +402,22 @@ export interface ScaffoldSelectorOptions {
   ink?: boolean;
 }
 
-export type ResolvedScaffoldSelector = Pick<
-  ScaffoldSelectorOptions,
-  "template" | "example" | "preset"
->;
+export interface ResolvedScaffoldSelector {
+  template?: string;
+  example?: string;
+  preset?: string;
+}
 
 const scaffoldSelectorHelp =
-  "Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.";
+  "Choose one scaffold selector: --template <name>, --example <name>, --native, or --ink. --preset <name-or-url> can be used with --template or by itself.";
 
 export function resolveScaffoldSelector(
   opts: ScaffoldSelectorOptions,
 ): ResolvedScaffoldSelector {
+  const hasPreset = opts.preset !== undefined;
   const selectors = [
-    opts.template ? "--template" : undefined,
-    opts.example ? "--example" : undefined,
-    opts.preset ? "--preset" : undefined,
+    opts.template !== undefined ? "--template" : undefined,
+    opts.example !== undefined ? "--example" : undefined,
     opts.native ? "--native" : undefined,
     opts.ink ? "--ink" : undefined,
   ].filter(Boolean);
@@ -427,12 +428,23 @@ export function resolveScaffoldSelector(
     );
   }
 
+  if (hasPreset && (opts.example !== undefined || opts.native || opts.ink)) {
+    throw new Error(
+      `Cannot use --preset with ${selectors[0]}. ${scaffoldSelectorHelp}`,
+    );
+  }
+
   if (opts.native) return { example: "with-expo" };
   if (opts.ink) return { example: "with-react-ink" };
+
+  if (opts.preset !== undefined && opts.template === undefined) {
+    return { template: "default", preset: opts.preset };
+  }
+
   return {
     ...(opts.template !== undefined && { template: opts.template }),
     ...(opts.example !== undefined && { example: opts.example }),
-    ...(opts.preset !== undefined && { preset: opts.preset }),
+    ...(hasPreset && { preset: opts.preset }),
   };
 }
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -380,10 +380,18 @@ export interface ResolvedScaffoldSelector {
 const scaffoldSelectorHelp =
   "Choose one scaffold selector: --template <name>, --example <name>, --native, or --ink. --preset <name-or-url> can be used with --template or by itself.";
 
+function getPresetConflict(opts: ScaffoldSelectorOptions): string | undefined {
+  if (opts.example !== undefined) return "--example";
+  if (opts.native) return "--native";
+  if (opts.ink) return "--ink";
+  return undefined;
+}
+
 export function resolveScaffoldSelector(
   opts: ScaffoldSelectorOptions,
 ): ResolvedScaffoldSelector {
   const hasPreset = opts.preset !== undefined;
+  const presetConflict = getPresetConflict(opts);
   const selectors = [
     opts.template !== undefined ? "--template" : undefined,
     opts.example !== undefined ? "--example" : undefined,
@@ -397,9 +405,9 @@ export function resolveScaffoldSelector(
     );
   }
 
-  if (hasPreset && (opts.example !== undefined || opts.native || opts.ink)) {
+  if (hasPreset && presetConflict) {
     throw new Error(
-      `Cannot use --preset with ${selectors[0]}. ${scaffoldSelectorHelp}`,
+      `Cannot use --preset with ${presetConflict}. ${scaffoldSelectorHelp}`,
     );
   }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,5 +1,4 @@
 import { Command, Option } from "commander";
-import { spawn } from "cross-spawn";
 import fs from "node:fs";
 import path from "node:path";
 import {
@@ -7,20 +6,12 @@ import {
   resolvePackageManager,
   resolvePackageManagerForCwd,
 } from "../lib/create-project";
+import { runSpawn, SpawnExitError } from "../lib/run-spawn";
 import { logger } from "../lib/utils/logger";
 import { create } from "./create";
 
 const DEFAULT_REGISTRY_URL =
   "https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json";
-
-class SpawnExitError extends Error {
-  code: number;
-
-  constructor(code: number) {
-    super(`Process exited with code ${code}`);
-    this.code = code;
-  }
-}
 
 interface ExistingProjectInitPlan {
   initArgs: string[] | null;
@@ -54,31 +45,6 @@ export function isNonInteractiveShell(
   stdinIsTTY = process.stdin.isTTY,
 ): boolean {
   return !stdinIsTTY;
-}
-
-async function runSpawn(
-  command: string,
-  args: string[],
-  cwd: string,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      stdio: "inherit",
-      cwd,
-    });
-
-    child.on("error", (error) => {
-      reject(error);
-    });
-
-    child.on("close", (code) => {
-      if (code !== 0) {
-        reject(new SpawnExitError(code || 1));
-      } else {
-        resolve();
-      }
-    });
-  });
 }
 
 export const init = new Command()

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,9 +2,13 @@ import { Command, Option } from "commander";
 import { spawn } from "cross-spawn";
 import fs from "node:fs";
 import path from "node:path";
-import { dlxCommand, resolvePackageManagerName } from "../lib/create-project";
+import {
+  dlxCommand,
+  resolvePackageManager,
+  resolvePackageManagerForCwd,
+} from "../lib/create-project";
 import { logger } from "../lib/utils/logger";
-import { create, resolvePackageManager } from "./create";
+import { create } from "./create";
 
 const DEFAULT_REGISTRY_URL =
   "https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json";
@@ -152,11 +156,8 @@ export const init = new Command()
     }
 
     try {
-      // resolvePackageManagerName calls detect({ cwd: path.dirname(dir) }),
-      // which is designed for `create` where the dir doesn't exist yet.
-      // For init, targetDir IS the project root, so append a dummy segment.
-      const pm = await resolvePackageManagerName(
-        path.join(targetDir, "_"),
+      const pm = await resolvePackageManagerForCwd(
+        targetDir,
         resolvePackageManager(opts),
       );
       const [dlxCmd, dlxArgs] = dlxCommand(pm);

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -362,6 +362,8 @@ async function installShadcnRegistry(
   pm: PackageManagerName,
 ): Promise<void> {
   const [cmd, dlxArgs] = dlxCommand(pm);
+  // For npm, dlxArgs may already include `--yes` for npx auto-install.
+  // The trailing `--yes` is for shadcn's own confirmation prompt.
   const addArgs = [...dlxArgs, "shadcn@latest", "add", ...components, "--yes"];
 
   try {

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -1,10 +1,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { downloadTemplate } from "giget";
-import { spawn } from "cross-spawn";
 import { sync as globSync } from "glob";
 import { detect } from "detect-package-manager";
 import { logger } from "./utils/logger";
+import { runSpawn, SpawnExitError } from "./run-spawn";
 
 export type PackageManagerName = "npm" | "pnpm" | "yarn" | "bun";
 
@@ -344,25 +344,15 @@ async function installDependencies(
   pm: PackageManagerName,
 ): Promise<void> {
   const args = pm === "yarn" ? [] : ["install"];
-
-  return new Promise((resolve, reject) => {
-    const child = spawn(pm, args, {
-      cwd: projectDir,
-      stdio: "inherit",
-    });
-
-    child.on("error", (error) => {
-      reject(new Error(`Failed to install dependencies: ${error.message}`));
-    });
-
-    child.on("close", (code) => {
-      if (code !== 0) {
-        reject(new Error(`${pm} install exited with code ${code}`));
-      } else {
-        resolve();
-      }
-    });
-  });
+  try {
+    await runSpawn(pm, args, projectDir);
+  } catch (error) {
+    if (error instanceof SpawnExitError) {
+      throw new Error(`${pm} install exited with code ${error.code}`);
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to install dependencies: ${message}`);
+  }
 }
 
 async function installShadcnRegistry(
@@ -372,27 +362,19 @@ async function installShadcnRegistry(
   pm: PackageManagerName,
 ): Promise<void> {
   const [cmd, dlxArgs] = dlxCommand(pm);
-  return new Promise((resolve, reject) => {
-    const child = spawn(
-      cmd,
-      [...dlxArgs, "shadcn@latest", "add", ...components, "--yes"],
-      {
-        cwd: projectDir,
-        stdio: "inherit",
-      },
-    );
+  const addArgs = [...dlxArgs, "shadcn@latest", "add", ...components, "--yes"];
 
-    child.on("error", (error) => {
-      reject(new Error(`Failed to install ${label}: ${error.message}`));
-    });
+  try {
+    await runSpawn(cmd, addArgs, projectDir);
+  } catch (error) {
+    if (error instanceof SpawnExitError) {
+      logger.warn(
+        `shadcn exited with code ${error.code}. Run the following to retry:\n  ${cmd} ${addArgs.slice(0, -1).join(" ")}`,
+      );
+      return;
+    }
 
-    child.on("close", (code) => {
-      if (code !== 0) {
-        logger.warn(
-          `shadcn exited with code ${code}. Run the following to retry:\n  ${cmd} ${[...dlxArgs, "shadcn@latest", "add", ...components].join(" ")}`,
-        );
-      }
-      resolve();
-    });
-  });
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to install ${label}: ${message}`);
+  }
 }

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -27,6 +27,19 @@ export interface TransformOptions {
   packageManager: PackageManagerName;
 }
 
+export function resolvePackageManager(opts: {
+  useNpm?: boolean;
+  usePnpm?: boolean;
+  useYarn?: boolean;
+  useBun?: boolean;
+}): PackageManagerName | undefined {
+  if (opts.useNpm) return "npm";
+  if (opts.usePnpm) return "pnpm";
+  if (opts.useYarn) return "yarn";
+  if (opts.useBun) return "bun";
+  return undefined;
+}
+
 export async function resolveLatestReleaseRef(): Promise<string | undefined> {
   try {
     const res = await fetch(
@@ -99,15 +112,15 @@ function detectFromUserAgent(): PackageManagerName | undefined {
   return undefined;
 }
 
-export async function resolvePackageManagerName(
-  projectDir: string,
+export async function resolvePackageManagerForCwd(
+  cwd: string,
   packageManager?: PackageManagerName,
 ): Promise<PackageManagerName> {
   if (packageManager) return packageManager;
   const fromAgent = detectFromUserAgent();
   if (fromAgent) return fromAgent;
   try {
-    return await detect({ cwd: path.dirname(projectDir) });
+    return await detect({ cwd });
   } catch {
     return "npm";
   }

--- a/packages/cli/src/lib/run-spawn.ts
+++ b/packages/cli/src/lib/run-spawn.ts
@@ -1,0 +1,32 @@
+import { spawn } from "cross-spawn";
+
+export class SpawnExitError extends Error {
+  code: number;
+
+  constructor(code: number) {
+    super(`Process exited with code ${code}`);
+    this.code = code;
+  }
+}
+
+export function runSpawn(
+  command: string,
+  args: string[],
+  cwd?: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+      cwd,
+    });
+
+    child.on("error", (error) => reject(error));
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new SpawnExitError(code || 1));
+      } else {
+        resolve();
+      }
+    });
+  });
+}

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { add, createAddComponentsPlan } from "../../src/commands/add";
+
+describe("add command", () => {
+  it("exposes package manager override options", () => {
+    expect(
+      add.options.find((option) => option.long === "--use-npm"),
+    ).toBeDefined();
+    expect(
+      add.options.find((option) => option.long === "--use-pnpm"),
+    ).toBeDefined();
+    expect(
+      add.options.find((option) => option.long === "--use-yarn"),
+    ).toBeDefined();
+    expect(
+      add.options.find((option) => option.long === "--use-bun"),
+    ).toBeDefined();
+  });
+});
+
+describe("createAddComponentsPlan", () => {
+  it("uses npx --yes for npm", () => {
+    expect(
+      createAddComponentsPlan({
+        components: ["thread"],
+        packageManager: "npm",
+        yes: true,
+        cwd: "/repo",
+      }),
+    ).toEqual({
+      command: "npx",
+      args: [
+        "--yes",
+        "shadcn@latest",
+        "add",
+        "https://r.assistant-ui.com/thread.json",
+        "--yes",
+        "--cwd",
+        "/repo",
+      ],
+    });
+  });
+
+  it("uses pnpm dlx for pnpm", () => {
+    expect(
+      createAddComponentsPlan({
+        components: ["thread", "markdown-text"],
+        packageManager: "pnpm",
+        overwrite: true,
+        cwd: "/repo",
+        path: "components/assistant-ui",
+      }),
+    ).toEqual({
+      command: "pnpm",
+      args: [
+        "dlx",
+        "shadcn@latest",
+        "add",
+        "https://r.assistant-ui.com/thread.json",
+        "https://r.assistant-ui.com/markdown-text.json",
+        "--overwrite",
+        "--cwd",
+        "/repo",
+        "--path",
+        "components/assistant-ui",
+      ],
+    });
+  });
+
+  it("uses bunx for bun", () => {
+    expect(
+      createAddComponentsPlan({
+        components: ["thread"],
+        packageManager: "bun",
+      }),
+    ).toEqual({
+      command: "bunx",
+      args: [
+        "shadcn@latest",
+        "add",
+        "https://r.assistant-ui.com/thread.json",
+      ],
+    });
+  });
+
+  it("rejects invalid component names", () => {
+    expect(() =>
+      createAddComponentsPlan({
+        components: ["../thread"],
+        packageManager: "pnpm",
+      }),
+    ).toThrow("Invalid component name: ../thread");
+  });
+});

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -75,11 +75,7 @@ describe("createAddComponentsPlan", () => {
       }),
     ).toEqual({
       command: "bunx",
-      args: [
-        "shadcn@latest",
-        "add",
-        "https://r.assistant-ui.com/thread.json",
-      ],
+      args: ["shadcn@latest", "add", "https://r.assistant-ui.com/thread.json"],
     });
   });
 

--- a/packages/cli/test/commands/create.test.ts
+++ b/packages/cli/test/commands/create.test.ts
@@ -129,9 +129,7 @@ describe("resolveScaffoldSelector", () => {
   });
 
   it("rejects --native with --ink", () => {
-    expect(() =>
-      resolveScaffoldSelector({ native: true, ink: true }),
-    ).toThrow(
+    expect(() => resolveScaffoldSelector({ native: true, ink: true })).toThrow(
       "Only one scaffold selector can be provided (--native, --ink). Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.",
     );
   });

--- a/packages/cli/test/commands/create.test.ts
+++ b/packages/cli/test/commands/create.test.ts
@@ -128,6 +128,12 @@ describe("resolveScaffoldSelector", () => {
     });
   });
 
+  it("keeps --preset on the resolved selector", () => {
+    expect(resolveScaffoldSelector({ preset: "chatgpt" })).toEqual({
+      preset: "chatgpt",
+    });
+  });
+
   it("rejects --native with --ink", () => {
     expect(() => resolveScaffoldSelector({ native: true, ink: true })).toThrow(
       "Only one scaffold selector can be provided (--native, --ink). Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.",

--- a/packages/cli/test/commands/create.test.ts
+++ b/packages/cli/test/commands/create.test.ts
@@ -153,6 +153,17 @@ describe("resolveScaffoldSelector", () => {
     );
   });
 
+  it("rejects --template with --example", () => {
+    expect(() =>
+      resolveScaffoldSelector({
+        template: "default",
+        example: "with-ai-sdk-v6",
+      }),
+    ).toThrow(
+      "Only one scaffold selector can be provided (--template, --example). Choose one scaffold selector: --template <name>, --example <name>, --native, or --ink. --preset <name-or-url> can be used with --template or by itself.",
+    );
+  });
+
   it("rejects --ink with --template", () => {
     expect(() =>
       resolveScaffoldSelector({ ink: true, template: "default" }),

--- a/packages/cli/test/commands/create.test.ts
+++ b/packages/cli/test/commands/create.test.ts
@@ -4,6 +4,7 @@ import {
   resolveCreateProjectDirectory,
   resolvePresetUrl,
   resolveProject,
+  resolveScaffoldSelector,
   PROJECT_METADATA,
 } from "../../src/commands/create";
 
@@ -111,6 +112,63 @@ describe("resolveProject", () => {
       isCancel,
     });
     expect(result).toBeNull();
+  });
+});
+
+describe("resolveScaffoldSelector", () => {
+  it("maps --native to the Expo example", () => {
+    expect(resolveScaffoldSelector({ native: true })).toEqual({
+      example: "with-expo",
+    });
+  });
+
+  it("maps --ink to the React Ink example", () => {
+    expect(resolveScaffoldSelector({ ink: true })).toEqual({
+      example: "with-react-ink",
+    });
+  });
+
+  it("rejects --native with --ink", () => {
+    expect(() =>
+      resolveScaffoldSelector({ native: true, ink: true }),
+    ).toThrow(
+      "Only one scaffold selector can be provided (--native, --ink). Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.",
+    );
+  });
+
+  it("rejects --native with --example", () => {
+    expect(() =>
+      resolveScaffoldSelector({ native: true, example: "with-tanstack" }),
+    ).toThrow(
+      "Only one scaffold selector can be provided (--example, --native). Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.",
+    );
+  });
+
+  it("rejects --ink with --template", () => {
+    expect(() =>
+      resolveScaffoldSelector({ ink: true, template: "default" }),
+    ).toThrow(
+      "Only one scaffold selector can be provided (--template, --ink). Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.",
+    );
+  });
+
+  it("rejects --preset with --template", () => {
+    expect(() =>
+      resolveScaffoldSelector({ preset: "chatgpt", template: "minimal" }),
+    ).toThrow(
+      "Only one scaffold selector can be provided (--template, --preset). Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.",
+    );
+  });
+
+  it("rejects --preset with --example", () => {
+    expect(() =>
+      resolveScaffoldSelector({
+        preset: "chatgpt",
+        example: "with-ai-sdk-v6",
+      }),
+    ).toThrow(
+      "Only one scaffold selector can be provided (--example, --preset). Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.",
+    );
   });
 });
 

--- a/packages/cli/test/commands/create.test.ts
+++ b/packages/cli/test/commands/create.test.ts
@@ -116,6 +116,10 @@ describe("resolveProject", () => {
 });
 
 describe("resolveScaffoldSelector", () => {
+  it("returns an empty selector when no scaffold selector is provided", () => {
+    expect(resolveScaffoldSelector({})).toEqual({});
+  });
+
   it("maps --native to the Expo example", () => {
     expect(resolveScaffoldSelector({ native: true })).toEqual({
       example: "with-expo",
@@ -128,15 +132,16 @@ describe("resolveScaffoldSelector", () => {
     });
   });
 
-  it("keeps --preset on the resolved selector", () => {
+  it("uses the default template when only --preset is provided", () => {
     expect(resolveScaffoldSelector({ preset: "chatgpt" })).toEqual({
+      template: "default",
       preset: "chatgpt",
     });
   });
 
   it("rejects --native with --ink", () => {
     expect(() => resolveScaffoldSelector({ native: true, ink: true })).toThrow(
-      "Only one scaffold selector can be provided (--native, --ink). Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.",
+      "Only one scaffold selector can be provided (--native, --ink). Choose one scaffold selector: --template <name>, --example <name>, --native, or --ink. --preset <name-or-url> can be used with --template or by itself.",
     );
   });
 
@@ -144,7 +149,7 @@ describe("resolveScaffoldSelector", () => {
     expect(() =>
       resolveScaffoldSelector({ native: true, example: "with-tanstack" }),
     ).toThrow(
-      "Only one scaffold selector can be provided (--example, --native). Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.",
+      "Only one scaffold selector can be provided (--example, --native). Choose one scaffold selector: --template <name>, --example <name>, --native, or --ink. --preset <name-or-url> can be used with --template or by itself.",
     );
   });
 
@@ -152,16 +157,17 @@ describe("resolveScaffoldSelector", () => {
     expect(() =>
       resolveScaffoldSelector({ ink: true, template: "default" }),
     ).toThrow(
-      "Only one scaffold selector can be provided (--template, --ink). Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.",
+      "Only one scaffold selector can be provided (--template, --ink). Choose one scaffold selector: --template <name>, --example <name>, --native, or --ink. --preset <name-or-url> can be used with --template or by itself.",
     );
   });
 
-  it("rejects --preset with --template", () => {
-    expect(() =>
+  it("allows --preset with --template", () => {
+    expect(
       resolveScaffoldSelector({ preset: "chatgpt", template: "minimal" }),
-    ).toThrow(
-      "Only one scaffold selector can be provided (--template, --preset). Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.",
-    );
+    ).toEqual({
+      template: "minimal",
+      preset: "chatgpt",
+    });
   });
 
   it("rejects --preset with --example", () => {
@@ -171,7 +177,29 @@ describe("resolveScaffoldSelector", () => {
         example: "with-ai-sdk-v6",
       }),
     ).toThrow(
-      "Only one scaffold selector can be provided (--example, --preset). Choose one of: --template <name>, --example <name>, --preset <name-or-url>, --native, or --ink.",
+      "Cannot use --preset with --example. Choose one scaffold selector: --template <name>, --example <name>, --native, or --ink. --preset <name-or-url> can be used with --template or by itself.",
+    );
+  });
+
+  it("rejects --preset with --native", () => {
+    expect(() =>
+      resolveScaffoldSelector({
+        preset: "chatgpt",
+        native: true,
+      }),
+    ).toThrow(
+      "Cannot use --preset with --native. Choose one scaffold selector: --template <name>, --example <name>, --native, or --ink. --preset <name-or-url> can be used with --template or by itself.",
+    );
+  });
+
+  it("rejects --preset with --ink", () => {
+    expect(() =>
+      resolveScaffoldSelector({
+        preset: "chatgpt",
+        ink: true,
+      }),
+    ).toThrow(
+      "Cannot use --preset with --ink. Choose one scaffold selector: --template <name>, --example <name>, --native, or --ink. --preset <name-or-url> can be used with --template or by itself.",
     );
   });
 });
@@ -196,9 +224,23 @@ describe("resolveProject error handling", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
+  it("--template rejects an empty name", async () => {
+    await expect(
+      resolveProject({ template: "", stdinIsTTY: true }),
+    ).rejects.toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
   it("--example rejects a template name", async () => {
     await expect(
       resolveProject({ example: "cloud", stdinIsTTY: true }),
+    ).rejects.toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("--example rejects an empty name", async () => {
+    await expect(
+      resolveProject({ example: "", stdinIsTTY: true }),
     ).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(1);
   });


### PR DESCRIPTION
## Summary

- Improve `assistant-ui create` scaffold selector validation while preserving `--native` / `--ink` shortcuts and preset overlay behavior
- Make `assistant-ui add` respect detected or explicitly selected package managers instead of always using `npx`
- Share spawn and package-manager helpers across CLI commands, add focused tests, and refresh README examples

## Testing

- `pnpm --filter assistant-ui test`