### PR TITLE
docs: gate AI playground behind feature flag

### DIFF
--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -26,6 +26,9 @@ AUIX_PRISM_API_KEY=
 
 # Xulux coding agent — Blaxel cloud sandbox (app/api/xulux).
 # Required to provision sandboxes for scaffolding.
+# Optional. Set to "1" to enable the AI playground (XuluxApp / Xulux chat routes).
+# When unset, /playground defaults to the non-AI UI Builder and all /api/xulux routes return 404.
+NEXT_PUBLIC_AUI_AI_PLAYGROUND_ENABLED=
 BL_WORKSPACE=
 BL_API_KEY=
 # Optional sandbox overrides:

--- a/apps/docs/app/(demos)/playground/page.tsx
+++ b/apps/docs/app/(demos)/playground/page.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
+import dynamic from "next/dynamic";
 import {
   CodeIcon,
   XIcon,
@@ -42,7 +43,11 @@ import {
   usePlaygroundState,
   type ViewportPreset,
 } from "@/lib/playground-url-state";
-import { XuluxApp } from "@/components/xulux/XuluxApp";
+import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
+
+const XuluxApp = dynamic(() =>
+  import("@/components/xulux/XuluxApp").then((mod) => mod.XuluxApp),
+);
 
 const VIEWPORT_PRESETS = {
   desktop: { width: "100%" as const, label: "Desktop", icon: Monitor },
@@ -127,81 +132,79 @@ function BuilderPlayground() {
     [viewportWidth, setViewportWidth],
   );
 
-  return (
-    <PlaygroundChatProvider config={config} setConfig={setConfig}>
-      <div className="bg-background flex h-full w-full gap-4 overflow-hidden p-2 md:p-4">
-        <div className="hidden w-72 shrink-0 overflow-hidden md:block lg:w-80">
-          <BuilderControls config={config} onChange={setConfig} />
-        </div>
+  const content = (
+    <div className="bg-background flex h-full w-full gap-4 overflow-hidden p-2 md:p-4">
+      <div className="hidden w-72 shrink-0 overflow-hidden md:block lg:w-80">
+        <BuilderControls config={config} onChange={setConfig} />
+      </div>
 
-        <div
-          ref={containerRef}
-          className="bg-muted/30 relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border"
-        >
-          <div className="bg-background/50 flex shrink-0 items-center justify-between border-b px-2 py-2 md:px-3">
-            <div className="hidden items-center gap-1 md:flex">
-              {(Object.keys(VIEWPORT_PRESETS) as ViewportPreset[]).map(
-                (key) => {
-                  const preset = VIEWPORT_PRESETS[key];
-                  const Icon = preset.icon;
-                  return (
-                    <button
-                      type="button"
-                      key={key}
-                      onClick={() => handlePresetChange(key)}
-                      className={cn(
-                        "flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors",
-                        viewportPreset === key
-                          ? "bg-foreground/10 text-foreground"
-                          : "text-muted-foreground hover:text-foreground",
-                      )}
-                    >
-                      <Icon className="size-3.5" />
-                      {preset.label}
-                    </button>
-                  );
-                },
-              )}
-              <code className="bg-muted text-muted-foreground ml-1.5 rounded-sm px-1.5 py-0.5 font-mono text-[11px] ring-1 ring-black/5 ring-inset dark:ring-white/10">
-                {viewportWidth === "100%" ? "100%" : `${viewportWidth}px`}
-              </code>
-            </div>
-
-            <Sheet open={controlsOpen} onOpenChange={setControlsOpen}>
-              <SheetTrigger asChild>
+      <div
+        ref={containerRef}
+        className="bg-muted/30 relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border"
+      >
+        <div className="bg-background/50 flex shrink-0 items-center justify-between border-b px-2 py-2 md:px-3">
+          <div className="hidden items-center gap-1 md:flex">
+            {(Object.keys(VIEWPORT_PRESETS) as ViewportPreset[]).map((key) => {
+              const preset = VIEWPORT_PRESETS[key];
+              const Icon = preset.icon;
+              return (
                 <button
                   type="button"
-                  className="text-muted-foreground hover:bg-foreground/5 hover:text-foreground flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors md:hidden"
-                  aria-label="Open controls"
+                  key={key}
+                  onClick={() => handlePresetChange(key)}
+                  className={cn(
+                    "flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors",
+                    viewportPreset === key
+                      ? "bg-foreground/10 text-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
                 >
-                  <SlidersHorizontal className="size-4" />
-                  <span>Customize</span>
+                  <Icon className="size-3.5" />
+                  {preset.label}
                 </button>
-              </SheetTrigger>
-              <SheetContent
-                side="bottom"
-                className="h-[85vh] overflow-hidden rounded-t-2xl"
+              );
+            })}
+            <code className="bg-muted text-muted-foreground ml-1.5 rounded-sm px-1.5 py-0.5 font-mono text-[11px] ring-1 ring-black/5 ring-inset dark:ring-white/10">
+              {viewportWidth === "100%" ? "100%" : `${viewportWidth}px`}
+            </code>
+          </div>
+
+          <Sheet open={controlsOpen} onOpenChange={setControlsOpen}>
+            <SheetTrigger asChild>
+              <button
+                type="button"
+                className="text-muted-foreground hover:bg-foreground/5 hover:text-foreground flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors md:hidden"
+                aria-label="Open controls"
               >
-                <SheetHeader>
-                  <SheetTitle>Customize</SheetTitle>
-                </SheetHeader>
-                <div className="h-[calc(100%-3rem)] overflow-y-auto px-4 pb-8">
-                  <BuilderControls config={config} onChange={setConfig} />
-                </div>
-              </SheetContent>
-            </Sheet>
+                <SlidersHorizontal className="size-4" />
+                <span>Customize</span>
+              </button>
+            </SheetTrigger>
+            <SheetContent
+              side="bottom"
+              className="h-[85vh] overflow-hidden rounded-t-2xl"
+            >
+              <SheetHeader>
+                <SheetTitle>Customize</SheetTitle>
+              </SheetHeader>
+              <div className="h-[calc(100%-3rem)] overflow-y-auto px-4 pb-8">
+                <BuilderControls config={config} onChange={setConfig} />
+              </div>
+            </SheetContent>
+          </Sheet>
 
-            <div className="flex items-center gap-1">
-              <ThreadListPrimitive.New
-                className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
-                aria-label="New thread"
-              >
-                <Plus className="size-3.5" />
-                <span className="hidden sm:inline">New Thread</span>
-              </ThreadListPrimitive.New>
+          <div className="flex items-center gap-1">
+            <ThreadListPrimitive.New
+              className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
+              aria-label="New thread"
+            >
+              <Plus className="size-3.5" />
+              <span className="hidden sm:inline">New Thread</span>
+            </ThreadListPrimitive.New>
 
-              <ShareButton />
+            <ShareButton />
 
+            {isAiPlaygroundEnabled && (
               <button
                 type="button"
                 onClick={() => setShowChat(!showChat)}
@@ -215,7 +218,9 @@ function BuilderPlayground() {
                 <Sparkles className="size-3.5" />
                 <span className="hidden sm:inline">AI</span>
               </button>
+            )}
 
+            {isAiPlaygroundEnabled && (
               <Sheet open={mobileSheetOpen} onOpenChange={setMobileSheetOpen}>
                 <SheetTrigger asChild>
                   <button
@@ -236,70 +241,74 @@ function BuilderPlayground() {
                   <PlaygroundChatThread onRunningChange={setAiRunning} />
                 </SheetContent>
               </Sheet>
+            )}
 
+            <button
+              type="button"
+              onClick={() => setShowCode(!showCode)}
+              className={cn(
+                "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+                showCode
+                  ? "bg-foreground/10 text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {showCode ? (
+                <>
+                  <XIcon className="size-3.5" />
+                  <span className="hidden sm:inline">Close</span>
+                </>
+              ) : (
+                <>
+                  <CodeIcon className="size-3.5" />
+                  <span className="hidden sm:inline">Code</span>
+                </>
+              )}
+            </button>
+
+            <CreateDialog
+              config={config}
+              container={previewContainerRef}
+              onOpenCodeView={() => setShowCode(true)}
+            >
               <button
                 type="button"
-                onClick={() => setShowCode(!showCode)}
-                className={cn(
-                  "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
-                  showCode
-                    ? "bg-foreground/10 text-foreground"
-                    : "text-muted-foreground hover:text-foreground",
-                )}
+                className="bg-foreground text-background hover:bg-foreground/90 flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
               >
-                {showCode ? (
-                  <>
-                    <XIcon className="size-3.5" />
-                    <span className="hidden sm:inline">Close</span>
-                  </>
-                ) : (
-                  <>
-                    <CodeIcon className="size-3.5" />
-                    <span className="hidden sm:inline">Code</span>
-                  </>
-                )}
+                <SquareTerminal className="size-3.5" />
+                <span className="hidden sm:inline">Create Project</span>
               </button>
-
-              <CreateDialog
-                config={config}
-                container={previewContainerRef}
-                onOpenCodeView={() => setShowCode(true)}
-              >
-                <button
-                  type="button"
-                  className="bg-foreground text-background hover:bg-foreground/90 flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors"
-                >
-                  <SquareTerminal className="size-3.5" />
-                  <span className="hidden sm:inline">Create Project</span>
-                </button>
-              </CreateDialog>
-            </div>
+            </CreateDialog>
           </div>
+        </div>
 
-          <div
-            ref={previewContainerRef}
-            className="relative min-h-0 flex-1 overflow-hidden"
-          >
-            <div className="flex h-full items-stretch justify-center p-2 md:p-4">
-              {viewportWidth !== "100%" && (
-                <div
-                  onMouseDown={(e) => handleResizeStart(e, "left")}
-                  className="group hidden w-4 shrink-0 cursor-ew-resize items-center justify-center md:flex"
-                >
-                  <div className="bg-border group-hover:bg-foreground/30 h-12 w-1 rounded-full transition-colors" />
-                </div>
-              )}
-
+        <div
+          ref={previewContainerRef}
+          className="relative min-h-0 flex-1 overflow-hidden"
+        >
+          <div className="flex h-full items-stretch justify-center p-2 md:p-4">
+            {viewportWidth !== "100%" && (
               <div
-                className="bg-background relative h-full overflow-hidden rounded-lg border shadow-sm max-md:!w-full"
-                style={{
-                  width: viewportWidth === "100%" ? "100%" : viewportWidth,
-                  maxWidth: "100%",
-                }}
+                onMouseDown={(e) => handleResizeStart(e, "left")}
+                className="group hidden w-4 shrink-0 cursor-ew-resize items-center justify-center md:flex"
               >
-                <BuilderPreview config={config} />
+                <div className="bg-border group-hover:bg-foreground/30 h-12 w-1 rounded-full transition-colors" />
+              </div>
+            )}
 
-                {aiRunning && !showCode && !mobileSheetOpen && (
+            <div
+              className="bg-background relative h-full overflow-hidden rounded-lg border shadow-sm max-md:!w-full"
+              style={{
+                width: viewportWidth === "100%" ? "100%" : viewportWidth,
+                maxWidth: "100%",
+              }}
+            >
+              <BuilderPreview config={config} />
+
+              {isAiPlaygroundEnabled &&
+                aiRunning &&
+                !showCode &&
+                !mobileSheetOpen && (
                   <div className="bg-background/90 absolute inset-0 z-4 flex items-center justify-center backdrop-blur-[2px]">
                     <div className="bg-background ring-border flex items-center gap-2 rounded-lg px-4 py-2.5 shadow-lg ring-1">
                       <Loader2 className="text-muted-foreground size-4 animate-spin" />
@@ -310,43 +319,50 @@ function BuilderPlayground() {
                   </div>
                 )}
 
-                {showCode && (
-                  <div className="bg-card absolute inset-0 z-5 overflow-hidden">
-                    <BuilderCodeOutput config={config} />
-                  </div>
-                )}
-              </div>
-
-              {viewportWidth !== "100%" && (
-                <div
-                  onMouseDown={(e) => handleResizeStart(e, "right")}
-                  className="group hidden w-4 shrink-0 cursor-ew-resize items-center justify-center md:flex"
-                >
-                  <div className="bg-border group-hover:bg-foreground/30 h-12 w-1 rounded-full transition-colors" />
+              {showCode && (
+                <div className="bg-card absolute inset-0 z-5 overflow-hidden">
+                  <BuilderCodeOutput config={config} />
                 </div>
               )}
             </div>
+
+            {viewportWidth !== "100%" && (
+              <div
+                onMouseDown={(e) => handleResizeStart(e, "right")}
+                className="group hidden w-4 shrink-0 cursor-ew-resize items-center justify-center md:flex"
+              >
+                <div className="bg-border group-hover:bg-foreground/30 h-12 w-1 rounded-full transition-colors" />
+              </div>
+            )}
           </div>
         </div>
-
-        {showChat && (
-          <div className="bg-background hidden h-full shrink-0 flex-col overflow-hidden rounded-xl border md:flex md:w-80">
-            <div className="flex items-center justify-between border-b px-3 py-2">
-              <span className="text-sm font-medium">AI Assistant</span>
-              <button
-                type="button"
-                onClick={() => setShowChat(false)}
-                className="text-muted-foreground hover:text-foreground rounded-md p-1 transition-colors"
-                aria-label="Close chat"
-              >
-                <XIcon className="size-4" />
-              </button>
-            </div>
-            <PlaygroundChatThread onRunningChange={setAiRunning} />
-          </div>
-        )}
       </div>
+
+      {isAiPlaygroundEnabled && showChat && (
+        <div className="bg-background hidden h-full shrink-0 flex-col overflow-hidden rounded-xl border md:flex md:w-80">
+          <div className="flex items-center justify-between border-b px-3 py-2">
+            <span className="text-sm font-medium">AI Assistant</span>
+            <button
+              type="button"
+              onClick={() => setShowChat(false)}
+              className="text-muted-foreground hover:text-foreground rounded-md p-1 transition-colors"
+              aria-label="Close chat"
+            >
+              <XIcon className="size-4" />
+            </button>
+          </div>
+          <PlaygroundChatThread onRunningChange={setAiRunning} />
+        </div>
+      )}
+    </div>
+  );
+
+  return isAiPlaygroundEnabled ? (
+    <PlaygroundChatProvider config={config} setConfig={setConfig}>
+      {content}
     </PlaygroundChatProvider>
+  ) : (
+    content
   );
 }
 
@@ -364,41 +380,49 @@ function HeaderPortal({ children }: { children: ReactNode }) {
 }
 
 export default function PlaygroundPage() {
-  const [mode, setMode] = useState<"agent" | "builder">("agent");
+  const [mode, setMode] = useState<"agent" | "builder">(
+    isAiPlaygroundEnabled ? "agent" : "builder",
+  );
 
   return (
     <>
-      <HeaderPortal>
-        <div className="bg-muted/40 grid grid-cols-2 rounded-md border p-0.5 text-xs">
-          <button
-            type="button"
-            onClick={() => setMode("agent")}
-            className={cn(
-              "rounded px-2.5 py-1 font-medium transition-colors",
-              mode === "agent"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            AI Builder
-          </button>
-          <button
-            type="button"
-            onClick={() => setMode("builder")}
-            className={cn(
-              "rounded px-2.5 py-1 font-medium transition-colors",
-              mode === "builder"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            UI Builder
-          </button>
-        </div>
-      </HeaderPortal>
+      {isAiPlaygroundEnabled && (
+        <HeaderPortal>
+          <div className="bg-muted/40 grid grid-cols-2 rounded-md border p-0.5 text-xs">
+            <button
+              type="button"
+              onClick={() => setMode("agent")}
+              className={cn(
+                "rounded px-2.5 py-1 font-medium transition-colors",
+                mode === "agent"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              AI Builder
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode("builder")}
+              className={cn(
+                "rounded px-2.5 py-1 font-medium transition-colors",
+                mode === "builder"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              UI Builder
+            </button>
+          </div>
+        </HeaderPortal>
+      )}
 
       <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
-        {mode === "agent" ? <XuluxApp /> : <BuilderPlayground />}
+        {isAiPlaygroundEnabled && mode === "agent" ? (
+          <XuluxApp />
+        ) : (
+          <BuilderPlayground />
+        )}
       </div>
     </>
   );

--- a/apps/docs/app/(demos)/playground/page.tsx
+++ b/apps/docs/app/(demos)/playground/page.tsx
@@ -359,12 +359,10 @@ function BuilderPlayground() {
     </div>
   );
 
-  return isAiPlaygroundEnabled ? (
+  return (
     <PlaygroundChatProvider config={config} setConfig={setConfig}>
       {content}
     </PlaygroundChatProvider>
-  ) : (
-    content
   );
 }
 

--- a/apps/docs/app/(demos)/playground/page.tsx
+++ b/apps/docs/app/(demos)/playground/page.tsx
@@ -45,9 +45,11 @@ import {
 } from "@/lib/playground-url-state";
 import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
 
-const XuluxApp = dynamic(() =>
-  import("@/components/xulux/XuluxApp").then((mod) => mod.XuluxApp),
-);
+const XuluxApp = isAiPlaygroundEnabled
+  ? dynamic(() =>
+      import("@/components/xulux/XuluxApp").then((mod) => mod.XuluxApp),
+    )
+  : null;
 
 const VIEWPORT_PRESETS = {
   desktop: { width: "100%" as const, label: "Desktop", icon: Monitor },
@@ -418,11 +420,7 @@ export default function PlaygroundPage() {
       )}
 
       <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
-        {isAiPlaygroundEnabled && mode === "agent" ? (
-          <XuluxApp />
-        ) : (
-          <BuilderPlayground />
-        )}
+        {XuluxApp && mode === "agent" ? <XuluxApp /> : <BuilderPlayground />}
       </div>
     </>
   );

--- a/apps/docs/app/api/playground-chat/route.ts
+++ b/apps/docs/app/api/playground-chat/route.ts
@@ -3,6 +3,7 @@ import { validateGeneralChatInput } from "@/lib/validate-input";
 import { getModel } from "@/lib/ai/provider";
 import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
 import { frontendTools } from "@assistant-ui/react-ai-sdk";
+import { NextResponse } from "next/server";
 import {
   convertToModelMessages,
   pruneMessages,
@@ -137,7 +138,7 @@ When using customCSS, APPEND to any existing customCSS (from current config) rat
 
 export async function POST(req: Request) {
   if (!isAiPlaygroundEnabled) {
-    return new Response("Not found", { status: 404 });
+    return NextResponse.json({ error: "Not found." }, { status: 404 });
   }
 
   try {

--- a/apps/docs/app/api/playground-chat/route.ts
+++ b/apps/docs/app/api/playground-chat/route.ts
@@ -1,6 +1,7 @@
 import { checkRateLimit } from "@/lib/rate-limit";
 import { validateGeneralChatInput } from "@/lib/validate-input";
 import { getModel } from "@/lib/ai/provider";
+import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
 import { frontendTools } from "@assistant-ui/react-ai-sdk";
 import {
   convertToModelMessages,
@@ -135,6 +136,10 @@ When using customCSS, APPEND to any existing customCSS (from current config) rat
 `;
 
 export async function POST(req: Request) {
+  if (!isAiPlaygroundEnabled) {
+    return new Response("Not found", { status: 404 });
+  }
+
   try {
     const rateLimitResponse = await checkRateLimit(req);
     if (rateLimitResponse) return rateLimitResponse;

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -4,6 +4,7 @@ import { injectQuoteContext } from "@assistant-ui/react-ai-sdk";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { validateDocChatInput } from "@/lib/validate-input";
 import { getModel, openai } from "@/lib/ai/provider";
+import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
 import { prismAISDK } from "@aui-x/prism";
 import { withTracing } from "@posthog/ai";
 import {
@@ -244,6 +245,10 @@ Use inline code (\`backticks\`) for:
 `;
 
 export async function POST(req: Request): Promise<Response> {
+  if (!isAiPlaygroundEnabled) {
+    return new Response("Not found", { status: 404 });
+  }
+
   try {
     const rateLimitResponse = await checkRateLimit(req);
     if (rateLimitResponse) return rateLimitResponse;

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -7,6 +7,7 @@ import { getModel, openai } from "@/lib/ai/provider";
 import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
 import { prismAISDK } from "@aui-x/prism";
 import { withTracing } from "@posthog/ai";
+import { NextResponse } from "next/server";
 import {
   convertToModelMessages,
   pruneMessages,
@@ -246,7 +247,7 @@ Use inline code (\`backticks\`) for:
 
 export async function POST(req: Request): Promise<Response> {
   if (!isAiPlaygroundEnabled) {
-    return new Response("Not found", { status: 404 });
+    return NextResponse.json({ error: "Not found." }, { status: 404 });
   }
 
   try {

--- a/apps/docs/app/api/xulux/download/route.ts
+++ b/apps/docs/app/api/xulux/download/route.ts
@@ -1,11 +1,16 @@
 import { Readable } from "node:stream";
 import { NextResponse } from "next/server";
 import { checkRateLimit } from "@/lib/rate-limit";
+import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
 import { exportWorkspaceArchive } from "../blaxel-sandbox";
 
 export const maxDuration = 120;
 
 export async function POST(request: Request) {
+  if (!isAiPlaygroundEnabled) {
+    return NextResponse.json({ error: "Not found." }, { status: 404 });
+  }
+
   let cleanup: (() => Promise<void>) | undefined;
   const runCleanup = () => {
     const current = cleanup;

--- a/apps/docs/app/api/xulux/examples/route.ts
+++ b/apps/docs/app/api/xulux/examples/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
+import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
 import { getXuluxExamplesCatalog } from "@/lib/xulux/examples-catalog";
 
 export function GET() {
+  if (!isAiPlaygroundEnabled) {
+    return NextResponse.json({ error: "Not found." }, { status: 404 });
+  }
+
   return NextResponse.json(getXuluxExamplesCatalog());
 }

--- a/apps/docs/app/xulux-preview/[slug]/page.tsx
+++ b/apps/docs/app/xulux-preview/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { ExamplePreview } from "@/components/xulux/examples/ExamplePreview";
+import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
 import { getXuluxExamplePreview } from "@/lib/xulux/examples-catalog";
 
 export default async function Page({
@@ -7,6 +8,8 @@ export default async function Page({
 }: {
   params: Promise<{ slug: string }>;
 }) {
+  if (!isAiPlaygroundEnabled) notFound();
+
   const { slug } = await params;
   const preview = getXuluxExamplePreview(slug);
   if (!preview) notFound();

--- a/apps/docs/lib/feature-flags.ts
+++ b/apps/docs/lib/feature-flags.ts
@@ -1,0 +1,2 @@
+export const isAiPlaygroundEnabled =
+  process.env.NEXT_PUBLIC_AUI_AI_PLAYGROUND_ENABLED === "1";


### PR DESCRIPTION
## Summary
- add a shared AI playground feature flag for the docs app
- default /playground to the non-AI UI Builder when the flag is off
- return 404 from playground AI and Xulux backend routes unless the flag is enabled

## Validation
- pnpm lint
- pnpm --filter @assistant-ui/docs exec tsc --noEmit
- pnpm build

No changeset: docs app is private.