### PR TITLE
docs(examples): redesign the Gemini clone to match Gemini's latest UI

### DIFF
--- a/apps/docs/components/examples/claude.tsx
+++ b/apps/docs/components/examples/claude.tsx
@@ -266,11 +266,7 @@ const ChatMessage: FC = () => {
               }}
             </MessagePrimitive.Parts>
           </div>
-          <ActionBarPrimitive.Root
-            hideWhenRunning
-            autohide="not-last"
-            className="-mt-px flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100"
-          >
+          <ActionBarPrimitive.Root className="-mt-px flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100">
             <ActionBarPrimitive.Edit className={messageActionButtonClassName}>
               <Pencil1Icon width={16} height={16} />
             </ActionBarPrimitive.Edit>
@@ -296,11 +292,7 @@ const ChatMessage: FC = () => {
               }}
             </MessagePrimitive.Parts>
           </div>
-          <ActionBarPrimitive.Root
-            hideWhenRunning
-            autohide="not-last"
-            className="mt-2 flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100"
-          >
+          <ActionBarPrimitive.Root className="mt-2 flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100">
             <ActionBarPrimitive.Copy className={messageActionButtonClassName}>
               <AuiIf condition={(s) => s.message.isCopied}>
                 <CheckIcon />

--- a/apps/docs/components/examples/gemini.tsx
+++ b/apps/docs/components/examples/gemini.tsx
@@ -2,19 +2,18 @@
 
 import {
   ActionBarPrimitive,
-  AuiIf,
   AttachmentPrimitive,
+  AuiIf,
   ComposerPrimitive,
   MessagePrimitive,
   ThreadPrimitive,
   useAuiState,
 } from "@assistant-ui/react";
-
 import {
+  ArrowUpIcon,
   CheckIcon,
   ChevronDownIcon,
   Cross2Icon,
-  MixerHorizontalIcon,
   Pencil1Icon,
   PlusIcon,
   ReloadIcon,
@@ -22,15 +21,11 @@ import {
 import {
   CopyIcon,
   EllipsisVertical,
-  Globe,
   ImageIcon,
   Lightbulb,
   Mic,
-  Music,
-  PenLine,
-  SendHorizonal,
-  Sparkles,
-  Square,
+  Paperclip,
+  PencilRuler,
   Telescope,
   ThumbsDown,
   ThumbsUp,
@@ -38,7 +33,6 @@ import {
 import { type FC, useEffect, useState } from "react";
 import { useShallow } from "zustand/shallow";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
-import { GeminiIcon } from "@/components/icons/gemini";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -49,126 +43,72 @@ import {
 
 export const Gemini: FC = () => {
   return (
-    <ThreadPrimitive.Root className="flex h-full flex-col items-stretch bg-[#f8f9fa] dark:bg-[#131314]">
+    <ThreadPrimitive.Root className="flex h-full flex-col overflow-hidden bg-[#fdfcfc] text-[#1f1f1f] dark:bg-[#131314] dark:text-[#e3e3e3]">
       <AuiIf condition={(s) => s.thread.isEmpty}>
-        <div className="flex h-full flex-col justify-center px-4">
-          <div className="mx-auto w-full max-w-3xl">
-            <div className="mb-1 flex items-center gap-3">
-              <GeminiIcon className="size-5" />
-              <p className="text-black text-xl dark:text-white">Hi there</p>
+        <div className="relative flex grow flex-col">
+          <div className="relative flex grow flex-col items-center justify-center px-4">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute top-1/2 left-1/2 h-[330px] w-[720px] max-w-[96%] -translate-x-1/2 -translate-y-1/2 bg-[radial-gradient(closest-side,#a9d1fb,transparent)] opacity-70 blur-[55px] dark:bg-[radial-gradient(closest-side,#1d4068,transparent)] dark:opacity-65"
+            />
+            <div className="relative z-10 flex w-full max-w-3xl flex-col">
+              <h1 className="mb-6 text-center font-normal text-4xl text-[#1f1f1f] dark:text-[#e3e3e3]">
+                How can I help you today?
+              </h1>
+              <Composer />
             </div>
-            <p className="mb-6 text-3xl text-black sm:text-4xl dark:text-white">
-              Where would you like to start?
-            </p>
           </div>
-          <Composer />
-          <div className="mx-auto mt-4 flex w-full max-w-3xl flex-wrap justify-center gap-2">
-            <SuggestionChip icon={<ImageIcon width={16} height={16} />}>
-              Create image
-            </SuggestionChip>
-            <SuggestionChip icon={<Music width={16} height={16} />}>
-              Make music
-            </SuggestionChip>
-            <SuggestionChip icon={<Lightbulb width={16} height={16} />}>
-              Help me learn
-            </SuggestionChip>
-            <SuggestionChip icon={<PenLine width={16} height={16} />}>
-              Write anything
-            </SuggestionChip>
-            <SuggestionChip icon={<Sparkles width={16} height={16} />}>
-              Boost my day
-            </SuggestionChip>
-          </div>
+          <p className="pb-3 text-center text-[#5e6063] text-xs dark:text-[#9aa0a6]">
+            Gemini can make mistakes, so double-check it.
+          </p>
         </div>
       </AuiIf>
 
       <AuiIf condition={(s) => !s.thread.isEmpty}>
-        <ThreadPrimitive.Viewport className="flex grow flex-col overflow-y-scroll pt-16">
+        <ThreadPrimitive.Viewport className="flex grow flex-col overflow-y-scroll pt-12">
           <ThreadPrimitive.Messages components={{ Message: ChatMessage }} />
+          <ThreadPrimitive.ViewportFooter className="sticky bottom-0 mt-auto flex w-full flex-col items-center gap-1.5 bg-[#fdfcfc] px-4 pb-3 dark:bg-[#131314]">
+            <Composer />
+            <p className="text-center text-[#5e6063] text-xs dark:text-[#9aa0a6]">
+              Gemini can make mistakes, so double-check it.
+            </p>
+          </ThreadPrimitive.ViewportFooter>
         </ThreadPrimitive.Viewport>
-        <div className="space-y-2 px-4 pb-4">
-          <Composer />
-          <p className="text-center text-[#70757a] text-xs dark:text-[#9aa0a6]">
-            Gemini may display inaccurate info, including about people, so
-            double-check its responses.
-          </p>
-        </div>
       </AuiIf>
     </ThreadPrimitive.Root>
   );
 };
 
-const SuggestionChip: FC<{
-  icon: React.ReactNode;
-  children: React.ReactNode;
-}> = ({ icon, children }) => (
-  <button
-    type="button"
-    className="flex items-center gap-2 rounded-full bg-white px-4 py-2.5 text-[#444746] text-sm shadow-[0_1px_3px_rgba(0,0,0,0.12)] transition-colors hover:bg-[#f1f3f4] dark:bg-[#282a2c] dark:text-[#c4c7c5] dark:shadow-[0_1px_3px_rgba(0,0,0,0.4)] dark:hover:bg-[#333537]"
-  >
-    {icon}
-    {children}
-  </button>
-);
+const ghostBtnClass =
+  "flex shrink-0 items-center justify-center rounded-full text-[#444746] transition-colors hover:bg-[#444746]/8 hover:text-[#1f1f1f] dark:text-[#c4c7c5] dark:hover:bg-[#c4c7c5]/10 dark:hover:text-[#e3e3e3]";
 
 const Composer: FC = () => {
-  const isEmpty = useAuiState((s) => s.composer.isEmpty);
-  const isRunning = useAuiState((s) => s.thread.isRunning);
   return (
-    <ComposerPrimitive.Root
-      data-empty={isEmpty}
-      data-running={isRunning}
-      className="group/composer mx-auto flex w-full max-w-3xl flex-col rounded-4xl bg-white p-3 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-[#1e1f20] dark:shadow-[0_2px_8px_-2px_rgba(0,0,0,0.5)]"
-    >
+    <ComposerPrimitive.Root className="mx-auto flex w-full max-w-3xl flex-col rounded-4xl bg-white p-3 shadow-[0_2px_10px_-2px_rgba(0,0,0,0.18)] dark:bg-[#1e1f20] dark:shadow-[0_2px_12px_-2px_rgba(0,0,0,0.6)]">
       <AuiIf condition={(s) => s.composer.attachments.length > 0}>
-        <div className="overflow-hidden rounded-t-3xl">
-          <div className="overflow-x-auto p-3.5">
-            <div className="flex flex-row gap-3">
-              <ComposerPrimitive.Attachments
-                components={{ Attachment: GeminiAttachment }}
-              />
-            </div>
-          </div>
+        <div className="flex flex-row gap-2.5 overflow-x-auto px-1 pt-1 pb-2.5">
+          <ComposerPrimitive.Attachments
+            components={{ Attachment: GeminiAttachment }}
+          />
         </div>
       </AuiIf>
 
-      <div className="flex flex-col gap-3">
-        <div className="relative">
-          <div className="wrap-break-word max-h-96 w-full overflow-y-auto">
-            <ComposerPrimitive.Input
-              placeholder="Ask Gemini"
-              className="block min-h-6 w-full resize-none bg-transparent px-3 py-2 text-[#1f1f1f] outline-none placeholder:text-[#70757a] dark:text-[#e3e3e3] dark:placeholder:text-[#9aa0a6]"
-            />
-          </div>
-        </div>
-
-        <div className="flex w-full items-center text-[#444746] dark:text-[#c4c7c5]">
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            <ComposerPrimitive.AddAttachment className="flex size-10 items-center justify-center rounded-full transition-all hover:bg-[#444746]/8 active:scale-[0.98] dark:hover:bg-[#c4c7c5]/8">
-              <PlusIcon width={20} height={20} />
-            </ComposerPrimitive.AddAttachment>
-            <GeminiToolsMenu />
-          </div>
-
-          <div className="flex items-center gap-2">
-            <GeminiModelPicker />
-            <div className="relative size-10 shrink-0">
-              <button
-                type="button"
-                className="absolute inset-0 flex items-center justify-center rounded-full transition-all duration-300 ease-out hover:bg-[#444746]/8 group-data-[empty=false]/composer:scale-0 group-data-[running=true]/composer:scale-0 group-data-[empty=false]/composer:opacity-0 group-data-[running=true]/composer:opacity-0 dark:hover:bg-[#c4c7c5]/8"
-                aria-label="Voice mode"
-              >
-                <Mic width={20} height={20} />
-              </button>
-              <ComposerPrimitive.Send className="absolute inset-0 flex items-center justify-center rounded-full bg-[#d3e3fd] text-[#1f1f1f] transition-all duration-300 ease-out hover:bg-[#c2d7fb] group-data-[empty=true]/composer:scale-0 group-data-[running=true]/composer:scale-0 group-data-[empty=true]/composer:opacity-0 group-data-[running=true]/composer:opacity-0 dark:bg-[#1f3760] dark:text-[#e3e3e3] dark:hover:bg-[#2a4a7a]">
-                <SendHorizonal width={20} height={20} />
-              </ComposerPrimitive.Send>
-              <ComposerPrimitive.Cancel className="absolute inset-0 flex items-center justify-center rounded-full bg-[#d3e3fd] text-[#1f1f1f] transition-all duration-300 ease-out hover:bg-[#c2d7fb] group-data-[running=false]/composer:scale-0 group-data-[running=false]/composer:opacity-0 dark:bg-[#1f3760] dark:text-[#e3e3e3] dark:hover:bg-[#2a4a7a]">
-                <Square width={14} height={14} fill="currentColor" />
-              </ComposerPrimitive.Cancel>
-            </div>
-          </div>
-        </div>
+      <div className="flex items-end gap-1">
+        <GeminiPlusMenu />
+        <ComposerPrimitive.Input
+          rows={1}
+          placeholder="Ask Gemini"
+          className="max-h-40 flex-1 resize-none bg-transparent px-2 py-1.5 text-[#1f1f1f] text-[17px] leading-6 outline-none placeholder:text-[#575b5f] dark:text-[#e3e3e3] dark:placeholder:text-[#9aa0a6]"
+        />
+        <GeminiModelPicker />
+        <button
+          type="button"
+          aria-label="Voice mode"
+          className={`${ghostBtnClass} size-9`}
+        >
+          <Mic width={20} height={20} />
+        </button>
+        <GeminiSendButton />
       </div>
     </ComposerPrimitive.Root>
   );
@@ -176,25 +116,32 @@ const Composer: FC = () => {
 
 const GEMINI_TOOLS = [
   { id: "research", label: "Deep Research", Icon: Telescope },
+  { id: "canvas", label: "Canvas", Icon: PencilRuler },
   { id: "image", label: "Create image", Icon: ImageIcon },
-  { id: "search", label: "Search the web", Icon: Globe },
-  { id: "study", label: "Help me learn", Icon: Lightbulb },
+  { id: "learn", label: "Guided Learning", Icon: Lightbulb },
 ];
 
-const GeminiToolsMenu: FC = () => {
+const GeminiPlusMenu: FC = () => {
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="flex h-10 items-center justify-center gap-1.5 rounded-full px-3 text-sm transition hover:bg-[#444746]/8 dark:hover:bg-[#c4c7c5]/8">
-        <MixerHorizontalIcon width={16} height={16} />
-        <span>Tools</span>
+      <DropdownMenuTrigger
+        aria-label="Add files and tools"
+        className={`${ghostBtnClass} size-9`}
+      >
+        <PlusIcon width={20} height={20} />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="min-w-56">
+      <DropdownMenuContent align="start" side="bottom" className="min-w-56">
+        <DropdownMenuItem asChild>
+          <ComposerPrimitive.AddAttachment>
+            <span className="flex size-4 items-center justify-center">
+              <Paperclip className="size-4" />
+            </span>
+            Add photos &amp; files
+          </ComposerPrimitive.AddAttachment>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         {GEMINI_TOOLS.map(({ id, label, Icon }) => (
-          <DropdownMenuItem
-            key={id}
-            icon={<Icon className="size-4" />}
-            className="text-foreground text-sm"
-          >
+          <DropdownMenuItem key={id} icon={<Icon className="size-4" />}>
             {label}
           </DropdownMenuItem>
         ))}
@@ -204,9 +151,12 @@ const GeminiToolsMenu: FC = () => {
 };
 
 const GEMINI_MODELS = [
-  { id: "fast", name: "Fast", description: "Best for quick chats" },
-  { id: "thinking", name: "Thinking", description: "Best for reasoning" },
-  { id: "pro", name: "Pro", description: "Best for complex tasks" },
+  { id: "fast", name: "Fast", description: "Quick everyday help" },
+  {
+    id: "thinking",
+    name: "Thinking",
+    description: "Reasons through harder problems",
+  },
 ];
 
 const GeminiModelPicker: FC = () => {
@@ -215,21 +165,21 @@ const GeminiModelPicker: FC = () => {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="flex h-10 items-center justify-center gap-1 whitespace-nowrap rounded-full px-3 text-sm transition hover:bg-[#444746]/8 dark:hover:bg-[#c4c7c5]/8">
+      <DropdownMenuTrigger className="h-9 shrink-0 gap-0.5 whitespace-nowrap rounded-full pr-1.5 pl-3 text-[#444746] text-sm transition-colors hover:bg-[#444746]/8 hover:text-[#1f1f1f] dark:text-[#c4c7c5] dark:hover:bg-[#c4c7c5]/10 dark:hover:text-[#e3e3e3]">
         <span>{current?.name}</span>
-        <ChevronDownIcon width={20} height={20} className="opacity-60" />
+        <ChevronDownIcon width={16} height={16} className="opacity-70" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="min-w-60">
+      <DropdownMenuContent align="end" side="bottom" className="min-w-64">
         {GEMINI_MODELS.map((m) => (
           <DropdownMenuItem
             key={m.id}
             onSelect={() => setModel(m.id)}
-            className="flex items-start gap-3"
+            className="items-start gap-3"
           >
-            <span className="mt-0.5 flex size-4 items-center justify-center text-[#1a73e8] dark:text-[#8ab4f8]">
+            <span className="mt-0.5 flex size-4 items-center justify-center text-[#0b57d0] dark:text-[#a8c7fa]">
               {m.id === model ? <CheckIcon /> : null}
             </span>
-            <span className="flex flex-1 flex-col">
+            <span className="flex flex-col">
               <span className="text-foreground text-sm">{m.name}</span>
               <span className="text-muted-foreground text-xs">
                 {m.description}
@@ -237,24 +187,46 @@ const GeminiModelPicker: FC = () => {
             </span>
           </DropdownMenuItem>
         ))}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem className="text-muted-foreground text-sm">
-          Upgrade to Gemini Advanced
-        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );
 };
 
+const sendBtnClass =
+  "flex size-9 shrink-0 items-center justify-center rounded-full bg-[#d3e3fd] text-[#062e6f] transition-colors hover:bg-[#c2d7fb] dark:bg-[#1f3760] dark:text-[#d3e3fd] dark:hover:bg-[#27497d]";
+
+const GeminiSendButton: FC = () => {
+  return (
+    <>
+      <AuiIf condition={(s) => !s.thread.isRunning}>
+        <ComposerPrimitive.Send
+          aria-label="Send message"
+          className={`${sendBtnClass} disabled:bg-[#e8eaed] disabled:text-[#1f1f1f]/40 dark:disabled:bg-[#2b2c2e] dark:disabled:text-white/30`}
+        >
+          <ArrowUpIcon width={20} height={20} />
+        </ComposerPrimitive.Send>
+      </AuiIf>
+      <AuiIf condition={(s) => s.thread.isRunning}>
+        <ComposerPrimitive.Cancel
+          aria-label="Stop generating"
+          className={sendBtnClass}
+        >
+          <span className="size-3 rounded-[3px] bg-current" />
+        </ComposerPrimitive.Cancel>
+      </AuiIf>
+    </>
+  );
+};
+
 const actionBtnClass =
-  "flex size-8 items-center justify-center rounded-full text-[#444746] transition-colors hover:bg-[#444746]/8 dark:text-[#c4c7c5] dark:hover:bg-[#c4c7c5]/8";
+  "flex size-8 items-center justify-center rounded-full text-[#444746] transition-colors hover:bg-[#444746]/8 hover:text-[#1f1f1f] dark:text-[#c4c7c5] dark:hover:bg-[#c4c7c5]/10 dark:hover:text-[#e3e3e3]";
 
 const ChatMessage: FC = () => {
   return (
-    <MessagePrimitive.Root className="group/message relative mx-auto mb-4 flex w-full max-w-3xl flex-col pb-0.5">
+    <MessagePrimitive.Root className="group/message mx-auto mb-7 flex w-full max-w-3xl flex-col px-4">
       <AuiIf condition={(s) => s.message.role === "user"}>
         <div className="flex items-center justify-end gap-1">
-          <ActionBarPrimitive.Root className="flex items-center gap-0.5 pt-1 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100">
+          <ActionBarPrimitive.Root className="flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100">
             <ActionBarPrimitive.Copy className={actionBtnClass}>
               <CopyIcon width={16} height={16} />
             </ActionBarPrimitive.Copy>
@@ -262,39 +234,39 @@ const ChatMessage: FC = () => {
               <Pencil1Icon width={16} height={16} />
             </ActionBarPrimitive.Edit>
           </ActionBarPrimitive.Root>
-          <div className="max-w-[85%] rounded-3xl rounded-tr bg-[#e9eef6] px-4 py-3 text-[#1f1f1f] dark:bg-[#282a2c] dark:text-[#e3e3e3]">
-            <div className="prose prose-sm dark:prose-invert wrap-break-word">
-              <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
-            </div>
+          <div className="wrap-break-word max-w-[75%] rounded-3xl bg-[#f2f0f0] px-5 py-3 text-[#1f1f1f] dark:bg-[#333537] dark:text-[#e3e3e3]">
+            <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
           </div>
         </div>
       </AuiIf>
 
       <AuiIf condition={(s) => s.message.role === "assistant"}>
-        <div className="flex items-start gap-3">
-          <GeminiIcon className="mt-1 size-5 shrink-0" />
-          <div className="min-w-0 flex-1">
-            <div className="prose prose-sm dark:prose-invert wrap-break-word prose-li:my-1 prose-ol:my-1 prose-p:my-2 prose-ul:my-1 text-[#1f1f1f] dark:text-[#e3e3e3]">
-              <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
-            </div>
-            <ActionBarPrimitive.Root className="mt-2 -ml-2 flex items-center gap-0.5 opacity-0 transition-opacity duration-300 group-focus-within/message:opacity-100 group-hover/message:opacity-100">
-              <ActionBarPrimitive.FeedbackPositive className={actionBtnClass}>
-                <ThumbsUp width={14} height={14} />
-              </ActionBarPrimitive.FeedbackPositive>
-              <ActionBarPrimitive.FeedbackNegative className={actionBtnClass}>
-                <ThumbsDown width={14} height={14} />
-              </ActionBarPrimitive.FeedbackNegative>
-              <ActionBarPrimitive.Reload className={actionBtnClass}>
-                <ReloadIcon width={14} height={14} />
-              </ActionBarPrimitive.Reload>
-              <ActionBarPrimitive.Copy className={actionBtnClass}>
-                <CopyIcon width={14} height={14} />
-              </ActionBarPrimitive.Copy>
-              <button type="button" className={actionBtnClass}>
-                <EllipsisVertical width={14} height={14} />
-              </button>
-            </ActionBarPrimitive.Root>
+        <div className="flex flex-col">
+          <div className="wrap-break-word text-[#1f1f1f] dark:text-[#e3e3e3]">
+            <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
           </div>
+          <ActionBarPrimitive.Root className="mt-1.5 -ml-2 flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100">
+            <ActionBarPrimitive.FeedbackPositive className={actionBtnClass}>
+              <ThumbsUp width={16} height={16} />
+            </ActionBarPrimitive.FeedbackPositive>
+            <ActionBarPrimitive.FeedbackNegative className={actionBtnClass}>
+              <ThumbsDown width={16} height={16} />
+            </ActionBarPrimitive.FeedbackNegative>
+            <ActionBarPrimitive.Copy className={actionBtnClass}>
+              <AuiIf condition={(s) => s.message.isCopied}>
+                <CheckIcon width={16} height={16} />
+              </AuiIf>
+              <AuiIf condition={(s) => !s.message.isCopied}>
+                <CopyIcon width={16} height={16} />
+              </AuiIf>
+            </ActionBarPrimitive.Copy>
+            <ActionBarPrimitive.Reload className={actionBtnClass}>
+              <ReloadIcon width={16} height={16} />
+            </ActionBarPrimitive.Reload>
+            <button type="button" aria-label="More" className={actionBtnClass}>
+              <EllipsisVertical width={16} height={16} />
+            </button>
+          </ActionBarPrimitive.Root>
         </div>
       </AuiIf>
     </MessagePrimitive.Root>
@@ -342,39 +314,21 @@ const GeminiAttachment: FC = () => {
 
   return (
     <AttachmentPrimitive.Root className="group/thumbnail relative">
-      <div
-        className="overflow-hidden rounded-lg border border-[#dadce0] shadow-sm hover:border-[#c4c7c5] hover:shadow-md dark:border-[#3c4043] dark:hover:border-[#5f6368]"
-        style={{
-          width: "120px",
-          height: "120px",
-          minWidth: "120px",
-          minHeight: "120px",
-        }}
-      >
-        <button
-          type="button"
-          className="relative"
-          style={{ width: "120px", height: "120px" }}
-        >
-          {isImage && src ? (
-            // biome-ignore lint/performance/noImgElement: example component
-            <img
-              className="h-full w-full object-cover transition duration-400"
-              alt="Attachment"
-              src={src}
-            />
-          ) : (
-            <div className="flex h-full w-full items-center justify-center text-[#70757a] dark:text-[#9aa0a6]">
-              <AttachmentPrimitive.unstable_Thumb className="text-xs" />
-            </div>
-          )}
-        </button>
+      <div className="size-[72px] overflow-hidden rounded-xl border border-[#dadce0] bg-[#f1f3f4] dark:border-[#3c4043] dark:bg-[#282a2c]">
+        {isImage && src ? (
+          // biome-ignore lint/performance/noImgElement: example component
+          <img className="size-full object-cover" alt="Attachment" src={src} />
+        ) : (
+          <div className="flex size-full items-center justify-center text-[#5e6063] dark:text-[#9aa0a6]">
+            <AttachmentPrimitive.unstable_Thumb className="text-xs" />
+          </div>
+        )}
       </div>
       <AttachmentPrimitive.Remove
-        className="absolute -top-2 -right-2 flex size-8 items-center justify-center rounded-full border border-[#dadce0] bg-white text-[#70757a] opacity-0 backdrop-blur-sm transition-all hover:bg-[#f1f3f4] hover:text-[#1f1f1f] group-focus-within/thumbnail:opacity-100 group-hover/thumbnail:opacity-100 dark:border-[#3c4043] dark:bg-[#1e1f20] dark:text-[#9aa0a6] dark:hover:bg-[#2b2c2f] dark:hover:text-[#e3e3e3]"
+        className="absolute -top-1.5 -right-1.5 flex size-6 items-center justify-center rounded-full border border-[#dadce0] bg-white text-[#5e6063] opacity-0 transition-all hover:bg-[#f1f3f4] hover:text-[#1f1f1f] group-focus-within/thumbnail:opacity-100 group-hover/thumbnail:opacity-100 dark:border-[#3c4043] dark:bg-[#1e1f20] dark:text-[#9aa0a6] dark:hover:bg-[#2b2c2f] dark:hover:text-[#e3e3e3]"
         aria-label="Remove attachment"
       >
-        <Cross2Icon width={16} height={16} />
+        <Cross2Icon width={14} height={14} />
       </AttachmentPrimitive.Remove>
     </AttachmentPrimitive.Root>
   );

--- a/apps/docs/components/examples/perplexity.tsx
+++ b/apps/docs/components/examples/perplexity.tsx
@@ -304,11 +304,7 @@ const ChatMessage: FC = () => {
           </div>
 
           <div className="flex items-start gap-2">
-            <ActionBarPrimitive.Root
-              hideWhenRunning
-              autohide="not-last"
-              className="mt-1 flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100"
-            >
+            <ActionBarPrimitive.Root className="mt-1 flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100">
               <ActionBarPrimitive.Copy className={messageActionClassName}>
                 <CopyIcon className="size-4" />
               </ActionBarPrimitive.Copy>
@@ -341,10 +337,7 @@ const ChatMessage: FC = () => {
 
             <div className="mt-2 flex items-center gap-2">
               <BranchPicker />
-              <ActionBarPrimitive.Root
-                hideWhenRunning
-                className="flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100"
-              >
+              <ActionBarPrimitive.Root className="flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100">
                 <ActionBarPrimitive.Reload className={messageActionClassName}>
                   <ReloadIcon className="size-4" />
                 </ActionBarPrimitive.Reload>

--- a/apps/docs/content/examples/gemini.mdx
+++ b/apps/docs/content/examples/gemini.mdx
@@ -1,6 +1,6 @@
 ---
 title: Gemini Clone
-description: Open-source Gemini clone in React — Material Design surface colors, two-line greeting, suggestion chips, functional Tools and Model dropdowns, and a Mic↔Send transition.
+description: Open-source Gemini clone in React with a centered greeting over an ambient glow, a single-row pill composer, avatar-free assistant replies, and disabled, ready, and stop send states.
 ---
 
 import { Gemini } from "@/components/examples/gemini";
@@ -11,17 +11,17 @@ import { Gemini } from "@/components/examples/gemini";
 
 ## Overview
 
-The Gemini Clone demonstrates how to customize assistant-ui to match Google Gemini's interface. The empty state shows a two-line greeting, a centered composer, and a row of suggestion chips. The composer has functional Tools and Model dropdowns, and the trailing slot animates between Mic, Send, and Cancel.
+The Gemini Clone shows how to restyle assistant-ui to match Google Gemini's current interface. The empty state centers a single-line greeting over a soft blue glow, and a single-row pill composer is shared by both the empty and chat states. Assistant replies render as full-width markdown with no avatar, and user turns sit in a rounded grey bubble.
 
 ## Features
 
-- **Two-line Greeting**: Sparkle icon + "Hi there" + large "Where would you like to start?" headline
-- **Five Suggestion Chips**: Create image, Make music, Help me learn, Write anything, Boost my day
-- **Functional Tools Dropdown**: Deep Research / Create image / Search the web / Help me learn
-- **Functional Model Picker**: Fast / Thinking / Pro with descriptions and "Upgrade to Gemini Advanced"
-- **Animated Send Slot**: Mic when composer is empty, Send circle when typing, Cancel when running (CSS `group-data-[empty]` transitions on `ComposerPrimitive.Root`)
-- **Distinctive User Bubble**: `rounded-3xl rounded-tr` — sharp top-right corner, signature Gemini look
-- **Sparkle Avatar**: Gemini icon on the left of every assistant message
+- **Centered greeting**: one "How can I help you today?" headline, centered over a blurred radial glow.
+- **Single-row composer**: a 32px pill that holds the `+` menu, the input, the model picker, the mic, and send on one line.
+- **Combined `+` menu**: "Add photos & files" sits next to the Deep Research, Canvas, Create image, and Guided Learning tools.
+- **Model picker**: Fast and Thinking, each with a short description and a check mark on the active model.
+- **Send states**: a disabled grey arrow when empty, a blue arrow when ready, and a stop square while a response streams.
+- **Avatar-free replies**: assistant messages are full-width markdown, with the action bar revealed on hover.
+- **Grey user bubble**: a `rounded-3xl` warm-grey bubble, right-aligned, with copy and edit actions on hover.
 
 ## Quick Start
 
@@ -31,108 +31,138 @@ npx assistant-ui add thread
 
 ## Code
 
-The empty state and chat state share the same `Composer`. The composer carries `data-empty` and `data-running` attributes that drive the Mic↔Send transition:
+The empty and chat states render the same `Composer`. It is a flex column: an optional attachment row on top, then a single action row with the input as the `flex-1` middle and the controls bottom-aligned around it.
 
 ```tsx
 import {
   AuiIf,
-  ThreadPrimitive,
   ComposerPrimitive,
-  useAuiState,
+  ThreadPrimitive,
 } from "@assistant-ui/react";
 
 export const Gemini = () => (
-  <ThreadPrimitive.Root className="bg-[#f8f9fa] dark:bg-[#131314]">
+  <ThreadPrimitive.Root className="bg-[#fdfcfc] dark:bg-[#131314]">
     <AuiIf condition={(s) => s.thread.isEmpty}>
       <EmptyState />
     </AuiIf>
     <AuiIf condition={(s) => !s.thread.isEmpty}>
       <ThreadPrimitive.Viewport>
         <ThreadPrimitive.Messages components={{ Message: ChatMessage }} />
+        <ThreadPrimitive.ViewportFooter className="sticky bottom-0">
+          <Composer />
+        </ThreadPrimitive.ViewportFooter>
       </ThreadPrimitive.Viewport>
-      <Composer />
     </AuiIf>
   </ThreadPrimitive.Root>
 );
 
-const Composer = () => {
-  const isEmpty = useAuiState((s) => s.composer.isEmpty);
-  const isRunning = useAuiState((s) => s.thread.isRunning);
-  return (
-    <ComposerPrimitive.Root
-      className="group/composer rounded-4xl bg-white p-3 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-[#1e1f20]"
-      data-empty={isEmpty}
-      data-running={isRunning}
-    >
-      <ComposerPrimitive.Input placeholder="Ask Gemini" />
-      <div className="flex items-center">
-        <ComposerPrimitive.AddAttachment />
-        <ToolsMenu />
-        <div className="ml-auto flex items-center gap-2">
-          <ModelPicker />
-          <SendOrMic />
-        </div>
-      </div>
-    </ComposerPrimitive.Root>
-  );
-};
+const Composer = () => (
+  <ComposerPrimitive.Root className="flex flex-col rounded-4xl bg-white p-3 shadow-[0_2px_10px_-2px_rgba(0,0,0,0.18)] dark:bg-[#1e1f20]">
+    <AuiIf condition={(s) => s.composer.attachments.length > 0}>
+      <ComposerPrimitive.Attachments
+        components={{ Attachment: GeminiAttachment }}
+      />
+    </AuiIf>
+    <div className="flex items-end gap-1">
+      <PlusMenu />
+      <ComposerPrimitive.Input
+        placeholder="Ask Gemini"
+        className="flex-1 resize-none bg-transparent text-[17px]"
+      />
+      <ModelPicker />
+      <VoiceButton />
+      <SendButton />
+    </div>
+  </ComposerPrimitive.Root>
+);
 ```
 
-### Mic ↔ Send Transition
+### Send states
 
-The composer passes `isEmpty` and `isRunning` as data attributes; the children animate via `group-data-[empty]` selectors:
+The trailing slot swaps between Send and Cancel with `AuiIf`. `ComposerPrimitive.Send` disables itself while the composer is empty, so the disabled, ready, and running looks are all driven by state instead of manual class toggling:
 
 ```tsx
-<div className="relative size-10 rounded-full">
-  {/* Mic: visible when empty + idle */}
-  <button className="group-data-[empty=false]/composer:scale-0 group-data-[running=true]/composer:scale-0">
-    <Mic />
-  </button>
-  {/* Send: visible when typing + idle */}
-  <ComposerPrimitive.Send className="bg-[#d3e3fd] group-data-[empty=true]/composer:scale-0 group-data-[running=true]/composer:scale-0">
-    <SendHorizonal />
+{/* Send: disabled grey when empty, blue when there is text */}
+<AuiIf condition={(s) => !s.thread.isRunning}>
+  <ComposerPrimitive.Send className="bg-[#d3e3fd] text-[#062e6f] disabled:bg-[#e8eaed] disabled:text-[#1f1f1f]/40">
+    <ArrowUpIcon />
   </ComposerPrimitive.Send>
-  {/* Cancel: visible while running */}
-  <ComposerPrimitive.Cancel className="bg-[#d3e3fd] group-data-[running=false]/composer:scale-0">
-    <Square />
+</AuiIf>
+{/* Cancel: stop square while a response streams */}
+<AuiIf condition={(s) => s.thread.isRunning}>
+  <ComposerPrimitive.Cancel className="bg-[#d3e3fd] text-[#062e6f]">
+    <span className="size-3 rounded-[3px] bg-current" />
   </ComposerPrimitive.Cancel>
-</div>
+</AuiIf>
 ```
 
-### Functional Dropdowns
+### Combined `+` menu
+
+The `+` button opens one menu for both attachments and tools. `ComposerPrimitive.AddAttachment` is rendered as the first item via `asChild`, so picking it opens the file dialog and closes the menu:
 
 ```tsx
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/shared/dropdown-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/shared/dropdown-menu";
 
 <DropdownMenu>
-  <DropdownMenuTrigger>Tools</DropdownMenuTrigger>
-  <DropdownMenuContent>
+  <DropdownMenuTrigger>
+    <PlusIcon />
+  </DropdownMenuTrigger>
+  <DropdownMenuContent align="start" side="bottom">
+    <DropdownMenuItem asChild>
+      <ComposerPrimitive.AddAttachment>
+        <Paperclip /> Add photos & files
+      </ComposerPrimitive.AddAttachment>
+    </DropdownMenuItem>
+    <DropdownMenuSeparator />
     <DropdownMenuItem icon={<Telescope />}>Deep Research</DropdownMenuItem>
-    <DropdownMenuItem icon={<ImageIcon />}>Create image</DropdownMenuItem>
-    {/* ... */}
+    <DropdownMenuItem icon={<PencilRuler />}>Canvas</DropdownMenuItem>
+    {/* Create image, Guided Learning ... */}
   </DropdownMenuContent>
 </DropdownMenu>
 ```
 
-### Color Palette
+### Ambient glow
 
-| Element | Light | Dark |
-|---------|-------|------|
-| Background | `#f8f9fa` | `#131314` |
-| Composer surface | `#ffffff` | `#1e1f20` |
-| Primary text | `#1f1f1f` | `#e3e3e3` |
-| Muted text | `#444746` | `#c4c7c5` |
-| User bubble | `#e9eef6` | `#282a2c` |
-| Send button | `#d3e3fd` (light blue) | `#1f3760` |
-| Suggestion chips | `#ffffff` | `#282a2c` |
-
-### User Message Bubble
-
-The distinctive Gemini user bubble has a sharp corner on one side:
+The empty state places a single blurred ellipse behind the greeting and composer. It is decorative, so it is `pointer-events-none` and `aria-hidden`:
 
 ```tsx
-<div className="rounded-3xl rounded-tr bg-[#e9eef6] dark:bg-[#282a2c]">
-  {/* 4px top-right, 24px everywhere else */}
+<div className="relative flex grow items-center justify-center">
+  <div
+    aria-hidden="true"
+    className="pointer-events-none absolute top-1/2 left-1/2 h-[330px] w-[720px] -translate-x-1/2 -translate-y-1/2 bg-[radial-gradient(closest-side,#a9d1fb,transparent)] opacity-70 blur-[55px] dark:bg-[radial-gradient(closest-side,#1d4068,transparent)] dark:opacity-65"
+  />
+  <div className="relative z-10">
+    <h1 className="text-center text-4xl">How can I help you today?</h1>
+    <Composer />
+  </div>
+</div>
+```
+
+### Color palette
+
+| Element            | Light                 | Dark      |
+| ------------------ | --------------------- | --------- |
+| Background         | `#fdfcfc`             | `#131314` |
+| Composer surface   | `#ffffff`             | `#1e1f20` |
+| Primary text       | `#1f1f1f`             | `#e3e3e3` |
+| Muted text & icons | `#444746`             | `#c4c7c5` |
+| User bubble        | `#f2f0f0`             | `#333537` |
+| Send (ready)       | `#d3e3fd`             | `#1f3760` |
+| Ambient glow       | `#a9d1fb`             | `#1d4068` |
+
+### Messages
+
+Assistant replies have no avatar; the markdown spans the full content width and the action bar (feedback, copy, regenerate, more) fades in on hover. User turns sit in a rounded grey bubble, right-aligned, with copy and edit actions to its left:
+
+```tsx
+<div className="max-w-[75%] rounded-3xl bg-[#f2f0f0] px-5 py-3 dark:bg-[#333537]">
+  <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
 </div>
 ```
 


### PR DESCRIPTION
## summary

- redesigned the Gemini clone example to match Gemini's current interface: a centered single-line greeting over an ambient blue glow, a single-row pill composer (combined `+` menu, inline model picker, mic, send), avatar-free full-width assistant replies, and a rounded grey user bubble. the old suggestion chips and sparkle avatars are gone.
- fixed a hover layout shift in the Claude and Perplexity clones. their message action bars used `autohide`/`hideWhenRunning`, which fully unmount the bar and remount it on hover, pushing the surrounding content. the bars now stay mounted and reveal through the opacity classes they already had, so hovering only fades them in.
- aligned the Gemini composer with the message column and vertically centered the controls inside it.

## test plan

### already verified

- [x] biome passed on all four files via the lint-staged pre-commit hook
- [x] hovered non-last messages in the Claude and Perplexity examples in the docs dev server: the action bar fades in with zero layout shift (measured `shiftPerMessage: [0,0,0,0]`)
- [x] Gemini example renders correctly in empty and chat states, light and dark; composer edges line up with the message column

### reviewer should verify

- [ ] open `/examples/gemini`, `/examples/claude`, and `/examples/perplexity`, hover messages and send a few turns to confirm the layout and hover behavior