### PR TITLE
fix(docs): correct star and downloads chart projections

### DIFF
--- a/apps/docs/components/traction/star-history-chart.tsx
+++ b/apps/docs/components/traction/star-history-chart.tsx
@@ -13,6 +13,7 @@ import { formatCompact } from "@/lib/format";
 type Point = { date: string; value: number };
 type ChartPoint = {
   date: string;
+  ts: number;
   value: number | null;
   forecast: number | null;
 };
@@ -31,10 +32,8 @@ const config = {
 const FORECAST_WINDOW_DAYS = 90;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-const formatTick = (iso: string) => {
-  const d = new Date(iso);
-  return d.toLocaleDateString("en-US", { month: "short", year: "2-digit" });
-};
+const formatTick = (ms: number) =>
+  new Date(ms).toLocaleDateString("en-US", { month: "short", year: "2-digit" });
 
 const formatTooltipLabel = (iso: string) =>
   new Date(iso).toLocaleDateString("en-US", {
@@ -46,6 +45,7 @@ const formatTooltipLabel = (iso: string) =>
 function buildChartData(data: Point[]): ChartPoint[] {
   const base: ChartPoint[] = data.map((p) => ({
     date: p.date,
+    ts: new Date(p.date).getTime(),
     value: p.value,
     forecast: null,
   }));
@@ -88,6 +88,7 @@ function buildChartData(data: Point[]): ChartPoint[] {
   base[base.length - 1] = { ...base[base.length - 1]!, forecast: last.value };
   base.push({
     date: new Date(monthEnd).toISOString(),
+    ts: monthEnd,
     value: null,
     forecast: projected,
   });
@@ -131,7 +132,10 @@ export function StarHistoryChart({ data }: { data: Point[] }) {
         </defs>
         <CartesianGrid vertical={false} strokeDasharray="3 3" />
         <XAxis
-          dataKey="date"
+          dataKey="ts"
+          type="number"
+          scale="time"
+          domain={["dataMin", "dataMax"]}
           tickFormatter={formatTick}
           tickLine={false}
           axisLine={false}

--- a/apps/docs/lib/npm.ts
+++ b/apps/docs/lib/npm.ts
@@ -37,10 +37,3 @@ export function getDownloadsRange(
     revalidate,
   );
 }
-
-export function getDownloadsLastYear(
-  pkg: string,
-  revalidate: number = NPM_REVALIDATE.WARM,
-): Promise<NpmDailyDownloads[]> {
-  return npmFetch(`/downloads/range/last-year/${pkg}`, revalidate);
-}

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -5,7 +5,7 @@ import {
   getReleases,
   getStargazersPage,
 } from "./github";
-import { getDownloadsLastYear, getDownloadsRange } from "./npm";
+import { getDownloadsRange } from "./npm";
 
 export type PackageInfo = {
   name: string;
@@ -532,7 +532,16 @@ export async function fetchDownloadsTimeline(
   name: string,
   revalidate?: number,
 ): Promise<TimelinePoint[]> {
-  const downloads = await getDownloadsLastYear(name, revalidate);
+  // npm's last-year endpoint stops at the last complete day, so it omits the
+  // in-flight month entirely; an explicit range through today keeps it.
+  const today = new Date();
+  const end = today.toISOString().slice(0, 10);
+  const start = new Date(
+    Date.UTC(today.getUTCFullYear() - 1, today.getUTCMonth(), 1),
+  )
+    .toISOString()
+    .slice(0, 10);
+  const downloads = await getDownloadsRange(name, start, end, revalidate);
   if (!downloads.length) return [];
   const cutoff = currentMonthKey();
   type MonthBucket = {


### PR DESCRIPTION
## summary

- the /traction downloads chart now shows its in-flight month projection from the first day of the month, instead of blanking out the dashed forecast for the first 1 to 2 days of every month.
- the /traction star history chart now draws the forecast to month end at its true width on a time scaled x axis. the axis was categorical, so a 1 day gap and a ~28 day forecast were rendered equal width and the projection looked wrong early in the month.
- under the hood: the downloads timeline now fetches an explicit npm range through today (npm's last-year endpoint is a rolling 365 day window that excludes the current month for the first day or two); the star chart x axis is now a numeric `scale="time"`; the now unused getDownloadsLastYear helper is removed.

## test plan

### already verified

- [x] `pnpm exec tsc --noEmit` on apps/docs -> no type errors in the changed files
- [x] `oxlint` on the three changed files -> clean, and the pre-commit oxlint/oxfmt hooks passed on both commits
- [x] confirmed the root cause against the live npm API: `range/last-year/@assistant-ui/react` ends at 2026-05-31 (zero June days), while `range/2025-06-01:2026-06-02/...` returns June 1 and June 2

### reviewer should verify

- [ ] open /traction on the 1st or 2nd of a month and confirm the downloads chart shows the dashed in-flight projection plus the month reference line
- [ ] confirm the star history chart's dashed forecast spans its real duration (segments proportional to time, not equal width)

## notes

- the page caches npm/GitHub data via revalidate (up to 6h), so on a deployed build the fix appears after the next revalidation or immediately with `?refresh=true`.