### PR TITLE
feat(devtools): scope graph tab with per-scope method catalog

### DIFF
--- a/.changeset/devtools-scope-graph.md
+++ b/.changeset/devtools-scope-graph.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-devtools": patch
+---
+
+feat: forward the scope graph from the host (each accessor's name, source, query, and available method names) so the devtools frame can show a Scopes tab with the scope hierarchy and a per-scope read-only method catalog

--- a/apps/devtools-frame/components/DevToolsUI.tsx
+++ b/apps/devtools-frame/components/DevToolsUI.tsx
@@ -18,6 +18,7 @@ import {
 import { McpView } from "./mcp";
 import { ModelContextView } from "./model-context";
 import { RunTimeline } from "./runs";
+import { ScopesView } from "./scopes";
 import {
   ThreadDetails,
   parseComposerPreview,
@@ -43,6 +44,7 @@ interface ApiInfo {
   state: AssistantState;
   logs: EventLogEntry[];
   modelContext?: ModelContext;
+  scopes?: unknown;
 }
 
 interface ApiData {
@@ -50,9 +52,10 @@ interface ApiData {
   state: any;
   events: any[];
   modelContext?: any;
+  scopes?: any;
 }
 
-type TabType = "state" | "events" | "modelContext" | "runs";
+type TabType = "state" | "events" | "modelContext" | "runs" | "scopes";
 
 const parseEventTime = (value: unknown): Date => {
   if (typeof value === "string") {
@@ -380,6 +383,7 @@ export function DevToolsUI() {
               data: event.data,
             })),
             modelContext: api.modelContext || extractModelContext(api.state),
+            scopes: api.scopes,
           };
         }) ?? [];
       setApis(convertedApis);
@@ -589,6 +593,12 @@ export function DevToolsUI() {
             Run timeline
           </div>
         );
+      case "scopes":
+        return (
+          <div className="flex h-full items-center px-4 text-xs text-zinc-500 dark:text-zinc-400">
+            Scope graph
+          </div>
+        );
       default:
         return (
           <div className="flex h-full items-center px-4 text-xs text-zinc-500 dark:text-zinc-400">
@@ -771,6 +781,16 @@ export function DevToolsUI() {
     return <RunTimeline logs={selectedApi.logs} />;
   };
 
+  const renderScopesContent = () => {
+    if (!selectedApi) {
+      return (
+        <CenteredMessage>Waiting for assistant-ui instance...</CenteredMessage>
+      );
+    }
+
+    return <ScopesView scopes={selectedApi.scopes} />;
+  };
+
   const renderTabContent = (): ReactNode => {
     switch (activeTab) {
       case "state":
@@ -779,6 +799,8 @@ export function DevToolsUI() {
         return renderEventsContent();
       case "runs":
         return renderRunsContent();
+      case "scopes":
+        return renderScopesContent();
       default:
         return renderContextContent();
     }
@@ -791,21 +813,23 @@ export function DevToolsUI() {
 
         <nav className="flex h-10 items-center justify-between border-b border-zinc-200 bg-zinc-50 px-2 dark:border-zinc-900 dark:bg-zinc-950">
           <div className="flex h-full items-center gap-1">
-            {["state", "modelContext", "events", "runs"].map((tab) => (
-              <button
-                type="button"
-                key={tab}
-                onClick={() => setActiveTab(tab as TabType)}
-                className={clsx(
-                  "flex h-full items-center px-2.5 text-[11px] font-semibold tracking-wide text-zinc-500 uppercase transition-colors",
-                  activeTab === tab
-                    ? "border-b-2 border-blue-500 text-zinc-900 dark:border-blue-400 dark:text-zinc-100"
-                    : "border-b-2 border-transparent hover:text-zinc-700 dark:hover:text-zinc-200",
-                )}
-              >
-                {tab === "modelContext" ? "Model Context" : tab}
-              </button>
-            ))}
+            {["state", "modelContext", "events", "runs", "scopes"].map(
+              (tab) => (
+                <button
+                  type="button"
+                  key={tab}
+                  onClick={() => setActiveTab(tab as TabType)}
+                  className={clsx(
+                    "flex h-full items-center px-2.5 text-[11px] font-semibold tracking-wide text-zinc-500 uppercase transition-colors",
+                    activeTab === tab
+                      ? "border-b-2 border-blue-500 text-zinc-900 dark:border-blue-400 dark:text-zinc-100"
+                      : "border-b-2 border-transparent hover:text-zinc-700 dark:hover:text-zinc-200",
+                  )}
+                >
+                  {tab === "modelContext" ? "Model Context" : tab}
+                </button>
+              ),
+            )}
           </div>
           {renderTabControls()}
         </nav>

--- a/apps/devtools-frame/components/scopes/ScopesView.tsx
+++ b/apps/devtools-frame/components/scopes/ScopesView.tsx
@@ -82,10 +82,7 @@ export const ScopesView = ({ scopes }: { scopes?: unknown }) => {
       </div>
       <div className="flex flex-col gap-2">
         {list.map((scope) => (
-          <ScopeCard
-            key={`${scope.source ?? "null"}-${scope.name}`}
-            scope={scope}
-          />
+          <ScopeCard key={scope.name} scope={scope} />
         ))}
       </div>
     </div>

--- a/apps/devtools-frame/components/scopes/ScopesView.tsx
+++ b/apps/devtools-frame/components/scopes/ScopesView.tsx
@@ -1,0 +1,93 @@
+import { isRecord } from "../common";
+import { SummaryItem } from "../ui";
+import { parseScopes } from "./parse";
+import type { ScopePreview } from "./types";
+
+const SourceBadge = ({ source }: { source: string | null }) => {
+  if (!source) return null;
+  if (source === "root") {
+    return (
+      <span className="rounded border border-emerald-300 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-emerald-700 uppercase dark:border-emerald-500/40 dark:text-emerald-300">
+        root
+      </span>
+    );
+  }
+  return (
+    <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+      ← {source}
+    </span>
+  );
+};
+
+const ScopeCard = ({ scope }: { scope: ScopePreview }) => {
+  const hasQuery = isRecord(scope.query) && Object.keys(scope.query).length > 0;
+
+  return (
+    <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] dark:border-zinc-800 dark:bg-zinc-900/40">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-semibold text-zinc-800 dark:text-zinc-100">
+          {scope.name}
+        </span>
+        <SourceBadge source={scope.source} />
+        {hasQuery ? (
+          <span className="font-mono text-[10px] text-zinc-500 dark:text-zinc-400">
+            {JSON.stringify(scope.query)}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="mt-2 text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
+        Methods ({scope.methods.length})
+      </div>
+      {scope.methods.length ? (
+        <div className="mt-1 flex flex-wrap gap-1">
+          {scope.methods.map((method) => (
+            <span
+              key={method}
+              className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200"
+            >
+              {method}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-1 text-zinc-400">No methods.</div>
+      )}
+    </div>
+  );
+};
+
+export const ScopesView = ({ scopes }: { scopes?: unknown }) => {
+  const list = parseScopes(scopes);
+
+  if (list.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="rounded-lg border border-dashed border-zinc-300 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
+          No scopes reported. Update `@assistant-ui/react-devtools` to forward
+          the scope graph.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid gap-2 sm:grid-cols-2">
+        <SummaryItem label="Scopes" value={String(list.length)} />
+        <SummaryItem
+          label="Roots"
+          value={String(list.filter((s) => s.source === "root").length)}
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        {list.map((scope) => (
+          <ScopeCard
+            key={`${scope.source ?? "null"}-${scope.name}`}
+            scope={scope}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/apps/devtools-frame/components/scopes/index.ts
+++ b/apps/devtools-frame/components/scopes/index.ts
@@ -1,0 +1,1 @@
+export { ScopesView } from "./ScopesView";

--- a/apps/devtools-frame/components/scopes/parse.test.ts
+++ b/apps/devtools-frame/components/scopes/parse.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { parseScopes } from "./parse";
+
+describe("parseScopes", () => {
+  it("parses scopes and sorts root first, then by name", () => {
+    const out = parseScopes([
+      {
+        name: "thread",
+        source: "threads",
+        query: { type: "main" },
+        methods: ["getState", "append"],
+      },
+      { name: "threads", source: "root", query: {}, methods: ["getState"] },
+    ]);
+
+    expect(out.map((s) => s.name)).toEqual(["threads", "thread"]);
+    expect(out[0]!.source).toBe("root");
+    expect(out[1]!.query).toEqual({ type: "main" });
+    expect(out[1]!.methods).toEqual(["getState", "append"]);
+  });
+
+  it("filters non-string methods and defaults a missing source to null", () => {
+    const out = parseScopes([{ name: "x", methods: ["a", 1, null, "b"] }]);
+    expect(out[0]!.methods).toEqual(["a", "b"]);
+    expect(out[0]!.source).toBeNull();
+  });
+
+  it("drops entries without a name and returns [] for non-arrays", () => {
+    expect(parseScopes([{ source: "root" }, 5, null])).toEqual([]);
+    expect(parseScopes(undefined)).toEqual([]);
+    expect(parseScopes(null)).toEqual([]);
+    expect(parseScopes(42)).toEqual([]);
+    expect(parseScopes({})).toEqual([]);
+  });
+});

--- a/apps/devtools-frame/components/scopes/parse.ts
+++ b/apps/devtools-frame/components/scopes/parse.ts
@@ -1,14 +1,10 @@
-import { isRecord } from "../common";
+import { isRecord, isStringArray } from "../common";
 import type { ScopePreview } from "./types";
 
 const parseScope = (value: unknown): ScopePreview | null => {
   if (!isRecord(value) || typeof value.name !== "string") return null;
 
-  const methods = Array.isArray(value.methods)
-    ? value.methods.filter(
-        (method): method is string => typeof method === "string",
-      )
-    : [];
+  const methods = isStringArray(value.methods);
 
   return {
     name: value.name,
@@ -25,7 +21,8 @@ export const parseScopes = (value: unknown): ScopePreview[] => {
     .map((scope) => parseScope(scope))
     .filter((scope): scope is ScopePreview => Boolean(scope));
 
-  // Root scopes first, then by name, so the graph reads parent-before-child.
+  // Root scopes first, then alphabetically by name. This is not a full
+  // hierarchy sort: a derived scope can sort before its parent.
   return scopes.sort((a, b) => {
     const rootDelta = Number(b.source === "root") - Number(a.source === "root");
     return rootDelta !== 0 ? rootDelta : a.name.localeCompare(b.name);

--- a/apps/devtools-frame/components/scopes/parse.ts
+++ b/apps/devtools-frame/components/scopes/parse.ts
@@ -1,0 +1,33 @@
+import { isRecord } from "../common";
+import type { ScopePreview } from "./types";
+
+const parseScope = (value: unknown): ScopePreview | null => {
+  if (!isRecord(value) || typeof value.name !== "string") return null;
+
+  const methods = Array.isArray(value.methods)
+    ? value.methods.filter(
+        (method): method is string => typeof method === "string",
+      )
+    : [];
+
+  return {
+    name: value.name,
+    source: typeof value.source === "string" ? value.source : null,
+    query: value.query,
+    methods,
+  };
+};
+
+export const parseScopes = (value: unknown): ScopePreview[] => {
+  if (!Array.isArray(value)) return [];
+
+  const scopes = value
+    .map((scope) => parseScope(scope))
+    .filter((scope): scope is ScopePreview => Boolean(scope));
+
+  // Root scopes first, then by name, so the graph reads parent-before-child.
+  return scopes.sort((a, b) => {
+    const rootDelta = Number(b.source === "root") - Number(a.source === "root");
+    return rootDelta !== 0 ? rootDelta : a.name.localeCompare(b.name);
+  });
+};

--- a/apps/devtools-frame/components/scopes/render.test.tsx
+++ b/apps/devtools-frame/components/scopes/render.test.tsx
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ScopesView } from "./ScopesView";
+
+describe("ScopesView", () => {
+  it("renders scope names, source, query, and methods", () => {
+    const html = renderToStaticMarkup(
+      <ScopesView
+        scopes={[
+          { name: "threads", source: "root", query: {}, methods: ["getState"] },
+          {
+            name: "composer",
+            source: "thread",
+            query: { type: "main" },
+            methods: ["send", "setText"],
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("threads");
+    expect(html).toContain("root");
+    expect(html).toContain("composer");
+    expect(html).toContain("send");
+    expect(html).toContain("setText");
+    // the query renders as escaped JSON ({&quot;type&quot;:&quot;main&quot;})
+    expect(html).toContain("type");
+    expect(html).toContain("main");
+  });
+
+  it("shows an empty state when no scopes are reported", () => {
+    const html = renderToStaticMarkup(<ScopesView scopes={undefined} />);
+    expect(html).toContain("No scopes reported");
+  });
+});

--- a/apps/devtools-frame/components/scopes/types.ts
+++ b/apps/devtools-frame/components/scopes/types.ts
@@ -1,0 +1,6 @@
+export interface ScopePreview {
+  readonly name: string;
+  readonly source: string | null;
+  readonly query: unknown;
+  readonly methods: readonly string[];
+}

--- a/packages/react-devtools/src/DevToolsHost.ts
+++ b/packages/react-devtools/src/DevToolsHost.ts
@@ -1,5 +1,6 @@
 import { DevToolsHooks } from "@assistant-ui/react";
 import {
+  redactSensitive,
   sanitizeForMessage,
   serializeModelContext,
 } from "./utils/serialization";
@@ -22,6 +23,7 @@ interface HostToFrameMessage {
       state: any;
       events: any[];
       modelContext?: any;
+      scopes?: any;
     }>;
   };
 }
@@ -106,16 +108,41 @@ export class DevToolsHost {
       for (const apiId of this.subscription.apis) {
         const apiEntry = allApis.get(apiId);
         if (apiEntry) {
-          // Collect state from api scopes (only root source)
+          // Collect root-scope state plus the identity and method catalog of
+          // every accessor (root and derived) for the scope graph.
           const state: Record<string, unknown> = {};
+          const scopes: Array<{
+            name: string;
+            source: string | null;
+            query: Record<string, unknown> | null;
+            methods: string[];
+          }> = [];
           if (apiEntry.api) {
             for (const [name, scope] of Object.entries(apiEntry.api)) {
               if (typeof scope === "function" && "source" in scope) {
-                // Only forward scopes with source === "root"
-                if (scope.source === "root") {
+                let methods: string[] = [];
+                try {
                   const scopeValue = scope();
-                  state[name] = scopeValue?.getState?.() ?? scopeValue;
+                  if (scopeValue && typeof scopeValue === "object") {
+                    methods = Object.keys(scopeValue).filter(
+                      (key) =>
+                        typeof (scopeValue as Record<string, unknown>)[key] ===
+                        "function",
+                    );
+                  }
+                  if (scope.source === "root") {
+                    state[name] = scopeValue?.getState?.() ?? scopeValue;
+                  }
+                } catch {
+                  // scope() may throw (derived scopes before the client is
+                  // mounted, or a broken root scope implementation).
                 }
+                scopes.push({
+                  name,
+                  source: scope.source,
+                  query: scope.query,
+                  methods,
+                });
               }
             }
           }
@@ -130,6 +157,7 @@ export class DevToolsHost {
             state: sanitizeForMessage(state),
             events: sanitizeForMessage(apiEntry.logs) as unknown[],
             modelContext: modelContext,
+            scopes: redactSensitive(sanitizeForMessage(scopes)),
           });
         }
       }

--- a/packages/react-devtools/src/DevToolsHost.ts
+++ b/packages/react-devtools/src/DevToolsHost.ts
@@ -1,6 +1,6 @@
 import { DevToolsHooks } from "@assistant-ui/react";
 import {
-  redactSensitive,
+  sanitizeAndRedact,
   sanitizeForMessage,
   serializeModelContext,
 } from "./utils/serialization";
@@ -157,7 +157,7 @@ export class DevToolsHost {
             state: sanitizeForMessage(state),
             events: sanitizeForMessage(apiEntry.logs) as unknown[],
             modelContext: modelContext,
-            scopes: redactSensitive(sanitizeForMessage(scopes)),
+            scopes: sanitizeAndRedact(scopes),
           });
         }
       }

--- a/packages/react-devtools/src/FrameClient.ts
+++ b/packages/react-devtools/src/FrameClient.ts
@@ -2,7 +2,8 @@ interface ApiData {
   apiId: number;
   state: any;
   events: any[];
-  context?: any;
+  modelContext?: any;
+  scopes?: any;
 }
 
 interface UpdateMessage {

--- a/packages/react-devtools/src/utils/serialization.ts
+++ b/packages/react-devtools/src/utils/serialization.ts
@@ -112,7 +112,7 @@ export const redactSensitive = (value: unknown, maskAll = false): unknown => {
   return maskAll ? REDACTED : value;
 };
 
-const sanitizeAndRedact = (value: unknown): unknown =>
+export const sanitizeAndRedact = (value: unknown): unknown =>
   redactSensitive(sanitizeForMessage(value));
 
 export const serializeModelContext = (


### PR DESCRIPTION
## summary

- new "Scopes" tab showing the assistant-ui scope graph: every registered scope with its name, `source → query` (so you can see e.g. that `composer` resolves from `thread`, which resolves from `threads` via `{type:"main"}`), and its available methods as a read-only catalog. before, the devtools only forwarded root-scope state, so the derived scopes and their verbs were invisible.
- the host (`@assistant-ui/react-devtools`) now forwards every accessor's identity (`name`/`source`/`query`) and method names, not just root-scope `getState()`. the scopes payload is sanitized and run through the same credential redaction as the model context before crossing the postMessage bridge.
- additive `scopes` field, so it is backward tolerant in both directions: an older deployed frame ignores it, and a newer frame paired with an older host shows an empty-state prompt to update the package.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-devtools build` + `tsc --noEmit` + `test` -> 12/12 green
- [x] `pnpm --filter @assistant-ui/devtools-frame test` -> 43/43 green (incl scope parse + render)
- [x] `pnpm --filter @assistant-ui/devtools-frame build` -> clean
- [x] `oxlint` + `oxfmt --check` (both packages) -> clean

### reviewer should verify

- [ ] open the devtools modal against a running app, switch to the Scopes tab, and confirm the registered scopes (threads / thread / threadListItem / composer / tools / modelContext / ...) render with their `source → query` and method lists, and that no credentials surface in any `query`.

## notes

- touches the published `@assistant-ui/react-devtools` (patch changeset included); the frame side ships on deploy. the method catalog is read-only for now; interactive invocation (calling a scope method from devtools) is a separate follow-up, as is per-instance event-to-scope correlation.