### PR TITLE
feat(react-ag-ui): honor CreateResumeRunConfig.stream in AgUiThreadRuntimeCore

### DIFF
--- a/.changeset/agui-resume-stream.md
+++ b/.changeset/agui-resume-stream.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat(react-ag-ui): honor `CreateResumeRunConfig.stream` in `AgUiThreadRuntimeCore`
+
+`resume()` previously logged `resume stream is not supported` and fell back to a fresh `agent.runAgent(...)`, re-running the agent on every resume. It now passes the resume generator into `startRun`, which replays each `ChatModelRunResult` into the existing assistant message (no new `runId`, no replayed `agent.runAgent`) — matching `LocalThreadRuntimeCore.resumeRun`. On history `load()` with `unstable_resume`, the adapter now feeds `history.resume()` when present (falling back to a fresh run otherwise), and `ResumeRunConfig.stream` is typed as the real `(options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>` instead of `unknown`. This lets apps that persist their own AG-UI event stream re-attach and continue consuming on reload.

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -5,6 +5,7 @@ import type {
   AddToolResultOptions,
   AppendMessage,
   AssistantRuntime,
+  ChatModelRunOptions,
   ChatModelRunResult,
   MessageStatus,
   ThreadAssistantMessage,
@@ -35,11 +36,14 @@ const isOptimisticId = (id: string) => id.startsWith(optimisticPrefix);
 const symbolResumeShim = Symbol("agui-resume-shim");
 
 type RunConfig = NonNullable<AppendMessage["runConfig"]>;
+type ResumeStream = (
+  options: ChatModelRunOptions,
+) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 type ResumeRunConfig = {
   parentId: string | null;
   sourceId: string | null;
   runConfig: RunConfig;
-  stream?: unknown;
+  stream?: ResumeStream;
 };
 
 type CoreOptions = {
@@ -136,7 +140,15 @@ export class AgUiThreadRuntimeCore {
 
         if (repo.unstable_resume) {
           const parentId = repo.headId ?? messages.at(-1)?.id ?? null;
-          await this.startRun(parentId, this.lastRunConfig);
+          // Re-attach to the persisted stream when the history adapter can
+          // replay it; otherwise fall back to a fresh agent run.
+          const resumeStream = this.history?.resume?.bind(this.history);
+          await this.startRun(
+            parentId,
+            this.lastRunConfig,
+            undefined,
+            resumeStream,
+          );
         }
       })
       .catch((error) => {
@@ -194,14 +206,11 @@ export class AgUiThreadRuntimeCore {
 
   async resume(config: ResumeRunConfig): Promise<void> {
     this.assertNoPendingInterrupts();
-    if (config.stream) {
-      this.logger.debug?.(
-        "[agui] resume stream is not supported, falling back to regular run",
-      );
-    }
     await this.startRun(
       config.parentId,
       config.runConfig ?? this.lastRunConfig,
+      undefined,
+      config.stream,
     );
   }
 
@@ -442,6 +451,7 @@ export class AgUiThreadRuntimeCore {
     parentId: string | null,
     runConfig?: RunConfig,
     resume?: AgUiResumeEntry[],
+    resumeStream?: ResumeStream,
   ): Promise<void> {
     const normalizedRunConfig = runConfig ?? {};
     this.lastRunConfig = normalizedRunConfig;
@@ -466,15 +476,17 @@ export class AgUiThreadRuntimeCore {
       return created;
     };
 
+    const applyUpdate = (update: ChatModelRunResult) => {
+      const resolved = this.updateAssistantMessage(ensureAssistant(), update);
+      if (resolved !== assistantMessageId) {
+        assistantMessageId = resolved;
+      }
+    };
+
     const aggregator = new RunAggregator({
       showThinking: this.showThinking,
       logger: this.logger,
-      emit: (update) => {
-        const resolved = this.updateAssistantMessage(ensureAssistant(), update);
-        if (resolved !== assistantMessageId) {
-          assistantMessageId = resolved;
-        }
-      },
+      emit: applyUpdate,
       onServerMessageId: (serverId) => {
         const placeholder = ensureAssistant();
         if (placeholder === serverId) return;
@@ -488,40 +500,60 @@ export class AgUiThreadRuntimeCore {
     const abortSignal = abortController.signal;
     this.abortController = abortController;
 
+    // A replayed resume stream owns the assistant content directly, so a cancel
+    // must flip only the status. Routing it through the aggregator (as the
+    // agent-run path does) would emit an empty content snapshot and wipe what
+    // the stream already produced.
+    let cancelRun = () => dispatch({ type: "RUN_CANCELLED" });
+
     abortSignal.addEventListener(
       "abort",
       () => {
-        dispatch({ type: "RUN_CANCELLED" });
+        cancelRun();
         this.finishRun(abortController);
         this.onCancel?.();
       },
       { once: true },
     );
 
-    const subscriber = createAgUiSubscriber({
-      dispatch,
-      runId,
-      logger: this.logger,
-      onRunFailed: (error) => {
-        this.pendingError = error;
-        this.onError?.(error);
-      },
-    });
-
     aggregator.handle({ type: "RUN_STARTED", runId });
     this.setRunning(true);
 
     try {
-      try {
-        (this.agent as any).messages = input.messages;
-        (this.agent as any).threadId = input.threadId;
-        (this.agent as any).state = input.state ?? null;
-      } catch {
-        // ignore
+      if (resumeStream) {
+        cancelRun = () =>
+          applyUpdate({ status: { type: "incomplete", reason: "cancelled" } });
+        await this.consumeResumeStream(resumeStream, {
+          runConfig: normalizedRunConfig,
+          threadId: input.threadId,
+          parentId: assistantParentId,
+          historicalMessages,
+          abortSignal,
+          ensureAssistant,
+          applyUpdate,
+          getAssistantMessageId: () => assistantMessageId,
+        });
+      } else {
+        const subscriber = createAgUiSubscriber({
+          dispatch,
+          runId,
+          logger: this.logger,
+          onRunFailed: (error) => {
+            this.pendingError = error;
+            this.onError?.(error);
+          },
+        });
+        try {
+          (this.agent as any).messages = input.messages;
+          (this.agent as any).threadId = input.threadId;
+          (this.agent as any).state = input.state ?? null;
+        } catch {
+          // ignore
+        }
+        await (this.agent as any).runAgent(input, subscriber, {
+          signal: abortSignal,
+        });
       }
-      await (this.agent as any).runAgent(input, subscriber, {
-        signal: abortSignal,
-      });
     } catch (error) {
       if (!abortSignal.aborted) {
         const err = error instanceof Error ? error : new Error(String(error));
@@ -537,6 +569,70 @@ export class AgUiThreadRuntimeCore {
       const err = this.pendingError;
       this.pendingError = null;
       throw err;
+    }
+  }
+
+  // Re-attach to a persisted run by replaying its `ChatModelRunResult` stream
+  // into the existing assistant message, instead of issuing a fresh
+  // `agent.runAgent(...)`. Mirrors `LocalThreadRuntimeCore.resumeRun`: each
+  // yielded result flows through the same update path the aggregator uses, so
+  // no new runId is generated and the agent is not re-invoked.
+  private async consumeResumeStream(
+    stream: ResumeStream,
+    ctx: {
+      runConfig: RunConfig;
+      threadId: string;
+      parentId: string | null;
+      historicalMessages: readonly ThreadMessage[];
+      abortSignal: AbortSignal;
+      ensureAssistant: () => string;
+      applyUpdate: (update: ChatModelRunResult) => void;
+      getAssistantMessageId: () => string | undefined;
+    },
+  ): Promise<void> {
+    const assistantId = ctx.ensureAssistant();
+    const options: ChatModelRunOptions = {
+      messages: ctx.historicalMessages,
+      runConfig: ctx.runConfig,
+      abortSignal: ctx.abortSignal,
+      context: this.runtime?.thread.getModelContext() ?? {},
+      unstable_assistantMessageId: assistantId,
+      unstable_threadId: ctx.threadId,
+      unstable_parentId: ctx.parentId,
+      unstable_getMessage: () => {
+        const id = ctx.getAssistantMessageId() ?? assistantId;
+        const message = this.messages.find((m) => m.id === id);
+        if (!message) {
+          throw new Error(
+            "[agui] resume stream requested the assistant message before it existed",
+          );
+        }
+        return message;
+      },
+    };
+
+    try {
+      for await (const result of stream(options)) {
+        if (ctx.abortSignal.aborted) return;
+        ctx.applyUpdate(result);
+      }
+    } catch (error) {
+      if (ctx.abortSignal.aborted) return;
+      const err = error instanceof Error ? error : new Error(String(error));
+      ctx.applyUpdate({
+        status: { type: "incomplete", reason: "error", error: err.message },
+      });
+      this.onError?.(err);
+      this.pendingError = this.pendingError ?? err;
+      return;
+    }
+
+    if (ctx.abortSignal.aborted) return;
+    const current = this.messages.find(
+      (m) => m.id === (ctx.getAssistantMessageId() ?? assistantId),
+    );
+    if (!current || current.status?.type === "running") {
+      ctx.applyUpdate({ status: { type: "complete", reason: "unknown" } });
     }
   }
 

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type {
   AppendMessage,
+  ChatModelRunResult,
   ThreadAssistantMessage,
   ThreadHistoryAdapter,
   ThreadMessage,
@@ -680,6 +681,176 @@ describe("AGUIThreadRuntimeCore", () => {
     });
 
     expect(runAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it("replays the resume stream instead of re-running the agent", async () => {
+    const runAgent = vi.fn(async (_input, subscriber) => {
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+    expect(runAgent).toHaveBeenCalledTimes(1);
+
+    const userId = core.getMessages()[0]!.id;
+    const stream = vi.fn(async function* (): AsyncGenerator<
+      ChatModelRunResult,
+      void,
+      unknown
+    > {
+      yield { content: [{ type: "text", text: "resumed" }] };
+      yield {
+        content: [{ type: "text", text: "resumed output" }],
+        status: { type: "complete", reason: "unknown" },
+      };
+    });
+
+    await core.resume({
+      parentId: userId,
+      sourceId: null,
+      runConfig: {} as TestRunConfig,
+      stream,
+    });
+
+    // The agent must NOT be re-invoked: the persisted stream is replayed.
+    expect(runAgent).toHaveBeenCalledTimes(1);
+    expect(stream).toHaveBeenCalledTimes(1);
+
+    const options = stream.mock.calls[0]?.[0];
+    expect(options?.messages?.[0]).toMatchObject({ id: userId, role: "user" });
+    expect(options?.unstable_assistantMessageId).toBeTruthy();
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.content.at(-1)).toMatchObject({
+      type: "text",
+      text: "resumed output",
+    });
+    expect(assistant.status).toMatchObject({
+      type: "complete",
+      reason: "unknown",
+    });
+    expect(core.isRunning()).toBe(false);
+  });
+
+  it("completes a resumed assistant when the stream omits a terminal status", async () => {
+    const runAgent = vi.fn(async (_input, subscriber) => {
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const userId = core.getMessages()[0]!.id;
+    const stream = async function* (): AsyncGenerator<
+      ChatModelRunResult,
+      void,
+      unknown
+    > {
+      yield { content: [{ type: "text", text: "partial" }] };
+    };
+
+    await core.resume({
+      parentId: userId,
+      sourceId: null,
+      runConfig: {} as TestRunConfig,
+      stream,
+    });
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.status).toMatchObject({
+      type: "complete",
+      reason: "unknown",
+    });
+  });
+
+  it("surfaces resume stream errors without wiping streamed content", async () => {
+    const runAgent = vi.fn(async (_input, subscriber) => {
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+    const onError = vi.fn();
+    const core = createCore(agent, { onError });
+    await core.append(createAppendMessage());
+
+    const userId = core.getMessages()[0]!.id;
+    const stream = async function* (): AsyncGenerator<
+      ChatModelRunResult,
+      void,
+      unknown
+    > {
+      yield { content: [{ type: "text", text: "before error" }] };
+      throw new Error("stream boom");
+    };
+
+    await expect(
+      core.resume({
+        parentId: userId,
+        sourceId: null,
+        runConfig: {} as TestRunConfig,
+        stream,
+      }),
+    ).rejects.toThrow("stream boom");
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.content.at(-1)).toMatchObject({
+      type: "text",
+      text: "before error",
+    });
+    expect(assistant.status).toMatchObject({
+      type: "incomplete",
+      reason: "error",
+      error: "stream boom",
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("feeds history.resume() stream on unstable_resume instead of re-running", async () => {
+    const runAgent = vi.fn(async (_input, subscriber) => {
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const userMessage: ThreadMessage = {
+      id: "msg-1",
+      role: "user",
+      createdAt: new Date(),
+      content: [{ type: "text", text: "Hello" }],
+      metadata: { custom: {} },
+    };
+
+    const resume = vi.fn(async function* (): AsyncGenerator<
+      ChatModelRunResult,
+      void,
+      unknown
+    > {
+      yield {
+        content: [{ type: "text", text: "recovered" }],
+        status: { type: "complete", reason: "unknown" },
+      };
+    });
+
+    const historyAdapter: ThreadHistoryAdapter = {
+      load: vi.fn().mockResolvedValue({
+        headId: "msg-1",
+        messages: [{ message: userMessage, parentId: null }],
+        unstable_resume: true,
+      }),
+      resume,
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const core = createCore(agent, { history: historyAdapter });
+    await core.__internal_load();
+
+    expect(resume).toHaveBeenCalledTimes(1);
+    expect(runAgent).not.toHaveBeenCalled();
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.content.at(-1)).toMatchObject({
+      type: "text",
+      text: "recovered",
+    });
+    expect(assistant.status).toMatchObject({ type: "complete" });
   });
 
   it("omits the placeholder assistant message from run input history", async () => {


### PR DESCRIPTION
Fixes #4219

## Problem

`AgUiThreadRuntimeCore` ignores the `stream` field of the resume-run contract. `resume()` logs `[agui] resume stream is not supported, falling back to regular run` and calls `startRun` with a freshly generated `runId`, so every resume re-invokes `agent.runAgent(...)`. `ResumeRunConfig.stream` was typed `unknown` and never consumed, and `__internal_load()` on `unstable_resume` also routed to a fresh `startRun` rather than `history.resume()` — unlike `LocalThreadRuntimeCore`.

This breaks apps that persist their own AG-UI event stream (durable runs / per-run buffers): they can't re-attach and continue consuming on reload — every resume re-runs the agent and (because `@ag-ui/client` re-appends `TEXT_MESSAGE_CONTENT`) duplicates assistant text unless the consumer truncates manually.

## Changes

- **`resume()`** now passes `config.stream` into `startRun` instead of logging and dropping it.
- **`startRun()`** accepts an optional resume generator. When provided, it consumes the generator via the new `consumeResumeStream`, piping each `ChatModelRunResult` through the same `updateAssistantMessage` path the aggregator uses — no new `runId`, no `agent.runAgent(...)` replay. This mirrors `LocalThreadRuntimeCore.resumeRun`/`performRoundtrip`.
- **`__internal_load()`** on `unstable_resume` now feeds `history.resume()` when the adapter provides it, falling back to a fresh agent run otherwise (preserving existing behavior for adapters without `resume`).
- **`ResumeRunConfig.stream`** is typed as the real `(options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>` instead of `unknown`.
- Cancel/error/finalization on the resume path emit **status-only** updates, so they don't wipe the content the stream already produced (the aggregator's content snapshot would be empty on this path).

## Tests

Added cases to `test/ag-ui-thread-runtime-core.spec.ts`:
- replays the resume stream instead of re-running the agent (asserts `runAgent` is not called again, and the stream receives prior messages + an assistant message id)
- completes a resumed assistant when the stream omits a terminal status
- surfaces resume stream errors without wiping streamed content
- feeds `history.resume()` on `unstable_resume` instead of re-running

All 111 package tests pass; `tsc --noEmit`, oxlint, and oxfmt are clean. A `patch` changeset is included.