### PR TITLE
docs: fix link for a2a protcol

### DIFF
--- a/.changeset/slimy-moles-glow.md
+++ b/.changeset/slimy-moles-glow.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+Update link to a2a overview

--- a/.changeset/tricky-shoes-kiss.md
+++ b/.changeset/tricky-shoes-kiss.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": minor
+---
+
+Update link to a2a runtime overview

--- a/.changeset/tricky-shoes-kiss.md
+++ b/.changeset/tricky-shoes-kiss.md
@@ -1,5 +1,0 @@
----
-"@assistant-ui/react-a2a": minor
----
-
-Update link to a2a runtime overview

--- a/apps/docs/content/docs/runtimes/a2a/client-and-hooks.mdx
+++ b/apps/docs/content/docs/runtimes/a2a/client-and-hooks.mdx
@@ -5,7 +5,7 @@ description: A2AClient, useA2ARuntime options, hooks, task states, artifacts, er
 
 import { A2AIcon } from "@/components/icons/a2a";
 
-Deep dive on the runtime's API surface. Start with [overview](/docs/runtimes/a2a) and [quickstart](/docs/runtimes/a2a/quickstart) if you have not already.
+Deep dive on the runtime's API surface. Start with [overview](/docs/runtimes/a2a/overview) and [quickstart](/docs/runtimes/a2a/quickstart) if you have not already.
 
 ## A2AClient
 
@@ -381,7 +381,7 @@ This prepends `/{tenant}` to all API paths (e.g. `/my-org/message:send`).
     icon={<A2AIcon width={20} height={20} />}
     title="A2A overview"
     description="What A2A is and when to pick it."
-    href="/docs/runtimes/a2a"
+    href="/docs/runtimes/a2a/overview"
   />
   <Card
     title="Quickstart"

--- a/apps/docs/content/docs/runtimes/pick-a-runtime.mdx
+++ b/apps/docs/content/docs/runtimes/pick-a-runtime.mdx
@@ -52,7 +52,7 @@ assistant-ui ships React adapter packages for these. Pick the matching card and 
     icon={<A2AIcon width={20} height={20} />}
     title="A2A Protocol"
     description="Any A2A v1.0-compliant agent server. Streaming task state, artifacts, multi-tenancy."
-    href="/docs/runtimes/a2a"
+    href="/docs/runtimes/a2a/overview"
   />
   <Card
     icon={<AguiIcon width={20} height={20} />}

--- a/packages/react-a2a/README.md
+++ b/packages/react-a2a/README.md
@@ -33,4 +33,4 @@ Supports all 9 A2A task states (including `input_required` and `auth_required`),
 - `@assistant-ui/react-ag-ui` for the AG-UI protocol.
 - `@assistant-ui/react-langgraph` for LangGraph agents.
 
-Full reference at [assistant-ui.com/docs/runtimes/a2a](https://www.assistant-ui.com/docs/runtimes/a2a).
+Full reference at [assistant-ui.com/docs/runtimes/a2a](https://www.assistant-ui.com/docs/runtimes/a2a/overview).


### PR DESCRIPTION
## Summary

Fixes old links to the overview page for A2A protocol