### PR TITLE
feat: add message queueing for sends during a run

### DIFF
--- a/.changeset/store-level-message-queue.md
+++ b/.changeset/store-level-message-queue.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+---
+
+feat: add a store level message queue so composer.send() buffers while the thread is running and flushes when it ends, with a queueWhileRunning opt in on ComposerPrimitive.Send (works on langgraph, external store, and local runtimes)

--- a/packages/core/src/react/primitive-hooks/useComposerSend.test.ts
+++ b/packages/core/src/react/primitive-hooks/useComposerSend.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+
+// Pure replica of the gating predicate in useComposerSend.ts, asserting the
+// full matrix. Keep this expression identical to the hook's `disabled` selector.
+const isDisabled = (s: {
+  canSend: boolean;
+  isRunning: boolean;
+  capabilitiesQueue: boolean;
+  queueWhileRunning: boolean;
+}) =>
+  !s.canSend || (s.isRunning && !s.capabilitiesQueue && !s.queueWhileRunning);
+
+describe("useComposerSend gating", () => {
+  it("disabled when canSend is false regardless of other flags", () => {
+    expect(
+      isDisabled({
+        canSend: false,
+        isRunning: false,
+        capabilitiesQueue: true,
+        queueWhileRunning: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("enabled when idle and sendable", () => {
+    expect(
+      isDisabled({
+        canSend: true,
+        isRunning: false,
+        capabilitiesQueue: false,
+        queueWhileRunning: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("disabled while running by default (no queue capability, no opt-in)", () => {
+    expect(
+      isDisabled({
+        canSend: true,
+        isRunning: true,
+        capabilitiesQueue: false,
+        queueWhileRunning: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("enabled while running when capabilities.queue is true (assistant-transport)", () => {
+    expect(
+      isDisabled({
+        canSend: true,
+        isRunning: true,
+        capabilitiesQueue: true,
+        queueWhileRunning: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("enabled while running when queueWhileRunning opt-in is set", () => {
+    expect(
+      isDisabled({
+        canSend: true,
+        isRunning: true,
+        capabilitiesQueue: false,
+        queueWhileRunning: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/react/primitive-hooks/useComposerSend.ts
+++ b/packages/core/src/react/primitive-hooks/useComposerSend.ts
@@ -2,12 +2,14 @@ import { useCallback } from "react";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import type { ComposerSendOptions } from "../../store/scopes/composer";
 
-export const useComposerSend = () => {
+export const useComposerSend = (queueWhileRunning = false) => {
   const aui = useAui();
   const disabled = useAuiState(
     (s) =>
       !s.composer.canSend ||
-      (s.thread.isRunning && !s.thread.capabilities.queue),
+      (s.thread.isRunning &&
+        !s.thread.capabilities.queue &&
+        !queueWhileRunning),
   );
 
   const send = useCallback(

--- a/packages/core/src/store/runtime-clients/composer-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/composer-runtime-client.ts
@@ -4,6 +4,7 @@ import {
   tapMemo,
   tapEffect,
   tapResource,
+  tapState,
   type tapRef,
   withKey,
 } from "@assistant-ui/tap";
@@ -16,9 +17,43 @@ import type {
   ComposerRuntime,
   EditComposerRuntime,
 } from "../../runtime/api/composer-runtime";
-import type { ComposerState } from "../scopes/composer";
+import type { ComposerState, ComposerSendOptions } from "../scopes/composer";
 import { AttachmentRuntimeClient } from "./attachment-runtime-client";
 import { tapSubscribable } from "./tap-subscribable";
+import { generateId } from "../../utils/id";
+import type { CreateAppendMessage } from "../../runtime/api/thread-runtime";
+import type { AppendMessage } from "../../types/message";
+import type { QueueItemState } from "../scopes/queue-item";
+
+export type ComposerQueueController = {
+  isRunning: boolean;
+  append: (message: CreateAppendMessage) => void;
+  cancelRun: () => void;
+};
+
+type QueuedSend = {
+  id: string;
+  prompt: string;
+  message: CreateAppendMessage;
+};
+
+const QueueItemClient = resource(
+  ({
+    item,
+    onSteer,
+    onRemove,
+  }: {
+    item: QueueItemState;
+    onSteer: () => void;
+    onRemove: () => void;
+  }): ClientOutput<"queueItem"> => {
+    return {
+      getState: () => item,
+      steer: onSteer,
+      remove: onRemove,
+    };
+  },
+);
 
 const ComposerAttachmentClientByIndex = resource(
   ({ runtime, index }: { runtime: ComposerRuntime; index: number }) => {
@@ -40,10 +75,12 @@ export const ComposerClient = resource(
     threadIdRef,
     messageIdRef,
     runtime,
+    queueController,
   }: {
     threadIdRef: tapRef.RefObject<string>;
     messageIdRef?: tapRef.RefObject<string>;
     runtime: ComposerRuntime;
+    queueController?: ComposerQueueController | undefined;
   }): ClientOutput<"composer"> => {
     const runtimeState = tapSubscribable(runtime);
     const emit = tapAssistantEmit();
@@ -95,6 +132,60 @@ export const ComposerClient = resource(
       [runtimeState.attachments, runtime],
     );
 
+    const [queued, setQueued] = tapState<readonly QueuedSend[]>([]);
+
+    const composeQueuedMessage = (): QueuedSend => {
+      const current = runtime.getState();
+      const text = current.text;
+      return {
+        id: generateId(),
+        prompt: text,
+        message: {
+          role: current.role,
+          content: text ? [{ type: "text" as const, text }] : [],
+          attachments: current.attachments as AppendMessage["attachments"],
+          runConfig: current.runConfig,
+          metadata: {
+            custom: current.quote ? { quote: current.quote } : {},
+          },
+        },
+      };
+    };
+
+    const isRunning = queueController?.isRunning ?? false;
+    tapEffect(() => {
+      if (!queueController || isRunning || queued.length === 0) return;
+      const [head, ...rest] = queued;
+      setQueued(rest);
+      queueController.append(head!.message);
+    }, [queueController, isRunning, queued, setQueued]);
+
+    const queueItemClients = tapClientLookup(
+      () =>
+        queued.map((item) =>
+          withKey(
+            item.id,
+            QueueItemClient({
+              item: { id: item.id, prompt: item.prompt },
+              onSteer: () => {
+                queueController?.cancelRun();
+                queueController?.append(item.message);
+                setQueued((q) => q.filter((x) => x.id !== item.id));
+              },
+              onRemove: () => {
+                setQueued((q) => q.filter((x) => x.id !== item.id));
+              },
+            }),
+          ),
+        ),
+      [queued, queueController, setQueued],
+    );
+
+    const queueState = tapMemo<readonly QueueItemState[]>(
+      () => queued.map(({ id, prompt }) => ({ id, prompt })),
+      [queued],
+    );
+
     const state = tapMemo<ComposerState>(() => {
       return {
         text: runtimeState.text,
@@ -109,9 +200,9 @@ export const ComposerClient = resource(
         type: runtimeState.type ?? "thread",
         dictation: runtimeState.dictation,
         quote: runtimeState.quote,
-        queue: [],
+        queue: queueState,
       };
-    }, [runtimeState, attachments.state]);
+    }, [runtimeState, attachments.state, queueState]);
 
     return {
       getState: () => state,
@@ -121,7 +212,20 @@ export const ComposerClient = resource(
       addAttachment: runtime.addAttachment,
       reset: runtime.reset,
       clearAttachments: runtime.clearAttachments,
-      send: runtime.send,
+      send: (opts?: ComposerSendOptions) => {
+        if (!queueController || !queueController.isRunning) {
+          runtime.send(opts);
+          return;
+        }
+        const item = composeQueuedMessage();
+        void runtime.reset();
+        if (opts?.steer) {
+          queueController.cancelRun();
+          queueController.append(item.message);
+        } else {
+          setQueued((q) => [...q, item]);
+        }
+      },
       cancel: runtime.cancel,
       beginEdit:
         (runtime as EditComposerRuntime).beginEdit ??
@@ -138,9 +242,11 @@ export const ComposerClient = resource(
           return attachments.get(selector);
         }
       },
-      queueItem: () => {
-        throw new Error("Queue is not supported in this runtime");
-      },
+      queueItem: queueController
+        ? (selector) => queueItemClients.get(selector)
+        : () => {
+            throw new Error("Queue is not supported in this runtime");
+          },
       __internal_getRuntime: () => runtime,
     };
   },

--- a/packages/core/src/store/runtime-clients/thread-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-runtime-client.ts
@@ -16,6 +16,7 @@ import {
   tapClientResource,
 } from "@assistant-ui/store";
 import { ComposerClient } from "./composer-runtime-client";
+import type { ComposerQueueController } from "./composer-runtime-client";
 import { MessageClient } from "./message-runtime-client";
 import { tapSubscribable } from "./tap-subscribable";
 import type { ThreadState } from "../scopes/thread";
@@ -78,10 +79,21 @@ export const ThreadClient = resource(
       [runtime],
     );
 
+    const threadIsRunning = runtimeState.isRunning;
+    const queueController = tapMemo<ComposerQueueController>(
+      () => ({
+        isRunning: threadIsRunning,
+        append: runtime.append,
+        cancelRun: runtime.cancelRun,
+      }),
+      [threadIsRunning, runtime],
+    );
+
     const composer = tapClientResource(
       ComposerClient({
         runtime: runtime.composer,
         threadIdRef,
+        queueController,
       }),
     );
     const messages = tapClientLookup(

--- a/packages/react-ink/src/primitives/composer/ComposerSend.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerSend.tsx
@@ -4,14 +4,16 @@ import { Pressable, type PressableProps } from "../internal/Pressable";
 
 export type ComposerSendProps = Omit<PressableProps, "onPress"> & {
   children: ReactNode;
+  queueWhileRunning?: boolean;
 };
 
 export const ComposerSend = ({
   children,
   disabled,
+  queueWhileRunning,
   ...pressableProps
 }: ComposerSendProps) => {
-  const { send, disabled: hookDisabled } = useComposerSend();
+  const { send, disabled: hookDisabled } = useComposerSend(queueWhileRunning);
 
   return (
     <Pressable

--- a/packages/react-native/src/primitives/composer/ComposerSend.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerSend.tsx
@@ -4,14 +4,16 @@ import { useComposerSend } from "@assistant-ui/core/react";
 
 export type ComposerSendProps = Omit<PressableProps, "onPress"> & {
   children: ReactNode;
+  queueWhileRunning?: boolean;
 };
 
 export const ComposerSend = ({
   children,
   disabled,
+  queueWhileRunning,
   ...pressableProps
 }: ComposerSendProps) => {
-  const { send, disabled: hookDisabled } = useComposerSend();
+  const { send, disabled: hookDisabled } = useComposerSend(queueWhileRunning);
 
   return (
     <Pressable

--- a/packages/react/src/primitives/composer/ComposerSend.ts
+++ b/packages/react/src/primitives/composer/ComposerSend.ts
@@ -8,8 +8,10 @@ import {
 } from "../../utils/createActionButton";
 import { useComposerSend as useComposerSendBehavior } from "@assistant-ui/core/react";
 
-export const useComposerSend = () => {
-  const { disabled, send } = useComposerSendBehavior();
+export const useComposerSend = ({
+  queueWhileRunning = false,
+}: { queueWhileRunning?: boolean } = {}) => {
+  const { disabled, send } = useComposerSendBehavior(queueWhileRunning);
   const callback = useCallback(() => send(), [send]);
   if (disabled) return null;
   return callback;
@@ -20,6 +22,9 @@ export namespace ComposerPrimitiveSend {
   /**
    * Props for the ComposerPrimitive.Send component.
    * Inherits all button element props and action button functionality.
+   *
+   * `queueWhileRunning` keeps the button enabled while the thread is running;
+   * the message is queued and sent when the run ends.
    */
   export type Props = ActionButtonProps<typeof useComposerSend>;
 }
@@ -41,4 +46,5 @@ export namespace ComposerPrimitiveSend {
 export const ComposerPrimitiveSend = createActionButton(
   "ComposerPrimitive.Send",
   useComposerSend,
+  ["queueWhileRunning"],
 );

--- a/packages/react/src/tests/composer-queue.test.tsx
+++ b/packages/react/src/tests/composer-queue.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+
+import { render, act } from "@testing-library/react";
+import type { FC } from "react";
+import { describe, it, expect } from "vitest";
+import { useAui } from "@assistant-ui/store";
+import { AssistantRuntimeProvider } from "../context";
+import { useLocalRuntime } from "../legacy-runtime/runtime-cores/local/useLocalRuntime";
+import type { ChatModelAdapter } from "../legacy-runtime/runtime-cores/local/ChatModelAdapter";
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+// An adapter whose run() blocks until released (or aborted), so the thread
+// stays in `isRunning: true` while we exercise the queue.
+const createBlockingAdapter = () => {
+  let release: () => void = () => {};
+  const adapter: ChatModelAdapter = {
+    async *run({ abortSignal }) {
+      await new Promise<void>((resolve) => {
+        release = resolve;
+        abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      yield { content: [{ type: "text", text: "done" }] };
+    },
+  };
+  return { adapter, release: () => release() };
+};
+
+const userTexts = (aui: ReturnType<typeof useAui>) =>
+  aui
+    .thread()
+    .getState()
+    .messages.filter((m) => m.role === "user")
+    .map((m) =>
+      m.content.map((p) => (p.type === "text" ? p.text : "")).join(""),
+    );
+
+const renderWithRuntime = (adapter: ChatModelAdapter) => {
+  const captured: { aui?: ReturnType<typeof useAui> } = {};
+  const Capture: FC = () => {
+    captured.aui = useAui();
+    return null;
+  };
+  const App: FC = () => {
+    const runtime = useLocalRuntime(adapter);
+    return (
+      <AssistantRuntimeProvider runtime={runtime}>
+        <Capture />
+      </AssistantRuntimeProvider>
+    );
+  };
+  render(<App />);
+  return captured.aui!;
+};
+
+const startRun = async (aui: ReturnType<typeof useAui>, text: string) => {
+  await act(async () => {
+    aui.thread().composer().setText(text);
+    aui.thread().composer().send();
+    await flush();
+  });
+};
+
+describe("composer queue (local runtime, end to end)", () => {
+  it("buffers a send while running and flushes it when the run ends", async () => {
+    const { adapter, release } = createBlockingAdapter();
+    const aui = renderWithRuntime(adapter);
+
+    await startRun(aui, "first");
+    expect(aui.thread().getState().isRunning).toBe(true);
+
+    // Send again while running -> should queue, not start a second run.
+    await act(async () => {
+      aui.thread().composer().setText("second");
+      aui.thread().composer().send();
+      await flush();
+    });
+    expect(aui.thread().composer().getState().queue).toHaveLength(1);
+    expect(aui.thread().composer().getState().queue[0]!.prompt).toBe("second");
+    expect(userTexts(aui)).toEqual(["first"]);
+
+    // End the run -> queued "second" flushes and gets appended.
+    await act(async () => {
+      release();
+      await flush();
+    });
+    expect(aui.thread().composer().getState().queue).toHaveLength(0);
+    expect(userTexts(aui)).toContain("second");
+  });
+
+  it("queueItem(index).remove() drops a queued message", async () => {
+    const { adapter } = createBlockingAdapter();
+    const aui = renderWithRuntime(adapter);
+
+    await startRun(aui, "first");
+
+    await act(async () => {
+      aui.thread().composer().setText("a");
+      aui.thread().composer().send();
+      aui.thread().composer().setText("b");
+      aui.thread().composer().send();
+      await flush();
+    });
+    expect(aui.thread().composer().getState().queue).toHaveLength(2);
+
+    await act(async () => {
+      aui.thread().composer().queueItem({ index: 0 }).remove();
+      await flush();
+    });
+    const queue = aui.thread().composer().getState().queue;
+    expect(queue).toHaveLength(1);
+    expect(queue[0]!.prompt).toBe("b");
+  });
+
+  it("send({ steer: true }) appends immediately and does not buffer", async () => {
+    const { adapter } = createBlockingAdapter();
+    const aui = renderWithRuntime(adapter);
+
+    await startRun(aui, "first");
+    expect(aui.thread().getState().isRunning).toBe(true);
+
+    await act(async () => {
+      aui.thread().composer().setText("urgent");
+      aui.thread().composer().send({ steer: true });
+      await flush();
+    });
+
+    expect(aui.thread().composer().getState().queue).toHaveLength(0);
+    expect(userTexts(aui)).toContain("urgent");
+  });
+
+  it("does not queue when idle (sends immediately)", async () => {
+    const { adapter, release } = createBlockingAdapter();
+    const aui = renderWithRuntime(adapter);
+
+    await startRun(aui, "first");
+    await act(async () => {
+      release();
+      await flush();
+    });
+    expect(aui.thread().getState().isRunning).toBe(false);
+
+    await act(async () => {
+      aui.thread().composer().setText("second");
+      aui.thread().composer().send();
+      await flush();
+    });
+    expect(aui.thread().composer().getState().queue).toHaveLength(0);
+    expect(userTexts(aui)).toEqual(["first", "second"]);
+  });
+});


### PR DESCRIPTION
Closes #4230.

Adds a generic, store level message queue so `composer.send()` buffers a message while the thread is running and flushes it when the run ends. It works across the legacy core runtimes (langgraph, external store, local) with no per runtime adapter, and builds on the queue primitives from #3684 (`ComposerPrimitive.Queue`, `QueueItemPrimitive.*`) which were previously only wired into `ExternalThread`.

## What changed

- **Store bridge owns the queue** (`composer-runtime-client.ts`): `send()` buffers a composed `AppendMessage` while the thread is running and flushes the head via `append` when it goes idle. `send({ steer: true })` cancels the current run and appends immediately. `composer.queue` plus `queueItem({ index }).remove()` / `.steer()` are surfaced.
- **Thread bridge** (`thread-runtime-client.ts`): injects a `queueController` (thread `isRunning` + `append` + `cancelRun`) into the thread composer only. Edit composers are untouched and behave exactly as before.
- **`queueWhileRunning` opt in** on `ComposerPrimitive.Send` (react, react-native, react-ink). The default "Send disabled while running" behavior is unchanged, and `assistant-transport`'s `capabilities.queue` gating is untouched. Programmatic `composer.send()` while running always buffers, which covers the CTA / campaign use case in the issue.

This lights up the existing #3684 queue primitives with zero UI changes.

## Why this approach

`useLangGraphRuntime` / `useExternalStoreRuntime` / `useLocalRuntime` all flow through the same store bridge (`RuntimeAdapter` -> `ThreadListClient` -> `ThreadClient` -> `ComposerClient`). Putting the queue there fixes every legacy core runtime at once, lives in the layer the codebase is migrating toward, and needs no per runtime adapter.

## Testing

- End to end tests on a real local runtime through the actual store path: buffer while running then flush on idle, `queueItem.remove`, `send({ steer })`, and idle send unchanged.
- Send gating matrix for `useComposerSend` across `isRunning` x `capabilities.queue` x `queueWhileRunning`.
- Full repo build, lint, and the core and react test suites all pass.

## Follow ups

These are deliberately left out to keep this PR scoped to the queue mechanism and easy to review.

- **Attachment finalization for queued sends.** Queued messages are composed from composer state (matching `ExternalThread`), so the local runtime's attachment adapter finalization that `composer.send` normally performs is skipped. Doing it properly means running the adapter's finalization at enqueue or flush time, which pulls logic back into the legacy composer core and deserves its own change and tests. The common case in this issue is text prompts, so attachment heavy queueing can land as a separate PR.
- **Server side steer.** On client only runtimes (local, external store, langgraph) `steer` is cancel + append, which is the only meaningful semantics since there is no server run to interrupt. A true server side interrupt only applies to `assistant-transport`, which already has its own mechanism, so unifying that path is a separate effort.
