### PR TITLE
fix(docs): silence 4 Upstash Redis errors during Vercel build

### DIFF
--- a/apps/docs/lib/rate-limit.ts
+++ b/apps/docs/lib/rate-limit.ts
@@ -1,7 +1,15 @@
+import type { Ratelimit } from "@upstash/ratelimit";
+
 const isDev = process.env.NODE_ENV === "development";
 
-const getRatelimit = async () => {
+const getRatelimit = async (): Promise<Ratelimit | null> => {
   if (isDev) return null;
+  if (
+    !process.env.UPSTASH_REDIS_REST_URL ||
+    !process.env.UPSTASH_REDIS_REST_TOKEN
+  ) {
+    return null;
+  }
   const { Redis } = await import("@upstash/redis");
   const { Ratelimit } = await import("@upstash/ratelimit");
   return new Ratelimit({
@@ -10,9 +18,10 @@ const getRatelimit = async () => {
   });
 };
 
-const ratelimitPromise = getRatelimit();
+let ratelimitPromise: Promise<Ratelimit | null> | undefined;
 
 export async function checkRateLimit(req: Request): Promise<Response | null> {
+  ratelimitPromise ??= getRatelimit();
   const ratelimit = await ratelimitPromise;
   if (ratelimit) {
     const ip = req.headers.get("x-forwarded-for") ?? "ip";


### PR DESCRIPTION
## Problem

Every Vercel/`next build` of the docs app printed 4 errors during page-data collection:

```
[Upstash Redis] Unable to find environment variable: `UPSTASH_REDIS_REST_URL`
[Upstash Redis] Unable to find environment variable: `UPSTASH_REDIS_REST_TOKEN`
[Upstash Redis] The 'url' property is missing or undefined in your Redis config.
[Upstash Redis] The 'token' property is missing or undefined in your Redis config.
```

They didn't break the build, but they were noise on every deploy.

## Cause

`apps/docs/lib/rate-limit.ts` called `getRatelimit()` at **module load time** (`const ratelimitPromise = getRatelimit()`). Since `NODE_ENV` is `production` during the build, that immediately ran `Redis.fromEnv()` while the Upstash env vars aren't available at build time — emitting the 4 errors above as the route modules were imported.

## Fix

- Defer instantiation to the first request (`ratelimitPromise ??= getRatelimit()` inside `checkRateLimit`) so nothing runs at import/build time.
- Return early when `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are absent, so it stays silent (rate limiting simply off) instead of logging.

Runtime behavior is unchanged when the env vars are present.

## Verification

Rebuilt the docs app (after building workspace packages). Build exits `0` and the page-data-collection phase no longer prints any `[Upstash Redis]` lines (grep count: 0, was 8).

`@assistant-ui/docs` is private, so no changeset is required per `AGENTS.md`.

https://claude.ai/code/session_01Pic31qjzKa1uiVuBsa5iyk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pic31qjzKa1uiVuBsa5iyk)_