### PR TITLE
chore: trim onlyBuiltDependencies to genuine native builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,21 +5,20 @@ packages:
   - templates/*
 
 ignoredBuiltDependencies:
+  - '@clerk/shared'
   - '@google/genai'
   - '@modelcontextprotocol/ext-apps'
   - '@mongodb-js/zstd'
+  - core-js
   - node-liblzma
+  - protobufjs
 
 onlyBuiltDependencies:
-  - '@clerk/shared'
-  - '@tailwindcss/oxide@4.1.17'
-  - core-js
-  - esbuild
-  - protobufjs
-  - react-grab
+  - esbuild@0.25.12
+  - esbuild@0.27.7
+  - esbuild@0.28.0
   - sharp@0.34.5
-  - sqlite3
-  - unrs-resolver@1.11.1
+  - sqlite3@5.1.7
 
 strictDepBuilds: true
 


### PR DESCRIPTION
## Summary

Every entry in `onlyBuiltDependencies` is a package granted permission to execute arbitrary code at install time. The previous list permitted nine packages, but only three actually need their install scripts to function. This PR trims the list to those three (pinned to current versions) so a future hijacked release can't silently inherit script-execution permission.

### Kept (genuine native builds)

- `sharp@0.34.5` — libvips bindings.
- `sqlite3@5.1.7` — node-gyp native module.
- `esbuild@{0.25.12, 0.27.7, 0.28.0}` — downloads its platform binary; failure mode is loud. All three resolved versions pinned.

### Moved to `ignoredBuiltDependencies` (non-functional scripts)

- `@clerk/shared` — pure-JS helper, no native code.
- `core-js` — postinstall is the funding/donation console message; pnpm's docs use it as the example for `neverBuiltDependencies`.
- `protobufjs` — postinstall is a version-schema compatibility check, not needed as a transitive.

Adding these to `ignoredBuiltDependencies` is required because `strictDepBuilds: true` + `verifyDepsBeforeRun: install` would otherwise fail `pnpm install` with `ERR_PNPM_IGNORED_BUILDS`.

### Dropped entirely (platform binary arrives via `optionalDependencies`)

- `@tailwindcss/oxide@4.1.17`
- `react-grab`
- `unrs-resolver@1.11.1`

On modern pnpm these resolve their native binary through `optionalDependencies`, so the postinstall is a legacy fallback. After removal, pnpm reports no ignored-build warning for any of them — so no entry in either list is needed.

### Pinning rationale

Pre-PR, only three entries were version-pinned; the other six auto-approved script execution for *every future version*, including a hijacked one. Every surviving entry is now pinned, so an updated version triggers a re-approval prompt instead of silent execution.

## Test plan

- [x] Fresh `pnpm install` succeeds with no `ERR_PNPM_IGNORED_BUILDS`.
- [x] `pnpm turbo build --filter="./packages/*"` — 32/32 packages built.
- [x] `pnpm turbo test --filter="./packages/*"` — 38/38 tasks passed.
- [x] `pnpm lint` — no new errors (pre-existing warnings/infos unchanged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1w1Nwtbb2icgMRDv9Ybue)_