### PR TITLE
feat(devtools): surface full tool metadata and redact credentials

### DIFF
--- a/.changeset/devtools-model-context-metadata.md
+++ b/.changeset/devtools-model-context-metadata.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-devtools": patch
+---
+
+feat: surface full tool metadata (type, provider id, MCP server, providerOptions, deferred-results, backend defaults) in the devtools model context, and redact credentials (apiKey, authorization headers, tokens, MCP server headers/env) at the serializer boundary before they cross the postMessage bridge

--- a/apps/devtools-frame/components/DevToolsUI.tsx
+++ b/apps/devtools-frame/components/DevToolsUI.tsx
@@ -10,6 +10,7 @@ import {
 } from "@assistant-ui/react-devtools";
 import { isRecord, truncate } from "./common";
 import { McpView } from "./mcp";
+import { ModelContextView } from "./model-context";
 import {
   ThreadDetails,
   parseComposerPreview,
@@ -17,14 +18,7 @@ import {
   parseThreadListPreview,
   parseThreadPreview,
 } from "./thread";
-import {
-  CenteredMessage,
-  ControlButton,
-  InfoCard,
-  JSONPreview,
-  SectionTitle,
-  SummaryItem,
-} from "./ui";
+import { CenteredMessage, ControlButton, JSONPreview, SummaryItem } from "./ui";
 
 interface AssistantState {
   [key: string]: unknown;
@@ -763,81 +757,7 @@ export function DevToolsUI() {
       );
     }
 
-    const toolList = normalizeToolList(selectedApi.modelContext?.tools);
-    const hasSystem = selectedApi.modelContext?.system;
-    const hasTools = toolList.length > 0;
-    const hasCallSettings =
-      selectedApi.modelContext?.callSettings &&
-      Object.keys(selectedApi.modelContext.callSettings).length > 0;
-
-    if (!hasSystem && !hasTools && !hasCallSettings) {
-      return (
-        <div className="flex h-full items-center justify-center">
-          <div className="rounded-lg border border-dashed border-zinc-300 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
-            No model context configured for this assistant instance.
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <div className="grid gap-3">
-        {hasSystem && (
-          <InfoCard>
-            <SectionTitle>System Prompt</SectionTitle>
-            <pre className="rounded-lg bg-zinc-100 p-3 text-[11px] whitespace-pre-wrap text-zinc-700 dark:bg-zinc-950 dark:text-zinc-200">
-              {selectedApi.modelContext!.system}
-            </pre>
-          </InfoCard>
-        )}
-        {hasTools && (
-          <InfoCard>
-            <SectionTitle>Tools</SectionTitle>
-            <div className="flex flex-col gap-3">
-              {toolList.map((tool) => (
-                <div
-                  key={tool.name}
-                  className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] text-zinc-700 transition-colors dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-zinc-200"
-                >
-                  <div className="flex flex-wrap items-center gap-2 font-semibold text-zinc-800 dark:text-zinc-100">
-                    <span>{tool.name}</span>
-                    {tool.type ? (
-                      <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300">
-                        {tool.type}
-                      </span>
-                    ) : null}
-                    {tool.disabled ? (
-                      <span className="text-[10px] font-semibold tracking-wide text-amber-600 uppercase dark:text-amber-400">
-                        Disabled
-                      </span>
-                    ) : null}
-                  </div>
-                  {tool.description ? (
-                    <p className="mt-1 text-[11px] text-zinc-600 dark:text-zinc-300">
-                      {tool.description}
-                    </p>
-                  ) : null}
-                  {tool.parameters ? (
-                    <div className="mt-2">
-                      <div className="mb-1 text-[10px] font-medium tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-                        Parameters
-                      </div>
-                      <JSONPreview value={tool.parameters} />
-                    </div>
-                  ) : null}
-                </div>
-              ))}
-            </div>
-          </InfoCard>
-        )}
-        {hasCallSettings && (
-          <InfoCard>
-            <SectionTitle>Call Settings</SectionTitle>
-            <JSONPreview value={selectedApi.modelContext!.callSettings} />
-          </InfoCard>
-        )}
-      </div>
-    );
+    return <ModelContextView modelContext={selectedApi.modelContext} />;
   };
 
   const renderTabContent = (): ReactNode => {

--- a/apps/devtools-frame/components/model-context/ModelContextView.tsx
+++ b/apps/devtools-frame/components/model-context/ModelContextView.tsx
@@ -1,0 +1,137 @@
+import {
+  normalizeToolList,
+  type NormalizedTool,
+} from "@assistant-ui/react-devtools";
+import type { ReactNode } from "react";
+import { InfoCard, JSONPreview, SectionTitle } from "../ui";
+
+interface ModelContextValue {
+  system?: string;
+  tools?: NormalizedTool[];
+  callSettings?: Record<string, unknown>;
+  config?: Record<string, unknown>;
+}
+
+const Badge = ({
+  children,
+  tone = "neutral",
+}: {
+  children: ReactNode;
+  tone?: "neutral" | "warn" | "accent";
+}) => {
+  const cls =
+    tone === "warn"
+      ? "text-amber-600 dark:text-amber-400"
+      : tone === "accent"
+        ? "bg-violet-500/15 text-violet-700 dark:text-violet-300"
+        : "bg-zinc-200 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300";
+  return (
+    <span
+      className={`rounded px-1.5 py-0.5 text-[10px] font-medium tracking-wide uppercase ${cls}`}
+    >
+      {children}
+    </span>
+  );
+};
+
+const Field = ({ label, value }: { label: string; value: unknown }) => (
+  <div className="mt-2">
+    <div className="mb-1 text-[10px] font-medium tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
+      {label}
+    </div>
+    <JSONPreview value={value} />
+  </div>
+);
+
+const ToolCard = ({ tool }: { tool: NormalizedTool }) => (
+  <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] text-zinc-700 transition-colors dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-zinc-200">
+    <div className="flex flex-wrap items-center gap-2 font-semibold text-zinc-800 dark:text-zinc-100">
+      <span>{tool.name}</span>
+      {tool.type ? <Badge>{tool.type}</Badge> : null}
+      {tool.providerId ? <Badge tone="accent">{tool.providerId}</Badge> : null}
+      {tool.display ? <Badge>{tool.display}</Badge> : null}
+      {tool.supportsDeferredResults ? <Badge>deferred</Badge> : null}
+      {tool.disabled ? <Badge tone="warn">disabled</Badge> : null}
+    </div>
+
+    {tool.description ? (
+      <p className="mt-1 text-[11px] text-zinc-600 dark:text-zinc-300">
+        {tool.description}
+      </p>
+    ) : null}
+
+    {tool.server !== undefined ? (
+      <Field label="MCP server" value={tool.server} />
+    ) : null}
+    {tool.providerArgs !== undefined ? (
+      <Field label="Provider args" value={tool.providerArgs} />
+    ) : null}
+    {tool.providerOptions !== undefined ? (
+      <Field label="Provider options" value={tool.providerOptions} />
+    ) : null}
+    {tool.backendDefault !== undefined ? (
+      <Field label="Backend defaults" value={tool.backendDefault} />
+    ) : null}
+    {tool.parameters ? (
+      <Field label="Parameters" value={tool.parameters} />
+    ) : null}
+  </div>
+);
+
+export const ModelContextView = ({
+  modelContext,
+}: {
+  modelContext?: ModelContextValue | undefined;
+}) => {
+  const toolList = normalizeToolList(modelContext?.tools);
+  const system = modelContext?.system;
+  const callSettings = modelContext?.callSettings;
+  const config = modelContext?.config;
+  const hasCallSettings = callSettings && Object.keys(callSettings).length > 0;
+  const hasConfig = config && Object.keys(config).length > 0;
+
+  if (!system && toolList.length === 0 && !hasCallSettings && !hasConfig) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="rounded-lg border border-dashed border-zinc-300 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
+          No model context configured for this assistant instance.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3">
+      {system ? (
+        <InfoCard>
+          <SectionTitle>System Prompt</SectionTitle>
+          <pre className="rounded-lg bg-zinc-100 p-3 text-[11px] whitespace-pre-wrap text-zinc-700 dark:bg-zinc-950 dark:text-zinc-200">
+            {system}
+          </pre>
+        </InfoCard>
+      ) : null}
+      {toolList.length > 0 ? (
+        <InfoCard>
+          <SectionTitle>Tools ({toolList.length})</SectionTitle>
+          <div className="flex flex-col gap-3">
+            {toolList.map((tool) => (
+              <ToolCard key={tool.name} tool={tool} />
+            ))}
+          </div>
+        </InfoCard>
+      ) : null}
+      {hasCallSettings ? (
+        <InfoCard>
+          <SectionTitle>Call Settings</SectionTitle>
+          <JSONPreview value={callSettings} />
+        </InfoCard>
+      ) : null}
+      {hasConfig ? (
+        <InfoCard>
+          <SectionTitle>Config</SectionTitle>
+          <JSONPreview value={config} />
+        </InfoCard>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/devtools-frame/components/model-context/ModelContextView.tsx
+++ b/apps/devtools-frame/components/model-context/ModelContextView.tsx
@@ -1,16 +1,9 @@
-import {
-  normalizeToolList,
-  type NormalizedTool,
+import type {
+  NormalizedTool,
+  SerializedModelContext,
 } from "@assistant-ui/react-devtools";
 import type { ReactNode } from "react";
 import { InfoCard, JSONPreview, SectionTitle } from "../ui";
-
-interface ModelContextValue {
-  system?: string;
-  tools?: NormalizedTool[];
-  callSettings?: Record<string, unknown>;
-  config?: Record<string, unknown>;
-}
 
 const Badge = ({
   children,
@@ -81,9 +74,9 @@ const ToolCard = ({ tool }: { tool: NormalizedTool }) => (
 export const ModelContextView = ({
   modelContext,
 }: {
-  modelContext?: ModelContextValue | undefined;
+  modelContext?: SerializedModelContext | undefined;
 }) => {
-  const toolList = normalizeToolList(modelContext?.tools);
+  const toolList = Array.isArray(modelContext?.tools) ? modelContext.tools : [];
   const system = modelContext?.system;
   const callSettings = modelContext?.callSettings;
   const config = modelContext?.config;

--- a/apps/devtools-frame/components/model-context/index.ts
+++ b/apps/devtools-frame/components/model-context/index.ts
@@ -1,0 +1,1 @@
+export { ModelContextView } from "./ModelContextView";

--- a/apps/devtools-frame/components/model-context/render.test.tsx
+++ b/apps/devtools-frame/components/model-context/render.test.tsx
@@ -1,0 +1,38 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ModelContextView } from "./ModelContextView";
+
+describe("ModelContextView", () => {
+  it("renders provider args and backend defaults from already-normalized tools", () => {
+    const html = renderToStaticMarkup(
+      <ModelContextView
+        modelContext={{
+          tools: [
+            {
+              name: "web_search",
+              type: "provider",
+              providerId: "openai.web_search_preview",
+              providerArgs: { searchContextSize: "high" },
+              backendDefault: { parameters: true },
+            },
+          ],
+          config: { modelName: "gpt", apiKey: "[redacted]" },
+        }}
+      />,
+    );
+
+    expect(html).toContain("web_search");
+    expect(html).toContain("openai.web_search_preview");
+    expect(html).toContain("Provider args");
+    expect(html).toContain("searchContextSize");
+    expect(html).toContain("Backend defaults");
+    expect(html).toContain("Config");
+  });
+
+  it("shows the empty state when nothing is configured", () => {
+    const html = renderToStaticMarkup(
+      <ModelContextView modelContext={undefined} />,
+    );
+    expect(html).toContain("No model context");
+  });
+});

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -27,7 +27,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "aui-build"
+    "build": "aui-build",
+    "test": "vitest run"
   },
   "dependencies": {
     "zod": "^4.4.3"
@@ -56,7 +57,8 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react-dom": "^19.2.6",
+    "vitest": "^4.1.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/react-devtools/src/utils/serialization.test.ts
+++ b/packages/react-devtools/src/utils/serialization.test.ts
@@ -26,6 +26,25 @@ describe("redactSensitive", () => {
     const out = redactSensitive([{ token: "a" }, { ok: 1 }]) as unknown[];
     expect(out).toEqual([{ token: REDACTED }, { ok: 1 }]);
   });
+
+  it("masks every value inside env/headers, including arbitrary names", () => {
+    const out = redactSensitive({
+      env: { OPENAI_API_KEY: "sk-1", GITHUB_TOKEN: "ghp", PATH: "/bin" },
+      headers: { "X-Custom-Auth": "abc", "Content-Type": "application/json" },
+      url: "https://mcp.example.com",
+    }) as Record<string, Record<string, unknown>>;
+
+    expect(out.env).toEqual({
+      OPENAI_API_KEY: REDACTED,
+      GITHUB_TOKEN: REDACTED,
+      PATH: REDACTED,
+    });
+    expect(out.headers).toEqual({
+      "X-Custom-Auth": REDACTED,
+      "Content-Type": REDACTED,
+    });
+    expect(out.url).toBe("https://mcp.example.com");
+  });
 });
 
 describe("serializeModelContext", () => {
@@ -78,6 +97,28 @@ describe("serializeModelContext", () => {
       type: "http",
       url: "https://x",
       headers: { token: REDACTED },
+    });
+  });
+
+  it("masks arbitrary env names on an MCP stdio server tool", () => {
+    const result = serializeModelContext({
+      tools: {
+        gh: {
+          type: "mcp",
+          server: {
+            type: "stdio",
+            command: "mcp-github",
+            env: { GITHUB_TOKEN: "ghp_secret", OPENAI_API_KEY: "sk" },
+          },
+        },
+      },
+    } as never);
+
+    const gh = result?.tools?.find((t) => t.name === "gh");
+    expect(gh?.server).toEqual({
+      type: "stdio",
+      command: "mcp-github",
+      env: { GITHUB_TOKEN: REDACTED, OPENAI_API_KEY: REDACTED },
     });
   });
 

--- a/packages/react-devtools/src/utils/serialization.test.ts
+++ b/packages/react-devtools/src/utils/serialization.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  REDACTED,
+  redactSensitive,
+  serializeModelContext,
+} from "./serialization";
+
+describe("redactSensitive", () => {
+  it("masks credential-named keys but leaves lookalikes alone", () => {
+    const out = redactSensitive({
+      apiKey: "sk-123",
+      authorization: "Bearer abc",
+      maxTokens: 100,
+      tokenCount: 42,
+      nested: { client_secret: "shh", model: "gpt" },
+    }) as Record<string, unknown>;
+
+    expect(out.apiKey).toBe(REDACTED);
+    expect(out.authorization).toBe(REDACTED);
+    expect(out.maxTokens).toBe(100);
+    expect(out.tokenCount).toBe(42);
+    expect(out.nested).toEqual({ client_secret: REDACTED, model: "gpt" });
+  });
+
+  it("recurses through arrays", () => {
+    const out = redactSensitive([{ token: "a" }, { ok: 1 }]) as unknown[];
+    expect(out).toEqual([{ token: REDACTED }, { ok: 1 }]);
+  });
+});
+
+describe("serializeModelContext", () => {
+  it("redacts secrets in config and call settings, keeps the rest", () => {
+    const result = serializeModelContext({
+      config: { apiKey: "sk-123", baseUrl: "https://api.example.com" },
+      callSettings: {
+        maxTokens: 256,
+        headers: { Authorization: "Bearer xyz" },
+      },
+    } as never);
+
+    expect(result?.config).toEqual({
+      apiKey: REDACTED,
+      baseUrl: "https://api.example.com",
+    });
+    expect(result?.callSettings).toEqual({
+      maxTokens: 256,
+      headers: { Authorization: REDACTED },
+    });
+  });
+
+  it("redacts tool providerOptions/server but never the parameters schema", () => {
+    const result = serializeModelContext({
+      tools: {
+        search: {
+          type: "frontend",
+          parameters: {
+            type: "object",
+            properties: { token: { type: "string" } },
+          },
+          providerOptions: { openai: { apiKey: "sk-xyz" } },
+        },
+        mcp_tool: {
+          type: "mcp",
+          server: { type: "http", url: "https://x", headers: { token: "t" } },
+        },
+      },
+    } as never);
+
+    const search = result?.tools?.find((t) => t.name === "search");
+    const mcpTool = result?.tools?.find((t) => t.name === "mcp_tool");
+
+    expect(search?.providerOptions).toEqual({ openai: { apiKey: REDACTED } });
+    expect(search?.parameters).toEqual({
+      type: "object",
+      properties: { token: { type: "string" } },
+    });
+    expect(mcpTool?.server).toEqual({
+      type: "http",
+      url: "https://x",
+      headers: { token: REDACTED },
+    });
+  });
+
+  it("returns undefined when there is no context", () => {
+    expect(serializeModelContext(undefined)).toBeUndefined();
+  });
+});

--- a/packages/react-devtools/src/utils/serialization.ts
+++ b/packages/react-devtools/src/utils/serialization.ts
@@ -1,6 +1,6 @@
 import type { ModelContext } from "@assistant-ui/react";
 import type { SerializedModelContext } from "../types";
-import { normalizeToolList } from "./toolNormalization";
+import { normalizeToolList, type NormalizedTool } from "./toolNormalization";
 
 export const sanitizeForMessage = (
   value: unknown,
@@ -52,6 +52,58 @@ export const sanitizeForMessage = (
   return value;
 };
 
+export const REDACTED = "[redacted]";
+
+const SENSITIVE_KEYS = new Set([
+  "apikey",
+  "xapikey",
+  "accesskey",
+  "authorization",
+  "password",
+  "passwd",
+  "secret",
+  "clientsecret",
+  "token",
+  "accesstoken",
+  "refreshtoken",
+  "cookie",
+  "setcookie",
+  "credential",
+  "credentials",
+  "privatekey",
+  "bearer",
+  "sessionid",
+]);
+
+const normalizeKey = (key: string) => key.toLowerCase().replace(/[-_]/g, "");
+
+/**
+ * Mask values whose key names a known credential. Operates on already
+ * sanitized plain data (primitives, arrays, plain objects). Applied only to
+ * config-bearing subtrees, never to a tool's parameters schema, so a schema
+ * property literally named `token` is not corrupted.
+ */
+export const redactSensitive = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSensitive(entry));
+  }
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      result[key] = SENSITIVE_KEYS.has(normalizeKey(key))
+        ? REDACTED
+        : redactSensitive(entry);
+    }
+    return result;
+  }
+  return value;
+};
+
+const sanitizeAndRedact = (value: unknown): unknown =>
+  redactSensitive(sanitizeForMessage(value));
+
 export const serializeModelContext = (
   context: ModelContext | undefined,
 ): SerializedModelContext | undefined => {
@@ -69,14 +121,28 @@ export const serializeModelContext = (
 
   const tools = normalizeToolList(modelContext.tools);
   if (tools.length > 0) {
-    result.tools = tools.map((tool) => ({
-      ...tool,
-      parameters: sanitizeForMessage(tool.parameters),
-    }));
+    result.tools = tools.map((tool): NormalizedTool => {
+      return {
+        ...tool,
+        parameters: sanitizeForMessage(tool.parameters),
+        ...(tool.providerOptions !== undefined
+          ? { providerOptions: sanitizeAndRedact(tool.providerOptions) }
+          : {}),
+        ...(tool.providerArgs !== undefined
+          ? { providerArgs: sanitizeAndRedact(tool.providerArgs) }
+          : {}),
+        ...(tool.server !== undefined
+          ? { server: sanitizeAndRedact(tool.server) }
+          : {}),
+        ...(tool.backendDefault !== undefined
+          ? { backendDefault: sanitizeForMessage(tool.backendDefault) }
+          : {}),
+      };
+    });
   }
 
   if (modelContext.callSettings !== undefined) {
-    const callSettings = sanitizeForMessage(modelContext.callSettings);
+    const callSettings = sanitizeAndRedact(modelContext.callSettings);
     if (
       callSettings &&
       typeof callSettings === "object" &&
@@ -87,7 +153,7 @@ export const serializeModelContext = (
   }
 
   if (modelContext.config !== undefined) {
-    const config = sanitizeForMessage(modelContext.config);
+    const config = sanitizeAndRedact(modelContext.config);
     if (config && typeof config === "object" && !Array.isArray(config)) {
       result.config = config as Record<string, unknown>;
     }

--- a/packages/react-devtools/src/utils/serialization.ts
+++ b/packages/react-devtools/src/utils/serialization.ts
@@ -78,27 +78,38 @@ const SENSITIVE_KEYS = new Set([
 const normalizeKey = (key: string) => key.toLowerCase().replace(/[-_]/g, "");
 
 /**
- * Mask values whose key names a known credential. Operates on already
- * sanitized plain data (primitives, arrays, plain objects). Applied only to
- * config-bearing subtrees, never to a tool's parameters schema, so a schema
- * property literally named `token` is not corrupted.
+ * Subtrees that are credential maps with arbitrary, user-defined key names
+ * (MCP stdio `env`, HTTP `headers`). Per-key name matching cannot catch
+ * `OPENAI_API_KEY` or a custom auth header, so every leaf inside one of these
+ * is masked wholesale.
  */
-export const redactSensitive = (value: unknown): unknown => {
+const MASK_ALL_KEYS = new Set(["env", "headers"]);
+
+/**
+ * Mask values whose key names a known credential, and mask every value inside
+ * an `env`/`headers` subtree wholesale. Operates on already sanitized plain
+ * data (primitives, arrays, plain objects). Applied only to config-bearing
+ * subtrees, never to a tool's parameters schema, so a schema property literally
+ * named `token` is not corrupted.
+ */
+export const redactSensitive = (value: unknown, maskAll = false): unknown => {
   if (Array.isArray(value)) {
-    return value.map((entry) => redactSensitive(entry));
+    return value.map((entry) => redactSensitive(entry, maskAll));
   }
   if (value && typeof value === "object") {
     const result: Record<string, unknown> = {};
     for (const [key, entry] of Object.entries(
       value as Record<string, unknown>,
     )) {
-      result[key] = SENSITIVE_KEYS.has(normalizeKey(key))
-        ? REDACTED
-        : redactSensitive(entry);
+      const normalized = normalizeKey(key);
+      result[key] =
+        maskAll || SENSITIVE_KEYS.has(normalized)
+          ? REDACTED
+          : redactSensitive(entry, MASK_ALL_KEYS.has(normalized));
     }
     return result;
   }
-  return value;
+  return maskAll ? REDACTED : value;
 };
 
 const sanitizeAndRedact = (value: unknown): unknown =>

--- a/packages/react-devtools/src/utils/toolNormalization.test.ts
+++ b/packages/react-devtools/src/utils/toolNormalization.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolList } from "./toolNormalization";
+
+describe("normalizeToolList", () => {
+  it("retains the full metadata of a provider tool", () => {
+    const [tool] = normalizeToolList({
+      web_search: {
+        type: "provider",
+        providerId: "openai.web_search_preview",
+        args: { searchContextSize: "high" },
+        supportsDeferredResults: true,
+        disabled: false,
+      },
+    });
+
+    expect(tool).toMatchObject({
+      name: "web_search",
+      type: "provider",
+      providerId: "openai.web_search_preview",
+      providerArgs: { searchContextSize: "high" },
+      supportsDeferredResults: true,
+      disabled: false,
+    });
+  });
+
+  it("retains the MCP server config and display mode", () => {
+    const [tool] = normalizeToolList({
+      list_repos: {
+        type: "mcp",
+        display: "standalone",
+        server: { type: "http", url: "https://mcp.example.com" },
+      },
+    });
+
+    expect(tool?.type).toBe("mcp");
+    expect(tool?.display).toBe("standalone");
+    expect(tool?.server).toEqual({
+      type: "http",
+      url: "https://mcp.example.com",
+    });
+  });
+
+  it("retains providerOptions and backend defaults", () => {
+    const [tool] = normalizeToolList({
+      submit: {
+        type: "frontend",
+        parameters: { type: "object" },
+        providerOptions: { openai: { strict: true } },
+        unstable_backendDefault: { parameters: true },
+      },
+    });
+
+    expect(tool?.providerOptions).toEqual({ openai: { strict: true } });
+    expect(tool?.backendDefault).toEqual({ parameters: true });
+    expect(tool?.parameters).toEqual({ type: "object" });
+  });
+
+  it("handles the array form", () => {
+    const tools = normalizeToolList([
+      { name: "a", type: "frontend" },
+      { name: "b", type: "backend", disabled: true },
+    ]);
+    expect(tools.map((t) => t.name)).toEqual(["a", "b"]);
+    expect(tools[1]?.disabled).toBe(true);
+  });
+
+  it("returns an empty list for non-objects", () => {
+    expect(normalizeToolList(undefined)).toEqual([]);
+    expect(normalizeToolList(null)).toEqual([]);
+  });
+});

--- a/packages/react-devtools/src/utils/toolNormalization.ts
+++ b/packages/react-devtools/src/utils/toolNormalization.ts
@@ -5,6 +5,13 @@ export type NormalizedTool = {
   type?: string;
   description?: string;
   disabled?: boolean;
+  display?: string;
+  providerId?: string;
+  supportsDeferredResults?: boolean;
+  backendDefault?: unknown;
+  providerOptions?: unknown;
+  providerArgs?: unknown;
+  server?: unknown;
   parameters?: unknown;
 };
 
@@ -39,6 +46,34 @@ const mapToNormalizedTool = (
 
   if (typeof raw.disabled === "boolean") {
     tool.disabled = raw.disabled as boolean;
+  }
+
+  if (typeof raw.display === "string") {
+    tool.display = raw.display as string;
+  }
+
+  if (typeof raw.providerId === "string") {
+    tool.providerId = raw.providerId as string;
+  }
+
+  if (typeof raw.supportsDeferredResults === "boolean") {
+    tool.supportsDeferredResults = raw.supportsDeferredResults as boolean;
+  }
+
+  if (raw.unstable_backendDefault !== undefined) {
+    tool.backendDefault = raw.unstable_backendDefault;
+  }
+
+  if (raw.providerOptions !== undefined) {
+    tool.providerOptions = raw.providerOptions;
+  }
+
+  if (raw.args !== undefined) {
+    tool.providerArgs = raw.args;
+  }
+
+  if (raw.server !== undefined) {
+    tool.server = raw.server;
   }
 
   if (Object.hasOwn(raw, "parameters")) {

--- a/packages/react-devtools/vitest.config.ts
+++ b/packages/react-devtools/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3468,6 +3468,9 @@ importers:
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/react-generative-ui:
     dependencies:
@@ -3510,7 +3513,7 @@ importers:
         version: link:../store
       '@google/adk':
         specifier: '>=0.5.0'
-        version: 1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+        version: 1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
       assistant-cloud:
         specifier: '*'
         version: link:../cloud
@@ -3535,7 +3538,7 @@ importers:
         version: 19.2.6
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/react-hook-form:
     dependencies:
@@ -18831,20 +18834,6 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
-  '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
-    dependencies:
-      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
-      '@google-cloud/precise-date': 4.0.0
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      googleapis: 137.1.0(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
       '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -18859,20 +18848,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
-    dependencies:
-      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
-      '@grpc/grpc-js': 1.14.4
-      '@grpc/proto-loader': 0.8.1
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-      google-auth-library: 9.15.1(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
       '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -18883,16 +18858,6 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
       google-auth-library: 9.15.1(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  '@google-cloud/opentelemetry-resource-util@3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
-    dependencies:
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      gcp-metadata: 6.1.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -18938,50 +18903,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  '@google/adk@1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
-    dependencies:
-      '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.12.0)(@grpc/grpc-js@1.14.4)(express@4.22.2)
-      '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
-      '@google-cloud/opentelemetry-cloud-trace-exporter': 3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
-      '@google-cloud/storage': 7.19.0(encoding@0.1.13)
-      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
-      '@mikro-orm/core': 6.6.14
-      '@mikro-orm/mariadb': 6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0)
-      '@mikro-orm/mssql': 6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0)
-      '@mikro-orm/mysql': 6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5)(pg@8.20.0)
-      '@mikro-orm/postgresql': 6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)
-      '@mikro-orm/reflection': 6.6.14(@mikro-orm/core@6.6.14)
-      '@mikro-orm/sqlite': 6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0)
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.205.0
-      '@opentelemetry/exporter-logs-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/exporter-trace-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resource-detector-gcp': 0.40.3(@opentelemetry/api@1.9.0)(encoding@0.1.13)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.0)
-      express: 4.22.2
-      google-auth-library: 10.6.2
-      js-yaml: 4.1.1
-      jsonpath-plus: 10.4.0
-      lodash-es: 4.18.1
-      winston: 3.19.0
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - '@bufbuild/protobuf'
-      - '@cfworker/json-schema'
-      - '@grpc/grpc-js'
-      - '@opentelemetry/core'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
 
   '@google/adk@1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)':
     dependencies:
@@ -30834,37 +30755,6 @@ snapshots:
   vitefu@1.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-
-  vitest@4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/runner': 4.1.7
-      '@vitest/snapshot': 4.1.7
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 25.9.1
-      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
-      '@vitest/ui': 4.1.7(vitest@4.1.7)
-      jsdom: 29.1.1
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## summary

- the devtools Model Context tab now renders the full tool registry: per-tool type, provider id (provider tools), MCP server config, providerOptions, deferred-results and backend-default flags, plus the model `config` block that was previously parsed but dropped. before, only name/type/description/disabled/parameters were shown.
- credentials are now redacted at the serializer boundary before they cross the postMessage bridge: `apiKey`, `authorization`/`x-api-key` headers, tokens, client secrets, and MCP server `headers`/`env` are masked to `[redacted]`, while non-secret lookalikes (`maxTokens`) and the parameters JSON schema are left intact. this resolves the credential-redaction follow-up deferred from #4288.
- implementation: widen `NormalizedTool` + the model-context serializer in `@assistant-ui/react-devtools`, and extract a dedicated rich model-context module in the frame (consistent with the message/mcp modules from #4288).

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-devtools test` -> 10/10 green (tool normalization, redaction, serializeModelContext)
- [x] `pnpm --filter @assistant-ui/devtools-frame test` -> 23/23 green
- [x] `pnpm --filter @assistant-ui/react-devtools build` and `--filter @assistant-ui/devtools-frame build` -> clean
- [x] `oxlint` + `oxfmt --check` + `tsc --noEmit` (both packages) -> clean

### reviewer should verify

- [ ] open the devtools Model Context tab against an app that registers provider tools and/or an MCP server, and confirm the richer per-tool fields render (type, provider id, server, providerOptions, params).
- [ ] confirm a tool whose providerOptions or MCP server headers carry an api key shows `[redacted]` in the panel, and that the raw secret never appears in the postMessage payload.

## notes

- touches the published `@assistant-ui/react-devtools` package (patch changeset included); the frame side ships on deploy. backward compatible (additive fields only), so an older host paired with the new frame degrades gracefully.