### PR TITLE
feat(devtools): redesign the panel ui onto the product design system

### DIFF
--- a/apps/devtools-frame/app/globals.css
+++ b/apps/devtools-frame/app/globals.css
@@ -1,16 +1,118 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
+@theme inline {
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.141 0.005 285.823);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.141 0.005 285.823);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.141 0.005 285.823);
+  --primary: oklch(0.21 0.006 285.885);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.552 0.016 285.938);
+  --accent: oklch(0.967 0.001 286.375);
+  --accent-foreground: oklch(0.21 0.006 285.885);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.92 0.004 286.32);
+  --input: oklch(0.92 0.004 286.32);
+  --ring: oklch(0.705 0.015 286.067);
+}
+
+/* Dark token values, shared by the explicit `.dark` class and the OS preference. */
+@layer theme {
+  .dark {
+    --background: oklch(0.141 0.005 285.823);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.21 0.006 285.885);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.21 0.006 285.885);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.92 0.004 286.32);
+    --primary-foreground: oklch(0.21 0.006 285.885);
+    --secondary: oklch(0.274 0.006 286.033);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.274 0.006 286.033);
+    --muted-foreground: oklch(0.705 0.015 286.067);
+    --accent: oklch(0.274 0.006 286.033);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --border: oklch(1 0 0 / 10%);
+    --input: oklch(1 0 0 / 15%);
+    --ring: oklch(0.552 0.016 285.938);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not(.light) {
+      --background: oklch(0.141 0.005 285.823);
+      --foreground: oklch(0.985 0 0);
+      --card: oklch(0.21 0.006 285.885);
+      --card-foreground: oklch(0.985 0 0);
+      --popover: oklch(0.21 0.006 285.885);
+      --popover-foreground: oklch(0.985 0 0);
+      --primary: oklch(0.92 0.004 286.32);
+      --primary-foreground: oklch(0.21 0.006 285.885);
+      --secondary: oklch(0.274 0.006 286.033);
+      --secondary-foreground: oklch(0.985 0 0);
+      --muted: oklch(0.274 0.006 286.033);
+      --muted-foreground: oklch(0.705 0.015 286.067);
+      --accent: oklch(0.274 0.006 286.033);
+      --accent-foreground: oklch(0.985 0 0);
+      --destructive: oklch(0.704 0.191 22.216);
+      --border: oklch(1 0 0 / 10%);
+      --input: oklch(1 0 0 / 15%);
+      --ring: oklch(0.552 0.016 285.938);
+    }
+  }
+}
+
 @layer base {
-  :root {
-    color-scheme: light dark;
+  *,
+  *::before,
+  *::after {
+    @apply border-border box-border;
+  }
+
+  *:focus-visible {
+    @apply ring-ring/50 ring-[3px] outline-none;
   }
 
   html,
   body {
-    @apply m-0 h-full min-h-full bg-neutral-50 text-zinc-900 antialiased;
-  }
+    @apply bg-background text-foreground m-0 h-full min-h-full antialiased;
 
-  * {
-    @apply box-border;
+    font-family: var(--font-sans);
   }
 }

--- a/apps/devtools-frame/app/globals.css
+++ b/apps/devtools-frame/app/globals.css
@@ -51,51 +51,27 @@
   --ring: oklch(0.705 0.015 286.067);
 }
 
-/* Dark token values, shared by the explicit `.dark` class and the OS preference. */
-@layer theme {
-  .dark {
-    --background: oklch(0.141 0.005 285.823);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.21 0.006 285.885);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.21 0.006 285.885);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.92 0.004 286.32);
-    --primary-foreground: oklch(0.21 0.006 285.885);
-    --secondary: oklch(0.274 0.006 286.033);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.274 0.006 286.033);
-    --muted-foreground: oklch(0.705 0.015 286.067);
-    --accent: oklch(0.274 0.006 286.033);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.552 0.016 285.938);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    :root:not(.light) {
-      --background: oklch(0.141 0.005 285.823);
-      --foreground: oklch(0.985 0 0);
-      --card: oklch(0.21 0.006 285.885);
-      --card-foreground: oklch(0.985 0 0);
-      --popover: oklch(0.21 0.006 285.885);
-      --popover-foreground: oklch(0.985 0 0);
-      --primary: oklch(0.92 0.004 286.32);
-      --primary-foreground: oklch(0.21 0.006 285.885);
-      --secondary: oklch(0.274 0.006 286.033);
-      --secondary-foreground: oklch(0.985 0 0);
-      --muted: oklch(0.274 0.006 286.033);
-      --muted-foreground: oklch(0.705 0.015 286.067);
-      --accent: oklch(0.274 0.006 286.033);
-      --accent-foreground: oklch(0.985 0 0);
-      --destructive: oklch(0.704 0.191 22.216);
-      --border: oklch(1 0 0 / 10%);
-      --input: oklch(1 0 0 / 15%);
-      --ring: oklch(0.552 0.016 285.938);
-    }
-  }
+/* Dark tokens stay unlayered so they win over the unlayered `:root` light block
+   by source order; the layout themeScript toggles `.dark` from prefers-color-scheme. */
+.dark {
+  --background: oklch(0.141 0.005 285.823);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.21 0.006 285.885);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.21 0.006 285.885);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.92 0.004 286.32);
+  --primary-foreground: oklch(0.21 0.006 285.885);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.274 0.006 286.033);
+  --muted-foreground: oklch(0.705 0.015 286.067);
+  --accent: oklch(0.274 0.006 286.033);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.552 0.016 285.938);
 }
 
 @layer base {

--- a/apps/devtools-frame/app/layout.tsx
+++ b/apps/devtools-frame/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -6,14 +8,26 @@ export const metadata: Metadata = {
   description: "DevTools interface for assistant-ui",
 };
 
+const themeScript = `try {
+  var m = window.matchMedia('(prefers-color-scheme: dark)');
+  var apply = function () {
+    document.documentElement.classList.toggle('dark', m.matches);
+  };
+  apply();
+  m.addEventListener('change', apply);
+} catch (e) {}`;
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className="h-full">{children}</body>
+    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
+      <body className="h-full">
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+        {children}
+      </body>
     </html>
   );
 }

--- a/apps/devtools-frame/components/DevToolsUI.tsx
+++ b/apps/devtools-frame/components/DevToolsUI.tsx
@@ -31,9 +31,11 @@ import {
 } from "./thread";
 import {
   CenteredMessage,
+  Chip,
   ControlButton,
   EmptyState,
   JSONPreview,
+  SectionLabel,
   SummaryItem,
 } from "./ui";
 
@@ -64,7 +66,22 @@ interface ApiData {
   scopes?: any;
 }
 
-type TabType = "state" | "events" | "modelContext" | "runs" | "scopes";
+type TabType = "thread" | "context" | "activity" | "raw";
+
+const TAB_LABELS: Record<TabType, string> = {
+  thread: "Thread",
+  context: "Context",
+  activity: "Activity",
+  raw: "Raw",
+};
+
+const THREAD_STATE_KEYS = new Set([
+  "threads",
+  "thread",
+  "threadListItem",
+  "threadlistitem",
+  "composer",
+]);
 
 const parseEventTime = (value: unknown): Date => {
   if (typeof value === "string") {
@@ -108,8 +125,8 @@ const renderToolUIsStatePreview = (value: unknown) => {
   const entries = Object.entries(value);
   if (entries.length === 0) {
     return (
-      <div className="text-[11px] text-zinc-500 dark:text-zinc-400">
-        &lt;no tool UI mappings&gt;
+      <div className="text-muted-foreground text-[11px]">
+        no tool UI mappings
       </div>
     );
   }
@@ -123,18 +140,16 @@ const renderToolUIsStatePreview = (value: unknown) => {
         return (
           <div
             key={toolName}
-            className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] text-zinc-700 transition-colors dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-200"
+            className="bg-muted/40 text-foreground rounded-md border p-3 text-[11px] transition-colors"
           >
             <div className="flex items-center justify-between gap-2">
-              <span className="font-semibold text-zinc-800 dark:text-zinc-100">
-                {toolName}
-              </span>
-              <span className="text-[10px] tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
+              <span className="text-foreground font-medium">{toolName}</span>
+              <Chip>
                 {list.length} component{list.length === 1 ? "" : "s"}
-              </span>
+              </Chip>
             </div>
             {firstEntry ? (
-              <div className="mt-1 text-[10px] text-zinc-500 dark:text-zinc-400">
+              <div className="text-muted-foreground mt-1 text-[10px]">
                 First entry: {truncate(firstEntry, 80)}
               </div>
             ) : null}
@@ -159,44 +174,39 @@ const renderThreadsStatePreview = (value: unknown) => {
   return (
     <div className="flex flex-col gap-4">
       <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-        <SummaryItem label="Main Thread" value={state.mainThreadId ?? "—"} />
-        <SummaryItem label="New Thread" value={state.newThreadId ?? "—"} />
-        <SummaryItem label="Active Threads" value={String(activeCount)} />
-        <SummaryItem label="Archived Threads" value={String(archivedCount)} />
+        <SummaryItem label="Main thread" value={state.mainThreadId ?? "—"} />
+        <SummaryItem label="New thread" value={state.newThreadId ?? "—"} />
+        <SummaryItem label="Active threads" value={String(activeCount)} />
+        <SummaryItem label="Archived threads" value={String(archivedCount)} />
       </div>
 
       {threadItems.length ? (
         <div className="flex flex-col gap-2">
-          <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-            Thread Items ({state.threadItems.length})
-          </div>
-          <div className="overflow-hidden rounded-md border border-zinc-200 dark:border-zinc-800">
+          <SectionLabel>Thread items ({state.threadItems.length})</SectionLabel>
+          <div className="bg-card overflow-hidden rounded-lg border">
             <table className="w-full table-fixed border-collapse text-left">
-              <thead className="bg-zinc-100 text-[10px] tracking-wide text-zinc-500 uppercase dark:bg-zinc-900 dark:text-zinc-400">
+              <thead className="bg-muted text-muted-foreground text-[10px]">
                 <tr>
-                  <th className="px-3 py-2">Title</th>
-                  <th className="px-3 py-2">Status</th>
-                  <th className="px-3 py-2">Identifiers</th>
+                  <th className="px-3 py-2 font-medium">Title</th>
+                  <th className="px-3 py-2 font-medium">Status</th>
+                  <th className="px-3 py-2 font-medium">Identifiers</th>
                 </tr>
               </thead>
-              <tbody className="text-[11px] text-zinc-700 dark:text-zinc-200">
+              <tbody className="text-foreground text-[11px]">
                 {threadItems.map((item) => (
-                  <tr
-                    key={item.id}
-                    className="border-t border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950/40"
-                  >
+                  <tr key={item.id} className="bg-card border-t">
                     <td className="px-3 py-2 align-top">
-                      <div className="font-medium text-zinc-800 dark:text-zinc-100">
+                      <div className="text-foreground font-medium">
                         {item.title || "(untitled)"}
                       </div>
-                      <div className="text-[10px] text-zinc-500 dark:text-zinc-400">
-                        ID: {item.id}
+                      <div className="text-muted-foreground font-mono text-[10px]">
+                        {item.id}
                       </div>
                     </td>
                     <td className="px-3 py-2 align-top">
                       {item.status ?? "—"}
                     </td>
-                    <td className="px-3 py-2 align-top text-[10px] text-zinc-500 dark:text-zinc-400">
+                    <td className="text-muted-foreground px-3 py-2 align-top font-mono text-[10px]">
                       {item.remoteId ? `Remote: ${item.remoteId}` : null}
                       {item.remoteId && item.externalId ? <br /> : null}
                       {item.externalId ? `External: ${item.externalId}` : null}
@@ -208,7 +218,7 @@ const renderThreadsStatePreview = (value: unknown) => {
             </table>
           </div>
           {state.threadItems.length > threadItems.length ? (
-            <div className="text-[10px] text-zinc-500 dark:text-zinc-400">
+            <div className="text-muted-foreground text-[10px]">
               Showing first {threadItems.length} items
             </div>
           ) : null}
@@ -216,7 +226,7 @@ const renderThreadsStatePreview = (value: unknown) => {
       ) : null}
 
       {main ? (
-        <ThreadDetails thread={main} title="Main Thread Overview" />
+        <ThreadDetails thread={main} title="Main thread overview" />
       ) : null}
     </div>
   );
@@ -227,7 +237,7 @@ const renderThreadStatePreview = (value: unknown) => {
   if (!thread) {
     return <JSONPreview value={value} />;
   }
-  return <ThreadDetails thread={thread} title="Thread Overview" />;
+  return <ThreadDetails thread={thread} title="Thread overview" />;
 };
 
 const renderThreadListItemStatePreview = (value: unknown) => {
@@ -260,7 +270,7 @@ const renderComposerStatePreview = (value: unknown) => {
     <div className="flex flex-col gap-3">
       <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
         <SummaryItem label="Role" value={composer.role ?? "—"} />
-        <SummaryItem label="Text Length" value={String(composer.textLength)} />
+        <SummaryItem label="Text length" value={String(composer.textLength)} />
         <SummaryItem
           label="Attachments"
           value={String(composer.attachments.length)}
@@ -270,20 +280,16 @@ const renderComposerStatePreview = (value: unknown) => {
       <ComposerFlags composer={composer} />
       <ComposerAttachments attachments={composer.attachments} />
       {text ? (
-        <div className="rounded-md border border-zinc-200 bg-white p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-950/40 dark:text-zinc-200">
-          <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-            Text Preview
-          </div>
-          <div className="mt-1 wrap-break-word whitespace-pre-wrap text-zinc-700 dark:text-zinc-200">
+        <div className="bg-card text-foreground flex flex-col gap-1 rounded-md border p-3 text-[11px]">
+          <SectionLabel>Text preview</SectionLabel>
+          <div className="text-foreground wrap-break-word whitespace-pre-wrap">
             {truncate(text, 240)}
           </div>
         </div>
       ) : null}
       {runConfig !== undefined ? (
-        <div className="rounded-md border border-zinc-200 bg-white p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-950/40 dark:text-zinc-200">
-          <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-            Run Config
-          </div>
+        <div className="bg-card text-foreground flex flex-col gap-1 rounded-md border p-3 text-[11px]">
+          <SectionLabel>Run config</SectionLabel>
           <JSONPreview value={runConfig} />
         </div>
       ) : null}
@@ -321,8 +327,7 @@ const renderStatePreview = (key: string, value: unknown) => {
 export function DevToolsUI() {
   const [apis, setApis] = useState<ApiInfo[]>([]);
   const [selectedApiId, setSelectedApiId] = useState<number | null>(null);
-  const [activeTab, setActiveTab] = useState<TabType>("state");
-  const [viewMode, setViewMode] = useState<"raw" | "preview">("preview");
+  const [activeTab, setActiveTab] = useState<TabType>("thread");
   const [expandedStates, setExpandedStates] = useState<Set<string>>(new Set());
   const [unselectedEventTypes, setUnselectedEventTypes] = useState<Set<string>>(
     new Set(),
@@ -562,7 +567,7 @@ export function DevToolsUI() {
     }
 
     return (
-      <div className="flex items-center gap-2 border-b border-zinc-200 bg-zinc-50 px-4 py-2 text-xs text-zinc-500 dark:border-zinc-900 dark:bg-zinc-950">
+      <div className="bg-muted text-muted-foreground flex items-center gap-2 border-b px-4 py-2 text-xs">
         <span className="font-medium">API</span>
         <select
           value={selectedApiId ?? ""}
@@ -570,7 +575,7 @@ export function DevToolsUI() {
             const value = Number(event.target.value);
             setSelectedApiId(Number.isNaN(value) ? null : value);
           }}
-          className="rounded-md border border-zinc-300 bg-zinc-50 px-2 py-1 text-xs text-zinc-900 shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100"
+          className="bg-card text-foreground rounded-md border px-2 py-1 text-xs"
         >
           {apis.map((api) => (
             <option key={api.id} value={api.id}>
@@ -583,191 +588,37 @@ export function DevToolsUI() {
   };
 
   const renderTabControls = () => {
-    switch (activeTab) {
-      case "events":
-        return (
-          <div className="flex h-full items-center gap-2 px-2">
-            <ControlButton onClick={clearEvents}>Clear Events</ControlButton>
-          </div>
-        );
-      case "state":
-        return (
-          <div className="flex h-full items-center gap-2 px-2">
-            <ControlButton
-              onClick={() =>
-                setViewMode((prev) => (prev === "preview" ? "raw" : "preview"))
-              }
-            >
-              View: {viewMode === "preview" ? "Preview" : "Raw"}
-            </ControlButton>
-          </div>
-        );
-      case "runs":
-        return (
-          <div className="flex h-full items-center px-4 text-xs text-zinc-500 dark:text-zinc-400">
-            Run timeline
-          </div>
-        );
-      case "scopes":
-        return (
-          <div className="flex h-full items-center px-4 text-xs text-zinc-500 dark:text-zinc-400">
-            Scope graph
-          </div>
-        );
-      default:
-        return (
-          <div className="flex h-full items-center px-4 text-xs text-zinc-500 dark:text-zinc-400">
-            Model context overview
-          </div>
-        );
+    if (activeTab === "activity") {
+      return (
+        <div className="flex h-full items-center gap-2 px-2">
+          <ControlButton onClick={clearEvents}>Clear events</ControlButton>
+        </div>
+      );
     }
+    return null;
   };
 
-  const renderStateContent = () => {
+  const renderThreadContent = () => {
     if (!selectedApi) {
       return (
         <CenteredMessage>Waiting for assistant-ui instance...</CenteredMessage>
       );
     }
 
-    if (Object.keys(selectedApi.state).length === 0) {
-      return (
-        <EmptyState>No state detected for this assistant instance.</EmptyState>
-      );
-    }
-
-    return (
-      <div className="flex flex-col gap-3">
-        {Object.entries(selectedApi.state).map(([key, value]) => {
-          const expanded = expandedStates.has(key);
-          return (
-            <div
-              key={key}
-              className="overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm transition-colors dark:border-zinc-800 dark:bg-zinc-900"
-            >
-              <button
-                type="button"
-                onClick={() => toggleStateSection(key)}
-                className="flex w-full items-center justify-between bg-zinc-50 px-4 py-3 text-left text-sm font-semibold text-zinc-800 transition-colors hover:bg-zinc-100 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800"
-              >
-                <span>{key}</span>
-                <span className="text-lg">{expanded ? "−" : "+"}</span>
-              </button>
-              {expanded && (
-                <div className="border-t border-zinc-200 p-4 text-[11px] transition-colors dark:border-zinc-800">
-                  {viewMode === "preview" ? (
-                    renderStatePreview(key, value)
-                  ) : (
-                    <pre className="overflow-auto rounded-lg bg-zinc-100 p-3 text-[11px] whitespace-pre text-zinc-800 dark:bg-zinc-950 dark:text-zinc-200">
-                      {JSON.stringify(value, null, 2)}
-                    </pre>
-                  )}
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
+    const entries = Object.entries(selectedApi.state).filter(([key]) =>
+      THREAD_STATE_KEYS.has(key),
     );
-  };
-
-  const renderEventsContent = () => {
-    if (!selectedApi) {
+    if (entries.length === 0) {
       return (
-        <CenteredMessage>Waiting for assistant-ui instance...</CenteredMessage>
+        <EmptyState>No thread state for this assistant instance.</EmptyState>
       );
     }
 
     return (
-      <div className="flex flex-col gap-3">
-        {eventTypesByScope.length > 0 && (
-          <div className="flex flex-col gap-2 rounded-lg border border-zinc-200 bg-zinc-50 p-3 transition-colors dark:border-zinc-800 dark:bg-zinc-900">
-            {eventTypesByScope.map(([scope, types]) => {
-              const allSelected = types.every(
-                (type) => !unselectedEventTypes.has(type),
-              );
-              return (
-                <div key={scope} className="flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleScope(types)}
-                    className={clsx(
-                      "rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase transition-colors",
-                      allSelected
-                        ? "bg-blue-500/15 text-blue-600 dark:text-blue-300"
-                        : "bg-zinc-200 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400",
-                    )}
-                  >
-                    {scope}
-                  </button>
-                  {types.map((eventType) => (
-                    <label
-                      key={eventType}
-                      title={eventType}
-                      className={clsx(
-                        "flex items-center gap-2 rounded-md border px-2 py-1 text-[11px] font-medium transition-colors",
-                        !unselectedEventTypes.has(eventType)
-                          ? "border-blue-500 bg-blue-500/10 text-blue-600 dark:border-blue-400 dark:bg-blue-500/20 dark:text-blue-200"
-                          : "border-zinc-200 bg-white text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300",
-                      )}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={!unselectedEventTypes.has(eventType)}
-                        onChange={() => toggleEventType(eventType)}
-                        className="size-3 rounded border-zinc-300 text-blue-600 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-900"
-                      />
-                      <span>
-                        {eventType.slice(scope.length + 1) || eventType}
-                      </span>
-                    </label>
-                  ))}
-                </div>
-              );
-            })}
-          </div>
-        )}
-        {filteredLogs.length === 0 ? (
-          <EmptyState>
-            {eventTypes.length === 0
-              ? "No events logged for this assistant instance."
-              : "No events match the current filters."}
-          </EmptyState>
-        ) : (
-          <div className="overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm transition-colors dark:border-zinc-800 dark:bg-zinc-900">
-            <table className="w-full table-auto border-collapse text-left">
-              <thead className="bg-zinc-100 text-[11px] tracking-wide text-zinc-500 uppercase dark:bg-zinc-800 dark:text-zinc-300">
-                <tr>
-                  <th className="px-4 py-2 font-semibold">Time</th>
-                  <th className="px-4 py-2 font-semibold">Scope</th>
-                  <th className="px-4 py-2 font-semibold">Event</th>
-                  <th className="px-4 py-2 font-semibold">Data</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredLogs.map((log, index) => (
-                  <tr
-                    key={`${log.event}-${index}`}
-                    className="border-t border-zinc-200 bg-white text-[11px] transition-colors dark:border-zinc-800 dark:bg-zinc-900"
-                  >
-                    <td className="px-4 py-2 align-top font-mono whitespace-nowrap text-zinc-600 dark:text-zinc-300">
-                      {formatClockTime(log.time)}
-                    </td>
-                    <td className="px-4 py-2 align-top text-zinc-500 dark:text-zinc-400">
-                      {eventScope(log.event)}
-                    </td>
-                    <td className="px-4 py-2 align-top font-semibold text-zinc-800 dark:text-zinc-100">
-                      {log.event}
-                    </td>
-                    <td className="px-4 py-2 align-top">
-                      <JSONPreview value={log.data} />
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
+      <div className="flex flex-col gap-4">
+        {entries.map(([key, value]) => (
+          <div key={key}>{renderStatePreview(key, value)}</div>
+        ))}
       </div>
     );
   };
@@ -779,65 +630,209 @@ export function DevToolsUI() {
       );
     }
 
-    return <ModelContextView modelContext={selectedApi.modelContext} />;
+    const mcp = selectedApi.state.mcp;
+    const toolUIs = selectedApi.state.tools;
+
+    return (
+      <div className="flex flex-col gap-4">
+        <ModelContextView modelContext={selectedApi.modelContext} />
+        {mcp !== undefined ? <McpView value={mcp} /> : null}
+        {toolUIs !== undefined ? renderToolUIsStatePreview(toolUIs) : null}
+      </div>
+    );
   };
 
-  const renderRunsContent = () => {
+  const renderActivityContent = () => {
     if (!selectedApi) {
       return (
         <CenteredMessage>Waiting for assistant-ui instance...</CenteredMessage>
       );
     }
 
-    return <RunTimeline logs={selectedApi.logs} />;
+    return (
+      <div className="flex flex-col gap-4">
+        <RunTimeline logs={selectedApi.logs} />
+
+        <div className="flex flex-col gap-3">
+          <SectionLabel>Event log</SectionLabel>
+          {eventTypesByScope.length > 0 && (
+            <div className="bg-muted/40 flex flex-col gap-2 rounded-lg border p-3">
+              {eventTypesByScope.map(([scope, types]) => {
+                const allSelected = types.every(
+                  (type) => !unselectedEventTypes.has(type),
+                );
+                return (
+                  <div
+                    key={scope}
+                    className="flex flex-wrap items-center gap-2"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => toggleScope(types)}
+                      className={clsx(
+                        "rounded-md px-1.5 py-0.5 text-[10px] font-medium transition-colors",
+                        allSelected
+                          ? "bg-accent text-foreground"
+                          : "bg-muted text-muted-foreground",
+                      )}
+                    >
+                      {scope}
+                    </button>
+                    {types.map((eventType) => (
+                      <label
+                        key={eventType}
+                        title={eventType}
+                        className={clsx(
+                          "flex items-center gap-2 rounded-md border px-2 py-1 text-[11px] font-medium transition-colors",
+                          !unselectedEventTypes.has(eventType)
+                            ? "border-foreground/40 bg-accent text-foreground"
+                            : "bg-card text-muted-foreground",
+                        )}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={!unselectedEventTypes.has(eventType)}
+                          onChange={() => toggleEventType(eventType)}
+                          className="accent-foreground size-3 rounded"
+                        />
+                        <span>
+                          {eventType.slice(scope.length + 1) || eventType}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          {filteredLogs.length === 0 ? (
+            <EmptyState>
+              {eventTypes.length === 0
+                ? "No events logged for this assistant instance."
+                : "No events match the current filters."}
+            </EmptyState>
+          ) : (
+            <div className="bg-card overflow-hidden rounded-lg border">
+              <table className="w-full table-auto border-collapse text-left">
+                <thead className="bg-muted text-muted-foreground text-[11px]">
+                  <tr>
+                    <th className="px-4 py-2 font-medium">Time</th>
+                    <th className="px-4 py-2 font-medium">Scope</th>
+                    <th className="px-4 py-2 font-medium">Event</th>
+                    <th className="px-4 py-2 font-medium">Data</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredLogs.map((log, index) => (
+                    <tr
+                      key={`${log.event}-${index}`}
+                      className="border-t text-[11px]"
+                    >
+                      <td className="text-muted-foreground px-4 py-2 align-top font-mono whitespace-nowrap">
+                        {formatClockTime(log.time)}
+                      </td>
+                      <td className="text-muted-foreground px-4 py-2 align-top">
+                        {eventScope(log.event)}
+                      </td>
+                      <td className="text-foreground px-4 py-2 align-top font-medium">
+                        {log.event}
+                      </td>
+                      <td className="px-4 py-2 align-top">
+                        <JSONPreview value={log.data} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    );
   };
 
-  const renderScopesContent = () => {
+  const renderRawContent = () => {
     if (!selectedApi) {
       return (
         <CenteredMessage>Waiting for assistant-ui instance...</CenteredMessage>
       );
     }
 
-    return <ScopesView scopes={selectedApi.scopes} />;
+    const stateEntries = Object.entries(selectedApi.state);
+
+    return (
+      <div className="flex flex-col gap-3">
+        {stateEntries.map(([key, value]) => {
+          const expanded = expandedStates.has(key);
+          return (
+            <div
+              key={key}
+              className="bg-card overflow-hidden rounded-lg border transition-colors"
+            >
+              <button
+                type="button"
+                onClick={() => toggleStateSection(key)}
+                className="bg-muted text-foreground hover:bg-accent flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium transition-colors"
+              >
+                <span>{key}</span>
+                <span
+                  className={clsx(
+                    "text-muted-foreground transition-transform",
+                    expanded && "rotate-90",
+                  )}
+                >
+                  ›
+                </span>
+              </button>
+              {expanded && (
+                <div className="border-t p-4">
+                  <pre className="bg-muted text-foreground overflow-auto rounded-lg p-3 font-mono text-[11px] whitespace-pre">
+                    {JSON.stringify(value, null, 2)}
+                  </pre>
+                </div>
+              )}
+            </div>
+          );
+        })}
+        <ScopesView scopes={selectedApi.scopes} />
+      </div>
+    );
   };
 
   const renderTabContent = (): ReactNode => {
     switch (activeTab) {
-      case "state":
-        return renderStateContent();
-      case "events":
-        return renderEventsContent();
-      case "runs":
-        return renderRunsContent();
-      case "scopes":
-        return renderScopesContent();
-      default:
+      case "thread":
+        return renderThreadContent();
+      case "context":
         return renderContextContent();
+      case "activity":
+        return renderActivityContent();
+      default:
+        return renderRawContent();
     }
   };
 
   return (
-    <div className="dark h-full w-full" data-theme="dark">
-      <div className="flex h-full flex-col bg-white font-mono text-xs text-zinc-900 transition-colors dark:bg-zinc-950 dark:text-zinc-100">
+    <div className="h-full w-full">
+      <div className="bg-background text-foreground flex h-full flex-col text-xs">
         {renderToolbar()}
 
-        <nav className="flex h-10 items-center justify-between border-b border-zinc-200 bg-zinc-50 px-2 dark:border-zinc-900 dark:bg-zinc-950">
+        <nav className="bg-muted flex h-10 items-center justify-between border-b px-2">
           <div className="flex h-full items-center gap-1">
-            {["state", "modelContext", "events", "runs", "scopes"].map(
+            {(["thread", "context", "activity", "raw"] as TabType[]).map(
               (tab) => (
                 <button
                   type="button"
                   key={tab}
-                  onClick={() => setActiveTab(tab as TabType)}
+                  onClick={() => setActiveTab(tab)}
                   className={clsx(
-                    "flex h-full items-center px-2.5 text-[11px] font-semibold tracking-wide text-zinc-500 uppercase transition-colors",
+                    "flex h-full items-center px-2.5 text-xs font-medium transition-colors",
                     activeTab === tab
-                      ? "border-b-2 border-blue-500 text-zinc-900 dark:border-blue-400 dark:text-zinc-100"
-                      : "border-b-2 border-transparent hover:text-zinc-700 dark:hover:text-zinc-200",
+                      ? "border-foreground text-foreground border-b-2"
+                      : "text-muted-foreground hover:text-foreground border-b-2 border-transparent",
                   )}
                 >
-                  {tab === "modelContext" ? "Model Context" : tab}
+                  {TAB_LABELS[tab]}
                 </button>
               ),
             )}
@@ -845,18 +840,18 @@ export function DevToolsUI() {
           {renderTabControls()}
         </nav>
 
-        <section className="flex-1 overflow-auto bg-white p-4 transition-colors dark:bg-zinc-950">
+        <section className="bg-background flex-1 overflow-auto p-4">
           {renderTabContent()}
         </section>
 
-        <footer className="flex items-center justify-between border-t border-zinc-200 bg-zinc-50 px-4 py-2 text-[11px] text-zinc-500 transition-colors dark:border-zinc-900 dark:bg-zinc-950 dark:text-zinc-500">
+        <footer className="bg-muted text-muted-foreground flex items-center justify-between border-t px-4 py-2 text-[11px]">
           <span>
-            Status:{" "}
             {apis.length > 0
               ? `${apis.length} assistant instance${apis.length > 1 ? "s" : ""} detected`
               : "Waiting for instances"}
           </span>
-          <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+          <span className="flex items-center gap-1.5 font-medium text-emerald-600 dark:text-emerald-400">
+            <span className="size-1.5 rounded-full bg-emerald-500" />
             Connected
           </span>
         </footer>

--- a/apps/devtools-frame/components/DevToolsUI.tsx
+++ b/apps/devtools-frame/components/DevToolsUI.tsx
@@ -77,6 +77,7 @@ const TAB_LABELS: Record<TabType, string> = {
 
 const THREAD_STATE_KEYS = new Set([
   "threads",
+  "threadListItems",
   "thread",
   "threadListItem",
   "threadlistitem",

--- a/apps/devtools-frame/components/mcp/McpView.tsx
+++ b/apps/devtools-frame/components/mcp/McpView.tsx
@@ -1,4 +1,4 @@
-import { JSONPreview, SummaryItem, ToneBadge } from "../ui";
+import { Chip, JSONPreview, SectionLabel, SummaryItem, ToneBadge } from "../ui";
 import type { BadgeTone } from "../ui";
 import { parseMcpManager } from "./parse";
 import type { McpServerPreview } from "./types";
@@ -13,29 +13,23 @@ const STATE_TONE: Record<string, BadgeTone> = {
 };
 
 const ServerCard = ({ server }: { server: McpServerPreview }) => (
-  <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] dark:border-zinc-800 dark:bg-zinc-900/40">
+  <div className="bg-card rounded-lg border p-3 text-[11px]">
     <div className="flex flex-wrap items-center gap-2">
-      <span className="font-semibold text-zinc-800 dark:text-zinc-100">
-        {server.name}
-      </span>
-      {server.kind ? (
-        <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[9px] font-semibold tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300">
-          {server.kind}
-        </span>
-      ) : null}
+      <span className="text-foreground font-semibold">{server.name}</span>
+      {server.kind ? <Chip>{server.kind}</Chip> : null}
       <ToneBadge tone={STATE_TONE[server.connectionState]}>
         {server.connectionState}
       </ToneBadge>
     </div>
 
     {server.url ? (
-      <div className="mt-1 font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+      <div className="text-muted-foreground mt-1 font-mono text-[10px]">
         {server.url}
       </div>
     ) : null}
 
     {server.lastError ? (
-      <div className="mt-2 rounded border border-red-300 bg-red-500/5 p-2 text-red-700 dark:border-red-500/40 dark:text-red-300">
+      <div className="mt-2 rounded-md border border-red-300 bg-red-500/10 p-2 text-red-700 dark:border-red-500/40 dark:text-red-300">
         {server.lastError}
       </div>
     ) : null}
@@ -46,24 +40,24 @@ const ServerCard = ({ server }: { server: McpServerPreview }) => (
       </div>
     ) : null}
 
-    <div className="mt-2 text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-      Tools ({server.tools.length})
+    <div className="mt-2">
+      <SectionLabel>Tools ({server.tools.length})</SectionLabel>
     </div>
     {server.tools.length ? (
       <ul className="mt-1 flex flex-col gap-1">
         {server.tools.map((tool) => (
-          <li key={tool.name} className="text-zinc-600 dark:text-zinc-300">
-            <span className="font-medium text-zinc-800 dark:text-zinc-100">
-              {tool.name}
-            </span>
+          <li key={tool.name} className="text-muted-foreground">
+            <span className="text-foreground font-medium">{tool.name}</span>
             {tool.description ? (
-              <span className="ml-1 text-zinc-400">{tool.description}</span>
+              <span className="text-muted-foreground ml-1">
+                {tool.description}
+              </span>
             ) : null}
           </li>
         ))}
       </ul>
     ) : (
-      <div className="mt-1 text-zinc-400">No tools discovered.</div>
+      <div className="text-muted-foreground mt-1">No tools discovered.</div>
     )}
   </div>
 );
@@ -87,7 +81,7 @@ export const McpView = ({ value }: { value: unknown }) => {
           ))}
         </div>
       ) : (
-        <div className="text-[11px] text-zinc-500 dark:text-zinc-400">
+        <div className="text-muted-foreground text-[11px]">
           No MCP servers registered.
         </div>
       )}

--- a/apps/devtools-frame/components/message/ChainOfThought.tsx
+++ b/apps/devtools-frame/components/message/ChainOfThought.tsx
@@ -1,3 +1,4 @@
+import { ToneBadge } from "../ui";
 import { partKey } from "./parse";
 import { PartView } from "./PartView";
 import { StatusBadge } from "./StatusBadge";
@@ -30,25 +31,23 @@ export const ChainOfThought = ({
   const status = rollupStatus(parts);
 
   return (
-    <details
-      open
-      className="group rounded-md border border-dashed border-violet-300/70 bg-violet-500/5 p-2 dark:border-violet-500/30 dark:bg-violet-500/10"
-    >
+    <details open className="group bg-muted/40 rounded-md border p-3">
       <summary className="flex cursor-pointer list-none items-center gap-2 select-none">
-        <span className="inline-block text-violet-500 transition-transform group-open:rotate-90">
+        <span className="text-muted-foreground inline-block transition-transform group-open:rotate-90">
           ›
         </span>
-        <span className="text-[10px] font-semibold tracking-wide text-violet-700 uppercase dark:text-violet-300">
+        <ToneBadge tone="violet">reasoning</ToneBadge>
+        <span className="text-foreground text-[10px] font-medium">
           Chain of thought
         </span>
-        <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+        <span className="text-muted-foreground text-[10px]">
           {parts.length} step{parts.length === 1 ? "" : "s"}
         </span>
         {status ? (
           <StatusBadge type={status.type} reason={status.reason} />
         ) : null}
       </summary>
-      <div className="mt-2 flex flex-col gap-2 border-l border-violet-300/50 pl-3 dark:border-violet-500/20">
+      <div className="mt-2 flex flex-col gap-2 border-l pl-3">
         {parts.map((part, index) => (
           <PartView key={partKey(part, index)} part={part} />
         ))}

--- a/apps/devtools-frame/components/message/MessageItem.tsx
+++ b/apps/devtools-frame/components/message/MessageItem.tsx
@@ -1,6 +1,5 @@
-import clsx from "clsx";
 import { formatDateTime } from "../common";
-import { JSONPreview, SummaryItem } from "../ui";
+import { Chip, JSONPreview, SummaryItem, ToneBadge } from "../ui";
 import { ChainOfThought } from "./ChainOfThought";
 import { partKey } from "./parse";
 import { PartView } from "./PartView";
@@ -57,15 +56,14 @@ const groupParts = (parts: readonly PartPreview[]): RenderGroup[] => {
   return groups;
 };
 
-const RoleLabel = ({ role }: { role: string }) => {
-  const tone =
-    role === "user"
-      ? "text-blue-600 dark:text-blue-300"
-      : role === "assistant"
-        ? "text-emerald-600 dark:text-emerald-300"
-        : "text-zinc-600 dark:text-zinc-300";
-  return <span className={clsx("font-semibold capitalize", tone)}>{role}</span>;
-};
+const RoleLabel = ({ role }: { role: string }) =>
+  role === "user" ? (
+    <span className="bg-accent text-foreground rounded px-1.5 py-0.5 text-[11px] font-semibold capitalize">
+      {role}
+    </span>
+  ) : (
+    <span className="text-foreground font-semibold capitalize">{role}</span>
+  );
 
 const MetaStrip = ({ message }: { message: MessagePreview }) => {
   const { timing, usage } = message;
@@ -78,11 +76,14 @@ const MetaStrip = ({ message }: { message: MessagePreview }) => {
   const items: { label: string; value: string }[] = [];
   if (ttft !== undefined) items.push({ label: "TTFT", value: formatMs(ttft) });
   if (timing?.totalStreamTime !== undefined) {
-    items.push({ label: "Stream", value: formatMs(timing.totalStreamTime) });
+    items.push({
+      label: "Stream time",
+      value: formatMs(timing.totalStreamTime),
+    });
   }
   if (timing?.tokensPerSecond !== undefined) {
     items.push({
-      label: "Tokens/s",
+      label: "Tokens / s",
       value: timing.tokensPerSecond.toFixed(1),
     });
   }
@@ -97,7 +98,7 @@ const MetaStrip = ({ message }: { message: MessagePreview }) => {
   }
   if (usage) {
     items.push({
-      label: "Usage",
+      label: "Input / output",
       value: `${usage.inputTokens} in / ${usage.outputTokens} out`,
     });
     items.push({ label: "Steps", value: String(usage.stepCount) });
@@ -131,7 +132,7 @@ export const MessageItem = ({ message }: { message: MessagePreview }) => {
         <div className="flex flex-wrap items-center gap-2">
           <RoleLabel role={message.role} />
           {message.index !== undefined ? (
-            <span className="text-[10px] text-zinc-400 dark:text-zinc-500">
+            <span className="text-muted-foreground text-[10px]">
               #{message.index}
             </span>
           ) : null}
@@ -142,22 +143,20 @@ export const MessageItem = ({ message }: { message: MessagePreview }) => {
             />
           ) : null}
           {hasBranches ? (
-            <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+            <Chip>
               branch {message.branchNumber}/{message.branchCount}
-            </span>
+            </Chip>
           ) : null}
           {message.isOptimistic ? (
-            <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-amber-700 uppercase dark:text-amber-300">
-              optimistic
-            </span>
+            <ToneBadge tone="amber">optimistic</ToneBadge>
           ) : null}
           {message.submittedFeedback ? (
-            <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+            <span className="text-muted-foreground text-[10px]">
               feedback: {message.submittedFeedback}
             </span>
           ) : null}
         </div>
-        <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+        <span className="text-muted-foreground text-[10px]">
           {formatDateTime(message.createdAt) ?? "—"}
         </span>
       </div>
@@ -165,23 +164,18 @@ export const MessageItem = ({ message }: { message: MessagePreview }) => {
       <MetaStrip message={message} />
 
       {errorValue !== undefined ? (
-        <div className="rounded border border-red-300 bg-red-500/5 p-2 text-[11px] dark:border-red-500/40 dark:bg-red-500/10">
-          <div className="text-[10px] font-semibold tracking-wide text-red-600 uppercase dark:text-red-300">
-            Error
+        <div className="bg-muted/40 rounded-md border p-2 text-[11px]">
+          <ToneBadge tone="red">error</ToneBadge>
+          <div className="mt-1">
+            <JSONPreview value={errorValue} />
           </div>
-          <JSONPreview value={errorValue} />
         </div>
       ) : null}
 
       {message.attachments.length ? (
         <div className="flex flex-wrap gap-1">
           {message.attachments.map((attachment, index) => (
-            <span
-              key={`${message.id}-attachment-${index}`}
-              className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300"
-            >
-              {attachment}
-            </span>
+            <Chip key={`${message.id}-attachment-${index}`}>{attachment}</Chip>
           ))}
         </div>
       ) : null}
@@ -197,7 +191,7 @@ export const MessageItem = ({ message }: { message: MessagePreview }) => {
           )}
         </div>
       ) : (
-        <div className="text-[11px] text-zinc-500 dark:text-zinc-400">
+        <div className="text-muted-foreground text-[11px]">
           No content parts
         </div>
       )}

--- a/apps/devtools-frame/components/message/MessageList.tsx
+++ b/apps/devtools-frame/components/message/MessageList.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { SectionLabel } from "../ui";
 import { MessageItem } from "./MessageItem";
 import type { MessagePreview } from "./types";
 
@@ -15,7 +16,7 @@ export const MessageList = ({
 
   if (!messages.length) {
     return (
-      <div className="rounded-md border border-dashed border-zinc-300 bg-white p-4 text-center text-[11px] text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900/30 dark:text-zinc-400">
+      <div className="bg-card text-muted-foreground rounded-lg border p-4 text-center text-[11px]">
         No messages in this thread.
       </div>
     );
@@ -25,12 +26,10 @@ export const MessageList = ({
   const visible = hidden > 0 ? messages.slice(-DEFAULT_LIMIT) : messages;
 
   return (
-    <div className="overflow-hidden rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950/40">
-      <div className="flex items-center justify-between border-b border-zinc-200 bg-zinc-100 px-3 py-2 dark:border-zinc-800 dark:bg-zinc-900">
-        <span className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-          {title}
-        </span>
-        <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+    <div className="bg-card overflow-hidden rounded-lg border">
+      <div className="bg-muted flex items-center justify-between border-b px-3 py-2">
+        <SectionLabel>{title}</SectionLabel>
+        <span className="text-muted-foreground text-[10px]">
           {messages.length} total
         </span>
       </div>
@@ -38,12 +37,12 @@ export const MessageList = ({
         <button
           type="button"
           onClick={() => setShowAll(true)}
-          className="w-full border-b border-zinc-200 bg-zinc-50 px-3 py-1.5 text-[10px] font-medium text-zinc-500 transition-colors hover:bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-400 dark:hover:bg-zinc-800"
+          className="bg-muted text-muted-foreground hover:bg-accent w-full border-b px-3 py-1.5 text-[10px] font-medium transition-colors"
         >
           Show {hidden} older message{hidden === 1 ? "" : "s"}
         </button>
       ) : null}
-      <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
+      <div className="divide-border divide-y">
         {visible.map((message) => (
           <MessageItem key={message.id} message={message} />
         ))}

--- a/apps/devtools-frame/components/message/PartView.tsx
+++ b/apps/devtools-frame/components/message/PartView.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { JSONPreview } from "../ui";
+import { Chip, JSONPreview, ToneBadge } from "../ui";
 import { StatusBadge } from "./StatusBadge";
 import { ToolCallView } from "./ToolCallView";
 import type { PartPreview, PartStatusPreview } from "./types";
@@ -17,15 +17,11 @@ const PartShell = ({
 }) => (
   <div className="flex flex-col gap-1">
     <div className="flex items-center gap-2">
-      <span
-        className={
-          tone === "reasoning"
-            ? "rounded bg-violet-500/15 px-1.5 py-0.5 text-[9px] font-semibold tracking-wide text-violet-700 uppercase dark:text-violet-300"
-            : "rounded bg-zinc-200 px-1.5 py-0.5 text-[9px] font-semibold tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300"
-        }
-      >
-        {type}
-      </span>
+      {tone === "reasoning" ? (
+        <ToneBadge tone="violet">{type}</ToneBadge>
+      ) : (
+        <Chip>{type}</Chip>
+      )}
       {status ? (
         <StatusBadge type={status.type} reason={status.reason} />
       ) : null}
@@ -38,8 +34,8 @@ const Text = ({ value, muted }: { value: string; muted?: boolean }) => (
   <div
     className={
       muted
-        ? "wrap-break-word whitespace-pre-wrap text-zinc-500 italic dark:text-zinc-400"
-        : "wrap-break-word whitespace-pre-wrap text-zinc-700 dark:text-zinc-200"
+        ? "text-muted-foreground wrap-break-word whitespace-pre-wrap italic"
+        : "text-foreground wrap-break-word whitespace-pre-wrap"
     }
   >
     {value || "(empty)"}
@@ -65,10 +61,10 @@ export const PartView = ({ part }: { part: PartPreview }) => {
     case "source":
       return (
         <PartShell type="source" status={part.status}>
-          <div className="text-zinc-600 dark:text-zinc-300">
+          <div className="text-foreground">
             {part.title ?? part.url ?? part.sourceType ?? "(source)"}
             {part.title && part.url ? (
-              <span className="ml-1 text-zinc-400">({part.url})</span>
+              <span className="text-muted-foreground ml-1">({part.url})</span>
             ) : null}
           </div>
         </PartShell>
@@ -76,18 +72,18 @@ export const PartView = ({ part }: { part: PartPreview }) => {
     case "image":
       return (
         <PartShell type="image" status={part.status}>
-          <div className="text-zinc-600 dark:text-zinc-300">
-            {part.filename ?? "(image)"}
-          </div>
+          <div className="text-foreground">{part.filename ?? "(image)"}</div>
         </PartShell>
       );
     case "file":
       return (
         <PartShell type="file" status={part.status}>
-          <div className="text-zinc-600 dark:text-zinc-300">
+          <div className="text-foreground">
             {part.filename ?? "(file)"}
             {part.mimeType ? (
-              <span className="ml-1 text-zinc-400">{part.mimeType}</span>
+              <span className="text-muted-foreground ml-1">
+                {part.mimeType}
+              </span>
             ) : null}
           </div>
         </PartShell>
@@ -95,9 +91,7 @@ export const PartView = ({ part }: { part: PartPreview }) => {
     case "audio":
       return (
         <PartShell type="audio" status={part.status}>
-          <div className="text-zinc-600 dark:text-zinc-300">
-            {part.format ?? "(audio)"}
-          </div>
+          <div className="text-foreground">{part.format ?? "(audio)"}</div>
         </PartShell>
       );
     case "data":

--- a/apps/devtools-frame/components/message/ToolCallView.tsx
+++ b/apps/devtools-frame/components/message/ToolCallView.tsx
@@ -1,6 +1,5 @@
-import clsx from "clsx";
 import type { ReactNode } from "react";
-import { JSONPreview } from "../ui";
+import { Chip, JSONPreview, ToneBadge } from "../ui";
 import { StatusBadge } from "./StatusBadge";
 import type { ToolCallPartPreview } from "./types";
 
@@ -14,7 +13,7 @@ const Disclosure = ({
   children: ReactNode;
 }) => (
   <details open={defaultOpen} className="group">
-    <summary className="cursor-pointer list-none text-[10px] font-semibold tracking-wide text-zinc-500 uppercase select-none hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200">
+    <summary className="text-muted-foreground hover:text-foreground cursor-pointer list-none text-[10px] font-medium select-none">
       <span className="mr-1 inline-block transition-transform group-open:rotate-90">
         ›
       </span>
@@ -29,48 +28,31 @@ export const ToolCallView = ({ part }: { part: ToolCallPartPreview }) => {
     part.status?.type === "requires-action" ||
     part.interrupt !== undefined ||
     (part.approval !== undefined && part.approval.approved === undefined);
-  const errored = part.isError === true || part.status?.type === "incomplete";
-
   return (
-    <div
-      className={clsx(
-        "rounded-md border p-3 text-[11px] transition-colors",
-        errored
-          ? "border-red-300 bg-red-500/5 dark:border-red-500/40 dark:bg-red-500/10"
-          : awaiting
-            ? "border-amber-300 bg-amber-500/5 dark:border-amber-500/40 dark:bg-amber-500/10"
-            : "border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900/60",
-      )}
-    >
+    <div className="bg-card rounded-md border p-3 text-[11px] transition-colors">
       <div className="flex flex-wrap items-center gap-2">
-        <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[9px] font-semibold tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300">
-          tool
-        </span>
-        <span className="font-semibold text-zinc-800 dark:text-zinc-100">
-          {part.toolName}
-        </span>
+        <Chip>tool</Chip>
+        <span className="text-foreground font-semibold">{part.toolName}</span>
         {part.status ? (
           <StatusBadge type={part.status.type} reason={part.status.reason} />
         ) : null}
         {part.isError ? <StatusBadge type="incomplete" reason="error" /> : null}
         {part.mcp !== undefined ? (
-          <span className="rounded bg-violet-500/15 px-1.5 py-0.5 text-[9px] font-semibold tracking-wide text-violet-700 uppercase dark:text-violet-300">
-            mcp
-          </span>
+          <ToneBadge tone="violet">MCP</ToneBadge>
         ) : null}
       </div>
 
       {part.toolCallId ? (
-        <div className="mt-1 font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+        <div className="text-muted-foreground mt-1 font-mono text-[10px]">
           {part.toolCallId}
         </div>
       ) : null}
 
       {awaiting ? (
-        <div className="mt-2 rounded border border-amber-300 bg-amber-500/10 p-2 text-amber-800 dark:border-amber-500/40 dark:text-amber-200">
-          <div className="text-[10px] font-semibold tracking-wide uppercase">
+        <div className="bg-muted text-foreground mt-2 rounded-md border p-2">
+          <ToneBadge tone="amber">
             {part.approval ? "Awaiting approval" : "Awaiting human input"}
-          </div>
+          </ToneBadge>
           {part.approval ? (
             <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px]">
               {part.approval.id ? <span>id: {part.approval.id}</span> : null}
@@ -103,7 +85,7 @@ export const ToolCallView = ({ part }: { part: ToolCallPartPreview }) => {
 
         {part.argsText !== undefined ? (
           <Disclosure label="Raw args text">
-            <pre className="rounded bg-zinc-100 p-2 text-[10px] break-words whitespace-pre-wrap text-zinc-700 dark:bg-zinc-950 dark:text-zinc-300">
+            <pre className="bg-muted text-foreground rounded-md p-2 text-[10px] break-words whitespace-pre-wrap">
               {part.argsText}
             </pre>
           </Disclosure>
@@ -134,7 +116,7 @@ export const ToolCallView = ({ part }: { part: ToolCallPartPreview }) => {
         ) : null}
 
         {part.subMessageCount > 0 ? (
-          <div className="text-[10px] text-zinc-500 dark:text-zinc-400">
+          <div className="text-muted-foreground text-[10px]">
             {part.subMessageCount} nested sub-agent message
             {part.subMessageCount === 1 ? "" : "s"}
           </div>

--- a/apps/devtools-frame/components/model-context/ModelContextView.tsx
+++ b/apps/devtools-frame/components/model-context/ModelContextView.tsx
@@ -2,53 +2,40 @@ import type {
   NormalizedTool,
   SerializedModelContext,
 } from "@assistant-ui/react-devtools";
-import type { ReactNode } from "react";
-import { EmptyState, InfoCard, JSONPreview, SectionTitle } from "../ui";
-
-const Badge = ({
-  children,
-  tone = "neutral",
-}: {
-  children: ReactNode;
-  tone?: "neutral" | "warn" | "accent";
-}) => {
-  const cls =
-    tone === "warn"
-      ? "text-amber-600 dark:text-amber-400"
-      : tone === "accent"
-        ? "bg-violet-500/15 text-violet-700 dark:text-violet-300"
-        : "bg-zinc-200 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300";
-  return (
-    <span
-      className={`rounded px-1.5 py-0.5 text-[10px] font-medium tracking-wide uppercase ${cls}`}
-    >
-      {children}
-    </span>
-  );
-};
+import {
+  Chip,
+  EmptyState,
+  InfoCard,
+  JSONPreview,
+  SectionLabel,
+  SectionTitle,
+  ToneBadge,
+} from "../ui";
 
 const Field = ({ label, value }: { label: string; value: unknown }) => (
   <div className="mt-2">
-    <div className="mb-1 text-[10px] font-medium tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-      {label}
+    <div className="mb-1">
+      <SectionLabel>{label}</SectionLabel>
     </div>
     <JSONPreview value={value} />
   </div>
 );
 
 const ToolCard = ({ tool }: { tool: NormalizedTool }) => (
-  <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] text-zinc-700 transition-colors dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-zinc-200">
-    <div className="flex flex-wrap items-center gap-2 font-semibold text-zinc-800 dark:text-zinc-100">
+  <div className="bg-card text-foreground rounded-lg border p-3 text-[11px] transition-colors">
+    <div className="text-foreground flex flex-wrap items-center gap-2 font-semibold">
       <span>{tool.name}</span>
-      {tool.type ? <Badge>{tool.type}</Badge> : null}
-      {tool.providerId ? <Badge tone="accent">{tool.providerId}</Badge> : null}
-      {tool.display ? <Badge>{tool.display}</Badge> : null}
-      {tool.supportsDeferredResults ? <Badge>deferred</Badge> : null}
-      {tool.disabled ? <Badge tone="warn">disabled</Badge> : null}
+      {tool.type ? <Chip>{tool.type}</Chip> : null}
+      {tool.providerId ? (
+        <ToneBadge tone="violet">{tool.providerId}</ToneBadge>
+      ) : null}
+      {tool.display ? <Chip>{tool.display}</Chip> : null}
+      {tool.supportsDeferredResults ? <Chip>deferred</Chip> : null}
+      {tool.disabled ? <ToneBadge tone="amber">disabled</ToneBadge> : null}
     </div>
 
     {tool.description ? (
-      <p className="mt-1 text-[11px] text-zinc-600 dark:text-zinc-300">
+      <p className="text-muted-foreground mt-1 text-[11px]">
         {tool.description}
       </p>
     ) : null}
@@ -95,10 +82,10 @@ export const ModelContextView = ({
     <div className="grid gap-3">
       {system ? (
         <InfoCard>
-          <SectionTitle>System Prompt</SectionTitle>
-          <pre className="rounded-lg bg-zinc-100 p-3 text-[11px] whitespace-pre-wrap text-zinc-700 dark:bg-zinc-950 dark:text-zinc-200">
+          <SectionTitle>System prompt</SectionTitle>
+          <div className="bg-muted text-foreground rounded-lg p-3 text-[11px] whitespace-pre-wrap">
             {system}
-          </pre>
+          </div>
         </InfoCard>
       ) : null}
       {toolList.length > 0 ? (
@@ -113,7 +100,7 @@ export const ModelContextView = ({
       ) : null}
       {hasCallSettings ? (
         <InfoCard>
-          <SectionTitle>Call Settings</SectionTitle>
+          <SectionTitle>Call settings</SectionTitle>
           <JSONPreview value={callSettings} />
         </InfoCard>
       ) : null}

--- a/apps/devtools-frame/components/runs/RunTimeline.tsx
+++ b/apps/devtools-frame/components/runs/RunTimeline.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx";
 import { useMemo } from "react";
 import { formatClockTime } from "../common";
 import type { EventLogEntry } from "../common";
-import { EmptyState, SummaryItem } from "../ui";
+import { Chip, EmptyState, SectionLabel, SummaryItem, ToneBadge } from "../ui";
 import { groupRuns } from "./parse";
 import type { RunEventEntry, RunPreview } from "./types";
 
@@ -23,8 +23,8 @@ const SCOPE_TONE: Record<string, { dot: string; text: string }> = {
 
 const toneFor = (scope: string) =>
   SCOPE_TONE[scope] ?? {
-    dot: "bg-zinc-400",
-    text: "text-zinc-500 dark:text-zinc-400",
+    dot: "bg-muted-foreground",
+    text: "text-muted-foreground",
   };
 
 const formatMs = (value: number) =>
@@ -37,13 +37,13 @@ const EventRow = ({ entry }: { entry: RunEventEntry }) => {
   const tone = toneFor(entry.scope);
   return (
     <div className="flex items-center gap-2 px-3 py-1">
-      <span className="w-14 shrink-0 text-right font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+      <span className="text-muted-foreground w-14 shrink-0 text-right font-mono text-[10px]">
         +{formatMs(entry.offsetMs)}
       </span>
       <span className={clsx("shrink-0 text-[10px] font-semibold", tone.text)}>
         {entry.scope}
       </span>
-      <span className="truncate text-[11px] text-zinc-700 dark:text-zinc-200">
+      <span className="text-foreground truncate text-[11px]">
         {entry.event.slice(entry.scope.length + 1) || entry.event}
       </span>
     </div>
@@ -51,35 +51,31 @@ const EventRow = ({ entry }: { entry: RunEventEntry }) => {
 };
 
 const RunCard = ({ run }: { run: RunPreview }) => (
-  <div className="overflow-hidden rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950/40">
-    <div className="flex flex-wrap items-center gap-2 border-b border-zinc-200 bg-zinc-50 px-3 py-2 dark:border-zinc-800 dark:bg-zinc-900">
-      <span className="text-[11px] font-semibold text-zinc-800 dark:text-zinc-100">
+  <div className="bg-card overflow-hidden rounded-lg border">
+    <div className="bg-muted flex flex-wrap items-center gap-2 border-b px-3 py-2">
+      <span className="text-foreground text-[11px] font-semibold">
         Run #{run.index}
       </span>
-      <span className="font-mono text-[10px] text-zinc-500 dark:text-zinc-400">
+      <span className="text-muted-foreground font-mono text-[10px]">
         {formatClockTime(run.startTime)}
       </span>
       {run.endTime === undefined ? (
-        <span className="rounded border border-blue-300 bg-blue-500/10 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-blue-700 uppercase dark:border-blue-500/40 dark:text-blue-300">
-          running
-        </span>
+        <ToneBadge tone="blue">running</ToneBadge>
       ) : (
-        <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
-          {formatMs(run.durationMs ?? 0)}
-        </span>
+        <Chip>{formatMs(run.durationMs ?? 0)}</Chip>
       )}
-      <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+      <span className="text-muted-foreground text-[10px]">
         {run.events.length} event{run.events.length === 1 ? "" : "s"}
       </span>
       {run.threadId ? (
-        <span className="ml-auto truncate font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+        <span className="text-muted-foreground ml-auto truncate font-mono text-[10px]">
           {run.threadId}
         </span>
       ) : null}
     </div>
 
     <div className="px-3 pt-3">
-      <div className="relative h-5 rounded bg-zinc-100 dark:bg-zinc-900">
+      <div className="bg-muted relative h-5 rounded">
         {run.events.map((entry, index) => {
           const tone = toneFor(entry.scope);
           return (
@@ -94,7 +90,7 @@ const RunCard = ({ run }: { run: RunPreview }) => (
       </div>
     </div>
 
-    <div className="mt-1 divide-y divide-zinc-100 dark:divide-zinc-900">
+    <div className="divide-border mt-1 divide-y">
       {run.events.map((entry, index) => (
         <EventRow key={index} entry={entry} />
       ))}
@@ -130,17 +126,17 @@ export const RunTimeline = ({ logs }: { logs: readonly EventLogEntry[] }) => {
       </div>
 
       {orphans.length ? (
-        <div className="overflow-hidden rounded-md border border-dashed border-zinc-300 bg-white dark:border-zinc-700 dark:bg-zinc-900/30">
-          <div className="border-b border-zinc-200 bg-zinc-50 px-3 py-2 text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
-            Outside runs ({orphans.length})
+        <div className="bg-card overflow-hidden rounded-lg border border-dashed">
+          <div className="bg-muted border-b px-3 py-2">
+            <SectionLabel>Outside runs ({orphans.length})</SectionLabel>
           </div>
-          <div className="divide-y divide-zinc-100 dark:divide-zinc-900">
+          <div className="divide-border divide-y">
             {orphans.map((entry, index) => (
               <div
                 key={index}
                 className="flex items-center gap-2 px-3 py-1 text-[11px]"
               >
-                <span className="w-20 shrink-0 font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+                <span className="text-muted-foreground w-20 shrink-0 font-mono text-[10px]">
                   {formatClockTime(entry.time)}
                 </span>
                 <span
@@ -151,9 +147,7 @@ export const RunTimeline = ({ logs }: { logs: readonly EventLogEntry[] }) => {
                 >
                   {entry.scope}
                 </span>
-                <span className="truncate text-zinc-700 dark:text-zinc-200">
-                  {entry.event}
-                </span>
+                <span className="text-foreground truncate">{entry.event}</span>
               </div>
             ))}
           </div>

--- a/apps/devtools-frame/components/scopes/ScopesView.tsx
+++ b/apps/devtools-frame/components/scopes/ScopesView.tsx
@@ -1,57 +1,44 @@
 import { isRecord } from "../common";
-import { EmptyState, SummaryItem } from "../ui";
+import { Chip, EmptyState, SectionLabel, SummaryItem, ToneBadge } from "../ui";
 import { parseScopes } from "./parse";
 import type { ScopePreview } from "./types";
 
 const SourceBadge = ({ source }: { source: string | null }) => {
   if (!source) return null;
   if (source === "root") {
-    return (
-      <span className="rounded border border-emerald-300 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-emerald-700 uppercase dark:border-emerald-500/40 dark:text-emerald-300">
-        root
-      </span>
-    );
+    return <ToneBadge tone="emerald">root</ToneBadge>;
   }
-  return (
-    <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
-      ← {source}
-    </span>
-  );
+  return <Chip>← {source}</Chip>;
 };
 
 const ScopeCard = ({ scope }: { scope: ScopePreview }) => {
   const hasQuery = isRecord(scope.query) && Object.keys(scope.query).length > 0;
 
   return (
-    <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] dark:border-zinc-800 dark:bg-zinc-900/40">
+    <div className="bg-card rounded-lg border p-3 text-[11px]">
       <div className="flex flex-wrap items-center gap-2">
-        <span className="font-semibold text-zinc-800 dark:text-zinc-100">
-          {scope.name}
-        </span>
+        <span className="text-foreground font-semibold">{scope.name}</span>
         <SourceBadge source={scope.source} />
         {hasQuery ? (
-          <span className="font-mono text-[10px] text-zinc-500 dark:text-zinc-400">
+          <span className="text-muted-foreground font-mono text-[10px]">
             {JSON.stringify(scope.query)}
           </span>
         ) : null}
       </div>
 
-      <div className="mt-2 text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-        Methods ({scope.methods.length})
+      <div className="mt-2">
+        <SectionLabel>Methods ({scope.methods.length})</SectionLabel>
       </div>
       {scope.methods.length ? (
         <div className="mt-1 flex flex-wrap gap-1">
           {scope.methods.map((method) => (
-            <span
-              key={method}
-              className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200"
-            >
+            <Chip key={method} className="font-mono">
               {method}
-            </span>
+            </Chip>
           ))}
         </div>
       ) : (
-        <div className="mt-1 text-zinc-400">No methods.</div>
+        <div className="text-muted-foreground mt-1">No methods.</div>
       )}
     </div>
   );

--- a/apps/devtools-frame/components/thread/ComposerAttachments.tsx
+++ b/apps/devtools-frame/components/thread/ComposerAttachments.tsx
@@ -1,4 +1,4 @@
-import { ToneBadge } from "../ui";
+import { Chip, SectionLabel, ToneBadge } from "../ui";
 import type { BadgeTone } from "../ui";
 import type { AttachmentPreview, AttachmentStatusPreview } from "./types";
 
@@ -29,26 +29,22 @@ export const ComposerAttachments = ({
   if (!attachments.length) return null;
 
   return (
-    <div className="overflow-hidden rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950/40">
-      <div className="border-b border-zinc-200 bg-zinc-100 px-3 py-1.5 text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
-        Attachments ({attachments.length})
+    <div className="bg-card overflow-hidden rounded-md border">
+      <div className="bg-muted border-b px-3 py-2">
+        <SectionLabel>Attachments ({attachments.length})</SectionLabel>
       </div>
-      <div className="divide-y divide-zinc-100 dark:divide-zinc-900">
+      <div className="divide-border divide-y">
         {attachments.map((attachment, index) => (
           <div
             key={attachment.id ?? index}
             className="flex flex-wrap items-center gap-2 px-3 py-1.5 text-[11px]"
           >
-            <span className="font-medium text-zinc-800 dark:text-zinc-100">
+            <span className="text-foreground font-medium">
               {attachment.name}
             </span>
-            {attachment.kind ? (
-              <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[9px] font-semibold tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300">
-                {attachment.kind}
-              </span>
-            ) : null}
+            {attachment.kind ? <Chip>{attachment.kind}</Chip> : null}
             {attachment.contentType ? (
-              <span className="text-[10px] text-zinc-400 dark:text-zinc-500">
+              <span className="text-muted-foreground text-[10px]">
                 {attachment.contentType}
               </span>
             ) : null}

--- a/apps/devtools-frame/components/thread/ComposerFlags.test.tsx
+++ b/apps/devtools-frame/components/thread/ComposerFlags.test.tsx
@@ -16,8 +16,8 @@ describe("ComposerFlags", () => {
       />,
     );
     expect(html).toContain("Edit: true");
-    expect(html).toContain("Can Send: false");
-    expect(html).not.toContain("Can Cancel");
+    expect(html).toContain("Can send: false");
+    expect(html).not.toContain("Can cancel");
     expect(html).not.toContain("Empty");
   });
 });

--- a/apps/devtools-frame/components/thread/ComposerFlags.tsx
+++ b/apps/devtools-frame/components/thread/ComposerFlags.tsx
@@ -2,15 +2,15 @@ import { formatBoolean } from "../common";
 import type { ComposerPreview } from "./types";
 
 export const ComposerFlags = ({ composer }: { composer: ComposerPreview }) => (
-  <div className="flex flex-wrap gap-2 text-[10px] tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
+  <div className="text-muted-foreground flex flex-wrap gap-2 text-[10px]">
     {typeof composer.isEditing === "boolean" ? (
       <span>Edit: {formatBoolean(composer.isEditing)}</span>
     ) : null}
     {typeof composer.canCancel === "boolean" ? (
-      <span>Can Cancel: {formatBoolean(composer.canCancel)}</span>
+      <span>Can cancel: {formatBoolean(composer.canCancel)}</span>
     ) : null}
     {typeof composer.canSend === "boolean" ? (
-      <span>Can Send: {formatBoolean(composer.canSend)}</span>
+      <span>Can send: {formatBoolean(composer.canSend)}</span>
     ) : null}
     {typeof composer.isEmpty === "boolean" ? (
       <span>Empty: {formatBoolean(composer.isEmpty)}</span>

--- a/apps/devtools-frame/components/thread/ComposerQueue.test.tsx
+++ b/apps/devtools-frame/components/thread/ComposerQueue.test.tsx
@@ -9,7 +9,7 @@ describe("ComposerQueue", () => {
         queue={[{ id: "q1", prompt: "first" }, { prompt: "second" }]}
       />,
     );
-    expect(html).toContain("Message Queue (2)");
+    expect(html).toContain("Message queue (2)");
     expect(html).toContain("first");
     expect(html).toContain("second");
   });

--- a/apps/devtools-frame/components/thread/ComposerQueue.tsx
+++ b/apps/devtools-frame/components/thread/ComposerQueue.tsx
@@ -1,3 +1,4 @@
+import { SectionLabel } from "../ui";
 import type { ComposerQueueItem } from "./types";
 
 export const ComposerQueue = ({
@@ -8,11 +9,9 @@ export const ComposerQueue = ({
   if (!queue.length) return null;
 
   return (
-    <div className="rounded-md border border-amber-300 bg-amber-500/5 p-3 dark:border-amber-500/40 dark:bg-amber-500/10">
-      <div className="text-[10px] font-semibold tracking-wide text-amber-700 uppercase dark:text-amber-300">
-        Message Queue ({queue.length})
-      </div>
-      <ol className="mt-1 list-decimal space-y-0.5 pl-5 text-[11px] text-zinc-700 dark:text-zinc-200">
+    <div className="bg-card rounded-md border p-3">
+      <SectionLabel>Message queue ({queue.length})</SectionLabel>
+      <ol className="text-foreground mt-1 list-decimal space-y-0.5 pl-5 text-[11px]">
         {queue.map((item, index) => (
           <li
             key={item.id ?? index}

--- a/apps/devtools-frame/components/thread/ThreadDetails.tsx
+++ b/apps/devtools-frame/components/thread/ThreadDetails.tsx
@@ -1,6 +1,6 @@
 import { formatBoolean } from "../common";
 import { MessageList } from "../message";
-import { SummaryItem } from "../ui";
+import { Chip, SectionLabel, SummaryItem } from "../ui";
 import { ComposerAttachments } from "./ComposerAttachments";
 import { ComposerFlags } from "./ComposerFlags";
 import { ComposerQueue } from "./ComposerQueue";
@@ -14,11 +14,7 @@ export const ThreadDetails = ({
   title?: string;
 }) => (
   <div className="flex flex-col gap-3">
-    {title ? (
-      <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-        {title}
-      </div>
-    ) : null}
+    {title ? <SectionLabel>{title}</SectionLabel> : null}
     <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
       <SummaryItem label="Messages" value={String(thread.messages.length)} />
       {typeof thread.isLoading === "boolean" ? (
@@ -42,18 +38,11 @@ export const ThreadDetails = ({
     </div>
 
     {thread.capabilities.length ? (
-      <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-200">
-        <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-          Capabilities
-        </div>
+      <div className="bg-card text-foreground rounded-md border p-3 text-[11px]">
+        <SectionLabel>Capabilities</SectionLabel>
         <div className="mt-1 flex flex-wrap gap-1">
           {thread.capabilities.map((capability) => (
-            <span
-              key={capability}
-              className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium tracking-wide text-zinc-600 uppercase dark:bg-zinc-800 dark:text-zinc-300"
-            >
-              {capability}
-            </span>
+            <Chip key={capability}>{capability}</Chip>
           ))}
         </div>
       </div>
@@ -62,10 +51,8 @@ export const ThreadDetails = ({
     <MessageList messages={thread.messages} />
 
     {thread.suggestions.length ? (
-      <div className="rounded-md border border-dashed border-zinc-300 bg-white p-3 text-[11px] text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900/30 dark:text-zinc-200">
-        <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-          Suggestions
-        </div>
+      <div className="bg-card text-foreground rounded-md border border-dashed p-3 text-[11px]">
+        <SectionLabel>Suggestions</SectionLabel>
         <ul className="mt-2 list-disc space-y-1 pl-5">
           {thread.suggestions.map((suggestion, index) => (
             <li key={index}>{suggestion.prompt || "(empty)"}</li>
@@ -75,14 +62,12 @@ export const ThreadDetails = ({
     ) : null}
 
     {thread.composer ? (
-      <div className="flex flex-col gap-2 rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-200">
-        <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-          Composer
-        </div>
+      <div className="bg-card text-foreground flex flex-col gap-2 rounded-md border p-3 text-[11px]">
+        <SectionLabel>Composer</SectionLabel>
         <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
           <SummaryItem label="Role" value={thread.composer.role ?? "—"} />
           <SummaryItem
-            label="Text Length"
+            label="Text length"
             value={String(thread.composer.textLength)}
           />
           <SummaryItem

--- a/apps/devtools-frame/components/thread/render.test.tsx
+++ b/apps/devtools-frame/components/thread/render.test.tsx
@@ -21,10 +21,10 @@ describe("ThreadDetails composer queue", () => {
     };
 
     const html = renderToStaticMarkup(<ThreadDetails thread={thread} />);
-    expect(html).toContain("Message Queue (2)");
+    expect(html).toContain("Message queue (2)");
     expect(html).toContain("queued one");
     expect(html).toContain("queued two");
-    expect(html).toContain("Can Send");
+    expect(html).toContain("Can send");
   });
 
   it("omits the queue section when empty", () => {
@@ -36,6 +36,6 @@ describe("ThreadDetails composer queue", () => {
     };
 
     const html = renderToStaticMarkup(<ThreadDetails thread={thread} />);
-    expect(html).not.toContain("Message Queue");
+    expect(html).not.toContain("Message queue");
   });
 });

--- a/apps/devtools-frame/components/ui/CenteredMessage.tsx
+++ b/apps/devtools-frame/components/ui/CenteredMessage.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 export const CenteredMessage = ({ children }: { children: ReactNode }) => (
-  <div className="flex h-full items-center justify-center text-sm text-zinc-500 dark:text-zinc-400">
+  <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
     {children}
   </div>
 );

--- a/apps/devtools-frame/components/ui/Chip.tsx
+++ b/apps/devtools-frame/components/ui/Chip.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import type { ReactNode } from "react";
+import { BADGE_BASE } from "./badgeTone";
 
 export const Chip = ({
   className,
@@ -9,10 +10,7 @@ export const Chip = ({
   children: ReactNode;
 }) => (
   <span
-    className={clsx(
-      "bg-muted text-muted-foreground inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium",
-      className,
-    )}
+    className={clsx(BADGE_BASE, "bg-muted text-muted-foreground", className)}
   >
     {children}
   </span>

--- a/apps/devtools-frame/components/ui/Chip.tsx
+++ b/apps/devtools-frame/components/ui/Chip.tsx
@@ -1,0 +1,19 @@
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+export const Chip = ({
+  className,
+  children,
+}: {
+  className?: string | undefined;
+  children: ReactNode;
+}) => (
+  <span
+    className={clsx(
+      "bg-muted text-muted-foreground inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium",
+      className,
+    )}
+  >
+    {children}
+  </span>
+);

--- a/apps/devtools-frame/components/ui/ControlButton.tsx
+++ b/apps/devtools-frame/components/ui/ControlButton.tsx
@@ -7,7 +7,7 @@ export const ControlButton = ({
 }: ButtonHTMLAttributes<HTMLButtonElement>) => (
   <button
     className={clsx(
-      "inline-flex h-8 items-center rounded-md border border-zinc-300 px-3 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:focus-visible:ring-offset-zinc-900",
+      "text-foreground hover:bg-accent inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium transition-colors",
       className,
     )}
     {...props}

--- a/apps/devtools-frame/components/ui/EmptyState.tsx
+++ b/apps/devtools-frame/components/ui/EmptyState.tsx
@@ -1,9 +1,7 @@
 import type { ReactNode } from "react";
 
 export const EmptyState = ({ children }: { children: ReactNode }) => (
-  <div className="flex h-full items-center justify-center">
-    <div className="rounded-lg border border-dashed border-zinc-300 bg-white p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
-      {children}
-    </div>
+  <div className="text-muted-foreground flex h-full items-center justify-center p-6 text-center text-sm">
+    {children}
   </div>
 );

--- a/apps/devtools-frame/components/ui/InfoCard.tsx
+++ b/apps/devtools-frame/components/ui/InfoCard.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 export const InfoCard = ({ children }: { children: ReactNode }) => (
-  <div className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm transition-colors dark:border-zinc-800 dark:bg-zinc-900">
+  <div className="bg-card rounded-lg border p-4 transition-colors">
     {children}
   </div>
 );

--- a/apps/devtools-frame/components/ui/JSONPreview.tsx
+++ b/apps/devtools-frame/components/ui/JSONPreview.tsx
@@ -1,5 +1,5 @@
 export const JSONPreview = ({ value }: { value: unknown }) => (
-  <pre className="rounded-lg bg-zinc-100 p-3 text-[11px] leading-relaxed break-words whitespace-pre-wrap text-zinc-800 dark:bg-zinc-900 dark:text-zinc-200">
+  <pre className="bg-muted text-foreground rounded-lg p-3 font-mono text-[11px] leading-relaxed break-words whitespace-pre-wrap">
     {JSON.stringify(value, null, 2)}
   </pre>
 );

--- a/apps/devtools-frame/components/ui/SectionLabel.tsx
+++ b/apps/devtools-frame/components/ui/SectionLabel.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export const SectionLabel = ({ children }: { children: ReactNode }) => (
+  <div className="text-muted-foreground text-xs font-medium">{children}</div>
+);

--- a/apps/devtools-frame/components/ui/SectionTitle.tsx
+++ b/apps/devtools-frame/components/ui/SectionTitle.tsx
@@ -1,7 +1,5 @@
 import type { ReactNode } from "react";
 
 export const SectionTitle = ({ children }: { children: ReactNode }) => (
-  <h3 className="mb-2 text-sm font-semibold text-zinc-800 dark:text-zinc-100">
-    {children}
-  </h3>
+  <h3 className="text-foreground mb-2 text-sm font-semibold">{children}</h3>
 );

--- a/apps/devtools-frame/components/ui/SummaryItem.tsx
+++ b/apps/devtools-frame/components/ui/SummaryItem.tsx
@@ -7,12 +7,8 @@ export const SummaryItem = ({
   label: string;
   value: ReactNode;
 }) => (
-  <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 text-[11px] text-zinc-700 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-200">
-    <div className="text-[10px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
-      {label}
-    </div>
-    <div className="mt-1 font-semibold text-zinc-800 dark:text-zinc-100">
-      {value}
-    </div>
+  <div className="bg-muted/40 rounded-md border p-3 text-xs">
+    <div className="text-muted-foreground text-[10px] font-medium">{label}</div>
+    <div className="text-foreground mt-1 font-medium">{value}</div>
   </div>
 );

--- a/apps/devtools-frame/components/ui/ToneBadge.tsx
+++ b/apps/devtools-frame/components/ui/ToneBadge.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import type { ReactNode } from "react";
-import { BADGE_TONE } from "./badgeTone";
+import { BADGE_BASE, BADGE_TONE } from "./badgeTone";
 import type { BadgeTone } from "./badgeTone";
 
 export const ToneBadge = ({
@@ -12,13 +12,7 @@ export const ToneBadge = ({
   className?: string | undefined;
   children: ReactNode;
 }) => (
-  <span
-    className={clsx(
-      "inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium",
-      BADGE_TONE[tone ?? "zinc"],
-      className,
-    )}
-  >
+  <span className={clsx(BADGE_BASE, BADGE_TONE[tone ?? "zinc"], className)}>
     {children}
   </span>
 );

--- a/apps/devtools-frame/components/ui/ToneBadge.tsx
+++ b/apps/devtools-frame/components/ui/ToneBadge.tsx
@@ -14,7 +14,7 @@ export const ToneBadge = ({
 }) => (
   <span
     className={clsx(
-      "rounded border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase",
+      "inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium",
       BADGE_TONE[tone ?? "zinc"],
       className,
     )}

--- a/apps/devtools-frame/components/ui/badgeTone.ts
+++ b/apps/devtools-frame/components/ui/badgeTone.ts
@@ -11,3 +11,6 @@ export const BADGE_TONE = {
 } as const;
 
 export type BadgeTone = keyof typeof BADGE_TONE;
+
+export const BADGE_BASE =
+  "inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium";

--- a/apps/devtools-frame/components/ui/badgeTone.ts
+++ b/apps/devtools-frame/components/ui/badgeTone.ts
@@ -5,6 +5,8 @@ export const BADGE_TONE = {
   amber:
     "border-amber-300 bg-amber-500/10 text-amber-700 dark:border-amber-500/40 dark:bg-amber-500/15 dark:text-amber-300",
   red: "border-red-300 bg-red-500/10 text-red-700 dark:border-red-500/40 dark:bg-red-500/15 dark:text-red-300",
+  violet:
+    "border-violet-300 bg-violet-500/10 text-violet-700 dark:border-violet-500/40 dark:bg-violet-500/15 dark:text-violet-300",
   zinc: "border-zinc-300 bg-zinc-500/10 text-zinc-600 dark:border-zinc-600 dark:bg-zinc-500/15 dark:text-zinc-300",
 } as const;
 

--- a/apps/devtools-frame/components/ui/index.ts
+++ b/apps/devtools-frame/components/ui/index.ts
@@ -1,10 +1,12 @@
 export { BADGE_TONE } from "./badgeTone";
 export type { BadgeTone } from "./badgeTone";
 export { CenteredMessage } from "./CenteredMessage";
+export { Chip } from "./Chip";
 export { ControlButton } from "./ControlButton";
 export { EmptyState } from "./EmptyState";
 export { InfoCard } from "./InfoCard";
 export { JSONPreview } from "./JSONPreview";
+export { SectionLabel } from "./SectionLabel";
 export { SectionTitle } from "./SectionTitle";
 export { SummaryItem } from "./SummaryItem";
 export { ToneBadge } from "./ToneBadge";

--- a/apps/devtools-frame/package.json
+++ b/apps/devtools-frame/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@assistant-ui/react-devtools": "workspace:*",
     "clsx": "^2.1.1",
+    "geist": "^1.7.1",
     "next": "^16.2.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      geist:
+        specifier: ^1.7.1
+        version: 1.7.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       next:
         specifier: ^16.2.6
         version: 16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3516,7 +3519,7 @@ importers:
         version: link:../store
       '@google/adk':
         specifier: '>=0.5.0'
-        version: 1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
+        version: 1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
       assistant-cloud:
         specifier: '*'
         version: link:../cloud
@@ -3541,7 +3544,7 @@ importers:
         version: 19.2.6
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/react-hook-form:
     dependencies:
@@ -18620,6 +18623,20 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
+  '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+    dependencies:
+      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/precise-date': 4.0.0
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      googleapis: 137.1.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
       '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -18634,6 +18651,20 @@ snapshots:
       - encoding
       - supports-color
 
+  '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+    dependencies:
+      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.8.1
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+      google-auth-library: 9.15.1(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
       '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -18644,6 +18675,16 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
       google-auth-library: 9.15.1(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@google-cloud/opentelemetry-resource-util@3.0.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+    dependencies:
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      gcp-metadata: 6.1.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -18689,6 +18730,50 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@google/adk@1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
+    dependencies:
+      '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.12.0)(@grpc/grpc-js@1.14.4)(express@4.22.2)
+      '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/opentelemetry-cloud-trace-exporter': 3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/storage': 7.19.0(encoding@0.1.13)
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
+      '@mikro-orm/core': 6.6.14
+      '@mikro-orm/mariadb': 6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0)
+      '@mikro-orm/mssql': 6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0)
+      '@mikro-orm/mysql': 6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5)(pg@8.20.0)
+      '@mikro-orm/postgresql': 6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)
+      '@mikro-orm/reflection': 6.6.14(@mikro-orm/core@6.6.14)
+      '@mikro-orm/sqlite': 6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.205.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resource-detector-gcp': 0.40.3(@opentelemetry/api@1.9.0)(encoding@0.1.13)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.0)
+      express: 4.22.2
+      google-auth-library: 10.6.2
+      js-yaml: 4.1.1
+      jsonpath-plus: 10.4.0
+      lodash-es: 4.18.1
+      winston: 3.19.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@bufbuild/protobuf'
+      - '@cfworker/json-schema'
+      - '@grpc/grpc-js'
+      - '@opentelemetry/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
 
   '@google/adk@1.1.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@azure/core-client@1.10.1)(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)':
     dependencies:
@@ -21393,9 +21478,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -30363,6 +30446,37 @@ snapshots:
   vitefu@1.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  vitest@4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.9.1
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
+      '@vitest/ui': 4.1.7(vitest@4.1.7)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## summary

- redesign the devtools ui to match the assistant-ui product: sentence case instead of all-caps, Geist Sans for chrome with mono reserved for ids/timestamps/json, neutral accents instead of blue, hairline borders and no shadows
- adopt the product oklch css-var token system and follow light/dark from prefers-color-scheme (the panel was previously forced dark)
- restructure the five tabs (state, modelContext, events, runs, scopes) into three job-based tabs (thread, context, activity) plus a raw escape hatch
- consolidate the shared primitives: every status badge onto ToneBadge, new Chip and SectionLabel, unified empty states

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/devtools-frame test` -> 55/55 green
- [x] `tsc --noEmit` clean, `next build` compiles, oxlint + oxfmt clean

### reviewer should verify

- [ ] open the devtools in a light-themed host and a dark-themed host and confirm the panel follows the os/host theme and reads cleanly in both
- [ ] click through the thread, context, activity, and raw tabs and confirm the message, tool-call, run, mcp, and model-context views all render correctly

## notes

- frame-only (apps/devtools-frame is the private vercel-deployed iframe ui); no changeset, the published @assistant-ui/react-devtools package and the postMessage wire protocol are unchanged
- this ships the redesigned ui in the web frame so every user gets it on deploy; a follow-up will migrate the panel to render in-page (shadow dom) inside the published package
- remaining in-frame ux (master/detail selection model, virtualized event log) is deferred to a follow-up