### PR TITLE
fix(assistant-stream): preserve parentId on streamed text and reasoning parts

### DIFF
--- a/.changeset/parent-id-text-parts.md
+++ b/.changeset/parent-id-text-parts.md
@@ -1,0 +1,7 @@
+---
+"assistant-stream": patch
+---
+
+fix: preserve parentId on streamed text and reasoning parts
+
+`AssistantStreamController` dropped `parentId` for text/reasoning parts written through a `withParentId(...)` controller: `addTextPart`/`addReasoningPart` never attached it, and `appendText`/`appendReasoning` reused the open append part across a `parentId` change. This silently merged parts and broke the `AuiTextDelta`/`AuiReasoningDelta` data-stream round trip (including the decoder's own `withParentId(...).appendText(...)` path).

--- a/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
@@ -49,4 +49,23 @@ describe("AssistantStreamController withParentId", () => {
     expect(grouped?.parentId).toBe("group-1");
     expect(source?.parentId).toBe("group-1");
   });
+
+  it("attaches parentId to reasoning parts across a data-stream round trip", async () => {
+    const response = createAssistantStreamResponse((controller) => {
+      controller.appendReasoning("thinking out loud");
+      const group = controller.withParentId("group-1");
+      group.appendReasoning("grouped reasoning");
+    });
+
+    const message = await accumulate(response);
+    const ungrouped = message.parts.find(
+      (p) => p.type === "reasoning" && p.text === "thinking out loud",
+    );
+    const grouped = message.parts.find(
+      (p) => p.type === "reasoning" && p.text === "grouped reasoning",
+    );
+
+    expect(ungrouped?.parentId).toBeUndefined();
+    expect(grouped?.parentId).toBe("group-1");
+  });
 });

--- a/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { createAssistantStreamResponse } from "./assistant-stream";
+import { AssistantStream } from "../AssistantStream";
+import { DataStreamDecoder } from "../serialization/data-stream/DataStream";
+import { AssistantMessageAccumulator } from "../accumulators/assistant-message-accumulator";
+import type { AssistantMessage } from "../utils/types";
+
+const accumulate = async (response: Response): Promise<AssistantMessage> => {
+  const stream = AssistantStream.fromResponse(
+    response,
+    new DataStreamDecoder(),
+  );
+  let last: AssistantMessage | undefined;
+  await stream.pipeThrough(new AssistantMessageAccumulator()).pipeTo(
+    new WritableStream({
+      write(message) {
+        last = message;
+      },
+    }),
+  );
+  return last!;
+};
+
+describe("AssistantStreamController withParentId", () => {
+  it("attaches parentId to text parts across a data-stream round trip", async () => {
+    const response = createAssistantStreamResponse((controller) => {
+      controller.appendText("intro");
+      const group = controller.withParentId("group-1");
+      group.appendSource({
+        type: "source",
+        sourceType: "url",
+        id: "s1",
+        url: "https://example.com",
+        title: "Example",
+      });
+      group.appendText("grouped text");
+    });
+
+    const message = await accumulate(response);
+    const intro = message.parts.find(
+      (p) => p.type === "text" && p.text === "intro",
+    );
+    const grouped = message.parts.find(
+      (p) => p.type === "text" && p.text === "grouped text",
+    );
+    const source = message.parts.find((p) => p.type === "source");
+
+    expect(intro?.parentId).toBeUndefined();
+    expect(grouped?.parentId).toBe("group-1");
+    expect(source?.parentId).toBe("group-1");
+  });
+});

--- a/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
@@ -68,4 +68,37 @@ describe("AssistantStreamController withParentId", () => {
     expect(ungrouped?.parentId).toBeUndefined();
     expect(grouped?.parentId).toBe("group-1");
   });
+
+  it("opens a new text part when withParentId switches between ids", async () => {
+    const response = createAssistantStreamResponse((controller) => {
+      controller.withParentId("group-1").appendText("first");
+      controller.withParentId("group-2").appendText("second");
+    });
+
+    const message = await accumulate(response);
+    const first = message.parts.find(
+      (p) => p.type === "text" && p.text === "first",
+    );
+    const second = message.parts.find(
+      (p) => p.type === "text" && p.text === "second",
+    );
+
+    expect(first?.parentId).toBe("group-1");
+    expect(second?.parentId).toBe("group-2");
+  });
+
+  it("attaches parentId on addTextPart called directly inside a withParentId scope", async () => {
+    const response = createAssistantStreamResponse((controller) => {
+      const part = controller.withParentId("group-1").addTextPart();
+      part.append("explicit");
+      part.close();
+    });
+
+    const message = await accumulate(response);
+    const text = message.parts.find(
+      (p) => p.type === "text" && p.text === "explicit",
+    );
+
+    expect(text?.parentId).toBe("group-1");
+  });
 });

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -96,6 +96,7 @@ type AssistantStreamControllerState = {
     | {
         controller: TextStreamController;
         kind: "text" | "reasoning";
+        parentId: string | undefined;
       }
     | undefined;
   contentCounter: Counter;
@@ -150,9 +151,13 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
   }
 
   appendText(textDelta: string) {
-    if (this._state.append?.kind !== "text") {
+    if (
+      this._state.append?.kind !== "text" ||
+      this._state.append.parentId !== this._parentId
+    ) {
       this._state.append = {
         kind: "text",
+        parentId: this._parentId,
         controller: this.addTextPart(),
       };
     }
@@ -160,9 +165,13 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
   }
 
   appendReasoning(textDelta: string) {
-    if (this._state.append?.kind !== "reasoning") {
+    if (
+      this._state.append?.kind !== "reasoning" ||
+      this._state.append.parentId !== this._parentId
+    ) {
       this._state.append = {
         kind: "reasoning",
+        parentId: this._parentId,
         controller: this.addReasoningPart(),
       };
     }
@@ -171,13 +180,13 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
 
   addTextPart() {
     const [stream, controller] = createTextStreamController();
-    this._addPart({ type: "text" }, stream);
+    this._addPart(this._withParentIdOption({ type: "text" }), stream);
     return controller;
   }
 
   addReasoningPart() {
     const [stream, controller] = createTextStreamController();
-    this._addPart({ type: "reasoning" }, stream);
+    this._addPart(this._withParentIdOption({ type: "reasoning" }), stream);
     return controller;
   }
 


### PR DESCRIPTION
## Summary

`AssistantStreamController` silently dropped `parentId` for **text and reasoning** parts written through a `withParentId(...)` controller, while every other part type (tool-call, source, file, data) preserved it. This is a protocol-consistency bug in the data-stream round trip, independent of any rendering primitive.

Two compounding causes:

1. `addTextPart` / `addReasoningPart` never attached the controller's `_parentId` (unlike `addToolCallPart` / `appendSource`, which use `_withParentIdOption`).
2. `appendText` / `appendReasoning` reused the currently-open append part even when `_parentId` changed, merging parts that belong to different groups.

The protocol was already designed to carry this: `TextPart`/`ReasoningPart` declare `parentId?`, `AssistantMessageAccumulator` reads `partInit.parentId` for every part type, and the decoder's own `AuiTextDelta`/`AuiReasoningDelta` path calls `controller.withParentId(value.parentId).appendText(...)` (`DataStream.ts`). So any data-stream containing `aui-text-delta` / `aui-reasoning-delta` chunks with a `parentId` had it dropped on decode.

## Changes

- `addTextPart` / `addReasoningPart` now attach `_parentId` via the existing `_withParentIdOption` helper.
- `appendText` / `appendReasoning` open a new part when `_parentId` changes, so adjacent appends with different parents don't merge.
- Added a round-trip regression test (`createAssistantStreamResponse` → `DataStreamEncoder` → `DataStreamDecoder` → `AssistantMessageAccumulator`) asserting grouped text/source parts keep their `parentId` and ungrouped text does not.

## Compatibility

No behavior change for the common case (`parentId === undefined`): the new comparison is `undefined === undefined`. Patch changeset included. Full `assistant-stream` suite passes (225) plus the new test; `react-ai-sdk` suite passes (44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)