### PR TITLE
feat(react-ag-ui): add STATE_DELTA event support

### DIFF
--- a/.changeset/state-delta.md
+++ b/.changeset/state-delta.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat(react-ag-ui): add STATE_DELTA event support

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -26,6 +26,7 @@ import {
   toAgUiTools,
 } from "./adapter/conversions";
 import { createAgUiSubscriber } from "./adapter/subscriber";
+import { applyJsonPatch } from "./json-patch";
 
 const optimisticPrefix = "__optimistic__";
 const generateOptimisticId = () => `${optimisticPrefix}${generateId()}`;
@@ -730,7 +731,15 @@ export class AgUiThreadRuntimeCore {
         return;
       }
       case "STATE_DELTA": {
-        this.logger.debug?.("[agui] state delta event ignored", event.delta);
+        try {
+          this.stateSnapshot = applyJsonPatch(
+            this.stateSnapshot,
+            event.delta,
+          ) as ReadonlyJSONValue;
+          this.notifyUpdate();
+        } catch (error) {
+          this.logger.error?.("[agui] failed to apply state delta", error);
+        }
         return;
       }
       case "MESSAGES_SNAPSHOT": {

--- a/packages/react-ag-ui/src/runtime/json-patch.ts
+++ b/packages/react-ag-ui/src/runtime/json-patch.ts
@@ -1,0 +1,184 @@
+type JsonPatchOp = {
+  op: "add" | "remove" | "replace" | "move" | "copy" | "test";
+  path: string;
+  value?: unknown;
+  from?: string;
+};
+
+function parsePath(path: string): string[] {
+  if (path === "") return [];
+  if (!path.startsWith("/")) throw new Error(`Invalid JSON Pointer: ${path}`);
+  return path
+    .slice(1)
+    .split("/")
+    .map((s) => s.replace(/~1/g, "/").replace(/~0/g, "~"));
+}
+
+function requireFrom(patch: JsonPatchOp): string {
+  if (typeof patch.from !== "string") {
+    throw new Error(`'${patch.op}' op requires a 'from' string pointer`);
+  }
+  return patch.from;
+}
+
+function getParentAndKey(
+  doc: any,
+  segments: string[],
+): { parent: any; key: string } {
+  let current = doc;
+  for (let i = 0; i < segments.length - 1; i++) {
+    current = current[segments[i]!];
+    if (current === undefined || current === null) {
+      throw new Error(`Path not found: ${segments.slice(0, i + 1).join("/")}`);
+    }
+  }
+  return { parent: current, key: segments[segments.length - 1]! };
+}
+
+function requireExists(parent: any, key: string, path: string): void {
+  if (Array.isArray(parent)) {
+    const index = Number(key);
+    if (!Number.isInteger(index) || index < 0 || index >= parent.length) {
+      throw new Error(`Path not found: ${path}`);
+    }
+  } else if (
+    parent === null ||
+    typeof parent !== "object" ||
+    !(key in parent)
+  ) {
+    throw new Error(`Path not found: ${path}`);
+  }
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b || a === null || b === null) return false;
+  if (typeof a !== "object") return false;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    return a.every((item, i) => deepEqual(item, b[i]));
+  }
+  const aKeys = Object.keys(a as object);
+  const bKeys = Object.keys(b as object);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every(
+    (k) =>
+      k in (b as object) &&
+      deepEqual((a as any)[k], (b as Record<string, unknown>)[k]),
+  );
+}
+
+function getValue(doc: any, segments: string[]): unknown {
+  let current = doc;
+  for (const seg of segments) {
+    if (current === undefined || current === null) {
+      throw new Error(`Path not found`);
+    }
+    current = current[seg];
+  }
+  return current;
+}
+
+function addAt(parent: any, key: string, value: unknown): void {
+  if (Array.isArray(parent)) {
+    if (key === "-") parent.push(value);
+    else parent.splice(Number(key), 0, value);
+  } else {
+    parent[key] = value;
+  }
+}
+
+export function applyJsonPatch(
+  doc: unknown,
+  patches: readonly JsonPatchOp[],
+): unknown {
+  if (patches.length === 0) return doc;
+  let result = structuredClone(doc);
+
+  for (const patch of patches) {
+    const segments = parsePath(patch.path);
+
+    switch (patch.op) {
+      case "add": {
+        if (segments.length === 0) {
+          result = patch.value;
+        } else {
+          const { parent, key } = getParentAndKey(result, segments);
+          addAt(parent, key, patch.value);
+        }
+        break;
+      }
+      case "remove": {
+        if (segments.length === 0) {
+          result = undefined;
+        } else {
+          const { parent, key } = getParentAndKey(result, segments);
+          if (Array.isArray(parent)) {
+            parent.splice(Number(key), 1);
+          } else {
+            delete parent[key];
+          }
+        }
+        break;
+      }
+      case "replace": {
+        if (segments.length === 0) {
+          result = patch.value;
+        } else {
+          const { parent, key } = getParentAndKey(result, segments);
+          requireExists(parent, key, patch.path);
+          parent[key] = patch.value;
+        }
+        break;
+      }
+      case "move": {
+        const from = requireFrom(patch);
+        const fromSegments = parsePath(from);
+        const { parent: fromParent, key: fromKey } = getParentAndKey(
+          result,
+          fromSegments,
+        );
+        requireExists(fromParent, fromKey, from);
+        const value = fromParent[fromKey];
+        if (Array.isArray(fromParent)) {
+          fromParent.splice(Number(fromKey), 1);
+        } else {
+          delete fromParent[fromKey];
+        }
+        if (segments.length === 0) {
+          result = value;
+        } else {
+          const { parent, key } = getParentAndKey(result, segments);
+          addAt(parent, key, value);
+        }
+        break;
+      }
+      case "copy": {
+        const fromSegments = parsePath(requireFrom(patch));
+        const value = structuredClone(getValue(result, fromSegments));
+        if (segments.length === 0) {
+          result = value;
+        } else {
+          const { parent, key } = getParentAndKey(result, segments);
+          addAt(parent, key, value);
+        }
+        break;
+      }
+      case "test": {
+        const actual = getValue(result, segments);
+        if (!deepEqual(actual, patch.value)) {
+          throw new Error(
+            `Test failed: ${patch.path} expected ${JSON.stringify(patch.value)} but got ${JSON.stringify(actual)}`,
+          );
+        }
+        break;
+      }
+      default:
+        throw new Error(`Unknown JSON Patch op: ${(patch as JsonPatchOp).op}`);
+    }
+  }
+
+  return result;
+}

--- a/packages/react-ag-ui/src/runtime/json-patch.ts
+++ b/packages/react-ag-ui/src/runtime/json-patch.ts
@@ -75,19 +75,26 @@ function deepEqual(a: unknown, b: unknown): boolean {
 
 function getValue(doc: any, segments: string[]): unknown {
   let current = doc;
-  for (const seg of segments) {
+  for (let i = 0; i < segments.length; i++) {
     if (current === undefined || current === null) {
-      throw new Error(`Path not found`);
+      throw new Error(`Path not found: ${segments.slice(0, i + 1).join("/")}`);
     }
-    current = current[seg];
+    current = current[segments[i]!];
   }
   return current;
 }
 
 function addAt(parent: any, key: string, value: unknown): void {
   if (Array.isArray(parent)) {
-    if (key === "-") parent.push(value);
-    else parent.splice(Number(key), 0, value);
+    if (key === "-") {
+      parent.push(value);
+      return;
+    }
+    const index = Number(key);
+    if (!Number.isInteger(index) || index < 0 || index > parent.length) {
+      throw new Error(`Invalid array index: ${key}`);
+    }
+    parent.splice(index, 0, value);
   } else {
     parent[key] = value;
   }
@@ -118,6 +125,7 @@ export function applyJsonPatch(
           result = undefined;
         } else {
           const { parent, key } = getParentAndKey(result, segments);
+          requireExists(parent, key, patch.path);
           if (Array.isArray(parent)) {
             parent.splice(Number(key), 1);
           } else {

--- a/packages/react-ag-ui/src/runtime/json-patch.ts
+++ b/packages/react-ag-ui/src/runtime/json-patch.ts
@@ -1,3 +1,6 @@
+// Minimal RFC 6902 (JSON Patch) implementation scoped to the ops AG-UI agents
+// emit via STATE_DELTA. Not a general-purpose patch library: it validates the
+// ops it supports and throws on anything outside that subset.
 type JsonPatchOp = {
   op: "add" | "remove" | "replace" | "move" | "copy" | "test";
   path: string;
@@ -156,7 +159,12 @@ export function applyJsonPatch(
         break;
       }
       case "copy": {
-        const fromSegments = parsePath(requireFrom(patch));
+        const from = requireFrom(patch);
+        const fromSegments = parsePath(from);
+        if (fromSegments.length > 0) {
+          const { parent, key } = getParentAndKey(result, fromSegments);
+          requireExists(parent, key, from);
+        }
         const value = structuredClone(getValue(result, fromSegments));
         if (segments.length === 0) {
           result = value;

--- a/packages/react-ag-ui/src/runtime/json-patch.ts
+++ b/packages/react-ag-ui/src/runtime/json-patch.ts
@@ -28,6 +28,9 @@ function getParentAndKey(
   doc: any,
   segments: string[],
 ): { parent: any; key: string } {
+  if (segments.length === 0) {
+    throw new Error("Cannot resolve a parent for the document root");
+  }
   let current = doc;
   for (let i = 0; i < segments.length - 1; i++) {
     current = current[segments[i]!];
@@ -76,7 +79,11 @@ function deepEqual(a: unknown, b: unknown): boolean {
 function getValue(doc: any, segments: string[]): unknown {
   let current = doc;
   for (let i = 0; i < segments.length; i++) {
-    if (current === undefined || current === null) {
+    if (
+      current === null ||
+      typeof current !== "object" ||
+      !(segments[i]! in current)
+    ) {
       throw new Error(`Path not found: ${segments.slice(0, i + 1).join("/")}`);
     }
     current = current[segments[i]!];
@@ -97,6 +104,14 @@ function addAt(parent: any, key: string, value: unknown): void {
     parent.splice(index, 0, value);
   } else {
     parent[key] = value;
+  }
+}
+
+function removeAt(parent: any, key: string): void {
+  if (Array.isArray(parent)) {
+    parent.splice(Number(key), 1);
+  } else {
+    delete parent[key];
   }
 }
 
@@ -126,11 +141,7 @@ export function applyJsonPatch(
         } else {
           const { parent, key } = getParentAndKey(result, segments);
           requireExists(parent, key, patch.path);
-          if (Array.isArray(parent)) {
-            parent.splice(Number(key), 1);
-          } else {
-            delete parent[key];
-          }
+          removeAt(parent, key);
         }
         break;
       }
@@ -146,6 +157,11 @@ export function applyJsonPatch(
       }
       case "move": {
         const from = requireFrom(patch);
+        if (from !== "" && patch.path.startsWith(`${from}/`)) {
+          throw new Error(
+            `move 'path' (${patch.path}) must not be a descendant of 'from' (${from})`,
+          );
+        }
         const fromSegments = parsePath(from);
         const { parent: fromParent, key: fromKey } = getParentAndKey(
           result,
@@ -153,11 +169,7 @@ export function applyJsonPatch(
         );
         requireExists(fromParent, fromKey, from);
         const value = fromParent[fromKey];
-        if (Array.isArray(fromParent)) {
-          fromParent.splice(Number(fromKey), 1);
-        } else {
-          delete fromParent[fromKey];
-        }
+        removeAt(fromParent, fromKey);
         if (segments.length === 0) {
           result = value;
         } else {
@@ -167,12 +179,7 @@ export function applyJsonPatch(
         break;
       }
       case "copy": {
-        const from = requireFrom(patch);
-        const fromSegments = parsePath(from);
-        if (fromSegments.length > 0) {
-          const { parent, key } = getParentAndKey(result, fromSegments);
-          requireExists(parent, key, from);
-        }
+        const fromSegments = parsePath(requireFrom(patch));
         const value = structuredClone(getValue(result, fromSegments));
         if (segments.length === 0) {
           result = value;

--- a/packages/react-ag-ui/test/json-patch.spec.ts
+++ b/packages/react-ag-ui/test/json-patch.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { applyJsonPatch } from "../src/runtime/json-patch";
+
+describe("applyJsonPatch", () => {
+  it("should apply 'replace' operation", () => {
+    const doc = { count: 1, name: "test" };
+    const result = applyJsonPatch(doc, [
+      { op: "replace", path: "/count", value: 42 },
+    ]);
+    expect(result).toEqual({ count: 42, name: "test" });
+  });
+
+  it("should apply 'add' operation", () => {
+    const doc = { items: ["a"] };
+    const result = applyJsonPatch(doc, [
+      { op: "add", path: "/items/-", value: "b" },
+    ]);
+    expect(result).toEqual({ items: ["a", "b"] });
+  });
+
+  it("should apply 'add' to nested path", () => {
+    const doc = { a: {} };
+    const result = applyJsonPatch(doc, [{ op: "add", path: "/a/b", value: 1 }]);
+    expect(result).toEqual({ a: { b: 1 } });
+  });
+
+  it("should apply 'remove' operation", () => {
+    const doc = { a: 1, b: 2 };
+    const result = applyJsonPatch(doc, [{ op: "remove", path: "/b" }]);
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it("should apply 'move' operation", () => {
+    const doc = { a: 1, b: { c: 2 } };
+    const result = applyJsonPatch(doc, [
+      { op: "move", from: "/b/c", path: "/d" },
+    ]);
+    expect(result).toEqual({ a: 1, b: {}, d: 2 });
+  });
+
+  it("should apply 'copy' operation", () => {
+    const doc = { a: 1 };
+    const result = applyJsonPatch(doc, [
+      { op: "copy", from: "/a", path: "/b" },
+    ]);
+    expect(result).toEqual({ a: 1, b: 1 });
+  });
+
+  it("should apply 'test' operation (passes)", () => {
+    const doc = { a: 1 };
+    expect(() =>
+      applyJsonPatch(doc, [{ op: "test", path: "/a", value: 1 }]),
+    ).not.toThrow();
+  });
+
+  it("should throw on failing 'test' operation", () => {
+    const doc = { a: 1 };
+    expect(() =>
+      applyJsonPatch(doc, [{ op: "test", path: "/a", value: 2 }]),
+    ).toThrow();
+  });
+
+  it("should apply multiple operations in order", () => {
+    const doc = { count: 0 };
+    const result = applyJsonPatch(doc, [
+      { op: "replace", path: "/count", value: 1 },
+      { op: "add", path: "/name", value: "test" },
+    ]);
+    expect(result).toEqual({ count: 1, name: "test" });
+  });
+
+  it("should handle root replacement", () => {
+    const doc = { old: true };
+    const result = applyJsonPatch(doc, [
+      { op: "replace", path: "", value: { new: true } },
+    ]);
+    expect(result).toEqual({ new: true });
+  });
+
+  it("should return original document if patch is empty", () => {
+    const doc = { a: 1 };
+    const result = applyJsonPatch(doc, []);
+    expect(result).toBe(doc);
+  });
+
+  it("should splice-insert (not overwrite) when 'move' targets an array index", () => {
+    const doc = { src: "x", items: ["a", "b", "c"] };
+    const result = applyJsonPatch(doc, [
+      { op: "move", from: "/src", path: "/items/1" },
+    ]);
+    expect(result).toEqual({ items: ["a", "x", "b", "c"] });
+  });
+
+  it("should splice-insert (not overwrite) when 'copy' targets an array index", () => {
+    const doc = { src: "x", items: ["a", "b", "c"] };
+    const result = applyJsonPatch(doc, [
+      { op: "copy", from: "/src", path: "/items/1" },
+    ]);
+    expect(result).toEqual({ src: "x", items: ["a", "x", "b", "c"] });
+  });
+
+  it("should throw a descriptive error when 'move' lacks 'from'", () => {
+    expect(() =>
+      applyJsonPatch({ a: 1 }, [{ op: "move", path: "/b" } as any]),
+    ).toThrow(/'move' op requires a 'from'/);
+  });
+
+  it("should throw a descriptive error when 'copy' lacks 'from'", () => {
+    expect(() =>
+      applyJsonPatch({ a: 1 }, [{ op: "copy", path: "/b" } as any]),
+    ).toThrow(/'copy' op requires a 'from'/);
+  });
+
+  it("should throw when 'replace' targets a non-existent path", () => {
+    expect(() =>
+      applyJsonPatch({ a: 1 }, [{ op: "replace", path: "/b", value: 2 }]),
+    ).toThrow(/Path not found/);
+  });
+
+  it("should throw when 'move' source does not exist", () => {
+    expect(() =>
+      applyJsonPatch({ a: 1 }, [{ op: "move", from: "/missing", path: "/b" }]),
+    ).toThrow(/Path not found/);
+  });
+
+  it("should throw on an unknown op", () => {
+    expect(() =>
+      applyJsonPatch({ a: 1 }, [{ op: "increment", path: "/a" } as any]),
+    ).toThrow(/Unknown JSON Patch op/);
+  });
+
+  it("should pass 'test' regardless of object key order", () => {
+    const doc = { obj: { a: 1, b: 2 } };
+    expect(() =>
+      applyJsonPatch(doc, [
+        { op: "test", path: "/obj", value: { b: 2, a: 1 } },
+      ]),
+    ).not.toThrow();
+  });
+});

--- a/packages/react-ag-ui/test/json-patch.spec.ts
+++ b/packages/react-ag-ui/test/json-patch.spec.ts
@@ -123,6 +123,12 @@ describe("applyJsonPatch", () => {
     ).toThrow(/Path not found/);
   });
 
+  it("should throw when 'copy' source does not exist", () => {
+    expect(() =>
+      applyJsonPatch({ a: 1 }, [{ op: "copy", from: "/missing", path: "/b" }]),
+    ).toThrow(/Path not found/);
+  });
+
   it("should throw on an unknown op", () => {
     expect(() =>
       applyJsonPatch({ a: 1 }, [{ op: "increment", path: "/a" } as any]),

--- a/packages/react-ag-ui/test/json-patch.spec.ts
+++ b/packages/react-ag-ui/test/json-patch.spec.ts
@@ -143,4 +143,40 @@ describe("applyJsonPatch", () => {
       ]),
     ).not.toThrow();
   });
+
+  it("should throw when 'remove' targets a non-existent key", () => {
+    expect(() =>
+      applyJsonPatch({ a: 1 }, [{ op: "remove", path: "/b" }]),
+    ).toThrow(/Path not found/);
+  });
+
+  it("should throw when 'remove' uses an out-of-range array index", () => {
+    expect(() =>
+      applyJsonPatch({ items: ["a"] }, [{ op: "remove", path: "/items/5" }]),
+    ).toThrow(/Path not found/);
+  });
+
+  it("should throw when 'add' uses a non-integer array index", () => {
+    expect(() =>
+      applyJsonPatch({ items: ["a"] }, [
+        { op: "add", path: "/items/x", value: "b" },
+      ]),
+    ).toThrow(/Invalid array index/);
+  });
+
+  it("should throw when 'add' index is past the end of the array", () => {
+    expect(() =>
+      applyJsonPatch({ items: ["a"] }, [
+        { op: "add", path: "/items/5", value: "b" },
+      ]),
+    ).toThrow(/Invalid array index/);
+  });
+
+  it("should include the failing path in 'test'/'copy' lookup errors", () => {
+    expect(() =>
+      applyJsonPatch({ a: { b: 1 } }, [
+        { op: "test", path: "/a/missing/leaf", value: 1 },
+      ]),
+    ).toThrow(/Path not found: a\/missing/);
+  });
 });

--- a/packages/react-ag-ui/test/json-patch.spec.ts
+++ b/packages/react-ag-ui/test/json-patch.spec.ts
@@ -179,4 +179,18 @@ describe("applyJsonPatch", () => {
       ]),
     ).toThrow(/Path not found: a\/missing/);
   });
+
+  it("should throw when 'test' targets a non-existent path", () => {
+    expect(() =>
+      applyJsonPatch({ a: 1 }, [{ op: "test", path: "/missing", value: 1 }]),
+    ).toThrow(/Path not found/);
+  });
+
+  it("should throw when 'move' targets a descendant of its source", () => {
+    expect(() =>
+      applyJsonPatch({ a: { b: 1 } }, [
+        { op: "move", from: "/a", path: "/a/c" },
+      ]),
+    ).toThrow(/must not be a descendant/);
+  });
 });

--- a/packages/react-ag-ui/test/state-delta.spec.ts
+++ b/packages/react-ag-ui/test/state-delta.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+import type { AppendMessage } from "@assistant-ui/core";
+import type { HttpAgent } from "@ag-ui/client";
+import { AgUiThreadRuntimeCore } from "../src/runtime/AgUiThreadRuntimeCore";
+import { makeLogger, type Logger } from "../src/runtime/logger";
+
+const createAppendMessage = (): AppendMessage => ({
+  role: "user",
+  content: [{ type: "text" as const, text: "hi" }],
+  attachments: [],
+  metadata: { custom: {} },
+  createdAt: new Date(),
+  parentId: null,
+  sourceId: null,
+  runConfig: {},
+  startRun: true,
+});
+
+const createCore = (agent: HttpAgent, logger: Logger = makeLogger()) =>
+  new AgUiThreadRuntimeCore({
+    agent,
+    logger,
+    showThinking: false,
+    notifyUpdate: () => {},
+  });
+
+const stateAgent = (emit: (subscriber: any) => void): HttpAgent =>
+  ({
+    runAgent: vi.fn(async (_input: unknown, subscriber: any) => {
+      emit(subscriber);
+      subscriber.onRunFinalized?.();
+    }),
+  }) as unknown as HttpAgent;
+
+describe("STATE_DELTA handling", () => {
+  it("applies a JSON patch to the state snapshot", async () => {
+    const core = createCore(
+      stateAgent((s) => {
+        s.onStateSnapshotEvent?.({
+          event: {
+            type: "STATE_SNAPSHOT",
+            snapshot: { count: 0, name: "test" },
+          },
+        });
+        s.onStateDeltaEvent?.({
+          event: {
+            type: "STATE_DELTA",
+            delta: [{ op: "replace", path: "/count", value: 42 }],
+          },
+        });
+      }),
+    );
+
+    await core.append(createAppendMessage());
+
+    expect(core.getState()).toEqual({ count: 42, name: "test" });
+  });
+
+  it("isolates a malformed delta: the run does not crash and state is unchanged", async () => {
+    const error = vi.fn();
+    const core = createCore(
+      stateAgent((s) => {
+        s.onStateSnapshotEvent?.({
+          event: { type: "STATE_SNAPSHOT", snapshot: { count: 0 } },
+        });
+        s.onStateDeltaEvent?.({
+          event: {
+            type: "STATE_DELTA",
+            delta: [{ op: "replace", path: "/missing", value: 1 }],
+          },
+        });
+      }),
+      makeLogger({ error }),
+    );
+
+    await expect(core.append(createAppendMessage())).resolves.toBeUndefined();
+
+    expect(core.getState()).toEqual({ count: 0 });
+    expect(error).toHaveBeenCalled();
+    expect(core.isRunning()).toBe(false);
+  });
+
+  it("isolates a delta that arrives before any snapshot", async () => {
+    const error = vi.fn();
+    const core = createCore(
+      stateAgent((s) => {
+        s.onStateDeltaEvent?.({
+          event: {
+            type: "STATE_DELTA",
+            delta: [{ op: "replace", path: "/count", value: 1 }],
+          },
+        });
+      }),
+      makeLogger({ error }),
+    );
+
+    await core.append(createAppendMessage());
+
+    expect(core.getState()).toBeUndefined();
+    expect(error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Previously, `STATE_DELTA` events were logged and silently ignored. Agents emitting incremental state updates per the AG-UI spec now have those updates applied to `stateSnapshot`.

- Adds a focused JSON Patch applier at packages/react-ag-ui/src/runtime/json-patch.ts, scoped to the ops AG-UI agents emit via STATE_DELTA (add, remove, replace, move, copy, test). It is not a general-purpose RFC 6902 library: it implements that subset, validates each op, and throws on anything outside it (existence checks on replace/move/copy targets and sources, unknown ops). Full-spec strict-conformance niceties (e.g. JSON Pointer URI-fragment form) are out of scope.
- Wires it into the `STATE_DELTA` case in `AgUiThreadRuntimeCore.handleEvent` with `try` / `catch` + `logger.error`, so a malformed agent delta cannot crash the active run stream. Mirrors the `importMessagesSnapshot` neighbor's error-isolation pattern.
- Covers edge cases: empty-patch short-circuit (no clone), `from` validation on `move` / `copy` with a descriptive error, splice-insert (not overwrite) when `move` / `copy` target an array index.

## Scope

Salvaged from closed #3790, scoped down to `STATE_DELTA` only. The `onCustomEvent` callback (also from that PR) is intentionally not included and can ship separately.
Because the applier validates and throws, an invalid delta is caught and logged rather than silently corrupting state: the agent patches its own snapshot, so failing loud (in the log) is the safer default.


## Test plan

- [x] `pnpm --filter @assistant-ui/react-ag-ui vitest run test/json-patch.spec.ts test/state-delta.spec.ts`: 23/23 pass (15 `applyJsonPatch` unit tests + 1 integration test driving `STATE_DELTA` through `AgUiThreadRuntimeCore` and verifying `stateSnapshot` is updated)
- [x] `pnpm --filter @assistant-ui/react-ag-ui build`: clean
- [x] `pnpm --filter with-ag-ui build`: clean (TypeScript check passes against the runtime's public surface)
