### PR TITLE
fix(react-langgraph): support reasoning content blocks without summary key

### DIFF
--- a/.changeset/langgraph-reasoning-content-block.md
+++ b/.changeset/langgraph-reasoning-content-block.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: support standard reasoning content blocks without summary key

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -389,6 +389,58 @@ describe("convertLangChainMessages file content", () => {
   });
 });
 
+describe("convertLangChainMessages reasoning content", () => {
+  it("converts reasoning blocks with a summary array", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-reasoning-summary",
+      content: [
+        {
+          type: "reasoning",
+          summary: [
+            { type: "summary_text", text: "first" },
+            { type: "summary_text", text: "second" },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      role: "assistant",
+      content: [{ type: "reasoning", text: "first\n\n\nsecond" }],
+    });
+  });
+
+  it("converts standard content blocks with a reasoning string (regression #4257)", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-reasoning-string",
+      content: [{ type: "reasoning", reasoning: "thinking out loud" }],
+    });
+
+    expect(result).toMatchObject({
+      role: "assistant",
+      content: [{ type: "reasoning", text: "thinking out loud" }],
+    });
+  });
+
+  it("skips reasoning blocks with neither summary nor reasoning", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-reasoning-malformed",
+      content: [
+        { type: "reasoning" } as never,
+        { type: "text", text: "hello" },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+    });
+  });
+});
+
 describe("convertLangChainMessages UI messages", () => {
   it("appends matching UI messages as data parts on the assistant message", () => {
     const uiMessage: UIMessage = {

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -174,6 +174,19 @@ const warnForUnsupportedFilePartShape = (part: FileContentPart) => {
   console.warn(`Unsupported file content block shape: ${shape}`);
 };
 
+const warnedReasoningPartShapes = new Set<string>();
+const warnForUnsupportedReasoningPartShape = (part: object) => {
+  if (
+    typeof process === "undefined" ||
+    process?.env?.NODE_ENV !== "development"
+  )
+    return;
+  const shape = Object.keys(part).sort().join(",");
+  if (warnedReasoningPartShapes.has(shape)) return;
+  warnedReasoningPartShapes.add(shape);
+  console.warn(`Unsupported reasoning content block shape: ${shape}`);
+};
+
 type FileContentPart = Extract<
   Exclude<LangChainMessage["content"], string>[number],
   { type: "file" }
@@ -249,10 +262,17 @@ const contentToParts = (
             return { type: "reasoning", text: part.thinking };
 
           case "reasoning":
-            return {
-              type: "reasoning",
-              text: part.summary.map((s) => s.text).join("\n\n\n"),
-            };
+            if (Array.isArray(part.summary)) {
+              return {
+                type: "reasoning",
+                text: part.summary.map((s) => s.text).join("\n\n\n"),
+              };
+            }
+            if (typeof part.reasoning === "string") {
+              return { type: "reasoning", text: part.reasoning };
+            }
+            warnForUnsupportedReasoningPartShape(part);
+            return null;
 
           case "tool_use":
             return null;

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -39,7 +39,8 @@ export type MessageContentReasoningSummaryText = {
 
 export type MessageContentReasoning = {
   type: "reasoning";
-  summary: MessageContentReasoningSummaryText[];
+  summary?: MessageContentReasoningSummaryText[];
+  reasoning?: string;
 };
 
 type MessageContentToolUse = {


### PR DESCRIPTION
Fixes #4257