### PR TITLE
fix(react): use instant scroll in top anchor reserve to eliminate scroll jitter

### DIFF
--- a/.changeset/fix-top-anchor-scroll-jitter.md
+++ b/.changeset/fix-top-anchor-scroll-jitter.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): use instant scroll in top anchor reserve to eliminate visible jitter

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -106,7 +106,7 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     );
 
     if (Math.abs(viewport.scrollTop - targetScrollTop) > 1) {
-      viewport.scrollTo({ top: targetScrollTop, behavior: "smooth" });
+      viewport.scrollTo({ top: targetScrollTop, behavior: "instant" });
     }
 
     if (anchorId !== undefined) lastScrolledAnchorId = anchorId;


### PR DESCRIPTION
## Problem

When using `turnAnchor="top"` on `ThreadPrimitive.Viewport`, there is a visible scroll "tick" (jitter) every time the assistant starts responding. The user message briefly shifts down a few pixels, momentarily revealing the message above it.

The root cause is in `mountTopAnchorReserve.ts`. The `apply()` function uses `behavior: "smooth"` for the scroll correction:

```ts
if (Math.abs(viewport.scrollTop - targetScrollTop) > 1)
  viewport.scrollTo({ top: targetScrollTop, behavior: "smooth" });
```

Since `apply()` is already deferred by at least one frame via `requestAnimationFrame`, the browser renders one frame at the wrong position first, then the smooth animation makes even a sub-pixel correction visually noticeable as a jitter.

Fixes #4104.

## Solution

Change `behavior: "smooth"` to `behavior: "instant"`. The correction is already happening at RAF time (synchronized with the browser's rendering cycle), so instant behavior eliminates the visible tick while still performing the correction:

```ts
viewport.scrollTo({ top: targetScrollTop, behavior: "instant" });
```

## Testing

1. Use `<ThreadPrimitive.Viewport turnAnchor="top">` in a chat with existing messages
2. Send a new message
3. Observe that the user message no longer shifts/jitters when the assistant response starts