### PR TITLE
chore: silence build warnings

### DIFF
--- a/apps/devtools-extension/scripts/build-extension.mts
+++ b/apps/devtools-extension/scripts/build-extension.mts
@@ -1,4 +1,4 @@
-import { build } from "esbuild";
+import { build, type BuildOptions } from "esbuild";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
@@ -14,6 +14,13 @@ console.log("frameUrl", frameUrl);
 const defineEnv = {
   "process.env.NODE_ENV": JSON.stringify(nodeEnv),
   "process.env.DEVTOOLS_FRAME_URL": JSON.stringify(frameUrl),
+};
+
+// tsdown's unbundle output keeps bare `import "./foo.js"` lines for files
+// whose named values were all inlined. With "sideEffects": false declared
+// upstream, esbuild correctly drops them — silence the noisy warning.
+const logOverride: BuildOptions["logOverride"] = {
+  "ignored-bare-import": "silent",
 };
 
 const buildExtension = async () => {
@@ -47,6 +54,7 @@ const buildExtension = async () => {
       minify: true,
       sourcemap: true,
       define: defineEnv,
+      logOverride,
     });
     console.log("✅ Content script built");
   } catch {
@@ -66,6 +74,7 @@ const buildExtension = async () => {
       minify: true,
       sourcemap: true,
       define: defineEnv,
+      logOverride,
     });
     console.log("✅ DevTools panel built");
   } catch {
@@ -84,6 +93,7 @@ const buildExtension = async () => {
       minify: true,
       sourcemap: true,
       define: defineEnv,
+      logOverride,
     });
     console.log("✅ DevTools main script built");
   } catch {
@@ -102,6 +112,7 @@ const buildExtension = async () => {
       minify: true,
       sourcemap: true,
       define: defineEnv,
+      logOverride,
     });
     console.log("✅ Background service worker built");
   } catch {
@@ -134,6 +145,7 @@ const buildExtension = async () => {
     // minify: true,
     sourcemap: true,
     define: defineEnv,
+    logOverride,
   });
   console.log("✅ Inject script built");
 

--- a/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
@@ -32,7 +32,7 @@ import { AssistantCloud, ChainOfThoughtClient, DevToolsHooks, ExportedMessageRep
 
 ### GenerativeUIRender
 
-Internal renderer. Resolves a GenerativeUISpec against the consumer
+Internal renderer. Resolves a [GenerativeUISpec](/docs/guides/generative-ui) against the consumer
 allowlist. Used by `MessagePrimitive.GenerativeUI` and by
 `MessagePrimitive.Parts` when handling a `generative-ui` part.
 

--- a/apps/docs/lib/og-template.tsx
+++ b/apps/docs/lib/og-template.tsx
@@ -150,7 +150,6 @@ export function OgTemplate({
           justifyContent: "center",
           alignItems: "center",
           gap: 24,
-          zIndex: 1,
         }}
       >
         {children}

--- a/apps/docs/scripts/api-reference/discover.mts
+++ b/apps/docs/scripts/api-reference/discover.mts
@@ -178,6 +178,15 @@ const MANUAL_API_REFERENCE_LINKS = new Map([
     "AssistantState",
     "/docs/api-reference/primitives/assistant-if#assistantstate",
   ],
+  [
+    "EnrichedPartState",
+    "/docs/api-reference/runtimes/message-part-runtime#enrichedpartstate",
+  ],
+  [
+    "GenerativeUIRenderError",
+    "/docs/api-reference/utilities/miscellaneous#generativeuirendererror",
+  ],
+  ["GenerativeUISpec", "/docs/guides/generative-ui"],
 ]);
 
 function collectExportInputs(entryPath: string): DiscoveredExportInput[] {
@@ -324,6 +333,12 @@ export function discoverExports(): ExportInfo[] {
   const inputs = getReactApiInputs();
   const linkResolver = createApiReferenceLinkResolver(getReactApiLinkItems());
   return inputs.map((input) => buildExportInfo(input, linkResolver));
+}
+
+export function createReactApiLinkResolver(): (
+  target: string,
+) => string | undefined {
+  return createApiReferenceLinkResolver(getReactApiLinkItems());
 }
 
 export function discoverIntegrationExports(

--- a/apps/docs/scripts/api-reference/primitive-extract.mts
+++ b/apps/docs/scripts/api-reference/primitive-extract.mts
@@ -470,10 +470,12 @@ export function extractPrimitivePartsFor(
 
 /** Extract every primitive part across every primitive. Used by
  *  generate-primitive-docs.mts. */
-export function extractPrimitiveParts(): PrimitivePartModel[] {
+export function extractPrimitiveParts(
+  options?: JsDocRenderOptions,
+): PrimitivePartModel[] {
   const result: PrimitivePartModel[] = [];
   for (const primitiveName of discoverPrimitiveBarrelExports().keys()) {
-    result.push(...extractPrimitivePartsFor(primitiveName));
+    result.push(...extractPrimitivePartsFor(primitiveName, options));
   }
   return result;
 }

--- a/apps/docs/scripts/generate-primitive-docs.mts
+++ b/apps/docs/scripts/generate-primitive-docs.mts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { createReactApiLinkResolver } from "./api-reference/discover.mts";
 import { PRIMITIVE_DOCS_OUTPUT } from "./api-reference/paths.mts";
 import {
   extractPrimitiveParts,
@@ -189,7 +190,9 @@ function serialize(grouped: GroupedPrimitives): string {
 // ── Main ───────────────────────────────────────────────────────────────────
 
 console.log("Generating primitive docs...");
-const parts = extractPrimitiveParts();
+const parts = extractPrimitiveParts({
+  linkResolver: createReactApiLinkResolver(),
+});
 const grouped = projectToPrimitiveDocs(parts);
 const output = serialize(grouped);
 


### PR DESCRIPTION
- Add manual API reference links for EnrichedPartState, GenerativeUIRenderError, and GenerativeUISpec so docs JSDoc {@link} tags resolve.
- Plumb a link resolver into the primitive-docs generator so the same names resolve in primitive JSDoc comments.
- Silence esbuild's ignored-bare-import warning in the devtools-extension build; tsdown's unbundle output keeps bare imports for files whose values were inlined, and esbuild correctly drops them given "sideEffects": false upstream.
- Drop unsupported zIndex from the OG image template (satori does not support z-index; DOM order already gives the correct layering).