### PR TITLE
fix(react): scroll initial thread messages into view

### DIFF
--- a/.changeset/fix-viewport-initial-messages-scroll.md
+++ b/.changeset/fix-viewport-initial-messages-scroll.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+Scroll thread viewports to bottom when initial messages are already loaded before the viewport subscribes to initialization events.

--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.test.tsx
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import type { FC, PropsWithChildren } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AssistantRuntimeProvider } from "../../context";
+import * as MessagePrimitive from "../message";
+import * as ThreadPrimitive from "../thread";
+import { useLocalRuntime } from "../../legacy-runtime/runtime-cores/local/useLocalRuntime";
+import type { ChatModelAdapter, ThreadMessageLike } from "../../index";
+
+class ResizeObserverMock {
+  observe = vi.fn();
+  disconnect = vi.fn();
+}
+
+const noOpAdapter: ChatModelAdapter = {
+  async *run() {},
+};
+
+const initialMessages: ThreadMessageLike[] = [
+  {
+    role: "user",
+    content: [{ type: "text", text: "hello" }],
+  },
+  {
+    role: "assistant",
+    content: [{ type: "text", text: "world" }],
+  },
+];
+
+const RuntimeProvider: FC<PropsWithChildren> = ({ children }) => {
+  const runtime = useLocalRuntime(noOpAdapter, { initialMessages });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+};
+
+const Message = () => (
+  <MessagePrimitive.Root>
+    <div style={{ minHeight: 120 }}>
+      <MessagePrimitive.Content />
+    </div>
+  </MessagePrimitive.Root>
+);
+
+let clientHeightDescriptor: PropertyDescriptor | undefined;
+let scrollHeightDescriptor: PropertyDescriptor | undefined;
+let scrollToDescriptor: PropertyDescriptor | undefined;
+let scrollTo: ReturnType<typeof vi.fn>;
+
+describe("useThreadViewportAutoScroll", () => {
+  beforeEach(() => {
+    clientHeightDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientHeight",
+    );
+    scrollHeightDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollHeight",
+    );
+    scrollToDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollTo",
+    );
+    scrollTo = vi.fn();
+
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get() {
+        return this.getAttribute("data-testid") === "thread-viewport" ? 100 : 0;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+      configurable: true,
+      get() {
+        return this.getAttribute("data-testid") === "thread-viewport" ? 300 : 0;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    restoreDescriptor("clientHeight", clientHeightDescriptor);
+    restoreDescriptor("scrollHeight", scrollHeightDescriptor);
+    restoreDescriptor("scrollTo", scrollToDescriptor);
+  });
+
+  it("scrolls to bottom when initial messages are already loaded before the viewport subscribes", async () => {
+    render(
+      <RuntimeProvider>
+        <ThreadPrimitive.Viewport
+          data-testid="thread-viewport"
+          scrollToBottomOnInitialize
+        >
+          <ThreadPrimitive.Messages components={{ Message }} />
+        </ThreadPrimitive.Viewport>
+      </RuntimeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(scrollTo).toHaveBeenCalledWith({
+        top: 300,
+        behavior: "instant",
+      });
+    });
+  });
+});
+
+const restoreDescriptor = (
+  key: "clientHeight" | "scrollHeight" | "scrollTo",
+  descriptor: PropertyDescriptor | undefined,
+) => {
+  if (descriptor) {
+    Object.defineProperty(HTMLElement.prototype, key, descriptor);
+  } else {
+    Reflect.deleteProperty(HTMLElement.prototype, key);
+  }
+};

--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import { useComposedRefs } from "@radix-ui/react-compose-refs";
-import { useCallback, useRef, type RefCallback } from "react";
-import { useAuiEvent } from "@assistant-ui/store";
+import { useCallback, useLayoutEffect, useRef, type RefCallback } from "react";
+import { useAuiEvent, useAuiState } from "@assistant-ui/store";
 import { useOnResizeContent } from "../../utils/hooks/useOnResizeContent";
 import { useOnScrollToBottom } from "../../utils/hooks/useOnScrollToBottom";
 import { useManagedRef } from "../../utils/hooks/useManagedRef";
@@ -61,6 +61,8 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
   // fix: delay the state change until the scroll is done
   // stores the scroll behavior to reuse during content resize, or null if not scrolling
   const scrollingToBottomBehaviorRef = useRef<ScrollBehavior | null>(null);
+  const didScrollOnInitializeRef = useRef(false);
+  const messageCount = useAuiState((s) => s.thread.messages.length);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior) => {
     const div = divRef.current;
@@ -132,6 +134,21 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
   useOnScrollToBottom(({ behavior }) => {
     scrollToBottom(behavior);
   });
+
+  useLayoutEffect(() => {
+    if (!scrollToBottomOnInitialize) return;
+    if (messageCount === 0) {
+      didScrollOnInitializeRef.current = false;
+      return;
+    }
+    if (didScrollOnInitializeRef.current) return;
+
+    didScrollOnInitializeRef.current = true;
+    scrollingToBottomBehaviorRef.current = "instant";
+    requestAnimationFrame(() => {
+      scrollToBottom("instant");
+    });
+  }, [messageCount, scrollToBottom, scrollToBottomOnInitialize]);
 
   // autoscroll on run start
   useAuiEvent("thread.runStart", () => {


### PR DESCRIPTION
## Summary
- make `useThreadViewportAutoScroll` also react to the first non-empty `thread.messages` state, not only the `thread.initialize` event
- keep the existing initialize-event path, but cover the case where `initialMessages` load before the viewport subscribes
- add a jsdom regression test and a patch changeset for `@assistant-ui/react`

Fixes #4009

## Tests
- `pnpm install --frozen-lockfile`
- `pnpm --filter assistant-stream --filter assistant-cloud --filter @assistant-ui/core build`
- `pnpm --filter safe-content-frame build`
- `pnpm exec biome check --write packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts packages/react/src/primitives/thread/useThreadViewportAutoScroll.test.tsx`
- `pnpm --dir packages/react exec vitest run src/primitives/thread/useThreadViewportAutoScroll.test.tsx`
- `pnpm --filter @assistant-ui/react build`