### PR TITLE
fix(with-expo): build @assistant-ui/metro for the Vercel deploy

### DIFF
--- a/examples/with-expo/vercel.json
+++ b/examples/with-expo/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "bash ../../scripts/vercel-ignore-changeset-release.sh",
-  "buildCommand": "cd ../.. && pnpm turbo build --filter=@assistant-ui/react-native --filter=@assistant-ui/react-ai-sdk && cd examples/with-expo && pnpm run export:web",
+  "buildCommand": "cd ../.. && pnpm turbo build --filter=@assistant-ui/react-native --filter=@assistant-ui/react-ai-sdk --filter=@assistant-ui/metro && cd examples/with-expo && pnpm run export:web",
   "outputDirectory": "dist",
   "framework": null
 }


### PR DESCRIPTION
## Why

The "Deploy Expo Example" build on main is failing:

```
Cannot find module '.../examples/with-expo/node_modules/@assistant-ui/metro/dist/index.cjs'
```

After #4244, `with-expo`'s `metro.config.js` requires `@assistant-ui/metro`, but the example's Vercel `buildCommand` only builds `@assistant-ui/react-native` and `@assistant-ui/react-ai-sdk`, so `@assistant-ui/metro` is never built and the `require` fails during `export:web`.

## What

Add `--filter=@assistant-ui/metro` to the example's `turbo build` in `vercel.json`. Verified locally: the build now produces `metro/dist/index.cjs` and `transformer.cjs`, and `export:web` succeeds.

Docs-/example-only; `with-expo` is private, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)