### PR TITLE
fix(react): resync useSmooth displayedText on part change

### DIFF
--- a/.changeset/use-smooth-render-resync.md
+++ b/.changeset/use-smooth-render-resync.md
@@ -1,0 +1,10 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react|useSmooth): render-phase resync of displayed text on part change
+
+Drop one frame of stale text after a thread switch by resyncing
+`displayedText` in render when the part instance flips or `text`
+breaks its streaming-append continuity, instead of waiting for
+the post-commit effect.

--- a/packages/react/src/utils/smooth/useSmooth.ts
+++ b/packages/react/src/utils/smooth/useSmooth.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAui } from "@assistant-ui/store";
 import type {
   MessagePartStatus,
@@ -82,16 +82,15 @@ export const useSmooth = (
 
   // Render-phase resync on part flip or text discontinuity, so the
   // first paint after a thread switch never shows the previous
-  // part's text (#4051).
+  // part's text (#4051). `displayedText` is already a prefix of
+  // `text` during normal streaming, so use it as the previous-text
+  // reference instead of carrying separate state — avoids the
+  // double render per streaming token.
   const part = useAui().part();
   const [prevPart, setPrevPart] = useState(part);
-  const [prevText, setPrevText] = useState(text);
-  if (part !== prevPart || (text !== prevText && !text.startsWith(prevText))) {
+  if (part !== prevPart || !text.startsWith(displayedText)) {
     setPrevPart(part);
-    setPrevText(text);
     setDisplayedText(state.status.type === "running" ? "" : text);
-  } else if (text !== prevText) {
-    setPrevText(text);
   }
 
   const smoothStatusStore = useSmoothStatusStore({ optional: true });
@@ -121,14 +120,21 @@ export const useSmooth = (
     new TextStreamAnimator(displayedText, setText),
   );
 
+  const animatorPartRef = useRef(part);
   useEffect(() => {
     if (!smooth) {
       animatorRef.stop();
       return;
     }
 
-    // Discontinuity — sync the animator's cursor to the new target.
-    if (!text.startsWith(animatorRef.targetText)) {
+    // Discontinuity: part flipped, or new text breaks continuation
+    // of the animator's current target. Either case requires
+    // resetting the cursor — without the part check, a new part
+    // whose text happens to share a prefix with the previous target
+    // would keep the stale cursor and flicker.
+    const partChanged = animatorPartRef.current !== part;
+    animatorPartRef.current = part;
+    if (partChanged || !text.startsWith(animatorRef.targetText)) {
       if (state.status.type === "running") {
         animatorRef.currentText = "";
         animatorRef.targetText = text;
@@ -143,7 +149,7 @@ export const useSmooth = (
 
     animatorRef.targetText = text;
     animatorRef.start();
-  }, [animatorRef, smooth, text, state.status.type]);
+  }, [animatorRef, smooth, text, state.status.type, part]);
 
   useEffect(() => {
     return () => {

--- a/packages/react/src/utils/smooth/useSmooth.ts
+++ b/packages/react/src/utils/smooth/useSmooth.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import { useAuiState } from "@assistant-ui/store";
+import { useEffect, useMemo, useState } from "react";
+import { useAui } from "@assistant-ui/store";
 import type {
   MessagePartStatus,
   ReasoningMessagePart,
@@ -75,12 +75,24 @@ export const useSmooth = (
   smooth: boolean = false,
 ): MessagePartState & (TextMessagePart | ReasoningMessagePart) => {
   const { text } = state;
-  const id = useAuiState((s) => s.message.id);
 
-  const idRef = useRef(id);
   const [displayedText, setDisplayedText] = useState(
     state.status.type === "running" ? "" : text,
   );
+
+  // Render-phase resync on part flip or text discontinuity, so the
+  // first paint after a thread switch never shows the previous
+  // part's text (#4051).
+  const part = useAui().part();
+  const [prevPart, setPrevPart] = useState(part);
+  const [prevText, setPrevText] = useState(text);
+  if (part !== prevPart || (text !== prevText && !text.startsWith(prevText))) {
+    setPrevPart(part);
+    setPrevText(text);
+    setDisplayedText(state.status.type === "running" ? "" : text);
+  } else if (text !== prevText) {
+    setPrevText(text);
+  }
 
   const smoothStatusStore = useSmoothStatusStore({ optional: true });
   const setText = useCallbackRef((text: string) => {
@@ -115,29 +127,23 @@ export const useSmooth = (
       return;
     }
 
-    if (idRef.current !== id || !text.startsWith(animatorRef.targetText)) {
-      idRef.current = id;
-
+    // Discontinuity — sync the animator's cursor to the new target.
+    if (!text.startsWith(animatorRef.targetText)) {
       if (state.status.type === "running") {
-        // New streaming message → animate from empty string
-        setText("");
         animatorRef.currentText = "";
         animatorRef.targetText = text;
         animatorRef.start();
       } else {
-        // Completed message → display immediately
-        setText(text);
         animatorRef.currentText = text;
         animatorRef.targetText = text;
         animatorRef.stop();
       }
-
       return;
     }
 
     animatorRef.targetText = text;
     animatorRef.start();
-  }, [setText, animatorRef, id, smooth, text, state.status.type]);
+  }, [animatorRef, smooth, text, state.status.type]);
 
   useEffect(() => {
     return () => {

--- a/packages/react/src/utils/smooth/useSmooth.ts
+++ b/packages/react/src/utils/smooth/useSmooth.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useAui } from "@assistant-ui/store";
+import { useAui, useAuiState } from "@assistant-ui/store";
 import type {
   MessagePartStatus,
   ReasoningMessagePart,
@@ -85,8 +85,12 @@ export const useSmooth = (
   // part's text (#4051). `displayedText` is already a prefix of
   // `text` during normal streaming, so use it as the previous-text
   // reference instead of carrying separate state — avoids the
-  // double render per streaming token.
-  const part = useAui().part();
+  // double render per streaming token. Read part identity through
+  // `useAuiState` so we actually subscribe to its changes instead
+  // of relying on a render-time proxy reference that may be stable
+  // across thread swaps.
+  const aui = useAui();
+  const part = useAuiState(() => aui.part());
   const [prevPart, setPrevPart] = useState(part);
   if (part !== prevPart || !text.startsWith(displayedText)) {
     setPrevPart(part);


### PR DESCRIPTION
## Summary

`useSmooth` (used by default in `MessagePartPrimitive.Text` via `smooth={true}`) buffers the displayed text in React state and only updated it inside a post-commit `useEffect`. On a thread switch — where a surviving `MessagePartPrimitive.Text` fiber receives a different `text` prop in the same render — the first paint after the switch would still show the previous thread's text against the new parent context (visible tearing).

This adds a render-phase resync: when the underlying part instance flips, or when `text` is no longer a streaming-append continuation of the previous render's `text`, `displayedText` resets in the same render. Smooth streaming (text growing as a prefix) continues to flow through the animator without churn.

The redundant `setText(...)` calls and `idRef` tracking inside the post-commit effect are removed; the effect now only mutates the animator's internal cursor.

May be a partial fix for some of the symptoms reported in #4051 (we have not yet reproduced the full crash there), but it closes a tearing path I was able to observe.

## Test plan

- [ ] `pnpm turbo build --filter=@assistant-ui/react` passes
- [ ] Existing `useSmooth` / `MessagePartText` consumers behave the same on streaming append
- [ ] Thread switch in `examples/repro-3652/app/thread-switch/` no longer shows previous-thread text against the new badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)