### PR TITLE
feat: expose joinStrategy on useAISDKRuntime / useChatRuntime

### DIFF
--- a/.changeset/aisdk-runtime-join-strategy.md
+++ b/.changeset/aisdk-runtime-join-strategy.md
@@ -1,0 +1,10 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/core": patch
+---
+
+feat: expose `joinStrategy` on `useAISDKRuntime` / `useChatRuntime`
+
+the new AI SDK runtime always merged consecutive `role: "assistant"` UIMessages into a single rendered turn, with no supported way to opt out (the converter accepts `joinStrategy` but the runtime never forwarded it, and `AISDKMessageConverter` is not exported). this follows up on #1633, where the same knob shipped on the legacy `useVercelUseChatRuntime` as `unstable_joinStrategy`. pass `joinStrategy: "none"` to keep proactive or history loaded consecutive assistant messages as separate turns.
+
+core now exports a shared `JoinStrategy` type so the `"concat-content" | "none"` union has a single source of truth across the converter and the runtimes.

--- a/packages/core/src/react/index.ts
+++ b/packages/core/src/react/index.ts
@@ -155,6 +155,7 @@ export {
   useExternalMessageConverter,
   convertExternalMessages,
 } from "./runtimes/external-message-converter";
+export type { JoinStrategy } from "./runtimes/external-message-converter";
 export { createMessageConverter } from "./runtimes/createMessageConverter";
 export { RemoteThreadListHookInstanceManager } from "./runtimes/RemoteThreadListHookInstanceManager";
 export { RemoteThreadListThreadListRuntimeCore } from "./runtimes/RemoteThreadListThreadListRuntimeCore";

--- a/packages/core/src/react/runtimes/createMessageConverter.ts
+++ b/packages/core/src/react/runtimes/createMessageConverter.ts
@@ -5,6 +5,7 @@ import { useAui, useAuiState } from "@assistant-ui/store";
 import {
   useExternalMessageConverter,
   convertExternalMessages,
+  type JoinStrategy,
 } from "./external-message-converter";
 import { getExternalStoreMessages } from "../../runtime/utils/external-store-message";
 
@@ -20,7 +21,7 @@ export const createMessageConverter = <T extends object>(
     }: {
       messages: T[];
       isRunning: boolean;
-      joinStrategy?: "concat-content" | "none" | undefined;
+      joinStrategy?: JoinStrategy | undefined;
       metadata?: useExternalMessageConverter.Metadata;
     }) => {
       return useExternalMessageConverter<T>({

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -22,6 +22,8 @@ import type {
 } from "../../types/message";
 import type { MessageTiming } from "../../types/message";
 
+export type JoinStrategy = "concat-content" | "none";
+
 type ThreadMessageLikeContentItem = Exclude<
   ThreadMessageLike["content"],
   string
@@ -42,7 +44,7 @@ export namespace useExternalMessageConverter {
   export type Message =
     | (ThreadMessageLike & {
         readonly convertConfig?: {
-          readonly joinStrategy?: "concat-content" | "none";
+          readonly joinStrategy?: JoinStrategy;
         };
       })
     | {
@@ -264,7 +266,7 @@ const joinExternalMessages = (
 
 const chunkExternalMessages = <T>(
   callbackResults: CallbackResult<T>[],
-  joinStrategy?: "concat-content" | "none",
+  joinStrategy?: JoinStrategy,
 ) => {
   const results: ChunkResult<T>[] = [];
   let isAssistant = false;
@@ -397,7 +399,7 @@ export const useExternalMessageConverter = <T extends WeakKey>({
   callback: useExternalMessageConverter.Callback<T>;
   messages: T[];
   isRunning: boolean;
-  joinStrategy?: "concat-content" | "none" | undefined;
+  joinStrategy?: JoinStrategy | undefined;
   metadata?: useExternalMessageConverter.Metadata | undefined;
 }) => {
   const state = useMemo(

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
@@ -37,6 +37,12 @@ const createChatHelpers = (messages: any[] = []) => {
   return chatHelpers;
 };
 
+const textOf = (message: any): string =>
+  message.content
+    .filter((part: any) => part.type === "text")
+    .map((part: any) => part.text)
+    .join("|");
+
 describe("useAISDKRuntime", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -438,5 +444,55 @@ describe("useAISDKRuntime", () => {
     const suggestions = [{ prompt: "tell me a joke" }];
     const { result } = renderHook(() => useAISDKRuntime(chat, { suggestions }));
     expect(result.current.thread.getState().suggestions).toEqual(suggestions);
+  });
+
+  it("merges consecutive assistant messages into one turn by default", async () => {
+    const chat = createChatHelpers([
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      { id: "a1", role: "assistant", parts: [{ type: "text", text: "first" }] },
+      {
+        id: "a2",
+        role: "assistant",
+        parts: [{ type: "text", text: "second" }],
+      },
+    ]);
+
+    const { result } = renderHook(() => useAISDKRuntime(chat));
+
+    await waitFor(() => {
+      expect(result.current.thread.getState().messages.length).toBe(2);
+    });
+
+    const messages = result.current.thread.getState().messages;
+    expect(messages.map((m: any) => m.role)).toEqual(["user", "assistant"]);
+    expect(textOf(messages[1])).toBe("first|second");
+  });
+
+  it('keeps consecutive assistant messages separate when joinStrategy is "none"', async () => {
+    const chat = createChatHelpers([
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      { id: "a1", role: "assistant", parts: [{ type: "text", text: "first" }] },
+      {
+        id: "a2",
+        role: "assistant",
+        parts: [{ type: "text", text: "second" }],
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useAISDKRuntime(chat, { joinStrategy: "none" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.thread.getState().messages.length).toBe(3);
+    });
+
+    const messages = result.current.thread.getState().messages;
+    expect(messages.map((m: any) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "assistant",
+    ]);
+    expect(messages.slice(1).map(textOf)).toEqual(["first", "second"]);
   });
 });

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -6,6 +6,7 @@ import { isToolUIPart, generateId } from "ai";
 import {
   useExternalStoreRuntime,
   useRuntimeAdapters,
+  type JoinStrategy,
 } from "@assistant-ui/core/react";
 import type { ToolExecutionStatus } from "@assistant-ui/core";
 import type {
@@ -82,6 +83,15 @@ export type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
    * (for example, an SSE reconnect endpoint keyed by turn id).
    */
   onResume?: ExternalStoreAdapter["onResume"];
+  /**
+   * How consecutive assistant messages are rendered.
+   *
+   * `"concat-content"` (the default) merges them into a single thread message.
+   * `"none"` keeps each assistant message as its own thread message, which is
+   * useful when a backend persists proactive or consecutive assistant messages
+   * as separate entries.
+   */
+  joinStrategy?: JoinStrategy | undefined;
 };
 
 export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
@@ -93,6 +103,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     toCreateMessage: customToCreateMessage,
     cancelPendingToolCallsOnSend = true,
     onResume,
+    joinStrategy,
   } = adapter;
   const contextAdapters = useRuntimeAdapters();
   const [toolStatuses, setToolStatuses] = useState<
@@ -126,6 +137,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const messages = AISDKMessageConverter.useThreadMessages({
     isRunning,
     messages: chatHelpers.messages,
+    joinStrategy,
     metadata: useMemo(
       () => ({
         toolStatuses,

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -29,6 +29,7 @@ export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
       adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
       toCreateMessage?: CustomToCreateMessageFunction;
       onResume?: AISDKRuntimeAdapter["onResume"];
+      joinStrategy?: AISDKRuntimeAdapter["joinStrategy"];
     };
 
 const useDynamicChatTransport = <UI_MESSAGE extends UIMessage = UIMessage>(
@@ -78,6 +79,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     unstable_capabilities: _unstable_capabilities,
     suggestions: _suggestions,
     onResume,
+    joinStrategy,
     ...chatOptions
   } = options ?? {};
   // peel guard: any shared key left in `chatOptions` collapses this to `never`
@@ -103,6 +105,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...pickExternalStoreSharedOptions(options ?? {}),
     ...(toCreateMessage && { toCreateMessage }),
     ...(onResume && { onResume }),
+    ...(joinStrategy && { joinStrategy }),
   });
 
   if (transport instanceof AssistantChatTransport) {


### PR DESCRIPTION
closes #4270

## summary

- `useAISDKRuntime` and `useChatRuntime` now accept a `joinStrategy` option. pass `joinStrategy: "none"` to keep consecutive `role: "assistant"` messages (from loaded history or proactive `setMessages` appends) as separate rendered turns instead of merging them into one.
- the new AI SDK runtime always called the converter without a `joinStrategy`, and `AISDKMessageConverter` is not exported, so there was no supported way to opt out. the option is now forwarded from the adapter into `AISDKMessageConverter.useThreadMessages(...)`; the converter and chunking logic already honored it.
- `@assistant-ui/core/react` now exports a shared `JoinStrategy` type so the `"concat-content" | "none"` union has a single source of truth across the converter and the runtimes.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` -> 75/75 green, including two new cases (default merges consecutive assistant messages; `joinStrategy: "none"` keeps them separate)
- [x] `tsc --noEmit` clean on both touched packages after rebuilding core; `pnpm lint` (oxlint + oxfmt) clean

### reviewer should verify

- [ ] in an app using `useChatRuntime`, load a thread whose history has two adjacent assistant messages, then confirm `joinStrategy: "none"` renders them as two turns while the default still merges them

## notes

- follows up on #1633, where the same knob shipped on the legacy `useVercelUseChatRuntime` as `unstable_joinStrategy`. exposed here as plain `joinStrategy` (no `unstable_` prefix) to match the stable core converter option it forwards to; the legacy runtime and its `unstable_joinStrategy` no longer exist in the repo.
- `joinStrategy: "none"` is a no-op for single response and multi step tool turns: a tool roundtrip is one assistant UIMessage with the result inlined, so it only splits genuinely separate adjacent assistant messages.