### PR TITLE
feat(docs): expose example docs pages to docs assistant

### DIFF
--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { injectQuoteContext } from "@assistant-ui/react-ai-sdk";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { validateDocChatInput } from "@/lib/validate-input";
-import { source } from "@/lib/source";
+import { source, examples as examplesSource } from "@/lib/source";
 import { getModel } from "@/lib/ai/provider";
 import { frontendTools } from "@assistant-ui/react-ai-sdk";
 import { createBashTool } from "bash-tool";
@@ -329,15 +329,35 @@ export async function POST(req: Request): Promise<Response> {
 
             if (!path) {
               // Return root categories
-              return pageTree.children
-                .filter(
-                  (node): node is PageTree.Folder => node.type === "folder",
-                )
-                .map((folder) => ({
-                  type: "folder",
-                  name: folder.name,
-                  ...(folder.index ? { url: folder.index.url } : {}),
-                }));
+              return [
+                ...pageTree.children
+                  .filter(
+                    (node): node is PageTree.Folder => node.type === "folder",
+                  )
+                  .map((folder) => ({
+                    type: "folder",
+                    name: folder.name,
+                    ...(folder.index ? { url: folder.index.url } : {}),
+                  })),
+                { type: "folder", name: "examples", url: "/examples" },
+              ];
+            }
+
+            if (path === "examples") {
+              return examplesSource.pageTree.children.flatMap((node) => {
+                switch (node.type) {
+                  case "page":
+                    return { type: "page", title: node.name, url: node.url };
+                  case "folder":
+                    return {
+                      type: "folder",
+                      name: node.name,
+                      ...(node.index ? { url: node.index.url } : {}),
+                    };
+                  default:
+                    return [];
+                }
+              });
             }
 
             // Find folder at path, return children
@@ -381,6 +401,13 @@ export async function POST(req: Request): Promise<Response> {
             }
 
             const slugs = normalized.split("/").filter(Boolean);
+            if (slugs[0] === "examples") {
+              const page = examplesSource.getPage(slugs.slice(1));
+              if (!page) return { error: `Page not found: ${slugOrUrl}` };
+
+              const content = await getLLMText(page);
+              return { title: page.data.title, url: page.url, content };
+            }
 
             const page = source.getPage(slugs);
             if (!page) return { error: `Page not found: ${slugOrUrl}` };

--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -82,6 +82,23 @@ function findFolderByPath(
   return currentFolder;
 }
 
+function listChildren(nodes: PageTree.Node[]) {
+  return nodes.flatMap((node) => {
+    switch (node.type) {
+      case "page":
+        return { type: "page", title: node.name, url: node.url };
+      case "folder":
+        return {
+          type: "folder",
+          name: node.name,
+          ...(node.index ? { url: node.index.url } : {}),
+        };
+      default:
+        return [];
+    }
+  });
+}
+
 const DOCS_PATH_ERROR = "Only local docs paths are supported";
 
 function normalizeDocPath(slugOrUrl: string, routeUrl: string): string {
@@ -343,41 +360,19 @@ export async function POST(req: Request): Promise<Response> {
               ];
             }
 
-            if (path === "examples") {
-              return examplesSource.pageTree.children.flatMap((node) => {
-                switch (node.type) {
-                  case "page":
-                    return { type: "page", title: node.name, url: node.url };
-                  case "folder":
-                    return {
-                      type: "folder",
-                      name: node.name,
-                      ...(node.index ? { url: node.index.url } : {}),
-                    };
-                  default:
-                    return [];
-                }
-              });
+            const segments = path.split("/").filter(Boolean);
+            if (segments[0] === "examples") {
+              const rest = segments.slice(1).join("/");
+              const target = rest
+                ? findFolderByPath(examplesSource.pageTree, rest)
+                : examplesSource.pageTree;
+              if (!target) return { error: "Path not found" };
+              return listChildren(target.children);
             }
 
-            // Find folder at path, return children
             const targetFolder = findFolderByPath(pageTree, path);
             if (!targetFolder) return { error: "Path not found" };
-
-            return targetFolder.children.flatMap((node) => {
-              switch (node.type) {
-                case "page":
-                  return { type: "page", title: node.name, url: node.url };
-                case "folder":
-                  return {
-                    type: "folder",
-                    name: node.name,
-                    ...(node.index ? { url: node.index.url } : {}),
-                  };
-                default:
-                  return [];
-              }
-            });
+            return listChildren(targetFolder.children);
           },
         }),
         readDoc: tool({
@@ -401,15 +396,11 @@ export async function POST(req: Request): Promise<Response> {
             }
 
             const slugs = normalized.split("/").filter(Boolean);
-            if (slugs[0] === "examples") {
-              const page = examplesSource.getPage(slugs.slice(1));
-              if (!page) return { error: `Page not found: ${slugOrUrl}` };
+            const isExample = slugs[0] === "examples";
+            const docSource = isExample ? examplesSource : source;
+            const docSlugs = isExample ? slugs.slice(1) : slugs;
 
-              const content = await getLLMText(page);
-              return { title: page.data.title, url: page.url, content };
-            }
-
-            const page = source.getPage(slugs);
+            const page = docSource.getPage(docSlugs);
             if (!page) return { error: `Page not found: ${slugOrUrl}` };
 
             const content = await getLLMText(page);

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -72,6 +72,9 @@ export const examples = defineCollections({
   type: "doc",
   dir: "content/examples",
   schema: frontmatterSchema,
+  postprocess: {
+    includeProcessedMarkdown: true,
+  },
 });
 
 export const blog = defineCollections({

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -72,9 +72,6 @@ export const examples = defineCollections({
   type: "doc",
   dir: "content/examples",
   schema: frontmatterSchema,
-  postprocess: {
-    includeProcessedMarkdown: true,
-  },
 });
 
 export const blog = defineCollections({


### PR DESCRIPTION
## Summary

Closes #4082.

Exposes official `/examples` docs pages through the docs assistant tools.

## Changes

- Adds processed markdown generation for the examples collection.
- Adds `examples` to the root `listDocs()` result.
- Supports browsing example docs pages with `listDocs({ path: "examples" })`.
- Supports reading example docs pages with `readDoc({ slugOrUrl: "examples/..." })`.

## Testing

Tested locally in the docs app on this branch.

Verified the docs assistant can now use the examples tool paths:

```ts
listDocs()
listDocs({ path: "examples" })
readDoc({ slugOrUrl: "examples/ai-sdk" })
```

Also ran Biome on the touched files:

```sh
node_modules\.bin\biome.cmd check apps/docs/app/api/doc/chat/route.ts apps/docs/source.config.ts
```
