### PR TITLE
fix: use defineToolkit in toolkit docs

### DIFF
--- a/.changeset/define-toolkit-runtime.md
+++ b/.changeset/define-toolkit-runtime.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+---
+
+fix: make defineToolkit usable for plain runtime toolkits

--- a/apps/docs/content/docs/(reference)/api-reference/tools/toolkits.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/toolkits.mdx
@@ -63,7 +63,7 @@ Named collection of tools exposed to the assistant model.
 Keys are the tool names the model receives and uses in tool calls.
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   get_weather: {
     type: "frontend",
     description: "Get the weather for a city.",
@@ -71,7 +71,7 @@ const toolkit = {
     execute: async ({ city }: { city: string }) => fetchWeather(city),
     render: WeatherToolUI,
   },
-} satisfies Toolkit;
+});
 ```
 
 ```ts

--- a/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
@@ -36,17 +36,14 @@ Defines MCP server tools as a spreadable toolkit fragment.
 
 ### defineToolkit
 
-Authoring helper for a `"use generative"` toolkit. Accepts the permissive
-ToolkitDefinition (a `backend` tool may carry its server `execute`)
-and types the result as the canonical [Toolkit](/docs/api-reference/tools/toolkits#toolkit).
+Toolkit authoring helper. Accepts the permissive ToolkitDefinition
+(a generative `backend` tool may carry its server `execute`) and types the
+result as the canonical [Toolkit](/docs/api-reference/tools/toolkits#toolkit).
 
-It has **no runtime implementation**. A `"use generative"` compiler (e.g.
-`@assistant-ui/next` or `@assistant-ui/vite`) strips the `defineToolkit(...)`
-wrapper (and its import) per build, so a correctly compiled
-`export default defineToolkit({...})` never calls this. If it *does* run, the
-module was not compiled by a use-generative loader — e.g. `defineToolkit` used
-outside a `"use generative"` file — which would ship a backend `execute` to the
-client. So it throws instead of silently leaking.
+In a `"use generative"` file, the compiler strips the wrapper per build so it
+can split schemas, renderers, and executors across the client/server boundary.
+Outside generative compilation, it returns the toolkit unchanged and can be
+used for plain frontend/backend/human toolkit objects.
 
 <ParametersTable {...defineToolkit} />
 
@@ -97,7 +94,7 @@ supplies the result instead of code. Use it as the tool's `execute`:
 confirm: { execute: humanTool(), render: (props) => <Confirm {...props} /> }
 ```
 
-Like [defineToolkit](/docs/api-reference/utilities/miscellaneous#definetoolkit), it has **no runtime implementation**: a
+Unlike [defineToolkit](/docs/api-reference/utilities/miscellaneous#definetoolkit), it has **no runtime implementation**: a
 `"use generative"` compiler (e.g. `@assistant-ui/next` or `@assistant-ui/vite`)
 detects `execute: humanTool()`, drops it, and stamps the tool `type: "human"`.
 Reaching it at runtime means the module wasn't compiled (used outside a

--- a/apps/docs/content/docs/ink/hooks.mdx
+++ b/apps/docs/content/docs/ink/hooks.mdx
@@ -249,7 +249,7 @@ const WeatherCardUI = makeAssistantDataUI({
 Wrap a render function component so that it always uses the latest version without re-creating a stable reference. Useful when passing a render prop inline and the function closes over changing state.
 
 ```tsx title="weather-toolkit.tsx"
-import { useInlineRender } from "@assistant-ui/react-ink";
+import { defineToolkit, useInlineRender } from "@assistant-ui/react-ink";
 import { Text } from "ink";
 import { useMemo } from "react";
 
@@ -260,7 +260,7 @@ export function useWeatherToolkit() {
 
   return useMemo(
     () =>
-      ({
+      defineToolkit({
         get_weather: {
           type: "backend",
           render,

--- a/apps/docs/content/docs/react-native/hooks.mdx
+++ b/apps/docs/content/docs/react-native/hooks.mdx
@@ -196,7 +196,7 @@ useAssistantInstructions("You are a helpful weather assistant.");
 Wrap a tool UI component so that inline state updates (from a parent component's render) are reflected without remounting. Use this when the render function closes over props that change over time.
 
 ```tsx title="my-tool-toolkit.tsx"
-import { useInlineRender } from "@assistant-ui/react-native";
+import { defineToolkit, useInlineRender } from "@assistant-ui/react-native";
 import { Text } from "react-native";
 import { useMemo } from "react";
 
@@ -207,7 +207,7 @@ export function useMyToolToolkit(someOuterProp: string) {
 
   return useMemo(
     () =>
-      ({
+      defineToolkit({
         my_tool: {
           type: "backend",
           render: stableRender,

--- a/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
@@ -353,6 +353,7 @@ Render the gate with a toolkit entry. The `approval` field carries the gate stat
 import { useChat } from "@ai-sdk/react";
 import {
   AssistantRuntimeProvider,
+  defineToolkit,
   Tools,
   useAui,
 } from "@assistant-ui/react";
@@ -360,7 +361,7 @@ import { useAISDKRuntime } from "@assistant-ui/react-ai-sdk";
 import { lastAssistantMessageIsCompleteWithApprovalResponses } from "ai";
 import { Thread } from "@/components/assistant-ui/thread";
 
-const toolkit = {
+const toolkit = defineToolkit({
   deploy: {
     type: "backend",
     render: ({ args, approval, respondToApproval, result }) => {
@@ -386,7 +387,7 @@ const toolkit = {
       return <p>Deployed {result.deployed}</p>;
     },
   },
-};
+});
 
 export default function Page() {
   const chat = useChat({

--- a/apps/docs/content/docs/runtimes/google-adk/hooks.mdx
+++ b/apps/docs/content/docs/runtimes/google-adk/hooks.mdx
@@ -389,6 +389,7 @@ Register the renderer with a backend toolkit entry inside `AssistantRuntimeProvi
 ```tsx
 import {
   AssistantRuntimeProvider,
+  defineToolkit,
   Tools,
   useAui,
 } from "@assistant-ui/react";
@@ -398,12 +399,12 @@ import {
 } from "@assistant-ui/react-google-adk";
 import { Thread } from "@/components/assistant-ui/thread";
 
-const toolkit = {
+const toolkit = defineToolkit({
   adk_request_input: {
     type: "backend",
     render: RequestInputToolUI,
   },
-};
+});
 
 function App() {
   const runtime = useAdkRuntime({
@@ -425,6 +426,7 @@ function App() {
 ```tsx
 import {
   AssistantRuntimeProvider,
+  defineToolkit,
   Tools,
   useAui,
 } from "@assistant-ui/react-native";
@@ -437,12 +439,12 @@ import { Thread } from "@/components/assistant-ui/thread";
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3000";
 
-const toolkit = {
+const toolkit = defineToolkit({
   adk_request_input: {
     type: "backend",
     render: RequestInputToolUI,
   },
-};
+});
 
 function App() {
   const runtime = useAdkRuntime({
@@ -466,6 +468,7 @@ function App() {
 ```tsx
 import {
   AssistantRuntimeProvider,
+  defineToolkit,
   Tools,
   useAui,
 } from "@assistant-ui/react-ink";
@@ -476,12 +479,12 @@ import {
 import { Box } from "ink";
 import { Thread } from "./components/thread.js";
 
-const toolkit = {
+const toolkit = defineToolkit({
   adk_request_input: {
     type: "backend",
     render: RequestInputToolUI,
   },
-};
+});
 
 function App() {
   const runtime = useAdkRuntime({

--- a/apps/docs/content/docs/runtimes/langgraph/tutorial/part-2.mdx
+++ b/apps/docs/content/docs/runtimes/langgraph/tutorial/part-2.mdx
@@ -94,14 +94,14 @@ This simply displays the tool name and arguments passed to it, but not the resul
 
 import { Thread } from "@/components/assistant-ui/thread";
 import { PriceSnapshotToolUI } from "@/components/tools/price-snapshot/PriceSnapshotTool";
-import { AuiProvider, Tools, useAui } from "@assistant-ui/react";
+import { AuiProvider, defineToolkit, Tools, useAui } from "@assistant-ui/react";
 
-const toolkit = {
+const toolkit = defineToolkit({
   price_snapshot: {
     type: "backend",
     render: PriceSnapshotToolUI,
   },
-};
+});
 
 export default function Home() {
   const aui = useAui({ tools: Tools({ toolkit }) });
@@ -326,12 +326,12 @@ export const ToolFallback: ToolCallMessagePartComponent = ({
 ### Bind fallback UI
 
 ```tsx title="@/app/page.tsx"
-const toolkit = {
+const toolkit = defineToolkit({
   price_snapshot: {
     type: "backend",
     render: PriceSnapshotToolUI,
   },
-};
+});
 
 export default function Home() {
   const aui = useAui({ tools: Tools({ toolkit }) });

--- a/apps/docs/content/docs/runtimes/langgraph/tutorial/part-3.mdx
+++ b/apps/docs/content/docs/runtimes/langgraph/tutorial/part-3.mdx
@@ -212,9 +212,9 @@ export function TransactionConfirmationPending(props: TransactionConfirmation) {
 import { Thread } from "@/components/assistant-ui/thread";
 import { PriceSnapshotToolUI } from "@/components/tools/price-snapshot/PriceSnapshotTool";
 import { PurchaseStockToolUI } from "@/components/tools/purchase-stock/PurchaseStockTool";
-import { AuiProvider, Tools, useAui } from "@assistant-ui/react";
+import { AuiProvider, defineToolkit, Tools, useAui } from "@assistant-ui/react";
 
-const toolkit = {
+const toolkit = defineToolkit({
   price_snapshot: {
     type: "backend",
     render: PriceSnapshotToolUI,
@@ -223,7 +223,7 @@ const toolkit = {
     type: "backend",
     render: PurchaseStockToolUI,
   },
-};
+});
 
 export default function Home() {
   const aui = useAui({ tools: Tools({ toolkit }) });

--- a/apps/docs/content/docs/tools/defining-tools.mdx
+++ b/apps/docs/content/docs/tools/defining-tools.mdx
@@ -315,14 +315,16 @@ compiler, declare a `"use client"` toolkit object with an explicit
 ```tsx title="app/tool-ui.tsx"
 "use client";
 
-export const toolkit = {
+import { defineToolkit } from "@assistant-ui/react";
+
+export const toolkit = defineToolkit({
   web_search: {
     type: "backend",
     render: ({ args, result }) => (
       <SearchResults query={args.query} results={result?.results ?? []} />
     ),
   },
-};
+});
 ```
 
 Register it exactly like a generative toolkit: `useAui({ tools: Tools({ toolkit }) })`. The key must match the tool name your backend or MCP server publishes. Render-only entries upload no schema and run no browser code — they only attach UI to matching tool-call message parts.

--- a/apps/docs/content/docs/tools/mcp.mdx
+++ b/apps/docs/content/docs/tools/mcp.mdx
@@ -242,12 +242,13 @@ export default defineToolkit({
 <Tab value="React Native">
 
 ```tsx title="components/GitHubIssueToolUI.tsx"
+import { defineToolkit } from "@assistant-ui/react-native";
 import { Linking, Pressable, Text, View } from "react-native";
 
 type Args = { repo: string; number: number };
 type Result = { title: string; state: string; url: string };
 
-export const toolkit = {
+export const toolkit = defineToolkit({
   github_get_issue: {
     type: "backend",
     render: ({ args, result }: { args: Args; result?: Result }) => (
@@ -265,19 +266,20 @@ export const toolkit = {
       </View>
     ),
   },
-};
+});
 ```
 
 </Tab>
 <Tab value="React Ink">
 
 ```tsx title="components/GitHubIssueToolUI.tsx"
+import { defineToolkit } from "@assistant-ui/react-ink";
 import { Box, Text } from "ink";
 
 type Args = { repo: string; number: number };
 type Result = { title: string; state: string; url: string };
 
-export const toolkit = {
+export const toolkit = defineToolkit({
   github_get_issue: {
     type: "backend",
     render: ({ args, result }: { args: Args; result?: Result }) => (
@@ -293,7 +295,7 @@ export const toolkit = {
       </Box>
     ),
   },
-};
+});
 ```
 
 </Tab>

--- a/apps/docs/content/docs/tools/multi-agent.mdx
+++ b/apps/docs/content/docs/tools/multi-agent.mdx
@@ -25,11 +25,12 @@ Key behaviors:
 
 ```tsx
 import {
+  defineToolkit,
   Tools,
   MessagePartPrimitive,
 } from "@assistant-ui/react";
 
-const toolkit = {
+const toolkit = defineToolkit({
   invoke_researcher: {
     type: "backend",
     render: ({ args, status }) => (
@@ -46,7 +47,7 @@ const toolkit = {
     </div>
   ),
   },
-};
+});
 ```
 
   </Step>
@@ -153,7 +154,7 @@ When using LangGraph, subgraph events (`onSubgraphValues` / `onSubgraphUpdates` 
 If a sub-agent's tool calls also have nested messages, the same pattern applies recursively:
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   invoke_planner: {
     type: "backend",
     render: () => (
@@ -188,7 +189,7 @@ const toolkit = {
     </div>
   ),
   },
-};
+});
 ```
 
 ## ReadonlyThreadProvider

--- a/apps/docs/content/docs/tools/tool-ui.mdx
+++ b/apps/docs/content/docs/tools/tool-ui.mdx
@@ -96,14 +96,14 @@ Learn more about creating tools in the [Tools Guide](/docs/tools/defining-tools)
 If your tool is defined elsewhere (e.g., in your backend API, MCP server, or LangGraph), register a backend toolkit entry with just `render`:
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   getWeather: {
     type: "backend",
     render: ({ args, result, status }) => {
       // UI rendering logic only
     },
   },
-};
+});
 ```
 
 ## Quick Start Example
@@ -180,12 +180,12 @@ const WeatherToolUI: ToolCallMessagePartComponent<
 Put the renderer on the matching backend toolkit entry:
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   getWeather: {
     type: "backend",
     render: WeatherToolUI,
   },
-};
+});
 
 function App({ runtime }: { runtime: AssistantRuntime }) {
   const aui = useAui({ tools: Tools({ toolkit }) });
@@ -286,12 +286,12 @@ export const WebSearchToolUI: ToolCallMessagePartComponent<
 Register it on the toolkit:
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   webSearch: {
     type: "backend",
     render: WebSearchToolUI,
   },
-};
+});
 ```
 
 ### Dynamic Toolkit Pattern
@@ -301,7 +301,7 @@ Use a toolkit hook in its own file when the renderer needs component state:
 ```tsx title="analyze-data-toolkit.tsx"
 "use client";
 
-import { useInlineRender } from "@assistant-ui/react";
+import { defineToolkit, useInlineRender } from "@assistant-ui/react";
 import { useMemo } from "react";
 
 export function useAnalyzeDataToolkit(theme: "light" | "dark") {
@@ -317,7 +317,7 @@ export function useAnalyzeDataToolkit(theme: "light" | "dark") {
 
   return useMemo(
     () =>
-      ({
+      defineToolkit({
         analyzeData: {
           type: "backend",
           render: renderAnalyzeData,
@@ -358,7 +358,7 @@ For tools that need access to parent component props:
 ```tsx title="inventory-toolkit.tsx"
 "use client";
 
-import { useInlineRender } from "@assistant-ui/react";
+import { defineToolkit, useInlineRender } from "@assistant-ui/react";
 import { useMemo } from "react";
 
 export function useInventoryToolkit(productId: string, productName: string) {
@@ -376,7 +376,7 @@ export function useInventoryToolkit(productId: string, productName: string) {
 
   return useMemo(
     () =>
-      ({
+      defineToolkit({
         checkInventory: {
           type: "backend",
           render: renderInventory,
@@ -419,7 +419,7 @@ Create tools that collect user input during execution:
 </Callout>
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   selectDate: {
     type: "human",
     description: "Ask the user to select a date.",
@@ -445,7 +445,7 @@ const toolkit = {
       );
     },
   },
-};
+});
 ```
 
 ### Multi-Step Interactions
@@ -540,7 +540,7 @@ export default defineToolkit({
 Some runtimes (notably AI SDK v6's `needsApproval` tools) pause on the server and emit an approval request that the client must acknowledge before the tool runs. assistant-ui surfaces this on the tool part as `approval` and exposes `respondToApproval({ approved, reason? })` on the renderer:
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   deploy: {
     type: "backend",
     render: ({ args, approval, respondToApproval, result }) => {
@@ -570,7 +570,7 @@ const toolkit = {
       return <p>Deployed</p>;
     },
   },
-};
+});
 ```
 
 `approval.approved` is a three-state signal:
@@ -626,7 +626,7 @@ Sometimes you want to capture a tool call's streaming arguments but only render 
 Return `null` from the tool UI's `render` until `status.type === "complete"`. The streaming args still arrive in `args` as the model emits them, you just ignore them until the call is done:
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   renderChart: {
     type: "backend",
     render: ({ args, status }) => {
@@ -634,7 +634,7 @@ const toolkit = {
       return <Chart title={args.title} data={args.series} />;
     },
   },
-};
+});
 ```
 
 The chart mounts once, with the final args, after streaming finishes. No re-renders during the stream.
@@ -682,7 +682,7 @@ Use `useToolArgsStatus` to react to per-field streaming state. The hook returns 
 ```tsx
 import { useToolArgsStatus } from "@assistant-ui/react";
 
-const toolkit = {
+const toolkit = defineToolkit({
   submitForm: {
     type: "backend",
     render: ({ args }) => {
@@ -714,7 +714,7 @@ const toolkit = {
       );
     },
   },
-};
+});
 ```
 
 ### Partial Results & Streaming
@@ -722,7 +722,7 @@ const toolkit = {
 Display results as they stream in:
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   analyzeData: {
     type: "backend",
     render: ({ result, status }) => {
@@ -757,7 +757,7 @@ const toolkit = {
       );
     },
   },
-};
+});
 ```
 
 ### Custom Tool Fallback
@@ -802,7 +802,7 @@ type ToolCallMessagePartProps<TArgs, TResult> = {
 When a tool calls `human()` during execution, the payload becomes available in the render function as `interrupt.payload`:
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   confirmAction: {
     type: "backend",
     render: ({ args, result, interrupt, resume }) => {
@@ -825,7 +825,7 @@ const toolkit = {
       return <div>Processing...</div>;
     },
   },
-};
+});
 ```
 
 Learn more about tool human input in the [Tools Guide](/docs/tools/defining-tools#human-tools).
@@ -882,7 +882,7 @@ Use `useInlineRender` to prevent unnecessary re-renders:
 ```tsx title="heavy-computation-toolkit.tsx"
 "use client";
 
-import { useInlineRender } from "@assistant-ui/react";
+import { defineToolkit, useInlineRender } from "@assistant-ui/react";
 import { useMemo } from "react";
 
 export function useHeavyComputationToolkit() {
@@ -892,7 +892,7 @@ export function useHeavyComputationToolkit() {
 
   return useMemo(
     () =>
-      ({
+      defineToolkit({
         heavyComputation: {
           type: "backend",
           render: renderHeavyComputation,

--- a/apps/docs/content/docs/ui/part-grouping.mdx
+++ b/apps/docs/content/docs/ui/part-grouping.mdx
@@ -213,7 +213,7 @@ Tool UIs fall into three buckets: prompting the user (human-in-the-loop), inform
 Mark a tool with `display: "standalone"` to keep its UI out of the grouped trace. `human` tools and MCP apps are standalone automatically; every other tool defaults to `"inline"` and opts in explicitly:
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   ask_user: { type: "human", render: AskUI }, // standalone (forced)
   search_web: { type: "frontend", render: SearchUI }, // inline trace (default)
   checkout: {
@@ -221,7 +221,7 @@ const toolkit = {
     render: CheckoutUI,
     display: "standalone", // opt in
   },
-};
+});
 ```
 
 The synthetic `"standalone-tool-call"` key on `groupPartByType` matches all of these. `MessagePrimitive.GroupedParts` passes the live tool-UI registry to `groupBy` as a second `context` argument, and the helper reads it to resolve the registry-driven cases — MCP-app calls are detected from the part alone, so nothing is threaded in:

--- a/apps/docs/content/examples/generative-ui.mdx
+++ b/apps/docs/content/examples/generative-ui.mdx
@@ -31,7 +31,7 @@ See the [Generative UI primitive guide](/docs/guides/generative-ui) for opt-in w
 These tools have backend `execute` functions and frontend toolkit renderers. The AI generates the data, the backend confirms, and the frontend renders rich UI from `args`:
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   generate_chart: {
     type: "backend",
     render: ({ args, status }) => {
@@ -40,7 +40,7 @@ const toolkit = {
     return <ChartContainer config={buildChartConfig(dataKeys)}>...</ChartContainer>;
   },
   },
-};
+});
 ```
 
 ### Frontend-Only Tools (Date Picker, Contact Form)
@@ -48,7 +48,7 @@ const toolkit = {
 These tools have no backend `execute` — the AI triggers the tool call, and the user completes it through interactive UI. The `addResult` callback sends the user's input back to the AI:
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   select_date: {
     type: "human",
     render: ({ args, result, addResult }) => {
@@ -63,7 +63,7 @@ const toolkit = {
     );
   },
   },
-};
+});
 ```
 
 ## Key Concepts

--- a/apps/docs/content/examples/stockbroker.mdx
+++ b/apps/docs/content/examples/stockbroker.mdx
@@ -123,7 +123,7 @@ app = graph.compile(interrupt_before=["execute"], checkpointer=MemorySaver())
 ### Approval UI Component
 
 ```tsx
-const toolkit = {
+const toolkit = defineToolkit({
   execute_trade: {
     type: "backend",
     render: ({ args, status, addResult }) => {
@@ -146,7 +146,7 @@ const toolkit = {
     return <p>Trade {status}...</p>;
   },
   },
-};
+});
 ```
 
 ## Source

--- a/examples/with-ag-ui/app/page.tsx
+++ b/examples/with-ag-ui/app/page.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import {
+  defineToolkit,
   useAui,
   AuiProvider,
   Suggestions,
   Tools,
-  type Toolkit,
 } from "@assistant-ui/react";
 import { Thread } from "@/components/assistant-ui/thread";
 import { PlusIcon } from "lucide-react";
 
-const toolkit = {
+const toolkit = defineToolkit({
   browser_alert: {
     description: "Display a native browser alert dialog to the user.",
     parameters: {
@@ -44,7 +44,7 @@ const toolkit = {
       </div>
     ),
   },
-} satisfies Toolkit;
+});
 
 function NewThreadButton() {
   const aui = useAui();

--- a/examples/with-assistant-transport/app/MyRuntimeProvider.tsx
+++ b/examples/with-assistant-transport/app/MyRuntimeProvider.tsx
@@ -2,9 +2,9 @@
 
 import {
   AssistantRuntimeProvider,
+  defineToolkit,
   Tools,
   type AssistantTransportConnectionMetadata,
-  type Toolkit,
   unstable_createMessageConverter as createMessageConverter,
   useAui,
   useAssistantTransportRuntime,
@@ -16,7 +16,7 @@ import {
 import type { ReactNode } from "react";
 import { z } from "zod";
 
-const toolkit = {
+const toolkit = defineToolkit({
   get_weather: {
     type: "frontend",
     description: "Get the current weather for a city",
@@ -64,7 +64,7 @@ const toolkit = {
           : "Weather lookup complete",
     },
   },
-} satisfies Toolkit;
+});
 
 type MyRuntimeProviderProps = {
   children: ReactNode;

--- a/examples/with-ffmpeg/app/toolkit.tsx
+++ b/examples/with-ffmpeg/app/toolkit.tsx
@@ -2,7 +2,7 @@
 
 import type { MutableRefObject } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { Toolkit } from "@assistant-ui/react";
+import { defineToolkit } from "@assistant-ui/react";
 import type { FFmpeg } from "@ffmpeg/ffmpeg";
 import {
   CircleCheckIcon,
@@ -19,7 +19,7 @@ export function useFfmpegToolkit(
 ) {
   return useMemo(
     () =>
-      ({
+      defineToolkit({
         run_ffmpeg: {
           type: "frontend",
           parameters: z.object({
@@ -281,7 +281,7 @@ export function useFfmpegToolkit(
             );
           },
         },
-      }) satisfies Toolkit,
+      }),
     [ffmpegRef, file],
   );
 }

--- a/packages/core/src/react/model-context/define-toolkit.test.ts
+++ b/packages/core/src/react/model-context/define-toolkit.test.ts
@@ -75,8 +75,9 @@ const checkToolkitDefinitionTypes = () => {
 expectTypeOf(checkToolkitDefinitionTypes).toEqualTypeOf<() => void>();
 
 describe("use-generative markers", () => {
-  it("defineToolkit throws at runtime — it must be stripped by the compiler, never called", () => {
-    expect(() => defineToolkit({})).toThrow(/no runtime implementation/);
+  it("defineToolkit returns the toolkit at runtime", () => {
+    const toolkit = {};
+    expect(defineToolkit(toolkit)).toBe(toolkit);
   });
 
   it("humanTool throws at runtime — it must be stripped by the compiler, never called", () => {

--- a/packages/core/src/react/model-context/define-toolkit.ts
+++ b/packages/core/src/react/model-context/define-toolkit.ts
@@ -5,37 +5,37 @@ import type {
 } from "./toolbox";
 
 /**
- * Authoring helper for a `"use generative"` toolkit. Accepts the permissive
- * {@link ToolkitDefinition} (a `backend` tool may carry its server `execute`)
- * and types the result as the canonical {@link Toolkit}.
+ * Toolkit authoring helper. Accepts the permissive {@link ToolkitDefinition}
+ * (a generative `backend` tool may carry its server `execute`) and types the
+ * result as the canonical {@link Toolkit}.
  *
- * It has **no runtime implementation**. A `"use generative"` compiler (e.g.
- * `@assistant-ui/next` or `@assistant-ui/vite`) strips the `defineToolkit(...)`
- * wrapper (and its import) per build, so a correctly compiled
- * `export default defineToolkit({...})` never calls this. If it *does* run, the
- * module was not compiled by a use-generative loader — e.g. `defineToolkit` used
- * outside a `"use generative"` file — which would ship a backend `execute` to the
- * client. So it throws instead of silently leaking.
+ * In a `"use generative"` file, the compiler strips the wrapper per build so it
+ * can split schemas, renderers, and executors across the client/server boundary.
+ * Outside generative compilation, it returns the toolkit unchanged and can be
+ * used for plain frontend/backend/human toolkit objects.
  */
 export function defineToolkit<
   TArgsByName extends {
     [K in keyof TArgsByName]: Record<string, unknown>;
   },
   TResultByName extends { [K in keyof TArgsByName]: unknown } = {
-    [K in keyof TArgsByName]: unknown;
+    [K in keyof TArgsByName]: any;
   },
 >(_definition: {
   [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<
     TArgsByName[K],
     TResultByName[K]
   >;
-}): Toolkit;
+}): Toolkit & {
+  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<
+    TArgsByName[K],
+    TResultByName[K]
+  >;
+};
+export function defineToolkit<const TDefinition extends ToolkitDefinition>(
+  _definition: TDefinition,
+): Toolkit & TDefinition;
 export function defineToolkit(_definition: ToolkitDefinition): Toolkit;
 export function defineToolkit(_definition: ToolkitDefinition): Toolkit {
-  throw new Error(
-    "[assistant-ui] defineToolkit() has no runtime implementation — it is " +
-      "stripped at build time by the use-generative compiler. Reaching it means " +
-      'this module was not compiled (e.g. defineToolkit used outside a "use ' +
-      'generative" file). Add the directive, or do not use defineToolkit here.',
-  );
+  return _definition as Toolkit;
 }

--- a/packages/core/src/react/model-context/define-toolkit.ts
+++ b/packages/core/src/react/model-context/define-toolkit.ts
@@ -35,7 +35,6 @@ export function defineToolkit<
 export function defineToolkit<const TDefinition extends ToolkitDefinition>(
   _definition: TDefinition,
 ): Toolkit & TDefinition;
-export function defineToolkit(_definition: ToolkitDefinition): Toolkit;
 export function defineToolkit(_definition: ToolkitDefinition): Toolkit {
   return _definition as Toolkit;
 }

--- a/packages/core/src/react/model-context/human-tool.ts
+++ b/packages/core/src/react/model-context/human-tool.ts
@@ -6,7 +6,7 @@
  * confirm: { execute: humanTool(), render: (props) => <Confirm {...props} /> }
  * ```
  *
- * Like {@link defineToolkit}, it has **no runtime implementation**: a
+ * Unlike {@link defineToolkit}, it has **no runtime implementation**: a
  * `"use generative"` compiler (e.g. `@assistant-ui/next` or `@assistant-ui/vite`)
  * detects `execute: humanTool()`, drops it, and stamps the tool `type: "human"`.
  * Reaching it at runtime means the module wasn't compiled (used outside a

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -128,7 +128,7 @@ export type ToolDefinition<
  *
  * @example
  * ```tsx
- * const toolkit = {
+ * const toolkit = defineToolkit({
  *   get_weather: {
  *     type: "frontend",
  *     description: "Get the weather for a city.",
@@ -136,7 +136,7 @@ export type ToolDefinition<
  *     execute: async ({ city }: { city: string }) => fetchWeather(city),
  *     render: WeatherToolUI,
  *   },
- * } satisfies Toolkit;
+ * });
  * ```
  */
 export type Toolkit = Record<string, ToolDefinition<any, any>>;

--- a/packages/core/src/react/primitives/part/PartMessages.tsx
+++ b/packages/core/src/react/primitives/part/PartMessages.tsx
@@ -34,7 +34,7 @@ const usePartMessages = (): readonly ThreadMessage[] | undefined => {
  *
  * @example
  * ```tsx
- * const toolkit = {
+ * const toolkit = defineToolkit({
  *   invoke_sub_agent: {
  *     type: "backend",
  *     render: () => (
@@ -46,7 +46,7 @@ const usePartMessages = (): readonly ThreadMessage[] | undefined => {
  *       </PartPrimitive.Messages>
  *     ),
  *   },
- * } satisfies Toolkit;
+ * });
  * ```
  */
 export const PartPrimitiveMessagesImpl: FC<PartPrimitiveMessages.Props> = ({

--- a/packages/react-generative-ui/src/defineGenerativeComponents.ts
+++ b/packages/react-generative-ui/src/defineGenerativeComponents.ts
@@ -19,7 +19,7 @@ import type { GenerativeUILibrary } from "./types";
  * });
  * ```
  *
- * Like {@link defineToolkit}, it has **no runtime implementation**. A
+ * Unlike {@link defineToolkit}, it has **no runtime implementation**. A
  * `"use generative"` compiler unwraps the `defineGenerativeComponents(...)` call
  * per build, dropping each `render` (and its client-only imports) from the server
  * build. Reaching it at runtime means the module wasn't compiled (the directive

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -158,8 +158,8 @@ export function compileGenerative(
           );
         }
         compileComponents(object, target, flags, filename);
-        // Unwrap the marker (it has no runtime implementation) to the bare
-        // library object so its import can be pruned.
+        // Unwrap the authoring helper to the bare library object so its import
+        // can be pruned.
         path.replaceWith(object);
         path.skip();
         return;
@@ -452,7 +452,7 @@ function ensureDefaultExport(ast: t.File, filename: string | undefined): void {
 
 /**
  * Unwraps a node through `satisfies`/`as`/parens to a call of the named function,
- * or returns `null`. Used to recognize `defineToolkit({...}) satisfies Toolkit`.
+ * or returns `null`.
  */
 function unwrapToCall(node: t.Node, name: string): t.CallExpression | null {
   if (t.isTSSatisfiesExpression(node) || t.isTSAsExpression(node)) {


### PR DESCRIPTION
## Summary
- replace remaining toolkit docs/examples that used plain objects or `satisfies Toolkit` with `defineToolkit(...)`
- make `defineToolkit` runtime-safe for plain toolkits while preserving generative compiler unwrapping
- update TypeDoc/API prose and add a patch changeset

## Validation
- pnpm --filter @assistant-ui/core test -- src/react/model-context/define-toolkit.test.ts
- pnpm lint
- pnpm build