### PR TITLE
fix(react-langgraph): batch parallel tool results into a single resume

### DIFF
--- a/.changeset/langgraph-parallel-tool-results.md
+++ b/.changeset/langgraph-parallel-tool-results.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: batch parallel tool results so a turn with multiple tool calls resumes in a single run

--- a/packages/react-langgraph/src/bufferToolResults.test.ts
+++ b/packages/react-langgraph/src/bufferToolResults.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { bufferToolResult } from "./bufferToolResults";
+
+type ToolMessage = { tool_call_id: string; content: string };
+
+const msg = (id: string): ToolMessage => ({
+  tool_call_id: id,
+  content: `result-${id}`,
+});
+
+describe("bufferToolResult", () => {
+  it("releases a single tool call immediately", () => {
+    const buffer = new Map<string, ToolMessage>();
+    const batch = bufferToolResult(buffer, [{ id: "a" }], msg("a"));
+    expect(batch).toEqual([msg("a")]);
+    expect(buffer.size).toBe(0);
+  });
+
+  it("buffers parallel tool calls until every one has a result", () => {
+    const buffer = new Map<string, ToolMessage>();
+    const pending = [{ id: "a" }, { id: "b" }];
+
+    // First result of the pair: keep waiting.
+    expect(bufferToolResult(buffer, pending, msg("a"))).toBeNull();
+    expect(buffer.size).toBe(1);
+
+    // Second result completes the turn: release both at once.
+    const batch = bufferToolResult(buffer, pending, msg("b"));
+    expect(batch).toEqual([msg("a"), msg("b")]);
+    expect(buffer.size).toBe(0);
+  });
+
+  it("releases the batch in pending-tool-call order, not arrival order", () => {
+    const buffer = new Map<string, ToolMessage>();
+    const pending = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+    expect(bufferToolResult(buffer, pending, msg("c"))).toBeNull();
+    expect(bufferToolResult(buffer, pending, msg("a"))).toBeNull();
+    const batch = bufferToolResult(buffer, pending, msg("b"));
+
+    expect(batch).toEqual([msg("a"), msg("b"), msg("c")]);
+  });
+
+  it("does not release while a sibling tool call is still outstanding", () => {
+    const buffer = new Map<string, ToolMessage>();
+    const pending = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+    expect(bufferToolResult(buffer, pending, msg("a"))).toBeNull();
+    expect(bufferToolResult(buffer, pending, msg("b"))).toBeNull();
+    expect(buffer.size).toBe(2);
+  });
+
+  it("releases a late or duplicate result on its own without wedging", () => {
+    const buffer = new Map<string, ToolMessage>();
+    // The resolved call is not among the turn's pending calls.
+    const batch = bufferToolResult(buffer, [{ id: "other" }], msg("a"));
+    expect(batch).toEqual([msg("a")]);
+    expect(buffer.has("a")).toBe(false);
+    // The unrelated pending call stays buffered-free; nothing leaks.
+    expect(buffer.size).toBe(0);
+  });
+
+  it("supports two pending turns sharing a buffer without cross-talk", () => {
+    const buffer = new Map<string, ToolMessage>();
+
+    // Turn 1: single call resolves and is released.
+    expect(bufferToolResult(buffer, [{ id: "a" }], msg("a"))).toEqual([
+      msg("a"),
+    ]);
+
+    // Turn 2: a fresh parallel pair buffers and releases independently.
+    const pending2 = [{ id: "b" }, { id: "c" }];
+    expect(bufferToolResult(buffer, pending2, msg("b"))).toBeNull();
+    expect(bufferToolResult(buffer, pending2, msg("c"))).toEqual([
+      msg("b"),
+      msg("c"),
+    ]);
+    expect(buffer.size).toBe(0);
+  });
+});

--- a/packages/react-langgraph/src/bufferToolResults.ts
+++ b/packages/react-langgraph/src/bufferToolResults.ts
@@ -1,0 +1,31 @@
+/**
+ * Buffer client tool results for a turn and release them only once every
+ * pending tool call has one. This lets the LangGraph runtime resume a turn
+ * that has parallel tool calls in a single run, instead of resuming once per
+ * result (which would resume the graph while sibling tool calls are still
+ * executing).
+ *
+ * Mutates `buffer`. Returns the batch (in pending-tool-call order) when the
+ * turn is complete, or `null` while results are still outstanding.
+ *
+ * A result whose tool call isn't among the turn's pending calls (a late or
+ * duplicate result) is released on its own rather than buffered indefinitely.
+ */
+export const bufferToolResult = <T extends { tool_call_id: string }>(
+  buffer: Map<string, T>,
+  pendingToolCalls: readonly { id: string }[],
+  result: T,
+): T[] | null => {
+  buffer.set(result.tool_call_id, result);
+
+  const pendingIds = pendingToolCalls.map((toolCall) => toolCall.id);
+  const expected = pendingIds.includes(result.tool_call_id)
+    ? pendingIds
+    : [result.tool_call_id];
+
+  if (!expected.every((id) => buffer.has(id))) return null;
+
+  const batch = expected.map((id) => buffer.get(id)!);
+  for (const id of expected) buffer.delete(id);
+  return batch;
+};

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -48,6 +48,7 @@ import {
 } from "./useLangGraphMessages";
 import { appendLangChainChunk } from "./appendLangChainChunk";
 import { useLangGraphStreamingTiming } from "./useLangGraphStreamingTiming";
+import { bufferToolResult } from "./bufferToolResults";
 
 const getPendingToolCalls = (messages: LangChainMessage[]) => {
   const pendingToolCalls = new Map<string, LangChainToolCall>();
@@ -432,6 +433,11 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   const toolArgsKeyOrderCacheRef = useRef<Map<string, Map<string, string[]>>>(
     new Map(),
   );
+  // Buffers client tool results within a turn so parallel tool calls resume the
+  // graph in one run once every pending call has a result. See bufferToolResult.
+  const toolResultBufferRef = useRef<
+    Map<string, LangChainMessage & { type: "tool" }>
+  >(new Map());
   const hasExecutingTools = Object.values(toolStatuses).some(
     (s) => s?.type === "executing",
   );
@@ -512,6 +518,8 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       send: handleSendMessage,
     } satisfies LangGraphRuntimeExtras,
     onNew: async (msg) => {
+      // A new turn abandons any half-collected parallel tool batch.
+      toolResultBufferRef.current.clear();
       const cancellations =
         autoCancelPendingToolCalls !== false
           ? getPendingToolCalls(messages).map(
@@ -546,24 +554,29 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       isError,
       artifact,
     }) => {
-      // TODO parallel human in the loop calls
-      await handleSendMessage(
-        [
-          {
-            type: "tool",
-            name: toolName,
-            tool_call_id: toolCallId,
-            content: JSON.stringify(result),
-            artifact,
-            status: isError ? "error" : "success",
-          },
-        ],
-        // TODO reuse runconfig here!
-        {},
+      // Buffer results until every pending tool call in the turn has one, then
+      // resume the graph with the full batch in a single run. Sending each
+      // result on its own would resume LangGraph while sibling tool calls of a
+      // parallel turn are still executing.
+      const batch = bufferToolResult(
+        toolResultBufferRef.current,
+        getPendingToolCalls(messages),
+        {
+          type: "tool",
+          name: toolName,
+          tool_call_id: toolCallId,
+          content: JSON.stringify(result),
+          artifact,
+          status: isError ? "error" : "success",
+        },
       );
+      if (!batch) return;
+      // TODO reuse runconfig here!
+      await handleSendMessage(batch, {});
     },
     onEdit: getCheckpointId
       ? async (msg) => {
+          toolResultBufferRef.current.clear();
           const truncated = truncateLangChainMessages(
             threadMessagesRef.current,
             msg.parentId,
@@ -588,6 +601,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       : undefined,
     onReload: getCheckpointId
       ? async (parentId, config) => {
+          toolResultBufferRef.current.clear();
           const truncated = truncateLangChainMessages(
             threadMessagesRef.current,
             parentId,
@@ -629,6 +643,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
 
       // drop stale callbacks and abort the pending load on thread switch/unmount
       const controller = new AbortController();
+      toolResultBufferRef.current.clear();
       setIsLoadingThread(true);
       load(externalId, { signal: controller.signal })
         .then(({ messages, interrupts, uiMessages }) => {


### PR DESCRIPTION
## Summary

Fixes parallel tool-call handling in `@assistant-ui/react-langgraph`. Previously `onAddToolResult` resumed the LangGraph run **once per tool result**, so a turn with multiple parallel tool calls (frontend / human-in-the-loop tools) resumed the graph while sibling tool calls were still executing — sending one run per result instead of one run for the whole turn. The code carried an explicit `// TODO parallel human in the loop calls`.

This was the one gap surfaced by a cross-runtime audit of parallel tool-call support: every other runtime (local, external-store, AI SDK, AG-UI, assistant-transport) buffers for **all** tool results before continuing; LangGraph submitted them sequentially.

## Changes

- **`bufferToolResult`** (`bufferToolResults.ts`) — a small pure helper that buffers a turn's client tool results and releases them only once **every pending tool call** has a result, returning the batch in pending-tool-call order (or `null` while results are outstanding). A late/duplicate result whose call isn't among the turn's pending calls is released on its own so it can't wedge the buffer.
- **`useLangGraphRuntime`** — `onAddToolResult` now buffers via `bufferToolResult(buffer, getPendingToolCalls(messages), …)` and resumes with a single batched `handleSendMessage` once the turn is complete. The buffer is cleared whenever a turn is abandoned (`onNew`, `onEdit`, `onReload`, thread load) so partial results never leak across turns.

Single-tool turns are unchanged (one pending call → released immediately).

## Tests

- `bufferToolResults.test.ts` — 6 cases: single-call passthrough, parallel buffering until complete, pending-order (not arrival-order) release, no early release while a sibling is outstanding, late/duplicate released alone, and two turns sharing a buffer without cross-talk.

`pnpm --filter @assistant-ui/react-langgraph test` (139 passed), `pnpm lint`, and `pnpm turbo build --filter=@assistant-ui/react-langgraph` all pass.
