### PR TITLE
test(tap): stabilize flaky StrictMode setTimeout rerender test

### DIFF
--- a/.changeset/fix-flaky-strictmode-settimeout-test.md
+++ b/.changeset/fix-flaky-strictmode-settimeout-test.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+test: stabilize flaky StrictMode setTimeout rerender test on slow CI

--- a/packages/tap/src/__tests__/strictmode/react-strictmode-rerender-sources.test.tsx
+++ b/packages/tap/src/__tests__/strictmode/react-strictmode-rerender-sources.test.tsx
@@ -3,7 +3,7 @@
  * for different sources of setState calls
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 import { StrictMode, useState, useEffect } from "react";
 
@@ -190,7 +190,17 @@ describe("React Strict Mode - Rerender Sources", () => {
   });
 
   describe("Source 5: setState in setTimeout", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it("should double-render AND double-call setTimeout callback (React 19)", async () => {
+      // Use fake timers so both strict-mode setTimeout callbacks fire
+      // synchronously before React gets a chance to flush a re-render
+      // between them. Without this, slow CI can process the first
+      // setTimeout, run its renders, and only then fire the second.
+      vi.useFakeTimers();
+
       const events: string[] = [];
 
       function TestComponent() {
@@ -215,9 +225,12 @@ describe("React Strict Mode - Rerender Sources", () => {
         </StrictMode>,
       );
 
-      // Wait for setTimeout
+      // Fire both setTimeout callbacks synchronously via fake timers
+      vi.advanceTimersByTime(10);
+      // Restore real timers and wait for React's scheduler (MessageChannel) to flush
+      vi.useRealTimers();
       await waitFor(() => {
-        expect(events).toContain("setTimeout");
+        expect(events).toHaveLength(6);
       });
 
       // ACTUAL: setTimeout callback runs TWICE and renders are DOUBLED


### PR DESCRIPTION
The Source 5 test in react-strictmode-rerender-sources asserted a strict
event ordering (setTimeout, setTimeout, render, render) that relied on
both strict-mode-doubled setTimeout callbacks firing before React
flushed any re-render. On slow CI the second callback could fire after
the first render cycle, producing extra interleaved events.

Switch to vi.useFakeTimers + advanceTimersByTime so both callbacks fire
synchronously, then restore real timers and wait for the React
scheduler's MessageChannel flush. Mirrors the existing pattern in
tap-strictmode-rerender-sources.test.ts.