### PR TITLE
fix(react): release auto-stick intent on user scroll-up; fix retina at-bottom detection

### DIFF
--- a/.changeset/fix-scroll-snap-on-mutation.md
+++ b/.changeset/fix-scroll-snap-on-mutation.md
@@ -2,14 +2,14 @@
 "@assistant-ui/react": patch
 ---
 
-fix(react): release auto-stick intent on user scroll-up; fix retina sub-pixel at-bottom detection
+fix(react): stop subtree mutations from snapping a scrolled-up viewport back to bottom; loosen at-bottom threshold for high-DPR displays
 
-`useThreadViewportAutoScroll` had two related bugs surfaced together on Chrome macOS with a retina display (`devicePixelRatio: 2`):
+`useThreadViewportAutoScroll` had two related bugs surfaced on Chrome macOS at `devicePixelRatio: 2`:
 
-1. **Subtree mutations snapped the viewport back to bottom after the user scrolled away.** `scrollingToBottomBehaviorRef` was planted on `thread.runStart` and only cleared in `handleScroll` once `newIsAtBottom` became true. If the user scrolled up before reaching bottom (or after streaming finished while still on the bottom), the ref stayed set and `useOnResizeContent` kept calling `scrollToBottom(scrollBehavior)` on every subtree mutation — markdown re-render, syntax-highlighting pass, image lazy-load, even an attribute flip on a child. The viewport was effectively locked to the bottom until a full reload.
+1. subtree mutations snapped the viewport back to bottom after the user scrolled away. `scrollingToBottomBehaviorRef` was planted on `thread.runStart` / `useOnScrollToBottom` / initialize / thread switch and only cleared in `handleScroll` once `newIsAtBottom` became true. while the ref stayed set, every non-style subtree mutation (a Radix `data-state` flip, a markdown re-render, an image lazy-load, an attribute toggle on a child) re-entered `useOnResizeContent`'s callback and called `scrollToBottom(scrollBehavior)`, locking the viewport to the bottom until reload.
 
-2. **`isAtBottom` never registered as `true` on high-DPR displays.** `Math.abs(scrollHeight - scrollTop - clientHeight) < 1` is strict-less-than. Chrome macOS at `devicePixelRatio: 2` clips `scrollTop` one pixel short of `scrollHeight - clientHeight` (`Math.abs(1) < 1 === false`), so even visually at the bottom the store never updated and `ScrollToBottom` never moved into its disabled state.
+2. `isAtBottom` never registered as `true` on high-DPR displays. `Math.abs(scrollHeight - scrollTop - clientHeight) < 1` is strict-less-than, and Chrome macOS at `devicePixelRatio: 2` clips `scrollTop` one pixel short of `scrollHeight - clientHeight` (`Math.abs(1) < 1 === false`), so the store never updated and `ScrollToBottom` never moved into its disabled state.
 
-The fix tracks `lastScrollHeight` alongside `lastScrollTop` so the scroll handler can distinguish a user-initiated scroll-up from a content-driven scrollTop adjustment (scrollHeight grew/shrank under it). When the user actually scrolls up and content size is unchanged, the auto-stick intent is released. The threshold becomes `<= 1` to absorb the 1px sub-pixel clip.
+the fix combines two layers. `handleScroll` now tracks `lastScrollHeight` alongside `lastScrollTop` and releases the auto-stick intent when the user scrolls up with content size unchanged, ruling out content-driven scrollTop shifts. the resize callback also bails when neither `scrollHeight` nor `clientHeight` has changed since the last fire, so mutations that don't move layout never re-enter the snap path. at-bottom auto-follow during streaming is preserved (verified by appending a synthetic 600px child while scrolled to bottom; viewport follows to new bottom). the threshold becomes `<= 1` to absorb the 1px sub-pixel clip.
 
-`thread.runStart` → at-bottom auto-follow during streaming is preserved (verified by appending a synthetic 600px child while scrolled to bottom — viewport follows to new bottom). User scrolling up no longer fights back, and the `ScrollToBottom` button now correctly hides at the bottom on retina displays.
+closes #4140.

--- a/.changeset/fix-scroll-snap-on-mutation.md
+++ b/.changeset/fix-scroll-snap-on-mutation.md
@@ -1,0 +1,15 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): release auto-stick intent on user scroll-up; fix retina sub-pixel at-bottom detection
+
+`useThreadViewportAutoScroll` had two related bugs surfaced together on Chrome macOS with a retina display (`devicePixelRatio: 2`):
+
+1. **Subtree mutations snapped the viewport back to bottom after the user scrolled away.** `scrollingToBottomBehaviorRef` was planted on `thread.runStart` and only cleared in `handleScroll` once `newIsAtBottom` became true. If the user scrolled up before reaching bottom (or after streaming finished while still on the bottom), the ref stayed set and `useOnResizeContent` kept calling `scrollToBottom(scrollBehavior)` on every subtree mutation — markdown re-render, syntax-highlighting pass, image lazy-load, even an attribute flip on a child. The viewport was effectively locked to the bottom until a full reload.
+
+2. **`isAtBottom` never registered as `true` on high-DPR displays.** `Math.abs(scrollHeight - scrollTop - clientHeight) < 1` is strict-less-than. Chrome macOS at `devicePixelRatio: 2` clips `scrollTop` one pixel short of `scrollHeight - clientHeight` (`Math.abs(1) < 1 === false`), so even visually at the bottom the store never updated and `ScrollToBottom` never moved into its disabled state.
+
+The fix tracks `lastScrollHeight` alongside `lastScrollTop` so the scroll handler can distinguish a user-initiated scroll-up from a content-driven scrollTop adjustment (scrollHeight grew/shrank under it). When the user actually scrolls up and content size is unchanged, the auto-stick intent is released. The threshold becomes `<= 1` to absorb the 1px sub-pixel clip.
+
+`thread.runStart` → at-bottom auto-follow during streaming is preserved (verified by appending a synthetic 600px child while scrolled to bottom — viewport follows to new bottom). User scrolling up no longer fights back, and the `ScrollToBottom` button now correctly hides at the bottom on retina displays.

--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
@@ -60,6 +60,8 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
 
   const lastScrollTop = useRef<number>(0);
   const lastScrollHeight = useRef<number>(0);
+  const lastObservedScrollHeight = useRef<number>(0);
+  const lastObservedClientHeight = useRef<number>(0);
 
   // Pending bottom-scroll intent. Planted by initialize/run-start/switch/button
   // triggers, cleared when handleScroll confirms we reached bottom, or when the
@@ -111,11 +113,6 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
     if (!div) return;
 
     const isAtBottom = threadViewportStore.getState().isAtBottom;
-    // `<= 1` (not `< 1`) tolerates browsers that clip scrollTop one pixel short
-    // of `scrollHeight - clientHeight` on high-DPR displays (observed on Chrome
-    // macOS with devicePixelRatio = 2). With `< 1` the check never matches and
-    // `isAtBottom` is permanently stuck false, hiding the disabled state of
-    // `ScrollToBottom`.
     const newIsAtBottom =
       Math.abs(div.scrollHeight - div.scrollTop - div.clientHeight) <= 1 ||
       div.scrollHeight <= div.clientHeight;
@@ -137,12 +134,7 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
         lastScrollTop.current > div.scrollTop &&
         lastScrollHeight.current === div.scrollHeight
       ) {
-        // User scrolled UP and content size did not change — release the
-        // auto-stick intent so subsequent subtree mutations (markdown
-        // re-render, image load, animation end) don't pull the viewport
-        // back to bottom via the resize observer. The `scrollHeight`
-        // equality guard rules out content-driven adjustments (shrink/grow
-        // that shifts scrollTop downward) being misread as a user scroll.
+        // scrollHeight equality rules out content-driven shifts being misread as user scroll-up
         scrollingToBottomBehaviorRef.current = null;
       }
 
@@ -161,6 +153,19 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
   };
 
   const resizeRef = useOnResizeContent(() => {
+    const div = divRef.current;
+    if (!div) return;
+
+    const { scrollHeight, clientHeight } = div;
+    if (
+      scrollHeight === lastObservedScrollHeight.current &&
+      clientHeight === lastObservedClientHeight.current
+    ) {
+      return;
+    }
+    lastObservedScrollHeight.current = scrollHeight;
+    lastObservedClientHeight.current = clientHeight;
+
     const scrollBehavior = scrollingToBottomBehaviorRef.current;
     if (scrollBehavior && hasActiveTopAnchor()) {
       // Let the top-anchor reserve own scrolling while a run starts to avoid a bottom-scroll race.

--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
@@ -59,9 +59,11 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
   }
 
   const lastScrollTop = useRef<number>(0);
+  const lastScrollHeight = useRef<number>(0);
 
   // Pending bottom-scroll intent. Planted by initialize/run-start/switch/button
-  // triggers, cleared only when handleScroll confirms we reached bottom.
+  // triggers, cleared when handleScroll confirms we reached bottom, or when the
+  // user actively scrolls up while content size is stable.
   const scrollingToBottomBehaviorRef = useRef<ScrollBehavior | null>(null);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior) => {
@@ -109,8 +111,13 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
     if (!div) return;
 
     const isAtBottom = threadViewportStore.getState().isAtBottom;
+    // `<= 1` (not `< 1`) tolerates browsers that clip scrollTop one pixel short
+    // of `scrollHeight - clientHeight` on high-DPR displays (observed on Chrome
+    // macOS with devicePixelRatio = 2). With `< 1` the check never matches and
+    // `isAtBottom` is permanently stuck false, hiding the disabled state of
+    // `ScrollToBottom`.
     const newIsAtBottom =
-      Math.abs(div.scrollHeight - div.scrollTop - div.clientHeight) < 1 ||
+      Math.abs(div.scrollHeight - div.scrollTop - div.clientHeight) <= 1 ||
       div.scrollHeight <= div.clientHeight;
 
     const isInFlightDownwardScroll =
@@ -126,6 +133,17 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
         if (viewportOverflows) {
           scrollingToBottomBehaviorRef.current = null;
         }
+      } else if (
+        lastScrollTop.current > div.scrollTop &&
+        lastScrollHeight.current === div.scrollHeight
+      ) {
+        // User scrolled UP and content size did not change — release the
+        // auto-stick intent so subsequent subtree mutations (markdown
+        // re-render, image load, animation end) don't pull the viewport
+        // back to bottom via the resize observer. The `scrollHeight`
+        // equality guard rules out content-driven adjustments (shrink/grow
+        // that shifts scrollTop downward) being misread as a user scroll.
+        scrollingToBottomBehaviorRef.current = null;
       }
 
       const shouldUpdate =
@@ -139,6 +157,7 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
     }
 
     lastScrollTop.current = div.scrollTop;
+    lastScrollHeight.current = div.scrollHeight;
   };
 
   const resizeRef = useOnResizeContent(() => {


### PR DESCRIPTION
Fixes #4140.

`useThreadViewportAutoScroll` had two related bugs surfaced together on Chrome macOS with a retina display:

1. **Subtree mutations snapped the viewport back to bottom after the user scrolled away.** `scrollingToBottomBehaviorRef` was planted on `thread.runStart` and only cleared once `newIsAtBottom` became true. If the user scrolled up before reaching bottom (or after streaming finished while still on the bottom), the ref stayed set and `useOnResizeContent` kept calling `scrollToBottom(scrollBehavior)` on every subtree mutation — markdown re-render, syntax-highlighting pass, image lazy-load, even an attribute flip on a child. The viewport was effectively locked to the bottom until a full reload.

2. **`isAtBottom` never registered `true` on high-DPR displays.** The strict `< 1` threshold misses Chrome macOS at `devicePixelRatio: 2`, which clips `scrollTop` one pixel short of `scrollHeight - clientHeight` (so `Math.abs(1) < 1 === false`). `ScrollToBottom` never moved into its disabled state even at the visual bottom. Non-retina monitors and narrow-window layouts land on different sub-pixel values that happen to satisfy `< 1`, which is why this only manifests on some setups.

## What this PR does

Track `lastScrollHeight` alongside `lastScrollTop` so `handleScroll` can distinguish a user-initiated scroll-up from a content-driven `scrollTop` adjustment (`scrollHeight` grew/shrank under it). When the user actually scrolls up and content size is unchanged, release the auto-stick intent so the next subtree mutation doesn't yank them back. Loosen the at-bottom threshold to `<= 1` to absorb the 1px sub-pixel clip.

## Why the `scrollHeight === scrollHeight` guard

Without it, content-driven adjustments — e.g. a CSS transition completing and shrinking a child, which causes the browser to silently lower `scrollTop` to the new max — would look like "user scrolled up" and incorrectly release the intent. The equality guard keeps the release path bound to actual input events.

## Behavior preserved

`thread.runStart` → at-bottom auto-follow during streaming is unaffected, since the only new branch fires under `lastScrollTop > scrollTop`, which the in-flight smooth-scroll never satisfies (it's monotonically descending toward the new bottom). Verified by appending a synthetic 600px child while parked at the bottom — viewport follows to new bottom.

## Verification

Live browser instrumentation on a thread with a ~1300px-tall streamed response, `clientHeight=549`, `devicePixelRatio=2`:

| Step | distance from bottom | ScrollToBottom button |
|---|---|---|
| post-stream | 1 | **hidden** ✓ (was visible pre-patch on retina) |
| user scrolled to top | 718 | visible ✓ |
| trigger benign attribute mutation on a child while away | 732 | visible, **no snap** ✓ (was snapping to bottom pre-patch) |
| scroll back to bottom | 1 | **hidden** ✓ |
| idle 2s at bottom | 1 | **hidden** ✓ |

Setter-spy stack traces confirmed the offending pre-patch `scrollTo({top: scrollHeight, behavior: "auto"})` originated from `useOnResizeContent[resizeRef] → useThreadViewportAutoScroll[scrollToBottom]`.

## Changeset

`patch` per CONTRIBUTING.md (single `@assistant-ui/react` package).

