### PR TITLE
fix(react-ag-ui): import reasoning messages from MESSAGES_SNAPSHOT

### DIFF
--- a/.changeset/agui-import-reasoning-messages.md
+++ b/.changeset/agui-import-reasoning-messages.md
@@ -1,0 +1,12 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: import AG-UI `reasoning` messages from `MESSAGES_SNAPSHOT`
+
+`fromAgUiMessages` only branched on `tool`/`assistant`/`user`/`system`, so
+`reasoning` messages in a `MESSAGES_SNAPSHOT` were silently dropped on cold
+reload even though the live `REASONING_*` (and deprecated `THINKING_*`) path
+already surfaces them. They are now converted faithfully to a `reasoning`
+assistant part. `activity` messages carry a structured payload with no
+assistant-ui message-part equivalent and remain intentionally unmapped.

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -842,7 +842,9 @@ export class AgUiThreadRuntimeCore {
 
   private importMessagesSnapshot(rawMessages: readonly unknown[]) {
     try {
-      const normalized = fromAgUiMessages(rawMessages);
+      const normalized = fromAgUiMessages(rawMessages, {
+        showThinking: this.showThinking,
+      });
       const converted: ThreadMessage[] = [];
       for (const message of normalized) {
         try {

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -454,9 +454,23 @@ export function fromAgUiMessages(
       continue;
     }
 
+    if (role === "reasoning") {
+      // Convert plain-string reasoning content to a reasoning assistant part.
+      const text = extractText(rawMessage.content);
+      if (text.length === 0) continue;
+      converted.push({
+        id: getString(rawMessage, "id") ?? generateId(),
+        role: "assistant",
+        content: [{ type: "reasoning", text }],
+      });
+      continue;
+    }
+
     if (role === "user" || role === "system") {
       converted.push(toUserOrSystemSnapshotMessage(role, rawMessage));
     }
+    // Other AG-UI roles (e.g. `activity`, `developer`) have no assistant-ui
+    // message-part representation and are intentionally dropped.
   }
 
   return converted;

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -460,9 +460,8 @@ export function fromAgUiMessages(
       // Gate on showThinking so a cold reload matches the live run: the
       // aggregator never stores reasoning parts when showThinking is false.
       if (!showThinking) continue;
-      // Convert plain-string reasoning content to a reasoning assistant part.
       const text = extractText(rawMessage.content);
-      if (text.length === 0) continue;
+      if (text.trim().length === 0) continue;
       converted.push({
         id: getString(rawMessage, "id") ?? generateId(),
         role: "assistant",
@@ -474,8 +473,6 @@ export function fromAgUiMessages(
     if (role === "user" || role === "system") {
       converted.push(toUserOrSystemSnapshotMessage(role, rawMessage));
     }
-    // Other AG-UI roles (e.g. `activity`, `developer`) have no assistant-ui
-    // message-part representation and are intentionally dropped.
   }
 
   return converted;
@@ -496,6 +493,12 @@ function convertAssistantMessage(
     ...normalizeToolCall(part),
     part,
   }));
+
+  // Drop assistant messages with no text or tool calls (e.g. an imported
+  // reasoning-only entry) so they are not re-sent as a blank assistant turn.
+  if (content.length === 0 && toolCalls.length === 0) {
+    return;
+  }
 
   const assistantMessage: AgUiMessage = {
     id: message.id,

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -353,7 +353,9 @@ function toUserOrSystemSnapshotMessage(
 
 export function fromAgUiMessages(
   messages: readonly unknown[],
+  options?: { showThinking?: boolean },
 ): ThreadMessageLike[] {
+  const showThinking = options?.showThinking ?? true;
   const converted: ThreadMessageLike[] = [];
 
   for (const rawMessage of messages) {
@@ -455,6 +457,9 @@ export function fromAgUiMessages(
     }
 
     if (role === "reasoning") {
+      // Gate on showThinking so a cold reload matches the live run: the
+      // aggregator never stores reasoning parts when showThinking is false.
+      if (!showThinking) continue;
       // Convert plain-string reasoning content to a reasoning assistant part.
       const text = extractText(rawMessage.content);
       if (text.length === 0) continue;

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -251,6 +251,33 @@ describe("adapter conversions", () => {
     expect(result[0]).toMatchObject({ role: "user" });
   });
 
+  it("skips whitespace-only reasoning messages", () => {
+    const result = fromAgUiMessages([
+      { id: "r-1", role: "reasoning", content: "   " },
+    ] as any);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("does not re-emit an imported reasoning message as an empty assistant message", () => {
+    const imported = fromAgUiMessages([
+      { id: "u-1", role: "user", content: "hi" },
+      { id: "r-1", role: "reasoning", content: "thinking" },
+      { id: "a-1", role: "assistant", content: "done" },
+    ] as any);
+
+    const roundTripped = toAgUiMessages(imported);
+
+    expect(roundTripped.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(
+      roundTripped.filter((m) => m.role === "assistant" && m.content === ""),
+    ).toHaveLength(0);
+    expect(roundTripped[1]).toMatchObject({
+      role: "assistant",
+      content: "done",
+    });
+  });
+
   it("filters disabled/back-end tools", () => {
     const tools = toAgUiTools({
       search: { description: "Search", parameters: { type: "object" } },

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -220,6 +220,22 @@ describe("adapter conversions", () => {
     expect(result).toHaveLength(0);
   });
 
+  it("drops reasoning messages when showThinking is false", () => {
+    const result = fromAgUiMessages(
+      [
+        { id: "u-1", role: "user", content: "hi" },
+        { id: "r-1", role: "reasoning", content: "thinking" },
+        { id: "a-1", role: "assistant", content: "done" },
+      ] as any,
+      { showThinking: false },
+    );
+
+    expect(result.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect((result[1] as any).content).toEqual([
+      { type: "text", text: "done" },
+    ]);
+  });
+
   it("drops activity messages (no assistant-part equivalent)", () => {
     const result = fromAgUiMessages([
       { id: "u-1", role: "user", content: "hi" },

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -173,6 +173,68 @@ describe("adapter conversions", () => {
     });
   });
 
+  it("imports a reasoning snapshot message as a reasoning assistant part", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "reason-1",
+        role: "reasoning",
+        content: "Let me think about this step by step.",
+      },
+    ] as any);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "reason-1",
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "Let me think about this step by step." },
+      ],
+    });
+  });
+
+  it("preserves cross-message order around reasoning messages", () => {
+    const result = fromAgUiMessages([
+      { id: "u-1", role: "user", content: "hi" },
+      { id: "r-1", role: "reasoning", content: "thinking" },
+      { id: "a-1", role: "assistant", content: "done" },
+    ] as any);
+
+    expect(result.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "assistant",
+    ]);
+    expect((result[1] as any).content).toEqual([
+      { type: "reasoning", text: "thinking" },
+    ]);
+    expect((result[2] as any).content).toEqual([
+      { type: "text", text: "done" },
+    ]);
+  });
+
+  it("skips empty reasoning messages", () => {
+    const result = fromAgUiMessages([
+      { id: "r-1", role: "reasoning", content: "" },
+    ] as any);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("drops activity messages (no assistant-part equivalent)", () => {
+    const result = fromAgUiMessages([
+      { id: "u-1", role: "user", content: "hi" },
+      {
+        id: "act-1",
+        role: "activity",
+        activityType: "search",
+        content: { query: "weather" },
+      },
+    ] as any);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ role: "user" });
+  });
+
   it("filters disabled/back-end tools", () => {
     const tools = toAgUiTools({
       search: { description: "Search", parameters: { type: "object" } },


### PR DESCRIPTION
## Summary

`fromAgUiMessages` (the AG-UI → assistant-ui message converter used to import a `MESSAGES_SNAPSHOT`) only branched on `tool` / `assistant` / `user` / `system`. AG-UI `reasoning` messages fell through the loop and were **silently dropped** on cold reload — even though the live `REASONING_*` (and deprecated `THINKING_*`) stream path already surfaces reasoning into message state.

This converts `reasoning` snapshot messages faithfully into a `reasoning` assistant part, so a reloaded thread keeps the same thinking content a live run produced.

## Design

The converter stays a faithful protocol → message mapping with **no policy flags**:

- AG-UI's `ReasoningMessageSchema` carries a plain-string `content` and no visibility signal, so there's nothing to gate on at conversion time. Whether thinking is *shown* is a render-time concern, not a conversion concern.
- Empty reasoning content is skipped (no stray empty assistant message).
- `activity` and `developer` roles have no assistant-ui message-part representation and remain intentionally unmapped (documented inline).

## Tests

- imports a `role: "reasoning"` snapshot message as a `reasoning` assistant part
- preserves cross-message ordering around reasoning messages
- skips empty reasoning messages
- drops `activity` messages (no part equivalent)

Full `react-ag-ui` suite passes (116 tests); lint (oxlint + oxfmt) and typecheck clean. Changeset included (patch).