### PR TITLE
chore: skip Vercel builds for version branches

### DIFF
--- a/apps/devtools-frame/vercel.json
+++ b/apps/devtools-frame/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash ../../scripts/vercel-ignore-changeset-release.sh"
+}

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash ../../scripts/vercel-ignore-changeset-release.sh"
+}

--- a/apps/registry/vercel.json
+++ b/apps/registry/vercel.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash ../../scripts/vercel-ignore-changeset-release.sh",
   "rewrites": [
     {
       "source": "/:path*",

--- a/examples/with-expo/vercel.json
+++ b/examples/with-expo/vercel.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash ../../scripts/vercel-ignore-changeset-release.sh",
   "buildCommand": "cd ../.. && pnpm turbo build --filter=@assistant-ui/react-native --filter=@assistant-ui/react-ai-sdk && cd examples/with-expo && pnpm run export:web",
   "outputDirectory": "dist",
   "framework": null

--- a/scripts/vercel-ignore-changeset-release.sh
+++ b/scripts/vercel-ignore-changeset-release.sh
@@ -12,6 +12,7 @@ case "$commit_ref" in
 esac
 
 case "$commit_message" in
+  # Keep in sync with `commit:` in .github/workflows/changeset.yaml.
   "chore: update versions"*)
     echo "Skipping Vercel build for Changesets version commit."
     exit 0

--- a/scripts/vercel-ignore-changeset-release.sh
+++ b/scripts/vercel-ignore-changeset-release.sh
@@ -5,7 +5,7 @@ commit_ref="${VERCEL_GIT_COMMIT_REF:-}"
 commit_message="${VERCEL_GIT_COMMIT_MESSAGE:-}"
 
 case "$commit_ref" in
-  changeset-release/* | chore/update-versions | chore-update-versions | chore-update-versions-*)
+  changeset-release/*)
     echo "Skipping Vercel build for Changesets version branch: $commit_ref"
     exit 0
     ;;

--- a/scripts/vercel-ignore-changeset-release.sh
+++ b/scripts/vercel-ignore-changeset-release.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit_ref="${VERCEL_GIT_COMMIT_REF:-}"
+commit_message="${VERCEL_GIT_COMMIT_MESSAGE:-}"
+
+case "$commit_ref" in
+  changeset-release/* | chore/update-versions | chore-update-versions | chore-update-versions-*)
+    echo "Skipping Vercel build for Changesets version branch: $commit_ref"
+    exit 0
+    ;;
+esac
+
+case "$commit_message" in
+  "chore: update versions"*)
+    echo "Skipping Vercel build for Changesets version commit."
+    exit 0
+    ;;
+esac
+
+exit 1

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash scripts/vercel-ignore-changeset-release.sh"
+}


### PR DESCRIPTION
## Summary
- add a shared Vercel ignore script for Changesets version branches / commits
- wire Vercel configs for root, docs, devtools frame, registry, and Expo to skip generated version PR builds

## Validation
- pnpm lint
- pnpm build
- jq empty vercel.json apps/docs/vercel.json apps/devtools-frame/vercel.json apps/registry/vercel.json examples/with-expo/vercel.json
- bash -n scripts/vercel-ignore-changeset-release.sh
- smoke-tested skip/continue exit codes for Changesets branch, version commit message, and normal feature branch

## Notes
- pnpm test currently fails during test:types in packages/vite/src/index.ts with an unrelated TransformResult SourceMapInput type error.