### PR TITLE
fix(docs): normalize docs assistant folder paths

### DIFF
--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -72,7 +72,7 @@ function findFolderByPath(
       (node): node is PageTree.Folder =>
         node.type === "folder" &&
         normalizeSegment(typeof node.name === "string" ? node.name : "") ===
-          segment.toLowerCase(),
+          normalizeSegment(segment),
     );
     if (!folder) return undefined;
     currentFolder = folder;


### PR DESCRIPTION
## Summary

Fixes docs assistant folder lookup for multi-word section names by normalizing the requested path segment with the same helper used for folder names.

## Details

`findFolderByPath` normalized folder names with `normalizeSegment`, but compared them against `segment.toLowerCase()`. That made a folder like `Getting Started` compare as `getting-started` vs `getting started`, causing `listDocs({ path: "Getting Started" })` to return `Path not found`.

This updates the comparison to normalize both sides consistently.

Fixes #4075.

## Testing

Not run; one-line normalization fix.
