### PR TITLE
fix(react-ag-ui): preserve frontend tool results and auto-continue across RUN_FINISHED

### DIFF
--- a/.changeset/agui-frontend-tool-result-resume.md
+++ b/.changeset/agui-frontend-tool-result-resume.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: preserve frontend tool results and auto-continue when they resolve before RUN_FINISHED

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -11,6 +11,7 @@ import type {
   ThreadAssistantMessage,
   ThreadHistoryAdapter,
   ThreadMessage,
+  ToolCallMessagePart,
 } from "@assistant-ui/core";
 import type { HttpAgent } from "@ag-ui/client";
 import jsonpatch, { type Operation } from "fast-json-patch";
@@ -78,6 +79,7 @@ export class AgUiThreadRuntimeCore {
   private readonly recordedHistoryIds = new Set<string>();
   private _isLoading = false;
   private _loadPromise: Promise<void> | undefined;
+  private pendingResumeMessageId: string | null = null;
 
   constructor(options: CoreOptions) {
     this.agent = options.agent;
@@ -368,7 +370,6 @@ export class AgUiThreadRuntimeCore {
 
   addToolResult(options: AddToolResultOptions): void {
     let updated = false;
-    let shouldResume = false;
     this.messages = this.messages.map((message) => {
       if (message.id !== options.messageId || message.role !== "assistant")
         return message;
@@ -387,47 +388,60 @@ export class AgUiThreadRuntimeCore {
       });
       if (!matchedToolCall) return message;
       updated = true;
-
-      if (
-        assistant.status?.type === "requires-action" &&
-        assistant.status.reason === "tool-calls" &&
-        content.every(
-          (part) =>
-            part.type !== "tool-call" ||
-            ("result" in part && part.result !== undefined),
-        )
-      ) {
-        shouldResume = true;
-        return {
-          ...assistant,
-          content,
-          status: { type: "complete" as const, reason: "unknown" as const },
-        };
-      }
-
-      return {
-        ...assistant,
-        content,
-      };
+      return { ...assistant, content };
     });
 
-    if (updated) {
-      this.notifyUpdate();
+    if (!updated) return;
+    this.notifyUpdate();
+    this.maybeResumeAfterToolResults(options.messageId);
+  }
 
-      if (shouldResume) {
-        this.persistAssistantHistory(options.messageId);
-
-        if (!this.isRunningFlag) {
-          void this.startRun(options.messageId, this.lastRunConfig).catch(
-            (error) => {
-              this.onError?.(
-                error instanceof Error ? error : new Error(String(error)),
-              );
-            },
-          );
-        }
-      }
+  // Re-evaluate whether every tool call on the assistant message now has a
+  // result and, if so, drive the follow-up run. Centralizing this lets the
+  // continuation fire whether the frontend result lands before RUN_FINISHED
+  // (status flips to requires-action only later, while a run is still draining)
+  // or after it. Idempotent: once the message is marked complete it no-ops.
+  private maybeResumeAfterToolResults(messageId: string): void {
+    const message = this.messages.find((m) => m.id === messageId);
+    if (!message || message.role !== "assistant") return;
+    const assistant = message as ThreadAssistantMessage;
+    if (
+      assistant.status?.type !== "requires-action" ||
+      assistant.status.reason !== "tool-calls"
+    ) {
+      return;
     }
+    const allResolved = assistant.content.every(
+      (part) =>
+        part.type !== "tool-call" ||
+        ("result" in part && part.result !== undefined),
+    );
+    if (!allResolved) return;
+
+    this.messages = this.messages.map((m) =>
+      m.id === messageId && m.role === "assistant"
+        ? {
+            ...(m as ThreadAssistantMessage),
+            status: { type: "complete" as const, reason: "unknown" as const },
+          }
+        : m,
+    );
+    this.notifyUpdate();
+    this.persistAssistantHistory(messageId);
+
+    if (this.isRunningFlag) {
+      // A run is still draining (RUN_FINISHED arrived but the stream has not
+      // closed). Defer until startRun's tail so we never start two runs.
+      this.pendingResumeMessageId = messageId;
+      return;
+    }
+    this.startResumeRun(messageId);
+  }
+
+  private startResumeRun(messageId: string): void {
+    void this.startRun(messageId, this.lastRunConfig).catch((error) => {
+      this.onError?.(error instanceof Error ? error : new Error(String(error)));
+    });
   }
 
   applyExternalMessages(messages: readonly ThreadMessage[]): void {
@@ -563,6 +577,16 @@ export class AgUiThreadRuntimeCore {
       const err = this.pendingError;
       this.pendingError = null;
       throw err;
+    }
+
+    // A tool result that landed before the run settled deferred its
+    // continuation here so a second run never overlaps the first.
+    if (this.pendingResumeMessageId !== null) {
+      const resumeMessageId = this.pendingResumeMessageId;
+      this.pendingResumeMessageId = null;
+      if (!abortSignal.aborted) {
+        this.startResumeRun(resumeMessageId);
+      }
     }
   }
 
@@ -753,10 +777,16 @@ export class AgUiThreadRuntimeCore {
         ? this.mergeAssistantMetadata(assistant.metadata, update.metadata)
         : assistant.metadata;
       latestStatus = update.status ?? assistant.status;
+      const content =
+        update.content !== undefined
+          ? this.preserveToolResults(
+              assistant.content,
+              update.content as ThreadAssistantMessage["content"],
+            )
+          : assistant.content;
       return {
         ...assistant,
-        content: (update.content ??
-          assistant.content) as ThreadAssistantMessage["content"],
+        content,
         status: latestStatus,
         metadata,
       };
@@ -776,7 +806,45 @@ export class AgUiThreadRuntimeCore {
     if (this.isPersistableStatus(latestStatus)) {
       this.persistAssistantHistory(resolvedMessageId);
     }
+    this.maybeResumeAfterToolResults(resolvedMessageId);
     return resolvedMessageId;
+  }
+
+  // The RunAggregator rebuilds the assistant content from stream events only,
+  // so a fresh snapshot omits results injected via addToolResult (frontend tool
+  // execution). Carry those results forward so the aggregator never clobbers
+  // them. Results are only ever added in this flow, so preserving is safe.
+  private preserveToolResults(
+    previous: ThreadAssistantMessage["content"],
+    next: ThreadAssistantMessage["content"],
+  ): ThreadAssistantMessage["content"] {
+    const resolved = new Map<string, ToolCallMessagePart>();
+    for (const part of previous) {
+      if (
+        part.type === "tool-call" &&
+        "result" in part &&
+        part.result !== undefined
+      ) {
+        resolved.set(part.toolCallId, part);
+      }
+    }
+    if (resolved.size === 0) return next;
+
+    let changed = false;
+    const merged = next.map((part) => {
+      if (part.type !== "tool-call") return part;
+      if ("result" in part && part.result !== undefined) return part;
+      const prior = resolved.get(part.toolCallId);
+      if (!prior) return part;
+      changed = true;
+      return {
+        ...part,
+        result: prior.result,
+        ...(prior.artifact !== undefined ? { artifact: prior.artifact } : {}),
+        ...(prior.isError !== undefined ? { isError: prior.isError } : {}),
+      };
+    });
+    return changed ? (merged as ThreadAssistantMessage["content"]) : next;
   }
 
   private mergeAssistantMetadata(

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -576,6 +576,7 @@ export class AgUiThreadRuntimeCore {
     if (this.pendingError) {
       const err = this.pendingError;
       this.pendingError = null;
+      this.pendingResumeMessageId = null;
       throw err;
     }
 

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -834,6 +834,59 @@ describe("AGUIThreadRuntimeCore", () => {
     ).toEqual(["call-1", "call-2"]);
   });
 
+  it("does not leak a deferred resume into a later run when the run errors", async () => {
+    let runCount = 0;
+    let core!: AgUiThreadRuntimeCore;
+    const onError = vi.fn();
+
+    const agent = {
+      runAgent: vi.fn(async (input: any, subscriber: any) => {
+        runCount++;
+        if (runCount === 1) {
+          subscriber.onToolCallStartEvent?.({
+            event: {
+              type: "TOOL_CALL_START",
+              toolCallId: "call-1",
+              toolCallName: "tool_a",
+            },
+          });
+          subscriber.onToolCallEndEvent?.({
+            event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+          });
+          const assistantMsg = core
+            .getMessages()
+            .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+          core.addToolResult({
+            messageId: assistantMsg.id,
+            toolCallId: "call-1",
+            toolName: "tool_a",
+            result: "ok",
+            isError: false,
+          });
+          // RUN_FINISHED defers the resume (the run is still draining)...
+          subscriber.onRunFinishedEvent?.({
+            event: { type: "RUN_FINISHED", runId: input.runId },
+          });
+          // ...then the run errors before the deferred resume can fire.
+          throw new Error("boom");
+        }
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    core = createCore(agent, { onError });
+
+    await expect(core.append(createAppendMessage())).rejects.toThrow("boom");
+    await new Promise((r) => setTimeout(r, 0));
+    // The errored run must not have scheduled a resume.
+    expect(runCount).toBe(1);
+
+    // A later run must not pick up the stale deferred resume.
+    await core.reload(null);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(runCount).toBe(2);
+  });
+
   it("resumes runs when requested", async () => {
     const runAgent = vi.fn(async (_input, subscriber) => {
       subscriber.onRunFinalized?.();

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -666,6 +666,174 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(runAgent).toHaveBeenCalledTimes(1);
   });
 
+  it("auto-resumes when a tool result is added before RUN_FINISHED", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    let core!: AgUiThreadRuntimeCore;
+
+    const agent = {
+      runAgent: vi.fn(async (input: any, subscriber: any) => {
+        runInputs.push(JSON.parse(JSON.stringify(input)));
+        runCount++;
+
+        if (runCount === 1) {
+          subscriber.onToolCallStartEvent?.({
+            event: {
+              type: "TOOL_CALL_START",
+              toolCallId: "call-1",
+              toolCallName: "get_weather",
+            },
+          });
+          subscriber.onToolCallArgsEvent?.({
+            event: {
+              type: "TOOL_CALL_ARGS",
+              toolCallId: "call-1",
+              delta: '{"city":"Paris"}',
+            },
+          });
+          subscriber.onToolCallEndEvent?.({
+            event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+          });
+          // Frontend tool resolves while the run is still streaming, before
+          // RUN_FINISHED transitions the message to requires-action.
+          const assistantMsg = core
+            .getMessages()
+            .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+          core.addToolResult({
+            messageId: assistantMsg.id,
+            toolCallId: "call-1",
+            toolName: "get_weather",
+            result: { temperature: "22C" },
+            isError: false,
+          });
+          subscriber.onRunFinalized?.();
+        } else {
+          subscriber.onTextMessageContentEvent?.({
+            event: { type: "TEXT_MESSAGE_CONTENT", delta: "It is sunny!" },
+          });
+          subscriber.onRunFinalized?.();
+        }
+      }),
+    } as unknown as HttpAgent;
+
+    core = createCore(agent);
+    await core.append(createAppendMessage());
+    // Let the deferred follow-up run (scheduled at startRun's tail) settle.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(runCount).toBe(2);
+
+    // The result survives the RUN_FINISHED snapshot instead of being clobbered.
+    const assistant = core
+      .getMessages()
+      .find(
+        (m) =>
+          m.role === "assistant" &&
+          m.content.some((p) => p.type === "tool-call"),
+      ) as ThreadAssistantMessage;
+    const toolPart = assistant.content.find(
+      (p) => p.type === "tool-call",
+    ) as any;
+    expect(toolPart.result).toEqual({ temperature: "22C" });
+    expect(assistant.status).toMatchObject({ type: "complete" });
+
+    // The follow-up run carries the tool result back to the backend.
+    const run2Messages = runInputs[1]?.messages ?? [];
+    const toolResultMsg = run2Messages.find(
+      (m: { role: string }) => m.role === "tool",
+    );
+    expect(toolResultMsg).toBeTruthy();
+    expect(toolResultMsg.toolCallId).toBe("call-1");
+    expect(toolResultMsg.content).toContain("22C");
+  });
+
+  it("resumes once all parallel tool results arrive across the RUN_FINISHED boundary", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    let core!: AgUiThreadRuntimeCore;
+
+    const agent = {
+      runAgent: vi.fn(async (input: any, subscriber: any) => {
+        runInputs.push(JSON.parse(JSON.stringify(input)));
+        runCount++;
+
+        if (runCount === 1) {
+          subscriber.onToolCallStartEvent?.({
+            event: {
+              type: "TOOL_CALL_START",
+              toolCallId: "call-1",
+              toolCallName: "tool_a",
+            },
+          });
+          subscriber.onToolCallEndEvent?.({
+            event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+          });
+          subscriber.onToolCallStartEvent?.({
+            event: {
+              type: "TOOL_CALL_START",
+              toolCallId: "call-2",
+              toolCallName: "tool_b",
+            },
+          });
+          subscriber.onToolCallEndEvent?.({
+            event: { type: "TOOL_CALL_END", toolCallId: "call-2" },
+          });
+          // Only the first parallel call resolves before the run finishes.
+          const assistantMsg = core
+            .getMessages()
+            .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+          core.addToolResult({
+            messageId: assistantMsg.id,
+            toolCallId: "call-1",
+            toolName: "tool_a",
+            result: "ra",
+            isError: false,
+          });
+          subscriber.onRunFinalized?.();
+        } else {
+          subscriber.onRunFinalized?.();
+        }
+      }),
+    } as unknown as HttpAgent;
+
+    core = createCore(agent);
+    await core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+
+    // call-2 is still pending, so no follow-up yet, and call-1's early result
+    // is preserved rather than wiped by RUN_FINISHED.
+    expect(runCount).toBe(1);
+    const pending = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    expect(pending.status).toMatchObject({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+    const call1 = pending.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "call-1",
+    ) as any;
+    expect(call1.result).toBe("ra");
+
+    // The remaining call resolves later; now the follow-up fires with both.
+    core.addToolResult({
+      messageId: pending.id,
+      toolCallId: "call-2",
+      toolName: "tool_b",
+      result: "rb",
+      isError: false,
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(runCount).toBe(2);
+    const toolMsgs = (runInputs[1]?.messages ?? []).filter(
+      (m: { role: string }) => m.role === "tool",
+    );
+    expect(
+      toolMsgs.map((m: { toolCallId: string }) => m.toolCallId).sort(),
+    ).toEqual(["call-1", "call-2"]);
+  });
+
   it("resumes runs when requested", async () => {
     const runAgent = vi.fn(async (_input, subscriber) => {
       subscriber.onRunFinalized?.();


### PR DESCRIPTION
## Summary

Fixes the AG-UI frontend-tool race conditions described in #4240.

In `@assistant-ui/react-ag-ui`, the assistant message had **two independent writers**: `RunAggregator` (which rebuilds the whole `content` from AG-UI stream events and knows nothing about frontend-injected results) and `addToolResult` (which patches `part.result` directly). When a **frontend tool** resolved *before* `RUN_FINISHED`:

1. the result was clobbered by the aggregator snapshot at `RUN_FINISHED`, and
2. the auto-continue never fired, because it was only evaluated at the instant `addToolResult` ran and required the status to *already* be `requires-action`/`tool-calls`.

A fast frontend tool (compute, read local state, etc.) therefore lost its result and the thread hung in `requires-action` with a resultless tool call — even though the tool's side effect had already run. Slow tools (e.g. the bundled `browser_alert`, which blocks on `alert()`) resolved after `RUN_FINISHED` and happened to work, which is the only path the tests covered.

## Changes

- **`preserveToolResults()`** — when `updateAssistantMessage` applies a fresh aggregator snapshot, results previously injected via `addToolResult` are carried forward so they are never wiped (results are only ever added in this flow, so preserving is safe).
- **`maybeResumeAfterToolResults()`** — centralizes the continuation decision so it is re-evaluated both from `addToolResult` and from the aggregator's status transition at `RUN_FINISHED`. When a run is still draining (`RUN_FINISHED` seen but the stream not yet closed), it defers the follow-up to `startRun`'s tail so a second run never overlaps the first.

This makes the auto-continue robust regardless of whether the result lands before or after `RUN_FINISHED`, including **parallel tool calls** whose results straddle the boundary.

## Tests

- `auto-resumes when a tool result is added before RUN_FINISHED` — asserts the result survives the `RUN_FINISHED` snapshot, the message settles to `complete`, and the follow-up run carries the result to the backend.
- `resumes once all parallel tool results arrive across the RUN_FINISHED boundary` — one parallel result lands before `RUN_FINISHED` (preserved, no premature continue), the other after; the follow-up then fires with both results.

`pnpm --filter @assistant-ui/react-ag-ui test` (114 passed), `pnpm lint`, and `pnpm turbo build --filter=@assistant-ui/react-ag-ui` all pass.

Closes #4240
