### PR TITLE
feat(ui): add ToolFallback.Approval slot for requires-action tools

### DIFF
--- a/apps/docs/components/docs/samples/tool-fallback.tsx
+++ b/apps/docs/components/docs/samples/tool-fallback.tsx
@@ -9,6 +9,7 @@ import {
   ToolFallbackContent,
   ToolFallbackArgs,
   ToolFallbackResult,
+  ToolFallbackApproval,
 } from "@/components/assistant-ui/tool-fallback";
 import { SampleFrame } from "@/components/docs/samples/sample-frame";
 import { Button } from "@/components/ui/button";
@@ -64,6 +65,33 @@ export function ToolFallbackCancelledSample() {
           <ToolFallbackArgs
             argsText={JSON.stringify({ task: "process_data" }, null, 2)}
             className="opacity-60"
+          />
+        </ToolFallbackContent>
+      </ToolFallbackRoot>
+    </SampleFrame>
+  );
+}
+
+export function ToolFallbackRequiresActionSample() {
+  return (
+    <SampleFrame className="flex h-auto items-center p-6">
+      <ToolFallbackRoot defaultOpen>
+        <ToolFallbackTrigger
+          toolName="delete_file"
+          status={{ type: "requires-action", reason: "interrupt" }}
+        />
+        <ToolFallbackContent>
+          <ToolFallbackArgs
+            argsText={JSON.stringify(
+              { path: "/tmp/work-in-progress.txt" },
+              null,
+              2,
+            )}
+          />
+          <ToolFallbackApproval
+            addResult={() => {}}
+            resume={() => {}}
+            interrupt={{ type: "human", payload: {} }}
           />
         </ToolFallbackContent>
       </ToolFallbackRoot>

--- a/apps/docs/content/docs/ui/tool-fallback.mdx
+++ b/apps/docs/content/docs/ui/tool-fallback.mdx
@@ -9,6 +9,7 @@ import {
   ToolFallbackRunningSample,
   ToolFallbackCancelledSample,
   ToolFallbackStreamingSample,
+  ToolFallbackRequiresActionSample,
 } from "@/components/docs/samples/tool-fallback";
 
 <ToolFallbackSample />
@@ -71,6 +72,12 @@ Shows a muted appearance when a tool call was cancelled.
 
 <ToolFallbackCancelledSample />
 
+### Approval State
+
+Shows the default Allow / Deny buttons rendered when a tool call enters `requires-action`. The block auto-expands so the decision is visible without a click. Edit your project's copy of `tool-fallback.tsx` to add trust escalation, edit-args, custom labels, or analytics hooks — the shadcn philosophy is you own the file.
+
+<ToolFallbackRequiresActionSample />
+
 ## Composable API
 
 All sub-components are exported for custom layouts:
@@ -83,6 +90,7 @@ All sub-components are exported for custom layouts:
 | `ToolFallback.Args` | Displays tool arguments |
 | `ToolFallback.Result` | Displays tool execution result |
 | `ToolFallback.Error` | Displays error or cancellation messages |
+| `ToolFallback.Approval` | Renders Allow / Deny buttons for `requires-action` tools; wires `resume` / `addResult` |
 
 ```tsx
 import {
@@ -93,6 +101,7 @@ import {
   ToolFallbackArgs,
   ToolFallbackResult,
   ToolFallbackError,
+  ToolFallbackApproval,
 } from "@/components/assistant-ui/tool-fallback";
 
 // Compound component syntax
@@ -101,6 +110,11 @@ import {
   <ToolFallback.Content>
     <ToolFallback.Error status={status} />
     <ToolFallback.Args argsText={argsText} />
+    <ToolFallback.Approval
+      addResult={addResult}
+      resume={resume}
+      interrupt={interrupt}
+    />
     <ToolFallback.Result result={result} />
   </ToolFallback.Content>
 </ToolFallback.Root>

--- a/apps/docs/content/docs/ui/tool-fallback.mdx
+++ b/apps/docs/content/docs/ui/tool-fallback.mdx
@@ -90,7 +90,7 @@ All sub-components are exported for custom layouts:
 | `ToolFallback.Args` | Displays tool arguments |
 | `ToolFallback.Result` | Displays tool execution result |
 | `ToolFallback.Error` | Displays error or cancellation messages |
-| `ToolFallback.Approval` | Renders Allow / Deny buttons for `requires-action` tools; wires `resume` / `addResult` |
+| `ToolFallback.Approval` | Renders Allow / Deny buttons for `requires-action` tools; wires `resume` / `addResult` / `respondToApproval` |
 
 ```tsx
 import {
@@ -114,6 +114,8 @@ import {
       addResult={addResult}
       resume={resume}
       interrupt={interrupt}
+      approval={approval}
+      respondToApproval={respondToApproval}
     />
     <ToolFallback.Result result={result} />
   </ToolFallback.Content>

--- a/packages/ui/src/components/assistant-ui/tool-fallback.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-fallback.tsx
@@ -10,6 +10,8 @@ import {
 } from "lucide-react";
 import {
   useScrollLock,
+  type ToolCallMessagePart,
+  type ToolCallMessagePartProps,
   type ToolCallMessagePartStatus,
   type ToolCallMessagePartComponent,
 } from "@assistant-ui/react";
@@ -269,30 +271,39 @@ function ToolFallbackError({
   );
 }
 
+const APPROVED_RESULT = "Approved by user";
+const DENIED_RESULT = "User denied tool execution";
+
 function ToolFallbackApproval({
   className,
   addResult,
   resume,
   interrupt,
+  approval,
+  respondToApproval,
   ...props
 }: React.ComponentProps<"div"> & {
   addResult?: (result: unknown) => void;
   resume?: (payload: unknown) => void;
-  interrupt?: { type: "human"; payload: unknown } | undefined;
+  interrupt?: ToolCallMessagePart["interrupt"];
+  approval?: ToolCallMessagePart["approval"];
+  respondToApproval?: ToolCallMessagePartProps["respondToApproval"];
 }) {
-  const handleAllow = () => {
-    if (interrupt) {
-      resume?.({ approved: true });
-    } else {
-      addResult?.("Approved by user");
-    }
-  };
+  const [submitted, setSubmitted] = useState(false);
 
-  const handleDeny = () => {
-    if (interrupt) {
-      resume?.({ approved: false });
+  const respond = (approved: boolean) => {
+    if (submitted) return;
+    setSubmitted(true);
+    if (
+      approval != null &&
+      approval.approved === undefined &&
+      respondToApproval
+    ) {
+      respondToApproval({ approved });
+    } else if (interrupt) {
+      resume?.({ approved });
     } else {
-      addResult?.("User denied tool execution");
+      addResult?.(approved ? APPROVED_RESULT : DENIED_RESULT);
     }
   };
 
@@ -305,10 +316,15 @@ function ToolFallbackApproval({
       )}
       {...props}
     >
-      <Button size="sm" onClick={handleAllow}>
+      <Button size="sm" onClick={() => respond(true)} disabled={submitted}>
         Allow
       </Button>
-      <Button size="sm" variant="outline" onClick={handleDeny}>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => respond(false)}
+        disabled={submitted}
+      >
         Deny
       </Button>
     </div>
@@ -323,14 +339,24 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
   addResult,
   resume,
   interrupt,
+  approval,
+  respondToApproval,
 }) => {
   const isCancelled =
     status?.type === "incomplete" && status.reason === "cancelled";
   const isRequiresAction = status?.type === "requires-action";
 
+  const [open, setOpen] = useState(isRequiresAction);
+  const [wasRequiresAction, setWasRequiresAction] = useState(isRequiresAction);
+  if (isRequiresAction && !wasRequiresAction) {
+    setWasRequiresAction(true);
+    setOpen(true);
+  }
+
   return (
     <ToolFallbackRoot
-      defaultOpen={isRequiresAction}
+      open={open}
+      onOpenChange={setOpen}
       className={cn(isCancelled && "border-muted-foreground/30 bg-muted/30")}
     >
       <ToolFallbackTrigger toolName={toolName} status={status} />
@@ -345,6 +371,8 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
             addResult={addResult}
             resume={resume}
             interrupt={interrupt}
+            approval={approval}
+            respondToApproval={respondToApproval}
           />
         )}
         {!isCancelled && <ToolFallbackResult result={result} />}

--- a/packages/ui/src/components/assistant-ui/tool-fallback.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-fallback.tsx
@@ -282,13 +282,13 @@ function ToolFallbackApproval({
   approval,
   respondToApproval,
   ...props
-}: React.ComponentProps<"div"> & {
-  addResult?: (result: unknown) => void;
-  resume?: (payload: unknown) => void;
-  interrupt?: ToolCallMessagePart["interrupt"];
-  approval?: ToolCallMessagePart["approval"];
-  respondToApproval?: ToolCallMessagePartProps["respondToApproval"];
-}) {
+}: React.ComponentProps<"div"> &
+  Partial<
+    Pick<ToolCallMessagePartProps, "addResult" | "resume" | "respondToApproval">
+  > & {
+    interrupt?: ToolCallMessagePart["interrupt"];
+    approval?: ToolCallMessagePart["approval"];
+  }) {
   const [submitted, setSubmitted] = useState(false);
 
   const respond = (approved: boolean) => {
@@ -347,10 +347,11 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
   const isRequiresAction = status?.type === "requires-action";
 
   const [open, setOpen] = useState(isRequiresAction);
-  const [wasRequiresAction, setWasRequiresAction] = useState(isRequiresAction);
-  if (isRequiresAction && !wasRequiresAction) {
-    setWasRequiresAction(true);
-    setOpen(true);
+  const [prevRequiresAction, setPrevRequiresAction] =
+    useState(isRequiresAction);
+  if (isRequiresAction !== prevRequiresAction) {
+    setPrevRequiresAction(isRequiresAction);
+    if (isRequiresAction) setOpen(true);
   }
 
   return (

--- a/packages/ui/src/components/assistant-ui/tool-fallback.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-fallback.tsx
@@ -19,6 +19,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
 const ANIMATION_DURATION = 200;
 
@@ -268,17 +269,68 @@ function ToolFallbackError({
   );
 }
 
+function ToolFallbackApproval({
+  className,
+  addResult,
+  resume,
+  interrupt,
+  ...props
+}: React.ComponentProps<"div"> & {
+  addResult?: (result: unknown) => void;
+  resume?: (payload: unknown) => void;
+  interrupt?: { type: "human"; payload: unknown } | undefined;
+}) {
+  const handleAllow = () => {
+    if (interrupt) {
+      resume?.({ approved: true });
+    } else {
+      addResult?.("Approved by user");
+    }
+  };
+
+  const handleDeny = () => {
+    if (interrupt) {
+      resume?.({ approved: false });
+    } else {
+      addResult?.("User denied tool execution");
+    }
+  };
+
+  return (
+    <div
+      data-slot="tool-fallback-approval"
+      className={cn(
+        "aui-tool-fallback-approval flex items-center gap-2 border-t border-dashed px-4 pt-2",
+        className,
+      )}
+      {...props}
+    >
+      <Button size="sm" onClick={handleAllow}>
+        Allow
+      </Button>
+      <Button size="sm" variant="outline" onClick={handleDeny}>
+        Deny
+      </Button>
+    </div>
+  );
+}
+
 const ToolFallbackImpl: ToolCallMessagePartComponent = ({
   toolName,
   argsText,
   result,
   status,
+  addResult,
+  resume,
+  interrupt,
 }) => {
   const isCancelled =
     status?.type === "incomplete" && status.reason === "cancelled";
+  const isRequiresAction = status?.type === "requires-action";
 
   return (
     <ToolFallbackRoot
+      defaultOpen={isRequiresAction}
       className={cn(isCancelled && "border-muted-foreground/30 bg-muted/30")}
     >
       <ToolFallbackTrigger toolName={toolName} status={status} />
@@ -288,6 +340,13 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
           argsText={argsText}
           className={cn(isCancelled && "opacity-60")}
         />
+        {isRequiresAction && (
+          <ToolFallbackApproval
+            addResult={addResult}
+            resume={resume}
+            interrupt={interrupt}
+          />
+        )}
         {!isCancelled && <ToolFallbackResult result={result} />}
       </ToolFallbackContent>
     </ToolFallbackRoot>
@@ -303,6 +362,7 @@ const ToolFallback = memo(
   Args: typeof ToolFallbackArgs;
   Result: typeof ToolFallbackResult;
   Error: typeof ToolFallbackError;
+  Approval: typeof ToolFallbackApproval;
 };
 
 ToolFallback.displayName = "ToolFallback";
@@ -312,6 +372,7 @@ ToolFallback.Content = ToolFallbackContent;
 ToolFallback.Args = ToolFallbackArgs;
 ToolFallback.Result = ToolFallbackResult;
 ToolFallback.Error = ToolFallbackError;
+ToolFallback.Approval = ToolFallbackApproval;
 
 export {
   ToolFallback,
@@ -321,4 +382,5 @@ export {
   ToolFallbackArgs,
   ToolFallbackResult,
   ToolFallbackError,
+  ToolFallbackApproval,
 };

--- a/templates/minimal/components/assistant-ui/tool-fallback.tsx
+++ b/templates/minimal/components/assistant-ui/tool-fallback.tsx
@@ -10,6 +10,8 @@ import {
 } from "lucide-react";
 import {
   useScrollLock,
+  type ToolCallMessagePart,
+  type ToolCallMessagePartProps,
   type ToolCallMessagePartStatus,
   type ToolCallMessagePartComponent,
 } from "@assistant-ui/react";
@@ -269,30 +271,39 @@ function ToolFallbackError({
   );
 }
 
+const APPROVED_RESULT = "Approved by user";
+const DENIED_RESULT = "User denied tool execution";
+
 function ToolFallbackApproval({
   className,
   addResult,
   resume,
   interrupt,
+  approval,
+  respondToApproval,
   ...props
 }: React.ComponentProps<"div"> & {
   addResult?: (result: unknown) => void;
   resume?: (payload: unknown) => void;
-  interrupt?: { type: "human"; payload: unknown } | undefined;
+  interrupt?: ToolCallMessagePart["interrupt"];
+  approval?: ToolCallMessagePart["approval"];
+  respondToApproval?: ToolCallMessagePartProps["respondToApproval"];
 }) {
-  const handleAllow = () => {
-    if (interrupt) {
-      resume?.({ approved: true });
-    } else {
-      addResult?.("Approved by user");
-    }
-  };
+  const [submitted, setSubmitted] = useState(false);
 
-  const handleDeny = () => {
-    if (interrupt) {
-      resume?.({ approved: false });
+  const respond = (approved: boolean) => {
+    if (submitted) return;
+    setSubmitted(true);
+    if (
+      approval != null &&
+      approval.approved === undefined &&
+      respondToApproval
+    ) {
+      respondToApproval({ approved });
+    } else if (interrupt) {
+      resume?.({ approved });
     } else {
-      addResult?.("User denied tool execution");
+      addResult?.(approved ? APPROVED_RESULT : DENIED_RESULT);
     }
   };
 
@@ -305,10 +316,15 @@ function ToolFallbackApproval({
       )}
       {...props}
     >
-      <Button size="sm" onClick={handleAllow}>
+      <Button size="sm" onClick={() => respond(true)} disabled={submitted}>
         Allow
       </Button>
-      <Button size="sm" variant="outline" onClick={handleDeny}>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => respond(false)}
+        disabled={submitted}
+      >
         Deny
       </Button>
     </div>
@@ -323,14 +339,24 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
   addResult,
   resume,
   interrupt,
+  approval,
+  respondToApproval,
 }) => {
   const isCancelled =
     status?.type === "incomplete" && status.reason === "cancelled";
   const isRequiresAction = status?.type === "requires-action";
 
+  const [open, setOpen] = useState(isRequiresAction);
+  const [wasRequiresAction, setWasRequiresAction] = useState(isRequiresAction);
+  if (isRequiresAction && !wasRequiresAction) {
+    setWasRequiresAction(true);
+    setOpen(true);
+  }
+
   return (
     <ToolFallbackRoot
-      defaultOpen={isRequiresAction}
+      open={open}
+      onOpenChange={setOpen}
       className={cn(isCancelled && "border-muted-foreground/30 bg-muted/30")}
     >
       <ToolFallbackTrigger toolName={toolName} status={status} />
@@ -345,6 +371,8 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
             addResult={addResult}
             resume={resume}
             interrupt={interrupt}
+            approval={approval}
+            respondToApproval={respondToApproval}
           />
         )}
         {!isCancelled && <ToolFallbackResult result={result} />}

--- a/templates/minimal/components/assistant-ui/tool-fallback.tsx
+++ b/templates/minimal/components/assistant-ui/tool-fallback.tsx
@@ -282,13 +282,13 @@ function ToolFallbackApproval({
   approval,
   respondToApproval,
   ...props
-}: React.ComponentProps<"div"> & {
-  addResult?: (result: unknown) => void;
-  resume?: (payload: unknown) => void;
-  interrupt?: ToolCallMessagePart["interrupt"];
-  approval?: ToolCallMessagePart["approval"];
-  respondToApproval?: ToolCallMessagePartProps["respondToApproval"];
-}) {
+}: React.ComponentProps<"div"> &
+  Partial<
+    Pick<ToolCallMessagePartProps, "addResult" | "resume" | "respondToApproval">
+  > & {
+    interrupt?: ToolCallMessagePart["interrupt"];
+    approval?: ToolCallMessagePart["approval"];
+  }) {
   const [submitted, setSubmitted] = useState(false);
 
   const respond = (approved: boolean) => {
@@ -347,10 +347,11 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
   const isRequiresAction = status?.type === "requires-action";
 
   const [open, setOpen] = useState(isRequiresAction);
-  const [wasRequiresAction, setWasRequiresAction] = useState(isRequiresAction);
-  if (isRequiresAction && !wasRequiresAction) {
-    setWasRequiresAction(true);
-    setOpen(true);
+  const [prevRequiresAction, setPrevRequiresAction] =
+    useState(isRequiresAction);
+  if (isRequiresAction !== prevRequiresAction) {
+    setPrevRequiresAction(isRequiresAction);
+    if (isRequiresAction) setOpen(true);
   }
 
   return (

--- a/templates/minimal/components/assistant-ui/tool-fallback.tsx
+++ b/templates/minimal/components/assistant-ui/tool-fallback.tsx
@@ -19,6 +19,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
 const ANIMATION_DURATION = 200;
 
@@ -268,17 +269,68 @@ function ToolFallbackError({
   );
 }
 
+function ToolFallbackApproval({
+  className,
+  addResult,
+  resume,
+  interrupt,
+  ...props
+}: React.ComponentProps<"div"> & {
+  addResult?: (result: unknown) => void;
+  resume?: (payload: unknown) => void;
+  interrupt?: { type: "human"; payload: unknown } | undefined;
+}) {
+  const handleAllow = () => {
+    if (interrupt) {
+      resume?.({ approved: true });
+    } else {
+      addResult?.("Approved by user");
+    }
+  };
+
+  const handleDeny = () => {
+    if (interrupt) {
+      resume?.({ approved: false });
+    } else {
+      addResult?.("User denied tool execution");
+    }
+  };
+
+  return (
+    <div
+      data-slot="tool-fallback-approval"
+      className={cn(
+        "aui-tool-fallback-approval flex items-center gap-2 border-t border-dashed px-4 pt-2",
+        className,
+      )}
+      {...props}
+    >
+      <Button size="sm" onClick={handleAllow}>
+        Allow
+      </Button>
+      <Button size="sm" variant="outline" onClick={handleDeny}>
+        Deny
+      </Button>
+    </div>
+  );
+}
+
 const ToolFallbackImpl: ToolCallMessagePartComponent = ({
   toolName,
   argsText,
   result,
   status,
+  addResult,
+  resume,
+  interrupt,
 }) => {
   const isCancelled =
     status?.type === "incomplete" && status.reason === "cancelled";
+  const isRequiresAction = status?.type === "requires-action";
 
   return (
     <ToolFallbackRoot
+      defaultOpen={isRequiresAction}
       className={cn(isCancelled && "border-muted-foreground/30 bg-muted/30")}
     >
       <ToolFallbackTrigger toolName={toolName} status={status} />
@@ -288,6 +340,13 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
           argsText={argsText}
           className={cn(isCancelled && "opacity-60")}
         />
+        {isRequiresAction && (
+          <ToolFallbackApproval
+            addResult={addResult}
+            resume={resume}
+            interrupt={interrupt}
+          />
+        )}
         {!isCancelled && <ToolFallbackResult result={result} />}
       </ToolFallbackContent>
     </ToolFallbackRoot>
@@ -303,6 +362,7 @@ const ToolFallback = memo(
   Args: typeof ToolFallbackArgs;
   Result: typeof ToolFallbackResult;
   Error: typeof ToolFallbackError;
+  Approval: typeof ToolFallbackApproval;
 };
 
 ToolFallback.displayName = "ToolFallback";
@@ -312,6 +372,7 @@ ToolFallback.Content = ToolFallbackContent;
 ToolFallback.Args = ToolFallbackArgs;
 ToolFallback.Result = ToolFallbackResult;
 ToolFallback.Error = ToolFallbackError;
+ToolFallback.Approval = ToolFallbackApproval;
 
 export {
   ToolFallback,
@@ -321,4 +382,5 @@ export {
   ToolFallbackArgs,
   ToolFallbackResult,
   ToolFallbackError,
+  ToolFallbackApproval,
 };


### PR DESCRIPTION
Adds Allow / Deny buttons to the shadcn `ToolFallback` block when a tool call enters `requires-action`. Apps using the out-of-the-box component no longer have to hand-roll an approval UI for human-in-the-loop tools.

## What ships

- A new `ToolFallback.Approval` compound sub-component that renders whenever `status?.type === "requires-action"`. Wires the two existing protocol flows:
  - Interrupt flow (`context.human()`): clicking Allow calls `resume({ approved: true })`; Deny calls `resume({ approved: false })`.
  - Human-tool-names flow (`unstable_humanToolNames`): Allow calls `addResult("Approved by user")`; Deny calls `addResult("User denied tool execution")`.
- `ToolFallbackImpl` now destructures `addResult`, `resume`, `interrupt` from `ToolCallMessagePartComponent` props and renders the approval slot between `Args` and `Result`.
- `ToolFallbackRoot` auto-expands (`defaultOpen={isRequiresAction}`) when waiting for a decision, so the buttons are visible without a click. Explicit `open` / `defaultOpen` overrides still win.
- Compound type alias, runtime assignment, and named exports extended with `ToolFallback.Approval` / `ToolFallbackApproval`.
- Docs sample (`ToolFallbackRequiresActionSample`) and a new "Approval State" example block on `apps/docs/content/docs/ui/tool-fallback.mdx`, plus a row in the Composable API table.

## What's deliberately out of scope

- Trust escalation ("Always allow this tool", "Allow this session")
- Edit-args inline editor
- Auto-reject countdown
- Custom labels / i18n props
- `onApprove` / `onDeny` callback props

Users who want any of these edit their copy of `tool-fallback.tsx` after `shadcn add`. That's the shadcn ownership model. The library default ships the minimum that's useful for the common case.

## Files changed

- `packages/ui/src/components/assistant-ui/tool-fallback.tsx`: the new sub-component, integration, and exports
- `apps/docs/components/docs/samples/tool-fallback.tsx`: new visual sample
- `apps/docs/content/docs/ui/tool-fallback.mdx`: docs example, API row, refreshed compound snippet

No changeset entry; `@assistant-ui/ui` is private.
