### PR TITLE
fix: externalize node builtins in package builds

### DIFF
--- a/.changeset/react-ink-node-builtins.md
+++ b/.changeset/react-ink-node-builtins.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-buildutils": patch
+---
+
+fix: treat node built-ins as explicit externals during package builds

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -9,7 +9,7 @@ await build({
   ],
   platform: "neutral",
   unbundle: true,
-  deps: { skipNodeModulesBundle: true },
+  deps: { neverBundle: /^node:/, skipNodeModulesBundle: true },
   dts: { sourcemap: true },
   sourcemap: true,
   plugins: [preserveReferenceDirectives()],


### PR DESCRIPTION
## Summary
- mark `node:*` imports as explicit externals in the shared `aui-build` tsdown config
- add a patch changeset for `@assistant-ui/x-buildutils`

## Validation
- `pnpm --filter @assistant-ui/react-ink build`
- `pnpm build`
- `pnpm exec oxlint packages/x-buildutils/src/index.ts`
- `pnpm exec oxfmt --check packages/x-buildutils/src/index.ts .changeset/react-ink-node-builtins.md`

## Notes
- `pnpm lint` currently fails on an unrelated existing parse error at `apps/docs/app/(demos)/playground/page.tsx:366`.
