### PR TITLE
fix: handle LangGraph reasoning without summary

### DIFF
--- a/.changeset/langgraph-reasoning-text-fallback.md
+++ b/.changeset/langgraph-reasoning-text-fallback.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: preserve LangChain reasoning content when `summary` is absent

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -389,6 +389,31 @@ describe("convertLangChainMessages file content", () => {
   });
 });
 
+describe("convertLangChainMessages reasoning content", () => {
+  it("falls back to reasoning text when summary is absent", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-reasoning",
+      content: [
+        {
+          type: "reasoning",
+          reasoning: "I should compare both options first.",
+        },
+      ],
+    } as unknown as LangChainMessage);
+
+    expect(result).toMatchObject({
+      role: "assistant",
+      content: [
+        {
+          type: "reasoning",
+          text: "I should compare both options first.",
+        },
+      ],
+    });
+  });
+});
+
 describe("convertLangChainMessages UI messages", () => {
   it("appends matching UI messages as data parts on the assistant message", () => {
     const uiMessage: UIMessage = {

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -390,6 +390,27 @@ describe("convertLangChainMessages file content", () => {
 });
 
 describe("convertLangChainMessages reasoning content", () => {
+  it("joins reasoning summary parts into a single reasoning part", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-reasoning-summary",
+      content: [
+        {
+          type: "reasoning",
+          summary: [
+            { type: "summary_text", text: "first" },
+            { type: "summary_text", text: "second" },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      role: "assistant",
+      content: [{ type: "reasoning", text: "first\n\n\nsecond" }],
+    });
+  });
+
   it("falls back to reasoning text when summary is absent", () => {
     const result = convertLangChainMessages({
       type: "ai",
@@ -400,7 +421,7 @@ describe("convertLangChainMessages reasoning content", () => {
           reasoning: "I should compare both options first.",
         },
       ],
-    } as unknown as LangChainMessage);
+    });
 
     expect(result).toMatchObject({
       role: "assistant",

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -251,7 +251,10 @@ const contentToParts = (
           case "reasoning":
             return {
               type: "reasoning",
-              text: part.summary.map((s) => s.text).join("\n\n\n"),
+              text:
+                part.summary?.map((s) => s.text).join("\n\n\n") ??
+                part.reasoning ??
+                "",
             };
 
           case "tool_use":

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -39,7 +39,8 @@ export type MessageContentReasoningSummaryText = {
 
 export type MessageContentReasoning = {
   type: "reasoning";
-  summary: MessageContentReasoningSummaryText[];
+  summary?: MessageContentReasoningSummaryText[];
+  reasoning?: string;
 };
 
 type MessageContentToolUse = {


### PR DESCRIPTION
Fixes #4257.

## Summary
- handle LangChain reasoning content blocks that provide a `reasoning` string without a `summary` array
- keep existing summary-array handling unchanged and fall back to an empty reasoning string if neither field is present
- add a regression test for the summary-less reasoning block shape
- add a patch changeset for `@assistant-ui/react-langgraph`

## Verification
- `pnpm --filter @assistant-ui/react-langgraph test -- convertLangChainMessages.test.ts -t "falls back to reasoning text"` failed before the fix with `TypeError: Cannot read properties of undefined (reading 'map')`\n- `pnpm --filter @assistant-ui/react-langgraph test -- convertLangChainMessages.test.ts -t "falls back to reasoning text"`\n- `pnpm --filter @assistant-ui/react-langgraph build`\n- `pnpm exec oxfmt --check packages/react-langgraph/src/convertLangChainMessages.ts packages/react-langgraph/src/convertLangChainMessages.test.ts packages/react-langgraph/src/types.ts`\n- `pnpm exec oxlint packages/react-langgraph/src/convertLangChainMessages.ts packages/react-langgraph/src/convertLangChainMessages.test.ts packages/react-langgraph/src/types.ts --no-error-on-unmatched-pattern`\n- `git diff --check`\n\nAI assistance was used for implementation and local verification; I reviewed the changes and test output before opening this PR.