### PR TITLE
test(react, react-ai-sdk): cover tool propagation through useRemoteThreadListRuntime runtimeHook

### DIFF
--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.toolPropagation.test.tsx
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.toolPropagation.test.tsx
@@ -45,6 +45,12 @@ const timeTool = {
   toolName: "get_local_time",
   type: "frontend" as const,
   description: "Get current local time",
+  parameters: {
+    type: "object" as const,
+    properties: {
+      format: { type: "string" as const, enum: ["iso", "time", "dateTime"] },
+    },
+  },
   execute: async () => ({ dateTime: "now" }),
 };
 
@@ -53,19 +59,40 @@ const ToolRegistrar: FC = () => {
   return null;
 };
 
+const emptyStreamResponse = () =>
+  new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+
 describe("useChatRuntime under useRemoteThreadListRuntime", () => {
-  it("includes makeAssistantTool tools in the thread model context", async () => {
+  it("sends makeAssistantTool tools in the AssistantChatTransport request body", async () => {
+    let sentTools: Record<string, unknown> | undefined;
+
+    const transport = new AssistantChatTransport({
+      api: "/api/chat",
+      // captures the serialized HTTP body — the tools field #4101 reports as
+      // empty, built from the inner useAISDKRuntime model context.
+      fetch: vi.fn(async (_input, init) => {
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        sentTools = body.tools;
+        return emptyStreamResponse();
+      }),
+    });
+
+    const adapter = makeAdapter();
     const runtimeRef: { current: AssistantRuntime | null } = { current: null };
 
-    const useThreadRuntime = () =>
-      useChatRuntime({
-        transport: new AssistantChatTransport({ api: "/api/chat" }),
-      });
+    const useThreadRuntime = () => useChatRuntime({ transport });
 
     const Inner: FC = () => {
       const runtime = useRemoteThreadListRuntime({
         runtimeHook: useThreadRuntime,
-        adapter: makeAdapter(),
+        adapter,
       });
       runtimeRef.current = runtime;
       return (
@@ -82,6 +109,17 @@ describe("useChatRuntime under useRemoteThreadListRuntime", () => {
     await waitFor(() => {
       const tools = runtimeRef.current?.thread.getModelContext().tools ?? {};
       expect(Object.keys(tools)).toContain("get_local_time");
+    });
+
+    await act(async () => {
+      await runtimeRef.current?.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "what time is it?" }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(Object.keys(sentTools ?? {})).toContain("get_local_time");
     });
   });
 });

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.toolPropagation.test.tsx
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.toolPropagation.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { act, render, waitFor } from "@testing-library/react";
+import type { FC } from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AssistantRuntimeProvider,
+  useRemoteThreadListRuntime,
+  useAssistantTool,
+} from "@assistant-ui/core/react";
+import type {
+  RemoteThreadListAdapter,
+  AssistantRuntime,
+} from "@assistant-ui/core";
+import { useChatRuntime } from "./useChatRuntime";
+import { AssistantChatTransport } from "./AssistantChatTransport";
+
+const makeAdapter = (): RemoteThreadListAdapter => ({
+  list: vi.fn(async () => ({ threads: [] })),
+  initialize: vi.fn(async (threadId: string) => ({
+    remoteId: threadId,
+    externalId: threadId,
+  })),
+  rename: vi.fn(async () => {}),
+  archive: vi.fn(async () => {}),
+  unarchive: vi.fn(async () => {}),
+  delete: vi.fn(async () => {}),
+  generateTitle: vi.fn(
+    async () =>
+      new ReadableStream({
+        start(c) {
+          c.close();
+        },
+      }) as never,
+  ),
+  fetch: vi.fn(async (id: string) => ({
+    status: "regular" as const,
+    remoteId: id,
+    externalId: id,
+    title: "Test",
+  })),
+});
+
+const timeTool = {
+  toolName: "get_local_time",
+  type: "frontend" as const,
+  description: "Get current local time",
+  execute: async () => ({ dateTime: "now" }),
+};
+
+const ToolRegistrar: FC = () => {
+  useAssistantTool(timeTool);
+  return null;
+};
+
+describe("useChatRuntime under useRemoteThreadListRuntime", () => {
+  it("includes makeAssistantTool tools in the thread model context", async () => {
+    const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+
+    const useThreadRuntime = () =>
+      useChatRuntime({
+        transport: new AssistantChatTransport({ api: "/api/chat" }),
+      });
+
+    const Inner: FC = () => {
+      const runtime = useRemoteThreadListRuntime({
+        runtimeHook: useThreadRuntime,
+        adapter: makeAdapter(),
+      });
+      runtimeRef.current = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <ToolRegistrar />
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    await act(async () => {
+      render(<Inner />);
+    });
+
+    await waitFor(() => {
+      const tools = runtimeRef.current?.thread.getModelContext().tools ?? {};
+      expect(Object.keys(tools)).toContain("get_local_time");
+    });
+  });
+});

--- a/packages/react/src/tests/RemoteThreadListRuntime.toolPropagation.test.tsx
+++ b/packages/react/src/tests/RemoteThreadListRuntime.toolPropagation.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { act, render, waitFor } from "@testing-library/react";
+import type { FC } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  useRemoteThreadListRuntime,
+  useRuntimeAdapters,
+  useAssistantTool,
+} from "@assistant-ui/core/react";
+import { makeAdapter } from "./remote-thread-list-test-helpers";
+import { useLocalRuntime } from "../legacy-runtime/runtime-cores/local/useLocalRuntime";
+import { AssistantRuntimeProvider } from "../context";
+import type { ChatModelAdapter } from "../index";
+import type { ModelContextProvider } from "@assistant-ui/core";
+
+const noOpAdapter: ChatModelAdapter = {
+  async *run() {},
+};
+
+const timeTool = {
+  toolName: "get_local_time",
+  type: "frontend" as const,
+  description: "Get current local time",
+  execute: async () => ({ dateTime: "now" }),
+};
+
+const ToolRegistrar: FC = () => {
+  useAssistantTool(timeTool);
+  return null;
+};
+
+describe("tool propagation through useRemoteThreadListRuntime runtimeHook", () => {
+  it("includes outer-registered tools in the inner thread runtime model context", async () => {
+    const capture: { modelContext: ModelContextProvider | undefined } = {
+      modelContext: undefined,
+    };
+
+    const runtimeHook = function useTestRuntimeHook() {
+      capture.modelContext = useRuntimeAdapters()?.modelContext;
+      // useLocalRuntime itself nests a remote-thread-list with allowNesting,
+      // mirroring useChatRuntime's structure in the issue.
+      return useLocalRuntime(noOpAdapter);
+    };
+
+    const adapter = makeAdapter();
+
+    const Inner: FC = () => {
+      const runtime = useRemoteThreadListRuntime({ runtimeHook, adapter });
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <ToolRegistrar />
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    await act(async () => {
+      render(<Inner />);
+    });
+
+    await waitFor(() => expect(capture.modelContext).toBeDefined());
+
+    await waitFor(() => {
+      const tools = capture.modelContext?.getModelContext().tools ?? {};
+      expect(Object.keys(tools)).toContain("get_local_time");
+    });
+  });
+});

--- a/packages/react/src/tests/RemoteThreadListRuntime.toolPropagation.test.tsx
+++ b/packages/react/src/tests/RemoteThreadListRuntime.toolPropagation.test.tsx
@@ -22,6 +22,12 @@ const timeTool = {
   toolName: "get_local_time",
   type: "frontend" as const,
   description: "Get current local time",
+  parameters: {
+    type: "object" as const,
+    properties: {
+      format: { type: "string" as const, enum: ["iso", "time", "dateTime"] },
+    },
+  },
   execute: async () => ({ dateTime: "now" }),
 };
 
@@ -57,8 +63,6 @@ describe("tool propagation through useRemoteThreadListRuntime runtimeHook", () =
     await act(async () => {
       render(<Inner />);
     });
-
-    await waitFor(() => expect(capture.modelContext).toBeDefined());
 
     await waitFor(() => {
       const tools = capture.modelContext?.getModelContext().tools ?? {};


### PR DESCRIPTION
 ## Summary

Adds regression coverage for tool propagation when a runtime is used as the runtimeHook` of useRemoteThreadListRuntime` — the path reported in #4101.

The existing `adapterProvider` test only checks that `modelContext` is *defined* on the hook's adapters. It never checks that a tool registered via makeAssistantTool` on the outer runtime actually shows up in thread.getModelContext().tools` — the data `AssistantChatTransport` puts in the  body. These tests close that gap.

Note: I could not reproduce #4101 on `main`; tools propagate correctly. These tests serve as a regression guard.

  ## Tests

  - `RemoteThreadListRuntime.toolPropagation.test.tsx` — outer runtime + `useLocalRuntime` hook; asserts the tool reaches the inner thread's model context.
  - `useChatRuntime.toolPropagation.test.tsx` — the exact #4101 setup (outer runtime + `useChatRuntime` + `AssistantChatTransport`); asserts the tool is in thread.getModelContext().tools`.

  Test-only; no changeset