### PR TITLE
feat(react-ag-ui): honor resume stream in AgUiThreadRuntimeCore

### DIFF
--- a/.changeset/agui-resume-stream.md
+++ b/.changeset/agui-resume-stream.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat(react-ag-ui): honor `CreateResumeRunConfig.stream` in `AgUiThreadRuntimeCore`
+
+`resume()` previously logged `resume stream is not supported` and fell back to a fresh `agent.runAgent(...)`, re-running the agent on every resume. It now passes the resume generator into `startRun`, which replays each `ChatModelRunResult` into the existing assistant message (no new `runId`, no replayed `agent.runAgent`). On history `load()` with `unstable_resume`, the adapter now feeds `history.resume()` when present (falling back to a fresh run otherwise), and `ResumeRunConfig.stream` is typed as the real `(options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>` instead of `unknown`. This lets apps that persist their own AG-UI event stream re-attach and continue consuming on reload.

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -140,8 +140,6 @@ export class AgUiThreadRuntimeCore {
 
         if (repo.unstable_resume) {
           const parentId = repo.headId ?? messages.at(-1)?.id ?? null;
-          // Re-attach to the persisted stream when the history adapter can
-          // replay it; otherwise fall back to a fresh agent run.
           const resumeStream = this.history?.resume?.bind(this.history);
           await this.startRun(
             parentId,
@@ -458,14 +456,7 @@ export class AgUiThreadRuntimeCore {
     this.resetHead(parentId);
     const historicalMessages = [...this.messages];
 
-    const runId = generateId();
     this.pendingError = null;
-    const input = this.buildRunInput(
-      runId,
-      normalizedRunConfig,
-      historicalMessages,
-      resume,
-    );
     const assistantParentId = parentId ?? this.messages.at(-1)?.id ?? null;
     let assistantMessageId: string | undefined;
     const ensureAssistant = () => {
@@ -500,12 +491,7 @@ export class AgUiThreadRuntimeCore {
     const abortSignal = abortController.signal;
     this.abortController = abortController;
 
-    // A replayed resume stream owns the assistant content directly, so a cancel
-    // must flip only the status. Routing it through the aggregator (as the
-    // agent-run path does) would emit an empty content snapshot and wipe what
-    // the stream already produced.
     let cancelRun = () => dispatch({ type: "RUN_CANCELLED" });
-
     abortSignal.addEventListener(
       "abort",
       () => {
@@ -516,16 +502,16 @@ export class AgUiThreadRuntimeCore {
       { once: true },
     );
 
-    aggregator.handle({ type: "RUN_STARTED", runId });
     this.setRunning(true);
 
     try {
       if (resumeStream) {
+        // Cancel flips only the status; an aggregator RUN_CANCELLED would emit an empty snapshot and wipe the replayed content.
         cancelRun = () =>
           applyUpdate({ status: { type: "incomplete", reason: "cancelled" } });
         await this.consumeResumeStream(resumeStream, {
           runConfig: normalizedRunConfig,
-          threadId: input.threadId,
+          threadId: this.agent.threadId || "main",
           parentId: assistantParentId,
           historicalMessages,
           abortSignal,
@@ -534,6 +520,14 @@ export class AgUiThreadRuntimeCore {
           getAssistantMessageId: () => assistantMessageId,
         });
       } else {
+        const runId = generateId();
+        aggregator.handle({ type: "RUN_STARTED", runId });
+        const input = this.buildRunInput(
+          runId,
+          normalizedRunConfig,
+          historicalMessages,
+          resume,
+        );
         const subscriber = createAgUiSubscriber({
           dispatch,
           runId,
@@ -572,11 +566,7 @@ export class AgUiThreadRuntimeCore {
     }
   }
 
-  // Re-attach to a persisted run by replaying its `ChatModelRunResult` stream
-  // into the existing assistant message, instead of issuing a fresh
-  // `agent.runAgent(...)`. Each yielded result flows through the same update
-  // path the aggregator uses, so no new runId is generated and the agent is
-  // not re-invoked.
+  // Replays a persisted run's snapshots into the existing assistant message, bypassing agent.runAgent so it is not re-invoked.
   private async consumeResumeStream(
     stream: ResumeStream,
     ctx: {
@@ -591,6 +581,7 @@ export class AgUiThreadRuntimeCore {
     },
   ): Promise<void> {
     const assistantId = ctx.ensureAssistant();
+    const currentId = () => ctx.getAssistantMessageId() ?? assistantId;
     const options: ChatModelRunOptions = {
       messages: ctx.historicalMessages,
       runConfig: ctx.runConfig,
@@ -600,8 +591,7 @@ export class AgUiThreadRuntimeCore {
       unstable_threadId: ctx.threadId,
       unstable_parentId: ctx.parentId,
       unstable_getMessage: () => {
-        const id = ctx.getAssistantMessageId() ?? assistantId;
-        const message = this.messages.find((m) => m.id === id);
+        const message = this.messages.find((m) => m.id === currentId());
         if (!message) {
           throw new Error(
             "[agui] resume stream requested the assistant message before it existed",
@@ -628,9 +618,7 @@ export class AgUiThreadRuntimeCore {
     }
 
     if (ctx.abortSignal.aborted) return;
-    const current = this.messages.find(
-      (m) => m.id === (ctx.getAssistantMessageId() ?? assistantId),
-    );
+    const current = this.messages.find((m) => m.id === currentId());
     if (!current || current.status?.type === "running") {
       ctx.applyUpdate({ status: { type: "complete", reason: "unknown" } });
     }

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -5,6 +5,7 @@ import type {
   AddToolResultOptions,
   AppendMessage,
   AssistantRuntime,
+  ChatModelRunOptions,
   ChatModelRunResult,
   MessageStatus,
   ThreadAssistantMessage,
@@ -35,11 +36,14 @@ const isOptimisticId = (id: string) => id.startsWith(optimisticPrefix);
 const symbolResumeShim = Symbol("agui-resume-shim");
 
 type RunConfig = NonNullable<AppendMessage["runConfig"]>;
+type ResumeStream = (
+  options: ChatModelRunOptions,
+) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 type ResumeRunConfig = {
   parentId: string | null;
   sourceId: string | null;
   runConfig: RunConfig;
-  stream?: unknown;
+  stream?: ResumeStream;
 };
 
 type CoreOptions = {
@@ -136,7 +140,15 @@ export class AgUiThreadRuntimeCore {
 
         if (repo.unstable_resume) {
           const parentId = repo.headId ?? messages.at(-1)?.id ?? null;
-          await this.startRun(parentId, this.lastRunConfig);
+          // Re-attach to the persisted stream when the history adapter can
+          // replay it; otherwise fall back to a fresh agent run.
+          const resumeStream = this.history?.resume?.bind(this.history);
+          await this.startRun(
+            parentId,
+            this.lastRunConfig,
+            undefined,
+            resumeStream,
+          );
         }
       })
       .catch((error) => {
@@ -194,14 +206,11 @@ export class AgUiThreadRuntimeCore {
 
   async resume(config: ResumeRunConfig): Promise<void> {
     this.assertNoPendingInterrupts();
-    if (config.stream) {
-      this.logger.debug?.(
-        "[agui] resume stream is not supported, falling back to regular run",
-      );
-    }
     await this.startRun(
       config.parentId,
       config.runConfig ?? this.lastRunConfig,
+      undefined,
+      config.stream,
     );
   }
 
@@ -442,6 +451,7 @@ export class AgUiThreadRuntimeCore {
     parentId: string | null,
     runConfig?: RunConfig,
     resume?: AgUiResumeEntry[],
+    resumeStream?: ResumeStream,
   ): Promise<void> {
     const normalizedRunConfig = runConfig ?? {};
     this.lastRunConfig = normalizedRunConfig;
@@ -466,15 +476,17 @@ export class AgUiThreadRuntimeCore {
       return created;
     };
 
+    const applyUpdate = (update: ChatModelRunResult) => {
+      const resolved = this.updateAssistantMessage(ensureAssistant(), update);
+      if (resolved !== assistantMessageId) {
+        assistantMessageId = resolved;
+      }
+    };
+
     const aggregator = new RunAggregator({
       showThinking: this.showThinking,
       logger: this.logger,
-      emit: (update) => {
-        const resolved = this.updateAssistantMessage(ensureAssistant(), update);
-        if (resolved !== assistantMessageId) {
-          assistantMessageId = resolved;
-        }
-      },
+      emit: applyUpdate,
       onServerMessageId: (serverId) => {
         const placeholder = ensureAssistant();
         if (placeholder === serverId) return;
@@ -488,40 +500,60 @@ export class AgUiThreadRuntimeCore {
     const abortSignal = abortController.signal;
     this.abortController = abortController;
 
+    // A replayed resume stream owns the assistant content directly, so a cancel
+    // must flip only the status. Routing it through the aggregator (as the
+    // agent-run path does) would emit an empty content snapshot and wipe what
+    // the stream already produced.
+    let cancelRun = () => dispatch({ type: "RUN_CANCELLED" });
+
     abortSignal.addEventListener(
       "abort",
       () => {
-        dispatch({ type: "RUN_CANCELLED" });
+        cancelRun();
         this.finishRun(abortController);
         this.onCancel?.();
       },
       { once: true },
     );
 
-    const subscriber = createAgUiSubscriber({
-      dispatch,
-      runId,
-      logger: this.logger,
-      onRunFailed: (error) => {
-        this.pendingError = error;
-        this.onError?.(error);
-      },
-    });
-
     aggregator.handle({ type: "RUN_STARTED", runId });
     this.setRunning(true);
 
     try {
-      try {
-        (this.agent as any).messages = input.messages;
-        (this.agent as any).threadId = input.threadId;
-        (this.agent as any).state = input.state ?? null;
-      } catch {
-        // ignore
+      if (resumeStream) {
+        cancelRun = () =>
+          applyUpdate({ status: { type: "incomplete", reason: "cancelled" } });
+        await this.consumeResumeStream(resumeStream, {
+          runConfig: normalizedRunConfig,
+          threadId: input.threadId,
+          parentId: assistantParentId,
+          historicalMessages,
+          abortSignal,
+          ensureAssistant,
+          applyUpdate,
+          getAssistantMessageId: () => assistantMessageId,
+        });
+      } else {
+        const subscriber = createAgUiSubscriber({
+          dispatch,
+          runId,
+          logger: this.logger,
+          onRunFailed: (error) => {
+            this.pendingError = error;
+            this.onError?.(error);
+          },
+        });
+        try {
+          (this.agent as any).messages = input.messages;
+          (this.agent as any).threadId = input.threadId;
+          (this.agent as any).state = input.state ?? null;
+        } catch {
+          // ignore
+        }
+        await (this.agent as any).runAgent(input, subscriber, {
+          signal: abortSignal,
+        });
       }
-      await (this.agent as any).runAgent(input, subscriber, {
-        signal: abortSignal,
-      });
     } catch (error) {
       if (!abortSignal.aborted) {
         const err = error instanceof Error ? error : new Error(String(error));
@@ -537,6 +569,70 @@ export class AgUiThreadRuntimeCore {
       const err = this.pendingError;
       this.pendingError = null;
       throw err;
+    }
+  }
+
+  // Re-attach to a persisted run by replaying its `ChatModelRunResult` stream
+  // into the existing assistant message, instead of issuing a fresh
+  // `agent.runAgent(...)`. Each yielded result flows through the same update
+  // path the aggregator uses, so no new runId is generated and the agent is
+  // not re-invoked.
+  private async consumeResumeStream(
+    stream: ResumeStream,
+    ctx: {
+      runConfig: RunConfig;
+      threadId: string;
+      parentId: string | null;
+      historicalMessages: readonly ThreadMessage[];
+      abortSignal: AbortSignal;
+      ensureAssistant: () => string;
+      applyUpdate: (update: ChatModelRunResult) => void;
+      getAssistantMessageId: () => string | undefined;
+    },
+  ): Promise<void> {
+    const assistantId = ctx.ensureAssistant();
+    const options: ChatModelRunOptions = {
+      messages: ctx.historicalMessages,
+      runConfig: ctx.runConfig,
+      abortSignal: ctx.abortSignal,
+      context: this.runtime?.thread.getModelContext() ?? {},
+      unstable_assistantMessageId: assistantId,
+      unstable_threadId: ctx.threadId,
+      unstable_parentId: ctx.parentId,
+      unstable_getMessage: () => {
+        const id = ctx.getAssistantMessageId() ?? assistantId;
+        const message = this.messages.find((m) => m.id === id);
+        if (!message) {
+          throw new Error(
+            "[agui] resume stream requested the assistant message before it existed",
+          );
+        }
+        return message;
+      },
+    };
+
+    try {
+      for await (const result of stream(options)) {
+        if (ctx.abortSignal.aborted) return;
+        ctx.applyUpdate(result);
+      }
+    } catch (error) {
+      if (ctx.abortSignal.aborted) return;
+      const err = error instanceof Error ? error : new Error(String(error));
+      ctx.applyUpdate({
+        status: { type: "incomplete", reason: "error", error: err.message },
+      });
+      this.onError?.(err);
+      this.pendingError = this.pendingError ?? err;
+      return;
+    }
+
+    if (ctx.abortSignal.aborted) return;
+    const current = this.messages.find(
+      (m) => m.id === (ctx.getAssistantMessageId() ?? assistantId),
+    );
+    if (!current || current.status?.type === "running") {
+      ctx.applyUpdate({ status: { type: "complete", reason: "unknown" } });
     }
   }
 

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -712,7 +712,6 @@ describe("AGUIThreadRuntimeCore", () => {
       stream,
     });
 
-    // The agent must NOT be re-invoked: the persisted stream is replayed.
     expect(runAgent).toHaveBeenCalledTimes(1);
     expect(stream).toHaveBeenCalledTimes(1);
 
@@ -823,7 +822,6 @@ describe("AGUIThreadRuntimeCore", () => {
     }): AsyncGenerator<ChatModelRunResult, void, unknown> {
       yield { content: [{ type: "text", text: "partial" }] };
       firstYielded();
-      // Stay open until the run is cancelled, mimicking a live re-attached stream.
       await new Promise<void>((resolve) => {
         options.abortSignal.addEventListener("abort", () => resolve(), {
           once: true,

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type {
   AppendMessage,
+  ChatModelRunResult,
   ThreadAssistantMessage,
   ThreadHistoryAdapter,
   ThreadMessage,
@@ -680,6 +681,227 @@ describe("AGUIThreadRuntimeCore", () => {
     });
 
     expect(runAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it("replays the resume stream instead of re-running the agent", async () => {
+    const runAgent = vi.fn(async (_input, subscriber) => {
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+    expect(runAgent).toHaveBeenCalledTimes(1);
+
+    const userId = core.getMessages()[0]!.id;
+    const stream = vi.fn(async function* (): AsyncGenerator<
+      ChatModelRunResult,
+      void,
+      unknown
+    > {
+      yield { content: [{ type: "text", text: "resumed" }] };
+      yield {
+        content: [{ type: "text", text: "resumed output" }],
+        status: { type: "complete", reason: "unknown" },
+      };
+    });
+
+    await core.resume({
+      parentId: userId,
+      sourceId: null,
+      runConfig: {} as TestRunConfig,
+      stream,
+    });
+
+    // The agent must NOT be re-invoked: the persisted stream is replayed.
+    expect(runAgent).toHaveBeenCalledTimes(1);
+    expect(stream).toHaveBeenCalledTimes(1);
+
+    const options = stream.mock.calls[0]?.[0];
+    expect(options?.messages?.[0]).toMatchObject({ id: userId, role: "user" });
+    expect(options?.unstable_assistantMessageId).toBeTruthy();
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.content.at(-1)).toMatchObject({
+      type: "text",
+      text: "resumed output",
+    });
+    expect(assistant.status).toMatchObject({
+      type: "complete",
+      reason: "unknown",
+    });
+    expect(core.isRunning()).toBe(false);
+  });
+
+  it("completes a resumed assistant when the stream omits a terminal status", async () => {
+    const runAgent = vi.fn(async (_input, subscriber) => {
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const userId = core.getMessages()[0]!.id;
+    const stream = async function* (): AsyncGenerator<
+      ChatModelRunResult,
+      void,
+      unknown
+    > {
+      yield { content: [{ type: "text", text: "partial" }] };
+    };
+
+    await core.resume({
+      parentId: userId,
+      sourceId: null,
+      runConfig: {} as TestRunConfig,
+      stream,
+    });
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.status).toMatchObject({
+      type: "complete",
+      reason: "unknown",
+    });
+  });
+
+  it("surfaces resume stream errors without wiping streamed content", async () => {
+    const runAgent = vi.fn(async (_input, subscriber) => {
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+    const onError = vi.fn();
+    const core = createCore(agent, { onError });
+    await core.append(createAppendMessage());
+
+    const userId = core.getMessages()[0]!.id;
+    const stream = async function* (): AsyncGenerator<
+      ChatModelRunResult,
+      void,
+      unknown
+    > {
+      yield { content: [{ type: "text", text: "before error" }] };
+      throw new Error("stream boom");
+    };
+
+    await expect(
+      core.resume({
+        parentId: userId,
+        sourceId: null,
+        runConfig: {} as TestRunConfig,
+        stream,
+      }),
+    ).rejects.toThrow("stream boom");
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.content.at(-1)).toMatchObject({
+      type: "text",
+      text: "before error",
+    });
+    expect(assistant.status).toMatchObject({
+      type: "incomplete",
+      reason: "error",
+      error: "stream boom",
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a resume stream without wiping already-streamed content", async () => {
+    const runAgent = vi.fn(async (_input, subscriber) => {
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+    const onCancel = vi.fn();
+    const core = createCore(agent, { onCancel });
+    await core.append(createAppendMessage());
+
+    const userId = core.getMessages()[0]!.id;
+    let firstYielded!: () => void;
+    const firstYieldedPromise = new Promise<void>((resolve) => {
+      firstYielded = resolve;
+    });
+    const stream = async function* (options: {
+      abortSignal: AbortSignal;
+    }): AsyncGenerator<ChatModelRunResult, void, unknown> {
+      yield { content: [{ type: "text", text: "partial" }] };
+      firstYielded();
+      // Stay open until the run is cancelled, mimicking a live re-attached stream.
+      await new Promise<void>((resolve) => {
+        options.abortSignal.addEventListener("abort", () => resolve(), {
+          once: true,
+        });
+      });
+    };
+
+    const resumePromise = core.resume({
+      parentId: userId,
+      sourceId: null,
+      runConfig: {} as TestRunConfig,
+      stream,
+    });
+
+    await firstYieldedPromise;
+    await core.cancel();
+    await resumePromise;
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.content.at(-1)).toMatchObject({
+      type: "text",
+      text: "partial",
+    });
+    expect(assistant.status).toMatchObject({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(core.isRunning()).toBe(false);
+  });
+
+  it("feeds history.resume() stream on unstable_resume instead of re-running", async () => {
+    const runAgent = vi.fn(async (_input, subscriber) => {
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const userMessage: ThreadMessage = {
+      id: "msg-1",
+      role: "user",
+      createdAt: new Date(),
+      content: [{ type: "text", text: "Hello" }],
+      metadata: { custom: {} },
+    };
+
+    const resume = vi.fn(async function* (): AsyncGenerator<
+      ChatModelRunResult,
+      void,
+      unknown
+    > {
+      yield {
+        content: [{ type: "text", text: "recovered" }],
+        status: { type: "complete", reason: "unknown" },
+      };
+    });
+
+    const historyAdapter: ThreadHistoryAdapter = {
+      load: vi.fn().mockResolvedValue({
+        headId: "msg-1",
+        messages: [{ message: userMessage, parentId: null }],
+        unstable_resume: true,
+      }),
+      resume,
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const core = createCore(agent, { history: historyAdapter });
+    await core.__internal_load();
+
+    expect(resume).toHaveBeenCalledTimes(1);
+    expect(runAgent).not.toHaveBeenCalled();
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.content.at(-1)).toMatchObject({
+      type: "text",
+      text: "recovered",
+    });
+    expect(assistant.status).toMatchObject({ type: "complete" });
   });
 
   it("omits the placeholder assistant message from run input history", async () => {


### PR DESCRIPTION
## Summary

`AgUiThreadRuntimeCore.resume()` previously logged `resume stream is not supported` and fell back to a fresh `agent.runAgent(...)`, re-running the agent on every resume. It now passes the resume generator into `startRun`, which replays each `ChatModelRunResult` into the existing assistant message — **no new `runId`, no replayed `agent.runAgent`**.

On history `load()` with `unstable_resume`, the adapter now feeds `history.resume()` when present (falling back to a fresh run otherwise), and `ResumeRunConfig.stream` is typed as the real `(options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>` instead of `unknown`.

This lets apps that persist their own AG-UI event stream re-attach and continue consuming on reload, consistent with the `unstable_resume` / `history.resume()` contract used by the local runtime.

## Behavior

- `resume({ stream })` replays the persisted stream into the existing assistant message instead of re-invoking the agent.
- `load()` with `unstable_resume: true` feeds `history.resume()` when the adapter provides it; otherwise falls back to a fresh agent run.
- A replayed resume stream owns the assistant content directly, so cancelling mid-stream flips only the status (`incomplete/cancelled`) and preserves already-streamed content rather than wiping it.

## Tests

Added coverage for each distinct path:
- replays the resume stream instead of re-running the agent
- completes a resumed assistant when the stream omits a terminal status
- surfaces resume stream errors without wiping streamed content
- cancels a resume stream mid-flight without wiping already-streamed content
- feeds `history.resume()` on `unstable_resume` instead of re-running

All 112 tests in the package pass; typecheck, lint, and format are clean.
closes: #4219