### PR TITLE
feat(core): add thread custom metadata updates

### DIFF
--- a/.changeset/thread-custom-update.md
+++ b/.changeset/thread-custom-update.md
@@ -1,5 +1,6 @@
 ---
 "@assistant-ui/core": patch
+"@assistant-ui/react": patch
 ---
 
-feat: add `updateCustom` to remote thread list runtimes and adapters
+feat: add `updateCustom` to thread list runtimes, adapters, and clients

--- a/.changeset/thread-custom-update.md
+++ b/.changeset/thread-custom-update.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat: add `updateCustom` to remote thread list runtimes and adapters

--- a/apps/docs/content/docs/guides/context-api.mdx
+++ b/apps/docs/content/docs/guides/context-api.mdx
@@ -219,6 +219,7 @@ aui.threads().getState();
 // ThreadListItem actions
 aui.threadListItem().switchTo();
 aui.threadListItem().rename(title);
+aui.threadListItem().updateCustom(custom);
 aui.threadListItem().archive();
 aui.threadListItem().unarchive();
 aui.threadListItem().delete();
@@ -517,7 +518,7 @@ The table below covers the most commonly used actions. For the full catalog, see
 | Scope          | Actions                                                                                                           | Use Cases                                  |
 | -------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
 | ThreadList     | `switchToNewThread()`, `switchToThread(id)`, `reload()`, `getLoadThreadsPromise()`, `item(selector)`, `thread("main")`, `getState()` | Thread navigation, creation, and sync |
-| ThreadListItem | `switchTo()`, `rename(title)`, `archive()`, `unarchive()`, `delete()`, `getState()`                              | Thread management operations               |
+| ThreadListItem | `switchTo()`, `rename(title)`, `updateCustom(custom)`, `archive()`, `unarchive()`, `delete()`, `getState()`      | Thread management operations               |
 | Thread         | `append(message)`, `startRun(config)`, `resumeRun(config)`, `cancelRun()`, `reset()`, `export()`, `import(repository)`, `message(selector)`, `composer()`, `getState()` | Message handling and conversation control |
 | Message        | `reload()`, `speak()`, `stopSpeaking()`, `submitFeedback(feedback)`, `switchToBranch(options)`, `getCopyText()`, `part(selector)`, `attachment(selector)`, `composer()`, `setIsCopied(value)`, `setIsHovering(value)`, `getState()` | Message interactions and regeneration |
 | Part           | `addToolResult(result)`, `resumeToolCall(result)`, `getState()`                                                   | Tool call result handling                  |

--- a/apps/docs/content/docs/runtimes/concepts/threads.mdx
+++ b/apps/docs/content/docs/runtimes/concepts/threads.mdx
@@ -288,6 +288,12 @@ A few invariants worth knowing when wiring a custom UI on top of `loadMore()`:
       required: true,
     },
     {
+      name: "updateCustom",
+      type: "(remoteId: string, custom: Record<string, unknown> | undefined) => Promise<void>",
+      description:
+        "Optional. Persist replacement custom metadata from `aui.threadListItem().updateCustom(custom)`.",
+    },
+    {
       name: "archive",
       type: "(remoteId: string) => Promise<void>",
       description: "Mark thread archived.",
@@ -355,7 +361,7 @@ function ThreadListItemMeta() {
 }
 ```
 
-`custom` is preserved across `rename`, `archive`, `unarchive`, and `generateTitle`. To mutate it, return updated values from a subsequent `fetch()` or call `runtime.threads.reload()`.
+`custom` is preserved across `rename`, `archive`, `unarchive`, and `generateTitle`. To replace it from your UI, implement `RemoteThreadListAdapter.updateCustom` and call `aui.threadListItem().updateCustom(custom)`. The cloud adapter persists this through `cloud.threads.update(threadId, { metadata })`. If your adapter mutates thread metadata through a separate application path, return the updated values from `fetch()` or call `aui.threads().reload()` to re-run `list()`.
 
 ## ExternalStoreThreadListAdapter
 

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
@@ -28,13 +28,12 @@ type LocalStorageAdapterOptions = {
   titleGenerator?: TitleGenerationAdapter | undefined;
 };
 
-// `RemoteThreadMetadata.custom` is intentionally not persisted; consumers that
-// need it across reloads should fork this adapter or use a remote backend.
 type StoredThreadMetadata = {
   remoteId: string;
   externalId?: string;
   status: "regular" | "archived";
   title?: string;
+  custom?: Record<string, unknown> | undefined;
 };
 
 class AsyncStorageHistoryAdapter implements ThreadHistoryAdapter {
@@ -131,6 +130,7 @@ export const createLocalStorageAdapter = (
           externalId: t.externalId,
           status: t.status,
           title: t.title,
+          custom: t.custom,
         })),
       };
     },
@@ -158,6 +158,18 @@ export const createLocalStorageAdapter = (
       const thread = threads.find((t) => t.remoteId === remoteId);
       if (thread) {
         thread.title = newTitle;
+        await saveThreadMetadata(threads);
+      }
+    },
+
+    async updateCustom(
+      remoteId: string,
+      custom: Record<string, unknown> | undefined,
+    ): Promise<void> {
+      const threads = await loadThreadMetadata();
+      const thread = threads.find((t) => t.remoteId === remoteId);
+      if (thread) {
+        thread.custom = custom;
         await saveThreadMetadata(threads);
       }
     },
@@ -196,6 +208,7 @@ export const createLocalStorageAdapter = (
         externalId: thread.externalId,
         status: thread.status,
         title: thread.title,
+        custom: thread.custom,
       };
     },
 

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -508,6 +508,45 @@ export class RemoteThreadListThreadListRuntimeCore
     });
   }
 
+  public updateCustom(
+    threadIdOrRemoteId: string,
+    custom: Record<string, unknown> | undefined,
+  ): Promise<void> {
+    const data = this.getItemById(threadIdOrRemoteId);
+    if (!data) throw new Error("Thread not found");
+    if (data.status === "new") throw new Error("Thread is not yet initialized");
+
+    const adapter = this._options.adapter;
+    const updateCustom = adapter.updateCustom;
+    if (!updateCustom) {
+      throw new Error(
+        "Remote thread list adapter does not support updating custom metadata",
+      );
+    }
+
+    return this._state.optimisticUpdate({
+      execute: async () => {
+        const { remoteId } = await data.initializeTask;
+        return updateCustom.call(adapter, remoteId, custom);
+      },
+      optimistic: (state) => {
+        const data = getThreadData(state, threadIdOrRemoteId);
+        if (!data || data.status === "new") return state;
+
+        return {
+          ...state,
+          threadData: {
+            ...state.threadData,
+            [data.id]: {
+              ...data,
+              custom,
+            },
+          },
+        };
+      },
+    });
+  }
+
   private async _ensureThreadIsNotMain(threadId: string) {
     if (threadId === this.newThreadId)
       throw new Error("Cannot ensure new thread is not main");

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -516,9 +516,7 @@ export class RemoteThreadListThreadListRuntimeCore
     if (!data) throw new Error("Thread not found");
     if (data.status === "new") throw new Error("Thread is not yet initialized");
 
-    const adapter = this._options.adapter;
-    const updateCustom = adapter.updateCustom;
-    if (!updateCustom) {
+    if (!this._options.adapter.updateCustom) {
       throw new Error(
         "Remote thread list adapter does not support updating custom metadata",
       );
@@ -527,11 +525,17 @@ export class RemoteThreadListThreadListRuntimeCore
     return this._state.optimisticUpdate({
       execute: async () => {
         const { remoteId } = await data.initializeTask;
-        return updateCustom.call(adapter, remoteId, custom);
+        const adapter = this._options.adapter;
+        if (!adapter.updateCustom) {
+          throw new Error(
+            "Remote thread list adapter does not support updating custom metadata",
+          );
+        }
+        return adapter.updateCustom(remoteId, custom);
       },
       optimistic: (state) => {
         const data = getThreadData(state, threadIdOrRemoteId);
-        if (!data || data.status === "new") return state;
+        if (!data) return state;
 
         return {
           ...state,

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -27,6 +27,9 @@ type CloudThreadListAdapterOptions = {
   delete?: ((threadId: string) => Promise<void>) | undefined;
 };
 
+const toCustom = (value: unknown): Record<string, unknown> | undefined =>
+  isRecord(value) ? value : undefined;
+
 const baseUrl =
   typeof process !== "undefined" &&
   process?.env?.NEXT_PUBLIC_ASSISTANT_BASE_URL;
@@ -92,7 +95,7 @@ export const useCloudThreadListAdapter = (
           remoteId: t.id,
           title: t.title,
           externalId: t.external_id ?? undefined,
-          custom: isRecord(t.metadata) ? t.metadata : undefined,
+          custom: toCustom(t.metadata),
         })),
       };
     },
@@ -151,7 +154,7 @@ export const useCloudThreadListAdapter = (
         remoteId: thread.id,
         title: thread.title,
         externalId: thread.external_id ?? undefined,
-        custom: isRecord(thread.metadata) ? thread.metadata : undefined,
+        custom: toCustom(thread.metadata),
       };
     },
 

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -14,6 +14,7 @@ import { InMemoryThreadListAdapter } from "../../../runtimes/remote-thread-list/
 import { useAssistantCloudThreadHistoryAdapter } from "./AssistantCloudThreadHistoryAdapter";
 import { RuntimeAdapterProvider } from "../RuntimeAdapterProvider";
 import { CloudFileAttachmentAdapter } from "./CloudFileAttachmentAdapter";
+import { isRecord } from "../../../utils/json/is-json";
 
 type ThreadData = {
   externalId: string | undefined;
@@ -91,6 +92,7 @@ export const useCloudThreadListAdapter = (
           remoteId: t.id,
           title: t.title,
           externalId: t.external_id ?? undefined,
+          custom: isRecord(t.metadata) ? t.metadata : undefined,
         })),
       };
     },
@@ -109,6 +111,9 @@ export const useCloudThreadListAdapter = (
 
     rename: async (threadId, newTitle) => {
       return cloud.threads.update(threadId, { title: newTitle });
+    },
+    updateCustom: async (threadId, custom) => {
+      return cloud.threads.update(threadId, { metadata: custom ?? null });
     },
     archive: async (threadId) => {
       return cloud.threads.update(threadId, { is_archived: true });
@@ -146,6 +151,7 @@ export const useCloudThreadListAdapter = (
         remoteId: thread.id,
         title: thread.title,
         externalId: thread.external_id ?? undefined,
+        custom: isRecord(thread.metadata) ? thread.metadata : undefined,
       };
     },
 

--- a/packages/core/src/runtime/api/thread-list-item-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-item-runtime.ts
@@ -38,6 +38,7 @@ export type ThreadListItemRuntime = {
 
   switchTo(options?: { unarchive?: boolean }): Promise<void>;
   rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
   archive(): Promise<void>;
   unarchive(): Promise<void>;
   delete(): Promise<void>;
@@ -74,6 +75,7 @@ export class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
   protected __internal_bindMethods() {
     this.switchTo = this.switchTo.bind(this);
     this.rename = this.rename.bind(this);
+    this.updateCustom = this.updateCustom.bind(this);
     this.archive = this.archive.bind(this);
     this.unarchive = this.unarchive.bind(this);
     this.delete = this.delete.bind(this);
@@ -98,6 +100,19 @@ export class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
     const state = this._core.getState();
 
     return this._threadListBinding.rename(state.id, newTitle);
+  }
+
+  public updateCustom(
+    custom: Record<string, unknown> | undefined,
+  ): Promise<void> {
+    const state = this._core.getState();
+    if (!this._threadListBinding.updateCustom) {
+      throw new Error(
+        "Thread list runtime does not support updating custom metadata",
+      );
+    }
+
+    return this._threadListBinding.updateCustom(state.id, custom);
   }
 
   public archive(): Promise<void> {

--- a/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
@@ -44,6 +44,10 @@ export type ThreadListRuntimeCore = {
 
   detach(threadId: string): Promise<void>;
   rename(threadId: string, newTitle: string): Promise<void>;
+  updateCustom?(
+    threadId: string,
+    custom: Record<string, unknown> | undefined,
+  ): Promise<void>;
   archive(threadId: string): Promise<void>;
   unarchive(threadId: string): Promise<void>;
   delete(threadId: string): Promise<void>;

--- a/packages/core/src/runtimes/external-store/external-store-adapter.ts
+++ b/packages/core/src/runtimes/external-store/external-store-adapter.ts
@@ -24,6 +24,7 @@ export type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
   remoteId?: string | undefined;
   externalId?: string | undefined;
   title?: string | undefined;
+  custom?: Record<string, unknown> | undefined;
 };
 
 export type ExternalStoreThreadListAdapter = {
@@ -46,6 +47,12 @@ export type ExternalStoreThreadListAdapter = {
     threadId: string,
     newTitle: string,
   ) => (Promise<void> | void) | undefined;
+  onUpdateCustom?:
+    | ((
+        threadId: string,
+        custom: Record<string, unknown> | undefined,
+      ) => Promise<void> | void)
+    | undefined;
   onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
   onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
   onDelete?: ((threadId: string) => Promise<void> | void) | undefined;

--- a/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
@@ -197,6 +197,19 @@ export class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCore
     await onRename(threadId, newTitle);
   }
 
+  public async updateCustom(
+    threadId: string,
+    custom: Record<string, unknown> | undefined,
+  ): Promise<void> {
+    const onUpdateCustom = this.adapter.onUpdateCustom;
+    if (!onUpdateCustom)
+      throw new Error(
+        "External store adapter does not support updating custom metadata",
+      );
+
+    await onUpdateCustom(threadId, custom);
+  }
+
   public async detach(): Promise<void> {
     // no-op
   }

--- a/packages/core/src/runtimes/local/local-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-list-runtime-core.ts
@@ -88,10 +88,6 @@ export class LocalThreadListRuntimeCore
     throw new Error("Method not implemented.");
   }
 
-  public updateCustom(): Promise<void> {
-    throw new Error("Method not implemented.");
-  }
-
   public archive(): Promise<void> {
     throw new Error("Method not implemented.");
   }

--- a/packages/core/src/runtimes/local/local-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-list-runtime-core.ts
@@ -88,6 +88,10 @@ export class LocalThreadListRuntimeCore
     throw new Error("Method not implemented.");
   }
 
+  public updateCustom(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
   public archive(): Promise<void> {
     throw new Error("Method not implemented.");
   }

--- a/packages/core/src/runtimes/remote-thread-list/adapter/in-memory.ts
+++ b/packages/core/src/runtimes/remote-thread-list/adapter/in-memory.ts
@@ -17,6 +17,10 @@ export class InMemoryThreadListAdapter implements RemoteThreadListAdapter {
     return Promise.resolve();
   }
 
+  updateCustom(): Promise<void> {
+    return Promise.resolve();
+  }
+
   archive(): Promise<void> {
     return Promise.resolve();
   }

--- a/packages/core/src/runtimes/remote-thread-list/types.ts
+++ b/packages/core/src/runtimes/remote-thread-list/types.ts
@@ -29,6 +29,10 @@ export type RemoteThreadListAdapter = {
   list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
 
   rename(remoteId: string, newTitle: string): Promise<void>;
+  updateCustom?(
+    remoteId: string,
+    custom: Record<string, unknown> | undefined,
+  ): Promise<void>;
   archive(remoteId: string): Promise<void>;
   unarchive(remoteId: string): Promise<void>;
   delete(remoteId: string): Promise<void>;

--- a/packages/core/src/store/runtime-clients/thread-list-item-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-list-item-runtime-client.ts
@@ -44,6 +44,7 @@ export const ThreadListItemClient = resource(
       getState: () => state,
       switchTo: runtime.switchTo,
       rename: runtime.rename,
+      updateCustom: runtime.updateCustom,
       archive: runtime.archive,
       unarchive: runtime.unarchive,
       delete: runtime.delete,

--- a/packages/core/src/store/scopes/thread-list-item.ts
+++ b/packages/core/src/store/scopes/thread-list-item.ts
@@ -14,6 +14,7 @@ export type ThreadListItemMethods = {
   getState(): ThreadListItemState;
   switchTo(options?: { unarchive?: boolean }): void;
   rename(newTitle: string): void;
+  updateCustom(custom: Record<string, unknown> | undefined): void;
   archive(): void;
   unarchive(): void;
   delete(): void;

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-custom-metadata.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-custom-metadata.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
-import { createCore, makeAdapter } from "./remote-thread-list-test-helpers";
+import {
+  createCore,
+  deferred,
+  makeAdapter,
+} from "./remote-thread-list-test-helpers";
 
 describe("RemoteThreadListThreadListRuntimeCore custom metadata", () => {
   it("preserves custom field from list() through to threadItems", async () => {
@@ -119,5 +123,69 @@ describe("RemoteThreadListThreadListRuntimeCore custom metadata", () => {
     expect(core.getItemById("thread-5")?.custom).toEqual({
       workspaceId: "ws-1",
     });
+  });
+
+  it("updates custom through the adapter with optimistic state", async () => {
+    const updateDeferred = deferred<void>();
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "regular" as const,
+            remoteId: "thread-6",
+            externalId: "ext-6",
+            title: "Test",
+            custom: { tag: "old" },
+          },
+        ],
+      })),
+      updateCustom: vi.fn(() => updateDeferred.promise),
+    });
+
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+
+    const updateTask = core.updateCustom("thread-6", { tag: "new" });
+
+    await Promise.resolve();
+
+    expect(adapter.updateCustom).toHaveBeenCalledWith("thread-6", {
+      tag: "new",
+    });
+    expect(core.getItemById("thread-6")?.custom).toEqual({ tag: "new" });
+
+    updateDeferred.resolve();
+    await updateTask;
+
+    expect(core.getItemById("thread-6")?.custom).toEqual({ tag: "new" });
+  });
+
+  it("rolls back custom when adapter update fails", async () => {
+    const updateDeferred = deferred<void>();
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "regular" as const,
+            remoteId: "thread-7",
+            externalId: "ext-7",
+            title: "Test",
+            custom: { tag: "old" },
+          },
+        ],
+      })),
+      updateCustom: vi.fn(() => updateDeferred.promise),
+    });
+
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+
+    const updateTask = core.updateCustom("thread-7", { tag: "new" });
+    expect(core.getItemById("thread-7")?.custom).toEqual({ tag: "new" });
+
+    updateDeferred.reject(new Error("update failed"));
+    await expect(updateTask).rejects.toThrow("update failed");
+
+    expect(core.getItemById("thread-7")?.custom).toEqual({ tag: "old" });
   });
 });

--- a/packages/core/src/tests/thread-list-runtime-getLoadThreadsPromise.test.ts
+++ b/packages/core/src/tests/thread-list-runtime-getLoadThreadsPromise.test.ts
@@ -41,6 +41,7 @@ const createMockCore = (
   getLoadThreadsPromise: () => loadPromise,
   detach: () => Promise.resolve(),
   rename: () => Promise.resolve(),
+  updateCustom: () => Promise.resolve(),
   archive: () => Promise.resolve(),
   unarchive: () => Promise.resolve(),
   delete: () => Promise.resolve(),

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -24,6 +24,7 @@ type ThreadData = {
   id: string;
   title?: string;
   status: "regular" | "archived";
+  custom?: Record<string, unknown> | undefined;
 };
 
 // ThreadListItem Client
@@ -31,11 +32,19 @@ const ThreadListItemClient = resource(
   (props: {
     data: ThreadData;
     onSwitchTo: () => void;
+    onUpdateCustom: (custom: Record<string, unknown> | undefined) => void;
     onArchive: () => void;
     onUnarchive: () => void;
     onDelete: () => void;
   }): ClientOutput<"threadListItem"> => {
-    const { data, onSwitchTo, onArchive, onUnarchive, onDelete } = props;
+    const {
+      data,
+      onSwitchTo,
+      onUpdateCustom,
+      onArchive,
+      onUnarchive,
+      onDelete,
+    } = props;
     const state = tapMemo(
       () => ({
         id: data.id,
@@ -43,14 +52,16 @@ const ThreadListItemClient = resource(
         externalId: undefined,
         title: data.title,
         status: data.status,
+        custom: data.custom,
       }),
-      [data.id, data.title, data.status],
+      [data.id, data.title, data.status, data.custom],
     );
 
     return {
       getState: () => state,
       switchTo: onSwitchTo,
       rename: () => {},
+      updateCustom: onUpdateCustom,
       archive: onArchive,
       unarchive: onUnarchive,
       delete: onDelete,
@@ -96,6 +107,15 @@ export const InMemoryThreadList = resource(
       );
     };
 
+    const handleUpdateCustom = (
+      threadId: string,
+      custom: Record<string, unknown> | undefined,
+    ) => {
+      setThreads((prev) =>
+        prev.map((t) => (t.id === threadId ? { ...t, custom } : t)),
+      );
+    };
+
     const handleDelete = (threadId: string) => {
       setThreads((prev) => prev.filter((t) => t.id !== threadId));
       if (mainThreadId === threadId) {
@@ -122,6 +142,7 @@ export const InMemoryThreadList = resource(
             ThreadListItemClient({
               data: t,
               onSwitchTo: () => handleSwitchToThread(t.id),
+              onUpdateCustom: (custom) => handleUpdateCustom(t.id, custom),
               onArchive: () => handleArchive(t.id),
               onUnarchive: () => handleUnarchive(t.id),
               onDelete: () => handleDelete(t.id),

--- a/packages/react/src/client/SingleThreadList.ts
+++ b/packages/react/src/client/SingleThreadList.ts
@@ -1,4 +1,4 @@
-import { resource, tapMemo } from "@assistant-ui/tap";
+import { resource, tapMemo, tapState } from "@assistant-ui/tap";
 import {
   type ClientElement,
   type ClientOutput,
@@ -9,6 +9,8 @@ const RESOLVED_PROMISE = Promise.resolve();
 const THREAD_ID = "default";
 
 const SingleThreadListItem = resource((): ClientOutput<"threadListItem"> => {
+  const [custom, setCustom] = tapState<Record<string, unknown> | undefined>();
+
   return {
     getState: () => ({
       id: THREAD_ID,
@@ -16,9 +18,11 @@ const SingleThreadListItem = resource((): ClientOutput<"threadListItem"> => {
       externalId: undefined,
       title: undefined,
       status: "regular",
+      custom,
     }),
     switchTo: () => {},
     rename: () => {},
+    updateCustom: setCustom,
     archive: () => {},
     unarchive: () => {},
     delete: () => {},


### PR DESCRIPTION
closes #4191

## summary

- add `aui.threadListItem().updateCustom(custom)` so apps can replace per-thread custom metadata without managing a manual reload path.
- wire `RemoteThreadListAdapter.updateCustom` through remote, cloud, local-storage, and external-store thread list runtimes, including cloud `metadata` readback from `list()` and `fetch()`.
- keep custom updates optimistic with rollback on adapter failure, while low-level core support stays optional for custom thread list cores.
- document the adapter contract and add a patch changeset for `@assistant-ui/core`.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/core test` -> 30 test files and 253 tests passed
- [x] `pnpm --filter @assistant-ui/core exec tsc --noEmit` -> passed
- [x] `pnpm --filter @assistant-ui/core build` -> build complete
- [x] `pnpm lint` -> oxlint and oxfmt clean

### reviewer should verify

- [ ] call `aui.threadListItem().updateCustom({ foo: "bar" })` from a cloud-backed runtime and confirm `useAuiState((s) => s.threadListItem.custom)` updates immediately and remains correct after `aui.threads().reload()`.

## notes

- `pnpm test:types` is currently blocked by an existing `packages/vite/src/index.ts` sourcemap type mismatch unrelated to this branch, so this PR was checked with targeted core TypeScript validation instead.