### PR TITLE
chore: enforce 1-day minimum package release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,3 +24,16 @@ onlyBuiltDependencies:
 strictDepBuilds: true
 
 verifyDepsBeforeRun: install
+
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@assistant-ui/*'
+  - assistant-cloud
+  - assistant-stream
+  - assistant-ui
+  - create-assistant-ui
+  - heat-graph
+  - mcp-app-studio
+  - safe-content-frame
+  - tw-glass
+  - tw-shimmer


### PR DESCRIPTION
## Summary
- Sets pnpm \`minimumReleaseAge: 1440\` (24h) to block installs of just-published npm versions — mitigates fast-moving supply-chain attacks like Shai-Hulud.
- Excludes our own workspace packages (\`@assistant-ui/*\` and the unscoped published ones) so internal releases aren't blocked.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)