### PR TITLE
fix(core): map cloud thread metadata into RemoteThreadMetadata.custom

### DIFF
--- a/.changeset/cloud-thread-custom-metadata.md
+++ b/.changeset/cloud-thread-custom-metadata.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: map cloud thread `metadata` into `RemoteThreadMetadata.custom` in the cloud adapter's `list()` and `fetch()` so backend custom fields surface in thread list item state

--- a/apps/docs/content/docs/runtimes/concepts/threads.mdx
+++ b/apps/docs/content/docs/runtimes/concepts/threads.mdx
@@ -355,7 +355,7 @@ function ThreadListItemMeta() {
 }
 ```
 
-`custom` is preserved across `rename`, `archive`, `unarchive`, and `generateTitle`. To mutate it, return updated values from a subsequent `fetch()` or call `runtime.threads.reload()`.
+`custom` is preserved across `rename`, `archive`, `unarchive`, and `generateTitle`. To change it, write the new values to your backend through your own code, then surface them locally by returning the updated values from a subsequent `fetch()` or by calling `aui.threads().reload()` to re-run `list()`. With the cloud adapter, persist via `cloud.threads.update(threadId, { metadata })`.
 
 ## ExternalStoreThreadListAdapter
 

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -14,6 +14,7 @@ import { InMemoryThreadListAdapter } from "../../../runtimes/remote-thread-list/
 import { useAssistantCloudThreadHistoryAdapter } from "./AssistantCloudThreadHistoryAdapter";
 import { RuntimeAdapterProvider } from "../RuntimeAdapterProvider";
 import { CloudFileAttachmentAdapter } from "./CloudFileAttachmentAdapter";
+import { isRecord } from "../../../utils/json/is-json";
 
 type ThreadData = {
   externalId: string | undefined;
@@ -91,6 +92,7 @@ export const useCloudThreadListAdapter = (
           remoteId: t.id,
           title: t.title,
           externalId: t.external_id ?? undefined,
+          custom: isRecord(t.metadata) ? t.metadata : undefined,
         })),
       };
     },
@@ -146,6 +148,7 @@ export const useCloudThreadListAdapter = (
         remoteId: thread.id,
         title: thread.title,
         externalId: thread.external_id ?? undefined,
+        custom: isRecord(thread.metadata) ? thread.metadata : undefined,
       };
     },
 


### PR DESCRIPTION
## Summary

Maps cloud thread `metadata` into `RemoteThreadMetadata.custom` in the cloud adapter's `list()` and `fetch()`, and documents how to change `custom` from the app layer.

Closes #4191.

## Background

#3889 added the `custom` slot to `RemoteThreadMetadata` and wired it through the runtime so adapter-supplied values surface in thread list item state via `useAuiState((s) => s.threadListItem.custom)`. It deliberately stopped at the read side and documented that `custom` is preserved (not mutated) across `rename` / `archive` / `unarchive` / `generateTitle`.

#4191 asks for a way to change `custom` after creation. Walking the code, the capability is already there for adapters that return `custom` from `list()`: the app writes the new values to its own backend, then calls `aui.threads().reload()` to re-run `list()` and pull them back into state. The cloud SDK already supports persistence via `cloud.threads.update(threadId, { metadata })`.

The real gap is that the cloud adapter never mapped the field. `#3889` did not touch `useCloudThreadListAdapter`, so both `list()` and `fetch()` dropped `t.metadata`. For cloud users `custom` was therefore neither read nor refreshable, which made the documented `reload()` pattern silently not work.

## Changes

- `useCloudThreadListAdapter`: map `t.metadata -> custom` in `list()` and `fetch()`, mirroring the existing `title` / `externalId` passthroughs.
- `threads.mdx`: tighten the mutation note. State that you write the change at your backend first, fix the API reference (`aui.threads().reload()`, consistent with the rest of the page), and point cloud users at `cloud.threads.update({ metadata })`.
- changeset (patch, `@assistant-ui/core`).

## Why no new public API

A `rename`-style mutation method would be the most ergonomic answer, but `rename` is public surface mirrored across both the legacy runtime cores and the in-progress tap store-scope architecture plus every adapter implementation. Since `reload()` already covers the use case, I scoped this to a patch: fix the cloud read gap and document the existing pattern. If we want optimistic ergonomics later, an `unstable_updateMetadata` is the natural follow-up; I'd rather land it deliberately once the tap migration settles than commit the surface in both architectures now.

## Test plan

- `pnpm turbo run build` (78/78 successful)
- `pnpm lint` (clean)
