### PR TITLE
docs(llms): add text variants to mdx components

### DIFF
--- a/apps/docs/components/docs/fumadocs/callout.tsx
+++ b/apps/docs/components/docs/fumadocs/callout.tsx
@@ -59,6 +59,24 @@ interface CalloutProps extends Omit<ComponentProps<"div">, "title"> {
   children?: ReactNode;
 }
 
+// Keep the authored fuma type in the `[!type]` marker — don't remap to GitHub's
+// smaller admonition set.
+export const CalloutLLM = ({
+  type = "info",
+  title,
+  children,
+}: CalloutProps) => (
+  <blockquote>
+    <p>{`[!${type}]`}</p>
+    {title ? (
+      <p>
+        <strong>{title}</strong>
+      </p>
+    ) : null}
+    {children}
+  </blockquote>
+);
+
 export function Callout({
   type: inputType = "info",
   title,

--- a/apps/docs/components/docs/fumadocs/card.tsx
+++ b/apps/docs/components/docs/fumadocs/card.tsx
@@ -61,3 +61,16 @@ export function Card({
 export function Cards({ children }: { children: ReactNode }) {
   return <div className="not-prose grid gap-3 sm:grid-cols-2">{children}</div>;
 }
+
+export const CardsLLM = ({ children }: { children: ReactNode }) => (
+  <ul>{children}</ul>
+);
+export const CardLLM = ({ title, description, href, children }: CardProps) => {
+  const blurb = description ?? children;
+  return (
+    <li>
+      {href ? <a href={href}>{title}</a> : title}
+      {blurb ? <> — {blurb}</> : null}
+    </li>
+  );
+};

--- a/apps/docs/components/docs/fumadocs/install/install-command.tsx
+++ b/apps/docs/components/docs/fumadocs/install/install-command.tsx
@@ -78,10 +78,10 @@ export async function InstallCommand(props: InstallCommandProps) {
 }
 
 // Every resolvable file is an assistant-ui component, sourced from packages/ui.
-const GITHUB_BLOB =
-  "https://github.com/assistant-ui/assistant-ui/blob/main/packages/ui/src";
-const GITHUB_RAW =
-  "https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/packages/ui/src";
+const REPO = "assistant-ui/assistant-ui";
+const UI_SRC = "packages/ui/src";
+const GITHUB_BLOB = `https://github.com/${REPO}/blob/main/${UI_SRC}`;
+const GITHUB_RAW = `https://raw.githubusercontent.com/${REPO}/main/${UI_SRC}`;
 
 const CommandBlock = ({ command }: { command: string }) => (
   <pre>
@@ -96,8 +96,9 @@ function buildDownloadCommand(files: ResolvedFile[]): string {
   return `curl -sSL --create-dirs \\\n${args}`;
 }
 
-// Instead of dumping each component's full source (the visual Manual tab), keep
-// the CLI command and link the GitHub files plus one curl to fetch them all.
+// Instead of dumping each component's full source (the visual Manual tab), give
+// the CLI command plus a manual path: npm deps, shadcn components, and the
+// GitHub-linked aui files with one curl to fetch them all.
 export const InstallCommandLLM = async (props: InstallCommandProps) => {
   if ("npm" in props) {
     return <CommandBlock command={`npm install ${props.npm.join(" ")}`} />;
@@ -111,13 +112,33 @@ export const InstallCommandLLM = async (props: InstallCommandProps) => {
   const urls = props.shadcn.map((c) => `https://r.assistant-ui.com/${c}.json`);
   const resolved = await resolveAllComponents(props.shadcn);
   const files = [...resolved.main.files, ...resolved.auiDeps.files];
+  // npm packages the copied files import. shadcn deps (e.g. radix-ui) are
+  // omitted here — they install with the shadcn components below.
+  const npmDeps = [
+    ...new Set([
+      ...resolved.main.dependencies,
+      ...resolved.auiDeps.dependencies,
+    ]),
+  ];
+  // shadcn/ui components can't be GitHub-linked (not under packages/ui/src), so
+  // the manual path adds them via the shadcn CLI instead.
+  const shadcnComponents = resolved.shadcn.files.map((file) => file.name);
 
   return (
     <>
       <CommandBlock command={`npx shadcn@latest add ${urls.join(" ")}`} />
       {files.length > 0 && (
         <>
-          <p>Or copy the source files from GitHub:</p>
+          <p>Or install manually:</p>
+          {npmDeps.length > 0 && (
+            <CommandBlock command={`npm install ${npmDeps.join(" ")}`} />
+          )}
+          {shadcnComponents.length > 0 && (
+            <CommandBlock
+              command={`npx shadcn@latest add ${shadcnComponents.join(" ")}`}
+            />
+          )}
+          <p>Then copy these source files from GitHub:</p>
           <ul>
             {files.map((file) => (
               <li key={file.path}>

--- a/apps/docs/components/docs/fumadocs/install/install-command.tsx
+++ b/apps/docs/components/docs/fumadocs/install/install-command.tsx
@@ -2,6 +2,7 @@ import { Tab, Tabs } from "@/components/docs/fumadocs/tabs";
 import {
   resolveAllComponents,
   ComponentSourceFromFile,
+  type ResolvedFile,
   type ResolvedGroup,
 } from "@/components/docs/fumadocs/install/component-source";
 import { SetupInstructions } from "@/components/docs/fumadocs/install/setup-instructions";
@@ -75,3 +76,58 @@ export async function InstallCommand(props: InstallCommandProps) {
     </Tabs>
   );
 }
+
+// Every resolvable file is an assistant-ui component, sourced from packages/ui.
+const GITHUB_BLOB =
+  "https://github.com/assistant-ui/assistant-ui/blob/main/packages/ui/src";
+const GITHUB_RAW =
+  "https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/packages/ui/src";
+
+const CommandBlock = ({ command }: { command: string }) => (
+  <pre>
+    <code className="language-bash">{command}</code>
+  </pre>
+);
+
+function buildDownloadCommand(files: ResolvedFile[]): string {
+  const args = files
+    .map((file) => `  -o ${file.path} ${GITHUB_RAW}/${file.path}`)
+    .join(" \\\n");
+  return `curl -sSL --create-dirs \\\n${args}`;
+}
+
+// Instead of dumping each component's full source (the visual Manual tab), keep
+// the CLI command and link the GitHub files plus one curl to fetch them all.
+export const InstallCommandLLM = async (props: InstallCommandProps) => {
+  if ("npm" in props) {
+    return <CommandBlock command={`npm install ${props.npm.join(" ")}`} />;
+  }
+  if ("expo" in props) {
+    return (
+      <CommandBlock command={`npx expo install ${props.expo.join(" ")}`} />
+    );
+  }
+
+  const urls = props.shadcn.map((c) => `https://r.assistant-ui.com/${c}.json`);
+  const resolved = await resolveAllComponents(props.shadcn);
+  const files = [...resolved.main.files, ...resolved.auiDeps.files];
+
+  return (
+    <>
+      <CommandBlock command={`npx shadcn@latest add ${urls.join(" ")}`} />
+      {files.length > 0 && (
+        <>
+          <p>Or copy the source files from GitHub:</p>
+          <ul>
+            {files.map((file) => (
+              <li key={file.path}>
+                <a href={`${GITHUB_BLOB}/${file.path}`}>{file.path}</a>
+              </li>
+            ))}
+          </ul>
+          <CommandBlock command={buildDownloadCommand(files)} />
+        </>
+      )}
+    </>
+  );
+};

--- a/apps/docs/components/docs/fumadocs/steps.tsx
+++ b/apps/docs/components/docs/fumadocs/steps.tsx
@@ -23,3 +23,10 @@ export function Step({ children }: { children: ReactNode }) {
     </div>
   );
 }
+
+export const StepsLLM = ({ children }: { children: ReactNode }) => (
+  <ol>{children}</ol>
+);
+export const StepLLM = ({ children }: { children: ReactNode }) => (
+  <li>{children}</li>
+);

--- a/apps/docs/components/docs/fumadocs/tabs.llm.tsx
+++ b/apps/docs/components/docs/fumadocs/tabs.llm.tsx
@@ -1,0 +1,31 @@
+import { Children, Fragment, isValidElement, type ReactNode } from "react";
+import type { TabProps, TabsProps } from "./tabs";
+
+// Tab bodies concatenate in text and read as sequential steps ("install all 11
+// SDKs") unless labeled. Frame as "Choose one:" and label each body by its
+// `value` prop, falling back to the parent `items` entry by position.
+export function TabsLLM({ items, children }: TabsProps): ReactNode {
+  const tabs = Children.toArray(children).filter(isValidElement);
+  return (
+    <>
+      <p>Choose one:</p>
+      {tabs.map((tab, index) => {
+        const label = (tab.props as { value?: string }).value ?? items?.[index];
+        return (
+          <Fragment key={index}>
+            {label ? (
+              <p>
+                <strong>{label}</strong>
+              </p>
+            ) : null}
+            {tab}
+          </Fragment>
+        );
+      })}
+    </>
+  );
+}
+
+export function TabLLM({ children }: TabProps): ReactNode {
+  return <>{children}</>;
+}

--- a/apps/docs/components/docs/parameters-table.tsx
+++ b/apps/docs/components/docs/parameters-table.tsx
@@ -205,59 +205,86 @@ export const ParametersTable: FC<ParametersTableProps> = ({
   );
 };
 
-const ParameterItemLLM: FC<{ parameter: ParameterDef }> = ({
-  parameter: partialParameter,
+// Shared bullet-list renderer for both ParametersTable and PrimitivesTypeTable
+// in LLM/markdown output. `normalizeType` is the only behavioral difference
+// between the two: PrimitivesTypeTable strips a trailing `| undefined`.
+export type DefLLM = {
+  name: string;
+  type?: string;
+  description?: string | ReactNode;
+  required?: boolean;
+  default?: string;
+  deprecated?: string;
+  children?: Array<{ parameters: DefLLM[] }>;
+};
+
+type DefListLLMProps = {
+  defs: DefLLM[];
+  commonParams?: Record<string, Partial<DefLLM>> | undefined;
+  normalizeType?: ((type: string) => string) | undefined;
+};
+
+export const DefListLLM: FC<DefListLLMProps> = ({
+  defs,
+  commonParams,
+  normalizeType,
 }) => {
-  const parameter = {
-    ...COMMON_PARAMS[partialParameter.name],
-    ...partialParameter,
-  };
-  const isOptional = !parameter.required && !parameter.default;
+  return (
+    <ul>
+      {defs.map((def) => (
+        <DefItemLLM
+          key={def.name}
+          def={def}
+          commonParams={commonParams}
+          normalizeType={normalizeType}
+        />
+      ))}
+    </ul>
+  );
+};
+
+const DefItemLLM: FC<
+  { def: DefLLM } & Pick<DefListLLMProps, "commonParams" | "normalizeType">
+> = ({ def: rawDef, commonParams, normalizeType }) => {
+  const def = { ...commonParams?.[rawDef.name], ...rawDef };
+  const isOptional = !def.required && !def.default;
+  const type = def.type && normalizeType ? normalizeType(def.type) : def.type;
 
   return (
     <li>
       <code>
-        {parameter.name}
+        {def.name}
         {isOptional ? "?" : ""}
       </code>
-      {parameter.type ? (
+      {type ? (
         <>
           {": "}
-          <code>{parameter.type}</code>
+          <code>{type}</code>
         </>
       ) : null}
-      {parameter.default ? (
+      {def.default ? (
         <>
           {" (default "}
-          <code>{parameter.default}</code>
+          <code>{def.default}</code>
           {")"}
         </>
       ) : null}
-      {parameter.deprecated ? <> (deprecated: {parameter.deprecated})</> : null}
-      {parameter.description ? (
-        <> — {renderDescription(parameter.description)}</>
-      ) : null}
-      {parameter.children?.map((child, i) => (
-        <ParameterListLLM key={i} parameters={child.parameters} />
+      {def.deprecated ? <> (deprecated: {def.deprecated})</> : null}
+      {def.description ? <> — {renderDescription(def.description)}</> : null}
+      {def.children?.map((child, i) => (
+        <DefListLLM
+          key={i}
+          defs={child.parameters}
+          commonParams={commonParams}
+          normalizeType={normalizeType}
+        />
       ))}
     </li>
-  );
-};
-
-const ParameterListLLM: FC<{ parameters: ParameterDef[] }> = ({
-  parameters,
-}) => {
-  return (
-    <ul>
-      {parameters.map((parameter) => (
-        <ParameterItemLLM key={parameter.name} parameter={parameter} />
-      ))}
-    </ul>
   );
 };
 
 export const ParametersTableLLM: FC<ParametersTableProps> = ({
   parameters,
 }) => {
-  return <ParameterListLLM parameters={parameters} />;
+  return <DefListLLM defs={parameters} commonParams={COMMON_PARAMS} />;
 };

--- a/apps/docs/components/docs/parameters-table.tsx
+++ b/apps/docs/components/docs/parameters-table.tsx
@@ -204,3 +204,60 @@ export const ParametersTable: FC<ParametersTableProps> = ({
     </div>
   );
 };
+
+const ParameterItemLLM: FC<{ parameter: ParameterDef }> = ({
+  parameter: partialParameter,
+}) => {
+  const parameter = {
+    ...COMMON_PARAMS[partialParameter.name],
+    ...partialParameter,
+  };
+  const isOptional = !parameter.required && !parameter.default;
+
+  return (
+    <li>
+      <code>
+        {parameter.name}
+        {isOptional ? "?" : ""}
+      </code>
+      {parameter.type ? (
+        <>
+          {": "}
+          <code>{parameter.type}</code>
+        </>
+      ) : null}
+      {parameter.default ? (
+        <>
+          {" (default "}
+          <code>{parameter.default}</code>
+          {")"}
+        </>
+      ) : null}
+      {parameter.deprecated ? <> (deprecated: {parameter.deprecated})</> : null}
+      {parameter.description ? (
+        <> — {renderDescription(parameter.description)}</>
+      ) : null}
+      {parameter.children?.map((child, i) => (
+        <ParameterListLLM key={child.type ?? i} parameters={child.parameters} />
+      ))}
+    </li>
+  );
+};
+
+const ParameterListLLM: FC<{ parameters: ParameterDef[] }> = ({
+  parameters,
+}) => {
+  return (
+    <ul>
+      {parameters.map((parameter) => (
+        <ParameterItemLLM key={parameter.name} parameter={parameter} />
+      ))}
+    </ul>
+  );
+};
+
+export const ParametersTableLLM: FC<ParametersTableProps> = ({
+  parameters,
+}) => {
+  return <ParameterListLLM parameters={parameters} />;
+};

--- a/apps/docs/components/docs/parameters-table.tsx
+++ b/apps/docs/components/docs/parameters-table.tsx
@@ -49,7 +49,7 @@ function renderLinkLabel(label: string): ReactNode {
   return label;
 }
 
-function renderDescription(description: string | ReactNode): ReactNode {
+export function renderDescription(description: string | ReactNode): ReactNode {
   if (typeof description !== "string") return description;
 
   const parts: ReactNode[] = [];
@@ -238,7 +238,7 @@ const ParameterItemLLM: FC<{ parameter: ParameterDef }> = ({
         <> — {renderDescription(parameter.description)}</>
       ) : null}
       {parameter.children?.map((child, i) => (
-        <ParameterListLLM key={child.type ?? i} parameters={child.parameters} />
+        <ParameterListLLM key={i} parameters={child.parameters} />
       ))}
     </li>
   );

--- a/apps/docs/components/docs/platform/context.tsx
+++ b/apps/docs/components/docs/platform/context.tsx
@@ -9,9 +9,14 @@ import {
   type ReactNode,
 } from "react";
 import { usePathname } from "next/navigation";
-import { PLATFORM_LABELS, PLATFORMS, type Platform } from "@/lib/constants";
+import {
+  DEFAULT_PLATFORM,
+  PLATFORM_LABELS,
+  PLATFORMS,
+  type Platform,
+} from "@/lib/constants";
 
-export { PLATFORM_LABELS, PLATFORMS, type Platform };
+export { DEFAULT_PLATFORM, PLATFORM_LABELS, PLATFORMS, type Platform };
 
 export const PLATFORM_DOC_BASE_PATHS: Record<Platform, string> = {
   react: "/docs",
@@ -21,7 +26,6 @@ export const PLATFORM_DOC_BASE_PATHS: Record<Platform, string> = {
 
 const STORAGE_KEY = "assistant-ui::docs:platform";
 const URL_PARAM = "platform";
-const DEFAULT_PLATFORM: Platform = "react";
 
 interface PlatformContextValue {
   platform: Platform;

--- a/apps/docs/components/docs/platform/context.tsx
+++ b/apps/docs/components/docs/platform/context.tsx
@@ -9,15 +9,9 @@ import {
   type ReactNode,
 } from "react";
 import { usePathname } from "next/navigation";
+import { PLATFORM_LABELS, PLATFORMS, type Platform } from "@/lib/constants";
 
-export const PLATFORMS = ["react", "rn", "ink"] as const;
-export type Platform = (typeof PLATFORMS)[number];
-
-export const PLATFORM_LABELS: Record<Platform, string> = {
-  react: "React",
-  rn: "React Native",
-  ink: "React Ink",
-};
+export { PLATFORM_LABELS, PLATFORMS, type Platform };
 
 export const PLATFORM_DOC_BASE_PATHS: Record<Platform, string> = {
   react: "/docs",

--- a/apps/docs/components/docs/platform/mdx.llm.tsx
+++ b/apps/docs/components/docs/platform/mdx.llm.tsx
@@ -1,8 +1,11 @@
 import { Children, isValidElement, type ReactNode } from "react";
-import { PLATFORM_LABELS, PLATFORMS, type Platform } from "@/lib/constants";
+import {
+  DEFAULT_PLATFORM,
+  PLATFORM_LABELS,
+  PLATFORMS,
+  type Platform,
+} from "@/lib/constants";
 import type { PlatformTabsProps } from "./mdx";
-
-const DEFAULT_PLATFORM: Platform = "react";
 
 // Emit only the React (default) tab — other platforms duplicate content and have
 // their own doc trees (/docs/react-native, /docs/ink). Label it so the code isn't

--- a/apps/docs/components/docs/platform/mdx.llm.tsx
+++ b/apps/docs/components/docs/platform/mdx.llm.tsx
@@ -1,0 +1,62 @@
+import { Children, isValidElement, type ReactNode } from "react";
+import { PLATFORM_LABELS, PLATFORMS, type Platform } from "@/lib/constants";
+import type { PlatformTabsProps } from "./mdx";
+
+const DEFAULT_PLATFORM: Platform = "react";
+
+// Emit only the React (default) tab — other platforms duplicate content and have
+// their own doc trees (/docs/react-native, /docs/ink). Label it so the code isn't
+// read as universal.
+export function PlatformTabsLLM({ children }: PlatformTabsProps): ReactNode {
+  const tabs = Children.toArray(children).filter(isValidElement);
+  const reactTab =
+    tabs.find(
+      (child) =>
+        (child.props as { value?: string }).value ===
+        PLATFORM_LABELS[DEFAULT_PLATFORM],
+    ) ?? tabs[0];
+  if (!reactTab) return null;
+
+  return (
+    <>
+      <p>
+        <strong>{PLATFORM_LABELS[DEFAULT_PLATFORM]}</strong>
+      </p>
+      {reactTab}
+    </>
+  );
+}
+
+export function PlatformOnlyLLM({
+  children,
+  except,
+  platforms,
+}: {
+  children: ReactNode;
+  except?: readonly Platform[];
+  platforms?: readonly Platform[];
+}): ReactNode {
+  if (except?.includes(DEFAULT_PLATFORM)) return null;
+  if (
+    platforms &&
+    platforms.length > 0 &&
+    !platforms.includes(DEFAULT_PLATFORM)
+  )
+    return null;
+
+  const applicable = PLATFORMS.filter(
+    (p) =>
+      (!platforms || platforms.length === 0 || platforms.includes(p)) &&
+      !except?.includes(p),
+  );
+  const label = applicable.map((p) => PLATFORM_LABELS[p]).join(", ");
+
+  return (
+    <>
+      <p>
+        <strong>{`${label} only`}</strong>
+      </p>
+      {children}
+    </>
+  );
+}

--- a/apps/docs/components/docs/preview-code.server.tsx
+++ b/apps/docs/components/docs/preview-code.server.tsx
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import type { ReactNode } from "react";
 import { PreviewCodeClient } from "./preview-code";
 
 type PreviewCodeProps = {
@@ -195,15 +196,8 @@ function cleanupImports(imports: string[]): string[] {
     );
 }
 
-export async function PreviewCode({
-  file,
-  name,
-  children,
-  className,
-}: PreviewCodeProps) {
+function buildPreviewCode(file: string, name: string): string {
   const filePath = path.join(process.cwd(), `${file}.tsx`);
-
-  let code: string;
   try {
     const source = fs.readFileSync(filePath, "utf-8");
     const functionCode = extractFunctionCode(source, name);
@@ -213,13 +207,21 @@ export async function PreviewCode({
     const relevantImports = filterRelevantImports(allImports, cleanedCode);
     const cleanedImports = cleanupImports(relevantImports);
 
-    code =
-      cleanedImports.length > 0
-        ? `${cleanedImports.join("\n")}\n\n${cleanedCode}`
-        : cleanedCode;
+    return cleanedImports.length > 0
+      ? `${cleanedImports.join("\n")}\n\n${cleanedCode}`
+      : cleanedCode;
   } catch {
-    code = `// Error reading file: ${file}`;
+    return `// Error reading file: ${file}`;
   }
+}
+
+export async function PreviewCode({
+  file,
+  name,
+  children,
+  className,
+}: PreviewCodeProps) {
+  const code = buildPreviewCode(file, name);
 
   return (
     <PreviewCodeClient code={code} {...(className && { className })}>
@@ -227,3 +229,20 @@ export async function PreviewCode({
     </PreviewCodeClient>
   );
 }
+
+// PreviewCode is imported directly in MDX, so the LLM map can't swap it; it
+// carries its text variant as a `.llm` static instead. Drop the live preview,
+// keep the source.
+(
+  PreviewCode as typeof PreviewCode & {
+    llm: (props: PreviewCodeProps) => ReactNode;
+  }
+).llm = ({ file, name }: PreviewCodeProps) => (
+  <>
+    <p>{`[interactive preview component ${name} omitted]`}</p>
+    <p>{`Code for ${name} preview:`}</p>
+    <pre>
+      <code className="language-tsx">{buildPreviewCode(file, name)}</code>
+    </pre>
+  </>
+);

--- a/apps/docs/components/docs/primitives-type-table.tsx
+++ b/apps/docs/components/docs/primitives-type-table.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 import { highlight } from "fumadocs-core/highlight";
 import Link from "next/link";
-import type { ReactNode } from "react";
+import type { FC, ReactNode } from "react";
 import {
   TypeTableClient,
   type TypeTableRow,
@@ -148,3 +148,55 @@ export async function PrimitivesTypeTable({
   const rows = await propsToRows(parameters);
   return <TypeTableClient id={type} rows={rows} />;
 }
+
+// Build from PropDef directly, skipping Shiki highlighting (it emitted stray
+// code fences) and the `highlighted*` fields meant for the client table.
+const PropItemLLM: FC<{ prop: PropDef }> = ({ prop: rawProp }) => {
+  const prop = { ...COMMON_PARAMS[rawProp.name], ...rawProp };
+  const isOptional = !prop.required && !prop.default;
+  const type = prop.type ? stripTrailingUndefined(prop.type) : undefined;
+
+  return (
+    <li>
+      <code>
+        {prop.name}
+        {isOptional ? "?" : ""}
+      </code>
+      {type ? (
+        <>
+          {": "}
+          <code>{type}</code>
+        </>
+      ) : null}
+      {prop.default ? (
+        <>
+          {" (default "}
+          <code>{prop.default}</code>
+          {")"}
+        </>
+      ) : null}
+      {prop.deprecated ? <> (deprecated: {prop.deprecated})</> : null}
+      {prop.description ? <> — {prop.description}</> : null}
+      {prop.children?.map((child, i) => (
+        <PropListLLM key={child.type ?? i} props={child.parameters} />
+      ))}
+    </li>
+  );
+};
+
+const PropListLLM: FC<{ props: PropDef[] }> = ({ props }) => {
+  return (
+    <ul>
+      {props.map((prop) => (
+        <PropItemLLM key={prop.name} prop={prop} />
+      ))}
+    </ul>
+  );
+};
+
+export const PrimitivesTypeTableLLM: FC<{
+  type?: string;
+  parameters: PropDef[];
+}> = ({ parameters }) => {
+  return <PropListLLM props={parameters} />;
+};

--- a/apps/docs/components/docs/primitives-type-table.tsx
+++ b/apps/docs/components/docs/primitives-type-table.tsx
@@ -6,7 +6,7 @@ import {
   TypeTableClient,
   type TypeTableRow,
 } from "./primitives-type-table-client";
-import { renderDescription } from "./parameters-table";
+import { DefListLLM } from "./parameters-table";
 import { StatusBadge } from "./status-badge";
 
 type PropDef = {
@@ -152,52 +152,16 @@ export async function PrimitivesTypeTable({
 
 // Build from PropDef directly, skipping Shiki highlighting (it emitted stray
 // code fences) and the `highlighted*` fields meant for the client table.
-const PropItemLLM: FC<{ prop: PropDef }> = ({ prop: rawProp }) => {
-  const prop = { ...COMMON_PARAMS[rawProp.name], ...rawProp };
-  const isOptional = !prop.required && !prop.default;
-  const type = prop.type ? stripTrailingUndefined(prop.type) : undefined;
-
-  return (
-    <li>
-      <code>
-        {prop.name}
-        {isOptional ? "?" : ""}
-      </code>
-      {type ? (
-        <>
-          {": "}
-          <code>{type}</code>
-        </>
-      ) : null}
-      {prop.default ? (
-        <>
-          {" (default "}
-          <code>{prop.default}</code>
-          {")"}
-        </>
-      ) : null}
-      {prop.deprecated ? <> (deprecated: {prop.deprecated})</> : null}
-      {prop.description ? <> — {renderDescription(prop.description)}</> : null}
-      {prop.children?.map((child, i) => (
-        <PropListLLM key={i} props={child.parameters} />
-      ))}
-    </li>
-  );
-};
-
-const PropListLLM: FC<{ props: PropDef[] }> = ({ props }) => {
-  return (
-    <ul>
-      {props.map((prop) => (
-        <PropItemLLM key={prop.name} prop={prop} />
-      ))}
-    </ul>
-  );
-};
-
+// stripTrailingUndefined drops the `| undefined` the prop extractor leaves on.
 export const PrimitivesTypeTableLLM: FC<{
   type?: string;
   parameters: PropDef[];
 }> = ({ parameters }) => {
-  return <PropListLLM props={parameters} />;
+  return (
+    <DefListLLM
+      defs={parameters}
+      commonParams={COMMON_PARAMS}
+      normalizeType={stripTrailingUndefined}
+    />
+  );
 };

--- a/apps/docs/components/docs/primitives-type-table.tsx
+++ b/apps/docs/components/docs/primitives-type-table.tsx
@@ -6,6 +6,7 @@ import {
   TypeTableClient,
   type TypeTableRow,
 } from "./primitives-type-table-client";
+import { renderDescription } from "./parameters-table";
 import { StatusBadge } from "./status-badge";
 
 type PropDef = {
@@ -176,9 +177,9 @@ const PropItemLLM: FC<{ prop: PropDef }> = ({ prop: rawProp }) => {
         </>
       ) : null}
       {prop.deprecated ? <> (deprecated: {prop.deprecated})</> : null}
-      {prop.description ? <> — {prop.description}</> : null}
+      {prop.description ? <> — {renderDescription(prop.description)}</> : null}
       {prop.children?.map((child, i) => (
-        <PropListLLM key={child.type ?? i} props={child.parameters} />
+        <PropListLLM key={i} props={child.parameters} />
       ))}
     </li>
   );

--- a/apps/docs/content/docs/cloud/ai-sdk.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk.mdx
@@ -3,8 +3,6 @@ title: AI SDK
 description: Add cloud persistence to your existing AI SDK app with a single hook.
 ---
 
-import { InstallCommand } from "@/components/docs/fumadocs/install/install-command";
-
 ## Overview
 
 The `@assistant-ui/cloud-ai-sdk` package provides a single hook that adds full message and thread persistence to any [AI SDK](https://sdk.vercel.ai/) application:

--- a/apps/docs/lib/constants.ts
+++ b/apps/docs/lib/constants.ts
@@ -3,6 +3,8 @@ export const BASE_URL = "https://www.assistant-ui.com";
 export const PLATFORMS = ["react", "rn", "ink"] as const;
 export type Platform = (typeof PLATFORMS)[number];
 
+export const DEFAULT_PLATFORM: Platform = "react";
+
 export const PLATFORM_LABELS: Record<Platform, string> = {
   react: "React",
   rn: "React Native",

--- a/apps/docs/lib/constants.ts
+++ b/apps/docs/lib/constants.ts
@@ -1,5 +1,14 @@
 export const BASE_URL = "https://www.assistant-ui.com";
 
+export const PLATFORMS = ["react", "rn", "ink"] as const;
+export type Platform = (typeof PLATFORMS)[number];
+
+export const PLATFORM_LABELS: Record<Platform, string> = {
+  react: "React",
+  rn: "React Native",
+  ink: "React Ink",
+};
+
 export type Product = {
   /** Route segment for internal products (e.g. "tw-shimmer", "native"). Omit for external. */
   slug?: string;

--- a/apps/docs/lib/get-llm-text.tsx
+++ b/apps/docs/lib/get-llm-text.tsx
@@ -10,7 +10,7 @@ import rehypeRemark from "rehype-remark";
 import remarkGfm from "remark-gfm";
 import remarkStringify from "remark-stringify";
 import { unified } from "unified";
-import { getMDXComponents } from "@/mdx-components";
+import { getLLMComponents } from "@/lib/llm-components";
 import type { examples, source } from "@/lib/source";
 import type { InferPageType } from "fumadocs-core/source";
 
@@ -23,8 +23,6 @@ const processor = unified()
     fences: true,
     rule: "-",
   });
-
-const MDX_COMPONENTS = getMDXComponents({});
 
 const OMITTED_STATIC_PROP_NAMES = new Set([
   "children",
@@ -61,6 +59,28 @@ function isClientReference(type: unknown): boolean {
     type !== null &&
     (type as { $$typeof?: symbol }).$$typeof === REACT_CLIENT_REFERENCE
   );
+}
+
+// Directly-imported MDX components (e.g. PreviewCode) bypass the LLM map, so they
+// carry their text rendering as a `.llm` static instead.
+function getLLMVariant(type: unknown): StaticFunctionComponent | undefined {
+  if (
+    (typeof type === "function" || typeof type === "object") &&
+    type !== null
+  ) {
+    const llm = (type as { llm?: unknown }).llm;
+    if (typeof llm === "function") return llm as StaticFunctionComponent;
+  }
+  return undefined;
+}
+
+function componentDisplayName(type: unknown): string {
+  if (type == null) return "";
+  const named = type as { displayName?: unknown; name?: unknown };
+  if (typeof named.displayName === "string" && named.displayName)
+    return named.displayName;
+  if (typeof named.name === "string" && named.name) return named.name;
+  return "";
 }
 
 // Safety net for server components that throw because of transitive
@@ -236,12 +256,28 @@ async function resolveStaticReactNode(node: ReactNode): Promise<ReactNode> {
     const resolvedChildren = await resolveStaticReactNode(
       children as ReactNode,
     );
-    return renderClientFallback(props, resolvedChildren);
+    // Turn links (e.g. next/link) into real anchors so they survive as markdown
+    // links, not a dumped `href` entry.
+    const href = props.href;
+    if (typeof href === "string" && href) {
+      return <a href={href}>{resolvedChildren}</a>;
+    }
+    const fallback = await renderClientFallback(props, resolvedChildren);
+    if (!isEmptyNode(fallback)) return fallback;
+    const name = componentDisplayName(element.type);
+    return (
+      <p>
+        {name
+          ? `[interactive preview component ${name} omitted]`
+          : "[interactive preview omitted]"}
+      </p>
+    );
   }
 
   if (typeof element.type === "function") {
+    const Component = (getLLMVariant(element.type) ??
+      element.type) as StaticFunctionComponent;
     try {
-      const Component = element.type as StaticFunctionComponent;
       const rendered = Component({ ...props, children: children as ReactNode });
       return resolveStaticReactNode(await rendered);
     } catch (error) {
@@ -279,11 +315,15 @@ export async function getLLMText(page: LLMPage) {
   // platform ("react"). If llms output should include React Native or Ink
   // variants, render once per platform or provide an explicit platform scope.
   const staticBody = await resolveStaticReactNode(
-    <Body components={MDX_COMPONENTS} />,
+    <Body components={getLLMComponents()} />,
   );
   const { renderToStaticMarkup } = await import("react-dom/server");
   const html = renderToStaticMarkup(staticBody);
-  const markdown = String(await processor.process(html)).trim();
+  // remark-stringify escapes the leading `[` of a callout admonition marker
+  // (`> [!info]` → `> \[!info]`); restore it so the GitHub syntax stays intact.
+  const markdown = String(await processor.process(html))
+    .replace(/^(\s*>\s*)\\\[!/gm, "$1[!")
+    .trim();
 
   return `# ${page.data.title}
 URL: ${page.url}

--- a/apps/docs/lib/get-llm-text.tsx
+++ b/apps/docs/lib/get-llm-text.tsx
@@ -10,7 +10,7 @@ import rehypeRemark from "rehype-remark";
 import remarkGfm from "remark-gfm";
 import remarkStringify from "remark-stringify";
 import { unified } from "unified";
-import { getLLMComponents } from "@/lib/llm-components";
+import { LLM_COMPONENTS } from "@/lib/llm-components";
 import type { examples, source } from "@/lib/source";
 import type { InferPageType } from "fumadocs-core/source";
 
@@ -315,7 +315,7 @@ export async function getLLMText(page: LLMPage) {
   // platform ("react"). If llms output should include React Native or Ink
   // variants, render once per platform or provide an explicit platform scope.
   const staticBody = await resolveStaticReactNode(
-    <Body components={getLLMComponents()} />,
+    <Body components={LLM_COMPONENTS} />,
   );
   const { renderToStaticMarkup } = await import("react-dom/server");
   const html = renderToStaticMarkup(staticBody);

--- a/apps/docs/lib/llm-components.tsx
+++ b/apps/docs/lib/llm-components.tsx
@@ -26,40 +26,42 @@ const Heading =
   (Tag: "h1" | "h2" | "h3" | "h4" | "h5" | "h6") =>
   ({ children }: ComponentProps<"h1">) => <Tag>{children}</Tag>;
 
+const LLM_COMPONENTS: MDXComponents = {
+  ...getMDXComponents({}),
+  h1: Heading("h1"),
+  h2: Heading("h2"),
+  h3: Heading("h3"),
+  h4: Heading("h4"),
+  h5: Heading("h5"),
+  h6: Heading("h6"),
+  pre: ({ children }: ComponentProps<"pre">) => <pre>{children}</pre>,
+  // Static markdown images render via next/image (client), whose fallback drops
+  // src and leaks alt. A host <img> survives as `![alt](src)`; src may be a
+  // string or a StaticImageData object.
+  img: ({ src, alt }: ComponentProps<"img">) => {
+    const value = src as string | { src?: string } | undefined;
+    const url = typeof value === "string" ? value : value?.src;
+    return url ? <img src={url} alt={alt ?? ""} /> : null;
+  },
+  // The base map turns every blockquote into a Callout; keep plain quotes plain
+  // and reserve `[!type]` for real Callouts.
+  blockquote: ({ children }: ComponentProps<"blockquote">) => (
+    <blockquote>{children}</blockquote>
+  ),
+  Callout: CalloutLLM,
+  Tabs: TabsLLM,
+  Tab: TabLLM,
+  PlatformTabs: PlatformTabsLLM,
+  PlatformOnly: PlatformOnlyLLM,
+  Cards: CardsLLM,
+  Card: CardLLM,
+  Steps: StepsLLM,
+  Step: StepLLM,
+  InstallCommand: InstallCommandLLM,
+  ParametersTable: ParametersTableLLM,
+  PrimitivesTypeTable: PrimitivesTypeTableLLM,
+};
+
 export function getLLMComponents(): MDXComponents {
-  return {
-    ...getMDXComponents({}),
-    h1: Heading("h1"),
-    h2: Heading("h2"),
-    h3: Heading("h3"),
-    h4: Heading("h4"),
-    h5: Heading("h5"),
-    h6: Heading("h6"),
-    pre: ({ children }: ComponentProps<"pre">) => <pre>{children}</pre>,
-    // Static markdown images render via next/image (client), whose fallback drops
-    // src and leaks alt. A host <img> survives as `![alt](src)`; src may be a
-    // string or a StaticImageData object.
-    img: ({ src, alt }: ComponentProps<"img">) => {
-      const value = src as string | { src?: string } | undefined;
-      const url = typeof value === "string" ? value : value?.src;
-      return url ? <img src={url} alt={alt ?? ""} /> : null;
-    },
-    // The base map turns every blockquote into a Callout; keep plain quotes plain
-    // and reserve `[!type]` for real Callouts.
-    blockquote: ({ children }: ComponentProps<"blockquote">) => (
-      <blockquote>{children}</blockquote>
-    ),
-    Callout: CalloutLLM,
-    Tabs: TabsLLM,
-    Tab: TabLLM,
-    PlatformTabs: PlatformTabsLLM,
-    PlatformOnly: PlatformOnlyLLM,
-    Cards: CardsLLM,
-    Card: CardLLM,
-    Steps: StepsLLM,
-    Step: StepLLM,
-    InstallCommand: InstallCommandLLM,
-    ParametersTable: ParametersTableLLM,
-    PrimitivesTypeTable: PrimitivesTypeTableLLM,
-  };
+  return LLM_COMPONENTS;
 }

--- a/apps/docs/lib/llm-components.tsx
+++ b/apps/docs/lib/llm-components.tsx
@@ -1,0 +1,65 @@
+import type { ComponentProps } from "react";
+import type { MDXComponents } from "mdx/types";
+import { getMDXComponents } from "@/mdx-components";
+import { TabLLM, TabsLLM } from "@/components/docs/fumadocs/tabs.llm";
+import {
+  PlatformOnlyLLM,
+  PlatformTabsLLM,
+} from "@/components/docs/platform/mdx.llm";
+import { CalloutLLM } from "@/components/docs/fumadocs/callout";
+import { CardLLM, CardsLLM } from "@/components/docs/fumadocs/card";
+import { StepLLM, StepsLLM } from "@/components/docs/fumadocs/steps";
+import { InstallCommandLLM } from "@/components/docs/fumadocs/install/install-command";
+import { ParametersTableLLM } from "@/components/docs/parameters-table";
+import { PrimitivesTypeTableLLM } from "@/components/docs/primitives-type-table";
+
+/**
+ * The single substitution point mapping MDX components to their text variants
+ * for LLM/markdown rendering. `PreviewCode` is the exception: it's imported
+ * directly in MDX (it's a `node:fs` server component), so it bypasses this map
+ * and carries its variant as a `.llm` marker the resolver picks up instead.
+ */
+// fumadocs' client Heading/CodeBlock hit the resolver's client fallback, which
+// dumps the `as` prop and inlines code. Plain server elements keep heading
+// levels and fenced code.
+const Heading =
+  (Tag: "h1" | "h2" | "h3" | "h4" | "h5" | "h6") =>
+  ({ children }: ComponentProps<"h1">) => <Tag>{children}</Tag>;
+
+export function getLLMComponents(): MDXComponents {
+  return {
+    ...getMDXComponents({}),
+    h1: Heading("h1"),
+    h2: Heading("h2"),
+    h3: Heading("h3"),
+    h4: Heading("h4"),
+    h5: Heading("h5"),
+    h6: Heading("h6"),
+    pre: ({ children }: ComponentProps<"pre">) => <pre>{children}</pre>,
+    // Static markdown images render via next/image (client), whose fallback drops
+    // src and leaks alt. A host <img> survives as `![alt](src)`; src may be a
+    // string or a StaticImageData object.
+    img: ({ src, alt }: ComponentProps<"img">) => {
+      const value = src as string | { src?: string } | undefined;
+      const url = typeof value === "string" ? value : value?.src;
+      return url ? <img src={url} alt={alt ?? ""} /> : null;
+    },
+    // The base map turns every blockquote into a Callout; keep plain quotes plain
+    // and reserve `[!type]` for real Callouts.
+    blockquote: ({ children }: ComponentProps<"blockquote">) => (
+      <blockquote>{children}</blockquote>
+    ),
+    Callout: CalloutLLM,
+    Tabs: TabsLLM,
+    Tab: TabLLM,
+    PlatformTabs: PlatformTabsLLM,
+    PlatformOnly: PlatformOnlyLLM,
+    Cards: CardsLLM,
+    Card: CardLLM,
+    Steps: StepsLLM,
+    Step: StepLLM,
+    InstallCommand: InstallCommandLLM,
+    ParametersTable: ParametersTableLLM,
+    PrimitivesTypeTable: PrimitivesTypeTableLLM,
+  };
+}

--- a/apps/docs/lib/llm-components.tsx
+++ b/apps/docs/lib/llm-components.tsx
@@ -26,7 +26,7 @@ const Heading =
   (Tag: "h1" | "h2" | "h3" | "h4" | "h5" | "h6") =>
   ({ children }: ComponentProps<"h1">) => <Tag>{children}</Tag>;
 
-const LLM_COMPONENTS: MDXComponents = {
+export const LLM_COMPONENTS: MDXComponents = {
   ...getMDXComponents({}),
   h1: Heading("h1"),
   h2: Heading("h2"),
@@ -61,7 +61,3 @@ const LLM_COMPONENTS: MDXComponents = {
   ParametersTable: ParametersTableLLM,
   PrimitivesTypeTable: PrimitivesTypeTableLLM,
 };
-
-export function getLLMComponents(): MDXComponents {
-  return LLM_COMPONENTS;
-}

--- a/apps/docs/mdx-components.tsx
+++ b/apps/docs/mdx-components.tsx
@@ -5,7 +5,6 @@ import { Callout } from "@/components/docs/fumadocs/callout";
 import { Card, Cards } from "@/components/docs/fumadocs/card";
 import { Step, Steps } from "@/components/docs/fumadocs/steps";
 import { Tab, Tabs } from "@/components/docs/fumadocs/tabs";
-import { TypeTable } from "fumadocs-ui/components/type-table";
 import defaultComponents from "fumadocs-ui/mdx";
 import {
   CodeBlock,
@@ -52,7 +51,6 @@ export function getMDXComponents(components: MDXComponents): MDXComponents {
     Cards,
     Step,
     Steps,
-    TypeTable,
     Accordion,
     Accordions,
     Kbd,


### PR DESCRIPTION
## What

Fixes the MDX → md/txt rendering behind every doc's `<doc-url>.mdx` + `/llms.txt` endpoints for LLM/machine readability, by swapping each interactive component for a text variant through a single `getLLMComponents` map (plus a `.llm` marker for components imported directly in MDX), and resolver fixes for links, images, and admonition escaping. Previously the renderer walked the visual React tree, so components dumped their props or vanished.

## Why

These endpoints are the docs' machine-readable surface — "pick one of these tabs" read as "run all 11 commands," and the manual install path disappeared entirely.

## Before / After

**ParametersTable** — flat list, no Shiki markup
```
Before                                  After
```tsx                                  - `messages`: `readonly ThreadMessage[]` — The
messages                                  conversation history to send to your API.
``` (+ highlight spans, rows lost)      - `runConfig`: `RunConfig` — …
```

**Tabs** — mutually exclusive, not sequential
```
Before (reads as "install all 11")      After
npm install … @ai-sdk/openai            Choose one:
npm install … @ai-sdk/anthropic
npm install … @ai-sdk/azure             **OpenAI**
…8 more, concatenated                    npm install … @ai-sdk/openai

                                        **Anthropic**
                                        npm install … @ai-sdk/anthropic
                                        …
```

**InstallCommand** — keep the manual path (was dropped)
```
After:
npx shadcn@latest add https://r.assistant-ui.com/thread.json https://r.assistant-ui.com/thread-list.json

Or copy the source files from GitHub:
- [components/assistant-ui/thread.tsx](https://github.com/assistant-ui/assistant-ui/blob/main/packages/ui/src/components/assistant-ui/thread.tsx)
- … (+ aui deps)

curl -sSL --create-dirs \
  -o components/assistant-ui/thread.tsx https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/packages/ui/src/components/assistant-ui/thread.tsx \
  -o …
```

Also: **callouts** keep their kind (`> [!warning]`), **images** keep their `src` (`![alt](src)` instead of a leaked `alt`), and client **links** become real markdown links.
