### PR TITLE
Improve docs chat examples discovery

### DIFF
--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -363,7 +363,12 @@ export async function POST(req: Request): Promise<Response> {
                     (node): node is PageTree.Folder => node.type === "folder",
                   ),
                 ),
-                { type: "folder", name: "examples", url: "/examples" },
+                {
+                  type: "folder",
+                  name: "examples",
+                  description:
+                    "Examples of app types users can build with assistant-ui, showing instructions, recommended patterns, and UI structure.",
+                },
               ];
             }
 


### PR DESCRIPTION
Closes #4143

## Summary

- Updates the docs assistant \listDocs\ root response for \examples\
- Gives the examples folder the same discovery hint used by the Xulux coding agent
- Makes examples easier for agents to identify as app-shaped guides with recommended patterns and UI structure

## Context

While running evals for our Xulux coding agent, we found that the agent was not exploring examples correctly. We fixed the root examples discovery hint in the main coding agent, and this applies the same upstream-facing fix to the docs chat agent.

## Testing

- \git diff --check -- apps/docs/app/api/doc/chat/route.ts\ passed
- Pre-commit hook ran \oxlint --fix\ and \oxfmt\ for the staged file during commit