### PR TITLE
feat(assistant-transport): honour Aui-Replay-Content-Length on resume

### DIFF
--- a/.changeset/replay-content-length.md
+++ b/.changeset/replay-content-length.md
@@ -2,6 +2,6 @@
 "@assistant-ui/react": patch
 ---
 
-feat(assistant-transport): honour `Aui-Replay-Content-Length` to suppress side-effects during sync-server replay
+feat(assistant-transport): honour `Aui-Replay-Content-Length` to split sync-server replay from live bytes
 
-`useAssistantTransportRuntime` now reads the `Aui-Replay-Content-Length` response header on resume and reports `isLoading: true` to the embedded tool-invocations tracker while the consumed body byte count is within the replay window. Tool calls in the replayed portion of the stream are recorded as historical and skip `streamCall` / `execute`, so reconnecting to a buffered run no longer re-fires frontend side effects. Live bytes after the boundary fire normally. Responses without the header behave as today.
+`useAssistantTransportRuntime` now reads the `Aui-Replay-Content-Length` response header on resume and gates the body at that byte boundary. The replay prefix is decoded while `isLoading: true` has rendered through React, then the reader pauses until `isLoading: false` has rendered before releasing live bytes. Tool calls in the replayed portion are recorded as historical and skip `streamCall` / `execute`, while tool calls that begin after the replay boundary fire normally. Responses without the header behave as today.

--- a/.changeset/replay-content-length.md
+++ b/.changeset/replay-content-length.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat(assistant-transport): honour `Aui-Replay-Content-Length` to suppress side-effects during sync-server replay
+
+`useAssistantTransportRuntime` now reads the `Aui-Replay-Content-Length` response header on resume and reports `isLoading: true` to the embedded tool-invocations tracker while the consumed body byte count is within the replay window. Tool calls in the replayed portion of the stream are recorded as historical and skip `streamCall` / `execute`, so reconnecting to a buffered run no longer re-fires frontend side effects. Live bytes after the boundary fire normally. Responses without the header behave as today.

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
@@ -1,11 +1,15 @@
+// @vitest-environment jsdom
+
 import {
   AssistantMessageAccumulator,
   DataStreamDecoder,
 } from "assistant-stream";
+import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
   createReplayBoundaryStream,
   REPLAY_CONTENT_LENGTH_HEADER,
+  useReplayRenderWait,
 } from "./replayBoundaryStream";
 
 const encoder = new TextEncoder();
@@ -68,6 +72,33 @@ const readText = async (stream: ReadableStream<Uint8Array>) => {
 
   return chunks.join("");
 };
+
+describe("useReplayRenderWait", () => {
+  it("resolves after its own render ticket commits", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const { result } = renderHook(() => useReplayRenderWait());
+
+      let resolved = false;
+      const wait = result.current().then(() => {
+        resolved = true;
+      });
+
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+      });
+      await wait;
+
+      expect(resolved).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
 
 describe("createReplayBoundaryStream", () => {
   it("short-circuits responses without a valid replay content length", async () => {

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
@@ -1,0 +1,174 @@
+import {
+  AssistantMessageAccumulator,
+  DataStreamDecoder,
+} from "assistant-stream";
+import { describe, expect, it, vi } from "vitest";
+import { createReplayBoundaryStream } from "./replayBoundaryStream";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const createBody = (chunks: readonly string[]) =>
+  new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+
+const createResponse = (
+  chunks: readonly string[],
+  replayContentLength?: number | string,
+) =>
+  new Response(createBody(chunks), {
+    headers:
+      replayContentLength === undefined
+        ? undefined
+        : { "Aui-Replay-Content-Length": String(replayContentLength) },
+  });
+
+const createRenderWait = () => {
+  const pending: Array<() => void> = [];
+  const waitForRender = vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        pending.push(resolve);
+      }),
+  );
+
+  const releaseNext = async () => {
+    const resolve = pending.shift();
+    expect(resolve).toBeDefined();
+    resolve!();
+    await Promise.resolve();
+  };
+
+  return { waitForRender, releaseNext };
+};
+
+const readText = async (stream: ReadableStream<Uint8Array>) => {
+  const reader = stream.getReader();
+  const chunks: string[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(decoder.decode(value, { stream: true }));
+  }
+  chunks.push(decoder.decode());
+
+  return chunks.join("");
+};
+
+describe("createReplayBoundaryStream", () => {
+  it("short-circuits responses without a valid replay content length", async () => {
+    const setReplaying = vi.fn();
+    const waitForRender = vi.fn();
+    const body = await createReplayBoundaryStream(createResponse(["live"]), {
+      setReplaying,
+      waitForRender,
+    });
+
+    expect(await readText(body)).toBe("live");
+    expect(setReplaying).not.toHaveBeenCalled();
+    expect(waitForRender).not.toHaveBeenCalled();
+  });
+
+  it("pauses at the replay boundary before releasing live bytes", async () => {
+    const { waitForRender, releaseNext } = createRenderWait();
+    const setReplaying = vi.fn();
+    const replayPrefix = '0:"hi"\nb:{"toolCallId":"call-1","toolName":"te';
+    const liveSuffix = 'st"}\n';
+    const replayContentLength = encoder.encode(replayPrefix).byteLength;
+
+    const streamPromise = createReplayBoundaryStream(
+      createResponse([replayPrefix + liveSuffix], replayContentLength),
+      { setReplaying, waitForRender },
+    );
+
+    expect(setReplaying).toHaveBeenCalledWith(true);
+    expect(waitForRender).toHaveBeenCalledTimes(1);
+
+    await releaseNext();
+    const stream = await streamPromise;
+    const reader = stream.getReader();
+
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: encoder.encode(replayPrefix),
+    });
+    expect(waitForRender).toHaveBeenCalledTimes(2);
+    expect(setReplaying).toHaveBeenCalledTimes(1);
+
+    let liveReadResolved = false;
+    const liveRead = reader.read().then((read) => {
+      liveReadResolved = true;
+      return read;
+    });
+    await Promise.resolve();
+    expect(liveReadResolved).toBe(false);
+
+    await releaseNext();
+    expect(setReplaying).toHaveBeenLastCalledWith(false);
+    expect(waitForRender).toHaveBeenCalledTimes(3);
+    await Promise.resolve();
+    expect(liveReadResolved).toBe(false);
+
+    await releaseNext();
+    await expect(liveRead).resolves.toMatchObject({
+      done: false,
+      value: encoder.encode(liveSuffix),
+    });
+  });
+
+  it("lets data-stream parsing commit replayed text before live tool calls", async () => {
+    const { waitForRender, releaseNext } = createRenderWait();
+    const setReplaying = vi.fn();
+    const replayPrefix = '0:"hi"\nb:{"toolCallId":"call-1","toolName":"te';
+    const liveSuffix = 'st"}\n';
+    const replayContentLength = encoder.encode(replayPrefix).byteLength;
+
+    const streamPromise = createReplayBoundaryStream(
+      createResponse([replayPrefix + liveSuffix], replayContentLength),
+      { setReplaying, waitForRender },
+    );
+
+    await releaseNext();
+    const messages = (await streamPromise)
+      .pipeThrough(new DataStreamDecoder())
+      .pipeThrough(new AssistantMessageAccumulator({ throttle: true }));
+    const reader = messages.getReader();
+
+    let sawReplayedText = false;
+    while (!sawReplayedText) {
+      const replayedMessage = await reader.read();
+      expect(replayedMessage.done).toBe(false);
+      expect(
+        replayedMessage.value?.parts.some((part) => part.type === "tool-call"),
+      ).toBe(false);
+      sawReplayedText =
+        replayedMessage.value?.parts.some(
+          (part) => part.type === "text" && part.text === "hi",
+        ) ?? false;
+    }
+    expect(setReplaying).toHaveBeenCalledTimes(1);
+
+    const liveMessagePromise = reader.read();
+    await releaseNext();
+    expect(setReplaying).toHaveBeenLastCalledWith(false);
+    await releaseNext();
+
+    let liveMessage = await liveMessagePromise;
+    while (
+      !liveMessage.done &&
+      !liveMessage.value?.parts.some(
+        (part) => part.type === "tool-call" && part.toolName === "test",
+      )
+    ) {
+      liveMessage = await reader.read();
+    }
+    expect(liveMessage.done).toBe(false);
+  });
+});

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
@@ -136,6 +136,101 @@ describe("createReplayBoundaryStream", () => {
     });
   });
 
+  it("pauses when a chunk ends exactly at the replay boundary", async () => {
+    const { waitForRender, releaseNext } = createRenderWait();
+    const setReplaying = vi.fn();
+    const replayPrefix = "replay";
+    const liveSuffix = "live";
+    const replayContentLength = encoder.encode(replayPrefix).byteLength;
+
+    const streamPromise = createReplayBoundaryStream(
+      createResponse([replayPrefix, liveSuffix], replayContentLength),
+      { setReplaying, waitForRender },
+    );
+
+    await releaseNext();
+    const stream = await streamPromise;
+    const reader = stream.getReader();
+
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: encoder.encode(replayPrefix),
+    });
+    expect(setReplaying).toHaveBeenCalledTimes(1);
+
+    let liveReadResolved = false;
+    const liveRead = reader.read().then((read) => {
+      liveReadResolved = true;
+      return read;
+    });
+    await Promise.resolve();
+    expect(liveReadResolved).toBe(false);
+
+    await releaseNext();
+    expect(setReplaying).toHaveBeenLastCalledWith(false);
+    await releaseNext();
+
+    await expect(liveRead).resolves.toMatchObject({
+      done: false,
+      value: encoder.encode(liveSuffix),
+    });
+  });
+
+  it("accumulates replay bytes across chunks before splitting live bytes", async () => {
+    const { waitForRender, releaseNext } = createRenderWait();
+    const setReplaying = vi.fn();
+    const firstReplayChunk = "part1";
+    const secondReplayChunk = "part2";
+    const firstLiveChunk = "live1";
+    const secondLiveChunk = "live2";
+    const replayContentLength = encoder.encode(
+      firstReplayChunk + secondReplayChunk,
+    ).byteLength;
+
+    const streamPromise = createReplayBoundaryStream(
+      createResponse(
+        [firstReplayChunk, secondReplayChunk + firstLiveChunk, secondLiveChunk],
+        replayContentLength,
+      ),
+      { setReplaying, waitForRender },
+    );
+
+    await releaseNext();
+    const stream = await streamPromise;
+    const reader = stream.getReader();
+
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: encoder.encode(firstReplayChunk),
+    });
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: encoder.encode(secondReplayChunk),
+    });
+    expect(setReplaying).toHaveBeenCalledTimes(1);
+
+    let liveReadResolved = false;
+    const liveRead = reader.read().then((read) => {
+      liveReadResolved = true;
+      return read;
+    });
+    await Promise.resolve();
+    expect(liveReadResolved).toBe(false);
+
+    await releaseNext();
+    expect(setReplaying).toHaveBeenLastCalledWith(false);
+    await releaseNext();
+
+    await expect(liveRead).resolves.toMatchObject({
+      done: false,
+      value: encoder.encode(firstLiveChunk),
+    });
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: encoder.encode(secondLiveChunk),
+    });
+  });
+
   it("clears replaying when the stream ends before the boundary", async () => {
     const { waitForRender, releaseNext } = createRenderWait();
     const setReplaying = vi.fn();

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
@@ -310,6 +310,40 @@ describe("createReplayBoundaryStream", () => {
     expect(cancelled).toBe(true);
   });
 
+  it("does not clear replaying twice when cancelled during replay completion", async () => {
+    const { waitForRender, releaseNext } = createRenderWait();
+    const setReplaying = vi.fn();
+    const replayStr = "replay";
+    const replayContentLength = encoder.encode(replayStr).byteLength;
+
+    const streamPromise = createReplayBoundaryStream(
+      createResponse([replayStr], replayContentLength),
+      { setReplaying, waitForRender },
+    );
+
+    await releaseNext();
+    const stream = await streamPromise;
+    const reader = stream.getReader();
+
+    await expect(reader.read()).resolves.toMatchObject({
+      done: false,
+      value: encoder.encode(replayStr),
+    });
+    expect(waitForRender).toHaveBeenCalledTimes(2);
+
+    const cancel = reader.cancel("done");
+    await Promise.resolve();
+    expect(setReplaying).toHaveBeenCalledTimes(1);
+
+    await releaseNext();
+    expect(setReplaying).toHaveBeenCalledTimes(2);
+    expect(setReplaying).toHaveBeenLastCalledWith(false);
+
+    await releaseNext();
+    await cancel;
+    expect(setReplaying).toHaveBeenCalledTimes(2);
+  });
+
   it("lets data-stream parsing commit replayed text before live tool calls", async () => {
     const { waitForRender, releaseNext } = createRenderWait();
     const setReplaying = vi.fn();

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
@@ -3,7 +3,10 @@ import {
   DataStreamDecoder,
 } from "assistant-stream";
 import { describe, expect, it, vi } from "vitest";
-import { createReplayBoundaryStream } from "./replayBoundaryStream";
+import {
+  createReplayBoundaryStream,
+  REPLAY_CONTENT_LENGTH_HEADER,
+} from "./replayBoundaryStream";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -26,7 +29,7 @@ const createResponse = (
     headers:
       replayContentLength === undefined
         ? undefined
-        : { "Aui-Replay-Content-Length": String(replayContentLength) },
+        : { [REPLAY_CONTENT_LENGTH_HEADER]: String(replayContentLength) },
   });
 
 const createRenderWait = () => {
@@ -265,7 +268,7 @@ describe("createReplayBoundaryStream", () => {
       },
     });
     const streamPromise = createReplayBoundaryStream(
-      new Response(body, { headers: { "Aui-Replay-Content-Length": "10" } }),
+      new Response(body, { headers: { [REPLAY_CONTENT_LENGTH_HEADER]: "10" } }),
       { setReplaying, waitForRender },
     );
 
@@ -287,7 +290,7 @@ describe("createReplayBoundaryStream", () => {
       },
     });
     const streamPromise = createReplayBoundaryStream(
-      new Response(body, { headers: { "Aui-Replay-Content-Length": "10" } }),
+      new Response(body, { headers: { [REPLAY_CONTENT_LENGTH_HEADER]: "10" } }),
       { setReplaying, waitForRender },
     );
 

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
@@ -39,6 +39,10 @@ const createRenderWait = () => {
   );
 
   const releaseNext = async () => {
+    for (let i = 0; pending.length === 0 && i < 10; i++) {
+      await Promise.resolve();
+    }
+
     const resolve = pending.shift();
     expect(resolve).toBeDefined();
     resolve!();
@@ -66,14 +70,23 @@ describe("createReplayBoundaryStream", () => {
   it("short-circuits responses without a valid replay content length", async () => {
     const setReplaying = vi.fn();
     const waitForRender = vi.fn();
-    const body = await createReplayBoundaryStream(createResponse(["live"]), {
-      setReplaying,
-      waitForRender,
-    });
 
-    expect(await readText(body)).toBe("live");
-    expect(setReplaying).not.toHaveBeenCalled();
-    expect(waitForRender).not.toHaveBeenCalled();
+    for (const replayContentLength of [undefined, "abc", "3.5", "-1"]) {
+      setReplaying.mockClear();
+      waitForRender.mockClear();
+
+      const body = await createReplayBoundaryStream(
+        createResponse(["live"], replayContentLength),
+        {
+          setReplaying,
+          waitForRender,
+        },
+      );
+
+      expect(await readText(body)).toBe("live");
+      expect(setReplaying).not.toHaveBeenCalled();
+      expect(waitForRender).not.toHaveBeenCalled();
+    }
   });
 
   it("pauses at the replay boundary before releasing live bytes", async () => {
@@ -121,6 +134,52 @@ describe("createReplayBoundaryStream", () => {
       done: false,
       value: encoder.encode(liveSuffix),
     });
+  });
+
+  it("clears replaying when the stream ends before the boundary", async () => {
+    const { waitForRender, releaseNext } = createRenderWait();
+    const setReplaying = vi.fn();
+    const streamPromise = createReplayBoundaryStream(
+      createResponse(["hi"], 10),
+      {
+        setReplaying,
+        waitForRender,
+      },
+    );
+
+    await releaseNext();
+    const stream = await streamPromise;
+    const text = readText(stream);
+    await releaseNext();
+    await releaseNext();
+
+    await expect(text).resolves.toBe("hi");
+    expect(setReplaying).toHaveBeenLastCalledWith(false);
+  });
+
+  it("clears replaying when the gated stream is cancelled", async () => {
+    const { waitForRender, releaseNext } = createRenderWait();
+    const setReplaying = vi.fn();
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("hi"));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const streamPromise = createReplayBoundaryStream(
+      new Response(body, { headers: { "Aui-Replay-Content-Length": "10" } }),
+      { setReplaying, waitForRender },
+    );
+
+    await releaseNext();
+    const stream = await streamPromise;
+    await stream.cancel("done");
+
+    expect(setReplaying).toHaveBeenLastCalledWith(false);
+    expect(cancelled).toBe(true);
   });
 
   it("lets data-stream parsing commit replayed text before live tool calls", async () => {

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
@@ -182,6 +182,36 @@ describe("createReplayBoundaryStream", () => {
     expect(cancelled).toBe(true);
   });
 
+  it("does not wait for replay completion after cancellation unblocks a read", async () => {
+    const { waitForRender, releaseNext } = createRenderWait();
+    const setReplaying = vi.fn();
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const streamPromise = createReplayBoundaryStream(
+      new Response(body, { headers: { "Aui-Replay-Content-Length": "10" } }),
+      { setReplaying, waitForRender },
+    );
+
+    await releaseNext();
+    const stream = await streamPromise;
+    const reader = stream.getReader();
+    const read = reader.read();
+
+    await Promise.resolve();
+    expect(waitForRender).toHaveBeenCalledTimes(1);
+
+    await reader.cancel("done");
+    await expect(read).resolves.toMatchObject({ done: true });
+
+    expect(waitForRender).toHaveBeenCalledTimes(1);
+    expect(setReplaying).toHaveBeenLastCalledWith(false);
+    expect(cancelled).toBe(true);
+  });
+
   it("lets data-stream parsing commit replayed text before live tool calls", async () => {
     const { waitForRender, releaseNext } = createRenderWait();
     const setReplaying = vi.fn();

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
@@ -96,6 +96,7 @@ export const createReplayBoundaryStream = async (
     if (replayFinished) return;
     replayFinished = true;
 
+    // Let replay bytes drain before rendering live mode, then render live mode before releasing live bytes.
     await waitForReplayRender();
     setReplaying(false);
     await waitForReplayRender();

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
@@ -6,13 +6,8 @@ export const REPLAY_CONTENT_LENGTH_HEADER = "Aui-Replay-Content-Length";
 
 type ReplayBoundaryStreamOptions = {
   setReplaying: (value: boolean) => void;
-  waitForRender?: () => Promise<void>;
+  waitForRender: () => Promise<void>;
 };
-
-const waitForRender = () =>
-  new Promise<void>((resolve) => {
-    setTimeout(resolve, 0);
-  });
 
 export const useReplayRenderWait = () => {
   const [, rerender] = useState(0);
@@ -69,7 +64,7 @@ export const createReplayBoundaryStream = async (
   response: Response,
   {
     setReplaying,
-    waitForRender: waitForReplayRender = waitForRender,
+    waitForRender: waitForReplayRender,
   }: ReplayBoundaryStreamOptions,
 ): Promise<ReadableStream<Uint8Array>> => {
   const body = response.body as ReadableStream<Uint8Array>;

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
@@ -23,6 +23,7 @@ export const useReplayRenderWait = () => {
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
     resolveWaiters();
   });
 

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
@@ -126,14 +126,12 @@ export const createReplayBoundaryStream = async (
       }
 
       if (nextBytesForwarded === replayContentLength) {
-        bytesForwarded = nextBytesForwarded;
         controller.enqueue(value);
         await finishReplay();
         return;
       }
 
       const replayBytesInChunk = replayContentLength - bytesForwarded;
-      bytesForwarded = nextBytesForwarded;
 
       controller.enqueue(value.subarray(0, replayBytesInChunk));
       await finishReplay();

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
@@ -135,14 +135,12 @@ export const createReplayBoundaryStream = async (
       const replayBytesInChunk = replayContentLength - bytesForwarded;
       bytesForwarded = nextBytesForwarded;
 
-      if (replayBytesInChunk > 0) {
-        controller.enqueue(value.subarray(0, replayBytesInChunk));
-      }
-
+      controller.enqueue(value.subarray(0, replayBytesInChunk));
       await finishReplay();
       controller.enqueue(value.subarray(replayBytesInChunk));
     },
     async cancel(reason) {
+      replayFinished = true;
       setReplaying(false);
       await reader.cancel(reason);
     },

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-const REPLAY_CONTENT_LENGTH_HEADER = "Aui-Replay-Content-Length";
+export const REPLAY_CONTENT_LENGTH_HEADER = "Aui-Replay-Content-Length";
 
 type ReplayBoundaryStreamOptions = {
   setReplaying: (value: boolean) => void;
@@ -64,13 +64,7 @@ const parseReplayContentLength = (headers: Headers): number => {
   return Number.isSafeInteger(boundary) && boundary > 0 ? boundary : 0;
 };
 
-/**
- * Splits the response body at `Aui-Replay-Content-Length` without closing the
- * decoder pipeline. The replay prefix is delivered while `isReplaying` has
- * rendered, then the stream pauses until React has rendered `isReplaying:
- * false` before live bytes are released. The render wait also gives the
- * downstream decoder/accumulator pipeline a task to consume the replay prefix.
- */
+// Gates replay bytes until isReplaying:true renders, then releases live bytes after isReplaying:false renders.
 export const createReplayBoundaryStream = async (
   response: Response,
   {

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
@@ -1,0 +1,149 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const REPLAY_CONTENT_LENGTH_HEADER = "Aui-Replay-Content-Length";
+
+type ReplayBoundaryStreamOptions = {
+  setReplaying: (value: boolean) => void;
+  waitForRender?: () => Promise<void>;
+};
+
+const waitForRender = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+export const useReplayRenderWait = () => {
+  const [, rerender] = useState(0);
+  const mountedRef = useRef(true);
+  const waitersRef = useRef<Array<() => void>>([]);
+
+  const resolveWaiters = useCallback(() => {
+    const waiters = waitersRef.current;
+    waitersRef.current = [];
+    for (const resolve of waiters) {
+      resolve();
+    }
+  }, []);
+
+  useEffect(() => {
+    resolveWaiters();
+  });
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+      resolveWaiters();
+    },
+    [resolveWaiters],
+  );
+
+  return useCallback(
+    () =>
+      new Promise<void>((resolve) => {
+        setTimeout(() => {
+          if (!mountedRef.current) {
+            resolve();
+            return;
+          }
+
+          waitersRef.current.push(resolve);
+          rerender((value) => value + 1);
+        }, 0);
+      }),
+    [],
+  );
+};
+
+const parseReplayContentLength = (headers: Headers): number => {
+  const raw = headers.get(REPLAY_CONTENT_LENGTH_HEADER);
+  if (raw == null) return 0;
+
+  const boundary = Number(raw);
+  return Number.isSafeInteger(boundary) && boundary > 0 ? boundary : 0;
+};
+
+/**
+ * Splits the response body at `Aui-Replay-Content-Length` without closing the
+ * decoder pipeline. The replay prefix is delivered while `isReplaying` has
+ * rendered, then the stream pauses until React has rendered `isReplaying:
+ * false` before live bytes are released. The render wait also gives the
+ * downstream decoder/accumulator pipeline a task to consume the replay prefix.
+ */
+export const createReplayBoundaryStream = async (
+  response: Response,
+  {
+    setReplaying,
+    waitForRender: waitForReplayRender = waitForRender,
+  }: ReplayBoundaryStreamOptions,
+): Promise<ReadableStream<Uint8Array>> => {
+  const body = response.body as ReadableStream<Uint8Array>;
+  const replayContentLength = parseReplayContentLength(response.headers);
+
+  if (replayContentLength <= 0) {
+    return body;
+  }
+
+  setReplaying(true);
+  await waitForReplayRender();
+
+  const reader = body.getReader();
+  let bytesForwarded = 0;
+  let replayFinished = false;
+
+  const finishReplay = async () => {
+    if (replayFinished) return;
+    replayFinished = true;
+
+    await waitForReplayRender();
+    setReplaying(false);
+    await waitForReplayRender();
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        await finishReplay();
+        controller.close();
+        return;
+      }
+
+      if (replayFinished) {
+        controller.enqueue(value);
+        return;
+      }
+
+      const nextBytesForwarded = bytesForwarded + value.byteLength;
+
+      if (nextBytesForwarded < replayContentLength) {
+        bytesForwarded = nextBytesForwarded;
+        controller.enqueue(value);
+        return;
+      }
+
+      if (nextBytesForwarded === replayContentLength) {
+        bytesForwarded = nextBytesForwarded;
+        controller.enqueue(value);
+        await finishReplay();
+        return;
+      }
+
+      const replayBytesInChunk = replayContentLength - bytesForwarded;
+      bytesForwarded = nextBytesForwarded;
+
+      if (replayBytesInChunk > 0) {
+        controller.enqueue(value.subarray(0, replayBytesInChunk));
+      }
+
+      await finishReplay();
+      controller.enqueue(value.subarray(replayBytesInChunk));
+    },
+    async cancel(reason) {
+      setReplaying(false);
+      await reader.cancel(reason);
+    },
+  });
+};

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
@@ -132,8 +132,9 @@ export const createReplayBoundaryStream = async (
       controller.enqueue(value.subarray(replayBytesInChunk));
     },
     async cancel(reason) {
+      const wasFinished = replayFinished;
       replayFinished = true;
-      setReplaying(false);
+      if (!wasFinished) setReplaying(false);
       await reader.cancel(reason);
     },
   });

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
@@ -10,22 +10,29 @@ type ReplayBoundaryStreamOptions = {
 };
 
 export const useReplayRenderWait = () => {
-  const [, rerender] = useState(0);
+  const [renderTicket, setRenderTicket] = useState(0);
   const mountedRef = useRef(true);
-  const waitersRef = useRef<Array<() => void>>([]);
+  const nextTicketRef = useRef(0);
+  const waitersRef = useRef<Array<{ ticket: number; resolve: () => void }>>([]);
 
-  const resolveWaiters = useCallback(() => {
-    const waiters = waitersRef.current;
-    waitersRef.current = [];
-    for (const resolve of waiters) {
-      resolve();
+  const resolveWaiters = useCallback((committedTicket?: number) => {
+    const pendingWaiters = [];
+
+    for (const waiter of waitersRef.current) {
+      if (committedTicket === undefined || waiter.ticket <= committedTicket) {
+        waiter.resolve();
+      } else {
+        pendingWaiters.push(waiter);
+      }
     }
+
+    waitersRef.current = pendingWaiters;
   }, []);
 
   useEffect(() => {
     mountedRef.current = true;
-    resolveWaiters();
-  });
+    resolveWaiters(renderTicket);
+  }, [renderTicket, resolveWaiters]);
 
   useEffect(
     () => () => {
@@ -44,8 +51,10 @@ export const useReplayRenderWait = () => {
             return;
           }
 
-          waitersRef.current.push(resolve);
-          rerender((value) => value + 1);
+          const ticket = nextTicketRef.current + 1;
+          nextTicketRef.current = ticket;
+          waitersRef.current.push({ ticket, resolve });
+          setRenderTicket(ticket);
         }, 0);
       }),
     [],

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -120,9 +120,7 @@ const useAssistantTransportThreadRuntime = <T>(
   const agentStateRef = useRef(options.initialState);
   const [, rerender] = useState(0);
   const resumeFlagRef = useRef(false);
-  // oxlint-disable-next-line react-hooks/rules-of-hooks -- intentional conditional/nested hook usage
   const [isReplaying, setIsReplaying] = useState(false);
-  // oxlint-disable-next-line react-hooks/rules-of-hooks -- intentional conditional/nested hook usage
   const waitForReplayRender = useReplayRenderWait();
   const parentIdRef = useRef<string | null | undefined>(undefined);
   const commandQueue = useCommandQueue({

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -68,31 +68,34 @@ const convertAppendMessageToCommand = (
 
 /**
  * Read `Aui-Replay-Content-Length` off the resume response and wrap
- * `response.body` in a byte-counting passthrough that flips `replayingRef`
- * to `false` once the consumed byte count crosses the boundary. The
- * paired sync server (assistant-ui-sync-server) emits the header.
+ * `response.body` in a byte-counting passthrough that flips
+ * `setReplaying` to `false` once the consumed byte count crosses the
+ * boundary. The paired sync server (assistant-ui-sync-server) emits the
+ * header.
  *
- * Responses without the header short-circuit — no extra pipeline node,
- * `replayingRef` stays `false`.
+ * Responses without (or with a malformed) header short-circuit — no
+ * extra pipeline node, replay state stays `false`.
  */
 const wrapReplayCounting = (
   response: Response,
-  replayingRef: { current: boolean },
+  setReplaying: (v: boolean) => void,
 ): ReadableStream<Uint8Array> => {
-  const boundary = parseInt(
-    response.headers.get("Aui-Replay-Content-Length") ?? "0",
-    10,
-  );
-  if (boundary <= 0) return response.body as ReadableStream<Uint8Array>;
+  const raw = response.headers.get("Aui-Replay-Content-Length");
+  const boundary = raw != null ? Number.parseInt(raw, 10) : 0;
+  if (!Number.isFinite(boundary) || boundary <= 0) {
+    return response.body as ReadableStream<Uint8Array>;
+  }
 
-  replayingRef.current = true;
+  setReplaying(true);
   let bytesConsumed = 0;
+  let flipped = false;
   return response.body!.pipeThrough(
     new TransformStream<Uint8Array, Uint8Array>({
       transform(chunk, controller) {
         bytesConsumed += chunk.byteLength;
-        if (replayingRef.current && bytesConsumed > boundary) {
-          replayingRef.current = false;
+        if (!flipped && bytesConsumed > boundary) {
+          flipped = true;
+          setReplaying(false);
         }
         controller.enqueue(chunk);
       },
@@ -150,7 +153,8 @@ const useAssistantTransportThreadRuntime = <T>(
   const agentStateRef = useRef(options.initialState);
   const [, rerender] = useState(0);
   const resumeFlagRef = useRef(false);
-  const replayingRef = useRef(false);
+  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
+  const [isReplaying, setIsReplaying] = useState(false);
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const parentIdRef = useRef<string | null | undefined>(undefined);
   const commandQueue = useCommandQueue({
@@ -163,7 +167,7 @@ const useAssistantTransportThreadRuntime = <T>(
     onRun: async (signal: AbortSignal) => {
       const isResume = resumeFlagRef.current;
       resumeFlagRef.current = false;
-      replayingRef.current = false;
+      setIsReplaying(false);
       const commands: QueuedCommand[] = isResume ? [] : commandQueue.flush();
       if (commands.length === 0 && !isResume)
         throw new Error("No commands to send");
@@ -224,7 +228,7 @@ const useAssistantTransportThreadRuntime = <T>(
       // Surfaced to the embedded tool-invocations tracker via `isLoading`
       // (set on the inner adapter store below), which gates streamCall /
       // execute side effects.
-      const body = wrapReplayCounting(response, replayingRef);
+      const body = wrapReplayCounting(response, setIsReplaying);
 
       // Select decoder based on protocol option
       const protocol = options.protocol ?? "data-stream";
@@ -332,7 +336,7 @@ const useAssistantTransportThreadRuntime = <T>(
     messages: converted.messages,
     state: converted.state,
     isRunning: converted.isRunning,
-    isLoading: replayingRef.current,
+    isLoading: isReplaying,
     adapters: options.adapters,
     unstable_enableToolInvocations: true,
     setToolStatuses,

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -116,6 +116,8 @@ const useAssistantTransportThreadRuntime = <T>(
   const agentStateRef = useRef(options.initialState);
   const [, rerender] = useState(0);
   const resumeFlagRef = useRef(false);
+  const replayingRef = useRef(false);
+  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const parentIdRef = useRef<string | null | undefined>(undefined);
   const commandQueue = useCommandQueue({
     onQueue: () => runManager.schedule(),
@@ -127,6 +129,7 @@ const useAssistantTransportThreadRuntime = <T>(
     onRun: async (signal: AbortSignal) => {
       const isResume = resumeFlagRef.current;
       resumeFlagRef.current = false;
+      replayingRef.current = false;
       const commands: QueuedCommand[] = isResume ? [] : commandQueue.flush();
       if (commands.length === 0 && !isResume)
         throw new Error("No commands to send");
@@ -182,6 +185,28 @@ const useAssistantTransportThreadRuntime = <T>(
         throw new Error("Response body is null");
       }
 
+      // Sync-server replay header: the first N body bytes were buffered
+      // before this resume started (historical), everything after is live.
+      // Surfaced to the embedded tool-invocations tracker via `isLoading`,
+      // which gates streamCall / execute side effects.
+      const replayContentLength = parseInt(
+        response.headers.get("Aui-Replay-Content-Length") ?? "0",
+        10,
+      );
+      replayingRef.current = replayContentLength > 0;
+      if (replayingRef.current) rerender((prev) => prev + 1);
+
+      let bytesConsumed = 0;
+      const replayCounter = new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, controller) {
+          bytesConsumed += chunk.byteLength;
+          if (replayingRef.current && bytesConsumed > replayContentLength) {
+            replayingRef.current = false;
+          }
+          controller.enqueue(chunk);
+        },
+      });
+
       // Select decoder based on protocol option
       const protocol = options.protocol ?? "data-stream";
       const decoder =
@@ -190,18 +215,21 @@ const useAssistantTransportThreadRuntime = <T>(
           : new DataStreamDecoder();
 
       let err: string | undefined;
-      const stream = response.body.pipeThrough(decoder).pipeThrough(
-        new AssistantMessageAccumulator({
-          initialMessage: createInitialMessage({
-            unstable_state:
-              (agentStateRef.current as ReadonlyJSONValue) ?? null,
+      const stream = response.body
+        .pipeThrough(replayCounter)
+        .pipeThrough(decoder)
+        .pipeThrough(
+          new AssistantMessageAccumulator({
+            initialMessage: createInitialMessage({
+              unstable_state:
+                (agentStateRef.current as ReadonlyJSONValue) ?? null,
+            }),
+            throttle: isResume,
+            onError: (error) => {
+              err = error;
+            },
           }),
-          throttle: isResume,
-          onError: (error) => {
-            err = error;
-          },
-        }),
-      );
+        );
 
       let markedDelivered = false;
 
@@ -288,6 +316,7 @@ const useAssistantTransportThreadRuntime = <T>(
     messages: converted.messages,
     state: converted.state,
     isRunning: converted.isRunning,
+    isLoading: replayingRef.current,
     adapters: options.adapters,
     unstable_enableToolInvocations: true,
     setToolStatuses,

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -27,6 +27,10 @@ import type {
   SendCommandsRequestBody,
 } from "./types";
 import { useCommandQueue } from "./commandQueue";
+import {
+  createReplayBoundaryStream,
+  useReplayRenderWait,
+} from "./replayBoundaryStream";
 import { useRunManager } from "./runManager";
 import { useConvertedState } from "./useConvertedState";
 import type { ToolExecutionStatus } from "@assistant-ui/core";
@@ -64,52 +68,6 @@ const convertAppendMessageToCommand = (
     parentId: message.parentId,
     sourceId: message.sourceId,
   };
-};
-
-/**
- * Read `Aui-Replay-Content-Length` off the resume response and wrap
- * `response.body` in a byte-counting passthrough that flips
- * `setReplaying` to `false` once the consumed byte count crosses the
- * boundary. The paired sync server (assistant-ui-sync-server) emits the
- * header.
- *
- * Responses without (or with a malformed) header short-circuit — no
- * extra pipeline node, replay state stays `false`.
- */
-const wrapReplayCounting = (
-  response: Response,
-  setReplaying: (v: boolean) => void,
-): ReadableStream<Uint8Array> => {
-  const raw = response.headers.get("Aui-Replay-Content-Length");
-  const boundary = raw != null ? Number.parseInt(raw, 10) : 0;
-  if (!Number.isFinite(boundary) || boundary <= 0) {
-    return response.body as ReadableStream<Uint8Array>;
-  }
-
-  setReplaying(true);
-  let bytesConsumed = 0;
-  let flipped = false;
-  const clearReplaying = () => {
-    if (flipped) return;
-    flipped = true;
-    setReplaying(false);
-  };
-  return response.body!.pipeThrough(
-    new TransformStream<Uint8Array, Uint8Array>({
-      transform(chunk, controller) {
-        bytesConsumed += chunk.byteLength;
-        if (bytesConsumed > boundary) clearReplaying();
-        controller.enqueue(chunk);
-      },
-      // If the stream ends without crossing the boundary (server sent
-      // fewer bytes than advertised, body was exactly the replay length,
-      // etc.), still clear the flag so the next snapshot processed
-      // outside the run isn't suppressed.
-      flush() {
-        clearReplaying();
-      },
-    }),
-  );
 };
 
 const symbolAssistantTransportExtras = Symbol("assistant-transport-extras");
@@ -162,9 +120,10 @@ const useAssistantTransportThreadRuntime = <T>(
   const agentStateRef = useRef(options.initialState);
   const [, rerender] = useState(0);
   const resumeFlagRef = useRef(false);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
+  // oxlint-disable-next-line react-hooks/rules-of-hooks -- intentional conditional/nested hook usage
   const [isReplaying, setIsReplaying] = useState(false);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
+  const waitForReplayRender = useReplayRenderWait();
+  // oxlint-disable-next-line react-hooks/rules-of-hooks -- intentional conditional/nested hook usage
   const parentIdRef = useRef<string | null | undefined>(undefined);
   const commandQueue = useCommandQueue({
     onQueue: () => runManager.schedule(),
@@ -232,12 +191,10 @@ const useAssistantTransportThreadRuntime = <T>(
         throw new Error("Response body is null");
       }
 
-      // Sync-server replay header: the first N body bytes were buffered
-      // before this resume started (historical), everything after is live.
-      // Surfaced to the embedded tool-invocations tracker via `isLoading`
-      // (set on the inner adapter store below), which gates streamCall /
-      // execute side effects.
-      const body = wrapReplayCounting(response, setIsReplaying);
+      const body = await createReplayBoundaryStream(response, {
+        setReplaying: setIsReplaying,
+        waitForRender: waitForReplayRender,
+      });
 
       // Select decoder based on protocol option
       const protocol = options.protocol ?? "data-stream";

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -271,6 +271,7 @@ const useAssistantTransportThreadRuntime = <T>(
     },
     onFinish: options.onFinish,
     onCancel: () => {
+      setIsReplaying(false);
       const cmds = [
         ...commandQueue.state.inTransit,
         ...commandQueue.state.queued,
@@ -287,6 +288,7 @@ const useAssistantTransportThreadRuntime = <T>(
       });
     },
     onError: async (error) => {
+      setIsReplaying(false);
       const inTransitCmds = [...commandQueue.state.inTransit];
       const queuedCmds = [...commandQueue.state.queued];
 

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -89,15 +89,24 @@ const wrapReplayCounting = (
   setReplaying(true);
   let bytesConsumed = 0;
   let flipped = false;
+  const clearReplaying = () => {
+    if (flipped) return;
+    flipped = true;
+    setReplaying(false);
+  };
   return response.body!.pipeThrough(
     new TransformStream<Uint8Array, Uint8Array>({
       transform(chunk, controller) {
         bytesConsumed += chunk.byteLength;
-        if (!flipped && bytesConsumed > boundary) {
-          flipped = true;
-          setReplaying(false);
-        }
+        if (bytesConsumed > boundary) clearReplaying();
         controller.enqueue(chunk);
+      },
+      // If the stream ends without crossing the boundary (server sent
+      // fewer bytes than advertised, body was exactly the replay length,
+      // etc.), still clear the flag so the next snapshot processed
+      // outside the run isn't suppressed.
+      flush() {
+        clearReplaying();
       },
     }),
   );

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -122,8 +122,8 @@ const useAssistantTransportThreadRuntime = <T>(
   const resumeFlagRef = useRef(false);
   // oxlint-disable-next-line react-hooks/rules-of-hooks -- intentional conditional/nested hook usage
   const [isReplaying, setIsReplaying] = useState(false);
-  const waitForReplayRender = useReplayRenderWait();
   // oxlint-disable-next-line react-hooks/rules-of-hooks -- intentional conditional/nested hook usage
+  const waitForReplayRender = useReplayRenderWait();
   const parentIdRef = useRef<string | null | undefined>(undefined);
   const commandQueue = useCommandQueue({
     onQueue: () => runManager.schedule(),

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -66,6 +66,40 @@ const convertAppendMessageToCommand = (
   };
 };
 
+/**
+ * Read `Aui-Replay-Content-Length` off the resume response and wrap
+ * `response.body` in a byte-counting passthrough that flips `replayingRef`
+ * to `false` once the consumed byte count crosses the boundary. The
+ * paired sync server (assistant-ui-sync-server) emits the header.
+ *
+ * Responses without the header short-circuit — no extra pipeline node,
+ * `replayingRef` stays `false`.
+ */
+const wrapReplayCounting = (
+  response: Response,
+  replayingRef: { current: boolean },
+): ReadableStream<Uint8Array> => {
+  const boundary = parseInt(
+    response.headers.get("Aui-Replay-Content-Length") ?? "0",
+    10,
+  );
+  if (boundary <= 0) return response.body as ReadableStream<Uint8Array>;
+
+  replayingRef.current = true;
+  let bytesConsumed = 0;
+  return response.body!.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        bytesConsumed += chunk.byteLength;
+        if (replayingRef.current && bytesConsumed > boundary) {
+          replayingRef.current = false;
+        }
+        controller.enqueue(chunk);
+      },
+    }),
+  );
+};
+
 const symbolAssistantTransportExtras = Symbol("assistant-transport-extras");
 type AssistantTransportExtras = {
   [symbolAssistantTransportExtras]: true;
@@ -187,25 +221,10 @@ const useAssistantTransportThreadRuntime = <T>(
 
       // Sync-server replay header: the first N body bytes were buffered
       // before this resume started (historical), everything after is live.
-      // Surfaced to the embedded tool-invocations tracker via `isLoading`,
-      // which gates streamCall / execute side effects.
-      const replayContentLength = parseInt(
-        response.headers.get("Aui-Replay-Content-Length") ?? "0",
-        10,
-      );
-      replayingRef.current = replayContentLength > 0;
-      if (replayingRef.current) rerender((prev) => prev + 1);
-
-      let bytesConsumed = 0;
-      const replayCounter = new TransformStream<Uint8Array, Uint8Array>({
-        transform(chunk, controller) {
-          bytesConsumed += chunk.byteLength;
-          if (replayingRef.current && bytesConsumed > replayContentLength) {
-            replayingRef.current = false;
-          }
-          controller.enqueue(chunk);
-        },
-      });
+      // Surfaced to the embedded tool-invocations tracker via `isLoading`
+      // (set on the inner adapter store below), which gates streamCall /
+      // execute side effects.
+      const body = wrapReplayCounting(response, replayingRef);
 
       // Select decoder based on protocol option
       const protocol = options.protocol ?? "data-stream";
@@ -215,21 +234,18 @@ const useAssistantTransportThreadRuntime = <T>(
           : new DataStreamDecoder();
 
       let err: string | undefined;
-      const stream = response.body
-        .pipeThrough(replayCounter)
-        .pipeThrough(decoder)
-        .pipeThrough(
-          new AssistantMessageAccumulator({
-            initialMessage: createInitialMessage({
-              unstable_state:
-                (agentStateRef.current as ReadonlyJSONValue) ?? null,
-            }),
-            throttle: isResume,
-            onError: (error) => {
-              err = error;
-            },
+      const stream = body.pipeThrough(decoder).pipeThrough(
+        new AssistantMessageAccumulator({
+          initialMessage: createInitialMessage({
+            unstable_state:
+              (agentStateRef.current as ReadonlyJSONValue) ?? null,
           }),
-        );
+          throttle: isResume,
+          onError: (error) => {
+            err = error;
+          },
+        }),
+      );
 
       let markedDelivered = false;
 

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -120,6 +120,8 @@ const useAssistantTransportThreadRuntime = <T>(
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const resumeFlagRef = useRef(false);
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
+  const replayingRef = useRef(false);
+  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const parentIdRef = useRef<string | null | undefined>(undefined);
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const commandQueue = useCommandQueue({
@@ -134,6 +136,7 @@ const useAssistantTransportThreadRuntime = <T>(
     onRun: async (signal: AbortSignal) => {
       const isResume = resumeFlagRef.current;
       resumeFlagRef.current = false;
+      replayingRef.current = false;
       const commands: QueuedCommand[] = isResume ? [] : commandQueue.flush();
       if (commands.length === 0 && !isResume)
         throw new Error("No commands to send");
@@ -189,6 +192,28 @@ const useAssistantTransportThreadRuntime = <T>(
         throw new Error("Response body is null");
       }
 
+      // Sync-server replay header: the first N body bytes were buffered
+      // before this resume started (historical), everything after is live.
+      // Surfaced to the embedded tool-invocations tracker via `isLoading`,
+      // which gates streamCall / execute side effects.
+      const replayContentLength = parseInt(
+        response.headers.get("Aui-Replay-Content-Length") ?? "0",
+        10,
+      );
+      replayingRef.current = replayContentLength > 0;
+      if (replayingRef.current) rerender((prev) => prev + 1);
+
+      let bytesConsumed = 0;
+      const replayCounter = new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, controller) {
+          bytesConsumed += chunk.byteLength;
+          if (replayingRef.current && bytesConsumed > replayContentLength) {
+            replayingRef.current = false;
+          }
+          controller.enqueue(chunk);
+        },
+      });
+
       // Select decoder based on protocol option
       const protocol = options.protocol ?? "data-stream";
       const decoder =
@@ -197,18 +222,21 @@ const useAssistantTransportThreadRuntime = <T>(
           : new DataStreamDecoder();
 
       let err: string | undefined;
-      const stream = response.body.pipeThrough(decoder).pipeThrough(
-        new AssistantMessageAccumulator({
-          initialMessage: createInitialMessage({
-            unstable_state:
-              (agentStateRef.current as ReadonlyJSONValue) ?? null,
+      const stream = response.body
+        .pipeThrough(replayCounter)
+        .pipeThrough(decoder)
+        .pipeThrough(
+          new AssistantMessageAccumulator({
+            initialMessage: createInitialMessage({
+              unstable_state:
+                (agentStateRef.current as ReadonlyJSONValue) ?? null,
+            }),
+            throttle: isResume,
+            onError: (error) => {
+              err = error;
+            },
           }),
-          throttle: isResume,
-          onError: (error) => {
-            err = error;
-          },
-        }),
-      );
+        );
 
       let markedDelivered = false;
 
@@ -299,6 +327,7 @@ const useAssistantTransportThreadRuntime = <T>(
     messages: converted.messages,
     state: converted.state,
     isRunning: converted.isRunning,
+    isLoading: replayingRef.current,
     adapters: options.adapters,
     unstable_enableToolInvocations: true,
     setToolStatuses,

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -68,31 +68,34 @@ const convertAppendMessageToCommand = (
 
 /**
  * Read `Aui-Replay-Content-Length` off the resume response and wrap
- * `response.body` in a byte-counting passthrough that flips `replayingRef`
- * to `false` once the consumed byte count crosses the boundary. The
- * paired sync server (assistant-ui-sync-server) emits the header.
+ * `response.body` in a byte-counting passthrough that flips
+ * `setReplaying` to `false` once the consumed byte count crosses the
+ * boundary. The paired sync server (assistant-ui-sync-server) emits the
+ * header.
  *
- * Responses without the header short-circuit — no extra pipeline node,
- * `replayingRef` stays `false`.
+ * Responses without (or with a malformed) header short-circuit — no
+ * extra pipeline node, replay state stays `false`.
  */
 const wrapReplayCounting = (
   response: Response,
-  replayingRef: { current: boolean },
+  setReplaying: (v: boolean) => void,
 ): ReadableStream<Uint8Array> => {
-  const boundary = parseInt(
-    response.headers.get("Aui-Replay-Content-Length") ?? "0",
-    10,
-  );
-  if (boundary <= 0) return response.body as ReadableStream<Uint8Array>;
+  const raw = response.headers.get("Aui-Replay-Content-Length");
+  const boundary = raw != null ? Number.parseInt(raw, 10) : 0;
+  if (!Number.isFinite(boundary) || boundary <= 0) {
+    return response.body as ReadableStream<Uint8Array>;
+  }
 
-  replayingRef.current = true;
+  setReplaying(true);
   let bytesConsumed = 0;
+  let flipped = false;
   return response.body!.pipeThrough(
     new TransformStream<Uint8Array, Uint8Array>({
       transform(chunk, controller) {
         bytesConsumed += chunk.byteLength;
-        if (replayingRef.current && bytesConsumed > boundary) {
-          replayingRef.current = false;
+        if (!flipped && bytesConsumed > boundary) {
+          flipped = true;
+          setReplaying(false);
         }
         controller.enqueue(chunk);
       },
@@ -153,7 +156,8 @@ const useAssistantTransportThreadRuntime = <T>(
   const [, rerender] = useState(0);
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const resumeFlagRef = useRef(false);
-  const replayingRef = useRef(false);
+  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
+  const [isReplaying, setIsReplaying] = useState(false);
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const parentIdRef = useRef<string | null | undefined>(undefined);
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
@@ -169,7 +173,7 @@ const useAssistantTransportThreadRuntime = <T>(
     onRun: async (signal: AbortSignal) => {
       const isResume = resumeFlagRef.current;
       resumeFlagRef.current = false;
-      replayingRef.current = false;
+      setIsReplaying(false);
       const commands: QueuedCommand[] = isResume ? [] : commandQueue.flush();
       if (commands.length === 0 && !isResume)
         throw new Error("No commands to send");
@@ -230,7 +234,7 @@ const useAssistantTransportThreadRuntime = <T>(
       // Surfaced to the embedded tool-invocations tracker via `isLoading`
       // (set on the inner adapter store below), which gates streamCall /
       // execute side effects.
-      const body = wrapReplayCounting(response, replayingRef);
+      const body = wrapReplayCounting(response, setIsReplaying);
 
       // Select decoder based on protocol option
       const protocol = options.protocol ?? "data-stream";
@@ -342,7 +346,7 @@ const useAssistantTransportThreadRuntime = <T>(
     messages: converted.messages,
     state: converted.state,
     isRunning: converted.isRunning,
-    isLoading: replayingRef.current,
+    isLoading: isReplaying,
     adapters: options.adapters,
     unstable_enableToolInvocations: true,
     setToolStatuses,

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -66,6 +66,40 @@ const convertAppendMessageToCommand = (
   };
 };
 
+/**
+ * Read `Aui-Replay-Content-Length` off the resume response and wrap
+ * `response.body` in a byte-counting passthrough that flips `replayingRef`
+ * to `false` once the consumed byte count crosses the boundary. The
+ * paired sync server (assistant-ui-sync-server) emits the header.
+ *
+ * Responses without the header short-circuit — no extra pipeline node,
+ * `replayingRef` stays `false`.
+ */
+const wrapReplayCounting = (
+  response: Response,
+  replayingRef: { current: boolean },
+): ReadableStream<Uint8Array> => {
+  const boundary = parseInt(
+    response.headers.get("Aui-Replay-Content-Length") ?? "0",
+    10,
+  );
+  if (boundary <= 0) return response.body as ReadableStream<Uint8Array>;
+
+  replayingRef.current = true;
+  let bytesConsumed = 0;
+  return response.body!.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        bytesConsumed += chunk.byteLength;
+        if (replayingRef.current && bytesConsumed > boundary) {
+          replayingRef.current = false;
+        }
+        controller.enqueue(chunk);
+      },
+    }),
+  );
+};
+
 const symbolAssistantTransportExtras = Symbol("assistant-transport-extras");
 type AssistantTransportExtras = {
   [symbolAssistantTransportExtras]: true;
@@ -119,7 +153,6 @@ const useAssistantTransportThreadRuntime = <T>(
   const [, rerender] = useState(0);
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const resumeFlagRef = useRef(false);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const replayingRef = useRef(false);
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const parentIdRef = useRef<string | null | undefined>(undefined);
@@ -194,25 +227,10 @@ const useAssistantTransportThreadRuntime = <T>(
 
       // Sync-server replay header: the first N body bytes were buffered
       // before this resume started (historical), everything after is live.
-      // Surfaced to the embedded tool-invocations tracker via `isLoading`,
-      // which gates streamCall / execute side effects.
-      const replayContentLength = parseInt(
-        response.headers.get("Aui-Replay-Content-Length") ?? "0",
-        10,
-      );
-      replayingRef.current = replayContentLength > 0;
-      if (replayingRef.current) rerender((prev) => prev + 1);
-
-      let bytesConsumed = 0;
-      const replayCounter = new TransformStream<Uint8Array, Uint8Array>({
-        transform(chunk, controller) {
-          bytesConsumed += chunk.byteLength;
-          if (replayingRef.current && bytesConsumed > replayContentLength) {
-            replayingRef.current = false;
-          }
-          controller.enqueue(chunk);
-        },
-      });
+      // Surfaced to the embedded tool-invocations tracker via `isLoading`
+      // (set on the inner adapter store below), which gates streamCall /
+      // execute side effects.
+      const body = wrapReplayCounting(response, replayingRef);
 
       // Select decoder based on protocol option
       const protocol = options.protocol ?? "data-stream";
@@ -222,21 +240,18 @@ const useAssistantTransportThreadRuntime = <T>(
           : new DataStreamDecoder();
 
       let err: string | undefined;
-      const stream = response.body
-        .pipeThrough(replayCounter)
-        .pipeThrough(decoder)
-        .pipeThrough(
-          new AssistantMessageAccumulator({
-            initialMessage: createInitialMessage({
-              unstable_state:
-                (agentStateRef.current as ReadonlyJSONValue) ?? null,
-            }),
-            throttle: isResume,
-            onError: (error) => {
-              err = error;
-            },
+      const stream = body.pipeThrough(decoder).pipeThrough(
+        new AssistantMessageAccumulator({
+          initialMessage: createInitialMessage({
+            unstable_state:
+              (agentStateRef.current as ReadonlyJSONValue) ?? null,
           }),
-        );
+          throttle: isResume,
+          onError: (error) => {
+            err = error;
+          },
+        }),
+      );
 
       let markedDelivered = false;
 

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -277,6 +277,7 @@ const useAssistantTransportThreadRuntime = <T>(
     },
     onFinish: options.onFinish,
     onCancel: () => {
+      setIsReplaying(false);
       const cmds = [
         ...commandQueue.state.inTransit,
         ...commandQueue.state.queued,
@@ -293,6 +294,7 @@ const useAssistantTransportThreadRuntime = <T>(
       });
     },
     onError: async (error) => {
+      setIsReplaying(false);
       const inTransitCmds = [...commandQueue.state.inTransit];
       const queuedCmds = [...commandQueue.state.queued];
 


### PR DESCRIPTION
## Summary

Pairs with sync-server commit `bdf7f9c` (assistant-ui-sync-server) which emits an `Aui-Replay-Content-Length` response header on resume. The header carries the byte count buffered when the resume started; the bytes before it are historical replay, everything after is live.

`useAssistantTransportRuntime` now:

- Reads the header off the resume response.
- Wraps `response.body` in a byte-counting passthrough that flips a `replayingRef` to `false` once the consumed byte count crosses the boundary.
- Reports `isLoading: replayingRef.current` to the inner `useExternalStoreRuntime` adapter. The embedded tool-invocations tracker already treats snapshots received while `isLoading` is true as historical (state is applied, `streamCall` / `execute` are *not* invoked), so frontend tool side effects no longer re-fire when reconnecting to a buffered run.

Responses without the header short-circuit — no extra pipeline node, `replayingRef` stays `false`, behaviour matches today.

See `assistant-ui-sync-server@bdf7f9c` for the server-side spec text.

## Test plan

- [x] `pnpm --filter @assistant-ui/react build` clean
- [x] `pnpm --filter @assistant-ui/react test` 320 pass
- [x] `pnpm lint` clean
- [ ] Manual: paired sync-server build, reconnect to a thread mid-run, confirm tool `streamCall` handlers fire exactly once for live calls and not at all for replayed calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)