### PR TITLE
docs: add descriptions to docs assistant listDocs

### DIFF
--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -84,14 +84,25 @@ function findFolderByPath(
 
 function listChildren(nodes: PageTree.Node[]) {
   return nodes.flatMap((node) => {
+    const description =
+      "description" in node && typeof node.description === "string"
+        ? node.description
+        : undefined;
+
     switch (node.type) {
       case "page":
-        return { type: "page", title: node.name, url: node.url };
+        return {
+          type: "page",
+          title: node.name,
+          url: node.url,
+          ...(description ? { description } : {}),
+        };
       case "folder":
         return {
           type: "folder",
           name: node.name,
           ...(node.index ? { url: node.index.url } : {}),
+          ...(description ? { description } : {}),
         };
       default:
         return [];
@@ -347,15 +358,11 @@ export async function POST(req: Request): Promise<Response> {
             if (!path) {
               // Return root categories
               return [
-                ...pageTree.children
-                  .filter(
+                ...listChildren(
+                  pageTree.children.filter(
                     (node): node is PageTree.Folder => node.type === "folder",
-                  )
-                  .map((folder) => ({
-                    type: "folder",
-                    name: folder.name,
-                    ...(folder.index ? { url: folder.index.url } : {}),
-                  })),
+                  ),
+                ),
                 { type: "folder", name: "examples", url: "/examples" },
               ];
             }

--- a/apps/docs/content/docs/(docs)/copilots/meta.json
+++ b/apps/docs/content/docs/(docs)/copilots/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Copilots",
+  "description": "APIs for making React components visible to assistants and registering instructions, tools, tool UIs, and model context.",
   "pages": [
     "motivation",
     "make-assistant-visible",

--- a/apps/docs/content/docs/(docs)/meta.json
+++ b/apps/docs/content/docs/(docs)/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Docs",
-  "description": "Getting started with assistant-ui",
+  "description": "Core assistant-ui docs for getting started, installation, CLI usage, architecture, DevTools, and foundational app-building concepts.",
   "icon": "BookOpen",
   "root": true,
   "pages": [

--- a/apps/docs/content/docs/integrations/attachments/meta.json
+++ b/apps/docs/content/docs/integrations/attachments/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Attachments",
+  "description": "Attachment integration guides for uploading and storing chat files with assistant-ui attachment adapters.",
   "pages": ["custom-adapter"]
 }

--- a/apps/docs/content/docs/integrations/auth/meta.json
+++ b/apps/docs/content/docs/integrations/auth/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Auth",
+  "description": "Auth integration guides for gating chat routes and scoping thread persistence to signed-in users.",
   "platforms": ["react"],
   "pages": ["clerk", "better-auth", "next-auth"]
 }

--- a/apps/docs/content/docs/integrations/frameworks/mastra/meta.json
+++ b/apps/docs/content/docs/integrations/frameworks/mastra/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Mastra",
+  "description": "Mastra integration docs for wiring Mastra agents to assistant-ui through Next.js API routes or a separate server.",
   "platforms": ["react"],
   "pages": ["overview", "full-stack", "separate-server"]
 }

--- a/apps/docs/content/docs/integrations/frameworks/meta.json
+++ b/apps/docs/content/docs/integrations/frameworks/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Frameworks",
+  "description": "Framework integration guides for running assistant backends and agent frameworks with assistant-ui.",
   "pages": ["ai-sdk", "cloudflare-agents", "mastra"]
 }

--- a/apps/docs/content/docs/integrations/gateways/meta.json
+++ b/apps/docs/content/docs/integrations/gateways/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Gateways",
+  "description": "Gateway integration guides for routing assistant-ui LLM traffic through OpenAI-compatible proxies and provider gateways.",
   "pages": ["index"]
 }

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Integrations",
+  "description": "Guides for adding services and app infrastructure around a runtime, including frameworks, tools, gateways, observability, auth, persistence, and attachments.",
   "icon": "Plug",
   "root": true,
   "pages": [

--- a/apps/docs/content/docs/integrations/observability/meta.json
+++ b/apps/docs/content/docs/integrations/observability/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Observability",
+  "description": "Observability integration guides for logging, tracing, monitoring, and evaluating LLM calls in assistant-ui apps.",
   "pages": ["helicone", "langfuse", "langsmith"]
 }

--- a/apps/docs/content/docs/integrations/persistence/meta.json
+++ b/apps/docs/content/docs/integrations/persistence/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Persistence",
+  "description": "Persistence guides for saving assistant-ui threads and messages to your own storage with thread list and history adapters.",
   "pages": ["custom-adapter"]
 }

--- a/apps/docs/content/docs/integrations/tools/meta.json
+++ b/apps/docs/content/docs/integrations/tools/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Tools",
+  "description": "Tool integration guides for connecting external tool catalogs and rendering tool activity in assistant-ui.",
   "pages": ["mcp", "react-mcp"]
 }

--- a/apps/docs/content/docs/runtimes/a2a/meta.json
+++ b/apps/docs/content/docs/runtimes/a2a/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "A2A Protocol",
+  "description": "A2A runtime docs for connecting protocol-compliant agent servers to assistant-ui with streaming tasks, artifacts, and hooks.",
   "pages": ["overview", "quickstart", "client-and-hooks"]
 }

--- a/apps/docs/content/docs/runtimes/ag-ui/meta.json
+++ b/apps/docs/content/docs/runtimes/ag-ui/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "AG-UI Protocol",
+  "description": "AG-UI runtime docs for connecting AG-UI agents to assistant-ui with streaming text, tool calls, state, and runtime options.",
   "pages": ["overview", "quickstart", "runtime-options"]
 }

--- a/apps/docs/content/docs/runtimes/ai-sdk/meta.json
+++ b/apps/docs/content/docs/runtimes/ai-sdk/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "AI SDK by Vercel",
+  "description": "Vercel AI SDK runtime docs for assistant-ui, including current v6 setup and legacy v5/v4 references.",
   "pages": ["overview", "v6", "v5-legacy", "v4-legacy"]
 }

--- a/apps/docs/content/docs/runtimes/concepts/meta.json
+++ b/apps/docs/content/docs/runtimes/concepts/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Concepts",
+  "description": "Shared runtime concepts for architecture, adapters, thread management, and stability across assistant-ui runtime integrations.",
   "pages": ["architecture", "adapters", "threads", "stability"]
 }

--- a/apps/docs/content/docs/runtimes/custom/meta.json
+++ b/apps/docs/content/docs/runtimes/custom/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Custom Backend",
+  "description": "Runtime patterns for custom backends, including local state, external stores, data streams, and assistant transport.",
   "pages": [
     "overview",
     "local-runtime",

--- a/apps/docs/content/docs/runtimes/google-adk/meta.json
+++ b/apps/docs/content/docs/runtimes/google-adk/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Google ADK",
+  "description": "Google ADK runtime docs for connecting ADK agents to assistant-ui with streaming, tools, sessions, hooks, and server helpers.",
   "pages": ["overview", "quickstart", "api", "hooks"]
 }

--- a/apps/docs/content/docs/runtimes/langgraph/meta.json
+++ b/apps/docs/content/docs/runtimes/langgraph/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "LangGraph Cloud",
+  "description": "LangGraph runtime docs for assistant-ui, covering setup, streaming, generative UI, interrupts, threads, and the stockbroker tutorial.",
   "pages": [
     "overview",
     "quickstart",

--- a/apps/docs/content/docs/runtimes/langgraph/tutorial/meta.json
+++ b/apps/docs/content/docs/runtimes/langgraph/tutorial/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Tutorial: Stockbroker",
+  "description": "Step-by-step LangGraph stockbroker tutorial covering setup, generative UI, and approval flows with assistant-ui.",
   "platforms": ["react"],
   "pages": ["introduction", "part-1", "part-2", "part-3"]
 }

--- a/apps/docs/content/docs/runtimes/meta.json
+++ b/apps/docs/content/docs/runtimes/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Runtimes",
-  "description": "Backend integrations",
+  "description": "Runtime adapters and backend connection guides for wiring assistant-ui to AI backends, protocols, and framework-specific streaming APIs.",
   "icon": "Server",
   "root": true,
   "pages": [

--- a/apps/docs/content/docs/runtimes/opencode/meta.json
+++ b/apps/docs/content/docs/runtimes/opencode/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "OpenCode",
+  "description": "OpenCode runtime docs for coding-agent chat UIs, including setup, permissions, questions, session state, file edits, and terminal output.",
   "platforms": ["react"],
   "pages": ["overview", "quickstart", "hooks"]
 }

--- a/apps/docs/content/docs/ui/meta.json
+++ b/apps/docs/content/docs/ui/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Components",
-  "description": "shadcn/ui components",
+  "description": "Reusable assistant-ui React components for chat surfaces, composers, thread lists, message rendering, attachments, markdown, tools, and related UI.",
   "icon": "PanelsTopLeft",
   "root": true,
   "platforms": ["react"],


### PR DESCRIPTION
## Summary

- include existing Fumadocs `description` metadata in docs assistant `listDocs` results
- add missing or clearer descriptions for important docs folders used during navigation
- keep page descriptions as-is because page MDX frontmatter already provides them

## Context

We found this while evaluating the Xulux coding agent against the assistant-ui docs. The agent performed better when `listDocs` returned enough context to choose the right docs branch. Folder names alone were sometimes too ambiguous, especially for sections like `Components`, `Runtimes`, and `Integrations`.

This PR only updates folder-level metadata that was missing or too vague and exposes that existing metadata through `listDocs`. It does not add a new metadata schema or change generated API reference docs.

Longer term, it would be useful for docs review to include a check that important docs folders have clear descriptions, since these descriptions improve docs-agent routing and reduce unnecessary exploration.

Closes #4086

## Testing

- Tested locally in the docs agent flow and confirmed `listDocs` returns descriptions for the updated folders.
- Confirmed page descriptions did not need extra metadata updates because MDX pages already define descriptions.
- Ran `git diff --check` successfully.

Note: `pnpm --filter docs typecheck` could not run in this shell because pnpm attempted a non-TTY modules purge and this environment is on Node 22 while the repo requires Node 24.