### PR TITLE
fix(docs): render markdown and tool fallback in ChatGPT example theme

### DIFF
--- a/apps/docs/components/examples/chatgpt.tsx
+++ b/apps/docs/components/examples/chatgpt.tsx
@@ -293,12 +293,14 @@ const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root className="relative mx-auto flex w-full max-w-3xl flex-col">
       <div className="text-[#0d0d0d] dark:text-[#ececec]">
-        <MessagePrimitive.Parts
-          components={{
-            Text: MarkdownText,
-            ToolFallback: ToolFallback,
+        <MessagePrimitive.Parts>
+          {({ part }) => {
+            if (part.type === "text") return <MarkdownText />;
+            if (part.type === "tool-call")
+              return part.toolUI ?? <ToolFallback {...part} />;
+            return null;
           }}
-        />
+        </MessagePrimitive.Parts>
       </div>
 
       <div className="-ml-2 flex items-center pt-1">

--- a/apps/docs/components/examples/chatgpt.tsx
+++ b/apps/docs/components/examples/chatgpt.tsx
@@ -48,6 +48,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/shared/dropdown-menu";
+import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
 
 export const ChatGPT: FC = () => {
   return (

--- a/apps/docs/components/examples/chatgpt.tsx
+++ b/apps/docs/components/examples/chatgpt.tsx
@@ -291,7 +291,12 @@ const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root className="relative mx-auto flex w-full max-w-3xl flex-col">
       <div className="text-[#0d0d0d] dark:text-[#ececec]">
-        <MessagePrimitive.Parts />
+        <MessagePrimitive.Parts
+          components={{
+            Text: MarkdownText,
+            ToolFallback: ToolFallback,
+          }}
+        />
       </div>
 
       <div className="-ml-2 flex items-center pt-1">


### PR DESCRIPTION
### Description
This PR fixes an issue where the ChatGPT example theme in the `assistant-ui` playground renders raw text instead of Markdown and fails to render the default tool fallback UI.

Currently, in `apps/docs/components/examples/chatgpt.tsx`, the `AssistantMessage` component uses `<MessagePrimitive.Parts />` without providing the `components` map. This causes Markdown formatting (like `**bold**`, `# headers`) to be rendered as literal text nodes (raw text) instead of being parsed, and also prevents the `ToolFallback` UI from rendering properly when tools are invoked.

### Changes
- Passed `MarkdownText` and `ToolFallback` components to `MessagePrimitive.Parts` in `chatgpt.tsx`, matching the default implementation in the shadcn theme examples.

This simple change restores the correct rendering of Markdown responses and Tool executions for users testing the ChatGPT theme on the official playground.