### PR TITLE
fix(react-ai-sdk): convert generative tool `toModelOutput` to AI SDK content shape

### DIFF
--- a/.changeset/great-weather-tools.md
+++ b/.changeset/great-weather-tools.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: convert generative tool `toModelOutput` to AI SDK content shape

--- a/packages/react-ai-sdk/src/frontendTools.ts
+++ b/packages/react-ai-sdk/src/frontendTools.ts
@@ -2,7 +2,7 @@ import { jsonSchema, type ToolSet } from "ai";
 import type { ToolJSONSchema, ToolModelContentPart } from "assistant-stream";
 import { unwrapModelContentEnvelope } from "./modelContentEnvelope";
 
-const toAISDKContent = (parts: readonly ToolModelContentPart[]) => ({
+export const toAISDKContent = (parts: readonly ToolModelContentPart[]) => ({
   type: "content" as const,
   value: parts.map((part) => {
     if (part.type === "text") {
@@ -24,14 +24,17 @@ const toAISDKContent = (parts: readonly ToolModelContentPart[]) => ({
   }),
 });
 
+export const toAISDKDefaultOutput = (output: unknown) =>
+  typeof output === "string"
+    ? { type: "text" as const, value: output }
+    : { type: "json" as const, value: (output ?? null) as any };
+
 export const defaultToModelOutput = ({ output }: { output: unknown }) => {
-  const { modelContent } = unwrapModelContentEnvelope(output);
+  const { result, modelContent } = unwrapModelContentEnvelope(output);
   if (modelContent !== undefined) {
     return toAISDKContent(modelContent);
   }
-  return typeof output === "string"
-    ? { type: "text" as const, value: output }
-    : { type: "json" as const, value: (output ?? null) as any };
+  return toAISDKDefaultOutput(result);
 };
 
 export const frontendTools = (tools: Record<string, ToolJSONSchema>): ToolSet =>

--- a/packages/react-ai-sdk/src/frontendTools.ts
+++ b/packages/react-ai-sdk/src/frontendTools.ts
@@ -1,33 +1,7 @@
 import { jsonSchema, type ToolSet } from "ai";
-import type { ToolJSONSchema, ToolModelContentPart } from "assistant-stream";
+import type { ToolJSONSchema } from "assistant-stream";
 import { unwrapModelContentEnvelope } from "./modelContentEnvelope";
-
-export const toAISDKContent = (parts: readonly ToolModelContentPart[]) => ({
-  type: "content" as const,
-  value: parts.map((part) => {
-    if (part.type === "text") {
-      return { type: "text" as const, text: part.text };
-    }
-    const isImage = part.mediaType.startsWith("image/");
-    return isImage
-      ? {
-          type: "image-data" as const,
-          data: part.data,
-          mediaType: part.mediaType,
-        }
-      : {
-          type: "file-data" as const,
-          data: part.data,
-          mediaType: part.mediaType,
-          ...(part.filename !== undefined && { filename: part.filename }),
-        };
-  }),
-});
-
-export const toAISDKDefaultOutput = (output: unknown) =>
-  typeof output === "string"
-    ? { type: "text" as const, value: output }
-    : { type: "json" as const, value: (output ?? null) as any };
+import { toAISDKContent, toAISDKDefaultOutput } from "./toolOutputConversion";
 
 export const defaultToModelOutput = ({ output }: { output: unknown }) => {
   const { result, modelContent } = unwrapModelContentEnvelope(output);

--- a/packages/react-ai-sdk/src/generativeTools.test.ts
+++ b/packages/react-ai-sdk/src/generativeTools.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AISDKToolkit, generativeTools } from "./generativeTools";
+import { wrapModelContentEnvelope } from "./modelContentEnvelope";
 
 const mocks = vi.hoisted(() => ({
   close: vi.fn(),
@@ -319,6 +320,71 @@ describe("AISDKToolkit", () => {
         args: { searchContextSize: "low" },
         supportsDeferredResults: false,
       },
+    });
+  });
+});
+
+describe("generativeTools toModelOutput", () => {
+  const createWeatherTools = (toModelOutput?: any) =>
+    generativeTools({
+      toolkit: {
+        get_weather: {
+          ...(toModelOutput && { toModelOutput }),
+        },
+      } as any,
+    });
+
+  it("adapts assistant-ui model content parts to the AI SDK tool output shape", async () => {
+    const tools = createWeatherTools(({ output }: any) => [
+      { type: "text", text: `Weather card displayed: ${output.location}` },
+    ]);
+
+    const output = await tools.get_weather!.toModelOutput!({
+      toolCallId: "tc-weather",
+      input: {},
+      output: { location: "San Francisco" },
+    });
+
+    expect(output).toEqual({
+      type: "content",
+      value: [{ type: "text", text: "Weather card displayed: San Francisco" }],
+    });
+  });
+
+  it("uses stored model content envelopes without re-running the custom projector", async () => {
+    let called = false;
+    const tools = createWeatherTools(() => {
+      called = true;
+      return [{ type: "text", text: "recomputed" }];
+    });
+
+    const output = await tools.get_weather!.toModelOutput!({
+      toolCallId: "tc-weather",
+      input: {},
+      output: wrapModelContentEnvelope({ location: "San Francisco" }, [
+        { type: "text", text: "cached weather receipt" },
+      ]),
+    });
+
+    expect(called).toBe(false);
+    expect(output).toEqual({
+      type: "content",
+      value: [{ type: "text", text: "cached weather receipt" }],
+    });
+  });
+
+  it("falls back to default model output when no custom projector is defined", async () => {
+    const tools = createWeatherTools();
+
+    const output = await tools.get_weather!.toModelOutput!({
+      toolCallId: "tc-weather",
+      input: {},
+      output: { location: "San Francisco" },
+    });
+
+    expect(output).toEqual({
+      type: "json",
+      value: { location: "San Francisco" },
     });
   });
 });

--- a/packages/react-ai-sdk/src/generativeTools.test.ts
+++ b/packages/react-ai-sdk/src/generativeTools.test.ts
@@ -387,4 +387,21 @@ describe("generativeTools toModelOutput", () => {
       value: { location: "San Francisco" },
     });
   });
+
+  it("uses stored model content envelopes when no custom projector is defined", async () => {
+    const tools = createWeatherTools();
+
+    const output = await tools.get_weather!.toModelOutput!({
+      toolCallId: "tc-weather",
+      input: {},
+      output: wrapModelContentEnvelope({ location: "San Francisco" }, [
+        { type: "text", text: "cached weather receipt" },
+      ]),
+    });
+
+    expect(output).toEqual({
+      type: "content",
+      value: [{ type: "text", text: "cached weather receipt" }],
+    });
+  });
 });

--- a/packages/react-ai-sdk/src/generativeTools.ts
+++ b/packages/react-ai-sdk/src/generativeTools.ts
@@ -7,9 +7,18 @@ import {
   type Tool,
   type McpServerConfig,
   type ToolJSONSchema,
+  type ToolModelOutputFunction,
 } from "assistant-stream";
 import type { Toolkit, ToolkitDefinition } from "@assistant-ui/core/react";
-import { defaultToModelOutput, frontendTools } from "./frontendTools";
+import {
+  frontendTools,
+  toAISDKContent,
+  toAISDKDefaultOutput,
+} from "./frontendTools";
+import {
+  unwrapModelContentEnvelope,
+  type ModelContentEnvelope,
+} from "./modelContentEnvelope";
 
 const EMPTY_SCHEMA = { type: "object" as const, properties: {} };
 
@@ -216,6 +225,33 @@ const assertNoMcpToolkitTools = (toolkit: Toolkit): void => {
   );
 };
 
+type AISDKToModelOutputOptions<TArgs, TResult> = Omit<
+  Parameters<ToolModelOutputFunction<TArgs, TResult>>[0],
+  "output"
+> & {
+  output: TResult | ModelContentEnvelope<TResult>;
+};
+
+const toAISDKToModelOutput =
+  <TArgs, TResult>(toModelOutput?: ToolModelOutputFunction<TArgs, TResult>) =>
+  async (options: AISDKToModelOutputOptions<TArgs, TResult>) => {
+    const { result, modelContent } = unwrapModelContentEnvelope(options.output);
+
+    if (modelContent !== undefined) {
+      return toAISDKContent(modelContent);
+    }
+
+    if (!toModelOutput) {
+      return toAISDKDefaultOutput(result);
+    }
+
+    const parts = await toModelOutput({
+      ...options,
+      output: result,
+    });
+    return toAISDKContent(parts);
+  };
+
 const toServerToolSet = (toolkit: ToolkitDefinition): ToolSet =>
   Object.fromEntries(
     Object.entries(toolkit)
@@ -229,7 +265,7 @@ const toServerToolSet = (toolkit: ToolkitDefinition): ToolSet =>
           {
             ...(t.description !== undefined && { description: t.description }),
             inputSchema: parametersToInputSchema(t.parameters),
-            toModelOutput: t.toModelOutput ?? defaultToModelOutput,
+            toModelOutput: toAISDKToModelOutput(t.toModelOutput),
             ...(t.providerOptions && { providerOptions: t.providerOptions }),
             ...(execute && {
               execute: (

--- a/packages/react-ai-sdk/src/generativeTools.ts
+++ b/packages/react-ai-sdk/src/generativeTools.ts
@@ -10,11 +10,8 @@ import {
   type ToolModelOutputFunction,
 } from "assistant-stream";
 import type { Toolkit, ToolkitDefinition } from "@assistant-ui/core/react";
-import {
-  frontendTools,
-  toAISDKContent,
-  toAISDKDefaultOutput,
-} from "./frontendTools";
+import { frontendTools } from "./frontendTools";
+import { toAISDKContent, toAISDKDefaultOutput } from "./toolOutputConversion";
 import {
   unwrapModelContentEnvelope,
   type ModelContentEnvelope,

--- a/packages/react-ai-sdk/src/modelContentEnvelope.ts
+++ b/packages/react-ai-sdk/src/modelContentEnvelope.ts
@@ -7,9 +7,9 @@ export type ModelContentEnvelope<TResult = unknown> = {
   readonly value: TResult;
 };
 
-export function isModelContentEnvelope(
-  value: unknown,
-): value is ModelContentEnvelope {
+export function isModelContentEnvelope<TResult = unknown>(
+  value: TResult | ModelContentEnvelope<TResult>,
+): value is ModelContentEnvelope<TResult> {
   return (
     value != null &&
     typeof value === "object" &&
@@ -25,8 +25,10 @@ export function wrapModelContentEnvelope<TResult>(
   return { [ENVELOPE_KEY]: modelContent, value: result };
 }
 
-export function unwrapModelContentEnvelope(output: unknown): {
-  result: unknown;
+export function unwrapModelContentEnvelope<TResult>(
+  output: TResult | ModelContentEnvelope<TResult>,
+): {
+  result: TResult;
   modelContent?: readonly ToolModelContentPart[];
 } {
   if (isModelContentEnvelope(output)) {

--- a/packages/react-ai-sdk/src/toolOutputConversion.ts
+++ b/packages/react-ai-sdk/src/toolOutputConversion.ts
@@ -1,0 +1,29 @@
+import type { JSONValue } from "ai";
+import type { ToolModelContentPart } from "assistant-stream";
+
+export const toAISDKContent = (parts: readonly ToolModelContentPart[]) => ({
+  type: "content" as const,
+  value: parts.map((part) => {
+    if (part.type === "text") {
+      return { type: "text" as const, text: part.text };
+    }
+    const isImage = part.mediaType.startsWith("image/");
+    return isImage
+      ? {
+          type: "image-data" as const,
+          data: part.data,
+          mediaType: part.mediaType,
+        }
+      : {
+          type: "file-data" as const,
+          data: part.data,
+          mediaType: part.mediaType,
+          ...(part.filename !== undefined && { filename: part.filename }),
+        };
+  }),
+});
+
+export const toAISDKDefaultOutput = (output: unknown) =>
+  typeof output === "string"
+    ? { type: "text" as const, value: output }
+    : { type: "json" as const, value: (output ?? null) as JSONValue };


### PR DESCRIPTION
matches `frontendTools` behavior, resolves error when defining `toModelOutput`