### PR TITLE
feat: add indicator slot to MessagePrimitive.GroupedParts

### DIFF
--- a/.changeset/grouped-parts-indicator.md
+++ b/.changeset/grouped-parts-indicator.md
@@ -1,0 +1,12 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+---
+
+feat: add `indicator` support to `MessagePrimitive.GroupedParts`.
+
+Restores empty/loading-state handling that was dropped from the grouped renderer. `GroupedParts` now emits a synthetic `{ part: { type: "indicator", status } }` render call you handle with `case "indicator"` in your `switch (part.type)` — render loading dots, a "thinking…" placeholder, or nothing.
+
+- New `indicator` prop controls when the slot fires: `"never"`, `"empty"` (no parts), `"no-text"` (default — last part isn't `text`/`reasoning`, e.g. the model ended on a tool call), or `"always"`. The default deliberately does **not** fire on truly empty messages.
+- The indicator's `status` mirrors the message's running/complete/incomplete state (`requires-action` reads as running; the message-only `tool-calls` incomplete reason maps to `"other"`).

--- a/.changeset/grouped-parts-indicator.md
+++ b/.changeset/grouped-parts-indicator.md
@@ -6,7 +6,7 @@
 
 feat: add `indicator` support to `MessagePrimitive.GroupedParts`.
 
-Restores empty/loading-state handling that was dropped from the grouped renderer. `GroupedParts` now emits a synthetic `{ part: { type: "indicator", status } }` render call you handle with `case "indicator"` in your `switch (part.type)` — render loading dots, a "thinking…" placeholder, or nothing.
+Restores loading-state handling that was dropped from the grouped renderer. `GroupedParts` now emits a synthetic `{ part: { type: "indicator" } }` render call you handle with `case "indicator"` in your `switch (part.type)` — render a "thinking…" dot or any loading affordance.
 
-- New `indicator` prop controls when the slot fires: `"never"`, `"empty"` (no parts), `"no-text"` (default — last part isn't `text`/`reasoning`, e.g. the model ended on a tool call), or `"always"`. The default deliberately does **not** fire on truly empty messages.
-- The indicator's `status` mirrors the message's running/complete/incomplete state (`requires-action` reads as running; the message-only `tool-calls` incomplete reason maps to `"other"`).
+- The indicator is only ever emitted while the message is **running**, so its presence alone means "render loading UI here" — there's no `status` to branch on.
+- New `indicator` prop restricts which running states qualify: `"never"`, `"empty"` (no parts yet), `"no-text"` (default — last part isn't `text`/`reasoning`, e.g. the model ended on a tool call), or `"always"` (any running state).

--- a/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
@@ -6,6 +6,7 @@ import { useShallow } from "zustand/shallow";
 import type { PartState } from "../../../store/scopes/part";
 import type {
   MessagePartStatus,
+  MessageStatus,
   ToolCallMessagePartStatus,
 } from "../../../types/message";
 import {
@@ -28,13 +29,40 @@ export namespace MessagePrimitiveGroupedParts {
     readonly indices: readonly number[];
   };
 
+  /**
+   * Synthetic trailing slot for status/loading UI (a "thinking…"
+   * indicator, an empty-message placeholder, etc.). Surfaced through the
+   * same `{ part }` channel as groups and leaf parts so a single
+   * `switch (part.type)` renders it via `case "indicator"`.
+   *
+   * Unlike a real part it has no underlying {@link PartState}; only
+   * `status`, which mirrors the message's running/complete/incomplete
+   * state. Emission is controlled by the `indicator` prop.
+   */
+  export type IndicatorPart = {
+    readonly type: "indicator";
+    readonly status: MessagePartStatus;
+  };
+
+  /**
+   * When to emit the synthetic {@link IndicatorPart}:
+   * - `"never"` — never.
+   * - `"empty"` — only when the message has no parts.
+   * - `"no-text"` (default) — when the message has parts but the last one
+   *   isn't `text`/`reasoning` (e.g. it ended on a tool call, so the
+   *   assistant likely isn't done). Does **not** fire on empty messages.
+   * - `"always"` — after every render, regardless of parts.
+   */
+  export type IndicatorMode = "never" | "empty" | "no-text" | "always";
+
   export type RenderInfo<TKey extends `group-${string}` = `group-${string}`> = {
     /**
      * Either a coalesced group ({@link GroupPart}, identified by a
-     * `group-…` `type`) or a single enriched part. Use one switch over
-     * `part.type` to handle both.
+     * `group-…` `type`), a single enriched leaf part, or the synthetic
+     * {@link IndicatorPart} (`type: "indicator"`). Use one switch over
+     * `part.type` to handle all three.
      */
-    readonly part: GroupPart<TKey> | EnrichedPartState;
+    readonly part: GroupPart<TKey> | EnrichedPartState | IndicatorPart;
     /**
      * For group nodes: the recursively-rendered subtree (subgroups +
      * leaf parts). For leaf parts: a sentinel that throws when rendered
@@ -74,9 +102,21 @@ export namespace MessagePrimitiveGroupedParts {
     readonly groupBy: (part: PartState) => readonly TKey[] | null;
 
     /**
-     * Render function called once per group node and once per leaf part.
-     * Switch on `part.type`: `"group-…"` cases wrap `children`; real
-     * part types (`"text"`, `"tool-call"`, …) render the part directly.
+     * Controls emission of the synthetic {@link IndicatorPart} — a
+     * trailing `{ part: { type: "indicator", status } }` render call you
+     * handle with `case "indicator"` to show loading/status UI.
+     *
+     * @default "no-text"
+     * @see IndicatorMode
+     */
+    readonly indicator?: IndicatorMode;
+
+    /**
+     * Render function called once per group node, once per leaf part, and
+     * (when the `indicator` condition is met) once for the trailing
+     * {@link IndicatorPart}. Switch on `part.type`: `"group-…"` cases wrap
+     * `children`; real part types (`"text"`, `"tool-call"`, …) render the
+     * part directly; `"indicator"` renders status/loading UI.
      *
      * Leaf parts receive the same {@link EnrichedPartState} that
      * `<MessagePrimitive.Parts>` would produce (`toolUI`, `addResult`,
@@ -87,6 +127,51 @@ export namespace MessagePrimitiveGroupedParts {
 }
 
 const COMPLETE_STATUS: MessagePartStatus = Object.freeze({ type: "complete" });
+const RUNNING_STATUS: MessagePartStatus = Object.freeze({ type: "running" });
+
+/**
+ * Project the message-level {@link MessageStatus} onto the part-level
+ * {@link MessagePartStatus} carried by the indicator. `requires-action`
+ * (waiting on a tool/human) reads as still-running; the message-only
+ * `tool-calls` incomplete reason collapses to `"other"`.
+ */
+const toIndicatorStatus = (
+  status: MessageStatus | undefined,
+): MessagePartStatus => {
+  switch (status?.type) {
+    case "running":
+    case "requires-action":
+      return RUNNING_STATUS;
+    case "incomplete":
+      return {
+        type: "incomplete",
+        reason: status.reason === "tool-calls" ? "other" : status.reason,
+        error: status.error,
+      };
+    default:
+      return COMPLETE_STATUS;
+  }
+};
+
+const shouldShowIndicator = (
+  mode: MessagePrimitiveGroupedParts.IndicatorMode,
+  parts: readonly PartState[],
+): boolean => {
+  switch (mode) {
+    case "never":
+      return false;
+    case "always":
+      return true;
+    case "empty":
+      return parts.length === 0;
+    case "no-text": {
+      const last = parts[parts.length - 1];
+      return (
+        last !== undefined && last.type !== "text" && last.type !== "reasoning"
+      );
+    }
+  }
+};
 
 /**
  * `children` placeholder passed for leaf-part renders. Leaf parts have no
@@ -161,6 +246,7 @@ const renderNode = <TKey extends `group-${string}`>(
  *       case "group-tool":      return <ToolStack>{children}</ToolStack>;
  *       case "text":            return <MarkdownText />;
  *       case "tool-call":       return part.toolUI ?? <ToolFallback {...part} />;
+ *       case "indicator":       return part.status.type === "running" ? <LoadingDots /> : null;
  *       default:                return null;
  *     }
  *   }}
@@ -169,9 +255,11 @@ const renderNode = <TKey extends `group-${string}`>(
  */
 export const MessagePrimitiveGroupedParts = <TKey extends `group-${string}`>({
   groupBy,
+  indicator = "no-text",
   children,
 }: MessagePrimitiveGroupedParts.Props<TKey>): ReactNode => {
   const parts = useAuiState(useShallow((s) => s.message.parts));
+  const messageStatus = useAuiState((s) => s.message.status);
 
   // Helpers like `groupPartByType` tag the function with `GROUPBY_MEMO_KEY`
   // (a stable string fingerprint of the helper config). When present,
@@ -188,7 +276,22 @@ export const MessagePrimitiveGroupedParts = <TKey extends `group-${string}`>({
     [parts, memoDep],
   );
 
-  return <>{tree.map((node) => renderNode(node, parts, children))}</>;
+  return (
+    <>
+      {tree.map((node) => renderNode(node, parts, children))}
+      {shouldShowIndicator(indicator, parts) && (
+        <Fragment key="indicator">
+          {children({
+            part: {
+              type: "indicator",
+              status: toIndicatorStatus(messageStatus),
+            },
+            children: <PartChildrenSentinel />,
+          })}
+        </Fragment>
+      )}
+    </>
+  );
 };
 
 MessagePrimitiveGroupedParts.displayName = "MessagePrimitive.GroupedParts";

--- a/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
@@ -6,7 +6,6 @@ import { useShallow } from "zustand/shallow";
 import type { PartState } from "../../../store/scopes/part";
 import type {
   MessagePartStatus,
-  MessageStatus,
   ToolCallMessagePartStatus,
 } from "../../../types/message";
 import {
@@ -30,28 +29,28 @@ export namespace MessagePrimitiveGroupedParts {
   };
 
   /**
-   * Synthetic trailing slot for status/loading UI (a "thinking…"
-   * indicator, an empty-message placeholder, etc.). Surfaced through the
-   * same `{ part }` channel as groups and leaf parts so a single
-   * `switch (part.type)` renders it via `case "indicator"`.
+   * Synthetic trailing slot for a streaming/loading affordance (a
+   * "thinking…" dot, etc.). Surfaced through the same `{ part }` channel
+   * as groups and leaf parts so a single `switch (part.type)` renders it
+   * via `case "indicator"`.
    *
-   * Unlike a real part it has no underlying {@link PartState}; only
-   * `status`, which mirrors the message's running/complete/incomplete
-   * state. Emission is controlled by the `indicator` prop.
+   * It is only ever emitted while the message is running, so its presence
+   * alone means "render your loading UI here" — there's no `status` to
+   * branch on.
    */
   export type IndicatorPart = {
     readonly type: "indicator";
-    readonly status: MessagePartStatus;
   };
 
   /**
-   * When to emit the synthetic {@link IndicatorPart}:
+   * When to emit the synthetic {@link IndicatorPart}. It is **only** emitted
+   * while the message is running (streaming); the mode further restricts
+   * which running states qualify:
    * - `"never"` — never.
-   * - `"empty"` — only when the message has no parts.
-   * - `"no-text"` (default) — when the message has parts but the last one
-   *   isn't `text`/`reasoning` (e.g. it ended on a tool call, so the
-   *   assistant likely isn't done). Does **not** fire on empty messages.
-   * - `"always"` — after every render, regardless of parts.
+   * - `"empty"` — only when the message has no parts yet.
+   * - `"no-text"` (default) — when the last part isn't `text`/`reasoning`
+   *   (e.g. it ended on a tool call, so the assistant likely isn't done).
+   * - `"always"` — whenever the message is running, regardless of parts.
    */
   export type IndicatorMode = "never" | "empty" | "no-text" | "always";
 
@@ -127,36 +126,16 @@ export namespace MessagePrimitiveGroupedParts {
 }
 
 const COMPLETE_STATUS: MessagePartStatus = Object.freeze({ type: "complete" });
-const RUNNING_STATUS: MessagePartStatus = Object.freeze({ type: "running" });
-
-/**
- * Project the message-level {@link MessageStatus} onto the part-level
- * {@link MessagePartStatus} carried by the indicator. `requires-action`
- * (waiting on a tool/human) reads as still-running; the message-only
- * `tool-calls` incomplete reason collapses to `"other"`.
- */
-const toIndicatorStatus = (
-  status: MessageStatus | null | undefined,
-): MessagePartStatus => {
-  switch (status?.type) {
-    case "running":
-    case "requires-action":
-      return RUNNING_STATUS;
-    case "incomplete":
-      return {
-        type: "incomplete",
-        reason: status.reason === "tool-calls" ? "other" : status.reason,
-        error: status.error,
-      };
-    default:
-      return COMPLETE_STATUS;
-  }
-};
 
 const shouldShowIndicator = (
   mode: MessagePrimitiveGroupedParts.IndicatorMode,
   parts: readonly PartState[],
+  isRunning: boolean,
 ): boolean => {
+  // The indicator is a streaming affordance — never show it on a settled
+  // message, whatever the mode.
+  if (!isRunning) return false;
+
   switch (mode) {
     case "never":
       return false;
@@ -246,7 +225,7 @@ const renderNode = <TKey extends `group-${string}`>(
  *       case "group-tool":      return <ToolStack>{children}</ToolStack>;
  *       case "text":            return <MarkdownText />;
  *       case "tool-call":       return part.toolUI ?? <ToolFallback {...part} />;
- *       case "indicator":       return part.status.type === "running" ? <LoadingDots /> : null;
+ *       case "indicator":       return <LoadingDots />;
  *       default:                return null;
  *     }
  *   }}
@@ -259,11 +238,10 @@ export const MessagePrimitiveGroupedParts = <TKey extends `group-${string}`>({
   children,
 }: MessagePrimitiveGroupedParts.Props<TKey>): ReactNode => {
   const parts = useAuiState(useShallow((s) => s.message.parts));
-  // Skip subscribing to status when the indicator is disabled — otherwise
-  // every streaming status transition re-renders the whole grouped tree
-  // for nothing.
-  const messageStatus = useAuiState((s) =>
-    indicator === "never" ? null : s.message.status,
+  // Subscribe to a boolean, not the status object: the tree only needs to
+  // re-render when running-ness flips, and `"never"` opts out entirely.
+  const isRunning = useAuiState((s) =>
+    indicator === "never" ? false : s.message.status?.type === "running",
   );
 
   // Helpers like `groupPartByType` tag the function with `GROUPBY_MEMO_KEY`
@@ -284,17 +262,11 @@ export const MessagePrimitiveGroupedParts = <TKey extends `group-${string}`>({
   return (
     <>
       {tree.map((node) => renderNode(node, parts, children))}
-      {shouldShowIndicator(indicator, parts) && (
-        <Fragment key="indicator">
-          {children({
-            part: {
-              type: "indicator",
-              status: toIndicatorStatus(messageStatus),
-            },
-            children: <PartChildrenSentinel />,
-          })}
-        </Fragment>
-      )}
+      {shouldShowIndicator(indicator, parts, isRunning) &&
+        children({
+          part: { type: "indicator" },
+          children: <PartChildrenSentinel />,
+        })}
     </>
   );
 };

--- a/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
@@ -136,7 +136,7 @@ const RUNNING_STATUS: MessagePartStatus = Object.freeze({ type: "running" });
  * `tool-calls` incomplete reason collapses to `"other"`.
  */
 const toIndicatorStatus = (
-  status: MessageStatus | undefined,
+  status: MessageStatus | null | undefined,
 ): MessagePartStatus => {
   switch (status?.type) {
     case "running":
@@ -259,7 +259,12 @@ export const MessagePrimitiveGroupedParts = <TKey extends `group-${string}`>({
   children,
 }: MessagePrimitiveGroupedParts.Props<TKey>): ReactNode => {
   const parts = useAuiState(useShallow((s) => s.message.parts));
-  const messageStatus = useAuiState((s) => s.message.status);
+  // Skip subscribing to status when the indicator is disabled — otherwise
+  // every streaming status transition re-renders the whole grouped tree
+  // for nothing.
+  const messageStatus = useAuiState((s) =>
+    indicator === "never" ? null : s.message.status,
+  );
 
   // Helpers like `groupPartByType` tag the function with `GROUPBY_MEMO_KEY`
   // (a stable string fingerprint of the helper config). When present,

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -278,6 +278,18 @@ const AssistantMessage: FC = () => {
                 return <Reasoning {...part} />;
               case "tool-call":
                 return part.toolUI ?? <ToolFallback {...part} />;
+              case "indicator":
+                return part.status.type === "running" ? (
+                  <div
+                    data-slot="aui_assistant-message-indicator"
+                    className="flex items-center gap-1 py-1"
+                    aria-label="Assistant is working"
+                  >
+                    <span className="bg-muted-foreground/50 size-1.5 animate-bounce rounded-full [animation-delay:-0.3s]" />
+                    <span className="bg-muted-foreground/50 size-1.5 animate-bounce rounded-full [animation-delay:-0.15s]" />
+                    <span className="bg-muted-foreground/50 size-1.5 animate-bounce rounded-full" />
+                  </div>
+                ) : null;
               default:
                 return null;
             }

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -279,17 +279,15 @@ const AssistantMessage: FC = () => {
               case "tool-call":
                 return part.toolUI ?? <ToolFallback {...part} />;
               case "indicator":
-                return part.status.type === "running" ? (
-                  <div
+                return (
+                  <span
                     data-slot="aui_assistant-message-indicator"
-                    className="flex items-center gap-1 py-1"
+                    className="animate-pulse font-sans"
                     aria-label="Assistant is working"
                   >
-                    <span className="bg-muted-foreground/50 size-1.5 animate-bounce rounded-full [animation-delay:-0.3s]" />
-                    <span className="bg-muted-foreground/50 size-1.5 animate-bounce rounded-full [animation-delay:-0.15s]" />
-                    <span className="bg-muted-foreground/50 size-1.5 animate-bounce rounded-full" />
-                  </div>
-                ) : null;
+                    {"●"}
+                  </span>
+                );
               default:
                 return null;
             }


### PR DESCRIPTION
## Summary

`MessagePrimitive.GroupedParts` dropped the loading-state handling that the non-grouped `MessagePrimitive.Parts` still has, so there was no way to render a "thinking…" indicator in the grouped renderer. This restores it via a synthetic `"indicator"` part.

- **New synthetic `indicator` part** — after the group tree, `GroupedParts` emits one `children({ part: { type: "indicator" }, children })` call. Consumers handle it with a single `case "indicator"` in their existing `switch (part.type)`, alongside groups and leaf parts. It is **only emitted while the message is running**, so its presence alone means "render loading UI here" — there is no `status` to branch on.
- **New `indicator` prop** restricts which running states qualify:
  | value | renders when running AND… |
  |---|---|
  | `"never"` | never |
  | `"empty"` | `parts.length === 0` |
  | `"no-text"` (**default**) | last part isn't `text`/`reasoning` (e.g. ended on a tool call) |
  | `"always"` | always |

  The running gate is universal — the indicator never appears on a settled message, whatever the mode.
- **shadcn `thread.tsx`** — wires up `case "indicator"` rendering the same pulsing `●` dot that `aui-md`'s `dot.css` uses for streaming text, so the bundled UI shows a thinking indicator again.

`MessagePrimitive.Parts` is intentionally left unchanged.

## Test plan

- [x] `tsc --noEmit` clean on `@assistant-ui/core` and the `@assistant-ui/ui` consumer
- [x] `oxlint` + `oxfmt` pass on changed files
- [x] `groupParts.test.ts` (16 tests) green
- [ ] Visual check of the running dot animation in a live thread (not done — requires a live model session)

https://claude.ai/code/session_01BYvBooPmABk7F8Gb6N4uug