### PR TITLE
docs(api-reference): automatically render jsdoc examples as markdown code blocks

### DIFF
--- a/apps/docs/content/docs/(reference)/api-reference/context-providers/assistant-runtime-provider.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/context-providers/assistant-runtime-provider.mdx
@@ -52,5 +52,13 @@ When mounting a runtime built with one of the runtime hooks, use
 [AssistantRuntimeProvider](/docs/api-reference/context-providers/assistant-runtime-provider#assistantruntimeprovider) — it installs an `AuiProvider`
 internally — rather than wiring `AuiProvider` yourself.
 
+```tsx
+function ScopedAssistant({ children, scopes }) {
+  const aui = useAui(scopes);
+
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+}
+```
+
 <ParametersTable {...AuiProvider} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/composer-triggers.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/composer-triggers.mdx
@@ -65,6 +65,11 @@ Creates a spreadable `{ adapter, directive }` bundle for `@` mentions.
 Supports tools registered via `useAssistantTool`, explicit items, or both —
 flat or categorized.
 
+```tsx
+const mention = unstable_useMentionAdapter();
+<ComposerTriggerPopover char="@" {...mention} />
+```
+
 <ParametersTable {...unstable_useMentionAdapter} />
 
 ### unstable_useSlashCommandAdapter
@@ -77,6 +82,17 @@ Bundles slash command definitions (with inline `execute` callbacks) into
 `{adapter, action}` that plug directly into `ComposerTriggerPopover`.
 `execute` stays in the hook closure and is never attached to the returned
 `TriggerItem`, keeping items serializable.
+
+```tsx
+const slash = unstable_useSlashCommandAdapter({
+  commands: [
+    { id: "summarize", execute: () => runSummarize(), icon: "FileText" },
+    { id: "translate", execute: () => runTranslate(), icon: "Languages" },
+  ],
+});
+
+<ComposerTriggerPopover char="/" {...slash} />
+```
 
 <ParametersTable {...unstable_useSlashCommandAdapter} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/primitives.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/primitives.mdx
@@ -44,6 +44,14 @@ Hook that returns the quote info for the current message, if any.
 
 Reads from `message.metadata.custom.quote`.
 
+```tsx
+function QuoteBlock() {
+  const quote = useMessageQuote();
+  if (!quote) return null;
+  return <blockquote>{quote.text}</blockquote>;
+}
+```
+
 ```ts
 const useMessageQuote: () => QuoteInfo;
 ```
@@ -53,6 +61,14 @@ const useMessageQuote: () => QuoteInfo;
 Hook that returns timing information for the current assistant message.
 
 Reads from `message.metadata.timing`.
+
+```tsx
+function MessageStats() {
+  const timing = useMessageTiming();
+  if (!timing) return null;
+  return <span>{timing.tokensPerSecond?.toFixed(1)} tok/s</span>;
+}
+```
 
 ```ts
 const useMessageTiming: () => MessageTiming;
@@ -81,6 +97,16 @@ temporarily locks its scroll position while the animation completes.
 - Prevents forced reflows: no layout reads, mutations scoped to scrollable parent only
 - Reactive: only intercepts scroll events when browser actually adjusts
 - Cleans up automatically after animation duration
+
+```tsx
+const collapsibleRef = useRef<HTMLDivElement>(null);
+const lockScroll = useScrollLock(collapsibleRef, 200);
+
+const handleCollapse = () => {
+  lockScroll(); // Lock scroll before collapsing
+  setIsOpen(false);
+};
+```
 
 <ParametersTable {...useScrollLock} />
 
@@ -121,6 +147,26 @@ Hook to access the AssistantRuntime from the current context.
 The AssistantRuntime provides access to the top-level assistant state and actions,
 including thread management, tool registration, and configuration.
 
+```tsx
+// Before:
+function MyComponent() {
+  const runtime = useAssistantRuntime();
+  const handleNewThread = () => {
+    runtime.switchToNewThread();
+  };
+  return <button onClick={handleNewThread}>New Thread</button>;
+}
+
+// After:
+function MyComponent() {
+  const aui = useAui();
+  const handleNewThread = () => {
+    aui.threads().switchToNewThread();
+  };
+  return <button onClick={handleNewThread}>New Thread</button>;
+}
+```
+
 <ParametersTable {...useAssistantRuntime} />
 
 ### useAttachment
@@ -152,6 +198,36 @@ Hook to access the current composer state.
 This hook provides reactive access to the composer's state, including text content,
 attachments, editing status, and send/cancel capabilities.
 
+```tsx
+// Before:
+function ComposerStatus() {
+  const text = useComposer((state) => state.text);
+  const canSend = useComposer((state) => state.canSend);
+  const attachmentCount = useComposer((state) => state.attachments.length);
+  return (
+    <div>
+      Text: {text.length} chars,
+      Attachments: {attachmentCount},
+      Can send: {canSend}
+    </div>
+  );
+}
+
+// After:
+function ComposerStatus() {
+  const text = useAuiState((s) => s.composer.text);
+  const canSend = useAuiState((s) => s.composer.canSend);
+  const attachmentCount = useAuiState((s) => s.composer.attachments.length);
+  return (
+    <div>
+      Text: {text.length} chars,
+      Attachments: {attachmentCount},
+      Can send: {canSend}
+    </div>
+  );
+}
+```
+
 ```ts
 const useComposer: { (): ComposerState; <TSelected>(selector: (state: ComposerState) => TSelected): TSelected; <TSelected>(selector: ((state: ComposerState) => TSelected) | undefined): ComposerState | TSelected; (options: { optional?: false | undefined; }): ComposerState; (options: { optional?: boolean | undefined; }): ComposerState | null; <TSelected>(options: { optional?: false | undefined; selector: (state: ComposerState) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: ComposerState) => TSelected) | undefined; }): ComposerState | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: ComposerState) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: ComposerState) => TSelected) | undefined; }): ComposerState | TSelected | null; };
 ```
@@ -168,6 +244,52 @@ The ComposerRuntime provides access to composer state and actions for message
 composition, including text input, attachments, and sending functionality.
 This hook automatically resolves to either the message's edit composer or
 the thread's main composer depending on the context.
+
+```tsx
+// Before:
+function ComposerActions() {
+  const runtime = useComposerRuntime();
+  const handleSend = () => {
+    if (runtime.getState().canSend) {
+      runtime.send();
+    }
+  };
+  const handleCancel = () => {
+    if (runtime.getState().canCancel) {
+      runtime.cancel();
+    }
+  };
+  return (
+    <div>
+      <button onClick={handleSend}>Send</button>
+      <button onClick={handleCancel}>Cancel</button>
+    </div>
+  );
+}
+
+// After:
+function ComposerActions() {
+  const aui = useAui();
+  const canSend = useAuiState((s) => s.composer.canSend);
+  const canCancel = useAuiState((s) => s.composer.canCancel);
+  const handleSend = () => {
+    if (canSend) {
+      aui.composer().send();
+    }
+  };
+  const handleCancel = () => {
+    if (canCancel) {
+      aui.composer().cancel();
+    }
+  };
+  return (
+    <div>
+      <button onClick={handleSend}>Send</button>
+      <button onClick={handleCancel}>Cancel</button>
+    </div>
+  );
+}
+```
 
 <ParametersTable {...useComposerRuntime} />
 
@@ -192,6 +314,32 @@ Hook to access the current message state.
 This hook provides reactive access to the message's state, including content,
 role, status, and other message-level properties.
 
+```tsx
+// Before:
+function MessageContent() {
+  const role = useMessage((state) => state.role);
+  const content = useMessage((state) => state.content);
+  const isLoading = useMessage((state) => state.status.type === "running");
+  return (
+    <div className={`message-${role}`}>
+      {isLoading ? "Loading..." : content.map(part => part.text).join("")}
+    </div>
+  );
+}
+
+// After:
+function MessageContent() {
+  const role = useAuiState((s) => s.message.role);
+  const content = useAuiState((s) => s.message.content);
+  const isLoading = useAuiState((s) => s.message.status.type === "running");
+  return (
+    <div className={`message-${role}`}>
+      {isLoading ? "Loading..." : content.map(part => part.text).join("")}
+    </div>
+  );
+}
+```
+
 ```ts
 const useMessage: { (): MessageState; <TSelected>(selector: (state: MessageState) => TSelected): TSelected; <TSelected>(selector: ((state: MessageState) => TSelected) | undefined): MessageState | TSelected; (options: { optional?: false | undefined; }): MessageState; (options: { optional?: boolean | undefined; }): MessageState | null; <TSelected>(options: { optional?: false | undefined; selector: (state: MessageState) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: MessageState) => TSelected) | undefined; }): MessageState | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: MessageState) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: MessageState) => TSelected) | undefined; }): MessageState | TSelected | null; };
 ```
@@ -214,6 +362,16 @@ Return `null` for optional rendering, or throw inside the selector to
 preserve the old hook's strict behavior.
 </Callout>
 
+```tsx
+const part = useAuiState((s) =>
+  s.part.type === "data" && (!name || s.part.name === name)
+    ? s.part
+    : null,
+);
+```
+
+See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+
 <ParametersTable {...useMessagePartData} />
 
 ### useMessagePartFile
@@ -223,6 +381,15 @@ preserve the old hook's strict behavior.
 Return `null` for optional rendering, or throw inside the selector to
 preserve the old hook's strict behavior.
 </Callout>
+
+```tsx
+const file = useAuiState((s) => {
+  if (s.part.type !== "file") return null;
+  return s.part;
+});
+```
+
+See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
 
 ```ts
 const useMessagePartFile: () => FileMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; };
@@ -236,6 +403,15 @@ Return `null` for optional rendering, or throw inside the selector to
 preserve the old hook's strict behavior.
 </Callout>
 
+```tsx
+const image = useAuiState((s) => {
+  if (s.part.type !== "image") return null;
+  return s.part;
+});
+```
+
+See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+
 ```ts
 const useMessagePartImage: () => ImageMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; };
 ```
@@ -247,6 +423,15 @@ const useMessagePartImage: () => ImageMessagePart & { readonly status: MessagePa
 Return `null` for optional rendering, or throw inside the selector to
 preserve the old hook's strict behavior.
 </Callout>
+
+```tsx
+const reasoning = useAuiState((s) => {
+  if (s.part.type !== "reasoning") return null;
+  return s.part;
+});
+```
+
+See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
 
 ```ts
 const useMessagePartReasoning: () => ReasoningMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; };
@@ -268,6 +453,15 @@ Return `null` for optional rendering, or throw inside the selector to
 preserve the old hook's strict behavior.
 </Callout>
 
+```tsx
+const source = useAuiState((s) => {
+  if (s.part.type !== "source") return null;
+  return s.part;
+});
+```
+
+See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
+
 ```ts
 const useMessagePartSource: () => ({ readonly type: "source"; readonly sourceType: "url"; readonly id: string; readonly url: string; readonly title?: string; readonly providerMetadata?: SourceProviderMetadata; readonly parentId?: string; } & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; }) | ({ readonly type: "source"; readonly sourceType: "document"; readonly id: string; readonly url?: undefined; readonly title: string; readonly mediaType: string; readonly filename?: string; readonly providerMetadata?: SourceProviderMetadata; readonly parentId?: string; } & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; });
 ```
@@ -279,6 +473,15 @@ const useMessagePartSource: () => ({ readonly type: "source"; readonly sourceTyp
 Return `null` for optional rendering, or throw inside the selector to
 preserve the old hook's strict behavior.
 </Callout>
+
+```tsx
+const text = useAuiState((s) => {
+  if (s.part.type !== "text" && s.part.type !== "reasoning") return null;
+  return s.part;
+});
+```
+
+See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
 
 ```ts
 const useMessagePartText: () => (TextMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; }) | (ReasoningMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; });
@@ -295,6 +498,42 @@ Hook to access the MessageRuntime from the current context.
 The MessageRuntime provides access to message-level state and actions,
 including message content, status, editing capabilities, and branching.
 
+```tsx
+// Before:
+function MessageActions() {
+  const runtime = useMessageRuntime();
+  const handleReload = () => {
+    runtime.reload();
+  };
+  const handleEdit = () => {
+    runtime.startEdit();
+  };
+  return (
+    <div>
+      <button onClick={handleReload}>Reload</button>
+      <button onClick={handleEdit}>Edit</button>
+    </div>
+  );
+}
+
+// After:
+function MessageActions() {
+  const aui = useAui();
+  const handleReload = () => {
+    aui.message().reload();
+  };
+  const handleEdit = () => {
+    aui.message().startEdit();
+  };
+  return (
+    <div>
+      <button onClick={handleReload}>Reload</button>
+      <button onClick={handleEdit}>Edit</button>
+    </div>
+  );
+}
+```
+
 <ParametersTable {...useMessageRuntime} />
 
 ### useThread
@@ -307,6 +546,22 @@ Hook to access the current thread state.
 
 This hook provides reactive access to the thread's state, including messages,
 running status, capabilities, and other thread-level properties.
+
+```tsx
+// Before:
+function ThreadStatus() {
+  const isRunning = useThread((state) => state.isRunning);
+  const messageCount = useThread((state) => state.messages.length);
+  return <div>Running: {isRunning}, Messages: {messageCount}</div>;
+}
+
+// After:
+function ThreadStatus() {
+  const isRunning = useAuiState((s) => s.thread.isRunning);
+  const messageCount = useAuiState((s) => s.thread.messages.length);
+  return <div>Running: {isRunning}, Messages: {messageCount}</div>;
+}
+```
 
 ```ts
 const useThread: { (): ThreadState; <TSelected>(selector: (state: ThreadState) => TSelected): TSelected; <TSelected>(selector: ((state: ThreadState) => TSelected) | undefined): ThreadState | TSelected; (options: { optional?: false | undefined; }): ThreadState; (options: { optional?: boolean | undefined; }): ThreadState | null; <TSelected>(options: { optional?: false | undefined; selector: (state: ThreadState) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: ThreadState) => TSelected) | undefined; }): ThreadState | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: ThreadState) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: ThreadState) => TSelected) | undefined; }): ThreadState | TSelected | null; };
@@ -360,6 +615,26 @@ Hook to access the ThreadRuntime from the current context.
 
 The ThreadRuntime provides access to thread-level state and actions,
 including message management, thread state, and composer functionality.
+
+```tsx
+// Before:
+function MyComponent() {
+  const runtime = useThreadRuntime();
+  const handleSendMessage = (text: string) => {
+    runtime.append({ role: "user", content: [{ type: "text", text }] });
+  };
+  return <button onClick={() => handleSendMessage("Hello!")}>Send</button>;
+}
+
+// After:
+function MyComponent() {
+  const aui = useAui();
+  const handleSendMessage = (text: string) => {
+    aui.thread().append({ role: "user", content: [{ type: "text", text }] });
+  };
+  return <button onClick={() => handleSendMessage("Hello!")}>Send</button>;
+}
+```
 
 <ParametersTable {...useThreadRuntime} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/integrations/react-ai-sdk.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/integrations/react-ai-sdk.mdx
@@ -41,6 +41,20 @@ Injects quote context into messages as markdown blockquotes.
 Use this in your route handler before `convertToModelMessages` so the LLM
 sees the quoted text that the user is referring to.
 
+```ts
+import { convertToModelMessages, streamText } from "ai";
+import { injectQuoteContext } from "@assistant-ui/react-ai-sdk";
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const result = streamText({
+    model: myModel,
+    messages: await convertToModelMessages(injectQuoteContext(messages)),
+  });
+  return result.toUIMessageStreamResponse();
+}
+```
+
 <ParametersTable {...reactAiSdk_injectQuoteContext} />
 
 ### RESUMABLE_STREAM_ID_HEADER

--- a/apps/docs/content/docs/(reference)/api-reference/overview.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/overview.mdx
@@ -21,7 +21,7 @@ export const contextColors = {
 The React API reference is organized by how you build with assistant-ui:
 
 <Cards>
-  <Card title="Tools" href="/docs/api-reference/tools/toolkits">
+  <Card title="Tools" href="/docs/api-reference/tools">
     Define toolkits, register component-scoped tools, and render tool or data parts.
   </Card>
   <Card title="Model Context" href="/docs/api-reference/model-context/context">
@@ -126,10 +126,10 @@ Add system prompt instructions
 
 Register tool UIs
 
-- [`makeAssistantTool`](/docs/api-reference/tools/component-tools)
-- [`makeAssistantToolUI`](/docs/api-reference/tools/rendering)
-- [`useAssistantTool`](/docs/api-reference/tools/component-tools)
-- [`useAssistantToolUI`](/docs/api-reference/tools/rendering)
+- [`makeAssistantTool`](/docs/api-reference/tools/component-tools#makeassistanttool)
+- [`makeAssistantToolUI`](/docs/api-reference/tools/rendering#makeassistanttoolui)
+- [`useAssistantTool`](/docs/api-reference/tools/component-tools#useassistanttool)
+- [`useAssistantToolUI`](/docs/api-reference/tools/rendering#useassistanttoolui)
 
 Programmatically access the list of registered tool UIs via `useAuiState((s) => s.tools)` and `useAui().tools()`.
 

--- a/apps/docs/content/docs/(reference)/api-reference/tools/component-tools.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/component-tools.mdx
@@ -48,5 +48,21 @@ component unmounts or the tool definition changes.
 Pass a referentially stable tool object, such as one declared at module
 scope or memoized with `useMemo`, to avoid re-registering on every render.
 
+```tsx
+const weatherTool = {
+  toolName: "get_weather",
+  type: "frontend",
+  description: "Get the weather for a city.",
+  parameters: weatherSchema,
+  execute: async ({ city }: { city: string }) => fetchWeather(city),
+  render: WeatherToolUI,
+} satisfies AssistantToolProps<{ city: string }, Weather>;
+
+function WeatherToolRegistration() {
+  useAssistantTool(weatherTool);
+  return null;
+}
+```
+
 <ParametersTable {...useAssistantTool} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/tools/status.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/status.mdx
@@ -22,6 +22,20 @@ still streaming or complete.
 Use inside a tool-call renderer to avoid showing incomplete argument values
 as final.
 
+```tsx
+function WeatherToolUI({
+  args,
+}: ToolCallMessagePartProps<{ city: string }>) {
+  const { propStatus } = useToolArgsStatus<{ city: string }>();
+
+  return (
+    <span>
+      {propStatus.city === "streaming" ? "Reading city..." : args.city}
+    </span>
+  );
+}
+```
+
 ```ts
 const useToolArgsStatus: <TArgs extends Record<string, unknown> = Record<string, unknown>>() => ToolArgsStatus<TArgs>;
 ```

--- a/apps/docs/content/docs/(reference)/api-reference/tools/toolkits.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/toolkits.mdx
@@ -30,6 +30,19 @@ export for a [Toolkit](/docs/api-reference/tools/toolkits#toolkit), [Tools](/doc
 Inference from parameter schemas is currently limited, so provide generic
 arguments when you need precise args or result types.
 
+```ts
+const getWeather = tool<{ city: string }, string>({
+  type: "frontend",
+  description: "Get the weather for a city.",
+  parameters: {
+    type: "object",
+    properties: { city: { type: "string" } },
+    required: ["city"],
+  },
+  execute: async ({ city }) => `Sunny in ${city}`,
+});
+```
+
 <ParametersTable {...tool} />
 
 ### ToolDefinition
@@ -49,6 +62,18 @@ required for frontend and human tools and optional for backend tools.
 Named collection of tools exposed to the assistant model.
 
 Keys are the tool names the model receives and uses in tool calls.
+
+```tsx
+const toolkit = {
+  get_weather: {
+    type: "frontend",
+    description: "Get the weather for a city.",
+    parameters: weatherSchema,
+    execute: async ({ city }: { city: string }) => fetchWeather(city),
+    render: WeatherToolUI,
+  },
+} satisfies Toolkit;
+```
 
 ```ts
 type Toolkit = Record<string, ToolDefinition<any, any>>;

--- a/apps/docs/scripts/api-reference/discover.mts
+++ b/apps/docs/scripts/api-reference/discover.mts
@@ -46,6 +46,7 @@ export type ExportInfo = {
   pageRole: "primary" | "related" | "supporting-type";
   sourcePath?: string;
   jsDoc?: string;
+  jsDocExamples?: string[];
   deprecated?: string;
   signature?: string;
   classificationRule: string;
@@ -308,6 +309,7 @@ function buildExportInfo(
     pageRole: overrides.pageRole ?? placement.role,
     sourcePath,
     jsDoc: docs.jsDoc,
+    jsDocExamples: docs.examples,
     deprecated: resolvedDeprecated,
     signature,
     classificationRule: overrides.classificationRule ?? placement.rule,

--- a/apps/docs/scripts/api-reference/extract.mts
+++ b/apps/docs/scripts/api-reference/extract.mts
@@ -335,6 +335,23 @@ export function jsDocTag(
     : undefined;
 }
 
+function jsDocTags(
+  doc: JSDoc | undefined,
+  name: string,
+  source = "unknown source",
+  options?: JsDocRenderOptions,
+): string[] | undefined {
+  const tags =
+    doc
+      ?.getTags()
+      .filter((tag) => tag.getTagName() === name)
+      .map((tag) => cleanJsDocTagText(tag.getCommentText()))
+      .filter((text): text is string => Boolean(text))
+      .map((text) => renderJsDocLinks(text, `${source} @${name}`, options)) ??
+    [];
+  return tags.length > 0 ? tags : undefined;
+}
+
 function getJsDocs(node: TsNode | undefined): JSDoc[] {
   if (!node) return [];
   if (
@@ -358,12 +375,14 @@ export function extractJsDoc(
 ): {
   jsDoc?: string;
   deprecated?: string;
+  examples?: string[];
 } {
   const doc = getJsDocs(node)[0];
   const source = jsDocSourceLabel(node);
   return {
     jsDoc: doc ? getJsDocCommentText(doc, source, options) : undefined,
     deprecated: jsDocTag(doc, "deprecated", source, options),
+    examples: jsDocTags(doc, "example", source, options),
   };
 }
 

--- a/apps/docs/scripts/api-reference/render.mts
+++ b/apps/docs/scripts/api-reference/render.mts
@@ -104,7 +104,7 @@ function renderJsDocExample(value: string): string {
   const trimmed = value.trim();
   const example = trimmed.includes("```")
     ? trimmed
-    : ["```ts", trimmed, "```"].join("\n");
+    : ["```tsx", trimmed, "```"].join("\n");
   return mdxEscape(example);
 }
 

--- a/apps/docs/scripts/api-reference/render.mts
+++ b/apps/docs/scripts/api-reference/render.mts
@@ -100,6 +100,14 @@ function mdxEscape(value: string): string {
     .join("");
 }
 
+function renderJsDocExample(value: string): string {
+  const trimmed = value.trim();
+  const example = trimmed.includes("```")
+    ? trimmed
+    : ["```ts", trimmed, "```"].join("\n");
+  return mdxEscape(example);
+}
+
 function mdxCommentMarker(name: string, boundary: "start" | "end"): string {
   return `{/* ${name}:${boundary} */}`;
 }
@@ -342,7 +350,13 @@ function exportSection(
     lines.push(mdxEscape(item.jsDoc), "");
   }
   const example = slots.examples.get(item.name);
-  if (example) lines.push(example, "");
+  if (example) {
+    lines.push(example, "");
+  } else if (item.jsDocExamples) {
+    for (const jsDocExample of item.jsDocExamples) {
+      lines.push(renderJsDocExample(jsDocExample), "");
+    }
+  }
   if (typeDocNames.has(item.name)) {
     lines.push(
       `<ParametersTable {...${typeDocBindings.get(item.name) ?? item.name}} />`,
@@ -363,6 +377,7 @@ function hasGeneratedEntryContent(
 ): boolean {
   return Boolean(
     item.jsDoc ||
+      item.jsDocExamples?.length ||
       item.deprecated ||
       typeDocNames.has(item.name) ||
       item.signature ||


### PR DESCRIPTION
update api-reference generator to extract @example tag content from jsdoc and render it as md code blocks in the generated api-reference.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #4059 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #4058 
<!-- GitButler Footer Boundary Bottom -->

