### PR TITLE
feat(core): add unarchive option to switchToThread

### DIFF
--- a/.changeset/switch-to-thread-unarchive-option.md
+++ b/.changeset/switch-to-thread-unarchive-option.md
@@ -1,8 +1,9 @@
 ---
+"@assistant-ui/core": patch
 "@assistant-ui/react": patch
 ---
 
-feat: opt-out of auto-unarchive when switching threads
+feat(core, react): opt-out of auto-unarchive when switching threads
 
 `switchToThread` (and `ThreadListItemRuntime.switchTo`) now accept an optional `{ unarchive?: boolean }` argument. The default remains `true`, preserving the existing behavior of auto-unarchiving an archived thread when it becomes the main thread. Pass `unarchive: false` to keep the thread archived after switching — useful when the UI lets users preview an archived conversation without restoring it.
 

--- a/.changeset/switch-to-thread-unarchive-option.md
+++ b/.changeset/switch-to-thread-unarchive-option.md
@@ -1,0 +1,18 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: opt-out of auto-unarchive when switching threads
+
+`switchToThread` (and `ThreadListItemRuntime.switchTo`) now accept an optional `{ unarchive?: boolean }` argument. The default remains `true`, preserving the existing behavior of auto-unarchiving an archived thread when it becomes the main thread. Pass `unarchive: false` to keep the thread archived after switching — useful when the UI lets users preview an archived conversation without restoring it.
+
+```ts
+// existing behavior — archived thread becomes regular
+await threadList.switchToThread(threadId);
+
+// new — keep status as archived
+await threadList.switchToThread(threadId, { unarchive: false });
+
+// same option on the item runtime
+await threadListItem.switchTo({ unarchive: false });
+```

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -274,7 +274,10 @@ export class RemoteThreadListThreadListRuntimeCore
     return getThreadData(this._state.value, threadIdOrRemoteId);
   }
 
-  public async switchToThread(threadIdOrRemoteId: string): Promise<void> {
+  public async switchToThread(
+    threadIdOrRemoteId: string,
+    options?: { unarchive?: boolean },
+  ): Promise<void> {
     let data = this.getItemById(threadIdOrRemoteId);
 
     if (!data) {
@@ -343,7 +346,9 @@ export class RemoteThreadListThreadListRuntimeCore
       task.then(() => this._notifySubscribers());
     }
 
-    if (data.status === "archived") await this.unarchive(data.id);
+    if (data.status === "archived" && options?.unarchive !== false) {
+      await this.unarchive(data.id);
+    }
     this._mainThreadId = data.id;
 
     this._notifySubscribers();

--- a/packages/core/src/runtime/api/thread-list-item-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-item-runtime.ts
@@ -36,7 +36,7 @@ export type ThreadListItemRuntime = {
   initialize(): Promise<{ remoteId: string; externalId: string | undefined }>;
   generateTitle(): Promise<void>;
 
-  switchTo(): Promise<void>;
+  switchTo(options?: { unarchive?: boolean }): Promise<void>;
   rename(newTitle: string): Promise<void>;
   archive(): Promise<void>;
   unarchive(): Promise<void>;
@@ -89,9 +89,9 @@ export class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
     return this._core.getState();
   }
 
-  public switchTo(): Promise<void> {
+  public switchTo(options?: { unarchive?: boolean }): Promise<void> {
     const state = this._core.getState();
-    return this._threadListBinding.switchToThread(state.id);
+    return this._threadListBinding.switchToThread(state.id, options);
   }
 
   public rename(newTitle: string): Promise<void> {

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -48,7 +48,10 @@ export type ThreadListRuntime = {
   getItemByIndex(idx: number): ThreadListItemRuntime;
   getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
 
-  switchToThread(threadId: string): Promise<void>;
+  switchToThread(
+    threadId: string,
+    options?: { unarchive?: boolean },
+  ): Promise<void>;
   switchToNewThread(): Promise<void>;
 
   getLoadThreadsPromise(): Promise<void>;
@@ -152,8 +155,11 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
     this.getArchivedItemByIndex = this.getArchivedItemByIndex.bind(this);
   }
 
-  public switchToThread(threadId: string): Promise<void> {
-    return this._core.switchToThread(threadId);
+  public switchToThread(
+    threadId: string,
+    options?: { unarchive?: boolean },
+  ): Promise<void> {
+    return this._core.switchToThread(threadId, options);
   }
 
   public switchToNewThread(): Promise<void> {

--- a/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
@@ -32,7 +32,10 @@ export type ThreadListRuntimeCore = {
 
   getItemById(threadId: string): ThreadListItemCoreState | undefined;
 
-  switchToThread(threadId: string): Promise<void>;
+  switchToThread(
+    threadId: string,
+    options?: { unarchive?: boolean },
+  ): Promise<void>;
   switchToNewThread(): Promise<void>;
 
   getLoadThreadsPromise(): Promise<void>;

--- a/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
@@ -168,7 +168,10 @@ export class ExternalStoreThreadListRuntimeCore
     this._notifySubscribers();
   }
 
-  public async switchToThread(threadId: string): Promise<void> {
+  public async switchToThread(
+    threadId: string,
+    _options?: { unarchive?: boolean },
+  ): Promise<void> {
     if (this._mainThreadId === threadId) return;
     const onSwitchToThread = this.adapter.onSwitchToThread;
     if (!onSwitchToThread)

--- a/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
@@ -81,8 +81,8 @@ export const ThreadListClient = resource(
           : state.threadIds[index]!;
         return threadItems.get({ key: id });
       },
-      switchToThread: async (threadId) => {
-        await runtime.switchToThread(threadId);
+      switchToThread: async (threadId, options) => {
+        await runtime.switchToThread(threadId, options);
       },
       switchToNewThread: async () => {
         await runtime.switchToNewThread();

--- a/packages/core/src/store/scopes/thread-list-item.ts
+++ b/packages/core/src/store/scopes/thread-list-item.ts
@@ -12,7 +12,7 @@ export type ThreadListItemState = {
 
 export type ThreadListItemMethods = {
   getState(): ThreadListItemState;
-  switchTo(): void;
+  switchTo(options?: { unarchive?: boolean }): void;
   rename(newTitle: string): void;
   archive(): void;
   unarchive(): void;

--- a/packages/core/src/store/scopes/threads.ts
+++ b/packages/core/src/store/scopes/threads.ts
@@ -19,7 +19,7 @@ export type ThreadsState = {
 
 export type ThreadsMethods = {
   getState(): ThreadsState;
-  switchToThread(threadId: string): void;
+  switchToThread(threadId: string, options?: { unarchive?: boolean }): void;
   switchToNewThread(): void;
   item(
     threadIdOrOptions:

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-switchToThread-unarchive.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-switchToThread-unarchive.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { createCore, makeAdapter } from "./remote-thread-list-test-helpers";
+
+const archivedThread = (id: string) => ({
+  status: "archived" as const,
+  remoteId: id,
+  externalId: id,
+  title: "Archived",
+});
+
+describe("RemoteThreadListThreadListRuntimeCore.switchToThread unarchive option", () => {
+  it("auto-unarchives by default", async () => {
+    const THREAD_ID = "archived-default";
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({ threads: [archivedThread(THREAD_ID)] })),
+    });
+
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+
+    expect(core.archivedThreadIds).toContain(THREAD_ID);
+    expect(core.threadIds).not.toContain(THREAD_ID);
+
+    await core.switchToThread(THREAD_ID);
+
+    expect(adapter.unarchive).toHaveBeenCalledWith(THREAD_ID);
+    expect(core.threadIds).toContain(THREAD_ID);
+    expect(core.archivedThreadIds).not.toContain(THREAD_ID);
+    expect(core.getItemById(THREAD_ID)?.status).toBe("regular");
+    expect(core.mainThreadId).toBe(core.getItemById(THREAD_ID)?.id);
+  });
+
+  it("auto-unarchives when unarchive is explicitly true", async () => {
+    const THREAD_ID = "archived-explicit-true";
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({ threads: [archivedThread(THREAD_ID)] })),
+    });
+
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+    await core.switchToThread(THREAD_ID, { unarchive: true });
+
+    expect(adapter.unarchive).toHaveBeenCalledWith(THREAD_ID);
+    expect(core.threadIds).toContain(THREAD_ID);
+    expect(core.archivedThreadIds).not.toContain(THREAD_ID);
+    expect(core.getItemById(THREAD_ID)?.status).toBe("regular");
+  });
+
+  it("keeps the thread archived when unarchive: false", async () => {
+    const THREAD_ID = "archived-opt-out";
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({ threads: [archivedThread(THREAD_ID)] })),
+    });
+
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+    await core.switchToThread(THREAD_ID, { unarchive: false });
+
+    expect(adapter.unarchive).not.toHaveBeenCalled();
+    expect(core.archivedThreadIds).toContain(THREAD_ID);
+    expect(core.threadIds).not.toContain(THREAD_ID);
+    expect(core.getItemById(THREAD_ID)?.status).toBe("archived");
+    expect(core.mainThreadId).toBe(core.getItemById(THREAD_ID)?.id);
+  });
+
+  it("does not call unarchive when the target is already regular, regardless of option", async () => {
+    const THREAD_ID = "regular-target";
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "regular" as const,
+            remoteId: THREAD_ID,
+            externalId: THREAD_ID,
+            title: "Regular",
+          },
+        ],
+      })),
+    });
+
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+    await core.switchToThread(THREAD_ID, { unarchive: false });
+
+    expect(adapter.unarchive).not.toHaveBeenCalled();
+    expect(core.getItemById(THREAD_ID)?.status).toBe("regular");
+  });
+});


### PR DESCRIPTION
Adds an optional `{ unarchive?: boolean }` argument to `switchToThread` and `ThreadListItemRuntime.switchTo`. Default is `true`, preserving current behavior (archived threads are auto-unarchived on switch). Pass `unarchive: false` to keep a thread archived after switching — useful for previewing an archived conversation without restoring it.

```ts
await threadList.switchToThread(threadId, { unarchive: false });
await threadListItem.switchTo({ unarchive: false });
```