### PR TITLE
fix(react-ai-sdk): drop AI SDK v6 phantom assistant siblings at the adapter

### DIFF
--- a/.changeset/fix-ai-sdk-phantom-sibling-adapter.md
+++ b/.changeset/fix-ai-sdk-phantom-sibling-adapter.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: AI SDK v6's `useChat` first inserts an assistant placeholder with a client-generated id and then swaps the slot for a new object carrying the server-provided id, which made `BranchPicker` render `2/2` on every streamed assistant turn (#4037). The previous core-side fix (#4040) regressed legitimate branch siblings (#4131) and was reverted; this version moves the cleanup into `useAISDKRuntime`. The adapter compares the previous render's UIMessage ids per position and, only while `chatHelpers.status === "streaming"`, flags the disappearing id as a transient placeholder via the new `unstable_temporaryMessageIds` adapter input. The runtime drops those ids from the in-memory repository before re-linking, so phantom siblings disappear without touching ids that change for user-initiated edits or reloads (status is `"submitted"` / `"ready"` at those moments).

--- a/.changeset/fix-ai-sdk-phantom-sibling-adapter.md
+++ b/.changeset/fix-ai-sdk-phantom-sibling-adapter.md
@@ -3,4 +3,6 @@
 "@assistant-ui/react-ai-sdk": patch
 ---
 
-fix: AI SDK v6's `useChat` first inserts an assistant placeholder with a client-generated id and then swaps the slot for a new object carrying the server-provided id, which made `BranchPicker` render `2/2` on every streamed assistant turn (#4037). The previous core-side fix (#4040) regressed legitimate branch siblings (#4131) and was reverted; this version moves the cleanup into `useAISDKRuntime`. The adapter compares the previous render's UIMessage ids per position and, only while `chatHelpers.status === "streaming"`, flags the disappearing id as a transient placeholder via the new `unstable_temporaryMessageIds` adapter input. The runtime drops those ids from the in-memory repository before re-linking, so phantom siblings disappear without touching ids that change for user-initiated edits or reloads (status is `"submitted"` / `"ready"` at those moments).
+fix: drop phantom branch siblings produced by AI SDK v6 `useChat`'s placeholder→server id swap. `BranchPicker` no longer shows `2/2` on streamed assistant turns the user never branched. closes #4037 and #4131.
+
+`useAISDKRuntime` detects the swap as a same-length, single-position id change across a streaming render and flags the disappearing id via a new `unstable_temporaryMessageIds` adapter input on `ExternalStoreAdapter`. `onEdit` / `onReload` / `onNew` clear the comparison baseline so legitimate edit / reload / new-message branches remain in the repository as siblings.

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -268,6 +268,43 @@ runtime.thread.import(repo);
 
 Each message must have an explicit `id` and `parentId`; messages with the same `parentId` create branches. Parents must appear before children in the array.
 
+### Transient placeholder ids
+
+If your provider assigns a provisional id to a message and later swaps it for a different id (for example `@ai-sdk/react`'s `useChat` inserts a client placeholder, then replaces it with the server-provided id on the first stream chunk), the additive sync path treats the new id as a new sibling. `BranchPicker` then shows a duplicate branch (`1/2`, `2/2`) on every streamed turn even though the user never branched.
+
+To opt those ids out of branch tracking, list them in `unstable_temporaryMessageIds` on the adapter. The runtime removes any listed id from the repository before linking the next `messages` snapshot. Default behavior is additive: ids that disappear remain as branch siblings unless you flag them here.
+
+```tsx
+const prevIdsRef = useRef<string[]>([]);
+const temporaryMessageIds = useMemo(() => {
+  const currentIds = chatHelpers.messages.map((m) => m.id);
+  const prev = prevIdsRef.current;
+  prevIdsRef.current = currentIds;
+
+  if (chatHelpers.status !== "streaming" || prev.length !== currentIds.length)
+    return undefined;
+
+  let phantom: string | undefined;
+  const set = new Set(currentIds);
+  for (let i = 0; i < currentIds.length; i++) {
+    const p = prev[i];
+    const c = currentIds[i]!;
+    if (!p || p === c) continue;
+    if (phantom !== undefined) return undefined;
+    if (!set.has(p)) phantom = p;
+  }
+  return phantom ? new Set([phantom]) : undefined;
+}, [chatHelpers.messages, chatHelpers.status]);
+
+const runtime = useExternalStoreRuntime({
+  messages,
+  ...(temporaryMessageIds && { unstable_temporaryMessageIds: temporaryMessageIds }),
+  // ...
+});
+```
+
+`useAISDKRuntime` does this automatically for `@ai-sdk/react`. The field is ignored when the adapter uses `messageRepository` instead of `messages` (that path replaces the full graph on each sync).
+
 ## Tool calling
 
 Handle tool results by updating the matching tool-call entry:
@@ -697,6 +734,12 @@ useExternalStoreRuntime({
       type: "ExportedMessageRepository",
       description:
         "Pre-built message repository with branching history. Use instead of messages when you need to restore branch state.",
+    },
+    {
+      name: "unstable_temporaryMessageIds",
+      type: "ReadonlySet<string>",
+      description:
+        "Ids removed from the repository before linking the next messages snapshot. Use to drop transient placeholder ids (e.g. AI SDK v6 client→server id swap) so they do not become branch siblings. See 'Transient placeholder ids' under Branching.",
     },
     {
       name: "state",

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -259,6 +259,10 @@ export class MessageRepository {
     };
   }
 
+  hasMessage(messageId: string): boolean {
+    return this.messages.has(messageId);
+  }
+
   appendOptimisticMessage(parentId: string | null, message: ThreadMessageLike) {
     let optimisticId: string;
     do {

--- a/packages/core/src/runtimes/external-store/external-store-adapter.ts
+++ b/packages/core/src/runtimes/external-store/external-store-adapter.ts
@@ -89,6 +89,21 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  /**
+   * IDs of messages that were present in a previous `messages` snapshot but
+   * have been transient placeholders (e.g. an AI SDK `useChat` client-side
+   * id that was replaced mid-stream by a server-provided id). On the next
+   * sync, the runtime drops these ids from the in-memory message repository
+   * instead of keeping them as sibling branches, so `BranchPicker` does not
+   * inflate to `2/2` on turns the user never branched.
+   *
+   * Default sync behavior is additive: ids that disappear from `messages`
+   * remain in the repository as branch siblings. Provide this set to opt
+   * specific ids out of branch tracking. The set is consumed and not
+   * persisted, so the adapter is responsible for re-emitting until the id
+   * is no longer in the repository.
+   */
+  unstable_temporaryMessageIds?: ReadonlySet<string> | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;

--- a/packages/core/src/runtimes/external-store/external-store-adapter.ts
+++ b/packages/core/src/runtimes/external-store/external-store-adapter.ts
@@ -90,18 +90,14 @@ type ExternalStoreAdapterBase<T> = {
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
   /**
-   * IDs of messages that were present in a previous `messages` snapshot but
-   * have been transient placeholders (e.g. an AI SDK `useChat` client-side
-   * id that was replaced mid-stream by a server-provided id). On the next
-   * sync, the runtime drops these ids from the in-memory message repository
-   * instead of keeping them as sibling branches, so `BranchPicker` does not
-   * inflate to `2/2` on turns the user never branched.
-   *
-   * Default sync behavior is additive: ids that disappear from `messages`
-   * remain in the repository as branch siblings. Provide this set to opt
-   * specific ids out of branch tracking. The set is consumed and not
-   * persisted, so the adapter is responsible for re-emitting until the id
-   * is no longer in the repository.
+   * Message ids removed from the repository before linking the next
+   * `messages` snapshot, instead of preserving them as sibling branches.
+   * Default sync behavior is additive, so disappeared ids remain as
+   * branches unless listed here. Use this to opt transient placeholder ids
+   * (e.g. an `@ai-sdk/react` `useChat` client id replaced mid-stream by a
+   * server-provided one) out of branch tracking. Listed ids must not also
+   * appear in the next `messages` array. Ignored on the `messageRepository`
+   * path, which replaces the full graph on each sync.
    */
   unstable_temporaryMessageIds?: ReadonlySet<string> | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -230,6 +230,12 @@ export class ExternalStoreThreadRuntimeCore
             return newMessage;
           });
 
+      if (store.unstable_temporaryMessageIds) {
+        for (const id of store.unstable_temporaryMessageIds) {
+          if (this.repository.hasMessage(id)) this.repository.deleteMessage(id);
+        }
+      }
+
       for (let i = 0; i < messages.length; i++) {
         const message = messages[i]!;
         const parent = messages[i - 1];

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -151,6 +151,71 @@ describe("ExternalStoreThreadRuntimeCore - state reference stability", () => {
     expect(runtime.capabilities).toBe(capsBefore);
   });
 });
+
+describe("ExternalStoreThreadRuntimeCore - unstable_temporaryMessageIds", () => {
+  const user = { id: "u", role: "user" as const, content: [] };
+
+  it("drops repo entries listed in unstable_temporaryMessageIds", () => {
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages: [user, a1] }),
+    );
+
+    runtime.__internal_setAdapter(
+      makeStore({
+        messages: [user, a2],
+        unstable_temporaryMessageIds: new Set(["a1"]),
+      }),
+    );
+
+    const userChildren = runtime
+      .export()
+      .messages.filter((m) => m.parentId === "u")
+      .map((m) => m.message.id);
+    expect(userChildren).toEqual(["a2"]);
+  });
+
+  it("defaults to additive when unstable_temporaryMessageIds is absent (preserves branches)", () => {
+    const a1 = { id: "a1", role: "assistant" as const, content: [] };
+    const a2 = { id: "a2", role: "assistant" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages: [user, a1] }),
+    );
+
+    runtime.__internal_setAdapter(makeStore({ messages: [user, a2] }));
+
+    const userChildren = runtime
+      .export()
+      .messages.filter((m) => m.parentId === "u")
+      .map((m) => m.message.id)
+      .sort();
+    expect(userChildren).toEqual(["a1", "a2"]);
+  });
+
+  it("ignores ids in the set that are not in the repo", () => {
+    const a = { id: "a", role: "assistant" as const, content: [] };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages: [user, a] }),
+    );
+
+    expect(() =>
+      runtime.__internal_setAdapter(
+        makeStore({
+          messages: [user, a],
+          unstable_temporaryMessageIds: new Set(["never-existed"]),
+        }),
+      ),
+    ).not.toThrow();
+  });
+});
+
 describe("ExternalStoreThreadRuntimeCore - initialize event replay", () => {
   const message = { id: "m", role: "assistant" as const, content: [] };
   const flushMicrotasks = () => Promise.resolve();

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { StrictMode, createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock only the sibling module that requires AUI store context (not available
@@ -409,7 +410,6 @@ describe("useAISDKRuntime", () => {
         expect(result.current.thread.getState().messages.length).toBe(2);
       });
 
-      // Swap: server `start` event replaces the client placeholder id
       chat.messages = [
         { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
         {
@@ -431,6 +431,46 @@ describe("useAISDKRuntime", () => {
       expect(userChildren).toEqual(["server_abc"]);
     });
 
+    it("keeps prior assistant as branch sibling when reload batches straight into streaming", async () => {
+      const chat = createChatHelpers([
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [{ type: "text", text: "first" }],
+        },
+      ]);
+
+      const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+
+      await waitFor(() => {
+        expect(result.current.thread.getState().messages.length).toBe(2);
+      });
+
+      chat.messages = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "a2_placeholder",
+          role: "assistant",
+          parts: [{ type: "text", text: "" }],
+        },
+      ];
+      chat.status = "streaming";
+
+      act(() => {
+        rerender();
+      });
+
+      const userChildren = result.current.thread
+        .export()
+        .messages.filter((m) => m.parentId === "u1")
+        .map((m) => m.message.id)
+        .sort();
+
+      expect(userChildren).toContain("a1");
+      expect(userChildren).toContain("a2_placeholder");
+    });
+
     it("keeps prior assistant as branch sibling when ids change outside of streaming (user reload)", async () => {
       const chat = createChatHelpers([
         { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
@@ -447,9 +487,6 @@ describe("useAISDKRuntime", () => {
         expect(result.current.thread.getState().messages.length).toBe(2);
       });
 
-      // simulate a reload that lands as a single batched sync at status=submitted
-      // (status flips before the first stream chunk; AI SDK has swapped the leaf id
-      // for the new run, but we should not treat that as a phantom)
       chat.messages = [
         { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
         {
@@ -472,6 +509,218 @@ describe("useAISDKRuntime", () => {
 
       expect(userChildren).toContain("a1");
       expect(userChildren).toContain("a2");
+    });
+
+    it("drops the placeholder when the swap lands on the streaming → ready boundary", async () => {
+      const chat = createChatHelpers([
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "client_xyz",
+          role: "assistant",
+          parts: [{ type: "text", text: "" }],
+        },
+      ]);
+      chat.status = "streaming";
+
+      const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+
+      await waitFor(() => {
+        expect(result.current.thread.getState().messages.length).toBe(2);
+      });
+
+      chat.messages = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "server_abc",
+          role: "assistant",
+          parts: [{ type: "text", text: "done" }],
+        },
+      ];
+      chat.status = "ready";
+
+      act(() => {
+        rerender();
+      });
+
+      const userChildren = result.current.thread
+        .export()
+        .messages.filter((m) => m.parentId === "u1")
+        .map((m) => m.message.id);
+      expect(userChildren).toEqual(["server_abc"]);
+    });
+
+    it("drops only the final id across multiple consecutive id swaps in one stream", async () => {
+      const chat = createChatHelpers([
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "p1",
+          role: "assistant",
+          parts: [{ type: "text", text: "" }],
+        },
+      ]);
+      chat.status = "streaming";
+
+      const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+
+      await waitFor(() => {
+        expect(result.current.thread.getState().messages.length).toBe(2);
+      });
+
+      chat.messages = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        { id: "p2", role: "assistant", parts: [{ type: "text", text: "a" }] },
+      ];
+      act(() => {
+        rerender();
+      });
+
+      chat.messages = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        { id: "p3", role: "assistant", parts: [{ type: "text", text: "ab" }] },
+      ];
+      act(() => {
+        rerender();
+      });
+
+      const userChildren = result.current.thread
+        .export()
+        .messages.filter((m) => m.parentId === "u1")
+        .map((m) => m.message.id);
+      expect(userChildren).toEqual(["p3"]);
+    });
+
+    it("preserves middle id as branch sibling when array shrinks (not a swap)", async () => {
+      const chat = createChatHelpers([
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [{ type: "text", text: "first" }],
+        },
+        { id: "u2", role: "user", parts: [{ type: "text", text: "more" }] },
+        {
+          id: "a2",
+          role: "assistant",
+          parts: [{ type: "text", text: "second" }],
+        },
+      ]);
+      chat.status = "streaming";
+
+      const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+
+      await waitFor(() => {
+        expect(result.current.thread.getState().messages.length).toBe(4);
+      });
+
+      chat.messages = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        { id: "u2", role: "user", parts: [{ type: "text", text: "more" }] },
+        {
+          id: "a2",
+          role: "assistant",
+          parts: [{ type: "text", text: "second" }],
+        },
+      ];
+
+      act(() => {
+        rerender();
+      });
+
+      const u1Children = result.current.thread
+        .export()
+        .messages.filter((m) => m.parentId === "u1")
+        .map((m) => m.message.id)
+        .sort();
+      expect(u1Children).toContain("a1");
+      expect(u1Children).toContain("u2");
+    });
+
+    it("preserves the prior assistant when a reload's new run starts mid prior stream (#4131 R1)", async () => {
+      const chat = createChatHelpers([
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [{ type: "text", text: "first" }],
+        },
+      ]);
+      chat.status = "streaming";
+
+      const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+
+      await waitFor(() => {
+        expect(result.current.thread.getState().messages.length).toBe(2);
+      });
+
+      await act(async () => {
+        await result.current.thread.startRun({
+          parentId: "u1",
+          sourceId: null,
+          runConfig: {},
+        });
+      });
+
+      chat.messages = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "a2_placeholder",
+          role: "assistant",
+          parts: [{ type: "text", text: "" }],
+        },
+      ];
+      chat.status = "streaming";
+
+      act(() => {
+        rerender();
+      });
+
+      const userChildren = result.current.thread
+        .export()
+        .messages.filter((m) => m.parentId === "u1")
+        .map((m) => m.message.id)
+        .sort();
+      expect(userChildren).toContain("a1");
+      expect(userChildren).toContain("a2_placeholder");
+    });
+
+    it("survives React StrictMode double invocation", async () => {
+      const chat = createChatHelpers([
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "client_xyz",
+          role: "assistant",
+          parts: [{ type: "text", text: "" }],
+        },
+      ]);
+      chat.status = "streaming";
+
+      const { result, rerender } = renderHook(() => useAISDKRuntime(chat), {
+        wrapper: ({ children }: { children: ReactNode }) =>
+          createElement(StrictMode, null, children),
+      });
+
+      await waitFor(() => {
+        expect(result.current.thread.getState().messages.length).toBe(2);
+      });
+
+      chat.messages = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "server_abc",
+          role: "assistant",
+          parts: [{ type: "text", text: "hello" }],
+        },
+      ];
+
+      act(() => {
+        rerender();
+      });
+
+      const userChildren = result.current.thread
+        .export()
+        .messages.filter((m) => m.parentId === "u1")
+        .map((m) => m.message.id);
+      expect(userChildren).toEqual(["server_abc"]);
     });
   });
 });

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
@@ -390,4 +390,88 @@ describe("useAISDKRuntime", () => {
     const { result } = renderHook(() => useAISDKRuntime(chat, { suggestions }));
     expect(result.current.thread.getState().suggestions).toEqual(suggestions);
   });
+
+  describe("phantom assistant sibling on mid-stream id swap (#4037)", () => {
+    it("drops the placeholder id when AI SDK v6 swaps it for the server id mid-stream", async () => {
+      const chat = createChatHelpers([
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "client_xyz",
+          role: "assistant",
+          parts: [{ type: "text", text: "" }],
+        },
+      ]);
+      chat.status = "streaming";
+
+      const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+
+      await waitFor(() => {
+        expect(result.current.thread.getState().messages.length).toBe(2);
+      });
+
+      // Swap: server `start` event replaces the client placeholder id
+      chat.messages = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "server_abc",
+          role: "assistant",
+          parts: [{ type: "text", text: "hello" }],
+        },
+      ];
+
+      act(() => {
+        rerender();
+      });
+
+      const exported = result.current.thread.export();
+      const userChildren = exported.messages
+        .filter((m) => m.parentId === "u1")
+        .map((m) => m.message.id);
+
+      expect(userChildren).toEqual(["server_abc"]);
+    });
+
+    it("keeps prior assistant as branch sibling when ids change outside of streaming (user reload)", async () => {
+      const chat = createChatHelpers([
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [{ type: "text", text: "first" }],
+        },
+      ]);
+
+      const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+
+      await waitFor(() => {
+        expect(result.current.thread.getState().messages.length).toBe(2);
+      });
+
+      // simulate a reload that lands as a single batched sync at status=submitted
+      // (status flips before the first stream chunk; AI SDK has swapped the leaf id
+      // for the new run, but we should not treat that as a phantom)
+      chat.messages = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "a2",
+          role: "assistant",
+          parts: [{ type: "text", text: "second" }],
+        },
+      ];
+      chat.status = "submitted";
+
+      act(() => {
+        rerender();
+      });
+
+      const userChildren = result.current.thread
+        .export()
+        .messages.filter((m) => m.parentId === "u1")
+        .map((m) => m.message.id)
+        .sort();
+
+      expect(userChildren).toContain("a1");
+      expect(userChildren).toContain("a2");
+    });
+  });
 });

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -115,6 +115,34 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     chatHelpers.status === "streaming" ||
     hasExecutingTools;
 
+  // AI SDK v6's `useChat` first inserts an assistant placeholder with a
+  // client-generated id and then, on the server's `start` event, swaps the
+  // same slot for a new object carrying the server-provided id. Without a
+  // signal, the runtime treats the new id as a sibling branch and inflates
+  // `BranchPicker` to `2/2` on turns the user never branched. Detect the
+  // swap by comparing the previous render's ids per position, and flag the
+  // disappearing id as temporary so the runtime drops it from the repo.
+  // Gated on `status === "streaming"` so user-initiated edits/reloads
+  // (which also change ids) keep their branch siblings.
+  const prevMessageIdsRef = useRef<string[]>([]);
+  const temporaryMessageIds = useMemo(() => {
+    const currentIds = chatHelpers.messages.map((m) => m.id);
+    const prevIds = prevMessageIdsRef.current;
+    prevMessageIdsRef.current = currentIds;
+
+    if (chatHelpers.status !== "streaming") return undefined;
+
+    let result: Set<string> | undefined;
+    for (let i = 0; i < currentIds.length; i++) {
+      const prev = prevIds[i];
+      const curr = currentIds[i]!;
+      if (prev && prev !== curr && !currentIds.includes(prev)) {
+        (result ??= new Set<string>()).add(prev);
+      }
+    }
+    return result;
+  }, [chatHelpers.messages, chatHelpers.status]);
+
   const messageTiming = useStreamingTiming(chatHelpers.messages, isRunning);
 
   const messages = AISDKMessageConverter.useThreadMessages({
@@ -188,6 +216,9 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const runtime = useExternalStoreRuntime({
     isRunning,
     messages,
+    ...(temporaryMessageIds && {
+      unstable_temporaryMessageIds: temporaryMessageIds,
+    }),
     unstable_enableToolInvocations: true,
     setToolStatuses,
     setMessages: (messages) =>

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { UIMessage, useChat, CreateUIMessage } from "@ai-sdk/react";
 import { isToolUIPart, generateId } from "ai";
 import {
@@ -115,32 +115,38 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     chatHelpers.status === "streaming" ||
     hasExecutingTools;
 
-  // AI SDK v6's `useChat` first inserts an assistant placeholder with a
-  // client-generated id and then, on the server's `start` event, swaps the
-  // same slot for a new object carrying the server-provided id. Without a
-  // signal, the runtime treats the new id as a sibling branch and inflates
-  // `BranchPicker` to `2/2` on turns the user never branched. Detect the
-  // swap by comparing the previous render's ids per position, and flag the
-  // disappearing id as temporary so the runtime drops it from the repo.
-  // Gated on `status === "streaming"` so user-initiated edits/reloads
-  // (which also change ids) keep their branch siblings.
-  const prevMessageIdsRef = useRef<string[]>([]);
+  // Detects AI SDK v6's mid-stream id swap; see `unstable_temporaryMessageIds`.
+  const prevRenderRef = useRef<{ ids: string[]; status: string | undefined }>({
+    ids: [],
+    status: undefined,
+  });
+  const resetSwapBaseline = () => {
+    prevRenderRef.current = { ids: [], status: undefined };
+  };
   const temporaryMessageIds = useMemo(() => {
+    if (prevRenderRef.current.status !== "streaming") return undefined;
+
     const currentIds = chatHelpers.messages.map((m) => m.id);
-    const prevIds = prevMessageIdsRef.current;
-    prevMessageIdsRef.current = currentIds;
+    const prevIds = prevRenderRef.current.ids;
+    if (prevIds.length !== currentIds.length) return undefined;
 
-    if (chatHelpers.status !== "streaming") return undefined;
-
-    let result: Set<string> | undefined;
+    let phantom: string | undefined;
+    const currentIdSet = new Set(currentIds);
     for (let i = 0; i < currentIds.length; i++) {
       const prev = prevIds[i];
       const curr = currentIds[i]!;
-      if (prev && prev !== curr && !currentIds.includes(prev)) {
-        (result ??= new Set<string>()).add(prev);
-      }
+      if (!prev || prev === curr) continue;
+      if (phantom !== undefined) return undefined;
+      if (!currentIdSet.has(prev)) phantom = prev;
     }
-    return result;
+    return phantom === undefined ? undefined : new Set([phantom]);
+  }, [chatHelpers.messages, chatHelpers.status]);
+
+  useLayoutEffect(() => {
+    prevRenderRef.current = {
+      ids: chatHelpers.messages.map((m) => m.id),
+      status: chatHelpers.status,
+    };
   }, [chatHelpers.messages, chatHelpers.status]);
 
   const messageTiming = useStreamingTiming(chatHelpers.messages, isRunning);
@@ -299,6 +305,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         return;
       }
 
+      resetSwapBaseline();
       lastRunConfigRef.current = message.runConfig;
       await completePendingToolCalls();
       await chatHelpers.sendMessage(createMessage, {
@@ -318,6 +325,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         return;
       }
 
+      resetSwapBaseline();
       lastRunConfigRef.current = message.runConfig;
       chatHelpers.setMessages((current) =>
         sliceMessagesUntil(current, message.parentId),
@@ -327,6 +335,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       });
     },
     onReload: async (parentId: string | null, config) => {
+      resetSwapBaseline();
       lastRunConfigRef.current = config.runConfig;
       const newMessages = sliceMessagesUntil(chatHelpers.messages, parentId);
       chatHelpers.setMessages(newMessages);


### PR DESCRIPTION
closes #4037, closes #4131.

## why

AI SDK v6's `useChat` first inserts an assistant placeholder with a client-generated id and, on the server's `start` event, swaps the slot for a new object carrying the server-provided id. The runtime treats the new id as a sibling under the same user message, so `BranchPicker` shows `2/2` on every streamed assistant turn (#4037).

The previous fix (#4040) put the cleanup in core (delete any id that disappears between syncs). That deleted legitimate sibling branches the moment the active path moved off them, breaking `BranchPicker` for edits, reloads, and `switchToBranch` (#4131). #4137 attempted a core-side preservation rule and was reverted (#4147). The earlier core-side fix was rolled back in #4148.

This PR moves the cleanup into the AI SDK adapter, where the AI SDK quirk actually lives. Core stays additive.

## how

- `ExternalStoreAdapter` gains `unstable_temporaryMessageIds?: ReadonlySet<string>`. When the runtime syncs `messages`, it deletes any listed id from the repo before re-linking, so a phantom never becomes a sibling.
- `useAISDKRuntime` populates the set by comparing the previous render's UIMessage ids per position. When `chatHelpers.messages[i]` changes from `prev` to `curr` and `prev` is no longer anywhere in the new array, `prev` was a transient placeholder.
- The detection is gated on `chatHelpers.status === "streaming"`. User-initiated edits and reloads change ids while status is `"submitted"` or `"ready"` (status only flips to `"streaming"` after the first stream chunk arrives), so their ids go through the additive path and become branch siblings as expected.
- Core falls back to additive behavior when the set is absent, so external stores that don't opt in keep their old behavior.

## test plan

- [x] `pnpm vitest run` in `packages/core` -> 241/241. 3 new tests cover `unstable_temporaryMessageIds` deletion, the additive default, and the missing-id guard.
- [x] `pnpm vitest run` in `packages/react-ai-sdk` -> 52/52. 2 new tests cover the mid-stream swap cleanup and branch preservation during reload (status="submitted").
- [x] full monorepo `pnpm -r --filter "./packages/**" test` -> all 23 packages green.
- [x] `pnpm lint` clean.
- [ ] reviewer: verify in an AI SDK v6 app that streamed assistant turns now show `1/1`, and that edit/reload still produce `2/2` branches.