### PR TITLE
fix(react-ink): show error icon for completed tool calls that errored

### DIFF
--- a/.changeset/fix-react-ink-toolfallback-error-icon.md
+++ b/.changeset/fix-react-ink-toolfallback-error-icon.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix(react-ink): show the error icon for completed tool calls that errored. `ToolFallback` resolved a part with a `complete` status to the success icon (`+`) even when `isError` was set, so a finished-but-failed tool call rendered green. It now checks `isError` within the complete branch and shows the error icon (`x`), matching `useToolCallChecklist`.

--- a/packages/react-ink/src/primitives/toolCall/ToolFallback.tsx
+++ b/packages/react-ink/src/primitives/toolCall/ToolFallback.tsx
@@ -90,7 +90,7 @@ const resolveStatus = (
 ): ToolCallStatus => {
   if (status?.type === "requires-action") return "requires-action";
   if (status?.type === "incomplete") return "error";
-  if (status?.type === "complete") return "complete";
+  if (status?.type === "complete") return part.isError ? "error" : "complete";
   if (part.isError) return "error";
   if (part.result !== undefined) return "complete";
   if (part.interrupt) return "requires-action";

--- a/packages/react-ink/src/tests/ToolFallback.test.tsx
+++ b/packages/react-ink/src/tests/ToolFallback.test.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render } from "ink-testing-library";
-import { ToolFallback } from "./ToolFallback";
+import { ToolFallback } from "../primitives/toolCall/ToolFallback";
 
 const renderFrame = async (node: ReactElement) => {
   const instance = render(node);
@@ -36,5 +36,25 @@ describe("ToolFallback", () => {
     expect(frame).toContain("... (2 more lines)");
     expect(frame).not.toContain("line 3");
     expect(frame).not.toContain("line 4");
+  });
+
+  it("shows the error icon for a completed tool call that errored", async () => {
+    const frame = await renderFrame(
+      <ToolFallback
+        type="tool-call"
+        toolCallId="tool-call-1"
+        toolName="run_tests"
+        args={{}}
+        argsText="{}"
+        result="FAIL: 1 test failed"
+        isError
+        status={{ type: "complete" }}
+      />,
+    );
+
+    expect(frame).toContain("x");
+    expect(frame).toContain("run_tests");
+    expect(frame).toContain("Error:");
+    expect(frame).not.toContain("+");
   });
 });


### PR DESCRIPTION
`ToolFallback` resolved a tool-call part with a `complete` status straight to the success icon (`+`), even when `isError` was set so a finished-but-failed tool rendered green. `resolveStatus` now checks `isError` inside the complete and shows the error icon (`x`), matching `useToolCallChecklist`'s logic.

Also moves the colocated `ToolFallback.test.tsx` into `src/tests/` (per the package convention that all tests live there) and adds a regression case for a type: "complete" }` + `isError` part.

- Verified the new test fails on the old code (`+ run_tests FAIL...`) and passes with the fix.
- Full react-ink suite: 200 passing. Lint + full repo build clean.