### PR TITLE
feat(metro): @assistant-ui/metro for "use generative" on React Native

### DIFF
--- a/.changeset/metro-use-generative.md
+++ b/.changeset/metro-use-generative.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/metro": patch
+---
+
+feat: add `@assistant-ui/metro` — the `"use generative"` directive compiler for Expo / React Native, so RN apps author tools with the same `defineToolkit` API as the web via `withAui` in `metro.config.js`

--- a/apps/docs/content/docs/react-native/hooks.mdx
+++ b/apps/docs/content/docs/react-native/hooks.mdx
@@ -116,7 +116,7 @@ const runtime = useRemoteThreadListRuntime({
 
 ### Tools
 
-Author tools in a `"use generative"` file with `defineToolkit` — the same API as on the web ([Defining Tools](/docs/tools/defining-tools)). The tool definition is forwarded to the model; when the model calls it, the `execute` function runs and the `render` component displays the result.
+Author tools in a `"use generative"` file with `defineToolkit`, the same API as on the web ([Defining Tools](/docs/tools/defining-tools)). The tool definition is forwarded to the model; when the model calls it, the `execute` function runs and the `render` component displays the result.
 
 Add the [`@assistant-ui/metro`](https://www.npmjs.com/package/@assistant-ui/metro) plugin so Metro compiles the `"use generative"` directive:
 

--- a/apps/docs/content/docs/react-native/hooks.mdx
+++ b/apps/docs/content/docs/react-native/hooks.mdx
@@ -116,39 +116,47 @@ const runtime = useRemoteThreadListRuntime({
 
 ### Tools
 
-Register tools with a toolkit. The tool definition is forwarded to the model, and when the model calls it, the `execute` function runs and the `render` component displays the result.
+Author tools in a `"use generative"` file with `defineToolkit` — the same API as on the web ([Defining Tools](/docs/tools/defining-tools)). The tool definition is forwarded to the model; when the model calls it, the `execute` function runs and the `render` component displays the result.
+
+Add the [`@assistant-ui/metro`](https://www.npmjs.com/package/@assistant-ui/metro) plugin so Metro compiles the `"use generative"` directive:
+
+```js title="metro.config.js"
+const { getDefaultConfig } = require("expo/metro-config");
+const { withAui } = require("@assistant-ui/metro");
+
+module.exports = withAui(getDefaultConfig(__dirname));
+```
 
 ```tsx title="weather-toolkit.tsx"
-import type { Toolkit } from "@assistant-ui/react-native";
-import { Text, View } from "react-native";
+"use generative";
 
-export const toolkit = {
+import { defineToolkit } from "@assistant-ui/react-native";
+import { Text, View } from "react-native";
+import { z } from "zod";
+
+export default defineToolkit({
   get_weather: {
-    type: "frontend",
     description: "Get the current weather for a city",
-    parameters: {
-      type: "object",
-      properties: {
-        city: { type: "string" },
-      },
-      required: ["city"],
-    },
+    parameters: z.object({ city: z.string() }),
     execute: async ({ city }) => {
+      "use client";
       const res = await fetch(`https://api.weather.example/${city}`);
       return res.json();
     },
     render: ({ args, result }) => (
       <View>
-        <Text>{args.city}: {result?.temperature}°F</Text>
+        <Text>
+          {args.city}: {result?.temperature}°F
+        </Text>
       </View>
     ),
   },
-} satisfies Toolkit;
+});
 ```
 
 ```tsx title="ToolProvider.tsx"
 import { AuiProvider, Tools, useAui } from "@assistant-ui/react-native";
-import { toolkit } from "./weather-toolkit";
+import toolkit from "./weather-toolkit";
 
 function ToolProvider({ children }: { children: React.ReactNode }) {
   const aui = useAui({ tools: Tools({ toolkit }) });

--- a/apps/docs/content/docs/tools/defining-tools.mdx
+++ b/apps/docs/content/docs/tools/defining-tools.mdx
@@ -55,7 +55,7 @@ export default defineConfig({
 });
 ```
 
-For Expo / React Native, wrap your Metro config with `withAui`:
+For Expo, wrap your Metro config with `withAui`:
 
 ```js title="metro.config.js"
 const { getDefaultConfig } = require("expo/metro-config");
@@ -63,6 +63,8 @@ const { withAui } = require("@assistant-ui/metro");
 
 module.exports = withAui(getDefaultConfig(__dirname));
 ```
+
+For a bare React Native app, import `getDefaultConfig` from `@react-native/metro-config` instead of `expo/metro-config`.
 
 </Step>
 <Step>

--- a/apps/docs/content/docs/tools/defining-tools.mdx
+++ b/apps/docs/content/docs/tools/defining-tools.mdx
@@ -55,6 +55,15 @@ export default defineConfig({
 });
 ```
 
+For Expo / React Native, wrap your Metro config with `withAui`:
+
+```js title="metro.config.js"
+const { getDefaultConfig } = require("expo/metro-config");
+const { withAui } = require("@assistant-ui/metro");
+
+module.exports = withAui(getDefaultConfig(__dirname));
+```
+
 </Step>
 <Step>
 

--- a/examples/with-expo/app/_layout.tsx
+++ b/examples/with-expo/app/_layout.tsx
@@ -18,7 +18,7 @@ import {
 } from "@assistant-ui/react-native";
 import { useAppRuntime } from "@/hooks/use-app-runtime";
 import { ThreadListDrawer } from "@/components/thread-list/ThreadListDrawer";
-import { expoToolkit } from "@/components/assistant-ui/tools";
+import toolkit from "@/components/assistant-ui/tools";
 
 function NewChatButton() {
   const aui = useAui();
@@ -66,7 +66,7 @@ export default function RootLayout() {
   const [fontsLoaded] = useFonts(Ionicons.font);
   const runtime = useAppRuntime();
   const aui = useAui({
-    tools: Tools({ toolkit: expoToolkit }),
+    tools: Tools({ toolkit }),
   });
 
   if (!fontsLoaded) return null;

--- a/examples/with-expo/components/assistant-ui/tools.tsx
+++ b/examples/with-expo/components/assistant-ui/tools.tsx
@@ -1,7 +1,9 @@
+"use generative";
+
 import { View, Text, StyleSheet, useColorScheme } from "react-native";
-import type {
-  Toolkit,
-  ToolCallMessagePartProps,
+import {
+  defineToolkit,
+  type ToolCallMessagePartProps,
 } from "@assistant-ui/react-native";
 import { z } from "zod";
 
@@ -332,14 +334,16 @@ function WeatherToolUI(
 
 // Toolkit definition
 
-export const expoToolkit: Toolkit = {
+export default defineToolkit({
   geocode_location: {
     description: "Geocode a location using Open-Meteo's geocoding API",
     parameters: z.object({
       query: z.string(),
     }),
-    execute: async (args: { query: string }) =>
-      geocodeLocationWithOpenMeteo(args.query),
+    execute: async (args: { query: string }) => {
+      "use client";
+      return geocodeLocationWithOpenMeteo(args.query);
+    },
     render: GeocodeToolUI,
   },
   weather_search: {
@@ -354,10 +358,13 @@ export const expoToolkit: Toolkit = {
       query: string;
       longitude: number;
       latitude: number;
-    }) => fetchWeatherFromOpenMeteo(args),
+    }) => {
+      "use client";
+      return fetchWeatherFromOpenMeteo(args);
+    },
     render: WeatherToolUI,
   },
-};
+});
 
 const styles = StyleSheet.create({
   card: {

--- a/examples/with-expo/metro.config.js
+++ b/examples/with-expo/metro.config.js
@@ -1,4 +1,5 @@
 const { getDefaultConfig } = require("expo/metro-config");
+const { withAui } = require("@assistant-ui/metro");
 const path = require("node:path");
 
 const projectRoot = __dirname;
@@ -39,4 +40,4 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
   return context.resolveRequest(context, moduleName, platform);
 };
 
-module.exports = config;
+module.exports = withAui(config);

--- a/examples/with-expo/package.json
+++ b/examples/with-expo/package.json
@@ -41,6 +41,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@assistant-ui/metro": "workspace:*",
     "@types/react": "~19.2.15",
     "typescript": "~6.0.3"
   },

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -1,0 +1,89 @@
+# @assistant-ui/metro
+
+Metro / Expo integration for [assistant-ui](https://www.assistant-ui.com): the
+`"use generative"` directive compiler for React Native. It lets you author tools
+with the **same** [`defineToolkit`](https://www.assistant-ui.com/docs/tools/defining-tools)
+API as on the web — one file colocating a tool's schema, its `execute`, and its
+`render` — and compiles them for the device (and any Expo Router server route).
+
+Works with **Expo** and **bare React Native** (both bundle with Metro).
+
+## Install
+
+```sh
+npm install --save-dev @assistant-ui/metro
+```
+
+## Setup
+
+Wrap your Metro config with `withAui`:
+
+```js
+// metro.config.js
+const { getDefaultConfig } = require("expo/metro-config");
+const { withAui } = require("@assistant-ui/metro");
+
+const config = getDefaultConfig(__dirname);
+
+module.exports = withAui(config);
+```
+
+Bare React Native (without Expo):
+
+```js
+// metro.config.js
+const { getDefaultConfig } = require("@react-native/metro-config");
+const { withAui } = require("@assistant-ui/metro");
+
+module.exports = withAui(getDefaultConfig(__dirname));
+```
+
+## Usage
+
+Author a `"use generative"` toolkit exactly like on the web, importing
+`defineToolkit` from `@assistant-ui/react-native`:
+
+```tsx
+// toolkit.tsx
+"use generative";
+
+import { defineToolkit } from "@assistant-ui/react-native";
+import { z } from "zod";
+import { WeatherCard } from "./WeatherCard";
+
+export default defineToolkit({
+  get_weather: {
+    description: "Get the weather for a city.",
+    parameters: z.object({ city: z.string() }),
+    execute: async ({ city }) => {
+      "use client";
+      return fetchWeather(city);
+    },
+    render: ({ args, result }) => <WeatherCard city={args.city} weather={result} />,
+  },
+});
+```
+
+Register it with `Tools({ toolkit })`, the same as on the web:
+
+```tsx
+import { Tools, useAui } from "@assistant-ui/react-native";
+import toolkit from "./toolkit";
+
+const aui = useAui({ tools: Tools({ toolkit }) });
+```
+
+## How it works
+
+`withAui` points Metro's `babelTransformerPath` at this package's transformer,
+which runs the `"use generative"` compiler and then delegates to your project's
+existing transformer (Expo's or React Native's).
+
+The build target follows Metro's environment: the device app gets the **client**
+build (schema + `render` + frontend `execute`), while an Expo Router `+api`
+route — bundled for a server environment — gets the **server** build (schema +
+backend `execute`). This mirrors [`@assistant-ui/next`](https://www.assistant-ui.com/docs/tools/defining-tools)
+and `@assistant-ui/vite`.
+
+See the [Tools docs](https://www.assistant-ui.com/docs/tools/defining-tools) for
+the full authoring API.

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -3,8 +3,8 @@
 Metro / Expo integration for [assistant-ui](https://www.assistant-ui.com): the
 `"use generative"` directive compiler for React Native. It lets you author tools
 with the **same** [`defineToolkit`](https://www.assistant-ui.com/docs/tools/defining-tools)
-API as on the web — one file colocating a tool's schema, its `execute`, and its
-`render` — and compiles them for the device (and any Expo Router server route).
+API as on the web: one file colocating a tool's schema, its `execute`, and its
+`render`, then compiles them for the device (and any Expo Router server route).
 
 Works with **Expo** and **bare React Native** (both bundle with Metro).
 
@@ -81,7 +81,7 @@ existing transformer (Expo's or React Native's).
 
 The build target follows Metro's environment: the device app gets the **client**
 build (schema + `render` + frontend `execute`), while an Expo Router `+api`
-route — bundled for a server environment — gets the **server** build (schema +
+route (bundled for a server environment) gets the **server** build (schema +
 backend `execute`). This mirrors [`@assistant-ui/next`](https://www.assistant-ui.com/docs/tools/defining-tools)
 and `@assistant-ui/vite`.
 

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -42,6 +42,7 @@
     "@babel/types": "^7.29.7"
   },
   "devDependencies": {
+    "@assistant-ui/x-buildutils": "workspace:*",
     "@assistant-ui/x-generative-compiler": "workspace:^",
     "@types/node": "^25.9.1",
     "tsdown": "^0.22.1",

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@assistant-ui/metro",
+  "version": "0.0.1",
+  "description": "Metro / Expo integration for assistant-ui: the \"use generative\" directive compiler that colocates a tool's schema, server execute, and client render in one file. Works with Expo and bare React Native.",
+  "keywords": [
+    "assistant-ui",
+    "metro",
+    "expo",
+    "react-native",
+    "generative",
+    "use generative",
+    "babel-transformer"
+  ],
+  "author": "AgentbaseAI Inc.",
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.cts",
+      "default": "./dist/index.cjs"
+    },
+    "./transformer": {
+      "types": "./dist/transformer.d.cts",
+      "default": "./dist/transformer.cjs"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@babel/generator": "^7.29.7",
+    "@babel/parser": "^7.29.7",
+    "@babel/traverse": "^7.29.7",
+    "@babel/types": "^7.29.7"
+  },
+  "devDependencies": {
+    "@assistant-ui/x-generative-compiler": "workspace:^",
+    "@types/node": "^25.9.1",
+    "tsdown": "^0.22.1",
+    "vitest": "^4.1.7"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://www.assistant-ui.com/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/assistant-ui/assistant-ui.git",
+    "directory": "packages/metro"
+  },
+  "bugs": {
+    "url": "https://github.com/assistant-ui/assistant-ui/issues"
+  }
+}

--- a/packages/metro/src/__fixtures__/mock-upstream.cjs
+++ b/packages/metro/src/__fixtures__/mock-upstream.cjs
@@ -1,0 +1,10 @@
+// A stand-in for the project's upstream Metro babel transformer. It echoes the
+// `src` it was handed so tests can assert what the wrapper produced.
+module.exports = {
+  transform(props) {
+    return { ast: null, src: props.src };
+  },
+  getCacheKey() {
+    return "mock-upstream-key";
+  },
+};

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -47,8 +47,14 @@ export const UPSTREAM_TRANSFORMER_ENV = "AUI_METRO_UPSTREAM_TRANSFORMER";
  * export is `defineToolkit({ ... })`, registered with `Tools({ toolkit })`.
  */
 export function withAui<T extends MetroConfigLike>(config: T): T {
+  const self = require.resolve("@assistant-ui/metro/transformer");
   const upstream = config.transformer?.babelTransformerPath;
-  if (upstream) {
+
+  // Guard against a double-wrap (`withAui(withAui(config))`, or a shared config
+  // already wrapped): if it already points at our transformer, keep the real
+  // upstream captured earlier rather than overwriting it with our own path,
+  // which would make `resolveUpstream()` return this transformer and recurse.
+  if (upstream && upstream !== self) {
     process.env[UPSTREAM_TRANSFORMER_ENV] = upstream;
   }
 
@@ -56,7 +62,7 @@ export function withAui<T extends MetroConfigLike>(config: T): T {
     ...config,
     transformer: {
       ...config.transformer,
-      babelTransformerPath: require.resolve("@assistant-ui/metro/transformer"),
+      babelTransformerPath: self,
     },
   };
 }

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -1,0 +1,62 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * The shape of a Metro / Expo config `withAui` accepts. Typed loosely so this
+ * package needs no hard dependency on `metro` or `expo`; the input shape is
+ * preserved and only `transformer.babelTransformerPath` is augmented.
+ */
+export type MetroConfigLike = {
+  transformer?:
+    | {
+        babelTransformerPath?: string | undefined;
+        [key: string]: unknown;
+      }
+    | undefined;
+  [key: string]: unknown;
+};
+
+/**
+ * Env var the transformer reads to delegate to the project's existing
+ * (Expo / React Native) babel transformer. Metro forks its transform workers
+ * after `metro.config` is evaluated, so they inherit this value.
+ */
+export const UPSTREAM_TRANSFORMER_ENV = "AUI_METRO_UPSTREAM_TRANSFORMER";
+
+/**
+ * Wraps a Metro (or Expo) config so assistant-ui `"use generative"` modules are
+ * compiled — files that colocate a tool's schema, its `execute`, and its
+ * `render` via {@link https://www.assistant-ui.com/docs/tools/defining-tools | defineToolkit}.
+ *
+ * It points Metro's `babelTransformerPath` at this package's transformer, which
+ * runs the `"use generative"` compiler and then delegates to your project's
+ * existing transformer. The device (client) build keeps each tool's `render`
+ * and any frontend `execute`; a server build (an Expo Router `+api` route)
+ * keeps a server `execute` instead.
+ *
+ * ```js
+ * // metro.config.js
+ * const { getDefaultConfig } = require("expo/metro-config");
+ * const { withAui } = require("@assistant-ui/metro");
+ *
+ * module.exports = withAui(getDefaultConfig(__dirname));
+ * ```
+ *
+ * Authoring is identical to the web: a `"use generative"` file whose default
+ * export is `defineToolkit({ ... })`, registered with `Tools({ toolkit })`.
+ */
+export function withAui<T extends MetroConfigLike>(config: T): T {
+  const upstream = config.transformer?.babelTransformerPath;
+  if (upstream) {
+    process.env[UPSTREAM_TRANSFORMER_ENV] = upstream;
+  }
+
+  return {
+    ...config,
+    transformer: {
+      ...config.transformer,
+      babelTransformerPath: require.resolve("@assistant-ui/metro/transformer"),
+    },
+  };
+}

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -26,7 +26,7 @@ export const UPSTREAM_TRANSFORMER_ENV = "AUI_METRO_UPSTREAM_TRANSFORMER";
 
 /**
  * Wraps a Metro (or Expo) config so assistant-ui `"use generative"` modules are
- * compiled — files that colocate a tool's schema, its `execute`, and its
+ * compiled. Such a file colocates a tool's schema, its `execute`, and its
  * `render` via {@link https://www.assistant-ui.com/docs/tools/defining-tools | defineToolkit}.
  *
  * It points Metro's `babelTransformerPath` at this package's transformer, which

--- a/packages/metro/src/transformer.test.ts
+++ b/packages/metro/src/transformer.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { withAui, UPSTREAM_TRANSFORMER_ENV } from "./index";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const mockUpstream = join(here, "__fixtures__/mock-upstream.cjs");
+
+const GENERATIVE = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import { z } from "zod";
+import { db } from "@/db";
+export default defineToolkit({
+  weather: {
+    description: "Show the weather.",
+    parameters: z.object({ city: z.string() }),
+    execute: async ({ city }) => db.get(city),
+    render: () => null,
+  },
+});
+`;
+
+describe("withAui", () => {
+  it("points babelTransformerPath at our transformer, preserving the rest", () => {
+    const config = withAui({
+      projectRoot: "/app",
+      transformer: {
+        babelTransformerPath: "/up/stream.js",
+        assetPlugins: ["x"],
+      },
+      resolver: { sourceExts: ["ts"] },
+    });
+
+    expect(config.transformer?.babelTransformerPath).toContain("transformer");
+    expect(config.transformer?.babelTransformerPath).not.toBe("/up/stream.js");
+    expect(config.transformer?.assetPlugins).toEqual(["x"]);
+    expect(config.resolver).toEqual({ sourceExts: ["ts"] });
+    expect(config.projectRoot).toBe("/app");
+    // stashes the upstream so the worker can delegate to it
+    expect(process.env[UPSTREAM_TRANSFORMER_ENV]).toBe("/up/stream.js");
+  });
+});
+
+describe("transformer", () => {
+  beforeAll(() => {
+    process.env[UPSTREAM_TRANSFORMER_ENV] = mockUpstream;
+  });
+
+  it("compiles a use-generative module to the client build by default", async () => {
+    const { transform } = await import("./transformer");
+    const out = transform({
+      filename: "/app/toolkit.tsx",
+      src: GENERATIVE,
+      options: {},
+    }) as { src: string };
+
+    // client build keeps render + schema, drops the backend execute + its import
+    expect(out.src).toContain("render");
+    expect(out.src).toContain("z.object");
+    expect(out.src).toContain('type: "backend"');
+    expect(out.src).not.toContain("db.get");
+    expect(out.src).not.toContain("@/db");
+  });
+
+  it("compiles to the server build for a node environment", async () => {
+    const { transform } = await import("./transformer");
+    const out = transform({
+      filename: "/app/toolkit.tsx",
+      src: GENERATIVE,
+      options: { customTransformOptions: { environment: "node" } },
+    }) as { src: string };
+
+    // server build keeps the backend execute, drops render
+    expect(out.src).toContain("db.get");
+    expect(out.src).not.toMatch(/render\s*:/);
+  });
+
+  it("passes non-generative modules through untouched", async () => {
+    const { transform } = await import("./transformer");
+    const src = `export const x = 1;\n`;
+    const out = transform({
+      filename: "/app/x.ts",
+      src,
+      options: {},
+    }) as { src: string };
+
+    expect(out.src).toBe(src);
+  });
+});

--- a/packages/metro/src/transformer.test.ts
+++ b/packages/metro/src/transformer.test.ts
@@ -39,6 +39,18 @@ describe("withAui", () => {
     // stashes the upstream so the worker can delegate to it
     expect(process.env[UPSTREAM_TRANSFORMER_ENV]).toBe("/up/stream.js");
   });
+
+  it("is idempotent: a double-wrap keeps the real upstream, not the wrapper", () => {
+    const once = withAui({
+      transformer: { babelTransformerPath: "/up/stream.js" },
+    });
+    const self = once.transformer?.babelTransformerPath;
+
+    const twice = withAui(once);
+    // still points at our transformer, and the env still names the real upstream
+    expect(twice.transformer?.babelTransformerPath).toBe(self);
+    expect(process.env[UPSTREAM_TRANSFORMER_ENV]).toBe("/up/stream.js");
+  });
 });
 
 describe("transformer", () => {

--- a/packages/metro/src/transformer.ts
+++ b/packages/metro/src/transformer.ts
@@ -1,0 +1,100 @@
+import { createRequire } from "node:module";
+import {
+  compileGenerative,
+  isGenerativeModule,
+} from "@assistant-ui/x-generative-compiler";
+import { UPSTREAM_TRANSFORMER_ENV } from "./index";
+
+const require = createRequire(import.meta.url);
+
+/** Source modules a `"use generative"` directive can appear in. */
+const SOURCE_RE = /\.[cm]?[jt]sx?$/;
+
+/** Minimal shape of a Metro babel transformer. */
+type BabelTransformer = {
+  transform: (props: {
+    filename: string;
+    src: string;
+    options?:
+      | { customTransformOptions?: { environment?: string } | undefined }
+      | undefined;
+    [key: string]: unknown;
+  }) => unknown;
+  getCacheKey?: (() => string) | undefined;
+  [key: string]: unknown;
+};
+
+/**
+ * The project's upstream babel transformer — what Metro would have used without
+ * this wrapper. Taken from {@link UPSTREAM_TRANSFORMER_ENV} (set by `withAui`),
+ * else auto-detected: Expo's transformer, then React Native's.
+ */
+function resolveUpstream(): BabelTransformer {
+  const fromEnv = process.env[UPSTREAM_TRANSFORMER_ENV];
+  if (fromEnv) return require(fromEnv) as BabelTransformer;
+
+  for (const id of [
+    "@expo/metro-config/babel-transformer",
+    "@react-native/metro-babel-transformer",
+  ]) {
+    try {
+      return require(id) as BabelTransformer;
+    } catch {
+      // try the next candidate
+    }
+  }
+
+  throw new Error(
+    "[@assistant-ui/metro] Could not resolve an upstream Metro babel " +
+      "transformer. Make sure `transformer.babelTransformerPath` is set before " +
+      "`withAui(...)` (Expo's `getDefaultConfig` sets it), or install " +
+      "`@expo/metro-config` or `@react-native/metro-babel-transformer`.",
+  );
+}
+
+// Resolved lazily on first use — by then Metro has loaded `metro.config` and
+// `withAui` has populated the env var, and forked workers have inherited it.
+let cachedUpstream: BabelTransformer | undefined;
+function upstreamTransformer(): BabelTransformer {
+  return (cachedUpstream ??= resolveUpstream());
+}
+
+/** Expo bundles `+api` routes / RSC for a server environment; the app is client. */
+function isServerEnvironment(environment: string | undefined): boolean {
+  return environment === "node" || environment === "react-server";
+}
+
+export function transform(
+  props: Parameters<BabelTransformer["transform"]>[0],
+): unknown {
+  const upstream = upstreamTransformer();
+  const { filename, src, options } = props;
+
+  if (SOURCE_RE.test(filename) && isGenerativeModule(src)) {
+    const target = isServerEnvironment(
+      options?.customTransformOptions?.environment,
+    )
+      ? "server"
+      : "client";
+
+    const { code } = compileGenerative(src, {
+      target,
+      filename,
+      // Metro has no `react-server` layer, so `import "server-only"` would not
+      // resolve; the environment split already keeps a server `execute` out of
+      // the client bundle.
+      injectServerOnly: false,
+    });
+
+    return upstream.transform({ ...props, src: code });
+  }
+
+  return upstream.transform(props);
+}
+
+export function getCacheKey(): string {
+  const upstream = upstreamTransformer();
+  const base = upstream.getCacheKey ? upstream.getCacheKey() : "";
+  // Bust Metro's transform cache when this integration changes.
+  return `${base}$aui-metro-1`;
+}

--- a/packages/metro/src/transformer.ts
+++ b/packages/metro/src/transformer.ts
@@ -25,7 +25,7 @@ type BabelTransformer = {
 };
 
 /**
- * The project's upstream babel transformer — what Metro would have used without
+ * The project's upstream babel transformer: what Metro would have used without
  * this wrapper. Taken from {@link UPSTREAM_TRANSFORMER_ENV} (set by `withAui`),
  * else auto-detected: Expo's transformer, then React Native's.
  */
@@ -52,7 +52,7 @@ function resolveUpstream(): BabelTransformer {
   );
 }
 
-// Resolved lazily on first use — by then Metro has loaded `metro.config` and
+// Resolved lazily on first use, by which point Metro has loaded `metro.config` and
 // `withAui` has populated the env var, and forked workers have inherited it.
 let cachedUpstream: BabelTransformer | undefined;
 function upstreamTransformer(): BabelTransformer {

--- a/packages/metro/src/transformer.ts
+++ b/packages/metro/src/transformer.ts
@@ -1,4 +1,6 @@
 import { createRequire } from "node:module";
+import { statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import {
   compileGenerative,
   isGenerativeModule,
@@ -92,9 +94,23 @@ export function transform(
   return upstream.transform(props);
 }
 
+// The bundled compiler lives in this file, so its own mtime moves whenever the
+// transform output could change (a newly published version, or an in-place
+// monorepo rebuild). Deriving the token from it busts Metro's cache
+// automatically, rather than relying on a hand-bumped constant.
+let cachedSelfToken: string | undefined;
+function selfCacheToken(): string {
+  if (cachedSelfToken !== undefined) return cachedSelfToken;
+  try {
+    cachedSelfToken = String(statSync(fileURLToPath(import.meta.url)).mtimeMs);
+  } catch {
+    cachedSelfToken = "0";
+  }
+  return cachedSelfToken;
+}
+
 export function getCacheKey(): string {
   const upstream = upstreamTransformer();
   const base = upstream.getCacheKey ? upstream.getCacheKey() : "";
-  // Bust Metro's transform cache when this integration changes.
-  return `${base}$aui-metro-1`;
+  return `${base}$aui-metro:${selfCacheToken()}`;
 }

--- a/packages/metro/tsconfig.json
+++ b/packages/metro/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "include": ["src"]
+}

--- a/packages/metro/tsdown.config.mts
+++ b/packages/metro/tsdown.config.mts
@@ -1,0 +1,17 @@
+import { defineConfig } from "tsdown";
+
+// Metro loads babel transformers via CommonJS `require`, and a babel transformer
+// must be synchronous — so this package emits CJS and bundles the (ESM)
+// `"use generative"` compiler in, rather than requiring it across the ESM/CJS
+// boundary at runtime. `@babel/*` stay external (declared deps, already CJS).
+export default defineConfig({
+  entry: ["src/index.ts", "src/transformer.ts"],
+  format: "cjs",
+  platform: "node",
+  dts: { sourcemap: true },
+  sourcemap: true,
+  deps: {
+    alwaysBundle: ["@assistant-ui/x-generative-compiler"],
+    neverBundle: [/^@babel\//],
+  },
+});

--- a/packages/metro/turbo.json
+++ b/packages/metro/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "dependsOn": ["^build", "build"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1545,6 +1545,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@assistant-ui/metro':
+        specifier: workspace:*
+        version: link:../../packages/metro
       '@types/react':
         specifier: ~19.2.15
         version: 19.2.15
@@ -3169,6 +3172,34 @@ importers:
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/metro:
+    dependencies:
+      '@babel/generator':
+        specifier: ^7.29.7
+        version: 7.29.7
+      '@babel/parser':
+        specifier: ^7.29.7
+        version: 7.29.7
+      '@babel/traverse':
+        specifier: ^7.29.7
+        version: 7.29.7
+      '@babel/types':
+        specifier: ^7.29.7
+        version: 7.29.7
+    devDependencies:
+      '@assistant-ui/x-generative-compiler':
+        specifier: workspace:^
+        version: link:../x-generative-compiler
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      tsdown:
+        specifier: ^0.22.1
+        version: 0.22.1(tsx@4.22.4)(typescript@6.0.3)
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3191,6 +3191,9 @@ importers:
         specifier: ^7.29.7
         version: 7.29.7
     devDependencies:
+      '@assistant-ui/x-buildutils':
+        specifier: workspace:*
+        version: link:../x-buildutils
       '@assistant-ui/x-generative-compiler':
         specifier: workspace:^
         version: link:../x-generative-compiler


### PR DESCRIPTION
## Why

React Native / Expo could not use the `defineToolkit` + `"use generative"` API. The directive compiler only shipped for Next (`withAui`) and Vite (`aui`), so RN docs and the `with-expo` example used a plain `satisfies Toolkit`, diverging from the web. This adds the missing Metro integration so RN apps author tools with the exact same API as the web.

## What

New package `@assistant-ui/metro` (a build integration, analogous to `@assistant-ui/next` and `@assistant-ui/vite`):

- `withAui(config)` wraps a Metro/Expo config. It captures the project's existing `babelTransformerPath` and points Metro at a wrapper transformer.
- The wrapper runs the `"use generative"` compiler on `"use generative"` modules, then delegates to the upstream transformer (Expo's or RN's), so all normal Metro behavior is preserved.
- Environment-aware (mirrors Vite): the device app gets the client build (schema, `render`, frontend `execute`); an Expo Router `+api` route, bundled for a server environment, gets the server build. Detected via `customTransformOptions.environment`.
- Ships as CommonJS (Metro loads transformers via `require`, synchronously) and bundles the compiler so the transformer is self-contained.

Example and docs:

- `with-expo` converted: `tools.tsx` becomes `export default defineToolkit({...})`, `metro.config.js` becomes `withAui(...)`. The `+api` route is unchanged (schemas still flow via `frontendTools`).
- React Native and Tools docs updated to show `defineToolkit` plus the Metro setup.

## Validation

- Unit tests: `withAui` wiring, client/server target selection, non-generative passthrough (4 passing).
- End to end: a real `expo export --platform web` bundle (1984 client modules plus 2120 server-render modules) compiles through the transformer; `unstable_backendDefault` is present in the client bundle, confirming the compiler ran on the toolkit.
- `pnpm lint` clean.

## Follow-up (maintainer, requires npm 2FA)

Trusted publishing for the new package name is configured per name on npm and needs an interactive OTP. Before the next release:

```
npm trust github @assistant-ui/metro --repository assistant-ui/assistant-ui --file npm-publish.yaml --environment "npm Publish" --allow-publish --allow-stage-publish
```

After the first publish, lock it down: `npm access set mfa=publish @assistant-ui/metro`.

Ink is a planned follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)