### PR TITLE
fix(react-ink): block Enter submission while running unless runtime supports queueing

### DIFF
--- a/.changeset/fix-react-ink-composer-send-gate.md
+++ b/.changeset/fix-react-ink-composer-send-gate.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix(react-ink): block Enter submission while the thread is running unless the runtime supports queueing. `ComposerInput` called `composer().send()` unconditionally, so pressing Enter mid-run interrupted the active stream even on runtimes with `capabilities.queue: false`. It now applies the same gate as the web `ComposerInput` (`isRunning && !capabilities.queue` no-ops, keeping the typed text). The `onSubmit` override path is unaffected; apps using it own their submit behavior.

--- a/packages/react-ink/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerInput.tsx
@@ -80,6 +80,9 @@ export const ComposerInput = ({
       return;
     }
 
+    const threadState = aui.thread().getState();
+    if (threadState.isRunning && !threadState.capabilities.queue) return;
+
     aui.composer().send();
   };
 

--- a/packages/react-ink/src/tests/ComposerInput.test.tsx
+++ b/packages/react-ink/src/tests/ComposerInput.test.tsx
@@ -139,6 +139,63 @@ describe("ComposerInput", () => {
         send,
         setText: vi.fn(),
       }),
+      thread: () => ({
+        getState: () => ({ isRunning: false, capabilities: { queue: false } }),
+      }),
+    });
+    mockUseFocus.mockReturnValue({ isFocused: true });
+
+    render(<ComposerInput submitOnEnter />);
+    await flush();
+
+    inputHandler?.("", { return: true });
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not send on enter while the thread is running without queue support", async () => {
+    const send = vi.fn(() => undefined);
+    const buffer = createBuffer("hello");
+
+    mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) =>
+      selector({ composer: { text: "hello" } } as never),
+    );
+    mockUseTextBuffer.mockReturnValue(buffer);
+    mockUseAui.mockReturnValue({
+      composer: () => ({
+        send,
+        setText: vi.fn(),
+      }),
+      thread: () => ({
+        getState: () => ({ isRunning: true, capabilities: { queue: false } }),
+      }),
+    });
+    mockUseFocus.mockReturnValue({ isFocused: true });
+
+    render(<ComposerInput submitOnEnter />);
+    await flush();
+
+    inputHandler?.("", { return: true });
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("sends on enter while running when the runtime supports queueing", async () => {
+    const send = vi.fn(() => undefined);
+    const buffer = createBuffer("hello");
+
+    mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) =>
+      selector({ composer: { text: "hello" } } as never),
+    );
+    mockUseTextBuffer.mockReturnValue(buffer);
+    mockUseAui.mockReturnValue({
+      composer: () => ({
+        send,
+        setText: vi.fn(),
+      }),
+      thread: () => ({
+        getState: () => ({ isRunning: true, capabilities: { queue: true } }),
+      }),
     });
     mockUseFocus.mockReturnValue({ isFocused: true });
 


### PR DESCRIPTION
### Summary
`ComposerInput`'s submit path called `aui.composer().send()` unconditionally, bypassing the gate that `useComposerSend` applies. On runtimes without queue support (`capabilities.queue: false`, e.g. the local runtime), pressing Enter mid-run interrupted the active stream and started a new turn.

Web's `ComposerInput` blocks this case on keypress (`if (threadState.isRunning && !hasQueue) return;`) and additionally no-ops at the form layer via `useComposerSend` returning null when disabled. This applies the same gate to the ink default send path: Enter while running without queue support is a silent no-op and the typed text stays in the composer. When the runtime does support queueing, Enter still sends (queues) as before.

The `onSubmit` override path is intentionally left ungated; apps using it own their submit behavior (e.g. custom queueing).

### Tests
Two new cases (running + no queue does not send; running + queue sends), plus the existing idle-case submit test updated for the thread-state read. Verified the no-queue test fails on the previous code. Full react-ink suite: 202 passing. Patch changeset included.
