### PR TITLE
feat(devtools): surface composer attachment lifecycle

### DIFF
--- a/apps/devtools-frame/components/DevToolsUI.tsx
+++ b/apps/devtools-frame/components/DevToolsUI.tsx
@@ -20,6 +20,7 @@ import { ModelContextView } from "./model-context";
 import { RunTimeline } from "./runs";
 import { ScopesView } from "./scopes";
 import {
+  ComposerAttachments,
   ComposerFlags,
   ComposerQueue,
   ThreadDetails,
@@ -28,7 +29,13 @@ import {
   parseThreadListPreview,
   parseThreadPreview,
 } from "./thread";
-import { CenteredMessage, ControlButton, JSONPreview, SummaryItem } from "./ui";
+import {
+  CenteredMessage,
+  ControlButton,
+  EmptyState,
+  JSONPreview,
+  SummaryItem,
+} from "./ui";
 
 interface AssistantState {
   [key: string]: unknown;
@@ -254,10 +261,14 @@ const renderComposerStatePreview = (value: unknown) => {
       <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
         <SummaryItem label="Role" value={composer.role ?? "—"} />
         <SummaryItem label="Text Length" value={String(composer.textLength)} />
-        <SummaryItem label="Attachments" value={String(composer.attachments)} />
+        <SummaryItem
+          label="Attachments"
+          value={String(composer.attachments.length)}
+        />
         <SummaryItem label="Mode" value={composer.type ?? "—"} />
       </div>
       <ComposerFlags composer={composer} />
+      <ComposerAttachments attachments={composer.attachments} />
       {text ? (
         <div className="rounded-md border border-zinc-200 bg-white p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-950/40 dark:text-zinc-200">
           <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
@@ -621,9 +632,7 @@ export function DevToolsUI() {
 
     if (Object.keys(selectedApi.state).length === 0) {
       return (
-        <div className="rounded-lg border border-dashed border-zinc-300 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
-          No state detected for this assistant instance.
-        </div>
+        <EmptyState>No state detected for this assistant instance.</EmptyState>
       );
     }
 
@@ -719,13 +728,11 @@ export function DevToolsUI() {
           </div>
         )}
         {filteredLogs.length === 0 ? (
-          <div className="flex h-full items-center justify-center">
-            <div className="rounded-lg border border-dashed border-zinc-300 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
-              {eventTypes.length === 0
-                ? "No events logged for this assistant instance."
-                : "No events match the current filters."}
-            </div>
-          </div>
+          <EmptyState>
+            {eventTypes.length === 0
+              ? "No events logged for this assistant instance."
+              : "No events match the current filters."}
+          </EmptyState>
         ) : (
           <div className="overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm transition-colors dark:border-zinc-800 dark:bg-zinc-900">
             <table className="w-full table-auto border-collapse text-left">

--- a/apps/devtools-frame/components/mcp/McpView.tsx
+++ b/apps/devtools-frame/components/mcp/McpView.tsx
@@ -1,21 +1,16 @@
 import clsx from "clsx";
-import { JSONPreview, SummaryItem } from "../ui";
+import { BADGE_TONE, JSONPreview, SummaryItem } from "../ui";
+import type { BadgeTone } from "../ui";
 import { parseMcpManager } from "./parse";
 import type { McpServerPreview } from "./types";
 
-const STATE_TONE: Record<string, string> = {
-  connected:
-    "border-emerald-300 bg-emerald-500/10 text-emerald-700 dark:border-emerald-500/40 dark:text-emerald-300",
-  connecting:
-    "border-blue-300 bg-blue-500/10 text-blue-700 dark:border-blue-500/40 dark:text-blue-300",
-  authPending:
-    "border-blue-300 bg-blue-500/10 text-blue-700 dark:border-blue-500/40 dark:text-blue-300",
-  authRequired:
-    "border-amber-300 bg-amber-500/10 text-amber-700 dark:border-amber-500/40 dark:text-amber-300",
-  disconnected:
-    "border-zinc-300 bg-zinc-500/10 text-zinc-600 dark:border-zinc-600 dark:text-zinc-300",
-  error:
-    "border-red-300 bg-red-500/10 text-red-700 dark:border-red-500/40 dark:text-red-300",
+const STATE_TONE: Record<string, BadgeTone> = {
+  connected: "emerald",
+  connecting: "blue",
+  authPending: "blue",
+  authRequired: "amber",
+  disconnected: "zinc",
+  error: "red",
 };
 
 const ServerCard = ({ server }: { server: McpServerPreview }) => (
@@ -32,7 +27,7 @@ const ServerCard = ({ server }: { server: McpServerPreview }) => (
       <span
         className={clsx(
           "rounded border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase",
-          STATE_TONE[server.connectionState] ?? STATE_TONE.disconnected,
+          BADGE_TONE[STATE_TONE[server.connectionState] ?? "zinc"],
         )}
       >
         {server.connectionState}

--- a/apps/devtools-frame/components/mcp/McpView.tsx
+++ b/apps/devtools-frame/components/mcp/McpView.tsx
@@ -1,5 +1,4 @@
-import clsx from "clsx";
-import { BADGE_TONE, JSONPreview, SummaryItem } from "../ui";
+import { JSONPreview, SummaryItem, ToneBadge } from "../ui";
 import type { BadgeTone } from "../ui";
 import { parseMcpManager } from "./parse";
 import type { McpServerPreview } from "./types";
@@ -24,14 +23,9 @@ const ServerCard = ({ server }: { server: McpServerPreview }) => (
           {server.kind}
         </span>
       ) : null}
-      <span
-        className={clsx(
-          "rounded border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase",
-          BADGE_TONE[STATE_TONE[server.connectionState] ?? "zinc"],
-        )}
-      >
+      <ToneBadge tone={STATE_TONE[server.connectionState]}>
         {server.connectionState}
-      </span>
+      </ToneBadge>
     </div>
 
     {server.url ? (

--- a/apps/devtools-frame/components/mcp/index.ts
+++ b/apps/devtools-frame/components/mcp/index.ts
@@ -1,7 +1,1 @@
 export { McpView } from "./McpView";
-export { parseMcpManager } from "./parse";
-export type {
-  McpManagerPreview,
-  McpServerPreview,
-  McpToolPreview,
-} from "./types";

--- a/apps/devtools-frame/components/mcp/render.test.tsx
+++ b/apps/devtools-frame/components/mcp/render.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { McpView } from "./McpView";
+
+describe("McpView rendering", () => {
+  it("renders server connection state and a discovered tool", () => {
+    const html = renderToStaticMarkup(
+      <McpView
+        value={{
+          isHydrated: true,
+          servers: [
+            {
+              id: "s1",
+              kind: "connector",
+              name: "GitHub",
+              connectionState: "connected",
+              lastError: null,
+              authorizationUrl: null,
+              tools: [{ name: "list_repos", description: "list repos" }],
+            },
+          ],
+        }}
+      />,
+    );
+    expect(html).toContain("GitHub");
+    expect(html).toContain("connected");
+    expect(html).toContain("list_repos");
+  });
+
+  it("falls back to raw JSON for non-manager values", () => {
+    const html = renderToStaticMarkup(<McpView value={42} />);
+    expect(html).toContain("42");
+  });
+});

--- a/apps/devtools-frame/components/message/StatusBadge.tsx
+++ b/apps/devtools-frame/components/message/StatusBadge.tsx
@@ -1,16 +1,12 @@
 import clsx from "clsx";
+import { BADGE_TONE } from "../ui";
+import type { BadgeTone } from "../ui";
 
-const TONE: Record<string, string> = {
-  running:
-    "border-blue-300 bg-blue-500/10 text-blue-700 dark:border-blue-500/40 dark:bg-blue-500/15 dark:text-blue-300",
-  complete:
-    "border-emerald-300 bg-emerald-500/10 text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/15 dark:text-emerald-300",
-  incomplete:
-    "border-red-300 bg-red-500/10 text-red-700 dark:border-red-500/40 dark:bg-red-500/15 dark:text-red-300",
-  "requires-action":
-    "border-amber-300 bg-amber-500/10 text-amber-700 dark:border-amber-500/40 dark:bg-amber-500/15 dark:text-amber-300",
-  unknown:
-    "border-zinc-300 bg-zinc-500/10 text-zinc-600 dark:border-zinc-600 dark:bg-zinc-500/15 dark:text-zinc-300",
+const TONE: Record<string, BadgeTone> = {
+  running: "blue",
+  complete: "emerald",
+  incomplete: "red",
+  "requires-action": "amber",
 };
 
 export const StatusBadge = ({
@@ -23,7 +19,7 @@ export const StatusBadge = ({
   <span
     className={clsx(
       "inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase",
-      TONE[type] ?? TONE.unknown,
+      BADGE_TONE[TONE[type] ?? "zinc"],
     )}
   >
     <span>{type}</span>

--- a/apps/devtools-frame/components/message/StatusBadge.tsx
+++ b/apps/devtools-frame/components/message/StatusBadge.tsx
@@ -1,5 +1,4 @@
-import clsx from "clsx";
-import { BADGE_TONE } from "../ui";
+import { ToneBadge } from "../ui";
 import type { BadgeTone } from "../ui";
 
 const TONE: Record<string, BadgeTone> = {
@@ -16,13 +15,8 @@ export const StatusBadge = ({
   type: string;
   reason?: string | undefined;
 }) => (
-  <span
-    className={clsx(
-      "inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase",
-      BADGE_TONE[TONE[type] ?? "zinc"],
-    )}
-  >
+  <ToneBadge tone={TONE[type]} className="inline-flex items-center gap-1">
     <span>{type}</span>
     {reason ? <span className="opacity-70">· {reason}</span> : null}
-  </span>
+  </ToneBadge>
 );

--- a/apps/devtools-frame/components/message/ToolCallView.tsx
+++ b/apps/devtools-frame/components/message/ToolCallView.tsx
@@ -109,7 +109,7 @@ export const ToolCallView = ({ part }: { part: ToolCallPartPreview }) => {
           </Disclosure>
         ) : null}
 
-        {part.hasResult ? (
+        {part.result !== undefined ? (
           <Disclosure label={part.isError ? "Result (error)" : "Result"}>
             <JSONPreview value={part.result} />
           </Disclosure>

--- a/apps/devtools-frame/components/message/index.ts
+++ b/apps/devtools-frame/components/message/index.ts
@@ -9,7 +9,6 @@ export type {
   MessagePreview,
   PartPreview,
   PartStatusPreview,
-  MessageStatusPreview,
   MessageTimingPreview,
   MessageUsagePreview,
   ToolCallPartPreview,

--- a/apps/devtools-frame/components/message/parse.test.ts
+++ b/apps/devtools-frame/components/message/parse.test.ts
@@ -43,7 +43,6 @@ describe("parsePart", () => {
       type: "tool-call",
       toolName: "search",
       toolCallId: "call_1",
-      hasResult: true,
       result: { temperature: 20 },
       argsText: '{"query":"weather"}',
       subMessageCount: 0,
@@ -81,7 +80,7 @@ describe("parsePart", () => {
     });
     if (part.type !== "tool-call") throw new Error("expected tool-call");
     expect(part.isError).toBe(true);
-    expect(part.hasResult).toBe(true);
+    expect(part.result).toBe("boom");
     expect(part.interrupt).toEqual({
       type: "human",
       payload: { question: "name?" },
@@ -146,7 +145,6 @@ describe("partKey", () => {
           toolCallId: "abc",
           toolName: "x",
           args: {},
-          hasResult: false,
           subMessageCount: 0,
         },
         3,

--- a/apps/devtools-frame/components/message/parse.ts
+++ b/apps/devtools-frame/components/message/parse.ts
@@ -81,7 +81,6 @@ const parseToolCall = (
     toolCallId: asString(value.toolCallId) ?? "",
     toolName: asString(value.toolName) ?? "(unknown)",
     args: value.args,
-    hasResult: "result" in value && value.result !== undefined,
     subMessageCount,
     ...(argsText !== undefined ? { argsText } : {}),
     ...("result" in value && value.result !== undefined

--- a/apps/devtools-frame/components/message/render.test.tsx
+++ b/apps/devtools-frame/components/message/render.test.tsx
@@ -1,6 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { McpView } from "../mcp";
 import { MessageItem } from "./MessageItem";
 import { MessageList } from "./MessageList";
 import { parseMessage } from "./parse";
@@ -85,36 +84,5 @@ describe("MessageItem rendering", () => {
   it("renders an empty message list placeholder", () => {
     const html = renderToStaticMarkup(<MessageList messages={[]} />);
     expect(html).toContain("No messages");
-  });
-});
-
-describe("McpView rendering", () => {
-  it("renders server connection state and a discovered tool", () => {
-    const html = renderToStaticMarkup(
-      <McpView
-        value={{
-          isHydrated: true,
-          servers: [
-            {
-              id: "s1",
-              kind: "connector",
-              name: "GitHub",
-              connectionState: "connected",
-              lastError: null,
-              authorizationUrl: null,
-              tools: [{ name: "list_repos", description: "list repos" }],
-            },
-          ],
-        }}
-      />,
-    );
-    expect(html).toContain("GitHub");
-    expect(html).toContain("connected");
-    expect(html).toContain("list_repos");
-  });
-
-  it("falls back to raw JSON for non-manager values", () => {
-    const html = renderToStaticMarkup(<McpView value={42} />);
-    expect(html).toContain("42");
   });
 });

--- a/apps/devtools-frame/components/message/types.ts
+++ b/apps/devtools-frame/components/message/types.ts
@@ -70,7 +70,6 @@ export interface ToolCallPartPreview extends BasePartPreview {
   readonly toolName: string;
   readonly args: unknown;
   readonly argsText?: string;
-  readonly hasResult: boolean;
   readonly result?: unknown;
   readonly isError?: boolean;
   readonly artifact?: unknown;
@@ -99,8 +98,6 @@ export type PartPreview =
   | ToolCallPartPreview
   | UnknownPartPreview;
 
-export type MessageStatusPreview = PartStatusPreview;
-
 export interface MessageTimingPreview {
   readonly streamStartTime?: number;
   readonly firstTokenTime?: number;
@@ -121,7 +118,7 @@ export interface MessagePreview {
   readonly id: string;
   readonly role: string;
   readonly createdAt?: string;
-  readonly status?: MessageStatusPreview;
+  readonly status?: PartStatusPreview;
   readonly parts: readonly PartPreview[];
   readonly attachments: readonly string[];
   readonly timing?: MessageTimingPreview;

--- a/apps/devtools-frame/components/model-context/ModelContextView.tsx
+++ b/apps/devtools-frame/components/model-context/ModelContextView.tsx
@@ -3,7 +3,7 @@ import type {
   SerializedModelContext,
 } from "@assistant-ui/react-devtools";
 import type { ReactNode } from "react";
-import { InfoCard, JSONPreview, SectionTitle } from "../ui";
+import { EmptyState, InfoCard, JSONPreview, SectionTitle } from "../ui";
 
 const Badge = ({
   children,
@@ -85,11 +85,9 @@ export const ModelContextView = ({
 
   if (!system && toolList.length === 0 && !hasCallSettings && !hasConfig) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <div className="rounded-lg border border-dashed border-zinc-300 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
-          No model context configured for this assistant instance.
-        </div>
-      </div>
+      <EmptyState>
+        No model context configured for this assistant instance.
+      </EmptyState>
     );
   }
 

--- a/apps/devtools-frame/components/runs/RunTimeline.tsx
+++ b/apps/devtools-frame/components/runs/RunTimeline.tsx
@@ -1,9 +1,10 @@
 import clsx from "clsx";
 import { useMemo } from "react";
 import { formatClockTime } from "../common";
-import { SummaryItem } from "../ui";
+import type { EventLogEntry } from "../common";
+import { EmptyState, SummaryItem } from "../ui";
 import { groupRuns } from "./parse";
-import type { RunEventEntry, RunLogEntry, RunPreview } from "./types";
+import type { RunEventEntry, RunPreview } from "./types";
 
 const SCOPE_TONE: Record<string, { dot: string; text: string }> = {
   thread: {
@@ -58,7 +59,7 @@ const RunCard = ({ run }: { run: RunPreview }) => (
       <span className="font-mono text-[10px] text-zinc-500 dark:text-zinc-400">
         {formatClockTime(run.startTime)}
       </span>
-      {run.running ? (
+      {run.endTime === undefined ? (
         <span className="rounded border border-blue-300 bg-blue-500/10 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-blue-700 uppercase dark:border-blue-500/40 dark:text-blue-300">
           running
         </span>
@@ -101,16 +102,14 @@ const RunCard = ({ run }: { run: RunPreview }) => (
   </div>
 );
 
-export const RunTimeline = ({ logs }: { logs: readonly RunLogEntry[] }) => {
+export const RunTimeline = ({ logs }: { logs: readonly EventLogEntry[] }) => {
   const { runs, orphans } = useMemo(() => groupRuns(logs), [logs]);
 
   if (runs.length === 0 && orphans.length === 0) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <div className="rounded-lg border border-dashed border-zinc-300 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
-          No runs recorded yet. Send a message to start one.
-        </div>
-      </div>
+      <EmptyState>
+        No runs recorded yet. Send a message to start one.
+      </EmptyState>
     );
   }
 

--- a/apps/devtools-frame/components/runs/parse.test.ts
+++ b/apps/devtools-frame/components/runs/parse.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
+import type { EventLogEntry } from "../common";
 import { groupRuns } from "./parse";
-import type { RunLogEntry } from "./types";
 
 const base = 2_000_000_000_000;
 const t = (ms: number) => new Date(base + ms);
 
 describe("groupRuns", () => {
   it("pairs runStart/runEnd and computes durations and offsets", () => {
-    const logs: RunLogEntry[] = [
+    const logs: EventLogEntry[] = [
       { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
       {
         time: t(150),
@@ -23,7 +23,7 @@ describe("groupRuns", () => {
     const run = runs[0]!;
     expect(run.index).toBe(0);
     expect(run.threadId).toBe("T1");
-    expect(run.running).toBe(false);
+    expect(run.endTime).toBeDefined();
     expect(run.durationMs).toBe(900);
     expect(run.spanMs).toBe(900);
     expect(run.events.map((e) => e.offsetMs)).toEqual([0, 150, 900]);
@@ -35,18 +35,18 @@ describe("groupRuns", () => {
   });
 
   it("marks a run with no runEnd as running, with span from last event", () => {
-    const logs: RunLogEntry[] = [
+    const logs: EventLogEntry[] = [
       { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
       { time: t(100), event: "composer.send", data: { threadId: "T1" } },
     ];
     const { runs } = groupRuns(logs);
-    expect(runs[0]!.running).toBe(true);
+    expect(runs[0]!.endTime).toBeUndefined();
     expect(runs[0]!.durationMs).toBeUndefined();
     expect(runs[0]!.spanMs).toBe(100);
   });
 
   it("buckets events outside any run as orphans", () => {
-    const logs: RunLogEntry[] = [
+    const logs: EventLogEntry[] = [
       {
         time: t(0),
         event: "thread.modelContextUpdate",
@@ -62,7 +62,7 @@ describe("groupRuns", () => {
   });
 
   it("sorts out-of-order logs before pairing", () => {
-    const logs: RunLogEntry[] = [
+    const logs: EventLogEntry[] = [
       { time: t(100), event: "thread.runEnd", data: { threadId: "T1" } },
       { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
     ];
@@ -73,7 +73,7 @@ describe("groupRuns", () => {
   });
 
   it("routes events to the matching thread when runs interleave", () => {
-    const logs: RunLogEntry[] = [
+    const logs: EventLogEntry[] = [
       { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
       { time: t(50), event: "thread.runStart", data: { threadId: "T2" } },
       { time: t(60), event: "composer.send", data: { threadId: "T2" } },
@@ -92,21 +92,21 @@ describe("groupRuns", () => {
   });
 
   it("closes a prior open run on the same thread when a new run starts", () => {
-    const logs: RunLogEntry[] = [
+    const logs: EventLogEntry[] = [
       { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
       { time: t(50), event: "thread.runStart", data: { threadId: "T1" } },
       { time: t(100), event: "thread.runEnd", data: { threadId: "T1" } },
     ];
     const { runs } = groupRuns(logs);
     expect(runs).toHaveLength(2);
-    expect(runs[0]!.running).toBe(false);
+    expect(runs[0]!.endTime).toBeDefined();
     expect(runs[0]!.durationMs).toBe(50);
-    expect(runs[1]!.running).toBe(false);
+    expect(runs[1]!.endTime).toBeDefined();
     expect(runs[1]!.durationMs).toBe(50);
   });
 
   it("orphans an event whose explicit threadId matches no open run", () => {
-    const logs: RunLogEntry[] = [
+    const logs: EventLogEntry[] = [
       { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
       { time: t(50), event: "composer.send", data: { threadId: "T2" } },
       { time: t(100), event: "thread.runEnd", data: { threadId: "T1" } },
@@ -121,7 +121,7 @@ describe("groupRuns", () => {
   });
 
   it("attaches a thread-less event to the single open run", () => {
-    const logs: RunLogEntry[] = [
+    const logs: EventLogEntry[] = [
       { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
       { time: t(50), event: "custom.event", data: {} },
       { time: t(100), event: "thread.runEnd", data: { threadId: "T1" } },
@@ -132,7 +132,7 @@ describe("groupRuns", () => {
   });
 
   it("keeps an empty-string threadId distinct from a thread-less run", () => {
-    const logs: RunLogEntry[] = [
+    const logs: EventLogEntry[] = [
       { time: t(0), event: "thread.runStart", data: { threadId: "" } },
       { time: t(50), event: "thread.runStart", data: {} },
       { time: t(100), event: "thread.runEnd", data: { threadId: "" } },
@@ -140,10 +140,10 @@ describe("groupRuns", () => {
     const { runs } = groupRuns(logs);
     expect(runs).toHaveLength(2);
     expect(runs[0]!.threadId).toBe("");
-    expect(runs[0]!.running).toBe(false);
+    expect(runs[0]!.endTime).toBeDefined();
     expect(runs[0]!.durationMs).toBe(100);
     expect(runs[1]!.threadId).toBeUndefined();
-    expect(runs[1]!.running).toBe(true);
+    expect(runs[1]!.endTime).toBeUndefined();
   });
 
   it("returns nothing for an empty log", () => {

--- a/apps/devtools-frame/components/runs/parse.ts
+++ b/apps/devtools-frame/components/runs/parse.ts
@@ -1,10 +1,6 @@
 import { eventScope, isRecord } from "../common";
-import type {
-  RunEventEntry,
-  RunGrouping,
-  RunLogEntry,
-  RunPreview,
-} from "./types";
+import type { EventLogEntry } from "../common";
+import type { RunEventEntry, RunGrouping, RunPreview } from "./types";
 
 // thread.runStart/runEnd are @deprecated in core but kept for backward
 // compatibility; they are the only run-boundary signal in the event log.
@@ -25,7 +21,7 @@ interface RunBuilder {
   events: RunEventEntry[];
 }
 
-const entryFor = (log: RunLogEntry, offsetMs: number): RunEventEntry => ({
+const entryFor = (log: EventLogEntry, offsetMs: number): RunEventEntry => ({
   time: log.time,
   event: log.event,
   scope: eventScope(log.event),
@@ -33,7 +29,7 @@ const entryFor = (log: RunLogEntry, offsetMs: number): RunEventEntry => ({
   data: log.data,
 });
 
-export const groupRuns = (logs: readonly RunLogEntry[]): RunGrouping => {
+export const groupRuns = (logs: readonly EventLogEntry[]): RunGrouping => {
   const sorted = [...logs].sort((a, b) => a.time.getTime() - b.time.getTime());
   const builders: RunBuilder[] = [];
   const openByThread = new Map<string | undefined, RunBuilder>();
@@ -105,7 +101,6 @@ export const groupRuns = (logs: readonly RunLogEntry[]): RunGrouping => {
       startTime: b.startTime,
       ...(b.endTime !== undefined ? { endTime: b.endTime } : {}),
       ...(durationMs !== undefined ? { durationMs } : {}),
-      running: b.endTime === undefined,
       spanMs: Math.max(durationMs ?? 0, maxOffset),
       events: b.events,
     };

--- a/apps/devtools-frame/components/runs/render.test.tsx
+++ b/apps/devtools-frame/components/runs/render.test.tsx
@@ -1,14 +1,14 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import type { EventLogEntry } from "../common";
 import { RunTimeline } from "./RunTimeline";
-import type { RunLogEntry } from "./types";
 
 const base = 2_000_000_000_000;
 const t = (ms: number) => new Date(base + ms);
 
 describe("RunTimeline", () => {
   it("renders a completed run with its duration and events", () => {
-    const logs: RunLogEntry[] = [
+    const logs: EventLogEntry[] = [
       { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
       { time: t(150), event: "composer.send", data: { threadId: "T1" } },
       { time: t(900), event: "thread.runEnd", data: { threadId: "T1" } },
@@ -22,7 +22,7 @@ describe("RunTimeline", () => {
   });
 
   it("marks an unfinished run as running", () => {
-    const logs: RunLogEntry[] = [
+    const logs: EventLogEntry[] = [
       { time: t(0), event: "thread.runStart", data: { threadId: "T1" } },
     ];
     const html = renderToStaticMarkup(<RunTimeline logs={logs} />);

--- a/apps/devtools-frame/components/runs/types.ts
+++ b/apps/devtools-frame/components/runs/types.ts
@@ -1,7 +1,3 @@
-import type { EventLogEntry } from "../common";
-
-export type RunLogEntry = EventLogEntry;
-
 export interface RunEventEntry {
   readonly time: Date;
   readonly event: string;
@@ -17,7 +13,6 @@ export interface RunPreview {
   readonly startTime: Date;
   readonly endTime?: Date;
   readonly durationMs?: number;
-  readonly running: boolean;
   readonly spanMs: number;
   readonly events: readonly RunEventEntry[];
 }

--- a/apps/devtools-frame/components/scopes/ScopesView.tsx
+++ b/apps/devtools-frame/components/scopes/ScopesView.tsx
@@ -1,5 +1,5 @@
 import { isRecord } from "../common";
-import { SummaryItem } from "../ui";
+import { EmptyState, SummaryItem } from "../ui";
 import { parseScopes } from "./parse";
 import type { ScopePreview } from "./types";
 
@@ -62,12 +62,10 @@ export const ScopesView = ({ scopes }: { scopes?: unknown }) => {
 
   if (list.length === 0) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <div className="rounded-lg border border-dashed border-zinc-300 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
-          No scopes reported. Update `@assistant-ui/react-devtools` to forward
-          the scope graph.
-        </div>
-      </div>
+      <EmptyState>
+        No scopes reported. Update `@assistant-ui/react-devtools` to forward the
+        scope graph.
+      </EmptyState>
     );
   }
 

--- a/apps/devtools-frame/components/thread/ComposerAttachments.test.tsx
+++ b/apps/devtools-frame/components/thread/ComposerAttachments.test.tsx
@@ -1,0 +1,36 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ComposerAttachments } from "./ComposerAttachments";
+
+describe("ComposerAttachments", () => {
+  it("renders attachments with name, kind, and upload status", () => {
+    const html = renderToStaticMarkup(
+      <ComposerAttachments
+        attachments={[
+          {
+            id: "a1",
+            name: "photo.png",
+            kind: "image",
+            status: { type: "running", reason: "uploading", progress: 0.5 },
+          },
+          {
+            id: "a2",
+            name: "doc.pdf",
+            kind: "file",
+            status: { type: "complete" },
+          },
+        ]}
+      />,
+    );
+    expect(html).toContain("Attachments (2)");
+    expect(html).toContain("photo.png");
+    expect(html).toContain("uploading 50%");
+    expect(html).toContain("complete");
+  });
+
+  it("renders nothing when there are no attachments", () => {
+    expect(renderToStaticMarkup(<ComposerAttachments attachments={[]} />)).toBe(
+      "",
+    );
+  });
+});

--- a/apps/devtools-frame/components/thread/ComposerAttachments.tsx
+++ b/apps/devtools-frame/components/thread/ComposerAttachments.tsx
@@ -1,0 +1,71 @@
+import clsx from "clsx";
+import { BADGE_TONE } from "../ui";
+import type { BadgeTone } from "../ui";
+import type { AttachmentPreview, AttachmentStatusPreview } from "./types";
+
+const STATUS_TONE: Record<string, BadgeTone> = {
+  running: "blue",
+  "requires-action": "amber",
+  incomplete: "red",
+  complete: "emerald",
+};
+
+const statusLabel = (status: AttachmentStatusPreview) => {
+  if (status.type === "running" && typeof status.progress === "number") {
+    const pct = status.progress <= 1 ? status.progress * 100 : status.progress;
+    return `${status.reason ?? "running"} ${Math.round(pct)}%`;
+  }
+  return status.reason ? `${status.type} · ${status.reason}` : status.type;
+};
+
+const StatusBadge = ({ status }: { status: AttachmentStatusPreview }) => (
+  <span
+    className={clsx(
+      "rounded border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase",
+      BADGE_TONE[STATUS_TONE[status.type] ?? "zinc"],
+    )}
+  >
+    {statusLabel(status)}
+  </span>
+);
+
+export const ComposerAttachments = ({
+  attachments,
+}: {
+  attachments: readonly AttachmentPreview[];
+}) => {
+  if (!attachments.length) return null;
+
+  return (
+    <div className="overflow-hidden rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950/40">
+      <div className="border-b border-zinc-200 bg-zinc-100 px-3 py-1.5 text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
+        Attachments ({attachments.length})
+      </div>
+      <div className="divide-y divide-zinc-100 dark:divide-zinc-900">
+        {attachments.map((attachment, index) => (
+          <div
+            key={attachment.id ?? index}
+            className="flex flex-wrap items-center gap-2 px-3 py-1.5 text-[11px]"
+          >
+            <span className="font-medium text-zinc-800 dark:text-zinc-100">
+              {attachment.name}
+            </span>
+            {attachment.kind ? (
+              <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[9px] font-semibold tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300">
+                {attachment.kind}
+              </span>
+            ) : null}
+            {attachment.contentType ? (
+              <span className="text-[10px] text-zinc-400 dark:text-zinc-500">
+                {attachment.contentType}
+              </span>
+            ) : null}
+            {attachment.status ? (
+              <StatusBadge status={attachment.status} />
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/apps/devtools-frame/components/thread/ComposerAttachments.tsx
+++ b/apps/devtools-frame/components/thread/ComposerAttachments.tsx
@@ -1,5 +1,4 @@
-import clsx from "clsx";
-import { BADGE_TONE } from "../ui";
+import { ToneBadge } from "../ui";
 import type { BadgeTone } from "../ui";
 import type { AttachmentPreview, AttachmentStatusPreview } from "./types";
 
@@ -19,14 +18,7 @@ const statusLabel = (status: AttachmentStatusPreview) => {
 };
 
 const StatusBadge = ({ status }: { status: AttachmentStatusPreview }) => (
-  <span
-    className={clsx(
-      "rounded border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase",
-      BADGE_TONE[STATUS_TONE[status.type] ?? "zinc"],
-    )}
-  >
-    {statusLabel(status)}
-  </span>
+  <ToneBadge tone={STATUS_TONE[status.type]}>{statusLabel(status)}</ToneBadge>
 );
 
 export const ComposerAttachments = ({

--- a/apps/devtools-frame/components/thread/ComposerFlags.test.tsx
+++ b/apps/devtools-frame/components/thread/ComposerFlags.test.tsx
@@ -8,7 +8,7 @@ describe("ComposerFlags", () => {
       <ComposerFlags
         composer={{
           textLength: 0,
-          attachments: 0,
+          attachments: [],
           queue: [],
           isEditing: true,
           canSend: false,

--- a/apps/devtools-frame/components/thread/ThreadDetails.tsx
+++ b/apps/devtools-frame/components/thread/ThreadDetails.tsx
@@ -1,6 +1,7 @@
 import { formatBoolean } from "../common";
 import { MessageList } from "../message";
 import { SummaryItem } from "../ui";
+import { ComposerAttachments } from "./ComposerAttachments";
 import { ComposerFlags } from "./ComposerFlags";
 import { ComposerQueue } from "./ComposerQueue";
 import type { ThreadPreview } from "./types";
@@ -19,7 +20,7 @@ export const ThreadDetails = ({
       </div>
     ) : null}
     <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-      <SummaryItem label="Messages" value={String(thread.messageCount)} />
+      <SummaryItem label="Messages" value={String(thread.messages.length)} />
       {typeof thread.isLoading === "boolean" ? (
         <SummaryItem
           label="Loading"
@@ -86,13 +87,14 @@ export const ThreadDetails = ({
           />
           <SummaryItem
             label="Attachments"
-            value={String(thread.composer.attachments)}
+            value={String(thread.composer.attachments.length)}
           />
           {typeof thread.composer.type === "string" ? (
             <SummaryItem label="Mode" value={thread.composer.type} />
           ) : null}
         </div>
         <ComposerFlags composer={thread.composer} />
+        <ComposerAttachments attachments={thread.composer.attachments} />
         <ComposerQueue queue={thread.composer.queue} />
       </div>
     ) : null}

--- a/apps/devtools-frame/components/thread/index.ts
+++ b/apps/devtools-frame/components/thread/index.ts
@@ -1,4 +1,5 @@
 export { ThreadDetails } from "./ThreadDetails";
+export { ComposerAttachments } from "./ComposerAttachments";
 export { ComposerFlags } from "./ComposerFlags";
 export { ComposerQueue } from "./ComposerQueue";
 export {
@@ -9,7 +10,6 @@ export {
 } from "./utils";
 export type {
   ComposerPreview,
-  SuggestionPreview,
   ThreadListItemPreview,
   ThreadListPreview,
   ThreadPreview,

--- a/apps/devtools-frame/components/thread/render.test.tsx
+++ b/apps/devtools-frame/components/thread/render.test.tsx
@@ -6,13 +6,12 @@ import type { ThreadPreview } from "./types";
 describe("ThreadDetails composer queue", () => {
   it("renders the pending message queue and canSend", () => {
     const thread: ThreadPreview = {
-      messageCount: 0,
       messages: [],
       suggestions: [],
       capabilities: [],
       composer: {
         textLength: 0,
-        attachments: 0,
+        attachments: [],
         canSend: false,
         queue: [
           { id: "q1", prompt: "queued one" },
@@ -30,11 +29,10 @@ describe("ThreadDetails composer queue", () => {
 
   it("omits the queue section when empty", () => {
     const thread: ThreadPreview = {
-      messageCount: 0,
       messages: [],
       suggestions: [],
       capabilities: [],
-      composer: { textLength: 0, attachments: 0, queue: [] },
+      composer: { textLength: 0, attachments: [], queue: [] },
     };
 
     const html = renderToStaticMarkup(<ThreadDetails thread={thread} />);

--- a/apps/devtools-frame/components/thread/types.ts
+++ b/apps/devtools-frame/components/thread/types.ts
@@ -17,10 +17,24 @@ export interface ComposerQueueItem {
   prompt: string;
 }
 
+export interface AttachmentStatusPreview {
+  type: string;
+  reason?: string;
+  progress?: number;
+}
+
+export interface AttachmentPreview {
+  id?: string;
+  name: string;
+  kind?: string;
+  contentType?: string;
+  status?: AttachmentStatusPreview;
+}
+
 export interface ComposerPreview {
   textLength: number;
   role?: string;
-  attachments: number;
+  attachments: AttachmentPreview[];
   isEditing?: boolean;
   canCancel?: boolean;
   canSend?: boolean;
@@ -33,7 +47,6 @@ export interface ThreadPreview {
   isDisabled?: boolean;
   isLoading?: boolean;
   isRunning?: boolean;
-  messageCount: number;
   messages: MessagePreview[];
   suggestions: SuggestionPreview[];
   capabilities: string[];

--- a/apps/devtools-frame/components/thread/utils.test.ts
+++ b/apps/devtools-frame/components/thread/utils.test.ts
@@ -32,4 +32,41 @@ describe("parseComposerPreview", () => {
     const composer = parseComposerPreview({ text: "", attachments: [] });
     expect(composer?.queue).toEqual([]);
   });
+
+  it("parses attachments with kind, contentType, and upload status", () => {
+    const composer = parseComposerPreview({
+      text: "",
+      attachments: [
+        {
+          id: "a1",
+          type: "image",
+          name: "photo.png",
+          contentType: "image/png",
+          status: { type: "running", reason: "uploading", progress: 0.5 },
+        },
+        {
+          id: "a2",
+          type: "file",
+          name: "doc.pdf",
+          status: { type: "complete" },
+        },
+      ],
+    });
+    expect(composer?.attachments).toHaveLength(2);
+    expect(composer?.attachments[0]).toMatchObject({
+      name: "photo.png",
+      kind: "image",
+      contentType: "image/png",
+      status: { type: "running", reason: "uploading", progress: 0.5 },
+    });
+    expect(composer?.attachments[1]?.status).toEqual({ type: "complete" });
+  });
+
+  it("falls back to the id for a nameless attachment", () => {
+    const composer = parseComposerPreview({
+      text: "",
+      attachments: [{ id: "x" }],
+    });
+    expect(composer?.attachments).toEqual([{ name: "x", id: "x" }]);
+  });
 });

--- a/apps/devtools-frame/components/thread/utils.ts
+++ b/apps/devtools-frame/components/thread/utils.ts
@@ -2,6 +2,8 @@ import { isRecord, isStringArray } from "../common";
 import { parseMessage } from "../message";
 import type { MessagePreview } from "../message";
 import type {
+  AttachmentPreview,
+  AttachmentStatusPreview,
   ComposerPreview,
   ComposerQueueItem,
   SuggestionPreview,
@@ -10,12 +12,41 @@ import type {
   ThreadPreview,
 } from "./types";
 
-export const parseSuggestionPreview = (
-  value: unknown,
-): SuggestionPreview | null => {
+const parseSuggestionPreview = (value: unknown): SuggestionPreview | null => {
   if (!isRecord(value)) return null;
   if (typeof value.prompt !== "string") return null;
   return { prompt: value.prompt };
+};
+
+const parseAttachmentStatus = (
+  value: unknown,
+): AttachmentStatusPreview | undefined => {
+  if (!isRecord(value) || typeof value.type !== "string") return undefined;
+  return {
+    type: value.type,
+    ...(typeof value.reason === "string" ? { reason: value.reason } : {}),
+    ...(typeof value.progress === "number" ? { progress: value.progress } : {}),
+  };
+};
+
+const parseAttachment = (value: unknown): AttachmentPreview | null => {
+  if (!isRecord(value)) return null;
+  const name =
+    typeof value.name === "string" && value.name
+      ? value.name
+      : typeof value.id === "string"
+        ? value.id
+        : "(attachment)";
+  const status = parseAttachmentStatus(value.status);
+  return {
+    name,
+    ...(typeof value.id === "string" ? { id: value.id } : {}),
+    ...(typeof value.type === "string" ? { kind: value.type } : {}),
+    ...(typeof value.contentType === "string"
+      ? { contentType: value.contentType }
+      : {}),
+    ...(status ? { status } : {}),
+  };
 };
 
 export const parseComposerPreview = (
@@ -25,8 +56,10 @@ export const parseComposerPreview = (
 
   const text = typeof value.text === "string" ? value.text : "";
   const attachments = Array.isArray(value.attachments)
-    ? value.attachments.length
-    : 0;
+    ? value.attachments
+        .map((item) => parseAttachment(item))
+        .filter((item): item is AttachmentPreview => Boolean(item))
+    : [];
   const queue = Array.isArray(value.queue)
     ? value.queue
         .map((item) => {
@@ -101,7 +134,6 @@ export const parseThreadPreview = (value: unknown): ThreadPreview | null => {
   const composer = parseComposerPreview(value.composer);
 
   return {
-    messageCount: messages.length,
     messages,
     suggestions,
     capabilities,

--- a/apps/devtools-frame/components/ui/EmptyState.tsx
+++ b/apps/devtools-frame/components/ui/EmptyState.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export const EmptyState = ({ children }: { children: ReactNode }) => (
+  <div className="flex h-full items-center justify-center">
+    <div className="rounded-lg border border-dashed border-zinc-300 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
+      {children}
+    </div>
+  </div>
+);

--- a/apps/devtools-frame/components/ui/ToneBadge.tsx
+++ b/apps/devtools-frame/components/ui/ToneBadge.tsx
@@ -1,0 +1,24 @@
+import clsx from "clsx";
+import type { ReactNode } from "react";
+import { BADGE_TONE } from "./badgeTone";
+import type { BadgeTone } from "./badgeTone";
+
+export const ToneBadge = ({
+  tone,
+  className,
+  children,
+}: {
+  tone?: BadgeTone | undefined;
+  className?: string | undefined;
+  children: ReactNode;
+}) => (
+  <span
+    className={clsx(
+      "rounded border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase",
+      BADGE_TONE[tone ?? "zinc"],
+      className,
+    )}
+  >
+    {children}
+  </span>
+);

--- a/apps/devtools-frame/components/ui/badgeTone.ts
+++ b/apps/devtools-frame/components/ui/badgeTone.ts
@@ -1,0 +1,11 @@
+export const BADGE_TONE = {
+  blue: "border-blue-300 bg-blue-500/10 text-blue-700 dark:border-blue-500/40 dark:bg-blue-500/15 dark:text-blue-300",
+  emerald:
+    "border-emerald-300 bg-emerald-500/10 text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/15 dark:text-emerald-300",
+  amber:
+    "border-amber-300 bg-amber-500/10 text-amber-700 dark:border-amber-500/40 dark:bg-amber-500/15 dark:text-amber-300",
+  red: "border-red-300 bg-red-500/10 text-red-700 dark:border-red-500/40 dark:bg-red-500/15 dark:text-red-300",
+  zinc: "border-zinc-300 bg-zinc-500/10 text-zinc-600 dark:border-zinc-600 dark:bg-zinc-500/15 dark:text-zinc-300",
+} as const;
+
+export type BadgeTone = keyof typeof BADGE_TONE;

--- a/apps/devtools-frame/components/ui/index.ts
+++ b/apps/devtools-frame/components/ui/index.ts
@@ -1,5 +1,8 @@
+export { BADGE_TONE } from "./badgeTone";
+export type { BadgeTone } from "./badgeTone";
 export { CenteredMessage } from "./CenteredMessage";
 export { ControlButton } from "./ControlButton";
+export { EmptyState } from "./EmptyState";
 export { InfoCard } from "./InfoCard";
 export { JSONPreview } from "./JSONPreview";
 export { SectionTitle } from "./SectionTitle";

--- a/apps/devtools-frame/components/ui/index.ts
+++ b/apps/devtools-frame/components/ui/index.ts
@@ -7,3 +7,4 @@ export { InfoCard } from "./InfoCard";
 export { JSONPreview } from "./JSONPreview";
 export { SectionTitle } from "./SectionTitle";
 export { SummaryItem } from "./SummaryItem";
+export { ToneBadge } from "./ToneBadge";


### PR DESCRIPTION
## summary

- surface the composer attachment lifecycle in the devtools: each pending attachment renders with its name, kind, content type, and a colored upload-status badge (uploading 50%, complete, requires-action, ...)
- merge the redundant attachment count into a single attachments array, and drop the derivable messageCount from the thread preview
- tidy the frame internals alongside: remove ui-derivable fields (tool-call hasResult, run running), drop dead exports and the no-op RunLogEntry alias, trim the mcp barrel
- dedupe shared ui into a BADGE_TONE palette and an EmptyState component, and move the McpView render test into the mcp folder

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/devtools-frame test` -> 55/55 green (14 files)
- [x] `tsc --noEmit` clean on the branch tip and on the refactor commit alone
- [x] `pnpm --filter @assistant-ui/devtools-frame build` -> next build compiles

### reviewer should verify

- [ ] open the devtools, attach a file in the composer, and confirm the state tab's composer block lists it with name, kind, content type, and a status badge that tracks the upload through to complete

## notes

- frame-only (apps/devtools-frame is the private vercel-deployed iframe ui); no changeset, the published @assistant-ui/react-devtools package and its postMessage wire protocol are unchanged