### PR TITLE
fix(docs): Expose examples in llms output

### DIFF
--- a/apps/docs/app/(home)/llms-full.txt/route.ts
+++ b/apps/docs/app/(home)/llms-full.txt/route.ts
@@ -1,11 +1,11 @@
-import { source } from "@/lib/source";
+import { examples, source } from "@/lib/source";
 import { getLLMText } from "@/lib/get-llm-text";
 
 // cached forever
 export const revalidate = false;
 
 export async function GET() {
-  const scan = source.getPages().map(getLLMText);
+  const scan = [...source.getPages(), ...examples.getPages()].map(getLLMText);
   const scanned = await Promise.all(scan);
 
   return new Response(scanned.join("\n\n"), {

--- a/apps/docs/app/(home)/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/(home)/llms.mdx/[[...slug]]/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getLLMText } from "@/lib/get-llm-text";
-import { source } from "@/lib/source";
+import { examples, source } from "@/lib/source";
 import { notFound } from "next/navigation";
 
 export const revalidate = false;
@@ -10,7 +10,9 @@ export async function GET(
   { params }: { params: Promise<{ slug?: string[] }> },
 ) {
   const { slug } = await params;
-  const page = source.getPage(slug);
+  const page =
+    source.getPage(slug) ??
+    (slug?.[0] === "examples" ? examples.getPage(slug.slice(1)) : undefined);
   if (!page) notFound();
 
   return new NextResponse(await getLLMText(page), {
@@ -22,7 +24,12 @@ export async function GET(
 }
 
 export function generateStaticParams() {
-  return source.getPages().map((page) => ({
-    slug: page.slugs,
-  }));
+  return [
+    ...source.getPages().map((page) => ({
+      slug: page.slugs,
+    })),
+    ...examples.getPages().map((page) => ({
+      slug: ["examples", ...page.slugs],
+    })),
+  ];
 }

--- a/apps/docs/app/(home)/llms.mdx/examples/[[...slug]]/route.ts
+++ b/apps/docs/app/(home)/llms.mdx/examples/[[...slug]]/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getLLMText } from "@/lib/get-llm-text";
-import { source } from "@/lib/source";
+import { examples } from "@/lib/source";
 import { notFound } from "next/navigation";
 
 export const revalidate = false;
@@ -10,7 +10,7 @@ export async function GET(
   { params }: { params: Promise<{ slug?: string[] }> },
 ) {
   const { slug } = await params;
-  const page = source.getPage(slug);
+  const page = examples.getPage(slug);
   if (!page) notFound();
 
   return new NextResponse(await getLLMText(page), {
@@ -22,7 +22,7 @@ export async function GET(
 }
 
 export function generateStaticParams() {
-  return source.getPages().map((page) => ({
+  return examples.getPages().map((page) => ({
     slug: page.slugs,
   }));
 }

--- a/apps/docs/app/(home)/llms.txt/route.ts
+++ b/apps/docs/app/(home)/llms.txt/route.ts
@@ -1,51 +1,10 @@
-import { source } from "@/lib/source";
-import { BASE_URL } from "@/lib/constants";
+import { examples, source } from "@/lib/source";
+import { buildLLMSIndex } from "@/lib/llms-index";
 
 export const revalidate = false;
 
 export async function GET() {
-  const lines: string[] = [];
-  lines.push("# assistant-ui");
-  lines.push("");
-  lines.push("> React components for AI chat interfaces");
-  lines.push("");
-  lines.push("## LLM Documentation Files");
-  lines.push("");
-  lines.push(
-    `- [Full documentation](${BASE_URL}/llms-full.txt): all docs pages rendered into one large text file.`,
-  );
-  lines.push(
-    "- Per-page markdown: append `.mdx` to any docs page URL. For example, `/docs/getting-started.mdx` returns the markdown for `/docs/getting-started`.",
-  );
-  lines.push(
-    "- Markdown by Accept header: requesting a docs page with `Accept: text/markdown` also returns that page's markdown.",
-  );
-  lines.push(
-    "- Use the index below to choose a specific page. Remove the `.mdx` suffix to open the human-readable docs page.",
-  );
-  lines.push("");
-  lines.push("## Table of Contents");
-
-  const map = new Map<string, string[]>();
-
-  for (const page of source.getPages()) {
-    const dir = page.slugs[0] || "root";
-    const list = map.get(dir) ?? [];
-    const markdownUrl = `${BASE_URL}${page.url}.mdx`;
-    list.push(
-      `- [${page.data.title}](${markdownUrl}): ${page.data.description || ""}`,
-    );
-    map.set(dir, list);
-  }
-
-  for (const [key, value] of map) {
-    lines.push("");
-    lines.push(`### ${key}`);
-    lines.push("");
-    lines.push(value.join("\n"));
-  }
-
-  return new Response(lines.join("\n"), {
+  return new Response(buildLLMSIndex(source.getPages(), examples.getPages()), {
     headers: {
       "Content-Type": "text/plain; charset=utf-8",
     },

--- a/apps/docs/lib/get-llm-text.tsx
+++ b/apps/docs/lib/get-llm-text.tsx
@@ -11,7 +11,7 @@ import remarkGfm from "remark-gfm";
 import remarkStringify from "remark-stringify";
 import { unified } from "unified";
 import { getMDXComponents } from "@/mdx-components";
-import type { source } from "@/lib/source";
+import type { examples, source } from "@/lib/source";
 import type { InferPageType } from "fumadocs-core/source";
 
 const processor = unified()
@@ -270,7 +270,9 @@ async function resolveStaticReactNode(node: ReactNode): Promise<ReactNode> {
   return renderClientFallback(props, resolvedChildren);
 }
 
-export async function getLLMText(page: InferPageType<typeof source>) {
+type LLMPage = InferPageType<typeof source> | InferPageType<typeof examples>;
+
+export async function getLLMText(page: LLMPage) {
   const Body = page.data.body;
 
   // TODO: Platform-scoped MDX currently renders with the server default

--- a/apps/docs/lib/llms-index.ts
+++ b/apps/docs/lib/llms-index.ts
@@ -1,0 +1,69 @@
+import { BASE_URL } from "./constants";
+
+type LLMIndexPage = {
+  url: string;
+  slugs: string[];
+  data: {
+    title: string;
+    description?: string | undefined;
+  };
+};
+
+function addPageToSection(
+  map: Map<string, string[]>,
+  section: string,
+  page: LLMIndexPage,
+) {
+  const list = map.get(section) ?? [];
+  const markdownUrl = `${BASE_URL}${page.url}.mdx`;
+  list.push(
+    `- [${page.data.title}](${markdownUrl}): ${page.data.description || ""}`,
+  );
+  map.set(section, list);
+}
+
+export function buildLLMSIndex(
+  docsPages: LLMIndexPage[],
+  examplesPages: LLMIndexPage[],
+) {
+  const lines: string[] = [];
+  lines.push("# assistant-ui");
+  lines.push("");
+  lines.push("> React components for AI chat interfaces");
+  lines.push("");
+  lines.push("## LLM Documentation Files");
+  lines.push("");
+  lines.push(
+    `- [Full documentation](${BASE_URL}/llms-full.txt): all docs and examples pages rendered into one large text file.`,
+  );
+  lines.push(
+    "- Per-page markdown: append `.mdx` to any docs page URL. For example, `/docs/getting-started.mdx` returns the markdown for `/docs/getting-started`, and `/examples/ai-sdk.mdx` returns the markdown for `/examples/ai-sdk`.",
+  );
+  lines.push(
+    "- Markdown by Accept header: requesting a docs or examples page with `Accept: text/markdown` also returns that page's markdown.",
+  );
+  lines.push(
+    "- Use the index below to choose a specific page. Remove the `.mdx` suffix to open the human-readable docs page.",
+  );
+  lines.push("");
+  lines.push("## Table of Contents");
+
+  const map = new Map<string, string[]>();
+
+  for (const page of docsPages) {
+    addPageToSection(map, page.slugs[0] || "root", page);
+  }
+
+  for (const page of examplesPages) {
+    addPageToSection(map, "examples", page);
+  }
+
+  for (const [key, value] of map) {
+    lines.push("");
+    lines.push(`### ${key}`);
+    lines.push("");
+    lines.push(value.join("\n"));
+  }
+
+  return lines.join("\n");
+}

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -65,6 +65,10 @@ const config: NextConfig = {
         destination: "/llms.mdx/:path*",
       },
       {
+        source: "/examples.mdx",
+        destination: "/llms.mdx/examples",
+      },
+      {
         source: "/examples/:path*.mdx",
         destination: "/llms.mdx/examples/:path*",
       },

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -50,12 +50,23 @@ const config: NextConfig = {
         destination: "/llms.mdx/:path*",
       },
       {
+        source: "/examples/:path*",
+        has: [
+          { type: "header", key: "accept", value: "(?:.*text/markdown.*)" },
+        ],
+        destination: "/llms.mdx/examples/:path*",
+      },
+      {
         source: "/umami/:path*",
         destination: "https://assistant-ui-umami.vercel.app/:path*",
       },
       {
         source: "/docs/:path*.mdx",
         destination: "/llms.mdx/:path*",
+      },
+      {
+        source: "/examples/:path*.mdx",
+        destination: "/llms.mdx/examples/:path*",
       },
       {
         source: "/blog/:path.md",


### PR DESCRIPTION
Closes #4146

## Summary

- Includes example pages in `/llms.txt` and `/llms-full.txt`
- Adds markdown routing for `/examples/*.mdx` and `Accept: text/markdown` on example pages
- Allows the shared LLM markdown renderer to accept both docs and example pages

## Testing

- `pnpm --filter=@assistant-ui/docs exec next build --debug-build-paths 'app/(home)/llms.txt/route.ts,app/(home)/llms-full.txt/route.ts,app/(home)/llms.mdx/[[...slug]]/route.ts'`
- `pnpm --filter=@assistant-ui/docs exec tsx .tmp-check-llms-index.ts`
- `pnpm exec oxfmt --check apps/docs/app/'(home)'/llms.txt/route.ts apps/docs/app/'(home)'/llms-full.txt/route.ts apps/docs/app/'(home)'/llms.mdx/'[[...slug]]'/route.ts apps/docs/next.config.ts apps/docs/lib/get-llm-text.tsx apps/docs/lib/llms-index.ts`
- `pnpm exec oxlint apps/docs/app/'(home)'/llms.txt/route.ts apps/docs/app/'(home)'/llms-full.txt/route.ts apps/docs/app/'(home)'/llms.mdx/'[[...slug]]'/route.ts apps/docs/next.config.ts apps/docs/lib/get-llm-text.tsx apps/docs/lib/llms-index.ts`
- `git diff --check`
