### PR TITLE
Ship assistant-ui agent skills in generated apps

### DIFF
--- a/.changeset/swift-skills-serve.md
+++ b/.changeset/swift-skills-serve.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+Ship assistant-ui agent skills in generated apps.

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -68,6 +68,31 @@ jobs:
       - name: Verify templates match packages/ui source
         run: bash scripts/sync-templates.sh
 
+  skills-docs-sync:
+    name: Skill Docs Sync
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify skill docs references are up to date
+        run: pnpm skills:check-docs
+
   build:
     name: Build Changed Packages
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,6 +9,8 @@
     "generate:reference-docs": "tsx ./scripts/generate-reference-docs.mts",
     "generate:source-snapshot": "tsx ./scripts/generate-source-snapshot.mts",
     "generate:all": "pnpm generate:reference-docs && pnpm generate:source-snapshot",
+    "skills:sync-docs": "tsx ./scripts/sync-skills-docs.mts",
+    "skills:check-docs": "tsx ./scripts/sync-skills-docs.mts --check",
     "start": "next start",
     "postinstall": "fumadocs-mdx"
   },

--- a/apps/docs/scripts/sync-skills-docs.mts
+++ b/apps/docs/scripts/sync-skills-docs.mts
@@ -1,0 +1,72 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const DOCS_ROOT = process.cwd();
+const REPO_ROOT = path.resolve(DOCS_ROOT, "../..");
+const GENERATED_HEADER =
+  "<!-- Generated from apps/docs content. Do not edit directly. -->";
+
+const CHECK_MODE = process.argv.includes("--check");
+
+const GENERATED_REFERENCES = [
+  {
+    sourcePath: "apps/docs/content/docs/(docs)/architecture.mdx",
+    outputPath:
+      "packages/cli/plugin/skills/assistant-ui/references/architecture.md",
+  },
+  {
+    sourcePath: "apps/docs/content/docs/(docs)/cli.mdx",
+    outputPath: "packages/cli/plugin/skills/assistant-ui/references/cli.md",
+  },
+] as const;
+
+async function renderReference(sourcePath: string) {
+  const content = await fs.readFile(path.join(REPO_ROOT, sourcePath), "utf-8");
+  return `${GENERATED_HEADER}\n<!-- Source: ${sourcePath} -->\n\n${content.trim()}\n`;
+}
+
+async function syncReference(config: (typeof GENERATED_REFERENCES)[number]) {
+  const outputPath = path.join(REPO_ROOT, config.outputPath);
+  const nextContent = await renderReference(config.sourcePath);
+
+  if (CHECK_MODE) {
+    let currentContent: string;
+    try {
+      currentContent = await fs.readFile(outputPath, "utf-8");
+    } catch (error) {
+      if (
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        throw new Error(`${config.outputPath} does not exist. Run sync first.`);
+      }
+
+      throw error;
+    }
+
+    if (currentContent !== nextContent) {
+      throw new Error(`${config.outputPath} is stale. Run skills:sync-docs.`);
+    }
+
+    return;
+  }
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, nextContent);
+}
+
+async function main() {
+  for (const config of GENERATED_REFERENCES) {
+    await syncReference(config);
+  }
+
+  console.log(
+    CHECK_MODE
+      ? "Skill docs references are up to date."
+      : "Skill docs references synced.",
+  );
+}
+
+await main();

--- a/apps/docs/scripts/sync-skills-docs.mts
+++ b/apps/docs/scripts/sync-skills-docs.mts
@@ -10,24 +10,27 @@ const CHECK_MODE = process.argv.includes("--check");
 
 const GENERATED_REFERENCES = [
   {
+    slugs: ["architecture"],
     sourcePath: "apps/docs/content/docs/(docs)/architecture.mdx",
     outputPath:
       "packages/cli/plugin/skills/assistant-ui/references/architecture.md",
   },
   {
+    slugs: ["cli"],
     sourcePath: "apps/docs/content/docs/(docs)/cli.mdx",
     outputPath: "packages/cli/plugin/skills/assistant-ui/references/cli.md",
   },
 ] as const;
 
-async function renderReference(sourcePath: string) {
+async function renderReference(config: (typeof GENERATED_REFERENCES)[number]) {
+  const { sourcePath, slugs } = config;
   const content = await fs.readFile(path.join(REPO_ROOT, sourcePath), "utf-8");
-  return `${GENERATED_HEADER}\n<!-- Source: ${sourcePath} -->\n\n${content.trim()}\n`;
+  return `${GENERATED_HEADER}\n<!-- Source: ${sourcePath} -->\n\n${renderMdxAsMarkdown(content, slugs)}\n`;
 }
 
 async function syncReference(config: (typeof GENERATED_REFERENCES)[number]) {
   const outputPath = path.join(REPO_ROOT, config.outputPath);
-  const nextContent = await renderReference(config.sourcePath);
+  const nextContent = await renderReference(config);
 
   if (CHECK_MODE) {
     let currentContent: string;
@@ -55,6 +58,83 @@ async function syncReference(config: (typeof GENERATED_REFERENCES)[number]) {
 
   await fs.mkdir(path.dirname(outputPath), { recursive: true });
   await fs.writeFile(outputPath, nextContent);
+}
+
+function renderMdxAsMarkdown(content: string, slugs: readonly string[]) {
+  const { frontmatter, body } = extractFrontmatter(content);
+  const renderedBody = stripMdxSyntax(body);
+  const lines = [
+    `# ${frontmatter.title ?? titleFromSlugs(slugs)}`,
+    "",
+    `URL: /docs/${slugs.join("/")}`,
+  ];
+
+  if (frontmatter.description) {
+    lines.push("", frontmatter.description);
+  }
+
+  lines.push("", renderedBody);
+  return `${lines.join("\n").trim()}\n`;
+}
+
+function extractFrontmatter(content: string) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match) return { frontmatter: {}, body: content };
+
+  const frontmatter: Record<string, string> = {};
+  for (const line of match[1]!.split(/\r?\n/)) {
+    const field = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!field) continue;
+    frontmatter[field[1]!] = field[2]!.replace(/^["']|["']$/g, "");
+  }
+
+  return {
+    frontmatter,
+    body: content.slice(match[0].length),
+  };
+}
+
+function stripMdxSyntax(content: string) {
+  let markdown = content
+    .replace(/^import\s+.*?;?\r?\n/gm, "")
+    .replace(/<div\b[^>]*>/g, "")
+    .replace(/<\/div>/g, "")
+    .replace(/<Cards>/g, "")
+    .replace(/<\/Cards>/g, "")
+    .replace(
+      /^\s*<Card\s+title=['"]([^'"]+)['"]>\s*([\s\S]*?)\s*<\/Card>/gm,
+      (_match, title: string, body: string) =>
+        `- **${title}**: ${stripInlineMdx(body).trim()}`,
+    )
+    .replace(/^\s*<Card\s+([\s\S]*?)\/>/gm, (_match, attrs: string) => {
+      const title = getAttribute(attrs, "title");
+      const description = getAttribute(attrs, "description");
+      const href = getAttribute(attrs, "href");
+
+      if (!title) return "";
+      const label = href ? `[${title}](${href})` : title;
+      return `- ${label}${description ? `: ${description}` : ""}`;
+    });
+
+  markdown = stripInlineMdx(markdown);
+  return markdown.replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function stripInlineMdx(content: string) {
+  return content.replace(/^\s*<[A-Z][^>]*>\s*$/gm, "").trim();
+}
+
+function getAttribute(attrs: string, name: string) {
+  const match = attrs.match(new RegExp(`${name}=["']([^"']+)["']`));
+  return match?.[1]?.replace(/â€”/g, "-");
+}
+
+function titleFromSlugs(slugs: readonly string[]) {
+  return slugs
+    .at(-1)!
+    .split("-")
+    .map((part) => `${part[0]!.toUpperCase()}${part.slice(1)}`)
+    .join(" ");
 }
 
 async function main() {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "format": "pnpm exec oxfmt --check",
     "format:fix": "pnpm exec oxfmt",
     "sync-templates": "bash scripts/sync-templates.sh",
+    "skills:sync-docs": "pnpm --filter=@assistant-ui/docs skills:sync-docs",
+    "skills:check-docs": "pnpm --filter=@assistant-ui/docs skills:check-docs",
     "test": "turbo test && pnpm test:types",
     "test:types": "pnpm -r --parallel exec sh -c '! test -f tsconfig.json || tsc --noEmit'",
     "prepare": "husky",

--- a/packages/cli/plugin/AGENTS.md
+++ b/packages/cli/plugin/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+This file provides context for AI coding assistants (Cursor, GitHub Copilot, Claude Code, etc.) working with assistant-ui generated app skills.
+
+## Project Overview
+
+The **assistant-ui Agent Skills** bundle provides official agent guidance for coding agents working with [assistant-ui](https://www.assistant-ui.com). These skills help AI assistants write accurate assistant-ui code using the current docs, CLI, architecture guidance, migrations, and common pitfalls.
+
+- **assistant-ui Framework**: https://github.com/assistant-ui/assistant-ui
+- **Documentation**: https://www.assistant-ui.com/docs
+- **LLM Docs Index**: https://www.assistant-ui.com/llms.txt
+- **License**: MIT
+
+## Repository Structure
+
+| Directory | Description |
+| --- | --- |
+| `skills/` | Agent skill definitions |
+| `skills/assistant-ui/` | Single comprehensive assistant-ui skill with progressive disclosure |
+
+## Specification
+
+Fetch the up-to-date [Agent Skills Specification](https://agentskills.io/specification.md) for details on skill structure, frontmatter fields, and best practices.
+
+## Development Guidelines
+
+### Updating Existing Skills
+
+1. **Validate against current docs**: Always verify patterns against assistant-ui docs and the latest assistant-ui source code.
+2. **Use hosted docs**: Check `https://www.assistant-ui.com/llms.txt` for current docs structure.
+3. **Test patterns**: Ensure all code examples are runnable.
+4. **Update references**: Keep migration guidance and common pitfalls current.
+5. **Version alignment**: Note which assistant-ui versions the patterns support when relevant.
+
+### Code Pattern Requirements
+
+- **Completeness**: Patterns should be copy-paste ready.
+- **Validation**: All APIs must be verified against current assistant-ui docs or codebase.
+- **TODO placeholders**: Use `// TODO:` for user customization points.
+- **Imports**: Include all necessary import statements.
+- **Comments**: Explain non-obvious concepts, not syntax.
+- **No marketing language**: Technical documentation only.

--- a/packages/cli/plugin/CLAUDE.md
+++ b/packages/cli/plugin/CLAUDE.md
@@ -1,0 +1,3 @@
+@AGENTS.md
+
+IMPORTANT: Read and follow all instructions in @AGENTS.md before starting any task.

--- a/packages/cli/plugin/README.md
+++ b/packages/cli/plugin/README.md
@@ -1,0 +1,24 @@
+# assistant-ui Agent Skills
+
+Official assistant-ui skills for agents working with the [assistant-ui framework](https://www.assistant-ui.com). assistant-ui is a React framework for building AI chat interfaces with composable UI primitives, shadcn-based components, runtimes, tools, generative UI, and optional Assistant Cloud persistence.
+
+## Included Skills
+
+### assistant-ui
+
+Single comprehensive skill for assistant-ui development. Uses progressive disclosure with reference files covering:
+
+- **Hosted Docs Lookup** (`skills/assistant-ui/references/remote-docs.md`): Find docs from `https://www.assistant-ui.com/llms.txt`
+- **Architecture** (`skills/assistant-ui/references/architecture.md`): assistant-ui architecture, components, runtimes, backend, and cloud layers
+- **CLI** (`skills/assistant-ui/references/cli.md`): Project setup, component installation, updates, MCP, and diagnostics
+- **Migrations** (`skills/assistant-ui/references/migrations.md`): Version upgrade workflows through the docs index and CLI reference
+- **Common Pitfalls** (`skills/assistant-ui/references/common-pitfalls.md`): Common errors and known agent failure modes
+
+Main skill file teaches core concepts and routes to appropriate reference files based on user questions.
+
+## Resources
+
+- [assistant-ui Docs](https://www.assistant-ui.com/docs)
+- [assistant-ui LLM Docs Index](https://www.assistant-ui.com/llms.txt)
+- [assistant-ui GitHub](https://github.com/assistant-ui/assistant-ui)
+- [Agent Skills Spec](https://agentskills.io)

--- a/packages/cli/plugin/skills/assistant-ui/SKILL.md
+++ b/packages/cli/plugin/skills/assistant-ui/SKILL.md
@@ -1,167 +1,77 @@
 ---
 name: assistant-ui
-description: Add, configure, and integrate assistant-ui components in React apps. Use when developers ask to add a chat thread, set up a runtime, integrate with AI SDK, configure tools, or build AI chat interfaces with assistant-ui.
+description: Comprehensive assistant-ui framework guide for creating or modifying AI chat interfaces in React. Use for project setup, chat UI, runtimes, tools, tool UI, generative UI, CLI commands, docs lookup, migrations, and common architecture pitfalls.
+license: MIT
+metadata:
+  author: assistant-ui
+  version: "1.0.0"
+  repository: https://github.com/assistant-ui/assistant-ui
 ---
 
-# assistant-ui
+# assistant-ui Framework Guide
 
-Use this skill to help users build AI chat interfaces with assistant-ui.
+assistant-ui is a React library for building AI chat interfaces. It provides composable UI primitives and shadcn-based components, runtime adapters for AI backends, and optional Assistant Cloud persistence.
 
-## Step 1: Check Project Setup
+This skill teaches you how to find current assistant-ui documentation and create or modify assistant-ui applications: chat threads, composers, messages, runtimes, backend tools, visible tool UI, generative UI, thread lists, migrations, and CLI-based setup.
 
-Check if the project has `components.json` (shadcn config) and `@assistant-ui/react` installed.
+## Critical: Do not trust internal knowledge
 
-If assistant-ui is not yet set up, run:
+assistant-ui APIs, CLI commands, runtime adapters, and generated components can change between versions. Do not rely only on memory.
 
-```bash
-npx assistant-ui init --yes
-```
+If installed package APIs conflict with remote docs, trust the installed package version for implementation details.
 
-This initializes shadcn and installs the default assistant-ui chat components.
+## Prerequisites
 
-## Step 2: Add Components
-
-Install components via the shadcn registry:
+Before writing any assistant-ui code, check if packages are installed:
 
 ```bash
-npx shadcn@latest add "https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json"
+ls node_modules/@assistant-ui/
 ```
 
-Available component presets:
+- If assistant-ui packages are installed: use hosted docs and local modules to get info.
+- If packages are not installed: use the local references and remote docs to set up assistant-ui.
 
-| Preset | Registry URL |
-|--------|-------------|
-| AI SDK Quick Start | `https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json` |
+## Resources
 
-You can also add individual assistant-ui shadcn components:
+### References
 
-```bash
-npx shadcn@latest add assistant-ui/thread
-npx shadcn@latest add assistant-ui/markdown-text
-```
+| User Question | First Check | How To |
+| --- | --- | --- |
+| Create/install new project or add components, run commands | [`references/cli.md`](references/cli.md) | CLI commands and flags for init, create, add, update, upgrade, mcp, info |
+| How do I do X? | [`references/remote-docs.md`](references/remote-docs.md) | Fetch from `https://www.assistant-ui.com/llms.txt` to know more about assistant-ui |
+| Need the architecture mental model | [`references/architecture.md`](references/architecture.md) | Frontend components -> runtime -> backend/agent flow |
+| Upgrade or breaking-change guidance | [`references/migrations.md`](references/migrations.md) | Version upgrade workflows |
+| I am getting an error? | [`references/common-pitfalls.md`](references/common-pitfalls.md) | Known errors and solutions from evals |
 
-## Step 3: Runtime Setup
+## Core concepts
 
-assistant-ui requires a runtime. The most common setup uses AI SDK:
+Start with [`references/cli.md`](references/cli.md) for project setup, adding components, and running assistant-ui commands. Use  [`references/architecture.md`](references/architecture.md) for the mental model of how assistant-ui works on high level, concepts like runtimes, components, and backends connect. Use [`references/remote-docs.md`](references/remote-docs.md) to drill into specifics: runtimes, tools, generative UI, thread lists, and migration guides.
 
-### AI SDK Runtime (recommended)
 
-Install the integration package:
-```bash
-npm install @assistant-ui/react-ai-sdk
-```
+## When you see errors
 
-Create a chat API route (Next.js App Router):
+Type errors often mean your knowledge is outdated.
 
-```ts
-// app/api/chat/route.ts
-import { openai } from "@ai-sdk/openai";
-import { streamText } from "ai";
+Common signs:
 
-export const maxDuration = 30;
+- `Property X does not exist on type Y`
+- `Cannot find module`
+- `Type mismatch` errors
+- Constructor parameter errors
 
-export async function POST(req: Request) {
-  const { messages, config } = await req.json();
+What to do:
 
-  const result = streamText({
-    model: openai("gpt-5.4-nano"),
-    messages,
-    ...config,
-  });
+1. Check [`references/common-pitfalls.md`](references/common-pitfalls.md)
+2. Verify current API in installed package files or hosted docs
+3. Don't assume the error is a user mistake - it might be your outdated knowledge
 
-  return result.toDataStreamResponse();
-}
-```
+## Development workflow
 
-Create the assistant component:
+Always verify before writing code:
 
-```tsx
-"use client";
-
-import { AssistantRuntimeProvider } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
-import { Thread } from "@/components/assistant-ui/thread";
-
-export const Assistant = () => {
-  const runtime = useChatRuntime({
-    api: "/api/chat",
-  });
-
-  return (
-    <AssistantRuntimeProvider runtime={runtime}>
-      <Thread />
-    </AssistantRuntimeProvider>
-  );
-};
-```
-
-## Step 4: Tools (optional)
-
-To add tool calling support, define tools on the backend and render them on the frontend:
-
-### Backend tool (AI SDK):
-
-```ts
-import { streamText, tool } from "ai";
-import { z } from "zod";
-
-const result = streamText({
-  model: openai("gpt-5.4-nano"),
-  messages,
-  tools: {
-    get_weather: tool({
-      description: "Get weather for a location",
-      parameters: z.object({
-        location: z.string(),
-      }),
-      execute: async ({ location }) => {
-        return { temperature: 72, condition: "sunny", location };
-      },
-    }),
-  },
-});
-```
-
-### Frontend tool UI:
-
-```tsx
-"use client";
-
-import { makeAssistantToolUI } from "@assistant-ui/react";
-
-export const WeatherToolUI = makeAssistantToolUI({
-  toolName: "get_weather",
-  render: ({ args, result }) => {
-    return (
-      <div>
-        <p>Weather for {args?.location}</p>
-        {result && <p>{result.temperature}F, {result.condition}</p>}
-      </div>
-    );
-  },
-});
-```
-
-Register the tool UI in your assistant component:
-
-```tsx
-<AssistantRuntimeProvider runtime={runtime}>
-  <WeatherToolUI />
-  <Thread />
-</AssistantRuntimeProvider>
-```
-
-## Key Packages
-
-| Package | Purpose |
-|---------|---------|
-| `@assistant-ui/react` | Core React components and primitives |
-| `@assistant-ui/react-ai-sdk` | Vercel AI SDK integration |
-| `@assistant-ui/react-markdown` | Markdown rendering |
-| `@assistant-ui/react-syntax-highlighter` | Code highlighting |
-| `@assistant-ui/ui` | Pre-built shadcn/ui component set |
-| `@assistant-ui/styles` | Pre-built CSS for non-Tailwind users |
-
-## Environment Variables
-
-For OpenAI-based setups, ensure `OPENAI_API_KEY` is set in `.env.local`.
+1. Check whether assistant-ui packages are installed
+2. Look up the current API
+   - If installed: understand architecture [`references/architecture.md`](references/architecture.md), remote docs [`references/remote-docs.md`](references/remote-docs.md), and then inspect local package source and types in `node_modules/@assistant-ui/`
+   - If not installed: understand architecture [`references/architecture.md`](references/architecture.md), use remote docs [`references/remote-docs.md`](references/remote-docs.md)
+3. Use CLI commands from [`references/cli.md`](references/cli.md); never guess flags
+4. Write code based on current docs, preserving existing runtime and component architecture

--- a/packages/cli/plugin/skills/assistant-ui/references/architecture.md
+++ b/packages/cli/plugin/skills/assistant-ui/references/architecture.md
@@ -1,30 +1,16 @@
 <!-- Generated from apps/docs content. Do not edit directly. -->
 <!-- Source: apps/docs/content/docs/(docs)/architecture.mdx -->
 
----
-title: "Architecture"
-description: How components, runtimes, and cloud services fit together.
----
+# Architecture
 
-import { Sparkles, PanelsTopLeft, Database, Terminal } from "lucide-react";
+URL: /docs/architecture
+
+How components, runtimes, and cloud services fit together.
 
 ## assistant-ui is built on these main pillars:
-
-<div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-    <Card title='1. Frontend components'>
-        Shadcn UI chat components with built-in state management
-    </Card>
-
-    <Card title='2. Runtime'>
-        State management layer connecting UI to LLMs and backend services
-    </Card>
-
-    <Card title='3. Assistant Cloud'>
-        Hosted service for thread persistence, history, and user management
-    </Card>
-</div>
-
-
+- **1. Frontend components**: Shadcn UI chat components with built-in state management
+- **2. Runtime**: State management layer connecting UI to LLMs and backend services
+- **3. Assistant Cloud**: Hosted service for thread persistence, history, and user management
 
 ### 1. Frontend components
 Stylized and functional chat components built on top of Shadcn components that have context state management provided by the assistantUI runtime provider. These pre-built React components come with intelligent state management. [View our components](/docs/ui/thread)
@@ -34,7 +20,6 @@ A React state management context for assistant chat. The runtime handles data co
 
 ### 3. Assistant Cloud
 A hosted service that enhances your assistant experience with comprehensive thread management and message history. Assistant Cloud stores complete message history, automatically persists threads, supports human-in-the-loop workflows, and integrates with common auth providers to seamlessly allow users to resume conversations at any point. [Cloud Docs](/docs/cloud)
-
 
 ## What each layer owns
 
@@ -117,21 +102,7 @@ graph TD
 ## Going deeper
 
 These pages go one level deeper on runtime internals, adapters, and persistence.
+- [Runtime architecture](/docs/runtimes/concepts/architecture): Core runtimes, protocol layers, and framework adapters — what each layer owns.
+- [Adapters](/docs/runtimes/concepts/adapters): Attachments, speech, feedback, history, suggestions across runtimes.
+- [Threads](/docs/runtimes/concepts/threads): Multi-thread support: cloud, custom database, ExternalStore.
 
-<Cards>
-  <Card
-    title="Runtime architecture"
-    description="Core runtimes, protocol layers, and framework adapters — what each layer owns."
-    href="/docs/runtimes/concepts/architecture"
-  />
-  <Card
-    title="Adapters"
-    description="Attachments, speech, feedback, history, suggestions across runtimes."
-    href="/docs/runtimes/concepts/adapters"
-  />
-  <Card
-    title="Threads"
-    description="Multi-thread support: cloud, custom database, ExternalStore."
-    href="/docs/runtimes/concepts/threads"
-  />
-</Cards>

--- a/packages/cli/plugin/skills/assistant-ui/references/architecture.md
+++ b/packages/cli/plugin/skills/assistant-ui/references/architecture.md
@@ -1,0 +1,137 @@
+<!-- Generated from apps/docs content. Do not edit directly. -->
+<!-- Source: apps/docs/content/docs/(docs)/architecture.mdx -->
+
+---
+title: "Architecture"
+description: How components, runtimes, and cloud services fit together.
+---
+
+import { Sparkles, PanelsTopLeft, Database, Terminal } from "lucide-react";
+
+## assistant-ui is built on these main pillars:
+
+<div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+    <Card title='1. Frontend components'>
+        Shadcn UI chat components with built-in state management
+    </Card>
+
+    <Card title='2. Runtime'>
+        State management layer connecting UI to LLMs and backend services
+    </Card>
+
+    <Card title='3. Assistant Cloud'>
+        Hosted service for thread persistence, history, and user management
+    </Card>
+</div>
+
+
+
+### 1. Frontend components
+Stylized and functional chat components built on top of Shadcn components that have context state management provided by the assistantUI runtime provider. These pre-built React components come with intelligent state management. [View our components](/docs/ui/thread)
+
+### 2. Runtime
+A React state management context for assistant chat. The runtime handles data conversions between the local state and calls to backends and LLMs. We offer different runtime solutions that work with various frameworks like Vercel AI SDK, LangGraph, LangChain, Helicone, local runtime, and an ExternalStore when you need full control of the frontend message state. [You can view the runtimes we support](/docs/runtimes/pick-a-runtime)
+
+### 3. Assistant Cloud
+A hosted service that enhances your assistant experience with comprehensive thread management and message history. Assistant Cloud stores complete message history, automatically persists threads, supports human-in-the-loop workflows, and integrates with common auth providers to seamlessly allow users to resume conversations at any point. [Cloud Docs](/docs/cloud)
+
+
+## What each layer owns
+
+Before picking a runtime or wiring components, it helps to see which layer owns which responsibility. assistant-ui draws hard lines between rendering, conversation state, and where the model actually runs.
+
+### UI layer
+Primitives and prebuilt components render the assistant experience: thread, messages, composer, message parts, actions, attachments, suggestions. They read and write through the runtime context, not directly against the backend or model.
+
+### Runtime layer
+The state and behavior boundary between UI and backend. The runtime owns or adapts conversation state: messages, thread state, composer state, run lifecycle, branching, editing, regeneration. Different runtimes exist because different backends own this state differently. `LocalRuntime` keeps state internal; `ExternalStoreRuntime` delegates to your store.
+
+### Backend / agent layer
+Produces assistant output and app-specific behavior. Depending on the runtime and protocol, the backend may emit text, message parts, tool calls, metadata, agent state, attachments, or other events that the runtime maps into UI state.
+
+### Integration / protocol layer
+Runtime adapters and protocols bridge assistant-ui to different backend shapes: AI SDK, LangGraph, LangChain, ADK, A2A, AG-UI, OpenCode, or your own. The DataStream and AssistantTransport protocols let a generic backend talk to assistant-ui without a custom adapter per app.
+
+### Persistence layer
+Thread and message history can be stored by Assistant Cloud or by your own database via thread and history adapters. Persistence is separate from rendering and backend generation, though the runtime coordinates with it.
+
+## There are three common ways to architect your assistant-ui application:
+
+#### **1. Direct Integration with External Providers**
+
+```mermaid
+graph TD
+    A[Frontend Components] --> B[Runtime]
+    B --> D[External Providers or LLM APIs]
+    
+    
+    classDef default color:#f8fafc,text-align:center
+    
+    style A fill:#e879f9,stroke:#2e1065,stroke-width:2px,color:#2e1065,font-weight:bold
+    style B fill:#93c5fd,stroke:#1e3a8a,stroke-width:2px,color:#1e3a8a,font-weight:bold
+    style D fill:#fca5a5,stroke:#7f1d1d,stroke-width:2px,color:#7f1d1d,font-weight:bold
+    
+    class A,B,C,D,E default
+```
+
+#### **2. Using your own API endpoint**
+
+```mermaid
+graph TD
+    A[Frontend Components] --> B[Runtime]
+    B --> E[Your API Backend]
+    E --> D[External Providers or LLM APIs]
+    
+    
+    classDef default color:#f8fafc,text-align:center
+    
+    style A fill:#e879f9,stroke:#2e1065,stroke-width:2px,color:#2e1065,font-weight:bold
+    style B fill:#93c5fd,stroke:#1e3a8a,stroke-width:2px,color:#1e3a8a,font-weight:bold
+    style D fill:#fca5a5,stroke:#7f1d1d,stroke-width:2px,color:#7f1d1d,font-weight:bold
+    style E fill:#fca5a5,stroke:#7f1d1d,stroke-width:2px,color:#7f1d1d,font-weight:bold
+    
+    class A,B,C,D,E default
+```
+
+#### **3. With Assistant Cloud**
+
+```mermaid
+graph TD
+    A[Frontend Components] --> B[Runtime]
+    B --> C[Cloud]
+    E --> C
+    C --> D[External Providers or LLM APIs]
+    B --> E[Your API Backend]
+    
+    classDef default color:#f8fafc,text-align:center
+    
+    style A fill:#e879f9,stroke:#2e1065,stroke-width:2px,color:#2e1065,font-weight:bold
+    style B fill:#93c5fd,stroke:#1e3a8a,stroke-width:2px,color:#1e3a8a,font-weight:bold
+    style C fill:#86efac,stroke:#064e3b,stroke-width:2px,color:#064e3b,font-weight:bold
+    style D fill:#fca5a5,stroke:#7f1d1d,stroke-width:2px,color:#7f1d1d,font-weight:bold
+    style E fill:#fca5a5,stroke:#7f1d1d,stroke-width:2px,color:#7f1d1d,font-weight:bold
+    
+    class A,B,C,D,E default
+```
+
+## Going deeper
+
+These pages go one level deeper on runtime internals, adapters, and persistence.
+
+<Cards>
+  <Card
+    title="Runtime architecture"
+    description="Core runtimes, protocol layers, and framework adapters — what each layer owns."
+    href="/docs/runtimes/concepts/architecture"
+  />
+  <Card
+    title="Adapters"
+    description="Attachments, speech, feedback, history, suggestions across runtimes."
+    href="/docs/runtimes/concepts/adapters"
+  />
+  <Card
+    title="Threads"
+    description="Multi-thread support: cloud, custom database, ExternalStore."
+    href="/docs/runtimes/concepts/threads"
+  />
+</Cards>

--- a/packages/cli/plugin/skills/assistant-ui/references/cli.md
+++ b/packages/cli/plugin/skills/assistant-ui/references/cli.md
@@ -1,11 +1,11 @@
 <!-- Generated from apps/docs content. Do not edit directly. -->
 <!-- Source: apps/docs/content/docs/(docs)/cli.mdx -->
 
----
-title: CLI
-description: Scaffold projects, add components, and manage updates from the command line.
-platforms: ["react"]
----
+# CLI
+
+URL: /docs/cli
+
+Scaffold projects, add components, and manage updates from the command line.
 
 Use the `assistant-ui` CLI to quickly set up new projects and add components to existing ones.
 
@@ -518,3 +518,4 @@ The CLI respects your project's configuration:
 - **TypeScript**: Works with your `tsconfig.json` paths
 - **Tailwind**: Uses your `tailwind.config.js` settings
 - **Import Aliases**: Respects `components.json` or `assistant-ui.json` configuration
+

--- a/packages/cli/plugin/skills/assistant-ui/references/cli.md
+++ b/packages/cli/plugin/skills/assistant-ui/references/cli.md
@@ -1,0 +1,520 @@
+<!-- Generated from apps/docs content. Do not edit directly. -->
+<!-- Source: apps/docs/content/docs/(docs)/cli.mdx -->
+
+---
+title: CLI
+description: Scaffold projects, add components, and manage updates from the command line.
+platforms: ["react"]
+---
+
+Use the `assistant-ui` CLI to quickly set up new projects and add components to existing ones.
+
+## init
+
+Use the `init` command to initialize configuration and dependencies for a new project.
+
+The `init` command installs dependencies, adds components, and configures your project for assistant-ui.
+
+```bash
+npx assistant-ui@latest init
+```
+
+This will:
+- Detect if you have an existing project with a `package.json`
+- Use `shadcn add` to install the assistant-ui quick-start component
+- Add the default assistant-ui components (thread, composer, etc.) to your project
+- Configure TypeScript paths and imports
+
+**When to use:**
+- Adding assistant-ui to an **existing** Next.js project
+- First-time setup in a project with `package.json`
+
+**Options**
+
+```bash
+Usage: assistant-ui init [options]
+
+initialize assistant-ui in a new or existing project
+
+Options:
+  -c, --cwd <cwd>  the working directory. defaults to the current directory.
+  -h, --help       display help for command
+```
+
+## create
+
+Use the `create` command to scaffold a new Next.js project with assistant-ui pre-configured.
+
+```bash
+npx assistant-ui@latest create [project-directory]
+```
+
+This command scaffolds a project from assistant-ui starter templates or examples.
+
+**Available Templates**
+
+| Template | Description | Command |
+|----------|-------------|---------|
+| `default` | Default template with Vercel AI SDK | `npx assistant-ui create` |
+| `minimal` | Bare-bones starting point | `npx assistant-ui create -t minimal` |
+| `cloud` | Cloud-backed persistence starter | `npx assistant-ui create -t cloud` |
+| `cloud-clerk` | Cloud-backed starter with Clerk auth | `npx assistant-ui create -t cloud-clerk` |
+| `langgraph` | LangGraph starter template | `npx assistant-ui create -t langgraph` |
+| `mcp` | MCP starter template | `npx assistant-ui create -t mcp` |
+
+**Available Examples**
+
+Use `--example` to create a project from one of the monorepo examples with full feature demonstrations:
+
+| Example | Description | Command |
+|---------|-------------|---------|
+| `with-ai-sdk-v6` | Vercel AI SDK v6 integration | `npx assistant-ui create my-app -e with-ai-sdk-v6` |
+| `with-artifacts` | HTML artifact rendering with live preview | `npx assistant-ui create my-app -e with-artifacts` |
+| `with-langgraph` | LangGraph agent with custom tools | `npx assistant-ui create my-app -e with-langgraph` |
+| `with-cloud` | Assistant Cloud persistence | `npx assistant-ui create my-app -e with-cloud` |
+| `with-ag-ui` | [AG-UI protocol](/docs/runtimes/ag-ui) integration | `npx assistant-ui create my-app -e with-ag-ui` |
+| `with-assistant-transport` | Custom backend via Assistant Transport | `npx assistant-ui create my-app -e with-assistant-transport` |
+| `with-resumable-stream` | Resumable LLM stream that survives reload mid-response | `npx assistant-ui create my-app -e with-resumable-stream` |
+| `with-chain-of-thought` | Chain-of-thought reasoning, tool calls, and source citations | `npx assistant-ui create my-app -e with-chain-of-thought` |
+| `with-external-store` | External message store | `npx assistant-ui create my-app -e with-external-store` |
+| `with-custom-thread-list` | Custom thread list UI | `npx assistant-ui create my-app -e with-custom-thread-list` |
+| `with-react-hook-form` | React Hook Form integration | `npx assistant-ui create my-app -e with-react-hook-form` |
+| `with-ffmpeg` | FFmpeg video processing tool | `npx assistant-ui create my-app -e with-ffmpeg` |
+| `with-elevenlabs-scribe` | ElevenLabs voice transcription | `npx assistant-ui create my-app -e with-elevenlabs-scribe` |
+| `with-expo` | Expo / React Native | `npx assistant-ui create my-app -e with-expo` |
+| `with-react-ink` | Terminal UI chat | `npx assistant-ui create my-app -e with-react-ink` |
+| `with-react-router` | React Router v7 integration | `npx assistant-ui create my-app -e with-react-router` |
+| `with-tanstack` | TanStack Start integration | `npx assistant-ui create my-app -e with-tanstack` |
+
+**Examples**
+
+```bash
+# Create with default template
+npx assistant-ui@latest create my-app
+
+# Create with cloud template
+npx assistant-ui@latest create my-app -t cloud
+
+# Create with cloud + clerk template
+npx assistant-ui@latest create my-app -t cloud-clerk
+
+# Create from an example
+npx assistant-ui@latest create my-app --example with-langgraph
+
+# Create with specific package manager
+npx assistant-ui@latest create my-app --use-pnpm
+
+# Skip package installation
+npx assistant-ui@latest create my-app --skip-install
+```
+
+**Options**
+
+```bash
+Usage: assistant-ui create [project-directory] [options]
+
+create a new project
+
+Arguments:
+  project-directory         name of the project directory
+
+Options:
+  -t, --template <template>      template to use (default, minimal, cloud, cloud-clerk, langgraph, mcp)
+  -e, --example <example>        create from an example (e.g., with-langgraph)
+  -p, --preset <name-or-url>     preset name or URL (e.g., chatgpt)
+  --native                       create an Expo / React Native project
+  --ink                          create a React Ink terminal project
+  --use-npm                      explicitly use npm
+  --use-pnpm                     explicitly use pnpm
+  --use-yarn                     explicitly use yarn
+  --use-bun                      explicitly use bun
+  --skip-install                 skip installing packages
+  -h, --help                     display help for command
+```
+
+## add
+
+Use the `add` command to add individual components to your project.
+
+```bash
+npx assistant-ui@latest add [component]
+```
+
+The `add` command fetches components from the assistant-ui registry and adds them to your project. It automatically:
+- Installs required dependencies
+- Adds TypeScript types
+- Configures imports
+
+**Popular Components**
+
+```bash
+# Add the basic thread component
+npx assistant-ui add thread
+
+# Add thread list for multi-conversation support
+npx assistant-ui add thread-list
+
+# Add assistant modal
+npx assistant-ui add assistant-modal
+
+# Add multiple components at once
+npx assistant-ui add thread thread-list assistant-sidebar
+```
+
+**Options**
+
+```bash
+Usage: assistant-ui add [options] <components...>
+
+add a component to your project
+
+Arguments:
+  components             the components to add
+
+Options:
+  -y, --yes              skip confirmation prompt. (default: true)
+  -o, --overwrite        overwrite existing files. (default: false)
+  -c, --cwd <cwd>        the working directory. defaults to the current directory.
+  -p, --path <path>      the path to add the component to.
+  -h, --help             display help for command
+```
+
+## update
+
+Use the `update` command to update all `@assistant-ui/*` packages to their latest versions.
+
+```bash
+npx assistant-ui@latest update
+```
+
+This command:
+- Scans your `package.json` for assistant-ui packages
+- Updates them to the latest versions using your package manager
+- Preserves other dependencies
+
+**Examples**
+
+```bash
+# Update all assistant-ui packages
+npx assistant-ui update
+
+# Dry run to see what would be updated
+npx assistant-ui update --dry
+```
+
+**Options**
+
+```bash
+Usage: assistant-ui update [options]
+
+update all '@assistant-ui/*' packages to latest versions
+
+Options:
+  --dry          print the command instead of running it
+  -c, --cwd <cwd>  the working directory. defaults to the current directory.
+  -h, --help       display help for command
+```
+
+## upgrade
+
+Use the `upgrade` command to automatically migrate your codebase when there are breaking changes.
+
+```bash
+npx assistant-ui@latest upgrade
+```
+
+This command:
+- Runs codemods to transform your code
+- Updates import paths and API usage
+- Detects required dependency changes
+- Prompts to install new packages
+
+**What it does:**
+- Applies all available codemods sequentially
+- Shows progress bar with file count
+- Reports any transformation errors
+- Automatically detects and offers to install new dependencies
+
+**Example output:**
+
+```bash
+Starting upgrade...
+Found 24 files to process.
+Progress |████████████████████| 100% | ETA: 0s || Running v0-11/content-part-to-message-part...
+Checking for package dependencies...
+✅ Upgrade complete!
+```
+
+**Options**
+
+```bash
+Usage: assistant-ui upgrade [options]
+
+upgrade and apply codemods for breaking changes
+
+Options:
+  -d, --dry              dry run (no changes are made to files)
+  -p, --print            print transformed files to stdout
+  --verbose              show more information about the transform process
+  -j, --jscodeshift <options>  pass options directly to jscodeshift
+  -h, --help             display help for command
+```
+
+## codemod
+
+Use the `codemod` command to run a specific codemod transformation.
+
+```bash
+npx assistant-ui@latest codemod <codemod> <source>
+```
+
+This is useful when you want to run a specific migration rather than all available upgrades.
+
+**Examples**
+
+```bash
+# Run specific codemod on a directory
+npx assistant-ui codemod v0-11/content-part-to-message-part ./src
+
+# Run with dry run to preview changes
+npx assistant-ui codemod v0-11/content-part-to-message-part ./src --dry
+
+# Print transformed output
+npx assistant-ui codemod v0-11/content-part-to-message-part ./src --print
+```
+
+**Options**
+
+```bash
+Usage: assistant-ui codemod [options] <codemod> <source>
+
+run a specific codemod transformation
+
+Arguments:
+  codemod                codemod to run
+  source                 path to source files or directory to transform
+
+Options:
+  -d, --dry              dry run (no changes are made to files)
+  -p, --print            print transformed files to stdout
+  --verbose              show more information about the transform process
+  -j, --jscodeshift <options>  pass options directly to jscodeshift
+  -h, --help             display help for command
+```
+
+## mcp
+
+Use the `mcp` command to install the assistant-ui MCP docs server for your IDE.
+
+```bash
+npx assistant-ui@latest mcp
+```
+
+This command configures the [Model Context Protocol](/docs/llm#mcp) server, giving your AI assistant direct access to assistant-ui documentation.
+
+**Examples**
+
+```bash
+# Interactive - prompts to select IDE
+npx assistant-ui mcp
+
+# Install for specific IDE
+npx assistant-ui mcp --cursor
+npx assistant-ui mcp --windsurf
+npx assistant-ui mcp --vscode
+npx assistant-ui mcp --zed
+npx assistant-ui mcp --claude-code
+npx assistant-ui mcp --claude-desktop
+```
+
+**Options**
+
+```bash
+Usage: assistant-ui mcp [options]
+
+install assistant-ui MCP docs server for your IDE
+
+Options:
+  --cursor          install for Cursor
+  --windsurf        install for Windsurf
+  --vscode          install for VSCode
+  --zed             install for Zed
+  --claude-code     install for Claude Code
+  --claude-desktop  install for Claude Desktop
+  -h, --help        display help for command
+```
+
+## info
+
+Use the `info` command to print your environment and package versions for bug reports.
+
+```bash
+npx assistant-ui@latest info
+```
+
+This command collects and prints:
+- OS, Node.js version, package manager, and framework
+- All installed `@assistant-ui/*` and `assistant-*` package versions
+- Key ecosystem dependency versions (React, Next.js, AI SDK, etc.)
+- Peer dependency warnings if any mismatches are detected
+
+**Example output:**
+
+```
+Environment:
+  OS:               macOS 15.3 (arm64)
+  Node.js:          v22.14.0
+  Package Manager:  pnpm 10.32.1
+  Framework:        Next.js 15.3.1
+
+Packages:
+  @assistant-ui/react            0.12.15
+  @assistant-ui/react-ai-sdk     1.3.12
+  @assistant-ui/react-markdown   0.3.8
+  assistant-stream                0.2.14
+
+Ecosystem:
+  react      19.1.0
+  react-dom  19.1.0
+  next       15.3.1
+  ai         6.0.120
+```
+
+The output includes a copy-pasteable markdown block that you can paste directly into a [bug report](https://github.com/assistant-ui/assistant-ui/issues/new?template=bug_report.yml).
+
+**Options**
+
+```bash
+Usage: assistant-ui info [options]
+
+Print environment and package information for bug reports.
+
+Options:
+  -c, --cwd <cwd>  the working directory. defaults to the current directory.
+  -h, --help       display help for command
+```
+
+## Common Workflows
+
+### Starting a new project
+
+```bash
+# Create a new project with the default template
+npx assistant-ui@latest create my-chatbot
+
+# Navigate into the directory
+cd my-chatbot
+
+# Start development
+npm run dev
+```
+
+### Adding to existing project
+
+```bash
+# Initialize assistant-ui
+npx assistant-ui@latest init
+
+# Add additional components
+npx assistant-ui@latest add thread-list assistant-modal
+
+# Start development
+npm run dev
+```
+
+### Keeping up to date
+
+```bash
+# Check for updates (dry run)
+npx assistant-ui@latest update --dry
+
+# Update all packages
+npx assistant-ui@latest update
+
+# Run upgrade codemods if needed
+npx assistant-ui@latest upgrade
+```
+
+### Migrating versions
+
+```bash
+# Run automated migration
+npx assistant-ui@latest upgrade
+
+# Or run specific codemod
+npx assistant-ui@latest codemod v0-11/content-part-to-message-part ./src
+
+# Update packages after migration
+npx assistant-ui@latest update
+```
+
+## Component Registry
+
+The CLI pulls components from our public registry at [r.assistant-ui.com](https://r.assistant-ui.com).
+
+Each component includes:
+- Full TypeScript source code
+- All required dependencies
+- Tailwind CSS configuration
+- Usage examples
+
+Components are added directly to your project's source code, giving you full control to customize them.
+
+## Troubleshooting
+
+### Command not found
+
+If you get a "command not found" error, make sure you're using `npx`:
+
+```bash
+npx assistant-ui@latest init
+```
+
+### Permission errors
+
+On Linux/macOS, if you encounter permission errors:
+
+```bash
+sudo npx assistant-ui@latest init
+```
+
+Or fix npm permissions: https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally
+
+### Diagnosing issues
+
+When filing a bug report, run `npx assistant-ui info` to collect environment details:
+
+```bash
+npx assistant-ui info
+```
+
+Paste the output into the "Environment info" field of the [bug report template](https://github.com/assistant-ui/assistant-ui/issues/new?template=bug_report.yml).
+
+### Conflicting dependencies
+
+If you see dependency conflicts:
+
+```bash
+# Try with --force flag
+npm install --force
+
+# Or use legacy peer deps
+npm install --legacy-peer-deps
+```
+
+### Component already exists
+
+Use the `--overwrite` flag to replace existing components:
+
+```bash
+npx assistant-ui@latest add thread --overwrite
+```
+
+## Configuration
+
+The CLI respects your project's configuration:
+
+- **Package Manager**: Automatically detects npm, pnpm, yarn, or bun
+- **TypeScript**: Works with your `tsconfig.json` paths
+- **Tailwind**: Uses your `tailwind.config.js` settings
+- **Import Aliases**: Respects `components.json` or `assistant-ui.json` configuration

--- a/packages/cli/plugin/skills/assistant-ui/references/common-pitfalls.md
+++ b/packages/cli/plugin/skills/assistant-ui/references/common-pitfalls.md
@@ -1,0 +1,49 @@
+# Common Pitfalls
+
+Comprehensive guide to common assistant-ui errors.
+
+## Skipping assistant-ui Docs And CLI
+
+Do not skip architecture, installation, and CLI docs and then manually scaffold with generic Next.js or React commands.
+
+Use assistant-ui docs, examples, CLI commands, and registry components.
+
+## Guessing CLI Flags
+
+Do not assume CLI flags. Use the CLI docs or run help:
+
+```bash
+npx assistant-ui@latest <command> --help
+```
+
+## Confusing Local Components With Package Exports
+
+Components under:
+
+```text
+@/components/assistant-ui/*
+```
+
+are project-local shadcn-based components. They are not the same thing as exports from:
+
+```text
+@assistant-ui/react
+```
+
+Customize local generated components when needed. Use `@assistant-ui/react` for primitives, hooks, runtime providers, and core APIs.
+
+## Replacing Real Runtime/API Code With Mock-Only Code
+
+Do not replace real API or LLM code with mock-only code.
+
+Keep the real code path. Add a mock fallback only when useful, such as when environment keys are absent.
+
+## Fabricating Docs URLs
+
+Do not guess assistant-ui docs URLs. Use the docs index, known docs files, or MCP docs server.
+
+## Replacing assistant-ui Architecture
+
+Do not replace assistant-ui runtime/component architecture with custom chat state unless the user explicitly asks.
+
+Preserve `AssistantRuntimeProvider`, existing runtime hooks/adapters, `Thread`/message/composer components, and registered tool UI patterns where present.

--- a/packages/cli/plugin/skills/assistant-ui/references/migrations.md
+++ b/packages/cli/plugin/skills/assistant-ui/references/migrations.md
@@ -1,0 +1,19 @@
+# Migrations
+
+Use this when assistant-ui APIs appear outdated or when package versions changed.
+
+Start from the assistant-ui docs index:
+
+```text
+https://www.assistant-ui.com/llms.txt
+```
+
+Find the `migrations` section and read the relevant version guide.
+
+Before hand-editing old APIs, read the CLI reference to find the current upgrade or update flow:
+
+```text
+references/cli.md
+```
+
+Do not guess migration commands from memory. Use the CLI docs or the CLI help output for the current command and flags.

--- a/packages/cli/plugin/skills/assistant-ui/references/remote-docs.md
+++ b/packages/cli/plugin/skills/assistant-ui/references/remote-docs.md
@@ -1,0 +1,70 @@
+# Remote Docs
+
+Use this reference to read up on assistant-ui docs, or when the user asks for latest assistant-ui guidance.
+
+
+## Preferred Sources
+
+Start with the AI-readable docs index:
+
+```text
+https://www.assistant-ui.com/llms.txt
+```
+
+
+Then for raw page content, assistant-ui docs pages can be read as markdown by using the `.mdx` form .
+
+## Exploration Pattern
+
+Follow this order:
+
+```text
+Read llms.txt, discover available docs sections -> read the relevant page -> inspect source/project -> plan -> implement
+```
+
+Do not guess docs URLs. Start from the index.
+
+## High-Value Sections
+
+Common starting points:
+
+```text
+/docs/architecture
+/docs/cli
+/docs/docs
+/docs/runtimes/
+/docs/guides/
+```
+
+Use the docs structure in llms.txt to find the exact page for the task instead of relying on memory.
+
+## Example: Looking up a thread component 
+
+### 1. Check main documentation index
+
+```
+WebFetch({
+  url: "https://www.assistant-ui.com/llms.txt",
+  prompt: "Where can I find documentation about thread component?"
+})
+```
+Or just fetch the whole llms.txt
+
+This will point you to the thread components reference section.
+
+### 2. Fetch specific method documentation
+
+```
+https://www.assistant-ui.com/docs/ui/thread.mdx
+```
+
+### 3. Use WebFetch tool or read the whole url data
+
+```
+WebFetch({
+  url: "https://www.assistant-ui.com/docs/ui/thread.mdx",
+  prompt: "How can use the thread components"
+})
+```
+
+Or just fetch the whole mdx file using the url

--- a/packages/cli/src/lib/agent-skill.ts
+++ b/packages/cli/src/lib/agent-skill.ts
@@ -1,0 +1,80 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const README_MARKER = "<!-- assistant-ui-agent-skill:start -->";
+const README_SECTION = `${README_MARKER}
+## AI Coding Assistants
+
+This project includes assistant-ui guidance for AI coding assistants at \`.agents/skills/assistant-ui\`.
+
+When asking an assistant to build or modify this app, have it read that skill first. It points to the current assistant-ui docs, CLI guidance, architecture notes, migration guidance, and common pitfalls for generated assistant-ui projects.
+<!-- assistant-ui-agent-skill:end -->`;
+
+export function installGeneratedAppAgentSkill(projectDir: string): void {
+  copyAgentBundleFiles(projectDir);
+  fs.cpSync(
+    resolveSkillSourceDir(),
+    path.join(projectDir, ".agents", "skills", "assistant-ui"),
+    {
+      recursive: true,
+      force: true,
+    },
+  );
+  appendReadmeSection(projectDir);
+}
+
+function copyAgentBundleFiles(projectDir: string): void {
+  const sourceDir = resolvePluginSourceDir();
+  const targetDir = path.join(projectDir, ".agents");
+
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  for (const file of ["README.md", "AGENTS.md", "CLAUDE.md"]) {
+    fs.copyFileSync(path.join(sourceDir, file), path.join(targetDir, file));
+  }
+}
+
+function resolvePluginSourceDir(): string {
+  const candidates = [
+    path.resolve(__dirname, "..", "..", "plugin"),
+    path.resolve(__dirname, "..", "plugin"),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(candidate, "AGENTS.md"))) return candidate;
+  }
+
+  throw new Error(
+    `Could not locate assistant-ui agent bundle. Checked:\n${candidates.map((candidate) => `  ${candidate}`).join("\n")}`,
+  );
+}
+
+function resolveSkillSourceDir(): string {
+  const candidates = [
+    path.resolve(__dirname, "..", "..", "plugin", "skills", "assistant-ui"),
+    path.resolve(__dirname, "..", "plugin", "skills", "assistant-ui"),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(candidate, "SKILL.md"))) return candidate;
+  }
+
+  throw new Error(
+    `Could not locate assistant-ui agent skill. Checked:\n${candidates.map((candidate) => `  ${candidate}`).join("\n")}`,
+  );
+}
+
+function appendReadmeSection(projectDir: string): void {
+  const readmePath = path.join(projectDir, "README.md");
+  const current = fs.existsSync(readmePath)
+    ? fs.readFileSync(readmePath, "utf-8")
+    : "";
+
+  if (current.includes(README_MARKER)) return;
+
+  const prefix = current.trim().length > 0 ? `${current.trimEnd()}\n\n` : "";
+  fs.writeFileSync(readmePath, `${prefix}${README_SECTION}\n`);
+}

--- a/packages/cli/src/lib/agent-skill.ts
+++ b/packages/cli/src/lib/agent-skill.ts
@@ -14,7 +14,6 @@ When asking an assistant to build or modify this app, have it read that skill fi
 <!-- assistant-ui-agent-skill:end -->`;
 
 export function installGeneratedAppAgentSkill(projectDir: string): void {
-  copyAgentBundleFiles(projectDir);
   fs.cpSync(
     resolveSkillSourceDir(),
     path.join(projectDir, ".agents", "skills", "assistant-ui"),
@@ -24,32 +23,6 @@ export function installGeneratedAppAgentSkill(projectDir: string): void {
     },
   );
   appendReadmeSection(projectDir);
-}
-
-function copyAgentBundleFiles(projectDir: string): void {
-  const sourceDir = resolvePluginSourceDir();
-  const targetDir = path.join(projectDir, ".agents");
-
-  fs.mkdirSync(targetDir, { recursive: true });
-
-  for (const file of ["README.md", "AGENTS.md", "CLAUDE.md"]) {
-    fs.copyFileSync(path.join(sourceDir, file), path.join(targetDir, file));
-  }
-}
-
-function resolvePluginSourceDir(): string {
-  const candidates = [
-    path.resolve(__dirname, "..", "..", "plugin"),
-    path.resolve(__dirname, "..", "plugin"),
-  ];
-
-  for (const candidate of candidates) {
-    if (fs.existsSync(path.join(candidate, "AGENTS.md"))) return candidate;
-  }
-
-  throw new Error(
-    `Could not locate assistant-ui agent bundle. Checked:\n${candidates.map((candidate) => `  ${candidate}`).join("\n")}`,
-  );
 }
 
 function resolveSkillSourceDir(): string {

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { downloadTemplate } from "giget";
 import { sync as globSync } from "glob";
 import { detect } from "detect-package-manager";
+import { installGeneratedAppAgentSkill } from "./agent-skill";
 import { logger } from "./utils/logger";
 import { runSpawn, SpawnExitError } from "./run-spawn";
 
@@ -194,6 +195,9 @@ export async function transformProject(
 ): Promise<void> {
   logger.step("Transforming package.json...");
   transformPackageJson(projectDir);
+
+  logger.step("Installing assistant-ui agent skill...");
+  installGeneratedAppAgentSkill(projectDir);
 
   let assistantUI: string[] | undefined;
   let shadcnUI: string[] | undefined;

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -197,7 +197,12 @@ export async function transformProject(
   transformPackageJson(projectDir);
 
   logger.step("Installing assistant-ui agent skill...");
-  installGeneratedAppAgentSkill(projectDir);
+  try {
+    installGeneratedAppAgentSkill(projectDir);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(`Could not install assistant-ui agent skill: ${message}`);
+  }
 
   let assistantUI: string[] | undefined;
   let shadcnUI: string[] | undefined;

--- a/packages/cli/test/lib/create-project.test.ts
+++ b/packages/cli/test/lib/create-project.test.ts
@@ -213,6 +213,45 @@ describe("transformProject — hasLocalComponents: true", () => {
     expect(pkg.devDependencies["@assistant-ui/x-buildutils"]).toBeUndefined();
     expect(pkg.devDependencies.typescript).toBe("^5.0.0");
     expect(pkg.name).toBe(path.basename(testDir));
+    expect(
+      fs.existsSync(
+        path.join(testDir, ".agents", "skills", "assistant-ui", "SKILL.md"),
+      ),
+    ).toBe(true);
+    expect(fs.existsSync(path.join(testDir, ".agents", "README.md"))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(testDir, ".agents", "AGENTS.md"))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(testDir, ".agents", "CLAUDE.md"))).toBe(
+      true,
+    );
+    expect(readFile("README.md")).toContain(
+      "This project includes assistant-ui guidance for AI coding assistants at `.agents/skills/assistant-ui`.",
+    );
+  });
+
+  it("does not duplicate the README assistant guidance section", async () => {
+    writeJSON("package.json", {
+      name: "old-name",
+      dependencies: {
+        "@assistant-ui/react": "workspace:*",
+      },
+    });
+    writeFile(
+      "README.md",
+      "# Test\n\n<!-- assistant-ui-agent-skill:start -->\nExisting section\n<!-- assistant-ui-agent-skill:end -->\n",
+    );
+
+    await transformProject(testDir, {
+      ...defaultOpts,
+      hasLocalComponents: true,
+    });
+
+    const readme = readFile("README.md");
+    expect(readme.match(/assistant-ui-agent-skill:start/g)).toHaveLength(1);
+    expect(readme).toContain("Existing section");
   });
 });
 

--- a/packages/cli/test/lib/create-project.test.ts
+++ b/packages/cli/test/lib/create-project.test.ts
@@ -219,13 +219,13 @@ describe("transformProject — hasLocalComponents: true", () => {
       ),
     ).toBe(true);
     expect(fs.existsSync(path.join(testDir, ".agents", "README.md"))).toBe(
-      true,
+      false,
     );
     expect(fs.existsSync(path.join(testDir, ".agents", "AGENTS.md"))).toBe(
-      true,
+      false,
     );
     expect(fs.existsSync(path.join(testDir, ".agents", "CLAUDE.md"))).toBe(
-      true,
+      false,
     );
     expect(readFile("README.md")).toContain(
       "This project includes assistant-ui guidance for AI coding assistants at `.agents/skills/assistant-ui`.",


### PR DESCRIPTION
## Summary

This PR improves the post-download / post-scaffold coding-agent experience for assistant-ui apps.

Apps generated by `npx assistant-ui create` now include assistant-ui Agent Skills under `.agents/`, plus a short README note pointing users and coding agents to the skill before modifying assistant-ui code.

This is based on findings from Xulux coding-agent evals, where agents editing downloaded/generated apps often skipped assistant-ui docs, guessed APIs, or replaced assistant-ui runtime/component patterns with custom chat implementations.

Closes #4152.

## Why

The goal is not to duplicate the full assistant-ui docs inside every generated app.

The goal is to give coding agents a reliable starting map:

- what assistant-ui is
- how to find the current docs
- how to use the CLI docs
- how the architecture is meant to fit together
- how to approach migrations
- which common mistakes to avoid

We took inspiration from Mastra's skill design: the skill should teach agents how to explore docs/source and avoid known failures, rather than becoming a large manually maintained docs copy.

## What Changed

- Added a complete assistant-ui skill bundle under:

```text
packages/cli/plugin/
```

- Generated apps now receive:

```text
.agents/
  README.md
  AGENTS.md
  CLAUDE.md
  skills/
    assistant-ui/
      SKILL.md
      references/
```

- Appended a small README section in generated apps pointing to `.agents/skills/assistant-ui`.
- Added a small CLI helper to install the `.agents` bundle during the shared project transform step.
- Added docs sync scripts:
  - `pnpm skills:sync-docs`
  - `pnpm skills:check-docs`
- Added a CI check so docs-derived skill references do not drift.
- Added tests for generated-app skill installation and README duplicate protection.

## Skill Architecture Decisions

For v1, `packages/cli/plugin/` is the single source of truth.

Reasoning:

- The CLI package is what powers `npx assistant-ui create`.
- The existing `npx assistant-ui agent` command already uses the CLI plugin folder.
- Generated apps can copy directly from this packaged plugin bundle.
- This avoids multiple manually maintained copies.

The skill is intentionally small:

- `architecture.md` and `cli.md` are generated from assistant-ui docs.
- `remote-docs.md` teaches agents how to explore `llms.txt` and hosted docs.
- `migrations.md` points agents to current migration docs and CLI upgrade flow.
- `common-pitfalls.md` captures failure modes seen in evals.

## Follow-up

The standalone `assistant-ui/skills` repo should be updated from this monorepo source of truth.

Recommended follow-up:

- Add a GitHub Action that mirrors `packages/cli/plugin/` into `assistant-ui/skills`.
- Use PR-based mirroring initially.
- This keeps external skill installation paths in sync with the CLI-packaged skill.

## Validation

- `pnpm skills:check-docs`
- `pnpm --filter=assistant-ui exec vitest run test/lib/create-project.test.ts`
- Smoke tested generated app output for one template and one example during local prep.

We also evaluated the redesigned skills with Codex against the Xulux post-download coding-agent workflow. The skill-guided behavior matched the intended Xulux coding-agent pattern: read docs/source first, preserve assistant-ui architecture, and avoid common known errors.