### PR TITLE
feat: merge toolkits across "use generative" files

### DIFF
--- a/.changeset/generative-cross-file-toolkit-merge.md
+++ b/.changeset/generative-cross-file-toolkit-merge.md
@@ -5,7 +5,7 @@
 
 feat: merge toolkits across "use generative" files and allow a bare defineMcpToolkit default export
 
-A `"use generative"` toolkit can now spread the default export of another `"use generative"` module, so tools can be split across files: `import weatherTools from "./tools/weather"; export default defineToolkit({ ...weatherTools })`. The compiler resolves the import and confirms the source is itself `"use generative"` before allowing the spread, so a backend `execute` can't leak to the client. Only default imports qualify, since named exports don't survive the build-split generative-module boundary.
+A `"use generative"` toolkit can now spread the default export of another `"use generative"` module, so tools can be split across files: `import weatherTools from "./tools/weather"; export default defineToolkit({ ...weatherTools })`. The compiler resolves the import (relative paths and `tsconfig` path aliases such as `@/tools/weather`) and confirms the source is itself `"use generative"` before allowing the spread, so a backend `execute` can't leak to the client. Only default imports qualify, since named exports don't survive the build-split generative-module boundary.
 
 `defineMcpToolkit({ ... })` is also now accepted directly as a file's default export, so an MCP-only toolkit no longer needs to be wrapped in an otherwise-empty `defineToolkit`.
 

--- a/.changeset/generative-cross-file-toolkit-merge.md
+++ b/.changeset/generative-cross-file-toolkit-merge.md
@@ -1,0 +1,12 @@
+---
+"@assistant-ui/x-generative-compiler": patch
+"@assistant-ui/metro": patch
+---
+
+feat: merge toolkits across "use generative" files and allow a bare defineMcpToolkit default export
+
+A `"use generative"` toolkit can now spread the default export of another `"use generative"` module, so tools can be split across files: `import weatherTools from "./tools/weather"; export default defineToolkit({ ...weatherTools })`. The compiler resolves the import and confirms the source is itself `"use generative"` before allowing the spread, so a backend `execute` can't leak to the client. Only default imports qualify, since named exports don't survive the build-split generative-module boundary.
+
+`defineMcpToolkit({ ... })` is also now accepted directly as a file's default export, so an MCP-only toolkit no longer needs to be wrapped in an otherwise-empty `defineToolkit`.
+
+`@assistant-ui/metro` is bumped because it bundles the compiler and would not otherwise pick up the new behavior.

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -86,6 +86,27 @@ function createMergeFixture(childSource: string): string {
   return nodePath.join(appRoot, "src", "toolkit.tsx");
 }
 
+/**
+ * Like {@link createMergeFixture}, but also writes a (JSONC) `tsconfig.json`
+ * with a `@/*` path alias so alias resolution can be exercised. The child lives
+ * at `src/tools/weather.tsx` and `@/*` maps to `./src/*`.
+ */
+function createAliasMergeFixture(childSource: string): string {
+  const filename = createMergeFixture(childSource);
+  const appRoot = nodePath.dirname(nodePath.dirname(filename));
+  writeFileSync(
+    nodePath.join(appRoot, "tsconfig.json"),
+    `{
+  // path aliases
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "@/*": ["./src/*"] },
+  }
+}`,
+  );
+  return filename;
+}
+
 const generativeChild = `"use generative";
 import { defineToolkit } from "@assistant-ui/react";
 export default defineToolkit({
@@ -566,6 +587,33 @@ export default defineToolkit({
     expect(() =>
       compileGenerative(src, { target: "client", filename }),
     ).toThrow(/compiler-visible toolkit spread/);
+  });
+
+  it("resolves a tsconfig path alias when spreading a generative module", () => {
+    const filename = createAliasMergeFixture(generativeChild);
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import weatherTools from "@/tools/weather";
+export default defineToolkit({
+  ...weatherTools,
+});`;
+
+    const client = compileGenerative(src, { target: "client", filename }).code;
+    expect(client).toContain("...weatherTools");
+    expect(client).toContain('from "@/tools/weather"');
+  });
+
+  it("resolves a .js specifier to its .tsx source when spreading", () => {
+    const filename = createMergeFixture(generativeChild);
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import weatherTools from "./tools/weather.js";
+export default defineToolkit({
+  ...weatherTools,
+});`;
+
+    const client = compileGenerative(src, { target: "client", filename }).code;
+    expect(client).toContain("...weatherTools");
   });
 
   it("allows defineMcpToolkit as the default export", () => {

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -73,6 +73,29 @@ function createCompatibilityFixture(range: string | null): string {
   return filename;
 }
 
+/**
+ * Writes a child module to disk next to a (not-yet-written) `toolkit.tsx` and
+ * returns the parent's filename, so a parent compiled from a string can resolve
+ * `./tools/child` relative to it. Used to exercise cross-file toolkit spreads.
+ */
+function createMergeFixture(childSource: string): string {
+  const appRoot = mkdtempSync(nodePath.join(tmpdir(), "aui-generative-merge-"));
+  const toolsRoot = nodePath.join(appRoot, "src", "tools");
+  mkdirSync(toolsRoot, { recursive: true });
+  writeFileSync(nodePath.join(toolsRoot, "weather.tsx"), childSource);
+  return nodePath.join(appRoot, "src", "toolkit.tsx");
+}
+
+const generativeChild = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  get_weather: {
+    execute: async () => 1,
+    render: () => null,
+  },
+});
+`;
+
 const source = `"use generative";
 import { z } from "zod";
 import { db } from "@/db";
@@ -495,6 +518,70 @@ export default defineToolkit({
     expect(() => compileGenerative(src, { target: "client" })).toThrow(
       /compiler-visible toolkit spread/,
     );
+  });
+
+  it("allows spreading the default import of a generative module", () => {
+    const filename = createMergeFixture(generativeChild);
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import weatherTools from "./tools/weather";
+export default defineToolkit({
+  ...weatherTools,
+});`;
+
+    const server = compileGenerative(src, { target: "server", filename }).code;
+    expect(server).toContain("...weatherTools");
+    expect(server).toContain('from "./tools/weather"');
+
+    const client = compileGenerative(src, { target: "client", filename }).code;
+    expect(client).toContain("...weatherTools");
+    expect(client).toContain('from "./tools/weather"');
+  });
+
+  it("rejects spreading the default import of a non-generative module", () => {
+    const filename = createMergeFixture(
+      `export default { get_weather: { execute: async () => 1 } };\n`,
+    );
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import weatherTools from "./tools/weather";
+export default defineToolkit({
+  ...weatherTools,
+});`;
+
+    expect(() =>
+      compileGenerative(src, { target: "client", filename }),
+    ).toThrow(/compiler-visible toolkit spread/);
+  });
+
+  it("rejects spreading a named import even from a generative module", () => {
+    const filename = createMergeFixture(generativeChild);
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import { weatherTools } from "./tools/weather";
+export default defineToolkit({
+  ...weatherTools,
+});`;
+
+    expect(() =>
+      compileGenerative(src, { target: "client", filename }),
+    ).toThrow(/compiler-visible toolkit spread/);
+  });
+
+  it("allows defineMcpToolkit as the default export", () => {
+    const src = `"use generative";
+import { defineMcpToolkit } from "@assistant-ui/react";
+export default defineMcpToolkit({
+  docs: { type: "http", url: "https://mcp.example.com/mcp" },
+});`;
+
+    const server = compileGenerative(src, { target: "server" }).code;
+    expect(server).toContain("defineMcpToolkit");
+    expect(server).toContain("docs");
+
+    const client = compileGenerative(src, { target: "client" }).code;
+    expect(client).toContain("defineMcpToolkit");
+    expect(client).toContain("docs");
   });
 
   it("still allows a flat toolkit tool named tools", () => {

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -603,6 +603,48 @@ export default defineToolkit({
     expect(client).toContain('from "@/tools/weather"');
   });
 
+  it("prefers the most specific tsconfig path alias", () => {
+    const appRoot = mkdtempSync(
+      nodePath.join(tmpdir(), "aui-generative-alias-spec-"),
+    );
+    mkdirSync(nodePath.join(appRoot, "src", "tools"), { recursive: true });
+    mkdirSync(nodePath.join(appRoot, "generated"), { recursive: true });
+    // The broader `@/*` alias would resolve here — a non-generative module.
+    writeFileSync(
+      nodePath.join(appRoot, "src", "tools", "weather.tsx"),
+      `export default { get_weather: { execute: async () => 1 } };\n`,
+    );
+    // The more specific `@/tools/*` alias resolves to the generative module.
+    writeFileSync(
+      nodePath.join(appRoot, "generated", "weather.tsx"),
+      generativeChild,
+    );
+    writeFileSync(
+      nodePath.join(appRoot, "tsconfig.json"),
+      `{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@/tools/*": ["./generated/*"]
+    }
+  }
+}`,
+    );
+    const filename = nodePath.join(appRoot, "src", "toolkit.tsx");
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import weatherTools from "@/tools/weather";
+export default defineToolkit({
+  ...weatherTools,
+});`;
+
+    // `@/tools/*` is more specific than `@/*`, so it wins and the spread is the
+    // generative module (allowed) rather than the non-generative `@/*` target.
+    const client = compileGenerative(src, { target: "client", filename }).code;
+    expect(client).toContain("...weatherTools");
+  });
+
   it("resolves a .js specifier to its .tsx source when spreading", () => {
     const filename = createMergeFixture(generativeChild);
     const src = `"use generative";

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -348,11 +348,14 @@ function resolvePackageJson(
 }
 
 function normalizeRequirePath(filename: string | undefined): string {
-  if (filename) {
-    const cleanFilename = filename.split(/[?#]/, 1)[0]!;
-    if (nodePath.isAbsolute(cleanFilename)) return cleanFilename;
-  }
-  return import.meta.url;
+  return cleanAbsoluteFilename(filename) ?? import.meta.url;
+}
+
+/** Strips a `?query`/`#hash` suffix and returns the path only if it is absolute. */
+function cleanAbsoluteFilename(filename: string | undefined): string | null {
+  if (!filename) return null;
+  const clean = filename.split(/[?#]/, 1)[0]!;
+  return nodePath.isAbsolute(clean) ? clean : null;
 }
 
 function findPackageJson(
@@ -546,25 +549,23 @@ const MODULE_EXTENSIONS = [
   ".cjs",
 ] as const;
 
+/** Extensions a specifier may carry that actually map to a TS source file. */
+const REWRITABLE_JS_EXTENSIONS = new Set([".js", ".jsx", ".mjs", ".cjs"]);
+
 /**
- * Whether a relative import specifier resolves on disk to a `"use generative"`
- * module. Only relative specifiers are resolved — a bundler alias (e.g.
- * `@/tools`) can't be resolved without the bundler's config, so it's treated as
+ * Whether an import specifier resolves on disk to a `"use generative"` module.
+ * Relative specifiers and `tsconfig` path aliases (e.g. `@/tools`) are resolved;
+ * anything else (a bare package, an unresolvable alias) is treated as
  * non-generative, and thus an unsafe spread.
  */
 function isGenerativeImport(
   source: string,
   filename: string | undefined,
 ): boolean {
-  if (!filename || !source.startsWith(".")) return false;
+  const cleanFilename = cleanAbsoluteFilename(filename);
+  if (!cleanFilename) return false;
 
-  const cleanFilename = filename.split(/[?#]/, 1)[0]!;
-  if (!nodePath.isAbsolute(cleanFilename)) return false;
-
-  const resolved = resolveRelativeModuleFile(
-    nodePath.dirname(cleanFilename),
-    source,
-  );
+  const resolved = resolveImportedModuleFile(source, cleanFilename);
   if (!resolved) return false;
 
   try {
@@ -574,23 +575,176 @@ function isGenerativeImport(
   }
 }
 
-/** Resolves a relative specifier to a file, trying TS/JS extensions then index files. */
-function resolveRelativeModuleFile(
-  baseDir: string,
+/** Resolves an import specifier (relative or `tsconfig`-aliased) to a file on disk. */
+function resolveImportedModuleFile(
   source: string,
+  fromFilename: string,
 ): string | null {
-  const base = nodePath.resolve(baseDir, source);
+  if (source.startsWith(".")) {
+    const base = nodePath.resolve(nodePath.dirname(fromFilename), source);
+    return resolveModuleFileAtPath(base);
+  }
+  return resolveAliasImport(source, fromFilename);
+}
 
+/**
+ * Resolves a candidate module path, trying TS/JS extensions then index files. A
+ * specifier may carry a `.js`-family extension that maps to a `.ts`/`.tsx`
+ * source (TypeScript's `bundler`/`nodenext` resolution), so the extension is
+ * dropped before probing.
+ */
+function resolveModuleFileAtPath(base: string): string | null {
   if (nodePath.extname(base) && existsSync(base)) return base;
-  for (const ext of MODULE_EXTENSIONS) {
-    const candidate = `${base}${ext}`;
+
+  const ext = nodePath.extname(base);
+  const stem = REWRITABLE_JS_EXTENSIONS.has(ext)
+    ? base.slice(0, -ext.length)
+    : base;
+
+  for (const candidateExt of MODULE_EXTENSIONS) {
+    const candidate = `${stem}${candidateExt}`;
     if (existsSync(candidate)) return candidate;
   }
-  for (const ext of MODULE_EXTENSIONS) {
-    const candidate = nodePath.join(base, `index${ext}`);
+  for (const candidateExt of MODULE_EXTENSIONS) {
+    const candidate = nodePath.join(base, `index${candidateExt}`);
     if (existsSync(candidate)) return candidate;
   }
   return null;
+}
+
+interface TsconfigAliases {
+  /** Absolute directory that `paths` targets resolve against. */
+  baseDir: string;
+  paths: Record<string, string[]>;
+}
+
+/** Resolves a `tsconfig` path alias (e.g. `@/tools/x`) to a file on disk. */
+function resolveAliasImport(
+  source: string,
+  fromFilename: string,
+): string | null {
+  const tsconfig = loadTsconfigAliases(nodePath.dirname(fromFilename));
+  if (!tsconfig) return null;
+
+  for (const [pattern, targets] of Object.entries(tsconfig.paths)) {
+    const matched = matchAliasPattern(pattern, source);
+    if (matched === null) continue;
+
+    for (const target of targets) {
+      const specifier = target.includes("*")
+        ? target.replace("*", matched)
+        : target;
+      const file = resolveModuleFileAtPath(
+        nodePath.resolve(tsconfig.baseDir, specifier),
+      );
+      if (file) return file;
+    }
+  }
+  return null;
+}
+
+/**
+ * Matches an import specifier against a `tsconfig` `paths` key. Returns the text
+ * captured by the key's `*` (or `""` for an exact, wildcard-free key), or `null`
+ * when the specifier doesn't match.
+ */
+function matchAliasPattern(pattern: string, source: string): string | null {
+  const star = pattern.indexOf("*");
+  if (star === -1) return pattern === source ? "" : null;
+
+  const prefix = pattern.slice(0, star);
+  const suffix = pattern.slice(star + 1);
+  if (
+    source.length >= prefix.length + suffix.length &&
+    source.startsWith(prefix) &&
+    source.endsWith(suffix)
+  ) {
+    return source.slice(prefix.length, source.length - suffix.length);
+  }
+  return null;
+}
+
+/** Walks up from a directory to the nearest `tsconfig.json` that declares `paths`. */
+function loadTsconfigAliases(fromDir: string): TsconfigAliases | null {
+  let dir = fromDir;
+  for (;;) {
+    const tsconfigPath = nodePath.join(dir, "tsconfig.json");
+    if (existsSync(tsconfigPath)) {
+      const aliases = readTsconfigAliases(tsconfigPath, new Set());
+      if (aliases) return aliases;
+    }
+    const parent = nodePath.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/** Reads `baseUrl`/`paths` from a tsconfig, following a single `extends` chain. */
+function readTsconfigAliases(
+  tsconfigPath: string,
+  seen: Set<string>,
+): TsconfigAliases | null {
+  if (seen.has(tsconfigPath)) return null;
+  seen.add(tsconfigPath);
+
+  let config: {
+    extends?: string;
+    compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> };
+  } | null;
+  try {
+    config = parseJsonc(readFileSync(tsconfigPath, "utf8"));
+  } catch {
+    return null;
+  }
+  if (!config) return null;
+
+  const configDir = nodePath.dirname(tsconfigPath);
+  const { baseUrl, paths } = config.compilerOptions ?? {};
+
+  if (paths) {
+    return {
+      baseDir: baseUrl ? nodePath.resolve(configDir, baseUrl) : configDir,
+      paths,
+    };
+  }
+
+  if (config.extends) {
+    const extended = resolveExtendedTsconfig(config.extends, configDir);
+    if (extended) return readTsconfigAliases(extended, seen);
+  }
+  return null;
+}
+
+/** Resolves a tsconfig `extends` value (relative path or installed package). */
+function resolveExtendedTsconfig(
+  extendsValue: string,
+  configDir: string,
+): string | null {
+  if (extendsValue.startsWith(".")) {
+    const base = nodePath.resolve(configDir, extendsValue);
+    if (nodePath.extname(base) === ".json")
+      return existsSync(base) ? base : null;
+    const withJson = `${base}.json`;
+    if (existsSync(withJson)) return withJson;
+    return existsSync(base) ? base : null;
+  }
+  try {
+    return createRequire(nodePath.join(configDir, "package.json")).resolve(
+      extendsValue.endsWith(".json") ? extendsValue : `${extendsValue}.json`,
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** Parses JSON with `//` and block comments and trailing commas stripped (tsconfig is JSONC). */
+function parseJsonc(text: string): any {
+  const withoutComments = text.replace(
+    /"(?:[^"\\]|\\.)*"|\/\/[^\n\r]*|\/\*[\s\S]*?\*\//g,
+    (match) => (match.startsWith('"') ? match : ""),
+  );
+  const withoutTrailingCommas = withoutComments.replace(/,(\s*[}\]])/g, "$1");
+  return JSON.parse(withoutTrailingCommas);
 }
 
 function unwrapToToolkitCall(node: t.Node): t.CallExpression | null {

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -594,9 +594,9 @@ function resolveImportedModuleFile(
  * dropped before probing.
  */
 function resolveModuleFileAtPath(base: string): string | null {
-  if (nodePath.extname(base) && existsSync(base)) return base;
-
   const ext = nodePath.extname(base);
+  if (ext && existsSync(base)) return base;
+
   const stem = REWRITABLE_JS_EXTENSIONS.has(ext)
     ? base.slice(0, -ext.length)
     : base;
@@ -626,14 +626,18 @@ function resolveAliasImport(
   const tsconfig = loadTsconfigAliases(nodePath.dirname(fromFilename));
   if (!tsconfig) return null;
 
-  for (const [pattern, targets] of Object.entries(tsconfig.paths)) {
+  // TypeScript matches the most specific key first: an exact (wildcard-free) key
+  // beats a wildcard one, and a longer static prefix beats a shorter one.
+  const patterns = Object.entries(tsconfig.paths).sort(
+    ([a], [b]) => aliasSpecificity(b) - aliasSpecificity(a),
+  );
+
+  for (const [pattern, targets] of patterns) {
     const matched = matchAliasPattern(pattern, source);
     if (matched === null) continue;
 
     for (const target of targets) {
-      const specifier = target.includes("*")
-        ? target.replace("*", matched)
-        : target;
+      const specifier = substituteAliasWildcard(target, matched);
       const file = resolveModuleFileAtPath(
         nodePath.resolve(tsconfig.baseDir, specifier),
       );
@@ -641,6 +645,19 @@ function resolveAliasImport(
     }
   }
   return null;
+}
+
+/** Ranks a `paths` key: an exact key outranks any wildcard; longer prefixes win. */
+function aliasSpecificity(pattern: string): number {
+  const star = pattern.indexOf("*");
+  return star === -1 ? pattern.length + 1 : star;
+}
+
+/** Substitutes the single `*` in a `paths` target with the matched text. */
+function substituteAliasWildcard(target: string, matched: string): string {
+  const star = target.indexOf("*");
+  if (star === -1) return target;
+  return target.slice(0, star) + matched + target.slice(star + 1);
 }
 
 /**
@@ -688,7 +705,7 @@ function readTsconfigAliases(
   seen.add(tsconfigPath);
 
   let config: {
-    extends?: string;
+    extends?: string | string[];
     compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> };
   } | null;
   try {
@@ -708,9 +725,22 @@ function readTsconfigAliases(
     };
   }
 
-  if (config.extends) {
-    const extended = resolveExtendedTsconfig(config.extends, configDir);
-    if (extended) return readTsconfigAliases(extended, seen);
+  // `extends` may be a string or (TS 5.0+) a string array; later entries take
+  // precedence, so try them last-first. Parsed from untrusted JSONC, so the
+  // array case is a real runtime shape, not just a type.
+  const extendsList = Array.isArray(config.extends)
+    ? config.extends
+    : config.extends
+      ? [config.extends]
+      : [];
+  for (let i = extendsList.length - 1; i >= 0; i--) {
+    const entry = extendsList[i];
+    if (typeof entry !== "string") continue;
+    const extended = resolveExtendedTsconfig(entry, configDir);
+    if (extended) {
+      const aliases = readTsconfigAliases(extended, seen);
+      if (aliases) return aliases;
+    }
   }
   return null;
 }

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -681,7 +681,6 @@ function matchAliasPattern(pattern: string, source: string): string | null {
   return null;
 }
 
-/** Walks up from a directory to the nearest `tsconfig.json` that declares `paths`. */
 /**
  * Memoizes resolved aliases per start directory. The compiler runs once per
  * file across a build, so without this every aliased spread re-walks and
@@ -690,6 +689,7 @@ function matchAliasPattern(pattern: string, source: string): string | null {
  */
 const tsconfigAliasesByDir = new Map<string, TsconfigAliases | null>();
 
+/** Walks up from a directory to the nearest `tsconfig.json` that declares `paths`. */
 function loadTsconfigAliases(fromDir: string): TsconfigAliases | null {
   const cached = tsconfigAliasesByDir.get(fromDir);
   if (cached !== undefined) return cached;

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -140,7 +140,7 @@ export function compileGenerative(
   // such entries pass through.
   ensureDefaultExport(ast, filename);
   const generativeInstances = collectGenerativeInstances(ast);
-  const safeToolkitSpreads = collectSafeToolkitSpreads(ast);
+  const safeToolkitSpreads = collectSafeToolkitSpreads(ast, filename);
 
   const flags: TargetFlags = { keptRender: false, keptBackendExecute: false };
 
@@ -431,11 +431,12 @@ function ensureDefaultExport(ast: t.File, filename: string | undefined): void {
   if (!def) {
     throw new GenerativeCompileError("missing a default export", filename);
   }
-  if (!unwrapToCall(def.declaration, TOOLKIT_WRAPPER)) {
+  if (!unwrapToToolkitCall(def.declaration)) {
     throw new GenerativeCompileError(
-      `the default export must be ${TOOLKIT_WRAPPER}({ ... }) (imported from ` +
-        '"@assistant-ui/react"); wrapping is required so a backend `execute` ' +
-        "can't be authored in a way that reaches the client",
+      `the default export must be ${TOOLKIT_WRAPPER}({ ... }) or ` +
+        `${MCP_TOOLKIT_WRAPPER}({ ... }) (imported from "@assistant-ui/react"); ` +
+        "wrapping is required so a backend `execute` can't be authored in a way " +
+        "that reaches the client",
       filename,
     );
   }
@@ -483,22 +484,113 @@ function collectGenerativeInstances(ast: t.File): Set<string> {
 }
 
 /**
- * Local toolkit variables whose initializer is visible to this compiler pass
- * are safe to spread. `defineToolkit(...)` initializers are compiled in-place
- * before a later spread reads them; `defineMcpToolkit(...)` entries cannot
- * contain executable code.
+ * Toolkit identifiers that are safe to spread into a `defineToolkit({ ... })`.
+ *
+ * Two kinds qualify:
+ *
+ * - A local variable whose initializer is visible to this compiler pass: a
+ *   `defineToolkit(...)` binding is compiled in-place before a later spread
+ *   reads it, and `defineMcpToolkit(...)` entries can't contain executable code.
+ * - The default import of another `"use generative"` module: that module is
+ *   split per-target by its own compiler pass, so spreading its default-exported
+ *   toolkit can't leak a backend `execute` to the client. Only the default
+ *   export crosses the generative-module boundary, so named imports don't
+ *   qualify — they would be `undefined` once that module is build-split.
  */
-function collectSafeToolkitSpreads(ast: t.File): Set<string> {
+function collectSafeToolkitSpreads(
+  ast: t.File,
+  filename: string | undefined,
+): Set<string> {
   const names = new Set<string>();
+  const generativeBySource = new Map<string, boolean>();
+
   for (const statement of ast.program.body) {
-    if (!t.isVariableDeclaration(statement)) continue;
-    for (const declaration of statement.declarations) {
-      const { id, init } = declaration;
-      if (!t.isIdentifier(id) || !init) continue;
-      if (unwrapToToolkitCall(init)) names.add(id.name);
+    if (t.isVariableDeclaration(statement)) {
+      for (const declaration of statement.declarations) {
+        const { id, init } = declaration;
+        if (t.isIdentifier(id) && init && unwrapToToolkitCall(init)) {
+          names.add(id.name);
+        }
+      }
+      continue;
+    }
+
+    if (t.isImportDeclaration(statement)) {
+      const defaultSpecifier = statement.specifiers.find(
+        (specifier): specifier is t.ImportDefaultSpecifier =>
+          t.isImportDefaultSpecifier(specifier),
+      );
+      if (!defaultSpecifier) continue;
+
+      const source = statement.source.value;
+      let isGenerative = generativeBySource.get(source);
+      if (isGenerative === undefined) {
+        isGenerative = isGenerativeImport(source, filename);
+        generativeBySource.set(source, isGenerative);
+      }
+      if (isGenerative) names.add(defaultSpecifier.local.name);
     }
   }
+
   return names;
+}
+
+const MODULE_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+] as const;
+
+/**
+ * Whether a relative import specifier resolves on disk to a `"use generative"`
+ * module. Only relative specifiers are resolved — a bundler alias (e.g.
+ * `@/tools`) can't be resolved without the bundler's config, so it's treated as
+ * non-generative, and thus an unsafe spread.
+ */
+function isGenerativeImport(
+  source: string,
+  filename: string | undefined,
+): boolean {
+  if (!filename || !source.startsWith(".")) return false;
+
+  const cleanFilename = filename.split(/[?#]/, 1)[0]!;
+  if (!nodePath.isAbsolute(cleanFilename)) return false;
+
+  const resolved = resolveRelativeModuleFile(
+    nodePath.dirname(cleanFilename),
+    source,
+  );
+  if (!resolved) return false;
+
+  try {
+    return isGenerativeModule(readFileSync(resolved, "utf8"));
+  } catch {
+    return false;
+  }
+}
+
+/** Resolves a relative specifier to a file, trying TS/JS extensions then index files. */
+function resolveRelativeModuleFile(
+  baseDir: string,
+  source: string,
+): string | null {
+  const base = nodePath.resolve(baseDir, source);
+
+  if (nodePath.extname(base) && existsSync(base)) return base;
+  for (const ext of MODULE_EXTENSIONS) {
+    const candidate = `${base}${ext}`;
+    if (existsSync(candidate)) return candidate;
+  }
+  for (const ext of MODULE_EXTENSIONS) {
+    const candidate = nodePath.join(base, `index${ext}`);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
 }
 
 function unwrapToToolkitCall(node: t.Node): t.CallExpression | null {

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -682,18 +682,33 @@ function matchAliasPattern(pattern: string, source: string): string | null {
 }
 
 /** Walks up from a directory to the nearest `tsconfig.json` that declares `paths`. */
+/**
+ * Memoizes resolved aliases per start directory. The compiler runs once per
+ * file across a build, so without this every aliased spread re-walks and
+ * re-parses the same `tsconfig.json`. Process-lifetime, like
+ * `checkedCorePackageJsonPaths`.
+ */
+const tsconfigAliasesByDir = new Map<string, TsconfigAliases | null>();
+
 function loadTsconfigAliases(fromDir: string): TsconfigAliases | null {
+  const cached = tsconfigAliasesByDir.get(fromDir);
+  if (cached !== undefined) return cached;
+
+  let aliases: TsconfigAliases | null = null;
   let dir = fromDir;
   for (;;) {
     const tsconfigPath = nodePath.join(dir, "tsconfig.json");
     if (existsSync(tsconfigPath)) {
-      const aliases = readTsconfigAliases(tsconfigPath, new Set());
-      if (aliases) return aliases;
+      aliases = readTsconfigAliases(tsconfigPath, new Set());
+      if (aliases) break;
     }
     const parent = nodePath.dirname(dir);
-    if (parent === dir) return null;
+    if (parent === dir) break;
     dir = parent;
   }
+
+  tsconfigAliasesByDir.set(fromDir, aliases);
+  return aliases;
 }
 
 /** Reads `baseUrl`/`paths` from a tsconfig, following a single `extends` chain. */
@@ -752,11 +767,9 @@ function resolveExtendedTsconfig(
 ): string | null {
   if (extendsValue.startsWith(".")) {
     const base = nodePath.resolve(configDir, extendsValue);
-    if (nodePath.extname(base) === ".json")
-      return existsSync(base) ? base : null;
-    const withJson = `${base}.json`;
-    if (existsSync(withJson)) return withJson;
-    return existsSync(base) ? base : null;
+    const candidates =
+      nodePath.extname(base) === ".json" ? [base] : [`${base}.json`, base];
+    return candidates.find((candidate) => existsSync(candidate)) ?? null;
   }
   try {
     return createRequire(nodePath.join(configDir, "package.json")).resolve(


### PR DESCRIPTION
## What

Two related compiler changes to `@assistant-ui/x-generative-compiler` that make it possible to organize generative toolkits across multiple files:

1. **Cross-file toolkit merge.** A `"use generative"` toolkit can now spread the **default import** of another `"use generative"` module:

   ```tsx title="app/toolkit.tsx"
   "use generative";
   import { defineToolkit } from "@assistant-ui/react";
   import weatherTools from "./tools/weather";   // export default defineToolkit({...})
   import databaseTools from "./tools/database";
   export default defineToolkit({ ...weatherTools, ...databaseTools });
   ```

   The compiler resolves the relative import and confirms the source module is itself `"use generative"` before allowing the spread. Because each generative module is build-split by its own compiler pass, spreading its default-exported toolkit can't leak a backend `execute` to the client. Only **default** imports qualify — a named import wouldn't survive the generative-module boundary (the build integrations forward only the default export), so named-import spreads are still rejected.

2. **Bare `defineMcpToolkit` default export.** `export default defineMcpToolkit({ ... })` is now accepted, so an MCP-only toolkit no longer needs to be wrapped in an otherwise-empty `defineToolkit`.

## Why

Previously every imported spread was rejected ("compiler-visible toolkit spread") because the compiler couldn't verify a backend `execute` wouldn't reach the client. Resolving the import and checking for the `"use generative"` directive makes the safe case (merging split toolkits) work while keeping the unsafe case (spreading an opaque/backend import) rejected.

## Notes

- Only **relative** specifiers are resolved; a bundler alias like `@/tools` can't be resolved without the bundler's config and is treated as a non-generative (unsafe) spread.
- `@assistant-ui/metro` is bumped because it bundles the compiler as a devDependency and wouldn't otherwise pick up the new behavior. `@assistant-ui/next` / `@assistant-ui/vite` import the compiler normally and are updated automatically.

## Tests

Added compiler tests covering: spreading a default import of a generative module (kept in both builds), rejecting a default import of a non-generative module, rejecting a named import even from a generative module, and accepting `defineMcpToolkit` as a default export. All 59 tests pass; lint clean; compiler + metro build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)