### PR TITLE
fix: check generative compiler compatibility

### DIFF
--- a/.changeset/check-generative-compiler-version.md
+++ b/.changeset/check-generative-compiler-version.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/x-generative-compiler": patch
+---
+
+feat: check the generative compiler version against the core package compatibility range

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,9 @@
     "assistant-stream": "^0.3.20",
     "nanoid": "^5.1.11"
   },
+  "optionalDevDependencies": {
+    "@assistant-ui/x-generative-compiler": "^0.0.3"
+  },
   "peerDependencies": {
     "@assistant-ui/store": "^0.2.13",
     "@assistant-ui/tap": "^0.5.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "nanoid": "^5.1.11"
   },
   "optionalDevDependencies": {
-    "@assistant-ui/x-generative-compiler": "^0.0.3"
+    "@assistant-ui/x-generative-compiler": ">=0.0.3"
   },
   "peerDependencies": {
     "@assistant-ui/store": "^0.2.13",

--- a/packages/x-generative-compiler/package.json
+++ b/packages/x-generative-compiler/package.json
@@ -37,13 +37,15 @@
     "@babel/generator": "^7.29.7",
     "@babel/parser": "^7.29.7",
     "@babel/traverse": "^7.29.7",
-    "@babel/types": "^7.29.7"
+    "@babel/types": "^7.29.7",
+    "semver": "^7.8.1"
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
     "@types/babel__generator": "^7.27.0",
     "@types/babel__traverse": "^7.28.0",
     "@types/node": "^25.9.1",
+    "@types/semver": "^7.7.1",
     "vitest": "^4.1.7"
   },
   "publishConfig": {

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -1,9 +1,77 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as nodePath from "node:path";
 import { describe, it, expect } from "vitest";
 import {
   compileGenerative,
   isGenerativeModule,
   GenerativeCompileError,
 } from "./compile";
+
+const minimalSource = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  weather: {
+    execute: async () => 1,
+  },
+});
+`;
+
+function createPackage(
+  root: string,
+  name: string,
+  packageJson: Record<string, unknown> = {},
+): string {
+  const packageRoot = nodePath.join(root, "node_modules", ...name.split("/"));
+  const distRoot = nodePath.join(packageRoot, "dist");
+  mkdirSync(distRoot, { recursive: true });
+  writeFileSync(nodePath.join(distRoot, "index.js"), "export {};\n");
+  writeFileSync(
+    nodePath.join(packageRoot, "package.json"),
+    JSON.stringify(
+      {
+        name,
+        version: "0.0.0",
+        type: "module",
+        exports: {
+          ".": "./dist/index.js",
+        },
+        ...packageJson,
+      },
+      null,
+      2,
+    ),
+  );
+  return packageRoot;
+}
+
+function createCompatibilityFixture(range: string | null): string {
+  const appRoot = mkdtempSync(
+    nodePath.join(tmpdir(), "aui-generative-compiler-"),
+  );
+  const srcRoot = nodePath.join(appRoot, "src");
+  mkdirSync(srcRoot, { recursive: true });
+  const filename = nodePath.join(srcRoot, "toolkit.tsx");
+  writeFileSync(filename, minimalSource);
+
+  const reactRoot = createPackage(appRoot, "@assistant-ui/react", {
+    dependencies: {
+      "@assistant-ui/core": "0.0.0",
+    },
+  });
+  createPackage(reactRoot, "@assistant-ui/core", {
+    version: "0.2.10",
+    ...(range
+      ? {
+          optionalDevDependencies: {
+            "@assistant-ui/x-generative-compiler": range,
+          },
+        }
+      : {}),
+  });
+
+  return filename;
+}
 
 const source = `"use generative";
 import { z } from "zod";
@@ -33,6 +101,32 @@ export default defineToolkit({
 
 const server = () => compileGenerative(source, { target: "server" }).code;
 const client = () => compileGenerative(source, { target: "client" }).code;
+
+describe("compileGenerative — core/compiler compatibility", () => {
+  it("allows a compiler version that satisfies core's optionalDevDependencies range", () => {
+    const filename = createCompatibilityFixture("^0.0.3");
+
+    expect(() =>
+      compileGenerative(minimalSource, { target: "server", filename }),
+    ).not.toThrow();
+  });
+
+  it("throws when core requires a different compiler range", () => {
+    const filename = createCompatibilityFixture("<0.0.3");
+
+    expect(() =>
+      compileGenerative(minimalSource, { target: "server", filename }),
+    ).toThrow(/requires @assistant-ui\/x-generative-compiler <0\.0\.3/);
+  });
+
+  it("skips the check for older core packages without compatibility metadata", () => {
+    const filename = createCompatibilityFixture(null);
+
+    expect(() =>
+      compileGenerative(minimalSource, { target: "server", filename }),
+    ).not.toThrow();
+  });
+});
 
 describe("compileGenerative — server target", () => {
   const code = server();
@@ -499,7 +593,7 @@ export default defineToolkit({
     expect(client).not.toContain("execute");
   });
 
-  it("infers `backend` from execute: externalTool() and strips schema/execution metadata", () => {
+  it("infers `backend` from execute: externalTool(), renders on the client, and omits from the server", () => {
     const src = `"use generative";
 import { z } from "zod";
 import { SearchResults } from "@/ui/search-results";

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -104,7 +104,7 @@ const client = () => compileGenerative(source, { target: "client" }).code;
 
 describe("compileGenerative — core/compiler compatibility", () => {
   it("allows a compiler version that satisfies core's optionalDevDependencies range", () => {
-    const filename = createCompatibilityFixture("^0.0.3");
+    const filename = createCompatibilityFixture(">=0.0.0");
 
     expect(() =>
       compileGenerative(minimalSource, { target: "server", filename }),
@@ -125,6 +125,23 @@ describe("compileGenerative — core/compiler compatibility", () => {
     expect(() =>
       compileGenerative(minimalSource, { target: "server", filename }),
     ).not.toThrow();
+  });
+
+  it("wraps malformed package metadata in a compile error", () => {
+    const filename = createCompatibilityFixture(">=0.0.0");
+    const packageJsonPath = nodePath.join(
+      nodePath.dirname(filename),
+      "..",
+      "node_modules",
+      "@assistant-ui",
+      "react",
+      "package.json",
+    );
+    writeFileSync(packageJsonPath, "{");
+
+    expect(() =>
+      compileGenerative(minimalSource, { target: "server", filename }),
+    ).toThrow(GenerativeCompileError);
   });
 });
 

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -414,7 +414,15 @@ function findPackageJsonFromNodeModules(
 
 function readPackageJson(packageJsonPath: string): PackageJson | null {
   if (!existsSync(packageJsonPath)) return null;
-  return JSON.parse(readFileSync(packageJsonPath, "utf8")) as PackageJson;
+  try {
+    return JSON.parse(readFileSync(packageJsonPath, "utf8")) as PackageJson;
+  } catch (error) {
+    throw new GenerativeCompileError(
+      `could not parse package metadata at ${packageJsonPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
 }
 
 /**

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -1,7 +1,11 @@
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import * as nodePath from "node:path";
 import { parse } from "@babel/parser";
 import _traverse, { type NodePath } from "@babel/traverse";
 import _generate from "@babel/generator";
 import * as t from "@babel/types";
+import { satisfies } from "semver";
 import { DIRECTIVE, type Target } from "./constants";
 
 // @babel/traverse and @babel/generator are CJS; their default export is the
@@ -21,6 +25,17 @@ const TOOLKIT_WRAPPER = "defineToolkit";
 const MCP_TOOLKIT_WRAPPER = "defineMcpToolkit";
 /** The required wrapper around a generative-UI library (stripped at build time). */
 const COMPONENTS_WRAPPER = "defineGenerativeComponents";
+/** The core package whose metadata declares supported compiler versions. */
+const CORE_PACKAGE = "@assistant-ui/core";
+/** This package, checked against core's compatibility range. */
+const COMPILER_PACKAGE = "@assistant-ui/x-generative-compiler";
+/** Packages that re-export core's generative markers. */
+const DISTRIBUTION_PACKAGES = [
+  CORE_PACKAGE,
+  "@assistant-ui/react",
+  "@assistant-ui/react-native",
+  "@assistant-ui/react-ink",
+] as const;
 /**
  * The class whose instances expose split-by-condition tools (`present()`,
  * `promptUser()`). A toolkit entry that calls a method on one of these passes
@@ -114,6 +129,8 @@ export function compileGenerative(
     );
   }
 
+  ensureCompilerCompatibleWithCore(ast, filename);
+
   // A module may hold several `defineToolkit(...)` / `defineGenerativeComponents(...)`
   // calls anywhere (e.g. a library built inside `new JSONGenerativeUI(...)` plus
   // the toolkit that exposes it). Tools may reference a `JSONGenerativeUI`
@@ -203,6 +220,201 @@ export function compileGenerative(
   );
 
   return { code: result.code, map: result.map };
+}
+
+interface PackageJson {
+  name?: string;
+  version?: string;
+  optionalDevDependencies?: Record<string, string>;
+}
+
+const checkedCorePackageJsonPaths = new Set<string>();
+let compilerPackageVersion: string | undefined;
+
+function ensureCompilerCompatibleWithCore(
+  ast: t.File,
+  filename: string | undefined,
+): void {
+  const corePackageJsonPath = resolveCorePackageJson(ast, filename);
+  if (
+    !corePackageJsonPath ||
+    checkedCorePackageJsonPaths.has(corePackageJsonPath)
+  ) {
+    return;
+  }
+
+  const corePackageJson = readPackageJson(corePackageJsonPath);
+  const range = corePackageJson?.optionalDevDependencies?.[COMPILER_PACKAGE];
+  if (!range) {
+    checkedCorePackageJsonPaths.add(corePackageJsonPath);
+    return;
+  }
+
+  const compilerVersion = getCompilerPackageVersion();
+  let compatible = false;
+  try {
+    compatible = satisfies(compilerVersion, range, {
+      includePrerelease: true,
+    });
+  } catch {
+    throw new GenerativeCompileError(
+      `${CORE_PACKAGE}@${corePackageJson.version ?? "unknown"} declares an ` +
+        `invalid optionalDevDependencies range for ${COMPILER_PACKAGE}: ` +
+        JSON.stringify(range),
+      filename,
+    );
+  }
+
+  if (!compatible) {
+    throw new GenerativeCompileError(
+      `${CORE_PACKAGE}@${corePackageJson.version ?? "unknown"} requires ` +
+        `${COMPILER_PACKAGE} ${range}, but the current compiler is ` +
+        `${compilerVersion}. Update @assistant-ui/next or @assistant-ui/vite ` +
+        "so their compiler satisfies the core package's " +
+        "optionalDevDependencies range.",
+      filename,
+    );
+  }
+
+  checkedCorePackageJsonPaths.add(corePackageJsonPath);
+}
+
+function getCompilerPackageVersion(): string {
+  if (compilerPackageVersion) return compilerPackageVersion;
+
+  const packageJsonPath = findPackageJson(import.meta.url, COMPILER_PACKAGE);
+  const packageJson = packageJsonPath ? readPackageJson(packageJsonPath) : null;
+  if (!packageJson?.version) {
+    throw new GenerativeCompileError(
+      `could not determine ${COMPILER_PACKAGE}'s package version`,
+    );
+  }
+  compilerPackageVersion = packageJson.version;
+  return compilerPackageVersion;
+}
+
+function resolveCorePackageJson(
+  ast: t.File,
+  filename: string | undefined,
+): string | null {
+  for (const packageName of collectImportedDistributionPackages(ast)) {
+    const packageJsonPath = resolvePackageJson(packageName, filename);
+    if (!packageJsonPath) continue;
+    if (packageName === CORE_PACKAGE) return packageJsonPath;
+
+    const corePackageJsonPath = resolvePackageJson(
+      CORE_PACKAGE,
+      packageJsonPath,
+    );
+    if (corePackageJsonPath) return corePackageJsonPath;
+  }
+
+  return null;
+}
+
+function collectImportedDistributionPackages(ast: t.File): Set<string> {
+  const packages = new Set<string>();
+
+  for (const statement of ast.program.body) {
+    const source =
+      (t.isImportDeclaration(statement) ||
+        t.isExportNamedDeclaration(statement) ||
+        t.isExportAllDeclaration(statement)) &&
+      statement.source
+        ? statement.source.value
+        : null;
+    if (!source) continue;
+
+    const packageName = packageNameFromSpecifier(source);
+    if (packageName) packages.add(packageName);
+  }
+
+  return packages;
+}
+
+function packageNameFromSpecifier(specifier: string): string | null {
+  for (const packageName of DISTRIBUTION_PACKAGES) {
+    if (specifier === packageName || specifier.startsWith(`${packageName}/`)) {
+      return packageName;
+    }
+  }
+
+  return null;
+}
+
+function resolvePackageJson(
+  packageName: string,
+  filename: string | undefined,
+): string | null {
+  const requirePath = normalizeRequirePath(filename);
+  const require = createRequire(requirePath);
+
+  try {
+    return findPackageJson(require.resolve(packageName), packageName);
+  } catch {
+    return findPackageJsonFromNodeModules(packageName, requirePath);
+  }
+}
+
+function normalizeRequirePath(filename: string | undefined): string {
+  if (filename) {
+    const cleanFilename = filename.split(/[?#]/, 1)[0]!;
+    if (nodePath.isAbsolute(cleanFilename)) return cleanFilename;
+  }
+  return import.meta.url;
+}
+
+function findPackageJson(
+  fromPathOrUrl: string,
+  packageName: string,
+): string | null {
+  let current = nodePath.dirname(
+    fromPathOrUrl.startsWith("file:")
+      ? new URL(fromPathOrUrl).pathname
+      : nodePath.resolve(fromPathOrUrl),
+  );
+
+  for (;;) {
+    const packageJsonPath = nodePath.join(current, "package.json");
+    const packageJson = readPackageJson(packageJsonPath);
+    if (packageJson?.name === packageName) return packageJsonPath;
+
+    const parent = nodePath.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function findPackageJsonFromNodeModules(
+  packageName: string,
+  fromPathOrUrl: string,
+): string | null {
+  const parts = packageName.split("/");
+  let current = nodePath.dirname(
+    fromPathOrUrl.startsWith("file:")
+      ? new URL(fromPathOrUrl).pathname
+      : nodePath.resolve(fromPathOrUrl),
+  );
+
+  for (;;) {
+    const packageJsonPath = nodePath.join(
+      current,
+      "node_modules",
+      ...parts,
+      "package.json",
+    );
+    const packageJson = readPackageJson(packageJsonPath);
+    if (packageJson?.name === packageName) return packageJsonPath;
+
+    const parent = nodePath.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function readPackageJson(packageJsonPath: string): PackageJson | null {
+  if (!existsSync(packageJsonPath)) return null;
+  return JSON.parse(readFileSync(packageJsonPath, "utf8")) as PackageJson;
 }
 
 /**

--- a/packages/x-generative-compiler/tsconfig.json
+++ b/packages/x-generative-compiler/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "extends": "@assistant-ui/x-buildutils/ts/base-node",
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4278,6 +4278,9 @@ importers:
       '@babel/types':
         specifier: ^7.29.7
         version: 7.29.7
+      semver:
+        specifier: ^7.8.1
+        version: 7.8.1
     devDependencies:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
@@ -4291,6 +4294,9 @@ importers:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -9824,6 +9830,9 @@ packages:
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22777,6 +22777,8 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
+  '@types/semver@7.7.1': {}
+
   '@types/send@1.2.1':
     dependencies:
       '@types/node': 25.9.1


### PR DESCRIPTION
## Summary
- add an optionalDevDependencies compiler compatibility range to @assistant-ui/core
- make @assistant-ui/x-generative-compiler read the installed core package metadata and throw when its own version does not satisfy that range
- cover compatible, incompatible, and missing-metadata core package scenarios

## Validation
- pnpm --filter @assistant-ui/x-generative-compiler test
- pnpm --filter @assistant-ui/x-generative-compiler build
- pnpm lint
- pnpm build