### PR TITLE
fix(registry): Avoid direct core dependency for directive text

### DIFF
--- a/apps/docs/components/docs/samples/directive-text.tsx
+++ b/apps/docs/components/docs/samples/directive-text.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { WrenchIcon } from "lucide-react";
-import { unstable_defaultDirectiveFormatter } from "@assistant-ui/core";
+import { unstable_defaultDirectiveFormatter } from "@assistant-ui/react";
 import { createDirectiveText } from "@/components/assistant-ui/directive-text";
 import { SampleFrame } from "@/components/docs/samples/sample-frame";
 

--- a/apps/docs/content/docs/guides/mentions.mdx
+++ b/apps/docs/content/docs/guides/mentions.mdx
@@ -144,7 +144,7 @@ Pass the adapter to `TriggerPopover` and declare a `Directive` sub-primitive to 
 
 ```tsx
 import { ComposerPrimitive } from "@assistant-ui/react";
-import { unstable_defaultDirectiveFormatter } from "@assistant-ui/core";
+import { unstable_defaultDirectiveFormatter } from "@assistant-ui/react";
 
 <ComposerPrimitive.Unstable_TriggerPopoverRoot>
   <ComposerPrimitive.Root>
@@ -302,7 +302,7 @@ When `id` equals `label`, the `{name=…}` attribute is omitted for brevity:
 Implement `Unstable_DirectiveFormatter` to use a different format:
 
 ```ts
-import type { Unstable_DirectiveFormatter } from "@assistant-ui/core";
+import type { Unstable_DirectiveFormatter } from "@assistant-ui/react";
 
 const slashFormatter: Unstable_DirectiveFormatter = {
   serialize(item) {

--- a/apps/docs/content/docs/ui/directive-text.mdx
+++ b/apps/docs/content/docs/ui/directive-text.mdx
@@ -49,7 +49,7 @@ Keep your markdown renderer (e.g. `MarkdownText`) for assistant messages — ass
 
 ```tsx
 import { createDirectiveText } from "@/components/assistant-ui/directive-text";
-import { unstable_defaultDirectiveFormatter } from "@assistant-ui/core";
+import { unstable_defaultDirectiveFormatter } from "@assistant-ui/react";
 import { FileTextIcon, SparklesIcon, UserIcon, WrenchIcon } from "lucide-react";
 
 const DirectiveTextWithIcons = createDirectiveText(
@@ -74,7 +74,7 @@ A matching `iconMap` / `fallbackIcon` option is accepted by [`ComposerTriggerPop
 The default format is `:type[label]{name=id}`. For a different format, build a custom `Unstable_DirectiveFormatter` and wrap it with `createDirectiveText`:
 
 ```tsx
-import type { Unstable_DirectiveFormatter } from "@assistant-ui/core";
+import type { Unstable_DirectiveFormatter } from "@assistant-ui/react";
 import { createDirectiveText } from "@/components/assistant-ui/directive-text";
 
 const slashFormatter: Unstable_DirectiveFormatter = {
@@ -97,7 +97,7 @@ Because `directive-text.tsx` is copied into your project, you can also edit it d
 
 ### `DirectiveText`
 
-A `TextMessagePartComponent` that parses `:type[label]{name=id}` directives and renders them as inline chips. Uses the default formatter from `@assistant-ui/core` and renders chips without icons. For per-type icons, build a component with `createDirectiveText(formatter, { iconMap })`.
+A `TextMessagePartComponent` that parses `:type[label]{name=id}` directives and renders them as inline chips. Uses the default formatter from `@assistant-ui/react` and renders chips without icons. For per-type icons, build a component with `createDirectiveText(formatter, { iconMap })`.
 
 ### `createDirectiveText(formatter, options?)`
 

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -593,7 +593,7 @@ export const registry: RegistryItem[] = [
           "../../packages/ui/src/components/assistant-ui/directive-text.tsx",
       },
     ],
-    dependencies: ["@assistant-ui/react", "@assistant-ui/core", "lucide-react"],
+    dependencies: ["@assistant-ui/react", "lucide-react"],
     registryDependencies: ["https://r.assistant-ui.com/badge.json"],
   },
 ];


### PR DESCRIPTION
## Summary

- remove the internal `@assistant-ui/core` package from the `directive-text` registry dependencies
- update the directive text docs and samples to import the formatter/types from `@assistant-ui/react`, which already re-exports them
- keeps the copied registry component aligned with the public package users install

## Validation

- `pnpm --filter=@assistant-ui/shadcn-registry build`
- `pnpm exec biome check apps/registry/src/registry.ts apps/docs/content/docs/ui/directive-text.mdx apps/docs/components/docs/samples/directive-text.tsx apps/docs/content/docs/guides/mentions.mdx`
- confirmed `apps/registry/dist/directive-text.json` lists only `@assistant-ui/react` and `lucide-react` as dependencies and its copied component content does not import `@assistant-ui/core`

Note: local validation was run on Node 22.22.0, so pnpm printed the repo's Node >=24 engine warning, but the commands above completed successfully.