### PR TITLE
feat(devtools): surface the composer message queue

### DIFF
--- a/apps/devtools-frame/components/DevToolsUI.tsx
+++ b/apps/devtools-frame/components/DevToolsUI.tsx
@@ -11,7 +11,6 @@ import {
 import {
   type EventLogEntry,
   eventScope,
-  formatBoolean,
   formatClockTime,
   isRecord,
   truncate,
@@ -21,6 +20,7 @@ import { ModelContextView } from "./model-context";
 import { RunTimeline } from "./runs";
 import { ScopesView } from "./scopes";
 import {
+  ComposerFlags,
   ComposerQueue,
   ThreadDetails,
   parseComposerPreview,
@@ -257,20 +257,7 @@ const renderComposerStatePreview = (value: unknown) => {
         <SummaryItem label="Attachments" value={String(composer.attachments)} />
         <SummaryItem label="Mode" value={composer.type ?? "—"} />
       </div>
-      <div className="flex flex-wrap gap-2 text-[10px] tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-        {typeof composer.isEditing === "boolean" ? (
-          <span>Edit: {formatBoolean(composer.isEditing)}</span>
-        ) : null}
-        {typeof composer.canCancel === "boolean" ? (
-          <span>Can Cancel: {formatBoolean(composer.canCancel)}</span>
-        ) : null}
-        {typeof composer.canSend === "boolean" ? (
-          <span>Can Send: {formatBoolean(composer.canSend)}</span>
-        ) : null}
-        {typeof composer.isEmpty === "boolean" ? (
-          <span>Empty: {formatBoolean(composer.isEmpty)}</span>
-        ) : null}
-      </div>
+      <ComposerFlags composer={composer} />
       {text ? (
         <div className="rounded-md border border-zinc-200 bg-white p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-950/40 dark:text-zinc-200">
           <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">

--- a/apps/devtools-frame/components/DevToolsUI.tsx
+++ b/apps/devtools-frame/components/DevToolsUI.tsx
@@ -11,6 +11,7 @@ import {
 import {
   type EventLogEntry,
   eventScope,
+  formatBoolean,
   formatClockTime,
   isRecord,
   truncate,
@@ -20,6 +21,7 @@ import { ModelContextView } from "./model-context";
 import { RunTimeline } from "./runs";
 import { ScopesView } from "./scopes";
 import {
+  ComposerQueue,
   ThreadDetails,
   parseComposerPreview,
   parseThreadListItemPreview,
@@ -255,6 +257,20 @@ const renderComposerStatePreview = (value: unknown) => {
         <SummaryItem label="Attachments" value={String(composer.attachments)} />
         <SummaryItem label="Mode" value={composer.type ?? "—"} />
       </div>
+      <div className="flex flex-wrap gap-2 text-[10px] tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
+        {typeof composer.isEditing === "boolean" ? (
+          <span>Edit: {formatBoolean(composer.isEditing)}</span>
+        ) : null}
+        {typeof composer.canCancel === "boolean" ? (
+          <span>Can Cancel: {formatBoolean(composer.canCancel)}</span>
+        ) : null}
+        {typeof composer.canSend === "boolean" ? (
+          <span>Can Send: {formatBoolean(composer.canSend)}</span>
+        ) : null}
+        {typeof composer.isEmpty === "boolean" ? (
+          <span>Empty: {formatBoolean(composer.isEmpty)}</span>
+        ) : null}
+      </div>
       {text ? (
         <div className="rounded-md border border-zinc-200 bg-white p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-950/40 dark:text-zinc-200">
           <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
@@ -273,6 +289,7 @@ const renderComposerStatePreview = (value: unknown) => {
           <JSONPreview value={runConfig} />
         </div>
       ) : null}
+      <ComposerQueue queue={composer.queue} />
     </div>
   );
 };

--- a/apps/devtools-frame/components/thread/ComposerFlags.test.tsx
+++ b/apps/devtools-frame/components/thread/ComposerFlags.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ComposerFlags } from "./ComposerFlags";
+
+describe("ComposerFlags", () => {
+  it("renders only the boolean flags that are present", () => {
+    const html = renderToStaticMarkup(
+      <ComposerFlags
+        composer={{
+          textLength: 0,
+          attachments: 0,
+          queue: [],
+          isEditing: true,
+          canSend: false,
+        }}
+      />,
+    );
+    expect(html).toContain("Edit: true");
+    expect(html).toContain("Can Send: false");
+    expect(html).not.toContain("Can Cancel");
+    expect(html).not.toContain("Empty");
+  });
+});

--- a/apps/devtools-frame/components/thread/ComposerFlags.tsx
+++ b/apps/devtools-frame/components/thread/ComposerFlags.tsx
@@ -1,0 +1,19 @@
+import { formatBoolean } from "../common";
+import type { ComposerPreview } from "./types";
+
+export const ComposerFlags = ({ composer }: { composer: ComposerPreview }) => (
+  <div className="flex flex-wrap gap-2 text-[10px] tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
+    {typeof composer.isEditing === "boolean" ? (
+      <span>Edit: {formatBoolean(composer.isEditing)}</span>
+    ) : null}
+    {typeof composer.canCancel === "boolean" ? (
+      <span>Can Cancel: {formatBoolean(composer.canCancel)}</span>
+    ) : null}
+    {typeof composer.canSend === "boolean" ? (
+      <span>Can Send: {formatBoolean(composer.canSend)}</span>
+    ) : null}
+    {typeof composer.isEmpty === "boolean" ? (
+      <span>Empty: {formatBoolean(composer.isEmpty)}</span>
+    ) : null}
+  </div>
+);

--- a/apps/devtools-frame/components/thread/ComposerQueue.test.tsx
+++ b/apps/devtools-frame/components/thread/ComposerQueue.test.tsx
@@ -1,0 +1,20 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ComposerQueue } from "./ComposerQueue";
+
+describe("ComposerQueue", () => {
+  it("renders the queued prompts", () => {
+    const html = renderToStaticMarkup(
+      <ComposerQueue
+        queue={[{ id: "q1", prompt: "first" }, { prompt: "second" }]}
+      />,
+    );
+    expect(html).toContain("Message Queue (2)");
+    expect(html).toContain("first");
+    expect(html).toContain("second");
+  });
+
+  it("renders nothing when the queue is empty", () => {
+    expect(renderToStaticMarkup(<ComposerQueue queue={[]} />)).toBe("");
+  });
+});

--- a/apps/devtools-frame/components/thread/ComposerQueue.tsx
+++ b/apps/devtools-frame/components/thread/ComposerQueue.tsx
@@ -1,0 +1,22 @@
+import type { ComposerQueueItem } from "./types";
+
+export const ComposerQueue = ({
+  queue,
+}: {
+  queue: readonly ComposerQueueItem[];
+}) => {
+  if (!queue.length) return null;
+
+  return (
+    <div className="rounded-md border border-amber-300 bg-amber-500/5 p-3 dark:border-amber-500/40 dark:bg-amber-500/10">
+      <div className="text-[10px] font-semibold tracking-wide text-amber-700 uppercase dark:text-amber-300">
+        Message Queue ({queue.length})
+      </div>
+      <ol className="mt-1 list-decimal space-y-0.5 pl-5 text-[11px] text-zinc-700 dark:text-zinc-200">
+        {queue.map((item, index) => (
+          <li key={item.id ?? index}>{item.prompt || "(empty)"}</li>
+        ))}
+      </ol>
+    </div>
+  );
+};

--- a/apps/devtools-frame/components/thread/ComposerQueue.tsx
+++ b/apps/devtools-frame/components/thread/ComposerQueue.tsx
@@ -14,7 +14,12 @@ export const ComposerQueue = ({
       </div>
       <ol className="mt-1 list-decimal space-y-0.5 pl-5 text-[11px] text-zinc-700 dark:text-zinc-200">
         {queue.map((item, index) => (
-          <li key={item.id ?? index}>{item.prompt || "(empty)"}</li>
+          <li
+            key={item.id ?? index}
+            className="wrap-break-word whitespace-pre-wrap"
+          >
+            {item.prompt || "(empty)"}
+          </li>
         ))}
       </ol>
     </div>

--- a/apps/devtools-frame/components/thread/ThreadDetails.tsx
+++ b/apps/devtools-frame/components/thread/ThreadDetails.tsx
@@ -1,6 +1,7 @@
 import { formatBoolean } from "../common";
 import { MessageList } from "../message";
 import { SummaryItem } from "../ui";
+import { ComposerFlags } from "./ComposerFlags";
 import { ComposerQueue } from "./ComposerQueue";
 import type { ThreadPreview } from "./types";
 
@@ -73,11 +74,11 @@ export const ThreadDetails = ({
     ) : null}
 
     {thread.composer ? (
-      <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-200">
+      <div className="flex flex-col gap-2 rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-200">
         <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
           Composer
         </div>
-        <div className="mt-1 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
           <SummaryItem label="Role" value={thread.composer.role ?? "—"} />
           <SummaryItem
             label="Text Length"
@@ -91,26 +92,8 @@ export const ThreadDetails = ({
             <SummaryItem label="Mode" value={thread.composer.type} />
           ) : null}
         </div>
-        <div className="mt-2 flex flex-wrap gap-2 text-[10px] tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-          {typeof thread.composer.isEditing === "boolean" ? (
-            <span>Edit: {formatBoolean(thread.composer.isEditing)}</span>
-          ) : null}
-          {typeof thread.composer.canCancel === "boolean" ? (
-            <span>Can Cancel: {formatBoolean(thread.composer.canCancel)}</span>
-          ) : null}
-          {typeof thread.composer.canSend === "boolean" ? (
-            <span>Can Send: {formatBoolean(thread.composer.canSend)}</span>
-          ) : null}
-          {typeof thread.composer.isEmpty === "boolean" ? (
-            <span>Empty: {formatBoolean(thread.composer.isEmpty)}</span>
-          ) : null}
-        </div>
-
-        {thread.composer.queue.length ? (
-          <div className="mt-2">
-            <ComposerQueue queue={thread.composer.queue} />
-          </div>
-        ) : null}
+        <ComposerFlags composer={thread.composer} />
+        <ComposerQueue queue={thread.composer.queue} />
       </div>
     ) : null}
   </div>

--- a/apps/devtools-frame/components/thread/ThreadDetails.tsx
+++ b/apps/devtools-frame/components/thread/ThreadDetails.tsx
@@ -1,6 +1,7 @@
 import { formatBoolean } from "../common";
 import { MessageList } from "../message";
 import { SummaryItem } from "../ui";
+import { ComposerQueue } from "./ComposerQueue";
 import type { ThreadPreview } from "./types";
 
 export const ThreadDetails = ({
@@ -97,10 +98,19 @@ export const ThreadDetails = ({
           {typeof thread.composer.canCancel === "boolean" ? (
             <span>Can Cancel: {formatBoolean(thread.composer.canCancel)}</span>
           ) : null}
+          {typeof thread.composer.canSend === "boolean" ? (
+            <span>Can Send: {formatBoolean(thread.composer.canSend)}</span>
+          ) : null}
           {typeof thread.composer.isEmpty === "boolean" ? (
             <span>Empty: {formatBoolean(thread.composer.isEmpty)}</span>
           ) : null}
         </div>
+
+        {thread.composer.queue.length ? (
+          <div className="mt-2">
+            <ComposerQueue queue={thread.composer.queue} />
+          </div>
+        ) : null}
       </div>
     ) : null}
   </div>

--- a/apps/devtools-frame/components/thread/index.ts
+++ b/apps/devtools-frame/components/thread/index.ts
@@ -1,4 +1,5 @@
 export { ThreadDetails } from "./ThreadDetails";
+export { ComposerQueue } from "./ComposerQueue";
 export {
   parseComposerPreview,
   parseThreadListItemPreview,

--- a/apps/devtools-frame/components/thread/index.ts
+++ b/apps/devtools-frame/components/thread/index.ts
@@ -1,4 +1,5 @@
 export { ThreadDetails } from "./ThreadDetails";
+export { ComposerFlags } from "./ComposerFlags";
 export { ComposerQueue } from "./ComposerQueue";
 export {
   parseComposerPreview,

--- a/apps/devtools-frame/components/thread/render.test.tsx
+++ b/apps/devtools-frame/components/thread/render.test.tsx
@@ -1,0 +1,43 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ThreadDetails } from "./ThreadDetails";
+import type { ThreadPreview } from "./types";
+
+describe("ThreadDetails composer queue", () => {
+  it("renders the pending message queue and canSend", () => {
+    const thread: ThreadPreview = {
+      messageCount: 0,
+      messages: [],
+      suggestions: [],
+      capabilities: [],
+      composer: {
+        textLength: 0,
+        attachments: 0,
+        canSend: false,
+        queue: [
+          { id: "q1", prompt: "queued one" },
+          { id: "q2", prompt: "queued two" },
+        ],
+      },
+    };
+
+    const html = renderToStaticMarkup(<ThreadDetails thread={thread} />);
+    expect(html).toContain("Message Queue (2)");
+    expect(html).toContain("queued one");
+    expect(html).toContain("queued two");
+    expect(html).toContain("Can Send");
+  });
+
+  it("omits the queue section when empty", () => {
+    const thread: ThreadPreview = {
+      messageCount: 0,
+      messages: [],
+      suggestions: [],
+      capabilities: [],
+      composer: { textLength: 0, attachments: 0, queue: [] },
+    };
+
+    const html = renderToStaticMarkup(<ThreadDetails thread={thread} />);
+    expect(html).not.toContain("Message Queue");
+  });
+});

--- a/apps/devtools-frame/components/thread/types.ts
+++ b/apps/devtools-frame/components/thread/types.ts
@@ -12,14 +12,21 @@ export interface SuggestionPreview {
   prompt?: string;
 }
 
+export interface ComposerQueueItem {
+  id?: string;
+  prompt: string;
+}
+
 export interface ComposerPreview {
   textLength: number;
   role?: string;
   attachments: number;
   isEditing?: boolean;
   canCancel?: boolean;
+  canSend?: boolean;
   isEmpty?: boolean;
   type?: string;
+  queue: ComposerQueueItem[];
 }
 
 export interface ThreadPreview {

--- a/apps/devtools-frame/components/thread/utils.test.ts
+++ b/apps/devtools-frame/components/thread/utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { parseComposerPreview } from "./utils";
+
+describe("parseComposerPreview", () => {
+  it("extracts the message queue and canSend", () => {
+    const composer = parseComposerPreview({
+      text: "hi",
+      attachments: [],
+      canSend: false,
+      queue: [
+        { id: "q1", prompt: "first" },
+        { id: "q2", prompt: "second" },
+      ],
+    });
+    expect(composer?.canSend).toBe(false);
+    expect(composer?.queue).toEqual([
+      { id: "q1", prompt: "first" },
+      { id: "q2", prompt: "second" },
+    ]);
+  });
+
+  it("drops malformed queue items and keeps prompt-only entries", () => {
+    const composer = parseComposerPreview({
+      text: "",
+      attachments: [],
+      queue: [{ prompt: "ok" }, { id: "x" }, 5, null],
+    });
+    expect(composer?.queue).toEqual([{ prompt: "ok" }]);
+  });
+
+  it("defaults the queue to an empty array when absent", () => {
+    const composer = parseComposerPreview({ text: "", attachments: [] });
+    expect(composer?.queue).toEqual([]);
+  });
+});

--- a/apps/devtools-frame/components/thread/utils.ts
+++ b/apps/devtools-frame/components/thread/utils.ts
@@ -3,6 +3,7 @@ import { parseMessage } from "../message";
 import type { MessagePreview } from "../message";
 import type {
   ComposerPreview,
+  ComposerQueueItem,
   SuggestionPreview,
   ThreadListItemPreview,
   ThreadListPreview,
@@ -26,10 +27,22 @@ export const parseComposerPreview = (
   const attachments = Array.isArray(value.attachments)
     ? value.attachments.length
     : 0;
+  const queue = Array.isArray(value.queue)
+    ? value.queue
+        .map((item) => {
+          if (!isRecord(item) || typeof item.prompt !== "string") return null;
+          return {
+            prompt: item.prompt,
+            ...(typeof item.id === "string" ? { id: item.id } : {}),
+          };
+        })
+        .filter((item): item is ComposerQueueItem => Boolean(item))
+    : [];
 
   return {
     textLength: text.length,
     attachments,
+    queue,
     ...(typeof value.role === "string" ? { role: value.role } : {}),
     ...(typeof value.isEditing === "boolean"
       ? { isEditing: value.isEditing }
@@ -37,6 +50,7 @@ export const parseComposerPreview = (
     ...(typeof value.canCancel === "boolean"
       ? { canCancel: value.canCancel }
       : {}),
+    ...(typeof value.canSend === "boolean" ? { canSend: value.canSend } : {}),
     ...(typeof value.isEmpty === "boolean" ? { isEmpty: value.isEmpty } : {}),
     ...(typeof value.type === "string" ? { type: value.type } : {}),
   };


### PR DESCRIPTION
## summary

- the composer view now shows a "Message Queue (N)" list of the pending queued messages (the message-queue feature, #4246). previously the queue was completely invisible in the devtools.
- also surfaces the previously-dropped `canSend` flag. the data comes from the already-forwarded `state.threads.main.composer.queue`, so this is frame-only (no host or package change, ships on deploy).
- extracts a shared `ComposerQueue` component used by both the thread composer block and the standalone composer state view, so the two render sites stay consistent and the queue rendering has one tested path.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/devtools-frame test` -> 50/50 green (composer queue parse + `ComposerQueue` + `ThreadDetails` render)
- [x] `pnpm --filter @assistant-ui/devtools-frame build` -> clean
- [x] `oxlint` + `oxfmt --check` + `tsc --noEmit` -> clean

### reviewer should verify

- [ ] in an app with a queue-capable runtime, send a message while a run is in progress so it queues, open the devtools modal, and confirm the queued message(s) show up under "Message Queue" in the thread's composer.

## notes

- frame-only, deploy-only, no changeset. read-only for now; the `queueItem` steer/remove actions need the reverse RPC channel (a separate follow-up).