### PR TITLE
fix(store): key Derived scopes by meta so consumers see new client in the same render pass

### DIFF
--- a/.changeset/derived-meta-fiber-key.md
+++ b/.changeset/derived-meta-fiber-key.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix(store): key `Derived` scopes by `{source, query}` so a meta change produces a new client function in the same render pass. Previously a `Derived` whose `query` changed (e.g. `MessageByIndexProvider` whose `index` prop changed across renders) kept its underlying resource fiber, and the `get` closure was updated via `tapEffectEvent` — which lags one commit. During the in-flight render after a meta change, child consumers reading through the derived scope could resolve through the previous closure and read an index the underlying store no longer had. Hashing the meta into the `tapResources` key forces the fiber to be replaced when meta changes, so the new `clientFunction` (and the new `get`) propagates through React context immediately. Also drops the unused dynamic-meta variant (`Derived({ getMeta })`); use static `source`/`query`.

--- a/apps/docs/content/tap-docs/store/api-reference.mdx
+++ b/apps/docs/content/tap-docs/store/api-reference.mdx
@@ -106,21 +106,14 @@ function Derived<K extends ClientNames>(config: Derived.Props<K>): DerivedElemen
 Creates a derived scope that points to data in a parent scope.
 
 ```ts
-// static meta
 Derived({
   source: "thread",
   query: { index: 0 },
   get: (aui) => aui.thread().message({ index: 0 }),
 });
-
-// dynamic meta
-Derived({
-  getMeta: (aui) => ({ source: "thread", query: { index } }),
-  get: (aui) => aui.thread().message({ index }),
-});
 ```
 
-The `get` function receives the current `AssistantClient` and must return the result of calling a parent scope method. It uses `tapEffectEvent` internally — always calls the latest closure.
+The `get` function receives the current `AssistantClient` and must return the result of calling a parent scope method. The meta (`source`, `query`) acts as identity: when `query` changes between renders, a new derived client function is returned in the same render pass — useful for keying child consumers like `MessageByIndex` by index.
 
 ### attachTransformScopes
 

--- a/packages/store/SPEC.md
+++ b/packages/store/SPEC.md
@@ -56,9 +56,8 @@ Selectors: `"client.event"` | `{ scope: "parent", event }` | `{ scope: "*", even
 ### Derived
 ```typescript
 Derived<K>({ source, query, get: (client) => methods });
-Derived<K>({ getMeta: (client) => { source, query }, get });
 ```
-Returns marker element. `get` uses `tapEffectEvent` - always calls latest closure.
+Returns marker element. Meta (`source`, `query`) keys the derived scope's resource fiber — a different meta yields a new client function in the same render pass, so consumers see the new derivation immediately rather than after the next commit.
 
 ### attachTransformScopes
 ```typescript

--- a/packages/store/src/Derived.ts
+++ b/packages/store/src/Derived.ts
@@ -42,5 +42,5 @@ export namespace Derived {
    */
   export type Props<K extends ClientNames> = {
     get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
-  } & (ClientMeta<K> | { getMeta: (client: AssistantClient) => ClientMeta<K> });
+  } & ClientMeta<K>;
 }

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -229,14 +229,13 @@ const DerivedClientAccessorResource = resource(
     propsRef.current = element.props;
 
     return tapMemo(() => {
-      const clientFunction = () =>
-        propsRef.current.get(clientRef.current!);
+      const clientFunction = () => propsRef.current.get(clientRef.current!);
       Object.defineProperties(clientFunction, {
         source: {
-          value: element.props.source,
+          value: propsRef.current.source,
         },
         query: {
-          value: element.props.query,
+          value: propsRef.current.query,
         },
         name: {
           value: name,

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -5,7 +5,6 @@ import {
   resource,
   tapMemo,
   tapResources,
-  tapEffectEvent,
   tapEffect,
   tapRef,
   tapResource,
@@ -19,7 +18,7 @@ import type {
   ClientElement,
   ClientMeta,
 } from "./types/client";
-import type { Derived, DerivedElement } from "./Derived";
+import type { DerivedElement } from "./Derived";
 import {
   useAssistantContextValue,
   DefaultAssistantClient,
@@ -209,24 +208,6 @@ const RootClientsAccessorsResource = resource(
   },
 );
 
-type MetaMemo<K extends ClientNames> = {
-  meta?: ClientMeta<K>;
-  dep?: unknown;
-};
-
-const getMeta = <K extends ClientNames>(
-  props: Derived.Props<K>,
-  clientRef: { parent: AssistantClient; current: AssistantClient | null },
-  memo: MetaMemo<K>,
-): ClientMeta<K> => {
-  if ("source" in props && "query" in props) return props;
-  if (memo.dep === props) return memo.meta!;
-  const meta = props.getMeta(clientRef.current!);
-  memo.meta = meta;
-  memo.dep = props;
-  return meta;
-};
-
 const DerivedClientAccessorResource = resource(
   <K extends ClientNames>({
     element,
@@ -237,17 +218,25 @@ const DerivedClientAccessorResource = resource(
     clientRef: { parent: AssistantClient; current: AssistantClient | null };
     name: K;
   }) => {
-    const get = tapEffectEvent(() => element.props);
+    // Track the latest props on a ref updated in render. The fiber is
+    // keyed on the scope's meta by DerivedClientsAccessorsResource, so
+    // source/query are stable for this fiber's lifetime and the only
+    // value that can change between renders for the same fiber is the
+    // identity of the `get` closure. Routing reads through the ref
+    // avoids the one-commit lag that the previous `tapEffectEvent`
+    // path imposed.
+    const propsRef = tapRef(element.props);
+    propsRef.current = element.props;
 
     return tapMemo(() => {
-      const clientFunction = () => get().get(clientRef.current!);
-      const metaMemo = {};
+      const clientFunction = () =>
+        propsRef.current.get(clientRef.current!);
       Object.defineProperties(clientFunction, {
         source: {
-          get: () => getMeta(get(), clientRef, metaMemo).source,
+          value: element.props.source,
         },
         query: {
-          get: () => getMeta(get(), clientRef, metaMemo).query,
+          value: element.props.query,
         },
         name: {
           value: name,
@@ -258,6 +247,11 @@ const DerivedClientAccessorResource = resource(
     }, [clientRef, name]);
   },
 );
+
+const serializeMeta = <K extends ClientNames>(
+  name: K,
+  meta: ClientMeta<K>,
+): string => `${name}::${meta.source}::${JSON.stringify(meta.query)}`;
 
 const DerivedClientsAccessorsResource = resource(
   ({
@@ -270,16 +264,18 @@ const DerivedClientsAccessorsResource = resource(
     return tapShallowMemoArray(
       tapResources(
         () =>
-          Object.keys(clients).map((key) =>
-            withKey(
-              key,
+          Object.keys(clients).map((key) => {
+            const name = key as keyof typeof clients;
+            const element = clients[name]!;
+            return withKey(
+              serializeMeta(name, element.props),
               DerivedClientAccessorResource({
-                element: clients[key as keyof typeof clients]!,
+                element,
                 clientRef,
-                name: key as keyof typeof clients,
+                name,
               }),
-            ),
-          ),
+            );
+          }),
         [clients, clientRef],
       ),
     );

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -250,7 +250,22 @@ const DerivedClientAccessorResource = resource(
 const serializeMeta = <K extends ClientNames>(
   name: K,
   meta: ClientMeta<K>,
-): string => `${name}::${meta.source}::${JSON.stringify(meta.query)}`;
+): string => {
+  // Sort top-level keys so {a, b} and {b, a} hash to the same fiber
+  // identity, and guard JSON.stringify against unusual values (BigInt,
+  // circular refs) so render never throws here.
+  let queryKey: string;
+  try {
+    const sorted: Record<string, unknown> = {};
+    for (const k of Object.keys(meta.query as object).sort()) {
+      sorted[k] = (meta.query as Record<string, unknown>)[k];
+    }
+    queryKey = JSON.stringify(sorted);
+  } catch {
+    queryKey = String(meta.query);
+  }
+  return `${name}::${meta.source}::${queryKey}`;
+};
 
 const DerivedClientsAccessorsResource = resource(
   ({

--- a/packages/store/src/utils/splitClients.ts
+++ b/packages/store/src/utils/splitClients.ts
@@ -6,7 +6,7 @@ import type {
 } from "../types/client";
 import { getTransformScopes } from "../attachTransformScopes";
 import type { useAui } from "../useAui";
-import { tapMemo } from "@assistant-ui/tap";
+import { tapMemo, type ResourceElement } from "@assistant-ui/tap";
 
 export type RootClients = Partial<
   Record<ClientNames, ClientElement<ClientNames>>
@@ -35,7 +35,9 @@ function splitClients(clients: useAui.Props, baseClient: AssistantClient) {
       if (visited.has(clientElement.type)) continue;
       visited.add(clientElement.type);
 
-      const transform = getTransformScopes(clientElement.type);
+      const transform = getTransformScopes(
+        clientElement.type as (props: any) => ResourceElement<any>,
+      );
       if (transform) {
         transform(scopes, baseClient);
         changed = true;


### PR DESCRIPTION
## Summary

- Hashes `Derived`'s `{source, query}` meta into the `tapResources` key for derived client fibers. When a `Derived` is re-rendered with a new meta (e.g. an index-keyed provider passes a new `index`), the derived fiber is replaced rather than reused — the new `clientFunction` (with the new `get` closure) propagates through React context in the same render pass.
- Drops the `Derived({ getMeta })` dynamic-meta variant. It had no production callers (only the type, SPEC, and one doc example). The static `{source, query}` shape is now the only supported form.
- Removes the `tapEffectEvent` wrapping in `DerivedClientAccessorResource` that was sitting one commit behind. Latest `get` is now read from a render-updated ref.

## Why

`tapEffectEvent` updates its callback ref in a post-commit `tapEffect`. So when a `Derived`'s `query` changed across renders, the underlying resource fiber was reused, and the `get` closure exposed through the proxy lagged by one commit. During the in-flight render after a meta change, child consumers resolving through the derived scope could call the previous closure into an underlying store that had already shrunk, surfacing as `tapClientLookup: Index N out of bounds`.

This is a candidate fix for one mechanism behind #4051, but probably not the only one — real apps that use `ThreadPrimitive.Messages` get `key={index}` reconciliation (same index per key, no meta change) and wouldn't hit this path. Leaving the issue open until other shapes are investigated.

## Test plan

- [ ] `pnpm --filter @assistant-ui/store test` passes.
- [ ] Repro in `examples/repro-3652` (push branch [`repro-3652`](https://github.com/assistant-ui/assistant-ui/compare/main...repro-3652)) was firing `tapClientLookup: Index N out of bounds` within ~5s without this change; with the change, 30+ seconds of churn stays clean.
- [ ] No production caller used `Derived({ getMeta })` (grep `getMeta:` across packages/apps/examples/templates).

Related: #3652

🤖 Generated with [Claude Code](https://claude.com/claude-code)