### PR TITLE
fix: avoid disposing OpenCode runtime in StrictMode

### DIFF
--- a/.changeset/quiet-opencode-streams.md
+++ b/.changeset/quiet-opencode-streams.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix(react-opencode): keep the OpenCode runtime registry alive during React StrictMode remount checks.

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -15,6 +15,7 @@ import {
   useEffect,
   useEffectEvent,
   useMemo,
+  useRef,
   useSyncExternalStore,
 } from "react";
 import type {
@@ -289,10 +290,28 @@ export const useOpenCodeRuntime = (
     [baseUrl, options.client],
   );
   const registry = useMemo(() => createRegistry(client), [client]);
+  const pendingRegistryDisposeRef = useRef(
+    new Map<OpenCodeControllerRegistry, ReturnType<typeof setTimeout>>(),
+  );
 
   useEffect(() => {
+    const pendingDispose = pendingRegistryDisposeRef.current.get(registry);
+    if (pendingDispose) {
+      clearTimeout(pendingDispose);
+      pendingRegistryDisposeRef.current.delete(registry);
+    }
+
     return () => {
-      registry.dispose();
+      const timeout = setTimeout(() => {
+        if (pendingRegistryDisposeRef.current.get(registry) !== timeout) {
+          return;
+        }
+
+        pendingRegistryDisposeRef.current.delete(registry);
+        registry.dispose();
+      }, 0);
+
+      pendingRegistryDisposeRef.current.set(registry, timeout);
     };
   }, [registry]);
 


### PR DESCRIPTION
Fixes #4064.

Delays OpenCode registry disposal by one tick so StrictMode's remount check does not close the active event stream.

Checks:
- pnpm --filter @assistant-ui/react-opencode exec vitest run src/OpenCodeEventSource.test.ts src/OpenCodeThreadController.test.ts src/openCodeThreadState.test.ts src/useOpenCodeStreamingTiming.test.ts
- pnpm exec biome check packages/react-opencode/src/useOpenCodeRuntime.ts .changeset/quiet-opencode-streams.md
- git diff --check