### PR TITLE
fix(docs): remove polynomial redos in xulux sandbox name sanitizer

### DIFF
--- a/apps/docs/app/api/xulux/blaxel-sandbox.ts
+++ b/apps/docs/app/api/xulux/blaxel-sandbox.ts
@@ -77,9 +77,9 @@ function toSandboxName(sessionId: string): string {
   const safe = sessionId
     .toLowerCase()
     .replace(/[^a-z0-9-]+/g, "-")
-    .replace(/^-+|-+$/g, "")
+    .replace(/^-+|(?<!-)-+$/g, "")
     .slice(0, 32);
-  return `xulux-${safe}`.slice(0, 40).replace(/-+$/g, "");
+  return `xulux-${safe}`.slice(0, 40).replace(/(?<!-)-+$/g, "");
 }
 
 async function withRetry<T>(fn: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
fixes the high-severity CodeQL alert [js/polynomial-redos #53](https://github.com/assistant-ui/assistant-ui/security/code-scanning/53).

## the problem

`toSandboxName` in `apps/docs/app/api/xulux/blaxel-sandbox.ts` trims leading and trailing dashes with `/^-+|-+$/g`. the `-+$` branch is ambiguous about where a trailing run of dashes starts, so on a string with a long internal run of `-` that is not at the end (e.g. `x------...x`), the engine retries the run from every position and degrades to O(n^2) backtracking. the `sessionId` it sanitizes flows straight from the chat route request body (`apps/docs/app/api/xulux/chat/route.ts`), so the input is fully attacker controlled, which is the DoS vector CodeQL flagged.

## the fix

anchor the trailing match with a `(?<!-)` negative lookbehind (`/^-+|(?<!-)-+$/g`) so it can only begin at the true start of a trailing dash run, removing the ambiguity and making matching linear. the same shape on the final `.replace(/-+$/g, "")` is hardened the same way for consistency, even though that one already runs on a length-bounded string.

## verification

- output is byte-identical to the old function across a sweep of 17 inputs (empty, all-dashes, internal dashes, mixed case, punctuation, etc.), so behavior is unchanged.
- timing on a malicious `x` + n×`-` + `x` input: old version is quadratic (37ms at 10k, 552ms at 40k, 8.5s at 160k); new version stays sub-millisecond (0.04ms / 0.15ms / 0.53ms). 160k dashes go from ~8.5s to ~0.5ms.
- `oxlint` and `oxfmt --check` clean on the file.

`apps/docs` is the private `@assistant-ui/docs` package, so no changeset is needed.