### PR TITLE
feat: add tool call renderText support

### DIFF
--- a/.changeset/tool-render-text.md
+++ b/.changeset/tool-render-text.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+"@assistant-ui/x-generative-compiler": patch
+---
+
+feat: add renderText helpers for tool call status text

--- a/apps/docs/content/docs/(reference)/api-reference/tools/component-tools.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/component-tools.mdx
@@ -12,6 +12,22 @@ import { useAssistantTool } from "@/generated/typeDocs";
 `useAssistantTool` and `makeAssistantTool` register a single tool while a React component is mounted, and remove it on unmount.
 
 Use these APIs when a tool's availability should follow a specific UI surface — for example, a tool that operates on whatever is currently selected in a panel that may or may not be present. For tools that should be available throughout an assistant subtree regardless of which UI is mounted, see [Toolkits](/docs/api-reference/tools/toolkits).
+
+For simple tool-call displays, use `renderText` instead of a custom `render` component:
+
+```tsx
+useAssistantTool({
+  toolName: "search_docs",
+  type: "frontend",
+  description: "Search the docs.",
+  parameters: searchDocsSchema,
+  execute: async ({ query }) => searchDocs(query),
+  renderText: {
+    running: ({ args }) => `Searching for ${args.query}...`,
+    complete: "Search complete",
+  },
+});
+```
 {/* api-manual:end */}
 
 {/* api-reference:start */}

--- a/apps/docs/content/docs/(reference)/api-reference/tools/component-tools.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/component-tools.mdx
@@ -31,6 +31,8 @@ rather than calling [useAssistantTool](/docs/api-reference/tools/component-tools
 type AssistantToolProps = CoreAssistantToolProps<TArgs, TResult> & {
   /** Component used to render calls to this tool in assistant messages. */
   render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
+  /** Lightweight text rendered while a tool call is running or complete. */
+  renderText?: ToolCallText<TArgs, TResult> | undefined;
 };
 
 const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => AssistantTool;

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -135,7 +135,7 @@ export const Tools = resource(
             render: _render,
             renderText: _renderText,
             ...rest
-          } = tool;
+          } = tool as typeof tool & { renderText?: unknown };
           acc[name] = rest as Tool<any, any>;
           return acc;
         },

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -131,8 +131,8 @@ export const Tools = resource(
         (acc, [name, tool]) => {
           if (tool.type === "mcp") return acc;
           const rest = { ...tool };
-          delete rest.display;
-          delete rest.render;
+          if ("display" in rest) delete rest.display;
+          if ("render" in rest) delete rest.render;
           if ("renderText" in rest) delete rest.renderText;
           acc[name] = rest as Tool<any, any>;
           return acc;

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -130,12 +130,10 @@ export const Tools = resource(
       const toolsWithoutRender = Object.entries(toolkit).reduce(
         (acc, [name, tool]) => {
           if (tool.type === "mcp") return acc;
-          const {
-            display: _display,
-            render: _render,
-            renderText: _renderText,
-            ...rest
-          } = tool;
+          const rest = { ...tool };
+          delete rest.display;
+          delete rest.render;
+          if ("renderText" in rest) delete rest.renderText;
           acc[name] = rest as Tool<any, any>;
           return acc;
         },

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -130,10 +130,12 @@ export const Tools = resource(
       const toolsWithoutRender = Object.entries(toolkit).reduce(
         (acc, [name, tool]) => {
           if (tool.type === "mcp") return acc;
-          const rest = { ...tool };
-          if ("display" in rest) delete rest.display;
-          if ("render" in rest) delete rest.render;
-          if ("renderText" in rest) delete rest.renderText;
+          const {
+            display: _display,
+            render: _render,
+            renderText: _renderText,
+            ...rest
+          } = tool;
           acc[name] = rest as Tool<any, any>;
           return acc;
         },

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -17,6 +17,7 @@ import type { McpAppResourceOutput, ToolsState } from "../types/scopes/tools";
 import type { Tool } from "assistant-stream";
 import {
   isStandaloneToolDisplay,
+  makeToolCallTextComponent,
   type Toolkit,
 } from "../model-context/toolbox";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
@@ -106,22 +107,35 @@ export const Tools = resource(
 
       // Register tool UIs (exclude symbols)
       for (const [toolName, tool] of Object.entries(toolkit)) {
-        if ("render" in tool && tool.render) {
+        const toolRender = "render" in tool ? tool.render : undefined;
+        const toolRenderText =
+          "renderText" in tool ? tool.renderText : undefined;
+        const render =
+          toolRender ??
+          (toolRenderText
+            ? makeToolCallTextComponent(toolRenderText)
+            : undefined);
+        if (render) {
           unsubscribes.push(
-            setToolUI(toolName, tool.render, {
+            setToolUI(toolName, render, {
               standalone: isStandaloneToolDisplay(tool),
             }),
           );
         }
       }
 
-      // Register tools with model context (exclude symbols). `render` and
-      // `display` are client-only presentation concerns and never reach the
-      // model.
+      // Register tools with model context (exclude symbols). `render`,
+      // `renderText`, and `display` are client-only presentation concerns and
+      // never reach the model.
       const toolsWithoutRender = Object.entries(toolkit).reduce(
         (acc, [name, tool]) => {
           if (tool.type === "mcp") return acc;
-          const { display: _display, render: _render, ...rest } = tool;
+          const {
+            display: _display,
+            render: _render,
+            renderText: _renderText,
+            ...rest
+          } = tool;
           acc[name] = rest as Tool<any, any>;
           return acc;
         },

--- a/packages/core/src/react/index.ts
+++ b/packages/core/src/react/index.ts
@@ -37,6 +37,7 @@ export {
   type ToolDefinition,
   type ToolkitDefinition,
   type ToolkitDefinitionEntry,
+  type ToolCallText,
 } from "./model-context/toolbox";
 export { defineToolkit } from "./model-context/define-toolkit";
 export { hitl, hitlTool } from "./model-context/hitl";

--- a/packages/core/src/react/model-context/toolbox.test.ts
+++ b/packages/core/src/react/model-context/toolbox.test.ts
@@ -139,4 +139,44 @@ describe("makeToolCallTextComponent", () => {
       }),
     ).toBe("Waiting for approval...");
   });
+
+  it("renders null for terminal status when only running text is provided", () => {
+    const Render = makeToolCallTextComponent({
+      running: "Searching...",
+    });
+
+    expect(
+      Render({
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "search",
+        args: {},
+        argsText: "{}",
+        status: { type: "complete" },
+        addResult: () => {},
+        resume: () => {},
+        respondToApproval: () => {},
+      }),
+    ).toBeNull();
+  });
+
+  it("renders null for running status when only complete text is provided", () => {
+    const Render = makeToolCallTextComponent({
+      complete: "Done",
+    });
+
+    expect(
+      Render({
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "search",
+        args: {},
+        argsText: "{}",
+        status: { type: "running" },
+        addResult: () => {},
+        resume: () => {},
+        respondToApproval: () => {},
+      }),
+    ).toBeNull();
+  });
 });

--- a/packages/core/src/react/model-context/toolbox.test.ts
+++ b/packages/core/src/react/model-context/toolbox.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { makeToolCallTextComponent } from "./toolbox";
+
+describe("makeToolCallTextComponent", () => {
+  it("renders static running and complete text", () => {
+    const Render = makeToolCallTextComponent({
+      running: "Searching...",
+      complete: "Done searching",
+    });
+
+    expect(
+      Render({
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "search",
+        args: {},
+        argsText: "{}",
+        status: { type: "running" },
+        addResult: () => {},
+        resume: () => {},
+        respondToApproval: () => {},
+      }),
+    ).toBe("Searching...");
+
+    expect(
+      Render({
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "search",
+        args: {},
+        argsText: "{}",
+        result: "ok",
+        status: { type: "complete" },
+        addResult: () => {},
+        resume: () => {},
+        respondToApproval: () => {},
+      }),
+    ).toBe("Done searching");
+  });
+
+  it("passes args and result to dynamic text functions", () => {
+    const Render = makeToolCallTextComponent<
+      { query: string },
+      { count: number }
+    >({
+      running: ({ args }) => `Searching ${args.query}...`,
+      complete: ({ args, result }) =>
+        `Found ${result?.count ?? 0} results for ${args.query}`,
+    });
+
+    expect(
+      Render({
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "search",
+        args: { query: "docs" },
+        argsText: '{"query":"docs"}',
+        status: { type: "running" },
+        addResult: () => {},
+        resume: () => {},
+        respondToApproval: () => {},
+      }),
+    ).toBe("Searching docs...");
+
+    expect(
+      Render({
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "search",
+        args: { query: "docs" },
+        argsText: '{"query":"docs"}',
+        result: { count: 3 },
+        status: { type: "complete" },
+        addResult: () => {},
+        resume: () => {},
+        respondToApproval: () => {},
+      }),
+    ).toBe("Found 3 results for docs");
+  });
+
+  it("treats missing status as complete", () => {
+    const Render = makeToolCallTextComponent({
+      running: "Running",
+      complete: "Complete",
+    });
+
+    expect(
+      Render({
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "search",
+        args: {},
+        argsText: "{}",
+        addResult: () => {},
+        resume: () => {},
+        respondToApproval: () => {},
+      }),
+    ).toBe("Complete");
+  });
+
+  it("treats incomplete status as a terminal state", () => {
+    const Render = makeToolCallTextComponent({
+      running: "Searching...",
+      complete: "Finished",
+    });
+
+    expect(
+      Render({
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "search",
+        args: {},
+        argsText: "{}",
+        status: { type: "incomplete", reason: "error" },
+        addResult: () => {},
+        resume: () => {},
+        respondToApproval: () => {},
+      }),
+    ).toBe("Finished");
+  });
+
+  it("treats requires-action status as running", () => {
+    const Render = makeToolCallTextComponent({
+      running: "Waiting for approval...",
+      complete: "Done",
+    });
+
+    expect(
+      Render({
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "confirm",
+        args: {},
+        argsText: "{}",
+        status: { type: "requires-action", reason: "interrupt" },
+        addResult: () => {},
+        resume: () => {},
+        respondToApproval: () => {},
+      }),
+    ).toBe("Waiting for approval...");
+  });
+});

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -46,10 +46,15 @@ type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> =
   | ReactNode
   | ((options: { args: TArgs; result: TResult | undefined }) => ReactNode);
 
-export type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
-};
+export type ToolCallText<TArgs extends Record<string, unknown>, TResult> =
+  | {
+      running: ToolCallRunningText<TArgs>;
+      complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+    }
+  | {
+      running?: ToolCallRunningText<TArgs> | undefined;
+      complete: ToolCallCompleteText<TArgs, TResult>;
+    };
 
 const resolveToolCallText = <TArgs extends Record<string, unknown>, TResult>(
   text: ToolCallText<TArgs, TResult>,

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -1,5 +1,9 @@
 import type { Tool, ToolDeclaration } from "assistant-stream";
-import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
+import type { ReactNode } from "react";
+import type {
+  ToolCallMessagePartComponent,
+  ToolCallMessagePartProps,
+} from "../types/MessagePartComponentTypes";
 
 /**
  * Resolves whether a tool's UI should be presented standalone (outside the
@@ -20,10 +24,61 @@ export const isStandaloneToolDisplay = (
 type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
   type: "frontend" | "human";
 }
-  ? T & { render: ToolCallMessagePartComponent<TArgs, TResult> }
+  ? T &
+      (T extends { type: "frontend" }
+        ?
+            | { render: ToolCallMessagePartComponent<TArgs, TResult> }
+            | {
+                render?: ToolCallMessagePartComponent<TArgs, TResult>;
+                renderText: ToolCallText<TArgs, TResult>;
+              }
+        : { render: ToolCallMessagePartComponent<TArgs, TResult> })
   : T & {
       render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
+      renderText?: ToolCallText<TArgs, TResult> | undefined;
     };
+
+type ToolCallRunningText<TArgs extends Record<string, unknown>> =
+  | ReactNode
+  | ((options: { args: TArgs }) => ReactNode);
+
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> =
+  | ReactNode
+  | ((options: { args: TArgs; result: TResult | undefined }) => ReactNode);
+
+export type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
+  running?: ToolCallRunningText<TArgs> | undefined;
+  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+};
+
+const resolveToolCallText = <TArgs extends Record<string, unknown>, TResult>(
+  text: ToolCallText<TArgs, TResult>,
+  part: ToolCallMessagePartProps<TArgs, TResult>,
+): ReactNode => {
+  const isRunning =
+    part.status?.type === "running" || part.status?.type === "requires-action";
+
+  if (!isRunning) {
+    const value = text.complete;
+    if (typeof value !== "function") return value ?? null;
+    return value({ args: part.args, result: part.result });
+  }
+
+  const value = text.running;
+  if (typeof value !== "function") return value ?? null;
+  return value({ args: part.args });
+};
+
+export const makeToolCallTextComponent = <
+  TArgs extends Record<string, unknown>,
+  TResult,
+>(
+  text: ToolCallText<TArgs, TResult>,
+): ToolCallMessagePartComponent<TArgs, TResult> => {
+  return function ToolCallTextComponent(part) {
+    return resolveToolCallText(text, part);
+  };
+};
 
 /**
  * Tool definition accepted by the React tool registry.

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -88,11 +88,10 @@ export const makeToolCallTextComponent = <
 /**
  * Tool definition accepted by the React tool registry.
  *
- * Extends the core tool contract with a render component. Human tools rely on
- * the renderer to collect input from the user. Frontend tools execute in the
- * browser and require a UI surface for their progress and result. Backend
- * tools execute server-side and may omit a renderer. The `render` component is
- * required for frontend and human tools and optional for backend tools.
+ * Extends the core tool contract with tool-call display options. Human tools
+ * rely on `render` to collect input from the user. Frontend tools execute in
+ * the browser and require either `render` or `renderText` for their progress
+ * and result. Backend tools execute server-side and may omit a renderer.
  */
 export type ToolDefinition<
   TArgs extends Record<string, unknown>,

--- a/packages/core/src/react/model-context/useAssistantTool.ts
+++ b/packages/core/src/react/model-context/useAssistantTool.ts
@@ -1,8 +1,12 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useAui } from "@assistant-ui/store";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
 import type { AssistantToolProps as CoreAssistantToolProps } from "../..";
-import { isStandaloneToolDisplay } from "./toolbox";
+import {
+  isStandaloneToolDisplay,
+  makeToolCallTextComponent,
+  type ToolCallText,
+} from "./toolbox";
 
 /**
  * Props used to register a tool from React.
@@ -13,6 +17,8 @@ export type AssistantToolProps<
 > = CoreAssistantToolProps<TArgs, TResult> & {
   /** Component used to render calls to this tool in assistant messages. */
   render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
+  /** Lightweight text rendered while a tool call is running or complete. */
+  renderText?: ToolCallText<TArgs, TResult> | undefined;
 };
 
 /**
@@ -54,16 +60,22 @@ export const useAssistantTool = <
   const aui = useAui();
 
   const standalone = isStandaloneToolDisplay(tool);
+  const renderTextComponent = useMemo(
+    () =>
+      tool.renderText ? makeToolCallTextComponent(tool.renderText) : undefined,
+    [tool.renderText],
+  );
+  const render = tool.render ?? renderTextComponent;
 
   useEffect(() => {
-    if (!tool.render) return undefined;
-    return aui.tools().setToolUI(tool.toolName, tool.render, { standalone });
-  }, [aui, tool.toolName, tool.render, standalone]);
+    if (!render) return undefined;
+    return aui.tools().setToolUI(tool.toolName, render, { standalone });
+  }, [aui, tool.toolName, render, standalone]);
 
   useEffect(() => {
-    // `render` and `display` are client-only presentation concerns and never
-    // reach the model.
-    const { toolName, render, display, ...rest } = tool;
+    // `render`, `renderText`, and `display` are client-only presentation
+    // concerns and never reach the model.
+    const { toolName, render, renderText, display, ...rest } = tool;
     const context = {
       tools: {
         [toolName]: rest,

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -195,6 +195,7 @@ export {
   type ToolDefinition,
   type ToolkitDefinition,
   type ToolkitDefinitionEntry,
+  type ToolCallText,
   defineToolkit,
   hitl,
   hitlTool,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -160,6 +160,7 @@ export {
   type ToolDefinition,
   type ToolkitDefinition,
   type ToolkitDefinitionEntry,
+  type ToolCallText,
   defineToolkit,
   hitl,
   hitlTool,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -187,6 +187,7 @@ export {
   useInlineRender,
   type Toolkit,
   type ToolDefinition,
+  type ToolCallText,
   type ToolkitDefinition,
   type ToolkitDefinitionEntry,
   defineToolkit,

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -378,6 +378,67 @@ export default defineToolkit({
     expect(client).toContain("render");
     expect(client).not.toContain("db.get");
   });
+
+  it("routes renderText like a lightweight tool renderer", () => {
+    const src = `"use generative";
+import { z } from "zod";
+import { db } from "@/db";
+import { formatResult } from "@/ui/format";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  search: {
+    parameters: z.object({ query: z.string() }),
+    execute: async ({ query }) => db.search(query),
+    renderText: {
+      running: ({ args }) => \`Searching \${args.query}...\`,
+      complete: ({ args, result }) => formatResult(args.query, result),
+    },
+  },
+});`;
+
+    const server = compileGenerative(src, { target: "server" }).code;
+    expect(server).toContain("db.search");
+    expect(server).toContain('type: "backend"');
+    expect(server).not.toContain("renderText");
+    expect(server).not.toContain("@/ui/format");
+
+    const client = compileGenerative(src, { target: "client" }).code;
+    expect(client.trimStart().startsWith('"use client"')).toBe(true);
+    expect(client).toContain("renderText");
+    expect(client).toContain("formatResult");
+    expect(client).toContain("@/ui/format");
+    expect(client).not.toContain("db.search");
+  });
+
+  it("allows frontend tools to use renderText instead of render", () => {
+    const src = `"use generative";
+import { z } from "zod";
+import { track } from "@/analytics";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  toast: {
+    parameters: z.object({ msg: z.string() }),
+    execute: async ({ msg }) => {
+      "use client";
+      return track(msg);
+    },
+    renderText: {
+      running: "Showing toast...",
+      complete: "Toast shown",
+    },
+  },
+});`;
+
+    const client = compileGenerative(src, { target: "client" }).code;
+    expect(client).toContain("track(msg)");
+    expect(client).toContain("renderText");
+    expect(client).toContain('type: "frontend"');
+
+    const server = compileGenerative(src, { target: "server" }).code;
+    expect(server).not.toContain("track");
+    expect(server).not.toContain("renderText");
+    expect(server).toContain('type: "frontend"');
+  });
 });
 
 describe("compileGenerative — local dead-code elimination", () => {
@@ -512,6 +573,15 @@ export default { weather: { execute: async () => 1, render: () => null } };`;
         { target: "client" },
       ),
     ).toThrow(/must declare a `render`/);
+  });
+
+  it("requires a render or renderText for frontend tools", () => {
+    expect(() =>
+      compileGenerative(
+        `"use generative";\nimport { defineToolkit } from "@assistant-ui/react";\nexport default defineToolkit({ toast: { execute: async () => { "use client"; return 1; } } });`,
+        { target: "client" },
+      ),
+    ).toThrow(/must declare a `render` or `renderText`/);
   });
 
   it("requires every tool to declare an execute", () => {

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -403,11 +403,12 @@ function compileToolkit(
     // `type`. The resolved type is written back below so the runtime keeps it.
     const type = inferToolType(value, filename);
     const hasRender = !!findMember(value, "render");
+    const hasRenderText = !!findMember(value, "renderText");
     const execute = findMember(value, "execute");
 
-    if (type === "frontend" && !hasRender) {
+    if (type === "frontend" && !hasRender && !hasRenderText) {
       throw new GenerativeCompileError(
-        "a frontend tool must declare a `render` " +
+        "a frontend tool must declare a `render` or `renderText` " +
           "(it has no server execute to show otherwise)",
         filename,
       );
@@ -429,10 +430,11 @@ function compileToolkit(
       // once the module is client); backend and sentinel executes are dropped.
       if (execute && type === "frontend") stripUseClient(execute);
       else if (execute) removeMember(value, "execute");
-      if (hasRender) flags.keptRender = true;
+      if (hasRender || hasRenderText) flags.keptRender = true;
     } else {
       // server: render is never needed; only a backend execute survives.
       if (hasRender) removeMember(value, "render");
+      if (hasRenderText) removeMember(value, "renderText");
       if (execute && type !== "backend") removeMember(value, "execute");
       if (execute && type === "backend") flags.keptBackendExecute = true;
     }


### PR DESCRIPTION
Adds renderText as a lightweight tool-call renderer surface, including hook/resource registration, compiler routing, docs, tests, and a patch changeset.\n\nPrepared as a separate draft PR; do not merge yet.