### PR TITLE
docs(api-reference): standalone-tool-call grouping + display hint

### DIFF
--- a/apps/docs/content/docs/(reference)/api-reference/primitives/message.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/message.mdx
@@ -258,16 +258,19 @@ Parts whose type isn't in the map are left ungrouped. The returned
 function carries a stable GROUPBY_MEMO_KEY fingerprint so
 `<MessagePrimitive.GroupedParts>` can memoize its tree across renders.
 
-Special key `"mcp-app"` matches tool-call parts that point at an
-assistant-ui MCP app resource (`ui://...`) and takes precedence over
-the `"tool-call"` entry for those parts.
+The synthetic `"standalone-tool-call"` key matches tool calls that should
+render outside the chain-of-thought grouping. MCP-app calls are detected from
+the part alone; the registry-driven cases (human tools, the generative-UI
+tool, `display: "standalone"` opt-ins) are resolved from the
+GroupByContext that `<MessagePrimitive.GroupedParts>` passes to the
+`groupBy` function — the helper needs nothing threaded into it.
 
 ```tsx
 <MessagePrimitive.GroupedParts
   groupBy={groupPartByType({
     reasoning: ["group-thought", "group-reasoning"],
     "tool-call": ["group-thought", "group-tool"],
-    "mcp-app": [],
+    "standalone-tool-call": [],
   })}
 >
   {({ part, children }) => { ... }}
@@ -275,6 +278,6 @@ the `"tool-call"` entry for those parts.
 ```
 
 ```ts
-const groupPartByType: <TKey extends `group-${string}`>(map: Partial<Readonly<Record<GroupPartType, readonly TKey[]>>>) => ((part: PartState) => readonly TKey[]);
+const groupPartByType: <TKey extends `group-${string}`>(map: Partial<Readonly<Record<GroupPartType, readonly TKey[]>>>) => ((part: PartState, context?: GroupByContext) => readonly TKey[]);
 ```
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/tools/rendering.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/rendering.mdx
@@ -65,6 +65,12 @@ type AssistantToolUIProps = {
   toolName: string;
   /** Component rendered for matching tool-call message parts. */
   render: ToolCallMessagePartComponent<TArgs, TResult>;
+  /**
+   * How the UI is presented relative to the chain-of-thought trace. Set
+   * `"standalone"` to surface it on its own (e.g. human-in-the-loop or
+   * generative UI for a backend/MCP tool). Defaults to `"inline"`.
+   */
+  display?: "standalone" | "inline";
 };
 
 const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<TArgs, TResult>) => AssistantToolUI;

--- a/apps/docs/scripts/api-reference/extract.mts
+++ b/apps/docs/scripts/api-reference/extract.mts
@@ -5,6 +5,7 @@ import {
   type InterfaceDeclaration,
   type JSDoc,
   type JSDocableNode,
+  type ModuleDeclaration,
   type Node as TsNode,
   type SourceFile,
   type Symbol as TsMorphSymbol,
@@ -44,9 +45,11 @@ let _allExportedNames: Set<string> | undefined;
 
 /** Every symbol name exported from the generator's package source trees —
  *  including internal exports that never reach the public api-reference (e.g.
- *  `GROUPBY_MEMO_KEY`). Lets the JSDoc renderer treat a `{@link}` to a real
- *  but unanchored symbol as a graceful no-op instead of a broken-link warning,
- *  reserving the warning for targets that name nothing that actually exists. */
+ *  `GROUPBY_MEMO_KEY`) and members nested inside an exported namespace (e.g.
+ *  `IndicatorPart` under `MessagePrimitive.GroupedParts`). Lets the JSDoc
+ *  renderer treat a `{@link}` to a real but unanchored symbol as a graceful
+ *  no-op instead of a broken-link warning, reserving the warning for targets
+ *  that name nothing that actually exists. */
 export function getAllExportedNames(): Set<string> {
   if (_allExportedNames) return _allExportedNames;
   const project = getProject();
@@ -56,12 +59,29 @@ export function getAllExportedNames(): Set<string> {
     if (!PACKAGE_SOURCE_ROOTS.some((root) => filePath.startsWith(root))) {
       continue;
     }
-    for (const symbol of sourceFile.getExportSymbols()) {
-      names.add(symbol.getName());
-    }
+    collectExportedNames(sourceFile, names);
   }
   _allExportedNames = names;
   return names;
+}
+
+/** Collects export names from a source file or namespace, recursing through
+ *  nested namespace declarations. Namespace-merged primitives (e.g.
+ *  `MessagePrimitive.GroupedParts`) keep their public types one level down, so
+ *  a `{@link IndicatorPart}` references the unqualified member name; without
+ *  the recursion those reads as broken links. */
+function collectExportedNames(
+  container: SourceFile | ModuleDeclaration,
+  names: Set<string>,
+): void {
+  for (const symbol of container.getExportSymbols()) {
+    names.add(symbol.getName());
+    for (const decl of symbol.getDeclarations()) {
+      if (Node.isModuleDeclaration(decl)) {
+        collectExportedNames(decl, names);
+      }
+    }
+  }
 }
 
 export function getProject(): Project {


### PR DESCRIPTION
## summary

- the grouped-parts docs on the message primitive api-reference page now cover the synthetic `standalone-tool-call` grouping key (replacing the stale `mcp-app` example) and the optional `GroupByContext` argument that `groupPartByType` now receives.
- the tool-rendering api-reference page documents the new `display: "standalone" | "inline"` hint on `AssistantToolUIProps`.
- the api-reference generator no longer prints false `unresolved JSDoc link` warnings for `{@link}` targets that resolve to namespace-nested exports (e.g. `IndicatorPart` under `MessagePrimitive.GroupedParts`); `getAllExportedNames` now recurses through namespace declarations so those count as known symbols. generated output is byte-identical.

## test plan

### already verified

- [x] `pnpm --filter=@assistant-ui/docs generate:reference-docs` -> zero `unresolved JSDoc link` warnings (previously two for `IndicatorPart`), and `apps/docs/generated/primitiveDocs.ts` unchanged so only the false warning is suppressed
- [x] oxlint + oxfmt clean on `extract.mts`

### reviewer should verify

- [ ] rendered docs: the grouped-parts page shows the `standalone-tool-call` example and the tool-rendering page shows the `display` prop

## notes

- follow-up to #4167 (`standalone-tool-call` grouping + `display` hint): documents that feature's public surface and clears the false build warnings its JSDoc produced.