### PR TITLE
fix: resolve workspace type-check errors

### DIFF
--- a/.changeset/fix-next-node-types.md
+++ b/.changeset/fix-next-node-types.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/next": patch
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: resolve type-check errors — `@assistant-ui/next` now extends the Node tsconfig so `node:path` resolves, and drop an unused import in `react-langgraph`

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "extends": "@assistant-ui/x-buildutils/ts/base-node",
   "include": ["src"]
 }

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type {
   LangChainMessage,
   LangChainToolCall,


### PR DESCRIPTION
## What

Fixes two type-check (`pnpm test:types`) errors surfaced by `tsc --noEmit` across the workspace:

1. **`@assistant-ui/next`** — `src/loader.ts` imports `node:path`, but the package's `tsconfig.json` extended the browser-oriented `base` config (`"types": ["browser-process"]`), so Node builtin types weren't available → `TS2591: Cannot find name 'node:path'`. Switched it to extend `base-node` (`"types": ["node", "browser-process"]`), matching the other Node-targeted packages (`cli`, `create-assistant-ui`, `mcp-docs-server`, `agent-launcher`).

2. **`@assistant-ui/react-langgraph`** — `useLangGraphRuntime.ts` imported `useCallback` but never used it → `TS6133` (and an oxlint `no-unused-vars` warning). Removed the unused import.

## Verification

- `pnpm test:types` — both errors gone (remaining `examples/with-react-router` `+types/*` errors are pre-existing react-router typegen artifacts, unrelated to this change).
- `pnpm exec oxlint` — clean (the prior unused-import warning is gone).
- `pnpm turbo build --filter=@assistant-ui/next --filter=@assistant-ui/react-langgraph` — all tasks succeed.

A patch changeset is included for both published packages.

https://claude.ai/code/session_01N793mKokuwpg2FUpd9hFdE

---
_Generated by [Claude Code](https://claude.ai/code/session_01N793mKokuwpg2FUpd9hFdE)_