### PR TITLE
Add `fetchOptions` passthrough for A2A client/runtime requests

### DIFF
--- a/.changeset/a2a-fetch-options.md
+++ b/.changeset/a2a-fetch-options.md
@@ -1,0 +1,14 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+add `fetchOptions` passthrough on `A2AClient` and `useA2ARuntime` so callers can forward `credentials`, `cache`, `mode`, `keepalive`, etc. to the underlying fetch.
+
+```ts
+const runtime = useA2ARuntime({
+  baseUrl: "https://my-agent.example.com",
+  fetchOptions: { credentials: "include" },
+});
+```
+
+`headers`, `body`, `method`, and `signal` stay internally managed: the four fields are stripped at construction time and cannot leak through even if a caller bypasses the type with an `as RequestInit` cast.

--- a/apps/docs/content/docs/runtimes/a2a/client-and-hooks.mdx
+++ b/apps/docs/content/docs/runtimes/a2a/client-and-hooks.mdx
@@ -37,6 +37,7 @@ const runtime = useA2ARuntime({ client });
 | `headers` | `Record<string, string>` or `() => Record<string, string>` | Static or dynamic headers (e.g. for auth tokens). |
 | `tenant` | `string` | Tenant ID for multi-tenant servers (prepended to URL paths). |
 | `extensions` | `string[]` | Extension URIs to negotiate via `A2A-Extensions` header. |
+| `fetchOptions` | `RequestInit` (partial) | Extra fetch options applied to every request (e.g. `{ credentials: "include" }`). `headers`, `body`, `method`, and `signal` are managed internally. |
 
 ### Client methods
 
@@ -67,6 +68,7 @@ Pass either a pre-built `client` or a `baseUrl` (the runtime creates a client fo
 | `tenant` | `string` | Tenant ID for multi-tenant servers. Only used with `baseUrl`. |
 | `headers` | `Record<string, string>` or `() => Record<string, string>` | Headers for the auto-created client. |
 | `extensions` | `string[]` | Extension URIs to negotiate. Only used with `baseUrl`. |
+| `fetchOptions` | `RequestInit` (partial) | Extra fetch options for the auto-created client. Only used with `baseUrl`. |
 | `contextId` | `string` | Initial context ID for the conversation. |
 | `configuration` | `A2ASendMessageConfiguration` | Default send message configuration. |
 | `onError` | `(error: Error) => void` | Error callback. |

--- a/apps/docs/content/docs/runtimes/a2a/client-and-hooks.mdx
+++ b/apps/docs/content/docs/runtimes/a2a/client-and-hooks.mdx
@@ -19,6 +19,7 @@ const client = new A2AClient({
   headers: { Authorization: "Bearer <token>" },
   tenant: "my-org",
   extensions: ["urn:a2a:ext:my-extension"],
+  fetchOptions: { credentials: "include" },
 });
 ```
 
@@ -68,7 +69,7 @@ Pass either a pre-built `client` or a `baseUrl` (the runtime creates a client fo
 | `tenant` | `string` | Tenant ID for multi-tenant servers. Only used with `baseUrl`. |
 | `headers` | `Record<string, string>` or `() => Record<string, string>` | Headers for the auto-created client. |
 | `extensions` | `string[]` | Extension URIs to negotiate. Only used with `baseUrl`. |
-| `fetchOptions` | `RequestInit` (partial) | Extra fetch options for the auto-created client. Only used with `baseUrl`. |
+| `fetchOptions` | `RequestInit` (partial) | Extra fetch options for the auto-created client (e.g. `{ credentials: "include" }`). `headers`, `body`, `method`, and `signal` are managed internally. Only used with `baseUrl`. |
 | `contextId` | `string` | Initial context ID for the conversation. |
 | `configuration` | `A2ASendMessageConfiguration` | Default send message configuration. |
 | `onError` | `(error: Error) => void` | Error callback. |

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -209,28 +209,51 @@ describe("A2AClient", () => {
       }
     });
 
-    it("keeps request method and headers controlled internally", async () => {
+    it("strips internally-managed fields even when smuggled via cast", async () => {
+      const smuggledSignal = new AbortController().signal;
       const fetchOptionsClient = new A2AClient({
         baseUrl: "https://agent.test",
         fetchOptions: {
           method: "GET",
           headers: { "X-Injected": "1" },
-          signal: new AbortController().signal,
+          body: "smuggled",
+          signal: smuggledSignal,
         } as RequestInit,
       });
 
-      fetchMock.mockResolvedValue(
-        mockFetchResponse({
-          task: { id: "t1", status: { state: "completed" } },
-        }),
-      );
+      fetchMock
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            task: { id: "t1", status: { state: "completed" } },
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            name: "Test",
+            description: "desc",
+            version: "1.0",
+            supportedInterfaces: [],
+            capabilities: {},
+            defaultInputModes: [],
+            defaultOutputModes: [],
+            skills: [],
+          }),
+        );
 
       await fetchOptionsClient.sendMessage(userMessage);
+      await fetchOptionsClient.getAgentCard();
 
-      const [, init] = fetchMock.mock.calls[0]!;
-      expect(init.method).toBe("POST");
-      expect(init.headers["Content-Type"]).toBe("application/a2a+json");
-      expect(init.headers["X-Injected"]).toBeUndefined();
+      for (const [, init] of fetchMock.mock.calls) {
+        expect(init.headers["X-Injected"]).toBeUndefined();
+        expect(init.body).not.toBe("smuggled");
+        expect(init.signal).not.toBe(smuggledSignal);
+      }
+
+      expect(fetchMock.mock.calls[0]![1].method).toBe("POST");
+      expect(fetchMock.mock.calls[0]![1].headers["Content-Type"]).toBe(
+        "application/a2a+json",
+      );
+      expect(fetchMock.mock.calls[1]![1].method).toBeUndefined();
     });
   });
 

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -148,6 +148,92 @@ describe("A2AClient", () => {
     });
   });
 
+  describe("fetchOptions", () => {
+    it("applies fetchOptions to all request types", async () => {
+      const fetchOptionsClient = new A2AClient({
+        baseUrl: "https://agent.test",
+        fetchOptions: { credentials: "include" },
+      });
+
+      fetchMock
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            task: { id: "t1", status: { state: "completed" } },
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            name: "Test Agent",
+            description: "A test",
+            version: "1.0",
+            supportedInterfaces: [],
+            capabilities: {},
+            defaultInputModes: [],
+            defaultOutputModes: [],
+            skills: [],
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockSSEResponse([
+            `data: ${JSON.stringify({ status_update: { task_id: "t1", context_id: "ctx-1", status: { state: "TASK_STATE_WORKING" } } })}`,
+            "",
+            "",
+          ]),
+        )
+        .mockResolvedValueOnce(
+          mockSSEResponse([
+            `data: ${JSON.stringify({ status_update: { task_id: "t1", context_id: "ctx-1", status: { state: "TASK_STATE_WORKING" } } })}`,
+            "",
+            "",
+          ]),
+        )
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 204,
+          statusText: "No Content",
+          headers: new Headers(),
+        });
+
+      await fetchOptionsClient.sendMessage(userMessage);
+      await fetchOptionsClient.getAgentCard();
+      for await (const _ of fetchOptionsClient.streamMessage(userMessage)) {
+        void _;
+      }
+      for await (const _ of fetchOptionsClient.subscribeToTask("t1")) {
+        void _;
+      }
+      await fetchOptionsClient.deleteTaskPushNotificationConfig("t1", "pnc-1");
+
+      for (const [, init] of fetchMock.mock.calls) {
+        expect(init.credentials).toBe("include");
+      }
+    });
+
+    it("keeps request method and headers controlled internally", async () => {
+      const fetchOptionsClient = new A2AClient({
+        baseUrl: "https://agent.test",
+        fetchOptions: {
+          method: "GET",
+          headers: { "X-Injected": "1" },
+          signal: new AbortController().signal,
+        } as RequestInit,
+      });
+
+      fetchMock.mockResolvedValue(
+        mockFetchResponse({
+          task: { id: "t1", status: { state: "completed" } },
+        }),
+      );
+
+      await fetchOptionsClient.sendMessage(userMessage);
+
+      const [, init] = fetchMock.mock.calls[0]!;
+      expect(init.method).toBe("POST");
+      expect(init.headers["Content-Type"]).toBe("application/a2a+json");
+      expect(init.headers["X-Injected"]).toBeUndefined();
+    });
+  });
+
   // --- Tenant ---
 
   describe("tenant", () => {

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -177,7 +177,14 @@ export class A2AClient {
       : "";
     this.tenant = options.tenant;
     this.extensionUris = options.extensions;
-    this.fetchOptions = options.fetchOptions ?? {};
+    const {
+      headers: _h,
+      body: _b,
+      method: _m,
+      signal: _s,
+      ...safeFetchOptions
+    } = (options.fetchOptions ?? {}) as RequestInit;
+    this.fetchOptions = safeFetchOptions;
     this.headersFn = options.headers ?? {};
   }
 

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -26,6 +26,10 @@ export type A2AClientOptions = {
     | undefined;
   /** A2A extension URIs to negotiate. Sent as A2A-Extensions header. */
   extensions?: string[] | undefined;
+  /** Extra fetch options applied to every request. */
+  fetchOptions?:
+    | Omit<RequestInit, "headers" | "body" | "method" | "signal">
+    | undefined;
 };
 
 export class A2AError extends Error {
@@ -158,6 +162,10 @@ export class A2AClient {
   private basePath: string;
   private tenant: string | undefined;
   private extensionUris: string[] | undefined;
+  private fetchOptions: Omit<
+    RequestInit,
+    "headers" | "body" | "method" | "signal"
+  >;
   private headersFn:
     | Record<string, string>
     | (() => Record<string, string> | Promise<Record<string, string>>);
@@ -169,6 +177,7 @@ export class A2AClient {
       : "";
     this.tenant = options.tenant;
     this.extensionUris = options.extensions;
+    this.fetchOptions = options.fetchOptions ?? {};
     this.headersFn = options.headers ?? {};
   }
 
@@ -229,6 +238,7 @@ export class A2AClient {
     const isGet = !options.method || options.method.toUpperCase() === "GET";
     const headers = await this.getHeaders(!isGet);
     const response = await fetch(`${this.baseUrl}${path}`, {
+      ...this.fetchOptions,
       ...options,
       headers: {
         ...headers,
@@ -247,7 +257,11 @@ export class A2AClient {
   async getAgentCard(signal?: AbortSignal): Promise<A2AAgentCard> {
     const headers = await this.getHeaders(false); // GET: no Content-Type
     const url = `${this.baseUrl}/.well-known/agent-card.json`;
-    const response = await fetch(url, { headers, ...signalInit(signal) });
+    const response = await fetch(url, {
+      ...this.fetchOptions,
+      headers,
+      ...signalInit(signal),
+    });
     if (!response.ok) {
       await this.throwResponseError(response);
     }
@@ -310,6 +324,7 @@ export class A2AClient {
     const response = await fetch(
       `${this.baseUrl}${this.getBasePath()}/message:stream`,
       {
+        ...this.fetchOptions,
         method: "POST",
         headers,
         body: JSON.stringify(body),
@@ -390,7 +405,11 @@ export class A2AClient {
 
     const response = await fetch(
       `${this.baseUrl}${this.getBasePath()}/tasks/${encodeURIComponent(taskId)}:subscribe`,
-      { headers, ...signalInit(signal) },
+      {
+        ...this.fetchOptions,
+        headers,
+        ...signalInit(signal),
+      },
     );
     if (!response.ok) {
       await this.throwResponseError(response);
@@ -453,7 +472,12 @@ export class A2AClient {
     const headers = await this.getHeaders(!isGet);
     const response = await fetch(
       `${this.baseUrl}${this.getBasePath()}/tasks/${encodeURIComponent(taskId)}/pushNotificationConfigs/${encodeURIComponent(configId)}`,
-      { method: "DELETE", headers, ...signalInit(signal) },
+      {
+        ...this.fetchOptions,
+        method: "DELETE",
+        headers,
+        ...signalInit(signal),
+      },
     );
     if (!response.ok) {
       await this.throwResponseError(response);

--- a/packages/react-a2a/src/useA2ARuntime.ts
+++ b/packages/react-a2a/src/useA2ARuntime.ts
@@ -92,6 +92,8 @@ export type UseA2ARuntimeOptions = ExternalStoreSharedOptions & {
   headers?: A2AClientOptions["headers"];
   /** A2A extension URIs to negotiate. Only used with baseUrl. */
   extensions?: string[];
+  /** Extra fetch options (e.g. `{ credentials: 'include' }`). Only used with `baseUrl`. */
+  fetchOptions?: A2AClientOptions["fetchOptions"];
 
   /** Initial context ID for the conversation. */
   contextId?: string;
@@ -137,6 +139,7 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
         tenant: options.tenant,
         headers: options.headers,
         extensions: options.extensions,
+        fetchOptions: options.fetchOptions,
       });
     } else {
       throw new Error("useA2ARuntime requires either `client` or `baseUrl`");


### PR DESCRIPTION
`A2AClient` and `useA2ARuntime` could not pass `RequestInit` options like `credentials: "include"` into underlying fetch calls. This PR adds first-class `fetchOptions` support in both APIs and documents usage.

- **Client API: add `fetchOptions` to `A2AClientOptions`**
  - Added `fetchOptions?: Omit<RequestInit, "headers" | "body" | "method" | "signal">`.
  - Stored once on the client instance and applied to all request paths.

- **Fetch plumbing: apply across all relevant request types**
  - `fetchJSON`: `...this.fetchOptions` spread before `...options`.
  - `streamMessage`: spread before `method`/`headers`/`body`.
  - `getAgentCard`: spread before `headers`.
  - `subscribeToTask`: spread before `headers`.
  - `deleteTaskPushNotificationConfig`: spread before `method`/`headers`.
  - Ordering preserves internal control of `headers`, `method`, `body`, and `signal`.

- **Runtime API: expose and forward `fetchOptions`**
  - Added `fetchOptions?: A2AClientOptions["fetchOptions"]` to `UseA2ARuntimeOptions`.
  - Forwarded into auto-created `A2AClient` when using `baseUrl`.

- **Docs: surface new option in both option tables**
  - Added `fetchOptions` rows to:
    - A2A **Client options**
    - `useA2ARuntime` **options**
  - Clarifies intended use and internally managed fields.

- **Tests: add focused coverage**
  - Added tests ensuring `fetchOptions` is applied across request categories and that internal request fields still win over external overrides.

```ts
const runtime = useA2ARuntime({
  baseUrl: "http://localhost:3011/workspaces/6/agents/a2a",
  basePath: "/v1",
  headers: () => ({ Authorization: "******" }),
  fetchOptions: { credentials: "include" },
});

const client = new A2AClient({
  baseUrl: "https://my-agent.example.com",
  headers: { Authorization: "******" },
  fetchOptions: { credentials: "include" },
});
```