### PR TITLE
fix(mcp-apps): send 2026-01-26 dialect on host→app bridge messages

### DIFF
--- a/.changeset/mcp-apps-outbound-spec-dialect.md
+++ b/.changeset/mcp-apps-outbound-spec-dialect.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(mcp-apps): send the 2026-01-26 dialect on host→app messages so widgets built with `@modelcontextprotocol/ext-apps` initialize and receive tool results
+
+the bridge already normalized inbound `ui/*` method names, but every outbound message (the `ui/initialize` result and the tool input/result/host context notifications) stayed in the pre-spec dialect. spec widgets zod-validate the initialize result and require `hostInfo` + `hostCapabilities`, so they failed init; tool results were posted as `notifications/tools/call/result`, a method the official SDK never listens for, so a patched widget still rendered empty. the bridge now additively dual-sends both dialects (the initialize result carries `host`/`capabilities` and `hostInfo`/`hostCapabilities`, echoes the app's requested `protocolVersion`, and each notification posts its `ui/notifications/*` counterpart with the spec param shapes). unknown methods and fields are ignored by either SDK, so legacy widgets are unaffected.

--- a/packages/react/src/mcp-apps/bridge.test.ts
+++ b/packages/react/src/mcp-apps/bridge.test.ts
@@ -69,6 +69,34 @@ describe("createMcpAppBridge", () => {
     expect(result["capabilities"]["ui"]["sendMessage"]).toBe(true);
     expect(result["capabilities"]["ui"]["openLink"]).toBe(false);
 
+    expect(result["hostInfo"]).toEqual({ name: "test-host", version: "9.9.9" });
+    expect(result["hostCapabilities"]).toEqual({
+      serverTools: {},
+      message: { text: {} },
+    });
+
+    bridge.dispose();
+  });
+
+  it("echoes the requested protocolVersion in the ui/initialize result", async () => {
+    const { frame, captured } = makeFrame();
+    const bridge = createMcpAppBridge({ frame });
+
+    dispatch(frame, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "ui/initialize",
+      params: { protocolVersion: "2026-01-26" },
+    });
+    await flush();
+
+    const result = (captured[0] as McpAppJsonRpcResponse).result as Record<
+      string,
+      any
+    >;
+    expect(result["protocolVersion"]).toBe("2026-01-26");
+    expect(result["hostCapabilities"]).toEqual({});
+
     bridge.dispose();
   });
 
@@ -217,7 +245,7 @@ describe("createMcpAppBridge", () => {
     bridge.dispose();
   });
 
-  it("notifyToolInput / notifyToolResult / notifyHostContextChanged post correct notifications", () => {
+  it("notifyToolInput / notifyToolResult / notifyHostContextChanged post both legacy and 2026-01-26 notifications", () => {
     const { frame, captured } = makeFrame();
     const bridge = createMcpAppBridge({ frame });
 
@@ -233,13 +261,59 @@ describe("createMcpAppBridge", () => {
       },
       {
         jsonrpc: "2.0",
+        method: "ui/notifications/tool-input",
+        params: { arguments: { a: 1 } },
+      },
+      {
+        jsonrpc: "2.0",
         method: "notifications/tools/call/result",
         params: { result: { ok: 1 } },
       },
       {
         jsonrpc: "2.0",
+        method: "ui/notifications/tool-result",
+        params: { ok: 1 },
+      },
+      {
+        jsonrpc: "2.0",
         method: "notifications/host_context/changed",
         params: { theme: "light" },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "ui/notifications/host-context-changed",
+        params: { theme: "light" },
+      },
+    ]);
+    bridge.dispose();
+  });
+
+  it("wraps non-object and array tool results in a valid content block for the spec dialect", () => {
+    const { frame, captured } = makeFrame();
+    const bridge = createMcpAppBridge({ frame });
+
+    bridge.notifyToolResult("done");
+    bridge.notifyToolResult([1, 2]);
+    bridge.notifyToolInput(null);
+
+    const spec = captured.filter((c) =>
+      (c as { method?: string }).method?.startsWith("ui/notifications/"),
+    );
+    expect(spec).toEqual([
+      {
+        jsonrpc: "2.0",
+        method: "ui/notifications/tool-result",
+        params: { content: [{ type: "text", text: "done" }] },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "ui/notifications/tool-result",
+        params: { content: [{ type: "text", text: "1,2" }] },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "ui/notifications/tool-input",
+        params: {},
       },
     ]);
     bridge.dispose();

--- a/packages/react/src/mcp-apps/bridge.ts
+++ b/packages/react/src/mcp-apps/bridge.ts
@@ -136,10 +136,18 @@ export function createMcpAppBridge(
 
       switch (normalizeMethod(req.method)) {
         case "ui/initialize": {
+          const requestedProtocolVersion =
+            params &&
+            typeof params === "object" &&
+            typeof (params as { protocolVersion?: unknown }).protocolVersion ===
+              "string"
+              ? (params as { protocolVersion: string }).protocolVersion
+              : MCP_APP_PROTOCOL_VERSION;
           respond(req.id, {
             result: {
-              protocolVersion: MCP_APP_PROTOCOL_VERSION,
+              protocolVersion: requestedProtocolVersion,
               host: hostInfo,
+              hostInfo,
               hostContext,
               capabilities: {
                 tools: handlers.callTool ? {} : undefined,
@@ -153,6 +161,18 @@ export function createMcpAppBridge(
                   requestDisplayMode: !!handlers.requestDisplayMode,
                   updateModelContext: !!handlers.updateModelContext,
                 },
+              },
+              hostCapabilities: {
+                ...(handlers.openLink ? { openLinks: {} } : {}),
+                ...(handlers.callTool ? { serverTools: {} } : {}),
+                ...(handlers.readResource || handlers.listResources
+                  ? { serverResources: {} }
+                  : {}),
+                ...(handlers.updateModelContext
+                  ? { updateModelContext: { text: {} } }
+                  : {}),
+                ...(handlers.sendMessage ? { message: { text: {} } } : {}),
+                ...(handlers.onLog ? { logging: {} } : {}),
               },
             },
           });
@@ -432,6 +452,14 @@ export function createMcpAppBridge(
         method: "notifications/tools/call/input",
         params: { input },
       });
+      post({
+        jsonrpc: "2.0",
+        method: "ui/notifications/tool-input",
+        params:
+          input && typeof input === "object" && !Array.isArray(input)
+            ? { arguments: input }
+            : {},
+      });
     },
     notifyToolResult: (result: unknown) => {
       post({
@@ -439,11 +467,24 @@ export function createMcpAppBridge(
         method: "notifications/tools/call/result",
         params: { result },
       });
+      post({
+        jsonrpc: "2.0",
+        method: "ui/notifications/tool-result",
+        params:
+          result && typeof result === "object" && !Array.isArray(result)
+            ? (result as Record<string, unknown>)
+            : { content: [{ type: "text", text: String(result) }] },
+      });
     },
     notifyHostContextChanged: (ctx: McpAppHostContext) => {
       post({
         jsonrpc: "2.0",
         method: "notifications/host_context/changed",
+        params: ctx,
+      });
+      post({
+        jsonrpc: "2.0",
+        method: "ui/notifications/host-context-changed",
         params: ctx,
       });
     },

--- a/packages/react/src/mcp-apps/bridge.ts
+++ b/packages/react/src/mcp-apps/bridge.ts
@@ -10,6 +10,7 @@ import {
   type McpAppJsonRpcRequest,
   type McpAppJsonRpcResponse,
 } from "./types";
+import { isRecord } from "../utils/json/is-json";
 
 const VALID_DISPLAY_MODES = [
   "inline",
@@ -57,9 +58,6 @@ const METHOD_ALIASES: Record<string, string> = {
 
 const normalizeMethod = (method: string): string =>
   METHOD_ALIASES[method] ?? method;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  !!value && typeof value === "object" && !Array.isArray(value);
 
 const JSONRPC_ERROR = {
   parseError: -32700,

--- a/packages/react/src/mcp-apps/bridge.ts
+++ b/packages/react/src/mcp-apps/bridge.ts
@@ -58,6 +58,9 @@ const METHOD_ALIASES: Record<string, string> = {
 const normalizeMethod = (method: string): string =>
   METHOD_ALIASES[method] ?? method;
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === "object" && !Array.isArray(value);
+
 const JSONRPC_ERROR = {
   parseError: -32700,
   invalidRequest: -32600,
@@ -137,11 +140,8 @@ export function createMcpAppBridge(
       switch (normalizeMethod(req.method)) {
         case "ui/initialize": {
           const requestedProtocolVersion =
-            params &&
-            typeof params === "object" &&
-            typeof (params as { protocolVersion?: unknown }).protocolVersion ===
-              "string"
-              ? (params as { protocolVersion: string }).protocolVersion
+            isRecord(params) && typeof params.protocolVersion === "string"
+              ? params.protocolVersion
               : MCP_APP_PROTOCOL_VERSION;
           respond(req.id, {
             result: {
@@ -455,10 +455,7 @@ export function createMcpAppBridge(
       post({
         jsonrpc: "2.0",
         method: "ui/notifications/tool-input",
-        params:
-          input && typeof input === "object" && !Array.isArray(input)
-            ? { arguments: input }
-            : {},
+        params: isRecord(input) ? { arguments: input } : {},
       });
     },
     notifyToolResult: (result: unknown) => {
@@ -470,10 +467,9 @@ export function createMcpAppBridge(
       post({
         jsonrpc: "2.0",
         method: "ui/notifications/tool-result",
-        params:
-          result && typeof result === "object" && !Array.isArray(result)
-            ? (result as Record<string, unknown>)
-            : { content: [{ type: "text", text: String(result) }] },
+        params: isRecord(result)
+          ? result
+          : { content: [{ type: "text", text: String(result) }] },
       });
     },
     notifyHostContextChanged: (ctx: McpAppHostContext) => {


### PR DESCRIPTION
closes #4276

## summary

- widgets built with `@modelcontextprotocol/ext-apps` (protocol `2026-01-26`) can now initialize against the MCP App iframe bridge and receive tool input/results. previously they failed `ui/initialize` zod validation and silently never heard tool results.
- the bridge already normalized inbound `ui/*` method names, but every outbound (host→app) message stayed in the pre-spec dialect. the `ui/initialize` result now carries both the legacy `host`/`capabilities` and the spec-required `hostInfo`/`hostCapabilities`, and echoes the app's requested `protocolVersion`; each notification additionally posts its `ui/notifications/*` counterpart with the spec param shapes (`{ arguments }`, the `CallToolResult` directly, the context directly).
- the dual-send is additive and non-breaking: the spec init schema is `.passthrough()` and unmatched notification methods are dropped, so single-dialect legacy widgets are unaffected.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react vitest run src/mcp-apps/bridge.test.ts` -> 16/16 green (covers the dual init shape, the requested-version echo, both notification dialects, and the non-object/array fallback branches)
- [x] `pnpm lint` -> clean (oxlint + oxfmt)
- [x] verified the produced shapes against the upstream `modelcontextprotocol/ext-apps@1.7.4` zod schemas and the core SDK `@modelcontextprotocol/sdk@v1.29.0` (`CallToolResultSchema.content` is `.default([])` over a `looseObject`, `ImplementationSchema` needs only name/version, `McpUiHostCapabilitiesSchema` fields are all optional)

### reviewer should verify

- [ ] mount a widget built with the official ext-apps SDK against `Tools({ mcpApp: McpAppRenderer(...) })`, confirm it completes the `ui/initialize` handshake and its `ontoolresult` handler fires with the tool result

## notes

- full `protocolVersion` negotiation is intentionally deferred (the issue calls it the longer-term option). the bridge echoes the requested version and gates feature availability through `hostCapabilities` rather than the version string; lifecycle-only notifications the bridge does not yet emit (`ui/notifications/tool-cancelled`, `tool-input-partial`) are not needed on the normal completion path.