### PR TITLE
feat(ag-ui): export fromAgUiMessages from the package root

### DIFF
--- a/.changeset/agui-export-from-ag-ui-messages.md
+++ b/.changeset/agui-export-from-ag-ui-messages.md
@@ -1,0 +1,11 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: export `fromAgUiMessages` from the package root
+
+Converting persisted AG-UI messages to assistant-ui messages (e.g. when
+restoring a conversation from a `GET /agents/state` endpoint on page load)
+previously required reaching into package internals. `fromAgUiMessages` is now
+a public export, typed to return `ThreadMessageLike[]` so its output plugs
+directly into `ExportedMessageRepository.fromArray` inside a history adapter.

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -29,6 +29,38 @@ Reference for the runtime's API surface. Start with [quickstart](/docs/runtimes/
 | History | `adapters.history` | Per-thread message persistence. |
 | Thread list | `adapters.threadList` | Multi-thread switching (experimental, see below). |
 
+## Loading conversation history
+
+If your backend exposes the persisted AG-UI messages of a conversation (for
+example a `GET /agents/state` endpoint), use `fromAgUiMessages` to convert them
+to assistant-ui messages and return them from the history adapter so the thread
+is restored on page load:
+
+```tsx
+import { fromAgUiMessages } from "@assistant-ui/react-ag-ui";
+import { ExportedMessageRepository } from "@assistant-ui/react";
+
+const runtime = useAgUiRuntime({
+  agent,
+  adapters: {
+    history: {
+      async load() {
+        const { messages } = await fetch("/agents/state").then((r) => r.json());
+        return ExportedMessageRepository.fromArray(fromAgUiMessages(messages));
+      },
+      async append() {
+        // persist new messages on your backend, or no-op if the agent already does
+      },
+    },
+  },
+});
+```
+
+`fromAgUiMessages` accepts an optional second argument: pass
+`{ showThinking: false }` to match a runtime configured with
+`showThinking: false`, so imported reasoning messages are dropped the same way
+they are hidden during a live run.
+
 ## Thread list (experimental)
 
 <Callout type="warn">

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -48,18 +48,27 @@ const runtime = useAgUiRuntime({
         const { messages } = await fetch("/agents/state").then((r) => r.json());
         return ExportedMessageRepository.fromArray(fromAgUiMessages(messages));
       },
-      async append() {
-        // persist new messages on your backend, or no-op if the agent already does
+      async append({ message }) {
+        // persist the newly sent message on your backend
       },
     },
   },
 });
 ```
 
+Messages sent during the session are always forwarded to the agent through the
+run input, independent of `append`. A no-op `append` is therefore only safe when
+your backend already persists the conversation on its own; otherwise those
+messages are gone on the next page load.
+
 `fromAgUiMessages` accepts an optional second argument: pass
 `{ showThinking: false }` to match a runtime configured with
-`showThinking: false`, so imported reasoning messages are dropped the same way
-they are hidden during a live run.
+`showThinking: false`, so imported reasoning messages are dropped at conversion
+time, the same way a live run never stores them.
+
+`fromAgUiMessages` reconstructs the text, reasoning, and tool calls of each
+message. Non-text message content such as images and files is not restored, so a
+backend that persists multimodal messages loads only their text on reload.
 
 ## Thread list (experimental)
 

--- a/packages/react-ag-ui/src/index.ts
+++ b/packages/react-ag-ui/src/index.ts
@@ -1,5 +1,7 @@
 export { useAgUiRuntime } from "./useAgUiRuntime";
 export type { AgUiAssistantRuntime } from "./useAgUiRuntime";
+export { fromAgUiMessages } from "./runtime/adapter/conversions";
+export type { FromAgUiMessagesOptions } from "./runtime/adapter/conversions";
 export type {
   AgUiInterrupt,
   AgUiInterruptReason,

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -918,11 +918,7 @@ export class AgUiThreadRuntimeCore {
       for (const message of normalized) {
         try {
           converted.push(
-            fromThreadMessageLike(
-              message as any,
-              generateId(),
-              FALLBACK_USER_STATUS,
-            ),
+            fromThreadMessageLike(message, generateId(), FALLBACK_USER_STATUS),
           );
         } catch (error) {
           this.logger.error?.(

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -1,7 +1,9 @@
 "use client";
 
 import type { InputContent } from "@ag-ui/client";
+import type { ThreadMessageLike as CoreThreadMessageLike } from "@assistant-ui/core";
 import { type Tool, toToolsJSONSchema } from "assistant-stream";
+import type { ReadonlyJSONObject } from "assistant-stream/utils";
 
 export type { InputContent };
 
@@ -46,9 +48,9 @@ export type AgUiMessage =
 type ToolCallPart = {
   type: "tool-call";
   toolCallId?: string;
-  toolName?: string;
+  toolName: string;
   argsText?: string;
-  args?: Record<string, unknown>;
+  args?: ReadonlyJSONObject;
   result?: unknown;
   isError?: boolean;
   unstable_toolMessageId?: string;
@@ -268,9 +270,9 @@ function toToolCallPart(value: unknown): ToolCallPart | null {
     typeof argsText === "string" ? parseJSONText(argsText) : undefined;
   const args =
     isObject(parsedArgs) && !Array.isArray(parsedArgs)
-      ? (parsedArgs as Record<string, unknown>)
+      ? (parsedArgs as ReadonlyJSONObject)
       : isObject(value.args) && !Array.isArray(value.args)
-        ? (value.args as Record<string, unknown>)
+        ? (value.args as ReadonlyJSONObject)
         : undefined;
 
   const part: ToolCallPart = {
@@ -330,7 +332,7 @@ function extractAssistantToolCalls(
 
 function toAssistantSnapshotMessage(
   rawMessage: Record<string, unknown>,
-): ThreadMessageLike {
+): CoreThreadMessageLike {
   const text = extractText(rawMessage.content);
   const toolCallParts = extractAssistantToolCalls(rawMessage);
   const assistantContent = [
@@ -349,7 +351,7 @@ function toAssistantSnapshotMessage(
 function toUserOrSystemSnapshotMessage(
   role: "user" | "system",
   rawMessage: Record<string, unknown>,
-): ThreadMessageLike {
+): CoreThreadMessageLike {
   const messageName = getString(rawMessage, "name");
   return {
     id: getString(rawMessage, "id") ?? generateId(),
@@ -359,12 +361,20 @@ function toUserOrSystemSnapshotMessage(
   };
 }
 
+export type FromAgUiMessagesOptions = {
+  /**
+   * Whether to convert `reasoning` messages into visible reasoning parts.
+   * Matches the `showThinking` option of `useAgUiRuntime`. Defaults to `true`.
+   */
+  showThinking?: boolean;
+};
+
 export function fromAgUiMessages(
   messages: readonly unknown[],
-  options?: { showThinking?: boolean },
-): ThreadMessageLike[] {
+  options?: FromAgUiMessagesOptions,
+): CoreThreadMessageLike[] {
   const showThinking = options?.showThinking ?? true;
-  const converted: ThreadMessageLike[] = [];
+  const converted: CoreThreadMessageLike[] = [];
 
   for (const rawMessage of messages) {
     if (!isObject(rawMessage)) continue;

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -3,6 +3,8 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import { UserMessageSchema } from "@ag-ui/client";
+import { ExportedMessageRepository } from "@assistant-ui/core";
+import { fromAgUiMessages as publicFromAgUiMessages } from "../src";
 import {
   fromAgUiMessages,
   toAgUiMessages,
@@ -801,5 +803,27 @@ describe("adapter conversions", () => {
     });
     expect((result[0] as any).content[0].source).not.toHaveProperty("data");
     expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+});
+
+describe("package exports", () => {
+  it("exposes fromAgUiMessages from the package root", () => {
+    expect(publicFromAgUiMessages).toBe(fromAgUiMessages);
+  });
+
+  it("composes with ExportedMessageRepository.fromArray for history loading", () => {
+    const repo = ExportedMessageRepository.fromArray(
+      publicFromAgUiMessages([
+        { id: "u-1", role: "user", content: "Hi" },
+        { id: "a-1", role: "assistant", content: "Hello!" },
+      ]),
+    );
+
+    expect(repo.messages).toHaveLength(2);
+    expect(repo.messages[0]).toMatchObject({
+      parentId: null,
+      message: { role: "user" },
+    });
+    expect(repo.messages[1]!.parentId).toBe(repo.messages[0]!.message.id);
   });
 });


### PR DESCRIPTION
## Motivation

Closes #4262.

When a backend exposes the persisted AG-UI messages of a conversation (e.g. adk + adk-agui-middleware's `GET /agents/state`), restoring the thread on page load requires converting AG-UI messages to assistant-ui messages — exactly what the internal `fromAgUiMessages` already does for `MESSAGES_SNAPSHOT` events. It just wasn't reachable from the package root, forcing either deep imports into package internals or a hacky empty message to trigger a snapshot.

## What this changes

- `fromAgUiMessages` is exported from `@assistant-ui/react-ag-ui`, along with a named `FromAgUiMessagesOptions` type for its options bag.
- The public signature is now typed to return `ThreadMessageLike[]` (from `@assistant-ui/core`) instead of a package-private structural type, so the output plugs directly into `ExportedMessageRepository.fromArray(...)` inside a history adapter without casts. The converter only ever emits `assistant`/`user`/`system` roles (tool messages are folded into assistant tool-call parts), so the tightened type reflects actual behavior — internal helper types were adjusted accordingly (`toolName` is always set, `args` is `ReadonlyJSONObject`).
- The now-redundant `as any` at the `fromThreadMessageLike` call site in `AgUiThreadRuntimeCore.importMessagesSnapshot` is removed.
- Docs: new "Loading conversation history" section on the AG-UI runtime-options page showing the page-load flow (`fetch` → `fromAgUiMessages` → `ExportedMessageRepository.fromArray` → history adapter), plus a note on matching `showThinking`.

## Why this approach

Exporting the existing converter (rather than adding a new API) keeps a single code path for both live `MESSAGES_SNAPSHOT` handling and consumer-side history loading, so future message-shape changes stay in one place.

## Testing

- Two new tests: the package-root export is the same function used internally, and its output composes with `ExportedMessageRepository.fromArray` (parent chain + roles verified).
- Full `react-ag-ui` suite: 126 tests pass. `tsc --noEmit` clean, `pnpm lint` (oxlint + oxfmt) clean.
- Changeset included (patch).