### PR TITLE
refactor: centralize thread-level shared options helper

### DIFF
--- a/.changeset/external-store-shared-options-helper.md
+++ b/.changeset/external-store-shared-options-helper.md
@@ -1,0 +1,21 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/react-a2a": patch
+"@assistant-ui/react-ag-ui": patch
+"@assistant-ui/react-google-adk": patch
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-opencode": patch
+---
+
+centralize thread-level shared options forwarding across runtime wrapper hooks. follow-up to #4135.
+
+new public exports from `@assistant-ui/core` (re-exported from `@assistant-ui/react`):
+
+- `ExternalStoreSharedOptions`, a typed `Pick` over `ExternalStoreAdapter` covering the four thread-level optional fields every wrapper forwards: `isDisabled`, `isSendDisabled`, `unstable_capabilities`, `suggestions`.
+- `pickExternalStoreSharedOptions(options)`, plucks those four fields from a wider options object. the body uses `satisfies Required<...>` so adding a key to the type without copying it in the function is a compile error rather than a silent missing-field bug.
+- `useExternalStoreSharedOptions(options)` (from `@assistant-ui/core/react`), a memoized variant for wrappers that wrap their store in `useMemo`. lets the wrapper list a single stable `shared` reference as a dep instead of enumerating the four fields. same `satisfies` guard internally so the destructure stays in sync with the type.
+
+internal: every runtime wrapper hook (`useChatRuntime`, `useAISDKRuntime`, `useLangGraphRuntime`, `useA2ARuntime`, `useAgUiRuntime`, `useAdkRuntime`, `useStreamRuntime`, `useOpenCodeRuntime`) now uses these helpers instead of inlining the conditional spreads added in #4135. each wrapper sheds 20 to 40 lines of duplicated declarations and conditional spreads; future additions to the shared option set propagate through a single edit in `pickExternalStoreSharedOptions` instead of touching every wrapper. no user-facing behavior change.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -282,6 +282,8 @@ export type {
   ExternalStoreThreadListAdapter,
   ExternalStoreThreadData,
 } from "./runtimes/external-store/external-store-adapter";
+export type { ExternalStoreSharedOptions } from "./runtimes/external-store/external-store-shared-options";
+export { pickExternalStoreSharedOptions } from "./runtimes/external-store/external-store-shared-options";
 
 // Remote Thread List (user-facing)
 export type {

--- a/packages/core/src/react/index.ts
+++ b/packages/core/src/react/index.ts
@@ -131,6 +131,7 @@ export {
   type RuntimeAdapters,
 } from "./runtimes/RuntimeAdapterProvider";
 export { useExternalStoreRuntime } from "./runtimes/useExternalStoreRuntime";
+export { useExternalStoreSharedOptions } from "./runtimes/useExternalStoreSharedOptions";
 export {
   useExternalMessageConverter,
   convertExternalMessages,

--- a/packages/core/src/react/runtimes/useExternalStoreSharedOptions.ts
+++ b/packages/core/src/react/runtimes/useExternalStoreSharedOptions.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  pickExternalStoreSharedOptions,
+  type ExternalStoreSharedOptions,
+} from "../../runtimes/external-store/external-store-shared-options";
+
+/**
+ * Memoizes the thread-level options shared across runtime wrapper hooks
+ * (`useChatRuntime`, `useLangGraphRuntime`, etc.) so a wrapper that wraps
+ * its own store in `useMemo` can list the returned object as a single
+ * dependency instead of enumerating every shared field individually.
+ *
+ * The result is stable while the picked fields are stable, and changes
+ * identity when any of them changes. This keeps the wrapper's `useMemo`
+ * deps array decoupled from the exact set of shared fields, so future
+ * additions to {@link ExternalStoreSharedOptions} flow through without
+ * touching every wrapper's deps array.
+ *
+ * ```ts
+ * const shared = useExternalStoreSharedOptions(options);
+ * const store = useMemo(
+ *   () => ({ ...shared, ...wrapperSpecific }),
+ *   [adapterAdapters, core, _version, shared],
+ * );
+ * ```
+ */
+export const useExternalStoreSharedOptions = (
+  options: ExternalStoreSharedOptions,
+): ExternalStoreSharedOptions => {
+  // Destructure each shared field into a primitive local so React's
+  // exhaustive-deps rule can validate the memo's dep array (it doesn't
+  // resolve member expressions like `options.isDisabled`). The
+  // `satisfies Required<...>` clause on the helper input forces every
+  // key on `ExternalStoreSharedOptions` to be passed here, so adding a
+  // key to that type without also updating this site is a compile error
+  // rather than a silent stale-memo bug.
+  const { isDisabled, isSendDisabled, unstable_capabilities, suggestions } =
+    options;
+  return useMemo(
+    () =>
+      pickExternalStoreSharedOptions({
+        isDisabled,
+        isSendDisabled,
+        unstable_capabilities,
+        suggestions,
+      } satisfies {
+        [K in keyof Required<ExternalStoreSharedOptions>]: ExternalStoreSharedOptions[K];
+      }),
+    [isDisabled, isSendDisabled, unstable_capabilities, suggestions],
+  );
+};

--- a/packages/core/src/react/runtimes/useExternalStoreSharedOptions.ts
+++ b/packages/core/src/react/runtimes/useExternalStoreSharedOptions.ts
@@ -1,53 +1,23 @@
 "use client";
 
 import { useMemo } from "react";
-import {
-  pickExternalStoreSharedOptions,
-  type ExternalStoreSharedOptions,
-} from "../../runtimes/external-store/external-store-shared-options";
+import type { ExternalStoreSharedOptions } from "../../runtimes/external-store/external-store-shared-options";
 
-/**
- * Memoizes the thread-level options shared across runtime wrapper hooks
- * (`useChatRuntime`, `useLangGraphRuntime`, etc.) so a wrapper that wraps
- * its own store in `useMemo` can list the returned object as a single
- * dependency instead of enumerating every shared field individually.
- *
- * The result is stable while the picked fields are stable, and changes
- * identity when any of them changes. This keeps the wrapper's `useMemo`
- * deps array decoupled from the exact set of shared fields, so future
- * additions to {@link ExternalStoreSharedOptions} flow through without
- * touching every wrapper's deps array.
- *
- * ```ts
- * const shared = useExternalStoreSharedOptions(options);
- * const store = useMemo(
- *   () => ({ ...shared, ...wrapperSpecific }),
- *   [adapterAdapters, core, _version, shared],
- * );
- * ```
- */
 export const useExternalStoreSharedOptions = (
   options: ExternalStoreSharedOptions,
 ): ExternalStoreSharedOptions => {
-  // Destructure each shared field into a primitive local so React's
-  // exhaustive-deps rule can validate the memo's dep array (it doesn't
-  // resolve member expressions like `options.isDisabled`). The
-  // `satisfies Required<...>` clause on the helper input forces every
-  // key on `ExternalStoreSharedOptions` to be passed here, so adding a
-  // key to that type without also updating this site is a compile error
-  // rather than a silent stale-memo bug.
   const { isDisabled, isSendDisabled, unstable_capabilities, suggestions } =
     options;
   return useMemo(
     () =>
-      pickExternalStoreSharedOptions({
+      ({
         isDisabled,
         isSendDisabled,
         unstable_capabilities,
         suggestions,
-      } satisfies {
+      }) satisfies {
         [K in keyof Required<ExternalStoreSharedOptions>]: ExternalStoreSharedOptions[K];
-      }),
+      },
     [isDisabled, isSendDisabled, unstable_capabilities, suggestions],
   );
 };

--- a/packages/core/src/runtimes/external-store/external-store-shared-options.ts
+++ b/packages/core/src/runtimes/external-store/external-store-shared-options.ts
@@ -1,0 +1,47 @@
+import type { ExternalStoreAdapter } from "./external-store-adapter";
+
+/**
+ * The subset of `ExternalStoreAdapter` fields that runtime wrapper hooks
+ * (`useChatRuntime`, `useLangGraphRuntime`, etc.) forward verbatim from
+ * their own options object. Use this as a mixin on a wrapper's options
+ * type so every wrapper exposes the same thread-level surface area:
+ *
+ * ```ts
+ * export type UseLangGraphRuntimeOptions = ExternalStoreSharedOptions & {
+ *   stream: LangGraphStreamCallback;
+ *   // ...other protocol-specific options
+ * };
+ * ```
+ *
+ * Then apply `pickExternalStoreSharedOptions(options)` inside the wrapper:
+ *
+ * ```ts
+ * return useExternalStoreRuntime({
+ *   ...pickExternalStoreSharedOptions(options),
+ *   isRunning,
+ *   messages,
+ *   onNew,
+ *   // ...wrapper-specific fields
+ * });
+ * ```
+ */
+export type ExternalStoreSharedOptions = Pick<
+  ExternalStoreAdapter,
+  "isDisabled" | "isSendDisabled" | "unstable_capabilities" | "suggestions"
+>;
+
+export const pickExternalStoreSharedOptions = (
+  options: ExternalStoreSharedOptions,
+): ExternalStoreSharedOptions =>
+  // `satisfies Required<...>` forces every key declared on
+  // `ExternalStoreSharedOptions` to appear in this object literal; if a new
+  // key is added to the Pick above without updating this body, the line
+  // below fails to compile.
+  ({
+    isDisabled: options.isDisabled,
+    isSendDisabled: options.isSendDisabled,
+    unstable_capabilities: options.unstable_capabilities,
+    suggestions: options.suggestions,
+  }) satisfies {
+    [K in keyof Required<ExternalStoreSharedOptions>]: ExternalStoreSharedOptions[K];
+  };

--- a/packages/core/src/runtimes/external-store/external-store-shared-options.ts
+++ b/packages/core/src/runtimes/external-store/external-store-shared-options.ts
@@ -1,30 +1,5 @@
 import type { ExternalStoreAdapter } from "./external-store-adapter";
 
-/**
- * The subset of `ExternalStoreAdapter` fields that runtime wrapper hooks
- * (`useChatRuntime`, `useLangGraphRuntime`, etc.) forward verbatim from
- * their own options object. Use this as a mixin on a wrapper's options
- * type so every wrapper exposes the same thread-level surface area:
- *
- * ```ts
- * export type UseLangGraphRuntimeOptions = ExternalStoreSharedOptions & {
- *   stream: LangGraphStreamCallback;
- *   // ...other protocol-specific options
- * };
- * ```
- *
- * Then apply `pickExternalStoreSharedOptions(options)` inside the wrapper:
- *
- * ```ts
- * return useExternalStoreRuntime({
- *   ...pickExternalStoreSharedOptions(options),
- *   isRunning,
- *   messages,
- *   onNew,
- *   // ...wrapper-specific fields
- * });
- * ```
- */
 export type ExternalStoreSharedOptions = Pick<
   ExternalStoreAdapter,
   "isDisabled" | "isSendDisabled" | "unstable_capabilities" | "suggestions"
@@ -33,10 +8,6 @@ export type ExternalStoreSharedOptions = Pick<
 export const pickExternalStoreSharedOptions = (
   options: ExternalStoreSharedOptions,
 ): ExternalStoreSharedOptions =>
-  // `satisfies Required<...>` forces every key declared on
-  // `ExternalStoreSharedOptions` to appear in this object literal; if a new
-  // key is added to the Pick above without updating this body, the line
-  // below fails to compile.
   ({
     isDisabled: options.isDisabled,
     isSendDisabled: options.isSendDisabled,

--- a/packages/react-a2a/src/useA2ARuntime.ts
+++ b/packages/react-a2a/src/useA2ARuntime.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   useExternalStoreRuntime,
+  useExternalStoreSharedOptions,
   useRuntimeAdapters,
 } from "@assistant-ui/core/react";
 import type {
@@ -11,12 +12,12 @@ import type {
   AttachmentAdapter,
   DictationAdapter,
   ExternalStoreAdapter,
+  ExternalStoreSharedOptions,
   FeedbackAdapter,
   RealtimeVoiceAdapter,
   SpeechSynthesisAdapter,
   ThreadHistoryAdapter,
   ThreadMessage,
-  ThreadSuggestion,
 } from "@assistant-ui/core";
 import { useAuiState } from "@assistant-ui/store";
 import { A2AClient } from "./A2AClient";
@@ -78,7 +79,7 @@ export type UseA2AThreadListAdapter = {
 
 // --- Options ---
 
-export type UseA2ARuntimeOptions = {
+export type UseA2ARuntimeOptions = ExternalStoreSharedOptions & {
   /** Pre-built A2A client instance. Provide this OR baseUrl. */
   client?: A2AClient;
   /** Base URL of the A2A server. Used to create a client if `client` is not provided. */
@@ -113,25 +114,6 @@ export type UseA2ARuntimeOptions = {
     history?: ThreadHistoryAdapter;
     threadList?: UseA2AThreadListAdapter;
   };
-  /**
-   * Whether the entire thread is disabled. When `true`, the composer's input
-   * is also disabled. For a narrower gate that keeps the input usable but
-   * blocks only sending, use `isSendDisabled`.
-   */
-  isDisabled?: boolean | undefined;
-  /**
-   * Whether sending new messages is currently disabled. The input stays
-   * usable but `send()` becomes a no-op and `composer.canSend` is `false`.
-   */
-  isSendDisabled?: boolean | undefined;
-  /**
-   * Optional thread capability overrides.
-   */
-  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
-  /**
-   * Follow up suggestions to surface on the thread.
-   */
-  suggestions?: readonly ThreadSuggestion[] | undefined;
 };
 
 // --- Main hook ---
@@ -230,21 +212,15 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
   );
 
   // Build store adapter
-  const isDisabled = options.isDisabled;
-  const isSendDisabled = options.isSendDisabled;
-  const unstable_capabilities = options.unstable_capabilities;
-  const suggestions = options.suggestions;
+  const shared = useExternalStoreSharedOptions(options);
   const store = useMemo(() => {
     void _version;
 
     return {
+      ...shared,
       isLoading: core.isLoading,
       messages: core.getMessages(),
       isRunning: core.isRunning(),
-      ...(isDisabled !== undefined && { isDisabled }),
-      ...(isSendDisabled !== undefined && { isSendDisabled }),
-      ...(unstable_capabilities && { unstable_capabilities }),
-      ...(suggestions && { suggestions }),
       extras: {
         [symbolA2AExtras]: true,
         task: core.getTask(),
@@ -261,15 +237,7 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
         core.applyExternalMessages(messages),
       adapters: adapterAdapters,
     } satisfies ExternalStoreAdapter<ThreadMessage>;
-  }, [
-    adapterAdapters,
-    core,
-    _version,
-    isDisabled,
-    isSendDisabled,
-    unstable_capabilities,
-    suggestions,
-  ]);
+  }, [adapterAdapters, core, _version, shared]);
 
   const runtime = useExternalStoreRuntime(store);
 

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -1,13 +1,12 @@
 import type {
   AttachmentAdapter,
   DictationAdapter,
-  ExternalStoreAdapter,
+  ExternalStoreSharedOptions,
   FeedbackAdapter,
   RealtimeVoiceAdapter,
   SpeechSynthesisAdapter,
   ThreadHistoryAdapter,
   ThreadMessage,
-  ThreadSuggestion,
 } from "@assistant-ui/core";
 import type { HttpAgent } from "@ag-ui/client";
 import type { Logger } from "./logger";
@@ -42,31 +41,13 @@ export type UseAgUiRuntimeAdapters = {
   threadList?: UseAgUiThreadListAdapter;
 };
 
-export type UseAgUiRuntimeOptions = {
+export type UseAgUiRuntimeOptions = ExternalStoreSharedOptions & {
   agent: HttpAgent;
   logger?: Partial<Logger>;
   showThinking?: boolean;
   onError?: (e: Error) => void;
   onCancel?: () => void;
   adapters?: UseAgUiRuntimeAdapters;
-  /**
-   * Whether the entire thread is disabled. When `true`, the composer's input
-   * is also disabled. For a narrower gate that keeps the input usable but
-   * blocks only sending, use `isSendDisabled`.
-   */
-  isDisabled?: boolean | undefined;
-  /**
-   * Whether sending new messages is currently disabled.
-   */
-  isSendDisabled?: boolean | undefined;
-  /**
-   * Optional thread capability overrides.
-   */
-  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
-  /**
-   * Follow up suggestions to surface on the thread.
-   */
-  suggestions?: readonly ThreadSuggestion[] | undefined;
 };
 
 export type AgUiInterruptReason =

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   useExternalStoreRuntime,
+  useExternalStoreSharedOptions,
   useRuntimeAdapters,
 } from "@assistant-ui/core/react";
 import type { ToolExecutionStatus } from "@assistant-ui/core";
@@ -108,23 +109,17 @@ export function useAgUiRuntime(
     [adapters, runtimeAdapters, threadList],
   );
 
-  const isDisabled = options.isDisabled;
-  const isSendDisabled = options.isSendDisabled;
-  const unstable_capabilities = options.unstable_capabilities;
-  const suggestions = options.suggestions;
+  const shared = useExternalStoreSharedOptions(options);
   const store = useMemo(
     () => {
       void _version; // rerender on version change
 
       return {
+        ...shared,
         isLoading: core.isLoading,
         messages: core.getMessages(),
         state: core.getState(),
         isRunning: core.isRunning() || hasExecutingTools,
-        ...(isDisabled !== undefined && { isDisabled }),
-        ...(isSendDisabled !== undefined && { isSendDisabled }),
-        ...(unstable_capabilities && { unstable_capabilities }),
-        ...(suggestions && { suggestions }),
         unstable_enableToolInvocations: true,
         setToolStatuses,
         onNew: (message: AppendMessage) => core.append(message),
@@ -147,16 +142,7 @@ export function useAgUiRuntime(
     },
     // _version is intentionally included to trigger re-computation when core state changes via notifyUpdate
     // toolInvocations intentionally excluded: abort/resume use refs internally and work with stale captures
-    [
-      adapterAdapters,
-      core,
-      _version,
-      hasExecutingTools,
-      isDisabled,
-      isSendDisabled,
-      unstable_capabilities,
-      suggestions,
-    ],
+    [adapterAdapters, core, _version, hasExecutingTools, shared],
   );
 
   const baseRuntime = useExternalStoreRuntime(store);

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -10,10 +10,10 @@ import {
 import type { ToolExecutionStatus } from "@assistant-ui/core";
 import type {
   ExternalStoreAdapter,
+  ExternalStoreSharedOptions,
   ThreadHistoryAdapter,
   AssistantRuntime,
   ThreadMessage,
-  ThreadSuggestion,
   MessageFormatAdapter,
   MessageFormatItem,
   MessageFormatRepository,
@@ -21,7 +21,10 @@ import type {
   RunConfig,
   McpAppMetadata,
 } from "@assistant-ui/core";
-import { getExternalStoreMessages } from "@assistant-ui/core";
+import {
+  getExternalStoreMessages,
+  pickExternalStoreSharedOptions,
+} from "@assistant-ui/core";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
 import { sliceMessagesUntil } from "../utils/sliceMessagesUntil";
 import { toCreateMessage } from "../utils/toCreateMessage";
@@ -55,7 +58,7 @@ const toUIMessage = <UI_MESSAGE extends UIMessage>(
     role: createMessage.role ?? fallbackRole,
   }) as UI_MESSAGE;
 
-export type AISDKRuntimeAdapter = {
+export type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
   adapters?:
     | (NonNullable<ExternalStoreAdapter["adapters"]> & {
         history?: ThreadHistoryAdapter | undefined;
@@ -72,24 +75,6 @@ export type AISDKRuntimeAdapter = {
    */
   cancelPendingToolCallsOnSend?: boolean | undefined;
   /**
-   * Whether the entire thread is disabled. When `true`, the composer's input
-   * is also disabled (the user cannot type, attach files, or submit). For a
-   * narrower gate that keeps the input usable but blocks only sending, use
-   * `isSendDisabled`.
-   */
-  isDisabled?: boolean | undefined;
-  /**
-   * Whether sending new messages is currently disabled. When `true`, the
-   * thread composer's input remains usable but `send()` becomes a no-op
-   * and the thread composer's `canSend` is `false`.
-   */
-  isSendDisabled?: boolean | undefined;
-  /**
-   * Optional thread capability overrides. Currently only `copy` is honored
-   * and controls whether the copy-message action is enabled.
-   */
-  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
-  /**
    * Called when `runtime.thread.resumeRun(config)` is invoked.
    *
    * When omitted, `resumeRun` throws `"Runtime does not support resuming runs."`.
@@ -97,28 +82,18 @@ export type AISDKRuntimeAdapter = {
    * (for example, an SSE reconnect endpoint keyed by turn id).
    */
   onResume?: ExternalStoreAdapter["onResume"];
-  /**
-   * Follow up suggestions to surface on the thread. Use this to drive
-   * dynamic suggestions from application state, tool results, or backend
-   * responses; flows into `thread.suggestions` and is rendered by
-   * components that read it (such as the shadcn `ThreadFollowupSuggestions`).
-   */
-  suggestions?: readonly ThreadSuggestion[] | undefined;
 };
 
 export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   chatHelpers: ReturnType<typeof useChat<UI_MESSAGE>>,
-  {
+  adapter: AISDKRuntimeAdapter = {},
+) => {
+  const {
     adapters,
     toCreateMessage: customToCreateMessage,
     cancelPendingToolCallsOnSend = true,
-    isDisabled,
-    isSendDisabled,
-    unstable_capabilities,
     onResume,
-    suggestions,
-  }: AISDKRuntimeAdapter = {},
-) => {
+  } = adapter;
   const contextAdapters = useRuntimeAdapters();
   const [toolStatuses, setToolStatuses] = useState<
     Record<string, ToolExecutionStatus>
@@ -365,11 +340,8 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         options: { metadata: lastRunConfigRef.current },
       });
     },
+    ...pickExternalStoreSharedOptions(adapter),
     ...(onResume && { onResume }),
-    ...(suggestions && { suggestions }),
-    ...(isDisabled !== undefined && { isDisabled }),
-    ...(isSendDisabled !== undefined && { isSendDisabled }),
-    ...(unstable_capabilities && { unstable_capabilities }),
     adapters: {
       attachments: vercelAttachmentAdapter,
       ...contextAdapters,

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -72,11 +72,6 @@ const getResumableAdapter = <UI_MESSAGE extends UIMessage>(
 const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   options?: UseChatRuntimeOptions<UI_MESSAGE>,
 ): AssistantRuntime => {
-  // The `_`-prefixed bindings exist only to peel the shared options off
-  // `...chatOptions` so they don't leak into `useChat`. Their values are
-  // re-extracted from the full options object via the helper below, which
-  // keeps the forward set in sync with `ExternalStoreSharedOptions` even
-  // when new fields are added.
   const {
     adapters,
     transport: transportOptions,
@@ -88,6 +83,11 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     onResume,
     ...chatOptions
   } = options ?? {};
+  // peel guard: any shared key left in `chatOptions` collapses this to `never`
+  true satisfies keyof typeof chatOptions &
+    keyof ExternalStoreSharedOptions extends never
+    ? true
+    : never;
 
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const transport = useDynamicChatTransport(

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -2,9 +2,10 @@
 
 import { useChat, type UIMessage } from "@ai-sdk/react";
 import type { AssistantCloud } from "assistant-cloud";
-import type {
-  AssistantRuntime,
-  ExternalStoreSharedOptions,
+import {
+  pickExternalStoreSharedOptions,
+  type AssistantRuntime,
+  type ExternalStoreSharedOptions,
 } from "@assistant-ui/core";
 import {
   useCloudThreadListAdapter,
@@ -71,14 +72,19 @@ const getResumableAdapter = <UI_MESSAGE extends UIMessage>(
 const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   options?: UseChatRuntimeOptions<UI_MESSAGE>,
 ): AssistantRuntime => {
+  // The `_`-prefixed bindings exist only to peel the shared options off
+  // `...chatOptions` so they don't leak into `useChat`. Their values are
+  // re-extracted from the full options object via the helper below, which
+  // keeps the forward set in sync with `ExternalStoreSharedOptions` even
+  // when new fields are added.
   const {
     adapters,
     transport: transportOptions,
     toCreateMessage,
-    isDisabled,
-    isSendDisabled,
-    unstable_capabilities,
-    suggestions,
+    isDisabled: _isDisabled,
+    isSendDisabled: _isSendDisabled,
+    unstable_capabilities: _unstable_capabilities,
+    suggestions: _suggestions,
     onResume,
     ...chatOptions
   } = options ?? {};
@@ -102,10 +108,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const runtime = useAISDKRuntime(chat, {
     adapters,
-    isDisabled,
-    isSendDisabled,
-    unstable_capabilities,
-    suggestions,
+    ...pickExternalStoreSharedOptions(options ?? {}),
     ...(toCreateMessage && { toCreateMessage }),
     ...(onResume && { onResume }),
   });

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -2,7 +2,10 @@
 
 import { useChat, type UIMessage } from "@ai-sdk/react";
 import type { AssistantCloud } from "assistant-cloud";
-import type { AssistantRuntime } from "@assistant-ui/core";
+import type {
+  AssistantRuntime,
+  ExternalStoreSharedOptions,
+} from "@assistant-ui/core";
 import {
   useCloudThreadListAdapter,
   useRemoteThreadListRuntime,
@@ -19,16 +22,13 @@ import type { AssistantChatResumableOptions } from "../resumable";
 import { useEffect, useMemo, useRef } from "react";
 
 export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
-  ChatInit<UI_MESSAGE> & {
-    cloud?: AssistantCloud | undefined;
-    adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
-    toCreateMessage?: CustomToCreateMessageFunction;
-    isDisabled?: AISDKRuntimeAdapter["isDisabled"];
-    isSendDisabled?: AISDKRuntimeAdapter["isSendDisabled"];
-    unstable_capabilities?: AISDKRuntimeAdapter["unstable_capabilities"];
-    onResume?: AISDKRuntimeAdapter["onResume"];
-    suggestions?: AISDKRuntimeAdapter["suggestions"];
-  };
+  ChatInit<UI_MESSAGE> &
+    ExternalStoreSharedOptions & {
+      cloud?: AssistantCloud | undefined;
+      adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
+      toCreateMessage?: CustomToCreateMessageFunction;
+      onResume?: AISDKRuntimeAdapter["onResume"];
+    };
 
 const useDynamicChatTransport = <UI_MESSAGE extends UIMessage = UIMessage>(
   transport: ChatTransport<UI_MESSAGE>,
@@ -78,8 +78,8 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     isDisabled,
     isSendDisabled,
     unstable_capabilities,
-    onResume,
     suggestions,
+    onResume,
     ...chatOptions
   } = options ?? {};
 
@@ -102,12 +102,12 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const runtime = useAISDKRuntime(chat, {
     adapters,
+    isDisabled,
+    isSendDisabled,
+    unstable_capabilities,
+    suggestions,
     ...(toCreateMessage && { toCreateMessage }),
     ...(onResume && { onResume }),
-    ...(suggestions && { suggestions }),
-    ...(isDisabled !== undefined && { isDisabled }),
-    ...(isSendDisabled !== undefined && { isSendDisabled }),
-    ...(unstable_capabilities && { unstable_capabilities }),
   });
 
   if (transport instanceof AssistantChatTransport) {

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -1,15 +1,15 @@
 import { useEffect, useRef, useState } from "react";
 import {
   getExternalStoreMessages,
+  pickExternalStoreSharedOptions,
   type AttachmentAdapter,
   type DictationAdapter,
-  type ExternalStoreAdapter,
+  type ExternalStoreSharedOptions,
   type FeedbackAdapter,
   type RealtimeVoiceAdapter,
   type SpeechSynthesisAdapter,
   type AppendMessage,
   type ThreadMessage,
-  type ThreadSuggestion,
   type ToolExecutionStatus,
 } from "@assistant-ui/core";
 import {
@@ -138,7 +138,7 @@ const truncateAdkMessages = (
   return truncated;
 };
 
-export type UseAdkRuntimeOptions = {
+export type UseAdkRuntimeOptions = ExternalStoreSharedOptions & {
   stream: AdkStreamCallback;
   autoCancelPendingToolCalls?: boolean | undefined;
   unstable_allowCancellation?: boolean | undefined;
@@ -158,24 +158,6 @@ export type UseAdkRuntimeOptions = {
         feedback?: FeedbackAdapter;
       }
     | undefined;
-  /**
-   * Whether the entire thread is disabled. When `true`, the composer's input
-   * is also disabled. For a narrower gate that keeps the input usable but
-   * blocks only sending, use `isSendDisabled`.
-   */
-  isDisabled?: boolean | undefined;
-  /**
-   * Whether sending new messages is currently disabled.
-   */
-  isSendDisabled?: boolean | undefined;
-  /**
-   * Optional thread capability overrides.
-   */
-  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
-  /**
-   * Follow up suggestions to surface on the thread.
-   */
-  suggestions?: readonly ThreadSuggestion[] | undefined;
   eventHandlers?:
     | {
         onError?: OnAdkErrorCallback;
@@ -191,19 +173,16 @@ export type UseAdkRuntimeOptions = {
   sessionAdapter?: RemoteThreadListAdapter | undefined;
 };
 
-const useAdkRuntimeImpl = ({
-  autoCancelPendingToolCalls,
-  adapters: { attachments, dictation, feedback, speech, voice } = {},
-  unstable_allowCancellation,
-  stream,
-  load,
-  getCheckpointId,
-  eventHandlers,
-  isDisabled,
-  isSendDisabled,
-  unstable_capabilities,
-  suggestions,
-}: UseAdkRuntimeOptions) => {
+const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
+  const {
+    autoCancelPendingToolCalls,
+    adapters: { attachments, dictation, feedback, speech, voice } = {},
+    unstable_allowCancellation,
+    stream,
+    load,
+    getCheckpointId,
+    eventHandlers,
+  } = options;
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const aui = useAui();
   const {
@@ -261,14 +240,11 @@ const useAdkRuntimeImpl = ({
 
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const runtime = useExternalStoreRuntime({
+    ...pickExternalStoreSharedOptions(options),
     isRunning: effectiveIsRunning,
     messages: threadMessages,
     unstable_enableToolInvocations: true,
     setToolStatuses,
-    ...(isDisabled !== undefined && { isDisabled }),
-    ...(isSendDisabled !== undefined && { isSendDisabled }),
-    ...(unstable_capabilities && { unstable_capabilities }),
-    ...(suggestions && { suggestions }),
     adapters: { attachments, dictation, feedback, speech, voice },
     extras: {
       [symbolAdkRuntimeExtras]: true,

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -6,14 +6,14 @@ import type {
   AppendMessage,
   AttachmentAdapter,
   DictationAdapter,
-  ExternalStoreAdapter,
+  ExternalStoreSharedOptions,
   FeedbackAdapter,
   RealtimeVoiceAdapter,
   RemoteThreadListAdapter,
   SpeechSynthesisAdapter,
-  ThreadSuggestion,
   ToolExecutionStatus,
 } from "@assistant-ui/core";
+import { pickExternalStoreSharedOptions } from "@assistant-ui/core";
 import {
   useCloudThreadListAdapter,
   useExternalStoreRuntime,
@@ -52,7 +52,7 @@ const asLangChainRuntimeExtras = (extras: unknown): LangChainRuntimeExtras => {
   return extras as LangChainRuntimeExtras;
 };
 
-type LangChainRuntimeExtraOptions = {
+type LangChainRuntimeExtraOptions = ExternalStoreSharedOptions & {
   cloud?: AssistantCloud | undefined;
   adapters?:
     | {
@@ -84,24 +84,6 @@ type LangChainRuntimeExtraOptions = {
   create?: (() => Promise<{ externalId: string | undefined }>) | undefined;
   /** Custom thread-deletion hook, forwarded to the cloud adapter. */
   delete?: ((threadId: string) => Promise<void>) | undefined;
-  /**
-   * Whether the entire thread is disabled. When `true`, the composer's input
-   * is also disabled. For a narrower gate that keeps the input usable but
-   * blocks only sending, use `isSendDisabled`.
-   */
-  isDisabled?: boolean | undefined;
-  /**
-   * Whether sending new messages is currently disabled.
-   */
-  isSendDisabled?: boolean | undefined;
-  /**
-   * Optional thread capability overrides.
-   */
-  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
-  /**
-   * Follow up suggestions to surface on the thread.
-   */
-  suggestions?: readonly ThreadSuggestion[] | undefined;
 };
 
 const getPendingToolCalls = (
@@ -190,15 +172,8 @@ const useStreamThreadRuntime = (
     "cloud" | "unstable_threadListAdapter" | "create" | "delete"
   >,
 ) => {
-  const {
-    adapters,
-    autoCancelPendingToolCalls,
-    unstable_allowCancellation,
-    isDisabled,
-    isSendDisabled,
-    unstable_capabilities,
-    suggestions,
-  } = options;
+  const { adapters, autoCancelPendingToolCalls, unstable_allowCancellation } =
+    options;
   const messagesKey = options.messagesKey ?? "messages";
 
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
@@ -254,16 +229,13 @@ const useStreamThreadRuntime = (
 
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const runtime = useExternalStoreRuntime({
+    ...pickExternalStoreSharedOptions(options),
     isRunning: effectiveIsRunning,
     messages: threadMessages,
     adapters,
     extras,
     unstable_enableToolInvocations: true,
     setToolStatuses,
-    ...(isDisabled !== undefined && { isDisabled }),
-    ...(isSendDisabled !== undefined && { isSendDisabled }),
-    ...(unstable_capabilities && { unstable_capabilities }),
-    ...(suggestions && { suggestions }),
     onNew: async (msg) => {
       const content = getMessageContent(msg);
       const cancellations =

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -17,15 +17,15 @@ import type {
 } from "./types";
 import {
   getExternalStoreMessages,
+  pickExternalStoreSharedOptions,
   type ThreadMessage,
   type AttachmentAdapter,
   type AppendMessage,
   type DictationAdapter,
-  type ExternalStoreAdapter,
+  type ExternalStoreSharedOptions,
   type FeedbackAdapter,
   type RealtimeVoiceAdapter,
   type SpeechSynthesisAdapter,
-  type ThreadSuggestion,
 } from "@assistant-ui/core";
 import type { ToolExecutionStatus } from "@assistant-ui/core";
 import {
@@ -189,7 +189,7 @@ export const useLangGraphUIMessages = () => {
   });
 };
 
-export type UseLangGraphRuntimeOptions = {
+export type UseLangGraphRuntimeOptions = ExternalStoreSharedOptions & {
   autoCancelPendingToolCalls?: boolean | undefined;
   /**
    * When true, renders the Cancel button in the composer and aborts the
@@ -239,28 +239,6 @@ export type UseLangGraphRuntimeOptions = {
         feedback?: FeedbackAdapter;
       }
     | undefined;
-  /**
-   * Whether the entire thread is disabled. When `true`, the composer's input
-   * is also disabled (the user cannot type, attach files, or submit). For a
-   * narrower gate that keeps the input usable but blocks only sending, use
-   * `isSendDisabled`.
-   */
-  isDisabled?: boolean | undefined;
-  /**
-   * Whether sending new messages is currently disabled. When `true`, the
-   * thread composer's input remains usable but `send()` becomes a no-op
-   * and the thread composer's `canSend` is `false`.
-   */
-  isSendDisabled?: boolean | undefined;
-  /**
-   * Optional thread capability overrides (e.g. `{ copy: false }` to disable
-   * the copy-message action).
-   */
-  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
-  /**
-   * Follow up suggestions to surface on the thread.
-   */
-  suggestions?: readonly ThreadSuggestion[] | undefined;
   eventHandlers?:
     | {
         /**
@@ -363,21 +341,18 @@ const filterUIMessagesBySurvivingIds = (
   });
 };
 
-const useLangGraphRuntimeImpl = ({
-  autoCancelPendingToolCalls,
-  adapters: { attachments, dictation, feedback, speech, voice } = {},
-  unstable_allowCancellation,
-  stream,
-  load,
-  getCheckpointId,
-  eventHandlers,
-  uiStateKey,
-  uiComponents,
-  isDisabled,
-  isSendDisabled,
-  unstable_capabilities,
-  suggestions,
-}: UseLangGraphRuntimeOptions) => {
+const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
+  const {
+    autoCancelPendingToolCalls,
+    adapters: { attachments, dictation, feedback, speech, voice } = {},
+    unstable_allowCancellation,
+    stream,
+    load,
+    getCheckpointId,
+    eventHandlers,
+    uiStateKey,
+    uiComponents,
+  } = options;
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const aui = useAui();
 
@@ -535,15 +510,12 @@ const useLangGraphRuntimeImpl = ({
 
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const runtime = useExternalStoreRuntime({
+    ...pickExternalStoreSharedOptions(options),
     isRunning: effectiveIsRunning,
     isLoading: isLoadingThread,
     messages: threadMessages,
     unstable_enableToolInvocations: true,
     setToolStatuses,
-    ...(isDisabled !== undefined && { isDisabled }),
-    ...(isSendDisabled !== undefined && { isSendDisabled }),
-    ...(unstable_capabilities && { unstable_capabilities }),
-    ...(suggestions && { suggestions }),
     adapters: {
       attachments,
       dictation,

--- a/packages/react-opencode/src/types.ts
+++ b/packages/react-opencode/src/types.ts
@@ -3,12 +3,11 @@ import type {
   AssistantRuntime,
   AttachmentAdapter,
   DictationAdapter,
-  ExternalStoreAdapter,
+  ExternalStoreSharedOptions,
   FeedbackAdapter,
   RealtimeVoiceAdapter,
   SpeechSynthesisAdapter,
   ThreadMessageLike,
-  ThreadSuggestion,
   ThreadUserMessagePart,
 } from "@assistant-ui/react";
 import type {
@@ -183,7 +182,7 @@ export type OpenCodeUserMessageOptions = {
   noReply?: boolean | undefined;
 };
 
-export type OpenCodeRuntimeOptions = {
+export type OpenCodeRuntimeOptions = ExternalStoreSharedOptions & {
   client?: OpencodeClient;
   baseUrl?: string | undefined;
   initialSessionId?: string | undefined;
@@ -204,24 +203,6 @@ export type OpenCodeRuntimeOptions = {
         feedback?: FeedbackAdapter;
       }
     | undefined;
-  /**
-   * Whether the entire thread is disabled. When `true`, the composer's input
-   * is also disabled. For a narrower gate that keeps the input usable but
-   * blocks only sending, use `isSendDisabled`.
-   */
-  isDisabled?: boolean | undefined;
-  /**
-   * Whether sending new messages is currently disabled.
-   */
-  isSendDisabled?: boolean | undefined;
-  /**
-   * Optional thread capability overrides.
-   */
-  unstable_capabilities?: ExternalStoreAdapter["unstable_capabilities"];
-  /**
-   * Follow up suggestions to surface on the thread.
-   */
-  suggestions?: readonly ThreadSuggestion[] | undefined;
 };
 
 export type OpenCodeRuntimeExtras = {

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -2,6 +2,7 @@
 
 import {
   ExportedMessageRepository,
+  pickExternalStoreSharedOptions,
   useAuiState,
   useExternalStoreRuntime,
   useRemoteThreadListRuntime,
@@ -204,18 +205,11 @@ const useOpenCodeThreadRuntime = (
 
   // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   return useExternalStoreRuntime<ThreadMessage>({
+    ...pickExternalStoreSharedOptions(options),
     isLoading: state.loadState.type === "loading",
     isRunning: isOpenCodeStateRunning(state),
     messageRepository,
     extras,
-    ...(options.isDisabled !== undefined && { isDisabled: options.isDisabled }),
-    ...(options.isSendDisabled !== undefined && {
-      isSendDisabled: options.isSendDisabled,
-    }),
-    ...(options.unstable_capabilities && {
-      unstable_capabilities: options.unstable_capabilities,
-    }),
-    ...(options.suggestions && { suggestions: options.suggestions }),
     ...(options.adapters && { adapters: options.adapters }),
     onNew: async (message: any) => {
       try {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -127,14 +127,17 @@ export type { ThreadMessageLike } from "@assistant-ui/core";
 export {
   getExternalStoreMessages,
   bindExternalStoreMessage,
+  pickExternalStoreSharedOptions,
 } from "@assistant-ui/core";
 export type {
   ExternalStoreAdapter,
   ExternalStoreMessageConverter,
+  ExternalStoreSharedOptions,
   ExternalStoreThreadListAdapter,
   ExternalStoreThreadData,
 } from "@assistant-ui/core";
 export { useExternalStoreRuntime } from "./legacy-runtime/runtime-cores/external-store/useExternalStoreRuntime";
+export { useExternalStoreSharedOptions } from "@assistant-ui/core/react";
 export {
   useExternalMessageConverter,
   convertExternalMessages as unstable_convertExternalMessages,


### PR DESCRIPTION
follow-up to #4135.

## summary

- introduces three shared primitives in `@assistant-ui/core` so runtime wrapper hooks stop reimplementing the same four-field forward pattern: `ExternalStoreSharedOptions` (typed `Pick`), `pickExternalStoreSharedOptions` (function), `useExternalStoreSharedOptions` (memoized hook, from `@assistant-ui/core/react`).
- every wrapper (`useChatRuntime`, `useAISDKRuntime`, `useLangGraphRuntime`, `useA2ARuntime`, `useAgUiRuntime`, `useAdkRuntime`, `useStreamRuntime`, `useOpenCodeRuntime`) migrates to these helpers; each sheds 20 to 40 lines of duplicated declarations and conditional spreads.
- both the function and the hook constrain their object literal with `satisfies { [K in keyof Required<ExternalStoreSharedOptions>]: ... }`, so adding a key to the shared type without updating the implementation site is a compile error rather than a silent missing-field bug.
- A2A and AgUi useMemos shed their per-field deps and the prior `oxlint-disable` comments; they now list a single stable `shared` reference as the dep, so future additions to the shared option set don't need to touch any wrapper deps array.

net diff across 7 wrappers: +85 / -277 = -192 lines. behavior unchanged.

## test plan

### already verified

- [x] `pnpm exec tsc --noEmit` per touched package: clean.
- [x] `pnpm lint`: exit 0 with no new warnings (one pre-existing unused-import warning in `react-langgraph`, unrelated).
- [x] `pnpm --filter @assistant-ui/{core,react,react-ai-sdk,react-langgraph,react-a2a,react-ag-ui,react-google-adk,react-langchain,react-opencode} test`: 1184/1184 green, including the 4 end-to-end `useAISDKRuntime` tests added in #4135 that assert `isDisabled` / `isSendDisabled` / `unstable_capabilities` / `suggestions` reach `thread.getState()` and `composer.canSend`. their passing here proves the refactor is behavior-equivalent.
- [x] satisfies guard manually verified: temporarily deleting one of the four assignments from `pickExternalStoreSharedOptions` produces `error TS1360: Property 'suggestions' is missing`; same for the hook. drift is caught at compile time.

### reviewer should verify

- [ ] in any non-AISDK runtime wrapper, pass `isSendDisabled: true` end-to-end and confirm Send is gated while the input stays usable. semantics inherit from #4135 but the wiring path is new.
- [ ] inspect the JSDoc rendered by IDEs when hovering `isDisabled` on a wrapper's options type — should still surface the description from `ExternalStoreAdapter` (preserved through `Pick`).

## notes

- no docs site update needed: `apps/docs/content/docs/runtimes/custom/external-store.mdx` already documents the four fields for direct `useExternalStoreRuntime` users; the new helpers target wrapper authors, an audience that learns from existing wrappers + JSDoc rather than a dedicated docs page. the api-reference page is auto-generated from typedocs and will pick up the new exports.
- root-fix design instead of palliative: the two earlier drift surfaces (function body forgetting a field; useMemo deps forgetting a field) are now both caught at compile time via `satisfies`, not by lint conventions or code review.