### PR TITLE
feat: forward per-tool providerOptions and stabilize tool order

### DIFF
--- a/.changeset/tool-provider-options.md
+++ b/.changeset/tool-provider-options.md
@@ -1,0 +1,19 @@
+---
+"assistant-stream": patch
+"@assistant-ui/react-ai-sdk": patch
+---
+
+forward per-tool `providerOptions` from `useAssistantTool` through `toToolsJSONSchema` and `frontendTools` into the AI SDK request body, and emit tool entries in alphabetical order so identical tool sets produce byte-identical request bodies for stable prompt caching.
+
+this lets you opt into provider-specific tool features (e.g. Anthropic's `defer_loading`, Anthropic Tool Search Tool) without any provider-aware code in assistant-ui:
+
+```ts
+useAssistantTool({
+  toolName: "get_weather",
+  parameters: schema,
+  providerOptions: { anthropic: { deferLoading: true } },
+  execute: async ({ city }) => fetchWeather(city),
+});
+```
+
+the value is passed through verbatim; the AI SDK provider (`@ai-sdk/anthropic`, `@ai-sdk/openai`, ...) interprets it.

--- a/.changeset/tool-provider-options.md
+++ b/.changeset/tool-provider-options.md
@@ -1,9 +1,10 @@
 ---
 "assistant-stream": patch
 "@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-ag-ui": patch
 ---
 
-forward per-tool `providerOptions` from `useAssistantTool` through `toToolsJSONSchema` and `frontendTools` into the AI SDK request body, and emit tool entries in alphabetical order so identical tool sets produce byte-identical request bodies for stable prompt caching.
+forward per-tool `providerOptions` from `useAssistantTool` through `toToolsJSONSchema` and `frontendTools` into the AI SDK request body, and emit tool entries in alphabetical order so identical tool sets produce byte-identical request bodies for stable prompt caching. `react-ag-ui` inherits the sort via `toAgUiTools`, so identical tool sets reach the AG-UI runtime in a stable order regardless of mount order.
 
 this lets you opt into provider-specific tool features (e.g. Anthropic's `defer_loading`, Anthropic Tool Search Tool) without any provider-aware code in assistant-ui:
 

--- a/apps/docs/content/docs/guides/tools.mdx
+++ b/apps/docs/content/docs/guides/tools.mdx
@@ -599,6 +599,32 @@ export async function POST(req: Request) {
 }
 ```
 
+### Per-tool Provider Options
+
+Every tool definition accepts an optional `providerOptions` field. assistant-ui does not interpret the value; it serializes it under the tool entry verbatim, the AI SDK route handler forwards it via `frontendTools(...)`, and the provider SDK reads the keys it cares about. This is how you opt into provider-specific tool behaviors (such as Anthropic's `defer_loading` for progressive tool disclosure on large catalogs) without adding any provider-aware code to assistant-ui itself.
+
+```tsx
+// Frontend: declare provider-specific metadata next to the tool.
+useAssistantTool({
+  toolName: "searchDocs",
+  description: "Search the documentation index.",
+  parameters: z.object({ query: z.string() }),
+  providerOptions: {
+    anthropic: { deferLoading: true },
+  },
+  execute: async ({ query }) => searchIndex(query),
+});
+```
+
+The same field is available on toolkit entries used with `Tools({ toolkit })` and on `makeAssistantTool`. The outer key is the provider name (`anthropic`, `openai`, ...); the inner object is whatever the provider's AI SDK package expects under `tool.providerOptions[<provider>]`. Refer to the provider's package docs for the exact shape and for any companion entries you may need in your route handler (for example, Anthropic exposes Tool Search Tool factories on the `anthropic.tools` namespace; see the [`@ai-sdk/anthropic` documentation](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic) for the current API).
+
+<Callout type="info">
+  `toToolsJSONSchema` emits tool entries in alphabetical order by name. Two
+  renders that register the same tool set in different orders produce
+  byte-identical request bodies, which keeps provider prompt caches stable
+  across renders.
+</Callout>
+
 ### MCP (Model Context Protocol) Tools
 
 Integration with MCP servers using AI SDK's experimental MCP support:

--- a/packages/assistant-stream/src/core/tool/schema-utils.test.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.test.ts
@@ -430,6 +430,62 @@ describe("toToolsJSONSchema", () => {
         properties: { converted: { type: "boolean" } },
       });
     });
+
+    it("forwards providerOptions verbatim when present", () => {
+      const tools: Record<string, Tool> = {
+        myTool: {
+          description: "Test",
+          parameters: { type: "object", properties: {} },
+          providerOptions: { anthropic: { deferLoading: true } },
+        },
+      };
+
+      const result = toToolsJSONSchema(tools);
+      expect(result.myTool).toEqual({
+        description: "Test",
+        parameters: { type: "object", properties: {} },
+        providerOptions: { anthropic: { deferLoading: true } },
+      });
+    });
+
+    it("omits providerOptions when absent", () => {
+      const tools: Record<string, Tool> = {
+        myTool: {
+          parameters: { type: "object", properties: {} },
+        },
+      };
+
+      const result = toToolsJSONSchema(tools);
+      expect(result.myTool).not.toHaveProperty("providerOptions");
+    });
+  });
+
+  describe("stable ordering", () => {
+    it("emits tool names in alphabetical order", () => {
+      const tools: Record<string, Tool> = {
+        zebra: { parameters: { type: "object", properties: {} } },
+        apple: { parameters: { type: "object", properties: {} } },
+        mango: { parameters: { type: "object", properties: {} } },
+      };
+
+      const result = toToolsJSONSchema(tools);
+      expect(Object.keys(result)).toEqual(["apple", "mango", "zebra"]);
+    });
+
+    it("produces byte-identical output regardless of insertion order", () => {
+      const a: Record<string, Tool> = {
+        zebra: { parameters: { type: "object", properties: {} } },
+        apple: { parameters: { type: "object", properties: {} } },
+      };
+      const b: Record<string, Tool> = {
+        apple: { parameters: { type: "object", properties: {} } },
+        zebra: { parameters: { type: "object", properties: {} } },
+      };
+
+      expect(JSON.stringify(toToolsJSONSchema(a))).toBe(
+        JSON.stringify(toToolsJSONSchema(b)),
+      );
+    });
   });
 
   describe("edge cases", () => {

--- a/packages/assistant-stream/src/core/tool/schema-utils.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.ts
@@ -153,7 +153,7 @@ export function toToolsJSONSchema(
   return Object.fromEntries(
     Object.entries(tools)
       .filter(([name, tool]) => filter(name, tool) && tool.parameters)
-      .sort(([a], [b]) => a.localeCompare(b))
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
       .map(([name, tool]) => [
         name,
         {

--- a/packages/assistant-stream/src/core/tool/schema-utils.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema7 } from "json-schema";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import type { Tool } from "./tool-types";
+import type { ProviderOptions, Tool } from "./tool-types";
 
 /**
  * Type for a tool definition with JSON Schema parameters.
@@ -8,7 +8,7 @@ import type { Tool } from "./tool-types";
 export type ToolJSONSchema = {
   description?: string;
   parameters: JSONSchema7;
-  providerOptions?: Record<string, Record<string, unknown>>;
+  providerOptions?: ProviderOptions;
 };
 
 export type ToToolsJSONSchemaOptions = {
@@ -153,7 +153,7 @@ export function toToolsJSONSchema(
   return Object.fromEntries(
     Object.entries(tools)
       .filter(([name, tool]) => filter(name, tool) && tool.parameters)
-      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .sort(([a], [b]) => a.localeCompare(b))
       .map(([name, tool]) => [
         name,
         {

--- a/packages/assistant-stream/src/core/tool/schema-utils.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.ts
@@ -8,6 +8,7 @@ import type { Tool } from "./tool-types";
 export type ToolJSONSchema = {
   description?: string;
   parameters: JSONSchema7;
+  providerOptions?: Record<string, Record<string, unknown>>;
 };
 
 export type ToToolsJSONSchemaOptions = {
@@ -135,6 +136,11 @@ function defaultToolFilter(_name: string, tool: Tool): boolean {
 /**
  * Converts a record of tools to a record of tool definitions with JSON Schema parameters.
  * By default, filters out disabled tools and backend tools.
+ *
+ * Entries are emitted in alphabetical order so the resulting request body is
+ * byte-identical regardless of the order in which tools were registered. This
+ * keeps provider prompt caches stable across renders that mount tools in
+ * different orders.
  */
 export function toToolsJSONSchema(
   tools: Record<string, Tool> | undefined,
@@ -147,11 +153,15 @@ export function toToolsJSONSchema(
   return Object.fromEntries(
     Object.entries(tools)
       .filter(([name, tool]) => filter(name, tool) && tool.parameters)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
       .map(([name, tool]) => [
         name,
         {
           ...(tool.description && { description: tool.description }),
           parameters: toJSONSchema(tool.parameters!),
+          ...(tool.providerOptions && {
+            providerOptions: tool.providerOptions,
+          }),
         },
       ]),
   );

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -169,10 +169,16 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<
 >;
 
 /**
- * Per-provider metadata attached to a tool and forwarded into the wire
- * request body verbatim. The outer key is the provider name (`anthropic`,
- * `openai`, ...); the inner object is whatever shape that provider's SDK
- * expects under `tool.providerOptions[providerName]`.
+ * Per-provider metadata forwarded into the wire request body verbatim.
+ * assistant-ui does not interpret these values; downstream adapters (AI SDK,
+ * custom routes) pass them to the model provider as-is.
+ *
+ * The outer key is the provider name (`anthropic`, `openai`, ...); the inner
+ * object is whatever shape that provider's SDK expects under
+ * `tool.providerOptions[providerName]`. Use this to enable provider-specific
+ * tool behaviors such as Anthropic's `defer_loading`
+ * (`{ anthropic: { deferLoading: true } }`) without adding provider-aware
+ * code in assistant-ui.
  */
 export type ProviderOptions = Record<string, Record<string, unknown>>;
 
@@ -184,20 +190,6 @@ type ToolBase<
    * @deprecated Experimental, API may change.
    */
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-};
-
-/**
- * Per-provider metadata forwarded into the wire request body. assistant-ui
- * does not interpret these values; it serializes them under each tool so
- * downstream adapters (AI SDK, custom routes) can pass them to the model
- * provider verbatim.
- *
- * Use this to enable provider-specific tool behaviors such as Anthropic's
- * `defer_loading` (set `{ anthropic: { deferLoading: true } }`) without
- * adding provider-aware code in assistant-ui.
- */
-type WireTool = {
-  providerOptions?: ProviderOptions;
 };
 
 type BackendTool<
@@ -219,43 +211,43 @@ type BackendTool<
 type FrontendTool<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
-> = ToolBase<TArgs, TResult> &
-  WireTool & {
-    /** Tool that is executed in the frontend runtime. */
-    type: "frontend";
+> = ToolBase<TArgs, TResult> & {
+  /** Tool that is executed in the frontend runtime. */
+  type: "frontend";
 
-    /** Natural-language description shown to the model when selecting tools. */
-    description?: string | undefined;
-    /** Schema for the arguments the model must provide when calling the tool. */
-    parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-    /** Prevents the tool from being exposed to the model while true. */
-    disabled?: boolean;
-    /** Executes the tool after the model provides valid arguments. */
-    execute: ToolExecuteFunction<TArgs, TResult>;
-    /** Converts the execution result into model-visible output. */
-    toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-    /** Handles invalid tool arguments when schema validation fails. */
-    experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  };
+  /** Natural-language description shown to the model when selecting tools. */
+  description?: string | undefined;
+  /** Schema for the arguments the model must provide when calling the tool. */
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  /** Prevents the tool from being exposed to the model while true. */
+  disabled?: boolean;
+  /** Executes the tool after the model provides valid arguments. */
+  execute: ToolExecuteFunction<TArgs, TResult>;
+  /** Converts the execution result into model-visible output. */
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  /** Handles invalid tool arguments when schema validation fails. */
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
 
 type HumanTool<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
-> = ToolBase<TArgs, TResult> &
-  WireTool & {
-    /** Tool that pauses the run until a user or UI supplies a result. */
-    type: "human";
+> = ToolBase<TArgs, TResult> & {
+  /** Tool that pauses the run until a user or UI supplies a result. */
+  type: "human";
 
-    /** Natural-language description shown to the model when selecting tools. */
-    description?: string | undefined;
-    /** Schema for the arguments the model must provide when requesting input. */
-    parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-    /** Prevents the tool from being exposed to the model while true. */
-    disabled?: boolean;
-    execute?: undefined;
-    toModelOutput?: undefined;
-    experimental_onSchemaValidationError?: undefined;
-  };
+  /** Natural-language description shown to the model when selecting tools. */
+  description?: string | undefined;
+  /** Schema for the arguments the model must provide when requesting input. */
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  /** Prevents the tool from being exposed to the model while true. */
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
 
 /**
  * Definition for a tool that can be exposed to the assistant model.

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -168,6 +168,14 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<
   TResult
 >;
 
+/**
+ * Per-provider metadata attached to a tool and forwarded into the wire
+ * request body verbatim. The outer key is the provider name (`anthropic`,
+ * `openai`, ...); the inner object is whatever shape that provider's SDK
+ * expects under `tool.providerOptions[providerName]`.
+ */
+export type ProviderOptions = Record<string, Record<string, unknown>>;
+
 type ToolBase<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
@@ -186,7 +194,7 @@ type ToolBase<
    * `defer_loading` (set `{ anthropic: { deferLoading: true } }`) without
    * adding provider-aware code in assistant-ui.
    */
-  providerOptions?: Record<string, Record<string, unknown>>;
+  providerOptions?: ProviderOptions;
 };
 
 type BackendTool<

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -184,16 +184,19 @@ type ToolBase<
    * @deprecated Experimental, API may change.
    */
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  /**
-   * Per-provider metadata forwarded into the wire request body. assistant-ui
-   * does not interpret these values; it serializes them under each tool so
-   * downstream adapters (AI SDK, custom routes) can pass them to the model
-   * provider verbatim.
-   *
-   * Use this to enable provider-specific tool behaviors such as Anthropic's
-   * `defer_loading` (set `{ anthropic: { deferLoading: true } }`) without
-   * adding provider-aware code in assistant-ui.
-   */
+};
+
+/**
+ * Per-provider metadata forwarded into the wire request body. assistant-ui
+ * does not interpret these values; it serializes them under each tool so
+ * downstream adapters (AI SDK, custom routes) can pass them to the model
+ * provider verbatim.
+ *
+ * Use this to enable provider-specific tool behaviors such as Anthropic's
+ * `defer_loading` (set `{ anthropic: { deferLoading: true } }`) without
+ * adding provider-aware code in assistant-ui.
+ */
+type WireTool = {
   providerOptions?: ProviderOptions;
 };
 
@@ -210,46 +213,49 @@ type BackendTool<
   execute?: undefined;
   toModelOutput?: undefined;
   experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
 };
 
 type FrontendTool<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
-> = ToolBase<TArgs, TResult> & {
-  /** Tool that is executed in the frontend runtime. */
-  type: "frontend";
+> = ToolBase<TArgs, TResult> &
+  WireTool & {
+    /** Tool that is executed in the frontend runtime. */
+    type: "frontend";
 
-  /** Natural-language description shown to the model when selecting tools. */
-  description?: string | undefined;
-  /** Schema for the arguments the model must provide when calling the tool. */
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  /** Prevents the tool from being exposed to the model while true. */
-  disabled?: boolean;
-  /** Executes the tool after the model provides valid arguments. */
-  execute: ToolExecuteFunction<TArgs, TResult>;
-  /** Converts the execution result into model-visible output. */
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  /** Handles invalid tool arguments when schema validation fails. */
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-};
+    /** Natural-language description shown to the model when selecting tools. */
+    description?: string | undefined;
+    /** Schema for the arguments the model must provide when calling the tool. */
+    parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+    /** Prevents the tool from being exposed to the model while true. */
+    disabled?: boolean;
+    /** Executes the tool after the model provides valid arguments. */
+    execute: ToolExecuteFunction<TArgs, TResult>;
+    /** Converts the execution result into model-visible output. */
+    toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+    /** Handles invalid tool arguments when schema validation fails. */
+    experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  };
 
 type HumanTool<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
-> = ToolBase<TArgs, TResult> & {
-  /** Tool that pauses the run until a user or UI supplies a result. */
-  type: "human";
+> = ToolBase<TArgs, TResult> &
+  WireTool & {
+    /** Tool that pauses the run until a user or UI supplies a result. */
+    type: "human";
 
-  /** Natural-language description shown to the model when selecting tools. */
-  description?: string | undefined;
-  /** Schema for the arguments the model must provide when requesting input. */
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  /** Prevents the tool from being exposed to the model while true. */
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-};
+    /** Natural-language description shown to the model when selecting tools. */
+    description?: string | undefined;
+    /** Schema for the arguments the model must provide when requesting input. */
+    parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+    /** Prevents the tool from being exposed to the model while true. */
+    disabled?: boolean;
+    execute?: undefined;
+    toModelOutput?: undefined;
+    experimental_onSchemaValidationError?: undefined;
+  };
 
 /**
  * Definition for a tool that can be exposed to the assistant model.

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -176,6 +176,17 @@ type ToolBase<
    * @deprecated Experimental, API may change.
    */
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  /**
+   * Per-provider metadata forwarded into the wire request body. assistant-ui
+   * does not interpret these values; it serializes them under each tool so
+   * downstream adapters (AI SDK, custom routes) can pass them to the model
+   * provider verbatim.
+   *
+   * Use this to enable provider-specific tool behaviors such as Anthropic's
+   * `defer_loading` (set `{ anthropic: { deferLoading: true } }`) without
+   * adding provider-aware code in assistant-ui.
+   */
+  providerOptions?: Record<string, Record<string, unknown>>;
 };
 
 type BackendTool<

--- a/packages/assistant-stream/src/index.ts
+++ b/packages/assistant-stream/src/index.ts
@@ -42,7 +42,7 @@ export type {
 } from "./core/tool/tool-types";
 export { ToolResponse, type ToolResponseLike } from "./core/tool/ToolResponse";
 export { ToolExecutionStream } from "./core/tool/ToolExecutionStream";
-export type { ToolCallReader } from "./core/tool/tool-types";
+export type { ProviderOptions, ToolCallReader } from "./core/tool/tool-types";
 export {
   toolResultStream as unstable_toolResultStream,
   unstable_runPendingTools,

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -191,23 +191,26 @@ describe("adapter conversions", () => {
       plain: { parameters: { type: "boolean" } },
     });
 
-    expect(tools).toEqual([
-      {
-        name: "jsonTool",
-        description: undefined,
-        parameters: { type: "object" },
-      },
-      {
-        name: "schemaTool",
-        description: undefined,
-        parameters: { type: "string" },
-      },
-      {
-        name: "plain",
-        description: undefined,
-        parameters: { type: "boolean" },
-      },
-    ]);
+    expect(tools).toHaveLength(3);
+    expect(tools).toEqual(
+      expect.arrayContaining([
+        {
+          name: "jsonTool",
+          description: undefined,
+          parameters: { type: "object" },
+        },
+        {
+          name: "schemaTool",
+          description: undefined,
+          parameters: { type: "string" },
+        },
+        {
+          name: "plain",
+          description: undefined,
+          parameters: { type: "boolean" },
+        },
+      ]),
+    );
   });
 
   it("preserves tool message ID through round-trip conversion", () => {

--- a/packages/react-ai-sdk/src/frontendTools.test.ts
+++ b/packages/react-ai-sdk/src/frontendTools.test.ts
@@ -135,9 +135,9 @@ describe("frontendTools", () => {
       },
     });
 
-    expect(
-      (tools.getWeather as { providerOptions?: unknown })?.providerOptions,
-    ).toEqual({ anthropic: { deferLoading: true } });
+    expect(tools.getWeather?.providerOptions).toEqual({
+      anthropic: { deferLoading: true },
+    });
   });
 
   it("omits providerOptions when absent", () => {

--- a/packages/react-ai-sdk/src/frontendTools.test.ts
+++ b/packages/react-ai-sdk/src/frontendTools.test.ts
@@ -125,4 +125,28 @@ describe("frontendTools", () => {
 
     expect(output).toEqual({ type: "text", value: "hello" });
   });
+
+  it("forwards providerOptions verbatim when present", () => {
+    const tools = frontendTools({
+      getWeather: {
+        description: "Get the weather",
+        parameters: { type: "object", properties: {} },
+        providerOptions: { anthropic: { deferLoading: true } },
+      },
+    });
+
+    expect(
+      (tools.getWeather as { providerOptions?: unknown })?.providerOptions,
+    ).toEqual({ anthropic: { deferLoading: true } });
+  });
+
+  it("omits providerOptions when absent", () => {
+    const tools = frontendTools({
+      getWeather: {
+        parameters: { type: "object", properties: {} },
+      },
+    });
+
+    expect(tools.getWeather).not.toHaveProperty("providerOptions");
+  });
 });

--- a/packages/react-ai-sdk/src/frontendTools.ts
+++ b/packages/react-ai-sdk/src/frontendTools.ts
@@ -1,6 +1,5 @@
 import { jsonSchema, type ToolSet } from "ai";
-import type { JSONSchema7 } from "json-schema";
-import type { ToolModelContentPart } from "assistant-stream";
+import type { ToolJSONSchema, ToolModelContentPart } from "assistant-stream";
 import { unwrapModelContentEnvelope } from "./modelContentEnvelope";
 
 const toAISDKContent = (parts: readonly ToolModelContentPart[]) => ({
@@ -35,16 +34,7 @@ const defaultToModelOutput = ({ output }: { output: unknown }) => {
     : { type: "json" as const, value: (output ?? null) as any };
 };
 
-export const frontendTools = (
-  tools: Record<
-    string,
-    {
-      description?: string;
-      parameters: JSONSchema7;
-      providerOptions?: Record<string, Record<string, unknown>>;
-    }
-  >,
-): ToolSet =>
+export const frontendTools = (tools: Record<string, ToolJSONSchema>): ToolSet =>
   Object.fromEntries(
     Object.entries(tools).map(([name, t]) => [
       name,

--- a/packages/react-ai-sdk/src/frontendTools.ts
+++ b/packages/react-ai-sdk/src/frontendTools.ts
@@ -36,7 +36,14 @@ const defaultToModelOutput = ({ output }: { output: unknown }) => {
 };
 
 export const frontendTools = (
-  tools: Record<string, { description?: string; parameters: JSONSchema7 }>,
+  tools: Record<
+    string,
+    {
+      description?: string;
+      parameters: JSONSchema7;
+      providerOptions?: Record<string, Record<string, unknown>>;
+    }
+  >,
 ): ToolSet =>
   Object.fromEntries(
     Object.entries(tools).map(([name, t]) => [
@@ -45,6 +52,7 @@ export const frontendTools = (
         ...(t.description !== undefined && { description: t.description }),
         inputSchema: jsonSchema(t.parameters),
         toModelOutput: defaultToModelOutput,
+        ...(t.providerOptions && { providerOptions: t.providerOptions }),
       },
     ]),
   ) as ToolSet;


### PR DESCRIPTION
## summary

- adds an optional `providerOptions` field on `useAssistantTool` that is passed through `toToolsJSONSchema` and `frontendTools` into the AI SDK `ToolSet`. users can opt into provider-specific tool features (Anthropic's `defer_loading`, OpenAI's `tool_search`, etc) without any provider-aware code in assistant-ui.
- `@ai-sdk/anthropic` already reads `tool.providerOptions.anthropic.deferLoading` and handles the wire payload, beta header, and Tool Search Tool entry on its own. this PR just opens the pipe.
- `toToolsJSONSchema` now emits tool names in alphabetical order so identical tool sets produce byte-identical request bodies regardless of mount order, keeping provider prompt caches stable.

## test plan

### already verified

- [x] `npx vitest run` in `packages/assistant-stream` -> 232 passed, 20 skipped.
- [x] `npx vitest run` in `packages/react-ai-sdk` -> 46 passed across 5 files.
- [x] `npx vitest run` in `packages/react-ag-ui` -> 102 passed.
- [x] `tsc --noEmit` clean on `assistant-stream`, `@assistant-ui/core`, `@assistant-ui/react-ai-sdk`.
- [x] `pnpm turbo build --filter="./packages/*"` -> 33/33 successful.

### reviewer should verify

- [ ] end-to-end check against `@ai-sdk/anthropic` claude-sonnet-4-5: register a tool with `providerOptions: { anthropic: { deferLoading: true } }`, add `anthropic.tools.toolSearchBm25_20251119()` in the route handler. confirm `defer_loading: true` and the `anthropic-beta` header land in the outbound request and that a second turn hits the prompt cache.

## notes

- minimal alternative to #4092, which targeted the same goal (cache-safe progressive tool disclosure) but reimplemented 90% of what `@ai-sdk/anthropic` already does (`AnthropicToolOptions`, `tool-search-bm25_20251119`, beta header management) inside assistant-ui. this PR keeps wire format, provider auto-detection, dated identifiers, and beta headers out of assistant-ui's API surface and lets the AI SDK provider own them. roughly 130 lines vs roughly 2300, no new abstractions, no `deferredTools` slot, no wrapper tools, no `ToolWireFormatAdapter`, no `mergeDeferredToolsWithWarning`.