### PR TITLE
feat(docs): list deprecated/new packages and add ?refresh=true

### DIFF
--- a/apps/docs/app/(home)/packages/page.tsx
+++ b/apps/docs/app/(home)/packages/page.tsx
@@ -38,7 +38,7 @@ const HERO_STAT_ICONS = {
 export default async function PackagesPage() {
   const npm = await fetchNpmDownloads();
 
-  const topPackages = [...PACKAGES]
+  const topPackages = PACKAGES.filter((pkg) => !pkg.deprecated)
     .map((pkg) => ({
       name: pkg.name,
       weekly: npm.perPackage[pkg.name]?.weekly ?? 0,
@@ -52,6 +52,11 @@ export default async function PackagesPage() {
     Object.keys(PACKAGE_CATEGORIES) as PackageCategory[]
   ).filter((c) => (grouped[c]?.length ?? 0) > 0);
 
+  const activeCount = PACKAGES.filter((pkg) => !pkg.deprecated).length;
+  const surfaceCount = visibleCategories.filter(
+    (c) => c !== "deprecated",
+  ).length;
+
   const totalWeekly = Object.values(npm.perPackage).reduce(
     (sum, p) => sum + (p?.weekly ?? 0),
     0,
@@ -60,13 +65,13 @@ export default async function PackagesPage() {
   const heroStats = [
     {
       icon: HERO_STAT_ICONS.Package,
-      value: PACKAGES.length.toString(),
+      value: activeCount.toString(),
       label: "Packages",
       caption: "across the ecosystem",
     },
     {
       icon: HERO_STAT_ICONS.Layers,
-      value: visibleCategories.length.toString(),
+      value: surfaceCount.toString(),
       label: "Surfaces",
       caption: "categories shipped",
     },
@@ -92,8 +97,8 @@ export default async function PackagesPage() {
           Every distribution, in one place.
         </h1>
         <p className="text-muted-foreground mt-3 md:text-lg">
-          {PACKAGES.length} packages on npm, grouped by surface area. Pick the
-          one that fits your stack.
+          {activeCount} packages on npm, grouped by surface area. Pick the one
+          that fits your stack.
         </p>
       </header>
 
@@ -254,15 +259,22 @@ function PackageRow({
       className="group border-border hover:border-foreground/30 hover:bg-muted/40 flex flex-col gap-1.5 rounded-lg border p-4 transition-colors"
     >
       <div className="flex items-center justify-between gap-3">
-        <span className="truncate font-mono text-sm font-medium">
-          {pkg.name}
-        </span>
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate font-mono text-sm font-medium">
+            {pkg.name}
+          </span>
+          {pkg.deprecated ? (
+            <span className="text-muted-foreground border-border flex-shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-medium tracking-wide uppercase">
+              Deprecated
+            </span>
+          ) : null}
+        </div>
         <ArrowUpRight className="text-muted-foreground size-3.5 flex-shrink-0 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
       </div>
       <p className="text-muted-foreground text-sm leading-relaxed">
         {pkg.description}
       </p>
-      {weekly > 0 ? (
+      {weekly > 0 && !pkg.deprecated ? (
         <div className="mt-1 flex items-center justify-between gap-3">
           <div className="flex items-center gap-2 text-xs tabular-nums">
             <span className="text-muted-foreground">

--- a/apps/docs/app/(home)/packages/page.tsx
+++ b/apps/docs/app/(home)/packages/page.tsx
@@ -35,8 +35,13 @@ const HERO_STAT_ICONS = {
   Download,
 };
 
-export default async function PackagesPage() {
-  const npm = await fetchNpmDownloads();
+export default async function PackagesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ refresh?: string }>;
+}) {
+  const forceFresh = (await searchParams).refresh === "true";
+  const npm = await fetchNpmDownloads(forceFresh ? 0 : undefined);
 
   const topPackages = PACKAGES.filter((pkg) => !pkg.deprecated)
     .map((pkg) => ({

--- a/apps/docs/app/(home)/traction/page.tsx
+++ b/apps/docs/app/(home)/traction/page.tsx
@@ -53,8 +53,15 @@ type HeroStat = {
 
 const FLAGSHIP_PACKAGE = "@assistant-ui/react";
 
-export default async function TractionPage() {
-  const repo = await getRepo();
+export default async function TractionPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ refresh?: string }>;
+}) {
+  const forceFresh = (await searchParams).refresh === "true";
+  const revalidate = forceFresh ? 0 : undefined;
+
+  const repo = await getRepo(revalidate);
 
   const [
     npm,
@@ -65,13 +72,13 @@ export default async function TractionPage() {
     commitActivity,
     releaseActivity,
   ] = await Promise.all([
-    fetchNpmDownloads(),
-    fetchStarHistory(repo.stars),
-    fetchTimelineSeries(TIMELINE_PACKAGES),
-    fetchContributors(),
-    getDependents(),
-    fetchCommitActivity(),
-    fetchReleaseActivity(),
+    fetchNpmDownloads(revalidate),
+    fetchStarHistory(repo.stars, revalidate),
+    fetchTimelineSeries(TIMELINE_PACKAGES, revalidate),
+    fetchContributors(revalidate),
+    getDependents(revalidate),
+    fetchCommitActivity(revalidate),
+    fetchReleaseActivity(revalidate),
   ]);
 
   const days = daysSince(PROJECT_FACTS.firstCommitDate);

--- a/apps/docs/lib/github.ts
+++ b/apps/docs/lib/github.ts
@@ -33,11 +33,14 @@ async function ghFetch(
   revalidate: number,
   init?: RequestInit & { headers?: Record<string, string> },
 ): Promise<Response> {
-  return fetch(`${API_BASE}${path}`, {
-    ...init,
-    headers: ghHeaders(init?.headers),
-    next: { revalidate, ...(init?.next ?? {}) },
-  });
+  const { next: initNext, ...rest } = init ?? {};
+  const common = { ...rest, headers: ghHeaders(init?.headers) };
+  return fetch(
+    `${API_BASE}${path}`,
+    revalidate === 0
+      ? { ...common, cache: "no-store" }
+      : { ...common, next: { revalidate, ...(initNext ?? {}) } },
+  );
 }
 
 function parseLastPage(linkHeader: string | null): number | null {
@@ -60,9 +63,11 @@ const REPO_FALLBACK: RepoStats = {
   watchers: 80,
 };
 
-export async function getRepo(): Promise<RepoStats> {
+export async function getRepo(
+  revalidate: number = REVALIDATE.WARM,
+): Promise<RepoStats> {
   try {
-    const res = await ghFetch("", REVALIDATE.WARM);
+    const res = await ghFetch("", revalidate);
     if (!res.ok) return REPO_FALLBACK;
     const data = await res.json();
     return {
@@ -86,13 +91,16 @@ export type GitHubRelease = {
   created_at: string;
 };
 
-export async function getReleases(maxPages = 5): Promise<GitHubRelease[]> {
+export async function getReleases(
+  maxPages = 5,
+  revalidate: number = REVALIDATE.WARM,
+): Promise<GitHubRelease[]> {
   const all: GitHubRelease[] = [];
   try {
     for (let page = 1; page <= maxPages; page++) {
       const res = await ghFetch(
         `/releases?per_page=100&page=${page}`,
-        REVALIDATE.WARM,
+        revalidate,
       );
       if (!res.ok) break;
       const batch = (await res.json()) as GitHubRelease[];
@@ -110,11 +118,11 @@ export type CommitActivityWeek = {
   week: number;
 };
 
-export async function getCommitActivityStats(): Promise<
-  CommitActivityWeek[] | null
-> {
+export async function getCommitActivityStats(
+  revalidate: number = REVALIDATE.COOL,
+): Promise<CommitActivityWeek[] | null> {
   try {
-    const res = await ghFetch("/stats/commit_activity", REVALIDATE.COOL);
+    const res = await ghFetch("/stats/commit_activity", revalidate);
     // 202 means GitHub is still computing; caller falls back to commit list.
     if (!res.ok || res.status === 202) return null;
     const data = (await res.json()) as CommitActivityWeek[];
@@ -134,13 +142,14 @@ export type CommitListItem = {
 export async function getCommitsSince(
   sinceIso: string,
   maxPages = 20,
+  revalidate: number = REVALIDATE.COOL,
 ): Promise<CommitListItem[]> {
   const all: CommitListItem[] = [];
   try {
     for (let page = 1; page <= maxPages; page++) {
       const res = await ghFetch(
         `/commits?since=${sinceIso}&per_page=100&page=${page}`,
-        REVALIDATE.COOL,
+        revalidate,
       );
       if (!res.ok) break;
       const batch = (await res.json()) as CommitListItem[];
@@ -162,13 +171,14 @@ export type GitHubContributor = {
 
 export async function getContributors(
   maxPages = 2,
+  revalidate: number = REVALIDATE.COOL,
 ): Promise<GitHubContributor[]> {
   const all: GitHubContributor[] = [];
   try {
     for (let page = 1; page <= maxPages; page++) {
       const res = await ghFetch(
         `/contributors?per_page=100&page=${page}`,
-        REVALIDATE.COOL,
+        revalidate,
       );
       if (!res.ok) break;
       const batch = (await res.json()) as GitHubContributor[];
@@ -182,14 +192,17 @@ export async function getContributors(
 
 export type StargazerEntry = { starred_at: string };
 
-export async function getStargazersPage(page: number): Promise<{
+export async function getStargazersPage(
+  page: number,
+  revalidate: number = REVALIDATE.COOL,
+): Promise<{
   data: StargazerEntry[];
   lastPage: number | null;
 }> {
   try {
     const res = await ghFetch(
       `/stargazers?per_page=100&page=${page}`,
-      REVALIDATE.COOL,
+      revalidate,
       { headers: { Accept: "application/vnd.github.star+json" } },
     );
     if (!res.ok) return { data: [], lastPage: null };
@@ -200,14 +213,18 @@ export async function getStargazersPage(page: number): Promise<{
   }
 }
 
-export async function getDependents(): Promise<{
+export async function getDependents(
+  revalidate: number = REVALIDATE.COOL,
+): Promise<{
   repos: number;
   packages: number;
 } | null> {
   try {
     const res = await fetch(`${HTML_BASE}/network/dependents`, {
       headers: { "User-Agent": "Mozilla/5.0 (assistant-ui-traction)" },
-      next: { revalidate: REVALIDATE.COOL },
+      ...(revalidate === 0
+        ? { cache: "no-store" as const }
+        : { next: { revalidate } }),
     });
     if (!res.ok) return null;
     const html = await res.text();

--- a/apps/docs/lib/npm.ts
+++ b/apps/docs/lib/npm.ts
@@ -14,7 +14,10 @@ async function npmFetch(
   revalidate: number,
 ): Promise<NpmDailyDownloads[]> {
   try {
-    const res = await fetch(`${NPM_BASE}${path}`, { next: { revalidate } });
+    const res = await fetch(
+      `${NPM_BASE}${path}`,
+      revalidate === 0 ? { cache: "no-store" } : { next: { revalidate } },
+    );
     if (!res.ok) return [];
     const data = (await res.json()) as { downloads?: NpmDailyDownloads[] };
     return data.downloads ?? [];

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -430,7 +430,7 @@ export async function fetchNpmDownloads(
   revalidate?: number,
 ): Promise<NpmDownloads> {
   const entries = await Promise.all(
-    PACKAGES.map(
+    PACKAGES.filter((pkg) => !pkg.deprecated).map(
       async (pkg) =>
         [
           pkg.name,

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -323,8 +323,10 @@ export type ActivityPoint = {
   count: number;
 };
 
-export async function fetchCommitActivity(): Promise<ActivityPoint[]> {
-  const stats = await getCommitActivityStats();
+export async function fetchCommitActivity(
+  revalidate?: number,
+): Promise<ActivityPoint[]> {
+  const stats = await getCommitActivityStats(revalidate);
   if (stats && stats.length > 0) {
     const points: ActivityPoint[] = [];
     for (const week of stats) {
@@ -342,7 +344,11 @@ export async function fetchCommitActivity(): Promise<ActivityPoint[]> {
 
   const since = new Date();
   since.setUTCDate(since.getUTCDate() - 365);
-  const items = await getCommitsSince(since.toISOString());
+  const items = await getCommitsSince(
+    since.toISOString(),
+    undefined,
+    revalidate,
+  );
 
   const counts = new Map<string, number>();
   for (const c of items) {
@@ -354,9 +360,11 @@ export async function fetchCommitActivity(): Promise<ActivityPoint[]> {
   return Array.from(counts.entries()).map(([date, count]) => ({ date, count }));
 }
 
-export async function fetchReleaseActivity(): Promise<ActivityPoint[]> {
+export async function fetchReleaseActivity(
+  revalidate?: number,
+): Promise<ActivityPoint[]> {
   const cutoff = Date.now() - 365 * 86_400_000;
-  const releases = await getReleases();
+  const releases = await getReleases(undefined, revalidate);
 
   const counts = new Map<string, number>();
   for (const r of releases) {
@@ -368,8 +376,10 @@ export async function fetchReleaseActivity(): Promise<ActivityPoint[]> {
   return Array.from(counts.entries()).map(([date, count]) => ({ date, count }));
 }
 
-export async function fetchContributors(): Promise<Contributor[]> {
-  const raw = await getContributors();
+export async function fetchContributors(
+  revalidate?: number,
+): Promise<Contributor[]> {
+  const raw = await getContributors(undefined, revalidate);
   return raw
     .filter((c) => c.type !== "Bot" && !/\[bot\]$/i.test(c.login))
     .map((c) => ({
@@ -391,6 +401,7 @@ const sum = (arr: number[]) => arr.reduce((acc, n) => acc + n, 0);
 
 async function fetchPackageDownloadRange(
   name: string,
+  revalidate?: number,
 ): Promise<PackageDownloads> {
   const today = new Date();
   const end = today.toISOString().slice(0, 10);
@@ -398,7 +409,7 @@ async function fetchPackageDownloadRange(
   start.setUTCDate(today.getUTCDate() - 60);
   const startStr = start.toISOString().slice(0, 10);
 
-  const downloads = await getDownloadsRange(name, startStr, end);
+  const downloads = await getDownloadsRange(name, startStr, end, revalidate);
   const all = downloads.map((d) => d.downloads);
   if (all.length === 0) return EMPTY_DOWNLOADS;
 
@@ -415,11 +426,16 @@ async function fetchPackageDownloadRange(
   };
 }
 
-export async function fetchNpmDownloads(): Promise<NpmDownloads> {
+export async function fetchNpmDownloads(
+  revalidate?: number,
+): Promise<NpmDownloads> {
   const entries = await Promise.all(
     PACKAGES.map(
       async (pkg) =>
-        [pkg.name, await fetchPackageDownloadRange(pkg.name)] as const,
+        [
+          pkg.name,
+          await fetchPackageDownloadRange(pkg.name, revalidate),
+        ] as const,
     ),
   );
   const perPackage: Record<string, PackageDownloads> = {};
@@ -456,6 +472,7 @@ export type TimelineSeries = {
 
 export async function fetchTimelineSeries(
   packages: readonly string[],
+  revalidate?: number,
 ): Promise<TimelineSeries> {
   const fetched = await Promise.all(
     packages.map(async (pkg, idx) => ({
@@ -463,7 +480,7 @@ export async function fetchTimelineSeries(
       pkg,
       label: pkg.replace(/^@assistant-ui\//, "").replace(/^assistant-/, ""),
       chartIndex: (idx % 5) + 1,
-      points: await fetchDownloadsTimeline(pkg),
+      points: await fetchDownloadsTimeline(pkg, revalidate),
     })),
   );
 
@@ -513,8 +530,9 @@ export async function fetchTimelineSeries(
 
 export async function fetchDownloadsTimeline(
   name: string,
+  revalidate?: number,
 ): Promise<TimelinePoint[]> {
-  const downloads = await getDownloadsLastYear(name);
+  const downloads = await getDownloadsLastYear(name, revalidate);
   if (!downloads.length) return [];
   const cutoff = currentMonthKey();
   type MonthBucket = {
@@ -597,9 +615,10 @@ function projectInflightMonth(
 
 export async function fetchStarHistory(
   totalStars: number,
+  revalidate?: number,
 ): Promise<TimelinePoint[]> {
   try {
-    const first = await getStargazersPage(1);
+    const first = await getStargazersPage(1, revalidate);
     if (first.data.length === 0) return [];
 
     const lastPage = first.lastPage ?? Math.max(1, Math.ceil(totalStars / 100));
@@ -619,7 +638,7 @@ export async function fetchStarHistory(
     const fetched = await Promise.all(
       pages.map(async (page) => {
         if (page === 1) return { page, data: first.data };
-        const result = await getStargazersPage(page);
+        const result = await getStargazersPage(page, revalidate);
         return { page, data: result.data };
       }),
     );

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -11,6 +11,7 @@ export type PackageInfo = {
   name: string;
   description: string;
   category: PackageCategory;
+  deprecated?: boolean;
 };
 
 export type PackageCategory =
@@ -23,7 +24,8 @@ export type PackageCategory =
   | "ui"
   | "effects"
   | "mcp"
-  | "observability";
+  | "observability"
+  | "deprecated";
 
 export const PACKAGE_CATEGORIES: Record<
   PackageCategory,
@@ -69,6 +71,10 @@ export const PACKAGE_CATEGORIES: Record<
     label: "Observability",
     description: "Trace, debug, and measure assistants.",
   },
+  deprecated: {
+    label: "Deprecated",
+    description: "No longer maintained. Kept on npm for existing installs.",
+  },
 };
 
 export const PACKAGES: PackageInfo[] = [
@@ -105,6 +111,21 @@ export const PACKAGES: PackageInfo[] = [
   {
     name: "@assistant-ui/x-buildutils",
     description: "Shared build utilities for the monorepo.",
+    category: "tooling",
+  },
+  {
+    name: "@assistant-ui/next",
+    description: "Next.js plugin for the generative UI compiler.",
+    category: "tooling",
+  },
+  {
+    name: "@assistant-ui/vite",
+    description: "Vite plugin for the generative UI compiler.",
+    category: "tooling",
+  },
+  {
+    name: "@assistant-ui/x-generative-compiler",
+    description: 'Framework-agnostic "use generative" compiler.',
     category: "tooling",
   },
   {
@@ -238,9 +259,38 @@ export const PACKAGES: PackageInfo[] = [
     category: "mcp",
   },
   {
+    name: "@assistant-ui/react-mcp",
+    description: "MCP server configuration and connection primitives.",
+    category: "mcp",
+  },
+  {
     name: "@assistant-ui/react-o11y",
     description: "Observability primitives for assistants.",
     category: "observability",
+  },
+  {
+    name: "@assistant-ui/react-edge",
+    description: "Legacy edge runtime, superseded by the AI SDK adapter.",
+    category: "deprecated",
+    deprecated: true,
+  },
+  {
+    name: "@assistant-ui/styles",
+    description: "Prebuilt styles for non-Tailwind users.",
+    category: "deprecated",
+    deprecated: true,
+  },
+  {
+    name: "@assistant-ui/react-trieve",
+    description: "Trieve search integration.",
+    category: "deprecated",
+    deprecated: true,
+  },
+  {
+    name: "@assistant-ui/react-playground",
+    description: "Standalone playground runtime.",
+    category: "deprecated",
+    deprecated: true,
   },
 ];
 
@@ -651,7 +701,7 @@ export const PROJECT_FACTS = {
   firstCommitDate: "2024-04-21",
   totalCommits: 3062,
   uniqueAuthors: 100,
-  publicPackages: PACKAGES.length,
+  publicPackages: PACKAGES.filter((pkg) => !pkg.deprecated).length,
   examples: 30,
   showcased: 8,
 } as const;

--- a/apps/docs/turbo.json
+++ b/apps/docs/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "dev": {
+      "dependsOn": ["^build"],
+      "cache": false,
+      "persistent": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "cleanup": "bash scripts/cleanup-monorepo.sh",
-    "docs:dev": "pnpm --filter=@assistant-ui/docs dev",
+    "docs:dev": "turbo run dev --filter=@assistant-ui/docs",
     "ci:version": "changeset version && pnpm install --no-frozen-lockfile",
     "ci:publish": "turbo build --filter=\"./packages/*\" && changeset publish",
     "build": "turbo build",

--- a/turbo.json
+++ b/turbo.json
@@ -45,7 +45,6 @@
       "dependsOn": ["build", "lint", "test"]
     },
     "dev": {
-      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     }

--- a/turbo.json
+++ b/turbo.json
@@ -45,6 +45,7 @@
       "dependsOn": ["build", "lint", "test"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     }


### PR DESCRIPTION
## summary

- the packages page now lists every published package: adds @assistant-ui/next, @assistant-ui/vite, @assistant-ui/x-generative-compiler, and @assistant-ui/react-mcp, plus a new "Deprecated" section for react-edge, styles, react-trieve, and react-playground (badged, and excluded from the download ranking, hero counts, and growth metrics).
- /packages and /traction now accept ?refresh=true to bypass the data cache and pull live npm/GitHub numbers; without the param the existing revalidate windows still apply (npm 1h, GitHub 1h/6h).
- docs dev no longer 500s after pulling new workspace packages: the turbo dev task now dependsOn "^build" and docs:dev runs through turbo, so deps like @assistant-ui/next (used by withAui() in next.config) are built before next dev starts.

## test plan

### already verified

- [x] `pnpm docs:dev`, then loaded /, /packages, /traction in Chrome -> all 200, no module-resolution 500s
- [x] forced-refresh actually bypasses cache: cached /traction ~452ms vs /traction?refresh=true ~1706ms (live refetch), both 200
- [x] `pnpm turbo run dev --filter=@assistant-ui/docs --dry=json` -> @assistant-ui/next#build and @assistant-ui/x-generative-compiler#build scheduled as cache HIT before @assistant-ui/docs#dev
- [x] oxlint + oxfmt clean on all changed files; tsc reports no errors in the changed files

### reviewer should verify

- [ ] visit /packages and confirm the Deprecated section renders with badges and the hero shows only active packages (38 packages, 10 surfaces)
- [ ] visit /traction?refresh=true and confirm the numbers reflect live data

## notes

- @assistant-ui/docs is a private package, so no changeset is required.
- both routes render dynamically now (they read searchParams); non-refresh requests still reuse the fetch data cache. unauthenticated GitHub calls are rate-limited to 60/hr, so heavy ?refresh=true spam falls back to cached/fallback values rather than erroring.