### PR TITLE
perf(core): memoize RuntimeAdapterProvider context value

### DIFF
--- a/.changeset/memoize-runtime-adapter-provider.md
+++ b/.changeset/memoize-runtime-adapter-provider.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+perf: memoize the `RuntimeAdapterProvider` context value so adapter consumers no longer re-render on every parent render when `adapters` is stable.

--- a/packages/core/src/react/runtimes/RuntimeAdapterProvider.tsx
+++ b/packages/core/src/react/runtimes/RuntimeAdapterProvider.tsx
@@ -1,4 +1,10 @@
-import { createContext, type FC, type ReactNode, useContext } from "react";
+import {
+  createContext,
+  type FC,
+  type ReactNode,
+  useContext,
+  useMemo,
+} from "react";
 import type { ThreadHistoryAdapter } from "../../adapters/thread-history";
 import type { AttachmentAdapter } from "../../adapters/attachment";
 import type { ModelContextProvider } from "../../model-context/types";
@@ -23,13 +29,12 @@ export const RuntimeAdapterProvider: FC<RuntimeAdapterProvider.Props> = ({
   children,
 }) => {
   const context = useContext(RuntimeAdaptersContext);
+  const value = useMemo(
+    () => ({ ...context, ...adapters }),
+    [context, adapters],
+  );
   return (
-    <RuntimeAdaptersContext.Provider
-      value={{
-        ...context,
-        ...adapters,
-      }}
-    >
+    <RuntimeAdaptersContext.Provider value={value}>
       {children}
     </RuntimeAdaptersContext.Provider>
   );

--- a/packages/ui/src/components/assistant-ui/context-display.tsx
+++ b/packages/ui/src/components/assistant-ui/context-display.tsx
@@ -13,6 +13,7 @@ import {
   createContext,
   useContext,
   useEffect,
+  useMemo,
   useState,
   type FC,
   type ReactNode,
@@ -125,15 +126,18 @@ function ContextDisplayRootBase({
   const totalTokens = tokenState.totalTokens;
   const percent = getUsagePercent(totalTokens, modelContextWindow);
 
+  const contextValue = useMemo(
+    () => ({
+      usage: tokenState.usage,
+      totalTokens,
+      percent,
+      modelContextWindow,
+    }),
+    [tokenState.usage, totalTokens, percent, modelContextWindow],
+  );
+
   return (
-    <ContextDisplayContext.Provider
-      value={{
-        usage: tokenState.usage,
-        totalTokens,
-        percent,
-        modelContextWindow,
-      }}
-    >
+    <ContextDisplayContext.Provider value={contextValue}>
       <Tooltip>{children}</Tooltip>
     </ContextDisplayContext.Provider>
   );

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -4,6 +4,7 @@ import {
   memo,
   useState,
   useEffect,
+  useMemo,
   createContext,
   useContext,
   type ComponentPropsWithoutRef,
@@ -68,8 +69,9 @@ function ModelSelectorRoot({
   ...selectProps
 }: ModelSelectorRootProps) {
   const defaultValue = defaultValueProp ?? models[0]?.id;
+  const contextValue = useMemo(() => ({ models, value }), [models, value]);
   return (
-    <ModelSelectorContext.Provider value={{ models, value }}>
+    <ModelSelectorContext.Provider value={contextValue}>
       <SelectRoot
         {...(defaultValue !== undefined ? { defaultValue } : undefined)}
         {...(value !== undefined ? { value } : undefined)}


### PR DESCRIPTION
The provider rebuilt `{ ...context, ...adapters }` on every render, forcing
every adapter consumer to re-render even when context and adapters were
unchanged. Wrap it in useMemo so consumers only re-render when the inputs
actually change (callers like LocalStorageThreadListAdapter and the cloud
adapter already memoize the `adapters` prop).

Surfaced by React Doctor (jsx-no-constructed-context-values).

https://claude.ai/code/session_018qSFLQnqF8Nw92XyxTgY8v