### PR TITLE
fix(react-ag-ui): preserve arrival order of parts in RunAggregator

### DIFF
--- a/.changeset/agui-grouping.md
+++ b/.changeset/agui-grouping.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: preserve arrival order of parts in RunAggregator
+
+The aggregator now strictly preserves the order events arrive from the upstream stream. Each `REASONING_START`, `TOOL_CALL_START`, and `TEXT_MESSAGE_END` acts as a boundary that closes the current active part, so consecutive events of the same type are grouped into one part while interleaved events of a different type produce separate parts in chronological order.
+
+Previously, the first reasoning block was always moved before the first text part regardless of arrival order, and multiple reasoning cycles were merged into a single block. Both behaviours have been removed.

--- a/.changeset/agui-grouping.md
+++ b/.changeset/agui-grouping.md
@@ -2,7 +2,7 @@
 "@assistant-ui/react-ag-ui": patch
 ---
 
-fix: preserve arrival order of parts in RunAggregator
+fix(react-ag-ui): preserve arrival order of parts in RunAggregator
 
 The aggregator now strictly preserves the order events arrive from the upstream stream. Each `REASONING_START`, `TOOL_CALL_START`, and `TEXT_MESSAGE_END` acts as a boundary that closes the current active part, so consecutive events of the same type are grouped into one part while interleaved events of a different type produce separate parts in chronological order.
 

--- a/.changeset/agui-reasoning-blocks.md
+++ b/.changeset/agui-reasoning-blocks.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: support multiple reasoning blocks per run in RunAggregator
+
+Models that emit multiple REASONING_START/REASONING_END cycles (e.g. one per LLM sub-call when tool results trigger re-evaluation) now produce separate reasoning parts interleaved with tool-call and text parts in chronological order, rather than having all reasoning content merged into a single block at position 0.

--- a/.changeset/agui-reasoning-blocks.md
+++ b/.changeset/agui-reasoning-blocks.md
@@ -1,7 +1,0 @@
----
-"@assistant-ui/react-ag-ui": patch
----
-
-fix: support multiple reasoning blocks per run in RunAggregator
-
-Models that emit multiple REASONING_START/REASONING_END cycles (e.g. one per LLM sub-call when tool results trigger re-evaluation) now produce separate reasoning parts interleaved with tool-call and text parts in chronological order, rather than having all reasoning content merged into a single block at position 0.

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -301,6 +301,9 @@ export class RunAggregator {
     parentMessageId?: string,
   ) {
     if (!id) return;
+    // A new tool call acts as a boundary: any anonymous text that arrives
+    // after it should be a new part, not appended to the pre-tool text.
+    this.activeTextMessageId = undefined;
     if (
       !this.partOrder.some(
         (part) => part.kind === "tool-call" && part.toolCallId === id,
@@ -484,19 +487,13 @@ export class RunAggregator {
 
   private handleReasoningStart(messageId?: string): void {
     if (!this.showThinking) return;
+    // A reasoning block acts as a boundary: anonymous text arriving after it
+    // should be a new part, not appended to any pre-reasoning text.
+    this.activeTextMessageId = undefined;
     const key = messageId ?? `__auto-reasoning-${++this.reasoningPartCounter}`;
     if (!this.reasoningParts.has(key)) {
       this.reasoningParts.set(key, "");
-      // First block: honour the existing heuristic (insert before first text).
-      // Subsequent blocks: append at the current tail of partOrder so they stay
-      // chronologically after the tool-call results that preceded them.
-      const isFirst = this.reasoningParts.size === 1;
-      const textIndex = this.partOrder.findIndex((p) => p.kind === "text");
-      if (isFirst && textIndex !== -1) {
-        this.partOrder.splice(textIndex, 0, { kind: "reasoning", key });
-      } else {
-        this.partOrder.push({ kind: "reasoning", key });
-      }
+      this.partOrder.push({ kind: "reasoning", key });
     }
     this.activeReasoningKey = key;
     this.emit();
@@ -504,7 +501,11 @@ export class RunAggregator {
 
   private handleReasoningContent(delta: string, messageId?: string): void {
     if (!this.showThinking || !delta) return;
-    const key = this.activeReasoningKey ?? messageId;
+    if (!this.activeReasoningKey) {
+      // Content arrived without a preceding START — create the slot lazily.
+      this.handleReasoningStart(messageId);
+    }
+    const key = this.activeReasoningKey;
     if (!key) return;
     this.reasoningParts.set(key, (this.reasoningParts.get(key) ?? "") + delta);
     this.emit();

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -54,15 +54,15 @@ export class RunAggregator {
     { buffer: string; touched: boolean }
   >();
   private activeTextMessageId: string | undefined;
-  private reasoningBuffer = "";
-  private reasoningActive = false;
+  private readonly reasoningParts = new Map<string, string>(); // key → buffer
+  private activeReasoningKey: string | undefined;
+  private reasoningPartCounter = 0;
   private readonly toolCalls = new Map<string, ToolCallState>();
   private readonly partOrder: (
     | { kind: "text"; key: string }
-    | { kind: "reasoning" }
+    | { kind: "reasoning"; key: string }
     | { kind: "tool-call"; toolCallId: string }
   )[] = [];
-  private hasReasoningPart = false;
   private textPartCounter = 0;
   private serverMessageIdReported = false;
 
@@ -81,11 +81,11 @@ export class RunAggregator {
     switch (event.type) {
       case "RUN_STARTED": {
         this.clearTextParts();
-        this.reasoningBuffer = "";
-        this.reasoningActive = false;
+        this.reasoningParts.clear();
+        this.activeReasoningKey = undefined;
+        this.reasoningPartCounter = 0;
         this.toolCalls.clear();
         this.partOrder.length = 0;
-        this.hasReasoningPart = false;
         this.textPartCounter = 0;
         this.activeTextMessageId = undefined;
         this.interrupts = undefined;
@@ -166,7 +166,9 @@ export class RunAggregator {
       case "THINKING_TEXT_MESSAGE_START":
       case "REASONING_START":
       case "REASONING_MESSAGE_START":
-        this.handleReasoningStart();
+        this.handleReasoningStart(
+          "messageId" in event ? event.messageId : undefined,
+        );
         break;
       case "THINKING_TEXT_MESSAGE_CONTENT":
       case "REASONING_MESSAGE_CONTENT":
@@ -376,14 +378,11 @@ export class RunAggregator {
 
     for (const part of this.partOrder) {
       if (part.kind === "reasoning") {
-        if (
-          this.showThinking &&
-          (this.reasoningActive || this.reasoningBuffer.length > 0)
-        ) {
-          snapshot.push({
-            type: "reasoning",
-            text: this.reasoningBuffer,
-          } as const);
+        if (this.showThinking) {
+          const buffer = this.reasoningParts.get(part.key) ?? "";
+          if (buffer.length > 0 || this.activeReasoningKey === part.key) {
+            snapshot.push({ type: "reasoning", text: buffer } as const);
+          }
         }
         continue;
       }
@@ -476,34 +475,37 @@ export class RunAggregator {
     };
   }
 
-  private handleReasoningStart(): void {
+  private handleReasoningStart(messageId?: string): void {
     if (!this.showThinking) return;
-    this.reasoningActive = true;
-    this.ensureReasoningPart();
+    const key = messageId ?? `reasoning-${++this.reasoningPartCounter}`;
+    if (!this.reasoningParts.has(key)) {
+      this.reasoningParts.set(key, "");
+      // First block: honour the existing heuristic (insert before first text).
+      // Subsequent blocks: append at the current tail of partOrder so they stay
+      // chronologically after the tool-call results that preceded them.
+      const isFirst = this.reasoningParts.size === 1;
+      const textIndex = this.partOrder.findIndex((p) => p.kind === "text");
+      if (isFirst && textIndex !== -1) {
+        this.partOrder.splice(textIndex, 0, { kind: "reasoning", key });
+      } else {
+        this.partOrder.push({ kind: "reasoning", key });
+      }
+    }
+    this.activeReasoningKey = key;
     this.emit();
   }
 
   private handleReasoningContent(delta: string): void {
     if (!this.showThinking || !delta) return;
-    this.reasoningBuffer += delta;
-    this.ensureReasoningPart();
+    const key = this.activeReasoningKey;
+    if (!key) return;
+    this.reasoningParts.set(key, (this.reasoningParts.get(key) ?? "") + delta);
     this.emit();
   }
 
   private handleReasoningEnd(): void {
     if (!this.showThinking) return;
+    this.activeReasoningKey = undefined;
     this.emit();
-  }
-
-  private ensureReasoningPart(): void {
-    if (this.hasReasoningPart) return;
-    // ensure reasoning appears before the first text segment if possible
-    const textIndex = this.partOrder.findIndex((part) => part.kind === "text");
-    if (textIndex === -1) {
-      this.partOrder.push({ kind: "reasoning" });
-    } else {
-      this.partOrder.splice(textIndex, 0, { kind: "reasoning" });
-    }
-    this.hasReasoningPart = true;
   }
 }

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -171,8 +171,15 @@ export class RunAggregator {
         );
         break;
       case "THINKING_TEXT_MESSAGE_CONTENT":
-      case "REASONING_MESSAGE_CONTENT":
         this.handleReasoningContent(event.delta);
+        this.totalChunks++;
+        this.recordFirstToken();
+        break;
+      case "REASONING_MESSAGE_CONTENT":
+        this.handleReasoningContent(
+          event.delta,
+          "messageId" in event ? event.messageId : undefined,
+        );
         this.totalChunks++;
         this.recordFirstToken();
         break;
@@ -477,7 +484,7 @@ export class RunAggregator {
 
   private handleReasoningStart(messageId?: string): void {
     if (!this.showThinking) return;
-    const key = messageId ?? `reasoning-${++this.reasoningPartCounter}`;
+    const key = messageId ?? `__auto-reasoning-${++this.reasoningPartCounter}`;
     if (!this.reasoningParts.has(key)) {
       this.reasoningParts.set(key, "");
       // First block: honour the existing heuristic (insert before first text).
@@ -495,9 +502,9 @@ export class RunAggregator {
     this.emit();
   }
 
-  private handleReasoningContent(delta: string): void {
+  private handleReasoningContent(delta: string, messageId?: string): void {
     if (!this.showThinking || !delta) return;
-    const key = this.activeReasoningKey;
+    const key = this.activeReasoningKey ?? messageId;
     if (!key) return;
     this.reasoningParts.set(key, (this.reasoningParts.get(key) ?? "") + delta);
     this.emit();

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -706,7 +706,7 @@ describe("RunAggregator", () => {
     expect((reasoningParts[0] as any).text).toBe("Part A Part B");
   });
 
-  it("positions first reasoning block before text using the existing heuristic", () => {
+  it("reasoning arriving after text starts a new part at its chronological position", () => {
     const aggregator = createAggregator(true);
 
     aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
@@ -731,8 +731,9 @@ describe("RunAggregator", () => {
 
     const last = results.at(-1);
     const types = (last?.content ?? []).map((p) => p.type);
-    expect(types[0]).toBe("reasoning");
-    expect(types[1]).toBe("text");
+    // Arrival order is preserved: text came first, then reasoning
+    expect(types[0]).toBe("text");
+    expect(types[1]).toBe("reasoning");
   });
 
   it("resets reasoning state on RUN_STARTED so blocks from the previous run do not leak", () => {

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -766,4 +766,37 @@ describe("RunAggregator", () => {
       "Clean slate",
     );
   });
+
+  it("creates a new anonymous text part after a tool call boundary", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "intro",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tc-1",
+      toolCallName: "search",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tc-1",
+      content: '"result"',
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "followup",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const last = results.at(-1);
+    const parts = last?.content ?? [];
+    const types = parts.map((p) => p.type);
+
+    expect(types).toEqual(["text", "tool-call", "text"]);
+    expect((parts[0] as any).text).toBe("intro");
+    expect((parts[2] as any).text).toBe("followup");
+  });
 });

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -601,4 +601,169 @@ describe("RunAggregator", () => {
     expect(last?.metadata?.timing).toBeDefined();
     expect(last?.metadata?.timing?.toolCallCount).toBe(1);
   });
+
+  it("emits multiple reasoning blocks as separate parts in chronological order", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+
+    // First reasoning block (before any text)
+    aggregator.handle({
+      type: "REASONING_MESSAGE_START",
+      messageId: "reason-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_CONTENT",
+      messageId: "reason-1",
+      delta: "First thought",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_END",
+      messageId: "reason-1",
+    } as AgUiEvent);
+
+    // Tool call in between
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tc-1",
+      toolCallName: "search",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tc-1",
+      content: '"found"',
+    } as AgUiEvent);
+
+    // Second reasoning block (after tool result)
+    aggregator.handle({
+      type: "REASONING_MESSAGE_START",
+      messageId: "reason-2",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_CONTENT",
+      messageId: "reason-2",
+      delta: "Second thought",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_END",
+      messageId: "reason-2",
+    } as AgUiEvent);
+
+    // Final text
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "Answer",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const last = results.at(-1);
+    const parts = last?.content ?? [];
+    const types = parts.map((p) => p.type);
+
+    // Expect: reasoning, tool-call, reasoning, text
+    expect(types).toEqual(["reasoning", "tool-call", "reasoning", "text"]);
+    expect((parts[0] as any).text).toBe("First thought");
+    expect((parts[2] as any).text).toBe("Second thought");
+  });
+
+  it("merges content into the same reasoning block when messageId is reused", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_START",
+      messageId: "reason-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_CONTENT",
+      messageId: "reason-1",
+      delta: "Part A",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_END",
+      messageId: "reason-1",
+    } as AgUiEvent);
+    // START again with the same messageId — should not create a second slot
+    aggregator.handle({
+      type: "REASONING_MESSAGE_START",
+      messageId: "reason-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_CONTENT",
+      messageId: "reason-1",
+      delta: " Part B",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_END",
+      messageId: "reason-1",
+    } as AgUiEvent);
+
+    const last = results.at(-1);
+    const reasoningParts = (last?.content ?? []).filter(
+      (p) => p.type === "reasoning",
+    );
+    expect(reasoningParts).toHaveLength(1);
+    expect((reasoningParts[0] as any).text).toBe("Part A Part B");
+  });
+
+  it("positions first reasoning block before text using the existing heuristic", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    // Text starts before reasoning
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "Answer",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_START",
+      messageId: "reason-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_CONTENT",
+      messageId: "reason-1",
+      delta: "Late reasoning",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_END",
+      messageId: "reason-1",
+    } as AgUiEvent);
+
+    const last = results.at(-1);
+    const types = (last?.content ?? []).map((p) => p.type);
+    expect(types[0]).toBe("reasoning");
+    expect(types[1]).toBe("text");
+  });
+
+  it("resets reasoning state on RUN_STARTED so blocks from the previous run do not leak", () => {
+    const aggregator = createAggregator(true);
+
+    // First run with a reasoning block
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_START",
+      messageId: "reason-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_MESSAGE_CONTENT",
+      messageId: "reason-1",
+      delta: "Old thought",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    // Second run with no reasoning
+    aggregator.handle({ type: "RUN_STARTED", runId: "r2" } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "Clean slate",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r2" } as AgUiEvent);
+
+    const last = results.at(-1);
+    const parts = last?.content ?? [];
+    expect(parts.every((p) => p.type !== "reasoning")).toBe(true);
+    expect((parts.find((p) => p.type === "text") as any)?.text).toBe(
+      "Clean slate",
+    );
+  });
 });


### PR DESCRIPTION
Fixes #4065

# Problem

`RunAggregator` had two ordering issues:

- All `REASONING_START`/`REASONING_END` cycles were merged into a single block and unconditionally moved to position 0 — reasoning that logically belonged after a tool result was visually displaced to the top of the message.
- Anonymous text arriving after a tool call or reasoning block was incorrectly appended to the pre-boundary text part instead of starting a new one at the correct chronological position.

# Solution

The aggregator now strictly preserves arrival order. Each event type acts as a boundary that closes the current active part:

- `TOOL_CALL_START` and `REASONING_START` clear `activeTextMessageId`, so anonymous text after either creates a new part at its chronological position
- `TEXT_MESSAGE_END` and `REASONING_END` close their respective active parts
Each reasoning cycle is keyed independently (by `messageId` when present, otherwise by a counter), producing separate parts interleaved with tool-call and text parts in arrival order
- The "insert first reasoning before first text" heuristic has been removed — grouping of related parts across boundaries is the responsibility of the UI layer (e.g. `MessagePrimitive.GroupedParts`)

# Changes

`run-aggregator.ts`: replace the single `reasoningBuffer`/`hasReasoningPart` fields with a keyed `Map`; add boundary clearing on tool call and reasoning start; remove the position heuristic; fix lazy reasoning part creation for content arriving without a preceding START event

`run-aggregator.spec.ts`: new tests covering multiple reasoning blocks, key deduplication, cross-run reset, lazy creation, and anonymous text boundaries across tool calls

# Backward compatibility

Models that emit one reasoning block before text are unaffected in terms of content — the block simply stays at its arrival position rather than being hoisted, which matches the stream order. Models like Gemini that reuse the same `messageId` across tool calls continue to accumulate into a single named part.

# Test plan

Added unit tests, also tested manually and confirmed that reasoning and text parts are interleaved correctly with tool calls.

P.S.: this PR was created with assistance from Github Copilot