### PR TITLE
fix(react-ai-sdk): make the package metro-bundleable in react native / expo

### DIFF
--- a/.changeset/react-ai-sdk-rn-mcp-stdio.md
+++ b/.changeset/react-ai-sdk-rn-mcp-stdio.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix(react-ai-sdk): make the package metro-bundleable in react native / expo by serving a client-only entry under the react-native export condition
+
+importing @assistant-ui/react-ai-sdk in an expo / react native app failed metro bundling because the root entry re-exports the server-only generativeTools / AISDKToolkit, which pull in @ai-sdk/mcp/mcp-stdio and node's child_process. react native now resolves a client-only entry that omits the server toolkit, so metro never reaches the node-only code. the node / server entry is unchanged and still exports the full api.

--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -17,12 +17,16 @@
   "type": "module",
   "exports": {
     ".": {
+      "react-native": {
+        "types": "./dist/index.native.d.ts",
+        "default": "./dist/index.native.js"
+      },
       "types": "./dist/index.d.ts",
-      "react-native": "./dist/index.native.js",
       "default": "./dist/index.js"
     }
   },
   "main": "./dist/index.js",
+  "react-native": "./dist/index.native.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -18,6 +18,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "react-native": "./dist/index.native.js",
       "default": "./dist/index.js"
     }
   },

--- a/packages/react-ai-sdk/src/client.ts
+++ b/packages/react-ai-sdk/src/client.ts
@@ -1,0 +1,18 @@
+/// <reference types="@assistant-ui/core/react" />
+
+export { useAISDKRuntime } from "./ui/use-chat/useAISDKRuntime";
+export { useChatRuntime } from "./ui/use-chat/useChatRuntime";
+export type { UseChatRuntimeOptions } from "./ui/use-chat/useChatRuntime";
+export { AssistantChatTransport } from "./ui/use-chat/AssistantChatTransport";
+export {
+  RESUMABLE_STREAM_ID_HEADER,
+  createResumableSessionStorage,
+} from "./ui/resumable";
+export type {
+  AssistantChatResumableOptions,
+  ResumableClientStorage,
+} from "./ui/resumable";
+export { frontendTools } from "./frontendTools";
+export { injectQuoteContext } from "./injectQuoteContext";
+export type { ThreadTokenUsage, TokenUsageExtractableMessage } from "./usage";
+export { getThreadMessageTokenUsage, useThreadTokenUsage } from "./usage";

--- a/packages/react-ai-sdk/src/index.native.ts
+++ b/packages/react-ai-sdk/src/index.native.ts
@@ -1,0 +1,3 @@
+/// <reference types="@assistant-ui/core/react" />
+
+export * from "./client";

--- a/packages/react-ai-sdk/src/index.ts
+++ b/packages/react-ai-sdk/src/index.ts
@@ -1,18 +1,6 @@
 /// <reference types="@assistant-ui/core/react" />
 
-export { useAISDKRuntime } from "./ui/use-chat/useAISDKRuntime";
-export { useChatRuntime } from "./ui/use-chat/useChatRuntime";
-export type { UseChatRuntimeOptions } from "./ui/use-chat/useChatRuntime";
-export { AssistantChatTransport } from "./ui/use-chat/AssistantChatTransport";
-export {
-  RESUMABLE_STREAM_ID_HEADER,
-  createResumableSessionStorage,
-} from "./ui/resumable";
-export type {
-  AssistantChatResumableOptions,
-  ResumableClientStorage,
-} from "./ui/resumable";
-export { frontendTools } from "./frontendTools";
+export * from "./client";
 export {
   AISDKToolkit,
   generativeTools,
@@ -20,6 +8,3 @@ export {
   type AISDKToolkitToolsOptions,
   type GenerativeToolsOptions,
 } from "./generativeTools";
-export { injectQuoteContext } from "./injectQuoteContext";
-export type { ThreadTokenUsage, TokenUsageExtractableMessage } from "./usage";
-export { getThreadMessageTokenUsage, useThreadTokenUsage } from "./usage";


### PR DESCRIPTION
closes #4283

## summary

- fixes metro bundling failure when importing `@assistant-ui/react-ai-sdk` in a react native / expo app (`The package at "@ai-sdk/mcp/dist/mcp-stdio/index.mjs" attempted to import the Node standard library module "child_process"`).
- root cause: the single root entry re-exports the server-only `generativeTools` / `AISDKToolkit`, which pull in `@ai-sdk/mcp/mcp-stdio` and node's `child_process`, dragging server code onto the rn client graph.
- splits the rn-safe client surface into `src/client.ts` (single source of truth), keeps the full api on the node / server entry (`src/index.ts`), and adds a client-only `src/index.native.ts` served under a `"react-native"` export condition.
- metro resolves the client-only entry on native and never reaches the server toolkit, so the node-only code stays off the device graph. the change is additive to the exports map: non-rn consumers (node, webpack, vite, next, esbuild, tsc) still resolve `"default"` unchanged.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` -> 75/75 green
- [x] `pnpm --filter @assistant-ui/react-ai-sdk build` -> clean, emits `dist/index.js`, `dist/index.native.js`, `dist/client.js`, no `[UNRESOLVED_IMPORT]` warnings
- [x] node resolver: `default` -> `dist/index.js` (full api), `--conditions=react-native` -> `dist/index.native.js` (client-only)
- [x] end-to-end on `examples/with-expo` (expo ~56, react-native 0.85): `npx expo export --platform ios` fails with the exact `child_process` error before this change, and succeeds (clean 6.8MB hermes bundle, zero node-stdlib errors) after it

### reviewer should verify

- [ ] in an expo / react native app, `import { useChatRuntime, AssistantChatTransport } from "@assistant-ui/react-ai-sdk"` bundles for native without the `child_process` error
- [ ] a node / next server route still imports `generativeTools` / `AISDKToolkit` from the package root (resolves the `default` entry)

## notes

- on react native the root entry intentionally omits the server-only `generativeTools` / `AISDKToolkit` (they assemble a `ToolSet` for `streamText` / `generateText`, which belongs on the server). only the stdio mcp transport is inherently rn-incompatible (it spawns a child process); the rest is excluded by design, matching the `react-google-adk` `./server` omission pattern.
- the shared `dist/index.d.ts` still advertises those server-only symbols to rn editors (they are absent at runtime on native). cosmetic; can later get a dedicated `types` target under the `react-native` condition if desired.