### PR TITLE
feat(react): sticky composer mode + ComposerPrimitive.Mode

### DIFF
--- a/.changeset/composer-modes.md
+++ b/.changeset/composer-modes.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+feat: add sticky composer `mode` (`setMode` / `ComposerPrimitive.Mode`) delivered to the backend via `runConfig.custom.mode`

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/composer.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/composer.mdx
@@ -3,7 +3,7 @@ title: ComposerPrimitive
 description: Composable input primitives for assistant-ui prompts, send controls, cancellation, attachments, and composer state.
 ---
 
-import { ComposerPrimitiveAddAttachmentProps, ComposerPrimitiveAttachmentByIndexProps, ComposerPrimitiveAttachmentDropzoneProps, ComposerPrimitiveAttachmentsProps, ComposerPrimitiveCancelProps, ComposerPrimitiveDictateProps, ComposerPrimitiveDictationTranscriptProps, ComposerPrimitiveIfProps, ComposerPrimitiveInputProps, ComposerPrimitiveQueueProps, ComposerPrimitiveQuoteDismissProps, ComposerPrimitiveQuoteProps, ComposerPrimitiveQuoteTextProps, ComposerPrimitiveRootProps, ComposerPrimitiveSendProps, ComposerPrimitiveStopDictationProps, ComposerPrimitiveUnstable_TriggerPopoverBackProps, ComposerPrimitiveUnstable_TriggerPopoverCategoriesProps, ComposerPrimitiveUnstable_TriggerPopoverCategoryItemProps, ComposerPrimitiveUnstable_TriggerPopoverItemProps, ComposerPrimitiveUnstable_TriggerPopoverItemsProps, ComposerPrimitiveUnstable_TriggerPopoverProps, ComposerPrimitiveUnstable_TriggerPopoverRootProps } from "@/generated/typeDocs";
+import { ComposerPrimitiveAddAttachmentProps, ComposerPrimitiveAttachmentByIndexProps, ComposerPrimitiveAttachmentDropzoneProps, ComposerPrimitiveAttachmentsProps, ComposerPrimitiveCancelProps, ComposerPrimitiveDictateProps, ComposerPrimitiveDictationTranscriptProps, ComposerPrimitiveIfProps, ComposerPrimitiveInputProps, ComposerPrimitiveModeProps, ComposerPrimitiveQueueProps, ComposerPrimitiveQuoteDismissProps, ComposerPrimitiveQuoteProps, ComposerPrimitiveQuoteTextProps, ComposerPrimitiveRootProps, ComposerPrimitiveSendProps, ComposerPrimitiveStopDictationProps, ComposerPrimitiveUnstable_TriggerPopoverBackProps, ComposerPrimitiveUnstable_TriggerPopoverCategoriesProps, ComposerPrimitiveUnstable_TriggerPopoverCategoryItemProps, ComposerPrimitiveUnstable_TriggerPopoverItemProps, ComposerPrimitiveUnstable_TriggerPopoverItemsProps, ComposerPrimitiveUnstable_TriggerPopoverProps, ComposerPrimitiveUnstable_TriggerPopoverRootProps } from "@/generated/typeDocs";
 import { ComposerPrimitive as ComposerPrimitiveDocs } from "@/generated/primitiveDocs";
 
 {/* AUTO-GENERATED PAGE by scripts/generate-api-reference.mts */}
@@ -349,6 +349,22 @@ Only takes effect when `submitMode` resolves to `"enter"` (the default); `"ctrlE
 )}
 
 <ParametersTable {...ComposerPrimitiveQuoteDismissProps} />
+
+### Mode
+
+{ComposerPrimitiveDocs.Mode?.deprecated && (
+  <Callout type="warn">
+    <strong>Deprecated.</strong> {ComposerPrimitiveDocs.Mode.deprecated}
+  </Callout>
+)}
+
+{ComposerPrimitiveDocs.Mode?.description}
+
+{ComposerPrimitiveDocs.Mode?.element && (
+  <p>This primitive renders a <code>{`<${ComposerPrimitiveDocs.Mode?.element}>`}</code> element unless <code>asChild</code> is set.</p>
+)}
+
+<ParametersTable {...ComposerPrimitiveModeProps} />
 
 ### Queue
 

--- a/apps/docs/content/docs/primitives/composer.mdx
+++ b/apps/docs/content/docs/primitives/composer.mdx
@@ -299,6 +299,8 @@ const mode = useAuiState((s) => s.composer.mode);
 aui.composer().setMode(undefined);
 ```
 
+Mode selection is single-select: clicking a mode sets it, and there is no built-in deselect — clear with `setMode(undefined)`. The active control only exposes `data-active`; add the ARIA semantics that match your markup (e.g. `aria-pressed` for a toolbar of toggles, `aria-checked` within a `radiogroup`, or `aria-current`).
+
 On the server, read the mode off the run config:
 
 ```ts

--- a/apps/docs/content/docs/primitives/composer.mdx
+++ b/apps/docs/content/docs/primitives/composer.mdx
@@ -274,6 +274,37 @@ Renders the interim transcript while dictation is active. Renders a `<span>` ele
 <ComposerPrimitive.DictationTranscript className="text-sm text-muted-foreground" />
 ```
 
+### Mode
+
+Unstyled button that selects a sticky composer mode (e.g. plan, debug). Render one per mode — the active control receives `data-active="true"` for styling. Clicking calls `setMode(value)`; the mode is sticky across sends and resets. On send, the active mode is delivered to the backend at `runConfig.custom.mode`. Renders a `<button>` element unless `asChild` is set.
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `value` | `string` | The mode id this button selects. |
+
+```tsx
+<div className="aui-composer-modes">
+  <ComposerPrimitive.Mode value="plan">Plan</ComposerPrimitive.Mode>
+  <ComposerPrimitive.Mode value="debug">Debug</ComposerPrimitive.Mode>
+</div>
+```
+
+Read the active mode from state or clear it:
+
+```tsx
+// read
+const mode = useAuiState((s) => s.composer.mode);
+
+// clear
+aui.composer().setMode(undefined);
+```
+
+On the server, read the mode off the run config:
+
+```ts
+const mode = runConfig?.custom?.mode as string | undefined;
+```
+
 ### If (deprecated)
 
 <Callout type="warn">
@@ -508,6 +539,36 @@ The dropzone sets `data-dragging` when a file is being dragged over it, so you c
 <Callout type="info">
 Voice input requires a `DictationAdapter` configured in your runtime. See [Dictation](/docs/guides/dictation) for setup.
 </Callout>
+
+### Composer Modes
+
+Modes let users switch between named contexts (e.g. plan / debug) that are delivered to the backend on every send. The active mode is sticky — it survives sends and `reset()`.
+
+```tsx
+<ComposerPrimitive.Root>
+  <div className="aui-composer-modes">
+    <ComposerPrimitive.Mode value="plan">Plan</ComposerPrimitive.Mode>
+    <ComposerPrimitive.Mode value="debug">Debug</ComposerPrimitive.Mode>
+  </div>
+  <ComposerPrimitive.Input placeholder="Ask anything..." />
+  <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+</ComposerPrimitive.Root>
+```
+
+Style the active button via the `data-active` attribute:
+
+```css
+.aui-composer-modes button[data-active="true"] {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+```
+
+On the server, read the mode from the run config:
+
+```ts
+const mode = runConfig?.custom?.mode as string | undefined;
+```
 
 ### Custom Submit Behavior
 

--- a/apps/docs/content/docs/primitives/composer.mdx
+++ b/apps/docs/content/docs/primitives/composer.mdx
@@ -299,7 +299,7 @@ const mode = useAuiState((s) => s.composer.mode);
 aui.composer().setMode(undefined);
 ```
 
-Mode selection is single-select: clicking a mode sets it, and there is no built-in deselect — clear with `setMode(undefined)`. The active control only exposes `data-active`; add the ARIA semantics that match your markup (e.g. `aria-pressed` for a toolbar of toggles, `aria-checked` within a `radiogroup`, or `aria-current`).
+Mode selection is single-select: clicking a mode sets it, and there is no built-in deselect — clear with `setMode(undefined)`. The active control only exposes `data-active`; add the ARIA that fits a single-select group — `role="radiogroup"` with `aria-checked` on each control, or `aria-current` for the active one.
 
 On the server, read the mode off the run config:
 

--- a/apps/docs/content/docs/primitives/composer.mdx
+++ b/apps/docs/content/docs/primitives/composer.mdx
@@ -570,6 +570,8 @@ On the server, read the mode from the run config:
 const mode = runConfig?.custom?.mode as string | undefined;
 ```
 
+The active mode takes precedence over `runConfig.custom.mode`: if you also call `setRunConfig({ custom: { mode } })`, the value set via `setMode` wins on send.
+
 ### Custom Submit Behavior
 
 Use `onSubmit` on `Root` to intercept submission:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -262,6 +262,9 @@ export type {
 // ThreadMessageLike
 export type { ThreadMessageLike } from "./runtime/utils/thread-message-like";
 
+// Composer mode
+export { applyModeToRunConfig } from "./runtime/utils/apply-mode-to-run-config";
+
 // External Store Message Utilities
 export {
   getExternalStoreMessages,

--- a/packages/core/src/runtime/api/composer-runtime.ts
+++ b/packages/core/src/runtime/api/composer-runtime.ts
@@ -63,6 +63,13 @@ type BaseComposerState = {
    * Undefined when no quote is set.
    */
   readonly quote: QuoteInfo | undefined;
+
+  /**
+   * The currently selected composer mode (e.g. "plan", "debug").
+   * Undefined when no mode is selected. Delivered to the backend via
+   * `runConfig.custom.mode` on send.
+   */
+  readonly mode: string | undefined;
 };
 
 export type ThreadComposerState = BaseComposerState & {
@@ -97,6 +104,7 @@ const getThreadComposerState = (
     attachmentAccept: runtime?.attachmentAccept ?? "",
     dictation: runtime?.dictation,
     quote: runtime?.quote,
+    mode: runtime?.mode,
 
     value: runtime?.text ?? "",
   });
@@ -120,6 +128,7 @@ const getEditComposerState = (
     attachmentAccept: runtime?.attachmentAccept ?? "",
     dictation: runtime?.dictation,
     quote: runtime?.quote,
+    mode: runtime?.mode,
 
     parentId: runtime?.parentId ?? null,
     sourceId: runtime?.sourceId ?? null,
@@ -159,6 +168,13 @@ export type ComposerRuntime = {
    * @param role The role to set in the composer.
    */
   setRole(role: MessageRole): void;
+
+  /**
+   * Set the composer mode (e.g. "plan", "debug"). Sticky across sends and
+   * delivered to the backend via `runConfig.custom.mode`. Pass undefined to clear.
+   * @param mode The mode id to set, or undefined to clear.
+   */
+  setMode(mode: string | undefined): void;
 
   /**
    * Set the run config of the composer. This is used to send custom configuration data to the model.
@@ -252,6 +268,7 @@ export abstract class ComposerRuntimeImpl implements ComposerRuntime {
     this.send = this.send.bind(this);
     this.cancel = this.cancel.bind(this);
     this.setRole = this.setRole.bind(this);
+    this.setMode = this.setMode.bind(this);
     this.getAttachmentByIndex = this.getAttachmentByIndex.bind(this);
     this.startDictation = this.startDictation.bind(this);
     this.stopDictation = this.stopDictation.bind(this);
@@ -307,6 +324,12 @@ export abstract class ComposerRuntimeImpl implements ComposerRuntime {
     const core = this._core.getState();
     if (!core) throw new Error("Composer is not available");
     core.setRole(role);
+  }
+
+  public setMode(mode: string | undefined) {
+    const core = this._core.getState();
+    if (!core) throw new Error("Composer is not available");
+    core.setMode(mode);
   }
 
   public startDictation() {

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -89,6 +89,19 @@ export abstract class BaseComposerRuntimeCore
     this._notifySubscribers();
   }
 
+  private _mode: string | undefined = undefined;
+
+  get mode() {
+    return this._mode;
+  }
+
+  public setMode(mode: string | undefined) {
+    if (this._mode === mode) return;
+
+    this._mode = mode;
+    this._notifySubscribers();
+  }
+
   public setText(value: string) {
     if (this._text === value) return;
 
@@ -188,7 +201,13 @@ export abstract class BaseComposerRuntimeCore
       role: this.role,
       content: text ? [{ type: "text", text }] : [],
       attachments: await attachments,
-      runConfig: this.runConfig,
+      runConfig:
+        this._mode === undefined
+          ? this.runConfig
+          : {
+              ...this.runConfig,
+              custom: { ...this.runConfig.custom, mode: this._mode },
+            },
       metadata: { custom: { ...(quote ? { quote } : {}) } },
     };
 

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -24,6 +24,7 @@ import type {
 } from "../interfaces/composer-runtime-core";
 import type { DictationAdapter } from "../../adapters/speech";
 import { generateId } from "../../utils/id";
+import { applyModeToRunConfig } from "../utils/apply-mode-to-run-config";
 
 const isAttachmentComplete = (a: Attachment): a is CompleteAttachment =>
   a.status.type === "complete";
@@ -201,13 +202,7 @@ export abstract class BaseComposerRuntimeCore
       role: this.role,
       content: text ? [{ type: "text", text }] : [],
       attachments: await attachments,
-      runConfig:
-        this._mode === undefined
-          ? this.runConfig
-          : {
-              ...this.runConfig,
-              custom: { ...this.runConfig.custom, mode: this._mode },
-            },
+      runConfig: applyModeToRunConfig(this.runConfig, this._mode),
       metadata: { custom: { ...(quote ? { quote } : {}) } },
     };
 

--- a/packages/core/src/runtime/interfaces/composer-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/composer-runtime-core.ts
@@ -66,6 +66,9 @@ export type ComposerRuntimeCore = Readonly<{
   role: MessageRole;
   setRole: (role: MessageRole) => void;
 
+  mode: string | undefined;
+  setMode: (mode: string | undefined) => void;
+
   runConfig: RunConfig;
   setRunConfig: (runConfig: RunConfig) => void;
 

--- a/packages/core/src/runtime/utils/apply-mode-to-run-config.ts
+++ b/packages/core/src/runtime/utils/apply-mode-to-run-config.ts
@@ -1,0 +1,12 @@
+import type { RunConfig } from "../../types/message";
+
+export const applyModeToRunConfig = (
+  runConfig: RunConfig,
+  mode: string | undefined,
+): RunConfig => {
+  if (mode === undefined) return runConfig;
+  return {
+    ...runConfig,
+    custom: { ...runConfig.custom, mode },
+  };
+};

--- a/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
+++ b/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
@@ -174,6 +174,12 @@ export class ReadonlyThreadRuntimeCore
       throw READONLY_THREAD_ERROR;
     },
 
+    mode: undefined,
+
+    setMode() {
+      throw READONLY_THREAD_ERROR;
+    },
+
     subscribe() {
       return () => {};
     },

--- a/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
+++ b/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
@@ -155,6 +155,12 @@ export const EMPTY_THREAD_CORE: ThreadRuntimeCore = {
       throw EMPTY_THREAD_ERROR;
     },
 
+    mode: undefined,
+
+    setMode() {
+      throw EMPTY_THREAD_ERROR;
+    },
+
     subscribe() {
       return () => {};
     },

--- a/packages/core/src/store/clients/no-op-composer-client.ts
+++ b/packages/core/src/store/clients/no-op-composer-client.ts
@@ -18,6 +18,7 @@ export const NoOpComposerClient = resource(
         type: type,
         dictation: undefined,
         quote: undefined,
+        mode: undefined,
         queue: [],
       };
     }, [type]);
@@ -61,6 +62,9 @@ export const NoOpComposerClient = resource(
         throw new Error("Not supported");
       },
       setQuote: () => {
+        throw new Error("Not supported");
+      },
+      setMode: () => {
         throw new Error("Not supported");
       },
       queueItem: () => {

--- a/packages/core/src/store/runtime-clients/composer-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/composer-runtime-client.ts
@@ -109,6 +109,7 @@ export const ComposerClient = resource(
         type: runtimeState.type ?? "thread",
         dictation: runtimeState.dictation,
         quote: runtimeState.quote,
+        mode: runtimeState.mode,
         queue: [],
       };
     }, [runtimeState, attachments.state]);
@@ -131,6 +132,7 @@ export const ComposerClient = resource(
       startDictation: runtime.startDictation,
       stopDictation: runtime.stopDictation,
       setQuote: runtime.setQuote,
+      setMode: runtime.setMode,
       attachment: (selector) => {
         if ("id" in selector) {
           return attachments.get({ key: selector.id });

--- a/packages/core/src/store/scopes/composer.ts
+++ b/packages/core/src/store/scopes/composer.ts
@@ -52,6 +52,12 @@ export type ComposerState = {
   readonly quote: QuoteInfo | undefined;
 
   /**
+   * The currently selected composer mode (e.g. "plan", "debug").
+   * Undefined when no mode is selected.
+   */
+  readonly mode: string | undefined;
+
+  /**
    * The queue of messages waiting to be processed.
    * Empty when no messages are queued.
    */
@@ -86,6 +92,12 @@ export type ComposerMethods = {
    * Set a quote for the next message. Pass undefined to clear.
    */
   setQuote(quote: QuoteInfo | undefined): void;
+
+  /**
+   * Set the composer mode. Sticky across sends; delivered to the backend via
+   * `runConfig.custom.mode`. Pass undefined to clear.
+   */
+  setMode(mode: string | undefined): void;
 
   /**
    * Access a queue item by index.

--- a/packages/core/src/tests/composer-mode.test.ts
+++ b/packages/core/src/tests/composer-mode.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import { BaseComposerRuntimeCore } from "../runtime/base/base-composer-runtime-core";
+import type { AppendMessage } from "../types/message";
+
+class TestComposerCore extends BaseComposerRuntimeCore {
+  public sent: Array<Omit<AppendMessage, "parentId" | "sourceId">> = [];
+  protected getAttachmentAdapter() {
+    return undefined;
+  }
+  protected getDictationAdapter() {
+    return undefined;
+  }
+  get canCancel() {
+    return false;
+  }
+  get canSend() {
+    return !this.isEmpty;
+  }
+  protected handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">) {
+    this.sent.push(message);
+  }
+  protected handleCancel() {}
+}
+
+describe("composer mode", () => {
+  it("defaults to undefined and updates via setMode with notification", () => {
+    const composer = new TestComposerCore();
+    expect(composer.mode).toBeUndefined();
+    const listener = vi.fn();
+    composer.subscribe(listener);
+    composer.setMode("plan");
+    expect(composer.mode).toBe("plan");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op when the mode is unchanged", () => {
+    const composer = new TestComposerCore();
+    composer.setMode("plan");
+    const listener = vi.fn();
+    composer.subscribe(listener);
+    composer.setMode("plan");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("survives reset()", async () => {
+    const composer = new TestComposerCore();
+    composer.setMode("plan");
+    composer.setText("hello");
+    await composer.reset();
+    expect(composer.text).toBe("");
+    expect(composer.mode).toBe("plan");
+  });
+
+  it("injects runConfig.custom.mode on send when a mode is set", async () => {
+    const composer = new TestComposerCore();
+    composer.setText("hello");
+    composer.setMode("debug");
+    await composer.send();
+    expect(composer.sent).toHaveLength(1);
+    expect(composer.sent[0]!.runConfig).toEqual({ custom: { mode: "debug" } });
+  });
+
+  it("leaves runConfig untouched on send when no mode is set", async () => {
+    const composer = new TestComposerCore();
+    composer.setText("hello");
+    composer.setRunConfig({ custom: { foo: "bar" } });
+    await composer.send();
+    expect(composer.sent[0]!.runConfig).toEqual({ custom: { foo: "bar" } });
+  });
+
+  it("merges mode with existing runConfig.custom keys", async () => {
+    const composer = new TestComposerCore();
+    composer.setText("hello");
+    composer.setRunConfig({ custom: { foo: "bar" } });
+    composer.setMode("plan");
+    await composer.send();
+    expect(composer.sent[0]!.runConfig).toEqual({
+      custom: { foo: "bar", mode: "plan" },
+    });
+  });
+
+  it("clears the mode and notifies when setMode(undefined) is called", () => {
+    const composer = new TestComposerCore();
+    composer.setMode("plan");
+    const listener = vi.fn();
+    composer.subscribe(listener);
+    composer.setMode(undefined);
+    expect(composer.mode).toBeUndefined();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays set across multiple sends", async () => {
+    const composer = new TestComposerCore();
+    composer.setMode("plan");
+    composer.setText("first");
+    await composer.send();
+    composer.setText("second");
+    await composer.send();
+    expect(composer.mode).toBe("plan");
+    expect(composer.sent).toHaveLength(2);
+    expect(composer.sent[0]!.runConfig).toEqual({ custom: { mode: "plan" } });
+    expect(composer.sent[1]!.runConfig).toEqual({ custom: { mode: "plan" } });
+  });
+
+  it("reset() is a no-op that preserves mode when no other state is dirty", async () => {
+    const composer = new TestComposerCore();
+    composer.setMode("plan");
+    const listener = vi.fn();
+    composer.subscribe(listener);
+    await composer.reset();
+    expect(listener).not.toHaveBeenCalled();
+    expect(composer.mode).toBe("plan");
+  });
+});

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -22,6 +22,7 @@ import type {
   ThreadUserMessagePart,
   ThreadMessage,
 } from "@assistant-ui/core";
+import { applyModeToRunConfig } from "@assistant-ui/core";
 import type { QueueItemState } from "@assistant-ui/core/store";
 import type { ComposerSendOptions } from "@assistant-ui/core/store";
 import { ModelContext, Suggestions } from "@assistant-ui/core/store";
@@ -441,18 +442,7 @@ const ComposerClientResource = resource(
           createdAt: new Date(),
           parentId: null,
           sourceId: null,
-          runConfig:
-            mode === undefined
-              ? runConfig
-              : {
-                  ...runConfig,
-                  custom: {
-                    ...(runConfig.custom as
-                      | Record<string, unknown>
-                      | undefined),
-                    mode,
-                  },
-                },
+          runConfig: applyModeToRunConfig(runConfig, mode),
           startRun: opts?.startRun,
           metadata: {
             custom: { ...(currentQuote ? { quote: currentQuote } : {}) },

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -295,6 +295,7 @@ const ComposerClientResource = resource(
     const [quote, setQuote] = tapState<
       { readonly text: string; readonly messageId: string } | undefined
     >(undefined);
+    const [mode, setMode] = tapState<string | undefined>(undefined);
 
     // Update composer values when editing begins
     const updateFromMessage = tapEffectEvent(() => {
@@ -366,6 +367,7 @@ const ComposerClientResource = resource(
         type,
         dictation: undefined,
         quote,
+        mode,
         queue: queueItems,
       };
     }, [
@@ -379,6 +381,7 @@ const ComposerClientResource = resource(
       type,
       attachments.length,
       quote,
+      mode,
       queueItems,
     ]);
 
@@ -438,7 +441,18 @@ const ComposerClientResource = resource(
           createdAt: new Date(),
           parentId: null,
           sourceId: null,
-          runConfig,
+          runConfig:
+            mode === undefined
+              ? runConfig
+              : {
+                  ...runConfig,
+                  custom: {
+                    ...(runConfig.custom as
+                      | Record<string, unknown>
+                      | undefined),
+                    mode,
+                  },
+                },
           startRun: opts?.startRun,
           metadata: {
             custom: { ...(currentQuote ? { quote: currentQuote } : {}) },
@@ -460,6 +474,7 @@ const ComposerClientResource = resource(
       startDictation: () => {},
       stopDictation: () => {},
       setQuote,
+      setMode,
       queueItem: (selector: { index: number }) => {
         return queueItemClients.get(selector);
       },

--- a/packages/react/src/primitives/composer.ts
+++ b/packages/react/src/primitives/composer.ts
@@ -13,6 +13,7 @@ export { ComposerPrimitiveIf as If } from "./composer/ComposerIf";
 export { ComposerPrimitiveQuote as Quote } from "./composer/ComposerQuote";
 export { ComposerPrimitiveQuoteText as QuoteText } from "./composer/ComposerQuote";
 export { ComposerPrimitiveQuoteDismiss as QuoteDismiss } from "./composer/ComposerQuote";
+export { ComposerPrimitiveMode as Mode } from "./composer/ComposerMode";
 export { ComposerPrimitiveQueue as Queue } from "./composer/ComposerQueue";
 
 export { ComposerPrimitiveTriggerPopover as Unstable_TriggerPopover } from "./composer/trigger";

--- a/packages/react/src/primitives/composer/ComposerMode.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerMode.test.tsx
@@ -59,8 +59,6 @@ describe("ComposerPrimitive.Mode", () => {
 
     expect(planBtn.getAttribute("data-active")).toBe("true");
     expect(debugBtn.getAttribute("data-active")).toBeNull();
-    expect(planBtn.getAttribute("aria-pressed")).toBe("true");
-    expect(debugBtn.getAttribute("aria-pressed")).toBe("false");
 
     act(() => {
       debugBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/packages/react/src/primitives/composer/ComposerMode.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerMode.test.tsx
@@ -59,6 +59,8 @@ describe("ComposerPrimitive.Mode", () => {
 
     expect(planBtn.getAttribute("data-active")).toBe("true");
     expect(debugBtn.getAttribute("data-active")).toBeNull();
+    expect(planBtn.getAttribute("aria-pressed")).toBe("true");
+    expect(debugBtn.getAttribute("aria-pressed")).toBe("false");
 
     act(() => {
       debugBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/packages/react/src/primitives/composer/ComposerMode.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerMode.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComposerPrimitiveMode } from "./ComposerMode";
+
+const setMode = vi.fn<(mode: string | undefined) => void>();
+
+const composerState = {
+  mode: "plan" as string | undefined,
+};
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("@assistant-ui/store", () => {
+  const aui = {
+    composer: () => ({ setMode }),
+  };
+  type Selector<T> = (s: { composer: typeof composerState }) => T;
+  return {
+    useAui: () => aui,
+    useAuiState: <T,>(selector: Selector<T>) =>
+      selector({ composer: composerState }),
+  };
+});
+
+describe("ComposerPrimitive.Mode", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    setMode.mockClear();
+    composerState.mode = "plan";
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("marks the active mode and calls setMode on click", () => {
+    act(() => {
+      root.render(
+        <>
+          <ComposerPrimitiveMode value="plan">Plan</ComposerPrimitiveMode>
+          <ComposerPrimitiveMode value="debug">Debug</ComposerPrimitiveMode>
+        </>,
+      );
+    });
+
+    const buttons = container.querySelectorAll("button");
+    const planBtn = buttons[0]!;
+    const debugBtn = buttons[1]!;
+
+    expect(planBtn.getAttribute("data-active")).toBe("true");
+    expect(debugBtn.getAttribute("data-active")).toBeNull();
+
+    act(() => {
+      debugBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setMode).toHaveBeenCalledWith("debug");
+  });
+});

--- a/packages/react/src/primitives/composer/ComposerMode.tsx
+++ b/packages/react/src/primitives/composer/ComposerMode.tsx
@@ -46,8 +46,7 @@ export const ComposerPrimitiveMode = forwardRef<
   return (
     <Primitive.button
       type="button"
-      aria-pressed={isActive}
-      {...(isActive ? { "data-active": "true" } : {})}
+      {...(isActive ? { "data-active": "true" } : null)}
       {...props}
       ref={forwardedRef}
       onClick={composeEventHandlers(onClick, handleSetMode)}

--- a/packages/react/src/primitives/composer/ComposerMode.tsx
+++ b/packages/react/src/primitives/composer/ComposerMode.tsx
@@ -46,6 +46,7 @@ export const ComposerPrimitiveMode = forwardRef<
   return (
     <Primitive.button
       type="button"
+      aria-pressed={isActive}
       {...(isActive ? { "data-active": "true" } : {})}
       {...props}
       ref={forwardedRef}

--- a/packages/react/src/primitives/composer/ComposerMode.tsx
+++ b/packages/react/src/primitives/composer/ComposerMode.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Primitive } from "../../utils/Primitive";
+import {
+  type ComponentRef,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  useCallback,
+} from "react";
+import { useAui, useAuiState } from "@assistant-ui/store";
+import { composeEventHandlers } from "@radix-ui/primitive";
+
+export namespace ComposerPrimitiveMode {
+  export type Element = ComponentRef<typeof Primitive.button>;
+  export type Props = Omit<
+    ComponentPropsWithoutRef<typeof Primitive.button>,
+    "value"
+  > & {
+    /** The mode id this control selects. */
+    value: string;
+  };
+}
+
+/**
+ * An unstyled button that selects a composer mode. Render one per mode you
+ * support; clicking it calls `setMode(value)`. The active control is marked
+ * with `data-active="true"`.
+ *
+ * @example
+ * ```tsx
+ * <ComposerPrimitive.Mode value="plan">Plan</ComposerPrimitive.Mode>
+ * <ComposerPrimitive.Mode value="debug">Debug</ComposerPrimitive.Mode>
+ * ```
+ */
+export const ComposerPrimitiveMode = forwardRef<
+  ComposerPrimitiveMode.Element,
+  ComposerPrimitiveMode.Props
+>(({ value, onClick, ...props }, forwardedRef) => {
+  const aui = useAui();
+  const isActive = useAuiState((s) => s.composer.mode === value);
+
+  const handleSetMode = useCallback(() => {
+    aui.composer().setMode(value);
+  }, [aui, value]);
+
+  return (
+    <Primitive.button
+      type="button"
+      {...(isActive ? { "data-active": "true" } : {})}
+      {...props}
+      ref={forwardedRef}
+      onClick={composeEventHandlers(onClick, handleSetMode)}
+    />
+  );
+});
+
+ComposerPrimitiveMode.displayName = "ComposerPrimitive.Mode";


### PR DESCRIPTION
## Summary

Adds a sticky, app-defined composer **mode** (e.g. `plan` / `debug`, cursor/codex style). The package tracks only the active mode id; the app owns the mode list and behavior. On send, the active mode is delivered to the backend through the existing `runConfig.custom.mode` channel, so there is no new transport and assistant-ui never interprets the value.

- `useAuiState((s) => s.composer.mode)`: active mode id (`string | undefined`)
- `aui.composer().setMode(id | undefined)`: set/clear, **sticky** across sends and `reset()`
- `ComposerPrimitive.Mode`: unstyled button (`value` prop, one per mode); active control gets `data-active="true"`
- Backend reads `runConfig.custom.mode`

Wired through every composer implementation (base core, runtime API, store scope/clients, readonly + empty-thread cores, and the external-store/AI-SDK path in `ExternalThread`).

### Usage

```tsx
<ComposerPrimitive.Root>
  <div className="aui-composer-modes">
    <ComposerPrimitive.Mode value="plan">Plan</ComposerPrimitive.Mode>
    <ComposerPrimitive.Mode value="debug">Debug</ComposerPrimitive.Mode>
  </div>
  <ComposerPrimitive.Input placeholder="Ask anything..." />
  <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
</ComposerPrimitive.Root>
```

```ts
// server: read the active mode off the run config
const mode = runConfig?.custom?.mode as string | undefined;
```

## Test plan

- New core tests: default/no-op/clear, **survives `reset()`**, **sticky across multiple sends**, send merges `custom.mode` only when set, merges with existing `custom` keys
- New React test: `ComposerPrimitive.Mode` marks active via `data-active`, calls `setMode` on click
- `pnpm turbo run build` passing; core 260 / react 323 tests passing; lint clean