### PR TITLE
feat(devtools): inspect messages, tool calls, and MCP servers

### DIFF
--- a/apps/devtools-frame/components/DevToolsUI.tsx
+++ b/apps/devtools-frame/components/DevToolsUI.tsx
@@ -2,12 +2,29 @@
 
 import clsx from "clsx";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { ButtonHTMLAttributes, ReactNode } from "react";
+import type { ReactNode } from "react";
 import {
   normalizeToolList,
   type NormalizedTool,
   FrameClient,
 } from "@assistant-ui/react-devtools";
+import { isRecord, truncate } from "./common";
+import { McpView } from "./mcp";
+import {
+  ThreadDetails,
+  parseComposerPreview,
+  parseThreadListItemPreview,
+  parseThreadListPreview,
+  parseThreadPreview,
+} from "./thread";
+import {
+  CenteredMessage,
+  ControlButton,
+  InfoCard,
+  JSONPreview,
+  SectionTitle,
+  SummaryItem,
+} from "./ui";
 
 interface AssistantState {
   [key: string]: unknown;
@@ -46,9 +63,13 @@ const formatTime = (value: Date) =>
   `${value.getHours().toString().padStart(2, "0")}:${value
     .getMinutes()
     .toString()
-    .padStart(2, "0")}:${value.getSeconds().toString().padStart(2, "0")}`;
+    .padStart(2, "0")}:${value.getSeconds().toString().padStart(2, "0")}.${value
+    .getMilliseconds()
+    .toString()
+    .padStart(3, "0")}`;
 
-// Extract model context from state for backward compatibility
+const eventScope = (event: string) => event.split(".")[0] ?? event;
+
 const extractModelContext = (state: any): ModelContext | undefined => {
   if (!isRecord(state)) return undefined;
 
@@ -74,472 +95,6 @@ const extractModelContext = (state: any): ModelContext | undefined => {
     ...(isRecord(modelContext.config) ? { config: modelContext.config } : {}),
   };
 };
-
-const ControlButton = ({
-  className,
-  ...props
-}: ButtonHTMLAttributes<HTMLButtonElement>) => (
-  <button
-    className={clsx(
-      "inline-flex h-8 items-center rounded-md border border-zinc-300 px-3 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:focus-visible:ring-offset-zinc-900",
-      className,
-    )}
-    {...props}
-  />
-);
-
-const JSONPreview = ({ value }: { value: unknown }) => (
-  <pre className="rounded-lg bg-zinc-100 p-3 text-[11px] leading-relaxed wrap-break-word whitespace-pre-wrap text-zinc-800 dark:bg-zinc-900 dark:text-zinc-200">
-    {JSON.stringify(value, null, 2)}
-  </pre>
-);
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === "object" && !Array.isArray(value);
-
-const isStringArray = (value: unknown): string[] =>
-  Array.isArray(value)
-    ? value.filter((item): item is string => typeof item === "string")
-    : [];
-
-const formatBoolean = (value: boolean | undefined) =>
-  typeof value === "boolean" ? String(value) : undefined;
-
-const formatDateTime = (value: string | undefined) => {
-  if (!value) return undefined;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
-};
-
-const truncate = (value: string, max = 120) =>
-  value.length > max ? `${value.slice(0, max)}...` : value;
-
-interface ThreadListItemPreview {
-  id: string;
-  title?: string;
-  status?: string;
-  externalId?: string;
-  remoteId?: string;
-}
-
-interface MessagePreview {
-  id: string;
-  role: string;
-  createdAt?: string;
-  summary: string;
-  status?: string;
-  attachments: string[];
-}
-
-interface SuggestionPreview {
-  prompt?: string;
-}
-
-interface ComposerPreview {
-  textLength: number;
-  role?: string;
-  attachments: number;
-  isEditing?: boolean;
-  canCancel?: boolean;
-  isEmpty?: boolean;
-  type?: string;
-}
-
-interface ThreadPreview {
-  isDisabled?: boolean;
-  isLoading?: boolean;
-  isRunning?: boolean;
-  messageCount: number;
-  messages: MessagePreview[];
-  suggestions: SuggestionPreview[];
-  capabilities: string[];
-  composer?: ComposerPreview;
-}
-
-interface ThreadListPreview {
-  mainThreadId?: string;
-  newThreadId?: string | null;
-  isLoading?: boolean;
-  threadIds: string[];
-  archivedThreadIds: string[];
-  threadItems: ThreadListItemPreview[];
-  main?: ThreadPreview;
-}
-
-const ThreadDetails = ({
-  thread,
-  title,
-}: {
-  thread: ThreadPreview;
-  title?: string;
-}) => (
-  <div className="flex flex-col gap-3">
-    {title ? (
-      <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-        {title}
-      </div>
-    ) : null}
-    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-      <SummaryItem label="Messages" value={String(thread.messageCount)} />
-      {typeof thread.isLoading === "boolean" ? (
-        <SummaryItem
-          label="Loading"
-          value={formatBoolean(thread.isLoading) ?? "—"}
-        />
-      ) : null}
-      {typeof thread.isRunning === "boolean" ? (
-        <SummaryItem
-          label="Running"
-          value={formatBoolean(thread.isRunning) ?? "—"}
-        />
-      ) : null}
-      {thread.isDisabled !== undefined ? (
-        <SummaryItem
-          label="Disabled"
-          value={formatBoolean(thread.isDisabled) ?? "—"}
-        />
-      ) : null}
-    </div>
-
-    {thread.capabilities.length ? (
-      <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-200">
-        <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-          Capabilities
-        </div>
-        <div className="mt-1 flex flex-wrap gap-1">
-          {thread.capabilities.map((capability) => (
-            <span
-              key={capability}
-              className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300"
-            >
-              {capability}
-            </span>
-          ))}
-        </div>
-      </div>
-    ) : null}
-
-    {thread.messages.length ? (
-      <div className="rounded-md border border-zinc-200 bg-white text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-950/40 dark:text-zinc-200">
-        <div className="border-b border-zinc-200 bg-zinc-100 px-3 py-2 text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
-          Recent Messages
-        </div>
-        <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
-          {thread.messages
-            .slice(-5)
-            .reverse()
-            .map((message) => (
-              <div key={message.id} className="flex flex-col gap-1 px-3 py-2">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="font-semibold text-zinc-800 capitalize dark:text-zinc-100">
-                    {message.role}
-                  </span>
-                  <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
-                    {formatDateTime(message.createdAt) ?? "—"}
-                  </span>
-                </div>
-                {message.summary ? (
-                  <div className="text-zinc-600 dark:text-zinc-300">
-                    {message.summary}
-                  </div>
-                ) : (
-                  <div className="text-zinc-500 dark:text-zinc-400">
-                    No textual content
-                  </div>
-                )}
-                {message.attachments.length ? (
-                  <div className="flex flex-wrap gap-1 text-[10px] text-zinc-500 dark:text-zinc-400">
-                    {message.attachments.map((attachment, index) => (
-                      <span
-                        key={`${message.id}-attachment-${index}`}
-                        className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300"
-                      >
-                        {attachment}
-                      </span>
-                    ))}
-                  </div>
-                ) : null}
-                {message.status ? (
-                  <div className="text-[10px] tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-                    Status: {message.status}
-                  </div>
-                ) : null}
-              </div>
-            ))}
-        </div>
-      </div>
-    ) : null}
-
-    {thread.suggestions.length ? (
-      <div className="rounded-md border border-dashed border-zinc-300 bg-white p-3 text-[11px] text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900/30 dark:text-zinc-200">
-        <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-          Suggestions
-        </div>
-        <ul className="mt-2 list-disc space-y-1 pl-5">
-          {thread.suggestions.map((suggestion, index) => (
-            <li key={index}>{suggestion.prompt || "(empty)"}</li>
-          ))}
-        </ul>
-      </div>
-    ) : null}
-
-    {thread.composer ? (
-      <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-200">
-        <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-          Composer
-        </div>
-        <div className="mt-1 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-          <SummaryItem label="Role" value={thread.composer.role ?? "—"} />
-          <SummaryItem
-            label="Text Length"
-            value={String(thread.composer.textLength)}
-          />
-          <SummaryItem
-            label="Attachments"
-            value={String(thread.composer.attachments)}
-          />
-          {typeof thread.composer.type === "string" ? (
-            <SummaryItem label="Mode" value={thread.composer.type} />
-          ) : null}
-        </div>
-        <div className="mt-2 flex flex-wrap gap-2 text-[10px] tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-          {typeof thread.composer.isEditing === "boolean" ? (
-            <span>Edit: {formatBoolean(thread.composer.isEditing)}</span>
-          ) : null}
-          {typeof thread.composer.canCancel === "boolean" ? (
-            <span>Can Cancel: {formatBoolean(thread.composer.canCancel)}</span>
-          ) : null}
-          {typeof thread.composer.isEmpty === "boolean" ? (
-            <span>Empty: {formatBoolean(thread.composer.isEmpty)}</span>
-          ) : null}
-        </div>
-      </div>
-    ) : null}
-  </div>
-);
-
-const extractMessageSummary = (content: unknown): string => {
-  if (!Array.isArray(content)) return "";
-
-  for (const part of content) {
-    if (!isRecord(part)) continue;
-    const type = typeof part.type === "string" ? part.type : undefined;
-
-    if (
-      (type === "text" || type === "reasoning") &&
-      typeof part.text === "string"
-    ) {
-      const text = part.text.trim();
-      if (text.length > 0) {
-        return truncate(text, 160);
-      }
-    }
-
-    if (type === "tool-call" && typeof part.toolName === "string") {
-      return `Tool call: ${part.toolName}`;
-    }
-
-    if (type === "image" && typeof part.filename === "string") {
-      return `Image: ${part.filename}`;
-    }
-
-    if (type === "file" && typeof part.filename === "string") {
-      return `File: ${part.filename}`;
-    }
-  }
-
-  const fallback = content.find((item) => typeof item === "string") as
-    | string
-    | undefined;
-  if (fallback) {
-    return truncate(fallback, 160);
-  }
-
-  return "";
-};
-
-const extractAttachmentNames = (value: unknown): string[] => {
-  if (!Array.isArray(value)) return [];
-
-  return value
-    .map((attachment) => {
-      if (!isRecord(attachment)) return null;
-
-      if (typeof attachment.name === "string" && attachment.name.length > 0) {
-        return attachment.name;
-      }
-
-      if (
-        typeof attachment.filename === "string" &&
-        attachment.filename.length > 0
-      ) {
-        return attachment.filename;
-      }
-
-      if (typeof attachment.type === "string" && attachment.type.length > 0) {
-        return attachment.type;
-      }
-
-      if (typeof attachment.id === "string" && attachment.id.length > 0) {
-        return attachment.id;
-      }
-
-      return null;
-    })
-    .filter((name): name is string => Boolean(name));
-};
-
-const parseSuggestionPreview = (value: unknown): SuggestionPreview | null => {
-  if (!isRecord(value)) return null;
-  if (typeof value.prompt !== "string") return null;
-  return { prompt: value.prompt };
-};
-
-const parseComposerPreview = (value: unknown): ComposerPreview | undefined => {
-  if (!isRecord(value)) return undefined;
-
-  const text = typeof value.text === "string" ? value.text : "";
-  const attachments = Array.isArray(value.attachments)
-    ? value.attachments.length
-    : 0;
-
-  return {
-    textLength: text.length,
-    attachments,
-    ...(typeof value.role === "string" ? { role: value.role } : {}),
-    ...(typeof value.isEditing === "boolean"
-      ? { isEditing: value.isEditing }
-      : {}),
-    ...(typeof value.canCancel === "boolean"
-      ? { canCancel: value.canCancel }
-      : {}),
-    ...(typeof value.isEmpty === "boolean" ? { isEmpty: value.isEmpty } : {}),
-    ...(typeof value.type === "string" ? { type: value.type } : {}),
-  };
-};
-
-const parseMessagePreview = (
-  value: unknown,
-  index: number,
-): MessagePreview | null => {
-  if (!isRecord(value)) return null;
-
-  const id = typeof value.id === "string" ? value.id : `message-${index}`;
-  const role = typeof value.role === "string" ? value.role : "unknown";
-  const summary = extractMessageSummary(value.content);
-
-  return {
-    id,
-    role,
-    summary,
-    attachments: extractAttachmentNames(value.attachments),
-    ...(typeof value.createdAt === "string"
-      ? { createdAt: value.createdAt }
-      : {}),
-    ...(typeof value.status === "string" ? { status: value.status } : {}),
-  };
-};
-
-const parseThreadListItemPreview = (
-  value: unknown,
-): ThreadListItemPreview | null => {
-  if (!isRecord(value) || typeof value.id !== "string") return null;
-
-  return {
-    id: value.id,
-    ...(typeof value.title === "string" ? { title: value.title } : {}),
-    ...(typeof value.status === "string" ? { status: value.status } : {}),
-    ...(typeof value.externalId === "string"
-      ? { externalId: value.externalId }
-      : {}),
-    ...(typeof value.remoteId === "string" ? { remoteId: value.remoteId } : {}),
-  };
-};
-
-const parseThreadPreview = (value: unknown): ThreadPreview | null => {
-  if (!isRecord(value)) return null;
-
-  const messages = Array.isArray(value.messages)
-    ? value.messages
-        .map((message, index) => parseMessagePreview(message, index))
-        .filter((message): message is MessagePreview => Boolean(message))
-    : [];
-
-  const suggestions = Array.isArray(value.suggestions)
-    ? value.suggestions
-        .map((suggestion) => parseSuggestionPreview(suggestion))
-        .filter((suggestion): suggestion is SuggestionPreview =>
-          Boolean(suggestion),
-        )
-    : [];
-
-  const capabilities = isRecord(value.capabilities)
-    ? Object.entries(value.capabilities)
-        .filter(([, flag]) => flag === true)
-        .map(([name]) => name)
-    : [];
-
-  const composer = parseComposerPreview(value.composer);
-
-  return {
-    messageCount: messages.length,
-    messages,
-    suggestions,
-    capabilities,
-    ...(typeof value.isDisabled === "boolean"
-      ? { isDisabled: value.isDisabled }
-      : {}),
-    ...(typeof value.isLoading === "boolean"
-      ? { isLoading: value.isLoading }
-      : {}),
-    ...(typeof value.isRunning === "boolean"
-      ? { isRunning: value.isRunning }
-      : {}),
-    ...(composer ? { composer } : {}),
-  };
-};
-
-const parseThreadListPreview = (value: unknown): ThreadListPreview | null => {
-  if (!isRecord(value)) return null;
-
-  const threadItems = Array.isArray(value.threadItems)
-    ? value.threadItems
-        .map((item) => parseThreadListItemPreview(item))
-        .filter((item): item is ThreadListItemPreview => Boolean(item))
-    : [];
-
-  const main = parseThreadPreview(value.main);
-
-  return {
-    threadIds: isStringArray(value.threadIds),
-    archivedThreadIds: isStringArray(value.archivedThreadIds),
-    threadItems,
-    ...(typeof value.mainThreadId === "string"
-      ? { mainThreadId: value.mainThreadId }
-      : {}),
-    ...(typeof value.newThreadId === "string"
-      ? { newThreadId: value.newThreadId }
-      : value.newThreadId === null
-        ? { newThreadId: null }
-        : {}),
-    ...(typeof value.isLoading === "boolean"
-      ? { isLoading: value.isLoading }
-      : {}),
-    ...(main ? { main } : {}),
-  };
-};
-
-const SummaryItem = ({ label, value }: { label: string; value: ReactNode }) => (
-  <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-200">
-    <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-      {label}
-    </div>
-    <div className="mt-1 font-semibold text-zinc-800 dark:text-zinc-100">
-      {value}
-    </div>
-  </div>
-);
 
 const renderToolUIsStatePreview = (value: unknown) => {
   if (!isRecord(value)) {
@@ -604,18 +159,6 @@ const renderThreadsStatePreview = (value: unknown) => {
         <SummaryItem label="New Thread" value={state.newThreadId ?? "—"} />
         <SummaryItem label="Active Threads" value={String(activeCount)} />
         <SummaryItem label="Archived Threads" value={String(archivedCount)} />
-        {typeof state.isLoading === "boolean" ? (
-          <SummaryItem
-            label="Loading"
-            value={formatBoolean(state.isLoading) ?? "—"}
-          />
-        ) : null}
-        {main && typeof main.isRunning === "boolean" ? (
-          <SummaryItem
-            label="Main Running"
-            value={formatBoolean(main.isRunning) ?? "—"}
-          />
-        ) : null}
       </div>
 
       {threadItems.length ? (
@@ -680,7 +223,6 @@ const renderThreadStatePreview = (value: unknown) => {
   if (!thread) {
     return <JSONPreview value={value} />;
   }
-
   return <ThreadDetails thread={thread} title="Thread Overview" />;
 };
 
@@ -691,57 +233,23 @@ const renderThreadListItemStatePreview = (value: unknown) => {
   }
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-        <SummaryItem label="ID" value={item.id} />
-        <SummaryItem label="Title" value={item.title ?? "(untitled)"} />
-        <SummaryItem label="Status" value={item.status ?? "—"} />
-        <SummaryItem label="Remote ID" value={item.remoteId ?? "—"} />
-        <SummaryItem label="External ID" value={item.externalId ?? "—"} />
-      </div>
-      {item.title ? (
-        <div className="rounded-md border border-zinc-200 bg-white p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-950/40 dark:text-zinc-200">
-          <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-            Title
-          </div>
-          <div className="mt-1 font-semibold text-zinc-800 dark:text-zinc-100">
-            {item.title}
-          </div>
-        </div>
-      ) : null}
+    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+      <SummaryItem label="ID" value={item.id} />
+      <SummaryItem label="Title" value={item.title ?? "(untitled)"} />
+      <SummaryItem label="Status" value={item.status ?? "—"} />
+      <SummaryItem label="Remote ID" value={item.remoteId ?? "—"} />
+      <SummaryItem label="External ID" value={item.externalId ?? "—"} />
     </div>
   );
 };
 
 const renderComposerStatePreview = (value: unknown) => {
-  if (!isRecord(value)) {
-    return <JSONPreview value={value} />;
-  }
-
   const composer = parseComposerPreview(value);
-  if (!composer) {
+  if (!composer || !isRecord(value)) {
     return <JSONPreview value={value} />;
   }
 
   const text = typeof value.text === "string" ? value.text : "";
-  const attachmentsDetail = Array.isArray(value.attachments)
-    ? value.attachments
-        .map((attachment) => {
-          if (!isRecord(attachment)) return null;
-          if (typeof attachment.name === "string" && attachment.name) {
-            return attachment.name;
-          }
-          if (typeof attachment.filename === "string" && attachment.filename) {
-            return attachment.filename;
-          }
-          if (typeof attachment.type === "string" && attachment.type) {
-            return attachment.type;
-          }
-          return null;
-        })
-        .filter((name): name is string => Boolean(name))
-    : [];
-
   const runConfig = value.runConfig;
 
   return (
@@ -751,20 +259,7 @@ const renderComposerStatePreview = (value: unknown) => {
         <SummaryItem label="Text Length" value={String(composer.textLength)} />
         <SummaryItem label="Attachments" value={String(composer.attachments)} />
         <SummaryItem label="Mode" value={composer.type ?? "—"} />
-        <SummaryItem
-          label="Editing"
-          value={formatBoolean(composer.isEditing) ?? "—"}
-        />
-        <SummaryItem
-          label="Can Cancel"
-          value={formatBoolean(composer.canCancel) ?? "—"}
-        />
-        <SummaryItem
-          label="Empty"
-          value={formatBoolean(composer.isEmpty) ?? "—"}
-        />
       </div>
-
       {text ? (
         <div className="rounded-md border border-zinc-200 bg-white p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-950/40 dark:text-zinc-200">
           <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
@@ -775,25 +270,6 @@ const renderComposerStatePreview = (value: unknown) => {
           </div>
         </div>
       ) : null}
-
-      {attachmentsDetail.length ? (
-        <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-200">
-          <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-            Attachments
-          </div>
-          <div className="mt-1 flex flex-wrap gap-1">
-            {attachmentsDetail.map((attachment, index) => (
-              <span
-                key={`composer-attachment-${index}`}
-                className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300"
-              >
-                {attachment}
-              </span>
-            ))}
-          </div>
-        </div>
-      ) : null}
-
       {runConfig !== undefined ? (
         <div className="rounded-md border border-zinc-200 bg-white p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-950/40 dark:text-zinc-200">
           <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
@@ -825,28 +301,12 @@ const renderStatePreview = (key: string, value: unknown) => {
       return renderToolUIsStatePreview(value);
     case "composer":
       return renderComposerStatePreview(value);
+    case "mcp":
+      return <McpView value={value} />;
     default:
       return <JSONPreview value={value} />;
   }
 };
-
-const CenteredMessage = ({ children }: { children: ReactNode }) => (
-  <div className="flex h-full items-center justify-center text-sm text-zinc-500 dark:text-zinc-400">
-    {children}
-  </div>
-);
-
-const SectionTitle = ({ children }: { children: ReactNode }) => (
-  <h3 className="mb-2 text-sm font-semibold text-zinc-800 dark:text-zinc-100">
-    {children}
-  </h3>
-);
-
-const InfoCard = ({ children }: { children: ReactNode }) => (
-  <div className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm transition-colors dark:border-zinc-800 dark:bg-zinc-900">
-    {children}
-  </div>
-);
 
 export function DevToolsUI() {
   const [apis, setApis] = useState<ApiInfo[]>([]);
@@ -884,11 +344,9 @@ export function DevToolsUI() {
     const handleFocus = () => {
       setIsWindowFocused(true);
     };
-
     const handleBlur = () => {
       setIsWindowFocused(false);
     };
-
     const handleVisibilityChange = () => {
       setIsWindowFocused(!document.hidden && document.hasFocus());
     };
@@ -906,12 +364,10 @@ export function DevToolsUI() {
     };
   }, []);
 
-  // Initialize FrameClient and convert data to match old format
   useEffect(() => {
     const client = new FrameClient();
     frameClientRef.current = client;
 
-    // Subscribe to updates
     const unsubscribe = client.subscribe((data) => {
       setSelectedApiId((id) => {
         const existingId = data.apis?.some((api) => api.apiId === id)
@@ -920,7 +376,6 @@ export function DevToolsUI() {
         return existingId ?? data.apis?.[0]?.apiId ?? null;
       });
 
-      // Convert to old ApiInfo format for compatibility
       const convertedApis: ApiInfo[] =
         data.apis?.map((api: ApiData) => {
           const events = Array.isArray(api.events) ? api.events : [];
@@ -941,9 +396,7 @@ export function DevToolsUI() {
       setApis(convertedApis);
     });
 
-    // Handle host reconnection (page refresh)
     const unsubscribeHostConnection = client.onHostConnected(() => {
-      console.log("[DevToolsUI] Host reconnected, re-subscribing...");
       if (isWindowFocusedRef.current) {
         const currentSelectedApiId = selectedApiIdRef.current;
         client.setSubscription({
@@ -965,7 +418,6 @@ export function DevToolsUI() {
     };
   }, []);
 
-  // Manage subscription based on focus state and selected API
   useEffect(() => {
     const client = frameClientRef.current;
     if (!client) {
@@ -1003,13 +455,26 @@ export function DevToolsUI() {
     return Array.from(types).sort();
   }, [apis]);
 
+  const eventTypesByScope = useMemo(() => {
+    const grouped = new Map<string, string[]>();
+    for (const type of eventTypes) {
+      const scope = eventScope(type);
+      const existing = grouped.get(scope);
+      if (existing) {
+        existing.push(type);
+      } else {
+        grouped.set(scope, [type]);
+      }
+    }
+    return Array.from(grouped.entries());
+  }, [eventTypes]);
+
   useEffect(() => {
     setUnselectedEventTypes((prev) => {
       const eventTypeSet = new Set(eventTypes);
       const next = new Set(prev);
       let changed = false;
 
-      // Remove unselected event types that no longer exist
       Array.from(next).forEach((value) => {
         if (!eventTypeSet.has(value)) {
           next.delete(value);
@@ -1018,11 +483,9 @@ export function DevToolsUI() {
         }
       });
 
-      // Track known event types
       eventTypes.forEach((type) => {
         if (!knownEventTypesRef.current.has(type)) {
           knownEventTypesRef.current.add(type);
-          // New event types are selected by default (not added to unselected)
           changed = true;
         }
       });
@@ -1033,7 +496,6 @@ export function DevToolsUI() {
 
   const filteredLogs = useMemo(() => {
     if (!selectedApi) return [];
-
     return selectedApi.logs.filter(
       (log) => !unselectedEventTypes.has(log.event),
     );
@@ -1063,10 +525,24 @@ export function DevToolsUI() {
     });
   }, []);
 
+  const toggleScope = useCallback((types: string[]) => {
+    setUnselectedEventTypes((prev) => {
+      const allSelected = types.every((type) => !prev.has(type));
+      const next = new Set(prev);
+      for (const type of types) {
+        if (allSelected) {
+          next.add(type);
+        } else {
+          next.delete(type);
+        }
+      }
+      return next;
+    });
+  }, []);
+
   const clearEvents = useCallback(() => {
     if (frameClientRef.current && selectedApiId !== null) {
       frameClientRef.current.clearEvents(selectedApiId);
-      // The update from FrameHost will handle clearing the UI
     }
   }, [selectedApiId]);
 
@@ -1184,31 +660,53 @@ export function DevToolsUI() {
       );
     }
 
-    const eventFilterChips = eventTypes.map((eventType) => (
-      <label
-        key={eventType}
-        className={clsx(
-          "flex items-center gap-2 rounded-md border px-2 py-1 text-[11px] font-medium transition-colors",
-          !unselectedEventTypes.has(eventType)
-            ? "border-blue-500 bg-blue-500/10 text-blue-600 dark:border-blue-400 dark:bg-blue-500/20 dark:text-blue-200"
-            : "border-zinc-200 bg-white text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300",
-        )}
-      >
-        <input
-          type="checkbox"
-          checked={!unselectedEventTypes.has(eventType)}
-          onChange={() => toggleEventType(eventType)}
-          className="size-3 rounded border-zinc-300 text-blue-600 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-900"
-        />
-        <span>{eventType}</span>
-      </label>
-    ));
-
     return (
       <div className="flex flex-col gap-3">
-        {eventTypes.length > 0 && (
-          <div className="flex flex-wrap gap-2 rounded-lg border border-zinc-200 bg-zinc-50 p-3 transition-colors dark:border-zinc-800 dark:bg-zinc-900">
-            {eventFilterChips}
+        {eventTypesByScope.length > 0 && (
+          <div className="flex flex-col gap-2 rounded-lg border border-zinc-200 bg-zinc-50 p-3 transition-colors dark:border-zinc-800 dark:bg-zinc-900">
+            {eventTypesByScope.map(([scope, types]) => {
+              const allSelected = types.every(
+                (type) => !unselectedEventTypes.has(type),
+              );
+              return (
+                <div key={scope} className="flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => toggleScope(types)}
+                    className={clsx(
+                      "rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase transition-colors",
+                      allSelected
+                        ? "bg-blue-500/15 text-blue-600 dark:text-blue-300"
+                        : "bg-zinc-200 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400",
+                    )}
+                  >
+                    {scope}
+                  </button>
+                  {types.map((eventType) => (
+                    <label
+                      key={eventType}
+                      title={eventType}
+                      className={clsx(
+                        "flex items-center gap-2 rounded-md border px-2 py-1 text-[11px] font-medium transition-colors",
+                        !unselectedEventTypes.has(eventType)
+                          ? "border-blue-500 bg-blue-500/10 text-blue-600 dark:border-blue-400 dark:bg-blue-500/20 dark:text-blue-200"
+                          : "border-zinc-200 bg-white text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300",
+                      )}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={!unselectedEventTypes.has(eventType)}
+                        onChange={() => toggleEventType(eventType)}
+                        className="size-3 rounded border-zinc-300 text-blue-600 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-900"
+                      />
+                      <span>
+                        {eventType.slice(scope.length + 1) || eventType}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              );
+            })}
           </div>
         )}
         {filteredLogs.length === 0 ? (
@@ -1225,6 +723,7 @@ export function DevToolsUI() {
               <thead className="bg-zinc-100 text-[11px] tracking-wide text-zinc-500 uppercase dark:bg-zinc-800 dark:text-zinc-300">
                 <tr>
                   <th className="px-4 py-2 font-semibold">Time</th>
+                  <th className="px-4 py-2 font-semibold">Scope</th>
                   <th className="px-4 py-2 font-semibold">Event</th>
                   <th className="px-4 py-2 font-semibold">Data</th>
                 </tr>
@@ -1235,8 +734,11 @@ export function DevToolsUI() {
                     key={`${log.event}-${index}`}
                     className="border-t border-zinc-200 bg-white text-[11px] transition-colors dark:border-zinc-800 dark:bg-zinc-900"
                   >
-                    <td className="px-4 py-2 align-top whitespace-nowrap text-zinc-600 dark:text-zinc-300">
+                    <td className="px-4 py-2 align-top font-mono whitespace-nowrap text-zinc-600 dark:text-zinc-300">
                       {formatTime(log.time)}
+                    </td>
+                    <td className="px-4 py-2 align-top text-zinc-500 dark:text-zinc-400">
+                      {eventScope(log.event)}
                     </td>
                     <td className="px-4 py-2 align-top font-semibold text-zinc-800 dark:text-zinc-100">
                       {log.event}
@@ -1268,7 +770,6 @@ export function DevToolsUI() {
       selectedApi.modelContext?.callSettings &&
       Object.keys(selectedApi.modelContext.callSettings).length > 0;
 
-    // Check if there's any context at all
     if (!hasSystem && !hasTools && !hasCallSettings) {
       return (
         <div className="flex h-full items-center justify-center">
@@ -1339,7 +840,7 @@ export function DevToolsUI() {
     );
   };
 
-  const renderTabContent = () => {
+  const renderTabContent = (): ReactNode => {
     switch (activeTab) {
       case "state":
         return renderStateContent();

--- a/apps/devtools-frame/components/common.ts
+++ b/apps/devtools-frame/components/common.ts
@@ -1,0 +1,47 @@
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+export const isStringArray = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+
+export const formatBoolean = (value: boolean | undefined) =>
+  typeof value === "boolean" ? String(value) : undefined;
+
+export const formatDateTime = (value: string | undefined) => {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+};
+
+export const truncate = (value: string, max = 120) =>
+  value.length > max ? `${value.slice(0, max)}...` : value;
+
+export const extractAttachmentNames = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((attachment) => {
+      if (!isRecord(attachment)) return null;
+
+      if (typeof attachment.name === "string" && attachment.name.length > 0) {
+        return attachment.name;
+      }
+      if (
+        typeof attachment.filename === "string" &&
+        attachment.filename.length > 0
+      ) {
+        return attachment.filename;
+      }
+      if (typeof attachment.type === "string" && attachment.type.length > 0) {
+        return attachment.type;
+      }
+      if (typeof attachment.id === "string" && attachment.id.length > 0) {
+        return attachment.id;
+      }
+      return null;
+    })
+    .filter((name): name is string => Boolean(name));
+};

--- a/apps/devtools-frame/components/common.ts
+++ b/apps/devtools-frame/components/common.ts
@@ -1,6 +1,15 @@
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 
+export const asString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
+export const asNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+export const asBool = (value: unknown): boolean | undefined =>
+  typeof value === "boolean" ? value : undefined;
+
 export const isStringArray = (value: unknown): string[] =>
   Array.isArray(value)
     ? value.filter((item): item is string => typeof item === "string")

--- a/apps/devtools-frame/components/mcp/McpView.tsx
+++ b/apps/devtools-frame/components/mcp/McpView.tsx
@@ -1,0 +1,107 @@
+import clsx from "clsx";
+import { JSONPreview, SummaryItem } from "../ui";
+import { parseMcpManager } from "./parse";
+import type { McpServerPreview } from "./types";
+
+const STATE_TONE: Record<string, string> = {
+  connected:
+    "border-emerald-300 bg-emerald-500/10 text-emerald-700 dark:border-emerald-500/40 dark:text-emerald-300",
+  connecting:
+    "border-blue-300 bg-blue-500/10 text-blue-700 dark:border-blue-500/40 dark:text-blue-300",
+  authPending:
+    "border-blue-300 bg-blue-500/10 text-blue-700 dark:border-blue-500/40 dark:text-blue-300",
+  authRequired:
+    "border-amber-300 bg-amber-500/10 text-amber-700 dark:border-amber-500/40 dark:text-amber-300",
+  disconnected:
+    "border-zinc-300 bg-zinc-500/10 text-zinc-600 dark:border-zinc-600 dark:text-zinc-300",
+  error:
+    "border-red-300 bg-red-500/10 text-red-700 dark:border-red-500/40 dark:text-red-300",
+};
+
+const ServerCard = ({ server }: { server: McpServerPreview }) => (
+  <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] dark:border-zinc-800 dark:bg-zinc-900/40">
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="font-semibold text-zinc-800 dark:text-zinc-100">
+        {server.name}
+      </span>
+      {server.kind ? (
+        <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[9px] font-semibold tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300">
+          {server.kind}
+        </span>
+      ) : null}
+      <span
+        className={clsx(
+          "rounded border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase",
+          STATE_TONE[server.connectionState] ?? STATE_TONE.disconnected,
+        )}
+      >
+        {server.connectionState}
+      </span>
+    </div>
+
+    {server.url ? (
+      <div className="mt-1 font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+        {server.url}
+      </div>
+    ) : null}
+
+    {server.lastError ? (
+      <div className="mt-2 rounded border border-red-300 bg-red-500/5 p-2 text-red-700 dark:border-red-500/40 dark:text-red-300">
+        {server.lastError}
+      </div>
+    ) : null}
+
+    {server.authorizationUrl ? (
+      <div className="mt-2 text-[10px] break-all text-amber-700 dark:text-amber-300">
+        Authorization required: {server.authorizationUrl}
+      </div>
+    ) : null}
+
+    <div className="mt-2 text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
+      Tools ({server.tools.length})
+    </div>
+    {server.tools.length ? (
+      <ul className="mt-1 flex flex-col gap-1">
+        {server.tools.map((tool) => (
+          <li key={tool.name} className="text-zinc-600 dark:text-zinc-300">
+            <span className="font-medium text-zinc-800 dark:text-zinc-100">
+              {tool.name}
+            </span>
+            {tool.description ? (
+              <span className="ml-1 text-zinc-400">{tool.description}</span>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <div className="mt-1 text-zinc-400">No tools discovered.</div>
+    )}
+  </div>
+);
+
+export const McpView = ({ value }: { value: unknown }) => {
+  const manager = parseMcpManager(value);
+  if (!manager) return <JSONPreview value={value} />;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+        <SummaryItem label="Servers" value={String(manager.servers.length)} />
+        {typeof manager.isHydrated === "boolean" ? (
+          <SummaryItem label="Hydrated" value={String(manager.isHydrated)} />
+        ) : null}
+      </div>
+      {manager.servers.length ? (
+        <div className="flex flex-col gap-2">
+          {manager.servers.map((server) => (
+            <ServerCard key={server.id} server={server} />
+          ))}
+        </div>
+      ) : (
+        <div className="text-[11px] text-zinc-500 dark:text-zinc-400">
+          No MCP servers registered.
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/devtools-frame/components/mcp/index.ts
+++ b/apps/devtools-frame/components/mcp/index.ts
@@ -1,0 +1,7 @@
+export { McpView } from "./McpView";
+export { parseMcpManager } from "./parse";
+export type {
+  McpManagerPreview,
+  McpServerPreview,
+  McpToolPreview,
+} from "./types";

--- a/apps/devtools-frame/components/mcp/parse.test.ts
+++ b/apps/devtools-frame/components/mcp/parse.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { parseMcpManager } from "./parse";
+
+describe("parseMcpManager", () => {
+  it("parses servers with connection state, error, and tools", () => {
+    const manager = parseMcpManager({
+      isHydrated: true,
+      servers: [
+        {
+          id: "s1",
+          kind: "connector",
+          name: "GitHub",
+          url: "https://mcp.example.com",
+          connectionState: "connected",
+          lastError: null,
+          authorizationUrl: null,
+          tools: [
+            { name: "list_repos", description: "list repositories" },
+            { name: "create_issue" },
+          ],
+        },
+        {
+          id: "s2",
+          kind: "custom",
+          name: "Broken",
+          connectionState: "error",
+          lastError: { message: "ECONNREFUSED" },
+          authorizationUrl: null,
+          tools: [],
+        },
+      ],
+    });
+
+    expect(manager).not.toBeNull();
+    if (!manager) return;
+    expect(manager.isHydrated).toBe(true);
+    expect(manager.servers).toHaveLength(2);
+    expect(manager.servers[0]).toMatchObject({
+      id: "s1",
+      name: "GitHub",
+      connectionState: "connected",
+    });
+    expect(manager.servers[0]?.tools).toHaveLength(2);
+    expect(manager.servers[1]?.lastError).toBe("ECONNREFUSED");
+  });
+
+  it("falls back to connectors + customServers when servers is absent", () => {
+    const manager = parseMcpManager({
+      connectors: [
+        { id: "c1", name: "A", connectionState: "disconnected", tools: [] },
+      ],
+      customServers: [
+        { id: "x1", name: "B", connectionState: "authRequired", tools: [] },
+      ],
+    });
+    if (!manager) return;
+    expect(manager.servers.map((s) => s.id)).toEqual(["c1", "x1"]);
+  });
+
+  it("returns null for non-records", () => {
+    expect(parseMcpManager(undefined)).toBeNull();
+  });
+});

--- a/apps/devtools-frame/components/mcp/parse.ts
+++ b/apps/devtools-frame/components/mcp/parse.ts
@@ -1,12 +1,9 @@
-import { isRecord } from "../common";
+import { asString, isRecord } from "../common";
 import type {
   McpManagerPreview,
   McpServerPreview,
   McpToolPreview,
 } from "./types";
-
-const asString = (value: unknown): string | undefined =>
-  typeof value === "string" ? value : undefined;
 
 const parseTool = (value: unknown): McpToolPreview | null => {
   if (!isRecord(value)) return null;
@@ -35,8 +32,8 @@ const parseServer = (value: unknown): McpServerPreview | null => {
 
   return {
     id,
-    name: asString(value.name) ?? id,
-    connectionState: asString(value.connectionState) ?? "unknown",
+    name: asString(value.name) || id,
+    connectionState: asString(value.connectionState) || "unknown",
     tools,
     ...(kind ? { kind } : {}),
     ...(url ? { url } : {}),

--- a/apps/devtools-frame/components/mcp/parse.ts
+++ b/apps/devtools-frame/components/mcp/parse.ts
@@ -1,0 +1,68 @@
+import { isRecord } from "../common";
+import type {
+  McpManagerPreview,
+  McpServerPreview,
+  McpToolPreview,
+} from "./types";
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
+const parseTool = (value: unknown): McpToolPreview | null => {
+  if (!isRecord(value)) return null;
+  const name = asString(value.name);
+  if (!name) return null;
+  const description = asString(value.description);
+  return { name, ...(description ? { description } : {}) };
+};
+
+const parseServer = (value: unknown): McpServerPreview | null => {
+  if (!isRecord(value)) return null;
+  const id = asString(value.id);
+  if (!id) return null;
+
+  const lastError = isRecord(value.lastError)
+    ? asString(value.lastError.message)
+    : undefined;
+  const kind = asString(value.kind);
+  const url = asString(value.url);
+  const authorizationUrl = asString(value.authorizationUrl);
+  const tools = Array.isArray(value.tools)
+    ? value.tools
+        .map((tool) => parseTool(tool))
+        .filter((tool): tool is McpToolPreview => Boolean(tool))
+    : [];
+
+  return {
+    id,
+    name: asString(value.name) ?? id,
+    connectionState: asString(value.connectionState) ?? "unknown",
+    tools,
+    ...(kind ? { kind } : {}),
+    ...(url ? { url } : {}),
+    ...(lastError ? { lastError } : {}),
+    ...(authorizationUrl ? { authorizationUrl } : {}),
+  };
+};
+
+export const parseMcpManager = (value: unknown): McpManagerPreview | null => {
+  if (!isRecord(value)) return null;
+
+  const source = Array.isArray(value.servers)
+    ? value.servers
+    : [
+        ...(Array.isArray(value.connectors) ? value.connectors : []),
+        ...(Array.isArray(value.customServers) ? value.customServers : []),
+      ];
+
+  const servers = source
+    .map((server) => parseServer(server))
+    .filter((server): server is McpServerPreview => Boolean(server));
+
+  return {
+    servers,
+    ...(typeof value.isHydrated === "boolean"
+      ? { isHydrated: value.isHydrated }
+      : {}),
+  };
+};

--- a/apps/devtools-frame/components/mcp/types.ts
+++ b/apps/devtools-frame/components/mcp/types.ts
@@ -1,0 +1,20 @@
+export interface McpToolPreview {
+  readonly name: string;
+  readonly description?: string;
+}
+
+export interface McpServerPreview {
+  readonly id: string;
+  readonly name: string;
+  readonly kind?: string;
+  readonly url?: string;
+  readonly connectionState: string;
+  readonly lastError?: string;
+  readonly authorizationUrl?: string;
+  readonly tools: readonly McpToolPreview[];
+}
+
+export interface McpManagerPreview {
+  readonly isHydrated?: boolean;
+  readonly servers: readonly McpServerPreview[];
+}

--- a/apps/devtools-frame/components/message/ChainOfThought.tsx
+++ b/apps/devtools-frame/components/message/ChainOfThought.tsx
@@ -1,0 +1,58 @@
+import { partKey } from "./parse";
+import { PartView } from "./PartView";
+import { StatusBadge } from "./StatusBadge";
+import type { PartPreview, PartStatusPreview } from "./types";
+
+const rollupStatus = (
+  parts: readonly PartPreview[],
+): PartStatusPreview | undefined => {
+  const statuses = parts
+    .map((part) => part.status)
+    .filter((status): status is PartStatusPreview => Boolean(status));
+  if (statuses.length === 0) return undefined;
+
+  if (statuses.some((status) => status.type === "running")) {
+    return { type: "running" };
+  }
+  if (statuses.some((status) => status.type === "requires-action")) {
+    return { type: "requires-action" };
+  }
+  const incomplete = statuses.find((status) => status.type === "incomplete");
+  if (incomplete) return incomplete;
+  return { type: "complete" };
+};
+
+export const ChainOfThought = ({
+  parts,
+}: {
+  parts: readonly PartPreview[];
+}) => {
+  const status = rollupStatus(parts);
+
+  return (
+    <details
+      open
+      className="group rounded-md border border-dashed border-violet-300/70 bg-violet-500/5 p-2 dark:border-violet-500/30 dark:bg-violet-500/10"
+    >
+      <summary className="flex cursor-pointer list-none items-center gap-2 select-none">
+        <span className="inline-block text-violet-500 transition-transform group-open:rotate-90">
+          ›
+        </span>
+        <span className="text-[10px] font-semibold tracking-wide text-violet-700 uppercase dark:text-violet-300">
+          Chain of thought
+        </span>
+        <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+          {parts.length} step{parts.length === 1 ? "" : "s"}
+        </span>
+        {status ? (
+          <StatusBadge type={status.type} reason={status.reason} />
+        ) : null}
+      </summary>
+      <div className="mt-2 flex flex-col gap-2 border-l border-violet-300/50 pl-3 dark:border-violet-500/20">
+        {parts.map((part, index) => (
+          <PartView key={partKey(part, index)} part={part} />
+        ))}
+      </div>
+    </details>
+  );
+};

--- a/apps/devtools-frame/components/message/MessageItem.tsx
+++ b/apps/devtools-frame/components/message/MessageItem.tsx
@@ -117,7 +117,9 @@ const MetaStrip = ({ message }: { message: MessagePreview }) => {
 export const MessageItem = ({ message }: { message: MessagePreview }) => {
   const groups = groupParts(message.parts);
   const hasBranches =
-    message.branchCount !== undefined && message.branchCount > 1;
+    message.branchNumber !== undefined &&
+    message.branchCount !== undefined &&
+    message.branchCount > 1;
   const errorValue =
     message.status && message.status.type === "incomplete"
       ? message.status.error
@@ -128,6 +130,11 @@ export const MessageItem = ({ message }: { message: MessagePreview }) => {
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex flex-wrap items-center gap-2">
           <RoleLabel role={message.role} />
+          {message.index !== undefined ? (
+            <span className="text-[10px] text-zinc-400 dark:text-zinc-500">
+              #{message.index}
+            </span>
+          ) : null}
           {message.status ? (
             <StatusBadge
               type={message.status.type}

--- a/apps/devtools-frame/components/message/MessageItem.tsx
+++ b/apps/devtools-frame/components/message/MessageItem.tsx
@@ -1,0 +1,199 @@
+import clsx from "clsx";
+import { formatDateTime } from "../common";
+import { JSONPreview, SummaryItem } from "../ui";
+import { ChainOfThought } from "./ChainOfThought";
+import { partKey } from "./parse";
+import { PartView } from "./PartView";
+import { StatusBadge } from "./StatusBadge";
+import type { MessagePreview, PartPreview } from "./types";
+
+const formatMs = (value: number) =>
+  value >= 1000 ? `${(value / 1000).toFixed(2)}s` : `${Math.round(value)}ms`;
+
+const isThoughtPart = (part: PartPreview) =>
+  part.type === "reasoning" || part.type === "tool-call";
+
+type RenderGroup =
+  | { kind: "cot"; key: string; parts: PartPreview[] }
+  | { kind: "part"; key: string; part: PartPreview };
+
+const groupParts = (parts: readonly PartPreview[]): RenderGroup[] => {
+  const groups: RenderGroup[] = [];
+  let run: { part: PartPreview; index: number }[] = [];
+
+  const flush = () => {
+    const first = run[0];
+    if (
+      first &&
+      run.length >= 2 &&
+      run.some((entry) => entry.part.type === "reasoning")
+    ) {
+      groups.push({
+        kind: "cot",
+        key: `cot:${partKey(first.part, first.index)}`,
+        parts: run.map((entry) => entry.part),
+      });
+    } else {
+      for (const entry of run) {
+        groups.push({
+          kind: "part",
+          key: partKey(entry.part, entry.index),
+          part: entry.part,
+        });
+      }
+    }
+    run = [];
+  };
+
+  parts.forEach((part, index) => {
+    if (isThoughtPart(part)) {
+      run.push({ part, index });
+    } else {
+      flush();
+      groups.push({ kind: "part", key: partKey(part, index), part });
+    }
+  });
+  flush();
+  return groups;
+};
+
+const RoleLabel = ({ role }: { role: string }) => {
+  const tone =
+    role === "user"
+      ? "text-blue-600 dark:text-blue-300"
+      : role === "assistant"
+        ? "text-emerald-600 dark:text-emerald-300"
+        : "text-zinc-600 dark:text-zinc-300";
+  return <span className={clsx("font-semibold capitalize", tone)}>{role}</span>;
+};
+
+const MetaStrip = ({ message }: { message: MessagePreview }) => {
+  const { timing, usage } = message;
+  const ttft =
+    timing?.firstTokenTime !== undefined &&
+    timing?.streamStartTime !== undefined
+      ? timing.firstTokenTime - timing.streamStartTime
+      : undefined;
+
+  const items: { label: string; value: string }[] = [];
+  if (ttft !== undefined) items.push({ label: "TTFT", value: formatMs(ttft) });
+  if (timing?.totalStreamTime !== undefined) {
+    items.push({ label: "Stream", value: formatMs(timing.totalStreamTime) });
+  }
+  if (timing?.tokensPerSecond !== undefined) {
+    items.push({
+      label: "Tokens/s",
+      value: timing.tokensPerSecond.toFixed(1),
+    });
+  }
+  if (timing?.tokenCount !== undefined) {
+    items.push({ label: "Tokens", value: String(timing.tokenCount) });
+  }
+  if (timing?.totalChunks !== undefined) {
+    items.push({ label: "Chunks", value: String(timing.totalChunks) });
+  }
+  if (timing?.toolCallCount !== undefined) {
+    items.push({ label: "Tool calls", value: String(timing.toolCallCount) });
+  }
+  if (usage) {
+    items.push({
+      label: "Usage",
+      value: `${usage.inputTokens} in / ${usage.outputTokens} out`,
+    });
+    items.push({ label: "Steps", value: String(usage.stepCount) });
+  }
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="grid gap-2 sm:grid-cols-3 lg:grid-cols-4">
+      {items.map((item) => (
+        <SummaryItem key={item.label} label={item.label} value={item.value} />
+      ))}
+    </div>
+  );
+};
+
+export const MessageItem = ({ message }: { message: MessagePreview }) => {
+  const groups = groupParts(message.parts);
+  const hasBranches =
+    message.branchCount !== undefined && message.branchCount > 1;
+  const errorValue =
+    message.status && message.status.type === "incomplete"
+      ? message.status.error
+      : undefined;
+
+  return (
+    <div className="flex flex-col gap-2 px-3 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <RoleLabel role={message.role} />
+          {message.status ? (
+            <StatusBadge
+              type={message.status.type}
+              reason={message.status.reason}
+            />
+          ) : null}
+          {hasBranches ? (
+            <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+              branch {message.branchNumber}/{message.branchCount}
+            </span>
+          ) : null}
+          {message.isOptimistic ? (
+            <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-amber-700 uppercase dark:text-amber-300">
+              optimistic
+            </span>
+          ) : null}
+          {message.submittedFeedback ? (
+            <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+              feedback: {message.submittedFeedback}
+            </span>
+          ) : null}
+        </div>
+        <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+          {formatDateTime(message.createdAt) ?? "—"}
+        </span>
+      </div>
+
+      <MetaStrip message={message} />
+
+      {errorValue !== undefined ? (
+        <div className="rounded border border-red-300 bg-red-500/5 p-2 text-[11px] dark:border-red-500/40 dark:bg-red-500/10">
+          <div className="text-[10px] font-semibold tracking-wide text-red-600 uppercase dark:text-red-300">
+            Error
+          </div>
+          <JSONPreview value={errorValue} />
+        </div>
+      ) : null}
+
+      {message.attachments.length ? (
+        <div className="flex flex-wrap gap-1">
+          {message.attachments.map((attachment, index) => (
+            <span
+              key={`${message.id}-attachment-${index}`}
+              className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300"
+            >
+              {attachment}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {groups.length ? (
+        <div className="flex flex-col gap-2">
+          {groups.map((group) =>
+            group.kind === "cot" ? (
+              <ChainOfThought key={group.key} parts={group.parts} />
+            ) : (
+              <PartView key={group.key} part={group.part} />
+            ),
+          )}
+        </div>
+      ) : (
+        <div className="text-[11px] text-zinc-500 dark:text-zinc-400">
+          No content parts
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/devtools-frame/components/message/MessageList.tsx
+++ b/apps/devtools-frame/components/message/MessageList.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { MessageItem } from "./MessageItem";
+import type { MessagePreview } from "./types";
+
+const DEFAULT_LIMIT = 20;
+
+export const MessageList = ({
+  messages,
+  title = "Messages",
+}: {
+  messages: readonly MessagePreview[];
+  title?: string;
+}) => {
+  const [showAll, setShowAll] = useState(false);
+
+  if (!messages.length) {
+    return (
+      <div className="rounded-md border border-dashed border-zinc-300 bg-white p-4 text-center text-[11px] text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900/30 dark:text-zinc-400">
+        No messages in this thread.
+      </div>
+    );
+  }
+
+  const hidden = showAll ? 0 : Math.max(0, messages.length - DEFAULT_LIMIT);
+  const visible = hidden > 0 ? messages.slice(-DEFAULT_LIMIT) : messages;
+
+  return (
+    <div className="overflow-hidden rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950/40">
+      <div className="flex items-center justify-between border-b border-zinc-200 bg-zinc-100 px-3 py-2 dark:border-zinc-800 dark:bg-zinc-900">
+        <span className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
+          {title}
+        </span>
+        <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+          {messages.length} total
+        </span>
+      </div>
+      {hidden > 0 ? (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="w-full border-b border-zinc-200 bg-zinc-50 px-3 py-1.5 text-[10px] font-medium text-zinc-500 transition-colors hover:bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-400 dark:hover:bg-zinc-800"
+        >
+          Show {hidden} older message{hidden === 1 ? "" : "s"}
+        </button>
+      ) : null}
+      <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
+        {visible.map((message) => (
+          <MessageItem key={message.id} message={message} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/apps/devtools-frame/components/message/PartView.tsx
+++ b/apps/devtools-frame/components/message/PartView.tsx
@@ -67,7 +67,7 @@ export const PartView = ({ part }: { part: PartPreview }) => {
         <PartShell type="source" status={part.status}>
           <div className="text-zinc-600 dark:text-zinc-300">
             {part.title ?? part.url ?? part.sourceType ?? "(source)"}
-            {part.url ? (
+            {part.title && part.url ? (
               <span className="ml-1 text-zinc-400">({part.url})</span>
             ) : null}
           </div>

--- a/apps/devtools-frame/components/message/PartView.tsx
+++ b/apps/devtools-frame/components/message/PartView.tsx
@@ -1,0 +1,125 @@
+import type { ReactNode } from "react";
+import { JSONPreview } from "../ui";
+import { StatusBadge } from "./StatusBadge";
+import { ToolCallView } from "./ToolCallView";
+import type { PartPreview, PartStatusPreview } from "./types";
+
+const PartShell = ({
+  type,
+  status,
+  children,
+  tone,
+}: {
+  type: string;
+  status?: PartStatusPreview | undefined;
+  children?: ReactNode;
+  tone?: "reasoning" | undefined;
+}) => (
+  <div className="flex flex-col gap-1">
+    <div className="flex items-center gap-2">
+      <span
+        className={
+          tone === "reasoning"
+            ? "rounded bg-violet-500/15 px-1.5 py-0.5 text-[9px] font-semibold tracking-wide text-violet-700 uppercase dark:text-violet-300"
+            : "rounded bg-zinc-200 px-1.5 py-0.5 text-[9px] font-semibold tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300"
+        }
+      >
+        {type}
+      </span>
+      {status ? (
+        <StatusBadge type={status.type} reason={status.reason} />
+      ) : null}
+    </div>
+    {children}
+  </div>
+);
+
+const Text = ({ value, muted }: { value: string; muted?: boolean }) => (
+  <div
+    className={
+      muted
+        ? "wrap-break-word whitespace-pre-wrap text-zinc-500 italic dark:text-zinc-400"
+        : "wrap-break-word whitespace-pre-wrap text-zinc-700 dark:text-zinc-200"
+    }
+  >
+    {value || "(empty)"}
+  </div>
+);
+
+export const PartView = ({ part }: { part: PartPreview }) => {
+  switch (part.type) {
+    case "tool-call":
+      return <ToolCallView part={part} />;
+    case "text":
+      return (
+        <PartShell type="text" status={part.status}>
+          <Text value={part.text} />
+        </PartShell>
+      );
+    case "reasoning":
+      return (
+        <PartShell type="reasoning" status={part.status} tone="reasoning">
+          <Text value={part.text} muted />
+        </PartShell>
+      );
+    case "source":
+      return (
+        <PartShell type="source" status={part.status}>
+          <div className="text-zinc-600 dark:text-zinc-300">
+            {part.title ?? part.url ?? part.sourceType ?? "(source)"}
+            {part.url ? (
+              <span className="ml-1 text-zinc-400">({part.url})</span>
+            ) : null}
+          </div>
+        </PartShell>
+      );
+    case "image":
+      return (
+        <PartShell type="image" status={part.status}>
+          <div className="text-zinc-600 dark:text-zinc-300">
+            {part.filename ?? "(image)"}
+          </div>
+        </PartShell>
+      );
+    case "file":
+      return (
+        <PartShell type="file" status={part.status}>
+          <div className="text-zinc-600 dark:text-zinc-300">
+            {part.filename ?? "(file)"}
+            {part.mimeType ? (
+              <span className="ml-1 text-zinc-400">{part.mimeType}</span>
+            ) : null}
+          </div>
+        </PartShell>
+      );
+    case "audio":
+      return (
+        <PartShell type="audio" status={part.status}>
+          <div className="text-zinc-600 dark:text-zinc-300">
+            {part.format ?? "(audio)"}
+          </div>
+        </PartShell>
+      );
+    case "data":
+      return (
+        <PartShell
+          type={part.name ? `data: ${part.name}` : "data"}
+          status={part.status}
+        >
+          <JSONPreview value={part.data} />
+        </PartShell>
+      );
+    case "generative-ui":
+      return (
+        <PartShell type="generative-ui" status={part.status}>
+          <JSONPreview value={part.spec} />
+        </PartShell>
+      );
+    default:
+      return (
+        <PartShell type={part.rawType || "unknown"} status={part.status}>
+          <JSONPreview value={part.raw} />
+        </PartShell>
+      );
+  }
+};

--- a/apps/devtools-frame/components/message/StatusBadge.tsx
+++ b/apps/devtools-frame/components/message/StatusBadge.tsx
@@ -1,0 +1,32 @@
+import clsx from "clsx";
+
+const TONE: Record<string, string> = {
+  running:
+    "border-blue-300 bg-blue-500/10 text-blue-700 dark:border-blue-500/40 dark:bg-blue-500/15 dark:text-blue-300",
+  complete:
+    "border-emerald-300 bg-emerald-500/10 text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/15 dark:text-emerald-300",
+  incomplete:
+    "border-red-300 bg-red-500/10 text-red-700 dark:border-red-500/40 dark:bg-red-500/15 dark:text-red-300",
+  "requires-action":
+    "border-amber-300 bg-amber-500/10 text-amber-700 dark:border-amber-500/40 dark:bg-amber-500/15 dark:text-amber-300",
+  unknown:
+    "border-zinc-300 bg-zinc-500/10 text-zinc-600 dark:border-zinc-600 dark:bg-zinc-500/15 dark:text-zinc-300",
+};
+
+export const StatusBadge = ({
+  type,
+  reason,
+}: {
+  type: string;
+  reason?: string | undefined;
+}) => (
+  <span
+    className={clsx(
+      "inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase",
+      TONE[type] ?? TONE.unknown,
+    )}
+  >
+    <span>{type}</span>
+    {reason ? <span className="opacity-70">· {reason}</span> : null}
+  </span>
+);

--- a/apps/devtools-frame/components/message/ToolCallView.tsx
+++ b/apps/devtools-frame/components/message/ToolCallView.tsx
@@ -101,7 +101,7 @@ export const ToolCallView = ({ part }: { part: ToolCallPartPreview }) => {
           <JSONPreview value={part.args} />
         </Disclosure>
 
-        {part.argsText ? (
+        {part.argsText !== undefined ? (
           <Disclosure label="Raw args text">
             <pre className="rounded bg-zinc-100 p-2 text-[10px] break-words whitespace-pre-wrap text-zinc-700 dark:bg-zinc-950 dark:text-zinc-300">
               {part.argsText}

--- a/apps/devtools-frame/components/message/ToolCallView.tsx
+++ b/apps/devtools-frame/components/message/ToolCallView.tsx
@@ -1,0 +1,145 @@
+import clsx from "clsx";
+import type { ReactNode } from "react";
+import { JSONPreview } from "../ui";
+import { StatusBadge } from "./StatusBadge";
+import type { ToolCallPartPreview } from "./types";
+
+const Disclosure = ({
+  label,
+  defaultOpen,
+  children,
+}: {
+  label: string;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}) => (
+  <details open={defaultOpen} className="group">
+    <summary className="cursor-pointer list-none text-[10px] font-semibold tracking-wide text-zinc-500 uppercase select-none hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200">
+      <span className="mr-1 inline-block transition-transform group-open:rotate-90">
+        ›
+      </span>
+      {label}
+    </summary>
+    <div className="mt-1">{children}</div>
+  </details>
+);
+
+export const ToolCallView = ({ part }: { part: ToolCallPartPreview }) => {
+  const awaiting =
+    part.status?.type === "requires-action" ||
+    part.interrupt !== undefined ||
+    (part.approval !== undefined && part.approval.approved === undefined);
+  const errored = part.isError === true || part.status?.type === "incomplete";
+
+  return (
+    <div
+      className={clsx(
+        "rounded-md border p-3 text-[11px] transition-colors",
+        errored
+          ? "border-red-300 bg-red-500/5 dark:border-red-500/40 dark:bg-red-500/10"
+          : awaiting
+            ? "border-amber-300 bg-amber-500/5 dark:border-amber-500/40 dark:bg-amber-500/10"
+            : "border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900/60",
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[9px] font-semibold tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300">
+          tool
+        </span>
+        <span className="font-semibold text-zinc-800 dark:text-zinc-100">
+          {part.toolName}
+        </span>
+        {part.status ? (
+          <StatusBadge type={part.status.type} reason={part.status.reason} />
+        ) : null}
+        {part.isError ? <StatusBadge type="incomplete" reason="error" /> : null}
+        {part.mcp !== undefined ? (
+          <span className="rounded bg-violet-500/15 px-1.5 py-0.5 text-[9px] font-semibold tracking-wide text-violet-700 uppercase dark:text-violet-300">
+            mcp
+          </span>
+        ) : null}
+      </div>
+
+      {part.toolCallId ? (
+        <div className="mt-1 font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+          {part.toolCallId}
+        </div>
+      ) : null}
+
+      {awaiting ? (
+        <div className="mt-2 rounded border border-amber-300 bg-amber-500/10 p-2 text-amber-800 dark:border-amber-500/40 dark:text-amber-200">
+          <div className="text-[10px] font-semibold tracking-wide uppercase">
+            {part.approval ? "Awaiting approval" : "Awaiting human input"}
+          </div>
+          {part.approval ? (
+            <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px]">
+              {part.approval.id ? <span>id: {part.approval.id}</span> : null}
+              <span>
+                approved:{" "}
+                {part.approval.approved === undefined
+                  ? "pending"
+                  : String(part.approval.approved)}
+              </span>
+              {part.approval.isAutomatic !== undefined ? (
+                <span>automatic: {String(part.approval.isAutomatic)}</span>
+              ) : null}
+              {part.approval.reason ? (
+                <span>reason: {part.approval.reason}</span>
+              ) : null}
+            </div>
+          ) : null}
+          {part.interrupt?.payload !== undefined ? (
+            <div className="mt-1">
+              <JSONPreview value={part.interrupt.payload} />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="mt-2 flex flex-col gap-2">
+        <Disclosure label="Arguments" defaultOpen>
+          <JSONPreview value={part.args} />
+        </Disclosure>
+
+        {part.argsText ? (
+          <Disclosure label="Raw args text">
+            <pre className="rounded bg-zinc-100 p-2 text-[10px] break-words whitespace-pre-wrap text-zinc-700 dark:bg-zinc-950 dark:text-zinc-300">
+              {part.argsText}
+            </pre>
+          </Disclosure>
+        ) : null}
+
+        {part.hasResult ? (
+          <Disclosure label={part.isError ? "Result (error)" : "Result"}>
+            <JSONPreview value={part.result} />
+          </Disclosure>
+        ) : null}
+
+        {part.artifact !== undefined ? (
+          <Disclosure label="Artifact">
+            <JSONPreview value={part.artifact} />
+          </Disclosure>
+        ) : null}
+
+        {part.modelContent !== undefined ? (
+          <Disclosure label="Model content">
+            <JSONPreview value={part.modelContent} />
+          </Disclosure>
+        ) : null}
+
+        {part.mcp !== undefined ? (
+          <Disclosure label="MCP metadata">
+            <JSONPreview value={part.mcp} />
+          </Disclosure>
+        ) : null}
+
+        {part.subMessageCount > 0 ? (
+          <div className="text-[10px] text-zinc-500 dark:text-zinc-400">
+            {part.subMessageCount} nested sub-agent message
+            {part.subMessageCount === 1 ? "" : "s"}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/apps/devtools-frame/components/message/index.ts
+++ b/apps/devtools-frame/components/message/index.ts
@@ -1,0 +1,16 @@
+export { MessageList } from "./MessageList";
+export { MessageItem } from "./MessageItem";
+export { PartView } from "./PartView";
+export { ToolCallView } from "./ToolCallView";
+export { ChainOfThought } from "./ChainOfThought";
+export { StatusBadge } from "./StatusBadge";
+export { parseMessage, parsePart, parsePartStatus } from "./parse";
+export type {
+  MessagePreview,
+  PartPreview,
+  PartStatusPreview,
+  MessageStatusPreview,
+  MessageTimingPreview,
+  MessageUsagePreview,
+  ToolCallPartPreview,
+} from "./types";

--- a/apps/devtools-frame/components/message/parse.test.ts
+++ b/apps/devtools-frame/components/message/parse.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+import { parseMessage, parsePart, parsePartStatus, partKey } from "./parse";
+
+describe("parsePartStatus", () => {
+  it("reads type and reason", () => {
+    expect(parsePartStatus({ type: "incomplete", reason: "error" })).toEqual({
+      type: "incomplete",
+      reason: "error",
+    });
+  });
+
+  it("returns undefined for non-records and typeless values", () => {
+    expect(parsePartStatus(undefined)).toBeUndefined();
+    expect(parsePartStatus({ reason: "error" })).toBeUndefined();
+  });
+});
+
+describe("parsePart", () => {
+  it("parses a text part with status", () => {
+    const part = parsePart({
+      type: "text",
+      text: "hello",
+      status: { type: "complete" },
+    });
+    expect(part).toEqual({
+      type: "text",
+      text: "hello",
+      status: { type: "complete" },
+    });
+  });
+
+  it("parses a completed tool-call with result", () => {
+    const part = parsePart({
+      type: "tool-call",
+      toolCallId: "call_1",
+      toolName: "search",
+      args: { query: "weather" },
+      argsText: '{"query":"weather"}',
+      result: { temperature: 20 },
+      status: { type: "complete" },
+    });
+    expect(part).toMatchObject({
+      type: "tool-call",
+      toolName: "search",
+      toolCallId: "call_1",
+      hasResult: true,
+      result: { temperature: 20 },
+      argsText: '{"query":"weather"}',
+      subMessageCount: 0,
+    });
+  });
+
+  it("surfaces a pending approval gate", () => {
+    const part = parsePart({
+      type: "tool-call",
+      toolCallId: "call_2",
+      toolName: "deleteFile",
+      args: {},
+      approval: { id: "appr_1" },
+      status: { type: "requires-action", reason: "interrupt" },
+    });
+    expect(part.type).toBe("tool-call");
+    if (part.type !== "tool-call") return;
+    expect(part.approval).toEqual({ id: "appr_1" });
+    expect(part.approval?.approved).toBeUndefined();
+    expect(part.status).toEqual({
+      type: "requires-action",
+      reason: "interrupt",
+    });
+  });
+
+  it("surfaces a human interrupt payload and error result", () => {
+    const part = parsePart({
+      type: "tool-call",
+      toolCallId: "call_3",
+      toolName: "askUser",
+      args: {},
+      isError: true,
+      result: "boom",
+      interrupt: { type: "human", payload: { question: "name?" } },
+    });
+    if (part.type !== "tool-call") throw new Error("expected tool-call");
+    expect(part.isError).toBe(true);
+    expect(part.hasResult).toBe(true);
+    expect(part.interrupt).toEqual({
+      type: "human",
+      payload: { question: "name?" },
+    });
+  });
+
+  it("counts nested sub-agent messages", () => {
+    const part = parsePart({
+      type: "tool-call",
+      toolCallId: "call_4",
+      toolName: "subAgent",
+      args: {},
+      messages: [{ role: "assistant" }, { role: "user" }],
+    });
+    if (part.type !== "tool-call") throw new Error("expected tool-call");
+    expect(part.subMessageCount).toBe(2);
+  });
+
+  it("falls back to unknown for unrecognized part types", () => {
+    const part = parsePart({ type: "mystery", foo: 1 });
+    expect(part.type).toBe("unknown");
+    if (part.type !== "unknown") return;
+    expect(part.rawType).toBe("mystery");
+  });
+
+  it("drops empty interrupt/approval objects so completed calls do not look pending", () => {
+    const part = parsePart({
+      type: "tool-call",
+      toolCallId: "c0",
+      toolName: "done",
+      args: {},
+      result: {},
+      interrupt: {},
+      approval: {},
+      status: { type: "complete" },
+    });
+    if (part.type !== "tool-call") throw new Error("expected tool-call");
+    expect(part.interrupt).toBeUndefined();
+    expect(part.approval).toBeUndefined();
+  });
+
+  it("preserves an empty argsText for finished zero-argument tool calls", () => {
+    const part = parsePart({
+      type: "tool-call",
+      toolCallId: "c5",
+      toolName: "noArgs",
+      args: {},
+      argsText: "",
+      status: { type: "complete" },
+    });
+    if (part.type !== "tool-call") throw new Error("expected tool-call");
+    expect(part.argsText).toBe("");
+  });
+});
+
+describe("partKey", () => {
+  it("keys tool-calls by toolCallId and other parts by index", () => {
+    expect(
+      partKey(
+        {
+          type: "tool-call",
+          toolCallId: "abc",
+          toolName: "x",
+          args: {},
+          hasResult: false,
+          subMessageCount: 0,
+        },
+        3,
+      ),
+    ).toBe("tc:abc");
+    expect(partKey({ type: "text", text: "hi" }, 3)).toBe("p:3");
+  });
+});
+
+describe("parseMessage", () => {
+  it("parses an enriched assistant message end to end", () => {
+    const message = parseMessage(
+      {
+        id: "msg_1",
+        role: "assistant",
+        createdAt: "2026-06-08T10:00:00.000Z",
+        status: { type: "complete", reason: "stop" },
+        branchNumber: 2,
+        branchCount: 3,
+        index: 1,
+        isLast: true,
+        parts: [
+          { type: "reasoning", text: "thinking", status: { type: "complete" } },
+          {
+            type: "tool-call",
+            toolCallId: "c1",
+            toolName: "search",
+            args: {},
+            result: {},
+            status: { type: "complete" },
+          },
+          { type: "text", text: "done", status: { type: "complete" } },
+        ],
+        metadata: {
+          timing: {
+            streamStartTime: 1000,
+            firstTokenTime: 1200,
+            totalStreamTime: 800,
+            tokenCount: 40,
+            tokensPerSecond: 50,
+            totalChunks: 12,
+            toolCallCount: 1,
+          },
+          steps: [
+            { usage: { inputTokens: 100, outputTokens: 20 } },
+            { usage: { inputTokens: 30, outputTokens: 10 } },
+          ],
+          isOptimistic: false,
+          custom: {},
+        },
+      },
+      0,
+    );
+
+    expect(message).not.toBeNull();
+    if (!message) return;
+    expect(message.id).toBe("msg_1");
+    expect(message.role).toBe("assistant");
+    expect(message.parts).toHaveLength(3);
+    expect(message.parts.map((p) => p.type)).toEqual([
+      "reasoning",
+      "tool-call",
+      "text",
+    ]);
+    expect(message.status).toEqual({ type: "complete", reason: "stop" });
+    expect(message.branchNumber).toBe(2);
+    expect(message.branchCount).toBe(3);
+    expect(message.isLast).toBe(true);
+    expect(message.timing?.firstTokenTime).toBe(1200);
+    expect(message.usage).toEqual({
+      inputTokens: 130,
+      outputTokens: 30,
+      stepCount: 2,
+    });
+  });
+
+  it("falls back to content[] when parts[] is absent (raw user message)", () => {
+    const message = parseMessage(
+      {
+        id: "msg_2",
+        role: "user",
+        createdAt: "2026-06-08T10:01:00.000Z",
+        content: [{ type: "text", text: "hi" }],
+        attachments: [{ name: "photo.png" }],
+        metadata: { custom: {} },
+      },
+      0,
+    );
+    if (!message) return;
+    expect(message.parts).toHaveLength(1);
+    expect(message.parts[0]?.type).toBe("text");
+    expect(message.attachments).toEqual(["photo.png"]);
+    expect(message.status).toBeUndefined();
+    expect(message.usage).toBeUndefined();
+  });
+
+  it("captures an incomplete message error", () => {
+    const message = parseMessage(
+      {
+        id: "msg_3",
+        role: "assistant",
+        status: { type: "incomplete", reason: "error", error: "rate limited" },
+        parts: [],
+        metadata: { custom: {} },
+      },
+      0,
+    );
+    if (!message) return;
+    expect(message.status).toEqual({
+      type: "incomplete",
+      reason: "error",
+      error: "rate limited",
+    });
+  });
+
+  it("returns null for non-records", () => {
+    expect(parseMessage(null, 0)).toBeNull();
+    expect(parseMessage("nope", 0)).toBeNull();
+  });
+});

--- a/apps/devtools-frame/components/message/parse.test.ts
+++ b/apps/devtools-frame/components/message/parse.test.ts
@@ -214,7 +214,7 @@ describe("parseMessage", () => {
     expect(message.status).toEqual({ type: "complete", reason: "stop" });
     expect(message.branchNumber).toBe(2);
     expect(message.branchCount).toBe(3);
-    expect(message.isLast).toBe(true);
+    expect(message.index).toBe(1);
     expect(message.timing?.firstTokenTime).toBe(1200);
     expect(message.usage).toEqual({
       inputTokens: 130,

--- a/apps/devtools-frame/components/message/parse.ts
+++ b/apps/devtools-frame/components/message/parse.ts
@@ -1,7 +1,12 @@
-import { extractAttachmentNames, isRecord } from "../common";
+import {
+  asBool,
+  asNumber,
+  asString,
+  extractAttachmentNames,
+  isRecord,
+} from "../common";
 import type {
   MessagePreview,
-  MessageStatusPreview,
   MessageTimingPreview,
   MessageUsagePreview,
   PartPreview,
@@ -10,15 +15,6 @@ import type {
   ToolCallInterruptPreview,
   ToolCallPartPreview,
 } from "./types";
-
-const asString = (value: unknown): string | undefined =>
-  typeof value === "string" ? value : undefined;
-
-const asNumber = (value: unknown): number | undefined =>
-  typeof value === "number" && Number.isFinite(value) ? value : undefined;
-
-const asBool = (value: unknown): boolean | undefined =>
-  typeof value === "boolean" ? value : undefined;
 
 export const partKey = (part: PartPreview, index: number) =>
   part.type === "tool-call" && part.toolCallId
@@ -171,22 +167,6 @@ export const parsePart = (value: unknown): PartPreview => {
   }
 };
 
-const parseMessageStatus = (
-  value: unknown,
-): MessageStatusPreview | undefined => {
-  if (!isRecord(value)) return undefined;
-  const type = asString(value.type);
-  if (!type) return undefined;
-  const reason = asString(value.reason);
-  return {
-    type,
-    ...(reason ? { reason } : {}),
-    ...("error" in value && value.error !== undefined
-      ? { error: value.error }
-      : {}),
-  };
-};
-
 const parseTiming = (value: unknown): MessageTimingPreview | undefined => {
   if (!isRecord(value)) return undefined;
 
@@ -251,7 +231,7 @@ export const parseMessage = (
       : [];
   const parts = rawParts.map((part) => parsePart(part));
 
-  const status = parseMessageStatus(value.status);
+  const status = parsePartStatus(value.status);
   const metadata = isRecord(value.metadata) ? value.metadata : undefined;
   const timing = parseTiming(metadata?.timing);
   const usage = parseUsage(metadata?.steps);
@@ -263,7 +243,6 @@ export const parseMessage = (
   const branchNumber = asNumber(value.branchNumber);
   const branchCount = asNumber(value.branchCount);
   const messageIndex = asNumber(value.index);
-  const isLast = asBool(value.isLast);
 
   return {
     id,
@@ -277,7 +256,6 @@ export const parseMessage = (
     ...(branchNumber !== undefined ? { branchNumber } : {}),
     ...(branchCount !== undefined ? { branchCount } : {}),
     ...(messageIndex !== undefined ? { index: messageIndex } : {}),
-    ...(isLast !== undefined ? { isLast } : {}),
     ...(isOptimistic !== undefined ? { isOptimistic } : {}),
     ...(submittedFeedback ? { submittedFeedback } : {}),
   };

--- a/apps/devtools-frame/components/message/parse.ts
+++ b/apps/devtools-frame/components/message/parse.ts
@@ -1,0 +1,284 @@
+import { extractAttachmentNames, isRecord } from "../common";
+import type {
+  MessagePreview,
+  MessageStatusPreview,
+  MessageTimingPreview,
+  MessageUsagePreview,
+  PartPreview,
+  PartStatusPreview,
+  ToolCallApprovalPreview,
+  ToolCallInterruptPreview,
+  ToolCallPartPreview,
+} from "./types";
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+const asBool = (value: unknown): boolean | undefined =>
+  typeof value === "boolean" ? value : undefined;
+
+export const partKey = (part: PartPreview, index: number) =>
+  part.type === "tool-call" && part.toolCallId
+    ? `tc:${part.toolCallId}`
+    : `p:${index}`;
+
+export const parsePartStatus = (
+  value: unknown,
+): PartStatusPreview | undefined => {
+  if (!isRecord(value)) return undefined;
+  const type = asString(value.type);
+  if (!type) return undefined;
+  const reason = asString(value.reason);
+  return {
+    type,
+    ...(reason ? { reason } : {}),
+    ...("error" in value && value.error !== undefined
+      ? { error: value.error }
+      : {}),
+  };
+};
+
+const parseInterrupt = (
+  value: unknown,
+): ToolCallInterruptPreview | undefined => {
+  if (!isRecord(value)) return undefined;
+  const type = asString(value.type);
+  const result: ToolCallInterruptPreview = {
+    ...(type ? { type } : {}),
+    ...("payload" in value ? { payload: value.payload } : {}),
+  };
+  return Object.keys(result).length > 0 ? result : undefined;
+};
+
+const parseApproval = (value: unknown): ToolCallApprovalPreview | undefined => {
+  if (!isRecord(value)) return undefined;
+  const id = asString(value.id);
+  const approved = asBool(value.approved);
+  const reason = asString(value.reason);
+  const isAutomatic = asBool(value.isAutomatic);
+  const result: ToolCallApprovalPreview = {
+    ...(id ? { id } : {}),
+    ...(approved !== undefined ? { approved } : {}),
+    ...(reason ? { reason } : {}),
+    ...(isAutomatic !== undefined ? { isAutomatic } : {}),
+  };
+  return Object.keys(result).length > 0 ? result : undefined;
+};
+
+const parseToolCall = (
+  value: Record<string, unknown>,
+  base: { status?: PartStatusPreview },
+): ToolCallPartPreview => {
+  const argsText = asString(value.argsText);
+  const isError = asBool(value.isError);
+  const interrupt = parseInterrupt(value.interrupt);
+  const approval = parseApproval(value.approval);
+  const subMessageCount = Array.isArray(value.messages)
+    ? value.messages.length
+    : 0;
+
+  return {
+    type: "tool-call",
+    toolCallId: asString(value.toolCallId) ?? "",
+    toolName: asString(value.toolName) ?? "(unknown)",
+    args: value.args,
+    hasResult: "result" in value && value.result !== undefined,
+    subMessageCount,
+    ...(argsText !== undefined ? { argsText } : {}),
+    ...("result" in value && value.result !== undefined
+      ? { result: value.result }
+      : {}),
+    ...(isError !== undefined ? { isError } : {}),
+    ...(value.artifact !== undefined ? { artifact: value.artifact } : {}),
+    ...(value.mcp !== undefined ? { mcp: value.mcp } : {}),
+    ...(value.modelContent !== undefined
+      ? { modelContent: value.modelContent }
+      : {}),
+    ...(interrupt ? { interrupt } : {}),
+    ...(approval ? { approval } : {}),
+    ...base,
+  };
+};
+
+export const parsePart = (value: unknown): PartPreview => {
+  if (!isRecord(value)) {
+    return { type: "unknown", rawType: typeof value, raw: value };
+  }
+
+  const status = parsePartStatus(value.status);
+  const base = status ? { status } : {};
+  const type = asString(value.type);
+
+  switch (type) {
+    case "text":
+      return { type: "text", text: asString(value.text) ?? "", ...base };
+    case "reasoning":
+      return { type: "reasoning", text: asString(value.text) ?? "", ...base };
+    case "source": {
+      const sourceType = asString(value.sourceType);
+      const title = asString(value.title);
+      const url = asString(value.url);
+      return {
+        type: "source",
+        ...(sourceType ? { sourceType } : {}),
+        ...(title ? { title } : {}),
+        ...(url ? { url } : {}),
+        ...base,
+      };
+    }
+    case "image": {
+      const filename = asString(value.filename);
+      return { type: "image", ...(filename ? { filename } : {}), ...base };
+    }
+    case "file": {
+      const filename = asString(value.filename);
+      const mimeType = asString(value.mimeType);
+      return {
+        type: "file",
+        ...(filename ? { filename } : {}),
+        ...(mimeType ? { mimeType } : {}),
+        ...base,
+      };
+    }
+    case "audio": {
+      const audio = isRecord(value.audio) ? value.audio : undefined;
+      const format = asString(audio?.format);
+      return { type: "audio", ...(format ? { format } : {}), ...base };
+    }
+    case "data": {
+      const name = asString(value.name);
+      return {
+        type: "data",
+        data: value.data,
+        ...(name ? { name } : {}),
+        ...base,
+      };
+    }
+    case "generative-ui":
+      return { type: "generative-ui", spec: value.spec, ...base };
+    case "tool-call":
+      return parseToolCall(value, base);
+    default:
+      return {
+        type: "unknown",
+        rawType: type ?? typeof value,
+        raw: value,
+        ...base,
+      };
+  }
+};
+
+const parseMessageStatus = (
+  value: unknown,
+): MessageStatusPreview | undefined => {
+  if (!isRecord(value)) return undefined;
+  const type = asString(value.type);
+  if (!type) return undefined;
+  const reason = asString(value.reason);
+  return {
+    type,
+    ...(reason ? { reason } : {}),
+    ...("error" in value && value.error !== undefined
+      ? { error: value.error }
+      : {}),
+  };
+};
+
+const parseTiming = (value: unknown): MessageTimingPreview | undefined => {
+  if (!isRecord(value)) return undefined;
+
+  const streamStartTime = asNumber(value.streamStartTime);
+  const firstTokenTime = asNumber(value.firstTokenTime);
+  const totalStreamTime = asNumber(value.totalStreamTime);
+  const tokenCount = asNumber(value.tokenCount);
+  const tokensPerSecond = asNumber(value.tokensPerSecond);
+  const totalChunks = asNumber(value.totalChunks);
+  const toolCallCount = asNumber(value.toolCallCount);
+
+  const result: MessageTimingPreview = {
+    ...(streamStartTime !== undefined ? { streamStartTime } : {}),
+    ...(firstTokenTime !== undefined ? { firstTokenTime } : {}),
+    ...(totalStreamTime !== undefined ? { totalStreamTime } : {}),
+    ...(tokenCount !== undefined ? { tokenCount } : {}),
+    ...(tokensPerSecond !== undefined ? { tokensPerSecond } : {}),
+    ...(totalChunks !== undefined ? { totalChunks } : {}),
+    ...(toolCallCount !== undefined ? { toolCallCount } : {}),
+  };
+  return Object.keys(result).length > 0 ? result : undefined;
+};
+
+const parseUsage = (value: unknown): MessageUsagePreview | undefined => {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let sawUsage = false;
+
+  for (const step of value) {
+    if (!isRecord(step) || !isRecord(step.usage)) continue;
+    const input = asNumber(step.usage.inputTokens);
+    const output = asNumber(step.usage.outputTokens);
+    if (input !== undefined) {
+      inputTokens += input;
+      sawUsage = true;
+    }
+    if (output !== undefined) {
+      outputTokens += output;
+      sawUsage = true;
+    }
+  }
+
+  if (!sawUsage) return undefined;
+  return { inputTokens, outputTokens, stepCount: value.length };
+};
+
+export const parseMessage = (
+  value: unknown,
+  index: number,
+): MessagePreview | null => {
+  if (!isRecord(value)) return null;
+
+  const id = asString(value.id) ?? `message-${index}`;
+  const role = asString(value.role) ?? "unknown";
+
+  const rawParts = Array.isArray(value.parts)
+    ? value.parts
+    : Array.isArray(value.content)
+      ? value.content
+      : [];
+  const parts = rawParts.map((part) => parsePart(part));
+
+  const status = parseMessageStatus(value.status);
+  const metadata = isRecord(value.metadata) ? value.metadata : undefined;
+  const timing = parseTiming(metadata?.timing);
+  const usage = parseUsage(metadata?.steps);
+  const submittedFeedback = isRecord(metadata?.submittedFeedback)
+    ? asString(metadata.submittedFeedback.type)
+    : undefined;
+  const isOptimistic = asBool(metadata?.isOptimistic);
+  const createdAt = asString(value.createdAt);
+  const branchNumber = asNumber(value.branchNumber);
+  const branchCount = asNumber(value.branchCount);
+  const messageIndex = asNumber(value.index);
+  const isLast = asBool(value.isLast);
+
+  return {
+    id,
+    role,
+    parts,
+    attachments: extractAttachmentNames(value.attachments),
+    ...(createdAt ? { createdAt } : {}),
+    ...(status ? { status } : {}),
+    ...(timing ? { timing } : {}),
+    ...(usage ? { usage } : {}),
+    ...(branchNumber !== undefined ? { branchNumber } : {}),
+    ...(branchCount !== undefined ? { branchCount } : {}),
+    ...(messageIndex !== undefined ? { index: messageIndex } : {}),
+    ...(isLast !== undefined ? { isLast } : {}),
+    ...(isOptimistic !== undefined ? { isOptimistic } : {}),
+    ...(submittedFeedback ? { submittedFeedback } : {}),
+  };
+};

--- a/apps/devtools-frame/components/message/render.test.tsx
+++ b/apps/devtools-frame/components/message/render.test.tsx
@@ -1,0 +1,120 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { McpView } from "../mcp";
+import { MessageItem } from "./MessageItem";
+import { MessageList } from "./MessageList";
+import { parseMessage } from "./parse";
+import type { MessagePreview } from "./types";
+
+const parsed = (value: unknown): MessagePreview => {
+  const message = parseMessage(value, 0);
+  if (!message) throw new Error("fixture failed to parse");
+  return message;
+};
+
+describe("MessageItem rendering", () => {
+  it("renders reasoning + tool-call grouped as chain of thought, plus answer", () => {
+    const message = parsed({
+      id: "m1",
+      role: "assistant",
+      status: { type: "complete", reason: "stop" },
+      branchNumber: 1,
+      branchCount: 2,
+      parts: [
+        {
+          type: "reasoning",
+          text: "let me think",
+          status: { type: "complete" },
+        },
+        {
+          type: "tool-call",
+          toolCallId: "c1",
+          toolName: "getWeather",
+          args: { city: "SF" },
+          result: { temp: 18 },
+          status: { type: "complete" },
+        },
+        {
+          type: "text",
+          text: "It is 18 degrees.",
+          status: { type: "complete" },
+        },
+      ],
+      metadata: {
+        timing: {
+          streamStartTime: 0,
+          firstTokenTime: 150,
+          totalStreamTime: 900,
+        },
+        steps: [{ usage: { inputTokens: 50, outputTokens: 12 } }],
+        custom: {},
+      },
+    });
+
+    const html = renderToStaticMarkup(<MessageItem message={message} />);
+    expect(html).toContain("getWeather");
+    expect(html).toContain("Chain of thought");
+    expect(html).toContain("It is 18 degrees.");
+    expect(html).toContain("branch 1/2");
+    expect(html).toContain("TTFT");
+  });
+
+  it("renders a pending approval gate prominently", () => {
+    const message = parsed({
+      id: "m2",
+      role: "assistant",
+      status: { type: "requires-action", reason: "tool-calls" },
+      parts: [
+        {
+          type: "tool-call",
+          toolCallId: "c2",
+          toolName: "deleteAll",
+          args: {},
+          approval: { id: "appr_9" },
+          status: { type: "requires-action", reason: "interrupt" },
+        },
+      ],
+      metadata: { custom: {} },
+    });
+
+    const html = renderToStaticMarkup(<MessageItem message={message} />);
+    expect(html).toContain("Awaiting approval");
+    expect(html).toContain("appr_9");
+  });
+
+  it("renders an empty message list placeholder", () => {
+    const html = renderToStaticMarkup(<MessageList messages={[]} />);
+    expect(html).toContain("No messages");
+  });
+});
+
+describe("McpView rendering", () => {
+  it("renders server connection state and a discovered tool", () => {
+    const html = renderToStaticMarkup(
+      <McpView
+        value={{
+          isHydrated: true,
+          servers: [
+            {
+              id: "s1",
+              kind: "connector",
+              name: "GitHub",
+              connectionState: "connected",
+              lastError: null,
+              authorizationUrl: null,
+              tools: [{ name: "list_repos", description: "list repos" }],
+            },
+          ],
+        }}
+      />,
+    );
+    expect(html).toContain("GitHub");
+    expect(html).toContain("connected");
+    expect(html).toContain("list_repos");
+  });
+
+  it("falls back to raw JSON for non-manager values", () => {
+    const html = renderToStaticMarkup(<McpView value={42} />);
+    expect(html).toContain("42");
+  });
+});

--- a/apps/devtools-frame/components/message/types.ts
+++ b/apps/devtools-frame/components/message/types.ts
@@ -1,0 +1,139 @@
+export interface PartStatusPreview {
+  readonly type: string;
+  readonly reason?: string;
+  readonly error?: unknown;
+}
+
+export interface ToolCallApprovalPreview {
+  readonly id?: string;
+  readonly approved?: boolean;
+  readonly reason?: string;
+  readonly isAutomatic?: boolean;
+}
+
+export interface ToolCallInterruptPreview {
+  readonly type?: string;
+  readonly payload?: unknown;
+}
+
+interface BasePartPreview {
+  readonly status?: PartStatusPreview;
+}
+
+export interface TextPartPreview extends BasePartPreview {
+  readonly type: "text";
+  readonly text: string;
+}
+
+export interface ReasoningPartPreview extends BasePartPreview {
+  readonly type: "reasoning";
+  readonly text: string;
+}
+
+export interface SourcePartPreview extends BasePartPreview {
+  readonly type: "source";
+  readonly sourceType?: string;
+  readonly title?: string;
+  readonly url?: string;
+}
+
+export interface ImagePartPreview extends BasePartPreview {
+  readonly type: "image";
+  readonly filename?: string;
+}
+
+export interface FilePartPreview extends BasePartPreview {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly mimeType?: string;
+}
+
+export interface AudioPartPreview extends BasePartPreview {
+  readonly type: "audio";
+  readonly format?: string;
+}
+
+export interface DataPartPreview extends BasePartPreview {
+  readonly type: "data";
+  readonly name?: string;
+  readonly data: unknown;
+}
+
+export interface GenerativeUiPartPreview extends BasePartPreview {
+  readonly type: "generative-ui";
+  readonly spec: unknown;
+}
+
+export interface ToolCallPartPreview extends BasePartPreview {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: unknown;
+  readonly argsText?: string;
+  readonly hasResult: boolean;
+  readonly result?: unknown;
+  readonly isError?: boolean;
+  readonly artifact?: unknown;
+  readonly mcp?: unknown;
+  readonly modelContent?: unknown;
+  readonly interrupt?: ToolCallInterruptPreview;
+  readonly approval?: ToolCallApprovalPreview;
+  readonly subMessageCount: number;
+}
+
+export interface UnknownPartPreview extends BasePartPreview {
+  readonly type: "unknown";
+  readonly rawType: string;
+  readonly raw: unknown;
+}
+
+export type PartPreview =
+  | TextPartPreview
+  | ReasoningPartPreview
+  | SourcePartPreview
+  | ImagePartPreview
+  | FilePartPreview
+  | AudioPartPreview
+  | DataPartPreview
+  | GenerativeUiPartPreview
+  | ToolCallPartPreview
+  | UnknownPartPreview;
+
+export interface MessageStatusPreview {
+  readonly type: string;
+  readonly reason?: string;
+  readonly error?: unknown;
+}
+
+export interface MessageTimingPreview {
+  readonly streamStartTime?: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks?: number;
+  readonly toolCallCount?: number;
+}
+
+export interface MessageUsagePreview {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly stepCount: number;
+}
+
+export interface MessagePreview {
+  readonly id: string;
+  readonly role: string;
+  readonly createdAt?: string;
+  readonly status?: MessageStatusPreview;
+  readonly parts: readonly PartPreview[];
+  readonly attachments: readonly string[];
+  readonly timing?: MessageTimingPreview;
+  readonly usage?: MessageUsagePreview;
+  readonly branchNumber?: number;
+  readonly branchCount?: number;
+  readonly index?: number;
+  readonly isLast?: boolean;
+  readonly isOptimistic?: boolean;
+  readonly submittedFeedback?: string;
+}

--- a/apps/devtools-frame/components/message/types.ts
+++ b/apps/devtools-frame/components/message/types.ts
@@ -99,11 +99,7 @@ export type PartPreview =
   | ToolCallPartPreview
   | UnknownPartPreview;
 
-export interface MessageStatusPreview {
-  readonly type: string;
-  readonly reason?: string;
-  readonly error?: unknown;
-}
+export type MessageStatusPreview = PartStatusPreview;
 
 export interface MessageTimingPreview {
   readonly streamStartTime?: number;
@@ -133,7 +129,6 @@ export interface MessagePreview {
   readonly branchNumber?: number;
   readonly branchCount?: number;
   readonly index?: number;
-  readonly isLast?: boolean;
   readonly isOptimistic?: boolean;
   readonly submittedFeedback?: string;
 }

--- a/apps/devtools-frame/components/thread/ThreadDetails.tsx
+++ b/apps/devtools-frame/components/thread/ThreadDetails.tsx
@@ -1,6 +1,7 @@
+import { formatBoolean } from "../common";
+import { MessageList } from "../message";
 import { SummaryItem } from "../ui";
 import type { ThreadPreview } from "./types";
-import { formatBoolean, formatDateTime } from "./utils";
 
 export const ThreadDetails = ({
   thread,
@@ -55,56 +56,7 @@ export const ThreadDetails = ({
       </div>
     ) : null}
 
-    {thread.messages.length ? (
-      <div className="rounded-md border border-zinc-200 bg-white text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-950/40 dark:text-zinc-200">
-        <div className="border-b border-zinc-200 bg-zinc-100 px-3 py-2 text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
-          Recent Messages
-        </div>
-        <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
-          {thread.messages
-            .slice(-5)
-            .reverse()
-            .map((message) => (
-              <div key={message.id} className="flex flex-col gap-1 px-3 py-2">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="font-semibold text-zinc-800 capitalize dark:text-zinc-100">
-                    {message.role}
-                  </span>
-                  <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
-                    {formatDateTime(message.createdAt) ?? "—"}
-                  </span>
-                </div>
-                {message.summary ? (
-                  <div className="text-zinc-600 dark:text-zinc-300">
-                    {message.summary}
-                  </div>
-                ) : (
-                  <div className="text-zinc-500 dark:text-zinc-400">
-                    No textual content
-                  </div>
-                )}
-                {message.attachments.length ? (
-                  <div className="flex flex-wrap gap-1 text-[10px] text-zinc-500 dark:text-zinc-400">
-                    {message.attachments.map((attachment, index) => (
-                      <span
-                        key={`${message.id}-attachment-${index}`}
-                        className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300"
-                      >
-                        {attachment}
-                      </span>
-                    ))}
-                  </div>
-                ) : null}
-                {message.status ? (
-                  <div className="text-[10px] tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-                    Status: {message.status}
-                  </div>
-                ) : null}
-              </div>
-            ))}
-        </div>
-      </div>
-    ) : null}
+    <MessageList messages={thread.messages} />
 
     {thread.suggestions.length ? (
       <div className="rounded-md border border-dashed border-zinc-300 bg-white p-3 text-[11px] text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900/30 dark:text-zinc-200">

--- a/apps/devtools-frame/components/thread/index.ts
+++ b/apps/devtools-frame/components/thread/index.ts
@@ -1,0 +1,14 @@
+export { ThreadDetails } from "./ThreadDetails";
+export {
+  parseComposerPreview,
+  parseThreadListItemPreview,
+  parseThreadListPreview,
+  parseThreadPreview,
+} from "./utils";
+export type {
+  ComposerPreview,
+  SuggestionPreview,
+  ThreadListItemPreview,
+  ThreadListPreview,
+  ThreadPreview,
+} from "./types";

--- a/apps/devtools-frame/components/thread/types.ts
+++ b/apps/devtools-frame/components/thread/types.ts
@@ -1,18 +1,11 @@
+import type { MessagePreview } from "../message";
+
 export interface ThreadListItemPreview {
   id: string;
   title?: string;
   status?: string;
   externalId?: string;
   remoteId?: string;
-}
-
-export interface MessagePreview {
-  id: string;
-  role: string;
-  createdAt?: string;
-  summary: string;
-  status?: string;
-  attachments: string[];
 }
 
 export interface SuggestionPreview {

--- a/apps/devtools-frame/components/thread/utils.ts
+++ b/apps/devtools-frame/components/thread/utils.ts
@@ -1,103 +1,13 @@
+import { isRecord, isStringArray } from "../common";
+import { parseMessage } from "../message";
+import type { MessagePreview } from "../message";
 import type {
   ComposerPreview,
-  MessagePreview,
   SuggestionPreview,
   ThreadListItemPreview,
   ThreadListPreview,
   ThreadPreview,
 } from "./types";
-
-export const isRecord = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === "object" && !Array.isArray(value);
-
-export const isStringArray = (value: unknown): string[] =>
-  Array.isArray(value)
-    ? value.filter((item): item is string => typeof item === "string")
-    : [];
-
-export const formatBoolean = (value: boolean | undefined) =>
-  typeof value === "boolean" ? String(value) : undefined;
-
-export const formatDateTime = (value: string | undefined) => {
-  if (!value) return undefined;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
-};
-
-export const truncate = (value: string, max = 120) =>
-  value.length > max ? `${value.slice(0, max)}...` : value;
-
-export const extractMessageSummary = (content: unknown): string => {
-  if (!Array.isArray(content)) return "";
-
-  for (const part of content) {
-    if (!isRecord(part)) continue;
-    const type = typeof part.type === "string" ? part.type : undefined;
-
-    if (
-      (type === "text" || type === "reasoning") &&
-      typeof part.text === "string"
-    ) {
-      const text = part.text.trim();
-      if (text.length > 0) {
-        return truncate(text, 160);
-      }
-    }
-
-    if (type === "tool-call" && typeof part.toolName === "string") {
-      return `Tool call: ${part.toolName}`;
-    }
-
-    if (type === "image" && typeof part.filename === "string") {
-      return `Image: ${part.filename}`;
-    }
-
-    if (type === "file" && typeof part.filename === "string") {
-      return `File: ${part.filename}`;
-    }
-  }
-
-  const fallback = content.find((item) => typeof item === "string") as
-    | string
-    | undefined;
-  if (fallback) {
-    return truncate(fallback, 160);
-  }
-
-  return "";
-};
-
-export const extractAttachmentNames = (value: unknown): string[] => {
-  if (!Array.isArray(value)) return [];
-
-  return value
-    .map((attachment) => {
-      if (!isRecord(attachment)) return null;
-
-      if (typeof attachment.name === "string" && attachment.name.length > 0) {
-        return attachment.name;
-      }
-
-      if (
-        typeof attachment.filename === "string" &&
-        attachment.filename.length > 0
-      ) {
-        return attachment.filename;
-      }
-
-      if (typeof attachment.type === "string" && attachment.type.length > 0) {
-        return attachment.type;
-      }
-
-      if (typeof attachment.id === "string" && attachment.id.length > 0) {
-        return attachment.id;
-      }
-
-      return null;
-    })
-    .filter((name): name is string => Boolean(name));
-};
 
 export const parseSuggestionPreview = (
   value: unknown,
@@ -132,27 +42,12 @@ export const parseComposerPreview = (
   };
 };
 
-export const parseMessagePreview = (
-  value: unknown,
-  index: number,
-): MessagePreview | null => {
-  if (!isRecord(value)) return null;
-
-  const id = typeof value.id === "string" ? value.id : `message-${index}`;
-  const role = typeof value.role === "string" ? value.role : "unknown";
-  const summary = extractMessageSummary(value.content);
-
-  return {
-    id,
-    role,
-    summary,
-    attachments: extractAttachmentNames(value.attachments),
-    ...(typeof value.createdAt === "string"
-      ? { createdAt: value.createdAt }
-      : {}),
-    ...(typeof value.status === "string" ? { status: value.status } : {}),
-  };
-};
+const parseMessages = (value: unknown): MessagePreview[] =>
+  Array.isArray(value)
+    ? value
+        .map((message, index) => parseMessage(message, index))
+        .filter((message): message is MessagePreview => Boolean(message))
+    : [];
 
 export const parseThreadListItemPreview = (
   value: unknown,
@@ -173,11 +68,7 @@ export const parseThreadListItemPreview = (
 export const parseThreadPreview = (value: unknown): ThreadPreview | null => {
   if (!isRecord(value)) return null;
 
-  const messages = Array.isArray(value.messages)
-    ? value.messages
-        .map((message, index) => parseMessagePreview(message, index))
-        .filter((message): message is MessagePreview => Boolean(message))
-    : [];
+  const messages = parseMessages(value.messages);
 
   const suggestions = Array.isArray(value.suggestions)
     ? value.suggestions

--- a/apps/devtools-frame/package.json
+++ b/apps/devtools-frame/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "next dev --port 3010",
     "build": "next build",
-    "start": "next start --port 3010"
+    "start": "next start --port 3010",
+    "test": "vitest run"
   },
   "dependencies": {
     "@assistant-ui/react-devtools": "workspace:*",
@@ -23,6 +24,7 @@
     "@types/react-dom": "^19.2.3",
     "postcss": "^8.5.15",
     "tailwindcss": "^4.3.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
   }
 }

--- a/apps/devtools-frame/vitest.config.ts
+++ b/apps/devtools-frame/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["components/**/*.test.{ts,tsx}"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/docs:
     dependencies:
@@ -3507,7 +3510,7 @@ importers:
         version: link:../store
       '@google/adk':
         specifier: '>=0.5.0'
-        version: 1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
+        version: 1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
       assistant-cloud:
         specifier: '*'
         version: link:../cloud
@@ -3532,7 +3535,7 @@ importers:
         version: 19.2.6
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/react-hook-form:
     dependencies:
@@ -18828,6 +18831,20 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
+  '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+    dependencies:
+      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/precise-date': 4.0.0
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      googleapis: 137.1.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
       '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -18842,6 +18859,20 @@ snapshots:
       - encoding
       - supports-color
 
+  '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+    dependencies:
+      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.8.1
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+      google-auth-library: 9.15.1(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
       '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -18852,6 +18883,16 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
       google-auth-library: 9.15.1(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@google-cloud/opentelemetry-resource-util@3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+    dependencies:
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      gcp-metadata: 6.1.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -18897,6 +18938,50 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@google/adk@1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+    dependencies:
+      '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.12.0)(@grpc/grpc-js@1.14.4)(express@4.22.2)
+      '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/opentelemetry-cloud-trace-exporter': 3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/storage': 7.19.0(encoding@0.1.13)
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
+      '@mikro-orm/core': 6.6.14
+      '@mikro-orm/mariadb': 6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0)
+      '@mikro-orm/mssql': 6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0)
+      '@mikro-orm/mysql': 6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5)(pg@8.20.0)
+      '@mikro-orm/postgresql': 6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)
+      '@mikro-orm/reflection': 6.6.14(@mikro-orm/core@6.6.14)
+      '@mikro-orm/sqlite': 6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resource-detector-gcp': 0.40.3(@opentelemetry/api@1.9.0)(encoding@0.1.13)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.0)
+      express: 4.22.2
+      google-auth-library: 10.6.2
+      js-yaml: 4.1.1
+      jsonpath-plus: 10.4.0
+      lodash-es: 4.18.1
+      winston: 3.19.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@bufbuild/protobuf'
+      - '@cfworker/json-schema'
+      - '@grpc/grpc-js'
+      - '@opentelemetry/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
 
   '@google/adk@1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)':
     dependencies:
@@ -30749,6 +30834,37 @@ snapshots:
   vitefu@1.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  vitest@4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.9.1
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
+      '@vitest/ui': 4.1.7(vitest@4.1.7)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## summary

- the devtools state tab now renders a full per-message inspector: every message part (text, reasoning, tool-call, source, file, image, audio, data, generative-ui) with its live status, replacing the old one-line summary of the last 5 messages. per-message timing (TTFT, stream duration, tokens/s, chunks), summed step usage, branch number, and optimistic flag are surfaced too.
- tool calls get a dedicated inspector: args (collapsible) plus raw argsText, result / isError, artifact, mcp metadata, and nested sub-agent count. pending approval gates and human-in-the-loop interrupts are called out prominently so a paused run no longer looks like a hung one.
- new MCP renderer (per-server connection state, last error, authorization url, discovered tools), an event-log Scope column with per-scope grouping/toggling, and consecutive reasoning + tool-call parts collapse into a chain-of-thought group with a rolled-up status.
- internals: consolidated DevToolsUI onto the previously-unused split-out components (removing ~795 lines of duplicated inline renderers), added shared defensive parsers for the serialized state, and fixed a message-status guard that never fired because it tested `typeof status === "string"` against an object.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/devtools-frame test` -> 23/23 green (parser fixtures + `react-dom/server` render smoke tests)
- [x] `pnpm --filter @assistant-ui/devtools-frame build` -> compiled + TypeScript clean
- [x] `pnpm exec oxlint apps/devtools-frame` and `oxfmt --check` -> clean

### reviewer should verify

- [ ] open the devtools modal against a running app, send a prompt that triggers a reasoning step and a tool call, and confirm the state tab shows the ordered parts, per-part status, timing strip, and the tool-call args/result; when a tool requires action, confirm the amber approval/HITL panel appears.
- [ ] with an `mcp` root scope present (react-mcp), confirm the new MCP renderer shows per-server connection state and discovered tools, and that no tokens/secrets are rendered.

## notes

- scope is the `devtools-frame` app only; no published package changed, so no changeset. this is the frame-only slice (data already crosses the existing transport via `state.threads`); deeper work (forwarding non-root scopes, a run timeline, interactive invocation) is follow-up.