### PR TITLE
docs: support Celsius weather widget display

### DIFF
--- a/apps/docs/lib/docs-toolkit.tsx
+++ b/apps/docs/lib/docs-toolkit.tsx
@@ -1,7 +1,11 @@
 "use generative";
 
 import { cn } from "@/lib/utils";
-import { WeatherWidget } from "@/components/tool-ui/weather-widget/runtime";
+import {
+  WeatherWidget,
+  type TemperatureUnit,
+  type WeatherWidgetPayload,
+} from "@/components/tool-ui/weather-widget/runtime";
 import {
   fetchWeatherWidgetFromOpenMeteo,
   geocodeLocationWithOpenMeteo,
@@ -15,6 +19,9 @@ import {
   generativeUIToJSX,
 } from "@assistant-ui/react-generative-ui";
 
+const weatherFormatSchema = z.enum(["fahrenheit", "celsius"]);
+type WeatherFormat = z.infer<typeof weatherFormatSchema>;
+
 // The user-facing component library the model renders through the `present`
 // tool. `Weather` shows the rich card for a `get_weather` result by `id`.
 const generative = new JSONGenerativeUI({
@@ -22,9 +29,15 @@ const generative = new JSONGenerativeUI({
     Weather: {
       description:
         "Show the user a rich weather card. Pass the `id` returned by " +
-        "`get_weather`; the card reads that result's payload.",
-      properties: z.object({ id: z.string() }),
-      render: (props: any) => <WeatherCard {...props} />,
+        "`get_weather`; optionally pass `format` to display temperatures as " +
+        "fahrenheit or celsius.",
+      properties: z.object({
+        id: z.string(),
+        format: weatherFormatSchema
+          .optional()
+          .describe("Temperature format to display in the weather card."),
+      }),
+      render: (props) => <WeatherCard {...props} />,
     },
   }),
 });
@@ -77,27 +90,20 @@ export default defineToolkit({
       location: z.string(),
       latitude: z.number(),
       longitude: z.number(),
-      format: z
-        .enum(["fahrenheit", "celsius"])
-        .default("fahrenheit")
-        .describe("Temperature format to use for the weather card."),
     }),
     execute: async ({
       location,
       latitude,
       longitude,
-      format,
     }: {
       location: string;
       latitude: number;
       longitude: number;
-      format: "fahrenheit" | "celsius";
     }) => {
       const weather = await fetchWeatherWidgetFromOpenMeteo({
         query: location,
         latitude,
         longitude,
-        unit: format,
       });
       if (!weather.success) {
         return { success: false as const, error: weather.error };
@@ -148,7 +154,13 @@ export default defineToolkit({
   present: generative.present({ display: "standalone" }),
 });
 
-const WeatherCard = ({ id }: any) => {
+const WeatherCard = ({
+  id,
+  format,
+}: {
+  id: string;
+  format?: WeatherFormat;
+}) => {
   // The payload lives on the `get_weather` result; the `Weather` component only
   // carries the `id`. Scan the whole thread (the two calls usually land in
   // separate assistant messages) for the matching result.
@@ -194,14 +206,59 @@ const WeatherCard = ({ id }: any) => {
     );
   }
 
+  const widget = format
+    ? convertWeatherWidgetFormat(source.widget, format)
+    : source.widget;
+  const generativeNode =
+    format !== undefined
+      ? { $type: "Weather", id, format }
+      : { $type: "Weather", id };
+
   return (
     <div className="mt-2 mb-4 flex flex-col items-center">
-      <WeatherWidget {...source.widget} />
+      <WeatherWidget {...widget} />
       <p className="text-muted-foreground/70 mt-1.5 text-center font-mono text-xs">
-        present({generativeUIToJSX({ $type: "Weather", id })})
+        present({generativeUIToJSX(generativeNode)})
       </p>
     </div>
   );
+};
+
+const convertTemperature = (
+  value: number,
+  from: TemperatureUnit,
+  to: TemperatureUnit,
+) => {
+  if (from === to) return value;
+  return to === "celsius" ? ((value - 32) * 5) / 9 : (value * 9) / 5 + 32;
+};
+
+const convertWeatherWidgetFormat = (
+  widget: WeatherWidgetPayload,
+  format: TemperatureUnit,
+): WeatherWidgetPayload => {
+  const sourceFormat = widget.units.temperature;
+  if (sourceFormat === format) return widget;
+
+  return {
+    ...widget,
+    units: { ...widget.units, temperature: format },
+    current: {
+      ...widget.current,
+      temperature: convertTemperature(
+        widget.current.temperature,
+        sourceFormat,
+        format,
+      ),
+      tempMin: convertTemperature(widget.current.tempMin, sourceFormat, format),
+      tempMax: convertTemperature(widget.current.tempMax, sourceFormat, format),
+    },
+    forecast: widget.forecast.map((day) => ({
+      ...day,
+      tempMin: convertTemperature(day.tempMin, sourceFormat, format),
+      tempMax: convertTemperature(day.tempMax, sourceFormat, format),
+    })),
+  };
 };
 
 // Shared Tool Card Components

--- a/apps/docs/lib/docs-toolkit.tsx
+++ b/apps/docs/lib/docs-toolkit.tsx
@@ -208,10 +208,11 @@ const WeatherCard = ({
   const widget = format
     ? convertWeatherWidgetFormat(source.widget, format)
     : source.widget;
-  const generativeNode =
-    format !== undefined
-      ? { $type: "Weather", id, format }
-      : { $type: "Weather", id };
+  const generativeNode = {
+    $type: "Weather",
+    id,
+    ...(format !== undefined && { format }),
+  };
 
   return (
     <div className="mt-2 mb-4 flex flex-col items-center">

--- a/apps/docs/lib/docs-toolkit.tsx
+++ b/apps/docs/lib/docs-toolkit.tsx
@@ -20,7 +20,6 @@ import {
 } from "@assistant-ui/react-generative-ui";
 
 const weatherFormatSchema = z.enum(["fahrenheit", "celsius"]);
-type WeatherFormat = z.infer<typeof weatherFormatSchema>;
 
 // The user-facing component library the model renders through the `present`
 // tool. `Weather` shows the rich card for a `get_weather` result by `id`.
@@ -159,7 +158,7 @@ const WeatherCard = ({
   format,
 }: {
   id: string;
-  format?: WeatherFormat;
+  format?: TemperatureUnit;
 }) => {
   // The payload lives on the `get_weather` result; the `Weather` component only
   // carries the `id`. Scan the whole thread (the two calls usually land in

--- a/apps/docs/lib/docs-toolkit.tsx
+++ b/apps/docs/lib/docs-toolkit.tsx
@@ -40,7 +40,7 @@ export default defineToolkit({
     }),
     execute: async ({ query }: { query: string }) =>
       geocodeLocationWithOpenMeteo(query),
-    render: ({ toolName, args, result }: any) => {
+    render: ({ toolName, args, result }) => {
       const signature = formatToolCall(toolName, args);
       const icon = <MapPin className="size-4" />;
 
@@ -77,20 +77,27 @@ export default defineToolkit({
       location: z.string(),
       latitude: z.number(),
       longitude: z.number(),
+      format: z
+        .enum(["fahrenheit", "celsius"])
+        .default("fahrenheit")
+        .describe("Temperature format to use for the weather card."),
     }),
     execute: async ({
       location,
       latitude,
       longitude,
+      format,
     }: {
       location: string;
       latitude: number;
       longitude: number;
+      format: "fahrenheit" | "celsius";
     }) => {
       const weather = await fetchWeatherWidgetFromOpenMeteo({
         query: location,
         latitude,
         longitude,
+        unit: format,
       });
       if (!weather.success) {
         return { success: false as const, error: weather.error };
@@ -122,13 +129,15 @@ export default defineToolkit({
       }
 
       const current = result.widget?.current;
+      const unitSymbol =
+        result.widget?.units.temperature === "celsius" ? "C" : "F";
       return (
         <ToolTraceCard
           icon={icon}
           signature={signature}
           description={
             current
-              ? `${Math.round(current.temperature)}°F · ${current.conditionCode} in ${result.location}`
+              ? `${Math.round(current.temperature)}°${unitSymbol} · ${current.conditionCode} in ${result.location}`
               : "Weather ready"
           }
           result={result}

--- a/apps/docs/lib/open-meteo-weather-adapter.ts
+++ b/apps/docs/lib/open-meteo-weather-adapter.ts
@@ -2,7 +2,6 @@ import type {
   ForecastDay,
   PrecipitationLevel,
   WeatherConditionCode,
-  TemperatureUnit,
   WeatherWidgetPayload,
 } from "@/components/tool-ui/weather-widget/runtime";
 
@@ -10,7 +9,6 @@ export interface WeatherSearchArgs {
   query: string;
   longitude: number;
   latitude: number;
-  unit?: TemperatureUnit;
 }
 
 type GeocodeResult =
@@ -155,11 +153,10 @@ export const fetchWeatherWidgetFromOpenMeteo = async ({
   query,
   longitude,
   latitude,
-  unit = "fahrenheit",
 }: WeatherSearchArgs): Promise<WeatherResult> => {
   try {
     const response = await fetch(
-      `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&timezone=auto&temperature_unit=${unit}&current=temperature_2m,weather_code,wind_speed_10m,precipitation&daily=weather_code,temperature_2m_max,temperature_2m_min&forecast_days=5`,
+      `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&timezone=auto&temperature_unit=fahrenheit&current=temperature_2m,weather_code,wind_speed_10m,precipitation&daily=weather_code,temperature_2m_max,temperature_2m_min&forecast_days=5`,
     );
 
     if (!response.ok) {
@@ -201,7 +198,7 @@ export const fetchWeatherWidgetFromOpenMeteo = async ({
         version: "3.1",
         id: `docs-weather-${query.toLowerCase().replaceAll(/\W+/g, "-")}`,
         location: { name: query },
-        units: { temperature: unit },
+        units: { temperature: "fahrenheit" },
         current: {
           conditionCode: mapOpenMeteoCodeToCondition(
             current.weather_code,

--- a/apps/docs/lib/open-meteo-weather-adapter.ts
+++ b/apps/docs/lib/open-meteo-weather-adapter.ts
@@ -2,6 +2,7 @@ import type {
   ForecastDay,
   PrecipitationLevel,
   WeatherConditionCode,
+  TemperatureUnit,
   WeatherWidgetPayload,
 } from "@/components/tool-ui/weather-widget/runtime";
 
@@ -9,6 +10,7 @@ export interface WeatherSearchArgs {
   query: string;
   longitude: number;
   latitude: number;
+  unit?: TemperatureUnit;
 }
 
 type GeocodeResult =
@@ -153,10 +155,11 @@ export const fetchWeatherWidgetFromOpenMeteo = async ({
   query,
   longitude,
   latitude,
+  unit = "fahrenheit",
 }: WeatherSearchArgs): Promise<WeatherResult> => {
   try {
     const response = await fetch(
-      `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&timezone=auto&temperature_unit=fahrenheit&current=temperature_2m,weather_code,wind_speed_10m,precipitation&daily=weather_code,temperature_2m_max,temperature_2m_min&forecast_days=5`,
+      `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&timezone=auto&temperature_unit=${unit}&current=temperature_2m,weather_code,wind_speed_10m,precipitation&daily=weather_code,temperature_2m_max,temperature_2m_min&forecast_days=5`,
     );
 
     if (!response.ok) {
@@ -198,7 +201,7 @@ export const fetchWeatherWidgetFromOpenMeteo = async ({
         version: "3.1",
         id: `docs-weather-${query.toLowerCase().replaceAll(/\W+/g, "-")}`,
         location: { name: query },
-        units: { temperature: "fahrenheit" },
+        units: { temperature: unit },
         current: {
           conditionCode: mapOpenMeteoCodeToCondition(
             current.weather_code,


### PR DESCRIPTION
## Summary
- add an optional Weather generative component format prop for fahrenheit/celsius display
- convert the weather widget temperatures at render time when a display format is requested
- keep get_weather as the source-data fetch and leave Open-Meteo results in their existing Fahrenheit payload format

## Validation
- pnpm exec oxfmt --check apps/docs/lib/docs-toolkit.tsx apps/docs/lib/open-meteo-weather-adapter.ts
- pnpm exec oxlint apps/docs/lib/docs-toolkit.tsx apps/docs/lib/open-meteo-weather-adapter.ts
- pnpm --filter @assistant-ui/docs exec tsc --noEmit --pretty false (blocked by existing apps/docs/app/(demos)/playground/page.tsx:366 parse error)
- pnpm --filter @assistant-ui/docs build (blocked by the same existing playground parse error)