### PR TITLE
fix: type defineToolkit streamCall args

### DIFF
--- a/.changeset/define-toolkit-stream-call-types.md
+++ b/.changeset/define-toolkit-stream-call-types.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: infer `defineToolkit` streamCall argument readers from Standard Schema parameters

--- a/packages/core/src/react/model-context/define-toolkit.test.ts
+++ b/packages/core/src/react/model-context/define-toolkit.test.ts
@@ -3,6 +3,46 @@ import { defineToolkit } from "./define-toolkit";
 import { hitl, hitlTool } from "./hitl";
 import { providerTool } from "./provider-tool";
 
+const expectType = <T>(_value: T) => {};
+
+type TestStandardSchema<T> = {
+  readonly "~standard": {
+    readonly version: 1;
+    readonly vendor: "test";
+    readonly types?: {
+      readonly input: T;
+      readonly output: T;
+    };
+    readonly validate: (value: unknown) => { readonly value: T };
+  };
+};
+
+const checkDefineToolkitTypes = () => {
+  defineToolkit({
+    search: {
+      parameters: {} as TestStandardSchema<{
+        query: string;
+        limit?: number;
+      }>,
+      execute: async ({ query, limit }: { query: string; limit?: number }) => ({
+        ids: [query],
+        count: limit ?? 0,
+      }),
+      streamCall: async (reader) => {
+        const query = await reader.args.get("query");
+        expectType<string>(query);
+
+        const response = await reader.response.get();
+        expectType<unknown>(response.result);
+
+        // @ts-expect-error unknown argument paths should not be accepted
+        reader.args.get("missing");
+      },
+    },
+  });
+};
+void checkDefineToolkitTypes;
+
 describe("use-generative markers", () => {
   it("defineToolkit throws at runtime — it must be stripped by the compiler, never called", () => {
     expect(() => defineToolkit({})).toThrow(/no runtime implementation/);

--- a/packages/core/src/react/model-context/define-toolkit.test.ts
+++ b/packages/core/src/react/model-context/define-toolkit.test.ts
@@ -1,10 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, expectTypeOf } from "vitest";
+import type { AsyncIterableStream } from "assistant-stream/utils";
 import { defineToolkit } from "./define-toolkit";
 import { hitl, hitlTool } from "./hitl";
 import { providerTool } from "./provider-tool";
 import type { ToolkitDefinition } from "./toolbox";
-
-const expectType = <T>(_value: T) => {};
 
 type TestStandardSchema<T> = {
   readonly "~standard": {
@@ -39,14 +38,20 @@ const checkDefineToolkitTypes = () => {
       }),
       streamCall: async (reader) => {
         const query = await reader.args.get("query");
-        expectType<string>(query);
+        expectTypeOf(query).toEqualTypeOf<string>();
 
-        expectType<AsyncIterable<string>>(reader.args.streamValues("query"));
-        expectType<AsyncIterable<unknown>>(reader.args.streamText("query"));
-        expectType<AsyncIterable<string>>(reader.args.forEach("tags"));
+        expectTypeOf(reader.args.streamValues("query")).toEqualTypeOf<
+          AsyncIterableStream<string>
+        >();
+        expectTypeOf(reader.args.streamText("query")).toEqualTypeOf<
+          AsyncIterableStream<unknown>
+        >();
+        expectTypeOf(reader.args.forEach("tags")).toEqualTypeOf<
+          AsyncIterableStream<string>
+        >();
 
         const response = await reader.response.get();
-        expectType<unknown>(response.result);
+        expectTypeOf(response.result).toEqualTypeOf<unknown>();
 
         // @ts-expect-error unknown argument paths should not be accepted
         reader.args.get("missing");
@@ -54,7 +59,7 @@ const checkDefineToolkitTypes = () => {
     },
   });
 };
-void checkDefineToolkitTypes;
+expectTypeOf(checkDefineToolkitTypes).toEqualTypeOf<() => void>();
 
 const checkToolkitDefinitionTypes = () => {
   ({
@@ -65,7 +70,7 @@ const checkToolkitDefinitionTypes = () => {
     },
   }) satisfies ToolkitDefinition;
 };
-void checkToolkitDefinitionTypes;
+expectTypeOf(checkToolkitDefinitionTypes).toEqualTypeOf<() => void>();
 
 describe("use-generative markers", () => {
   it("defineToolkit throws at runtime — it must be stripped by the compiler, never called", () => {

--- a/packages/core/src/react/model-context/define-toolkit.test.ts
+++ b/packages/core/src/react/model-context/define-toolkit.test.ts
@@ -23,14 +23,26 @@ const checkDefineToolkitTypes = () => {
       parameters: {} as TestStandardSchema<{
         query: string;
         limit?: number;
+        tags: string[];
       }>,
-      execute: async ({ query, limit }: { query: string; limit?: number }) => ({
+      execute: async ({
+        query,
+        limit,
+      }: {
+        query: string;
+        limit?: number;
+        tags: string[];
+      }) => ({
         ids: [query],
         count: limit ?? 0,
       }),
       streamCall: async (reader) => {
         const query = await reader.args.get("query");
         expectType<string>(query);
+
+        expectType<AsyncIterable<string>>(reader.args.streamValues("query"));
+        expectType<AsyncIterable<unknown>>(reader.args.streamText("query"));
+        expectType<AsyncIterable<string>>(reader.args.forEach("tags"));
 
         const response = await reader.response.get();
         expectType<unknown>(response.result);

--- a/packages/core/src/react/model-context/define-toolkit.test.ts
+++ b/packages/core/src/react/model-context/define-toolkit.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { defineToolkit } from "./define-toolkit";
 import { hitl, hitlTool } from "./hitl";
 import { providerTool } from "./provider-tool";
+import type { ToolkitDefinition } from "./toolbox";
 
 const expectType = <T>(_value: T) => {};
 
@@ -54,6 +55,17 @@ const checkDefineToolkitTypes = () => {
   });
 };
 void checkDefineToolkitTypes;
+
+const checkToolkitDefinitionTypes = () => {
+  ({
+    invalidMcp: {
+      // @ts-expect-error MCP-shaped tools cannot also declare an execute callback
+      server: { type: "http", url: "https://example.com/mcp" },
+      execute: async () => "invalid",
+    },
+  }) satisfies ToolkitDefinition;
+};
+void checkToolkitDefinitionTypes;
 
 describe("use-generative markers", () => {
   it("defineToolkit throws at runtime — it must be stripped by the compiler, never called", () => {

--- a/packages/core/src/react/model-context/define-toolkit.ts
+++ b/packages/core/src/react/model-context/define-toolkit.ts
@@ -1,4 +1,8 @@
-import type { Toolkit, ToolkitDefinition } from "./toolbox";
+import type {
+  Toolkit,
+  ToolkitDefinition,
+  ToolkitDefinitionEntryWithParameters,
+} from "./toolbox";
 
 /**
  * Authoring helper for a `"use generative"` toolkit. Accepts the permissive
@@ -13,6 +17,20 @@ import type { Toolkit, ToolkitDefinition } from "./toolbox";
  * outside a `"use generative"` file — which would ship a backend `execute` to the
  * client. So it throws instead of silently leaking.
  */
+export function defineToolkit<
+  TArgsByName extends {
+    [K in keyof TArgsByName]: Record<string, unknown>;
+  },
+  TResultByName extends { [K in keyof TArgsByName]: unknown } = {
+    [K in keyof TArgsByName]: unknown;
+  },
+>(_definition: {
+  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<
+    TArgsByName[K],
+    TResultByName[K]
+  >;
+}): Toolkit;
+export function defineToolkit(_definition: ToolkitDefinition): Toolkit;
 export function defineToolkit(_definition: ToolkitDefinition): Toolkit {
   throw new Error(
     "[assistant-ui] defineToolkit() has no runtime implementation — it is " +

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -153,6 +153,9 @@ export type Toolkit = Record<string, ToolDefinition<any, any>>;
  * directive → frontend; otherwise backend) and writes it back — so declaring it
  * here is a type error.
  */
+// Keep this authoring shape in sync with ToolDeclaration. It is spelled out so
+// callback fields can control inference while streamCall still infers from
+// schema-backed parameters.
 type ToolkitDefinitionInput<TArgs extends Record<string, unknown>, TResult> = {
   type?: never;
   description?: string | undefined;
@@ -196,7 +199,7 @@ export type ToolkitDefinitionEntryWithParameters<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
 > = ToolkitDefinitionInput<TArgs, TResult> & {
-  parameters: ToolParameters<TArgs, TResult>;
+  parameters: NonNullable<ToolParameters<TArgs, TResult>>;
 };
 
 /**

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -59,17 +59,9 @@ type ToolExecute<TArgs extends Record<string, unknown>, TResult> = (
   context: ToolExecuteContext,
 ) => TResult | Promise<TResult>;
 
-type ToolStreamCallContext = Parameters<
-  NonNullable<ToolDeclaration["streamCall"]>
->[1];
-
 type ToolStreamCall<TArgs extends Record<string, unknown>, TResult> = (
-  reader: {
-    args: ToolCallReader<TArgs, TResult>["args"];
-    response: ToolCallReader<TArgs, TResult>["response"];
-    result: ToolCallReader<TArgs, TResult>["result"];
-  },
-  context: ToolStreamCallContext,
+  reader: ToolCallReader<TArgs, TResult>,
+  context: ToolExecuteContext,
 ) => void;
 
 type ToolCallRunningText<TArgs extends Record<string, unknown>> =
@@ -113,10 +105,10 @@ export const makeToolCallTextComponent = <
   TResult,
 >(
   text: ToolCallText<TArgs, TResult>,
-) => {
+): ToolCallMessagePartComponent<TArgs, TResult> => {
   return function ToolCallTextComponent(part) {
     return resolveToolCallText(text, part);
-  } satisfies ToolCallMessagePartComponent<TArgs, TResult>;
+  };
 };
 
 /**

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -1,6 +1,4 @@
 import type {
-  McpServerConfig,
-  ProviderOptions,
   Tool,
   ToolCallReader,
   ToolDeclaration,
@@ -152,33 +150,71 @@ export type Toolkit = Record<string, ToolDefinition<any, any>>;
  * directive → frontend; otherwise backend) and writes it back — so declaring it
  * here is a type error.
  */
-// Keep this authoring shape in sync with ToolDeclaration. It is spelled out so
-// callback fields can control inference while streamCall still infers from
-// schema-backed parameters.
-type ToolkitDefinitionInput<TArgs extends Record<string, unknown>, TResult> = {
+type OverrideOptionalField<
+  T,
+  TKey extends keyof T,
+  TValue,
+> = undefined extends T[TKey]
+  ? Exclude<T[TKey], undefined> extends never
+    ? { [K in TKey]?: undefined }
+    : { [K in TKey]?: TValue | undefined }
+  : { [K in TKey]: TValue };
+
+type OverrideToolDeclarationCallbacks<
+  T,
+  TArgs extends Record<string, unknown>,
+  TResult,
+> = Omit<
+  T,
+  | "type"
+  | "execute"
+  | "toModelOutput"
+  | "experimental_onSchemaValidationError"
+  | "streamCall"
+> & {
   type?: never;
-  description?: string | undefined;
-  parameters?: ToolParameters<TArgs>;
-  disabled?: boolean | undefined;
-  display?: "standalone" | "inline" | undefined;
-  execute?: ToolExecute<NoInfer<TArgs>, TResult>;
-  toModelOutput?: ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>;
-  experimental_onSchemaValidationError?: (
-    args: unknown,
-    context: ToolExecuteContext,
-  ) => NoInfer<TResult> | Promise<NoInfer<TResult>>;
-  providerOptions?: ProviderOptions | undefined;
-  streamCall?: ToolStreamCall<TArgs, NoInfer<TResult>>;
-  providerId?: `${string}.${string}` | undefined;
-  args?: Record<string, unknown> | undefined;
-  supportsDeferredResults?: boolean | undefined;
-  server?: McpServerConfig | undefined;
-  render?: ToolCallMessagePartComponent<NoInfer<TArgs>, NoInfer<TResult>>;
-  renderText?: ToolCallText<NoInfer<TArgs>, NoInfer<TResult>>;
-  unstable_backendDefault?: {
-    parameters?: boolean;
-  };
-};
+} & ("execute" extends keyof T
+    ? OverrideOptionalField<T, "execute", ToolExecute<NoInfer<TArgs>, TResult>>
+    : {}) &
+  ("toModelOutput" extends keyof T
+    ? OverrideOptionalField<
+        T,
+        "toModelOutput",
+        ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>
+      >
+    : {}) &
+  ("experimental_onSchemaValidationError" extends keyof T
+    ? OverrideOptionalField<
+        T,
+        "experimental_onSchemaValidationError",
+        (
+          args: unknown,
+          context: ToolExecuteContext,
+        ) => NoInfer<TResult> | Promise<NoInfer<TResult>>
+      >
+    : {}) &
+  ("streamCall" extends keyof T
+    ? OverrideOptionalField<
+        T,
+        "streamCall",
+        ToolStreamCall<TArgs, NoInfer<TResult>>
+      >
+    : {});
+
+// Keep the authored shape tied to ToolDeclaration's union variants while
+// overriding callback fields to avoid inference pollution.
+type ToolkitDefinitionInput<
+  TArgs extends Record<string, unknown>,
+  TResult,
+> = WithRender<
+  ToolDeclaration<TArgs, TResult> extends infer T
+    ? T extends unknown
+      ? OverrideToolDeclarationCallbacks<T, TArgs, TResult>
+      : never
+    : never,
+  TArgs,
+  TResult
+>;
 
 /**
  * A single entry in a {@link ToolkitDefinition}.

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -1,4 +1,11 @@
-import type { Tool, ToolDeclaration } from "assistant-stream";
+import type {
+  McpServerConfig,
+  ProviderOptions,
+  Tool,
+  ToolCallReader,
+  ToolDeclaration,
+  ToolModelOutputFunction,
+} from "assistant-stream";
 import type { ReactNode } from "react";
 import type {
   ToolCallMessagePartComponent,
@@ -37,6 +44,33 @@ type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
       render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
       renderText?: ToolCallText<TArgs, TResult> | undefined;
     };
+
+type ToolParameters<
+  TArgs extends Record<string, unknown>,
+  _TResult = unknown,
+> = ToolDeclaration<TArgs, _TResult>["parameters"];
+
+type ToolExecuteContext = Parameters<
+  NonNullable<ToolDeclaration["execute"]>
+>[1];
+
+type ToolExecute<TArgs extends Record<string, unknown>, TResult> = (
+  args: TArgs,
+  context: ToolExecuteContext,
+) => TResult | Promise<TResult>;
+
+type ToolStreamCallContext = Parameters<
+  NonNullable<ToolDeclaration["streamCall"]>
+>[1];
+
+type ToolStreamCall<TArgs extends Record<string, unknown>, TResult> = (
+  reader: {
+    args: ToolCallReader<TArgs, TResult>["args"];
+    response: ToolCallReader<TArgs, TResult>["response"];
+    result: ToolCallReader<TArgs, TResult>["result"];
+  },
+  context: ToolStreamCallContext,
+) => void;
 
 type ToolCallRunningText<TArgs extends Record<string, unknown>> =
   | ReactNode
@@ -79,10 +113,10 @@ export const makeToolCallTextComponent = <
   TResult,
 >(
   text: ToolCallText<TArgs, TResult>,
-): ToolCallMessagePartComponent<TArgs, TResult> => {
+) => {
   return function ToolCallTextComponent(part) {
     return resolveToolCallText(text, part);
-  };
+  } satisfies ToolCallMessagePartComponent<TArgs, TResult>;
 };
 
 /**
@@ -94,8 +128,8 @@ export const makeToolCallTextComponent = <
  * and result. Backend tools execute server-side and may omit a renderer.
  */
 export type ToolDefinition<
-  TArgs extends Record<string, unknown>,
-  TResult,
+  TArgs extends Record<string, unknown> = Record<string, unknown>,
+  TResult = unknown,
 > = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
 
 /**
@@ -127,15 +161,29 @@ export type Toolkit = Record<string, ToolDefinition<any, any>>;
  * directive → frontend; otherwise backend) and writes it back — so declaring it
  * here is a type error.
  */
-type ToolkitDefinitionInput<
-  TArgs extends Record<string, unknown>,
-  TResult,
-> = WithRender<
-  Omit<ToolDeclaration<TArgs, TResult>, "type">,
-  TArgs,
-  TResult
-> & {
+type ToolkitDefinitionInput<TArgs extends Record<string, unknown>, TResult> = {
   type?: never;
+  description?: string | undefined;
+  parameters?: ToolParameters<TArgs, TResult>;
+  disabled?: boolean | undefined;
+  display?: "standalone" | "inline" | undefined;
+  execute?: ToolExecute<NoInfer<TArgs>, TResult>;
+  toModelOutput?: ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>;
+  experimental_onSchemaValidationError?: ToolExecute<
+    Record<string, unknown>,
+    NoInfer<TResult>
+  >;
+  providerOptions?: ProviderOptions | undefined;
+  streamCall?: ToolStreamCall<TArgs, NoInfer<TResult>>;
+  providerId?: `${string}.${string}` | undefined;
+  args?: Record<string, unknown> | undefined;
+  supportsDeferredResults?: boolean | undefined;
+  server?: McpServerConfig | undefined;
+  render?: ToolCallMessagePartComponent<NoInfer<TArgs>, NoInfer<TResult>>;
+  renderText?: ToolCallText<NoInfer<TArgs>, NoInfer<TResult>>;
+  unstable_backendDefault?: {
+    parameters?: boolean;
+  };
 };
 
 /**
@@ -147,16 +195,36 @@ type ToolkitDefinitionInput<
  * carries a `type`, so it can only match the {@link ToolDefinition} arm of this
  * union.
  */
-export type ToolkitDefinitionEntry =
-  | ToolkitDefinitionInput<any, any>
-  | ToolDefinition<any, any>;
+export type ToolkitDefinitionEntry<
+  TArgs extends Record<string, unknown> = Record<string, unknown>,
+  TResult = unknown,
+> = ToolkitDefinitionInput<TArgs, TResult> | ToolDefinition<any, any>;
+
+export type ToolkitDefinitionEntryWithParameters<
+  TArgs extends Record<string, unknown> = Record<string, unknown>,
+  TResult = unknown,
+> = ToolkitDefinitionInput<TArgs, TResult> & {
+  parameters: ToolParameters<TArgs, TResult>;
+};
 
 /**
  * The permissive, authoring-time counterpart to {@link Toolkit} — the input to
  * {@link defineToolkit}. Backend entries may carry their server `execute` here;
  * the canonical {@link Toolkit} keeps those fields `undefined`.
  */
-export type ToolkitDefinition = Record<string, ToolkitDefinitionEntry>;
+export type ToolkitDefinition<
+  TArgsByName extends {
+    [K in keyof TArgsByName]: Record<string, unknown>;
+  } = Record<string, any>,
+  TResultByName extends { [K in keyof TArgsByName]: unknown } = {
+    [K in keyof TArgsByName]: any;
+  },
+> = {
+  [K in keyof TArgsByName]: ToolkitDefinitionEntry<
+    TArgsByName[K],
+    TResultByName[K]
+  >;
+};
 
 /** Configuration for the {@link Tools} resource. */
 export type ToolsConfig = {

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -155,13 +155,15 @@ type OverrideOptionalField<
   TKey extends keyof T,
   TValue,
 > = undefined extends T[TKey]
-  ? Exclude<T[TKey], undefined> extends never
+  ? // Preserve `?: undefined` fields (for variants that explicitly disallow a
+    // callback) instead of widening them to accept the override value.
+    Exclude<T[TKey], undefined> extends never
     ? { [K in TKey]?: undefined }
     : { [K in TKey]?: TValue | undefined }
   : { [K in TKey]: TValue };
 
 type OverrideToolDeclarationCallbacks<
-  T,
+  T extends { streamCall?: unknown },
   TArgs extends Record<string, unknown>,
   TResult,
 > = Omit<
@@ -193,13 +195,11 @@ type OverrideToolDeclarationCallbacks<
         ) => NoInfer<TResult> | Promise<NoInfer<TResult>>
       >
     : {}) &
-  ("streamCall" extends keyof T
-    ? OverrideOptionalField<
-        T,
-        "streamCall",
-        ToolStreamCall<TArgs, NoInfer<TResult>>
-      >
-    : {});
+  OverrideOptionalField<
+    T,
+    "streamCall",
+    ToolStreamCall<TArgs, NoInfer<TResult>>
+  >;
 
 // Keep the authored shape tied to ToolDeclaration's union variants while
 // overriding callback fields to avoid inference pollution.
@@ -208,7 +208,7 @@ type ToolkitDefinitionInput<
   TResult,
 > = WithRender<
   ToolDeclaration<TArgs, TResult> extends infer T
-    ? T extends unknown
+    ? T extends { streamCall?: unknown }
       ? OverrideToolDeclarationCallbacks<T, TArgs, TResult>
       : never
     : never,

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -45,11 +45,10 @@ type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
       renderText?: ToolCallText<TArgs, TResult> | undefined;
     };
 
-type ToolParameters<
-  TArgs extends Record<string, unknown>,
-  _TResult = unknown,
-> = ToolDeclaration<TArgs, _TResult>["parameters"];
+type ToolParameters<TArgs extends Record<string, unknown>> =
+  ToolDeclaration<TArgs>["parameters"];
 
+// ToolExecutionContext is not re-exported from assistant-stream's public entry.
 type ToolExecuteContext = Parameters<
   NonNullable<ToolDeclaration["execute"]>
 >[1];
@@ -159,15 +158,15 @@ export type Toolkit = Record<string, ToolDefinition<any, any>>;
 type ToolkitDefinitionInput<TArgs extends Record<string, unknown>, TResult> = {
   type?: never;
   description?: string | undefined;
-  parameters?: ToolParameters<TArgs, TResult>;
+  parameters?: ToolParameters<TArgs>;
   disabled?: boolean | undefined;
   display?: "standalone" | "inline" | undefined;
   execute?: ToolExecute<NoInfer<TArgs>, TResult>;
   toModelOutput?: ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>;
-  experimental_onSchemaValidationError?: ToolExecute<
-    Record<string, unknown>,
-    NoInfer<TResult>
-  >;
+  experimental_onSchemaValidationError?: (
+    args: unknown,
+    context: ToolExecuteContext,
+  ) => NoInfer<TResult> | Promise<NoInfer<TResult>>;
   providerOptions?: ProviderOptions | undefined;
   streamCall?: ToolStreamCall<TArgs, NoInfer<TResult>>;
   providerId?: `${string}.${string}` | undefined;
@@ -199,7 +198,7 @@ export type ToolkitDefinitionEntryWithParameters<
   TArgs extends Record<string, unknown> = Record<string, unknown>,
   TResult = unknown,
 > = ToolkitDefinitionInput<TArgs, TResult> & {
-  parameters: NonNullable<ToolParameters<TArgs, TResult>>;
+  parameters: NonNullable<ToolParameters<TArgs>>;
 };
 
 /**


### PR DESCRIPTION
## Summary
- infer `defineToolkit` tool argument types from Standard Schema `parameters` for `streamCall` readers
- keep the permissive fallback overload for existing user code and factory-produced tools
- add a type coverage case for `reader.args.get(...)` paths plus a patch changeset

## Validation
- `pnpm exec oxfmt --check packages/core/src/react/model-context/define-toolkit.ts packages/core/src/react/model-context/toolbox.ts packages/core/src/react/model-context/define-toolkit.test.ts .changeset/define-toolkit-stream-call-types.md`
- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
- `pnpm --filter @assistant-ui/core test`
- `pnpm lint`
- `pnpm --filter @assistant-ui/core build`
- `pnpm --filter @assistant-ui/react build`
- `pnpm --filter @assistant-ui/react-ai-sdk build`

## Note
- `pnpm build` still fails outside this change in `@assistant-ui/devtools-extension#build`: esbuild cannot resolve `@assistant-ui/react` from `packages/react-devtools/dist/DevToolsHost.js` (`./dist/index.js` missing via that package link).

Not merging yet per request.