### PR TITLE
feat(react-ag-ui): apply STATE_DELTA events

### DIFF
--- a/.changeset/state-delta-ag-ui.md
+++ b/.changeset/state-delta-ag-ui.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat(react-ag-ui): apply AG-UI STATE_DELTA events

--- a/packages/react-ag-ui/package.json
+++ b/packages/react-ag-ui/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "@ag-ui/client": "^0.0.54",
     "@assistant-ui/core": "^0.2.9",
-    "assistant-stream": "^0.3.19"
+    "assistant-stream": "^0.3.19",
+    "fast-json-patch": "^3.1.1"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -733,13 +733,12 @@ export class AgUiThreadRuntimeCore {
       case "STATE_DELTA": {
         if (event.delta.length === 0) return;
         try {
-          const state =
-            this.stateSnapshot === undefined ? {} : this.stateSnapshot;
+          const state = this.stateSnapshot ?? {};
           const result = jsonpatch.applyPatch(
             state,
             event.delta as Operation[],
-            true,
-            false,
+            /* validateOperation */ true,
+            /* mutateDocument */ false,
           );
           this.stateSnapshot = result.newDocument as ReadonlyJSONValue;
           this.notifyUpdate();

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -12,6 +12,7 @@ import type {
   ThreadMessage,
 } from "@assistant-ui/core";
 import type { HttpAgent } from "@ag-ui/client";
+import jsonpatch, { type Operation } from "fast-json-patch";
 import type { Logger } from "./logger";
 import type { AgUiEvent, AgUiInterrupt, AgUiResumeEntry } from "./types";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
@@ -730,7 +731,21 @@ export class AgUiThreadRuntimeCore {
         return;
       }
       case "STATE_DELTA": {
-        this.logger.debug?.("[agui] state delta event ignored", event.delta);
+        if (event.delta.length === 0) return;
+        try {
+          const state =
+            this.stateSnapshot === undefined ? {} : this.stateSnapshot;
+          const result = jsonpatch.applyPatch(
+            state,
+            event.delta as Operation[],
+            true,
+            false,
+          );
+          this.stateSnapshot = result.newDocument as ReadonlyJSONValue;
+          this.notifyUpdate();
+        } catch (error) {
+          this.logger.error?.("[agui] failed to apply state delta", error);
+        }
         return;
       }
       case "MESSAGES_SNAPSHOT": {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -9,7 +9,7 @@ import type {
 } from "@assistant-ui/core";
 import type { HttpAgent } from "@ag-ui/client";
 import { AgUiThreadRuntimeCore } from "../src/runtime/AgUiThreadRuntimeCore";
-import { makeLogger } from "../src/runtime/logger";
+import { makeLogger, type Logger } from "../src/runtime/logger";
 
 const createAppendMessage = (
   overrides: Partial<AppendMessage> = {},
@@ -33,11 +33,12 @@ const createCore = (
     onError?: (e: Error) => void;
     onCancel?: () => void;
     history?: ThreadHistoryAdapter;
+    logger?: Logger;
   } = {},
 ) =>
   new AgUiThreadRuntimeCore({
     agent,
-    logger: noopLogger,
+    logger: hooks.logger ?? noopLogger,
     showThinking: true,
     ...(hooks.onError ? { onError: hooks.onError } : {}),
     ...(hooks.onCancel ? { onCancel: hooks.onCancel } : {}),
@@ -196,6 +197,113 @@ describe("AGUIThreadRuntimeCore", () => {
         content: '{"temperature":"22C"}',
       }),
     );
+  });
+
+  it("applies state deltas to the current state snapshot", async () => {
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onStateSnapshotEvent?.({
+          event: {
+            type: "STATE_SNAPSHOT",
+            snapshot: { count: 0, label: "initial" },
+          },
+        });
+        subscriber.onStateDeltaEvent?.({
+          event: {
+            type: "STATE_DELTA",
+            delta: [{ op: "replace", path: "/count", value: 1 }],
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    expect(core.getState()).toEqual({ count: 1, label: "initial" });
+  });
+
+  it("applies deltas before a snapshot from an empty state object", async () => {
+    const runInputs: any[] = [];
+    const agent = {
+      runAgent: vi.fn(async (input, subscriber) => {
+        runInputs.push(JSON.parse(JSON.stringify(input)));
+        if (runInputs.length === 1) {
+          subscriber.onStateDeltaEvent?.({
+            event: {
+              type: "STATE_DELTA",
+              delta: [{ op: "add", path: "/foo", value: "bar" }],
+            },
+          });
+        }
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+    expect(core.getState()).toEqual({ foo: "bar" });
+
+    await core.resume({
+      parentId: null,
+      sourceId: null,
+      runConfig: {} as TestRunConfig,
+    });
+
+    expect(runInputs[1].state).toEqual({ foo: "bar" });
+  });
+
+  it("isolates invalid state deltas and leaves state unchanged", async () => {
+    const error = vi.fn();
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onStateSnapshotEvent?.({
+          event: { type: "STATE_SNAPSHOT", snapshot: { count: 0 } },
+        });
+        subscriber.onStateDeltaEvent?.({
+          event: {
+            type: "STATE_DELTA",
+            delta: [{ op: "replace", path: "/missing", value: 1 }],
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent, { logger: makeLogger({ error }) });
+    await core.append(createAppendMessage());
+
+    expect(core.getState()).toEqual({ count: 0 });
+    expect(error).toHaveBeenCalledWith(
+      "[agui] failed to apply state delta",
+      expect.any(Error),
+    );
+  });
+
+  it("does not allow state deltas to modify object prototypes", async () => {
+    const error = vi.fn();
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onStateSnapshotEvent?.({
+          event: { type: "STATE_SNAPSHOT", snapshot: {} },
+        });
+        subscriber.onStateDeltaEvent?.({
+          event: {
+            type: "STATE_DELTA",
+            delta: [{ op: "add", path: "/__proto__/polluted", value: true }],
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent, { logger: makeLogger({ error }) });
+    await core.append(createAppendMessage());
+
+    expect(core.getState()).toEqual({});
+    expect(({} as any).polluted).toBeUndefined();
+    expect(error).toHaveBeenCalled();
   });
 
   it("marks runs as cancelled when aborting", async () => {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -254,6 +254,30 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(runInputs[1].state).toEqual({ foo: "bar" });
   });
 
+  it("applies state deltas after a null state snapshot", async () => {
+    const error = vi.fn();
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onStateSnapshotEvent?.({
+          event: { type: "STATE_SNAPSHOT", snapshot: null },
+        });
+        subscriber.onStateDeltaEvent?.({
+          event: {
+            type: "STATE_DELTA",
+            delta: [{ op: "add", path: "/foo", value: "bar" }],
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent, { logger: makeLogger({ error }) });
+    await core.append(createAppendMessage());
+
+    expect(core.getState()).toEqual({ foo: "bar" });
+    expect(error).not.toHaveBeenCalled();
+  });
+
   it("isolates invalid state deltas and leaves state unchanged", async () => {
     const error = vi.fn();
     const agent = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3307,6 +3307,9 @@ importers:
       assistant-stream:
         specifier: ^0.3.19
         version: link:../assistant-stream
+      fast-json-patch:
+        specifier: ^3.1.1
+        version: 3.1.1
     devDependencies:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*


### PR DESCRIPTION
## summary

- apply AG-UI `STATE_DELTA` events to `react-ag-ui` state snapshots instead of ignoring them
- use `fast-json-patch` to match AG-UI client behavior, including validation and prototype pollution protection
- preserve error isolation for malformed deltas and keep the previous state unchanged
- add a patch changeset for `@assistant-ui/react-ag-ui`

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ag-ui exec vitest run test/ag-ui-thread-runtime-core.spec.ts` -> 40/40 green
- [x] `pnpm --filter @assistant-ui/react-ag-ui test` -> 106/106 green
- [x] `pnpm --filter @assistant-ui/react-ag-ui build` -> build complete
- [x] `pnpm lint` -> oxlint and oxfmt passed
- [x] built ESM smoke test with `node --input-type=module` -> `STATE_DELTA` applied through `dist/runtime/AgUiThreadRuntimeCore.js`

### reviewer should verify

- [ ] run an AG-UI agent that emits `STATE_DELTA` before a full snapshot and confirm the next run receives the updated state in `RunAgentInput.state`

## notes

- replaces the abandoned #4188 direction with AG-UI client aligned patch handling