### PR TITLE
feat: align shared adapter options across runtime wrapper hooks

### DIFF
--- a/.changeset/runtime-wrapper-shared-options.md
+++ b/.changeset/runtime-wrapper-shared-options.md
@@ -1,0 +1,26 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/react-a2a": patch
+"@assistant-ui/react-ag-ui": patch
+"@assistant-ui/react-google-adk": patch
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-opencode": patch
+---
+
+align the runtime wrapper hooks so every distribution forwards the same set of optional adapter-level fields to `useExternalStoreRuntime`. closes #4134.
+
+new options on `useChatRuntime`, `useAISDKRuntime`, `useLangGraphRuntime`, `useA2ARuntime`, `useAgUiRuntime`, `useAdkRuntime`, `useStreamRuntime`, `useOpenCodeRuntime`:
+
+- `isDisabled` — disables the composer input entirely.
+- `isSendDisabled` — keeps the input usable but makes `send()` a no-op (paired with `composer.canSend`).
+- `unstable_capabilities` — per-thread capability overrides (currently `{ copy?: boolean }`).
+- `suggestions` — follow-up suggestions list, flows into `thread.suggestions`.
+
+adapter-level additions, where missing:
+
+- `useChatRuntime` / `useAISDKRuntime` already accepted `dictation` and `voice` through the `ExternalStoreAdapter` adapter shape; this just confirms the typing.
+- `useLangGraphRuntime`, `useA2ARuntime`, `useAgUiRuntime`, `useAdkRuntime`, `useStreamRuntime`, `useOpenCodeRuntime` now accept `dictation` and `voice` in their `adapters` object and forward them through.
+- `useOpenCodeRuntime` gains an `adapters` option for the first time (attachments / speech / dictation / voice / feedback).
+
+every new field is optional and defaults to the prior behavior, so existing call sites need no changes.

--- a/.changeset/runtime-wrapper-shared-options.md
+++ b/.changeset/runtime-wrapper-shared-options.md
@@ -10,12 +10,13 @@
 
 align the runtime wrapper hooks so every distribution forwards the same set of optional adapter-level fields to `useExternalStoreRuntime`. closes #4134.
 
-new options on `useChatRuntime`, `useAISDKRuntime`, `useLangGraphRuntime`, `useA2ARuntime`, `useAgUiRuntime`, `useAdkRuntime`, `useStreamRuntime`, `useOpenCodeRuntime`:
+`useChatRuntime` and `useAISDKRuntime` (which already accepted `suggestions`) gain three new options:
 
-- `isDisabled` — disables the composer input entirely.
-- `isSendDisabled` — keeps the input usable but makes `send()` a no-op (paired with `composer.canSend`).
-- `unstable_capabilities` — per-thread capability overrides (currently `{ copy?: boolean }`).
-- `suggestions` — follow-up suggestions list, flows into `thread.suggestions`.
+- `isDisabled`, disables the composer input entirely.
+- `isSendDisabled`, keeps the input usable but makes `send()` a no-op (paired with `composer.canSend`).
+- `unstable_capabilities`, per-thread capability overrides (currently `{ copy?: boolean }`).
+
+`useLangGraphRuntime`, `useA2ARuntime`, `useAgUiRuntime`, `useAdkRuntime`, `useStreamRuntime`, `useOpenCodeRuntime` gain all four (the three above plus `suggestions`).
 
 adapter-level additions, where missing:
 

--- a/packages/react-a2a/src/useA2ARuntime.ts
+++ b/packages/react-a2a/src/useA2ARuntime.ts
@@ -9,11 +9,14 @@ import type {
   AssistantRuntime,
   AppendMessage,
   AttachmentAdapter,
+  DictationAdapter,
   ExternalStoreAdapter,
   FeedbackAdapter,
+  RealtimeVoiceAdapter,
   SpeechSynthesisAdapter,
   ThreadHistoryAdapter,
   ThreadMessage,
+  ThreadSuggestion,
 } from "@assistant-ui/core";
 import { useAuiState } from "@assistant-ui/store";
 import { A2AClient } from "./A2AClient";
@@ -104,10 +107,31 @@ export type UseA2ARuntimeOptions = {
   adapters?: {
     attachments?: AttachmentAdapter;
     speech?: SpeechSynthesisAdapter;
+    dictation?: DictationAdapter;
+    voice?: RealtimeVoiceAdapter;
     feedback?: FeedbackAdapter;
     history?: ThreadHistoryAdapter;
     threadList?: UseA2AThreadListAdapter;
   };
+  /**
+   * Whether the entire thread is disabled. When `true`, the composer's input
+   * is also disabled. For a narrower gate that keeps the input usable but
+   * blocks only sending, use `isSendDisabled`.
+   */
+  isDisabled?: boolean | undefined;
+  /**
+   * Whether sending new messages is currently disabled. The input stays
+   * usable but `send()` becomes a no-op and `composer.canSend` is `false`.
+   */
+  isSendDisabled?: boolean | undefined;
+  /**
+   * Optional thread capability overrides.
+   */
+  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
+  /**
+   * Follow up suggestions to surface on the thread.
+   */
+  suggestions?: readonly ThreadSuggestion[] | undefined;
 };
 
 // --- Main hook ---
@@ -197,6 +221,8 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
     () => ({
       attachments: adapters?.attachments ?? runtimeAdapters?.attachments,
       speech: adapters?.speech,
+      dictation: adapters?.dictation,
+      voice: adapters?.voice,
       feedback: adapters?.feedback,
       threadList,
     }),
@@ -204,6 +230,10 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
   );
 
   // Build store adapter
+  const isDisabled = options.isDisabled;
+  const isSendDisabled = options.isSendDisabled;
+  const unstable_capabilities = options.unstable_capabilities;
+  const suggestions = options.suggestions;
   const store = useMemo(() => {
     void _version;
 
@@ -211,6 +241,10 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
       isLoading: core.isLoading,
       messages: core.getMessages(),
       isRunning: core.isRunning(),
+      ...(isDisabled !== undefined && { isDisabled }),
+      ...(isSendDisabled !== undefined && { isSendDisabled }),
+      ...(unstable_capabilities && { unstable_capabilities }),
+      ...(suggestions && { suggestions }),
       extras: {
         [symbolA2AExtras]: true,
         task: core.getTask(),
@@ -227,7 +261,15 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
         core.applyExternalMessages(messages),
       adapters: adapterAdapters,
     } satisfies ExternalStoreAdapter<ThreadMessage>;
-  }, [adapterAdapters, core, _version]);
+  }, [
+    adapterAdapters,
+    core,
+    _version,
+    isDisabled,
+    isSendDisabled,
+    unstable_capabilities,
+    suggestions,
+  ]);
 
   const runtime = useExternalStoreRuntime(store);
 

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -1,10 +1,13 @@
 import type {
   AttachmentAdapter,
   DictationAdapter,
+  ExternalStoreAdapter,
   FeedbackAdapter,
+  RealtimeVoiceAdapter,
   SpeechSynthesisAdapter,
   ThreadHistoryAdapter,
   ThreadMessage,
+  ThreadSuggestion,
 } from "@assistant-ui/core";
 import type { HttpAgent } from "@ag-ui/client";
 import type { Logger } from "./logger";
@@ -30,6 +33,7 @@ export type UseAgUiRuntimeAdapters = {
   attachments?: AttachmentAdapter;
   speech?: SpeechSynthesisAdapter;
   dictation?: DictationAdapter;
+  voice?: RealtimeVoiceAdapter;
   feedback?: FeedbackAdapter;
   history?: ThreadHistoryAdapter;
   /**
@@ -45,6 +49,24 @@ export type UseAgUiRuntimeOptions = {
   onError?: (e: Error) => void;
   onCancel?: () => void;
   adapters?: UseAgUiRuntimeAdapters;
+  /**
+   * Whether the entire thread is disabled. When `true`, the composer's input
+   * is also disabled. For a narrower gate that keeps the input usable but
+   * blocks only sending, use `isSendDisabled`.
+   */
+  isDisabled?: boolean | undefined;
+  /**
+   * Whether sending new messages is currently disabled.
+   */
+  isSendDisabled?: boolean | undefined;
+  /**
+   * Optional thread capability overrides.
+   */
+  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
+  /**
+   * Follow up suggestions to surface on the thread.
+   */
+  suggestions?: readonly ThreadSuggestion[] | undefined;
 };
 
 export type AgUiInterruptReason =

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -101,12 +101,17 @@ export function useAgUiRuntime(
       attachments: adapters?.attachments ?? runtimeAdapters?.attachments,
       speech: adapters?.speech,
       dictation: adapters?.dictation,
+      voice: adapters?.voice,
       feedback: adapters?.feedback,
       threadList,
     }),
     [adapters, runtimeAdapters, threadList],
   );
 
+  const isDisabled = options.isDisabled;
+  const isSendDisabled = options.isSendDisabled;
+  const unstable_capabilities = options.unstable_capabilities;
+  const suggestions = options.suggestions;
   const store = useMemo(
     () => {
       void _version; // rerender on version change
@@ -116,6 +121,10 @@ export function useAgUiRuntime(
         messages: core.getMessages(),
         state: core.getState(),
         isRunning: core.isRunning() || hasExecutingTools,
+        ...(isDisabled !== undefined && { isDisabled }),
+        ...(isSendDisabled !== undefined && { isSendDisabled }),
+        ...(unstable_capabilities && { unstable_capabilities }),
+        ...(suggestions && { suggestions }),
         unstable_enableToolInvocations: true,
         setToolStatuses,
         onNew: (message: AppendMessage) => core.append(message),
@@ -138,7 +147,16 @@ export function useAgUiRuntime(
     },
     // _version is intentionally included to trigger re-computation when core state changes via notifyUpdate
     // toolInvocations intentionally excluded: abort/resume use refs internally and work with stale captures
-    [adapterAdapters, core, _version, hasExecutingTools],
+    [
+      adapterAdapters,
+      core,
+      _version,
+      hasExecutingTools,
+      isDisabled,
+      isSendDisabled,
+      unstable_capabilities,
+      suggestions,
+    ],
   );
 
   const baseRuntime = useExternalStoreRuntime(store);

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
@@ -354,4 +354,40 @@ describe("useAISDKRuntime", () => {
       metadata: { custom: { maxTokens: 100 } },
     });
   });
+
+  it("forwards isDisabled to thread state", () => {
+    const chat = createChatHelpers();
+    const { result } = renderHook(() =>
+      useAISDKRuntime(chat, { isDisabled: true }),
+    );
+    expect(result.current.thread.getState().isDisabled).toBe(true);
+  });
+
+  it("forwards isSendDisabled to the composer canSend gate", () => {
+    const chat = createChatHelpers();
+    const { result } = renderHook(() =>
+      useAISDKRuntime(chat, { isSendDisabled: true }),
+    );
+    act(() => {
+      result.current.thread.composer.setText("hello");
+    });
+    expect(result.current.thread.composer.getState().canSend).toBe(false);
+  });
+
+  it("forwards unstable_capabilities to thread capabilities", () => {
+    const chat = createChatHelpers();
+    const { result } = renderHook(() =>
+      useAISDKRuntime(chat, { unstable_capabilities: { copy: false } }),
+    );
+    expect(result.current.thread.getState().capabilities.unstable_copy).toBe(
+      false,
+    );
+  });
+
+  it("forwards suggestions to thread state", () => {
+    const chat = createChatHelpers();
+    const suggestions = [{ prompt: "tell me a joke" }];
+    const { result } = renderHook(() => useAISDKRuntime(chat, { suggestions }));
+    expect(result.current.thread.getState().suggestions).toEqual(suggestions);
+  });
 });

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -72,6 +72,24 @@ export type AISDKRuntimeAdapter = {
    */
   cancelPendingToolCallsOnSend?: boolean | undefined;
   /**
+   * Whether the entire thread is disabled. When `true`, the composer's input
+   * is also disabled (the user cannot type, attach files, or submit). For a
+   * narrower gate that keeps the input usable but blocks only sending, use
+   * `isSendDisabled`.
+   */
+  isDisabled?: boolean | undefined;
+  /**
+   * Whether sending new messages is currently disabled. When `true`, the
+   * thread composer's input remains usable but `send()` becomes a no-op
+   * and the thread composer's `canSend` is `false`.
+   */
+  isSendDisabled?: boolean | undefined;
+  /**
+   * Optional thread capability overrides. Currently only `copy` is honored
+   * and controls whether the copy-message action is enabled.
+   */
+  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
+  /**
    * Called when `runtime.thread.resumeRun(config)` is invoked.
    *
    * When omitted, `resumeRun` throws `"Runtime does not support resuming runs."`.
@@ -94,6 +112,9 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     adapters,
     toCreateMessage: customToCreateMessage,
     cancelPendingToolCallsOnSend = true,
+    isDisabled,
+    isSendDisabled,
+    unstable_capabilities,
     onResume,
     suggestions,
   }: AISDKRuntimeAdapter = {},
@@ -346,6 +367,9 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     },
     ...(onResume && { onResume }),
     ...(suggestions && { suggestions }),
+    ...(isDisabled !== undefined && { isDisabled }),
+    ...(isSendDisabled !== undefined && { isSendDisabled }),
+    ...(unstable_capabilities && { unstable_capabilities }),
     adapters: {
       attachments: vercelAttachmentAdapter,
       ...contextAdapters,

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -23,6 +23,9 @@ export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
     cloud?: AssistantCloud | undefined;
     adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
     toCreateMessage?: CustomToCreateMessageFunction;
+    isDisabled?: AISDKRuntimeAdapter["isDisabled"];
+    isSendDisabled?: AISDKRuntimeAdapter["isSendDisabled"];
+    unstable_capabilities?: AISDKRuntimeAdapter["unstable_capabilities"];
     onResume?: AISDKRuntimeAdapter["onResume"];
     suggestions?: AISDKRuntimeAdapter["suggestions"];
   };
@@ -72,6 +75,9 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     adapters,
     transport: transportOptions,
     toCreateMessage,
+    isDisabled,
+    isSendDisabled,
+    unstable_capabilities,
     onResume,
     suggestions,
     ...chatOptions
@@ -99,6 +105,9 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(toCreateMessage && { toCreateMessage }),
     ...(onResume && { onResume }),
     ...(suggestions && { suggestions }),
+    ...(isDisabled !== undefined && { isDisabled }),
+    ...(isSendDisabled !== undefined && { isSendDisabled }),
+    ...(unstable_capabilities && { unstable_capabilities }),
   });
 
   if (transport instanceof AssistantChatTransport) {

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -3,10 +3,13 @@ import {
   getExternalStoreMessages,
   type AttachmentAdapter,
   type DictationAdapter,
+  type ExternalStoreAdapter,
   type FeedbackAdapter,
+  type RealtimeVoiceAdapter,
   type SpeechSynthesisAdapter,
   type AppendMessage,
   type ThreadMessage,
+  type ThreadSuggestion,
   type ToolExecutionStatus,
 } from "@assistant-ui/core";
 import {
@@ -151,9 +154,28 @@ export type UseAdkRuntimeOptions = {
         attachments?: AttachmentAdapter;
         speech?: SpeechSynthesisAdapter;
         dictation?: DictationAdapter;
+        voice?: RealtimeVoiceAdapter;
         feedback?: FeedbackAdapter;
       }
     | undefined;
+  /**
+   * Whether the entire thread is disabled. When `true`, the composer's input
+   * is also disabled. For a narrower gate that keeps the input usable but
+   * blocks only sending, use `isSendDisabled`.
+   */
+  isDisabled?: boolean | undefined;
+  /**
+   * Whether sending new messages is currently disabled.
+   */
+  isSendDisabled?: boolean | undefined;
+  /**
+   * Optional thread capability overrides.
+   */
+  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
+  /**
+   * Follow up suggestions to surface on the thread.
+   */
+  suggestions?: readonly ThreadSuggestion[] | undefined;
   eventHandlers?:
     | {
         onError?: OnAdkErrorCallback;
@@ -171,12 +193,16 @@ export type UseAdkRuntimeOptions = {
 
 const useAdkRuntimeImpl = ({
   autoCancelPendingToolCalls,
-  adapters: { attachments, dictation, feedback, speech } = {},
+  adapters: { attachments, dictation, feedback, speech, voice } = {},
   unstable_allowCancellation,
   stream,
   load,
   getCheckpointId,
   eventHandlers,
+  isDisabled,
+  isSendDisabled,
+  unstable_capabilities,
+  suggestions,
 }: UseAdkRuntimeOptions) => {
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const aui = useAui();
@@ -239,7 +265,11 @@ const useAdkRuntimeImpl = ({
     messages: threadMessages,
     unstable_enableToolInvocations: true,
     setToolStatuses,
-    adapters: { attachments, dictation, feedback, speech },
+    ...(isDisabled !== undefined && { isDisabled }),
+    ...(isSendDisabled !== undefined && { isSendDisabled }),
+    ...(unstable_capabilities && { unstable_capabilities }),
+    ...(suggestions && { suggestions }),
+    adapters: { attachments, dictation, feedback, speech, voice },
     extras: {
       [symbolAdkRuntimeExtras]: true,
       agentInfo,

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -5,9 +5,13 @@ import { useMemo, useRef, useState } from "react";
 import type {
   AppendMessage,
   AttachmentAdapter,
+  DictationAdapter,
+  ExternalStoreAdapter,
   FeedbackAdapter,
+  RealtimeVoiceAdapter,
   RemoteThreadListAdapter,
   SpeechSynthesisAdapter,
+  ThreadSuggestion,
   ToolExecutionStatus,
 } from "@assistant-ui/core";
 import {
@@ -54,6 +58,8 @@ type LangChainRuntimeExtraOptions = {
     | {
         attachments?: AttachmentAdapter | undefined;
         speech?: SpeechSynthesisAdapter | undefined;
+        dictation?: DictationAdapter | undefined;
+        voice?: RealtimeVoiceAdapter | undefined;
         feedback?: FeedbackAdapter | undefined;
       }
     | undefined;
@@ -78,6 +84,24 @@ type LangChainRuntimeExtraOptions = {
   create?: (() => Promise<{ externalId: string | undefined }>) | undefined;
   /** Custom thread-deletion hook, forwarded to the cloud adapter. */
   delete?: ((threadId: string) => Promise<void>) | undefined;
+  /**
+   * Whether the entire thread is disabled. When `true`, the composer's input
+   * is also disabled. For a narrower gate that keeps the input usable but
+   * blocks only sending, use `isSendDisabled`.
+   */
+  isDisabled?: boolean | undefined;
+  /**
+   * Whether sending new messages is currently disabled.
+   */
+  isSendDisabled?: boolean | undefined;
+  /**
+   * Optional thread capability overrides.
+   */
+  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
+  /**
+   * Follow up suggestions to surface on the thread.
+   */
+  suggestions?: readonly ThreadSuggestion[] | undefined;
 };
 
 const getPendingToolCalls = (
@@ -166,8 +190,15 @@ const useStreamThreadRuntime = (
     "cloud" | "unstable_threadListAdapter" | "create" | "delete"
   >,
 ) => {
-  const { adapters, autoCancelPendingToolCalls, unstable_allowCancellation } =
-    options;
+  const {
+    adapters,
+    autoCancelPendingToolCalls,
+    unstable_allowCancellation,
+    isDisabled,
+    isSendDisabled,
+    unstable_capabilities,
+    suggestions,
+  } = options;
   const messagesKey = options.messagesKey ?? "messages";
 
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
@@ -229,6 +260,10 @@ const useStreamThreadRuntime = (
     extras,
     unstable_enableToolInvocations: true,
     setToolStatuses,
+    ...(isDisabled !== undefined && { isDisabled }),
+    ...(isSendDisabled !== undefined && { isSendDisabled }),
+    ...(unstable_capabilities && { unstable_capabilities }),
+    ...(suggestions && { suggestions }),
     onNew: async (msg) => {
       const content = getMessageContent(msg);
       const cancellations =

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -20,8 +20,12 @@ import {
   type ThreadMessage,
   type AttachmentAdapter,
   type AppendMessage,
+  type DictationAdapter,
+  type ExternalStoreAdapter,
   type FeedbackAdapter,
+  type RealtimeVoiceAdapter,
   type SpeechSynthesisAdapter,
+  type ThreadSuggestion,
 } from "@assistant-ui/core";
 import type { ToolExecutionStatus } from "@assistant-ui/core";
 import {
@@ -230,9 +234,33 @@ export type UseLangGraphRuntimeOptions = {
     | {
         attachments?: AttachmentAdapter;
         speech?: SpeechSynthesisAdapter;
+        dictation?: DictationAdapter;
+        voice?: RealtimeVoiceAdapter;
         feedback?: FeedbackAdapter;
       }
     | undefined;
+  /**
+   * Whether the entire thread is disabled. When `true`, the composer's input
+   * is also disabled (the user cannot type, attach files, or submit). For a
+   * narrower gate that keeps the input usable but blocks only sending, use
+   * `isSendDisabled`.
+   */
+  isDisabled?: boolean | undefined;
+  /**
+   * Whether sending new messages is currently disabled. When `true`, the
+   * thread composer's input remains usable but `send()` becomes a no-op
+   * and the thread composer's `canSend` is `false`.
+   */
+  isSendDisabled?: boolean | undefined;
+  /**
+   * Optional thread capability overrides (e.g. `{ copy: false }` to disable
+   * the copy-message action).
+   */
+  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
+  /**
+   * Follow up suggestions to surface on the thread.
+   */
+  suggestions?: readonly ThreadSuggestion[] | undefined;
   eventHandlers?:
     | {
         /**
@@ -337,7 +365,7 @@ const filterUIMessagesBySurvivingIds = (
 
 const useLangGraphRuntimeImpl = ({
   autoCancelPendingToolCalls,
-  adapters: { attachments, feedback, speech } = {},
+  adapters: { attachments, dictation, feedback, speech, voice } = {},
   unstable_allowCancellation,
   stream,
   load,
@@ -345,6 +373,10 @@ const useLangGraphRuntimeImpl = ({
   eventHandlers,
   uiStateKey,
   uiComponents,
+  isDisabled,
+  isSendDisabled,
+  unstable_capabilities,
+  suggestions,
 }: UseLangGraphRuntimeOptions) => {
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const aui = useAui();
@@ -508,10 +540,16 @@ const useLangGraphRuntimeImpl = ({
     messages: threadMessages,
     unstable_enableToolInvocations: true,
     setToolStatuses,
+    ...(isDisabled !== undefined && { isDisabled }),
+    ...(isSendDisabled !== undefined && { isSendDisabled }),
+    ...(unstable_capabilities && { unstable_capabilities }),
+    ...(suggestions && { suggestions }),
     adapters: {
       attachments,
+      dictation,
       feedback,
       speech,
+      voice,
     },
     extras: {
       [symbolLangGraphRuntimeExtras]: true,

--- a/packages/react-opencode/src/types.ts
+++ b/packages/react-opencode/src/types.ts
@@ -1,7 +1,14 @@
 import type {
   AppendMessage,
   AssistantRuntime,
+  AttachmentAdapter,
+  DictationAdapter,
+  ExternalStoreAdapter,
+  FeedbackAdapter,
+  RealtimeVoiceAdapter,
+  SpeechSynthesisAdapter,
   ThreadMessageLike,
+  ThreadSuggestion,
   ThreadUserMessagePart,
 } from "@assistant-ui/react";
 import type {
@@ -188,6 +195,33 @@ export type OpenCodeRuntimeOptions = {
     | undefined;
   defaultAgent?: string | undefined;
   onError?: (error: unknown) => void;
+  adapters?:
+    | {
+        attachments?: AttachmentAdapter;
+        speech?: SpeechSynthesisAdapter;
+        dictation?: DictationAdapter;
+        voice?: RealtimeVoiceAdapter;
+        feedback?: FeedbackAdapter;
+      }
+    | undefined;
+  /**
+   * Whether the entire thread is disabled. When `true`, the composer's input
+   * is also disabled. For a narrower gate that keeps the input usable but
+   * blocks only sending, use `isSendDisabled`.
+   */
+  isDisabled?: boolean | undefined;
+  /**
+   * Whether sending new messages is currently disabled.
+   */
+  isSendDisabled?: boolean | undefined;
+  /**
+   * Optional thread capability overrides.
+   */
+  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
+  /**
+   * Follow up suggestions to surface on the thread.
+   */
+  suggestions?: readonly ThreadSuggestion[] | undefined;
 };
 
 export type OpenCodeRuntimeExtras = {

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -208,6 +208,15 @@ const useOpenCodeThreadRuntime = (
     isRunning: isOpenCodeStateRunning(state),
     messageRepository,
     extras,
+    ...(options.isDisabled !== undefined && { isDisabled: options.isDisabled }),
+    ...(options.isSendDisabled !== undefined && {
+      isSendDisabled: options.isSendDisabled,
+    }),
+    ...(options.unstable_capabilities && {
+      unstable_capabilities: options.unstable_capabilities,
+    }),
+    ...(options.suggestions && { suggestions: options.suggestions }),
+    ...(options.adapters && { adapters: options.adapters }),
     onNew: async (message: any) => {
       try {
         const sendOptions = {


### PR DESCRIPTION
closes #4134

## summary

- every distribution's runtime wrapper hook now accepts the same set of optional adapter-level fields, so users no longer hit a gap where `ExternalStoreAdapter` supports something but the wrapper they happen to use does not.
- new options on `useChatRuntime`, `useAISDKRuntime`, `useLangGraphRuntime`, `useA2ARuntime`, `useAgUiRuntime`, `useAdkRuntime`, `useStreamRuntime`, `useOpenCodeRuntime`: `isDisabled`, `isSendDisabled`, `unstable_capabilities`, `suggestions`.
- the `dictation` and `voice` adapter slots are now accepted by every wrapper that exposes an `adapters` object (previously only some did); `useOpenCodeRuntime` gains an `adapters` option for the first time.
- all additive, every field optional. existing call sites need no changes.

## test plan

### already verified

- [x] `pnpm exec tsc --noEmit` per touched package: clean.
- [x] `pnpm lint`: exit 0 (one pre-existing unused-import warning in `react-langgraph` unrelated to this PR).
- [x] `pnpm --filter @assistant-ui/react-ai-sdk --filter @assistant-ui/react-langgraph --filter @assistant-ui/react-a2a --filter @assistant-ui/react-ag-ui --filter @assistant-ui/react-google-adk --filter @assistant-ui/react-langchain --filter @assistant-ui/react-opencode --filter @assistant-ui/core --filter @assistant-ui/react test`: 1184/1184 green, including 4 new `useAISDKRuntime` tests asserting `isDisabled` / `isSendDisabled` / `unstable_capabilities` / `suggestions` actually reach `thread.getState()` and `composer.getState().canSend`.

### reviewer should verify

- [ ] in any non-AISDK runtime wrapper (e.g. `useLangGraphRuntime`), pass `isSendDisabled: true` and confirm the composer input stays typeable but the Send button greys out and Enter does nothing.
- [ ] in `useOpenCodeRuntime`, pass `adapters: { attachments: ... }` and confirm attachments work end-to-end (previously there was no way to wire any adapter through this hook).

## notes

- protocol-dependent fields (`onResume`, `onRespondToToolApproval`, `onResumeToolCall`) intentionally left out of this pass. they only make sense per-runtime and `useAISDKRuntime` / `useAgUiRuntime` already implement the ones their protocols support.