### PR TITLE
feat(examples): showcase react-ink primitives in terminal agent demo

### DIFF
--- a/examples/with-react-ink/src/app.tsx
+++ b/examples/with-react-ink/src/app.tsx
@@ -3,74 +3,36 @@ import { Box, Text } from "ink";
 import {
   AssistantRuntimeProvider,
   useLocalRuntime,
-  type ChatModelAdapter,
+  StatusBarPrimitive,
 } from "@assistant-ui/react-ink";
 import { Thread } from "./components/thread.js";
+import { createScriptedAdapter, MODEL_NAME } from "./scripted-adapter.js";
+import { ApplyPatchToolUI } from "./tools.js";
 
-const createDemoAdapter = (): ChatModelAdapter => ({
-  async *run({ messages }) {
-    const lastUserMessage = messages.filter((m) => m.role === "user").at(-1);
-
-    const userText =
-      lastUserMessage?.content
-        .filter((p) => p.type === "text")
-        .map((p) => ("text" in p ? p.text : ""))
-        .join("") ?? "";
-
-    // Simulate streaming with a markdown-rich response
-    const response = `## Response to your question
-
-You asked: **"${userText}"**
-
-Here's a quick example in JavaScript:
-
-\`\`\`js
-const promise = new Promise((resolve, reject) => {
-  setTimeout(() => resolve("done!"), 1000);
-});
-
-promise.then(result => console.log(result));
-\`\`\`
-
-### Key points
-
-- A \`Promise\` represents an **async operation**
-- It can be *pending*, *fulfilled*, or *rejected*
-- Use \`.then()\` and \`.catch()\` to handle results
-
-> Promises are the foundation of modern async JavaScript.
-
-| Method | Purpose |
-|--------|---------|
-| \`.then()\` | Handle success |
-| \`.catch()\` | Handle errors |
-| \`.finally()\` | Run cleanup |
-
-Learn more at [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).`;
-    const words = response.split(" ");
-
-    let accumulated = "";
-    for (const word of words) {
-      accumulated += (accumulated ? " " : "") + word;
-      yield { content: [{ type: "text" as const, text: accumulated }] };
-      await new Promise((r) => setTimeout(r, 50));
-    }
-  },
-});
+const StatusBar = () => (
+  <StatusBarPrimitive.Root>
+    <Text dimColor>
+      model: <StatusBarPrimitive.ModelName name={MODEL_NAME} /> ·{" "}
+      <StatusBarPrimitive.MessageCount /> · <StatusBarPrimitive.Status />
+    </Text>
+  </StatusBarPrimitive.Root>
+);
 
 export const App = () => {
-  const adapter = useMemo(() => createDemoAdapter(), []);
+  const adapter = useMemo(() => createScriptedAdapter(), []);
   const runtime = useLocalRuntime(adapter);
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
+      <ApplyPatchToolUI />
       <Box flexDirection="column" padding={1}>
-        <Text bold color="cyan">
-          assistant-ui Terminal Chat
-        </Text>
-        <Text dimColor>
-          Type a message and press Enter to send. Ctrl+C to exit.
-        </Text>
+        <Box>
+          <Text bold color="cyan">
+            demo-agent
+          </Text>
+          <Text dimColor>{"  ~/acme-app"}</Text>
+        </Box>
+        <StatusBar />
         <Box marginTop={1}>
           <Thread />
         </Box>

--- a/examples/with-react-ink/src/components/thread.tsx
+++ b/examples/with-react-ink/src/components/thread.tsx
@@ -37,11 +37,9 @@ const AssistantMessage = () => (
         )}
       />
       <LiveChecklist title="Plan" showProgress marginTop={1} />
-      <MessagePrimitive.Error>
-        <ErrorPrimitive.Root>
-          <ErrorPrimitive.Message />
-        </ErrorPrimitive.Root>
-      </MessagePrimitive.Error>
+      <ErrorPrimitive.Root>
+        <ErrorPrimitive.Message />
+      </ErrorPrimitive.Root>
     </Box>
   </MessagePrimitive.Root>
 );

--- a/examples/with-react-ink/src/components/thread.tsx
+++ b/examples/with-react-ink/src/components/thread.tsx
@@ -2,62 +2,70 @@ import { Box, Text } from "ink";
 import {
   ThreadPrimitive,
   ComposerPrimitive,
-  useAuiState,
+  MessagePrimitive,
+  ErrorPrimitive,
+  LoadingPrimitive,
+  LiveChecklist,
 } from "@assistant-ui/react-ink";
 import { MarkdownText } from "@assistant-ui/react-ink-markdown";
 
-const UserMessage = () => {
-  const text = useAuiState((s) =>
-    s.message.parts
-      .filter((p) => p.type === "text")
-      .map((p) => ("text" in p ? p.text : ""))
-      .join(""),
-  );
-
-  return (
+const UserMessage = () => (
+  <MessagePrimitive.Root>
     <Box marginBottom={1}>
       <Text bold color="green">
         You:{" "}
       </Text>
-      <Text wrap="wrap">{text}</Text>
+      <MessagePrimitive.Content
+        renderText={({ part }) => <Text wrap="wrap">{part.text}</Text>}
+      />
     </Box>
-  );
-};
+  </MessagePrimitive.Root>
+);
 
-const AssistantMessage = () => {
-  const text = useAuiState((s) =>
-    s.message.parts
-      .filter((p) => p.type === "text")
-      .map((p) => ("text" in p ? p.text : ""))
-      .join(""),
-  );
-
-  return (
+const AssistantMessage = () => (
+  <MessagePrimitive.Root>
     <Box flexDirection="column" marginBottom={1}>
       <Text bold color="blue">
         AI:
       </Text>
-      <MarkdownText text={text} />
+      <MessagePrimitive.Content
+        renderText={({ part }) => <MarkdownText text={part.text} />}
+        renderReasoning={({ part }) => (
+          <Text dimColor italic>
+            {part.text}
+          </Text>
+        )}
+      />
+      <LiveChecklist title="Plan" showProgress marginTop={1} />
+      <MessagePrimitive.Error>
+        <ErrorPrimitive.Root>
+          <ErrorPrimitive.Message />
+        </ErrorPrimitive.Root>
+      </MessagePrimitive.Error>
     </Box>
-  );
-};
+  </MessagePrimitive.Root>
+);
 
-const StatusIndicator = () => {
-  const isRunning = useAuiState((s) => s.thread.isRunning);
-  if (!isRunning) return null;
-  return (
-    <Box marginBottom={1}>
-      <Text color="yellow">Thinking...</Text>
-    </Box>
-  );
-};
+const Loading = () => (
+  <LoadingPrimitive.Root marginBottom={1}>
+    <LoadingPrimitive.Spinner />
+    <Text> </Text>
+    <LoadingPrimitive.Text>Working</LoadingPrimitive.Text>
+    <Text> </Text>
+    <LoadingPrimitive.ElapsedTime />
+  </LoadingPrimitive.Root>
+);
 
 export const Thread = () => {
   return (
     <ThreadPrimitive.Root>
       <ThreadPrimitive.Empty>
-        <Box marginBottom={1}>
-          <Text dimColor>No messages yet. Start typing below!</Text>
+        <Box flexDirection="column" marginBottom={1}>
+          <Text>
+            Working in this project. <Text color="yellow">fetchUser()</Text> is
+            flaky in prod and has no retry logic.
+          </Text>
+          <Text dimColor>{'  try: "make fetchUser retry on failure"'}</Text>
         </Box>
       </ThreadPrimitive.Empty>
 
@@ -67,13 +75,14 @@ export const Thread = () => {
         }
       </ThreadPrimitive.Messages>
 
-      <StatusIndicator />
+      <Loading />
 
       <Box borderStyle="round" borderColor="gray" paddingX={1}>
         <Text color="gray">{"> "}</Text>
         <ComposerPrimitive.Input
           submitOnEnter
-          placeholder="Type a message..."
+          multiLine
+          placeholder="Type a message... (Enter to send)"
           autoFocus
         />
       </Box>

--- a/examples/with-react-ink/src/scripted-adapter.ts
+++ b/examples/with-react-ink/src/scripted-adapter.ts
@@ -18,7 +18,7 @@ const RETRY_PATCH = `--- a/src/retry.ts
 +
 +export async function retry<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
 +  let lastError: unknown;
-+  for (let i = 0; i < attempts; i++) {
++  for (let i = 0; i <= attempts; i++) {
 +    try {
 +      return await fn();
 +    } catch (err) {
@@ -34,20 +34,20 @@ const RETRY_PATCH_FIX = `--- a/src/retry.ts
 +++ b/src/retry.ts
 @@ -6,7 +6,7 @@ export async function retry<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
    let lastError: unknown;
--  for (let i = 0; i < attempts; i++) {
-+  for (let i = 0; i <= attempts; i++) {
+-  for (let i = 0; i <= attempts; i++) {
++  for (let i = 0; i < attempts; i++) {
      try {
        return await fn();
      } catch (err) {
 `;
 
 const isTaskRequest = (text: string) =>
-  /fetch|retry|resilient|flaky|backoff|fail|robust|network|\byes\b|sure|ok\b|go ahead|do it|please/i.test(
+  /fetch|retry|resilient|flaky|backoff|robust|network|\byes\b|sure|\bok\b|go ahead|do it|please/i.test(
     text,
   );
 
 const lastUserText = (
-  messages: { role: string; content: readonly { type: string }[] }[],
+  messages: readonly { role: string; content: readonly { type: string }[] }[],
 ) => {
   const last = messages.filter((m) => m.role === "user").at(-1);
   return (
@@ -58,127 +58,108 @@ const lastUserText = (
   );
 };
 
+async function* streamText(
+  parts: ThreadAssistantMessagePart[],
+  index: number,
+  text: string,
+  delay: number,
+): AsyncGenerator<{ content: ThreadAssistantMessagePart[] }> {
+  for (const word of text.split(" ")) {
+    const p = parts[index] as Extract<
+      ThreadAssistantMessagePart,
+      { type: "text" | "reasoning" }
+    >;
+    parts[index] = { ...p, text: p.text ? `${p.text} ${word}` : word };
+    yield { content: [...parts] };
+    await sleep(delay);
+  }
+}
+
 async function* runAgentScript(): AsyncGenerator<{
   content: ThreadAssistantMessagePart[];
 }> {
   const parts: ThreadAssistantMessagePart[] = [];
   const emit = () => ({ content: [...parts] });
+  const setResult = (result: unknown, isError = false) => {
+    parts[parts.length - 1] = {
+      ...parts[parts.length - 1],
+      result,
+      ...(isError ? { isError: true } : {}),
+    } as ThreadAssistantMessagePart;
+  };
+  const pushToolCall = (
+    toolCallId: string,
+    toolName: string,
+    args: Record<string, string>,
+  ) =>
+    parts.push({
+      type: "tool-call",
+      toolCallId,
+      toolName,
+      args,
+      argsText: JSON.stringify(args),
+    });
 
-  const reasoning =
-    "Let me look at how fetchUser is implemented, wrap it in retry-with-backoff, and run the tests to make sure it holds up.";
-  parts.push({ type: "reasoning", text: "" });
-  for (const word of reasoning.split(" ")) {
-    const p = parts[0] as Extract<
-      ThreadAssistantMessagePart,
-      { type: "reasoning" }
-    >;
-    parts[0] = { ...p, text: (p.text ? p.text + " " : "") + word };
-    yield emit();
-    await sleep(20);
-  }
+  const reasoningIdx = parts.push({ type: "reasoning", text: "" }) - 1;
+  yield* streamText(
+    parts,
+    reasoningIdx,
+    "Let me look at how fetchUser is implemented, wrap it in retry-with-backoff, and run the tests to make sure it holds up.",
+    20,
+  );
 
-  const readArgs = { path: "src/retry.ts" };
-  parts.push({
-    type: "tool-call",
-    toolCallId: "read-1",
-    toolName: "read_file",
-    args: readArgs,
-    argsText: JSON.stringify(readArgs),
-  });
+  pushToolCall("read-1", "read_file", { path: "src/retry.ts" });
   yield emit();
   await sleep(500);
-  parts[parts.length - 1] = {
-    ...parts[parts.length - 1],
-    result: "12 lines read",
-  } as ThreadAssistantMessagePart;
+  setResult("12 lines read");
   yield emit();
   await sleep(300);
 
-  const patchArgs = { path: "src/retry.ts", patch: RETRY_PATCH };
-  parts.push({
-    type: "tool-call",
-    toolCallId: "patch-1",
-    toolName: "apply_patch",
-    args: patchArgs,
-    argsText: JSON.stringify(patchArgs),
+  pushToolCall("patch-1", "apply_patch", {
+    path: "src/retry.ts",
+    patch: RETRY_PATCH,
   });
   yield emit();
   await sleep(600);
-  parts[parts.length - 1] = {
-    ...parts[parts.length - 1],
-    result: { applied: true },
-  } as ThreadAssistantMessagePart;
+  setResult({ applied: true });
   yield emit();
   await sleep(300);
 
-  const testArgs = { command: "pnpm test retry" };
-  parts.push({
-    type: "tool-call",
-    toolCallId: "test-1",
-    toolName: "run_tests",
-    args: testArgs,
-    argsText: JSON.stringify(testArgs),
-  });
+  pushToolCall("test-1", "run_tests", { command: "pnpm test retry" });
   yield emit();
   await sleep(700);
-  parts[parts.length - 1] = {
-    ...parts[parts.length - 1],
-    isError: true,
-    result:
-      "FAIL src/retry.test.ts - retry() ran 4 times, expected 3 (off-by-one in loop bound)",
-  } as ThreadAssistantMessagePart;
+  setResult(
+    "FAIL src/retry.test.ts - retry() ran 4 times, expected 3 (off-by-one in loop bound)",
+    true,
+  );
   yield emit();
   await sleep(400);
 
-  const noteIndex = parts.length;
-  parts.push({ type: "text", text: "" });
-  const note = "The loop bound was off by one. Tightening it and re-running.";
-  for (const word of note.split(" ")) {
-    const p = parts[noteIndex] as Extract<
-      ThreadAssistantMessagePart,
-      { type: "text" }
-    >;
-    parts[noteIndex] = { ...p, text: (p.text ? p.text + " " : "") + word };
-    yield emit();
-    await sleep(20);
-  }
+  const noteIdx = parts.push({ type: "text", text: "" }) - 1;
+  yield* streamText(
+    parts,
+    noteIdx,
+    "The loop bound was off by one. Tightening it and re-running.",
+    20,
+  );
 
-  const fixArgs = { path: "src/retry.ts", patch: RETRY_PATCH_FIX };
-  parts.push({
-    type: "tool-call",
-    toolCallId: "patch-2",
-    toolName: "apply_patch",
-    args: fixArgs,
-    argsText: JSON.stringify(fixArgs),
+  pushToolCall("patch-2", "apply_patch", {
+    path: "src/retry.ts",
+    patch: RETRY_PATCH_FIX,
   });
   yield emit();
   await sleep(500);
-  parts[parts.length - 1] = {
-    ...parts[parts.length - 1],
-    result: { applied: true },
-  } as ThreadAssistantMessagePart;
+  setResult({ applied: true });
   yield emit();
   await sleep(300);
 
-  const runArgs = { command: "pnpm test retry" };
-  parts.push({
-    type: "tool-call",
-    toolCallId: "test-2",
-    toolName: "run_tests",
-    args: runArgs,
-    argsText: JSON.stringify(runArgs),
-  });
+  pushToolCall("test-2", "run_tests", { command: "pnpm test retry" });
   yield emit();
   await sleep(600);
-  parts[parts.length - 1] = {
-    ...parts[parts.length - 1],
-    result: "PASS src/retry.test.ts (3 passed)",
-  } as ThreadAssistantMessagePart;
+  setResult("PASS src/retry.test.ts (3 passed)");
   yield emit();
   await sleep(300);
 
-  const summaryIndex = parts.length;
-  parts.push({ type: "text", text: "" });
   const summary = `### Done
 
 Added a \`retry()\` helper and routed \`fetchUser\` through it:
@@ -188,15 +169,8 @@ Added a \`retry()\` helper and routed \`fetchUser\` through it:
 - fixed an off-by-one that ran one extra attempt
 
 Tests are green.`;
-  for (const word of summary.split(" ")) {
-    const p = parts[summaryIndex] as Extract<
-      ThreadAssistantMessagePart,
-      { type: "text" }
-    >;
-    parts[summaryIndex] = { ...p, text: (p.text ? p.text + " " : "") + word };
-    yield emit();
-    await sleep(15);
-  }
+  const summaryIdx = parts.push({ type: "text", text: "" }) - 1;
+  yield* streamText(parts, summaryIdx, summary, 15);
 }
 
 async function* runProposalReply(): AsyncGenerator<{
@@ -215,7 +189,8 @@ Want me to wrap it in retry-with-backoff? Just say *make fetchUser retry on fail
 
 export const createScriptedAdapter = (): ChatModelAdapter => ({
   run({ messages }) {
-    const text = lastUserText(messages as never);
-    return isTaskRequest(text) ? runAgentScript() : runProposalReply();
+    return isTaskRequest(lastUserText(messages))
+      ? runAgentScript()
+      : runProposalReply();
   },
 });

--- a/examples/with-react-ink/src/scripted-adapter.ts
+++ b/examples/with-react-ink/src/scripted-adapter.ts
@@ -1,0 +1,221 @@
+import type {
+  ChatModelAdapter,
+  ThreadAssistantMessagePart,
+} from "@assistant-ui/react-ink";
+
+export const MODEL_NAME = "demo-agent";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const RETRY_PATCH = `--- a/src/retry.ts
++++ b/src/retry.ts
+@@ -1,6 +1,18 @@
+ export async function fetchUser(id: string) {
+-  const res = await fetch(\`/api/users/\${id}\`);
+-  return res.json();
++  return retry(() => fetch(\`/api/users/\${id}\`).then((r) => r.json()));
++}
++
++export async function retry<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
++  let lastError: unknown;
++  for (let i = 0; i < attempts; i++) {
++    try {
++      return await fn();
++    } catch (err) {
++      lastError = err;
++      await new Promise((r) => setTimeout(r, 2 ** i * 100));
++    }
++  }
++  throw lastError;
+ }
+`;
+
+const RETRY_PATCH_FIX = `--- a/src/retry.ts
++++ b/src/retry.ts
+@@ -6,7 +6,7 @@ export async function retry<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
+   let lastError: unknown;
+-  for (let i = 0; i < attempts; i++) {
++  for (let i = 0; i <= attempts; i++) {
+     try {
+       return await fn();
+     } catch (err) {
+`;
+
+const isTaskRequest = (text: string) =>
+  /fetch|retry|resilient|flaky|backoff|fail|robust|network|\byes\b|sure|ok\b|go ahead|do it|please/i.test(
+    text,
+  );
+
+const lastUserText = (
+  messages: { role: string; content: readonly { type: string }[] }[],
+) => {
+  const last = messages.filter((m) => m.role === "user").at(-1);
+  return (
+    last?.content
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("") ?? ""
+  );
+};
+
+async function* runAgentScript(): AsyncGenerator<{
+  content: ThreadAssistantMessagePart[];
+}> {
+  const parts: ThreadAssistantMessagePart[] = [];
+  const emit = () => ({ content: [...parts] });
+
+  const reasoning =
+    "Let me look at how fetchUser is implemented, wrap it in retry-with-backoff, and run the tests to make sure it holds up.";
+  parts.push({ type: "reasoning", text: "" });
+  for (const word of reasoning.split(" ")) {
+    const p = parts[0] as Extract<
+      ThreadAssistantMessagePart,
+      { type: "reasoning" }
+    >;
+    parts[0] = { ...p, text: (p.text ? p.text + " " : "") + word };
+    yield emit();
+    await sleep(20);
+  }
+
+  const readArgs = { path: "src/retry.ts" };
+  parts.push({
+    type: "tool-call",
+    toolCallId: "read-1",
+    toolName: "read_file",
+    args: readArgs,
+    argsText: JSON.stringify(readArgs),
+  });
+  yield emit();
+  await sleep(500);
+  parts[parts.length - 1] = {
+    ...parts[parts.length - 1],
+    result: "12 lines read",
+  } as ThreadAssistantMessagePart;
+  yield emit();
+  await sleep(300);
+
+  const patchArgs = { path: "src/retry.ts", patch: RETRY_PATCH };
+  parts.push({
+    type: "tool-call",
+    toolCallId: "patch-1",
+    toolName: "apply_patch",
+    args: patchArgs,
+    argsText: JSON.stringify(patchArgs),
+  });
+  yield emit();
+  await sleep(600);
+  parts[parts.length - 1] = {
+    ...parts[parts.length - 1],
+    result: { applied: true },
+  } as ThreadAssistantMessagePart;
+  yield emit();
+  await sleep(300);
+
+  const testArgs = { command: "pnpm test retry" };
+  parts.push({
+    type: "tool-call",
+    toolCallId: "test-1",
+    toolName: "run_tests",
+    args: testArgs,
+    argsText: JSON.stringify(testArgs),
+  });
+  yield emit();
+  await sleep(700);
+  parts[parts.length - 1] = {
+    ...parts[parts.length - 1],
+    isError: true,
+    result:
+      "FAIL src/retry.test.ts - retry() ran 4 times, expected 3 (off-by-one in loop bound)",
+  } as ThreadAssistantMessagePart;
+  yield emit();
+  await sleep(400);
+
+  const noteIndex = parts.length;
+  parts.push({ type: "text", text: "" });
+  const note = "The loop bound was off by one. Tightening it and re-running.";
+  for (const word of note.split(" ")) {
+    const p = parts[noteIndex] as Extract<
+      ThreadAssistantMessagePart,
+      { type: "text" }
+    >;
+    parts[noteIndex] = { ...p, text: (p.text ? p.text + " " : "") + word };
+    yield emit();
+    await sleep(20);
+  }
+
+  const fixArgs = { path: "src/retry.ts", patch: RETRY_PATCH_FIX };
+  parts.push({
+    type: "tool-call",
+    toolCallId: "patch-2",
+    toolName: "apply_patch",
+    args: fixArgs,
+    argsText: JSON.stringify(fixArgs),
+  });
+  yield emit();
+  await sleep(500);
+  parts[parts.length - 1] = {
+    ...parts[parts.length - 1],
+    result: { applied: true },
+  } as ThreadAssistantMessagePart;
+  yield emit();
+  await sleep(300);
+
+  const runArgs = { command: "pnpm test retry" };
+  parts.push({
+    type: "tool-call",
+    toolCallId: "test-2",
+    toolName: "run_tests",
+    args: runArgs,
+    argsText: JSON.stringify(runArgs),
+  });
+  yield emit();
+  await sleep(600);
+  parts[parts.length - 1] = {
+    ...parts[parts.length - 1],
+    result: "PASS src/retry.test.ts (3 passed)",
+  } as ThreadAssistantMessagePart;
+  yield emit();
+  await sleep(300);
+
+  const summaryIndex = parts.length;
+  parts.push({ type: "text", text: "" });
+  const summary = `### Done
+
+Added a \`retry()\` helper and routed \`fetchUser\` through it:
+
+- exponential backoff (\`100ms\`, \`200ms\`, \`400ms\`)
+- rethrows the **last error** after exhausting attempts
+- fixed an off-by-one that ran one extra attempt
+
+Tests are green.`;
+  for (const word of summary.split(" ")) {
+    const p = parts[summaryIndex] as Extract<
+      ThreadAssistantMessagePart,
+      { type: "text" }
+    >;
+    parts[summaryIndex] = { ...p, text: (p.text ? p.text + " " : "") + word };
+    yield emit();
+    await sleep(15);
+  }
+}
+
+async function* runProposalReply(): AsyncGenerator<{
+  content: ThreadAssistantMessagePart[];
+}> {
+  const response = `I'm set up to work in this repo. The obvious thing to fix is the flaky \`fetchUser()\` call in \`src/retry.ts\` — it has no retry logic, so a single network blip fails the request.
+
+Want me to wrap it in retry-with-backoff? Just say *make fetchUser retry on failure*.`;
+  let acc = "";
+  for (const word of response.split(" ")) {
+    acc += (acc ? " " : "") + word;
+    yield { content: [{ type: "text", text: acc }] };
+    await sleep(20);
+  }
+}
+
+export const createScriptedAdapter = (): ChatModelAdapter => ({
+  run({ messages }) {
+    const text = lastUserText(messages as never);
+    return isTaskRequest(text) ? runAgentScript() : runProposalReply();
+  },
+});

--- a/examples/with-react-ink/src/tools.tsx
+++ b/examples/with-react-ink/src/tools.tsx
@@ -1,0 +1,18 @@
+import { Box, Text } from "ink";
+import { makeAssistantToolUI, DiffView } from "@assistant-ui/react-ink";
+
+export const ApplyPatchToolUI = makeAssistantToolUI<
+  { path: string; patch: string },
+  unknown
+>({
+  toolName: "apply_patch",
+  render: ({ args }) => {
+    if (!args?.patch) return null;
+    return (
+      <Box flexDirection="column" marginBottom={1}>
+        <Text color="cyan">edit {args.path}</Text>
+        <DiffView patch={args.patch} showLineNumbers />
+      </Box>
+    );
+  },
+});


### PR DESCRIPTION
Reworks `examples/with-react-ink` from a single canned markdown reply into a scripted coding-agent session that exercises the react-ink primitives shipped since the example was last touched. No API key required — runs with `pnpm dev`.

## What it shows
Ask it to make the flaky `fetchUser()` call resilient and the agent streams a full turn:

- **reasoning** then `read_file` / `apply_patch` / `run_tests` tool calls (`ToolFallback`)
- **`DiffView`** for the file edit (line numbers + intra-line highlighting)
- a `run_tests` step that **fails**, the agent fixes the off-by-one, and reruns green (`ErrorPrimitive` path + error recovery)
- per-turn **`LiveChecklist`** auto-derived from the tool calls
- **`StatusBarPrimitive`** (model / message count / status) and **`LoadingPrimitive`** chrome
- **multi-line composer** input

Routing is intent-based and stays in character: a request about the task runs the agent; anything else gets an in-character proposal to fix `fetchUser` (no fourth-wall "this is a demo" text).

## Notes
- Adapter/diff/checklist data is fully scripted and deterministic.
- Attachments and `ComposerPrimitive.Queue` were intentionally left out — `useLocalRuntime` reports `queue: false`, and core's text attachment adapter is browser-only (`FileReader`); both need follow-ups rather than example-local workarounds.
 
Holding for review while a couple of related react-ink items settle (the `ToolFallback` error-icon fix, and whether to add attachment / queue coverage). I'll update the example once those land,then mark it ready for review