### PR TITLE
chore: drop stale biome-ignore pragmas after migrating to oxlint

### DIFF
--- a/.changeset/drop-stale-biome-ignore.md
+++ b/.changeset/drop-stale-biome-ignore.md
@@ -1,0 +1,18 @@
+---
+"assistant-stream": patch
+"@assistant-ui/core": patch
+"heat-graph": patch
+"mcp-app-studio": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-devtools": patch
+"@assistant-ui/react-google-adk": patch
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/react-mcp": patch
+"@assistant-ui/react-opencode": patch
+"@assistant-ui/store": patch
+"@assistant-ui/tap": patch
+---
+
+chore: drop stale `biome-ignore` pragmas now that the repo lints with oxlint

--- a/apps/devtools-frame/components/DevToolsUI.tsx
+++ b/apps/devtools-frame/components/DevToolsUI.tsx
@@ -998,7 +998,6 @@ export function DevToolsUI() {
   const eventTypes = useMemo(() => {
     const types = new Set<string>();
     apis.forEach((api) => {
-      // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
       api.logs.forEach((log) => types.add(log.event));
     });
     return Array.from(types).sort();

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -72,10 +72,8 @@ export default function Layout({ children }: { children: ReactNode }) {
           data-website-id="6f07c001-46a2-411f-9241-4f7f5afb60ee"
           data-domains="www.assistant-ui.com"
         ></script>
-        {/* biome-ignore lint/correctness/useUniqueElementIds: static page with unique context */}
         <Script
           id="vector-script"
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: analytics script injection
           dangerouslySetInnerHTML={{
             __html: `
         !function(e,r){try{if(e.vector)return void console.log("Vector snippet included more than once.");var t={};t.q=t.q||[];for(var o=["load","identify","on"],n=function(e){return function(){var r=Array.prototype.slice.call(arguments);t.q.push([e,r])}},c=0;c<o.length;c++){var a=o[c];t[a]=n(a)}if(e.vector=t,!t.loaded){var i=r.createElement("script");i.type="text/javascript",i.async=!0,i.src="https://cdn.vector.co/pixel.js";var l=r.getElementsByTagName("script")[0];l.parentNode.insertBefore(i,l),t.loaded=!0}}catch(e){console.error("Error loading Vector:",e)}}(window,document);

--- a/apps/docs/app/mcp-app-studio/page.tsx
+++ b/apps/docs/app/mcp-app-studio/page.tsx
@@ -632,7 +632,6 @@ export default function McpAppStudioPage() {
                   <div className="size-3 rounded-full bg-yellow-500/80" />
                   <div className="size-3 rounded-full bg-green-500/80" />
                 </div>
-                {/* biome-ignore lint/correctness/useUniqueElementIds: static page with unique context */}
                 <span
                   id="workbench-fullscreen-title"
                   className="font-mono text-sm text-zinc-400"

--- a/apps/docs/app/playground/page.tsx
+++ b/apps/docs/app/playground/page.tsx
@@ -274,7 +274,6 @@ export default function PlaygroundPage() {
           >
             <div className="flex h-full items-stretch justify-center p-2 md:p-4">
               {viewportWidth !== "100%" && (
-                // biome-ignore lint/a11y/noStaticElementInteractions: resize drag handle
                 <div
                   onMouseDown={(e) => handleResizeStart(e, "left")}
                   className="group hidden w-4 shrink-0 cursor-ew-resize items-center justify-center md:flex"
@@ -311,7 +310,6 @@ export default function PlaygroundPage() {
               </div>
 
               {viewportWidth !== "100%" && (
-                // biome-ignore lint/a11y/noStaticElementInteractions: resize drag handle
                 <div
                   onMouseDown={(e) => handleResizeStart(e, "right")}
                   className="group hidden w-4 shrink-0 cursor-ew-resize items-center justify-center md:flex"

--- a/apps/docs/app/tw-glass/(home)/doc-components.tsx
+++ b/apps/docs/app/tw-glass/(home)/doc-components.tsx
@@ -89,14 +89,12 @@ export function CodeBlock({
         transformerMetaWordHighlight(),
       ]}
       components={{
-        // biome-ignore lint/correctness/noNestedComponentDefinitions: false positive
         Pre: ({
           className,
           ...props
         }: React.HTMLAttributes<HTMLPreElement>) => (
           <pre className={className} {...props} />
         ),
-        // biome-ignore lint/correctness/noNestedComponentDefinitions: false positive
         Code: ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
           <code className={className} {...props} />
         ),

--- a/apps/docs/app/tw-shimmer/(home)/page.tsx
+++ b/apps/docs/app/tw-shimmer/(home)/page.tsx
@@ -617,11 +617,9 @@ function CodeBlock({
         transformerMetaWordHighlight(),
       ]}
       components={{
-        // biome-ignore lint/correctness/noNestedComponentDefinitions: false positive
         Pre: ({ className, ...props }: any) => (
           <pre className={className} {...props} />
         ),
-        // biome-ignore lint/correctness/noNestedComponentDefinitions: false positive
         Code: ({ className, ...props }: any) => (
           <code className={className} {...props} />
         ),

--- a/apps/docs/app/tw-shimmer/opengraph-image.tsx
+++ b/apps/docs/app/tw-shimmer/opengraph-image.tsx
@@ -20,7 +20,6 @@ export default async function Image() {
 
   return new ImageResponse(
     <OgTemplate subtleBranding>
-      {/* biome-ignore lint/performance/noImgElement: next/image not applicable here */}
       <img
         src={shimmerTextSrc}
         alt="tw-shimmer"

--- a/apps/docs/components/docs/assistant/composer.tsx
+++ b/apps/docs/components/docs/assistant/composer.tsx
@@ -44,7 +44,6 @@ const subscribeModelStore = (listener: ModelStoreListener) => {
 const setSharedDocsModelName = (modelName: KnownModelId) => {
   if (sharedDocsModelName === modelName) return;
   sharedDocsModelName = modelName;
-  // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
   modelStoreListeners.forEach((listener) => listener());
 };
 

--- a/apps/docs/components/docs/assistant/panel.tsx
+++ b/apps/docs/components/docs/assistant/panel.tsx
@@ -39,7 +39,6 @@ function ResizeHandle() {
   );
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: resize drag handle
     <div
       onMouseDown={handleMouseDown}
       className={cn(

--- a/apps/docs/components/docs/layout/sidebar-content.tsx
+++ b/apps/docs/components/docs/layout/sidebar-content.tsx
@@ -246,12 +246,10 @@ export function SidebarContent({ tree }: { tree?: PageTree.Root }) {
     activeSectionId,
   );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the change trigger
   useEffect(() => {
     if (activeSectionId) setOpenSectionId(activeSectionId);
   }, [activeSectionId, pathname]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: deps are change triggers
   useEffect(() => {
     if (openSectionId !== activeSectionId) return;
     const timer = setTimeout(() => {

--- a/apps/docs/components/docs/layout/table-of-contents.tsx
+++ b/apps/docs/components/docs/layout/table-of-contents.tsx
@@ -164,7 +164,6 @@ export function TableOfContents({
   if (items.length === 0) return null;
 
   return (
-    // biome-ignore lint/correctness/useUniqueElementIds: framework-specific toc anchor
     <div id="nd-toc" className="w-56 [grid-area:toc] max-xl:hidden">
       <div className="sticky top-14 flex max-h-[calc(100vh-3.5rem)] flex-col pe-4 pb-2">
         <p className="text-muted-foreground/70 mb-3 shrink-0 text-xs">

--- a/apps/docs/components/docs/platform/context.tsx
+++ b/apps/docs/components/docs/platform/context.tsx
@@ -219,7 +219,6 @@ export function PlatformProvider({ children }: { children: ReactNode }) {
     platformStore.getServerSnapshot,
   );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the route-change trigger
   useEffect(() => {
     platformStore.syncUrlAndStore();
   }, [pathname]);

--- a/apps/docs/components/docs/samples/attachment.tsx
+++ b/apps/docs/components/docs/samples/attachment.tsx
@@ -14,7 +14,6 @@ function AttachmentTileStatic({ name, isImage }: AttachmentTileStaticProps) {
 
   return (
     <div className="aui-attachment-root relative">
-      {/* biome-ignore lint/a11y/useSemanticElements: styled div with role */}
       <div
         className="aui-attachment-tile aui-attachment-tile-composer border-foreground/20 bg-muted size-14 cursor-pointer overflow-hidden rounded-[14px] border transition-opacity hover:opacity-75"
         role="button"

--- a/apps/docs/components/examples/chatgpt.tsx
+++ b/apps/docs/components/examples/chatgpt.tsx
@@ -414,7 +414,6 @@ const ChatGPTAttachmentUI: FC = () => {
       <div className="bg-secondary flex items-center gap-2 overflow-hidden rounded-2xl border dark:bg-white/5">
         <AuiIf condition={(s) => s.attachment.type === "image"}>
           {src ? (
-            // biome-ignore lint/performance/noImgElement: example component
             <img
               className="size-32 rounded-md object-cover"
               alt="Attachment"

--- a/apps/docs/components/examples/claude.tsx
+++ b/apps/docs/components/examples/claude.tsx
@@ -367,7 +367,6 @@ const ClaudeAttachment: FC = () => {
         style={{ width: "80px", height: "80px" }}
       >
         {isImage && src ? (
-          // biome-ignore lint/performance/noImgElement: example component
           <img
             className="h-full w-full object-cover"
             alt="Attachment"

--- a/apps/docs/components/examples/gemini.tsx
+++ b/apps/docs/components/examples/gemini.tsx
@@ -316,7 +316,6 @@ const GeminiAttachment: FC = () => {
     <AttachmentPrimitive.Root className="group/thumbnail relative">
       <div className="size-[72px] overflow-hidden rounded-xl border border-[#dadce0] bg-[#f1f3f4] dark:border-[#3c4043] dark:bg-[#282a2c]">
         {isImage && src ? (
-          // biome-ignore lint/performance/noImgElement: example component
           <img className="size-full object-cover" alt="Attachment" src={src} />
         ) : (
           <div className="flex size-full items-center justify-center text-[#5e6063] dark:text-[#9aa0a6]">

--- a/apps/docs/components/examples/grok.tsx
+++ b/apps/docs/components/examples/grok.tsx
@@ -349,7 +349,6 @@ const GrokAttachment: FC = () => {
       <div className="flex h-12 items-center gap-2 overflow-hidden rounded-xl border border-[#e5e5e5] bg-[#f0f0f0] p-0.5 transition-colors hover:border-[#d0d0d0] dark:border-[#2a2a2a] dark:bg-[#252525] dark:hover:border-[#3a3a3a]">
         <AuiIf condition={(s) => s.attachment.type === "image"}>
           {src ? (
-            // biome-ignore lint/performance/noImgElement: example component
             <img
               className="h-full w-12 rounded-[9px] object-cover"
               alt="Attachment"

--- a/apps/docs/components/examples/perplexity.tsx
+++ b/apps/docs/components/examples/perplexity.tsx
@@ -444,7 +444,6 @@ const AttachmentPreview: FC<{ removable: boolean }> = ({ removable }) => {
       <div className="flex max-w-65 items-center gap-3 rounded-2xl border border-[#e3dbcf] bg-[#f5f1eb] py-2 pr-3 pl-2 transition-colors hover:bg-[#efe8de] dark:border-[#3a342f] dark:bg-[#2a2724] dark:hover:bg-[#302c29]">
         <div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-[#fffdfa] text-[#6f675d] dark:bg-[#201d1b] dark:text-[#a59f96]">
           {src ? (
-            // biome-ignore lint/performance/noImgElement: example component
             <img
               src={src}
               alt="Attachment"

--- a/apps/docs/components/icons/gemini.tsx
+++ b/apps/docs/components/icons/gemini.tsx
@@ -5,7 +5,6 @@ export function GeminiIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg aria-hidden="true" {...props} viewBox="0 0 65 65" fill="none">
       <defs>
-        {/* biome-ignore lint/correctness/useUniqueElementIds: static page with unique context */}
         <linearGradient
           id="gemini-blue"
           x1="18.447"

--- a/apps/docs/components/legacy/attachment-old.tsx
+++ b/apps/docs/components/legacy/attachment-old.tsx
@@ -67,7 +67,6 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({ src }) => {
   const [isLoaded, setIsLoaded] = useState(false);
 
   return (
-    // biome-ignore lint/performance/noImgElement: example component
     <img
       src={src}
       style={{

--- a/apps/docs/components/shared/footer.tsx
+++ b/apps/docs/components/shared/footer.tsx
@@ -92,7 +92,6 @@ export function Footer(): React.ReactElement {
           </Link>
 
           <div className="flex gap-3">
-            {/* biome-ignore lint/a11y/useAnchorContent: icon-only link with aria-label */}
             <a
               href="https://x.com/assistantui"
               target="_blank"

--- a/apps/docs/hooks/use-persistent-boolean.ts
+++ b/apps/docs/hooks/use-persistent-boolean.ts
@@ -28,7 +28,6 @@ class PersistentBooleanStore {
   };
 
   private notifyListeners = () => {
-    // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
     this.listeners.forEach((listener) => listener());
   };
 

--- a/apps/social-media/src/launches/cloud-dashboard.tsx
+++ b/apps/social-media/src/launches/cloud-dashboard.tsx
@@ -60,7 +60,6 @@ export default function CloudDashboardLaunch() {
           top: "220px",
         }}
       >
-        {/* biome-ignore lint/performance/noImgElement: next/image not applicable here */}
         <img
           alt=""
           src={screenshotBase64}

--- a/examples/waterfall/lib/waterfall-timeline.tsx
+++ b/examples/waterfall/lib/waterfall-timeline.tsx
@@ -115,7 +115,6 @@ export function WaterfallTimeline() {
   ) as SpanState["timeRange"];
 
   // Measure outer container width — re-attach when scroll container mounts
-  // biome-ignore lint/correctness/useExhaustiveDependencies: hasSpans triggers re-attach when scroll container mounts
   useEffect(() => {
     const el = outerRef.current;
     if (!el) return;
@@ -134,7 +133,6 @@ export function WaterfallTimeline() {
   }, [hasSpans]);
 
   // Cmd + scroll wheel zoom — re-attach when scroll container mounts
-  // biome-ignore lint/correctness/useExhaustiveDependencies: hasSpans triggers re-attach when scroll container mounts
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -230,8 +228,6 @@ export function WaterfallTimeline() {
 
         {/* Span rows */}
         <WaterfallLayoutContext.Provider value={layoutValue}>
-          {/* biome-ignore lint/a11y/useKeyWithClickEvents: event delegation on span rows */}
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: event delegation on span rows */}
           <div
             style={{ width: contentWidth }}
             onClick={(e) => {

--- a/examples/with-a2a/app/page.tsx
+++ b/examples/with-a2a/app/page.tsx
@@ -125,7 +125,6 @@ function ArtifactPartView({ part }: { part: A2APart }) {
     const isImage = part.mediaType?.startsWith("image/");
     if (isImage) {
       return (
-        // biome-ignore lint/performance/noImgElement: example component
         <img
           src={part.url}
           alt={part.filename ?? "image"}
@@ -154,7 +153,6 @@ function ArtifactPartView({ part }: { part: A2APart }) {
     const isImage = part.mediaType?.startsWith("image/");
     if (isImage) {
       return (
-        // biome-ignore lint/performance/noImgElement: example component
         <img
           src={`data:${part.mediaType};base64,${part.raw}`}
           alt={part.filename ?? "image"}

--- a/examples/with-chain-of-thought/app/page.tsx
+++ b/examples/with-chain-of-thought/app/page.tsx
@@ -20,7 +20,6 @@ const ExecuteJsTool = makeAssistantTool({
   }),
   execute: async ({ code }) => {
     try {
-      // biome-ignore lint/security/noGlobalEval: example code
       const result = eval(code);
       return { success: true, result: String(result) };
     } catch (e) {

--- a/examples/with-cloud-standalone/components/chat/Composer.tsx
+++ b/examples/with-cloud-standalone/components/chat/Composer.tsx
@@ -45,7 +45,6 @@ export function Composer({
           placeholder="Send a message..."
           className="placeholder:text-muted-foreground max-h-32 min-h-8 flex-1 resize-none bg-transparent py-1 text-sm leading-normal outline-none"
           rows={1}
-          // biome-ignore lint/a11y/noAutofocus: chat input should autofocus
           autoFocus
         />
         {isRunning ? (

--- a/examples/with-ffmpeg/app/page.tsx
+++ b/examples/with-ffmpeg/app/page.tsx
@@ -224,10 +224,8 @@ const FfmpegTool: FC<{ file: File }> = ({ file }) => {
       args: { fileName, mimeType },
       result,
     }) {
-      // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       const [blobUrl, setBlobUrl] = useState<string | null>(null);
 
-      // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       const readFile = useCallback(async () => {
         const ffmpeg = ffmpegRef.current;
         const data = (await ffmpeg.readFile(
@@ -236,7 +234,6 @@ const FfmpegTool: FC<{ file: File }> = ({ file }) => {
         return URL.createObjectURL(new Blob([data.buffer], { type: mimeType }));
       }, [fileName, mimeType]);
 
-      // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       useEffect(() => {
         if (!result?.success) return;
         let revoked = false;
@@ -288,25 +285,16 @@ const FfmpegTool: FC<{ file: File }> = ({ file }) => {
 
       return (
         <div className="mb-2 flex flex-col gap-3 rounded-lg border px-5 py-4">
-          {blobUrl &&
-            isImage && (
-              // biome-ignore lint/performance/noImgElement: blob URL display
-              <img
-                src={blobUrl}
-                alt={fileName}
-                className="max-h-64 w-fit rounded"
-              />
-            )}
-          {blobUrl &&
-            isVideo && (
-              // biome-ignore lint/a11y/useMediaCaption: generated output
-              <video
-                src={blobUrl}
-                controls
-                className="max-h-64 w-fit rounded"
-              />
-            )}
-          {/* biome-ignore lint/a11y/useMediaCaption: generated output */}
+          {blobUrl && isImage && (
+            <img
+              src={blobUrl}
+              alt={fileName}
+              className="max-h-64 w-fit rounded"
+            />
+          )}
+          {blobUrl && isVideo && (
+            <video src={blobUrl} controls className="max-h-64 w-fit rounded" />
+          )}
           {blobUrl && isAudio && <audio src={blobUrl} controls />}
           {blobUrl && !isImage && !isVideo && !isAudio && (
             <div className="text-muted-foreground flex items-center gap-2">

--- a/examples/with-interactables/app/page.tsx
+++ b/examples/with-interactables/app/page.tsx
@@ -227,7 +227,6 @@ function NoteCard({
   };
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: styled interactive card
     <div
       role="button"
       tabIndex={0}

--- a/examples/with-tanstack/src/routes/__root.tsx
+++ b/examples/with-tanstack/src/routes/__root.tsx
@@ -30,7 +30,6 @@ export const Route = createRootRoute({
 function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      {/* biome-ignore lint/style/noHeadElement: TanStack Start uses standard HTML head */}
       <head>
         <HeadContent />
       </head>

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -419,7 +419,6 @@ export class DataStreamDecoder extends PipeableTransformStream<
         flush() {
           activeToolCallArgsText?.close();
           activeToolCallArgsText = undefined;
-          // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
           toolCallControllers.forEach((controller) => controller.close());
           toolCallControllers.clear();
         },

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -264,7 +264,6 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
         },
         flush() {
           activeToolCallArgsText?.close();
-          // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
           toolCallControllers.forEach((ctrl) => ctrl.close());
           toolCallControllers.clear();
         },

--- a/packages/core/src/adapters/speech.ts
+++ b/packages/core/src/adapters/speech.ts
@@ -64,7 +64,6 @@ export class WebSpeechSynthesisAdapter implements SpeechSynthesisAdapter {
       if (res.status.type === "ended") return;
 
       res.status = { type: "ended", reason, error };
-      // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
       subscribers.forEach((handler) => handler());
     };
 

--- a/packages/core/src/model-context/frame/host.ts
+++ b/packages/core/src/model-context/frame/host.ts
@@ -175,7 +175,6 @@ export class AssistantFrameHost implements ModelContextProvider {
   }
 
   private notifySubscribers() {
-    // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
     this._subscribers.forEach((callback) => callback());
   }
 

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -179,7 +179,6 @@ export class AssistantFrameProvider {
       const instance = AssistantFrameProvider._instance;
       window.removeEventListener("message", instance.handleMessage);
 
-      // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
       instance._providerUnsubscribes.forEach((unsubscribe) => unsubscribe?.());
       instance._providerUnsubscribes.clear();
       instance._providers.clear();

--- a/packages/core/src/react/client/Interactables.ts
+++ b/packages/core/src/react/client/Interactables.ts
@@ -253,7 +253,6 @@ export const Interactables = resource((): ClientOutput<"interactables"> => {
     [setDefState],
   );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: state dep triggers notification
   tapEffect(() => {
     for (const cb of subscribersRef.current) cb();
   }, [state]);

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -112,7 +112,6 @@ export const Tools = resource(
       );
 
       return () => {
-        // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
         unsubscribes.forEach((fn) => fn());
       };
     }, [toolkit, setToolUI, clientRef]);

--- a/packages/core/src/react/model-context/useInlineRender.ts
+++ b/packages/core/src/react/model-context/useInlineRender.ts
@@ -17,7 +17,6 @@ export const useInlineRender = <TArgs, TResult>(
 
   return useCallback(
     function ToolUI(args) {
-      // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       const store = useToolUIStore();
       return store.toolUI(args);
     },

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -62,7 +62,6 @@ export class RemoteThreadListThreadListRuntimeCore
               isLoading: true,
             };
           },
-          // biome-ignore lint/suspicious/noThenProperty: OptimisticState reducer pattern
           then: (state, l) => {
             if (generation !== this._loadGeneration) return state;
             const fresh = classifyThreads(l.threads, {
@@ -120,7 +119,6 @@ export class RemoteThreadListThreadListRuntimeCore
       .optimisticUpdate({
         execute: () => adapter.list({ after: cursor }),
         loading: (state) => ({ ...state, isLoadingMore: true }),
-        // biome-ignore lint/suspicious/noThenProperty: OptimisticState reducer pattern
         then: (state, l) => {
           if (generation !== this._loadGeneration) return state;
           if (adapter !== this._options.adapter) return state;
@@ -423,7 +421,6 @@ export class RemoteThreadListThreadListRuntimeCore
           },
         };
       },
-      // biome-ignore lint/suspicious/noThenProperty: OptimisticState reducer pattern
       then: (state, { remoteId, externalId }) => {
         const data = getThreadData(state, threadId);
         if (!data) return state;

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -43,20 +43,17 @@ export const useCloudThreadListAdapter = (
 
   const unstable_Provider = useCallback<FC<PropsWithChildren>>(
     function Provider({ children }) {
-      // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       const history = useAssistantCloudThreadHistoryAdapter({
         get current() {
           return adapterRef.current.cloud ?? autoCloud!;
         },
       });
       const cloudInstance = adapterRef.current.cloud ?? autoCloud!;
-      // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       const attachments = useMemo(
         () => new CloudFileAttachmentAdapter(cloudInstance),
         [cloudInstance],
       );
 
-      // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       const adapters = useMemo(
         () => ({
           history,

--- a/packages/core/src/react/runtimes/useLocalRuntime.ts
+++ b/packages/core/src/react/runtimes/useLocalRuntime.ts
@@ -22,7 +22,6 @@ const useLocalThreadRuntime = (
   chatModel: ChatModelAdapter,
   { initialMessages, ...options }: LocalRuntimeOptions,
 ): AssistantRuntime => {
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const { modelContext, ...threadListAdapters } = useRuntimeAdapters() ?? {};
   const opt = {
     ...options,
@@ -33,41 +32,33 @@ const useLocalThreadRuntime = (
     },
   };
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const [runtime] = useState(() => new LocalRuntimeCore(opt, initialMessages));
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const threadIdRef = useRef<string | undefined>(undefined);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   threadIdRef.current = useAuiState((s) => s.threadListItem.remoteId);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   useEffect(() => {
     runtime.threads
       .getMainThreadRuntimeCore()
       .__internal_setGetThreadId(() => threadIdRef.current);
   }, [runtime]);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   useEffect(() => {
     return () => {
       runtime.threads.getMainThreadRuntimeCore().detach();
     };
   }, [runtime]);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   useEffect(() => {
     runtime.threads.getMainThreadRuntimeCore().__internal_setOptions(opt);
     runtime.threads.getMainThreadRuntimeCore().__internal_load();
   });
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   useEffect(() => {
     if (!modelContext) return undefined;
     return runtime.registerModelContextProvider(modelContext);
   }, [modelContext, runtime]);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   return useMemo(() => new AssistantRuntimeImpl(runtime), [runtime]);
 };
 
@@ -102,7 +93,6 @@ export const useLocalRuntime = (
   const cloudAdapter = useCloudThreadListAdapter({ cloud });
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
-      // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       return useLocalThreadRuntime(chatModel, options);
     },
     adapter: cloudAdapter,

--- a/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
+++ b/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
@@ -29,15 +29,12 @@ class RemoteThreadListRuntimeCore
 const useRemoteThreadListRuntimeImpl = (
   options: RemoteThreadListOptions,
 ): AssistantRuntime => {
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const [runtime] = useState(() => new RemoteThreadListRuntimeCore(options));
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   useEffect(() => {
     runtime.threads.__internal_setOptions(options);
     runtime.threads.__internal_load();
   }, [runtime, options]);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   return useMemo(() => new AssistantRuntimeImpl(runtime), [runtime]);
 };
 
@@ -80,12 +77,9 @@ export const useRemoteThreadListRuntime = (
     return stableRuntimeHook();
   }
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const runtime = useRemoteThreadListRuntimeImpl(stableOptions);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const prevThreadIdRef = useRef(options.threadId);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   useEffect(() => {
     if (options.threadId === prevThreadIdRef.current) return;
     prevThreadIdRef.current = options.threadId;

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
@@ -446,7 +446,6 @@ export class ToolInvocationTracker {
 
     if (this._executing.size === 0) {
       const resolvers = this._settledResolvers.splice(0);
-      // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
       resolvers.forEach((resolve) => {
         try {
           resolve();

--- a/packages/core/src/tests/OptimisticState-list-race.test.ts
+++ b/packages/core/src/tests/OptimisticState-list-race.test.ts
@@ -89,7 +89,6 @@ describe("list + delete race condition", () => {
     const listPromise = state.optimisticUpdate({
       execute: () => listDeferred.promise,
       loading: (s) => ({ ...s, isLoading: true }),
-      // biome-ignore lint/suspicious/noThenProperty: OptimisticState reducer pattern
       then: applyListResult,
     });
 
@@ -147,7 +146,6 @@ describe("list + delete race condition", () => {
     const listPromise = state.optimisticUpdate({
       execute: () => listDeferred.promise,
       loading: (s) => ({ ...s, isLoading: true }),
-      // biome-ignore lint/suspicious/noThenProperty: OptimisticState reducer pattern
       then: applyListResult,
     });
 
@@ -185,7 +183,6 @@ describe("list + delete race condition", () => {
     const listPromise = state.optimisticUpdate({
       execute: () => listDeferred.promise,
       loading: (s) => ({ ...s, isLoading: true }),
-      // biome-ignore lint/suspicious/noThenProperty: OptimisticState reducer pattern
       then: applyListResult,
     });
 
@@ -223,7 +220,6 @@ describe("list + delete race condition", () => {
     const listPromise = state.optimisticUpdate({
       execute: () => listDeferred.promise,
       loading: (s) => ({ ...s, isLoading: true }),
-      // biome-ignore lint/suspicious/noThenProperty: OptimisticState reducer pattern
       then: applyListResult,
     });
 

--- a/packages/core/src/tests/remote-thread-list-isLoading.test.ts
+++ b/packages/core/src/tests/remote-thread-list-isLoading.test.ts
@@ -86,7 +86,6 @@ describe("RemoteThreadList isLoading lifecycle", () => {
     state.optimisticUpdate({
       execute: () => d.promise,
       loading: (s) => ({ ...s, isLoading: true }),
-      // biome-ignore lint/suspicious/noThenProperty: OptimisticState reducer pattern
       then: applyListResult,
     });
 
@@ -100,7 +99,6 @@ describe("RemoteThreadList isLoading lifecycle", () => {
     const promise = state.optimisticUpdate({
       execute: () => d.promise,
       loading: (s) => ({ ...s, isLoading: true }),
-      // biome-ignore lint/suspicious/noThenProperty: OptimisticState reducer pattern
       then: applyListResult,
     });
 
@@ -117,7 +115,6 @@ describe("RemoteThreadList isLoading lifecycle", () => {
     const promise = state.optimisticUpdate({
       execute: () => d.promise,
       loading: (s) => ({ ...s, isLoading: true }),
-      // biome-ignore lint/suspicious/noThenProperty: OptimisticState reducer pattern
       then: applyListResult,
     });
 
@@ -142,7 +139,6 @@ describe("RemoteThreadList isLoading lifecycle", () => {
     const promise = state.optimisticUpdate({
       execute: () => d.promise,
       loading: (s) => ({ ...s, isLoading: true }),
-      // biome-ignore lint/suspicious/noThenProperty: OptimisticState reducer pattern
       then: applyListResult,
     });
 
@@ -166,7 +162,6 @@ describe("RemoteThreadList isLoading error path", () => {
       .optimisticUpdate({
         execute: () => d.promise,
         loading: (s) => ({ ...s, isLoading: true }),
-        // biome-ignore lint/suspicious/noThenProperty: OptimisticState reducer pattern
         then: applyListResult,
       })
       .catch(() => {

--- a/packages/heat-graph/src/components/Cell.tsx
+++ b/packages/heat-graph/src/components/Cell.tsx
@@ -29,7 +29,6 @@ export const Cell = forwardRef<HTMLDivElement, CellProps>(
     );
 
     return (
-      // biome-ignore lint/a11y/noStaticElementInteractions: hover interaction for tooltip
       <div
         ref={ref}
         style={mergedStyle}

--- a/packages/mcp-app-studio/src/platforms/mcp/bridge.ts
+++ b/packages/mcp-app-studio/src/platforms/mcp/bridge.ts
@@ -86,13 +86,11 @@ export class MCPBridge implements ExtendedBridge {
 
     this.app.ontoolinput = (params) => {
       const args = (params.arguments ?? {}) as Record<string, unknown>;
-      // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
       this.toolInputCallbacks.forEach((cb) => cb(args));
     };
 
     this.app.ontoolinputpartial = (params) => {
       const args = (params.arguments ?? {}) as Record<string, unknown>;
-      // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
       this.toolInputPartialCallbacks.forEach((cb) => cb(args));
     };
 
@@ -112,19 +110,16 @@ export class MCPBridge implements ExtendedBridge {
       if (params._meta) {
         result._meta = params._meta as Record<string, unknown>;
       }
-      // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
       this.toolResultCallbacks.forEach((cb) => cb(result));
     };
 
     this.app.ontoolcancelled = (params) => {
       const reason = (params.reason ?? "") as string;
-      // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
       this.toolCancelledCallbacks.forEach((cb) => cb(reason));
     };
 
     this.app.onhostcontextchanged = (params: Record<string, unknown>) => {
       const ctx = this.mapHostContext(params);
-      // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
       this.contextCallbacks.forEach((cb) => cb(ctx));
     };
 

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -34,13 +34,10 @@ export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
 const useDynamicChatTransport = <UI_MESSAGE extends UIMessage = UIMessage>(
   transport: ChatTransport<UI_MESSAGE>,
 ): ChatTransport<UI_MESSAGE> => {
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const transportRef = useRef<ChatTransport<UI_MESSAGE>>(transport);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   useEffect(() => {
     transportRef.current = transport;
   });
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const dynamicTransport = useMemo(
     () =>
       new Proxy(transportRef.current, {
@@ -89,23 +86,18 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     ? true
     : never;
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const transport = useDynamicChatTransport(
     transportOptions ?? new AssistantChatTransport(),
   );
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const id = useAuiState((s) => s.threadListItem.id);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const aui = useAui();
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const chat = useChat({
     ...chatOptions,
     id,
     transport,
   });
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const runtime = useAISDKRuntime(chat, {
     adapters,
     ...pickExternalStoreSharedOptions(options ?? {}),
@@ -120,9 +112,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     );
   }
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const resumeFiredRef = useRef(false);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   useEffect(() => {
     if (resumeFiredRef.current) return;
     const adapter = getResumableAdapter(transport);
@@ -149,7 +139,6 @@ export const useChatRuntime = <UI_MESSAGE extends UIMessage = UIMessage>({
   const cloudAdapter = useCloudThreadListAdapter({ cloud });
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
-      // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       return useChatThreadRuntime(options);
     },
     adapter: cloudAdapter,

--- a/packages/react-devtools/src/DevToolsModal.tsx
+++ b/packages/react-devtools/src/DevToolsModal.tsx
@@ -117,8 +117,6 @@ const DevToolsModalImpl = () => {
 
       {isOpen && (
         <>
-          {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click is a convenience; keyboard users use the close button */}
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop overlay */}
           <div style={styles.backdrop} onClick={() => setIsOpen(false)} />
 
           <div style={styles.modal} data-devtools-modal>

--- a/packages/react-devtools/src/FrameClient.ts
+++ b/packages/react-devtools/src/FrameClient.ts
@@ -43,7 +43,6 @@ export class FrameClient {
         this.notifyListeners(message.data);
       } else if (message.type === "host-connected") {
         // Host has reconnected (page refresh), notify listeners to re-subscribe
-        // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
         this.connectionListeners.forEach((listener) => listener());
       }
     });
@@ -90,7 +89,6 @@ export class FrameClient {
   }
 
   private notifyListeners(data: UpdateMessage["data"]) {
-    // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
     this.listeners.forEach((listener) => listener(data));
   }
 

--- a/packages/react-google-adk/src/server/adkEventStream.test.ts
+++ b/packages/react-google-adk/src/server/adkEventStream.test.ts
@@ -50,7 +50,6 @@ describe("adkEventStream", () => {
   });
 
   it("emits an error event when the generator throws", async () => {
-    // biome-ignore lint/correctness/useYield: intentionally throws before yielding
     async function* throwingGen() {
       throw new Error("Test error");
     }
@@ -67,7 +66,6 @@ describe("adkEventStream", () => {
 
   it("calls onError callback when the generator throws", async () => {
     const onError = vi.fn();
-    // biome-ignore lint/correctness/useYield: intentionally throws before yielding
     async function* throwingGen() {
       throw new Error("Test error");
     }

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -183,7 +183,6 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
     getCheckpointId,
     eventHandlers,
   } = options;
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const aui = useAui();
   const {
     messages,
@@ -198,15 +197,12 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
     sendMessage,
     cancel,
     replaceMessages,
-    // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   } = useAdkMessages({
     stream,
     ...(eventHandlers && { eventHandlers }),
   });
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const [isRunning, setIsRunning] = useState(false);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const [toolStatuses, setToolStatuses] = useState<
     Record<string, ToolExecutionStatus>
   >({});
@@ -227,18 +223,15 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
     }
   };
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const threadMessages = useExternalMessageConverter({
     callback: convertAdkMessage,
     messages,
     isRunning: effectiveIsRunning,
   });
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const threadMessagesRef = useRef(threadMessages);
   threadMessagesRef.current = threadMessages;
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const runtime = useExternalStoreRuntime({
     ...pickExternalStoreSharedOptions(options),
     isRunning: effectiveIsRunning,
@@ -349,14 +342,11 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
   });
 
   {
-    // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
     const loadRef = useRef(load);
-    // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
     useEffect(() => {
       loadRef.current = load;
     });
 
-    // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
     useEffect(() => {
       const loadFn = loadRef.current;
       if (!loadFn) return;
@@ -400,7 +390,6 @@ export const useAdkRuntime = ({
 
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
-      // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       return useAdkRuntimeImpl(options);
     },
     adapter,

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -176,7 +176,6 @@ const useStreamThreadRuntime = (
     options;
   const messagesKey = options.messagesKey ?? "messages";
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const externalId = useAuiState((s) => s.threadListItem.externalId) as
     | string
     | null;
@@ -185,10 +184,8 @@ const useStreamThreadRuntime = (
   // literal merges both arms' transport types, breaking arm assignment.
   options.threadId = externalId;
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const stream = useStream(options);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const [toolStatuses, setToolStatuses] = useState<
     Record<string, ToolExecutionStatus>
   >({});
@@ -197,18 +194,15 @@ const useStreamThreadRuntime = (
   );
   const effectiveIsRunning = stream.isLoading || hasExecutingTools;
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const threadMessages = useExternalMessageConverter({
     callback: convertLangChainBaseMessage,
     messages: stream.messages as LangChainBaseMessage[],
     isRunning: effectiveIsRunning,
   });
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const streamRef = useRef(stream);
   streamRef.current = stream;
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const extras = useMemo(
     (): LangChainRuntimeExtras => ({
       [symbolLangChainRuntimeExtras]: true,
@@ -227,7 +221,6 @@ const useStreamThreadRuntime = (
     ],
   );
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const runtime = useExternalStoreRuntime({
     ...pickExternalStoreSharedOptions(options),
     isRunning: effectiveIsRunning,
@@ -330,7 +323,6 @@ export const useStreamRuntime = (rawOptions: UseStreamRuntimeOptions) => {
 
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
-      // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       return useStreamThreadRuntime(optionsRef.current);
     },
     adapter,

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -590,20 +590,17 @@ describe("useLangGraphRuntime", () => {
     let initResult:
       | { remoteId: string; externalId: string | undefined }
       | undefined;
-    const streamMock = vi.fn().mockImplementation(
-      // biome-ignore lint/correctness/useYield: empty stream — only used to await initialize
-      async function* (
-        _messages: LangChainMessage[],
-        config: {
-          initialize: () => Promise<{
-            remoteId: string;
-            externalId: string | undefined;
-          }>;
-        },
-      ) {
-        initResult = await config.initialize();
+    const streamMock = vi.fn().mockImplementation(async function* (
+      _messages: LangChainMessage[],
+      config: {
+        initialize: () => Promise<{
+          remoteId: string;
+          externalId: string | undefined;
+        }>;
       },
-    );
+    ) {
+      initResult = await config.initialize();
+    });
 
     const { result: runtimeResult } = renderHook(() =>
       useLangGraphRuntime({

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -353,25 +353,19 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     uiStateKey,
     uiComponents,
   } = options;
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const aui = useAui();
 
   // Ref-based reconcile so inline `uiComponents` objects don't re-register
   // every render via `useEffect` dependency identity.
   const uiFallback = uiComponents?.fallback;
   const uiRenderers = uiComponents?.renderers;
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const registeredRenderersRef = useRef<Map<string, DataMessagePartComponent>>(
     new Map(),
   );
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const rendererCleanupsRef = useRef<Map<string, () => void>>(new Map());
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const fallbackRef = useRef<DataMessagePartComponent | undefined>(undefined);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const fallbackCleanupRef = useRef<(() => void) | undefined>(undefined);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   useEffect(() => {
     const registered = registeredRenderersRef.current;
     const cleanups = rendererCleanupsRef.current;
@@ -401,7 +395,6 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     }
   });
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   useEffect(() => {
     const cleanups = rendererCleanupsRef.current;
     const registered = registeredRenderersRef.current;
@@ -424,7 +417,6 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     cancel,
     setMessages,
     setUIMessages,
-    // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   } = useLangGraphMessages({
     appendMessage: appendLangChainChunk,
     stream,
@@ -432,15 +424,11 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     ...(uiStateKey !== undefined && { uiStateKey }),
   });
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const [isRunning, setIsRunning] = useState(false);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const [isLoadingThread, setIsLoadingThread] = useState(false);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const [toolStatuses, setToolStatuses] = useState<
     Record<string, ToolExecutionStatus>
   >({});
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const toolArgsKeyOrderCacheRef = useRef<Map<string, Map<string, string[]>>>(
     new Map(),
   );
@@ -449,13 +437,11 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   );
   const effectiveIsRunning = isRunning || hasExecutingTools;
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const messageTiming = useLangGraphStreamingTiming(
     messages,
     effectiveIsRunning,
   );
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const uiMessagesByParent = useMemo(() => {
     const map = new Map<string, UIMessage[]>();
     for (const ui of uiMessages) {
@@ -472,7 +458,6 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   }, [uiMessages]);
 
   // fresh metadata identity invalidates the converter cache; each UI event re-converts all messages
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const converterMetadata = useMemo(
     () =>
       ({
@@ -492,7 +477,6 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     return sendMessage(messages, config, () => setIsRunning(false));
   };
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const threadMessages = useExternalMessageConverter({
     callback: convertLangChainMessages,
     messages,
@@ -500,15 +484,12 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     metadata: converterMetadata,
   });
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const threadMessagesRef = useRef(threadMessages);
   threadMessagesRef.current = threadMessages;
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const uiMessagesRef = useRef(uiMessages);
   uiMessagesRef.current = uiMessages;
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const runtime = useExternalStoreRuntime({
     ...pickExternalStoreSharedOptions(options),
     isRunning: effectiveIsRunning,
@@ -634,14 +615,11 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   });
 
   {
-    // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
     const loadRef = useRef(load);
-    // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
     useEffect(() => {
       loadRef.current = load;
     });
 
-    // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
     useEffect(() => {
       const load = loadRef.current;
       if (!load) return;
@@ -706,7 +684,6 @@ export const useLangGraphRuntime = ({
 
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
-      // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       return useLangGraphRuntimeImpl(options);
     },
     adapter,

--- a/packages/react-mcp/src/primitives/server/McpServerIcon.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerIcon.tsx
@@ -27,7 +27,6 @@ export const McpServerPrimitiveIcon = forwardRef<
   const effective = src ?? iconUrl;
   if (!effective) return null;
   return (
-    // biome-ignore lint/performance/noImgElement: unstyled primitive — consumers can swap via asChild
     <Primitive.img {...props} ref={ref} src={effective} alt={alt ?? name} />
   );
 });

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -132,7 +132,6 @@ const NOOP_ON_NEW = () =>
 const useOpenCodeControllerState = (
   controller: OpenCodeThreadControllerLike,
 ): OpenCodeThreadState => {
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   return useSyncExternalStore(
     (listener) => controller.subscribe(listener),
     () => controller.getState(),
@@ -151,14 +150,11 @@ const useOpenCodeThreadRuntime = (
   controller: OpenCodeThreadControllerLike,
   options: OpenCodeRuntimeOptions,
 ): AssistantRuntime => {
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const state = useOpenCodeControllerState(controller);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const onLoadError = useEffectEvent((error: unknown) => {
     options.onError?.(error);
   });
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   useEffect(() => {
     if (controller === NOOP_CONTROLLER) return;
     void controller.load().catch(onLoadError);
@@ -166,16 +162,13 @@ const useOpenCodeThreadRuntime = (
 
   const isRunning = isOpenCodeStateRunning(state);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const messageTiming = useOpenCodeStreamingTiming(state, isRunning);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const messageRepository = useMemo(
     () => projectOpenCodeThreadRepository(state, messageTiming),
     [state, messageTiming],
   );
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const extras = useMemo(
     () =>
       ({
@@ -203,7 +196,6 @@ const useOpenCodeThreadRuntime = (
     [controller, state],
   );
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   return useExternalStoreRuntime<ThreadMessage>({
     ...pickExternalStoreSharedOptions(options),
     isLoading: state.loadState.type === "loading",
@@ -248,7 +240,6 @@ const useRuntimeHook = (
   registry: OpenCodeControllerRegistry,
   options: OpenCodeRuntimeOptions,
 ) => {
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const sessionId = useAuiState(
     (state: any) =>
       state.threadListItem.externalId ?? state.threadListItem.remoteId,
@@ -258,10 +249,8 @@ const useRuntimeHook = (
     ? getController(registry, client, sessionId)
     : NOOP_CONTROLLER;
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const threadRuntime = useOpenCodeThreadRuntime(controller, options);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const fallbackRuntime = useExternalStoreRuntime<ThreadMessage>({
     isDisabled: true,
     isLoading: true,

--- a/packages/react/src/augmentations.ts
+++ b/packages/react/src/augmentations.ts
@@ -22,10 +22,8 @@
  * ```
  */
 export namespace Assistant {
-  // biome-ignore lint/suspicious/noEmptyInterface: declaration merging
   export interface Commands {}
 
-  // biome-ignore lint/suspicious/noEmptyInterface: declaration merging
   export interface ExternalState {}
 }
 

--- a/packages/react/src/context/react/utils/createStateHookForRuntime.ts
+++ b/packages/react/src/context/react/utils/createStateHookForRuntime.ts
@@ -75,7 +75,6 @@ export function createStateHookForRuntime<TState>(
     if (!store) return null;
 
     // it is ok to call useRuntimeStateInternal conditionally because it will never become null if its available
-    // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
     return useRuntimeStateInternal(store, selector);
   }
 

--- a/packages/react/src/devtools/DevToolsHooks.ts
+++ b/packages/react/src/devtools/DevToolsHooks.ts
@@ -54,7 +54,6 @@ const getHook = (): DevToolsHook => {
   return newHook;
 };
 
-// biome-ignore lint/complexity/noStaticOnlyClass: intentional namespace for DevTools API
 export class DevToolsHooks {
   static subscribe(listener: () => void): Unsubscribe {
     const hook = getHook();
@@ -79,12 +78,10 @@ export class DevToolsHooks {
 
   private static notifyListeners(apiId: number): void {
     const hook = getHook();
-    // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
     hook.listeners.forEach((listener) => listener(apiId));
   }
 }
 
-// biome-ignore lint/complexity/noStaticOnlyClass: intentional namespace for DevTools API
 export class DevToolsProviderApi {
   private static readonly MAX_EVENT_LOGS_PER_API = 200;
 
@@ -145,7 +142,6 @@ export class DevToolsProviderApi {
 
   private static notifyListeners(apiId: number): void {
     const hook = getHook();
-    // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
     hook.listeners.forEach((listener) => listener(apiId));
   }
 }

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -113,23 +113,16 @@ export function useAssistantTransportState<T>(
 const useAssistantTransportThreadRuntime = <T>(
   options: AssistantTransportOptions<T>,
 ): AssistantRuntime => {
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const agentStateRef = useRef(options.initialState);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const [, rerender] = useState(0);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const resumeFlagRef = useRef(false);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const parentIdRef = useRef<string | null | undefined>(undefined);
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const commandQueue = useCommandQueue({
     onQueue: () => runManager.schedule(),
   });
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const threadId = useAuiState((s) => s.threadListItem.remoteId);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const runManager = useRunManager({
     onRun: async (signal: AbortSignal) => {
       const isResume = resumeFlagRef.current;
@@ -273,18 +266,15 @@ const useAssistantTransportThreadRuntime = <T>(
   });
 
   // Tool execution status state
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const [toolStatuses, setToolStatuses] = useState<
     Record<string, ToolExecutionStatus>
   >({});
 
   // Reactive conversion of agent state + connection metadata → UI state
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const pendingCommands = useMemo(
     () => [...commandQueue.state.inTransit, ...commandQueue.state.queued],
     [commandQueue.state],
   );
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const converted = useConvertedState(
     options.converter,
     agentStateRef.current,
@@ -294,7 +284,6 @@ const useAssistantTransportThreadRuntime = <T>(
   );
 
   // Create runtime
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const runtime = useExternalStoreRuntime({
     messages: converted.messages,
     state: converted.state,
@@ -365,7 +354,6 @@ export const useAssistantTransportRuntime = <T>(
 ): AssistantRuntime => {
   const runtime = useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
-      // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
       return useAssistantTransportThreadRuntime(options);
     },
     adapter: new InMemoryThreadListAdapter(),

--- a/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.ts
+++ b/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.ts
@@ -64,12 +64,10 @@ export const TriggerKeyboardResource = resource(
   }): TriggerKeyboardResourceOutput => {
     const [highlightedIndex, setHighlightedIndex] = tapState(0);
 
-    // biome-ignore lint/correctness/useExhaustiveDependencies: intentional reset on list change
     tapEffect(() => {
       setHighlightedIndex(0);
     }, [navigableList]);
 
-    // biome-ignore lint/correctness/useExhaustiveDependencies: intentional reset
     tapEffect(() => {
       setHighlightedIndex(0);
     }, [isSearchMode, activeCategoryId]);

--- a/packages/react/src/primitives/messagePart/MessagePartImage.tsx
+++ b/packages/react/src/primitives/messagePart/MessagePartImage.tsx
@@ -37,7 +37,6 @@ export const MessagePartPrimitiveImage = forwardRef<
   MessagePartPrimitiveImage.Props
 >((props, forwardedRef) => {
   const { image } = useMessagePartImage();
-  // biome-ignore lint/performance/noImgElement: next/image not applicable here
   return <Primitive.img src={image} {...props} ref={forwardedRef} />;
 });
 

--- a/packages/react/src/unstable/useMentionAdapter.ts
+++ b/packages/react/src/unstable/useMentionAdapter.ts
@@ -92,7 +92,6 @@ export function unstable_useMentionAdapter(
   iconMap?: Record<string, Unstable_IconComponent>;
   fallbackIcon?: Unstable_IconComponent;
 } {
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const aui = useAui();
 
   const items = options?.items;
@@ -105,7 +104,6 @@ export function unstable_useMentionAdapter(
   const formatter = options?.formatter;
   const onInserted = options?.onInserted;
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   const adapter = useMemo<Unstable_TriggerAdapter>(() => {
     const getModelContextTools = (): Unstable_TriggerItem[] => {
       if (!wantsTools) return [];
@@ -182,7 +180,6 @@ export function unstable_useMentionAdapter(
     };
   }, [aui, items, categories, wantsTools, toolsConfig]);
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: `unstable_` prefix not recognized as hook
   const directive = useMemo<Unstable_MentionDirective>(
     () => ({
       formatter: formatter ?? unstable_defaultDirectiveFormatter,

--- a/packages/react/src/unstable/useSlashCommandAdapter.ts
+++ b/packages/react/src/unstable/useSlashCommandAdapter.ts
@@ -60,11 +60,9 @@ export function unstable_useSlashCommandAdapter(
 } {
   const { commands, removeOnExecute } = options;
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: `unstable_` prefix not recognized as hook
   const commandsRef = useRef(commands);
   commandsRef.current = commands;
 
-  // biome-ignore lint/correctness/useHookAtTopLevel: `unstable_` prefix not recognized as hook
   return useMemo(() => {
     const adapter: Unstable_TriggerAdapter = {
       categories: () => [],

--- a/packages/store/src/__tests__/RenderChildrenWithAccessor.test.tsx
+++ b/packages/store/src/__tests__/RenderChildrenWithAccessor.test.tsx
@@ -39,7 +39,6 @@ const createTestAuiClient = () => {
     update: (next: Partial<typeof itemState>) => {
       itemState = { ...itemState, ...next };
       proxiedState.item = itemState;
-      // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
       listeners.forEach((listener) => listener());
     },
   };

--- a/packages/store/src/__tests__/hooks.test.tsx
+++ b/packages/store/src/__tests__/hooks.test.tsx
@@ -46,7 +46,6 @@ const createTestAuiClient = (initialState: Record<string, unknown>) => {
   return {
     client,
     state,
-    // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
     notify: () => listeners.forEach((listener) => listener()),
     emitEvent: (event: string, payload: unknown) => {
       for (const entry of eventEntries) {

--- a/packages/store/src/types/client.ts
+++ b/packages/store/src/types/client.ts
@@ -60,7 +60,6 @@ export type ClientSchema<
  * }
  * ```
  */
-// biome-ignore lint/suspicious/noEmptyInterface: declaration merging
 export interface ScopeRegistry {}
 
 type ClientEventsType<K extends ClientNames> = Record<

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -442,7 +442,6 @@ export function useAui(
   },
 ): AssistantClient {
   if (clients) {
-    // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
     return useResource(
       AssistantClientResource({
         parent: parent ?? DefaultAssistantClient,

--- a/packages/tap/src/__tests__/basic/tapEffect.basic.test.ts
+++ b/packages/tap/src/__tests__/basic/tapEffect.basic.test.ts
@@ -107,7 +107,6 @@ describe("tapEffect - Basic Functionality", () => {
       ];
 
       const testFiber = createTestResource(() => {
-        // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
         effects.forEach((fn) => tapEffect(fn));
         return null;
       });
@@ -135,7 +134,6 @@ describe("tapEffect - Basic Functionality", () => {
         }, []);
 
         // Effect with deps - runs when deps change
-        // biome-ignore lint/correctness/useExhaustiveDependencies: test
         tapEffect(() => {
           effectCalls.conditional++;
         }, [props.value]);

--- a/packages/tap/src/__tests__/lifecycle/lifecycle.mount-unmount.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/lifecycle.mount-unmount.test.ts
@@ -13,7 +13,6 @@ describe("Lifecycle - Mount/Unmount", () => {
     const effects = [vi.fn(), vi.fn(), vi.fn()];
 
     const resource = createTestResource(() => {
-      // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
       effects.forEach((fn) => tapEffect(fn));
       return null;
     });
@@ -36,11 +35,9 @@ describe("Lifecycle - Mount/Unmount", () => {
     });
 
     renderTest(resource, undefined);
-    // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
     cleanups.forEach((fn) => expect(fn).not.toHaveBeenCalled());
 
     unmountResource(resource);
-    // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
     cleanups.forEach((fn) => expect(fn).toHaveBeenCalledTimes(1));
   });
 

--- a/packages/tap/src/__tests__/strictmode/react-strictmode-behavior.test.tsx
+++ b/packages/tap/src/__tests__/strictmode/react-strictmode-behavior.test.tsx
@@ -712,7 +712,6 @@ describe("React Strict Mode Behavior Verification", () => {
         const [count, setCount] = useState(0);
         events.push(`render count=${count}`);
 
-        // biome-ignore lint/correctness/useExhaustiveDependencies: testing strict mode behavior with intentionally incomplete deps
         useEffect(() => {
           effectRunCount++;
           events.push(`effect mount #${effectRunCount} count=${count}`);
@@ -763,7 +762,6 @@ describe("React Strict Mode Behavior Verification", () => {
         const [count, setCount] = useState(0);
         events.push(`render count=${count}`);
 
-        // biome-ignore lint/correctness/useExhaustiveDependencies: testing strict mode behavior with intentionally incomplete deps
         useEffect(() => {
           effectRunCount++;
           events.push(`effect mount #${effectRunCount} count=${count}`);
@@ -814,7 +812,6 @@ describe("React Strict Mode Behavior Verification", () => {
         const [count, setCount] = useState(0);
         events.push(`render count=${count}`);
 
-        // biome-ignore lint/correctness/useExhaustiveDependencies: testing strict mode behavior with intentionally incomplete deps
         useEffect(() => {
           effectRunCount++;
           events.push(`effect mount #${effectRunCount} count=${count}`);

--- a/packages/tap/src/__tests__/strictmode/tap-strictmode-rerender-sources.test.ts
+++ b/packages/tap/src/__tests__/strictmode/tap-strictmode-rerender-sources.test.ts
@@ -551,7 +551,6 @@ describe("Tap Strict Mode - Rerender Sources", () => {
         const [count, setCount] = tapState(0);
         events.push(`render count=${count}`);
 
-        // biome-ignore lint/correctness/useExhaustiveDependencies: testing strict mode behavior with intentionally incomplete deps
         tapEffect(() => {
           effectRunCount++;
           events.push(`effect mount #${effectRunCount} count=${count}`);
@@ -598,7 +597,6 @@ describe("Tap Strict Mode - Rerender Sources", () => {
         const [count, setCount] = tapState(0);
         events.push(`render count=${count}`);
 
-        // biome-ignore lint/correctness/useExhaustiveDependencies: testing strict mode behavior with intentionally incomplete deps
         tapEffect(() => {
           effectRunCount++;
           events.push(`effect mount #${effectRunCount} count=${count}`);
@@ -644,7 +642,6 @@ describe("Tap Strict Mode - Rerender Sources", () => {
         const [count, setCount] = tapState(0);
         events.push(`render count=${count}`);
 
-        // biome-ignore lint/correctness/useExhaustiveDependencies: testing strict mode behavior with intentionally incomplete deps
         tapEffect(() => {
           effectRunCount++;
           events.push(`effect mount #${effectRunCount} count=${count}`);

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -74,7 +74,6 @@ export function unmountResource<R, P>(fiber: ResourceFiber<R, P>) {
  * Cleans up all resources. Should be called after each test.
  */
 export function cleanupAllResources() {
-  // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
   activeResources.forEach((fiber) => unmountResourceFiber(fiber));
   activeResources.clear();
 }

--- a/packages/tap/src/core/helpers/root.ts
+++ b/packages/tap/src/core/helpers/root.ts
@@ -49,7 +49,6 @@ export const setRootVersion = (
         root.changelog.pop();
       }
 
-      // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
       root.changelog.forEach((apply) => apply());
       commitRoot(root);
     }

--- a/packages/tap/src/tapResourceRoot.ts
+++ b/packages/tap/src/tapResourceRoot.ts
@@ -97,7 +97,6 @@ export const tapResourceRoot = <TState>(
 
     if (scheduler.isDirty || valueRef.current === render.output) return;
     valueRef.current = render.output;
-    // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
     subscribers.forEach((callback) => callback());
   });
 
@@ -116,7 +115,6 @@ export const tapResourceRoot = <TState>(
 
     if (scheduler.isDirty || valueRef.current === render.output) return;
     valueRef.current = render.output;
-    // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback intentionally has no return
     subscribers.forEach((callback) => callback());
   });
 

--- a/packages/ui/src/components/assistant-ui/voice.tsx
+++ b/packages/ui/src/components/assistant-ui/voice.tsx
@@ -262,7 +262,6 @@ function initWebGL(canvas: HTMLCanvasElement) {
   gl.attachShader(program, fs);
   gl.linkProgram(program);
   if (!gl.getProgramParameter(program, gl.LINK_STATUS)) return null;
-  // biome-ignore lint/correctness/useHookAtTopLevel: intentional conditional/nested hook usage
   gl.useProgram(program);
 
   const buf = gl.createBuffer();

--- a/packages/ui/src/components/icons/gemini.tsx
+++ b/packages/ui/src/components/icons/gemini.tsx
@@ -5,7 +5,6 @@ export function GeminiIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg aria-hidden="true" {...props} viewBox="0 0 65 65" fill="none">
       <defs>
-        {/* biome-ignore lint/correctness/useUniqueElementIds: static page with unique context */}
         <linearGradient
           id="gemini-blue"
           x1="18.447"

--- a/packages/ui/src/components/ui/chart.tsx
+++ b/packages/ui/src/components/ui/chart.tsx
@@ -92,7 +92,6 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 
   return (
     <style
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: dynamic chart CSS variables
       dangerouslySetInnerHTML={{
         __html: Object.entries(THEMES)
           .map(


### PR DESCRIPTION
## summary

- removes 211 stale `biome-ignore` pragmas across 79 files. the repo migrated lint/format from Biome to oxlint + oxfmt in #4100, so these pragmas no longer suppress anything.
- pure comment deletions; two files (`examples/with-ffmpeg/app/page.tsx`, `packages/react-langgraph/src/useLangGraphRuntime.test.tsx`) were re-flowed by oxfmt where line removal disrupted indentation.

no test plan, comment-only removals; `pnpm lint` is green (the lone `useCallback` unused-import warning in `packages/react-langgraph/src/useLangGraphRuntime.ts:1` is pre-existing on main, confirmed by re-running oxlint against the unstaged tree).