### PR TITLE
fix(react-opencode): recover event stream after StrictMode cleanup

### DIFF
--- a/.changeset/fix-opencode-strictmode-registry.md
+++ b/.changeset/fix-opencode-strictmode-registry.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix(react-opencode): make the OpenCode runtime registry recover after React StrictMode cleanup.

--- a/packages/react-opencode/src/OpenCodeEventSource.test.ts
+++ b/packages/react-opencode/src/OpenCodeEventSource.test.ts
@@ -1,6 +1,64 @@
 import { OpenCodeEventSource } from "./OpenCodeEventSource";
 
+const waitFor = async (assertion: () => void) => {
+  let lastError: unknown;
+
+  for (let i = 0; i < 20; i++) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+
+  throw lastError;
+};
+
+const createAbortableStream = (signal: AbortSignal) =>
+  (async function* () {
+    await new Promise<void>((resolve) => {
+      if (signal.aborted) {
+        resolve();
+        return;
+      }
+
+      signal.addEventListener("abort", () => resolve(), { once: true });
+    });
+  })();
+
 describe("OpenCodeEventSource", () => {
+  it("reconnects immediately when a listener returns after disconnect", async () => {
+    const client = {
+      event: {
+        subscribe: vi.fn((_: unknown, options: { signal: AbortSignal }) =>
+          Promise.resolve({
+            stream: createAbortableStream(options.signal),
+          }),
+        ),
+      },
+    };
+    const source = new OpenCodeEventSource(client as never);
+
+    const unsubscribe = source.subscribe(vi.fn());
+
+    await waitFor(() => {
+      expect(client.event.subscribe).toHaveBeenCalledTimes(1);
+    });
+    expect(client.event.subscribe).toHaveBeenLastCalledWith(undefined, {
+      signal: expect.any(AbortSignal),
+      sseMaxRetryAttempts: 1,
+    });
+
+    unsubscribe();
+    source.subscribe(vi.fn());
+
+    await waitFor(() => {
+      expect(client.event.subscribe).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it("continues notifying listeners when one throws", () => {
     const source = new OpenCodeEventSource({} as never) as any;
     const listener = vi.fn();

--- a/packages/react-opencode/src/OpenCodeEventSource.ts
+++ b/packages/react-opencode/src/OpenCodeEventSource.ts
@@ -137,6 +137,7 @@ export class OpenCodeEventSource {
       try {
         const subscription = await this.client.event.subscribe(undefined, {
           signal: abortController.signal,
+          sseMaxRetryAttempts: 1,
         });
         failedToConnect = false;
         this.nextReconnectDelayMs = this.reconnectDelayMs;
@@ -149,6 +150,9 @@ export class OpenCodeEventSource {
           const normalized = normalizeEventPayload(event);
           if (!normalized) continue;
           this.emit(normalized);
+        }
+        if (abortController.signal.aborted || this.stopped) {
+          return;
         }
       } catch (error) {
         if (abortController.signal.aborted || this.stopped) return;

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -1,4 +1,5 @@
 import { OpenCodeThreadController } from "./OpenCodeThreadController";
+import type { OpenCodeServerEvent } from "./types";
 
 const createDeferred = <T>() => {
   let resolve!: (value: T) => void;
@@ -12,7 +13,106 @@ const createDeferred = <T>() => {
   return { promise, resolve, reject };
 };
 
+const createEventSource = () => {
+  let listener: ((event: OpenCodeServerEvent) => void) | undefined;
+  const unsubscribe = vi.fn();
+
+  return {
+    emit(event: OpenCodeServerEvent) {
+      listener?.(event);
+    },
+    subscribe: vi.fn((nextListener: (event: OpenCodeServerEvent) => void) => {
+      listener = nextListener;
+      return unsubscribe;
+    }),
+    unsubscribe,
+  };
+};
+
 describe("OpenCodeThreadController", () => {
+  it("re-subscribes through the provider after dispose", () => {
+    let eventSource = createEventSource();
+    const getEventSource = vi.fn(() => eventSource);
+    const controller = new OpenCodeThreadController(
+      {} as never,
+      getEventSource as never,
+      "ses_1",
+    );
+
+    const firstListener = vi.fn();
+    controller.subscribe(firstListener);
+
+    expect(getEventSource).toHaveBeenCalledTimes(1);
+    expect(eventSource.subscribe).toHaveBeenCalledTimes(1);
+
+    controller.dispose();
+
+    expect(eventSource.unsubscribe).toHaveBeenCalledTimes(1);
+
+    eventSource = createEventSource();
+    const secondListener = vi.fn();
+    controller.subscribe(secondListener);
+
+    eventSource.emit({
+      type: "session.updated",
+      sessionId: "ses_1",
+      properties: {
+        info: {
+          id: "ses_1",
+          title: "Recovered session",
+          time: {},
+        },
+      },
+      raw: {},
+    });
+
+    expect(getEventSource).toHaveBeenCalledTimes(2);
+    expect(eventSource.subscribe).toHaveBeenCalledTimes(1);
+    expect(secondListener).toHaveBeenCalledTimes(1);
+    expect(controller.getState().session).toMatchObject({
+      id: "ses_1",
+      title: "Recovered session",
+    });
+  });
+
+  it("detaches from OpenCode events when the last state listener unsubscribes", () => {
+    const eventSource = createEventSource();
+    const controller = new OpenCodeThreadController(
+      {} as never,
+      eventSource as never,
+      "ses_1",
+    );
+
+    const unsubscribeFirstState = controller.subscribe(vi.fn());
+    const secondListener = vi.fn();
+    const unsubscribeSecondState = controller.subscribe(secondListener);
+
+    expect(eventSource.subscribe).toHaveBeenCalledTimes(1);
+
+    unsubscribeFirstState();
+
+    expect(eventSource.unsubscribe).not.toHaveBeenCalled();
+
+    eventSource.emit({
+      type: "session.updated",
+      sessionId: "ses_1",
+      properties: {
+        info: {
+          id: "ses_1",
+          title: "Still attached",
+          time: {},
+        },
+      },
+      raw: {},
+    });
+
+    expect(secondListener).toHaveBeenCalledTimes(1);
+
+    unsubscribeSecondState();
+
+    expect(eventSource.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps forced reloads authoritative while earlier loads finish", async () => {
     const firstSession = createDeferred<{ data: unknown }>();
     const firstMessages = createDeferred<{ data: unknown[] }>();

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -35,7 +35,7 @@ describe("OpenCodeThreadController", () => {
     const getEventSource = vi.fn(() => eventSource);
     const controller = new OpenCodeThreadController(
       {} as never,
-      getEventSource as never,
+      getEventSource,
       "ses_1",
     );
 
@@ -79,7 +79,7 @@ describe("OpenCodeThreadController", () => {
     const eventSource = createEventSource();
     const controller = new OpenCodeThreadController(
       {} as never,
-      eventSource as never,
+      () => eventSource,
       "ses_1",
     );
 
@@ -134,7 +134,7 @@ describe("OpenCodeThreadController", () => {
 
     const controller = new OpenCodeThreadController(
       client as never,
-      { subscribe: () => () => {} } as never,
+      () => ({ subscribe: () => () => {} }),
       "ses_1",
     );
 
@@ -212,7 +212,7 @@ describe("OpenCodeThreadController", () => {
 
     const controller = new OpenCodeThreadController(
       client as never,
-      { subscribe: () => () => {} } as never,
+      () => ({ subscribe: () => () => {} }),
       "ses_1",
     );
 
@@ -260,7 +260,7 @@ describe("OpenCodeThreadController", () => {
 
     const controller = new OpenCodeThreadController(
       client as never,
-      { subscribe: () => () => {} } as never,
+      () => ({ subscribe: () => () => {} }),
       "ses_1",
     );
 

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -24,6 +24,10 @@ import type {
 import type { OpenCodeEventSource } from "./OpenCodeEventSource";
 import { serializeUserParts } from "./serializeUserParts";
 
+type OpenCodeEventSourceProvider =
+  | OpenCodeEventSource
+  | (() => OpenCodeEventSource);
+
 const createLocalId = (prefix: string) =>
   `${prefix}_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
 
@@ -161,23 +165,32 @@ const isSupportedDelta = (
 export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   private state: OpenCodeThreadState;
   private readonly listeners = new Set<() => void>();
-  private readonly unsubscribeFromEvents: () => void;
+  private readonly getEventSource: () => OpenCodeEventSource;
+  private unsubscribeFromEvents: (() => void) | null = null;
   private loadPromise: Promise<void> | null = null;
 
   constructor(
     private readonly client: OpencodeClient,
-    private readonly eventSource: OpenCodeEventSource,
+    eventSource: OpenCodeEventSourceProvider,
     private readonly sessionId: string,
   ) {
     this.state = createOpenCodeThreadState(sessionId);
-    this.unsubscribeFromEvents = this.eventSource.subscribe((event) => {
-      if (event.sessionId !== sessionId) return;
+    this.getEventSource =
+      typeof eventSource === "function" ? eventSource : () => eventSource;
+  }
+
+  private ensureEventSubscription() {
+    if (this.unsubscribeFromEvents) return;
+
+    this.unsubscribeFromEvents = this.getEventSource().subscribe((event) => {
+      if (event.sessionId !== this.sessionId) return;
       this.handleServerEvent(event);
     });
   }
 
   public dispose() {
-    this.unsubscribeFromEvents();
+    this.unsubscribeFromEvents?.();
+    this.unsubscribeFromEvents = null;
     this.listeners.clear();
   }
 
@@ -187,7 +200,15 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
 
   public subscribe(listener: () => void) {
     this.listeners.add(listener);
-    return () => this.listeners.delete(listener);
+    this.ensureEventSubscription();
+
+    return () => {
+      this.listeners.delete(listener);
+      if (this.listeners.size === 0) {
+        this.unsubscribeFromEvents?.();
+        this.unsubscribeFromEvents = null;
+      }
+    };
   }
 
   public async load(force = false) {

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -24,9 +24,7 @@ import type {
 import type { OpenCodeEventSource } from "./OpenCodeEventSource";
 import { serializeUserParts } from "./serializeUserParts";
 
-type OpenCodeEventSourceProvider =
-  | OpenCodeEventSource
-  | (() => OpenCodeEventSource);
+type OpenCodeEventSourceProvider = () => Pick<OpenCodeEventSource, "subscribe">;
 
 const createLocalId = (prefix: string) =>
   `${prefix}_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
@@ -165,18 +163,17 @@ const isSupportedDelta = (
 export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   private state: OpenCodeThreadState;
   private readonly listeners = new Set<() => void>();
-  private readonly getEventSource: () => OpenCodeEventSource;
+  private readonly getEventSource: OpenCodeEventSourceProvider;
   private unsubscribeFromEvents: (() => void) | null = null;
   private loadPromise: Promise<void> | null = null;
 
   constructor(
     private readonly client: OpencodeClient,
-    eventSource: OpenCodeEventSourceProvider,
+    getEventSource: OpenCodeEventSourceProvider,
     private readonly sessionId: string,
   ) {
     this.state = createOpenCodeThreadState(sessionId);
-    this.getEventSource =
-      typeof eventSource === "function" ? eventSource : () => eventSource;
+    this.getEventSource = getEventSource;
   }
 
   private ensureEventSubscription() {
@@ -189,6 +186,7 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   }
 
   public dispose() {
+    // React StrictMode can detach and then resubscribe the same controller.
     this.unsubscribeFromEvents?.();
     this.unsubscribeFromEvents = null;
     this.listeners.clear();

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -87,6 +87,8 @@ const createRegistry = (
       for (const controller of controllers.values()) {
         controller.dispose();
       }
+      // Keep controllers cached across React StrictMode cleanup/remount.
+      // Cleanup only detaches subscriptions; a real unmount drops this registry.
     },
   };
 };

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -30,7 +30,7 @@ import { createOpenCodeThreadState } from "./openCodeThreadState";
 import { useOpenCodeStreamingTiming } from "./useOpenCodeStreamingTiming";
 
 type OpenCodeControllerRegistry = {
-  eventSource: OpenCodeEventSource;
+  getEventSource(): OpenCodeEventSource;
   controllers: Map<string, OpenCodeThreadController>;
   dispose(): void;
 };
@@ -70,18 +70,23 @@ const EMPTY_THREAD_STATE = createOpenCodeThreadState("__pending__");
 const createRegistry = (
   client: ReturnType<typeof createOpencodeClient>,
 ): OpenCodeControllerRegistry => {
-  const eventSource = new OpenCodeEventSource(client);
+  let eventSource: OpenCodeEventSource | null = null;
   const controllers = new Map<string, OpenCodeThreadController>();
 
+  const getEventSource = () => {
+    eventSource ??= new OpenCodeEventSource(client);
+    return eventSource;
+  };
+
   return {
-    eventSource,
+    getEventSource,
     controllers,
     dispose() {
-      eventSource.dispose();
+      eventSource?.dispose();
+      eventSource = null;
       for (const controller of controllers.values()) {
         controller.dispose();
       }
-      controllers.clear();
     },
   };
 };
@@ -96,7 +101,7 @@ const getController = (
 
   const controller = new OpenCodeThreadController(
     client,
-    registry.eventSource,
+    registry.getEventSource,
     sessionId,
   );
   registry.controllers.set(sessionId, controller);


### PR DESCRIPTION
closes #4064

## summary

- keep OpenCode streaming alive when React StrictMode replays mount cleanup, so the runtime no longer needs a manual browser refresh to receive new messages.
- make the OpenCode runtime registry recreate the SSE event source after cleanup while preserving per-session controller state.
- subscribe controllers to OpenCode events only while assistant-ui has active state listeners, and let the adapter own SSE reconnect timing instead of stacking it with SDK retries.
- add regression coverage for dispose and resubscribe behavior, listener ref counting, and immediate SSE reconnect after abort.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-opencode exec vitest run` -> 5 files, 32 tests passed
- [x] `pnpm exec biome check packages/react-opencode/src/useOpenCodeRuntime.ts packages/react-opencode/src/OpenCodeThreadController.ts packages/react-opencode/src/OpenCodeThreadController.test.ts packages/react-opencode/src/OpenCodeEventSource.ts packages/react-opencode/src/OpenCodeEventSource.test.ts .changeset/fix-opencode-strictmode-registry.md` -> no fixes applied
- [x] `pnpm --filter @assistant-ui/react-opencode build` -> built 9 files to dist
- [x] `git diff --check origin/main..HEAD` -> no output

### reviewer should verify

- [ ] run an app using `useOpenCodeRuntime` inside `<StrictMode>`, start or reload an OpenCode run, and confirm new messages stream without refreshing the browser.