### PR TITLE
docs: cross-link runtime architecture, adapters, threads

### DIFF
--- a/apps/docs/content/docs/(docs)/architecture.mdx
+++ b/apps/docs/content/docs/(docs)/architecture.mdx
@@ -33,7 +33,26 @@ A React state management context for assistant chat. The runtime handles data co
 A hosted service that enhances your assistant experience with comprehensive thread management and message history. Assistant Cloud stores complete message history, automatically persists threads, supports human-in-the-loop workflows, and integrates with common auth providers to seamlessly allow users to resume conversations at any point. [Cloud Docs](/docs/cloud)
 
 
-### There are three common ways to architect your assistant-ui application:
+## What each layer owns
+
+Before picking a runtime or wiring components, it helps to see which layer owns which responsibility. assistant-ui draws hard lines between rendering, conversation state, and where the model actually runs.
+
+### UI layer
+Primitives and prebuilt components render the assistant experience: thread, messages, composer, message parts, actions, attachments, suggestions. They read and write through the runtime context, not directly against the backend or model.
+
+### Runtime layer
+The state and behavior boundary between UI and backend. The runtime owns or adapts conversation state: messages, thread state, composer state, run lifecycle, branching, editing, regeneration. Different runtimes exist because different backends own this state differently. `LocalRuntime` keeps state internal; `ExternalStoreRuntime` delegates to your store.
+
+### Backend / agent layer
+Produces assistant output and app-specific behavior. Depending on the runtime and protocol, the backend may emit text, message parts, tool calls, metadata, agent state, attachments, or other events that the runtime maps into UI state.
+
+### Integration / protocol layer
+Runtime adapters and protocols bridge assistant-ui to different backend shapes: AI SDK, LangGraph, LangChain, ADK, A2A, AG-UI, OpenCode, or your own. The DataStream and AssistantTransport protocols let a generic backend talk to assistant-ui without a custom adapter per app.
+
+### Persistence layer
+Thread and message history can be stored by Assistant Cloud or by your own database via thread and history adapters. Persistence is separate from rendering and backend generation, though the runtime coordinates with it.
+
+## There are three common ways to architect your assistant-ui application:
 
 #### **1. Direct Integration with External Providers**
 
@@ -94,7 +113,7 @@ graph TD
 
 ## Going deeper
 
-These pages explain what each layer owns and how features flow across runtimes, protocols, and persistence.
+These pages go one level deeper on runtime internals, adapters, and persistence.
 
 <Cards>
   <Card

--- a/apps/docs/content/docs/(docs)/architecture.mdx
+++ b/apps/docs/content/docs/(docs)/architecture.mdx
@@ -91,3 +91,25 @@ graph TD
     
     class A,B,C,D,E default
 ```
+
+## Going deeper
+
+These pages explain what each layer owns and how features flow across runtimes, protocols, and persistence.
+
+<Cards>
+  <Card
+    title="Runtime architecture"
+    description="Core runtimes, protocol layers, and framework adapters — what each layer owns."
+    href="/docs/runtimes/concepts/architecture"
+  />
+  <Card
+    title="Adapters"
+    description="Attachments, speech, feedback, history, suggestions across runtimes."
+    href="/docs/runtimes/concepts/adapters"
+  />
+  <Card
+    title="Threads"
+    description="Multi-thread support: cloud, custom database, ExternalStore."
+    href="/docs/runtimes/concepts/threads"
+  />
+</Cards>


### PR DESCRIPTION
  ## Summary

 The `/docs/architecture` page describes the three pillars (Frontend components, Runtime, Assistant Cloud) but doesn't link onward to the deeper conceptual docs. The layer-ownership, protocol, and persistence model already exists at `/docs/runtimes/concepts/architecture` (plus adapters and threads), but a reader landing on the top-level architecture page has no path to discover it.

This adds a **Going deeper** section linking to those pages, using the same `<Cards>` link pattern already used on the runtime concepts page.

  ## Changes

  - Add "Going deeper" card section to `apps/docs/content/docs/(docs)/architecture.mdx` linking to:
     - Runtime architecture (`/docs/runtimes/concepts/architecture`)
     - Adapters (`/docs/runtimes/concepts/adapters`)
     - Threads (`/docs/runtimes/concepts/threads`)

  ## Context

Addresses #4109, which asks whether the Architecture page should go a level deeper on layer boundaries. The deeper material already exists but wasn't discoverable from the  entry-point page; this closes that gap without expanding the page into a feature catalog .

