### PR TITLE
fix(core): replay latched initialize event to late subscribers

### DIFF
--- a/.changeset/fix-initialize-event-replay.md
+++ b/.changeset/fix-initialize-event-replay.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): replay the latched `initialize` thread event to late subscribers. `ensureInitialized` emits `initialize` once during construction, so a runtime seeded with non-empty `messages` (e.g. `useChatRuntime({ messages })` under `useRemoteThreadListRuntime`) fired it before the title binder's effect subscribed, and the `runEnd` → `generateTitle` wiring was never installed. `unstable_on("initialize", ...)` now schedules a one-off replay (on a microtask, re-checking the subscription) when the thread has already initialized, mirroring a BehaviorSubject, so late subscribers (the title binder, and `ThreadViewport`'s `thread.initialize` top-anchor reset) no longer miss it.

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -140,6 +140,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     }, [threadBinding]);
 
     useEffect(() => {
+      hasInitializedRef.current = false;
       return runtime.threads.main.unstable_on("initialize", () => {
         if (hasInitializedRef.current) return;
 

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -128,6 +128,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
 
     const aui = useAui();
     const initPromiseRef = useRef<Promise<unknown> | undefined>(undefined);
+    const hasInitializedRef = useRef(false);
 
     useEffect(() => {
       const runtimeCore = threadBinding.getState();
@@ -140,16 +141,18 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
 
     useEffect(() => {
       return runtime.threads.main.unstable_on("initialize", () => {
+        if (hasInitializedRef.current) return;
+
         const state = aui.threadListItem().getState();
-        if (state.status === "new") {
-          initPromiseRef.current = aui.threadListItem().initialize();
+        if (state.status !== "new") return;
+        hasInitializedRef.current = true;
 
-          const dispose = runtime.thread.unstable_on("runEnd", () => {
-            dispose();
+        initPromiseRef.current = aui.threadListItem().initialize();
 
-            aui.threadListItem().generateTitle();
-          });
-        }
+        const dispose = runtime.thread.unstable_on("runEnd", () => {
+          dispose();
+          aui.threadListItem().generateTitle();
+        });
       });
     }, [runtime, aui]);
 

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -478,6 +478,14 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
     }
     subscribers.add(wrapped);
 
+    // `initialize` latches: replay it (deferred) to subscribers that attach
+    // after the thread already initialized, mirroring a BehaviorSubject.
+    if (event === "initialize" && this._isInitialized) {
+      queueMicrotask(() => {
+        if (this._eventSubscribers.get(event)?.has(wrapped)) wrapped({});
+      });
+    }
+
     return () => {
       this._eventSubscribers.get(event)?.delete(wrapped);
     };

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -482,7 +482,7 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
     // after the thread already initialized, mirroring a BehaviorSubject.
     if (event === "initialize" && this._isInitialized) {
       queueMicrotask(() => {
-        if (this._eventSubscribers.get(event)?.has(wrapped)) wrapped({});
+        if (subscribers.has(wrapped)) wrapped({});
       });
     }
 

--- a/packages/core/src/runtime/interfaces/thread-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-runtime-core.ts
@@ -85,11 +85,12 @@ export type ThreadRuntimeEventPayload = {
    */
   runEnd: Record<string, never>;
   /**
-   * @deprecated State-derivable. This event fires at the initialization
-   * transition immediately BEFORE the first message is added, so reading state
-   * inside the handler still sees an empty thread; observe `state.messages`
-   * becoming non-empty via a regular `subscribe` callback instead. Kept for
-   * backward compatibility.
+   * @deprecated State-derivable. Observe `state.messages` becoming non-empty
+   * via a regular `subscribe` callback instead. This event fires once at the
+   * initialization transition; subscribers that attach afterwards receive a
+   * one-off replay (on a microtask), by which point the thread already has
+   * messages, so handler-visible state differs between live and replayed
+   * delivery. Kept for backward compatibility.
    */
   initialize: Record<string, never>;
   /**

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -266,8 +266,7 @@ describe("ExternalStoreThreadRuntimeCore - messages reconciliation", () => {
 
 describe("ExternalStoreThreadRuntimeCore - initialize event replay", () => {
   const message = { id: "m", role: "assistant" as const, content: [] };
-  const flushMicrotasks = () =>
-    new Promise<void>((resolve) => setTimeout(resolve, 0));
+  const flushMicrotasks = () => Promise.resolve();
 
   it("replays initialize to subscribers that attach after initialization", async () => {
     const runtime = new ExternalStoreThreadRuntimeCore(

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -263,3 +263,87 @@ describe("ExternalStoreThreadRuntimeCore - messages reconciliation", () => {
     expect(userChildren).toEqual(["server_id"]);
   });
 });
+
+describe("ExternalStoreThreadRuntimeCore - initialize event replay", () => {
+  const message = { id: "m", role: "assistant" as const, content: [] };
+  const flushMicrotasks = () =>
+    new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  it("replays initialize to subscribers that attach after initialization", async () => {
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages: [message] }),
+    );
+
+    const callback = vi.fn();
+    runtime.unstable_on("initialize", callback);
+
+    expect(callback).not.toHaveBeenCalled();
+    await flushMicrotasks();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire before initialization, then fires exactly once", () => {
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages: [] }),
+    );
+
+    const callback = vi.fn();
+    runtime.unstable_on("initialize", callback);
+    expect(callback).not.toHaveBeenCalled();
+
+    runtime.__internal_setAdapter(makeStore({ messages: [message] }));
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    runtime.__internal_setAdapter(makeStore({ messages: [message] }));
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers initialize once to each late subscriber", async () => {
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages: [message] }),
+    );
+
+    const late1 = vi.fn();
+    const late2 = vi.fn();
+    runtime.unstable_on("initialize", late1);
+    runtime.unstable_on("initialize", late2);
+
+    await flushMicrotasks();
+    expect(late1).toHaveBeenCalledTimes(1);
+    expect(late2).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the replay when the subscriber unsubscribes before it runs", async () => {
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages: [message] }),
+    );
+
+    const callback = vi.fn();
+    const unsubscribe = runtime.unstable_on("initialize", callback);
+    unsubscribe();
+
+    await flushMicrotasks();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("does not replay non-latched events such as runEnd", async () => {
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages: [message], isRunning: true }),
+    );
+
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [message], isRunning: false }),
+    );
+
+    const callback = vi.fn();
+    runtime.unstable_on("runEnd", callback);
+
+    await flushMicrotasks();
+    expect(callback).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
closes #4070

## summary

- remote threads seeded with non-empty `messages` (e.g. a welcome message via `useChatRuntime({ messages })` under `useRemoteThreadListRuntime`) now get auto-generated titles again; the `runEnd` → `generateTitle` wiring fires after the first run.
- root cause: `initialize` is a latched, one-shot event that `ensureInitialized` emits during construction, before the title binder's `useEffect` subscribes, so the subscription registered too late and the wiring was never installed. `ThreadViewport`'s `thread.initialize` top-anchor reset had the same latent race.
- `unstable_on("initialize", ...)` now replays the latched event to late subscribers (deferred to a microtask, re-checking the subscription), mirroring a BehaviorSubject, so any consumer attaching after init still receives it.
- the remote-thread-list title binder gets an idempotency guard so the replay and StrictMode re-subscribes wire `generateTitle` exactly once.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/core test` -> 26 files / 215 tests green (incl. 5 new replay cases)
- [x] `pnpm --filter @assistant-ui/react exec vitest run RemoteThreadList useThreadViewportAutoScroll` -> 10/10 green against rebuilt core
- [x] `pnpm --filter @assistant-ui/core build` -> typecheck passes, biome clean on changed files

### reviewer should verify

- [ ] in an app using `useRemoteThreadListRuntime` with a per-thread `useChatRuntime({ messages: [seed] })`, start a new thread and send the first message; confirm `RemoteThreadListAdapter.generateTitle` is called and the thread title updates

## notes

- the replay is scoped to the latched `initialize` event only; `runStart`/`runEnd`/`modelContextUpdate` are unaffected. the implicit contract is now that `initialize` consumers must be idempotent, since a re-subscribe (StrictMode, dep change) replays once per subscription; both current consumers (the title binder and `ThreadViewport`) satisfy this.
- same class of timing race as #4063 (`scrollToBottomOnInitialize`), but fixed at the event primitive so every `initialize` consumer benefits instead of patching each call site.