### PR TITLE
docs(tools): use AISDKToolkit in the defining-tools server step

### DIFF
--- a/apps/docs/content/docs/tools/defining-tools.mdx
+++ b/apps/docs/content/docs/tools/defining-tools.mdx
@@ -141,13 +141,15 @@ export function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
 
 ### Expose the toolkit to the model on your server
 
-The same import resolves to the **server build** inside a route handler. Pass it to `generativeTools` so the model is configured with every tool's schema:
+The same import resolves to the **server build** inside a route handler. Wrap it in an `AISDKToolkit` so the model is configured with every tool's schema:
 
 ```ts title="app/api/chat/route.ts"
-import { generativeTools } from "@assistant-ui/react-ai-sdk";
+import { AISDKToolkit } from "@assistant-ui/react-ai-sdk";
 import { streamText, convertToModelMessages } from "ai";
 import { openai } from "@ai-sdk/openai";
 import toolkit from "../../toolkit";
+
+const aiToolkit = new AISDKToolkit({ toolkit });
 
 export async function POST(req: Request) {
   const { messages, tools } = await req.json();
@@ -155,7 +157,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: openai("gpt-5.4-nano"),
     messages: await convertToModelMessages(messages),
-    tools: generativeTools({ toolkit, frontendTools: tools }),
+    tools: await aiToolkit.tools({ frontend: tools }),
   });
 
   return result.toUIMessageStreamResponse();


### PR DESCRIPTION
Follow-up to #4266. Converts the final `generativeTools` reference in the docs (the "Expose the toolkit to the model on your server" step in `defining-tools.mdx`) to the module-scope `AISDKToolkit` pattern, matching `backend.mdx`.

This one line was deferred from #4266 because `defining-tools.mdx` was being concurrently rewritten by #4267; both have since merged, so there is now no `generativeTools` usage anywhere in product code, examples, templates, tests, or docs.

`@assistant-ui/docs` is private, so no changeset is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)