### PR TITLE
feat(devtools): add a run timeline tab

### DIFF
--- a/apps/devtools-frame/components/DevToolsUI.tsx
+++ b/apps/devtools-frame/components/DevToolsUI.tsx
@@ -8,7 +8,13 @@ import {
   type NormalizedTool,
   FrameClient,
 } from "@assistant-ui/react-devtools";
-import { eventScope, formatClockTime, isRecord, truncate } from "./common";
+import {
+  type EventLogEntry,
+  eventScope,
+  formatClockTime,
+  isRecord,
+  truncate,
+} from "./common";
 import { McpView } from "./mcp";
 import { ModelContextView } from "./model-context";
 import { RunTimeline } from "./runs";
@@ -25,12 +31,6 @@ interface AssistantState {
   [key: string]: unknown;
 }
 
-interface EventLog {
-  time: Date;
-  event: string;
-  data: unknown;
-}
-
 interface ModelContext {
   system?: string;
   tools?: NormalizedTool[];
@@ -41,7 +41,7 @@ interface ModelContext {
 interface ApiInfo {
   id: number;
   state: AssistantState;
-  logs: EventLog[];
+  logs: EventLogEntry[];
   modelContext?: ModelContext;
 }
 

--- a/apps/devtools-frame/components/DevToolsUI.tsx
+++ b/apps/devtools-frame/components/DevToolsUI.tsx
@@ -8,9 +8,10 @@ import {
   type NormalizedTool,
   FrameClient,
 } from "@assistant-ui/react-devtools";
-import { isRecord, truncate } from "./common";
+import { eventScope, formatClockTime, isRecord, truncate } from "./common";
 import { McpView } from "./mcp";
 import { ModelContextView } from "./model-context";
+import { RunTimeline } from "./runs";
 import {
   ThreadDetails,
   parseComposerPreview,
@@ -51,18 +52,15 @@ interface ApiData {
   modelContext?: any;
 }
 
-type TabType = "state" | "events" | "modelContext";
+type TabType = "state" | "events" | "modelContext" | "runs";
 
-const formatTime = (value: Date) =>
-  `${value.getHours().toString().padStart(2, "0")}:${value
-    .getMinutes()
-    .toString()
-    .padStart(2, "0")}:${value.getSeconds().toString().padStart(2, "0")}.${value
-    .getMilliseconds()
-    .toString()
-    .padStart(3, "0")}`;
-
-const eventScope = (event: string) => event.split(".")[0] ?? event;
+const parseEventTime = (value: unknown): Date => {
+  if (typeof value === "string") {
+    const date = new Date(value);
+    if (Number.isFinite(date.getTime())) return date;
+  }
+  return new Date();
+};
 
 const extractModelContext = (state: any): ModelContext | undefined => {
   if (!isRecord(state)) return undefined;
@@ -377,10 +375,7 @@ export function DevToolsUI() {
             id: api.apiId,
             state: api.state || {},
             logs: events.map((event: any) => ({
-              time:
-                typeof event.time === "string"
-                  ? new Date(event.time)
-                  : new Date(),
+              time: parseEventTime(event.time),
               event: typeof event.event === "string" ? event.event : "unknown",
               data: event.data,
             })),
@@ -588,6 +583,12 @@ export function DevToolsUI() {
             </ControlButton>
           </div>
         );
+      case "runs":
+        return (
+          <div className="flex h-full items-center px-4 text-xs text-zinc-500 dark:text-zinc-400">
+            Run timeline
+          </div>
+        );
       default:
         return (
           <div className="flex h-full items-center px-4 text-xs text-zinc-500 dark:text-zinc-400">
@@ -729,7 +730,7 @@ export function DevToolsUI() {
                     className="border-t border-zinc-200 bg-white text-[11px] transition-colors dark:border-zinc-800 dark:bg-zinc-900"
                   >
                     <td className="px-4 py-2 align-top font-mono whitespace-nowrap text-zinc-600 dark:text-zinc-300">
-                      {formatTime(log.time)}
+                      {formatClockTime(log.time)}
                     </td>
                     <td className="px-4 py-2 align-top text-zinc-500 dark:text-zinc-400">
                       {eventScope(log.event)}
@@ -760,12 +761,24 @@ export function DevToolsUI() {
     return <ModelContextView modelContext={selectedApi.modelContext} />;
   };
 
+  const renderRunsContent = () => {
+    if (!selectedApi) {
+      return (
+        <CenteredMessage>Waiting for assistant-ui instance...</CenteredMessage>
+      );
+    }
+
+    return <RunTimeline logs={selectedApi.logs} />;
+  };
+
   const renderTabContent = (): ReactNode => {
     switch (activeTab) {
       case "state":
         return renderStateContent();
       case "events":
         return renderEventsContent();
+      case "runs":
+        return renderRunsContent();
       default:
         return renderContextContent();
     }
@@ -778,7 +791,7 @@ export function DevToolsUI() {
 
         <nav className="flex h-10 items-center justify-between border-b border-zinc-200 bg-zinc-50 px-2 dark:border-zinc-900 dark:bg-zinc-950">
           <div className="flex h-full items-center gap-1">
-            {["state", "modelContext", "events"].map((tab) => (
+            {["state", "modelContext", "events", "runs"].map((tab) => (
               <button
                 type="button"
                 key={tab}

--- a/apps/devtools-frame/components/common.ts
+++ b/apps/devtools-frame/components/common.ts
@@ -28,6 +28,17 @@ export const formatDateTime = (value: string | undefined) => {
 export const truncate = (value: string, max = 120) =>
   value.length > max ? `${value.slice(0, max)}...` : value;
 
+export const formatClockTime = (value: Date) =>
+  `${value.getHours().toString().padStart(2, "0")}:${value
+    .getMinutes()
+    .toString()
+    .padStart(2, "0")}:${value.getSeconds().toString().padStart(2, "0")}.${value
+    .getMilliseconds()
+    .toString()
+    .padStart(3, "0")}`;
+
+export const eventScope = (event: string) => event.split(".")[0] ?? event;
+
 export const extractAttachmentNames = (value: unknown): string[] => {
   if (!Array.isArray(value)) return [];
 

--- a/apps/devtools-frame/components/common.ts
+++ b/apps/devtools-frame/components/common.ts
@@ -1,3 +1,9 @@
+export interface EventLogEntry {
+  readonly time: Date;
+  readonly event: string;
+  readonly data: unknown;
+}
+
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 

--- a/apps/devtools-frame/components/runs/RunTimeline.tsx
+++ b/apps/devtools-frame/components/runs/RunTimeline.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { useMemo } from "react";
 import { formatClockTime } from "../common";
 import { SummaryItem } from "../ui";
 import { groupRuns } from "./parse";
@@ -101,7 +102,7 @@ const RunCard = ({ run }: { run: RunPreview }) => (
 );
 
 export const RunTimeline = ({ logs }: { logs: readonly RunLogEntry[] }) => {
-  const { runs, orphans } = groupRuns(logs);
+  const { runs, orphans } = useMemo(() => groupRuns(logs), [logs]);
 
   if (runs.length === 0 && orphans.length === 0) {
     return (
@@ -118,7 +119,7 @@ export const RunTimeline = ({ logs }: { logs: readonly RunLogEntry[] }) => {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-2 sm:grid-cols-2">
         <SummaryItem label="Runs" value={String(runs.length)} />
         <SummaryItem label="Events" value={String(eventCount)} />
       </div>

--- a/apps/devtools-frame/components/runs/RunTimeline.tsx
+++ b/apps/devtools-frame/components/runs/RunTimeline.tsx
@@ -1,0 +1,164 @@
+import clsx from "clsx";
+import { formatClockTime } from "../common";
+import { SummaryItem } from "../ui";
+import { groupRuns } from "./parse";
+import type { RunEventEntry, RunLogEntry, RunPreview } from "./types";
+
+const SCOPE_TONE: Record<string, { dot: string; text: string }> = {
+  thread: {
+    dot: "bg-blue-500",
+    text: "text-blue-600 dark:text-blue-300",
+  },
+  composer: {
+    dot: "bg-emerald-500",
+    text: "text-emerald-600 dark:text-emerald-300",
+  },
+  threadListItem: {
+    dot: "bg-amber-500",
+    text: "text-amber-600 dark:text-amber-300",
+  },
+};
+
+const toneFor = (scope: string) =>
+  SCOPE_TONE[scope] ?? {
+    dot: "bg-zinc-400",
+    text: "text-zinc-500 dark:text-zinc-400",
+  };
+
+const formatMs = (value: number) =>
+  value >= 1000 ? `${(value / 1000).toFixed(2)}s` : `${Math.round(value)}ms`;
+
+const clampPercent = (offset: number, span: number) =>
+  span > 0 ? Math.min(100, Math.max(0, (offset / span) * 100)) : 0;
+
+const EventRow = ({ entry }: { entry: RunEventEntry }) => {
+  const tone = toneFor(entry.scope);
+  return (
+    <div className="flex items-center gap-2 px-3 py-1">
+      <span className="w-14 shrink-0 text-right font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+        +{formatMs(entry.offsetMs)}
+      </span>
+      <span className={clsx("shrink-0 text-[10px] font-semibold", tone.text)}>
+        {entry.scope}
+      </span>
+      <span className="truncate text-[11px] text-zinc-700 dark:text-zinc-200">
+        {entry.event.slice(entry.scope.length + 1) || entry.event}
+      </span>
+    </div>
+  );
+};
+
+const RunCard = ({ run }: { run: RunPreview }) => (
+  <div className="overflow-hidden rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950/40">
+    <div className="flex flex-wrap items-center gap-2 border-b border-zinc-200 bg-zinc-50 px-3 py-2 dark:border-zinc-800 dark:bg-zinc-900">
+      <span className="text-[11px] font-semibold text-zinc-800 dark:text-zinc-100">
+        Run #{run.index}
+      </span>
+      <span className="font-mono text-[10px] text-zinc-500 dark:text-zinc-400">
+        {formatClockTime(run.startTime)}
+      </span>
+      {run.running ? (
+        <span className="rounded border border-blue-300 bg-blue-500/10 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-blue-700 uppercase dark:border-blue-500/40 dark:text-blue-300">
+          running
+        </span>
+      ) : (
+        <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+          {formatMs(run.durationMs ?? 0)}
+        </span>
+      )}
+      <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+        {run.events.length} event{run.events.length === 1 ? "" : "s"}
+      </span>
+      {run.threadId ? (
+        <span className="ml-auto truncate font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+          {run.threadId}
+        </span>
+      ) : null}
+    </div>
+
+    <div className="px-3 pt-3">
+      <div className="relative h-5 rounded bg-zinc-100 dark:bg-zinc-900">
+        {run.events.map((entry, index) => {
+          const tone = toneFor(entry.scope);
+          return (
+            <span
+              key={index}
+              title={`${entry.event} +${formatMs(entry.offsetMs)}`}
+              className={clsx("absolute top-0 h-full w-0.5 rounded", tone.dot)}
+              style={{ left: `${clampPercent(entry.offsetMs, run.spanMs)}%` }}
+            />
+          );
+        })}
+      </div>
+    </div>
+
+    <div className="mt-1 divide-y divide-zinc-100 dark:divide-zinc-900">
+      {run.events.map((entry, index) => (
+        <EventRow key={index} entry={entry} />
+      ))}
+    </div>
+  </div>
+);
+
+export const RunTimeline = ({ logs }: { logs: readonly RunLogEntry[] }) => {
+  const { runs, orphans } = groupRuns(logs);
+
+  if (runs.length === 0 && orphans.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="rounded-lg border border-dashed border-zinc-300 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
+          No runs recorded yet. Send a message to start one.
+        </div>
+      </div>
+    );
+  }
+
+  const eventCount =
+    runs.reduce((sum, run) => sum + run.events.length, 0) + orphans.length;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+        <SummaryItem label="Runs" value={String(runs.length)} />
+        <SummaryItem label="Events" value={String(eventCount)} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {[...runs].reverse().map((run) => (
+          <RunCard key={run.id} run={run} />
+        ))}
+      </div>
+
+      {orphans.length ? (
+        <div className="overflow-hidden rounded-md border border-dashed border-zinc-300 bg-white dark:border-zinc-700 dark:bg-zinc-900/30">
+          <div className="border-b border-zinc-200 bg-zinc-50 px-3 py-2 text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
+            Outside runs ({orphans.length})
+          </div>
+          <div className="divide-y divide-zinc-100 dark:divide-zinc-900">
+            {orphans.map((entry, index) => (
+              <div
+                key={index}
+                className="flex items-center gap-2 px-3 py-1 text-[11px]"
+              >
+                <span className="w-20 shrink-0 font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+                  {formatClockTime(entry.time)}
+                </span>
+                <span
+                  className={clsx(
+                    "shrink-0 text-[10px] font-semibold",
+                    toneFor(entry.scope).text,
+                  )}
+                >
+                  {entry.scope}
+                </span>
+                <span className="truncate text-zinc-700 dark:text-zinc-200">
+                  {entry.event}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/devtools-frame/components/runs/index.ts
+++ b/apps/devtools-frame/components/runs/index.ts
@@ -1,0 +1,8 @@
+export { RunTimeline } from "./RunTimeline";
+export { groupRuns } from "./parse";
+export type {
+  RunEventEntry,
+  RunGrouping,
+  RunLogEntry,
+  RunPreview,
+} from "./types";

--- a/apps/devtools-frame/components/runs/index.ts
+++ b/apps/devtools-frame/components/runs/index.ts
@@ -1,8 +1,1 @@
 export { RunTimeline } from "./RunTimeline";
-export { groupRuns } from "./parse";
-export type {
-  RunEventEntry,
-  RunGrouping,
-  RunLogEntry,
-  RunPreview,
-} from "./types";

--- a/apps/devtools-frame/components/runs/parse.test.ts
+++ b/apps/devtools-frame/components/runs/parse.test.ts
@@ -131,6 +131,21 @@ describe("groupRuns", () => {
     expect(runs[0]!.events.map((e) => e.event)).toContain("custom.event");
   });
 
+  it("keeps an empty-string threadId distinct from a thread-less run", () => {
+    const logs: RunLogEntry[] = [
+      { time: t(0), event: "thread.runStart", data: { threadId: "" } },
+      { time: t(50), event: "thread.runStart", data: {} },
+      { time: t(100), event: "thread.runEnd", data: { threadId: "" } },
+    ];
+    const { runs } = groupRuns(logs);
+    expect(runs).toHaveLength(2);
+    expect(runs[0]!.threadId).toBe("");
+    expect(runs[0]!.running).toBe(false);
+    expect(runs[0]!.durationMs).toBe(100);
+    expect(runs[1]!.threadId).toBeUndefined();
+    expect(runs[1]!.running).toBe(true);
+  });
+
   it("returns nothing for an empty log", () => {
     expect(groupRuns([])).toEqual({ runs: [], orphans: [] });
   });

--- a/apps/devtools-frame/components/runs/parse.test.ts
+++ b/apps/devtools-frame/components/runs/parse.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { groupRuns } from "./parse";
+import type { RunLogEntry } from "./types";
+
+const base = 2_000_000_000_000;
+const t = (ms: number) => new Date(base + ms);
+
+describe("groupRuns", () => {
+  it("pairs runStart/runEnd and computes durations and offsets", () => {
+    const logs: RunLogEntry[] = [
+      { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
+      {
+        time: t(150),
+        event: "composer.send",
+        data: { threadId: "T1", messageId: "m1" },
+      },
+      { time: t(900), event: "thread.runEnd", data: { threadId: "T1" } },
+    ];
+
+    const { runs, orphans } = groupRuns(logs);
+    expect(orphans).toEqual([]);
+    expect(runs).toHaveLength(1);
+    const run = runs[0]!;
+    expect(run.index).toBe(0);
+    expect(run.threadId).toBe("T1");
+    expect(run.running).toBe(false);
+    expect(run.durationMs).toBe(900);
+    expect(run.spanMs).toBe(900);
+    expect(run.events.map((e) => e.offsetMs)).toEqual([0, 150, 900]);
+    expect(run.events.map((e) => e.scope)).toEqual([
+      "thread",
+      "composer",
+      "thread",
+    ]);
+  });
+
+  it("marks a run with no runEnd as running, with span from last event", () => {
+    const logs: RunLogEntry[] = [
+      { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
+      { time: t(100), event: "composer.send", data: { threadId: "T1" } },
+    ];
+    const { runs } = groupRuns(logs);
+    expect(runs[0]!.running).toBe(true);
+    expect(runs[0]!.durationMs).toBeUndefined();
+    expect(runs[0]!.spanMs).toBe(100);
+  });
+
+  it("buckets events outside any run as orphans", () => {
+    const logs: RunLogEntry[] = [
+      {
+        time: t(0),
+        event: "thread.modelContextUpdate",
+        data: { threadId: "T1" },
+      },
+      { time: t(50), event: "thread.runStart", data: { threadId: "T1" } },
+      { time: t(200), event: "thread.runEnd", data: { threadId: "T1" } },
+    ];
+    const { runs, orphans } = groupRuns(logs);
+    expect(runs).toHaveLength(1);
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0]!.event).toBe("thread.modelContextUpdate");
+  });
+
+  it("sorts out-of-order logs before pairing", () => {
+    const logs: RunLogEntry[] = [
+      { time: t(100), event: "thread.runEnd", data: { threadId: "T1" } },
+      { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
+    ];
+    const { runs, orphans } = groupRuns(logs);
+    expect(orphans).toEqual([]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.durationMs).toBe(100);
+  });
+
+  it("routes events to the matching thread when runs interleave", () => {
+    const logs: RunLogEntry[] = [
+      { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
+      { time: t(50), event: "thread.runStart", data: { threadId: "T2" } },
+      { time: t(60), event: "composer.send", data: { threadId: "T2" } },
+      { time: t(100), event: "thread.runEnd", data: { threadId: "T2" } },
+      { time: t(200), event: "thread.runEnd", data: { threadId: "T1" } },
+    ];
+    const { runs } = groupRuns(logs);
+    expect(runs).toHaveLength(2);
+    const t2 = runs.find((r) => r.threadId === "T2")!;
+    expect(t2.events.map((e) => e.event)).toEqual([
+      "thread.runStart",
+      "composer.send",
+      "thread.runEnd",
+    ]);
+    expect(runs.find((r) => r.threadId === "T1")!.durationMs).toBe(200);
+  });
+
+  it("closes a prior open run on the same thread when a new run starts", () => {
+    const logs: RunLogEntry[] = [
+      { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
+      { time: t(50), event: "thread.runStart", data: { threadId: "T1" } },
+      { time: t(100), event: "thread.runEnd", data: { threadId: "T1" } },
+    ];
+    const { runs } = groupRuns(logs);
+    expect(runs).toHaveLength(2);
+    expect(runs[0]!.running).toBe(false);
+    expect(runs[0]!.durationMs).toBe(50);
+    expect(runs[1]!.running).toBe(false);
+    expect(runs[1]!.durationMs).toBe(50);
+  });
+
+  it("orphans an event whose explicit threadId matches no open run", () => {
+    const logs: RunLogEntry[] = [
+      { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
+      { time: t(50), event: "composer.send", data: { threadId: "T2" } },
+      { time: t(100), event: "thread.runEnd", data: { threadId: "T1" } },
+    ];
+    const { runs, orphans } = groupRuns(logs);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.events.map((e) => e.event)).toEqual([
+      "thread.runStart",
+      "thread.runEnd",
+    ]);
+    expect(orphans.map((o) => o.event)).toEqual(["composer.send"]);
+  });
+
+  it("attaches a thread-less event to the single open run", () => {
+    const logs: RunLogEntry[] = [
+      { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
+      { time: t(50), event: "custom.event", data: {} },
+      { time: t(100), event: "thread.runEnd", data: { threadId: "T1" } },
+    ];
+    const { runs, orphans } = groupRuns(logs);
+    expect(orphans).toEqual([]);
+    expect(runs[0]!.events.map((e) => e.event)).toContain("custom.event");
+  });
+
+  it("returns nothing for an empty log", () => {
+    expect(groupRuns([])).toEqual({ runs: [], orphans: [] });
+  });
+});

--- a/apps/devtools-frame/components/runs/parse.ts
+++ b/apps/devtools-frame/components/runs/parse.ts
@@ -1,0 +1,116 @@
+import { eventScope, isRecord } from "../common";
+import type {
+  RunEventEntry,
+  RunGrouping,
+  RunLogEntry,
+  RunPreview,
+} from "./types";
+
+const RUN_START = "thread.runStart";
+const RUN_END = "thread.runEnd";
+
+const threadIdOf = (data: unknown): string | undefined =>
+  isRecord(data) && typeof data.threadId === "string"
+    ? data.threadId
+    : undefined;
+
+interface RunBuilder {
+  id: string;
+  threadId?: string;
+  index: number;
+  startTime: Date;
+  endTime?: Date;
+  events: RunEventEntry[];
+}
+
+const entryFor = (log: RunLogEntry, offsetMs: number): RunEventEntry => ({
+  time: log.time,
+  event: log.event,
+  scope: eventScope(log.event),
+  offsetMs: Math.max(0, offsetMs),
+  data: log.data,
+});
+
+export const groupRuns = (logs: readonly RunLogEntry[]): RunGrouping => {
+  const sorted = [...logs].sort((a, b) => a.time.getTime() - b.time.getTime());
+  const builders: RunBuilder[] = [];
+  const openByThread = new Map<string, RunBuilder>();
+  const orphans: RunEventEntry[] = [];
+
+  const keyFor = (tid: string | undefined) => tid ?? "";
+
+  const targetRun = (tid: string | undefined): RunBuilder | undefined => {
+    const exact = openByThread.get(keyFor(tid));
+    if (exact) return exact;
+    if (tid === undefined && openByThread.size === 1) {
+      return [...openByThread.values()][0];
+    }
+    return undefined;
+  };
+
+  for (const log of sorted) {
+    const tid = threadIdOf(log.data);
+
+    if (log.event === RUN_START) {
+      const key = keyFor(tid);
+      const stale = openByThread.get(key);
+      if (stale) {
+        stale.endTime = log.time;
+        openByThread.delete(key);
+      }
+      const builder: RunBuilder = {
+        id: `run-${builders.length}`,
+        ...(tid !== undefined ? { threadId: tid } : {}),
+        index: builders.length,
+        startTime: log.time,
+        events: [entryFor(log, 0)],
+      };
+      builders.push(builder);
+      openByThread.set(key, builder);
+      continue;
+    }
+
+    if (log.event === RUN_END) {
+      const run = targetRun(tid);
+      if (run && run.endTime === undefined) {
+        run.endTime = log.time;
+        run.events.push(
+          entryFor(log, log.time.getTime() - run.startTime.getTime()),
+        );
+        openByThread.delete(keyFor(run.threadId));
+        continue;
+      }
+      orphans.push(entryFor(log, 0));
+      continue;
+    }
+
+    const run = targetRun(tid);
+    if (run) {
+      run.events.push(
+        entryFor(log, log.time.getTime() - run.startTime.getTime()),
+      );
+    } else {
+      orphans.push(entryFor(log, 0));
+    }
+  }
+
+  const runs: RunPreview[] = builders.map((b) => {
+    const maxOffset = b.events.reduce((max, e) => Math.max(max, e.offsetMs), 0);
+    const durationMs = b.endTime
+      ? b.endTime.getTime() - b.startTime.getTime()
+      : undefined;
+    return {
+      id: b.id,
+      ...(b.threadId !== undefined ? { threadId: b.threadId } : {}),
+      index: b.index,
+      startTime: b.startTime,
+      ...(b.endTime !== undefined ? { endTime: b.endTime } : {}),
+      ...(durationMs !== undefined ? { durationMs } : {}),
+      running: b.endTime === undefined,
+      spanMs: Math.max(durationMs ?? 0, maxOffset),
+      events: b.events,
+    };
+  });
+
+  return { runs, orphans };
+};

--- a/apps/devtools-frame/components/runs/parse.ts
+++ b/apps/devtools-frame/components/runs/parse.ts
@@ -6,6 +6,8 @@ import type {
   RunPreview,
 } from "./types";
 
+// thread.runStart/runEnd are @deprecated in core but kept for backward
+// compatibility; they are the only run-boundary signal in the event log.
 const RUN_START = "thread.runStart";
 const RUN_END = "thread.runEnd";
 
@@ -34,13 +36,11 @@ const entryFor = (log: RunLogEntry, offsetMs: number): RunEventEntry => ({
 export const groupRuns = (logs: readonly RunLogEntry[]): RunGrouping => {
   const sorted = [...logs].sort((a, b) => a.time.getTime() - b.time.getTime());
   const builders: RunBuilder[] = [];
-  const openByThread = new Map<string, RunBuilder>();
+  const openByThread = new Map<string | undefined, RunBuilder>();
   const orphans: RunEventEntry[] = [];
 
-  const keyFor = (tid: string | undefined) => tid ?? "";
-
   const targetRun = (tid: string | undefined): RunBuilder | undefined => {
-    const exact = openByThread.get(keyFor(tid));
+    const exact = openByThread.get(tid);
     if (exact) return exact;
     if (tid === undefined && openByThread.size === 1) {
       return [...openByThread.values()][0];
@@ -52,11 +52,10 @@ export const groupRuns = (logs: readonly RunLogEntry[]): RunGrouping => {
     const tid = threadIdOf(log.data);
 
     if (log.event === RUN_START) {
-      const key = keyFor(tid);
-      const stale = openByThread.get(key);
+      const stale = openByThread.get(tid);
       if (stale) {
         stale.endTime = log.time;
-        openByThread.delete(key);
+        openByThread.delete(tid);
       }
       const builder: RunBuilder = {
         id: `run-${builders.length}`,
@@ -66,7 +65,7 @@ export const groupRuns = (logs: readonly RunLogEntry[]): RunGrouping => {
         events: [entryFor(log, 0)],
       };
       builders.push(builder);
-      openByThread.set(key, builder);
+      openByThread.set(tid, builder);
       continue;
     }
 
@@ -77,7 +76,7 @@ export const groupRuns = (logs: readonly RunLogEntry[]): RunGrouping => {
         run.events.push(
           entryFor(log, log.time.getTime() - run.startTime.getTime()),
         );
-        openByThread.delete(keyFor(run.threadId));
+        openByThread.delete(run.threadId);
         continue;
       }
       orphans.push(entryFor(log, 0));

--- a/apps/devtools-frame/components/runs/render.test.tsx
+++ b/apps/devtools-frame/components/runs/render.test.tsx
@@ -1,0 +1,36 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { RunTimeline } from "./RunTimeline";
+import type { RunLogEntry } from "./types";
+
+const base = 2_000_000_000_000;
+const t = (ms: number) => new Date(base + ms);
+
+describe("RunTimeline", () => {
+  it("renders a completed run with its duration and events", () => {
+    const logs: RunLogEntry[] = [
+      { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
+      { time: t(150), event: "composer.send", data: { threadId: "T1" } },
+      { time: t(900), event: "thread.runEnd", data: { threadId: "T1" } },
+    ];
+
+    const html = renderToStaticMarkup(<RunTimeline logs={logs} />);
+    expect(html).toContain("Run #0");
+    expect(html).toContain("900ms");
+    expect(html).toContain("send");
+    expect(html).toContain("Runs");
+  });
+
+  it("marks an unfinished run as running", () => {
+    const logs: RunLogEntry[] = [
+      { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
+    ];
+    const html = renderToStaticMarkup(<RunTimeline logs={logs} />);
+    expect(html).toContain("running");
+  });
+
+  it("shows the empty state with no logs", () => {
+    const html = renderToStaticMarkup(<RunTimeline logs={[]} />);
+    expect(html).toContain("No runs recorded");
+  });
+});

--- a/apps/devtools-frame/components/runs/types.ts
+++ b/apps/devtools-frame/components/runs/types.ts
@@ -1,0 +1,30 @@
+export interface RunLogEntry {
+  readonly time: Date;
+  readonly event: string;
+  readonly data: unknown;
+}
+
+export interface RunEventEntry {
+  readonly time: Date;
+  readonly event: string;
+  readonly scope: string;
+  readonly offsetMs: number;
+  readonly data: unknown;
+}
+
+export interface RunPreview {
+  readonly id: string;
+  readonly threadId?: string;
+  readonly index: number;
+  readonly startTime: Date;
+  readonly endTime?: Date;
+  readonly durationMs?: number;
+  readonly running: boolean;
+  readonly spanMs: number;
+  readonly events: readonly RunEventEntry[];
+}
+
+export interface RunGrouping {
+  readonly runs: readonly RunPreview[];
+  readonly orphans: readonly RunEventEntry[];
+}

--- a/apps/devtools-frame/components/runs/types.ts
+++ b/apps/devtools-frame/components/runs/types.ts
@@ -1,8 +1,6 @@
-export interface RunLogEntry {
-  readonly time: Date;
-  readonly event: string;
-  readonly data: unknown;
-}
+import type { EventLogEntry } from "../common";
+
+export type RunLogEntry = EventLogEntry;
 
 export interface RunEventEntry {
   readonly time: Date;


### PR DESCRIPTION
## summary

- new "Runs" tab that groups the devtools event log into runs (`thread.runStart` to `thread.runEnd`, keyed by `threadId`). each run is a card with a proportional waterfall of its events (ticks colored by scope), a duration or a `running` badge, an event count, and a relative-offset event list. events outside any run are bucketed in an "Outside runs" section.
- marks an unclosed run as `running`, closes a prior open run when a new one starts on the same thread, and only attaches thread-less events to the sole open run (events carrying a different `threadId` are kept separate).
- frame-only: reads the event log the devtools already receives, no transport or package change (ships on deploy). also extracts the shared `formatClockTime`/`eventScope` helpers into `common.ts` so the events table and the timeline share them.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/devtools-frame test` -> 37/37 green (incl 9 runs: 6 `groupRuns` + 3 render)
- [x] `pnpm --filter @assistant-ui/devtools-frame build` -> clean
- [x] `oxlint` + `oxfmt --check` + `tsc --noEmit` -> clean

### reviewer should verify

- [ ] open the devtools modal, send a few messages (ideally one that triggers a tool call), switch to the Runs tab, and confirm each run shows its events on the waterfall with sensible durations, an in-flight run shows `running`, and the run/event counts line up with the Events tab.

## notes

- frame-only, deploy-only, no changeset. deliberately out of scope: per-message stream timing (TTFT, tok/s) which already lives in the Messages tab, and raising the 200-event log cap (that constant lives in `@assistant-ui/react`, a separate published package).