### PR TITLE
feat(examples): add opt-in generative UI adoption path

### DIFF
--- a/apps/docs/content/docs/guides/generative-ui.mdx
+++ b/apps/docs/content/docs/guides/generative-ui.mdx
@@ -13,6 +13,29 @@ a tree of components by name. assistant-ui resolves each name against a
 > not in it throws a typed `GenerativeUIRenderError` (no implicit fallback). It
 > does not constrain the props passed to those components; see [Security](#security).
 
+> **Opt-in feature:** The default shadcn `Thread` does **not** render
+> `generative-ui` parts. You must wire the primitive explicitly — see
+> [Opt-in wiring](#opt-in-wiring).
+
+## Which generative UI pattern?
+
+assistant-ui uses "generative UI" in three different places. Pick the one that
+matches your integration:
+
+| Pattern | API | Best for | Streaming |
+|---------|-----|----------|-----------|
+| **Generative UI primitive** | `MessagePrimitive.GenerativeUI` + allowlist | Composing dashboards, cards, and layouts from a component vocabulary you ship | Native `generative-ui` parts update progressively when the part spec changes incrementally |
+| **Tool UI** | `makeAssistantToolUI` | Interactive widgets tied to a known tool (forms, pickers, charts) | Tool **args** stream while the model fills them in |
+| **LangGraph data UI** | `makeAssistantDataUI` + `ui_message` | LangGraph agents emitting UI via the LangGraph stream | UI messages arrive on the LangGraph custom channel |
+
+See also: [Tool UI guide](/docs/guides/tool-ui), [LangGraph generative UI](/docs/runtimes/langgraph/generative-ui).
+
+## When not to use the primitive
+
+- **User input and two-way interaction** → [Tool UI](/docs/guides/tool-ui) or [Interactables](/docs/guides/interactables)
+- **LangGraph `push_ui_message`** → [LangGraph data UI](/docs/runtimes/langgraph/generative-ui)
+- **Untrusted HTML or arbitrary code** → [Artifacts](/docs/guides/artifacts) with sandboxed frames
+
 ## Quick start
 
 ### 1. Define your component allowlist
@@ -36,30 +59,11 @@ export const componentsAllowlist = { Card, Button };
 
 ### 2. Wire the primitive into your message renderer
 
-```tsx title="components/assistant-message.tsx"
-import { MessagePrimitive } from "@assistant-ui/react";
-import { componentsAllowlist } from "./gui";
+See [Opt-in wiring](#opt-in-wiring) for all three integration patterns.
 
-export function AssistantMessage() {
-  return (
-    <MessagePrimitive.Parts
-      components={{
-        generativeUI: { components: componentsAllowlist },
-      }}
-    />
-  );
-}
-```
+### 3. Have the agent emit UI
 
-You can also use the standalone primitive form:
-
-```tsx
-<MessagePrimitive.GenerativeUI components={componentsAllowlist} />
-```
-
-### 3. Have the agent emit a `generative-ui` part
-
-A `GenerativeUIMessagePart` carries a JSON spec:
+**ExternalStore / manual messages** attach a native part:
 
 ```ts
 {
@@ -75,6 +79,70 @@ A `GenerativeUIMessagePart` carries a JSON spec:
   },
 }
 ```
+
+**AI SDK (`useChatRuntime`)** — the adapter maps tool results to `tool-call`
+parts, not `generative-ui` parts. Use the [AI SDK interim bridge](#pattern-3--ai-sdk-interim-bridge) until a native emission helper ships.
+
+Live examples in [`examples/with-generative-ui`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-generative-ui): Tool UI demo (`/`), static primitive (`/primitive`), GUI chat (`/gui-chat`).
+
+## Opt-in wiring
+
+The stock `@assistant-ui/ui` `Thread` switch returns `null` for unknown part
+types — including `generative-ui`. Add one of these patterns in **your**
+assistant message renderer (~15 lines).
+
+### Pattern 1 — `MessagePrimitive.Parts`
+
+```tsx
+<MessagePrimitive.Parts
+  components={{
+    generativeUI: {
+      components: componentsAllowlist,
+      Fallback: UnknownComponentFallback,
+    },
+  }}
+/>
+```
+
+### Pattern 2 — `GroupedParts` case (shadcn Thread fork)
+
+```tsx
+case "generative-ui":
+  return (
+    <MessagePrimitive.GenerativeUI
+      components={componentsAllowlist}
+      Fallback={UnknownComponentFallback}
+    />
+  );
+```
+
+Also exclude `render_gui` from tool-group chrome in `groupBy` if you use the
+AI SDK bridge (return `null` for that tool name).
+
+### Pattern 3 — AI SDK interim bridge
+
+When using `useChatRuntime`, map a dedicated tool result to the renderer:
+
+```tsx
+case "tool-call":
+  if (part.toolName === "render_gui") {
+    const spec = parseRenderGuiResult(part.result);
+    if (spec) {
+      return (
+        <MessagePrimitive.GenerativeUI
+          spec={spec}
+          components={componentsAllowlist}
+          Fallback={UnknownComponentFallback}
+        />
+      );
+    }
+  }
+  return part.toolUI ?? <ToolFallback {...part} />;
+```
+
+The message store still holds a `tool-call` on this path — not a
+`generative-ui` part. See `examples/with-generative-ui/app/gui-chat` for a
+working reference.
 
 Bare strings act as inline text leaves.
 
@@ -100,9 +168,13 @@ on the server before delivery.
 
 ## Streaming
 
-The primitive is stream-friendly: any partial spec renders progressively. As
-new nodes arrive (filling in `children`, refining `props`), the rendered tree
-updates without reflows or lost local state for already-mounted children.
+When a message contains native `generative-ui` parts whose `spec` updates
+incrementally (for example via ExternalStore), the primitive renders
+progressively as nodes and props arrive.
+
+The AI SDK `render_gui` tool path returns the full spec at **tool completion**
+— not incrementally during the tool execute step. For args streaming during
+generation, use [Tool UI](/docs/guides/tool-ui) instead.
 
 ## Security
 
@@ -138,5 +210,5 @@ reasoning in the same message.
 
 Tool-call UI is great when the agent already invoked a known tool. Generative
 UI flips it: the agent _composes_ UI from a vocabulary you ship. Useful for
-forms, dashboards, status panels, multi-step flows, and anywhere the
-component library you want is broader than a single tool's render surface.
+dashboards, status panels, and structured layouts — not for collecting user
+input (use Tool UI for that).

--- a/apps/docs/content/docs/guides/tool-ui.mdx
+++ b/apps/docs/content/docs/guides/tool-ui.mdx
@@ -21,6 +21,9 @@ Tool UIs in assistant-ui allow you to create custom interfaces that appear when 
 
 This guide demonstrates building tool UIs with the **Vercel AI SDK**.
 
+For composing UI from a JSON spec and component allowlist (display-only layouts),
+see the [Generative UI primitive guide](/docs/guides/generative-ui).
+
 ## Creating Tool UIs
 
 There are two main approaches to creating tool UIs in assistant-ui:

--- a/apps/docs/content/examples/generative-ui.mdx
+++ b/apps/docs/content/examples/generative-ui.mdx
@@ -1,16 +1,28 @@
 ---
-title: Generative UI Example
-description: Live generative UI demo — AI tool calls render as interactive charts, date pickers, contact forms, and maps in React, all powered by assistant-ui.
+title: Generative UI Example (Tool UI)
+description: Live demo of makeAssistantToolUI patterns — charts, date pickers, contact forms, and maps. For the GenerativeUI JSON-spec primitive, see /gui-chat and /primitive in the same example app.
 ---
 
 ## Overview
 
-This example demonstrates four common generative UI patterns using `makeAssistantToolUI`:
+The main route (`examples/with-generative-ui`) demonstrates **Tool UI**
+patterns using `makeAssistantToolUI` — not the `MessagePrimitive.GenerativeUI`
+JSON-spec primitive.
 
 - **Chart Generation** — AI returns structured data, rendered as bar/line/pie charts via Recharts
 - **Date Picker** — AI requests a date selection, user picks via native input, result sent back with `addResult`
 - **Contact Form** — AI collects name, email, and phone through an interactive form tool
 - **Location Map** — AI shows a place on an embedded OpenStreetMap
+
+### Related routes in the same example app
+
+| Route | What it demonstrates |
+|-------|---------------------|
+| `/` | Tool UI (`makeAssistantToolUI`) — interactive widgets |
+| `/primitive` | Static `GenerativeUIRender` with a hand-written spec |
+| `/gui-chat` | End-to-end chat with `render_gui` tool → `MessagePrimitive.GenerativeUI` bridge |
+
+See the [Generative UI primitive guide](/docs/guides/generative-ui) for opt-in wiring and pattern comparison.
 
 ## Patterns Demonstrated
 

--- a/examples/with-generative-ui/app/api/chat/route.ts
+++ b/examples/with-generative-ui/app/api/chat/route.ts
@@ -54,7 +54,7 @@ export async function POST(req: Request) {
         description: renderGuiToolDescription,
         inputSchema: zodSchema(renderGuiToolInputSchema),
         execute: async (input) => ({
-          spec: renderGuiToolInputSchema.parse(input).spec,
+          spec: input.spec,
         }),
       }),
 

--- a/examples/with-generative-ui/app/api/chat/route.ts
+++ b/examples/with-generative-ui/app/api/chat/route.ts
@@ -9,6 +9,10 @@ import {
 } from "ai";
 import type { UIMessage } from "ai";
 import { z } from "zod";
+import {
+  renderGuiToolDescription,
+  renderGuiToolInputSchema,
+} from "../../../lib/render-gui-tool";
 
 export const maxDuration = 30;
 
@@ -45,6 +49,14 @@ export async function POST(req: Request) {
     ...(system ? { system } : {}),
     tools: {
       ...frontendToolDefs,
+
+      render_gui: tool({
+        description: renderGuiToolDescription,
+        inputSchema: zodSchema(renderGuiToolInputSchema),
+        execute: async (input) => ({
+          spec: renderGuiToolInputSchema.parse(input).spec,
+        }),
+      }),
 
       // Backend tool: generate chart data
       generate_chart: tool({

--- a/examples/with-generative-ui/app/gui-chat/page.tsx
+++ b/examples/with-generative-ui/app/gui-chat/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { ExampleNav } from "@/components/example-nav";
+import { GuiThread } from "@/components/gui-thread";
+import {
+  AssistantRuntimeProvider,
+  Suggestions,
+  useAssistantInstructions,
+  useAui,
+} from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
+import { renderGuiChatInstructions } from "@/lib/render-gui-tool";
+
+const GuiChatInstructions = () => {
+  useAssistantInstructions(renderGuiChatInstructions);
+  return null;
+};
+
+export default function GuiChatPage() {
+  const runtime = useChatRuntime({
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+  });
+
+  const aui = useAui({
+    suggestions: Suggestions([
+      {
+        title: "Welcome card",
+        label: "with a Get started button",
+        prompt:
+          "Show me a welcome card with a Get started button using render_gui.",
+      },
+      {
+        title: "Stats dashboard",
+        label: "revenue and users",
+        prompt:
+          "Use render_gui to show a stats card with Revenue $124k and Active Users 8.2k.",
+      },
+    ]),
+  });
+
+  return (
+    <AssistantRuntimeProvider aui={aui} runtime={runtime}>
+      <GuiChatInstructions />
+      <div className="flex h-full flex-col">
+        <ExampleNav />
+        <main className="min-h-0 flex-1">
+          <GuiThread />
+        </main>
+      </div>
+    </AssistantRuntimeProvider>
+  );
+}

--- a/examples/with-generative-ui/app/page.tsx
+++ b/examples/with-generative-ui/app/page.tsx
@@ -14,6 +14,7 @@ import { ChartToolUI } from "@/components/chart-tool-ui";
 import { DatePickerToolUI } from "@/components/date-picker-tool-ui";
 import { ContactFormToolUI } from "@/components/contact-form-tool-ui";
 import { LocationToolUI } from "@/components/location-tool-ui";
+import { ExampleNav } from "@/components/example-nav";
 
 // Register frontend tool schemas (no execute — resolved via addResult in the UI)
 function FrontendTools() {
@@ -84,9 +85,12 @@ export default function Home() {
       <LocationToolUI />
       <DatePickerToolUI />
       <ContactFormToolUI />
-      <main className="h-full">
-        <Thread />
-      </main>
+      <div className="flex h-full flex-col">
+        <ExampleNav />
+        <main className="min-h-0 flex-1">
+          <Thread />
+        </main>
+      </div>
     </AssistantRuntimeProvider>
   );
 }

--- a/examples/with-generative-ui/app/primitive/page.tsx
+++ b/examples/with-generative-ui/app/primitive/page.tsx
@@ -1,13 +1,11 @@
 "use client";
 
 import { GenerativeUIRender, type GenerativeUISpec } from "@assistant-ui/react";
-import { componentsAllowlist } from "@/components/gui";
-
-const UnknownComponentFallback = ({ component }: { component: string }) => (
-  <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
-    unknown component: {component}
-  </span>
-);
+import {
+  UnknownComponentFallback,
+  componentsAllowlist,
+} from "@/components/gui";
+import { ExampleNav } from "@/components/example-nav";
 
 /**
  * Self-contained demo of the GenerativeUI primitive.
@@ -73,22 +71,25 @@ const exampleSpec: GenerativeUISpec = {
 
 export default function GenerativeUIPrimitivePage() {
   return (
-    <main className="mx-auto flex h-full max-w-2xl flex-col gap-6 p-8">
-      <header>
-        <h1 className="font-bold text-2xl">MessagePrimitive.GenerativeUI</h1>
-        <p className="mt-1 text-muted-foreground text-sm">
-          Agent-described React UI rendered from a JSON spec via a
-          consumer-provided component allowlist.
-        </p>
-      </header>
+    <div className="flex h-full flex-col">
+      <ExampleNav />
+      <main className="mx-auto flex h-full max-w-2xl flex-col gap-6 overflow-y-auto p-8">
+        <header>
+          <h1 className="font-bold text-2xl">MessagePrimitive.GenerativeUI</h1>
+          <p className="mt-1 text-muted-foreground text-sm">
+            Agent-described React UI rendered from a JSON spec via a
+            consumer-provided component allowlist.
+          </p>
+        </header>
 
-      <section className="flex flex-col gap-4">
-        <GenerativeUIRender
-          spec={exampleSpec}
-          components={componentsAllowlist}
-          Fallback={UnknownComponentFallback}
-        />
-      </section>
-    </main>
+        <section className="flex flex-col gap-4">
+          <GenerativeUIRender
+            spec={exampleSpec}
+            components={componentsAllowlist}
+            Fallback={UnknownComponentFallback}
+          />
+        </section>
+      </main>
+    </div>
   );
 }

--- a/examples/with-generative-ui/components/assistant-message-gui.tsx
+++ b/examples/with-generative-ui/components/assistant-message-gui.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningRoot,
+  ReasoningText,
+  ReasoningTrigger,
+} from "@/components/assistant-ui/reasoning";
+import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
+import {
+  ToolGroupContent,
+  ToolGroupRoot,
+  ToolGroupTrigger,
+} from "@/components/assistant-ui/tool-group";
+import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import {
+  UnknownComponentFallback,
+  componentsAllowlist,
+} from "@/components/gui";
+import {
+  RENDER_GUI_TOOL_NAME,
+  isLeakedRenderGuiText,
+  parseRenderGuiResult,
+} from "@/lib/render-gui-tool";
+import { cn } from "@/lib/utils";
+import type { GenerativeUISpec } from "@assistant-ui/react";
+import {
+  ActionBarPrimitive,
+  AuiIf,
+  BranchPickerPrimitive,
+  ErrorPrimitive,
+  getMcpAppFromToolPart,
+  MessagePrimitive,
+  useAuiState,
+} from "@assistant-ui/react";
+import {
+  CheckIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CopyIcon,
+  RefreshCwIcon,
+} from "lucide-react";
+import { type FC, useEffect, useRef } from "react";
+
+type AssistantMessageGuiProps = {
+  /** Set false in dev to surface the dropped-bridge warning. */
+  bridgeEnabled?: boolean;
+};
+
+const AllowlistedGenerativeUI = ({ spec }: { spec?: GenerativeUISpec }) => (
+  <MessagePrimitive.GenerativeUI
+    spec={spec}
+    components={componentsAllowlist}
+    Fallback={UnknownComponentFallback}
+  />
+);
+
+const useDroppedGenerativeUIWarning = (bridgeEnabled: boolean) => {
+  const content = useAuiState((s) => s.message.content);
+  const warned = useRef(false);
+
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV === "production" ||
+      bridgeEnabled ||
+      warned.current
+    ) {
+      return;
+    }
+
+    const hasRenderGui = content.some(
+      (part) =>
+        part.type === "tool-call" &&
+        part.toolName === RENDER_GUI_TOOL_NAME &&
+        part.result != null &&
+        parseRenderGuiResult(part.result) != null,
+    );
+
+    const hasUnhandledGenerativeUI = content.some(
+      (part) => part.type === "generative-ui",
+    );
+
+    if (hasRenderGui || hasUnhandledGenerativeUI) {
+      warned.current = true;
+      console.warn(
+        "[generative-ui] Message contains render_gui or generative-ui parts but the bridge is disabled. " +
+          "Enable the bridge in assistant-message-gui.tsx or wire MessagePrimitive.GenerativeUI.",
+      );
+    }
+  }, [bridgeEnabled, content]);
+};
+
+export const AssistantMessageGui: FC<AssistantMessageGuiProps> = ({
+  bridgeEnabled = true,
+}) => {
+  useDroppedGenerativeUIWarning(bridgeEnabled);
+
+  const hasBridgedRenderGui = useAuiState((s) =>
+    s.message.content.some(
+      (part) =>
+        part.type === "tool-call" &&
+        part.toolName === RENDER_GUI_TOOL_NAME &&
+        parseRenderGuiResult(part.result) != null,
+    ),
+  );
+
+  const ACTION_BAR_PT = "pt-1.5";
+  const ACTION_BAR_HEIGHT = `-mb-7.5 min-h-7.5 ${ACTION_BAR_PT}`;
+
+  return (
+    <MessagePrimitive.Root
+      data-slot="aui_assistant-message-root"
+      data-role="assistant"
+      className="fade-in slide-in-from-bottom-1 relative animate-in duration-150 [contain-intrinsic-size:auto_300px] [content-visibility:auto]"
+    >
+      <div
+        data-slot="aui_assistant-message-content"
+        className="wrap-break-word px-2 text-foreground leading-relaxed"
+      >
+        <MessagePrimitive.GroupedParts
+          groupBy={(part) => {
+            if (part.type === "reasoning") {
+              return ["group-chainOfThought", "group-reasoning"];
+            }
+            if (part.type === "tool-call") {
+              if (getMcpAppFromToolPart(part)) return null;
+              if (part.toolName === RENDER_GUI_TOOL_NAME) return null;
+              return ["group-chainOfThought", "group-tool"];
+            }
+            return null;
+          }}
+        >
+          {({ part, children }) => {
+            switch (part.type) {
+              case "group-chainOfThought":
+                return <div data-slot="aui_chain-of-thought">{children}</div>;
+              case "group-reasoning": {
+                const running = part.status.type === "running";
+                return (
+                  <ReasoningRoot defaultOpen={running}>
+                    <ReasoningTrigger active={running} />
+                    <ReasoningContent aria-busy={running}>
+                      <ReasoningText>{children}</ReasoningText>
+                    </ReasoningContent>
+                  </ReasoningRoot>
+                );
+              }
+              case "group-tool":
+                return (
+                  <ToolGroupRoot>
+                    <ToolGroupTrigger
+                      count={part.indices.length}
+                      active={part.status.type === "running"}
+                    />
+                    <ToolGroupContent>{children}</ToolGroupContent>
+                  </ToolGroupRoot>
+                );
+              case "text":
+                if (
+                  bridgeEnabled &&
+                  hasBridgedRenderGui &&
+                  isLeakedRenderGuiText(part.text)
+                ) {
+                  return null;
+                }
+                return <MarkdownText />;
+              case "reasoning":
+                return <Reasoning {...part} />;
+              case "generative-ui":
+                return bridgeEnabled ? <AllowlistedGenerativeUI /> : null;
+              case "tool-call": {
+                if (bridgeEnabled && part.toolName === RENDER_GUI_TOOL_NAME) {
+                  const spec = parseRenderGuiResult(part.result);
+                  if (spec) return <AllowlistedGenerativeUI spec={spec} />;
+                }
+                return part.toolUI ?? <ToolFallback {...part} />;
+              }
+              default:
+                return null;
+            }
+          }}
+        </MessagePrimitive.GroupedParts>
+        <MessagePrimitive.Error>
+          <ErrorPrimitive.Root className="aui-message-error-root mt-2 rounded-md border border-destructive bg-destructive/10 p-3 text-destructive text-sm dark:bg-destructive/5 dark:text-red-200">
+            <ErrorPrimitive.Message className="aui-message-error-message line-clamp-2" />
+          </ErrorPrimitive.Root>
+        </MessagePrimitive.Error>
+      </div>
+
+      <div
+        data-slot="aui_assistant-message-footer"
+        className={cn("ms-2 flex items-center", ACTION_BAR_HEIGHT)}
+      >
+        <BranchPickerPrimitive.Root
+          hideWhenSingleBranch
+          className="aui-branch-picker-root -ms-2 me-2 inline-flex items-center text-muted-foreground text-xs"
+        >
+          <BranchPickerPrimitive.Previous asChild>
+            <TooltipIconButton tooltip="Previous">
+              <ChevronLeftIcon />
+            </TooltipIconButton>
+          </BranchPickerPrimitive.Previous>
+          <span className="aui-branch-picker-state font-medium">
+            <BranchPickerPrimitive.Number /> / <BranchPickerPrimitive.Count />
+          </span>
+          <BranchPickerPrimitive.Next asChild>
+            <TooltipIconButton tooltip="Next">
+              <ChevronRightIcon />
+            </TooltipIconButton>
+          </BranchPickerPrimitive.Next>
+        </BranchPickerPrimitive.Root>
+        <ActionBarPrimitive.Root
+          hideWhenRunning
+          autohide="not-last"
+          className="aui-assistant-action-bar-root -ms-1 flex gap-1 text-muted-foreground"
+        >
+          <ActionBarPrimitive.Copy asChild>
+            <TooltipIconButton tooltip="Copy">
+              <AuiIf condition={(s) => s.message.isCopied}>
+                <CheckIcon />
+              </AuiIf>
+              <AuiIf condition={(s) => !s.message.isCopied}>
+                <CopyIcon />
+              </AuiIf>
+            </TooltipIconButton>
+          </ActionBarPrimitive.Copy>
+          <ActionBarPrimitive.Reload asChild>
+            <TooltipIconButton tooltip="Refresh">
+              <RefreshCwIcon />
+            </TooltipIconButton>
+          </ActionBarPrimitive.Reload>
+        </ActionBarPrimitive.Root>
+      </div>
+    </MessagePrimitive.Root>
+  );
+};

--- a/examples/with-generative-ui/components/example-nav.tsx
+++ b/examples/with-generative-ui/components/example-nav.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+const links = [
+  { href: "/", label: "Tool UI demo" },
+  { href: "/primitive", label: "Static primitive" },
+  { href: "/gui-chat", label: "GUI chat" },
+] as const;
+
+export function ExampleNav() {
+  return (
+    <nav className="flex flex-wrap items-center gap-2 border-b bg-background px-4 py-2 text-sm">
+      <span className="font-medium text-muted-foreground">Examples:</span>
+      {links.map(({ href, label }) => (
+        <Link
+          key={href}
+          href={href}
+          className="rounded-md px-2 py-1 text-foreground hover:bg-muted"
+        >
+          {label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/examples/with-generative-ui/components/gui-thread.tsx
+++ b/examples/with-generative-ui/components/gui-thread.tsx
@@ -1,0 +1,292 @@
+import {
+  ComposerAddAttachment,
+  ComposerAttachments,
+  UserMessageAttachments,
+} from "@/components/assistant-ui/attachment";
+import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  ActionBarPrimitive,
+  AuiIf,
+  BranchPickerPrimitive,
+  ComposerPrimitive,
+  MessagePrimitive,
+  SuggestionPrimitive,
+  ThreadPrimitive,
+  useAuiState,
+} from "@assistant-ui/react";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  PencilIcon,
+  SquareIcon,
+} from "lucide-react";
+import type { FC } from "react";
+import { AssistantMessageGui } from "@/components/assistant-message-gui";
+
+/** Thread fork: swaps the assistant message renderer for the generative-ui bridge. */
+export const GuiThread: FC = () => {
+  return (
+    <ThreadPrimitive.Root
+      className="aui-root aui-thread-root @container flex h-full flex-col bg-background"
+      style={{
+        ["--thread-max-width" as string]: "44rem",
+        ["--composer-radius" as string]: "24px",
+        ["--composer-padding" as string]: "10px",
+      }}
+    >
+      <ThreadPrimitive.Viewport
+        turnAnchor="top"
+        data-slot="aui_thread-viewport"
+        className="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth"
+      >
+        <div className="mx-auto flex w-full max-w-(--thread-max-width) flex-1 flex-col px-4 pt-4">
+          <AuiIf condition={(s) => s.thread.isEmpty}>
+            <ThreadWelcome />
+          </AuiIf>
+
+          <div
+            data-slot="aui_message-group"
+            className="mb-10 flex flex-col gap-y-8 empty:hidden"
+          >
+            <ThreadPrimitive.Messages>
+              {() => <ThreadMessage />}
+            </ThreadPrimitive.Messages>
+          </div>
+
+          <ThreadPrimitive.ViewportFooter className="aui-thread-viewport-footer sticky bottom-0 mt-auto flex flex-col gap-4 overflow-visible rounded-t-(--composer-radius) bg-background pb-4 md:pb-6">
+            <ThreadScrollToBottom />
+            <Composer />
+          </ThreadPrimitive.ViewportFooter>
+        </div>
+      </ThreadPrimitive.Viewport>
+    </ThreadPrimitive.Root>
+  );
+};
+
+const ThreadMessage: FC = () => {
+  const role = useAuiState((s) => s.message.role);
+  const isEditing = useAuiState((s) => s.message.composer.isEditing);
+
+  if (isEditing) return <EditComposer />;
+  if (role === "user") return <UserMessage />;
+  return <AssistantMessageGui />;
+};
+
+const ThreadScrollToBottom: FC = () => {
+  return (
+    <ThreadPrimitive.ScrollToBottom asChild>
+      <TooltipIconButton
+        tooltip="Scroll to bottom"
+        variant="outline"
+        className="aui-thread-scroll-to-bottom absolute -top-12 z-10 self-center rounded-full p-4 disabled:invisible dark:border-border dark:bg-background dark:hover:bg-accent"
+      >
+        <ArrowDownIcon />
+      </TooltipIconButton>
+    </ThreadPrimitive.ScrollToBottom>
+  );
+};
+
+const ThreadWelcome: FC = () => {
+  return (
+    <div className="aui-thread-welcome-root my-auto flex grow flex-col">
+      <div className="aui-thread-welcome-center flex w-full grow flex-col items-center justify-center">
+        <div className="aui-thread-welcome-message flex size-full flex-col justify-center px-4">
+          <h1 className="aui-thread-welcome-message-inner fade-in slide-in-from-bottom-1 animate-in fill-mode-both font-semibold text-2xl duration-200">
+            Compose UI from a spec
+          </h1>
+          <p className="aui-thread-welcome-message-inner fade-in slide-in-from-bottom-1 animate-in fill-mode-both text-muted-foreground text-xl delay-75 duration-200">
+            Ask the agent to call render_gui with Card, Button, and Stack.
+          </p>
+        </div>
+      </div>
+      <ThreadSuggestions />
+    </div>
+  );
+};
+
+const ThreadSuggestions: FC = () => {
+  return (
+    <div className="aui-thread-welcome-suggestions grid w-full @md:grid-cols-2 gap-2 pb-4">
+      <ThreadPrimitive.Suggestions>
+        {() => <ThreadSuggestionItem />}
+      </ThreadPrimitive.Suggestions>
+    </div>
+  );
+};
+
+const ThreadSuggestionItem: FC = () => {
+  return (
+    <div className="aui-thread-welcome-suggestion-display fade-in slide-in-from-bottom-2 @md:nth-[n+3]:block nth-[n+3]:hidden animate-in fill-mode-both duration-200">
+      <SuggestionPrimitive.Trigger send asChild>
+        <Button
+          variant="ghost"
+          className="aui-thread-welcome-suggestion h-auto w-full @md:flex-col flex-wrap items-start justify-start gap-1 rounded-3xl border bg-background px-4 py-3 text-start text-sm transition-colors hover:bg-muted"
+        >
+          <SuggestionPrimitive.Title className="aui-thread-welcome-suggestion-text-1 font-medium" />
+          <SuggestionPrimitive.Description className="aui-thread-welcome-suggestion-text-2 text-muted-foreground empty:hidden" />
+        </Button>
+      </SuggestionPrimitive.Trigger>
+    </div>
+  );
+};
+
+const Composer: FC = () => {
+  return (
+    <ComposerPrimitive.Root className="aui-composer-root relative flex w-full flex-col">
+      <ComposerPrimitive.AttachmentDropzone asChild>
+        <div
+          data-slot="aui_composer-shell"
+          className="flex w-full flex-col gap-2 rounded-(--composer-radius) border bg-background p-(--composer-padding) transition-shadow focus-within:border-ring/75 focus-within:ring-2 focus-within:ring-ring/20 data-[dragging=true]:border-ring data-[dragging=true]:border-dashed data-[dragging=true]:bg-accent/50"
+        >
+          <ComposerAttachments />
+          <ComposerPrimitive.Input
+            placeholder="Send a message..."
+            className="aui-composer-input max-h-32 min-h-10 w-full resize-none bg-transparent px-1.75 py-1 text-sm outline-none placeholder:text-muted-foreground/80"
+            rows={1}
+            autoFocus
+            aria-label="Message input"
+          />
+          <ComposerAction />
+        </div>
+      </ComposerPrimitive.AttachmentDropzone>
+    </ComposerPrimitive.Root>
+  );
+};
+
+const ComposerAction: FC = () => {
+  return (
+    <div className="aui-composer-action-wrapper relative flex items-center justify-between">
+      <ComposerAddAttachment />
+      <AuiIf condition={(s) => !s.thread.isRunning}>
+        <ComposerPrimitive.Send asChild>
+          <TooltipIconButton
+            tooltip="Send message"
+            side="bottom"
+            type="button"
+            variant="default"
+            size="icon"
+            className="aui-composer-send size-8 rounded-full"
+            aria-label="Send message"
+          >
+            <ArrowUpIcon className="aui-composer-send-icon size-4" />
+          </TooltipIconButton>
+        </ComposerPrimitive.Send>
+      </AuiIf>
+      <AuiIf condition={(s) => s.thread.isRunning}>
+        <ComposerPrimitive.Cancel asChild>
+          <Button
+            type="button"
+            variant="default"
+            size="icon"
+            className="aui-composer-cancel size-8 rounded-full"
+            aria-label="Stop generating"
+          >
+            <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
+          </Button>
+        </ComposerPrimitive.Cancel>
+      </AuiIf>
+    </div>
+  );
+};
+
+const UserMessage: FC = () => {
+  return (
+    <MessagePrimitive.Root
+      data-slot="aui_user-message-root"
+      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [contain-intrinsic-size:auto_60px] [content-visibility:auto] [&:where(>*)]:col-start-2"
+      data-role="user"
+    >
+      <UserMessageAttachments />
+
+      <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
+        <div className="aui-user-message-content wrap-break-word peer rounded-2xl bg-muted px-4 py-2.5 text-foreground empty:hidden">
+          <MessagePrimitive.Parts />
+        </div>
+        <div className="aui-user-action-bar-wrapper absolute start-0 top-1/2 -translate-x-full -translate-y-1/2 pe-2 peer-empty:hidden rtl:translate-x-full">
+          <UserActionBar />
+        </div>
+      </div>
+
+      <BranchPicker
+        data-slot="aui_user-branch-picker"
+        className="col-span-full col-start-1 row-start-3 -me-1 justify-end"
+      />
+    </MessagePrimitive.Root>
+  );
+};
+
+const UserActionBar: FC = () => {
+  return (
+    <ActionBarPrimitive.Root
+      hideWhenRunning
+      autohide="not-last"
+      className="aui-user-action-bar-root flex flex-col items-end"
+    >
+      <ActionBarPrimitive.Edit asChild>
+        <TooltipIconButton tooltip="Edit" className="aui-user-action-edit p-4">
+          <PencilIcon />
+        </TooltipIconButton>
+      </ActionBarPrimitive.Edit>
+    </ActionBarPrimitive.Root>
+  );
+};
+
+const EditComposer: FC = () => {
+  return (
+    <MessagePrimitive.Root
+      data-slot="aui_edit-composer-wrapper"
+      className="flex flex-col px-2"
+    >
+      <ComposerPrimitive.Root className="aui-edit-composer-root ms-auto flex w-full max-w-[85%] flex-col rounded-2xl bg-muted">
+        <ComposerPrimitive.Input
+          className="aui-edit-composer-input min-h-14 w-full resize-none bg-transparent p-4 text-foreground text-sm outline-none"
+          autoFocus
+        />
+        <div className="aui-edit-composer-footer mx-3 mb-3 flex items-center gap-2 self-end">
+          <ComposerPrimitive.Cancel asChild>
+            <Button variant="ghost" size="sm">
+              Cancel
+            </Button>
+          </ComposerPrimitive.Cancel>
+          <ComposerPrimitive.Send asChild>
+            <Button size="sm">Update</Button>
+          </ComposerPrimitive.Send>
+        </div>
+      </ComposerPrimitive.Root>
+    </MessagePrimitive.Root>
+  );
+};
+
+const BranchPicker: FC<BranchPickerPrimitive.Root.Props> = ({
+  className,
+  ...rest
+}) => {
+  return (
+    <BranchPickerPrimitive.Root
+      hideWhenSingleBranch
+      className={cn(
+        "aui-branch-picker-root -ms-2 me-2 inline-flex items-center text-muted-foreground text-xs",
+        className,
+      )}
+      {...rest}
+    >
+      <BranchPickerPrimitive.Previous asChild>
+        <TooltipIconButton tooltip="Previous">
+          <ChevronLeftIcon />
+        </TooltipIconButton>
+      </BranchPickerPrimitive.Previous>
+      <span className="aui-branch-picker-state font-medium">
+        <BranchPickerPrimitive.Number /> / <BranchPickerPrimitive.Count />
+      </span>
+      <BranchPickerPrimitive.Next asChild>
+        <TooltipIconButton tooltip="Next">
+          <ChevronRightIcon />
+        </TooltipIconButton>
+      </BranchPickerPrimitive.Next>
+    </BranchPickerPrimitive.Root>
+  );
+};

--- a/examples/with-generative-ui/components/gui/index.tsx
+++ b/examples/with-generative-ui/components/gui/index.tsx
@@ -7,6 +7,16 @@ import type { ComponentType, PropsWithChildren } from "react";
  * The agent's JSON spec can reference any of these by name.
  */
 
+export const UnknownComponentFallback = ({
+  component,
+}: {
+  component: string;
+}) => (
+  <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+    unknown component: {component}
+  </span>
+);
+
 const Card: ComponentType<
   PropsWithChildren<{ title?: string; description?: string }>
 > = ({ title, description, children }) => (

--- a/examples/with-generative-ui/lib/render-gui-tool.test.ts
+++ b/examples/with-generative-ui/lib/render-gui-tool.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  generativeUISpecSchema,
+  isLeakedRenderGuiText,
+  parseRenderGuiResult,
+  renderGuiToolResultSchema,
+} from "./render-gui-tool";
+
+describe("render-gui-tool", () => {
+  it("accepts a valid Card + Button spec", () => {
+    const spec = {
+      root: {
+        component: "Card",
+        props: { title: "Welcome" },
+        children: [
+          {
+            component: "Button",
+            props: { label: "Get started", variant: "primary" },
+          },
+        ],
+      },
+    };
+
+    expect(generativeUISpecSchema.parse(spec)).toEqual(spec);
+    expect(
+      parseRenderGuiResult(renderGuiToolResultSchema.parse({ spec })),
+    ).toEqual(spec);
+  });
+
+  it("rejects a spec with empty component name", () => {
+    expect(() =>
+      generativeUISpecSchema.parse({
+        root: { component: "", props: { title: "Bad" } },
+      }),
+    ).toThrow();
+  });
+
+  it("returns undefined for malformed tool results", () => {
+    expect(parseRenderGuiResult({ notSpec: true })).toBeUndefined();
+    expect(parseRenderGuiResult(null)).toBeUndefined();
+  });
+
+  it("detects leaked render_gui tool result text", () => {
+    const payload = renderGuiToolResultSchema.parse({
+      spec: {
+        root: {
+          component: "Card",
+          children: [{ component: "Text", children: ["Hello"] }],
+        },
+      },
+    });
+
+    expect(isLeakedRenderGuiText(JSON.stringify(payload, null, 2))).toBe(true);
+    expect(
+      isLeakedRenderGuiText(
+        "```json\n" + JSON.stringify(payload, null, 2) + "\n```",
+      ),
+    ).toBe(true);
+    expect(isLeakedRenderGuiText("Here is your card.")).toBe(false);
+  });
+});

--- a/examples/with-generative-ui/lib/render-gui-tool.ts
+++ b/examples/with-generative-ui/lib/render-gui-tool.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import type { GenerativeUISpec } from "@assistant-ui/react";
+
+export const RENDER_GUI_TOOL_NAME = "render_gui" as const;
+
+const generativeUINodeSchema: z.ZodType<unknown> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.object({
+      component: z.string().min(1),
+      props: z.record(z.string(), z.unknown()).optional(),
+      children: z.array(generativeUINodeSchema).optional(),
+      key: z.string().optional(),
+    }),
+  ]),
+);
+
+export const generativeUISpecSchema = z.object({
+  root: z.union([
+    generativeUINodeSchema,
+    z.array(generativeUINodeSchema).min(1),
+  ]),
+});
+
+export const renderGuiToolInputSchema = z.object({
+  spec: generativeUISpecSchema,
+});
+
+export const renderGuiToolResultSchema = renderGuiToolInputSchema;
+
+export const parseRenderGuiResult = (
+  result: unknown,
+): GenerativeUISpec | undefined => {
+  const parsed = renderGuiToolResultSchema.safeParse(result);
+  return parsed.success ? (parsed.data.spec as GenerativeUISpec) : undefined;
+};
+
+export const renderGuiToolDescription =
+  "Compose inline UI from the allowlisted component library (Card, Text, Button, Stack, Stat, Heading). " +
+  "Pass a JSON spec with a root node tree. Use for dashboards, status panels, and structured layouts — not for user input forms (use interactive tool UI instead).";
+
+export const renderGuiChatInstructions =
+  "When the user asks for UI, call render_gui with the spec. " +
+  "Do not paste JSON, code blocks, or the tool result in your text reply — the client renders the UI from the tool output automatically. " +
+  "Keep any text reply brief or omit it when the UI alone answers the request.";
+
+const stripMarkdownJsonFence = (text: string): string => {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```\s*$/i);
+  return match ? match[1]!.trim() : trimmed;
+};
+
+/** Text echo of a render_gui tool result/spec — hide when the bridge already rendered it. */
+export const isLeakedRenderGuiText = (text: string): boolean => {
+  const candidate = stripMarkdownJsonFence(text);
+  if (!candidate.startsWith("{")) return false;
+
+  try {
+    const parsed = JSON.parse(candidate);
+    if (renderGuiToolResultSchema.safeParse(parsed).success) return true;
+    if (generativeUISpecSchema.safeParse(parsed).success) return true;
+  } catch {
+    return false;
+  }
+
+  return false;
+};

--- a/examples/with-generative-ui/package.json
+++ b/examples/with-generative-ui/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.64",
@@ -33,6 +34,7 @@
     "postcss": "^8.5.15",
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/examples/with-generative-ui/vitest.config.ts
+++ b/examples/with-generative-ui/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["lib/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1710,6 +1710,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
 
   examples/with-google-adk:
     dependencies:
@@ -3434,7 +3437,7 @@ importers:
         version: link:../store
       '@google/adk':
         specifier: '>=0.5.0'
-        version: 1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
+        version: 1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
       assistant-cloud:
         specifier: '*'
         version: link:../cloud
@@ -3459,7 +3462,7 @@ importers:
         version: 19.2.6
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/react-hook-form:
     dependencies:
@@ -18037,6 +18040,20 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
+  '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+    dependencies:
+      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/precise-date': 4.0.0
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      googleapis: 137.1.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
       '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -18051,6 +18068,20 @@ snapshots:
       - encoding
       - supports-color
 
+  '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+    dependencies:
+      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.8.1
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+      google-auth-library: 9.15.1(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
       '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -18061,6 +18092,16 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
       google-auth-library: 9.15.1(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@google-cloud/opentelemetry-resource-util@3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+    dependencies:
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      gcp-metadata: 6.1.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -18106,6 +18147,50 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@google/adk@1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+    dependencies:
+      '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.12.0)(@grpc/grpc-js@1.14.4)(express@4.22.2)
+      '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/opentelemetry-cloud-trace-exporter': 3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/storage': 7.19.0(encoding@0.1.13)
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
+      '@mikro-orm/core': 6.6.14
+      '@mikro-orm/mariadb': 6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0)
+      '@mikro-orm/mssql': 6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0)
+      '@mikro-orm/mysql': 6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5)(pg@8.20.0)
+      '@mikro-orm/postgresql': 6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)
+      '@mikro-orm/reflection': 6.6.14(@mikro-orm/core@6.6.14)
+      '@mikro-orm/sqlite': 6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resource-detector-gcp': 0.40.3(@opentelemetry/api@1.9.0)(encoding@0.1.13)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.0)
+      express: 4.22.2
+      google-auth-library: 10.6.2
+      js-yaml: 4.1.1
+      jsonpath-plus: 10.4.0
+      lodash-es: 4.18.1
+      winston: 3.19.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@bufbuild/protobuf'
+      - '@cfworker/json-schema'
+      - '@grpc/grpc-js'
+      - '@opentelemetry/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
 
   '@google/adk@1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)':
     dependencies:
@@ -20583,9 +20668,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -29300,6 +29383,37 @@ snapshots:
   vitefu@1.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
+
+  vitest@4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.9.1
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
+      '@vitest/ui': 4.1.7(vitest@4.1.7)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## Summary

- Document opt-in wiring for `MessagePrimitive.GenerativeUI` — pattern comparison table, three integration patterns, and AI SDK interim bridge guidance
- Extend `examples/with-generative-ui` with `/gui-chat`: a Thread fork that bridges `render_gui` tool results to the primitive (without modifying default `@assistant-ui/ui` Thread)
- Filter leaked JSON spec echoes from assistant text when the bridge already rendered the UI; add system instructions and vitest coverage for the bridge helpers

## Test plan

- [x] `pnpm --filter with-generative-ui test` (4/4)
- [x] `pnpm --filter with-generative-ui build`
- [x] `pnpm --filter @assistant-ui/docs build`
- [x] Manual: `/primitive` static card renders
- [x] Manual: `/gui-chat` suggestion → Welcome card renders without raw JSON block
- [x] Manual: `/` Tool UI demo still loads


Made with [Cursor](https://cursor.com)