### PR TITLE
feat(react-langchain): parity with react-langgraph (path to deprecation)

### DIFF
--- a/.changeset/react-langchain-parity.md
+++ b/.changeset/react-langchain-parity.md
@@ -1,0 +1,20 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): parity options + send hooks (toward deprecating `react-langgraph`)
+
+- Adds `autoCancelPendingToolCalls` (default `true`): when a new user
+  message is submitted while previous tool calls are still pending,
+  automatically submit `tool` messages cancelling them so the agent's
+  tool-call accounting stays consistent.
+- Adds `unstable_allowCancellation`: when set, surfaces a Cancel
+  button that calls `useStream().stop()`. Off by default (mirrors the
+  legacy `react-langgraph` behaviour).
+- Adds `unstable_threadListAdapter`: custom `RemoteThreadListAdapter`
+  override for self-hosted persistence (takes precedence over `cloud`).
+- Adds `create` and `delete` options, forwarded to the underlying
+  `useCloudThreadListAdapter`.
+- Adds `useLangChainSend()` and `useLangChainSendCommand()` parity
+  helpers for migrating away from `useLangGraphSend` /
+  `useLangGraphSendCommand`.

--- a/.changeset/react-langchain-parity.md
+++ b/.changeset/react-langchain-parity.md
@@ -8,9 +8,8 @@ feat(react-langchain): parity options + send hooks (toward deprecating `react-la
   message is submitted while previous tool calls are still pending,
   automatically submit `tool` messages cancelling them so the agent's
   tool-call accounting stays consistent.
-- Adds `unstable_allowCancellation`: when set, surfaces a Cancel
-  button that calls `useStream().stop()`. Off by default (mirrors the
-  legacy `react-langgraph` behaviour).
+- Adds `unstable_allowCancellation`: routes the Cancel button to
+  `useStream().stop()`. On by default; pass `false` to disable.
 - Adds `unstable_threadListAdapter`: custom `RemoteThreadListAdapter`
   override for self-hosted persistence (takes precedence over `cloud`).
 - Adds `create` and `delete` options, forwarded to the underlying

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -4,7 +4,7 @@ import type { useExternalMessageConverter } from "@assistant-ui/core/react";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
 import type { LangChainBaseMessage, LangChainContentBlock } from "./types";
 
-const getMessageType = (message: LangChainBaseMessage): string => {
+export const getMessageType = (message: LangChainBaseMessage): string => {
   if (typeof message._getType === "function") return message._getType();
   if ("type" in message)
     return (message as Record<string, unknown>).type as string;

--- a/packages/react-langchain/src/index.ts
+++ b/packages/react-langchain/src/index.ts
@@ -1,6 +1,8 @@
 export {
   useStreamRuntime,
   useLangChainInterruptState,
+  useLangChainSend,
+  useLangChainSendCommand,
   useLangChainState,
   useLangChainSubmit,
 } from "./useStreamRuntime";

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -5,6 +5,7 @@ import type {
   AppendMessage,
   AttachmentAdapter,
   FeedbackAdapter,
+  RemoteThreadListAdapter,
   SpeechSynthesisAdapter,
 } from "@assistant-ui/core";
 import {
@@ -18,7 +19,7 @@ import {
 import { useAui, useAuiState } from "@assistant-ui/store";
 import type { AssistantCloud } from "assistant-cloud";
 import { useStream, type UseStreamOptions } from "@langchain/react";
-import type { LangChainBaseMessage } from "./types";
+import type { LangChainBaseMessage, LangChainToolCall } from "./types";
 import { convertLangChainBaseMessage } from "./convertMessages";
 
 const symbolLangChainRuntimeExtras = Symbol("langchain-runtime-extras");
@@ -56,6 +57,45 @@ type LangChainRuntimeExtraOptions = {
         feedback?: FeedbackAdapter | undefined;
       }
     | undefined;
+  /**
+   * When the user sends a new message while previous tool calls are
+   * still pending, automatically submit `tool` messages that cancel
+   * them so the agent's tool-call accounting stays consistent.
+   * Defaults to `true`.
+   */
+  autoCancelPendingToolCalls?: boolean | undefined;
+  /**
+   * Enables the Cancel button in the composer and routes its click to
+   * `useStream().stop()`. Off by default.
+   */
+  unstable_allowCancellation?: boolean | undefined;
+  /**
+   * Custom `RemoteThreadListAdapter`. When provided, replaces the
+   * cloud-backed thread list adapter.
+   */
+  unstable_threadListAdapter?: RemoteThreadListAdapter | undefined;
+  /** Custom thread-creation hook, forwarded to the cloud adapter. */
+  create?: (() => Promise<{ externalId: string | undefined }>) | undefined;
+  /** Custom thread-deletion hook, forwarded to the cloud adapter. */
+  delete?: ((threadId: string) => Promise<void>) | undefined;
+};
+
+const getPendingToolCalls = (
+  messages: readonly LangChainBaseMessage[],
+): LangChainToolCall[] => {
+  const pending = new Map<string, LangChainToolCall>();
+  for (const m of messages) {
+    const type =
+      typeof m._getType === "function"
+        ? m._getType()
+        : (m as unknown as { type: string }).type;
+    if (type === "ai") {
+      for (const tc of m.tool_calls ?? []) pending.set(tc.id, tc);
+    } else if (type === "tool" && m.tool_call_id) {
+      pending.delete(m.tool_call_id);
+    }
+  }
+  return [...pending.values()];
 };
 
 // Distribute the intersection through the union arms of `UseStreamOptions`
@@ -120,9 +160,13 @@ type DistributiveOmit<T, K extends keyof any> = T extends unknown
   : never;
 
 const useStreamThreadRuntime = (
-  options: DistributiveOmit<UseStreamRuntimeOptions, "cloud">,
+  options: DistributiveOmit<
+    UseStreamRuntimeOptions,
+    "cloud" | "unstable_threadListAdapter" | "create" | "delete"
+  >,
 ) => {
-  const { adapters } = options;
+  const { adapters, autoCancelPendingToolCalls, unstable_allowCancellation } =
+    options;
   const messagesKey = options.messagesKey ?? "messages";
 
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
@@ -220,8 +264,20 @@ const useStreamThreadRuntime = (
     onNew: async (msg) => {
       await toolInvocations.abort();
       const content = getMessageContent(msg);
+      const cancellations =
+        autoCancelPendingToolCalls !== false
+          ? getPendingToolCalls(
+              streamRef.current.messages as readonly LangChainBaseMessage[],
+            ).map((t) => ({
+              type: "tool" as const,
+              name: t.name,
+              tool_call_id: t.id,
+              content: JSON.stringify({ cancelled: true }),
+              status: "error" as const,
+            }))
+          : [];
       await stream.submit({
-        [messagesKey]: [{ type: "human", content }],
+        [messagesKey]: [...cancellations, { type: "human", content }],
       });
     },
     onAddToolResult: async ({
@@ -244,10 +300,12 @@ const useStreamThreadRuntime = (
         ],
       });
     },
-    onCancel: async () => {
-      await stream.stop();
-      await toolInvocations.abort();
-    },
+    onCancel: unstable_allowCancellation
+      ? async () => {
+          await stream.stop();
+          await toolInvocations.abort();
+        }
+      : undefined,
   });
 
   return runtime;
@@ -277,20 +335,31 @@ const useStreamThreadRuntime = (
  * }
  * ```
  */
-export const useStreamRuntime = ({
-  cloud,
-  ...options
-}: UseStreamRuntimeOptions) => {
+export const useStreamRuntime = (rawOptions: UseStreamRuntimeOptions) => {
+  const {
+    cloud,
+    unstable_threadListAdapter,
+    create,
+    delete: deleteFn,
+    ...options
+  } = rawOptions;
+
   const optionsRef = useRef(options);
   optionsRef.current = options;
 
-  const cloudAdapter = useCloudThreadListAdapter({ cloud });
+  const cloudAdapter = useCloudThreadListAdapter({
+    cloud,
+    ...(create && { create }),
+    ...(deleteFn && { delete: deleteFn }),
+  });
+  const adapter = unstable_threadListAdapter ?? cloudAdapter;
+
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
       // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       return useStreamThreadRuntime(optionsRef.current);
     },
-    adapter: cloudAdapter,
+    adapter,
     allowNesting: true,
   });
 };

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -400,9 +400,11 @@ export const useLangChainSubmit = () => {
  */
 export const useLangChainSend = () => {
   const aui = useAui();
-  const submit = useLangChainSubmit();
-  return (messages: readonly unknown[], options?: Record<string, unknown>) => {
-    const { messagesKey } = asLangChainRuntimeExtras(
+  return (
+    messages: readonly LangChainBaseMessage[],
+    options?: Record<string, unknown>,
+  ) => {
+    const { submit, messagesKey } = asLangChainRuntimeExtras(
       aui.thread().getState().extras,
     );
     return submit({ [messagesKey]: messages }, options);

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -20,7 +20,7 @@ import { useAui, useAuiState } from "@assistant-ui/store";
 import type { AssistantCloud } from "assistant-cloud";
 import { useStream, type UseStreamOptions } from "@langchain/react";
 import type { LangChainBaseMessage, LangChainToolCall } from "./types";
-import { convertLangChainBaseMessage } from "./convertMessages";
+import { convertLangChainBaseMessage, getMessageType } from "./convertMessages";
 
 const symbolLangChainRuntimeExtras = Symbol("langchain-runtime-extras");
 
@@ -85,10 +85,7 @@ const getPendingToolCalls = (
 ): LangChainToolCall[] => {
   const pending = new Map<string, LangChainToolCall>();
   for (const m of messages) {
-    const type =
-      typeof m._getType === "function"
-        ? m._getType()
-        : (m as unknown as { type: string }).type;
+    const type = getMessageType(m);
     if (type === "ai") {
       for (const tc of m.tool_calls ?? []) pending.set(tc.id, tc);
     } else if (type === "tool" && m.tool_call_id) {

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -65,8 +65,8 @@ type LangChainRuntimeExtraOptions = {
    */
   autoCancelPendingToolCalls?: boolean | undefined;
   /**
-   * Enables the Cancel button in the composer and routes its click to
-   * `useStream().stop()`. Off by default.
+   * Routes the Cancel button's click to `useStream().stop()`. On by
+   * default. Pass `false` to disable the Cancel button.
    */
   unstable_allowCancellation?: boolean | undefined;
   /**
@@ -300,12 +300,13 @@ const useStreamThreadRuntime = (
         ],
       });
     },
-    onCancel: unstable_allowCancellation
-      ? async () => {
-          await stream.stop();
-          await toolInvocations.abort();
-        }
-      : undefined,
+    onCancel:
+      unstable_allowCancellation !== false
+        ? async () => {
+            await stream.stop();
+            await toolInvocations.abort();
+          }
+        : undefined,
   });
 
   return runtime;
@@ -349,8 +350,8 @@ export const useStreamRuntime = (rawOptions: UseStreamRuntimeOptions) => {
 
   const cloudAdapter = useCloudThreadListAdapter({
     cloud,
-    ...(create && { create }),
-    ...(deleteFn && { delete: deleteFn }),
+    create,
+    delete: deleteFn,
   });
   const adapter = unstable_threadListAdapter ?? cloudAdapter;
 
@@ -399,9 +400,11 @@ export const useLangChainSubmit = () => {
  */
 export const useLangChainSend = () => {
   const aui = useAui();
+  const submit = useLangChainSubmit();
   return (messages: readonly unknown[], options?: Record<string, unknown>) => {
-    const extras = aui.thread().getState().extras;
-    const { submit, messagesKey } = asLangChainRuntimeExtras(extras);
+    const { messagesKey } = asLangChainRuntimeExtras(
+      aui.thread().getState().extras,
+    );
     return submit({ [messagesKey]: messages }, options);
   };
 };

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -32,6 +32,7 @@ type LangChainRuntimeExtras = {
     options?: Record<string, unknown>,
   ) => Promise<void>;
   values: Record<string, unknown>;
+  messagesKey: string;
 };
 
 const asLangChainRuntimeExtras = (extras: unknown): LangChainRuntimeExtras => {
@@ -199,8 +200,15 @@ const useStreamThreadRuntime = (
       interrupts: stream.interrupts,
       submit: stream.submit,
       values: stream.values,
+      messagesKey,
     }),
-    [stream.interrupt, stream.interrupts, stream.submit, stream.values],
+    [
+      stream.interrupt,
+      stream.interrupts,
+      stream.submit,
+      stream.values,
+      messagesKey,
+    ],
   );
 
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
@@ -313,6 +321,32 @@ export const useLangChainSubmit = () => {
     const { submit } = asLangChainRuntimeExtras(extras);
     return submit(values, options);
   };
+};
+
+/**
+ * Submit a list of LangChain-shaped messages on the current thread.
+ * Parity helper for migrating from `useLangGraphSend`. Routes to
+ * `useStream().submit({ [messagesKey]: messages }, options)`.
+ */
+export const useLangChainSend = () => {
+  const aui = useAui();
+  return (messages: readonly unknown[], options?: Record<string, unknown>) => {
+    const extras = aui.thread().getState().extras;
+    const { submit, messagesKey } = asLangChainRuntimeExtras(extras);
+    return submit({ [messagesKey]: messages }, options);
+  };
+};
+
+/**
+ * Submit a `useStream` command (e.g. interrupt resume). Parity helper
+ * for migrating from `useLangGraphSendCommand`. Note that v1's command
+ * shape (`{ resume?, goto?, update? }`) differs from the legacy
+ * `{ resume: string }` form — to carry a payload, use the input or
+ * `stream.respond` instead.
+ */
+export const useLangChainSendCommand = () => {
+  const submit = useLangChainSubmit();
+  return (command: Record<string, unknown>) => submit(null, { command });
 };
 
 /**


### PR DESCRIPTION
Stacked on #4048.

## Summary

Adds the parity options + hooks needed to migrate users off `@assistant-ui/react-langgraph` — for features that map cleanly onto `useStream` v1 without forking the hook or reaching into internals.

### Added
- `autoCancelPendingToolCalls` (default `true`)
- `unstable_allowCancellation`
- `unstable_threadListAdapter`
- `create` / `delete`
- `useLangChainSend()` / `useLangChainSendCommand()`

### Intentionally left out (gaps for `react-langgraph` deprecation)
These all depend on bespoke pipeline internals that `useStream` v1 either exposes differently or not at all. Listed so you can decide what to invest in next:

1. **Custom `stream` callback** (custom backend support) — v1 replaces this with `transport: AgentServerAdapter`. Different API; consumers using `examples/with-langgraph`'s custom backend pattern need to write an adapter.
2. **`eventHandlers`** (10 callbacks: `onMessageChunk`, `onValues`, `onUpdates`, `onMetadata`, `onInfo`, `onError`, `onSubgraphValues`, `onSubgraphUpdates`, `onSubgraphError`, `onCustomEvent`) — v1 dropped all of them. Replacement is `useChannel(stream, channel)` / `useExtension(stream, name)` selector hooks, which the consumer calls themselves.
3. **Generative UI** (`uiStateKey`, `uiComponents`, `useLangGraphUIMessages`) — doable on top of `stream.values[uiStateKey]` + `useChannel(stream, "custom")` for `push_ui_message`, plus parent-message linkage via `metadata.message_id`. Substantial port (~200–300 LOC + the dataRenderers integration); deferred.
4. **Edit / regenerate via `getCheckpointId` → `forkFrom`** — v1 exposes parent-checkpoint id only via `useMessageMetadata(stream, msgId)`, a hook keyed by message id. There's no imperative map-style getter usable from inside an `onEdit`/`onReload` callback that receives only the parent message id. Could be unlocked if assistant-ui's `onEdit`/`onReload` API also passed per-message metadata, or if we taught `useExternalStoreRuntime` to take a metadata accessor. Out of scope here.
5. **`useLangGraphMessageMetadata` (full tuple-metadata `Map`)** — v1's `useMessageMetadata` returns only `{ parentCheckpointId }`, per message. Richer tuple metadata isn't on the public surface.
6. **`convertLangChainMessages` (wire-format)**, **`appendLangChainChunk`**, **`LangGraphMessageAccumulator`**, **`unstable_createLangGraphStream`** — internal stream-pipeline utilities; not needed once `useStream` owns the pipeline. Our `convertLangChainBaseMessage` already handles the `BaseMessage` class instances `useStream` emits.

## Test plan
- [x] `pnpm --filter @assistant-ui/react-langchain build`
- [x] `pnpm --filter @assistant-ui/react-langchain test` (7 passed)
- [x] `pnpm --filter with-langchain build`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)