### PR TITLE
fix: bake generative compiler version at build time so the compat check works when bundled into metro

### DIFF
--- a/.changeset/fix-bundled-compiler-version.md
+++ b/.changeset/fix-bundled-compiler-version.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/x-generative-compiler": patch
+"@assistant-ui/metro": patch
+---
+
+fix: bake the compiler version into the build so the core compatibility check works when the compiler is bundled
+
+The core/compiler compatibility check found the compiler's version by walking up from `import.meta.url` to its own `package.json`. That works when the compiler is installed as a standalone package (Next.js and Vite import it externally), but `@assistant-ui/metro` bundles the compiler into `transformer.cjs`, so at runtime there is no separate `@assistant-ui/x-generative-compiler` on disk to walk up to. The check then threw `could not determine @assistant-ui/x-generative-compiler's package version` during Expo/Metro bundling. The version is now imported from `package.json`, so the literal is inlined at build time and survives being bundled. `@assistant-ui/metro` is bumped (it carries the compiler as a bundled devDependency, so it would not pick up the fix automatically) so its bundled transformer ships the fix.

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -7,6 +7,7 @@ import _generate from "@babel/generator";
 import * as t from "@babel/types";
 import { satisfies } from "semver";
 import { DIRECTIVE, type Target } from "./constants";
+import pkgJson from "../package.json" with { type: "json" };
 
 // @babel/traverse and @babel/generator are CJS; their default export is the
 // function itself under some interop and `{ default }` under others.
@@ -229,7 +230,12 @@ interface PackageJson {
 }
 
 const checkedCorePackageJsonPaths = new Set<string>();
-let compilerPackageVersion: string | undefined;
+
+// This compiler's own version, inlined from package.json at build time. Read via
+// an import (not by walking the filesystem at runtime) so the literal survives
+// being bundled into a host package like `@assistant-ui/metro`, where no
+// standalone `@assistant-ui/x-generative-compiler` sits on disk to walk up to.
+const COMPILER_VERSION = pkgJson.version;
 
 function ensureCompilerCompatibleWithCore(
   ast: t.File,
@@ -250,10 +256,9 @@ function ensureCompilerCompatibleWithCore(
     return;
   }
 
-  const compilerVersion = getCompilerPackageVersion();
   let compatible = false;
   try {
-    compatible = satisfies(compilerVersion, range, {
+    compatible = satisfies(COMPILER_VERSION, range, {
       includePrerelease: true,
     });
   } catch {
@@ -269,7 +274,7 @@ function ensureCompilerCompatibleWithCore(
     throw new GenerativeCompileError(
       `${CORE_PACKAGE}@${corePackageJson.version ?? "unknown"} requires ` +
         `${COMPILER_PACKAGE} ${range}, but the current compiler is ` +
-        `${compilerVersion}. Update @assistant-ui/next or @assistant-ui/vite ` +
+        `${COMPILER_VERSION}. Update @assistant-ui/next or @assistant-ui/vite ` +
         "so their compiler satisfies the core package's " +
         "optionalDevDependencies range.",
       filename,
@@ -277,20 +282,6 @@ function ensureCompilerCompatibleWithCore(
   }
 
   checkedCorePackageJsonPaths.add(corePackageJsonPath);
-}
-
-function getCompilerPackageVersion(): string {
-  if (compilerPackageVersion) return compilerPackageVersion;
-
-  const packageJsonPath = findPackageJson(import.meta.url, COMPILER_PACKAGE);
-  const packageJson = packageJsonPath ? readPackageJson(packageJsonPath) : null;
-  if (!packageJson?.version) {
-    throw new GenerativeCompileError(
-      `could not determine ${COMPILER_PACKAGE}'s package version`,
-    );
-  }
-  compilerPackageVersion = packageJson.version;
-  return compilerPackageVersion;
 }
 
 function resolveCorePackageJson(

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -274,8 +274,8 @@ function ensureCompilerCompatibleWithCore(
     throw new GenerativeCompileError(
       `${CORE_PACKAGE}@${corePackageJson.version ?? "unknown"} requires ` +
         `${COMPILER_PACKAGE} ${range}, but the current compiler is ` +
-        `${COMPILER_VERSION}. Update @assistant-ui/next or @assistant-ui/vite ` +
-        "so their compiler satisfies the core package's " +
+        `${COMPILER_VERSION}. Update @assistant-ui/next, @assistant-ui/vite, ` +
+        "or @assistant-ui/metro so their compiler satisfies the core package's " +
         "optionalDevDependencies range.",
       filename,
     );


### PR DESCRIPTION
## Problem

Expo/Metro bundling fails with:

```
GenerativeCompileError: [assistant-ui/next] could not determine @assistant-ui/x-generative-compiler's package version
    at getCompilerPackageVersion (packages/metro/dist/transformer.cjs)
```

The core/compiler compatibility check in `packages/x-generative-compiler/src/compile.ts` resolved the compiler's own version by walking **up the filesystem** from `import.meta.url` to find a `package.json` named `@assistant-ui/x-generative-compiler`.

That works for `@assistant-ui/next` and `@assistant-ui/vite`, which import the compiler as an external dependency. But `@assistant-ui/metro` **bundles** the compiler into `transformer.cjs` (`tsdown` `alwaysBundle`), so at runtime `import.meta.url` points inside the metro package and there is no standalone `@assistant-ui/x-generative-compiler` on disk to walk up to. The check threw before it could compare versions.

It passed CI unit tests because they run from source (the walk finds the real `package.json`) and the metro fixture used a fake filename that can't resolve `@assistant-ui/react`, short-circuiting the check. Only the built + bundled path hit it. The trigger is recent: `@assistant-ui/core` now declares `optionalDevDependencies["@assistant-ui/x-generative-compiler"]` (still an unreleased feature, so no shipped regression, but the monorepo's own Expo build fails since it builds from source).

## Fix

Import the version instead of reading it from disk:

```ts
import pkgJson from "../package.json" with { type: "json" };
const COMPILER_VERSION = pkgJson.version;
```

`tsdown` tree-shakes this to a `dist/package.js` chunk (`var version = "x"`), and metro's re-bundle inlines the literal into `transformer.cjs`. The filesystem-walk function is removed (net -18/+9). Works uniformly for dev/test, Next/Vite (external import), and bundled metro.

## Changeset

`@assistant-ui/x-generative-compiler` (the fix) **and** `@assistant-ui/metro`. metro carries the compiler as a bundled `devDependency`, so changesets won't auto-bump it; without an explicit entry the fixed bundle never reaches Expo/RN users. Next/Vite carry it as a real dependency and auto-bump.

## Verification

- Reproduced the exact error against the prebuilt `transformer.cjs`, confirmed `OK` after rebuild.
- Output inspected: compiler `dist/package.js` tree-shaken to just the version; metro bakes the literal.
- Tests: compiler 55/55, metro 5/5, vite 5/5. Lint, format, typecheck, and full `pnpm build` (80/80) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)