### PR TITLE
fix(react-ai-sdk): strip stale approval when cancelling tool pending approval

### DIFF
--- a/.changeset/cancel-pending-approval-strip.md
+++ b/.changeset/cancel-pending-approval-strip.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: strip stale approval object when cancelling a tool pending approval so the next request passes validateUIMessages

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
@@ -2,6 +2,7 @@
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { validateUIMessages } from "ai";
 
 // Mock only the sibling module that requires AUI store context (not available
 // in isolation). Every other dependency — useExternalStoreRuntime,
@@ -138,6 +139,54 @@ describe("useAISDKRuntime", () => {
     );
     // Completed tool (tc-2) should remain unchanged
     expect(chat.messages[0].parts[1].state).toBe("output-available");
+  });
+
+  it("strips stale approval when cancelling a tool pending approval so history stays valid (#4195)", async () => {
+    const chat = createChatHelpers([
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "mcp_search",
+            toolCallId: "tc-1",
+            state: "approval-requested",
+            input: { q: "hi" },
+            approval: { id: "appr-1" },
+          },
+        ],
+      },
+    ]);
+
+    const { result } = renderHook(() => useAISDKRuntime(chat));
+
+    await waitFor(() => {
+      expect(result.current.thread.getState().messages.length).toBeGreaterThan(
+        0,
+      );
+    });
+
+    act(() => {
+      result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "what" }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(chat.sendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    const part = chat.messages[0].parts[0];
+    expect(part.state).toBe("output-error");
+    // The pending-approval object must not survive into the terminal state,
+    // otherwise AI SDK's validateUIMessages rejects the next request.
+    expect(part.approval).toBeUndefined();
+
+    await expect(
+      validateUIMessages({ messages: chat.messages }),
+    ).resolves.toBeDefined();
   });
 
   it("appends a new user message without sending when startRun is false", async () => {

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -180,8 +180,9 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
           return part;
 
         hasChanges = true;
+        const { approval: _approval, ...rest } = part;
         return {
-          ...part,
+          ...rest,
           state: "output-error" as const,
           errorText: "User cancelled tool call by sending a new message.",
         };


### PR DESCRIPTION
Fixes #4195

## Problem

When a user sends a new message while a tool is in `approval-requested`, `completePendingToolCalls` marked the part `output-error` but kept the stale `approval: { id }` object from the pending-approval state.

AI SDK's `validateUIMessages` rejects that history: the `output-error` branch allows `approval` only when `approved: true`. So the next chat request failed with `AI_TypeValidationError` instead of continuing.

## Fix

Strip `approval` during the cancel transition in `useAISDKRuntime.ts`, so the terminal `output-error` part stays valid.

```ts
const { approval: _approval, ...rest } = part;
return {
  ...rest,
  state: "output-error" as const,
  errorText: "User cancelled tool call by sending a new message.",
};
```

## Test

Added a regression test in `useAISDKRuntime.test.ts` that drives the real hook to cancel a `dynamic-tool` part in `approval-requested`, asserts `approval` is gone, and runs the result through AI SDK's real `validateUIMessages`.

Verified the test fails on the old code (approval leaks `AI_TypeValidationError`) and passes with the fix. Full file: 14/14 pass.
