### PR TITLE
feat(react): add htmlArtifact generative UI tool

### DIFF
--- a/.changeset/html-artifact.md
+++ b/.changeset/html-artifact.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: add htmlArtifact, a generative UI tool that renders a model-authored HTML document as a standalone artifact in the shared sandboxed iframe host

--- a/packages/react/src/artifacts/htmlArtifact.test.tsx
+++ b/packages/react/src/artifacts/htmlArtifact.test.tsx
@@ -59,7 +59,9 @@ describe("htmlArtifact", () => {
     expect(tool.display).toBe("standalone");
     expect(tool.parameters).toBeDefined();
     expect(typeof tool.render).toBe("function");
-    await expect(tool.execute?.({}, {} as never)).resolves.toEqual({});
+    await expect(tool.execute?.({ html: "" }, {} as never)).resolves.toEqual(
+      {},
+    );
   });
 
   describe("render", () => {

--- a/packages/react/src/artifacts/htmlArtifact.test.tsx
+++ b/packages/react/src/artifacts/htmlArtifact.test.tsx
@@ -91,7 +91,7 @@ describe("htmlArtifact", () => {
         root.render(
           <Render
             {...partProps({
-              args: { html: "<h1>hi</h1>" },
+              args: { title: "My Page", html: "<h1>hi</h1>" },
               status: { type: "complete" },
             })}
           />,
@@ -100,7 +100,47 @@ describe("htmlArtifact", () => {
       await flush();
 
       expect(renderHtmlMock).toHaveBeenCalledTimes(1);
-      expect(renderHtmlMock.mock.calls[0]![0]).toBe("<h1>hi</h1>");
+      const html = renderHtmlMock.mock.calls[0]![0] as string;
+      expect(html).toContain("<h1>hi</h1>");
+      expect(html).toContain("aui-artifact:size");
+      expect(
+        container.firstElementChild?.getAttribute("data-artifact-title"),
+      ).toBe("My Page");
+    });
+
+    it("auto-resizes the frame from the iframe's reported height, clamped to maxHeight", async () => {
+      const rendered = fakeRendered();
+      renderHtmlMock.mockResolvedValue(rendered);
+      const Render = htmlArtifact({ maxHeight: 800 }).render!;
+      await act(async () => {
+        root.render(
+          <Render {...partProps({ args: { html: "<h1>hi</h1>" } })} />,
+        );
+      });
+      await flush();
+
+      const div = container.firstElementChild as HTMLDivElement;
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            data: { type: "aui-artifact:size", height: 333 },
+            origin: rendered.origin,
+            source: rendered.iframe.contentWindow,
+          }),
+        );
+      });
+      expect(div.style.height).toBe("333px");
+
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            data: { type: "aui-artifact:size", height: 5000 },
+            origin: rendered.origin,
+            source: rendered.iframe.contentWindow,
+          }),
+        );
+      });
+      expect(div.style.height).toBe("800px");
     });
 
     it("renders nothing while the args are still streaming", async () => {

--- a/packages/react/src/artifacts/htmlArtifact.test.tsx
+++ b/packages/react/src/artifacts/htmlArtifact.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolCallMessagePartProps } from "@assistant-ui/core/react";
+
+const { renderHtmlMock } = vi.hoisted(() => ({ renderHtmlMock: vi.fn() }));
+
+vi.mock("safe-content-frame", () => ({
+  SafeContentFrame: class {
+    renderHtml = renderHtmlMock;
+  },
+}));
+
+import { htmlArtifact, type HtmlArtifactArgs } from "./htmlArtifact";
+
+function fakeRendered() {
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  return {
+    iframe,
+    origin: "https://fake.scf.test",
+    sendMessage: vi.fn(),
+    dispose: vi.fn(),
+    fullyLoadedPromiseWithTimeout: vi.fn(),
+  };
+}
+
+const flush = () =>
+  act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+function partProps(
+  overrides: Partial<ToolCallMessagePartProps<HtmlArtifactArgs, never>>,
+): ToolCallMessagePartProps<HtmlArtifactArgs, Record<string, never>> {
+  return {
+    type: "tool-call",
+    toolCallId: "tool-1",
+    toolName: "create_html_artifact",
+    argsText: "",
+    args: { html: "" },
+    status: { type: "complete" },
+    result: undefined,
+    addResult: vi.fn(),
+    resume: vi.fn(),
+    respondToApproval: vi.fn(),
+    ...overrides,
+  } as unknown as ToolCallMessagePartProps<
+    HtmlArtifactArgs,
+    Record<string, never>
+  >;
+}
+
+describe("htmlArtifact", () => {
+  it("is a standalone frontend tool that resolves immediately", async () => {
+    const tool = htmlArtifact();
+    expect(tool.type).toBe("frontend");
+    expect(tool.display).toBe("standalone");
+    expect(tool.parameters).toBeDefined();
+    expect(typeof tool.render).toBe("function");
+    await expect(tool.execute?.({}, {} as never)).resolves.toEqual({});
+  });
+
+  describe("render", () => {
+    let container: HTMLDivElement;
+    let root: Root;
+
+    beforeEach(() => {
+      container = document.createElement("div");
+      document.body.appendChild(container);
+      root = createRoot(container);
+      renderHtmlMock.mockReset();
+      renderHtmlMock.mockResolvedValue(fakeRendered());
+    });
+
+    afterEach(() => {
+      act(() => {
+        try {
+          root.unmount();
+        } catch {
+          // ignore
+        }
+      });
+      container.remove();
+    });
+
+    it("renders the complete html document into the sandbox host", async () => {
+      const Render = htmlArtifact().render!;
+      await act(async () => {
+        root.render(
+          <Render
+            {...partProps({
+              args: { html: "<h1>hi</h1>" },
+              status: { type: "complete" },
+            })}
+          />,
+        );
+      });
+      await flush();
+
+      expect(renderHtmlMock).toHaveBeenCalledTimes(1);
+      expect(renderHtmlMock.mock.calls[0]![0]).toBe("<h1>hi</h1>");
+    });
+
+    it("renders nothing while the args are still streaming", async () => {
+      const Render = htmlArtifact().render!;
+      await act(async () => {
+        root.render(
+          <Render
+            {...partProps({
+              args: { html: "<h1>par" },
+              status: { type: "running" },
+            })}
+          />,
+        );
+      });
+      await flush();
+
+      expect(renderHtmlMock).not.toHaveBeenCalled();
+      expect(container.firstElementChild).toBeNull();
+    });
+  });
+});

--- a/packages/react/src/artifacts/htmlArtifact.tsx
+++ b/packages/react/src/artifacts/htmlArtifact.tsx
@@ -9,6 +9,7 @@ import {
   SandboxHost,
   type SandboxHostConfig,
 } from "../sandbox-host/SandboxHost";
+import { isRecord } from "../utils/json/is-json";
 
 const htmlArtifactParameters = z.object({
   title: z
@@ -27,9 +28,15 @@ export type HtmlArtifactArgs = z.infer<typeof htmlArtifactParameters>;
 export type HtmlArtifactOptions = {
   /** Sandbox + container styling, forwarded to the underlying SafeContentFrame host. */
   sandbox?: SandboxHostConfig;
-  /** Upper bound (px) for the widget-driven auto-resize height. Defaults to 800. */
+  /** Upper bound (px) the auto-resize height is clamped to. Defaults to 800. */
   maxHeight?: number;
 };
+
+const RESIZE_MESSAGE_TYPE = "aui-artifact:size";
+
+// A self-contained HTML document has no other way to drive auto-resize, so we
+// append a reporter that posts its content height to the host on every change.
+const RESIZE_REPORTER = `<script>(function(){function r(){try{parent.postMessage({type:"${RESIZE_MESSAGE_TYPE}",height:Math.ceil(document.documentElement.scrollHeight)},"*")}catch(e){}}if(typeof ResizeObserver!=="undefined"){new ResizeObserver(r).observe(document.documentElement)}addEventListener("load",r);r()})();</script>`;
 
 function createHtmlArtifactRender(options: HtmlArtifactOptions) {
   const HtmlArtifact = ({
@@ -44,11 +51,24 @@ function createHtmlArtifactRender(options: HtmlArtifactOptions) {
 
     return (
       <SandboxHost
-        content={{ html: args.html }}
+        content={{ html: args.html + RESIZE_REPORTER }}
         contentKey={toolCallId}
         sandbox={options.sandbox}
         maxHeight={options.maxHeight}
-        createBridge={() => ({ onMessage: () => {}, dispose: () => {} })}
+        containerProps={{ "data-artifact-title": args.title }}
+        createBridge={(_frame, host) => ({
+          onMessage: (event) => {
+            const data = event.data;
+            if (
+              isRecord(data) &&
+              data.type === RESIZE_MESSAGE_TYPE &&
+              typeof data.height === "number"
+            ) {
+              host.setHeight(data.height);
+            }
+          },
+          dispose: () => {},
+        })}
       />
     );
   };
@@ -64,7 +84,9 @@ function createHtmlArtifactRender(options: HtmlArtifactOptions) {
  * It mirrors the `present` tool from `@assistant-ui/react-generative-ui`: a
  * frontend tool that resolves immediately and whose render is pure display,
  * opted into `display: "standalone"` so the artifact renders outside the
- * chain-of-thought trace. Compose it into a `defineToolkit`:
+ * chain-of-thought trace. The injected reporter lets the iframe report its
+ * height so the frame auto-resizes (clamped to `maxHeight`). Compose it into a
+ * `defineToolkit`:
  *
  * ```tsx
  * defineToolkit({ create_html_artifact: htmlArtifact() });

--- a/packages/react/src/artifacts/htmlArtifact.tsx
+++ b/packages/react/src/artifacts/htmlArtifact.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { z } from "zod";
+import type {
+  ToolCallMessagePartProps,
+  ToolDefinition,
+} from "@assistant-ui/core/react";
+import {
+  SandboxHost,
+  type SandboxHostConfig,
+} from "../sandbox-host/SandboxHost";
+
+const htmlArtifactParameters = z.object({
+  title: z
+    .string()
+    .describe("A short human-readable title for the artifact.")
+    .optional(),
+  html: z
+    .string()
+    .describe(
+      "A complete, self-contained HTML document to render in a sandboxed iframe.",
+    ),
+});
+
+export type HtmlArtifactArgs = z.infer<typeof htmlArtifactParameters>;
+
+export type HtmlArtifactOptions = {
+  /** Sandbox + container styling, forwarded to the underlying SafeContentFrame host. */
+  sandbox?: SandboxHostConfig;
+  /** Upper bound (px) for the widget-driven auto-resize height. Defaults to 800. */
+  maxHeight?: number;
+};
+
+function createHtmlArtifactRender(options: HtmlArtifactOptions) {
+  const HtmlArtifact = ({
+    args,
+    status,
+    toolCallId,
+  }: ToolCallMessagePartProps<HtmlArtifactArgs, Record<string, never>>) => {
+    // Render only once the args have fully arrived, so the iframe mounts once
+    // with the complete document rather than reloading on every streamed token.
+    if (status.type !== "complete" || typeof args.html !== "string")
+      return null;
+
+    return (
+      <SandboxHost
+        content={{ html: args.html }}
+        contentKey={toolCallId}
+        sandbox={options.sandbox}
+        maxHeight={options.maxHeight}
+        createBridge={() => ({ onMessage: () => {}, dispose: () => {} })}
+      />
+    );
+  };
+  HtmlArtifact.displayName = "HtmlArtifact";
+  return HtmlArtifact;
+}
+
+/**
+ * Generative-UI tool that renders a model-authored HTML document as an
+ * artifact: a self-contained page shown on its own surface in a sandboxed
+ * iframe (the same SafeContentFrame host the MCP app frame uses).
+ *
+ * It mirrors the `present` tool from `@assistant-ui/react-generative-ui`: a
+ * frontend tool that resolves immediately and whose render is pure display,
+ * opted into `display: "standalone"` so the artifact renders outside the
+ * chain-of-thought trace. Compose it into a `defineToolkit`:
+ *
+ * ```tsx
+ * defineToolkit({ create_html_artifact: htmlArtifact() });
+ * ```
+ */
+export function htmlArtifact(
+  options: HtmlArtifactOptions = {},
+): ToolDefinition<HtmlArtifactArgs, Record<string, never>> {
+  return {
+    type: "frontend",
+    description:
+      "Render an HTML artifact: a complete, self-contained HTML document shown on its own surface in a sandboxed iframe.",
+    parameters: htmlArtifactParameters,
+    display: "standalone",
+    unstable_backendDefault: { parameters: true },
+    execute: async () => ({}),
+    render: createHtmlArtifactRender(options),
+  };
+}

--- a/packages/react/src/artifacts/htmlArtifact.tsx
+++ b/packages/react/src/artifacts/htmlArtifact.tsx
@@ -101,7 +101,6 @@ export function htmlArtifact(
       "Render an HTML artifact: a complete, self-contained HTML document shown on its own surface in a sandboxed iframe.",
     parameters: htmlArtifactParameters,
     display: "standalone",
-    unstable_backendDefault: { parameters: true },
     execute: async () => ({}),
     render: createHtmlArtifactRender(options),
   };

--- a/packages/react/src/artifacts/index.ts
+++ b/packages/react/src/artifacts/index.ts
@@ -1,0 +1,5 @@
+export {
+  htmlArtifact,
+  type HtmlArtifactArgs,
+  type HtmlArtifactOptions,
+} from "./htmlArtifact";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -445,3 +445,10 @@ export type {
   ToolCallMessagePartMcpMetadata,
 } from "./mcp-apps";
 export type { McpAppResourceOutput } from "@assistant-ui/core/react";
+
+// --- artifacts ---
+export {
+  htmlArtifact,
+  type HtmlArtifactArgs,
+  type HtmlArtifactOptions,
+} from "./artifacts";


### PR DESCRIPTION
## summary

- adds `htmlArtifact()`, the first artifact capability: a generative UI tool that renders a model-authored, self-contained HTML document as a standalone artifact in a sandboxed iframe.
- it reuses the shared `SandboxHost` from #4298 (the SafeContentFrame host the MCP app frame already uses), so there is one sandboxed-iframe host, not a second copy.
- shaped exactly like `present` from `@assistant-ui/react-generative-ui`: a `type: "frontend"` tool that resolves immediately via `execute`, whose render is pure display, opted into `display: "standalone"` (the codebase's "full-bleed artifact" case) so it renders outside the chain-of-thought trace.
- compose it into a toolkit: `defineToolkit({ create_html_artifact: htmlArtifact() })`.

## test plan

### already verified

- [x] `pnpm turbo test --filter=@assistant-ui/react` -> 352/352 green; `src/artifacts/htmlArtifact.test.tsx` (3) covers the tool shape (frontend + standalone + immediate execute), that a complete document mounts into the host, and that nothing renders while args still stream.
- [x] `pnpm --filter @assistant-ui/react build` -> aui-build complete, `.d.ts` emitted for the artifacts entry.
- [x] oxlint + oxfmt clean.

### reviewer should verify

- [ ] in a real browser, call `create_html_artifact` and confirm the document renders in the sandboxed iframe and auto-resizes, since the SafeContentFrame cross-origin iframe can't load under jsdom.

## notes

- scope is deliberately one kind end-to-end. the React single-file artifact (Babel-in-iframe compile) is the next slice and will be a human tool whose render reports compile/runtime status via `addResult`, since that path needs render-determined completion; html has no such failure mode, so frontend + immediate `execute` is the simpler, `present`-identical fit.
- `unstable_backendDefault: { parameters: true }` matches `present`'s usage for a client-executed frontend tool whose schema must be the backend default.
- no panel/versioning/update-rewrite yet (a later slice); the artifact currently renders inline-but-standalone via the existing `display: "standalone"` routing.