### PR TITLE
fix(react-a2a): send 'parts' on wire per A2A v1.0 spec

### DIFF
--- a/.changeset/a2a-revert-content-to-parts.md
+++ b/.changeset/a2a-revert-content-to-parts.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix(react-a2a): send `parts` on the wire per A2A v1.0 spec.
+

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -384,7 +384,7 @@ describe("A2AClient", () => {
       expect(body.message.messageId).toBe("msg-1");
     });
 
-    it("sends 'content' not 'parts' per A2A v1.0 proto spec", async () => {
+    it("sends 'parts' per A2A v1.0 spec (gRPC + JSON-RPC unified in a2aproject/A2A#1100)", async () => {
       fetchMock.mockResolvedValue(
         mockFetchResponse({
           task: { id: "t1", status: { state: "completed" } },
@@ -394,8 +394,8 @@ describe("A2AClient", () => {
       await client.sendMessage(userMessage);
 
       const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
-      expect(body.message.content).toEqual([{ text: "Hello" }]);
-      expect(body.message.parts).toBeUndefined();
+      expect(body.message.parts).toEqual([{ text: "Hello" }]);
+      expect(body.message.content).toBeUndefined();
     });
 
     it("unwraps task from SendMessageResponse", async () => {

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -429,7 +429,7 @@ describe("A2AClient", () => {
       expect((result as any).role).toBe("agent");
     });
 
-    it("normalizes 'content' array from v1.0 server response to internal 'parts'", async () => {
+    it("normalizes 'content' array from v0.3 server response to internal 'parts'", async () => {
       fetchMock.mockResolvedValue(
         mockFetchResponse({
           message: {
@@ -887,7 +887,7 @@ describe("A2AClient", () => {
       expect(events).toHaveLength(2);
     });
 
-    it("normalizes v1.0 'content' to 'parts' in SSE artifact update events", async () => {
+    it("normalizes 'content' array from v0.3 server response to 'parts' in SSE artifact update events", async () => {
       const sseData = JSON.stringify({
         artifact_update: {
           task_id: "t1",
@@ -919,7 +919,7 @@ describe("A2AClient", () => {
       expect((evt.event.artifact as any).content).toBeUndefined();
     });
 
-    it("normalizes v1.0 'content' to 'parts' in SSE status update messages", async () => {
+    it("normalizes 'content' array from v0.3 server response to 'parts' in SSE status update messages", async () => {
       const sseData = JSON.stringify({
         status_update: {
           task_id: "t1",

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -91,10 +91,10 @@ function normalizeKeys(obj: unknown, opaque = false): unknown {
       ) {
         result[camelKey] = value.slice(5).toLowerCase();
       } else if (camelKey === "content" && Array.isArray(value)) {
-        // v1.0 proto uses "content" for message/artifact parts; map to internal "parts"
+        // v0.3 servers used "content" for message/artifact parts; normalize to "parts" for backward compat
         result.parts = normalizeKeys(value, false);
       } else if (camelKey !== "parts" || !("parts" in result)) {
-        // skip "parts" if "content" already mapped it (prefer content over parts)
+        // dedup: "content" was already mapped to parts above; don't overwrite
         result[camelKey] = isOpaqueChild ? value : normalizeKeys(value, false);
       }
     }

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -115,8 +115,7 @@ function toWireTaskState(state: A2ATaskState): string {
 }
 
 function toWireMessage(msg: A2AMessage): unknown {
-  const { parts, ...rest } = msg;
-  return { ...rest, role: toWireRole(msg.role), content: parts };
+  return { ...msg, role: toWireRole(msg.role) };
 }
 
 function discriminateStreamResponse(


### PR DESCRIPTION
# Summary

- Revert the outbound `parts → content` rename from #3725. The wire now sends `parts`, matching the A2A v1.0 spec (`A2A-Version: 1.0` header was always set; the payload now actually matches it).
- Keep the inbound `content → parts` normalization in `A2AClient.normalizeKeys` as defensive cover for any straggler A2A v0.3 server response.
- Flip the corresponding assertion in `A2AClient.test.ts`; inbound-normalization tests stay as-is.

## Why

A2A spec PR [a2aproject/A2A#1100](https://github.com/a2aproject/A2A/pull/1100) (Oct 2025) renamed the gRPC `Message.content` field to `parts`, aligning gRPC with JSON-RPC. As of A2A v1.0 both transports use `parts` — the JSON Schema is generated from the proto, so they cannot diverge.

Timeline check on `a2a-python` (confirmed against the SDK's `Message` definition at each tag):

- `v0.3.25` (Mar 10, 2026): `Message.content` — pre-#1100 schema.
- `v1.0.0-alpha.0` (Mar 17, 2026): `Message.parts` — already aligned with the post-#1100 spec.
- `v1.0.0` GA (Apr 20, 2026): `Message.parts`.

When #3725 merged (Apr 1, 2026), the v1 alpha already shipped `parts`. The bug report it was based on (#3723) was filed against a v0.3.x backend that legitimately used `content`, so #3725 made our outbound match v0.3 wire — while our client still advertises itself as `A2A-Version: 1.0`. That contradiction stayed invisible until v1.0 GA traffic showed up, and #4157 is the first report of it.

The `compat/v0_3/a2a_v0_3.proto` shim in `a2a-python` is the cleanest confirmation: it preserves `repeated Part content = 5` under an explicit `v0_3` namespace, while the live v1.0 types use `parts`.

Fixes #4157. Re-opens the original surface of #3723 only for users still on a frozen pre-v1.0 server — they should upgrade their SDK; the inbound normalization means their responses still parse.
