### PR TITLE
chore: drop tracker-behaviour explainer comments in satellites

### DIFF
--- a/.changeset/drop-tracker-explainer-comments.md
+++ b/.changeset/drop-tracker-explainer-comments.md
@@ -1,0 +1,10 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-google-adk": patch
+"@assistant-ui/react-ag-ui": patch
+---
+
+chore: drop tracker-behaviour explainer comments left behind in satellite runtimes

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -123,14 +123,10 @@ export function useAgUiRuntime(
         onReload: (parentId: string | null, config: { runConfig?: any }) =>
           core.reload(parentId, config),
         onCancel: async () => {
-          // The embedded tracker's abort() runs before this callback via
-          // the runtime's cancelRun.
           core.cancel();
         },
         onAddToolResult: (options) => core.addToolResult(options),
         onResume: (config) => core.resume(config),
-        // onResumeToolCall: the runtime calls the embedded tracker's
-        // resume() automatically.
         setMessages: (messages: readonly ThreadMessage[]) =>
           core.applyExternalMessages(messages),
         onImport: (messages: readonly ThreadMessage[]) =>

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -257,8 +257,6 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       runtimeRef.current.thread.import(exportedRepo);
     },
     onCancel: async () => {
-      // The embedded tracker's abort() is invoked by the runtime's
-      // cancelRun before this callback runs.
       chatHelpers.stop();
     },
     onNew: async (message) => {
@@ -338,9 +336,6 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         });
       }
     },
-    // onResumeToolCall: the runtime calls the embedded tracker's resume()
-    // automatically before invoking this callback, so no adapter-level
-    // handler is needed.
     onRespondToToolApproval: ({ approvalId, approved, reason }) => {
       void chatHelpers.addToolApprovalResponse({
         id: approvalId,

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -335,12 +335,8 @@ const useAdkRuntimeImpl = ({
         {},
       );
     },
-    // onResumeToolCall: the runtime calls the embedded tracker's
-    // resume() automatically.
     onCancel: unstable_allowCancellation
       ? async () => {
-          // The embedded tracker's abort() runs before this callback via
-          // the runtime's cancelRun.
           cancel();
         }
       : undefined,

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -270,8 +270,6 @@ const useStreamThreadRuntime = (
     onCancel:
       unstable_allowCancellation !== false
         ? async () => {
-            // The embedded tracker's abort() runs before this callback via
-            // the runtime's cancelRun.
             await stream.stop();
           }
         : undefined,

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -618,9 +618,6 @@ const useLangGraphRuntimeImpl = ({
       : undefined,
     onCancel: unstable_allowCancellation
       ? async () => {
-          // The embedded tracker's abort() runs before this callback via
-          // the runtime's cancelRun; no need to call abortToolInvocations
-          // here as well.
           cancel();
         }
       : undefined,

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -300,11 +300,6 @@ const useAssistantTransportThreadRuntime = <T>(
     state: converted.state,
     isRunning: converted.isRunning,
     adapters: options.adapters,
-    // Opt the embedded tool-invocations tracker in. The transport runtime
-    // is the canonical client-side tool-execution surface: tool callbacks
-    // (streamCall/execute) fire on tool-call parts in the converted state,
-    // and their results flow back via `onAddToolResult` below, which
-    // forwards them to the backend as `add-tool-result` commands.
     unstable_enableToolInvocations: true,
     setToolStatuses,
     extras: {
@@ -327,9 +322,6 @@ const useAssistantTransportThreadRuntime = <T>(
       },
     }),
     onCancel: async () => {
-      // The embedded tracker's `abort()` is invoked by the runtime's
-      // `cancelRun` before this adapter callback runs, so no need to call
-      // it again here.
       runManager.cancel();
     },
     onResume: async () => {
@@ -357,9 +349,6 @@ const useAssistantTransportThreadRuntime = <T>(
       commandQueue.enqueue(command);
     },
     onLoadExternalState: async (state) => {
-      // The runtime's `importExternalState` already calls
-      // `tracker.reset()` before invoking this callback, so no need to
-      // reset here.
       agentStateRef.current = state as T;
       rerender((prev) => prev + 1);
     },


### PR DESCRIPTION
## Summary

- Removes the explainer comments left behind in the six satellite runtimes by #4118 (e.g. `// The embedded tracker's abort() runs before this callback via the runtime's cancelRun.`, `// onResumeToolCall: the runtime calls the embedded tracker's resume() automatically.`).
- These describe parent-runtime behaviour rather than anything load-bearing in the satellite; they belong in the PR thread, not as orphan noise on `main`. Reviewer flagged them across 11 threads on #4118 after merge.

## Test plan

- [x] `pnpm turbo build` for all six satellites + `@assistant-ui/react` (12 tasks, all pass)
- [x] `pnpm --filter @assistant-ui/react test` (320 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)