### PR TITLE
feat(react): add unstable_insertNewlineOnTouchEnter to composer input

### DIFF
--- a/.changeset/composer-insert-newline-on-touch-enter.md
+++ b/.changeset/composer-insert-newline-on-touch-enter.md
@@ -1,0 +1,18 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat(react): `unstable_insertNewlineOnTouchEnter` on `ComposerPrimitive.Input`
+
+When set, plain Enter on a touch-primary device — detected via the `(pointer: coarse) and (not (any-pointer: fine))` media query — inserts a newline instead of submitting. Messages then dispatch only via the explicit Send button, matching the chat-input convention used by WhatsApp, Slack, Discord, iMessage, ChatGPT, and Claude.ai, and avoiding the consumer-side caret-aware re-insertion dance the previous workaround required.
+
+Orthogonal to `submitMode`: only takes effect when `submitMode` resolves to `"enter"` (the default). A tablet paired with a hardware keyboard can still submit via `submitMode="ctrlEnter"` (Cmd/Ctrl+Enter), and `submitMode="none"` is unchanged.
+
+```tsx
+<ComposerPrimitive.Input
+  placeholder="Ask anything..."
+  unstable_insertNewlineOnTouchEnter
+/>
+```
+
+Stays `unstable_` until we have enough field signal to flip the behavior on by default.

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/composer.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/composer.mdx
@@ -114,6 +114,26 @@ With `submitMode="ctrlEnter"`:
 | <Kbd>Ctrl/Cmd + Enter</Kbd> | Sends the message. |
 | <Kbd>Enter</Kbd> | Inserts a newline. |
 | <Kbd>Escape</Kbd> | Sends a cancel action. |
+
+With `submitMode="none"`:
+
+| Key | Description |
+| --- | --- |
+| <Kbd>Enter</Kbd> | Inserts a newline (no keyboard submission). |
+| <Kbd>Escape</Kbd> | Sends a cancel action. |
+
+#### Touch-primary devices
+
+Pass `unstable_insertNewlineOnTouchEnter` to make plain Enter insert a newline on phones and tablets without a hardware keyboard, detected via the `(pointer: coarse) and (not (any-pointer: fine))` media query. Messages then dispatch only via the explicit Send button, matching the chat-input convention used by WhatsApp, Slack, Discord, iMessage, ChatGPT, and Claude.ai.
+
+```tsx
+<ComposerPrimitive.Input
+  placeholder="Ask anything..."
+  unstable_insertNewlineOnTouchEnter
+/>
+```
+
+Only takes effect when `submitMode` resolves to `"enter"` (the default); `"ctrlEnter"` and `"none"` are unchanged, so a tablet paired with a hardware keyboard can still submit via Cmd/Ctrl+Enter.
 {/* api-manual:ComposerPrimitive.Input:end */}
 
 ### Send

--- a/apps/docs/content/docs/primitives/composer.mdx
+++ b/apps/docs/content/docs/primitives/composer.mdx
@@ -577,6 +577,19 @@ For the difference between `isDisabled` and `isSendDisabled`, see the [external 
 
 With `submitMode="ctrlEnter"`, plain Enter inserts a newline and Ctrl/Cmd+Enter submits.
 
+### Mobile / touch devices
+
+```tsx
+<ComposerPrimitive.Root>
+  <ComposerPrimitive.Input unstable_insertNewlineOnTouchEnter />
+  <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+</ComposerPrimitive.Root>
+```
+
+`unstable_insertNewlineOnTouchEnter` switches Enter to insert a newline on touch-primary devices (detected via `(pointer: coarse) and (not (any-pointer: fine))`), so the on-screen Return key never accidentally sends a half-finished message. Submission moves to the explicit Send button, matching WhatsApp, Slack, Discord, iMessage, ChatGPT, and Claude.ai.
+
+Desktop behavior is unchanged. A tablet paired with a hardware keyboard still gets `submitMode`'s usual semantics if you set `submitMode="ctrlEnter"` or `"none"` — the flag only downgrades the default `"enter"` mode.
+
 ### Floating Composer
 
 Primitives aren't bound to any layout. Here's how the floating composer on this docs site is built, using the same `ComposerPrimitive.Root` and `ComposerPrimitive.Input` positioned with CSS:

--- a/packages/react/src/primitives/composer/ComposerInput.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.test.tsx
@@ -8,6 +8,7 @@ import { ComposerPrimitiveInput } from "./ComposerInput";
 
 const setText = vi.fn<(text: string) => void>();
 const setCursorPosition = vi.fn<(pos: number) => void>();
+const sendSpy = vi.fn<(options?: { steer?: boolean }) => void>();
 
 const composerState = {
   isEditing: true,
@@ -15,6 +16,7 @@ const composerState = {
   type: "thread" as const,
   isEmpty: true,
   canCancel: false,
+  canSend: true,
   dictation: undefined as undefined | { inputDisabled: boolean },
 };
 
@@ -39,7 +41,7 @@ vi.mock("@assistant-ui/store", () => {
       setText,
       getState: () => composerState,
       cancel: () => {},
-      send: () => {},
+      send: sendSpy,
       addAttachment: async () => {},
     }),
     thread: () => ({
@@ -166,9 +168,11 @@ describe("ComposerPrimitiveInput", () => {
   beforeEach(() => {
     setText.mockReset();
     setCursorPosition.mockReset();
+    sendSpy.mockReset();
     composerState.isEditing = true;
     composerState.text = "";
     composerState.isEmpty = true;
+    composerState.canSend = true;
     composerState.dictation = undefined;
     threadState.isDisabled = false;
     threadState.isRunning = false;
@@ -456,6 +460,44 @@ describe("ComposerPrimitiveInput", () => {
       });
 
       expect(requestSubmitSpy).toHaveBeenCalledTimes(1);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("unstable_insertNewlineOnTouchEnter does not override submitMode='none'", async () => {
+      setMatchMedia(true);
+      const textarea = await mount({
+        submitMode: "none",
+        unstable_insertNewlineOnTouchEnter: true,
+      });
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(textarea, { key: "Enter" });
+      });
+
+      expect(requestSubmitSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("preserves steer (Cmd+Shift+Enter) on touch when unstable_insertNewlineOnTouchEnter is set", async () => {
+      setMatchMedia(true);
+      threadState.capabilities = { queue: true, attachments: false };
+      const textarea = await mount({
+        unstable_insertNewlineOnTouchEnter: true,
+      });
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(textarea, {
+          key: "Enter",
+          metaKey: true,
+          shiftKey: true,
+        });
+      });
+
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      expect(sendSpy).toHaveBeenCalledWith({ steer: true });
+      expect(requestSubmitSpy).not.toHaveBeenCalled();
       expect(event.defaultPrevented).toBe(true);
     });
   });

--- a/packages/react/src/primitives/composer/ComposerInput.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { act } from "react";
+import { act, type ComponentProps } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ComposerPrimitiveInput } from "./ComposerInput";
@@ -115,9 +115,53 @@ const fireCompositionEnd = (textarea: HTMLTextAreaElement, value: string) => {
   );
 };
 
+const fireKeyDown = (
+  textarea: HTMLTextAreaElement,
+  opts: {
+    key?: string;
+    shiftKey?: boolean;
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    isComposing?: boolean;
+  } = {},
+): KeyboardEvent => {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key: opts.key ?? "Enter",
+    shiftKey: opts.shiftKey ?? false,
+    ctrlKey: opts.ctrlKey ?? false,
+    metaKey: opts.metaKey ?? false,
+    isComposing: opts.isComposing ?? false,
+  });
+  textarea.dispatchEvent(event);
+  return event;
+};
+
+const setMatchMedia = (matches: boolean) => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+};
+
 describe("ComposerPrimitiveInput", () => {
   let container: HTMLDivElement;
   let root: Root;
+  let requestSubmitSpy: ReturnType<
+    typeof vi.fn<(submitter?: HTMLElement | null) => void>
+  >;
+  let originalRequestSubmit: HTMLFormElement["requestSubmit"] | undefined;
 
   beforeEach(() => {
     setText.mockReset();
@@ -131,6 +175,11 @@ describe("ComposerPrimitiveInput", () => {
     threadState.capabilities = { queue: false, attachments: false };
     pluginRegistry = null;
     activeAria = null;
+    setMatchMedia(false);
+
+    requestSubmitSpy = vi.fn<(submitter?: HTMLElement | null) => void>();
+    originalRequestSubmit = HTMLFormElement.prototype.requestSubmit;
+    HTMLFormElement.prototype.requestSubmit = requestSubmitSpy;
 
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -142,12 +191,24 @@ describe("ComposerPrimitiveInput", () => {
       root.unmount();
     });
     container.remove();
+    if (originalRequestSubmit) {
+      HTMLFormElement.prototype.requestSubmit = originalRequestSubmit;
+    } else {
+      delete (HTMLFormElement.prototype as Partial<HTMLFormElement>)
+        .requestSubmit;
+    }
     vi.restoreAllMocks();
   });
 
-  const mount = async () => {
+  const mount = async (
+    props: Partial<ComponentProps<typeof ComposerPrimitiveInput>> = {},
+  ) => {
     await act(async () => {
-      root.render(<ComposerPrimitiveInput data-testid="input" />);
+      root.render(
+        <form>
+          <ComposerPrimitiveInput data-testid="input" {...props} />
+        </form>,
+      );
     });
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
     expect(textarea).not.toBeNull();
@@ -276,5 +337,126 @@ describe("ComposerPrimitiveInput", () => {
     expect(textarea.getAttribute("aria-expanded")).toBe("true");
     expect(textarea.getAttribute("aria-haspopup")).toBe("listbox");
     expect(textarea.getAttribute("aria-activedescendant")).toBeNull();
+  });
+
+  describe("submit behavior", () => {
+    it("submits on plain Enter under the default submitMode", async () => {
+      const textarea = await mount();
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(textarea, { key: "Enter" });
+      });
+
+      expect(requestSubmitSpy).toHaveBeenCalledTimes(1);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("inserts a newline on Shift+Enter without submitting", async () => {
+      const textarea = await mount();
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(textarea, { key: "Enter", shiftKey: true });
+      });
+
+      expect(requestSubmitSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("ignores Enter while an IME composition is active", async () => {
+      const textarea = await mount();
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(textarea, { key: "Enter", isComposing: true });
+      });
+
+      expect(requestSubmitSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("submitMode='ctrlEnter' submits on Cmd/Ctrl+Enter but not on plain Enter", async () => {
+      const textarea = await mount({ submitMode: "ctrlEnter" });
+
+      let plain!: KeyboardEvent;
+      await act(async () => {
+        plain = fireKeyDown(textarea, { key: "Enter" });
+      });
+      expect(requestSubmitSpy).not.toHaveBeenCalled();
+      expect(plain.defaultPrevented).toBe(false);
+
+      let withMeta!: KeyboardEvent;
+      await act(async () => {
+        withMeta = fireKeyDown(textarea, { key: "Enter", metaKey: true });
+      });
+      expect(requestSubmitSpy).toHaveBeenCalledTimes(1);
+      expect(withMeta.defaultPrevented).toBe(true);
+
+      let withCtrl!: KeyboardEvent;
+      await act(async () => {
+        withCtrl = fireKeyDown(textarea, { key: "Enter", ctrlKey: true });
+      });
+      expect(requestSubmitSpy).toHaveBeenCalledTimes(2);
+      expect(withCtrl.defaultPrevented).toBe(true);
+    });
+
+    it("submitMode='none' leaves Enter to insert a native newline", async () => {
+      const textarea = await mount({ submitMode: "none" });
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(textarea, { key: "Enter" });
+      });
+
+      expect(requestSubmitSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("unstable_insertNewlineOnTouchEnter downgrades Enter on touch-primary devices", async () => {
+      setMatchMedia(true);
+      const textarea = await mount({
+        unstable_insertNewlineOnTouchEnter: true,
+      });
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(textarea, { key: "Enter" });
+      });
+
+      expect(requestSubmitSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("unstable_insertNewlineOnTouchEnter is a no-op on desktop", async () => {
+      setMatchMedia(false);
+      const textarea = await mount({
+        unstable_insertNewlineOnTouchEnter: true,
+      });
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(textarea, { key: "Enter" });
+      });
+
+      expect(requestSubmitSpy).toHaveBeenCalledTimes(1);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("unstable_insertNewlineOnTouchEnter does not override submitMode='ctrlEnter'", async () => {
+      setMatchMedia(true);
+      const textarea = await mount({
+        submitMode: "ctrlEnter",
+        unstable_insertNewlineOnTouchEnter: true,
+      });
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(textarea, { key: "Enter", metaKey: true });
+      });
+
+      expect(requestSubmitSpy).toHaveBeenCalledTimes(1);
+      expect(event.defaultPrevented).toBe(true);
+    });
   });
 });

--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -171,7 +171,9 @@ export const ComposerPrimitiveInput = forwardRef<
 
     const declaredSubmitMode =
       submitMode ?? (submitOnEnter === false ? "none" : "enter");
-    const isTouchPrimary = useMediaQuery(TOUCH_PRIMARY_QUERY);
+    const isTouchPrimary = useMediaQuery(
+      unstable_insertNewlineOnTouchEnter ? TOUCH_PRIMARY_QUERY : null,
+    );
     const effectiveSubmitMode =
       unstable_insertNewlineOnTouchEnter &&
       isTouchPrimary &&
@@ -235,7 +237,7 @@ export const ComposerPrimitiveInput = forwardRef<
           e.shiftKey &&
           (e.ctrlKey || e.metaKey) &&
           hasQueue &&
-          effectiveSubmitMode !== "none" &&
+          declaredSubmitMode !== "none" &&
           aui.composer().getState().canSend
         ) {
           e.preventDefault();

--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -20,10 +20,13 @@ import TextareaAutosize, {
 } from "react-textarea-autosize";
 import { useEscapeKeydown } from "@radix-ui/react-use-escape-keydown";
 import { useOnScrollToBottom } from "../../utils/hooks/useOnScrollToBottom";
+import { useMediaQuery } from "../../utils/hooks/useMediaQuery";
 import { useAuiState, useAui } from "@assistant-ui/store";
 import { flushResourcesSync } from "@assistant-ui/tap";
 import { useComposerInputPluginRegistryOptional } from "./ComposerInputPluginContext";
 import { useTriggerPopoverActiveAriaOptional } from "./trigger/TriggerPopoverRootContext";
+
+const TOUCH_PRIMARY_QUERY = "(pointer: coarse) and (not (any-pointer: fine))";
 
 export namespace ComposerPrimitiveInput {
   export type Element = HTMLTextAreaElement;
@@ -58,6 +61,14 @@ export namespace ComposerPrimitiveInput {
      * @default true
      */
     unstable_focusOnThreadSwitched?: boolean | undefined;
+    /**
+     * Whether plain Enter on a touch-primary device should insert a newline
+     * instead of submitting, detected via
+     * `(pointer: coarse) and (not (any-pointer: fine))`. Only takes effect
+     * when `submitMode` resolves to `"enter"`.
+     * @default false
+     */
+    unstable_insertNewlineOnTouchEnter?: boolean | undefined;
     /**
      * Whether to automatically add pasted files as attachments.
      * @default true
@@ -115,6 +126,12 @@ export namespace ComposerPrimitiveInput {
  *   submitMode="ctrlEnter"
  * />
  *
+ * // Insert a newline on Enter on touch-primary devices.
+ * <ComposerPrimitive.Input
+ *   placeholder="Type your message..."
+ *   unstable_insertNewlineOnTouchEnter
+ * />
+ *
  * // Old API (deprecated, still supported)
  * <ComposerPrimitive.Input
  *   placeholder="Type your message..."
@@ -142,6 +159,7 @@ export const ComposerPrimitiveInput = forwardRef<
       unstable_focusOnRunStart = true,
       unstable_focusOnScrollToBottom = true,
       unstable_focusOnThreadSwitched = true,
+      unstable_insertNewlineOnTouchEnter = false,
       addAttachmentOnPaste = true,
       ...rest
     },
@@ -151,8 +169,15 @@ export const ComposerPrimitiveInput = forwardRef<
     const pluginRegistry = useComposerInputPluginRegistryOptional();
     const activeAria = useTriggerPopoverActiveAriaOptional();
 
-    const effectiveSubmitMode =
+    const declaredSubmitMode =
       submitMode ?? (submitOnEnter === false ? "none" : "enter");
+    const isTouchPrimary = useMediaQuery(TOUCH_PRIMARY_QUERY);
+    const effectiveSubmitMode =
+      unstable_insertNewlineOnTouchEnter &&
+      isTouchPrimary &&
+      declaredSubmitMode === "enter"
+        ? "none"
+        : declaredSubmitMode;
 
     const value = useAuiState((s) => {
       if (!s.composer.isEditing) return "";

--- a/packages/react/src/utils/hooks/useMediaQuery.ts
+++ b/packages/react/src/utils/hooks/useMediaQuery.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+const getServerSnapshot = () => false;
+
+export const useMediaQuery = (query: string): boolean => {
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      if (typeof window === "undefined") return () => {};
+      const mql = window.matchMedia(query);
+      mql.addEventListener("change", callback);
+      return () => mql.removeEventListener("change", callback);
+    },
+    [query],
+  );
+
+  const getSnapshot = useCallback(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(query).matches;
+  }, [query]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+};

--- a/packages/react/src/utils/hooks/useMediaQuery.ts
+++ b/packages/react/src/utils/hooks/useMediaQuery.ts
@@ -3,11 +3,13 @@
 import { useCallback, useSyncExternalStore } from "react";
 
 const getServerSnapshot = () => false;
+const noopUnsubscribe = () => {};
 
-export const useMediaQuery = (query: string): boolean => {
+export const useMediaQuery = (query: string | null): boolean => {
   const subscribe = useCallback(
     (callback: () => void) => {
-      if (typeof window === "undefined") return () => {};
+      if (typeof window === "undefined" || query === null)
+        return noopUnsubscribe;
       const mql = window.matchMedia(query);
       mql.addEventListener("change", callback);
       return () => mql.removeEventListener("change", callback);
@@ -16,7 +18,7 @@ export const useMediaQuery = (query: string): boolean => {
   );
 
   const getSnapshot = useCallback(() => {
-    if (typeof window === "undefined") return false;
+    if (typeof window === "undefined" || query === null) return false;
     return window.matchMedia(query).matches;
   }, [query]);
 


### PR DESCRIPTION
closes #4091

## summary

- new `unstable_insertNewlineOnTouchEnter` prop on `ComposerPrimitive.Input`. when set, plain Enter on a touch-primary device (detected via `(pointer: coarse) and (not (any-pointer: fine))`) inserts a newline instead of submitting; messages dispatch only via the explicit Send button. matches the chat-input convention used by WhatsApp, Slack, Discord, iMessage, ChatGPT, and Claude.ai.
- orthogonal to `submitMode`: only downgrades when `submitMode` resolves to `"enter"` (the default). `"ctrlEnter"` and `"none"` are unchanged, so a tablet paired with a hardware keyboard can still submit via Cmd/Ctrl+Enter.
- detection lives in a new internal `useMediaQuery` hook (`useSyncExternalStore`, SSR-safe initial value of `false`).
- ships `unstable_` until enough field signal to flip the behavior on by default.

## test plan

### already verified

- [x] `pnpm vitest run packages/react/src/primitives/composer/ComposerInput.test.tsx` -> 17/17 green. 8 new keyboard-behavior tests covering all `submitMode` branches, touch downgrade, touch + `ctrlEnter` non-interference, and IME composition early-exit (PR #3246 originally shipped with zero keyboard coverage).
- [x] manual Chrome verification: built a minimal probe page mounting two `ComposerPrimitive.Input` instances (control vs with-prop). on the default desktop pointer, both submit on Enter (`matchMedia` -> `false`). under Chrome DevTools iPhone 12 emulation (`matchMedia` -> `true`), control reproduces the #4091 bug (form submit fires, no newline inserted) and with-prop demonstrates the fix (submit suppressed, textarea value contains a real `\n`).

### reviewer should verify

- [ ] open the composer on a real touch-primary device (iOS Safari / Android Chrome) with `unstable_insertNewlineOnTouchEnter` enabled, type a multi-line message, confirm the on-screen Return key inserts a newline without dispatching.
- [ ] on a tablet with hardware keyboard, set `submitMode="ctrlEnter"` + `unstable_insertNewlineOnTouchEnter`, confirm Cmd/Ctrl+Enter still submits.

## notes

- `"none"` is also surfaced in the keyboard-shortcut tables for the first time. PR #3246 added `submitMode="none"` as a value but never gave it a row in the api-reference table or an `@example`; this PR fixes that gap in the same diff so the issue's discoverability complaint is fully addressed.