### PR TITLE
feat: add respondToApproval prop for AI SDK v6 tool approvals

### DIFF
--- a/.changeset/tool-approval-response.md
+++ b/.changeset/tool-approval-response.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+"@assistant-ui/react": patch
+---
+
+feat: surface AI SDK v6 tool approvals as a first-class `respondToApproval` prop on tool components. tool-call parts in the `approval-requested` state now carry `part.approval = { id, isAutomatic? }`; tool components call `respondToApproval({ approved, reason? })` to ack the gate without threading `chatHelpers` through application context. also fixes a transient `requires-action` flicker for the `approval-responded` state and tightens the external-message converter so interrupt vs pending tool calls are distinguished by an actual `interrupt`/`approval` field rather than by `result === undefined`.

--- a/.changeset/tool-approval-response.md
+++ b/.changeset/tool-approval-response.md
@@ -1,4 +1,5 @@
 ---
+"@assistant-ui/core": patch
 "@assistant-ui/react-ai-sdk": patch
 "@assistant-ui/react-native": patch
 "@assistant-ui/react-ink": patch

--- a/apps/docs/content/docs/guides/tool-ui.mdx
+++ b/apps/docs/content/docs/guides/tool-ui.mdx
@@ -474,6 +474,54 @@ const ApprovalTool = makeAssistantTool({
   through user interaction.
 </Callout>
 
+### Server-side approval gates
+
+Some runtimes (notably AI SDK v6's `needsApproval` tools) pause on the server and emit an approval request that the client must acknowledge before the tool runs. assistant-ui surfaces this on the tool part as `approval` and exposes `respondToApproval({ approved, reason? })` on the renderer:
+
+```tsx
+import { makeAssistantToolUI } from "@assistant-ui/react";
+
+const DeployToolUI = makeAssistantToolUI<{ target: string }, { ok: boolean }>({
+  toolName: "deploy",
+  render: ({ args, approval, respondToApproval, result }) => {
+    if (approval?.approved === undefined) {
+      return (
+        <div>
+          <p>Approve deploy to {args.target}?</p>
+          <button onClick={() => respondToApproval({ approved: true })}>
+            Approve
+          </button>
+          <button
+            onClick={() =>
+              respondToApproval({ approved: false, reason: "user denied" })
+            }
+          >
+            Deny
+          </button>
+        </div>
+      );
+    }
+
+    if (approval?.approved === false) {
+      return <p>Denied{approval.reason ? `: ${approval.reason}` : ""}</p>;
+    }
+
+    if (result === undefined) return <p>Approved, running…</p>;
+    return <p>Deployed</p>;
+  },
+});
+```
+
+`approval.approved` is a three-state signal:
+
+- `undefined`: gate is open, the renderer should ask the user. This is the only state in which `respondToApproval` is legal.
+- `true`: decision recorded as allow. The server is producing the result (or has produced one, available on `result`).
+- `false`: decision recorded as deny. `output-denied` from the runtime sets `isError` and exposes `approval.reason`.
+
+`approval.isAutomatic` is `true` when the runtime granted the decision from a server-side policy rather than the user; render a "auto-approved" badge instead of buttons in that case.
+
+For the wire-side setup (`needsApproval`, `sendAutomaticallyWhen`), see [AI SDK v6 server-side tool approval](/docs/runtimes/ai-sdk/v6#server-side-tool-approval).
+
 ## Advanced Features
 
 ### Tool Status Handling

--- a/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
@@ -286,6 +286,100 @@ export async function POST(req: Request) {
 
 Without a `stopWhen`, AI SDK runs a single inference step. Set `stepCountIs` (or one of AI SDK's other stop conditions) when your tools chain multiple calls.
 
+## Server-side tool approval
+
+AI SDK v6 lets a tool gate its own execution with `needsApproval`. The server pauses, emits an `approval-requested` part, and resumes once the client posts an approval response. assistant-ui surfaces the gate as `approval` on the tool part and adds a `respondToApproval` prop on the renderer, so tool components stay decoupled from `chatHelpers`.
+
+On the backend, mark the tool with `needsApproval` (boolean or function):
+
+```ts title="@/app/api/chat/route.ts"
+import { openai } from "@ai-sdk/openai";
+import { streamText, convertToModelMessages, tool } from "ai";
+import { z } from "zod";
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = streamText({
+    model: openai("gpt-5.4-mini"),
+    messages: await convertToModelMessages(messages),
+    tools: {
+      deploy: tool({
+        description: "Deploy the current build to an environment.",
+        inputSchema: z.object({ target: z.string() }),
+        needsApproval: ({ input }) => input.target === "production",
+        execute: async ({ target }) => ({ deployed: target }),
+      }),
+    },
+  });
+
+  return result.toUIMessageStreamResponse();
+}
+```
+
+On the client, configure `useChat` with `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses` so the response is sent back to the server when the user decides:
+
+```tsx title="@/app/page.tsx"
+import { useChat } from "@ai-sdk/react";
+import {
+  AssistantRuntimeProvider,
+  useAISDKRuntime,
+} from "@assistant-ui/react-ai-sdk";
+import { lastAssistantMessageIsCompleteWithApprovalResponses } from "ai";
+import { Thread } from "@/components/assistant-ui/thread";
+
+export default function Page() {
+  const chat = useChat({
+    api: "/api/chat",
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+  });
+  const runtime = useAISDKRuntime(chat);
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+Render the gate with a tool UI. The `approval` field carries the gate state, and `respondToApproval` is the only correct way to acknowledge it (it reads the approval id from the part):
+
+```tsx title="@/components/DeployToolUI.tsx"
+import { makeAssistantToolUI } from "@assistant-ui/react";
+
+export const DeployToolUI = makeAssistantToolUI<
+  { target: string },
+  { deployed: string }
+>({
+  toolName: "deploy",
+  render: ({ args, approval, respondToApproval, result }) => {
+    if (approval?.approved === undefined) {
+      return (
+        <div>
+          <p>Approve deploy to {args.target}?</p>
+          <button onClick={() => respondToApproval({ approved: true })}>
+            Approve
+          </button>
+          <button
+            onClick={() =>
+              respondToApproval({ approved: false, reason: "user denied" })
+            }
+          >
+            Deny
+          </button>
+        </div>
+      );
+    }
+    if (approval?.approved === false) return <p>Denied</p>;
+    if (result === undefined) return <p>Approved, deploying…</p>;
+    return <p>Deployed {result.deployed}</p>;
+  },
+});
+```
+
+See the [tool UI guide](/docs/guides/tool-ui#server-side-approval-gates) for the full three-state semantics of `approval.approved` and the `isAutomatic` flag.
+
 ## Quote context
 
 assistant-ui's composer can attach quote metadata to user messages (e.g. when the user selects text and clicks "Quote"). On the server, `injectQuoteContext` flattens that metadata into a markdown blockquote prefix so the LLM sees the quoted text:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -170,6 +170,7 @@ export type {
   RuntimeCapabilities,
   AddToolResultOptions,
   ResumeToolCallOptions,
+  RespondToToolApprovalOptions,
   SubmitFeedbackOptions,
   ThreadSuggestion,
   SpeechState,

--- a/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
@@ -79,7 +79,7 @@ export namespace MessagePrimitiveGroupedParts {
      *
      * Leaf parts receive the same {@link EnrichedPartState} that
      * `<MessagePrimitive.Parts>` would produce (`toolUI`, `addResult`,
-     * `resume`, `dataRendererUI`).
+     * `resume`, `respondToApproval`, `dataRendererUI`).
      */
     readonly children: (info: RenderInfo<TKey>) => ReactNode;
   };

--- a/packages/core/src/react/primitives/message/MessageParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageParts.tsx
@@ -379,8 +379,16 @@ export const MessagePartComponent: FC<MessagePartComponentProps> = ({
   if (type === "tool-call") {
     const addResult = aui.part().addToolResult;
     const resume = aui.part().resumeToolCall;
+    const respondToApproval = aui.part().respondToToolApproval;
     if ("Override" in tools)
-      return <tools.Override {...part} addResult={addResult} resume={resume} />;
+      return (
+        <tools.Override
+          {...part}
+          addResult={addResult}
+          resume={resume}
+          respondToApproval={respondToApproval}
+        />
+      );
     const Tool = tools.by_name?.[part.toolName] ?? tools.Fallback;
     return (
       <ToolUIDisplay
@@ -388,6 +396,7 @@ export const MessagePartComponent: FC<MessagePartComponentProps> = ({
         Fallback={Tool}
         addResult={addResult}
         resume={resume}
+        respondToApproval={respondToApproval}
       />
     );
   }
@@ -592,6 +601,7 @@ const RegisteredToolUI: FC = () => {
       {...part}
       addResult={aui.part().addToolResult}
       resume={aui.part().resumeToolCall}
+      respondToApproval={aui.part().respondToToolApproval}
     />
   );
 };
@@ -657,6 +667,8 @@ export type EnrichedPartState =
       addResult: ToolCallMessagePartProps["addResult"];
       /** Resume a tool call waiting for human input. */
       resume: ToolCallMessagePartProps["resume"];
+      /** Respond to a server-side tool approval gate. */
+      respondToApproval: ToolCallMessagePartProps["respondToApproval"];
     })
   | (Extract<PartState, { type: "data" }> & {
       /** The registered data renderer UI element, or null if none registered. */
@@ -706,6 +718,7 @@ export const MessagePartChildren: FC<{
                   toolUI: hasUI ? <RegisteredToolUI /> : null,
                   addResult: partMethods.addToolResult,
                   resume: partMethods.resumeToolCall,
+                  respondToApproval: partMethods.respondToToolApproval,
                 };
               }
               if (state.type === "data") {

--- a/packages/core/src/react/providers/TextMessagePartProvider.tsx
+++ b/packages/core/src/react/providers/TextMessagePartProvider.tsx
@@ -28,6 +28,9 @@ const TextMessagePartClient = resource(
       resumeToolCall: () => {
         throw new Error("Not supported");
       },
+      respondToToolApproval: () => {
+        throw new Error("Not supported");
+      },
     };
   },
 );

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -11,6 +11,22 @@ import {
   fromThreadMessageLike,
   type ThreadMessageLike,
 } from "../../runtime/utils/thread-message-like";
+
+type ThreadMessageLikeContentItem = Exclude<
+  ThreadMessageLike["content"],
+  string
+>[number];
+
+const isPendingToolCall = (c: ThreadMessageLikeContentItem): boolean =>
+  c.type === "tool-call" && c.result === undefined;
+
+const isInterruptedToolCall = (c: ThreadMessageLikeContentItem): boolean => {
+  if (c.type !== "tool-call" || c.result !== undefined) return false;
+  return (
+    c.interrupt != null ||
+    (c.approval != null && c.approval.approved === undefined)
+  );
+};
 import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
 import type { ToolExecutionStatus } from "./useToolInvocations";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
@@ -337,18 +353,10 @@ export const convertExternalMessages = <T extends WeakKey>(
     const joined = joinExternalMessages(message.outputs);
     const hasInterruptedToolCalls =
       typeof joined.content === "object" &&
-      joined.content.some(
-        (c) =>
-          c.type === "tool-call" &&
-          c.result === undefined &&
-          (c.interrupt != null ||
-            (c.approval != null && c.approval.approved === undefined)),
-      );
+      joined.content.some(isInterruptedToolCall);
     const hasPendingToolCalls =
       typeof joined.content === "object" &&
-      joined.content.some(
-        (c) => c.type === "tool-call" && c.result === undefined,
-      );
+      joined.content.some(isPendingToolCall);
     const autoStatus = getAutoStatus(
       isLast,
       isRunning,
@@ -436,18 +444,10 @@ export const useExternalMessageConverter = <T extends WeakKey>({
         const joined = joinExternalMessages(message.outputs);
         const hasInterruptedToolCalls =
           typeof joined.content === "object" &&
-          joined.content.some(
-            (c) =>
-              c.type === "tool-call" &&
-              c.result === undefined &&
-              (c.interrupt != null ||
-                (c.approval != null && c.approval.approved === undefined)),
-          );
+          joined.content.some(isInterruptedToolCall);
         const hasPendingToolCalls =
           typeof joined.content === "object" &&
-          joined.content.some(
-            (c) => c.type === "tool-call" && c.result === undefined,
-          );
+          joined.content.some(isPendingToolCall);
         const autoStatus = getAutoStatus(
           isLast,
           isRunning,

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -11,6 +11,16 @@ import {
   fromThreadMessageLike,
   type ThreadMessageLike,
 } from "../../runtime/utils/thread-message-like";
+import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
+import type { ToolExecutionStatus } from "./useToolInvocations";
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
+import { generateErrorMessageId } from "../../utils/id";
+import type {
+  ThreadAssistantMessage,
+  ThreadMessage,
+  ToolCallMessagePart,
+} from "../../types/message";
+import type { MessageTiming } from "../../types/message";
 
 type ThreadMessageLikeContentItem = Exclude<
   ThreadMessageLike["content"],
@@ -27,16 +37,6 @@ const isInterruptedToolCall = (c: ThreadMessageLikeContentItem): boolean => {
     (c.approval != null && c.approval.approved === undefined)
   );
 };
-import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
-import type { ToolExecutionStatus } from "./useToolInvocations";
-import type { ReadonlyJSONValue } from "assistant-stream/utils";
-import { generateErrorMessageId } from "../../utils/id";
-import type {
-  ThreadAssistantMessage,
-  ThreadMessage,
-  ToolCallMessagePart,
-} from "../../types/message";
-import type { MessageTiming } from "../../types/message";
 
 export namespace useExternalMessageConverter {
   export type Message =

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -335,6 +335,15 @@ export const convertExternalMessages = <T extends WeakKey>(
   const result = chunks.map((message, idx) => {
     const isLast = idx === chunks.length - 1;
     const joined = joinExternalMessages(message.outputs);
+    const hasInterruptedToolCalls =
+      typeof joined.content === "object" &&
+      joined.content.some(
+        (c) =>
+          c.type === "tool-call" &&
+          c.result === undefined &&
+          (c.interrupt != null ||
+            (c.approval != null && c.approval.approved === undefined)),
+      );
     const hasPendingToolCalls =
       typeof joined.content === "object" &&
       joined.content.some(
@@ -343,7 +352,7 @@ export const convertExternalMessages = <T extends WeakKey>(
     const autoStatus = getAutoStatus(
       isLast,
       isRunning,
-      hasPendingToolCalls,
+      hasInterruptedToolCalls,
       hasPendingToolCalls,
       isLast ? metadata.error : undefined,
     );
@@ -425,10 +434,14 @@ export const useExternalMessageConverter = <T extends WeakKey>({
         const isLast = idx === chunks.length - 1;
 
         const joined = joinExternalMessages(message.outputs);
-        const hasSuspendedToolCalls =
+        const hasInterruptedToolCalls =
           typeof joined.content === "object" &&
           joined.content.some(
-            (c) => c.type === "tool-call" && c.result === undefined,
+            (c) =>
+              c.type === "tool-call" &&
+              c.result === undefined &&
+              (c.interrupt != null ||
+                (c.approval != null && c.approval.approved === undefined)),
           );
         const hasPendingToolCalls =
           typeof joined.content === "object" &&
@@ -438,7 +451,7 @@ export const useExternalMessageConverter = <T extends WeakKey>({
         const autoStatus = getAutoStatus(
           isLast,
           isRunning,
-          hasSuspendedToolCalls,
+          hasInterruptedToolCalls,
           hasPendingToolCalls,
           isLast ? state.metadata.error : undefined,
         );

--- a/packages/core/src/react/types/MessagePartComponentTypes.ts
+++ b/packages/core/src/react/types/MessagePartComponentTypes.ts
@@ -71,6 +71,14 @@ export type ToolCallMessagePartProps<
      * paused frontend tool execution.
      */
     resume: (payload: unknown) => void;
+    /**
+     * Responds to a server-side tool approval gate. Only valid while
+     * `approval` is set on the part and `approval.approved === undefined`.
+     */
+    respondToApproval: (response: {
+      approved: boolean;
+      reason?: string;
+    }) => void;
   };
 
 /** Component used to render a tool-call message part. */

--- a/packages/core/src/runtime/api/message-part-runtime.ts
+++ b/packages/core/src/runtime/api/message-part-runtime.ts
@@ -26,6 +26,7 @@ type MessagePartSnapshotBinding = SubscribableWithState<
 export type MessagePartRuntime = {
   addToolResult(result: any | ToolResponse<any>): void;
   resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: { approved: boolean; reason?: string }): void;
 
   readonly path: MessagePartRuntimePath;
   getState(): MessagePartState;
@@ -48,6 +49,7 @@ export class MessagePartRuntimeImpl implements MessagePartRuntime {
   protected __internal_bindMethods() {
     this.addToolResult = this.addToolResult.bind(this);
     this.resumeToolCall = this.resumeToolCall.bind(this);
+    this.respondToToolApproval = this.respondToToolApproval.bind(this);
     this.getState = this.getState.bind(this);
     this.subscribe = this.subscribe.bind(this);
   }
@@ -99,6 +101,30 @@ export class MessagePartRuntimeImpl implements MessagePartRuntime {
     this.threadApi.getState().resumeToolCall({
       toolCallId,
       payload,
+    });
+  }
+
+  public respondToToolApproval(response: {
+    approved: boolean;
+    reason?: string;
+  }) {
+    const state = this.contentBinding.getState();
+    if (!state) throw new Error("Message part is not available");
+
+    if (state.type !== "tool-call")
+      throw new Error(
+        "Tried to respond to tool approval on non-tool message part",
+      );
+
+    if (!state.approval || state.approval.approved !== undefined)
+      throw new Error("Tool call has no pending approval");
+
+    if (!this.threadApi) throw new Error("Thread API is not available");
+
+    this.threadApi.getState().respondToToolApproval({
+      approvalId: state.approval.id,
+      approved: response.approved,
+      ...(response.reason != null && { reason: response.reason }),
     });
   }
 

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -15,6 +15,7 @@ import { DefaultThreadComposerRuntimeCore } from "./default-thread-composer-runt
 import type {
   AddToolResultOptions,
   ResumeToolCallOptions,
+  RespondToToolApprovalOptions,
   ThreadSuggestion,
   SubmitFeedbackOptions,
   ThreadRuntimeCore,
@@ -59,6 +60,9 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   public abstract resumeRun(config: ResumeRunConfig): void;
   public abstract addToolResult(options: AddToolResultOptions): void;
   public abstract resumeToolCall(options: ResumeToolCallOptions): void;
+  public abstract respondToToolApproval(
+    options: RespondToToolApprovalOptions,
+  ): void;
   public abstract cancelRun(): void;
   public abstract exportExternalState(): any;
   public abstract importExternalState(state: any): void;

--- a/packages/core/src/runtime/interfaces/thread-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-runtime-core.ts
@@ -45,6 +45,12 @@ export type ResumeToolCallOptions = {
   payload: unknown;
 };
 
+export type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  reason?: string;
+};
+
 export type SubmitFeedbackOptions = {
   messageId: string;
   type: "negative" | "positive";
@@ -137,6 +143,7 @@ export type ThreadRuntimeCore = Readonly<{
 
   addToolResult: (options: AddToolResultOptions) => void;
   resumeToolCall: (options: ResumeToolCallOptions) => void;
+  respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
 
   speak: (messageId: string) => void;
   stopSpeaking: () => void;

--- a/packages/core/src/runtime/utils/thread-message-like.ts
+++ b/packages/core/src/runtime/utils/thread-message-like.ts
@@ -54,6 +54,13 @@ export type ThreadMessageLike = {
             readonly isError?: boolean | undefined;
             readonly parentId?: string | undefined;
             readonly messages?: readonly ThreadMessage[] | undefined;
+            readonly interrupt?: { type: "human"; payload: unknown };
+            readonly approval?: {
+              readonly id: string;
+              readonly approved?: boolean;
+              readonly reason?: string;
+              readonly isAutomatic?: boolean;
+            };
           }
       )[];
   readonly id?: string | undefined;

--- a/packages/core/src/runtimes/external-store/external-store-adapter.ts
+++ b/packages/core/src/runtimes/external-store/external-store-adapter.ts
@@ -9,6 +9,7 @@ import type { RealtimeVoiceAdapter } from "../../adapters/voice";
 import type { FeedbackAdapter } from "../../adapters/feedback";
 import type {
   AddToolResultOptions,
+  RespondToToolApprovalOptions,
   StartRunConfig,
   ResumeRunConfig,
   ThreadSuggestion,
@@ -107,6 +108,9 @@ type ExternalStoreAdapterBase<T> = {
     | undefined;
   onResumeToolCall?:
     | ((options: { toolCallId: string; payload: unknown }) => void)
+    | undefined;
+  onRespondToToolApproval?:
+    | ((options: RespondToToolApprovalOptions) => Promise<void> | void)
     | undefined;
   convertMessage?: ExternalStoreMessageConverter<T> | undefined;
   adapters?:

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -3,6 +3,7 @@ import type {
   AddToolResultOptions,
   ResumeRunConfig,
   ResumeToolCallOptions,
+  RespondToToolApprovalOptions,
   StartRunConfig,
   ThreadSuggestion,
 } from "../../runtime/interfaces/thread-runtime-core";
@@ -370,6 +371,12 @@ export class ExternalStoreThreadRuntimeCore
     if (!this._store.onResumeToolCall)
       throw new Error("Runtime does not support resuming tool calls.");
     this._store.onResumeToolCall(options);
+  }
+
+  public respondToToolApproval(options: RespondToToolApprovalOptions) {
+    if (!this._store.onRespondToToolApproval)
+      throw new Error("Runtime does not support tool approvals.");
+    this._store.onRespondToToolApproval(options);
   }
 
   public override reset(initialMessages?: readonly ThreadMessageLike[]) {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -9,6 +9,7 @@ import type { LocalRuntimeOptionsBase } from "./local-runtime-options";
 import type {
   AddToolResultOptions,
   ResumeToolCallOptions,
+  RespondToToolApprovalOptions,
   ThreadSuggestion,
   ThreadRuntimeCore,
   StartRunConfig,
@@ -534,5 +535,9 @@ export class LocalThreadRuntimeCore
 
   public resumeToolCall(_options: ResumeToolCallOptions) {
     throw new Error("Local runtime does not support resuming tool calls.");
+  }
+
+  public respondToToolApproval(_options: RespondToToolApprovalOptions) {
+    throw new Error("Local runtime does not support tool approvals.");
   }
 }

--- a/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
+++ b/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
@@ -65,6 +65,10 @@ export class ReadonlyThreadRuntimeCore
     throw READONLY_THREAD_ERROR;
   }
 
+  respondToToolApproval(): void {
+    throw READONLY_THREAD_ERROR;
+  }
+
   speak(): void {
     throw READONLY_THREAD_ERROR;
   }

--- a/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
+++ b/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
@@ -40,6 +40,10 @@ export const EMPTY_THREAD_CORE: ThreadRuntimeCore = {
     throw EMPTY_THREAD_ERROR;
   },
 
+  respondToToolApproval() {
+    throw EMPTY_THREAD_ERROR;
+  },
+
   speak() {
     throw EMPTY_THREAD_ERROR;
   },

--- a/packages/core/src/store/clients/thread-message-client.ts
+++ b/packages/core/src/store/clients/thread-message-client.ts
@@ -38,6 +38,9 @@ const ThreadMessagePartClient = resource(
       resumeToolCall: () => {
         throw new Error("Not supported");
       },
+      respondToToolApproval: () => {
+        throw new Error("Not supported");
+      },
     };
   },
 );

--- a/packages/core/src/store/runtime-clients/message-part-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/message-part-runtime-client.ts
@@ -11,6 +11,8 @@ export const MessagePartClient = resource(
       getState: () => state,
       addToolResult: (result) => runtime.addToolResult(result),
       resumeToolCall: (payload) => runtime.resumeToolCall(payload),
+      respondToToolApproval: (response) =>
+        runtime.respondToToolApproval(response),
       __internal_getRuntime: () => runtime,
     };
   },

--- a/packages/core/src/store/scopes/part.ts
+++ b/packages/core/src/store/scopes/part.ts
@@ -26,6 +26,10 @@ export type PartMethods = {
    * This is useful when a tool has requested human input and is waiting for a response.
    */
   resumeToolCall(payload: unknown): void;
+  /**
+   * Respond to a server-side tool approval gate. The approval id is read from the part.
+   */
+  respondToToolApproval(response: { approved: boolean; reason?: string }): void;
   __internal_getRuntime?(): MessagePartRuntime;
 };
 

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -165,6 +165,13 @@ export type ToolCallMessagePart<
   readonly modelContent?: readonly ToolModelContentPart[] | undefined;
   /** Human-input request that must be resolved before the run can continue. */
   readonly interrupt?: { type: "human"; payload: unknown };
+  /** Server-side approval gate. `approved === undefined` is the only state in which `respondToApproval` may be called. */
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+  };
   /** Parent message-part ID when this part belongs to a nested structure. */
   readonly parentId?: string;
   /**

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -350,6 +350,14 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     },
     onResumeToolCall: (options) =>
       toolInvocations.resume(options.toolCallId, options.payload),
+    onRespondToToolApproval: ({ approvalId, approved, reason }) => {
+      void chatHelpers.addToolApprovalResponse({
+        id: approvalId,
+        approved,
+        ...(reason != null && { reason }),
+        options: { metadata: lastRunConfigRef.current },
+      });
+    },
     ...(onResume && { onResume }),
     ...(suggestions && { suggestions }),
     adapters: {

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
@@ -186,7 +186,7 @@ describe("AISDKMessageConverter", () => {
     });
   });
 
-  it("deduplicates tool calls by toolCallId and maps interrupt states", () => {
+  it("deduplicates tool calls by toolCallId and surfaces approval / interrupt state", () => {
     const converted = AISDKMessageConverter.toThreadMessages(
       [
         {
@@ -212,13 +212,46 @@ describe("AISDKMessageConverter", () => {
               toolCallId: "tc-2",
               state: "approval-requested",
               input: { action: "deploy" },
-              approval: { reason: "need human review" },
+              approval: { id: "appr-1" },
             },
             {
               type: "tool-human",
               toolCallId: "tc-3",
               state: "input-available",
               input: { task: "confirm" },
+            },
+            {
+              type: "tool-approve",
+              toolCallId: "tc-4",
+              state: "approval-responded",
+              input: { action: "rollback" },
+              approval: { id: "appr-2", approved: true, reason: "looks ok" },
+            },
+            {
+              type: "tool-approve",
+              toolCallId: "tc-5",
+              state: "approval-requested",
+              input: { action: "auto" },
+              approval: { id: "appr-3", isAutomatic: true },
+            },
+            {
+              type: "tool-approve",
+              toolCallId: "tc-6",
+              state: "output-denied",
+              input: { action: "wipe" },
+              approval: {
+                id: "appr-4",
+                approved: false,
+                reason: "user denied",
+              },
+            },
+            {
+              type: "tool-approve",
+              toolCallId: "tc-7",
+              state: "output-available",
+              input: { action: "ship" },
+              output: { ok: true },
+              approval: { id: "appr-5", approved: true, isAutomatic: true },
             },
           ],
         } as any,
@@ -237,16 +270,48 @@ describe("AISDKMessageConverter", () => {
     const toolCalls = converted[0]?.content.filter(
       (part): part is any => part.type === "tool-call",
     );
-    expect(toolCalls).toHaveLength(3);
+    expect(toolCalls).toHaveLength(7);
 
     expect(toolCalls?.filter((p) => p.toolCallId === "tc-1")).toHaveLength(1);
-    expect(toolCalls?.find((p) => p.toolCallId === "tc-2")?.status).toEqual({
-      type: "requires-action",
-      reason: "interrupt",
+
+    expect(toolCalls?.find((p) => p.toolCallId === "tc-2")?.approval).toEqual({
+      id: "appr-1",
     });
+    expect(
+      toolCalls?.find((p) => p.toolCallId === "tc-2")?.interrupt,
+    ).toBeUndefined();
+
     expect(toolCalls?.find((p) => p.toolCallId === "tc-3")?.interrupt).toEqual({
       type: "human",
       payload: { kind: "human" },
+    });
+    expect(
+      toolCalls?.find((p) => p.toolCallId === "tc-3")?.approval,
+    ).toBeUndefined();
+
+    expect(toolCalls?.find((p) => p.toolCallId === "tc-4")?.approval).toEqual({
+      id: "appr-2",
+      approved: true,
+      reason: "looks ok",
+    });
+
+    expect(toolCalls?.find((p) => p.toolCallId === "tc-5")?.approval).toEqual({
+      id: "appr-3",
+      isAutomatic: true,
+    });
+
+    const denied = toolCalls?.find((p) => p.toolCallId === "tc-6");
+    expect(denied?.approval).toEqual({
+      id: "appr-4",
+      approved: false,
+      reason: "user denied",
+    });
+    expect(denied?.isError).toBe(true);
+
+    expect(toolCalls?.find((p) => p.toolCallId === "tc-7")?.approval).toEqual({
+      id: "appr-5",
+      approved: true,
+      isAutomatic: true,
     });
   });
 

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -141,37 +141,39 @@ function stableStringifyToolArgs(
   return JSON.stringify(stableArgs);
 }
 
-/**
- * Resolves the interrupt fields for a tool call part.
- *
- * Two interrupt paths for tool approvals:
- * 1. AI SDK server-side approval: approval-requested state with part.approval payload
- * 2. Frontend tools: toolStatuses interrupt from context.human()
- */
-function getToolInterrupt(
-  part: { state: string; approval?: unknown },
+function getToolApprovalAndInterrupt(
+  part: {
+    approval?:
+      | {
+          id: string;
+          approved?: boolean;
+          reason?: string;
+          isAutomatic?: boolean;
+        }
+      | undefined;
+  },
   toolStatus: { type: string; payload?: unknown } | undefined,
-): Record<string, unknown> {
-  if (part.state === "approval-requested" && "approval" in part) {
+): {
+  approval?: NonNullable<ToolCallMessagePart["approval"]>;
+  interrupt?: NonNullable<ToolCallMessagePart["interrupt"]>;
+} {
+  if (part.approval && typeof part.approval.id === "string") {
+    const { id, approved, reason, isAutomatic } = part.approval;
     return {
-      interrupt: {
-        type: "human" as const,
-        payload: (part as { approval: unknown }).approval,
-      },
-      status: {
-        type: "requires-action" as const,
-        reason: "interrupt" as const,
+      approval: {
+        id,
+        ...(typeof approved === "boolean" && { approved }),
+        ...(typeof reason === "string" && { reason }),
+        ...(isAutomatic === true && { isAutomatic: true }),
       },
     };
   }
 
   if (toolStatus?.type === "interrupt") {
     return {
-      interrupt: toolStatus.payload,
-      status: {
-        type: "requires-action" as const,
-        reason: "interrupt" as const,
-      },
+      interrupt: toolStatus.payload as NonNullable<
+        ToolCallMessagePart["interrupt"]
+      >,
     };
   }
 
@@ -281,7 +283,7 @@ function convertParts(
           isError,
           ...(modelContent !== undefined && { modelContent }),
           ...(mcpApp && { mcp: { app: mcpApp } }),
-          ...getToolInterrupt(part, toolStatus),
+          ...getToolApprovalAndInterrupt(part, toolStatus),
         } satisfies ToolCallMessagePart;
       }
 

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -244,7 +244,7 @@ function convertParts(
           isError = true;
           result = {
             error:
-              (part as { approval: { reason?: string } }).approval.reason ||
+              (part as { approval?: { reason?: string } }).approval?.reason ||
               "Tool approval denied",
           };
         }

--- a/packages/react-ink/src/primitives/message/MessageContent.tsx
+++ b/packages/react-ink/src/primitives/message/MessageContent.tsx
@@ -98,6 +98,7 @@ const ToolUIDisplay = ({
     ...(part as ToolCallMessagePartProps),
     addResult: partMethods.addToolResult,
     resume: partMethods.resumeToolCall,
+    respondToApproval: partMethods.respondToToolApproval,
   };
 
   if (Render) {

--- a/packages/react-ink/src/primitives/toolCall/ToolFallback.tsx
+++ b/packages/react-ink/src/primitives/toolCall/ToolFallback.tsx
@@ -12,9 +12,11 @@ export type ToolCallStatus =
 
 type ToolFallbackBaseProps = Omit<
   ToolCallMessagePartProps,
-  "addResult" | "resume"
+  "addResult" | "resume" | "respondToApproval"
 > &
-  Partial<Pick<ToolCallMessagePartProps, "addResult" | "resume">>;
+  Partial<
+    Pick<ToolCallMessagePartProps, "addResult" | "resume" | "respondToApproval">
+  >;
 
 const STATUS_ICONS: Record<Exclude<ToolCallStatus, "running">, string> = {
   complete: "+",

--- a/packages/react-native/src/primitives/message/MessageContent.tsx
+++ b/packages/react-native/src/primitives/message/MessageContent.tsx
@@ -82,6 +82,7 @@ const ToolUIDisplay = ({
         {...(part as ToolCallMessagePartProps)}
         addResult={partMethods.addToolResult}
         resume={partMethods.resumeToolCall}
+        respondToApproval={partMethods.respondToToolApproval}
       />
     );
   }

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -220,6 +220,7 @@ const PartResource = resource(
       getState: () => state,
       addToolResult: () => {},
       resumeToolCall: () => {},
+      respondToToolApproval: () => {},
     };
   },
 );

--- a/packages/react/src/primitives/message/MessagePartsGrouped.tsx
+++ b/packages/react/src/primitives/message/MessagePartsGrouped.tsx
@@ -294,8 +294,16 @@ const MessagePartComponent: FC<MessagePartComponentProps> = ({
   if (type === "tool-call") {
     const addResult = aui.part().addToolResult;
     const resume = aui.part().resumeToolCall;
+    const respondToApproval = aui.part().respondToToolApproval;
     if ("Override" in tools)
-      return <tools.Override {...part} addResult={addResult} resume={resume} />;
+      return (
+        <tools.Override
+          {...part}
+          addResult={addResult}
+          resume={resume}
+          respondToApproval={respondToApproval}
+        />
+      );
     const Tool = tools.by_name?.[part.toolName] ?? tools.Fallback;
     return (
       <ToolUIDisplay
@@ -303,6 +311,7 @@ const MessagePartComponent: FC<MessagePartComponentProps> = ({
         Fallback={Tool}
         addResult={addResult}
         resume={resume}
+        respondToApproval={respondToApproval}
       />
     );
   }


### PR DESCRIPTION
closes #4105

## summary

- expose AI SDK v6's server-side approval gate as a first-class `respondToApproval({ approved, reason? })` prop on tool components, so renderers no longer thread `chatHelpers` through React context to call `addToolApprovalResponse`
- add `ToolCallMessagePart.approval` carrying the full AI SDK shape (`{ id, approved?, reason?, isAutomatic? }`). `approval.approved === undefined` is the only state in which `respondToApproval` is callable; `true` / `false` discriminate allowed / denied across the entire approval lifecycle (`approval-requested`, `approval-responded`, `output-available`, `output-error`, `output-denied`)
- fix a latent transient where `approval-responded` parts left the message stuck on `requires-action / interrupt`. the external-message converter now distinguishes interrupted from pending tool calls by an actual `interrupt` or `approval` field, not by `result === undefined` (the two were collapsed into the same expression before)
- plumb `respondToToolApproval` through runtime core interfaces, base class, local / external-store / readonly / empty implementations, tap part scope, all three React distributions, and the AI SDK v6 runtime adapter (forwards to `chatHelpers.addToolApprovalResponse` with the active runConfig)

## breaking changes

- `BaseThreadRuntimeCore` gains a new abstract `respondToToolApproval(options)` method. every in-repo subclass is updated. third-party code extending `BaseThreadRuntimeCore` directly will need to add the method (or throw a "not supported" error). the changeset is `patch`; bump to `minor` if you treat the abstract class as public surface

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/core test` -> 219 / 219 green
- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` -> 44 / 44 green (extended `convertMessage.test.ts` to cover all five gated AI SDK states, plus `isAutomatic` and denial reason)
- [x] `pnpm --filter @assistant-ui/react test` -> 333 / 333 green
- [x] `pnpm --filter @assistant-ui/react-ink test` -> 151 / 151 green
- [x] `pnpm build` clean across core, react, react-ai-sdk, react-native, react-ink, react-langchain, react-a2a, react-ag-ui, react-google-adk, react-data-stream, and the docs site
- [x] `pnpm exec biome check` on edited paths reports no errors

### reviewer should verify

- [ ] end-to-end with a real `needsApproval: true` tool on an AI SDK v6 backend plus `useChat({ sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses })` on the client. approve, deny (with reason), and the resulting `output-available` / `output-denied` paths all round-trip without re-introducing the `ChatHelpersContext` workaround from #4105
- [ ] auto-approval path: when `needsApproval` returns false at runtime for a given input, the renderer sees `approval.isAutomatic === true` on the final `output-available` part and renders the audit branch instead of the buttons

## notes

- `respondToToolApproval` defaults to a "not supported" throw on local / readonly / empty / external-store-without-adapter runtimes. only `useAISDKRuntime` opts in this PR. `react-langchain`, `react-a2a`, `react-ag-ui`, and `react-google-adk` can wire `onRespondToToolApproval` on their adapter when they grow server-side approval support
- `approval` is added as a sibling field to `interrupt` rather than as a new variant of the `interrupt` union, to keep `react-ag-ui` and `react-langchain`'s `{ type: "human"; payload }` interrupt consumers unchanged