### PR TITLE
feat: simplify GroupedParts API and add groupPartByType helper

### DIFF
--- a/.changeset/group-parts-redesign.md
+++ b/.changeset/group-parts-redesign.md
@@ -1,0 +1,13 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+---
+
+feat: simplify `MessagePrimitive.GroupedParts` API and add `groupPartByType` helper.
+
+- New `groupPartByType({ ... })` helper builds a `groupBy` from a `part.type → group-key path` lookup. The map keys are typed against `PartState["type"]` (autocomplete + typo rejection), missing keys leave the part ungrouped, and the returned function carries an internal memo fingerprint so the tree survives unrelated re-renders even when reconstructed inline.
+- Special map key `"mcp-app"` matches tool-call parts that point at an assistant-ui MCP app resource (`ui://...`). It takes precedence over the `"tool-call"` entry for those parts, so MCP apps can be routed separately (e.g. rendered outside a chain-of-thought wrapper).
+- `groupBy` signature simplified from `(part, index, parts) => string | string[] | null | undefined` to `(part) => readonly \`group-${string}\`[] | null`. The 2nd/3rd args were unused in practice. Arrays are required (no bare-string shorthand); `null` is accepted as an alias for `[]` to soften the migration.
+- Internal memoization now uses the helper's memo fingerprint when present, otherwise rebuilds the tree per render (O(n), cheap). The previous "pass a stable reference" advice is dropped — inline `groupBy` is fine.
+- Docs and examples updated to lead with `groupPartByType`. The `getMcpAppFromToolPart` branch in `packages/ui` switches to `"mcp-app": []` via the helper.

--- a/apps/docs/components/docs/samples/chain-of-thought-primitive.tsx
+++ b/apps/docs/components/docs/samples/chain-of-thought-primitive.tsx
@@ -2,6 +2,7 @@
 
 import { Collapsible } from "radix-ui";
 import {
+  groupPartByType,
   MessagePrimitive,
   MessagePartPrimitive,
   ThreadPrimitive,
@@ -157,13 +158,10 @@ function AssistantMessage() {
       <div className="min-w-0 flex-1">
         <div className="space-y-2">
           <MessagePrimitive.GroupedParts
-            groupBy={(part) => {
-              if (part.type === "reasoning")
-                return ["group-chainOfThought", "group-reasoning"];
-              if (part.type === "tool-call")
-                return ["group-chainOfThought", "group-tool"];
-              return null;
-            }}
+            groupBy={groupPartByType({
+              reasoning: ["group-chainOfThought", "group-reasoning"],
+              "tool-call": ["group-chainOfThought", "group-tool"],
+            })}
           >
             {({ part, children }) => {
               switch (part.type) {

--- a/apps/docs/components/examples/shadcn.tsx
+++ b/apps/docs/components/examples/shadcn.tsx
@@ -39,6 +39,7 @@ import {
   BranchPickerPrimitive,
   ComposerPrimitive,
   ErrorPrimitive,
+  groupPartByType,
   MessagePrimitive,
   SuggestionPrimitive,
   ThreadPrimitive,
@@ -437,13 +438,10 @@ const AssistantMessage: FC = () => {
         className="wrap-break-word px-2 text-foreground leading-relaxed"
       >
         <MessagePrimitive.GroupedParts
-          groupBy={(part) => {
-            if (part.type === "reasoning")
-              return ["group-chainOfThought", "group-reasoning"];
-            if (part.type === "tool-call")
-              return ["group-chainOfThought", "group-tool"];
-            return null;
-          }}
+          groupBy={groupPartByType({
+            reasoning: ["group-chainOfThought", "group-reasoning"],
+            "tool-call": ["group-chainOfThought", "group-tool"],
+          })}
         >
           {({ part, children }) => {
             switch (part.type) {

--- a/apps/docs/content/docs/guides/chain-of-thought.mdx
+++ b/apps/docs/content/docs/guides/chain-of-thought.mdx
@@ -26,6 +26,7 @@ Return the same top-level group for reasoning and tool calls, with nested groups
 ```tsx
 import {
   MessagePrimitive,
+  groupPartByType,
 } from "@assistant-ui/react";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import {
@@ -47,13 +48,10 @@ const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root>
       <MessagePrimitive.GroupedParts
-        groupBy={(part) => {
-          if (part.type === "reasoning")
-            return ["group-chainOfThought", "group-reasoning"];
-          if (part.type === "tool-call")
-            return ["group-chainOfThought", "group-tool"];
-          return null;
-        }}
+        groupBy={groupPartByType({
+          reasoning: ["group-chainOfThought", "group-reasoning"],
+          "tool-call": ["group-chainOfThought", "group-tool"],
+        })}
       >
         {({ part, children }) => {
           switch (part.type) {

--- a/apps/docs/content/docs/primitives/chain-of-thought.mdx
+++ b/apps/docs/content/docs/primitives/chain-of-thought.mdx
@@ -22,19 +22,16 @@ For new grouped reasoning/tool-call UI, use `MessagePrimitive.GroupedParts`. `Ch
   </Tab>
   <Tab>
 ```tsx
-import { MessagePrimitive } from "@assistant-ui/react";
+import { MessagePrimitive, groupPartByType } from "@assistant-ui/react";
 
 function AssistantMessage() {
   return (
     <MessagePrimitive.Root>
       <MessagePrimitive.GroupedParts
-        groupBy={(part) => {
-          if (part.type === "reasoning")
-            return ["group-chainOfThought", "group-reasoning"];
-          if (part.type === "tool-call")
-            return ["group-chainOfThought", "group-tool"];
-          return null;
-        }}
+        groupBy={groupPartByType({
+          reasoning: ["group-chainOfThought", "group-reasoning"],
+          "tool-call": ["group-chainOfThought", "group-tool"],
+        })}
       >
         {({ part, children }) => {
           switch (part.type) {
@@ -67,17 +64,14 @@ function AssistantMessage() {
 Group reasoning and tool-call parts directly in your assistant message:
 
 ```tsx
-import { MessagePrimitive } from "@assistant-ui/react";
+import { MessagePrimitive, groupPartByType } from "@assistant-ui/react";
 
 <MessagePrimitive.Root>
   <MessagePrimitive.GroupedParts
-    groupBy={(part) => {
-      if (part.type === "reasoning")
-        return ["group-chainOfThought", "group-reasoning"];
-      if (part.type === "tool-call")
-        return ["group-chainOfThought", "group-tool"];
-      return null;
-    }}
+    groupBy={groupPartByType({
+      reasoning: ["group-chainOfThought", "group-reasoning"],
+      "tool-call": ["group-chainOfThought", "group-tool"],
+    })}
   >
     {({ part, children }) => {
       switch (part.type) {

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -250,17 +250,16 @@ Renders each content part with type-based component resolution.
 
 ### GroupedParts
 
-Groups adjacent message parts into a nested tree. Use `groupBy` to return group keys for parts that should be grouped, then switch on `part.type` in the render function. Group cases render `children`; leaf cases render their own UI.
+Groups adjacent message parts into a nested tree. Use `groupBy` to map each part to a group-key path, then switch on `part.type` in the render function. Group cases render `children`; leaf cases render their own UI. Prefer the `groupPartByType` helper for the common `part.type → path` case.
 
 ```tsx
+import { MessagePrimitive, groupPartByType } from "@assistant-ui/react";
+
 <MessagePrimitive.GroupedParts
-  groupBy={(part) => {
-    if (part.type === "reasoning")
-      return ["group-chainOfThought", "group-reasoning"];
-    if (part.type === "tool-call")
-      return ["group-chainOfThought", "group-tool"];
-    return null;
-  }}
+  groupBy={groupPartByType({
+    reasoning: ["group-chainOfThought", "group-reasoning"],
+    "tool-call": ["group-chainOfThought", "group-tool"],
+  })}
 >
   {({ part, children }) => {
     switch (part.type) {

--- a/apps/docs/content/docs/ui/part-grouping.mdx
+++ b/apps/docs/content/docs/ui/part-grouping.mdx
@@ -10,18 +10,19 @@ import { PartGroupingSample } from "@/components/docs/samples/part-grouping";
 
 ## Basic Usage
 
-For adjacent grouping, use `MessagePrimitive.GroupedParts`. Return a group-key path for each part; adjacent parts that share a group key are coalesced and rendered through the group case.
+For adjacent grouping, use `MessagePrimitive.GroupedParts`. For the common case — grouping by `part.type` — pass `groupPartByType` to map each part type to a group-key path. Adjacent parts that share a group key are coalesced and rendered through the group case.
 
 ```tsx title="/components/assistant-ui/thread.tsx"
+import { MessagePrimitive, groupPartByType } from "@assistant-ui/react";
+
 const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root className="...">
       <div className="...">
         <MessagePrimitive.GroupedParts
-          groupBy={(part) => {
-            if (part.type === "tool-call") return ["group-tool"];
-            return null;
-          }}
+          groupBy={groupPartByType({
+            "tool-call": ["group-tool"],
+          })}
         >
           {({ part, children }) => {
             switch (part.type) {
@@ -41,6 +42,8 @@ const AssistantMessage: FC = () => {
   );
 };
 ```
+
+Reach for an inline `groupBy={(part) => …}` only when the helper isn't expressive enough — e.g. you need to branch on `part.toolName`, `part.parentId`, or part metadata.
 
 ## How Adjacent Grouping Works
 
@@ -89,7 +92,7 @@ function ParentGroup({
 
 <MessagePrimitive.GroupedParts
   groupBy={(part) => {
-    if (!part.parentId) return null;
+    if (!part.parentId) return [];
     return [`group-parent-${part.parentId}`];
   }}
 >
@@ -117,7 +120,7 @@ Organize adjacent tool calls by tool name:
 ```tsx
 <MessagePrimitive.GroupedParts
   groupBy={(part) => {
-    if (part.type !== "tool-call") return null;
+    if (part.type !== "tool-call") return [];
     return [`group-tool-${part.toolName}`];
   }}
 >
@@ -147,10 +150,9 @@ Combine multiple text parts into cohesive blocks:
 
 ```tsx
 <MessagePrimitive.GroupedParts
-  groupBy={(part) => {
-    if (part.type === "text") return ["group-text-block"];
-    return null;
-  }}
+  groupBy={groupPartByType({
+    text: ["group-text-block"],
+  })}
 >
   {({ part, children }) => {
     switch (part.type) {
@@ -177,12 +179,11 @@ Separate different types of content for distinct visual treatment:
 
 ```tsx
 <MessagePrimitive.GroupedParts
-  groupBy={(part) => {
-    if (part.type === "text") return ["group-content-text"];
-    if (part.type === "tool-call") return ["group-content-tools"];
-    if (part.type === "reasoning") return ["group-content-reasoning"];
-    return null;
-  }}
+  groupBy={groupPartByType({
+    text: ["group-content-text"],
+    "tool-call": ["group-content-tools"],
+    reasoning: ["group-content-reasoning"],
+  })}
 >
   {({ part, children }) => {
     switch (part.type) {
@@ -219,7 +220,7 @@ const priorityStyles = {
 <MessagePrimitive.GroupedParts
   groupBy={(part) => {
     const priority = part.metadata?.priority;
-    if (!priority) return null;
+    if (!priority) return [];
     return [`group-priority-${priority}`];
   }}
 >
@@ -300,9 +301,9 @@ const stream = createAssistantStream(async (controller) => {
   parameters={[
     {
       name: "groupBy",
-      type: "(part: PartState, index: number, parts: readonly PartState[]) => GroupKey",
+      type: "(part: PartState) => readonly `group-${string}`[]",
       description:
-        "Maps a part to a group-key path. Return null, undefined, or [] to leave the part ungrouped. Group keys must start with group-.",
+        "Maps a part to a group-key path. Return `[]` to leave the part ungrouped. Group keys must start with `group-`. Prefer `groupPartByType` for the common `part.type → path` case.",
       required: true,
     },
     {
@@ -314,6 +315,19 @@ const stream = createAssistantStream(async (controller) => {
     },
   ]}
 />
+
+### groupPartByType helper
+
+`groupPartByType` builds a `groupBy` from a `part.type → group-key path` map. Part types missing from the map are left ungrouped. The returned function carries an internal memo fingerprint so the tree survives unrelated re-renders.
+
+```typescript
+import { groupPartByType } from "@assistant-ui/react";
+
+groupPartByType({
+  reasoning: ["group-thought", "group-reasoning"],
+  "tool-call": ["group-thought", "group-tool"],
+});
+```
 
 ### GroupPart Type
 
@@ -331,33 +345,8 @@ type GroupPart<TKey extends `group-${string}` = `group-${string}`> = {
 2. **Handle ungrouped parts**: Always include leaf cases for the part types your message can render.
 3. **Only render `children` for groups**: Leaf parts receive a sentinel `children` value that throws if rendered accidentally.
 4. **Use `group-` prefixes**: Synthetic group keys must start with `group-` so they cannot collide with real part types.
-5. **Keep `groupBy` stable**: Prefer a module-level function or `useCallback` for frequently re-rendering message trees.
 
 ## Common Patterns
-
-### Conditional Grouping
-
-Only group when certain conditions are met:
-
-```tsx
-<MessagePrimitive.GroupedParts
-  groupBy={(part, index, parts) => {
-    const hasManyParts = parts.length >= 5;
-    if (!hasManyParts) return null;
-    if (part.type === "tool-call") return ["group-tools"];
-    return null;
-  }}
->
-  {({ part, children }) => {
-    if (part.type === "group-tools") {
-      return <div className="rounded-lg border p-3">{children}</div>;
-    }
-    if (part.type === "tool-call") return part.toolUI ?? <ToolFallback {...part} />;
-    if (part.type === "text") return <MarkdownText />;
-    return null;
-  }}
-</MessagePrimitive.GroupedParts>
-```
 
 ### Nested Grouping
 
@@ -370,7 +359,7 @@ Create hierarchical adjacent groups by returning multiple keys:
       return ["group-chainOfThought", "group-reasoning"];
     if (part.type === "tool-call")
       return ["group-chainOfThought", `group-tool-${part.toolName}`];
-    return null;
+    return [];
   }}
 >
   {({ part, children }) => {
@@ -391,10 +380,9 @@ Adjust group appearance based on the group node's status or indices:
 
 ```tsx
 <MessagePrimitive.GroupedParts
-  groupBy={(part) => {
-    if (part.type === "tool-call") return ["group-tools"];
-    return null;
-  }}
+  groupBy={groupPartByType({
+    "tool-call": ["group-tools"],
+  })}
 >
   {({ part, children }) => {
     if (part.type === "group-tools") {

--- a/apps/docs/content/docs/ui/reasoning.mdx
+++ b/apps/docs/content/docs/ui/reasoning.mdx
@@ -31,7 +31,7 @@ Render reasoning parts through `MessagePrimitive.GroupedParts`. Group consecutiv
 While reasoning is streaming, `part.status.type === "running"`. Pass that to `defaultOpen` so the accordion auto-opens during streaming and lets the user collapse it once the model moves on.
 
 ```tsx title="/app/components/assistant-ui/thread.tsx"
-import { MessagePrimitive } from "@assistant-ui/react";
+import { MessagePrimitive, groupPartByType } from "@assistant-ui/react";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
 import {
@@ -47,10 +47,9 @@ const AssistantMessage: FC = () => {
     <MessagePrimitive.Root className="...">
       <div className="...">
         <MessagePrimitive.GroupedParts // [!code ++]
-          groupBy={(part) => { // [!code ++]
-            if (part.type === "reasoning") return ["group-reasoning"]; // [!code ++]
-            return null; // [!code ++]
-          }} // [!code ++]
+          groupBy={groupPartByType({ // [!code ++]
+            reasoning: ["group-reasoning"], // [!code ++]
+          })} // [!code ++]
         > // [!code ++]
           {({ part, children }) => { // [!code ++]
             switch (part.type) { // [!code ++]

--- a/apps/docs/content/docs/ui/tool-group.mdx
+++ b/apps/docs/content/docs/ui/tool-group.mdx
@@ -29,10 +29,10 @@ This adds `/components/assistant-ui/tool-group.tsx` and `/components/assistant-u
 
 ### Use it in your application
 
-Use `MessagePrimitive.GroupedParts` and return `"group-tool"` for tool-call parts. The group case wraps `children`; the tool-call leaf renders the resolved tool UI or your fallback.
+Use `MessagePrimitive.GroupedParts` with `groupPartByType` to map tool-call parts to `"group-tool"`. The group case wraps `children`; the tool-call leaf renders the resolved tool UI or your fallback.
 
 ```tsx title="/components/assistant-ui/thread.tsx"
-import { MessagePrimitive } from "@assistant-ui/react";
+import { MessagePrimitive, groupPartByType } from "@assistant-ui/react";
 import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
 import {
   ToolGroupContent,
@@ -44,10 +44,9 @@ const AssistantMessage = () => {
   return (
     <MessagePrimitive.Root>
       <MessagePrimitive.GroupedParts
-        groupBy={(part) => {
-          if (part.type === "tool-call") return ["group-tool"];
-          return null;
-        }}
+        groupBy={groupPartByType({
+          "tool-call": ["group-tool"],
+        })}
       >
         {({ part, children }) => {
           switch (part.type) {

--- a/examples/with-chain-of-thought/app/MyThread.tsx
+++ b/examples/with-chain-of-thought/app/MyThread.tsx
@@ -7,6 +7,7 @@ import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button
 import { Button } from "@/components/ui/button";
 import {
   ComposerPrimitive,
+  groupPartByType,
   MessagePrimitive,
   SuggestionPrimitive,
   ThreadPrimitive,
@@ -113,14 +114,11 @@ const AssistantMessage: FC = () => {
     <MessagePrimitive.Root className="mx-auto w-full max-w-(--thread-max-width) py-3">
       <div className="flex flex-col gap-2 px-2 leading-relaxed">
         <MessagePrimitive.GroupedParts
-          groupBy={(part) => {
-            if (part.type === "reasoning")
-              return ["group-chainOfThought", "group-reasoning"];
-            if (part.type === "tool-call")
-              return ["group-chainOfThought", "group-tool"];
-            if (part.type === "source") return ["group-sources"];
-            return null;
-          }}
+          groupBy={groupPartByType({
+            reasoning: ["group-chainOfThought", "group-reasoning"],
+            "tool-call": ["group-chainOfThought", "group-tool"],
+            source: ["group-sources"],
+          })}
         >
           {({ part, children }) => {
             switch (part.type) {

--- a/examples/with-generative-ui/components/assistant-message-gui.tsx
+++ b/examples/with-generative-ui/components/assistant-message-gui.tsx
@@ -125,11 +125,11 @@ export const AssistantMessageGui: FC<AssistantMessageGuiProps> = ({
               return ["group-chainOfThought", "group-reasoning"];
             }
             if (part.type === "tool-call") {
-              if (getMcpAppFromToolPart(part)) return null;
-              if (part.toolName === RENDER_GUI_TOOL_NAME) return null;
+              if (getMcpAppFromToolPart(part)) return [];
+              if (part.toolName === RENDER_GUI_TOOL_NAME) return [];
               return ["group-chainOfThought", "group-tool"];
             }
-            return null;
+            return [];
           }}
         >
           {({ part, children }) => {

--- a/examples/with-opencode/components/assistant-ui/thread.tsx
+++ b/examples/with-opencode/components/assistant-ui/thread.tsx
@@ -34,6 +34,7 @@ import {
   BranchPickerPrimitive,
   ComposerPrimitive,
   ErrorPrimitive,
+  groupPartByType,
   MessagePrimitive,
   SuggestionPrimitive,
   ThreadPrimitive,
@@ -278,13 +279,10 @@ const AssistantMessage: FC = () => {
     >
       <div className="aui-assistant-message-content wrap-break-word px-2 text-foreground leading-relaxed">
         <MessagePrimitive.GroupedParts
-          groupBy={(part) => {
-            if (part.type === "reasoning")
-              return ["group-chainOfThought", "group-reasoning"];
-            if (part.type === "tool-call")
-              return ["group-chainOfThought", "group-tool"];
-            return null;
-          }}
+          groupBy={groupPartByType({
+            reasoning: ["group-chainOfThought", "group-reasoning"],
+            "tool-call": ["group-chainOfThought", "group-tool"],
+          })}
         >
           {({ part, children }) => {
             switch (part.type) {

--- a/packages/core/src/react/index.ts
+++ b/packages/core/src/react/index.ts
@@ -178,6 +178,7 @@ export {
   type PartState,
 } from "./primitives/message/MessageParts";
 export { MessagePrimitiveGroupedParts } from "./primitives/message/MessageGroupedParts";
+export { groupPartByType } from "./utils/groupParts";
 export {
   MessagePrimitiveGenerativeUI,
   GenerativeUIRender,

--- a/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
@@ -10,9 +10,8 @@ import type {
 } from "../../../types/message";
 import {
   buildGroupTree,
-  type GroupKey,
+  GROUPBY_MEMO_KEY,
   type GroupNode,
-  normalizeGroupKey,
 } from "../../utils/groupParts";
 import { MessagePartChildren, type EnrichedPartState } from "./MessageParts";
 
@@ -47,30 +46,32 @@ export namespace MessagePrimitiveGroupedParts {
 
   export type Props<TKey extends `group-${string}` = `group-${string}`> = {
     /**
-     * Maps each part to its group key path. Adjacent parts that share a
-     * prefix coalesce up to that prefix. Return `null`, `undefined`, or
-     * `[]` to leave a part ungrouped — it will be rendered as a leaf
-     * through `children` with `part` set to its {@link EnrichedPartState}.
+     * Maps each part to a group-key path. Adjacent parts that share a
+     * prefix coalesce into the same group. Return `[]` (or `null`) to
+     * leave a part ungrouped.
      *
-     * Keys must start with `"group-"` so the renderer's
-     * `switch (part.type)` can distinguish groups from real part types.
+     * Group keys must start with `"group-"` so the renderer's
+     * `switch (part.type)` can tell groups apart from real part types.
      *
-     * For best performance, pass a stable reference (module-level
-     * constant or `useCallback`).
+     * **Prefer {@link groupPartByType}** for the common case of mapping by
+     * `part.type` — it ships a stable memo fingerprint so the tree
+     * survives unrelated re-renders. Use an inline function only when
+     * the helper isn't expressive enough (e.g. branching on
+     * `part.toolName` or part metadata).
      *
      * @example
-     * ```ts
-     * const groupBy = (part) =>
-     *   part.type === "reasoning" ? ["group-thought", "group-reasoning"] :
-     *   part.type === "tool-call" ? ["group-thought", "group-tool"] :
-     *   null;
+     * ```tsx
+     * import { groupPartByType } from "@assistant-ui/react";
+     *
+     * <MessagePrimitive.GroupedParts
+     *   groupBy={groupPartByType({
+     *     reasoning: ["group-thought", "group-reasoning"],
+     *     "tool-call": ["group-thought", "group-tool"],
+     *   })}
+     * >
      * ```
      */
-    readonly groupBy: (
-      part: PartState,
-      index: number,
-      parts: readonly PartState[],
-    ) => GroupKey<TKey>;
+    readonly groupBy: (part: PartState) => readonly TKey[] | null;
 
     /**
      * Render function called once per group node and once per leaf part.
@@ -148,11 +149,10 @@ const renderNode = <TKey extends `group-${string}`>(
  * @example
  * ```tsx
  * <MessagePrimitive.GroupedParts
- *   groupBy={(part) =>
- *     part.type === "reasoning" ? ["group-thought", "group-reasoning"] :
- *     part.type === "tool-call" ? ["group-thought", "group-tool"] :
- *     null
- *   }
+ *   groupBy={groupPartByType({
+ *     reasoning: ["group-thought", "group-reasoning"],
+ *     "tool-call": ["group-thought", "group-tool"],
+ *   })}
  * >
  *   {({ part, children }) => {
  *     switch (part.type) {
@@ -173,12 +173,18 @@ export const MessagePrimitiveGroupedParts = <TKey extends `group-${string}`>({
 }: MessagePrimitiveGroupedParts.Props<TKey>): ReactNode => {
   const parts = useAuiState(useShallow((s) => s.message.parts));
 
+  // Helpers like `groupPartByType` tag the function with `GROUPBY_MEMO_KEY`
+  // (a stable string fingerprint of the helper config). When present,
+  // memo on `[parts, memoKey]` so the tree survives unrelated renders.
+  // For inline `groupBy`, fall back to recomputing each render — O(n)
+  // and cheap.
+  const memoKey = (groupBy as { [GROUPBY_MEMO_KEY]?: string })[
+    GROUPBY_MEMO_KEY
+  ];
   const tree = useMemo(
-    () =>
-      buildGroupTree(
-        parts.map((part, i) => normalizeGroupKey(groupBy(part, i, parts))),
-      ),
-    [parts, groupBy],
+    () => buildGroupTree(parts.map((part) => groupBy(part) ?? [])),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [parts, memoKey ?? groupBy],
   );
 
   return <>{tree.map((node) => renderNode(node, parts, children))}</>;

--- a/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
@@ -181,10 +181,11 @@ export const MessagePrimitiveGroupedParts = <TKey extends `group-${string}`>({
   const memoKey = (groupBy as { [GROUPBY_MEMO_KEY]?: string })[
     GROUPBY_MEMO_KEY
   ];
+  const memoDep = memoKey ?? groupBy;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: groupBy is captured via memoDep — either as its identity (no memoKey) or as the helper's memoKey fingerprint. Listing groupBy directly would defeat the helper-tagged memo path.
   const tree = useMemo(
     () => buildGroupTree(parts.map((part) => groupBy(part) ?? [])),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [parts, memoKey ?? groupBy],
+    [parts, memoDep],
   );
 
   return <>{tree.map((node) => renderNode(node, parts, children))}</>;

--- a/packages/core/src/react/utils/groupParts.ts
+++ b/packages/core/src/react/utils/groupParts.ts
@@ -1,3 +1,6 @@
+import { isMcpAppUri } from "../../types/message";
+import type { PartState } from "../../store/scopes/part";
+
 /**
  * Hierarchical adjacent-coalescing grouping for message parts.
  *
@@ -11,16 +14,66 @@
  */
 
 /**
- * Public group key type. Group keys must be prefixed with `group-` so
- * that a unified `switch (part.type)` in the renderer can distinguish
- * a group key (e.g. `"group-thought"`) from a real part type
- * (`"text"`, `"tool-call"`).
+ * Symbol attached to memoizable `groupBy` functions (e.g. those returned
+ * by {@link groupPartByType}). Carries a string fingerprint of the config
+ * so `MessagePrimitive.GroupedParts` can memo the tree on
+ * `[parts, memoKey]` across renders — even when the helper call site
+ * reconstructs the function each render.
  */
-export type GroupKey<TKey extends `group-${string}` = `group-${string}`> =
-  | TKey
-  | readonly TKey[]
-  | null
-  | undefined;
+export const GROUPBY_MEMO_KEY: unique symbol = Symbol.for(
+  "@assistant-ui/groupBy.memoKey",
+);
+
+/**
+ * Synthetic part-type key recognized by {@link groupPartByType}: a
+ * tool-call whose `mcp.app.resourceUri` points at an assistant-ui MCP
+ * app. Map this key to control how MCP-app tool calls are grouped —
+ * separately from regular `"tool-call"` parts.
+ */
+type GroupPartType = PartState["type"] | "mcp-app";
+
+/**
+ * Build a `groupBy` from a `part.type → group-key path` lookup.
+ * Parts whose type isn't in the map are left ungrouped. The returned
+ * function carries a stable {@link GROUPBY_MEMO_KEY} fingerprint so
+ * `<MessagePrimitive.GroupedParts>` can memoize its tree across renders.
+ *
+ * Special key `"mcp-app"` matches tool-call parts that point at an
+ * assistant-ui MCP app resource (`ui://...`) and takes precedence over
+ * the `"tool-call"` entry for those parts.
+ *
+ * @example
+ * ```tsx
+ * <MessagePrimitive.GroupedParts
+ *   groupBy={groupPartByType({
+ *     reasoning: ["group-thought", "group-reasoning"],
+ *     "tool-call": ["group-thought", "group-tool"],
+ *     "mcp-app": [],
+ *   })}
+ * >
+ *   {({ part, children }) => { ... }}
+ * </MessagePrimitive.GroupedParts>
+ * ```
+ */
+export const groupPartByType = <TKey extends `group-${string}`>(
+  map: Partial<Readonly<Record<GroupPartType, readonly TKey[]>>>,
+): ((part: PartState) => readonly TKey[]) => {
+  const lookup = map as Readonly<Record<string, readonly TKey[] | undefined>>;
+  const fn = ((part) => {
+    if (
+      part.type === "tool-call" &&
+      lookup["mcp-app"] !== undefined &&
+      isMcpAppUri(part.mcp?.app?.resourceUri)
+    ) {
+      return lookup["mcp-app"]!;
+    }
+    return lookup[part.type] ?? [];
+  }) as ((part: PartState) => readonly TKey[]) & {
+    [GROUPBY_MEMO_KEY]?: string;
+  };
+  fn[GROUPBY_MEMO_KEY] = `groupPartByType:${JSON.stringify(map)}`;
+  return fn;
+};
 
 export type GroupNode = GroupNodeGroup | GroupNodePart;
 
@@ -42,19 +95,6 @@ export interface GroupNodePart {
   /** Structural React key: sibling-index path within parent. */
   readonly nodeKey: string;
 }
-
-const EMPTY_PATH: readonly string[] = Object.freeze([]);
-
-/**
- * Normalize a `groupBy` return value to a path array.
- * `null`/`undefined`/`[]` → `[]` (ungrouped).
- * `"foo"` → `["foo"]`. Arrays pass through.
- */
-export const normalizeGroupKey = (key: GroupKey): readonly string[] => {
-  if (key == null) return EMPTY_PATH;
-  if (typeof key === "string") return [key];
-  return key;
-};
 
 interface BuildFrame {
   key: string;

--- a/packages/core/src/react/utils/groupParts.ts
+++ b/packages/core/src/react/utils/groupParts.ts
@@ -71,7 +71,12 @@ export const groupPartByType = <TKey extends `group-${string}`>(
   }) as ((part: PartState) => readonly TKey[]) & {
     [GROUPBY_MEMO_KEY]?: string;
   };
-  fn[GROUPBY_MEMO_KEY] = `groupPartByType:${JSON.stringify(map)}`;
+  // Sort keys so the fingerprint is insensitive to map insertion order —
+  // two maps with the same key/value pairs but different declaration order
+  // would otherwise hash differently and invalidate the memo unnecessarily.
+  const sortedKeys = Object.keys(map).sort();
+  const sortedEntries = sortedKeys.map((k) => [k, map[k as keyof typeof map]]);
+  fn[GROUPBY_MEMO_KEY] = `groupPartByType:${JSON.stringify(sortedEntries)}`;
   return fn;
 };
 

--- a/packages/core/src/tests/groupParts.test.ts
+++ b/packages/core/src/tests/groupParts.test.ts
@@ -1,12 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   buildGroupTree,
-  normalizeGroupKey,
   type GroupNode,
 } from "../react/utils/groupParts";
 
-const asPaths = (keys: readonly (string | readonly string[] | null)[]) =>
-  keys.map((k) => normalizeGroupKey(k));
+const asPaths = (keys: readonly (readonly string[])[]) => keys;
 
 // Compact tree dump: "G:key#nodeKey[i,j]{...}" | "P:#nodeKey(i)"
 const dump = (nodes: readonly GroupNode[]): string =>
@@ -20,39 +18,23 @@ const dump = (nodes: readonly GroupNode[]): string =>
     })
     .join(",");
 
-describe("normalizeGroupKey", () => {
-  it("maps null/undefined/[] to []", () => {
-    expect(normalizeGroupKey(null)).toEqual([]);
-    expect(normalizeGroupKey(undefined)).toEqual([]);
-    expect(normalizeGroupKey([])).toEqual([]);
-  });
-
-  it("wraps a string into a single-element array", () => {
-    expect(normalizeGroupKey("foo")).toEqual(["foo"]);
-  });
-
-  it("passes arrays through", () => {
-    expect(normalizeGroupKey(["a", "b"])).toEqual(["a", "b"]);
-  });
-});
-
 describe("buildGroupTree", () => {
   it("returns an empty list for no parts", () => {
     expect(buildGroupTree([])).toEqual([]);
   });
 
   it("emits one part leaf per ungrouped part (no coalescing)", () => {
-    const tree = buildGroupTree(asPaths([null, null, null]));
+    const tree = buildGroupTree(asPaths([[], [], []]));
     expect(dump(tree)).toBe("P:#0(0),P:#1(1),P:#2(2)");
   });
 
   it("wraps adjacent same-key parts in one group with one part child each", () => {
-    const tree = buildGroupTree(asPaths(["a", "a", "a"]));
+    const tree = buildGroupTree(asPaths([["a"], ["a"], ["a"]]));
     expect(dump(tree)).toBe("G:a#0[0,1,2]{P:#0.0(0),P:#0.1(1),P:#0.2(2)}");
   });
 
   it("splits non-adjacent runs of the same key into separate groups", () => {
-    const tree = buildGroupTree(asPaths(["a", null, "a"]));
+    const tree = buildGroupTree(asPaths([["a"], [], ["a"]]));
     expect(dump(tree)).toBe("G:a#0[0]{P:#0.0(0)},P:#1(1),G:a#2[2]{P:#2.0(2)}");
   });
 
@@ -95,17 +77,9 @@ describe("buildGroupTree", () => {
     );
   });
 
-  it("accepts strings and arrays interchangeably via normalizeGroupKey", () => {
-    const tree = buildGroupTree([
-      normalizeGroupKey("A"),
-      normalizeGroupKey(["A"]),
-    ]);
-    expect(dump(tree)).toBe("G:A#0[0,1]{P:#0.0(0),P:#0.1(1)}");
-  });
-
   it("assigns stable nodeKeys under append (existing keys do not shift)", () => {
-    const before = buildGroupTree(asPaths([["A"], null]));
-    const after = buildGroupTree(asPaths([["A"], null, ["B"]]));
+    const before = buildGroupTree(asPaths([["A"], []]));
+    const after = buildGroupTree(asPaths([["A"], [], ["B"]]));
 
     expect(before[0]!.nodeKey).toBe(after[0]!.nodeKey);
     expect(before[1]!.nodeKey).toBe(after[1]!.nodeKey);

--- a/packages/core/src/tests/groupParts.test.ts
+++ b/packages/core/src/tests/groupParts.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  buildGroupTree,
-  type GroupNode,
-} from "../react/utils/groupParts";
+import { buildGroupTree, type GroupNode } from "../react/utils/groupParts";
 
 const asPaths = (keys: readonly (readonly string[])[]) => keys;
 

--- a/packages/core/src/tests/groupParts.test.ts
+++ b/packages/core/src/tests/groupParts.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { buildGroupTree, type GroupNode } from "../react/utils/groupParts";
+import type { PartState } from "../store/scopes/part";
+import {
+  buildGroupTree,
+  GROUPBY_MEMO_KEY,
+  groupPartByType,
+  type GroupNode,
+} from "../react/utils/groupParts";
 
 const asPaths = (keys: readonly (readonly string[])[]) => keys;
 
@@ -81,5 +87,114 @@ describe("buildGroupTree", () => {
     expect(before[0]!.nodeKey).toBe(after[0]!.nodeKey);
     expect(before[1]!.nodeKey).toBe(after[1]!.nodeKey);
     expect(after[2]!.nodeKey).toBe("2");
+  });
+});
+
+const part = (overrides: Partial<PartState>): PartState =>
+  ({
+    type: "text",
+    text: "",
+    status: { type: "complete" },
+    ...overrides,
+  }) as PartState;
+
+describe("groupPartByType", () => {
+  it("maps part.type to the configured path", () => {
+    const fn = groupPartByType({
+      reasoning: ["group-thought", "group-reasoning"],
+      "tool-call": ["group-thought", "group-tool"],
+    });
+    expect(fn(part({ type: "reasoning" }))).toEqual([
+      "group-thought",
+      "group-reasoning",
+    ]);
+    expect(fn(part({ type: "tool-call" }))).toEqual([
+      "group-thought",
+      "group-tool",
+    ]);
+  });
+
+  it("returns [] for part types not in the map", () => {
+    const fn = groupPartByType({ reasoning: ["group-r"] });
+    expect(fn(part({ type: "text" }))).toEqual([]);
+  });
+
+  it("routes MCP-app tool calls through the 'mcp-app' entry when present", () => {
+    const fn = groupPartByType({
+      "tool-call": ["group-tool"],
+      "mcp-app": [],
+    });
+    const mcpApp = part({
+      type: "tool-call",
+      toolName: "render",
+      mcp: { app: { resourceUri: "ui://my-app" } },
+    } as Partial<PartState>);
+    const regular = part({
+      type: "tool-call",
+      toolName: "search",
+    } as Partial<PartState>);
+    expect(fn(mcpApp)).toEqual([]);
+    expect(fn(regular)).toEqual(["group-tool"]);
+  });
+
+  it("falls back to 'tool-call' for MCP-app parts when 'mcp-app' is absent", () => {
+    const fn = groupPartByType({ "tool-call": ["group-tool"] });
+    const mcpApp = part({
+      type: "tool-call",
+      toolName: "render",
+      mcp: { app: { resourceUri: "ui://x" } },
+    } as Partial<PartState>);
+    expect(fn(mcpApp)).toEqual(["group-tool"]);
+  });
+
+  it("does not route non-`ui://` tool calls through 'mcp-app'", () => {
+    const fn = groupPartByType({
+      "tool-call": ["group-tool"],
+      "mcp-app": ["group-mcp"],
+    });
+    const notMcp = part({
+      type: "tool-call",
+      toolName: "x",
+      mcp: { app: { resourceUri: "http://example.com" } },
+    } as Partial<PartState>);
+    expect(fn(notMcp)).toEqual(["group-tool"]);
+  });
+
+  it("tags the function with a GROUPBY_MEMO_KEY fingerprint", () => {
+    const fn = groupPartByType({ reasoning: ["group-r"] });
+    const memoKey = (fn as unknown as { [GROUPBY_MEMO_KEY]: string })[
+      GROUPBY_MEMO_KEY
+    ];
+    expect(memoKey).toMatch(/^groupPartByType:/);
+  });
+
+  it("produces the same fingerprint regardless of map key order", () => {
+    const a = groupPartByType({
+      reasoning: ["group-r"],
+      "tool-call": ["group-t"],
+    });
+    const b = groupPartByType({
+      "tool-call": ["group-t"],
+      reasoning: ["group-r"],
+    });
+    const keyA = (a as unknown as { [GROUPBY_MEMO_KEY]: string })[
+      GROUPBY_MEMO_KEY
+    ];
+    const keyB = (b as unknown as { [GROUPBY_MEMO_KEY]: string })[
+      GROUPBY_MEMO_KEY
+    ];
+    expect(keyA).toBe(keyB);
+  });
+
+  it("produces different fingerprints for different configs", () => {
+    const a = groupPartByType({ reasoning: ["group-r"] });
+    const b = groupPartByType({ reasoning: ["group-r2"] });
+    const keyA = (a as unknown as { [GROUPBY_MEMO_KEY]: string })[
+      GROUPBY_MEMO_KEY
+    ];
+    const keyB = (b as unknown as { [GROUPBY_MEMO_KEY]: string })[
+      GROUPBY_MEMO_KEY
+    ];
+    expect(keyA).not.toBe(keyB);
   });
 });

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -125,6 +125,8 @@ export * as ChainOfThoughtPrimitive from "./primitives/chainOfThought";
 export * as SuggestionPrimitive from "./primitives/suggestion";
 export * as ErrorPrimitive from "./primitives/error";
 
+export { groupPartByType } from "@assistant-ui/core/react";
+
 // Re-export shared providers from core/react
 export {
   ThreadListItemByIndexProvider,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -254,6 +254,7 @@ export * as ThreadListItemPrimitive from "./primitives/threadListItem";
 export * as ThreadListItemMorePrimitive from "./primitives/threadListItemMore";
 export * as SelectionToolbarPrimitive from "./primitives/selectionToolbar";
 
+export { groupPartByType } from "@assistant-ui/core/react";
 export { useMessagePartText } from "./primitives/messagePart/useMessagePartText";
 export { useMessagePartReasoning } from "./primitives/messagePart/useMessagePartReasoning";
 export { useMessagePartSource } from "./primitives/messagePart/useMessagePartSource";

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -27,7 +27,7 @@ import {
   BranchPickerPrimitive,
   ComposerPrimitive,
   ErrorPrimitive,
-  getMcpAppFromToolPart,
+  groupPartByType,
   MessagePrimitive,
   SuggestionPrimitive,
   ThreadPrimitive,
@@ -241,15 +241,11 @@ const AssistantMessage: FC = () => {
         className="wrap-break-word px-2 text-foreground leading-relaxed"
       >
         <MessagePrimitive.GroupedParts
-          groupBy={(part) => {
-            if (part.type === "reasoning")
-              return ["group-chainOfThought", "group-reasoning"];
-            if (part.type === "tool-call") {
-              if (getMcpAppFromToolPart(part)) return null;
-              return ["group-chainOfThought", "group-tool"];
-            }
-            return null;
-          }}
+          groupBy={groupPartByType({
+            reasoning: ["group-chainOfThought", "group-reasoning"],
+            "tool-call": ["group-chainOfThought", "group-tool"],
+            "mcp-app": [],
+          })}
         >
           {({ part, children }) => {
             switch (part.type) {


### PR DESCRIPTION
## Summary

- New `groupPartByType({ ... })` helper builds a `groupBy` from a `part.type → group-key path` lookup. Map keys are typed against `PartState["type"]` for autocomplete + typo rejection, missing keys leave the part ungrouped, and the returned function carries an internal memo fingerprint so the tree survives unrelated re-renders.
- Special key `"mcp-app"` matches tool-call parts pointing at an assistant-ui MCP app resource (`ui://...`) and takes precedence over `"tool-call"` — so MCP apps can be routed out of a chain-of-thought wrapper without inline branching.
- `groupBy` signature simplified from `(part, index, parts) => string | string[] | null | undefined` to `(part) => readonly \`group-${string}\`[] | null`. Arrays are required; `null` aliases to `[]` to soften the migration. The previous "pass a stable reference" perf advice is dropped.
- Internal memo now uses the helper's fingerprint when present, otherwise rebuilds the tree per render (O(n), cheap).
- Docs and examples updated to lead with `groupPartByType`. `packages/ui/thread.tsx` switches from a `getMcpAppFromToolPart` branch to `"mcp-app": []`.

### Why this design

Earlier the `groupBy` JSDoc actively told callers to hoist the function to a stable reference for performance, and the 3-arg `(part, index, parts)` shape looked like `Array.prototype.map`. Both nudges made LLM-generated code routinely move `groupBy` to a module-level constant. The redesign removes those signals: single-arg, no perf-hint, and a helper that's terser than the inline form for the common case.

Two fresh-context subagent tests confirmed the change — the first iteration kept `groupBy` inline (no hoist), and after adding `groupPartByType` the agent reached for the helper unprompted.

## Test plan

- [x] `pnpm turbo build --filter=@assistant-ui/core --filter=@assistant-ui/react --filter=@assistant-ui/react-native` passes
- [x] `pnpm --filter @assistant-ui/core test` — 215 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)