### PR TITLE
feat(cli): prompt to add agent skills on create

### DIFF
--- a/.changeset/create-skills-prompt.md
+++ b/.changeset/create-skills-prompt.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+feat: prompt to add assistant-ui agent skills when creating a project. `npx assistant-ui create` now asks whether to add the agent skills and, on yes, delegates to the `skills` CLI (`skills add assistant-ui/skills`) so it installs into your chosen agent platforms (Claude Code, Cursor, Zed, etc.). Use `--skills` / `--no-skills` to skip the prompt; non-interactive runs default to adding them.

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -14,6 +14,10 @@ import {
   transformProject,
 } from "../lib/create-project";
 import { runSpawn, SpawnExitError } from "../lib/run-spawn";
+import {
+  buildSkillsAddCommand,
+  resolveSkillsInstall,
+} from "../lib/agent-skill";
 
 export interface ProjectMetadata {
   name: string;
@@ -442,6 +446,8 @@ export const create = new Command()
   .option("--native", "create an Expo / React Native project")
   .option("--ink", "create a React Ink terminal project")
   .option("--skip-install", "skip installing packages")
+  .option("--skills", "add assistant-ui agent skills for AI coding assistants")
+  .option("--no-skills", "skip adding assistant-ui agent skills")
   .addOption(
     new Option(
       "--debug-source-root <path>",
@@ -530,6 +536,21 @@ export const create = new Command()
       process.exit(0);
     }
 
+    let installSkills = resolveSkillsInstall({ skills: opts.skills });
+    if (installSkills === undefined) {
+      const result = await p.confirm({
+        message: "Add assistant-ui agent skills for AI coding assistants?",
+        initialValue: true,
+      });
+
+      if (p.isCancel(result)) {
+        p.cancel("Project creation cancelled.");
+        process.exit(0);
+      }
+
+      installSkills = result;
+    }
+
     logger.info(`Creating project from ${project.category}: ${project.label}`);
     logger.break();
 
@@ -588,6 +609,18 @@ export const create = new Command()
           skipInstall: opts.skipInstall,
           packageManager: pm,
         });
+
+        if (installSkills) {
+          logger.step("Adding assistant-ui agent skills...");
+          const [skillsCmd, skillsArgs] = buildSkillsAddCommand(pm);
+          try {
+            await runSpawn(skillsCmd, skillsArgs, absoluteProjectDir);
+          } catch {
+            logger.warn(
+              `Could not add assistant-ui agent skills. You can add them later with:\n  ${skillsCmd} ${skillsArgs.join(" ")}`,
+            );
+          }
+        }
       } catch (err) {
         // Clean up partially created project directory
         fs.rmSync(absoluteProjectDir, { recursive: true, force: true });

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -536,7 +536,11 @@ export const create = new Command()
       process.exit(0);
     }
 
-    let installSkills = resolveSkillsInstall({ skills: opts.skills });
+    const stdinIsTTY = process.stdin.isTTY;
+    let installSkills = resolveSkillsInstall({
+      skills: opts.skills,
+      stdinIsTTY,
+    });
     if (installSkills === undefined) {
       const result = await p.confirm({
         message: "Add assistant-ui agent skills for AI coding assistants?",
@@ -612,7 +616,9 @@ export const create = new Command()
 
         if (installSkills) {
           logger.step("Adding assistant-ui agent skills...");
-          const [skillsCmd, skillsArgs] = buildSkillsAddCommand(pm);
+          const [skillsCmd, skillsArgs] = buildSkillsAddCommand(pm, {
+            stdinIsTTY,
+          });
           try {
             await runSpawn(skillsCmd, skillsArgs, absoluteProjectDir);
           } catch {

--- a/packages/cli/src/lib/agent-skill.ts
+++ b/packages/cli/src/lib/agent-skill.ts
@@ -1,0 +1,28 @@
+import { dlxCommand, type PackageManagerName } from "./create-project";
+
+export const SKILLS_PACKAGE = "assistant-ui/skills";
+
+export function resolveSkillsInstall(params: {
+  skills?: boolean;
+  stdinIsTTY?: boolean;
+}): boolean | undefined {
+  const { skills, stdinIsTTY = process.stdin.isTTY } = params;
+  if (skills !== undefined) return skills;
+  if (!stdinIsTTY) return true;
+  return undefined;
+}
+
+export function buildSkillsAddCommand(
+  pm: PackageManagerName,
+  params: { stdinIsTTY?: boolean } = {},
+): [string, string[]] {
+  const { stdinIsTTY = process.stdin.isTTY } = params;
+  const [command, dlxArgs] = dlxCommand(pm);
+  const args = [...dlxArgs, "skills", "add", SKILLS_PACKAGE];
+
+  // Without a TTY the skills CLI cannot prompt for agent platforms, so skip its
+  // confirmation; with a TTY it owns the platform selection interactively.
+  if (!stdinIsTTY) args.push("--yes");
+
+  return [command, args];
+}

--- a/packages/cli/test/lib/agent-skill.test.ts
+++ b/packages/cli/test/lib/agent-skill.test.ts
@@ -41,6 +41,14 @@ describe("buildSkillsAddCommand", () => {
       "pnpm",
       ["dlx", "skills", "add", SKILLS_PACKAGE],
     ]);
+    expect(buildSkillsAddCommand("yarn", { stdinIsTTY: true })).toEqual([
+      "yarn",
+      ["dlx", "skills", "add", SKILLS_PACKAGE],
+    ]);
+    expect(buildSkillsAddCommand("bun", { stdinIsTTY: true })).toEqual([
+      "bunx",
+      ["skills", "add", SKILLS_PACKAGE],
+    ]);
     expect(buildSkillsAddCommand("npm", { stdinIsTTY: true })).toEqual([
       "npx",
       ["--yes", "skills", "add", SKILLS_PACKAGE],
@@ -52,9 +60,23 @@ describe("buildSkillsAddCommand", () => {
     expect(args).not.toContain("--yes");
   });
 
-  it("passes --yes to the skills CLI when there is no TTY to prompt on", () => {
-    const [, args] = buildSkillsAddCommand("pnpm", { stdinIsTTY: false });
-    expect(args).toContain("--yes");
-    expect(args.at(-1)).toBe("--yes");
+  it("appends the skills CLI's --yes for every package manager when non-TTY", () => {
+    expect(buildSkillsAddCommand("pnpm", { stdinIsTTY: false })).toEqual([
+      "pnpm",
+      ["dlx", "skills", "add", SKILLS_PACKAGE, "--yes"],
+    ]);
+    expect(buildSkillsAddCommand("yarn", { stdinIsTTY: false })).toEqual([
+      "yarn",
+      ["dlx", "skills", "add", SKILLS_PACKAGE, "--yes"],
+    ]);
+    expect(buildSkillsAddCommand("bun", { stdinIsTTY: false })).toEqual([
+      "bunx",
+      ["skills", "add", SKILLS_PACKAGE, "--yes"],
+    ]);
+    // npm carries npx's own --yes (auto-confirm the package download) plus the skills CLI's --yes
+    expect(buildSkillsAddCommand("npm", { stdinIsTTY: false })).toEqual([
+      "npx",
+      ["--yes", "skills", "add", SKILLS_PACKAGE, "--yes"],
+    ]);
   });
 });

--- a/packages/cli/test/lib/agent-skill.test.ts
+++ b/packages/cli/test/lib/agent-skill.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveSkillsInstall,
+  buildSkillsAddCommand,
+  SKILLS_PACKAGE,
+} from "../../src/lib/agent-skill";
+
+describe("resolveSkillsInstall", () => {
+  it("honors an explicit --skills flag", () => {
+    expect(resolveSkillsInstall({ skills: true, stdinIsTTY: true })).toBe(true);
+    expect(resolveSkillsInstall({ skills: true, stdinIsTTY: false })).toBe(
+      true,
+    );
+  });
+
+  it("honors an explicit --no-skills flag", () => {
+    expect(resolveSkillsInstall({ skills: false, stdinIsTTY: true })).toBe(
+      false,
+    );
+    expect(resolveSkillsInstall({ skills: false, stdinIsTTY: false })).toBe(
+      false,
+    );
+  });
+
+  it("defers to a prompt (undefined) when no flag is set and stdin is a TTY", () => {
+    expect(
+      resolveSkillsInstall({ skills: undefined, stdinIsTTY: true }),
+    ).toBeUndefined();
+  });
+
+  it("defaults to true when no flag is set and stdin is not a TTY", () => {
+    expect(resolveSkillsInstall({ skills: undefined, stdinIsTTY: false })).toBe(
+      true,
+    );
+  });
+});
+
+describe("buildSkillsAddCommand", () => {
+  it("delegates to the skills CLI via the package manager's dlx runner", () => {
+    expect(buildSkillsAddCommand("pnpm", { stdinIsTTY: true })).toEqual([
+      "pnpm",
+      ["dlx", "skills", "add", SKILLS_PACKAGE],
+    ]);
+    expect(buildSkillsAddCommand("npm", { stdinIsTTY: true })).toEqual([
+      "npx",
+      ["--yes", "skills", "add", SKILLS_PACKAGE],
+    ]);
+  });
+
+  it("lets the skills CLI prompt for agent platforms when a TTY is available", () => {
+    const [, args] = buildSkillsAddCommand("pnpm", { stdinIsTTY: true });
+    expect(args).not.toContain("--yes");
+  });
+
+  it("passes --yes to the skills CLI when there is no TTY to prompt on", () => {
+    const [, args] = buildSkillsAddCommand("pnpm", { stdinIsTTY: false });
+    expect(args).toContain("--yes");
+    expect(args.at(-1)).toBe("--yes");
+  });
+});


### PR DESCRIPTION
closes #4152

## summary

- `npx assistant-ui create` now asks whether to add assistant-ui agent skills, and on yes delegates to the skills CLI (`skills add assistant-ui/skills`), which prompts for the agent platforms (Claude Code, Cursor, Zed, ...) and installs into each one's native location.
- skills stay in the separate `assistant-ui/skills` repo as the single source of truth; nothing is copied into the monorepo, so there is no second bundle to keep in sync.
- adds `--skills` / `--no-skills` to skip the prompt; non-interactive runs (CI, no TTY) default to adding them, and the install is non-fatal (warns with a manual retry command on failure).

## deliberately not included

these diverge from #4152's original proposal, on purpose:

- the canonical bundle is NOT moved into `packages/cli/plugin`. the separate `assistant-ui/skills` repo stays canonical, so `create` delegates to the `skills` CLI rather than shipping its own copy.
- the generated-app README pointer note, the `skills:sync-docs` / `skills:check-docs` CI guard, and the monorepo to repo mirror Action are omitted. they only mattered under the rejected "CLI plugin is canonical" design, or are the separate repo's own maintenance concern. trackable separately if wanted.

## test plan

### already verified

- [x] cli package: `pnpm vitest run test/lib/agent-skill.test.ts test/lib/create-project.test.ts` -> 24/24 green
- [x] `tsc --noEmit` + oxlint + oxfmt clean on the changed files

### reviewer should verify

- [ ] in a TTY, `npx assistant-ui create my-app`, answer yes at the skills prompt, confirm the skills CLI runs and installs into the selected platform (e.g. `.claude/skills/`)
- [ ] `npx assistant-ui create my-app --no-skills` shows no skills prompt and runs no skills install
- [ ] the skills CLI's own platform selection (Claude Code / Cursor / Zed / ...) appears when run interactively