### PR TITLE
fix(react|safe-content-frame): handle MCP-UI 2026-01-26 method names + guard onload

### DIFF
--- a/.changeset/mcp-ui-ungroup.md
+++ b/.changeset/mcp-ui-ungroup.md
@@ -1,5 +1,0 @@
----
-"@assistant-ui/react": patch
----
-
-feat(react): export `getMcpAppFromToolPart` so hosts can detect MCP-app tool parts

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -33,7 +33,7 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.14.3",
+    "@assistant-ui/react": "^0.14.5",
     "@assistant-ui/tap": "^0.5.11",
     "@types/react": "*",
     "@types/react-dom": "*",

--- a/packages/react-lexical/package.json
+++ b/packages/react-lexical/package.json
@@ -39,7 +39,7 @@
     "lexical": "^0.44.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.14.3",
+    "@assistant-ui/react": "^0.14.5",
     "@assistant-ui/core": "^0.2.2",
     "@assistant-ui/store": "*",
     "@types/react": "*",

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -45,7 +45,7 @@
     "react-markdown": "^10.1.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.14.3",
+    "@assistant-ui/react": "^0.14.5",
     "@types/react": "*",
     "react": "^18 || ^19"
   },

--- a/packages/react-opencode/package.json
+++ b/packages/react-opencode/package.json
@@ -49,7 +49,7 @@
     "@opencode-ai/sdk": "^1.14.39"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.14.3",
+    "@assistant-ui/react": "^0.14.5",
     "@types/react": "*",
     "react": "^18 || ^19"
   },

--- a/packages/react-streamdown/package.json
+++ b/packages/react-streamdown/package.json
@@ -40,7 +40,7 @@
     "streamdown": "^2.5.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.14.3",
+    "@assistant-ui/react": "^0.14.5",
     "@streamdown/code": "^1.0.0",
     "@streamdown/cjk": "^1.0.0",
     "@streamdown/math": "^1.0.0",

--- a/packages/react-syntax-highlighter/package.json
+++ b/packages/react-syntax-highlighter/package.json
@@ -37,7 +37,7 @@
     "build": "aui-build"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.14.3",
+    "@assistant-ui/react": "^0.14.5",
     "@assistant-ui/react-markdown": "^0.14.0",
     "@types/react": "*",
     "@types/react-syntax-highlighter": "*",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @assistant-ui/react
 
+## 0.14.5
+
+### Patch Changes
+
+- Accept the MCP-UI `2026-01-26` method names in the MCP App bridge (e.g. `ui/notifications/size-changed`, `ui/request-display-mode`, `ui/open-link`, `ui/message`). Widgets built with the current xmcp host-bridge emit these names; previously the host silently ignored them, leaving features like auto-resize broken (iframe never received a height change from `onSizeChange`).
+
+## 0.14.4
+
+### Patch Changes
+
+- [#4033](https://github.com/assistant-ui/assistant-ui/pull/4033) [`552ffb0`](https://github.com/assistant-ui/assistant-ui/commit/552ffb0ed145f2e2a57db910b99dac5d5b834626) - feat(react): export `getMcpAppFromToolPart` so hosts can detect MCP-app tool parts ([@Yonom](https://github.com/Yonom))
+
+- Updated dependencies []:
+  - safe-content-frame@0.0.19
+
 ## 0.14.3
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react",
-  "version": "0.14.3",
+  "version": "0.14.5",
   "description": "Open-source TypeScript/React library for building production-grade AI chat experiences",
   "keywords": [
     "radix-ui",
@@ -69,7 +69,7 @@
     "nanoid": "^5.1.11",
     "radix-ui": "^1.4.3",
     "react-textarea-autosize": "^8.5.9",
-    "safe-content-frame": "^0.0.18",
+    "safe-content-frame": "^0.0.19",
     "zod": "^4.4.3",
     "zustand": "^5.0.13"
   },

--- a/packages/react/src/mcp-apps/bridge.ts
+++ b/packages/react/src/mcp-apps/bridge.ts
@@ -42,6 +42,22 @@ const DEFAULT_HOST_INFO: McpAppHostInfo = {
   version: "0.1",
 };
 
+// Accept both the legacy method names and the MCP-UI 2026-01-26 names that
+// `ui/*` capable widgets (e.g. xmcp's host-bridge) emit. Normalize on input
+// so downstream switch statements only need to know the legacy names.
+const METHOD_ALIASES: Record<string, string> = {
+  "ui/notifications/initialized": "notifications/initialized",
+  "ui/notifications/size-changed": "notifications/size_changed",
+  "ui/request-display-mode": "requestDisplayMode",
+  "ui/open-link": "openLink",
+  "ui/update-model-context": "updateModelContext",
+  "ui/message": "sendMessage",
+  "notifications/message": "notifications/log",
+};
+
+const normalizeMethod = (method: string): string =>
+  METHOD_ALIASES[method] ?? method;
+
 const JSONRPC_ERROR = {
   parseError: -32700,
   invalidRequest: -32600,
@@ -118,7 +134,7 @@ export function createMcpAppBridge(
     try {
       const params = req.params;
 
-      switch (req.method) {
+      switch (normalizeMethod(req.method)) {
         case "ui/initialize": {
           respond(req.id, {
             result: {
@@ -356,7 +372,7 @@ export function createMcpAppBridge(
   };
 
   const handleNotification = (note: McpAppJsonRpcNotification) => {
-    switch (note.method) {
+    switch (normalizeMethod(note.method)) {
       case "notifications/initialized": {
         handlers.onInitialized?.();
         return;

--- a/packages/safe-content-frame/CHANGELOG.md
+++ b/packages/safe-content-frame/CHANGELOG.md
@@ -1,5 +1,11 @@
 # safe-content-frame
 
+## 0.0.19
+
+### Patch Changes
+
+- Guard the iframe `onload` handler against firing twice. When the browser fires `load` for both the initial about:blank and the navigated shim URL, the second invocation tried to transfer an already-transferred `MessagePort`, throwing `"Failed to execute 'postMessage' on 'Window': Port at index 0 is already neutered."` and leaving the real shim without a working back-channel (breaking auto-resize and any other host↔widget messaging).
+
 ## 0.0.18
 
 ### Patch Changes

--- a/packages/safe-content-frame/package.json
+++ b/packages/safe-content-frame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-content-frame",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Secure iframe rendering for untrusted content using SafeContentFrame",
   "keywords": [
     "iframe",

--- a/packages/safe-content-frame/src/index.ts
+++ b/packages/safe-content-frame/src/index.ts
@@ -156,7 +156,10 @@ export class SafeContentFrame {
         else if (e.data?.type === "error") reject(new Error(e.data.message));
       };
 
+      let loadHandled = false;
       iframe.onload = () => {
+        if (loadHandled) return;
+        loadHandled = true;
         iframe.contentWindow?.postMessage(
           {
             body: content.buffer.slice(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2998,7 +2998,7 @@ importers:
         specifier: ^8.5.9
         version: 8.5.9(@types/react@19.2.14)(react@19.2.5)
       safe-content-frame:
-        specifier: ^0.0.18
+        specifier: ^0.0.19
         version: link:../safe-content-frame
       zod:
         specifier: ^4.4.3


### PR DESCRIPTION
## Summary

- MCP App bridge now aliases the MCP-UI `2026-01-26` method names (`ui/notifications/size-changed`, `ui/request-display-mode`, `ui/open-link`, `ui/update-model-context`, `ui/message`, `notifications/message`) to the legacy names the switch statements already handle. Widgets built with the current xmcp host-bridge emit `ui/*`; previously the host silently ignored them, leaving auto-resize and other host↔widget messaging broken.
- `SafeContentFrame.iframe.onload` now ignores the second invocation. Browsers fire `load` for both the initial `about:blank` and the navigated shim URL; the second call tried to transfer an already-transferred `MessagePort`, throwing `"Port at index 0 is already neutered."` and leaving the real shim without a working back-channel.
- Releases `@assistant-ui/react@0.14.5` and `safe-content-frame@0.0.19`. Provenance stays enabled (the disablement that landed in #4029 is unrelated to this code change — investigating the underlying npm publish OIDC failure separately).

## Test plan

- [ ] Verify in a host using xmcp host-bridge that auto-resize works again (size notifications reach the host).
- [ ] CI green.