### PR TITLE
fix(core): branch picker not appearing

### DIFF
--- a/.changeset/branch-picker-external-store.md
+++ b/.changeset/branch-picker-external-store.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: branch picker not appearing when multiple branches are available

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -189,6 +189,10 @@ export class MessageRepository {
     return this.head?.current.id ?? null;
   }
 
+  hasMessage(messageId: string) {
+    return this.messages.has(messageId);
+  }
+
   getMessages(headId?: string) {
     if (headId === undefined || headId === this.head?.current.id) {
       return this._messages.value;

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -56,8 +56,8 @@ export class ExternalStoreThreadRuntimeCore
 {
   private _assistantOptimisticId: string | null = null;
   private _lastSyncedMessageIds = new Set<string>();
-  private _branchPreservationSourceIds = new Set<string>();
-  private _branchSwitchPreservationIds = new Set<string>();
+  private _pendingEditOrReloadSources = new Set<string>();
+  private _pendingSwitchSiblings = new Set<string>();
 
   private _capabilities: RuntimeCapabilities = {
     switchToBranch: false,
@@ -110,8 +110,8 @@ export class ExternalStoreThreadRuntimeCore
 
   private _getBranchPreservationIds() {
     if (
-      this._branchPreservationSourceIds.size === 0 &&
-      this._branchSwitchPreservationIds.size === 0
+      this._pendingEditOrReloadSources.size === 0 &&
+      this._pendingSwitchSiblings.size === 0
     )
       return undefined;
 
@@ -122,20 +122,22 @@ export class ExternalStoreThreadRuntimeCore
     const preservedIds = new Set<string>();
 
     const shouldPreserve = (messageId: string): boolean => {
-      if (preservedIds.has(messageId)) return true;
-
+      const chain: string[] = [];
       const visited = new Set<string>();
       let currentId: string | null | undefined = messageId;
       while (currentId != null && !visited.has(currentId)) {
         if (
-          this._branchPreservationSourceIds.has(currentId) ||
-          this._branchSwitchPreservationIds.has(currentId)
+          preservedIds.has(currentId) ||
+          this._pendingEditOrReloadSources.has(currentId) ||
+          this._pendingSwitchSiblings.has(currentId)
         ) {
-          preservedIds.add(messageId);
+          preservedIds.add(currentId);
+          for (const id of chain) preservedIds.add(id);
           return true;
         }
 
         visited.add(currentId);
+        chain.push(currentId);
         currentId = parentById.get(currentId);
       }
 
@@ -151,7 +153,7 @@ export class ExternalStoreThreadRuntimeCore
 
   private _preserveBranchSiblings(messageId: string) {
     for (const branchId of this.repository.getBranches(messageId)) {
-      this._branchSwitchPreservationIds.add(branchId);
+      this._pendingSwitchSiblings.add(branchId);
     }
   }
 
@@ -229,8 +231,8 @@ export class ExternalStoreThreadRuntimeCore
       this.repository.clear();
       this._assistantOptimisticId = null;
       this._lastSyncedMessageIds = new Set();
-      this._branchPreservationSourceIds.clear();
-      this._branchSwitchPreservationIds.clear();
+      this._pendingEditOrReloadSources.clear();
+      this._pendingSwitchSiblings.clear();
       this.repository.import(store.messageRepository);
 
       messages = this.repository.getMessages();
@@ -284,18 +286,24 @@ export class ExternalStoreThreadRuntimeCore
           });
 
       const nextIds = new Set(messages.map((m) => m.id));
-      const preservedBranchIds = this._getBranchPreservationIds();
+      let preservedBranchIds: Set<string> | undefined;
+      let computedPreservation = false;
       for (const prevId of this._lastSyncedMessageIds) {
-        if (!nextIds.has(prevId) && !preservedBranchIds?.has(prevId)) {
+        if (nextIds.has(prevId)) continue;
+        if (!computedPreservation) {
+          preservedBranchIds = this._getBranchPreservationIds();
+          computedPreservation = true;
+        }
+        if (!preservedBranchIds?.has(prevId)) {
           this.repository.deleteMessage(prevId);
         }
       }
-      for (const sourceId of this._branchPreservationSourceIds) {
-        if (!nextIds.has(sourceId)) {
-          this._branchPreservationSourceIds.delete(sourceId);
-        }
-      }
-      this._branchSwitchPreservationIds.clear();
+      this._pendingEditOrReloadSources = new Set(
+        [...this._pendingEditOrReloadSources].filter((sourceId) =>
+          nextIds.has(sourceId),
+        ),
+      );
+      this._pendingSwitchSiblings.clear();
       this._lastSyncedMessageIds = nextIds;
 
       for (let i = 0; i < messages.length; i++) {
@@ -476,7 +484,7 @@ export class ExternalStoreThreadRuntimeCore
       if (!this._store.onEdit)
         throw new Error("Runtime does not support editing messages.");
       if (message.sourceId)
-        this._branchPreservationSourceIds.add(message.sourceId);
+        this._pendingEditOrReloadSources.add(message.sourceId);
       await this._store.onEdit(message);
     } else {
       await this._store.onNew(message);
@@ -492,7 +500,7 @@ export class ExternalStoreThreadRuntimeCore
     // exists. See `append` above for full rationale.
     await this._toolInvocations?.abort();
 
-    if (config.sourceId) this._branchPreservationSourceIds.add(config.sourceId);
+    if (config.sourceId) this._pendingEditOrReloadSources.add(config.sourceId);
     await this._store.onReload(config.parentId, config);
   }
 
@@ -602,8 +610,8 @@ export class ExternalStoreThreadRuntimeCore
 
   public override reset(initialMessages?: readonly ThreadMessageLike[]) {
     this._lastSyncedMessageIds = new Set();
-    this._branchPreservationSourceIds.clear();
-    this._branchSwitchPreservationIds.clear();
+    this._pendingEditOrReloadSources.clear();
+    this._pendingSwitchSiblings.clear();
     const repo = new MessageRepository();
     repo.import(ExportedMessageRepository.fromArray(initialMessages ?? []));
     this.updateMessages(repo.getMessages());
@@ -612,8 +620,8 @@ export class ExternalStoreThreadRuntimeCore
   public override import(data: ExportedMessageRepository) {
     this._assistantOptimisticId = null;
     this._lastSyncedMessageIds = new Set();
-    this._branchPreservationSourceIds.clear();
-    this._branchSwitchPreservationIds.clear();
+    this._pendingEditOrReloadSources.clear();
+    this._pendingSwitchSiblings.clear();
 
     super.import(data);
 

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -157,6 +157,29 @@ export class ExternalStoreThreadRuntimeCore
     }
   }
 
+  private _moveBranchSiblingsToParent(
+    messageId: string,
+    parentId: string | null,
+  ) {
+    let existingParentId: string | null;
+    let branchIds: string[];
+    try {
+      existingParentId = this.repository.getMessage(messageId).parentId;
+      if (existingParentId === parentId) return;
+      branchIds = this.repository.getBranches(messageId);
+    } catch {
+      return;
+    }
+
+    if (branchIds.length <= 1) return;
+
+    for (const branchId of branchIds) {
+      const branch = this.repository.getMessage(branchId);
+      if (branch.parentId !== existingParentId) continue;
+      this.repository.addOrUpdateMessage(parentId, branch.message);
+    }
+  }
+
   /**
    * Client-side tool-invocations pipeline. Constructed lazily on first
    * snapshot — only when `adapter.unstable_enableToolInvocations === true`.
@@ -311,7 +334,9 @@ export class ExternalStoreThreadRuntimeCore
       for (let i = 0; i < messages.length; i++) {
         const message = messages[i]!;
         const parent = messages[i - 1];
-        this.repository.addOrUpdateMessage(parent?.id ?? null, message);
+        const parentId = parent?.id ?? null;
+        this._moveBranchSiblingsToParent(message.id, parentId);
+        this.repository.addOrUpdateMessage(parentId, message);
       }
     } else {
       throw new Error(

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -56,6 +56,8 @@ export class ExternalStoreThreadRuntimeCore
 {
   private _assistantOptimisticId: string | null = null;
   private _lastSyncedMessageIds = new Set<string>();
+  private _branchPreservationSourceIds = new Set<string>();
+  private _branchSwitchPreservationIds = new Set<string>();
 
   private _capabilities: RuntimeCapabilities = {
     switchToBranch: false,
@@ -105,6 +107,53 @@ export class ExternalStoreThreadRuntimeCore
   private _converter = new ThreadMessageConverter();
 
   private _store!: ExternalStoreAdapter<any>;
+
+  private _getBranchPreservationIds() {
+    if (
+      this._branchPreservationSourceIds.size === 0 &&
+      this._branchSwitchPreservationIds.size === 0
+    )
+      return undefined;
+
+    const exportedMessages = this.repository.export().messages;
+    const parentById = new Map(
+      exportedMessages.map(({ message, parentId }) => [message.id, parentId]),
+    );
+    const preservedIds = new Set<string>();
+
+    const shouldPreserve = (messageId: string): boolean => {
+      if (preservedIds.has(messageId)) return true;
+
+      const visited = new Set<string>();
+      let currentId: string | null | undefined = messageId;
+      while (currentId != null && !visited.has(currentId)) {
+        if (
+          this._branchPreservationSourceIds.has(currentId) ||
+          this._branchSwitchPreservationIds.has(currentId)
+        ) {
+          preservedIds.add(messageId);
+          return true;
+        }
+
+        visited.add(currentId);
+        currentId = parentById.get(currentId);
+      }
+
+      return false;
+    };
+
+    for (const { message } of exportedMessages) {
+      shouldPreserve(message.id);
+    }
+
+    return preservedIds;
+  }
+
+  private _preserveBranchSiblings(messageId: string) {
+    for (const branchId of this.repository.getBranches(messageId)) {
+      this._branchSwitchPreservationIds.add(branchId);
+    }
+  }
 
   /**
    * Client-side tool-invocations pipeline. Constructed lazily on first
@@ -180,6 +229,8 @@ export class ExternalStoreThreadRuntimeCore
       this.repository.clear();
       this._assistantOptimisticId = null;
       this._lastSyncedMessageIds = new Set();
+      this._branchPreservationSourceIds.clear();
+      this._branchSwitchPreservationIds.clear();
       this.repository.import(store.messageRepository);
 
       messages = this.repository.getMessages();
@@ -233,9 +284,18 @@ export class ExternalStoreThreadRuntimeCore
           });
 
       const nextIds = new Set(messages.map((m) => m.id));
+      const preservedBranchIds = this._getBranchPreservationIds();
       for (const prevId of this._lastSyncedMessageIds) {
-        if (!nextIds.has(prevId)) this.repository.deleteMessage(prevId);
+        if (!nextIds.has(prevId) && !preservedBranchIds?.has(prevId)) {
+          this.repository.deleteMessage(prevId);
+        }
       }
+      for (const sourceId of this._branchPreservationSourceIds) {
+        if (!nextIds.has(sourceId)) {
+          this._branchPreservationSourceIds.delete(sourceId);
+        }
+      }
+      this._branchSwitchPreservationIds.clear();
       this._lastSyncedMessageIds = nextIds;
 
       for (let i = 0; i < messages.length; i++) {
@@ -397,6 +457,7 @@ export class ExternalStoreThreadRuntimeCore
     }
 
     this.repository.switchToBranch(branchId);
+    this._preserveBranchSiblings(branchId);
     this.updateMessages(this.repository.getMessages());
   }
 
@@ -414,6 +475,8 @@ export class ExternalStoreThreadRuntimeCore
     if (message.parentId !== (this.messages.at(-1)?.id ?? null)) {
       if (!this._store.onEdit)
         throw new Error("Runtime does not support editing messages.");
+      if (message.sourceId)
+        this._branchPreservationSourceIds.add(message.sourceId);
       await this._store.onEdit(message);
     } else {
       await this._store.onNew(message);
@@ -429,6 +492,7 @@ export class ExternalStoreThreadRuntimeCore
     // exists. See `append` above for full rationale.
     await this._toolInvocations?.abort();
 
+    if (config.sourceId) this._branchPreservationSourceIds.add(config.sourceId);
     await this._store.onReload(config.parentId, config);
   }
 
@@ -538,6 +602,8 @@ export class ExternalStoreThreadRuntimeCore
 
   public override reset(initialMessages?: readonly ThreadMessageLike[]) {
     this._lastSyncedMessageIds = new Set();
+    this._branchPreservationSourceIds.clear();
+    this._branchSwitchPreservationIds.clear();
     const repo = new MessageRepository();
     repo.import(ExportedMessageRepository.fromArray(initialMessages ?? []));
     this.updateMessages(repo.getMessages());
@@ -546,6 +612,8 @@ export class ExternalStoreThreadRuntimeCore
   public override import(data: ExportedMessageRepository) {
     this._assistantOptimisticId = null;
     this._lastSyncedMessageIds = new Set();
+    this._branchPreservationSourceIds.clear();
+    this._branchSwitchPreservationIds.clear();
 
     super.import(data);
 

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -108,45 +108,29 @@ export class ExternalStoreThreadRuntimeCore
 
   private _store!: ExternalStoreAdapter<any>;
 
-  private _getBranchPreservationIds() {
-    if (
-      this._pendingEditOrReloadSources.size === 0 &&
-      this._pendingSwitchSiblings.size === 0
-    )
-      return undefined;
-
-    const preservedIds = new Set<string>();
-
-    const shouldPreserve = (messageId: string): boolean => {
-      const chain: string[] = [];
-      let currentId: string | null = messageId;
-      while (currentId != null) {
-        if (
-          preservedIds.has(currentId) ||
-          this._pendingEditOrReloadSources.has(currentId) ||
-          this._pendingSwitchSiblings.has(currentId)
-        ) {
-          preservedIds.add(currentId);
-          for (const id of chain) preservedIds.add(id);
-          return true;
-        }
-
-        chain.push(currentId);
-        try {
-          currentId = this.repository.getMessage(currentId).parentId;
-        } catch {
-          return false;
-        }
+  private _isMessagePreserved(messageId: string, cache: Set<string>): boolean {
+    const chain: string[] = [];
+    let currentId: string | null = messageId;
+    while (currentId != null) {
+      if (
+        cache.has(currentId) ||
+        this._pendingEditOrReloadSources.has(currentId) ||
+        this._pendingSwitchSiblings.has(currentId)
+      ) {
+        cache.add(currentId);
+        for (const id of chain) cache.add(id);
+        return true;
       }
 
-      return false;
-    };
-
-    for (const { message } of this.repository.export().messages) {
-      shouldPreserve(message.id);
+      chain.push(currentId);
+      try {
+        currentId = this.repository.getMessage(currentId).parentId;
+      } catch {
+        return false;
+      }
     }
 
-    return preservedIds;
+    return false;
   }
 
   private _preserveBranchSiblings(messageId: string) {
@@ -343,17 +327,20 @@ export class ExternalStoreThreadRuntimeCore
           });
 
       const nextIds = new Set(messages.map((m) => m.id));
-      let preservedBranchIds: Set<string> | undefined;
+      const hasPendingPreservation =
+        this._pendingEditOrReloadSources.size > 0 ||
+        this._pendingSwitchSiblings.size > 0;
+      const preservedCache = new Set<string>();
       let computedPreservation = false;
       for (const prevId of this._lastSyncedMessageIds) {
         if (nextIds.has(prevId)) continue;
-        if (!computedPreservation) {
-          preservedBranchIds = this._getBranchPreservationIds();
-          computedPreservation = true;
-        }
-        if (!preservedBranchIds?.has(prevId)) {
-          this.repository.deleteMessage(prevId);
-        }
+        computedPreservation = true;
+        if (
+          hasPendingPreservation &&
+          this._isMessagePreserved(prevId, preservedCache)
+        )
+          continue;
+        this.repository.deleteMessage(prevId);
       }
       this._pendingEditOrReloadSources = new Set(
         [...this._pendingEditOrReloadSources].filter((sourceId) =>

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -109,7 +109,7 @@ export class ExternalStoreThreadRuntimeCore
   private _store!: ExternalStoreAdapter<any>;
 
   private _isMessagePreserved(messageId: string, cache: Set<string>): boolean {
-    const chain: string[] = [];
+    let chain: string[] | undefined;
     let currentId: string | null = messageId;
     while (currentId != null) {
       if (
@@ -118,11 +118,13 @@ export class ExternalStoreThreadRuntimeCore
         this._pendingSwitchSiblings.has(currentId)
       ) {
         cache.add(currentId);
-        for (const id of chain) cache.add(id);
+        if (chain) {
+          for (const id of chain) cache.add(id);
+        }
         return true;
       }
 
-      chain.push(currentId);
+      (chain ??= []).push(currentId);
       try {
         currentId = this.repository.getMessage(currentId).parentId;
       } catch {
@@ -171,7 +173,6 @@ export class ExternalStoreThreadRuntimeCore
     const branchIndex = switchedMessages.findIndex(
       (message) => message.id === branchId,
     );
-    if (branchIndex === -1) return switchedMessages;
 
     // Keep a target branch's own selected child chain. If it has none, carry
     // over the active descendant continuation from the branch being left.
@@ -188,7 +189,8 @@ export class ExternalStoreThreadRuntimeCore
     if (continuationIndex < switchedMessages.length) return switchedMessages;
 
     let parentId = switchedMessages.at(-1)!.id;
-    for (const message of previousMessages.slice(continuationIndex)) {
+    for (let i = continuationIndex; i < previousMessages.length; i++) {
+      const message = previousMessages[i]!;
       this._moveBranchSiblingsToParent(message.id, parentId);
       this.repository.addOrUpdateMessage(parentId, message);
       this.repository.switchToBranch(message.id);
@@ -326,29 +328,41 @@ export class ExternalStoreThreadRuntimeCore
             return newMessage;
           });
 
-      const nextIds = new Set(messages.map((m) => m.id));
+      const nextIds = new Set<string>();
+      for (const message of messages) nextIds.add(message.id);
+
       const hasPendingPreservation =
         this._pendingEditOrReloadSources.size > 0 ||
         this._pendingSwitchSiblings.size > 0;
-      const preservedCache = new Set<string>();
-      let computedPreservation = false;
+      let preservedCache: Set<string> | undefined;
+      let hasPruneCandidate = false;
       for (const prevId of this._lastSyncedMessageIds) {
         if (nextIds.has(prevId)) continue;
-        computedPreservation = true;
+        hasPruneCandidate = true;
         if (
           hasPendingPreservation &&
-          this._isMessagePreserved(prevId, preservedCache)
+          this._isMessagePreserved(prevId, (preservedCache ??= new Set()))
         )
           continue;
         this.repository.deleteMessage(prevId);
       }
-      this._pendingEditOrReloadSources = new Set(
-        [...this._pendingEditOrReloadSources].filter((sourceId) =>
-          nextIds.has(sourceId),
-        ),
-      );
-      if (computedPreservation) {
+
+      for (const sourceId of this._pendingEditOrReloadSources) {
+        if (!nextIds.has(sourceId)) {
+          this._pendingEditOrReloadSources.delete(sourceId);
+        }
+      }
+      if (hasPruneCandidate) {
         this._pendingSwitchSiblings.clear();
+      } else {
+        for (const siblingId of this._pendingSwitchSiblings) {
+          if (
+            !nextIds.has(siblingId) &&
+            !this.repository.hasMessage(siblingId)
+          ) {
+            this._pendingSwitchSiblings.delete(siblingId);
+          }
+        }
       }
       this._lastSyncedMessageIds = nextIds;
 

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -146,21 +146,21 @@ export class ExternalStoreThreadRuntimeCore
     parentId: string | null,
   ) {
     let existingParentId: string | null;
-    let branchIds: string[];
+    let siblingIds: string[];
     try {
       existingParentId = this.repository.getMessage(messageId).parentId;
       if (existingParentId === parentId) return;
-      branchIds = this.repository.getBranches(messageId);
+      siblingIds = this.repository.getBranches(messageId);
     } catch {
       return;
     }
 
-    if (branchIds.length <= 1) return;
+    if (siblingIds.length <= 1) return;
 
-    for (const branchId of branchIds) {
-      const branch = this.repository.getMessage(branchId);
-      if (branch.parentId !== existingParentId) continue;
-      this.repository.addOrUpdateMessage(parentId, branch.message);
+    for (const siblingId of siblingIds) {
+      const sibling = this.repository.getMessage(siblingId);
+      if (sibling.parentId !== existingParentId) continue;
+      this.repository.addOrUpdateMessage(parentId, sibling.message);
     }
   }
 
@@ -347,6 +347,7 @@ export class ExternalStoreThreadRuntimeCore
         this.repository.deleteMessage(prevId);
       }
 
+      // Keep edit/reload sources armed until the source id leaves the host snapshot.
       for (const sourceId of this._pendingEditOrReloadSources) {
         if (!nextIds.has(sourceId)) {
           this._pendingEditOrReloadSources.delete(sourceId);

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -115,17 +115,12 @@ export class ExternalStoreThreadRuntimeCore
     )
       return undefined;
 
-    const exportedMessages = this.repository.export().messages;
-    const parentById = new Map(
-      exportedMessages.map(({ message, parentId }) => [message.id, parentId]),
-    );
     const preservedIds = new Set<string>();
 
     const shouldPreserve = (messageId: string): boolean => {
       const chain: string[] = [];
-      const visited = new Set<string>();
-      let currentId: string | null | undefined = messageId;
-      while (currentId != null && !visited.has(currentId)) {
+      let currentId: string | null = messageId;
+      while (currentId != null) {
         if (
           preservedIds.has(currentId) ||
           this._pendingEditOrReloadSources.has(currentId) ||
@@ -136,15 +131,18 @@ export class ExternalStoreThreadRuntimeCore
           return true;
         }
 
-        visited.add(currentId);
         chain.push(currentId);
-        currentId = parentById.get(currentId);
+        try {
+          currentId = this.repository.getMessage(currentId).parentId;
+        } catch {
+          return false;
+        }
       }
 
       return false;
     };
 
-    for (const { message } of exportedMessages) {
+    for (const { message } of this.repository.export().messages) {
       shouldPreserve(message.id);
     }
 
@@ -205,7 +203,7 @@ export class ExternalStoreThreadRuntimeCore
 
     if (continuationIndex < switchedMessages.length) return switchedMessages;
 
-    let parentId = switchedMessages.at(-1)?.id ?? branchId;
+    let parentId = switchedMessages.at(-1)!.id;
     for (const message of previousMessages.slice(continuationIndex)) {
       this._moveBranchSiblingsToParent(message.id, parentId);
       this.repository.addOrUpdateMessage(parentId, message);

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -303,7 +303,9 @@ export class ExternalStoreThreadRuntimeCore
           nextIds.has(sourceId),
         ),
       );
-      this._pendingSwitchSiblings.clear();
+      if (computedPreservation) {
+        this._pendingSwitchSiblings.clear();
+      }
       this._lastSyncedMessageIds = nextIds;
 
       for (let i = 0; i < messages.length; i++) {

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -180,6 +180,42 @@ export class ExternalStoreThreadRuntimeCore
     }
   }
 
+  private _switchToBranchWithActiveContinuation(branchId: string) {
+    const previousMessages = this.repository.getMessages();
+
+    this.repository.switchToBranch(branchId);
+
+    const switchedMessages = this.repository.getMessages();
+    const branchIndex = switchedMessages.findIndex(
+      (message) => message.id === branchId,
+    );
+    if (branchIndex === -1) return switchedMessages;
+
+    // Keep a target branch's own selected child chain. If it has none, carry
+    // over the active descendant continuation from the branch being left.
+    let continuationIndex = branchIndex + 1;
+    while (
+      continuationIndex < switchedMessages.length &&
+      continuationIndex < previousMessages.length &&
+      switchedMessages[continuationIndex]?.id ===
+        previousMessages[continuationIndex]?.id
+    ) {
+      continuationIndex++;
+    }
+
+    if (continuationIndex < switchedMessages.length) return switchedMessages;
+
+    let parentId = switchedMessages.at(-1)?.id ?? branchId;
+    for (const message of previousMessages.slice(continuationIndex)) {
+      this._moveBranchSiblingsToParent(message.id, parentId);
+      this.repository.addOrUpdateMessage(parentId, message);
+      this.repository.switchToBranch(message.id);
+      parentId = message.id;
+    }
+
+    return this.repository.getMessages();
+  }
+
   /**
    * Client-side tool-invocations pipeline. Constructed lazily on first
    * snapshot — only when `adapter.unstable_enableToolInvocations === true`.
@@ -491,9 +527,9 @@ export class ExternalStoreThreadRuntimeCore
       return;
     }
 
-    this.repository.switchToBranch(branchId);
+    const messages = this._switchToBranchWithActiveContinuation(branchId);
     this._preserveBranchSiblings(branchId);
-    this.updateMessages(this.repository.getMessages());
+    this.updateMessages(messages);
   }
 
   public async append(message: AppendMessage): Promise<void> {

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -207,6 +207,206 @@ describe("ExternalStoreThreadRuntimeCore - messages reconciliation", () => {
     ]);
   });
 
+  it("preserves a reloaded assistant as a branch", async () => {
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [user, a1],
+        onReload: vi.fn(),
+        setMessages: vi.fn(),
+      }),
+    );
+
+    await runtime.startRun({ parentId: "u", sourceId: "a1", runConfig: {} });
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [user, a2], setMessages: vi.fn() }),
+    );
+
+    const exported = runtime.export().messages;
+    expect(exported.map((m) => m.message.id)).toEqual(["u", "a1", "a2"]);
+    expect(
+      exported.filter((m) => m.parentId === "u").map((m) => m.message.id),
+    ).toEqual(["a1", "a2"]);
+    expect(runtime.getBranches("a2")).toEqual(["a1", "a2"]);
+  });
+
+  it("keeps reloaded assistant branches after switching back to an inactive branch", async () => {
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [user, a1],
+        onReload: vi.fn(),
+        setMessages: vi.fn(),
+      }),
+    );
+
+    await runtime.startRun({ parentId: "u", sourceId: "a1", runConfig: {} });
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [user, a2], setMessages: vi.fn() }),
+    );
+
+    runtime.switchToBranch("a1");
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [user, a1], setMessages: vi.fn() }),
+    );
+
+    expect(runtime.getBranches("a1")).toEqual(["a1", "a2"]);
+
+    runtime.switchToBranch("a2");
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [user, a2], setMessages: vi.fn() }),
+    );
+
+    expect(runtime.getBranches("a2")).toEqual(["a1", "a2"]);
+  });
+
+  it("does not keep a phantom selected branch id after branch switch preservation", async () => {
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+    const serverA1 = {
+      id: "server-a1",
+      role: "assistant" as const,
+      content: [],
+    };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [user, a1],
+        onReload: vi.fn(),
+        setMessages: vi.fn(),
+      }),
+    );
+
+    await runtime.startRun({ parentId: "u", sourceId: "a1", runConfig: {} });
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [user, a2], setMessages: vi.fn() }),
+    );
+
+    runtime.switchToBranch("a1");
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [user, a1], setMessages: vi.fn() }),
+    );
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [user, serverA1], setMessages: vi.fn() }),
+    );
+
+    expect(runtime.export().messages.map((m) => m.message.id)).toEqual([
+      "u",
+      "a2",
+      "server-a1",
+    ]);
+    expect(runtime.getBranches("server-a1")).toEqual(["a2", "server-a1"]);
+  });
+
+  it("preserves an edited user and its old descendants as a branch", async () => {
+    const u1 = { id: "u1", role: "user" as const, content: [] };
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const u2 = { id: "u2", role: "user" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [u1, a1],
+        onEdit: vi.fn(),
+        setMessages: vi.fn(),
+      }),
+    );
+
+    await runtime.append({
+      role: "user",
+      content: [],
+      parentId: null,
+      sourceId: "u1",
+      runConfig: {},
+    });
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [u2, a2], setMessages: vi.fn() }),
+    );
+
+    const exported = runtime.export().messages;
+    expect(exported.map((m) => m.message.id)).toEqual(["u1", "a1", "u2", "a2"]);
+    expect(exported.find((m) => m.message.id === "a1")?.parentId).toBe("u1");
+    expect(exported.find((m) => m.message.id === "a2")?.parentId).toBe("u2");
+    expect(runtime.getBranches("u2")).toEqual(["u1", "u2"]);
+  });
+
+  it("keeps edited user branches after switching back to an inactive branch", async () => {
+    const u1 = { id: "u1", role: "user" as const, content: [] };
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const u2 = { id: "u2", role: "user" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [u1, a1],
+        onEdit: vi.fn(),
+        setMessages: vi.fn(),
+      }),
+    );
+
+    await runtime.append({
+      role: "user",
+      content: [],
+      parentId: null,
+      sourceId: "u1",
+      runConfig: {},
+    });
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [u2, a2], setMessages: vi.fn() }),
+    );
+
+    runtime.switchToBranch("u1");
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [u1, a1], setMessages: vi.fn() }),
+    );
+
+    expect(runtime.getBranches("u1")).toEqual(["u1", "u2"]);
+
+    runtime.switchToBranch("u2");
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [u2, a2], setMessages: vi.fn() }),
+    );
+
+    expect(runtime.getBranches("u2")).toEqual(["u1", "u2"]);
+  });
+
+  it("does not clear pending branch preservation on a pre-truncation sync", async () => {
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [user, a1],
+        onReload: vi.fn(),
+        setMessages: vi.fn(),
+      }),
+    );
+
+    await runtime.startRun({ parentId: "u", sourceId: "a1", runConfig: {} });
+    runtime.__internal_setAdapter(
+      makeStore({
+        messages: [user, a1],
+        isRunning: true,
+        setMessages: vi.fn(),
+      }),
+    );
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [user, a2], setMessages: vi.fn() }),
+    );
+
+    expect(runtime.getBranches("a2")).toEqual(["a1", "a2"]);
+  });
+
   it("does not crash on the next sync after cancelRun removes a leaf user", () => {
     const userWithText = {
       id: "u",

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -449,6 +449,74 @@ describe("ExternalStoreThreadRuntimeCore - messages reconciliation", () => {
     expect(runtime.getBranches("b1")).toEqual(["b1", "b2"]);
   });
 
+  it("keeps three assistant branches when switching away from a branch with nested branches", async () => {
+    type TestMessage = {
+      id: string;
+      role: "user" | "assistant";
+      content: [];
+    };
+    const u0 = { id: "u0", role: "user" as const, content: [] };
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+    const a3 = { id: "a3", role: "assistant" as const, content: [] };
+    const u1 = { id: "u1", role: "user" as const, content: [] };
+    const u1a = { id: "u1a", role: "assistant" as const, content: [] };
+    const u2 = { id: "u2", role: "user" as const, content: [] };
+    const b1 = { id: "b1", role: "assistant" as const, content: [] };
+    const b2 = { id: "b2", role: "assistant" as const, content: [] };
+
+    let runtime!: ExternalStoreThreadRuntimeCore;
+    const makeBranchingStore = (
+      messages: readonly TestMessage[],
+    ): ExternalStoreAdapter =>
+      makeStore({
+        messages,
+        onEdit: vi.fn(),
+        onReload: vi.fn(),
+        setMessages: vi.fn(),
+      });
+    const syncMessages = (messages: readonly TestMessage[]) => {
+      runtime.__internal_setAdapter(makeBranchingStore(messages));
+    };
+
+    runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeBranchingStore([u0, a1]),
+    );
+
+    await runtime.startRun({ parentId: "u0", sourceId: "a1", runConfig: {} });
+    syncMessages([u0, a2]);
+
+    await runtime.startRun({ parentId: "u0", sourceId: "a2", runConfig: {} });
+    syncMessages([u0, a3]);
+
+    runtime.switchToBranch("a1");
+    syncMessages([u0, a1, u1, u1a]);
+
+    await runtime.append({
+      role: "user",
+      content: [],
+      parentId: "a1",
+      sourceId: "u1",
+      runConfig: {},
+    });
+    syncMessages([u0, a1, u2, b1]);
+
+    await runtime.startRun({ parentId: "u2", sourceId: "b1", runConfig: {} });
+    syncMessages([u0, a1, u2, b2]);
+
+    expect(runtime.getBranches("a1")).toEqual(["a1", "a2", "a3"]);
+    expect(runtime.getBranches("u2")).toEqual(["u1", "u2"]);
+    expect(runtime.getBranches("b2")).toEqual(["b1", "b2"]);
+
+    runtime.switchToBranch("a2");
+    syncMessages([u0, a2, u2, b2]);
+
+    expect(runtime.getBranches("a2")).toEqual(["a1", "a2", "a3"]);
+    expect(runtime.getBranches("u2")).toEqual(["u1", "u2"]);
+    expect(runtime.getBranches("b2")).toEqual(["b1", "b2"]);
+  });
+
   it("does not clear pending branch preservation on a pre-truncation sync", async () => {
     const a1 = { id: "a1", role: "assistant" as const, content: [] };
     const a2 = { id: "a2", role: "assistant" as const, content: [] };

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -379,6 +379,76 @@ describe("ExternalStoreThreadRuntimeCore - messages reconciliation", () => {
     expect(runtime.getBranches("u2")).toEqual(["u1", "u2"]);
   });
 
+  it("keeps nested assistant branches after switching an ancestor branch away and back", async () => {
+    type TestMessage = {
+      id: string;
+      role: "user" | "assistant";
+      content: [];
+    };
+    const u0 = { id: "u0", role: "user" as const, content: [] };
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+    const u2 = { id: "u2", role: "user" as const, content: [] };
+    const u1 = { id: "u1", role: "user" as const, content: [] };
+    const u1a = { id: "u1a", role: "assistant" as const, content: [] };
+    const b1 = { id: "b1", role: "assistant" as const, content: [] };
+    const b2 = { id: "b2", role: "assistant" as const, content: [] };
+
+    let runtime!: ExternalStoreThreadRuntimeCore;
+    const makeBranchingStore = (
+      messages: readonly TestMessage[],
+    ): ExternalStoreAdapter =>
+      makeStore({
+        messages,
+        onEdit: vi.fn(),
+        onReload: vi.fn(),
+        setMessages: vi.fn(),
+      });
+    const syncMessages = (messages: readonly TestMessage[]) => {
+      runtime.__internal_setAdapter(makeBranchingStore(messages));
+    };
+
+    runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeBranchingStore([u0, a1]),
+    );
+
+    await runtime.startRun({ parentId: "u0", sourceId: "a1", runConfig: {} });
+    syncMessages([u0, a2]);
+
+    runtime.switchToBranch("a1");
+
+    syncMessages([u0, a1, u1, u1a]);
+
+    await runtime.append({
+      role: "user",
+      content: [],
+      parentId: "a1",
+      sourceId: "u1",
+      runConfig: {},
+    });
+    syncMessages([u0, a1, u2, b1]);
+
+    await runtime.startRun({ parentId: "u2", sourceId: "b1", runConfig: {} });
+    syncMessages([u0, a1, u2, b2]);
+
+    runtime.switchToBranch("b1");
+    syncMessages([u0, a1, u2, b1]);
+
+    expect(runtime.getBranches("a1")).toEqual(["a1", "a2"]);
+    expect(runtime.getBranches("u2")).toEqual(["u1", "u2"]);
+    expect(runtime.getBranches("b1")).toEqual(["b1", "b2"]);
+
+    runtime.switchToBranch("a2");
+    syncMessages([u0, a1, u2, b1]);
+    syncMessages([u0, a2]);
+
+    runtime.switchToBranch("a1");
+    syncMessages([u0, a1, u2, b1]);
+
+    expect(runtime.getBranches("b1")).toEqual(["b1", "b2"]);
+  });
+
   it("does not clear pending branch preservation on a pre-truncation sync", async () => {
     const a1 = { id: "a1", role: "assistant" as const, content: [] };
     const a2 = { id: "a2", role: "assistant" as const, content: [] };

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -600,6 +600,166 @@ describe("ExternalStoreThreadRuntimeCore - messages reconciliation", () => {
     expect(runtime.getBranches("a2")).toEqual(["a1", "a2"]);
   });
 
+  it("carries inactive branch siblings under the new active parent on switch", () => {
+    const u0 = { id: "u0", role: "user" as const, content: [] };
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+    const u1 = { id: "u1", role: "user" as const, content: [] };
+    const u1_edited = { id: "u1_edited", role: "user" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages: [u0, a1, u1], setMessages: vi.fn() }),
+    );
+
+    runtime.import(
+      ExportedMessageRepository.fromBranchableArray(
+        [
+          { parentId: null, message: u0 },
+          { parentId: "u0", message: a1 },
+          { parentId: "u0", message: a2 },
+          { parentId: "a1", message: u1 },
+          { parentId: "a1", message: u1_edited },
+        ],
+        { headId: "u1" },
+      ),
+    );
+
+    expect(runtime.getBranches("u1")).toEqual(["u1", "u1_edited"]);
+
+    runtime.switchToBranch("a2");
+
+    const afterSwitch = runtime.export().messages;
+    expect(afterSwitch.find((m) => m.message.id === "u1")?.parentId).toBe("a2");
+    expect(
+      afterSwitch.find((m) => m.message.id === "u1_edited")?.parentId,
+    ).toBe("a2");
+
+    runtime.switchToBranch("a1");
+
+    const afterSwitchBack = runtime.export().messages;
+    expect(afterSwitchBack.find((m) => m.message.id === "u1")?.parentId).toBe(
+      "a1",
+    );
+    expect(
+      afterSwitchBack.find((m) => m.message.id === "u1_edited")?.parentId,
+    ).toBe("a1");
+  });
+
+  it("carries a multi-level descendant chain across branch switches", () => {
+    const u0 = { id: "u0", role: "user" as const, content: [] };
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+    const u1 = { id: "u1", role: "user" as const, content: [] };
+    const b1 = { id: "b1", role: "assistant" as const, content: [] };
+    const u2 = { id: "u2", role: "user" as const, content: [] };
+    const c1 = { id: "c1", role: "assistant" as const, content: [] };
+    const setMessages = vi.fn();
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages: [u0, a1, u1, b1, u2, c1], setMessages }),
+    );
+
+    runtime.import(
+      ExportedMessageRepository.fromBranchableArray(
+        [
+          { parentId: null, message: u0 },
+          { parentId: "u0", message: a1 },
+          { parentId: "u0", message: a2 },
+          { parentId: "a1", message: u1 },
+          { parentId: "u1", message: b1 },
+          { parentId: "b1", message: u2 },
+          { parentId: "u2", message: c1 },
+        ],
+        { headId: "c1" },
+      ),
+    );
+    setMessages.mockClear();
+
+    runtime.switchToBranch("a2");
+
+    const switchedAway = setMessages.mock.calls.at(-1)?.[0] as
+      | { id: string }[]
+      | undefined;
+    expect(switchedAway?.map((m) => m.id)).toEqual([
+      "u0",
+      "a2",
+      "u1",
+      "b1",
+      "u2",
+      "c1",
+    ]);
+
+    runtime.switchToBranch("a1");
+
+    const switchedBack = setMessages.mock.calls.at(-1)?.[0] as
+      | { id: string }[]
+      | undefined;
+    expect(switchedBack?.map((m) => m.id)).toEqual([
+      "u0",
+      "a1",
+      "u1",
+      "b1",
+      "u2",
+      "c1",
+    ]);
+  });
+
+  it("retains switch sibling preservation across a no-prune sync", async () => {
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [user, a1],
+        onReload: vi.fn(),
+        setMessages: vi.fn(),
+      }),
+    );
+
+    await runtime.startRun({ parentId: "u", sourceId: "a1", runConfig: {} });
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [user, a2], setMessages: vi.fn() }),
+    );
+
+    runtime.switchToBranch("a1");
+
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [user, a2], setMessages: vi.fn() }),
+    );
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [user, a1], setMessages: vi.fn() }),
+    );
+
+    expect(runtime.getBranches("a1")).toEqual(["a1", "a2"]);
+  });
+
+  it("preserves a phantom branch when reload returns the same id (known limitation)", async () => {
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const b1 = { id: "b1", role: "assistant" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [user, a1],
+        onReload: vi.fn(),
+        setMessages: vi.fn(),
+      }),
+    );
+
+    await runtime.startRun({ parentId: "u", sourceId: "a1", runConfig: {} });
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [user, a1], setMessages: vi.fn() }),
+    );
+    runtime.__internal_setAdapter(
+      makeStore({ messages: [user, b1], setMessages: vi.fn() }),
+    );
+
+    expect(runtime.getBranches("b1")).toEqual(["a1", "b1"]);
+  });
+
   it("does not crash on the next sync after cancelRun removes a leaf user", () => {
     const userWithText = {
       id: "u",

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ExternalStoreThreadRuntimeCore } from "../runtimes/external-store/external-store-thread-runtime-core";
 import type { ExternalStoreAdapter } from "../runtimes/external-store/external-store-adapter";
 import type { ModelContextProvider } from "../model-context/types";
+import { ExportedMessageRepository } from "../runtime/utils/message-repository";
 
 const mockContextProvider: ModelContextProvider = {
   getModelContext: () => ({}),
@@ -515,6 +516,60 @@ describe("ExternalStoreThreadRuntimeCore - messages reconciliation", () => {
     expect(runtime.getBranches("a2")).toEqual(["a1", "a2", "a3"]);
     expect(runtime.getBranches("u2")).toEqual(["u1", "u2"]);
     expect(runtime.getBranches("b2")).toEqual(["b1", "b2"]);
+  });
+
+  it("keeps nested branch continuation in outgoing messages when switching an ancestor branch", () => {
+    type TestMessage = {
+      id: string;
+      role: "user" | "assistant";
+      content: [];
+    };
+    const u0 = { id: "u0", role: "user" as const, content: [] };
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+    const a3 = { id: "a3", role: "assistant" as const, content: [] };
+    const u1 = { id: "u1", role: "user" as const, content: [] };
+    const u2 = { id: "u2", role: "user" as const, content: [] };
+    const b1 = { id: "b1", role: "assistant" as const, content: [] };
+    const b2 = { id: "b2", role: "assistant" as const, content: [] };
+    const setMessages = vi.fn();
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [u0, a1, u2, b2],
+        setMessages,
+      }),
+    );
+
+    runtime.import(
+      ExportedMessageRepository.fromBranchableArray(
+        [
+          { parentId: null, message: u0 },
+          { parentId: "u0", message: a1 },
+          { parentId: "u0", message: a2 },
+          { parentId: "u0", message: a3 },
+          { parentId: "a1", message: u1 },
+          { parentId: "a1", message: u2 },
+          { parentId: "u2", message: b1 },
+          { parentId: "u2", message: b2 },
+        ],
+        { headId: "b2" },
+      ),
+    );
+    setMessages.mockClear();
+
+    runtime.switchToBranch("a2");
+
+    const switchedMessages = setMessages.mock.calls.at(-1)?.[0] as
+      | TestMessage[]
+      | undefined;
+    expect(switchedMessages?.map((message) => message.id)).toEqual([
+      "u0",
+      "a2",
+      "u2",
+      "b2",
+    ]);
   });
 
   it("does not clear pending branch preservation on a pre-truncation sync", async () => {


### PR DESCRIPTION
## Summary

PR #4040 introduced stale-id pruning for external-store runtimes to fix phantom siblings when message ids are swapped. That pruning also caused this regression (issue #4131): after switching branches, the next linear external-store sync could treat the inactive sibling branch as stale and delete it, making BranchPicker disappear.

This fix preserves known edit/reload branch siblings for the one sync caused by `switchToBranch`, so BranchPicker metadata survives branch navigation. The preservation is intentionally one-sync only, so #4040's phantom sibling cleanup for swapped message ids remains intact.

This also fixes the nested branch case found during testing: when switching an ancestor assistant branch, `switchToBranch` could emit a truncated linear message path and drop the currently selected descendant chain. The switch path now carries the active nested continuation forward when the target branch does not already have its own selected continuation, so downstream user/assistant branch pickers stay visible.

fixes #4131 

## Verification

- [x] all tests passing
- [x] Manually verifiy through testing on homepage demo and several examples