### PR TITLE
fix(docs): persist Xulux playground state and local chat history

### DIFF
--- a/apps/docs/app/(demos)/playground/layout.tsx
+++ b/apps/docs/app/(demos)/playground/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { type ReactNode, Suspense } from "react";
 import { SubProjectLayout } from "@/components/shared/sub-project-layout";
-import { PlaygroundRuntimeProvider } from "@/contexts/PlaygroundRuntimeProvider";
 import { createOgMetadata } from "@/lib/og";
 
 const title = "Playground";
@@ -26,9 +25,7 @@ export default function PlaygroundLayout({
       fullHeight
       hideFooter
     >
-      <Suspense>
-        <PlaygroundRuntimeProvider>{children}</PlaygroundRuntimeProvider>
-      </Suspense>
+      <Suspense>{children}</Suspense>
     </SubProjectLayout>
   );
 }

--- a/apps/docs/app/(demos)/playground/page.tsx
+++ b/apps/docs/app/(demos)/playground/page.tsx
@@ -383,6 +383,18 @@ export default function PlaygroundPage() {
   const [mode, setMode] = useState<"agent" | "builder">(
     isAiPlaygroundEnabled ? "agent" : "builder",
   );
+  const [visitedModes, setVisitedModes] = useState({
+    agent: isAiPlaygroundEnabled,
+    builder: !isAiPlaygroundEnabled,
+  });
+
+  const handleModeChange = useCallback((nextMode: "agent" | "builder") => {
+    setMode(nextMode);
+    setVisitedModes((current) => ({
+      ...current,
+      [nextMode]: true,
+    }));
+  }, []);
 
   return (
     <>
@@ -391,7 +403,7 @@ export default function PlaygroundPage() {
           <div className="bg-muted/40 grid grid-cols-2 rounded-md border p-0.5 text-xs">
             <button
               type="button"
-              onClick={() => setMode("agent")}
+              onClick={() => handleModeChange("agent")}
               className={cn(
                 "rounded px-2.5 py-1 font-medium transition-colors",
                 mode === "agent"
@@ -403,7 +415,7 @@ export default function PlaygroundPage() {
             </button>
             <button
               type="button"
-              onClick={() => setMode("builder")}
+              onClick={() => handleModeChange("builder")}
               className={cn(
                 "rounded px-2.5 py-1 font-medium transition-colors",
                 mode === "builder"
@@ -418,7 +430,28 @@ export default function PlaygroundPage() {
       )}
 
       <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
-        {XuluxApp && mode === "agent" ? <XuluxApp /> : <BuilderPlayground />}
+        {XuluxApp && visitedModes.agent && (
+          <div
+            className={cn(
+              "h-full min-h-0 w-full flex-col overflow-hidden",
+              mode === "agent" ? "flex" : "hidden",
+            )}
+            aria-hidden={mode !== "agent"}
+          >
+            <XuluxApp />
+          </div>
+        )}
+        {visitedModes.builder && (
+          <div
+            className={cn(
+              "h-full min-h-0 w-full flex-col overflow-hidden",
+              mode === "builder" ? "flex" : "hidden",
+            )}
+            aria-hidden={mode !== "builder"}
+          >
+            <BuilderPlayground />
+          </div>
+        )}
       </div>
     </>
   );

--- a/apps/docs/app/(demos)/playground/page.tsx
+++ b/apps/docs/app/(demos)/playground/page.tsx
@@ -44,6 +44,7 @@ import {
   type ViewportPreset,
 } from "@/lib/playground-url-state";
 import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
+import { PlaygroundRuntimeProvider } from "@/contexts/PlaygroundRuntimeProvider";
 
 const XuluxApp = isAiPlaygroundEnabled
   ? dynamic(() =>
@@ -360,9 +361,11 @@ function BuilderPlayground() {
   );
 
   return (
-    <PlaygroundChatProvider config={config} setConfig={setConfig}>
-      {content}
-    </PlaygroundChatProvider>
+    <PlaygroundRuntimeProvider>
+      <PlaygroundChatProvider config={config} setConfig={setConfig}>
+        {content}
+      </PlaygroundChatProvider>
+    </PlaygroundRuntimeProvider>
   );
 }
 

--- a/apps/docs/components/xulux/XuluxApp.tsx
+++ b/apps/docs/components/xulux/XuluxApp.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
-import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  AssistantRuntimeProvider,
+  useRemoteThreadListRuntime,
+} from "@assistant-ui/react";
 import {
   AssistantChatTransport,
   useChatRuntime,
@@ -9,6 +12,8 @@ import {
 import { AssistantPanelProvider } from "@/components/docs/assistant/context";
 import type { XuluxTemplate } from "./templates/types";
 import { XuluxShell } from "./shell/XuluxShell";
+import { createXuluxLocalThreadListAdapter } from "./runtime/xulux-thread-list-adapter";
+import { XuluxThreadStatusObserver } from "./runtime/XuluxThreadStatusObserver";
 
 export type SelectedTemplateContext = Pick<
   XuluxTemplate,
@@ -22,18 +27,17 @@ export function XuluxApp() {
 
   const resetSession = () => {
     setSelectedTemplateContext(null);
-    setSessionId(crypto.randomUUID());
   };
 
   return (
     <XuluxRuntimeProvider
-      key={sessionId}
       sessionId={sessionId}
       selectedTemplateContext={selectedTemplateContext}
     >
       <AssistantPanelProvider>
         <XuluxShell
           sessionId={sessionId}
+          onSetSessionId={setSessionId}
           onSetSelectedTemplateContext={setSelectedTemplateContext}
           onResetSession={resetSession}
         />
@@ -51,18 +55,35 @@ function XuluxRuntimeProvider({
   selectedTemplateContext: SelectedTemplateContext | null;
   children: ReactNode;
 }) {
-  const runtime = useChatRuntime({
-    transport: new AssistantChatTransport({
-      api: "/api/xulux/chat",
-      body: {
-        sessionId,
-        selectedTemplate: selectedTemplateContext,
-      },
-    }),
+  const sessionIdRef = useRef(sessionId);
+  sessionIdRef.current = sessionId;
+
+  const adapter = useMemo(
+    () =>
+      createXuluxLocalThreadListAdapter({
+        getCurrentSessionId: () => sessionIdRef.current,
+      }),
+    [],
+  );
+
+  const runtime = useRemoteThreadListRuntime({
+    adapter,
+    runtimeHook: function XuluxChatRuntimeHook() {
+      return useChatRuntime({
+        transport: new AssistantChatTransport({
+          api: "/api/xulux/chat",
+          body: {
+            sessionId,
+            selectedTemplate: selectedTemplateContext,
+          },
+        }),
+      });
+    },
   });
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
+      <XuluxThreadStatusObserver />
       {children}
     </AssistantRuntimeProvider>
   );

--- a/apps/docs/components/xulux/landing/CategoryGrid.tsx
+++ b/apps/docs/components/xulux/landing/CategoryGrid.tsx
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export function CategoryGrid({ onBrowseAll, onSelectTemplate }: Props) {
-  const { templates, error } = useXuluxTemplateCatalog();
+  const { templates, isLoading, error } = useXuluxTemplateCatalog();
   const [selected, setSelected] = useState<XuluxTemplate | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -40,6 +40,10 @@ export function CategoryGrid({ onBrowseAll, onSelectTemplate }: Props) {
       resizeObserver.disconnect();
     };
   }, [updateScrollState, templates]);
+
+  if (isLoading) {
+    return <TemplateGridSkeleton />;
+  }
 
   const scrollLeft = () => {
     const el = scrollRef.current;
@@ -155,5 +159,34 @@ export function CategoryGrid({ onBrowseAll, onSelectTemplate }: Props) {
         }}
       />
     </>
+  );
+}
+
+function TemplateGridSkeleton() {
+  return (
+    <section className="w-full">
+      <div className="mb-4 flex items-baseline justify-between">
+        <h2 className="text-lg font-semibold tracking-tight">Templates</h2>
+        <div className="bg-muted h-4 w-20 animate-pulse rounded" />
+      </div>
+
+      <div className="flex gap-4 overflow-hidden">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={index}
+            className="border-border bg-card/40 flex min-w-[190px] flex-1 flex-col gap-2 rounded-xl border p-2"
+          >
+            <div className="bg-muted aspect-video w-full animate-pulse rounded-md" />
+            <div className="space-y-2 px-1 pb-1">
+              <div className="bg-muted h-4 w-3/4 animate-pulse rounded" />
+              <div className="space-y-1">
+                <div className="bg-muted h-3 w-full animate-pulse rounded" />
+                <div className="bg-muted h-3 w-2/3 animate-pulse rounded" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }

--- a/apps/docs/components/xulux/runtime/XuluxThreadStatusObserver.tsx
+++ b/apps/docs/components/xulux/runtime/XuluxThreadStatusObserver.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useAuiState } from "@assistant-ui/react";
+import {
+  getXuluxTextFromParts,
+  updateXuluxPendingUserMessage,
+  updateXuluxThreadStatus,
+} from "./xulux-local-storage";
+
+export function XuluxThreadStatusObserver() {
+  const remoteId = useAuiState((state) => state.threadListItem.remoteId);
+  const isRunning = useAuiState((state) => state.thread.isRunning);
+  const messages = useAuiState((state) => state.thread.messages);
+  const previous = useRef<{
+    remoteId: string | undefined;
+    isRunning: boolean;
+  }>({ remoteId: undefined, isRunning: false });
+
+  useEffect(() => {
+    if (!remoteId || !isRunning) return;
+
+    const latestUserText = getLatestUserText(messages);
+    if (latestUserText) {
+      updateXuluxPendingUserMessage(remoteId, latestUserText);
+    }
+  }, [isRunning, messages, remoteId]);
+
+  useEffect(() => {
+    const prior = previous.current;
+    previous.current = { remoteId, isRunning };
+
+    if (!remoteId) return;
+    if (prior.remoteId !== remoteId) return;
+
+    if (isRunning && !prior.isRunning) {
+      updateXuluxThreadStatus(remoteId, "running");
+      return;
+    }
+
+    if (!isRunning && prior.isRunning) {
+      updateXuluxThreadStatus(remoteId, "idle");
+      updateXuluxPendingUserMessage(remoteId, null);
+    }
+  }, [remoteId, isRunning]);
+
+  return null;
+}
+
+function getLatestUserText(
+  messages: readonly {
+    role: string;
+    content: readonly unknown[];
+  }[],
+): string | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "user") continue;
+
+    const text = getXuluxTextFromParts(message.content);
+    if (text) return text;
+  }
+
+  return null;
+}

--- a/apps/docs/components/xulux/runtime/xulux-local-storage.ts
+++ b/apps/docs/components/xulux/runtime/xulux-local-storage.ts
@@ -1,0 +1,277 @@
+"use client";
+
+import { useEffect, useSyncExternalStore } from "react";
+import type { SelectedTemplateContext } from "../XuluxApp";
+
+export type XuluxThreadStatus = "idle" | "running" | "interrupted";
+
+export type XuluxCanvasSnapshot = {
+  status: "empty" | "ready" | "error";
+  url: string | null;
+  source: "template" | "refresh" | null;
+  error: string | null;
+  title?: string;
+};
+
+export type XuluxStoredThread = {
+  remoteId: string;
+  externalId?: string;
+  status: "regular" | "archived";
+  title?: string;
+  custom: {
+    xuluxStatus: XuluxThreadStatus;
+    sessionId: string;
+    updatedAt: number;
+    pendingUserMessage?: string | null;
+    selectedTemplate?: SelectedTemplateContext | null;
+    canvas?: XuluxCanvasSnapshot;
+  };
+};
+
+export type XuluxStoredMessageRow = {
+  id: string;
+  parent_id: string | null;
+  format: string;
+  content: Record<string, unknown>;
+};
+
+export type XuluxStoredMessageRepository = {
+  headId?: string | null;
+  messages: XuluxStoredMessageRow[];
+};
+
+export function getXuluxTextFromParts(parts: unknown): string {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .flatMap((part) => {
+      if (!part || typeof part !== "object") return [];
+      const typedPart = part as Record<string, unknown>;
+      return typedPart.type === "text" && typeof typedPart.text === "string"
+        ? [typedPart.text]
+        : [];
+    })
+    .join("\n")
+    .trim();
+}
+
+const PREFIX = "xulux:";
+const THREADS_KEY = `${PREFIX}threads`;
+const MESSAGES_PREFIX = `${PREFIX}messages:`;
+const STORAGE_EVENT = "xulux-storage";
+const EMPTY_THREADS: XuluxStoredThread[] = [];
+
+let cachedThreadsRaw: string | null = null;
+let cachedThreadsSnapshot: XuluxStoredThread[] = EMPTY_THREADS;
+
+function isBrowser() {
+  return typeof window !== "undefined";
+}
+
+function notify() {
+  if (!isBrowser()) return;
+  window.dispatchEvent(new Event(STORAGE_EVENT));
+}
+
+function readJson<T>(key: string, fallback: T): T {
+  if (!isBrowser()) return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson<T>(key: string, value: T) {
+  if (!isBrowser()) return;
+  const nextRaw = JSON.stringify(value);
+  if (window.localStorage.getItem(key) === nextRaw) return;
+  window.localStorage.setItem(key, nextRaw);
+  notify();
+}
+
+function removeItem(key: string) {
+  if (!isBrowser()) return;
+  window.localStorage.removeItem(key);
+  notify();
+}
+
+function messagesKey(remoteId: string) {
+  return `${MESSAGES_PREFIX}${remoteId}`;
+}
+
+function normalizeThread(thread: XuluxStoredThread): XuluxStoredThread {
+  if (thread.custom.xuluxStatus !== "running") return thread;
+  return {
+    ...thread,
+    custom: {
+      ...thread.custom,
+      xuluxStatus: "interrupted",
+      updatedAt: Date.now(),
+    },
+  };
+}
+
+export function readXuluxThreads(): XuluxStoredThread[] {
+  if (!isBrowser()) return EMPTY_THREADS;
+
+  const raw = window.localStorage.getItem(THREADS_KEY);
+  if (raw === cachedThreadsRaw) {
+    return cachedThreadsSnapshot;
+  }
+
+  cachedThreadsRaw = raw;
+  if (!raw) {
+    cachedThreadsSnapshot = EMPTY_THREADS;
+    return cachedThreadsSnapshot;
+  }
+
+  try {
+    cachedThreadsSnapshot = JSON.parse(raw) as XuluxStoredThread[];
+  } catch {
+    cachedThreadsSnapshot = EMPTY_THREADS;
+  }
+  return cachedThreadsSnapshot;
+}
+
+function normalizePersistedThreads() {
+  const threads = readXuluxThreads();
+  const normalized = threads.map(normalizeThread);
+  if (JSON.stringify(threads) !== JSON.stringify(normalized)) {
+    writeXuluxThreads(normalized);
+  }
+}
+
+export function writeXuluxThreads(threads: XuluxStoredThread[]) {
+  writeJson(THREADS_KEY, threads);
+}
+
+export function readXuluxMessages(
+  remoteId: string,
+): XuluxStoredMessageRepository {
+  return readJson<XuluxStoredMessageRepository>(messagesKey(remoteId), {
+    headId: null,
+    messages: [],
+  });
+}
+
+export function writeXuluxMessages(
+  remoteId: string,
+  repository: XuluxStoredMessageRepository,
+) {
+  writeJson(messagesKey(remoteId), repository);
+}
+
+export function deleteXuluxMessages(remoteId: string) {
+  removeItem(messagesKey(remoteId));
+}
+
+export function findXuluxThread(remoteId: string): XuluxStoredThread | null {
+  return (
+    readXuluxThreads().find((thread) => thread.remoteId === remoteId) ?? null
+  );
+}
+
+export function upsertXuluxThread(
+  remoteId: string,
+  updater: (thread: XuluxStoredThread | null) => XuluxStoredThread,
+) {
+  const threads = readXuluxThreads();
+  const index = threads.findIndex((thread) => thread.remoteId === remoteId);
+  const nextThread = updater(index === -1 ? null : threads[index]!);
+  writeXuluxThreads(
+    index === -1
+      ? [nextThread, ...threads]
+      : threads.map((thread, threadIndex) =>
+          threadIndex === index ? nextThread : thread,
+        ),
+  );
+}
+
+export function updateXuluxThread(
+  remoteId: string,
+  updater: (thread: XuluxStoredThread) => XuluxStoredThread,
+) {
+  const thread = findXuluxThread(remoteId);
+  if (thread) upsertXuluxThread(remoteId, () => updater(thread));
+}
+
+function patchXuluxThread(
+  remoteId: string,
+  patch: Partial<XuluxStoredThread["custom"]>,
+) {
+  updateXuluxThread(remoteId, (thread) => ({
+    ...thread,
+    custom: {
+      ...thread.custom,
+      ...patch,
+      updatedAt: Date.now(),
+    },
+  }));
+}
+
+export function updateXuluxThreadStatus(
+  remoteId: string,
+  status: XuluxThreadStatus,
+) {
+  patchXuluxThread(remoteId, { xuluxStatus: status });
+}
+
+export function updateXuluxPendingUserMessage(
+  remoteId: string,
+  pendingUserMessage: string | null,
+) {
+  upsertXuluxThread(remoteId, (thread) =>
+    thread
+      ? {
+          ...thread,
+          custom: {
+            ...thread.custom,
+            pendingUserMessage,
+            updatedAt: Date.now(),
+          },
+        }
+      : {
+          remoteId,
+          status: "regular",
+          custom: {
+            xuluxStatus: pendingUserMessage ? "running" : "idle",
+            sessionId: remoteId,
+            updatedAt: Date.now(),
+            pendingUserMessage,
+          },
+        },
+  );
+}
+
+export function updateXuluxThreadContext(
+  remoteId: string,
+  context: {
+    selectedTemplate?: SelectedTemplateContext | null;
+    canvas?: XuluxCanvasSnapshot;
+  },
+) {
+  patchXuluxThread(remoteId, context);
+}
+
+export function useXuluxStoredThreads() {
+  return useSyncExternalStore(
+    (listener) => {
+      if (!isBrowser()) return () => {};
+      window.addEventListener(STORAGE_EVENT, listener);
+      window.addEventListener("storage", listener);
+      return () => {
+        window.removeEventListener(STORAGE_EVENT, listener);
+        window.removeEventListener("storage", listener);
+      };
+    },
+    readXuluxThreads,
+    () => EMPTY_THREADS,
+  );
+}
+
+export function useNormalizeInterruptedXuluxThreads() {
+  useEffect(() => {
+    normalizePersistedThreads();
+  }, []);
+}

--- a/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
+++ b/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { createAssistantStream } from "assistant-stream";
+import { type FC, type PropsWithChildren, useMemo } from "react";
+import {
+  RuntimeAdapterProvider,
+  useAui,
+  type MessageFormatAdapter,
+  type RemoteThreadListAdapter,
+  type ThreadHistoryAdapter,
+  type ThreadMessage,
+} from "@assistant-ui/react";
+import {
+  deleteXuluxMessages,
+  findXuluxThread,
+  readXuluxMessages,
+  readXuluxThreads,
+  updateXuluxThread,
+  upsertXuluxThread,
+  writeXuluxMessages,
+  writeXuluxThreads,
+  type XuluxStoredMessageRow,
+  type XuluxStoredThread,
+} from "./xulux-local-storage";
+
+function getTextFromMessages(messages: readonly ThreadMessage[]): string {
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    const text = message.content
+      .flatMap((part) => (part.type === "text" ? [part.text] : []))
+      .join(" ")
+      .trim();
+    if (text) return text;
+  }
+  return "New chat";
+}
+
+function titleFromMessages(messages: readonly ThreadMessage[]): string {
+  const text = getTextFromMessages(messages);
+  return text.length > 44 ? `${text.slice(0, 41)}...` : text;
+}
+
+function toRemoteThread(thread: XuluxStoredThread) {
+  return {
+    remoteId: thread.remoteId,
+    externalId: thread.externalId,
+    status: thread.status,
+    title: thread.title,
+    custom: thread.custom,
+  };
+}
+
+function upsertMessage(
+  messages: XuluxStoredMessageRow[],
+  row: XuluxStoredMessageRow,
+) {
+  const index = messages.findIndex((message) => message.id === row.id);
+  return index === -1
+    ? [...messages, row]
+    : messages.map((message, messageIndex) =>
+        messageIndex === index ? row : message,
+      );
+}
+
+class XuluxLocalHistoryAdapter implements ThreadHistoryAdapter {
+  constructor(private aui: ReturnType<typeof useAui>) {}
+
+  async load() {
+    return { messages: [] };
+  }
+
+  async append() {}
+
+  withFormat<TMessage, TStorageFormat extends Record<string, unknown>>(
+    fmt: MessageFormatAdapter<TMessage, TStorageFormat>,
+  ) {
+    const adapter = this;
+    return {
+      async load() {
+        const remoteId = adapter.aui.threadListItem().getState().remoteId;
+        if (!remoteId) return { headId: null, messages: [] };
+        const repository = readXuluxMessages(remoteId);
+        return {
+          headId: repository.headId ?? null,
+          messages: repository.messages
+            .filter((row) => row.format === fmt.format)
+            .map((row) =>
+              fmt.decode({
+                id: row.id,
+                parent_id: row.parent_id,
+                format: row.format,
+                content: row.content as TStorageFormat,
+              }),
+            ),
+        };
+      },
+      async append(item: { parentId: string | null; message: TMessage }) {
+        const { remoteId } = await adapter.aui.threadListItem().initialize();
+        const repository = readXuluxMessages(remoteId);
+        const row: XuluxStoredMessageRow = {
+          id: fmt.getId(item.message),
+          parent_id: item.parentId,
+          format: fmt.format,
+          content: fmt.encode(item),
+        };
+        writeXuluxMessages(remoteId, {
+          headId: row.id,
+          messages: upsertMessage(repository.messages, row),
+        });
+      },
+      async update(
+        item: { parentId: string | null; message: TMessage },
+        localMessageId: string,
+      ) {
+        const remoteId = adapter.aui.threadListItem().getState().remoteId;
+        if (!remoteId) return;
+        const repository = readXuluxMessages(remoteId);
+        const row: XuluxStoredMessageRow = {
+          id: localMessageId,
+          parent_id: item.parentId,
+          format: fmt.format,
+          content: fmt.encode(item),
+        };
+        writeXuluxMessages(remoteId, {
+          headId: repository.headId ?? null,
+          messages: repository.messages.map((message) =>
+            message.id === localMessageId ? row : message,
+          ),
+        });
+      },
+    };
+  }
+}
+
+function XuluxLocalHistoryProvider({ children }: PropsWithChildren) {
+  const aui = useAui();
+  const history = useMemo(() => new XuluxLocalHistoryAdapter(aui), [aui]);
+  const adapters = useMemo(() => ({ history }), [history]);
+  return (
+    <RuntimeAdapterProvider adapters={adapters}>
+      {children}
+    </RuntimeAdapterProvider>
+  );
+}
+
+export function createXuluxLocalThreadListAdapter({
+  getCurrentSessionId,
+}: {
+  getCurrentSessionId: () => string;
+}): RemoteThreadListAdapter {
+  const Provider: FC<PropsWithChildren> = XuluxLocalHistoryProvider;
+
+  return {
+    unstable_Provider: Provider,
+    async list() {
+      return { threads: readXuluxThreads().map(toRemoteThread) };
+    },
+    async initialize() {
+      const sessionId = getCurrentSessionId();
+      upsertXuluxThread(sessionId, (existing) => ({
+        ...existing,
+        remoteId: sessionId,
+        status: existing?.status ?? "regular",
+        custom: {
+          sessionId,
+          xuluxStatus: "idle",
+          ...existing?.custom,
+          updatedAt: Date.now(),
+        },
+      }));
+      return { remoteId: sessionId, externalId: undefined };
+    },
+    async rename(remoteId, title) {
+      updateXuluxThread(remoteId, (thread) => ({
+        ...thread,
+        title,
+        custom: { ...thread.custom, updatedAt: Date.now() },
+      }));
+    },
+    async archive(remoteId) {
+      updateXuluxThread(remoteId, (thread) => ({
+        ...thread,
+        status: "archived",
+        custom: { ...thread.custom, updatedAt: Date.now() },
+      }));
+    },
+    async unarchive(remoteId) {
+      updateXuluxThread(remoteId, (thread) => ({
+        ...thread,
+        status: "regular",
+        custom: { ...thread.custom, updatedAt: Date.now() },
+      }));
+    },
+    async delete(remoteId) {
+      writeXuluxThreads(
+        readXuluxThreads().filter((thread) => thread.remoteId !== remoteId),
+      );
+      deleteXuluxMessages(remoteId);
+    },
+    async fetch(remoteId) {
+      const thread = findXuluxThread(remoteId);
+      if (!thread) throw new Error("Thread not found");
+      return toRemoteThread(thread);
+    },
+    async generateTitle(remoteId, messages) {
+      const title = titleFromMessages(messages);
+      updateXuluxThread(remoteId, (thread) => ({
+        ...thread,
+        title,
+        custom: { ...thread.custom, updatedAt: Date.now() },
+      }));
+      return createAssistantStream((controller) => {
+        controller.appendText(title);
+      });
+    },
+  };
+}

--- a/apps/docs/components/xulux/shell/XuluxHeaderActions.tsx
+++ b/apps/docs/components/xulux/shell/XuluxHeaderActions.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { LayoutGrid, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import type { XuluxStoredThread } from "../runtime/xulux-local-storage";
+import { XuluxHistoryMenu } from "./XuluxHistoryMenu";
 
 function HeaderPortal({ children }: { children: ReactNode }) {
   const [container, setContainer] = useState<HTMLElement | null>(null);
@@ -19,38 +21,46 @@ function HeaderPortal({ children }: { children: ReactNode }) {
 }
 
 export function XuluxHeaderActions({
-  visible,
+  showChatActions,
   onNewChat,
   onShowTemplates,
+  onRestoreThread,
 }: {
-  visible: boolean;
+  showChatActions: boolean;
   onNewChat: () => void;
   onShowTemplates: () => void;
+  onRestoreThread: (thread: XuluxStoredThread) => void;
 }) {
-  if (!visible) return null;
-
   return (
     <HeaderPortal>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="h-7 gap-1.5 px-2.5 text-xs"
-        onClick={onShowTemplates}
-      >
-        <LayoutGrid className="size-3.5" />
-        <span className="hidden md:inline">Templates</span>
-      </Button>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="h-7 gap-1.5 px-2.5 text-xs"
-        onClick={onNewChat}
-      >
-        <Plus className="size-3.5" />
-        <span className="hidden md:inline">New</span>
-      </Button>
+      <XuluxHistoryMenu
+        onNewChat={onNewChat}
+        onRestoreThread={onRestoreThread}
+      />
+      {showChatActions && (
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1.5 px-2.5 text-xs"
+            onClick={onShowTemplates}
+          >
+            <LayoutGrid className="size-3.5" />
+            <span className="hidden md:inline">Templates</span>
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1.5 px-2.5 text-xs"
+            onClick={onNewChat}
+          >
+            <Plus className="size-3.5" />
+            <span className="hidden md:inline">New</span>
+          </Button>
+        </>
+      )}
     </HeaderPortal>
   );
 }

--- a/apps/docs/components/xulux/shell/XuluxHistoryMenu.tsx
+++ b/apps/docs/components/xulux/shell/XuluxHistoryMenu.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { ChevronDown, History } from "lucide-react";
+import { useAui, useAuiState } from "@assistant-ui/react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/shared/dropdown-menu";
+import { cn } from "@/lib/utils";
+import {
+  useNormalizeInterruptedXuluxThreads,
+  useXuluxStoredThreads,
+} from "../runtime/xulux-local-storage";
+import type { XuluxStoredThread } from "../runtime/xulux-local-storage";
+
+function formatUpdatedAt(updatedAt: number): string {
+  const delta = Date.now() - updatedAt;
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (delta < minute) return "Just now";
+  if (delta < hour) return `${Math.max(1, Math.floor(delta / minute))}m ago`;
+  if (delta < day) return `${Math.floor(delta / hour)}h ago`;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(updatedAt));
+}
+
+function fallbackTitle(thread: XuluxStoredThread): string {
+  return thread.title?.trim() || "New chat";
+}
+
+export function XuluxHistoryMenu({
+  onRestoreThread,
+  onNewChat,
+}: {
+  onRestoreThread: (thread: XuluxStoredThread) => void;
+  onNewChat: () => void;
+}) {
+  useNormalizeInterruptedXuluxThreads();
+  const threads = useXuluxStoredThreads().filter(
+    (thread) => thread.status === "regular",
+  );
+  const aui = useAui();
+  const currentRemoteId = useAuiState((state) => state.threadListItem.remoteId);
+  const hasInterrupted = threads.some(
+    (thread) => thread.custom.xuluxStatus === "interrupted",
+  );
+
+  const handleSelect = (thread: XuluxStoredThread) => {
+    onRestoreThread(thread);
+    void aui.threads().switchToThread(thread.remoteId);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="relative h-7 gap-1.5 px-2.5 text-xs"
+        >
+          <History className="size-3.5" />
+          <span className="hidden md:inline">History</span>
+          <ChevronDown className="size-3" />
+          {hasInterrupted && (
+            <span className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-amber-500" />
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="max-h-80 w-64 overflow-y-auto"
+      >
+        <div className="text-muted-foreground px-2.5 py-1 text-xs font-medium">
+          History
+        </div>
+        {threads.length === 0 ? (
+          <div className="text-muted-foreground px-2.5 py-2 text-sm">
+            No saved chats yet.
+          </div>
+        ) : (
+          threads.map((thread) => {
+            const status = thread.custom.xuluxStatus;
+            const isCurrent = currentRemoteId === thread.remoteId;
+            return (
+              <DropdownMenuItem
+                key={thread.remoteId}
+                className="items-start px-2 py-1.5"
+                onSelect={() => handleSelect(thread)}
+              >
+                <span className="min-w-0 flex-1">
+                  <span className="text-foreground block truncate text-xs font-medium">
+                    {fallbackTitle(thread)}
+                  </span>
+                  <span className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-[11px] leading-none">
+                    {formatUpdatedAt(thread.custom.updatedAt)}
+                    {isCurrent && (
+                      <span className="bg-muted text-muted-foreground rounded px-1 py-0.5 text-[10px] font-medium">
+                        Current
+                      </span>
+                    )}
+                    {status !== "idle" && (
+                      <span
+                        className={cn(
+                          "rounded px-1 py-0.5 text-[10px] font-medium",
+                          status === "interrupted"
+                            ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                            : "bg-muted text-muted-foreground",
+                        )}
+                      >
+                        {status === "interrupted" ? "Interrupted" : "Running"}
+                      </span>
+                    )}
+                  </span>
+                </span>
+              </DropdownMenuItem>
+            );
+          })
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="px-2 py-1.5 text-xs" onSelect={onNewChat}>
+          New chat
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/docs/components/xulux/shell/XuluxShell.tsx
+++ b/apps/docs/components/xulux/shell/XuluxShell.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAui, useAuiState } from "@assistant-ui/react";
 import { useAssistantPanel } from "@/components/docs/assistant/context";
+import { Button } from "@/components/ui/button";
 import { XuluxThread } from "../chat/XuluxThread";
 import type { XuluxTemplate } from "../templates/types";
 import type { SelectedTemplateContext } from "../XuluxApp";
@@ -10,6 +12,15 @@ import { XuluxCanvasObserver } from "../canvas/XuluxCanvasObserver";
 import { XuluxLandingPage } from "../landing/XuluxLandingPage";
 import { TemplatesModal } from "../landing/TemplatesModal";
 import { XuluxHeaderActions } from "./XuluxHeaderActions";
+import {
+  getXuluxTextFromParts,
+  readXuluxMessages,
+  updateXuluxPendingUserMessage,
+  updateXuluxThreadContext,
+  useXuluxStoredThreads,
+  type XuluxCanvasSnapshot,
+  type XuluxStoredThread,
+} from "../runtime/xulux-local-storage";
 
 const ASSISTANT_UI_REPO_URL = "https://github.com/assistant-ui/assistant-ui";
 
@@ -23,19 +34,26 @@ type CanvasState = {
 
 export function XuluxShell({
   sessionId,
+  onSetSessionId,
   onSetSelectedTemplateContext,
   onResetSession,
 }: {
   sessionId: string;
+  onSetSessionId: (sessionId: string) => void;
   onSetSelectedTemplateContext: (
     template: SelectedTemplateContext | null,
   ) => void;
   onResetSession: () => void;
 }) {
   const { askAI } = useAssistantPanel();
+  const aui = useAui();
+  const currentRemoteId = useAuiState((state) => state.threadListItem.remoteId);
+  const storedThreads = useXuluxStoredThreads();
   const [viewMode, setViewMode] = useState<XuluxViewMode>("landing");
   const [selectedTemplate, setSelectedTemplate] =
     useState<XuluxTemplate | null>(null);
+  const [selectedTemplateContext, setSelectedTemplateContext] =
+    useState<SelectedTemplateContext | null>(null);
   const [templatesOpen, setTemplatesOpen] = useState(false);
   const [canvas, setCanvas] = useState<CanvasState>({
     status: "empty",
@@ -46,19 +64,24 @@ export function XuluxShell({
 
   const handleStartChat = useCallback(
     (prompt: string) => {
+      updateXuluxPendingUserMessage(currentRemoteId ?? sessionId, prompt);
+      setSelectedTemplate(null);
+      setSelectedTemplateContext(null);
       onSetSelectedTemplateContext(null);
       setCanvas({ status: "empty", url: null, source: null, error: null });
       setViewMode("chat");
       setTemplatesOpen(false);
       askAI(prompt);
     },
-    [askAI, onSetSelectedTemplateContext],
+    [askAI, currentRemoteId, onSetSelectedTemplateContext, sessionId],
   );
 
   const handleSelectTemplate = useCallback(
     (template: XuluxTemplate) => {
+      const context = toSelectedTemplateContext(template);
       setSelectedTemplate(template);
-      onSetSelectedTemplateContext(toSelectedTemplateContext(template));
+      setSelectedTemplateContext(context);
+      onSetSelectedTemplateContext(context);
       setCanvas({
         status: template.previewUrl ? "ready" : "empty",
         url: template.previewUrl ?? null,
@@ -72,15 +95,67 @@ export function XuluxShell({
   );
 
   const handleNewChat = useCallback(() => {
+    const nextSessionId = crypto.randomUUID();
+    onSetSessionId(nextSessionId);
     setSelectedTemplate(null);
+    setSelectedTemplateContext(null);
     setCanvas({ status: "empty", url: null, source: null, error: null });
     setTemplatesOpen(false);
     setViewMode("landing");
     onResetSession();
-  }, [onResetSession]);
+    void aui.threads().switchToNewThread();
+  }, [aui, onResetSession, onSetSessionId]);
+
+  const handleRestoreThread = useCallback(
+    (thread: XuluxStoredThread) => {
+      const restoredTemplate = thread.custom.selectedTemplate ?? null;
+      onSetSessionId(thread.custom.sessionId);
+      setSelectedTemplate(null);
+      setSelectedTemplateContext(restoredTemplate);
+      onSetSelectedTemplateContext(restoredTemplate);
+      setCanvas(fromCanvasSnapshot(thread.custom.canvas));
+      setTemplatesOpen(false);
+      setViewMode(thread.custom.canvas?.url ? "preview" : "chat");
+    },
+    [onSetSelectedTemplateContext, onSetSessionId],
+  );
+
+  const activeStoredThread =
+    storedThreads.find((thread) => thread.remoteId === currentRemoteId) ?? null;
+  const isInterrupted =
+    activeStoredThread?.custom.xuluxStatus === "interrupted";
+  const interruptedUserMessage = useMemo(() => {
+    if (!isInterrupted || !currentRemoteId) return null;
+    const pending = activeStoredThread?.custom.pendingUserMessage?.trim();
+    if (pending) return pending;
+    return getLatestSavedUserMessage(currentRemoteId);
+  }, [activeStoredThread, currentRemoteId, isInterrupted]);
+
+  const handleRetryInterrupted = useCallback(() => {
+    if (!interruptedUserMessage) return;
+    updateXuluxPendingUserMessage(
+      currentRemoteId ?? sessionId,
+      interruptedUserMessage,
+    );
+    setViewMode("chat");
+    askAI(interruptedUserMessage);
+  }, [askAI, currentRemoteId, interruptedUserMessage, sessionId]);
+
+  useEffect(() => {
+    if (!currentRemoteId) return;
+    updateXuluxThreadContext(currentRemoteId, {
+      selectedTemplate: selectedTemplateContext,
+      canvas: toCanvasSnapshot(
+        canvas,
+        selectedTemplate?.title ?? selectedTemplateContext?.title,
+      ),
+    });
+  }, [canvas, currentRemoteId, selectedTemplate, selectedTemplateContext]);
+
   const sourceUrl =
-    canvas.source === "template" && selectedTemplate
-      ? getTemplateSourceUrl(selectedTemplate)
+    canvas.source === "template" &&
+    (selectedTemplate || selectedTemplateContext)
+      ? getTemplateSourceUrl(selectedTemplate ?? selectedTemplateContext!)
       : undefined;
 
   return (
@@ -102,9 +177,10 @@ export function XuluxShell({
       />
 
       <XuluxHeaderActions
-        visible={viewMode !== "landing"}
+        showChatActions={viewMode !== "landing"}
         onNewChat={handleNewChat}
         onShowTemplates={() => setTemplatesOpen(true)}
+        onRestoreThread={handleRestoreThread}
       />
 
       {viewMode === "landing" ? (
@@ -121,6 +197,12 @@ export function XuluxShell({
                 : "flex flex-1 flex-col"
             }
           >
+            {isInterrupted && (
+              <InterruptedRunBanner
+                lastUserMessage={interruptedUserMessage}
+                onRetry={handleRetryInterrupted}
+              />
+            )}
             <XuluxThread onNewThread={handleNewChat} />
           </section>
 
@@ -165,8 +247,89 @@ function toSelectedTemplateContext(
   };
 }
 
-function getTemplateSourceUrl(template: XuluxTemplate): string | undefined {
+function getTemplateSourceUrl(
+  template: XuluxTemplate | SelectedTemplateContext,
+): string | undefined {
   if (!template.sourcePath) return template.docsUrl;
   if (/^https?:\/\//i.test(template.sourcePath)) return template.sourcePath;
   return `${ASSISTANT_UI_REPO_URL}/tree/main/${template.sourcePath}`;
+}
+
+function toCanvasSnapshot(
+  canvas: CanvasState,
+  title: string | undefined,
+): XuluxCanvasSnapshot {
+  return {
+    status: canvas.status === "loading" ? "empty" : canvas.status,
+    url: canvas.url,
+    source: canvas.source,
+    error: canvas.error,
+    ...(title ? { title } : {}),
+  };
+}
+
+function fromCanvasSnapshot(
+  snapshot: XuluxCanvasSnapshot | undefined,
+): CanvasState {
+  if (!snapshot) {
+    return { status: "empty", url: null, source: null, error: null };
+  }
+  return {
+    status: snapshot.status,
+    url: snapshot.url,
+    source: snapshot.source,
+    error: snapshot.error,
+  };
+}
+
+function getLatestSavedUserMessage(remoteId: string): string | null {
+  const repository = readXuluxMessages(remoteId);
+  for (let index = repository.messages.length - 1; index >= 0; index -= 1) {
+    const row = repository.messages[index];
+    if (row?.format !== "ai-sdk/v6") continue;
+    if (row.content.role !== "user") continue;
+
+    const text = getXuluxTextFromParts(row.content.parts);
+    if (text) return text;
+  }
+  return null;
+}
+
+function previewText(text: string): string {
+  return text.length > 96 ? `${text.slice(0, 93)}...` : text;
+}
+
+function InterruptedRunBanner({
+  lastUserMessage,
+  onRetry,
+}: {
+  lastUserMessage: string | null;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="mx-3 mt-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="font-medium text-amber-700 dark:text-amber-300">
+            This run was interrupted.
+          </p>
+          <p className="text-muted-foreground mt-0.5 text-xs">
+            {lastUserMessage
+              ? `Retry the last saved request: "${previewText(lastUserMessage)}"`
+              : "The original request was not saved, so this run cannot be retried safely."}
+          </p>
+        </div>
+        {lastUserMessage && (
+          <Button
+            type="button"
+            size="sm"
+            className="h-7 shrink-0 px-2.5 text-xs"
+            onClick={onRetry}
+          >
+            Retry
+          </Button>
+        )}
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- keep visited AI Builder / UI Builder panels mounted so switching tabs preserves local frontend state
- add a skeleton loading row for the Xulux template catalog below the landing composer
- rebase onto latest upstream `main`, including the `NEXT_PUBLIC_AUI_AI_PLAYGROUND_ENABLED=1` playground flag
- add browser-local Xulux thread/message persistence with `localStorage`, `useRemoteThreadListRuntime`, and `ThreadHistoryAdapter.withFormat`
- add a compact History menu, visible on the landing page and chat views, with interrupted-thread status
- preserve per-thread Xulux `sessionId`, selected template context, and canvas snapshot
- mark active runs as `running`, normalize stale `running` threads to `interrupted`, and recover with `Retry` only when the latest user request was saved
- store `pendingUserMessage` immediately on send so mid-run reloads can retry the exact latest request before full AI SDK history is persisted

Fixes #4205

## Testing
- `pnpm exec oxlint 'apps/docs/app/(demos)/playground/page.tsx' 'apps/docs/app/(demos)/playground/layout.tsx' apps/docs/components/xulux/XuluxApp.tsx apps/docs/components/xulux/shell/XuluxShell.tsx apps/docs/components/xulux/shell/XuluxHeaderActions.tsx apps/docs/components/xulux/shell/XuluxHistoryMenu.tsx apps/docs/components/xulux/runtime/types.ts apps/docs/components/xulux/runtime/xulux-local-storage.ts apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx apps/docs/components/xulux/runtime/XuluxThreadStatusObserver.tsx`
- `pnpm --filter @assistant-ui/docs exec tsc --noEmit`
- `GET http://localhost:3001/playground` returns `200`

Note: local validation reports the existing engine warning because this machine is on Node v22.13.1 while the repo declares Node >=24.