### PR TITLE
fix(core): make Simple attachment adapters work without FileReader

### DIFF
--- a/.changeset/attachment-adapters-no-filereader.md
+++ b/.changeset/attachment-adapters-no-filereader.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(adapters): make Simple attachment adapters work outside the browser (no more `FileReader`).

--- a/packages/core/src/adapters/attachment.ts
+++ b/packages/core/src/adapters/attachment.ts
@@ -49,13 +49,22 @@ export class SimpleImageAttachmentAdapter implements AttachmentAdapter {
   }
 }
 
-const getFileDataURL = (file: File) =>
-  new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = (error) => reject(error);
-    reader.readAsDataURL(file);
-  });
+const bytesToBase64 = (bytes: Uint8Array): string => {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(bytes).toString("base64");
+  }
+
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+};
+
+const getFileDataURL = async (file: File): Promise<string> => {
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  return `data:${file.type};base64,${bytesToBase64(bytes)}`;
+};
 
 export class SimpleTextAttachmentAdapter implements AttachmentAdapter {
   public accept =
@@ -92,13 +101,7 @@ export class SimpleTextAttachmentAdapter implements AttachmentAdapter {
   }
 }
 
-const getFileText = (file: File) =>
-  new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = (error) => reject(error);
-    reader.readAsText(file);
-  });
+const getFileText = (file: File): Promise<string> => file.text();
 
 export function fileMatchesAccept(
   file: { name: string; type: string },

--- a/packages/core/src/tests/attachment-adapters.test.ts
+++ b/packages/core/src/tests/attachment-adapters.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import {
+  SimpleImageAttachmentAdapter,
+  SimpleTextAttachmentAdapter,
+} from "../adapters/attachment";
+import type { PendingAttachment } from "../types/attachment";
+
+const pending = (
+  file: File,
+  type: "image" | "document",
+): PendingAttachment => ({
+  id: file.name,
+  type,
+  name: file.name,
+  contentType: file.type,
+  file,
+  status: { type: "requires-action", reason: "composer-send" },
+});
+
+describe("Simple attachment adapters (no FileReader)", () => {
+  it("SimpleTextAttachmentAdapter reads text without FileReader", async () => {
+    const file = new File(["hello world"], "note.txt", { type: "text/plain" });
+    const result = await new SimpleTextAttachmentAdapter().send(
+      pending(file, "document"),
+    );
+
+    expect(result.status).toEqual({ type: "complete" });
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: "<attachment name=note.txt>\nhello world\n</attachment>",
+      },
+    ]);
+  });
+
+  it("SimpleImageAttachmentAdapter produces a base64 data URL without FileReader", async () => {
+    const bytes = new Uint8Array([137, 80, 78, 71]);
+    const file = new File([bytes], "pixel.png", { type: "image/png" });
+    const result = await new SimpleImageAttachmentAdapter().send(
+      pending(file, "image"),
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "image",
+        image: `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #4166
  
`SimpleImageAttachmentAdapter` / `SimpleTextAttachmentAdapter` used the browser-only `FileReader`, so sending an attachment in a non-browser environment (e.g. `@assistant-ui/react-ink`, which re-exports them) threw `ReferenceError: FileReader is not defined`.
  
  ## Changes
  - `getFileText` now uses `file.text()`.
  - `getFileDataURL` now uses `file.arrayBuffer()` + base64, rebuilding the `data:<mime>;base64,...` URL.
  - Added a `bytesToBase64` helper that prefers `Buffer` (Node) and falls back to `btoa` (browser). No new deps.
  - Added `attachment-adapters.test.ts` covering both adapters' `send()`. It runs in vitest's `node` env (no `FileReader`), so it reproduces the original crash.

Behavior-preserving for web/RN: `file.text()` and `arrayBuffer()`+base64 produce the same output `FileReader` did. RN keeps its own `FileReader`.