### PR TITLE
fix(assistant-stream): resolve argsReader.get() to undefined once args close

### DIFF
--- a/.changeset/args-reader-optional-resolve.md
+++ b/.changeset/args-reader-optional-resolve.md
@@ -1,0 +1,7 @@
+---
+"assistant-stream": patch
+---
+
+fix(assistant-stream): resolve `argsReader.get()` to `undefined` once args close
+
+Awaiting an optional arg that the model never produced (`reader.args.get("optional")`) previously hung forever, because the args stream was never closed and pending handles were never settled. The reader now closes when args streaming finishes, resolving outstanding `get()` calls to `undefined` for absent fields and closing open `streamValues`/`streamText`/`forEach` streams.

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.test.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { ToolCallReaderImpl } from "./ToolCallReader";
+
+type Args = {
+  required: string;
+  optional?: string;
+  items?: string[];
+};
+
+const createReader = () => new ToolCallReaderImpl<Args, string>();
+
+describe("ToolCallArgsReader.get", () => {
+  it("resolves with the value once the field is complete", async () => {
+    const reader = createReader();
+    const promise = reader.args.get("required");
+
+    await reader.appendArgsTextDelta('{"required":"hello"}');
+
+    expect(await promise).toBe("hello");
+  });
+
+  it("resolves to undefined for an absent field once args close", async () => {
+    const reader = createReader();
+    const promise = reader.args.get("optional");
+
+    await reader.appendArgsTextDelta('{"required":"hello"}');
+    await reader.finishArgsText();
+
+    // Previously this never resolved and deadlocked the tool.
+    expect(await promise).toBeUndefined();
+  });
+
+  it("resolves to undefined for a field requested after args close", async () => {
+    const reader = createReader();
+
+    await reader.appendArgsTextDelta('{"required":"hello"}');
+    await reader.finishArgsText();
+
+    expect(await reader.args.get("optional")).toBeUndefined();
+    expect(await reader.args.get("required")).toBe("hello");
+  });
+
+  it("does not deadlock awaiting an optional arg inside a side effect", async () => {
+    const reader = createReader();
+
+    const sideEffect = (async () => {
+      const optional = await reader.args.get("optional");
+      return optional ?? "fallback";
+    })();
+
+    await reader.appendArgsTextDelta('{"required":"hello"}');
+    await reader.finishArgsText();
+
+    expect(await sideEffect).toBe("fallback");
+  });
+});
+
+describe("ToolCallArgsReader streams", () => {
+  it("closes streamValues when args close without the field", async () => {
+    const reader = createReader();
+
+    await reader.appendArgsTextDelta('{"required":"hello"}');
+    await reader.finishArgsText();
+
+    const seen: unknown[] = [];
+    for await (const value of reader.args.streamValues("items")) {
+      seen.push(value);
+    }
+
+    expect(seen).toEqual([]);
+  });
+
+  it("emits completed array items and closes via forEach", async () => {
+    const reader = createReader();
+
+    await reader.appendArgsTextDelta('{"required":"hi","items":["a","b"]}');
+    await reader.finishArgsText();
+
+    const seen: string[] = [];
+    for await (const item of reader.args.forEach("items")) {
+      seen.push(item);
+    }
+
+    expect(seen).toEqual(["a", "b"]);
+  });
+});

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.ts
@@ -381,9 +381,10 @@ export class ToolCallArgsReaderImpl<
     // Use a type assertion to convert the complex TypePath to a simple array
     const simplePath = fieldPath as unknown as (string | number)[];
 
+    let handle: StreamTextHandle<T> | undefined;
     const stream = new ReadableStream<unknown>({
       start: (controller) => {
-        const handle = new StreamTextHandle<T>(controller, simplePath);
+        handle = new StreamTextHandle<T>(controller, simplePath);
         if (!this.finished) this.handles.add(handle);
 
         // Check current args immediately
@@ -392,13 +393,11 @@ export class ToolCallArgsReaderImpl<
         if (this.finished) handle.end();
       },
       cancel: () => {
-        // Find and dispose the corresponding handle
-        for (const handle of this.handles) {
-          if (handle instanceof StreamTextHandle) {
-            handle.dispose();
-            this.handles.delete(handle);
-            break;
-          }
+        // Dispose this stream's own handle (captured above) — scanning for the
+        // first match would dispose a concurrent streamText()'s handle.
+        if (handle) {
+          handle.dispose();
+          this.handles.delete(handle);
         }
       },
     });
@@ -414,9 +413,10 @@ export class ToolCallArgsReaderImpl<
     // Use a type assertion to convert the complex TypePath to a simple array
     const simplePath = fieldPath as unknown as (string | number)[];
 
+    let handle: ForEachHandle<T> | undefined;
     const stream = new ReadableStream<unknown>({
       start: (controller) => {
-        const handle = new ForEachHandle<T>(controller, simplePath);
+        handle = new ForEachHandle<T>(controller, simplePath);
         if (!this.finished) this.handles.add(handle);
 
         // Check current args immediately
@@ -425,13 +425,11 @@ export class ToolCallArgsReaderImpl<
         if (this.finished) handle.end();
       },
       cancel: () => {
-        // Find and dispose the corresponding handle
-        for (const handle of this.handles) {
-          if (handle instanceof ForEachHandle) {
-            handle.dispose();
-            this.handles.delete(handle);
-            break;
-          }
+        // Dispose this stream's own handle (captured above) — scanning for the
+        // first match would dispose a concurrent forEach()'s handle.
+        if (handle) {
+          handle.dispose();
+          this.handles.delete(handle);
         }
       },
     });

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.ts
@@ -349,9 +349,10 @@ export class ToolCallArgsReaderImpl<
     // Use a type assertion to convert the complex TypePath to a simple array
     const simplePath = fieldPath as unknown as (string | number)[];
 
+    let handle: StreamValuesHandle<T> | undefined;
     const stream = new ReadableStream<DeepPartial<TypeAtPath<T, PathT>>>({
       start: (controller) => {
-        const handle = new StreamValuesHandle<T>(controller, simplePath);
+        handle = new StreamValuesHandle<T>(controller, simplePath);
         if (!this.finished) this.handles.add(handle);
 
         // Check current args immediately
@@ -360,13 +361,11 @@ export class ToolCallArgsReaderImpl<
         if (this.finished) handle.end(this.args);
       },
       cancel: () => {
-        // Find and dispose the corresponding handle
-        for (const handle of this.handles) {
-          if (handle instanceof StreamValuesHandle) {
-            handle.dispose();
-            this.handles.delete(handle);
-            break;
-          }
+        // Dispose this stream's own handle (captured above) — scanning for the
+        // first match would dispose a concurrent streamValues()'s handle.
+        if (handle) {
+          handle.dispose();
+          this.handles.delete(handle);
         }
       },
     });
@@ -491,6 +490,8 @@ export class ToolCallReaderImpl<
       await writer.close();
     } catch (err) {
       console.warn(err);
+    } finally {
+      writer.releaseLock();
     }
   }
 

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.ts
@@ -358,7 +358,7 @@ export class ToolCallArgsReaderImpl<
         // Check current args immediately
         handle.update(this.args);
 
-        if (this.finished) handle.end(this.args);
+        if (this.finished) handle.end();
       },
       cancel: () => {
         // Dispose this stream's own handle (captured above) — scanning for the
@@ -389,7 +389,7 @@ export class ToolCallArgsReaderImpl<
         // Check current args immediately
         handle.update(this.args);
 
-        if (this.finished) handle.end(this.args);
+        if (this.finished) handle.end();
       },
       cancel: () => {
         // Find and dispose the corresponding handle
@@ -422,7 +422,7 @@ export class ToolCallArgsReaderImpl<
         // Check current args immediately
         handle.update(this.args);
 
-        if (this.finished) handle.end(this.args);
+        if (this.finished) handle.end();
       },
       cancel: () => {
         // Find and dispose the corresponding handle

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.ts
@@ -32,6 +32,7 @@ function getField<T>(obj: T, fieldPath: (string | number)[]): unknown {
 
 interface Handle {
   update(args: unknown): void;
+  end(args: unknown): void;
   dispose(): void;
 }
 
@@ -70,6 +71,19 @@ class GetHandle<T, TValue> implements Handle {
       }
     } catch (e) {
       this.reject(e);
+      this.dispose();
+    }
+  }
+
+  end(args: unknown): void {
+    if (this.disposed) return;
+
+    try {
+      const value = getField(args as T, this.fieldPath);
+      this.resolve(value as TValue);
+    } catch (e) {
+      this.reject(e);
+    } finally {
       this.dispose();
     }
   }
@@ -118,6 +132,12 @@ class StreamValuesHandle<T> implements Handle {
     }
   }
 
+  end(): void {
+    if (this.disposed) return;
+    this.controller.close();
+    this.dispose();
+  }
+
   dispose(): void {
     this.disposed = true;
   }
@@ -163,6 +183,12 @@ class StreamTextHandle<T> implements Handle {
       this.controller.error(e);
       this.dispose();
     }
+  }
+
+  end(): void {
+    if (this.disposed) return;
+    this.controller.close();
+    this.dispose();
   }
 
   dispose(): void {
@@ -226,6 +252,12 @@ class ForEachHandle<T> implements Handle {
     }
   }
 
+  end(): void {
+    if (this.disposed) return;
+    this.controller.close();
+    this.dispose();
+  }
+
   dispose(): void {
     this.disposed = true;
   }
@@ -238,6 +270,7 @@ export class ToolCallArgsReaderImpl<
   private argTextDeltas: ReadableStream<string>;
   private handles: Set<Handle> = new Set();
   private args: unknown = parsePartialJsonObject("");
+  private finished = false;
 
   constructor(argTextDeltas: ReadableStream<string>) {
     this.argTextDeltas = argTextDeltas;
@@ -266,10 +299,12 @@ export class ToolCallArgsReaderImpl<
       }
     } catch (error) {
       console.error("Error processing argument stream:", error);
-      // Notify handles of the error
+    } finally {
+      this.finished = true;
       for (const handle of this.handles) {
-        handle.dispose();
+        handle.end(this.args);
       }
+      this.handles.clear();
     }
   }
 
@@ -298,6 +333,11 @@ export class ToolCallArgsReaderImpl<
         }
       }
 
+      if (this.finished) {
+        handle.end(this.args);
+        return;
+      }
+
       this.handles.add(handle);
       handle.update(this.args);
     });
@@ -312,10 +352,12 @@ export class ToolCallArgsReaderImpl<
     const stream = new ReadableStream<DeepPartial<TypeAtPath<T, PathT>>>({
       start: (controller) => {
         const handle = new StreamValuesHandle<T>(controller, simplePath);
-        this.handles.add(handle);
+        if (!this.finished) this.handles.add(handle);
 
         // Check current args immediately
         handle.update(this.args);
+
+        if (this.finished) handle.end(this.args);
       },
       cancel: () => {
         // Find and dispose the corresponding handle
@@ -343,10 +385,12 @@ export class ToolCallArgsReaderImpl<
     const stream = new ReadableStream<unknown>({
       start: (controller) => {
         const handle = new StreamTextHandle<T>(controller, simplePath);
-        this.handles.add(handle);
+        if (!this.finished) this.handles.add(handle);
 
         // Check current args immediately
         handle.update(this.args);
+
+        if (this.finished) handle.end(this.args);
       },
       cancel: () => {
         // Find and dispose the corresponding handle
@@ -374,10 +418,12 @@ export class ToolCallArgsReaderImpl<
     const stream = new ReadableStream<unknown>({
       start: (controller) => {
         const handle = new ForEachHandle<T>(controller, simplePath);
-        this.handles.add(handle);
+        if (!this.finished) this.handles.add(handle);
 
         // Check current args immediately
         handle.update(this.args);
+
+        if (this.finished) handle.end(this.args);
       },
       cancel: () => {
         // Find and dispose the corresponding handle
@@ -437,6 +483,15 @@ export class ToolCallReaderImpl<
     }
 
     this.argsText += text;
+  }
+
+  async finishArgsText(): Promise<void> {
+    const writer = this.writable.getWriter();
+    try {
+      await writer.close();
+    } catch (err) {
+      console.warn(err);
+    }
   }
 
   setResponse(value: ToolResponse<TResult>): void {

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -117,6 +117,9 @@ export class ToolExecutionStream extends PipeableTransformStream<
               if (!streamController)
                 throw new Error("No controller found for tool call");
 
+              // Args fully streamed: close the reader so awaited absent fields resolve.
+              streamController.finishArgsText();
+
               let isExecuting = false;
               const promise = withPromiseOrValue(
                 () => {

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -57,7 +57,7 @@ export class ToolExecutionStream extends PipeableTransformStream<
         AssistantMetaStreamChunk,
         AssistantStreamChunk
       >({
-        transform(chunk, controller) {
+        async transform(chunk, controller) {
           // forward everything
           if (chunk.type !== "part-finish" || chunk.meta.type !== "tool-call") {
             controller.enqueue(chunk);
@@ -88,7 +88,9 @@ export class ToolExecutionStream extends PipeableTransformStream<
                 const controller = toolCallControllers.get(toolCallId);
                 if (!controller)
                   throw new Error("No controller found for tool call");
-                controller.appendArgsTextDelta(chunk.textDelta);
+                // Awaited so the writer lock is released (and argsText updated)
+                // before the next chunk acquires the writer.
+                await controller.appendArgsTextDelta(chunk.textDelta);
               }
               break;
             }
@@ -117,8 +119,9 @@ export class ToolExecutionStream extends PipeableTransformStream<
               if (!streamController)
                 throw new Error("No controller found for tool call");
 
-              // Args fully streamed: close the reader so awaited absent fields resolve.
-              streamController.finishArgsText();
+              // Args fully streamed: close the reader so awaited absent fields
+              // resolve. Awaited so the close settles before the writer is reused.
+              await streamController.finishArgsText();
 
               let isExecuting = false;
               const promise = withPromiseOrValue(


### PR DESCRIPTION
## Problem

`reader.args.get("optionalField")` never resolved when the model never produced that field, deadlocking any tool that awaited an optional arg inside a side effect.

Two root causes:
1. The args text stream (`ToolCallReaderImpl`) was **never closed** — `appendArgsTextDelta` wrote deltas but nothing signaled end-of-stream, so `processStream`'s `reader.read()` never returned `done`.
2. Even on close, `processStream` only `break`'d out of its loop; pending `GetHandle`s were never settled.

## Fix

- Add `ToolCallReaderImpl.finishArgsText()` which closes the args writable, and call it from `ToolExecutionStream` when `tool-call-args-text-finish` fires.
- Give each handle an `end()` method and finalize all outstanding handles when the stream closes:
  - `get()` resolves to the current value — `undefined` for absent fields — instead of hanging.
  - `streamValues` / `streamText` / `forEach` close cleanly.
- Handle accessors called *after* the stream already closed (`finished` guard) so a late `get()` resolves immediately rather than hanging.

## Tests

New `ToolCallReader.test.ts` covering: value resolves on completion, absent optional resolves to `undefined` (before and after close), no deadlock awaiting an optional arg in a side effect, and stream accessors closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)