### PR TITLE
feat(react-ag-ui): emit multimodal input parts for file attachments

### DIFF
--- a/.changeset/agui-multimodal-input-parts.md
+++ b/.changeset/agui-multimodal-input-parts.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: emit AG-UI multimodal input parts (image/audio/video/document with typed data/url sources) for file attachments instead of the legacy `binary` input content

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -127,6 +127,40 @@ function parseDataUrl(
 
 const httpUrlPattern = /^https?:\/\//i;
 
+type InputContentSource =
+  | { type: "data"; value: string; mimeType: string }
+  | { type: "url"; value: string; mimeType?: string };
+
+type MediaInputType = "image" | "audio" | "video" | "document";
+
+function mediaTypeForMime(mimeType: string | undefined): MediaInputType {
+  if (mimeType?.startsWith("image/")) return "image";
+  if (mimeType?.startsWith("audio/")) return "audio";
+  if (mimeType?.startsWith("video/")) return "video";
+  return "document";
+}
+
+// Build an AG-UI multimodal source from a data URL, raw base64 payload, or an
+// http(s) URL. A `url` source may omit the mime type; a `data` source always
+// resolves one (falling back to application/octet-stream).
+function buildInputSource(
+  value: string,
+  declaredMimeType: string | undefined,
+): InputContentSource {
+  if (httpUrlPattern.test(value)) {
+    return declaredMimeType !== undefined
+      ? { type: "url", value, mimeType: declaredMimeType }
+      : { type: "url", value };
+  }
+  const parsed = parseDataUrl(value);
+  return {
+    type: "data",
+    value: parsed?.data ?? value,
+    mimeType:
+      parsed?.mimeType ?? declaredMimeType ?? "application/octet-stream",
+  };
+}
+
 function toInputContent(
   part: unknown,
   fallbackMimeType: string | undefined,
@@ -143,52 +177,26 @@ function toInputContent(
   if (type === "image") {
     const image = getString(part, "image");
     if (image === undefined) return null;
-    const parsed = parseDataUrl(image);
-    if (parsed) {
-      return {
-        type: "image",
-        source: {
-          type: "data",
-          value: parsed.data,
-          mimeType: parsed.mimeType,
-        },
-      };
-    }
-    return {
-      type: "image",
-      source: {
-        type: "url",
-        value: image,
-        ...(fallbackMimeType !== undefined
-          ? { mimeType: fallbackMimeType }
-          : {}),
-      },
-    };
+    return { type: "image", source: buildInputSource(image, fallbackMimeType) };
   }
 
   if (type === "file") {
     const data = getString(part, "data");
     if (data === undefined) return null;
-    const partMimeType = getString(part, "mimeType");
+    const declaredMimeType = getString(part, "mimeType") || fallbackMimeType;
     const filename = getString(part, "filename");
-    const mimeType =
-      partMimeType || fallbackMimeType || "application/octet-stream";
-
-    if (httpUrlPattern.test(data)) {
-      return {
-        type: "binary",
-        mimeType,
-        url: data,
-        ...(filename !== undefined ? { filename } : {}),
-      };
+    const source = buildInputSource(data, declaredMimeType);
+    const metadata = filename !== undefined ? { filename } : undefined;
+    switch (mediaTypeForMime(source.mimeType)) {
+      case "image":
+        return { type: "image", source, ...(metadata && { metadata }) };
+      case "audio":
+        return { type: "audio", source, ...(metadata && { metadata }) };
+      case "video":
+        return { type: "video", source, ...(metadata && { metadata }) };
+      default:
+        return { type: "document", source, ...(metadata && { metadata }) };
     }
-    const parsed = parseDataUrl(data);
-    return {
-      type: "binary",
-      mimeType: parsed?.mimeType ?? mimeType,
-      data: parsed?.data ?? data,
-      ...(filename !== undefined ? { filename } : {}),
-    };
   }
 
   return null;

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -375,7 +375,7 @@ describe("adapter conversions", () => {
     expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
   });
 
-  it("converts file attachment to AG-UI binary with filename preserved", () => {
+  it("converts a file attachment to an AG-UI document part with filename in metadata", () => {
     const result = toAgUiMessages([
       {
         id: "u-1",
@@ -405,10 +405,107 @@ describe("adapter conversions", () => {
       content: [
         { type: "text", text: "review this" },
         {
-          type: "binary",
-          mimeType: "application/pdf",
-          data: "JVBERi0xLjQK",
-          filename: "spec.pdf",
+          type: "document",
+          source: {
+            type: "data",
+            value: "JVBERi0xLjQK",
+            mimeType: "application/pdf",
+          },
+          metadata: { filename: "spec.pdf" },
+        },
+      ],
+    });
+    expect((result[0] as any).content[1]).not.toHaveProperty("filename");
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
+  it("classifies audio/video files into their own multimodal parts", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [],
+        attachments: [
+          {
+            id: "a-1",
+            type: "file",
+            name: "clip.mp3",
+            content: [
+              {
+                type: "file",
+                data: "data:audio/mpeg;base64,QUJD",
+                mimeType: "audio/mpeg",
+              },
+            ],
+          },
+          {
+            id: "a-2",
+            type: "file",
+            name: "clip.mp4",
+            content: [
+              {
+                type: "file",
+                data: "ZmFrZQ==",
+                mimeType: "video/mp4",
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "audio",
+          source: { type: "data", value: "QUJD", mimeType: "audio/mpeg" },
+        },
+        {
+          type: "video",
+          source: { type: "data", value: "ZmFrZQ==", mimeType: "video/mp4" },
+        },
+      ],
+    });
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
+  it("converts an http(s) file attachment to a url source document part", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [],
+        attachments: [
+          {
+            id: "a-1",
+            type: "document",
+            name: "spec.pdf",
+            contentType: "application/pdf",
+            content: [
+              {
+                type: "file",
+                data: "https://example.com/spec.pdf",
+                mimeType: "application/pdf",
+                filename: "spec.pdf",
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "document",
+          source: {
+            type: "url",
+            value: "https://example.com/spec.pdf",
+            mimeType: "application/pdf",
+          },
+          metadata: { filename: "spec.pdf" },
         },
       ],
     });
@@ -559,7 +656,7 @@ describe("adapter conversions", () => {
     expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
   });
 
-  it("routes http file data to binary.url not binary.data", () => {
+  it("routes http file data to a url source, not an inline data source", () => {
     const result = toAgUiMessages([
       {
         id: "u-1",
@@ -587,14 +684,17 @@ describe("adapter conversions", () => {
       role: "user",
       content: [
         {
-          type: "binary",
-          mimeType: "application/pdf",
-          url: "https://cdn.example.com/report.pdf",
-          filename: "report.pdf",
+          type: "document",
+          source: {
+            type: "url",
+            value: "https://cdn.example.com/report.pdf",
+            mimeType: "application/pdf",
+          },
+          metadata: { filename: "report.pdf" },
         },
       ],
     });
-    expect((result[0] as any).content[0]).not.toHaveProperty("data");
+    expect((result[0] as any).content[0].source).not.toHaveProperty("data");
     expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
   });
 });


### PR DESCRIPTION
File attachments were still being sent as AG-UI's deprecated `binary` input content. This switches them to the current multimodal parts (`image`/`audio`/`video`/`document`) with typed `data`/`url` sources — the part kind is picked from the mime type, and `filename` moves into `metadata`.

Image attachments already used the new source-based shape, so this just brings files in line. Conversion tests updated to cover the new shapes.