### PR TITLE
fix: omit external tools from server builds

### DIFF
--- a/.changeset/strip-external-tools.md
+++ b/.changeset/strip-external-tools.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-generative-compiler": patch
+---
+
+fix: omit externalTool entries from server toolkits

--- a/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
@@ -54,8 +54,9 @@ Marks a generative toolkit entry as an externally executed backend tool.
 
 Use this when another system (for example a backend route or LangGraph node)
 already defines and executes the tool, but assistant-ui should render its
-tool calls. The use-generative compiler converts `execute: externalTool()`
-into `type: "backend"` and strips schema/executor metadata from both builds.
+tool calls. The use-generative compiler omits `execute: externalTool()`
+entries from the server build and keeps a `type: "backend"` renderer on the
+client build.
 
 ```ts
 function externalTool(): never;

--- a/apps/docs/content/docs/migrations/toolkit-tools.mdx
+++ b/apps/docs/content/docs/migrations/toolkit-tools.mdx
@@ -105,8 +105,8 @@ export function App() {
 
 If you used `makeAssistantToolUI` or `useAssistantToolUI` for a backend, MCP, or
 LangGraph tool, the tool executes elsewhere. Prefer a `"use generative"` toolkit
-with `execute: externalTool()` so the compiler emits `type: "backend"` with no
-schema or executor, while the client keeps your renderer:
+with `execute: externalTool()` so the compiler omits the server entry, while the
+client keeps your renderer as `type: "backend"`:
 
 ```tsx
 // app/toolkit.tsx

--- a/apps/docs/content/docs/tools/defining-tools.mdx
+++ b/apps/docs/content/docs/tools/defining-tools.mdx
@@ -26,7 +26,7 @@ client/server boundary for you.
 In a `"use generative"` file every tool declares an `execute`, and you never
 write `type` yourself — the compiler infers it. For render-only external tools,
 `externalTool()` is the escape hatch that satisfies the compiler without
-emitting schema or executable code.
+emitting schema or executable code on the server.
 
 ## Quick start (`"use generative"`)
 
@@ -180,7 +180,7 @@ The tool's **kind is inferred from its `execute`** and written back as a `type` 
 | `hitlTool()` | **human** | schema only | schema + `render` |
 | `stubTool()` | **frontend** (executor supplied at runtime) | schema only | schema + `render`/`renderText` |
 | `providerTool({ … })` | **provider** | schema + provider config | schema + provider config |
-| `externalTool()` | **backend** (defined elsewhere) | `type: "backend"` only | `type: "backend"` + `render`/`renderText` |
+| `externalTool()` | **backend** (defined elsewhere) | omitted | `type: "backend"` + `render`/`renderText` |
 
 The compiler also enforces, at build time:
 
@@ -283,10 +283,10 @@ web_search: {
 },
 ```
 
-The compiler emits `type: "backend"` with no schema, parameters, or executor on
-the server, so the model still gets the tool definition from the external
-system. The client build keeps only `type: "backend"` and the renderer (or
-`renderText`) for matching tool-call message parts.
+The compiler omits this entry from the server build, so the model still gets
+the tool definition from the external system. The client build keeps only
+`type: "backend"` and the renderer (or `renderText`) for matching tool-call
+message parts.
 
 ### Dynamic (stateful) tools
 

--- a/examples/with-artifacts/app/page.tsx
+++ b/examples/with-artifacts/app/page.tsx
@@ -4,7 +4,6 @@ import { Thread } from "@/components/assistant-ui/thread";
 import {
   AssistantRuntimeProvider,
   Tools,
-  type Toolkit,
   useAui,
   useAuiState,
   AuiProvider,
@@ -12,30 +11,9 @@ import {
 } from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 import type { ToolCallMessagePart } from "@assistant-ui/react";
-import { TerminalIcon, CodeIcon, EyeIcon } from "lucide-react";
+import { CodeIcon, EyeIcon } from "lucide-react";
 import { useState } from "react";
-import { z } from "zod";
-
-const toolkit = {
-  render_html: {
-    description:
-      "Whenever the user asks for HTML code, call this function. The user will see the HTML code rendered in their browser.",
-    parameters: z.object({
-      code: z.string(),
-    }),
-    execute: async () => {
-      return {};
-    },
-    render: () => {
-      return (
-        <div className="bg-primary text-primary-foreground my-2 inline-flex items-center gap-2 rounded-full border px-4 py-2">
-          <TerminalIcon className="size-4" />
-          render_html(&#123; code: &quot;...&quot; &#125;)
-        </div>
-      );
-    },
-  },
-} satisfies Toolkit;
+import toolkit from "./toolkit";
 
 function ArtifactsView() {
   const [tab, setTab] = useState<"source" | "preview">("source");

--- a/examples/with-artifacts/app/toolkit.tsx
+++ b/examples/with-artifacts/app/toolkit.tsx
@@ -1,0 +1,22 @@
+"use generative";
+
+import { defineToolkit, externalTool } from "@assistant-ui/react";
+import { TerminalIcon } from "lucide-react";
+import { z } from "zod";
+
+export default defineToolkit({
+  render_html: {
+    parameters: z.object({
+      code: z.string(),
+    }),
+    execute: externalTool(),
+    render: () => {
+      return (
+        <div className="bg-primary text-primary-foreground my-2 inline-flex items-center gap-2 rounded-full border px-4 py-2">
+          <TerminalIcon className="size-4" />
+          render_html(&#123; code: &quot;...&quot; &#125;)
+        </div>
+      );
+    },
+  },
+});

--- a/examples/with-chain-of-thought/app/api/chat/route.ts
+++ b/examples/with-chain-of-thought/app/api/chat/route.ts
@@ -9,8 +9,9 @@ import {
   JsonToSseTransformStream,
 } from "ai";
 import type { UIMessage, UIMessageStreamWriter } from "ai";
-import { frontendTools } from "@assistant-ui/react-ai-sdk";
+import { generativeTools } from "@assistant-ui/react-ai-sdk";
 import { z } from "zod";
+import toolkit from "../../toolkit";
 
 export const maxDuration = 30;
 
@@ -113,7 +114,7 @@ async function streamModel(
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(10),
     tools: {
-      ...frontendTools(frontendToolDefs),
+      ...generativeTools({ toolkit, frontendTools: frontendToolDefs }),
       get_current_weather: tool({
         description: "Get the current weather for a city",
         inputSchema: zodSchema(z.object({ city: z.string() })),

--- a/examples/with-chain-of-thought/app/page.tsx
+++ b/examples/with-chain-of-thought/app/page.tsx
@@ -3,51 +3,14 @@
 import {
   AssistantRuntimeProvider,
   Tools,
-  type Toolkit,
   useAui,
   AuiProvider,
   Suggestions,
 } from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
-import { z } from "zod";
 import { MyThread } from "./MyThread";
 import { lastAssistantMessageIsCompleteWithApprovalResponses } from "ai";
-
-const toolkit = {
-  execute_js: {
-    type: "frontend",
-    description: "Execute JavaScript code and return the result",
-    parameters: z.object({
-      code: z.string().describe("The JavaScript code to execute"),
-    }),
-    execute: async ({ code }) => {
-      try {
-        const result = eval(code);
-        return { success: true, result: String(result) };
-      } catch (e) {
-        return { success: false, error: String(e) };
-      }
-    },
-    render: ({ args, result, status }) => (
-      <div className="bg-muted/30 my-2 rounded-lg border p-4 text-sm">
-        <p className="mb-1 font-semibold">execute_js</p>
-        <pre className="bg-background rounded p-2 font-mono text-xs whitespace-pre-wrap">
-          {args.code}
-        </pre>
-        {status.type !== "running" && result && (
-          <div className="mt-2 border-t pt-2">
-            <p className="text-muted-foreground font-semibold">
-              {result.success ? "Result:" : "Error:"}
-            </p>
-            <pre className="font-mono text-xs whitespace-pre-wrap">
-              {result.success ? result.result : result.error}
-            </pre>
-          </div>
-        )}
-      </div>
-    ),
-  },
-} satisfies Toolkit;
+import toolkit from "./toolkit";
 
 function MyThreadWithSuggestions() {
   const aui = useAui({

--- a/examples/with-chain-of-thought/app/toolkit.tsx
+++ b/examples/with-chain-of-thought/app/toolkit.tsx
@@ -1,0 +1,47 @@
+"use generative";
+
+import { defineToolkit } from "@assistant-ui/react";
+import { z } from "zod";
+
+type ExecuteJsResult =
+  | { success: true; result: string }
+  | { success: false; error: string };
+
+export default defineToolkit({
+  execute_js: {
+    description: "Execute JavaScript code and return the result",
+    parameters: z.object({
+      code: z.string().describe("The JavaScript code to execute"),
+    }),
+    execute: async ({ code }) => {
+      "use client";
+      try {
+        const result = eval(code);
+        return { success: true, result: String(result) };
+      } catch (e) {
+        return { success: false, error: String(e) };
+      }
+    },
+    render: ({ args, result, status }) => {
+      const output = result as ExecuteJsResult | undefined;
+      return (
+        <div className="bg-muted/30 my-2 rounded-lg border p-4 text-sm">
+          <p className="mb-1 font-semibold">execute_js</p>
+          <pre className="bg-background rounded p-2 font-mono text-xs whitespace-pre-wrap">
+            {args.code}
+          </pre>
+          {status.type !== "running" && output && (
+            <div className="mt-2 border-t pt-2">
+              <p className="text-muted-foreground font-semibold">
+                {output.success ? "Result:" : "Error:"}
+              </p>
+              <pre className="font-mono text-xs whitespace-pre-wrap">
+                {output.success ? output.result : output.error}
+              </pre>
+            </div>
+          )}
+        </div>
+      );
+    },
+  },
+});

--- a/examples/with-generative-ui/app/api/chat/route.ts
+++ b/examples/with-generative-ui/app/api/chat/route.ts
@@ -3,20 +3,23 @@ import {
   streamText,
   convertToModelMessages,
   stepCountIs,
-  jsonSchema,
   tool,
   zodSchema,
 } from "ai";
 import type { UIMessage } from "ai";
 import { z } from "zod";
+import { generativeTools } from "@assistant-ui/react-ai-sdk";
 import {
   renderGuiToolDescription,
   renderGuiToolInputSchema,
 } from "../../../lib/render-gui-tool";
+import toolkit from "../../toolkit";
 
 export const maxDuration = 30;
 
-type ToolDef = { description?: string; parameters: Record<string, unknown> };
+type FrontendToolDefs = NonNullable<
+  Parameters<typeof generativeTools>[0]["frontendTools"]
+>;
 
 export async function POST(req: Request) {
   const {
@@ -26,21 +29,8 @@ export async function POST(req: Request) {
   }: {
     messages: UIMessage[];
     system?: string;
-    tools?: Record<string, ToolDef>;
+    tools?: FrontendToolDefs;
   } = await req.json();
-
-  // Convert client-defined frontend tools to AI SDK format
-  const frontendToolDefs = clientTools
-    ? Object.fromEntries(
-        Object.entries(clientTools).map(([name, def]) => [
-          name,
-          {
-            description: def.description ?? "",
-            inputSchema: jsonSchema(def.parameters),
-          },
-        ]),
-      )
-    : {};
 
   const result = streamText({
     model: openai("gpt-5.4-nano"),
@@ -48,7 +38,10 @@ export async function POST(req: Request) {
     stopWhen: stepCountIs(10),
     ...(system ? { system } : {}),
     tools: {
-      ...frontendToolDefs,
+      ...generativeTools({
+        toolkit,
+        ...(clientTools && { frontendTools: clientTools }),
+      }),
 
       render_gui: tool({
         description: renderGuiToolDescription,

--- a/examples/with-generative-ui/app/page.tsx
+++ b/examples/with-generative-ui/app/page.tsx
@@ -5,51 +5,12 @@ import {
   AssistantRuntimeProvider,
   Suggestions,
   Tools,
-  type Toolkit,
   useAui,
 } from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
-import { z } from "zod";
-import { ChartToolUI } from "@/components/chart-tool-ui";
-import { DatePickerToolUI } from "@/components/date-picker-tool-ui";
-import { ContactFormToolUI } from "@/components/contact-form-tool-ui";
-import { LocationToolUI } from "@/components/location-tool-ui";
 import { ExampleNav } from "@/components/example-nav";
-
-const toolkit = {
-  select_date: {
-    type: "human",
-    description:
-      "Ask the user to select a date. Use this when you need to collect a date (e.g. for scheduling, booking, deadlines).",
-    parameters: z.object({
-      prompt: z.string().describe("Message to display to the user"),
-      minDate: z.string().optional().describe("Minimum date (ISO string)"),
-      maxDate: z.string().optional().describe("Maximum date (ISO string)"),
-    }),
-    render: DatePickerToolUI,
-  },
-  collect_contact: {
-    type: "human",
-    description:
-      "Collect contact information from the user. Use this when you need the user's name, email, or phone number.",
-    parameters: z.object({
-      prompt: z.string().describe("Message to display to the user"),
-      fields: z
-        .array(z.enum(["name", "email", "phone"]))
-        .describe("Which fields to collect"),
-    }),
-    render: ContactFormToolUI,
-  },
-  generate_chart: {
-    type: "backend",
-    render: ChartToolUI,
-  },
-  show_location: {
-    type: "backend",
-    render: LocationToolUI,
-  },
-} satisfies Toolkit;
+import toolkit from "./toolkit";
 
 export default function Home() {
   const runtime = useChatRuntime({

--- a/examples/with-generative-ui/app/toolkit.tsx
+++ b/examples/with-generative-ui/app/toolkit.tsx
@@ -1,0 +1,42 @@
+"use generative";
+
+import { defineToolkit, externalTool, hitlTool } from "@assistant-ui/react";
+import { ChartToolUI } from "@/components/chart-tool-ui";
+import { DatePickerToolUI } from "@/components/date-picker-tool-ui";
+import { ContactFormToolUI } from "@/components/contact-form-tool-ui";
+import { LocationToolUI } from "@/components/location-tool-ui";
+import { z } from "zod";
+
+export default defineToolkit({
+  select_date: {
+    description:
+      "Ask the user to select a date. Use this when you need to collect a date (e.g. for scheduling, booking, deadlines).",
+    parameters: z.object({
+      prompt: z.string().describe("Message to display to the user"),
+      minDate: z.string().optional().describe("Minimum date (ISO string)"),
+      maxDate: z.string().optional().describe("Maximum date (ISO string)"),
+    }),
+    execute: hitlTool(),
+    render: DatePickerToolUI,
+  },
+  collect_contact: {
+    description:
+      "Collect contact information from the user. Use this when you need the user's name, email, or phone number.",
+    parameters: z.object({
+      prompt: z.string().describe("Message to display to the user"),
+      fields: z
+        .array(z.enum(["name", "email", "phone"]))
+        .describe("Which fields to collect"),
+    }),
+    execute: hitlTool(),
+    render: ContactFormToolUI,
+  },
+  generate_chart: {
+    execute: externalTool(),
+    render: ChartToolUI,
+  },
+  show_location: {
+    execute: externalTool(),
+    render: LocationToolUI,
+  },
+});

--- a/examples/with-langgraph/app/page.tsx
+++ b/examples/with-langgraph/app/page.tsx
@@ -1,27 +1,9 @@
 "use client";
 
 import { Thread } from "@/components/assistant-ui/thread";
-import { PriceSnapshotToolUI } from "@/components/tools/price-snapshot/PriceSnapshotTool";
-import { PurchaseStockToolUI } from "@/components/tools/purchase-stock/PurchaseStockTool";
 import { ThreadList } from "@/components/assistant-ui/thread-list";
-import {
-  useAui,
-  AuiProvider,
-  Suggestions,
-  Tools,
-  type Toolkit,
-} from "@assistant-ui/react";
-
-const toolkit = {
-  price_snapshot: {
-    type: "backend",
-    render: PriceSnapshotToolUI,
-  },
-  purchase_stock: {
-    type: "backend",
-    render: PurchaseStockToolUI,
-  },
-} satisfies Toolkit;
+import { useAui, AuiProvider, Suggestions, Tools } from "@assistant-ui/react";
+import toolkit from "./toolkit";
 
 function ThreadWithSuggestions() {
   const aui = useAui({

--- a/examples/with-langgraph/app/toolkit.tsx
+++ b/examples/with-langgraph/app/toolkit.tsx
@@ -1,0 +1,16 @@
+"use generative";
+
+import { defineToolkit, externalTool } from "@assistant-ui/react";
+import { PriceSnapshotToolUI } from "@/components/tools/price-snapshot/PriceSnapshotTool";
+import { PurchaseStockToolUI } from "@/components/tools/purchase-stock/PurchaseStockTool";
+
+export default defineToolkit({
+  price_snapshot: {
+    execute: externalTool(),
+    render: PriceSnapshotToolUI,
+  },
+  purchase_stock: {
+    execute: externalTool(),
+    render: PurchaseStockToolUI,
+  },
+});

--- a/packages/core/src/react/model-context/external-tool.ts
+++ b/packages/core/src/react/model-context/external-tool.ts
@@ -3,8 +3,9 @@
  *
  * Use this when another system (for example a backend route or LangGraph node)
  * already defines and executes the tool, but assistant-ui should render its
- * tool calls. The use-generative compiler converts `execute: externalTool()`
- * into `type: "backend"` and strips schema/executor metadata from both builds.
+ * tool calls. The use-generative compiler omits `execute: externalTool()`
+ * entries from the server build and keeps a `type: "backend"` renderer on the
+ * client build.
  */
 export function externalTool(): never {
   throw new Error(

--- a/packages/x-generative-compiler/README.md
+++ b/packages/x-generative-compiler/README.md
@@ -11,7 +11,8 @@ colocates a tool's schema, its server-only `execute`, and its client-only
   drops backend `execute` and `hitl()` sentinels, and stamps each tool's inferred
   `type`.
 - **server** — keeps the backend `execute` (importing `server-only`), drops
-  `render`.
+  `render`, and omits externally-defined backend tools marked with
+  `externalTool()`.
 
 The marker functions a `"use generative"` file imports — `defineToolkit` and
 `hitl` — live in `@assistant-ui/core/react` (re-exported from `@assistant-ui/react`).

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -514,7 +514,8 @@ export default defineToolkit({
 });`;
 
     const server = compileGenerative(src, { target: "server" }).code;
-    expect(server).toContain('type: "backend"');
+    expect(server).not.toContain("web_search");
+    expect(server).not.toContain('type: "backend"');
     expect(server).not.toContain("server-only");
     expect(server).not.toContain("description");
     expect(server).not.toContain("parameters");

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -375,6 +375,8 @@ function compileToolkit(
   flags: TargetFlags,
   filename: string | undefined,
 ): void {
+  const nextProperties: t.ObjectExpression["properties"] = [];
+
   for (const entry of object.properties) {
     const value = entryValue(entry);
     if (!value) {
@@ -382,6 +384,7 @@ function compileToolkit(
         t.isSpreadElement(entry) &&
         isSafeToolkitSpread(entry, safeToolkitSpreads)
       ) {
+        nextProperties.push(entry);
         continue;
       }
       // A generative tool (`generative.present()`) is split by the library's
@@ -389,7 +392,10 @@ function compileToolkit(
       // method or opaque call like `makeTool()` — can't be analyzed, so its
       // `execute` could reach the client unstripped.
       const raw = entryRawValue(entry);
-      if (raw && isGenerativeToolEntry(raw, instances)) continue;
+      if (raw && isGenerativeToolEntry(raw, instances)) {
+        nextProperties.push(entry);
+        continue;
+      }
       throw new GenerativeCompileError(
         "each tool must be an inline object literal (`name: { ... }`) or a " +
           "compiler-visible toolkit spread / generative tool (e.g. " +
@@ -435,6 +441,7 @@ function compileToolkit(
           filename,
         );
       }
+      if (target === "server") continue;
       stripExternalToolMetadata(value);
     }
 
@@ -456,7 +463,10 @@ function compileToolkit(
 
     setToolType(value, type);
     setBackendDefault(value, target, type);
+    nextProperties.push(entry);
   }
+
+  object.properties = nextProperties;
 }
 
 function applyProviderToolConfig(


### PR DESCRIPTION
## Summary
- omit `externalTool()` entries from generated server toolkits while keeping backend renderers on the client
- update docs/API reference wording for the new server omission behavior
- migrate examples with plain toolkits to `"use generative"` toolkits where their backend routes can consume the compiled server toolkit

## Validation
- pnpm --filter @assistant-ui/x-generative-compiler test
- pnpm --filter with-chain-of-thought build
- pnpm --filter with-artifacts build
- pnpm --filter with-generative-ui build
- pnpm --filter with-langgraph build
- pnpm lint
- pnpm build

## Remaining plain toolkit source cases
Left intentionally because they rely on frontend-uploaded schemas or runtime state: `with-ag-ui`, `with-assistant-transport`, `with-ffmpeg`, `apps/docs/lib/playground-chat-toolkit.tsx`, and `apps/docs/contexts/ArtifactsRuntimeProvider.tsx`.
