### PR TITLE
perf(cli): merge create's two shadcn add calls into one

### DIFF
--- a/.changeset/cli-single-shadcn-add.md
+++ b/.changeset/cli-single-shadcn-add.md
@@ -1,0 +1,7 @@
+---
+"assistant-ui": patch
+---
+
+perf(cli): merge the two `shadcn add` calls in `create` into one
+
+`create` for templates without local components ran `shadcn@latest add` twice (once for the shadcn UI components, once for the `@assistant-ui/*` components), paying for a separate dlx cold start, a separate registry index fetch, and a separate package-manager `add` subprocess each time. `@assistant-ui` is publicly listed in shadcn's registry index, so a single `shadcn add <shadcn components> @assistant-ui/...` resolves the whole mixed tree in one topologically sorted pass; the `tw-shimmer` CSS injection and the `components.json` registries write still happen. This roughly halves the component install time, including on the `--skip-install` path.

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -219,16 +219,10 @@ export async function transformProject(
     const allShadcn = shadcnUI.includes("utils")
       ? shadcnUI
       : [...shadcnUI, "utils"];
-    logger.step(`Installing shadcn UI components: ${allShadcn.join(", ")}...`);
-    await installShadcnRegistry(projectDir, allShadcn, "shadcn components", pm);
-
-    if (assistantUI.length > 0) {
-      const auiComponents = assistantUI.map((c) => `@assistant-ui/${c}`);
-      logger.step(
-        `Installing assistant-ui components: ${assistantUI.join(", ")}...`,
-      );
-      await installShadcnRegistry(projectDir, auiComponents, "components", pm);
-    }
+    const auiComponents = assistantUI.map((c) => `@assistant-ui/${c}`);
+    const components = [...allShadcn, ...auiComponents];
+    logger.step(`Installing components: ${components.join(", ")}...`);
+    await installShadcnRegistry(projectDir, components, "components", pm);
   }
 }
 

--- a/packages/cli/test/lib/create-project.test.ts
+++ b/packages/cli/test/lib/create-project.test.ts
@@ -348,15 +348,7 @@ describe("transformProject — hasLocalComponents: false", () => {
 
   // Component scanning tests
   describe("component scanning", () => {
-    function findSpawnCall(
-      predicate: (cmd: string, args: string[]) => boolean,
-    ) {
-      return (spawn as Mock).mock.calls.find(
-        ([cmd, args]: [string, string[]]) => predicate(cmd, args),
-      );
-    }
-
-    it("detects assistant-ui and shadcn component imports", async () => {
+    it("installs shadcn and assistant-ui components in a single shadcn add call", async () => {
       writeFile(
         "app/page.tsx",
         'import { Thread } from "@/components/assistant-ui/thread.tsx";\nimport { Button } from "@/components/ui/button.tsx";\nexport default function Page() { return <Thread />; }\n',
@@ -364,26 +356,19 @@ describe("transformProject — hasLocalComponents: false", () => {
 
       await run();
 
-      // assistant-ui components installed via shadcn registry
-      const auiCall = findSpawnCall(
-        (cmd, args) =>
+      const addCalls = (spawn as Mock).mock.calls.filter(
+        ([cmd, args]: [string, string[]]) =>
           cmd === TEST_DLX_CMD &&
           args.includes("shadcn@latest") &&
-          args.some((a) => a.includes("@assistant-ui/")),
+          args.includes("add"),
       );
-      expect(auiCall).toBeDefined();
-      expect(auiCall![1]).toContain("@assistant-ui/thread");
-      expect(auiCall![1]).not.toContain("@assistant-ui/thread.tsx");
+      expect(addCalls).toHaveLength(1);
 
-      // shadcn UI components installed separately
-      const shadcnCall = findSpawnCall(
-        (cmd, args) =>
-          cmd === TEST_DLX_CMD &&
-          args.includes("shadcn@latest") &&
-          args.includes("button"),
-      );
-      expect(shadcnCall).toBeDefined();
-      expect(shadcnCall![1]).not.toContain("button.tsx");
+      const args = addCalls[0]![1] as string[];
+      expect(args).toContain("button");
+      expect(args).toContain("@assistant-ui/thread");
+      expect(args).not.toContain("button.tsx");
+      expect(args).not.toContain("@assistant-ui/thread.tsx");
     });
   });
 });


### PR DESCRIPTION
## summary

- `assistant-ui create` now runs a single `shadcn add` instead of two for templates without local components, roughly halving component install time (including on `--skip-install`), since one dlx cold start, one registry index fetch, and one package-manager add are removed. partial fix for #4215.
- `@assistant-ui` is listed in shadcn's public registry index, so a mixed `shadcn add <ui components> @assistant-ui/...` resolves the whole tree in one topologically sorted pass; the tw-shimmer CSS injection and the `components.json` registries write still happen.

## test plan

### already verified

- [x] `pnpm --filter assistant-ui exec vitest run` -> 192/192 green; the create-project test now asserts exactly one `shadcn add` call carrying both `button` and `@assistant-ui/thread`
- [x] `tsc --noEmit` passes, oxlint + oxfmt clean

### reviewer should verify

- [ ] `npx assistant-ui@latest create my-app --template default --skip-install` scaffolds a compiling project in one shadcn add pass (components present, `globals.css` has `@import "tw-shimmer";`, `components.json` carries the `@assistant-ui` registry)

## notes

- this halves the shadcn overhead but does not make `--skip-install` fully offline. the surviving single `shadcn add` still hits the network and runs a dependency install (shadcn has no `--no-deps`, and `--dry-run` skips file writes too). a fully offline create would need local materialization from a CI guarded `packages/ui` snapshot, which is a larger follow-up that also has to decide whether to ship the RTL forked base primitives.