### PR TITLE
feat: add externalTool for generative toolkits

### DIFF
--- a/.changeset/external-tool-generative.md
+++ b/.changeset/external-tool-generative.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+"@assistant-ui/x-generative-compiler": patch
+---
+
+feat: add externalTool for render-only generative toolkit entries

--- a/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
@@ -48,6 +48,19 @@ client. So it throws instead of silently leaking.
 
 <ParametersTable {...DevToolsHooks} />
 
+### externalTool
+
+Marks a generative toolkit entry as an externally executed backend tool.
+
+Use this when another system (for example a backend route or LangGraph node)
+already defines and executes the tool, but assistant-ui should render its
+tool calls. The use-generative compiler converts `execute: externalTool()`
+into `type: "backend"` and strips schema/executor metadata from both builds.
+
+```ts
+function externalTool(): never;
+```
+
 ### hitl
 
 <Callout type="warn">

--- a/apps/docs/content/docs/migrations/toolkit-tools.mdx
+++ b/apps/docs/content/docs/migrations/toolkit-tools.mdx
@@ -103,25 +103,31 @@ export function App() {
 
 ## UI-Only Tool Renderers
 
-If you used `makeAssistantToolUI` or `useAssistantToolUI` for a backend, MCP, or LangGraph tool, the tool executes elsewhere, so there is no `execute` to author. That makes it a **render-only** entry, which belongs in a plain `satisfies Toolkit` object — not a `"use generative"` file (a generative tool must declare an `execute`). Author an explicit `type: "backend"` with just a `render`:
+If you used `makeAssistantToolUI` or `useAssistantToolUI` for a backend, MCP, or
+LangGraph tool, the tool executes elsewhere. Prefer a `"use generative"` toolkit
+with `execute: externalTool()` so the compiler emits `type: "backend"` with no
+schema or executor, while the client keeps your renderer:
 
 ```tsx
-// app/tool-ui.tsx
-"use client";
+// app/toolkit.tsx
+"use generative";
 
-import type { Toolkit } from "@assistant-ui/react";
+import { defineToolkit, externalTool } from "@assistant-ui/react";
 
-export const toolkit = {
+export default defineToolkit({
   web_search: {
-    type: "backend",
+    execute: externalTool(),
     render: ({ args, result }) => (
       <SearchResults query={args.query} results={result?.results ?? []} />
     ),
   },
-} satisfies Toolkit;
+});
 ```
 
-Register it like any toolkit: `useAui({ tools: Tools({ toolkit }) })`. Render-only entries upload no schema and run no browser code — they only attach UI for matching tool-call message parts.
+Register it like any toolkit: `useAui({ tools: Tools({ toolkit }) })`.
+Render-only entries upload no schema and run no browser code — they only attach
+UI for matching tool-call message parts. For MCP server catalogs, spread
+`defineMcpToolkit({ ... })` in the same generative toolkit.
 
 For a one-off renderer that should only affect a particular message surface, use `MessagePrimitive.Parts` inline tool render overrides instead of a global registration.
 

--- a/apps/docs/content/docs/tools/backend.mdx
+++ b/apps/docs/content/docs/tools/backend.mdx
@@ -58,7 +58,9 @@ export async function POST(req: Request) {
 
 ## Client-defined tools: `frontendTools`
 
-If you don't use the generative compiler — for example a plain [`satisfies Toolkit`](/docs/tools/defining-tools#render-only-tools-for-externally-executed-tools) with browser-executed tools — the AI SDK adapter still serializes those tools into the request `tools`. Convert them to the AI SDK shape with `frontendTools` and spread your own server tools alongside:
+If a toolkit cannot go through the generative compiler, the AI SDK adapter still
+serializes browser-executed tools into the request `tools`. Convert them to the
+AI SDK shape with `frontendTools` and spread your own server tools alongside:
 
 ```ts title="app/api/chat/route.ts"
 import { frontendTools } from "@assistant-ui/react-ai-sdk";
@@ -86,7 +88,8 @@ export async function POST(req: Request) {
 }
 ```
 
-`generativeTools` calls `frontendTools` for you under the hood; reach for `frontendTools` directly when you're not on the generative build.
+`generativeTools` calls `frontendTools` for you under the hood; reach for
+`frontendTools` directly when you're not on the generative build.
 
 <Callout type="tip">
   `toToolsJSONSchema` emits the uploaded tools in alphabetical order, so two

--- a/apps/docs/content/docs/tools/defining-tools.mdx
+++ b/apps/docs/content/docs/tools/defining-tools.mdx
@@ -8,23 +8,25 @@ Tools let the model take actions: fetch data, call an API, query a database, dri
 
 This page covers how to **author** tools. To render a tool call as a custom component, see [Tool UI](/docs/tools/tool-ui). To wire tools into your server, see [Backend tools](/docs/tools/backend).
 
-## Two ways to define a toolkit
+## Define tools with `"use generative"`
 
-There are two authoring models. Most apps use the first; the second is for attaching UI to tools that execute somewhere you don't control.
+Use `"use generative"` + `defineToolkit` for toolkits. The compiler co-locates
+the schema, executor, and renderer in one file and splits them across the
+client/server boundary for you.
 
 <Callout type="info">
-  **Use `"use generative"` + `defineToolkit`** when you author the tool's
-  behavior yourself (it runs in the browser or in your own backend code). The
-  compiler co-locates the schema, the executor, and the renderer in one file and
-  splits them across the client/server boundary for you.
+  You can still use the generative toolkit pattern when a tool executes
+  elsewhere:
 
-  **Use a plain `satisfies Toolkit` object** when the tool already executes
-  elsewhere — an MCP server, a separate backend route, a LangGraph node — and you
-  only want to attach a renderer. These are render-only entries with an explicit
-  `type`.
+  - for MCP servers, spread `defineMcpToolkit({ ... })`;
+  - for non-MCP tools defined by another backend or runtime, write
+    `execute: externalTool()` and provide a renderer.
 </Callout>
 
-The difference matters because of one rule: **in a `"use generative"` file every tool must declare an `execute`, and you never write `type` yourself** — the compiler infers it. A render-only `{ type: "backend", render }` entry (no `execute`) is a plain-toolkit construct and will **not** compile inside a `"use generative"` file.
+In a `"use generative"` file every tool declares an `execute`, and you never
+write `type` yourself — the compiler infers it. For render-only external tools,
+`externalTool()` is the escape hatch that satisfies the compiler without
+emitting schema or executable code.
 
 ## Quick start (`"use generative"`)
 
@@ -178,6 +180,7 @@ The tool's **kind is inferred from its `execute`** and written back as a `type` 
 | `hitlTool()` | **human** | schema only | schema + `render` |
 | `stubTool()` | **frontend** (executor supplied at runtime) | schema only | schema + `render`/`renderText` |
 | `providerTool({ … })` | **provider** | schema + provider config | schema + provider config |
+| `externalTool()` | **backend** (defined elsewhere) | `type: "backend"` only | `type: "backend"` + `render`/`renderText` |
 
 The compiler also enforces, at build time:
 
@@ -223,8 +226,8 @@ geocode_location: {
 <Callout type="tip">
   A backend tool authored this way **has** an `execute`. To attach a renderer to
   a tool whose execution lives entirely elsewhere (an MCP server, a different
-  backend route) — where there is no `execute` to write — use a [plain
-  toolkit](#render-only-tools-for-externally-executed-tools) instead.
+  backend route) — where there is no real executor to write — use
+  `externalTool()` or `defineMcpToolkit()`.
 </Callout>
 
 ### Human tools
@@ -263,6 +266,28 @@ web_search: {
 },
 ```
 
+### Externally defined tools
+
+Use `externalTool()` when a non-MCP tool is already defined and executed by
+another system (for example a separate backend route or LangGraph node), but you
+want assistant-ui to render its tool calls. Import `externalTool` from
+`@assistant-ui/react`:
+
+```tsx
+web_search: {
+  parameters: z.object({ query: z.string() }),
+  execute: externalTool(),
+  render: ({ args, result }) => (
+    <SearchResults query={args.query} results={result?.results ?? []} />
+  ),
+},
+```
+
+The compiler emits `type: "backend"` with no schema, parameters, or executor on
+the server, so the model still gets the tool definition from the external
+system. The client build keeps only `type: "backend"` and the renderer (or
+`renderText`) for matching tool-call message parts.
+
 ### Dynamic (stateful) tools
 
 When a tool's executor must close over React state, declare its contract with `execute: stubTool()` and supply the real executor at runtime with `useAuiToolOverrides`. See [Dynamic tools](/docs/tools/dynamic-tools).
@@ -282,7 +307,11 @@ If you don't provide a renderer, add the [`ToolFallback`](/docs/ui/tool-fallback
 
 ## Render-only tools (for externally-executed tools)
 
-When the tool already runs somewhere you don't control — an MCP server, a separate backend route, a LangGraph node — there is no `execute` to author. Declare a **plain** toolkit (a `"use client"` file, no `"use generative"`, no `defineToolkit`) with an explicit `type: "backend"` and only a `render`:
+Prefer `"use generative"` with `externalTool()` for non-MCP tools, or
+`defineMcpToolkit()` for MCP servers. Plain `satisfies Toolkit` render-only
+entries are only needed when a file cannot go through the generative compiler.
+In that case, declare a `"use client"` toolkit with an explicit
+`type: "backend"` and only a `render`:
 
 ```tsx title="app/tool-ui.tsx"
 "use client";
@@ -302,9 +331,9 @@ export const toolkit = {
 Register it exactly like a generative toolkit: `useAui({ tools: Tools({ toolkit }) })`. The key must match the tool name your backend or MCP server publishes. Render-only entries upload no schema and run no browser code — they only attach UI to matching tool-call message parts.
 
 <Callout type="warn">
-  This `{ type: "backend", render }` shape is **plain-toolkit only**. Putting it
-  inside a `"use generative"` file is a compile error — a generative tool must
-  declare an `execute`, and you never author `type` there.
+  This `{ type: "backend", render }` shape is **plain-toolkit only**. Inside a
+  `"use generative"` file, use `execute: externalTool()` instead; generative
+  tools must declare an `execute`, and you never author `type` there.
 </Callout>
 
 ## Organizing toolkits

--- a/apps/docs/content/docs/tools/index.mdx
+++ b/apps/docs/content/docs/tools/index.mdx
@@ -23,22 +23,17 @@ Tools are how the model takes action: fetch data, call an API, query a database,
   </Card>
 </Cards>
 
-## Two ways to define a toolkit
+## Define tools with `"use generative"`
 
 <Callout type="info">
-  **`"use generative"` + `defineToolkit`** — for tools you author yourself
-  (browser or your own backend). The compiler co-locates the schema, executor,
-  and renderer in one file and splits them across the client/server boundary.
-
-  **Plain `satisfies Toolkit`** — for tools that already execute elsewhere (an
-  MCP server, a separate backend route, a LangGraph node) where you only attach a
-  renderer.
+  Use `"use generative"` + `defineToolkit` for toolkits. For tools that execute
+  elsewhere, spread `defineMcpToolkit({ ... })` for MCP servers or use
+  `execute: externalTool()` to attach a renderer to a non-MCP external tool.
 </Callout>
 
 In a `"use generative"` file every tool declares an `execute` and the kind is
-**inferred** from it (you never write `type`). In a plain toolkit you author
-`type` and write render-only `{ type: "backend", render }` entries. See
-[Defining Tools](/docs/tools/defining-tools#two-ways-to-define-a-toolkit).
+**inferred** from it (you never write `type`). See
+[Defining Tools](/docs/tools/defining-tools#define-tools-with-use-generative).
 
 ## Rendering AI output as UI
 

--- a/apps/docs/content/docs/tools/mcp.mdx
+++ b/apps/docs/content/docs/tools/mcp.mdx
@@ -15,6 +15,12 @@ client  ──►  /api/chat  ──►  MCP client  ──►  MCP server (HTTP
 
 The MCP client lives on the server inside your AI SDK route handler. It connects to one or more MCP servers, calls `tools()` to get a tool map, and hands that map to `streamText`. assistant-ui's existing tool-call UI (`ToolFallback`, or toolkit entries with `render`) renders the results.
 
+<Callout type="info">
+  If you use a `"use generative"` toolkit, spread `defineMcpToolkit({ ... })`
+  in the toolkit and use `AISDKToolkit` in your route. It opens the MCP clients,
+  merges their tools with your toolkit, and closes them for you.
+</Callout>
+
 ## Setup
 
 <Steps>
@@ -71,9 +77,64 @@ const mcpClient = await createMCPClient({
 </Step>
 <Step>
 
+### Define MCP servers in your toolkit
+
+In a generative toolkit, spread `defineMcpToolkit({ ... })` with one entry per
+MCP server. The entry key names the server connection; the MCP server publishes
+the actual tool names.
+
+```tsx title="app/toolkit.tsx"
+"use generative";
+
+import { defineMcpToolkit, defineToolkit } from "@assistant-ui/react";
+
+export default defineToolkit({
+  ...defineMcpToolkit({
+    github: {
+      type: "http",
+      url: "https://mcp.example.com/mcp",
+    },
+  }),
+});
+```
+
+Use `AISDKToolkit` in the route instead of `generativeTools` when the toolkit
+contains MCP entries:
+
+```ts title="app/api/chat/route.ts"
+import { AISDKToolkit } from "@assistant-ui/react-ai-sdk";
+import { openai } from "@ai-sdk/openai";
+import { streamText, convertToModelMessages } from "ai";
+import type { UIMessage } from "ai";
+import toolkit from "../../toolkit";
+
+export async function POST(req: Request) {
+  const { messages, tools }: { messages: UIMessage[]; tools?: Record<string, any> } =
+    await req.json();
+
+  const aiToolkit = new AISDKToolkit({ toolkit });
+
+  const result = streamText({
+    model: openai("gpt-5.4-mini"),
+    messages: await convertToModelMessages(messages),
+    tools: await aiToolkit.tools({ frontend: tools }),
+    onFinish: async () => {
+      await aiToolkit.close();
+    },
+  });
+
+  return result.toUIMessageStreamResponse();
+}
+```
+
+</Step>
+<Step>
+
 ### Wire the tools into the route
 
-`mcpClient.tools()` returns an object shaped exactly like the `tools` argument of `streamText`. Spread it in alongside any of your own tools, and close the client when the response finishes:
+For manual MCP client control, `mcpClient.tools()` returns an object shaped
+exactly like the `tools` argument of `streamText`. Spread it in alongside any of
+your own tools, and close the client when the response finishes:
 
 ```ts title="app/api/chat/route.ts"
 import { createMCPClient } from "@ai-sdk/mcp";
@@ -141,22 +202,28 @@ If two servers expose tools with the same name, the later spread wins. Rename or
 
 ### Render results in the UI
 
-Tool calls flow through the existing assistant-ui tool-call rendering. With no setup, the bundled `<ToolFallback>` component renders the call name, arguments, and result. To customize the appearance for a specific tool, add a backend entry to your toolkit:
+Tool calls flow through the existing assistant-ui tool-call rendering. With no
+setup, the bundled `<ToolFallback>` component renders the call name, arguments,
+and result. To customize the appearance for a specific tool in a generative
+toolkit, add an `externalTool()` renderer whose key matches the MCP tool name:
 
 <PlatformTabs>
 <Tab value="React">
 
-```tsx title="app/components/GitHubIssueToolUI.tsx"
-"use client";
+```tsx title="app/toolkit.tsx"
+"use generative";
 
-import type { Toolkit } from "@assistant-ui/react";
+import { defineMcpToolkit, defineToolkit, externalTool } from "@assistant-ui/react";
 
 type Args = { repo: string; number: number };
 type Result = { title: string; state: string; url: string };
 
-export const toolkit = {
+export default defineToolkit({
+  ...defineMcpToolkit({
+    github: { type: "http", url: "https://mcp.example.com/mcp" },
+  }),
   github_get_issue: {
-    type: "backend",
+    execute: externalTool(),
     render: ({ args, result }: { args: Args; result?: Result }) => (
       <div className="rounded border p-3">
         <div className="font-mono text-sm">{args.repo}#{args.number}</div>
@@ -168,7 +235,7 @@ export const toolkit = {
       </div>
     ),
   },
-} satisfies Toolkit;
+});
 ```
 
 </Tab>
@@ -234,7 +301,8 @@ export const toolkit = {
 </Tab>
 </PlatformTabs>
 
-Register the toolkit once with `Tools({ toolkit })`. The toolkit key must match the name your MCP server publishes.
+Register the toolkit once with `Tools({ toolkit })`. Renderer keys such as
+`github_get_issue` must match the tool names your MCP server publishes.
 
 ```tsx title="app/components/RuntimeProvider.tsx"
 "use client";

--- a/packages/core/src/react/index.ts
+++ b/packages/core/src/react/index.ts
@@ -41,6 +41,7 @@ export {
 } from "./model-context/toolbox";
 export { defineToolkit } from "./model-context/define-toolkit";
 export { stubTool } from "./model-context/stub-tool";
+export { externalTool } from "./model-context/external-tool";
 export { useAuiToolOverrides } from "./model-context/useAuiToolOverrides";
 export { hitl, hitlTool } from "./model-context/hitl";
 export {

--- a/packages/core/src/react/model-context/define-toolkit.test.ts
+++ b/packages/core/src/react/model-context/define-toolkit.test.ts
@@ -4,6 +4,7 @@ import { defineToolkit } from "./define-toolkit";
 import { hitl, hitlTool } from "./hitl";
 import { providerTool } from "./provider-tool";
 import { stubTool } from "./stub-tool";
+import { externalTool } from "./external-tool";
 import type { ToolkitDefinition } from "./toolbox";
 
 type TestStandardSchema<T> = {
@@ -97,5 +98,9 @@ describe("use-generative markers", () => {
 
   it("stubTool throws at runtime — it must be stripped by the compiler, never called", () => {
     expect(() => stubTool()).toThrow(/no runtime implementation/);
+  });
+
+  it("externalTool throws at runtime — it must be stripped by the compiler, never called", () => {
+    expect(() => externalTool()).toThrow(/no runtime implementation/);
   });
 });

--- a/packages/core/src/react/model-context/external-tool.ts
+++ b/packages/core/src/react/model-context/external-tool.ts
@@ -1,0 +1,15 @@
+/**
+ * Marks a generative toolkit entry as an externally executed backend tool.
+ *
+ * Use this when another system (for example a backend route or LangGraph node)
+ * already defines and executes the tool, but assistant-ui should render its
+ * tool calls. The use-generative compiler converts `execute: externalTool()`
+ * into `type: "backend"` and strips schema/executor metadata from both builds.
+ */
+export function externalTool(): never {
+  throw new Error(
+    "[assistant-ui] externalTool() has no runtime implementation - it marks a " +
+      "tool that executes outside assistant-ui and is stripped at build time " +
+      'by the use-generative compiler. Make sure this module is compiled as "use generative".',
+  );
+}

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -198,6 +198,7 @@ export {
   type ToolCallText,
   defineToolkit,
   stubTool,
+  externalTool,
   useAuiToolOverrides,
   hitl,
   hitlTool,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -163,6 +163,7 @@ export {
   type ToolCallText,
   defineToolkit,
   stubTool,
+  externalTool,
   useAuiToolOverrides,
   hitl,
   hitlTool,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -192,6 +192,7 @@ export {
   type ToolkitDefinitionEntry,
   defineToolkit,
   stubTool,
+  externalTool,
   useAuiToolOverrides,
   hitl,
   hitlTool,

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -498,6 +498,51 @@ export default defineToolkit({
     expect(client).not.toContain("stubTool");
     expect(client).not.toContain("execute");
   });
+
+  it("infers `backend` from execute: externalTool() and strips schema/execution metadata", () => {
+    const src = `"use generative";
+import { z } from "zod";
+import { SearchResults } from "@/ui/search-results";
+import { defineToolkit, externalTool } from "@assistant-ui/react";
+export default defineToolkit({
+  web_search: {
+    description: "Search the web.",
+    parameters: z.object({ query: z.string() }),
+    execute: externalTool(),
+    render: ({ args, result }) => <SearchResults query={args.query} results={result} />,
+  },
+});`;
+
+    const server = compileGenerative(src, { target: "server" }).code;
+    expect(server).toContain('type: "backend"');
+    expect(server).not.toContain("server-only");
+    expect(server).not.toContain("description");
+    expect(server).not.toContain("parameters");
+    expect(server).not.toContain("execute");
+    expect(server).not.toContain("externalTool");
+    expect(server).not.toContain("SearchResults");
+    expect(server).not.toContain('from "zod"');
+
+    const client = compileGenerative(src, { target: "client" }).code;
+    expect(client.trimStart().startsWith('"use client"')).toBe(true);
+    expect(client).toContain('type: "backend"');
+    expect(client).toContain("render");
+    expect(client).toContain("SearchResults");
+    expect(client).not.toContain("description");
+    expect(client).not.toContain("parameters");
+    expect(client).not.toContain("execute");
+    expect(client).not.toContain("externalTool");
+    expect(client).not.toContain('from "zod"');
+  });
+
+  it("requires a renderer for external tools", () => {
+    expect(() =>
+      compileGenerative(
+        `"use generative";\nimport { defineToolkit, externalTool } from "@assistant-ui/react";\nexport default defineToolkit({ search: { execute: externalTool() } });`,
+        { target: "client" },
+      ),
+    ).toThrow(/external tool must declare a `render` or `renderText`/);
+  });
 });
 
 describe("compileGenerative — local dead-code elimination", () => {

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -659,6 +659,9 @@ function inferToolType(
 }
 
 function stripExternalToolMetadata(object: t.ObjectExpression): void {
+  // Mirror BackendTool's forbidden metadata fields: execute is stripped by the
+  // main routing loop, while streamCall is also removed because there is no
+  // assistant-ui executor to stream from.
   removeMember(object, "description");
   removeMember(object, "parameters");
   removeMember(object, "disabled");

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -447,14 +447,12 @@ function compileToolkit(
       else if (execute) removeMember(value, "execute");
       if (hasRender || hasRenderText) flags.keptRender = true;
     } else {
-      // server: render is never needed; only a backend execute survives.
+      // server: render is never needed; only a non-external backend execute survives.
       if (hasRender) removeMember(value, "render");
       if (hasRenderText) removeMember(value, "renderText");
-      if (execute && (type !== "backend" || isExternal)) {
-        removeMember(value, "execute");
-      }
-      if (execute && type === "backend" && !isExternal) {
-        flags.keptBackendExecute = true;
+      if (execute) {
+        if (type === "backend" && !isExternal) flags.keptBackendExecute = true;
+        else removeMember(value, "execute");
       }
     }
 

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -19,8 +19,6 @@ export type ToolType = "frontend" | "backend" | "human" | "provider";
 const TOOLKIT_WRAPPER = "defineToolkit";
 /** The helper that produces MCP-only toolkit fragments. */
 const MCP_TOOLKIT_WRAPPER = "defineMcpToolkit";
-/** The sentinel for tools whose schema/execution are defined elsewhere. */
-const EXTERNAL_TOOL_SENTINEL = "externalTool";
 /** The required wrapper around a generative-UI library (stripped at build time). */
 const COMPONENTS_WRAPPER = "defineGenerativeComponents";
 /**
@@ -616,7 +614,7 @@ function executeIsStubTool(member: t.ObjectProperty | t.ObjectMethod): boolean {
 function executeIsExternalTool(
   member: t.ObjectProperty | t.ObjectMethod,
 ): boolean {
-  return executeIsSentinel(member, EXTERNAL_TOOL_SENTINEL);
+  return executeIsSentinel(member, "externalTool");
 }
 
 /** Drops the `"use client"` directive from an `execute` body (kept frontend). */

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -19,6 +19,8 @@ export type ToolType = "frontend" | "backend" | "human" | "provider";
 const TOOLKIT_WRAPPER = "defineToolkit";
 /** The helper that produces MCP-only toolkit fragments. */
 const MCP_TOOLKIT_WRAPPER = "defineMcpToolkit";
+/** The sentinel for tools whose schema/execution are defined elsewhere. */
+const EXTERNAL_TOOL_SENTINEL = "externalTool";
 /** The required wrapper around a generative-UI library (stripped at build time). */
 const COMPONENTS_WRAPPER = "defineGenerativeComponents";
 /**
@@ -403,6 +405,7 @@ function compileToolkit(
     // `type`. The resolved type is written back below so the runtime keeps it.
     const execute = findMember(value, "execute");
     const isStub = execute ? executeIsStubTool(execute) : false;
+    const isExternal = execute ? executeIsExternalTool(execute) : false;
     const type = inferToolType(value, filename);
     const hasRender = !!findMember(value, "render");
     const hasRenderText = !!findMember(value, "renderText");
@@ -426,6 +429,17 @@ function compileToolkit(
       applyProviderToolConfig(value, execute, filename);
     }
 
+    if (isExternal) {
+      if (!hasRender && !hasRenderText) {
+        throw new GenerativeCompileError(
+          "an external tool must declare a `render` or `renderText` " +
+            "(assistant-ui only renders calls for tools defined elsewhere)",
+          filename,
+        );
+      }
+      stripExternalToolMetadata(value);
+    }
+
     if (target === "client") {
       // A non-stub frontend execute stays (its `"use client"` marker is no longer needed
       // once the module is client); backend, sentinel, and stub executes are dropped.
@@ -436,8 +450,12 @@ function compileToolkit(
       // server: render is never needed; only a backend execute survives.
       if (hasRender) removeMember(value, "render");
       if (hasRenderText) removeMember(value, "renderText");
-      if (execute && type !== "backend") removeMember(value, "execute");
-      if (execute && type === "backend") flags.keptBackendExecute = true;
+      if (execute && (type !== "backend" || isExternal)) {
+        removeMember(value, "execute");
+      }
+      if (execute && type === "backend" && !isExternal) {
+        flags.keptBackendExecute = true;
+      }
     }
 
     setToolType(value, type);
@@ -596,6 +614,13 @@ function executeIsStubTool(member: t.ObjectProperty | t.ObjectMethod): boolean {
   return executeIsSentinel(member, "stubTool");
 }
 
+/** Whether an `execute` is the externally-defined backend tool sentinel. */
+function executeIsExternalTool(
+  member: t.ObjectProperty | t.ObjectMethod,
+): boolean {
+  return executeIsSentinel(member, EXTERNAL_TOOL_SENTINEL);
+}
+
 /** Drops the `"use client"` directive from an `execute` body (kept frontend). */
 function stripUseClient(member: t.ObjectProperty | t.ObjectMethod): void {
   const body = executeBody(member);
@@ -609,7 +634,8 @@ function stripUseClient(member: t.ObjectProperty | t.ObjectMethod): void {
 /**
  * The tool's nature, inferred from its (mandatory) `execute` rather than an
  * authored `type`: `hitlTool()` → `human`; `providerTool(...)` → `provider`;
- * `stubTool()` → `frontend`; `"use client"` → `frontend`; otherwise `backend`.
+ * `stubTool()` → `frontend`; `externalTool()` → `backend`; `"use client"` →
+ * `frontend`; otherwise `backend`.
  * The loader writes the result back as a `type` field (see {@link setToolType})
  * so the runtime keeps it.
  */
@@ -628,7 +654,18 @@ function inferToolType(
   if (executeIsHitl(execute)) return "human";
   if (executeIsProviderTool(execute)) return "provider";
   if (executeIsStubTool(execute)) return "frontend";
+  if (executeIsExternalTool(execute)) return "backend";
   return executeIsClient(execute) ? "frontend" : "backend";
+}
+
+function stripExternalToolMetadata(object: t.ObjectExpression): void {
+  removeMember(object, "description");
+  removeMember(object, "parameters");
+  removeMember(object, "disabled");
+  removeMember(object, "toModelOutput");
+  removeMember(object, "experimental_onSchemaValidationError");
+  removeMember(object, "providerOptions");
+  removeMember(object, "streamCall");
 }
 
 /** Writes the resolved `type` back onto the tool object (replacing any author's). */


### PR DESCRIPTION
## Summary
- add externalTool() as a use-generative sentinel for externally executed backend tools
- teach the generative compiler to emit type: "backend" while stripping schema/executor metadata across builds
- update docs to recommend use generative, document defineMcpToolkit for MCP, and show externalTool for non-MCP external tools

## Validation
- pnpm --filter @assistant-ui/x-generative-compiler test
- pnpm --filter @assistant-ui/core test -- --run packages/core/src/react/model-context/define-toolkit.test.ts
- pnpm lint
- pnpm build