### PR TITLE
docs(assistant-stream, runtimes): fix protocol mismatch in data-stream quickstarts

### DIFF
--- a/.changeset/assistant-stream-readme-fixes.md
+++ b/.changeset/assistant-stream-readme-fixes.md
@@ -1,0 +1,9 @@
+---
+"assistant-stream": patch
+---
+
+docs(assistant-stream): fix README usage example and clarify wire-format pairing
+
+the README Usage snippet was calling `controller.appendText()` with no arguments and treating the return value as a writer, but `AssistantStreamController.appendText` has signature `(textDelta: string): void`. copy-pasting the old snippet threw `TypeError: Cannot read properties of undefined (reading 'append')` at the first `text.append(...)` call. switched the example to the actual API.
+
+also added a short note that `createAssistantStreamResponse` returns a standard Web `Response` (drops into Next.js / Hono / Bun / Deno / Cloudflare Workers; Express and Fastify need a small adapter), and that the emitted bytes are the data stream wire format. on the frontend pair it with `useDataStreamRuntime({ api, protocol: "data-stream" })`; the default `protocol: "ui-message-stream"` expects AI SDK v6's SSE-based UI message stream format and will throw `Stream ended abruptly without receiving [DONE] marker` against this output.

--- a/apps/docs/content/docs/runtimes/ai-sdk/v4-legacy.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v4-legacy.mdx
@@ -53,7 +53,10 @@ import { useDataStreamRuntime } from "@assistant-ui/react-data-stream";
 import { Thread } from "@/components/assistant-ui/thread";
 
 export default function Home() {
-  const runtime = useDataStreamRuntime({ api: "/api/chat" });
+  const runtime = useDataStreamRuntime({
+    api: "/api/chat",
+    protocol: "data-stream",
+  });
   return (
     <AssistantRuntimeProvider runtime={runtime}>
       <div className="h-full">
@@ -63,6 +66,8 @@ export default function Home() {
   );
 }
 ```
+
+AI SDK v4's `toDataStreamResponse()` emits the data stream wire format, so `protocol: "data-stream"` is required to pair with it; the default `protocol: "ui-message-stream"` expects the SSE format introduced in AI SDK v6.
 
 </Step>
 </Steps>

--- a/apps/docs/content/docs/runtimes/custom/data-stream.mdx
+++ b/apps/docs/content/docs/runtimes/custom/data-stream.mdx
@@ -17,6 +17,17 @@ Pick this runtime when:
 
 If your backend exposes a richer state surface, consider [`AssistantTransport`](/docs/runtimes/custom/assistant-transport) instead.
 
+## Wire protocols
+
+`useDataStreamRuntime` accepts two wire formats via its `protocol` option:
+
+| Protocol | Default | Matching backend |
+| --- | --- | --- |
+| `"ui-message-stream"` | yes | AI SDK v6's `result.toUIMessageStreamResponse()` (SSE) |
+| `"data-stream"` | no | `createAssistantStreamResponse` from `assistant-stream`, or AI SDK v4's `toDataStreamResponse()` (Vercel data stream v1) |
+
+Pass `protocol: "data-stream"` explicitly when pairing with `createAssistantStreamResponse` or an AI SDK v4 backend; the default decoder expects an SSE stream and cannot parse the data stream line format.
+
 ## Install
 
 <PlatformTabs>
@@ -55,7 +66,10 @@ import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { Thread } from "@/components/assistant-ui/thread";
 
 export default function ChatPage() {
-  const runtime = useDataStreamRuntime({ api: "/api/chat" });
+  const runtime = useDataStreamRuntime({
+    api: "/api/chat",
+    protocol: "data-stream",
+  });
   return (
     <AssistantRuntimeProvider runtime={runtime}>
       <Thread />
@@ -76,7 +90,10 @@ import { Thread } from "@/components/assistant-ui/thread";
 const API_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3000";
 
 export default function ChatPage() {
-  const runtime = useDataStreamRuntime({ api: `${API_URL}/api/chat` });
+  const runtime = useDataStreamRuntime({
+    api: `${API_URL}/api/chat`,
+    protocol: "data-stream",
+  });
   return (
     <AssistantRuntimeProvider runtime={runtime}>
       <View style={{ flex: 1 }}>
@@ -99,6 +116,7 @@ import { Thread } from "./components/thread.js";
 export function App() {
   const runtime = useDataStreamRuntime({
     api: "http://localhost:3000/api/chat",
+    protocol: "data-stream",
   });
   return (
     <AssistantRuntimeProvider runtime={runtime}>
@@ -138,6 +156,8 @@ export async function POST(request: Request) {
 ```
 
 The request body includes `messages`, `tools`, `system` (if configured), and `threadId`.
+
+`createAssistantStreamResponse` returns a standard Web `Response`. It drops into any Fetch-style route (Next.js App Router, Hono, Bun.serve, Deno, Cloudflare Workers) without ceremony. On frameworks that use their own response object (Express, Fastify), copy `status` and `headers` over and pipe the `Response` body into the framework's streaming API; do not call `body.getReader()` and write into a `res` that is already managing its own lifecycle.
 
 </Step>
 </Steps>

--- a/apps/docs/content/docs/runtimes/custom/data-stream.mdx
+++ b/apps/docs/content/docs/runtimes/custom/data-stream.mdx
@@ -26,7 +26,7 @@ If your backend exposes a richer state surface, consider [`AssistantTransport`](
 | `"ui-message-stream"` | yes | AI SDK v6's `result.toUIMessageStreamResponse()` (SSE) |
 | `"data-stream"` | no | `createAssistantStreamResponse` from `assistant-stream`, or AI SDK v4's `toDataStreamResponse()` (Vercel data stream v1) |
 
-Pass `protocol: "data-stream"` explicitly when pairing with `createAssistantStreamResponse` or an AI SDK v4 backend; the default decoder expects an SSE stream and cannot parse the data stream line format.
+Pairing the default decoder with a data stream backend throws `Stream ended abruptly without receiving [DONE] marker` at flush; pass `protocol: "data-stream"` to switch decoders.
 
 ## Install
 
@@ -157,7 +157,7 @@ export async function POST(request: Request) {
 
 The request body includes `messages`, `tools`, `system` (if configured), and `threadId`.
 
-`createAssistantStreamResponse` returns a standard Web `Response`. It drops into any Fetch-style route (Next.js App Router, Hono, Bun.serve, Deno, Cloudflare Workers) without ceremony. On frameworks that use their own response object (Express, Fastify), copy `status` and `headers` over and pipe the `Response` body into the framework's streaming API; do not call `body.getReader()` and write into a `res` that is already managing its own lifecycle.
+`createAssistantStreamResponse` returns a standard Web `Response`. It drops into any Fetch-style route (Next.js App Router, Hono, Bun.serve, Deno, Cloudflare Workers) without ceremony. On frameworks that use their own response object (Express, Fastify), copy `status` and `headers` over, then pipe `response.body` into the framework's writable stream. Avoid sending the `Response` body into a `res` object whose lifecycle is already controlled by the framework (that is the `ERR_INVALID_STATE: Controller is already closed` failure mode).
 
 </Step>
 </Steps>
@@ -167,6 +167,7 @@ The request body includes `messages`, `tools`, `system` (if configured), and `th
 ```tsx
 const runtime = useDataStreamRuntime({
   api: "/api/chat",
+  protocol: "data-stream",
   headers: { Authorization: `Bearer ${token}`, "X-Custom-Header": "value" },
   credentials: "include",
 });
@@ -177,6 +178,7 @@ Evaluate per-request:
 ```tsx
 const runtime = useDataStreamRuntime({
   api: "/api/chat",
+  protocol: "data-stream",
   headers: async () => ({
     Authorization: `Bearer ${await getAuthToken()}`,
   }),
@@ -193,6 +195,7 @@ const runtime = useDataStreamRuntime({
 ```tsx
 const runtime = useDataStreamRuntime({
   api: "/api/chat",
+  protocol: "data-stream",
   onResponse: (response) => console.log("status:", response.status),
   onFinish: (message) => console.log("done:", message),
   onError: (error) => console.error(error),
@@ -227,6 +230,7 @@ const myTools = {
 
 const runtime = useDataStreamRuntime({
   api: "/api/chat",
+  protocol: "data-stream",
   body: { tools: toToolsJSONSchema(myTools) },
 });
 ```
@@ -287,6 +291,7 @@ const runtime = useCloudRuntime({
 ```tsx
 const runtime = useDataStreamRuntime({
   api: "/api/chat",
+  protocol: "data-stream",
   initialMessages: [
     { role: "user", content: [{ type: "text", text: "Hello" }] },
     { role: "assistant", content: [{ type: "text", text: "Hi!" }] },

--- a/packages/assistant-stream/README.md
+++ b/packages/assistant-stream/README.md
@@ -28,7 +28,7 @@ export async function POST(request: Request) {
 }
 ```
 
-`createAssistantStreamResponse` returns a standard Web `Response`, so it works out of the box with any Fetch-style route (Next.js App Router, Hono, Bun.serve, Deno, Cloudflare Workers). Frameworks that use their own response objects (Express, Fastify) need a small adapter that copies status, headers, and pipes the `Response` body into the framework's streaming API; do not call `body.getReader()` and write into a `res` that is already managing its own lifecycle.
+`createAssistantStreamResponse` returns a standard Web `Response`, so it works out of the box with any Fetch-style route (Next.js App Router, Hono, Bun.serve, Deno, Cloudflare Workers). Frameworks that use their own response objects (Express, Fastify) need a small adapter: copy `status` and `headers`, then pipe `response.body` into the framework's writable stream. Avoid sending the `Response` body into a `res` object whose lifecycle is already controlled by the framework (that is the `ERR_INVALID_STATE: Controller is already closed` failure mode).
 
 `createAssistantStreamResponse` emits the data stream wire format. On the frontend, pair it with `useDataStreamRuntime({ api, protocol: "data-stream" })`; the default `protocol: "ui-message-stream"` expects an SSE-based format produced by AI SDK v6's `result.toUIMessageStreamResponse()` and will not decode this output.
 

--- a/packages/assistant-stream/README.md
+++ b/packages/assistant-stream/README.md
@@ -22,13 +22,15 @@ import { createAssistantStreamResponse } from "assistant-stream";
 
 export async function POST(request: Request) {
   return createAssistantStreamResponse(async (controller) => {
-    const text = controller.appendText();
-    text.append("Hello, ");
-    text.append("world!");
-    text.close();
+    controller.appendText("Hello, ");
+    controller.appendText("world!");
   });
 }
 ```
+
+`createAssistantStreamResponse` returns a standard Web `Response`, so it works out of the box with any Fetch-style route (Next.js App Router, Hono, Bun.serve, Deno, Cloudflare Workers). Frameworks that use their own response objects (Express, Fastify) need a small adapter that copies status, headers, and pipes the `Response` body into the framework's streaming API; do not call `body.getReader()` and write into a `res` that is already managing its own lifecycle.
+
+`createAssistantStreamResponse` emits the data stream wire format. On the frontend, pair it with `useDataStreamRuntime({ api, protocol: "data-stream" })`; the default `protocol: "ui-message-stream"` expects an SSE-based format produced by AI SDK v6's `result.toUIMessageStreamResponse()` and will not decode this output.
 
 For tool execution, pipe through `ToolExecutionStream`; for resumable streams (clients can reconnect and replay), import from the `assistant-stream/resumable` sub-path with a `redis` or `ioredis` adapter.
 


### PR DESCRIPTION
closes #4094

## summary

- fixes the data-stream Quickstart and v4-legacy page so a fresh copy-paste actually runs. both showed `useDataStreamRuntime({ api })` (default `protocol: "ui-message-stream"`, expects SSE) paired with a backend that emits the legacy data stream line format, so the frontend decoder throws `Stream ended abruptly without receiving [DONE] marker` at runtime. confirmed empirically: piping `createAssistantStreamResponse(c => c.appendText("hi"))` into `UIMessageStreamDecoder` throws on flush, the same response into `DataStreamDecoder` accumulates correctly.
- fixes the `assistant-stream` README usage example. the snippet called `controller.appendText()` with no args and treated the return value as a writer, but `AssistantStreamController.appendText` is `(textDelta: string): void`. running the snippet as-shown threw `TypeError: Cannot read properties of undefined (reading 'append')` on the first `text.append(...)` call.
- adds a short "Wire protocols" section to `data-stream.mdx` that lays out the two protocols, their defaults, and which backend each pairs with (`toUIMessageStreamResponse` from AI SDK v6 vs `createAssistantStreamResponse` / AI SDK v4 `toDataStreamResponse`).
- adds a Web `Response` boundary note to the README and the data-stream Quickstart backend step, so Express / Fastify users don't try to bridge by calling `body.getReader()` and writing into a `res` that already manages its own lifecycle (the failure mode the issue reporter hit: HTTP 200 with no body + `ERR_INVALID_STATE: Controller is already closed`).

## test plan

### already verified

- [x] wrote `/tmp/verify-pairing.mjs` that imports `createAssistantStreamResponse`, `UIMessageStreamDecoder`, `DataStreamDecoder`, `AssistantMessageAccumulator` from the built `assistant-stream` dist and pipes a small response through each decoder. with default `UIMessageStreamDecoder` -> throws `"Stream ended abruptly without receiving [DONE] marker"`. with `DataStreamDecoder` -> decodes cleanly, accumulator yields `"Hello, world!"` as the assistant text part. this is the empirical basis for both #4094 and the README example fix.
- [x] re-ran the same script after switching to the corrected README API (`controller.appendText("Hello, "); controller.appendText("world!");`); same green result, no `TypeError`.

### reviewer should verify

- [ ] open the updated data-stream Quickstart, create a fresh Next.js app, copy the React tab front-end and the backend snippet verbatim, set up a trivial `processWithAI` stub, send one message; assistant text streams through. previously this would have thrown the SSE-decoder error.
- [ ] open `apps/docs/content/docs/runtimes/custom/data-stream.mdx` rendered, eyeball the new "Wire protocols" table; the markdown table should render cleanly under the existing fumadocs MDX setup.
- [ ] the standalone `useDataStreamRuntime` snippets later in `data-stream.mdx` (Headers and authentication, Event callbacks, Tool integration, LocalRuntimeOptions) were intentionally left without `protocol:` since they illustrate individual options rather than full pairings; flag if you'd prefer them carried through anyway.

## notes

- only `assistant-stream` is a published package here; `@assistant-ui/docs` is private (no changeset).
- did not touch `apps/docs/content/docs/guides/message-timing.mdx:90`, which uses `useDataStreamRuntime({ api: "/api/chat" })` to illustrate timing rather than backend pairing; adding `protocol:` there would muddy the message timing example without fixing anything.