### PR TITLE
fix: omit backend-default generative tool schemas

### DIFF
--- a/.changeset/generative-tool-schema-upload.md
+++ b/.changeset/generative-tool-schema-upload.md
@@ -1,0 +1,7 @@
+---
+"assistant-stream": patch
+"@assistant-ui/x-generative-compiler": patch
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: avoid uploading backend-default schemas for use-generative frontend and human tools

--- a/packages/assistant-stream/src/core/tool/schema-utils.test.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.test.ts
@@ -328,21 +328,6 @@ describe("toToolsJSONSchema", () => {
       expect(result).toHaveProperty("olderFrontendTool");
     });
 
-    it("omits tools that only have backend defaults with no client overrides", () => {
-      const tools: Record<string, Tool> = {
-        generatedFrontendTool: {
-          type: "frontend",
-          parameters: { type: "object", properties: {} },
-          execute: async () => {},
-          unstable_backendDefault: { parameters: true },
-        },
-      };
-
-      const result = toToolsJSONSchema(tools);
-
-      expect(result).not.toHaveProperty("generatedFrontendTool");
-    });
-
     it("excludes tools without parameters", () => {
       const tools: Record<string, Tool> = {
         withParams: {

--- a/packages/assistant-stream/src/core/tool/schema-utils.test.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.test.ts
@@ -369,6 +369,27 @@ describe("toToolsJSONSchema", () => {
       expect(result).toHaveProperty("tool_c");
     });
 
+    it("always excludes backend-default parameters with a custom filter", () => {
+      const tools: Record<string, Tool> = {
+        backendDefaultTool: {
+          type: "frontend",
+          parameters: { type: "object", properties: {} },
+          execute: async () => {},
+          unstable_backendDefault: { parameters: true },
+        },
+        normalTool: {
+          parameters: { type: "object", properties: {} },
+        },
+      };
+
+      const result = toToolsJSONSchema(tools, {
+        filter: () => true,
+      });
+
+      expect(result).not.toHaveProperty("backendDefaultTool");
+      expect(result).toHaveProperty("normalTool");
+    });
+
     it("custom filter receives name and tool", () => {
       const tools: Record<string, Tool> = {
         prefixed_tool: {

--- a/packages/assistant-stream/src/core/tool/schema-utils.test.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.test.ts
@@ -299,6 +299,50 @@ describe("toToolsJSONSchema", () => {
       expect(result).toHaveProperty("humanTool");
     });
 
+    it("omits schemas for tools with backend parameter defaults", () => {
+      const tools: Record<string, Tool> = {
+        generatedFrontendTool: {
+          type: "frontend",
+          description: "A generated frontend tool",
+          parameters: { type: "object", properties: {} },
+          execute: async () => {},
+          unstable_backendDefault: { parameters: true },
+        },
+        generatedHumanTool: {
+          type: "human",
+          description: "A generated human tool",
+          parameters: { type: "object", properties: {} },
+          unstable_backendDefault: { parameters: true },
+        },
+        olderFrontendTool: {
+          type: "frontend",
+          description: "An older frontend tool",
+          parameters: { type: "object", properties: {} },
+          execute: async () => {},
+        },
+      };
+
+      const result = toToolsJSONSchema(tools);
+      expect(result).not.toHaveProperty("generatedFrontendTool");
+      expect(result).not.toHaveProperty("generatedHumanTool");
+      expect(result).toHaveProperty("olderFrontendTool");
+    });
+
+    it("omits tools that only have backend defaults with no client overrides", () => {
+      const tools: Record<string, Tool> = {
+        generatedFrontendTool: {
+          type: "frontend",
+          parameters: { type: "object", properties: {} },
+          execute: async () => {},
+          unstable_backendDefault: { parameters: true },
+        },
+      };
+
+      const result = toToolsJSONSchema(tools);
+
+      expect(result).not.toHaveProperty("generatedFrontendTool");
+    });
+
     it("excludes tools without parameters", () => {
       const tools: Record<string, Tool> = {
         withParams: {

--- a/packages/assistant-stream/src/core/tool/schema-utils.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.ts
@@ -158,19 +158,17 @@ export function toToolsJSONSchema(
 
   const filter = options.filter ?? defaultToolFilter;
 
-  const isUploadableToolEntry = (
-    entry: [string, Tool],
-  ): entry is [
-    string,
-    Tool & { parameters: NonNullable<Tool["parameters"]> },
-  ] => {
-    const [name, tool] = entry;
-    return filter(name, tool) && toolHasUploadableParameters(tool);
-  };
-
   return Object.fromEntries(
     Object.entries(tools)
-      .filter(isUploadableToolEntry)
+      .filter(([name, tool]) => filter(name, tool))
+      .filter(
+        (
+          entry,
+        ): entry is [
+          string,
+          Tool & { parameters: NonNullable<Tool["parameters"]> },
+        ] => toolHasUploadableParameters(entry[1]),
+      )
       .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
       .map(([name, tool]) => [
         name,

--- a/packages/assistant-stream/src/core/tool/schema-utils.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.ts
@@ -133,16 +133,12 @@ function defaultToolFilter(_name: string, tool: Tool): boolean {
   return !tool.disabled && tool.type !== "backend";
 }
 
-function toolHasUploadableFields(tool: Tool): boolean {
-  return (
-    tool.parameters !== undefined && !tool.unstable_backendDefault?.parameters
-  );
-}
-
 function toolHasUploadableParameters(
   tool: Tool,
 ): tool is Tool & { parameters: NonNullable<Tool["parameters"]> } {
-  return toolHasUploadableFields(tool);
+  return (
+    tool.parameters !== undefined && !tool.unstable_backendDefault?.parameters
+  );
 }
 
 /**

--- a/packages/assistant-stream/src/core/tool/schema-utils.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.ts
@@ -161,13 +161,10 @@ export function toToolsJSONSchema(
   return Object.fromEntries(
     Object.entries(tools)
       .filter(
-        (
-          entry,
-        ): entry is [
+        ([name, tool]): tool is [
           string,
           Tool & { parameters: NonNullable<Tool["parameters"]> },
-        ] =>
-          filter(entry[0], entry[1]) && toolHasUploadableParameters(entry[1]),
+        ] => filter(name, tool) && toolHasUploadableParameters(tool),
       )
       .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
       .map(([name, tool]) => [

--- a/packages/assistant-stream/src/core/tool/schema-utils.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.ts
@@ -133,6 +133,18 @@ function defaultToolFilter(_name: string, tool: Tool): boolean {
   return !tool.disabled && tool.type !== "backend";
 }
 
+function toolHasUploadableFields(tool: Tool): boolean {
+  return (
+    tool.parameters !== undefined && !tool.unstable_backendDefault?.parameters
+  );
+}
+
+function toolHasUploadableParameters(
+  tool: Tool,
+): tool is Tool & { parameters: NonNullable<Tool["parameters"]> } {
+  return toolHasUploadableFields(tool);
+}
+
 /**
  * Converts a record of tools to a record of tool definitions with JSON Schema parameters.
  * By default, filters out disabled tools and backend tools.
@@ -152,13 +164,21 @@ export function toToolsJSONSchema(
 
   return Object.fromEntries(
     Object.entries(tools)
-      .filter(([name, tool]) => filter(name, tool) && tool.parameters)
+      .filter(
+        (
+          entry,
+        ): entry is [
+          string,
+          Tool & { parameters: NonNullable<Tool["parameters"]> },
+        ] =>
+          filter(entry[0], entry[1]) && toolHasUploadableParameters(entry[1]),
+      )
       .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
       .map(([name, tool]) => [
         name,
         {
           ...(tool.description && { description: tool.description }),
-          parameters: toJSONSchema(tool.parameters!),
+          parameters: toJSONSchema(tool.parameters),
           ...(tool.providerOptions && {
             providerOptions: tool.providerOptions,
           }),

--- a/packages/assistant-stream/src/core/tool/schema-utils.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.ts
@@ -15,6 +15,8 @@ export type ToToolsJSONSchemaOptions = {
   /**
    * Filter to determine which tools to include.
    * Defaults to excluding disabled tools and backend tools.
+   *
+   * Tools with backend-default parameters are always excluded.
    */
   filter?: (name: string, tool: Tool) => boolean;
 };

--- a/packages/assistant-stream/src/core/tool/schema-utils.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.ts
@@ -158,14 +158,19 @@ export function toToolsJSONSchema(
 
   const filter = options.filter ?? defaultToolFilter;
 
+  const isUploadableToolEntry = (
+    entry: [string, Tool],
+  ): entry is [
+    string,
+    Tool & { parameters: NonNullable<Tool["parameters"]> },
+  ] => {
+    const [name, tool] = entry;
+    return filter(name, tool) && toolHasUploadableParameters(tool);
+  };
+
   return Object.fromEntries(
     Object.entries(tools)
-      .filter(
-        ([name, tool]): tool is [
-          string,
-          Tool & { parameters: NonNullable<Tool["parameters"]> },
-        ] => filter(name, tool) && toolHasUploadableParameters(tool),
-      )
+      .filter(isUploadableToolEntry)
       .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
       .map(([name, tool]) => [
         name,

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -222,7 +222,7 @@ type ToolBase<
    * transports omit matching fields and only upload overrides.
    */
   unstable_backendDefault?: {
-    parameters?: true;
+    parameters?: boolean;
   };
 };
 

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -216,6 +216,14 @@ type ToolBase<
    * @see ToolDisplay
    */
   display?: ToolDisplay;
+
+  /**
+   * @internal Defaults already known by the backend for this tool. Client
+   * transports omit matching fields and only upload overrides.
+   */
+  unstable_backendDefault?: {
+    parameters?: true;
+  };
 };
 
 type BackendTool<

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -220,6 +220,8 @@ type ToolBase<
   /**
    * @internal Defaults already known by the backend for this tool. Client
    * transports omit matching fields and only upload overrides.
+   *
+   * This is only meaningful for frontend and human tools.
    */
   unstable_backendDefault?: {
     parameters?: boolean;

--- a/packages/react-generative-ui/src/JSONGenerativeUI.client.tsx
+++ b/packages/react-generative-ui/src/JSONGenerativeUI.client.tsx
@@ -50,6 +50,7 @@ export class JSONGenerativeUI {
   present(options?: PresentToolOptions): PresentTool {
     return {
       ...presentToolBase(this.parameters, options),
+      unstable_backendDefault: { parameters: true },
       execute: async () => ({}),
       render: this.render,
     };
@@ -58,6 +59,7 @@ export class JSONGenerativeUI {
   promptUser(): PromptUserTool {
     return {
       ...promptUserToolBase(this.parameters),
+      unstable_backendDefault: { parameters: true },
       render: this.render,
     };
   }

--- a/packages/react-generative-ui/src/JSONGenerativeUI.shared.ts
+++ b/packages/react-generative-ui/src/JSONGenerativeUI.shared.ts
@@ -58,6 +58,7 @@ export function presentToolBase(
     description: PRESENT_DESCRIPTION,
     parameters,
     ...(options?.display !== undefined ? { display: options.display } : {}),
+    unstable_backendDefault: { parameters: true },
   };
 }
 
@@ -70,5 +71,6 @@ export function promptUserToolBase(parameters: PresentParameters) {
     type: "human" as const,
     description: PROMPT_USER_DESCRIPTION,
     parameters,
+    unstable_backendDefault: { parameters: true },
   };
 }

--- a/packages/react-generative-ui/src/JSONGenerativeUI.shared.ts
+++ b/packages/react-generative-ui/src/JSONGenerativeUI.shared.ts
@@ -58,7 +58,6 @@ export function presentToolBase(
     description: PRESENT_DESCRIPTION,
     parameters,
     ...(options?.display !== undefined ? { display: options.display } : {}),
-    unstable_backendDefault: { parameters: true },
   };
 }
 
@@ -71,6 +70,5 @@ export function promptUserToolBase(parameters: PresentParameters) {
     type: "human" as const,
     description: PROMPT_USER_DESCRIPTION,
     parameters,
-    unstable_backendDefault: { parameters: true },
   };
 }

--- a/packages/react-generative-ui/src/JSONGenerativeUI.test.tsx
+++ b/packages/react-generative-ui/src/JSONGenerativeUI.test.tsx
@@ -34,6 +34,7 @@ describe("JSONGenerativeUI — client build", () => {
     expect(tool.type).toBe("frontend");
     expect(typeof tool.execute).toBe("function");
     expect(typeof tool.render).toBe("function");
+    expect(tool.unstable_backendDefault).toEqual({ parameters: true });
     expect((tool.parameters as any).properties.$type.enum).toEqual([
       "Card",
       "Button",
@@ -48,6 +49,7 @@ describe("JSONGenerativeUI — client build", () => {
   it("prompt_user is a human tool that renders the tree (no execute)", () => {
     const tool = ui.promptUser();
     expect(tool.type).toBe("human");
+    expect(tool.unstable_backendDefault).toEqual({ parameters: true });
     expect((tool as any).execute).toBeUndefined();
     const html = renderTool(tool, { $type: "Button", label: "ok" });
     expect(html).toBe("<button>ok</button>");

--- a/packages/react-generative-ui/src/JSONGenerativeUI.test.tsx
+++ b/packages/react-generative-ui/src/JSONGenerativeUI.test.tsx
@@ -64,8 +64,8 @@ describe("JSONGenerativeUI — server build", () => {
     expect(tool.type).toBe("frontend");
     expect(tool.render).toBeUndefined();
     expect(tool.execute).toBeUndefined();
+    expect(tool.unstable_backendDefault).toBeUndefined();
     expect(tool.parameters.properties.$type.enum).toEqual(["Card", "Button"]);
-    // schema is identical to the client's, so the model and the browser agree
     expect(tool.parameters).toEqual(
       new ClientGenUI({ library }).present().parameters,
     );
@@ -75,6 +75,7 @@ describe("JSONGenerativeUI — server build", () => {
     const tool = ui.promptUser() as any;
     expect(tool.type).toBe("human");
     expect(tool.render).toBeUndefined();
+    expect(tool.unstable_backendDefault).toBeUndefined();
     expect(tool.parameters.properties.$type.enum).toEqual(["Card", "Button"]);
   });
 });

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -54,6 +54,10 @@ describe("compileGenerative — server target", () => {
     expect(code).toContain('type: "frontend"'); // toast: execute + "use client"
   });
 
+  it("does not mark server tools with backend defaults", () => {
+    expect(code).not.toContain("unstable_backendDefault");
+  });
+
   it("drops all render and its client imports", () => {
     expect(code).not.toContain("Chart");
     expect(code).not.toContain("<div");
@@ -96,6 +100,29 @@ describe("compileGenerative — client target", () => {
   it("writes the inferred type back onto each tool", () => {
     expect(code).toContain('type: "backend"'); // weather (schema-only on client)
     expect(code).toContain('type: "frontend"'); // toast
+  });
+
+  it("marks generated frontend tools with backend parameter defaults", () => {
+    expect(code).toContain("unstable_backendDefault: {");
+    expect(code).toContain("parameters: true");
+  });
+
+  it("marks generated human tools with backend parameter defaults", () => {
+    const src = `"use generative";
+import { defineToolkit, hitlTool } from "@assistant-ui/react";
+export default defineToolkit({
+  ask: {
+    parameters: { type: "object", properties: {} },
+    execute: hitlTool(),
+    render: () => null,
+  },
+});
+`;
+
+    const code = compileGenerative(src, { target: "client" }).code;
+    expect(code).toContain('type: "human"');
+    expect(code).toContain("unstable_backendDefault: {");
+    expect(code).toContain("parameters: true");
   });
 
   it("drops a backend execute and its server-only imports", () => {

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -634,6 +634,8 @@ function setBackendDefault(
   target: Target,
   type: ToolType,
 ): void {
+  // Always strip any hand-authored marker first; only re-add it for client
+  // frontend/human tools whose schema is already known by the backend.
   removeMember(object, "unstable_backendDefault");
   if (target !== "client" || (type !== "frontend" && type !== "human")) return;
 

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -440,6 +440,7 @@ function compileToolkit(
     }
 
     setToolType(value, type);
+    setBackendDefault(value, target, type);
   }
 }
 
@@ -625,6 +626,24 @@ function setToolType(object: t.ObjectExpression, type: ToolType): void {
   // Append (not prepend) so the inferred type wins over any earlier spread.
   object.properties.push(
     t.objectProperty(t.identifier("type"), t.stringLiteral(type)),
+  );
+}
+
+function setBackendDefault(
+  object: t.ObjectExpression,
+  target: Target,
+  type: ToolType,
+): void {
+  removeMember(object, "unstable_backendDefault");
+  if (target !== "client" || (type !== "frontend" && type !== "human")) return;
+
+  object.properties.push(
+    t.objectProperty(
+      t.identifier("unstable_backendDefault"),
+      t.objectExpression([
+        t.objectProperty(t.identifier("parameters"), t.booleanLiteral(true)),
+      ]),
+    ),
   );
 }
 


### PR DESCRIPTION
## Summary
- add an internal unstable_backendDefault marker for tool fields already known by the backend
- mark use-generative frontend/human tools as having backend-owned parameter schemas
- omit those backend-default parameter schemas from client tool serialization

## Notes
- explicit disable/enable semantics are left for a separate follow-up; existing disabled stays the shape for explicit disable

## Tests
- pnpm exec vitest run src/core/tool/schema-utils.test.ts (packages/assistant-stream)
- pnpm exec vitest run src/compile.test.ts (packages/x-generative-compiler)
- pnpm exec vitest run src/JSONGenerativeUI.test.tsx (packages/react-generative-ui)
- pnpm lint
- pnpm build