### PR TITLE
docs: render the weather_search tool standalone (not geocode_location)

### DIFF
--- a/apps/docs/lib/docs-toolkit.tsx
+++ b/apps/docs/lib/docs-toolkit.tsx
@@ -19,7 +19,6 @@ export default defineToolkit({
     }),
     execute: async (args: { query: string }) =>
       geocodeLocationWithOpenMeteo(args.query),
-    display: "standalone",
     render: ({ result }: any) => {
       if (result?.error) {
         return (
@@ -79,6 +78,7 @@ export default defineToolkit({
       longitude: number;
       latitude: number;
     }) => fetchWeatherWidgetFromOpenMeteo(args),
+    display: "standalone",
     render: ({ args, result }: any) => {
       const isLoading = !result;
       const error = result?.success === false ? result.error : null;


### PR DESCRIPTION
Moves `display: "standalone"` from `geocode_location` to `weather_search` — the latter renders the `WeatherWidget`, so it's the one meant to display standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)