### PR TITLE
feat(react): add reactArtifact single-file React component artifact

### DIFF
--- a/.changeset/react-artifact.md
+++ b/.changeset/react-artifact.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: add reactArtifact, a generative UI tool that compiles a model-authored single-file React component (Babel in a sandboxed iframe) and renders it as a standalone artifact, reporting compile/runtime status back to the model

--- a/examples/with-artifacts/app/api/chat/route.ts
+++ b/examples/with-artifacts/app/api/chat/route.ts
@@ -2,43 +2,50 @@ import { openai } from "@ai-sdk/openai";
 import {
   streamText,
   convertToModelMessages,
-  tool,
   stepCountIs,
-  zodSchema,
+  jsonSchema,
 } from "ai";
 import type { UIMessage } from "ai";
-import { z } from "zod";
 
 export const maxDuration = 30;
 
+type ToolDef = { description?: string; parameters: Record<string, unknown> };
+
+const SYSTEM =
+  "You are a helpful assistant that renders artifacts. Use create_html_artifact " +
+  "for a self-contained HTML document, and create_react_artifact for an " +
+  "interactive single-file React component (TSX with a default export). Prefer " +
+  "an artifact tool over showing code in a code block.";
+
 export async function POST(req: Request) {
-  const { messages }: { messages: UIMessage[] } = await req.json();
+  const {
+    messages,
+    tools: clientTools,
+  }: { messages: UIMessage[]; tools?: Record<string, ToolDef> } =
+    await req.json();
+
+  // The artifact tools are frontend/human tools executed on the client via
+  // Tools({ toolkit }); the client forwards their schemas in the request, and
+  // we relay them to the model without a server `execute`.
+  const tools = clientTools
+    ? Object.fromEntries(
+        Object.entries(clientTools).map(([name, def]) => [
+          name,
+          {
+            description: def.description ?? "",
+            inputSchema: jsonSchema(def.parameters),
+          },
+        ]),
+      )
+    : undefined;
 
   const result = streamText({
     model: openai("gpt-5.4-nano"),
-    system:
-      "You are a helpful assistant that can generate HTML code. When the user asks you to create any visual content, UI, or webpage, use the render_html tool to render it in the browser. Always use the render_html tool for HTML output rather than showing code in a code block.",
+    system: SYSTEM,
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(10),
-    tools: {
-      render_html: tool({
-        description:
-          "Render HTML code in the user's browser. Use this whenever the user asks for HTML, a webpage, a UI component, or any visual content.",
-        inputSchema: zodSchema(
-          z.object({
-            code: z
-              .string()
-              .describe(
-                "The complete HTML code to render, including inline CSS and JavaScript if needed.",
-              ),
-          }),
-        ),
-        execute: async () => {
-          return { success: true };
-        },
-      }),
-    },
-  });
+    ...(tools ? { tools } : {}),
+  } as Parameters<typeof streamText>[0]);
 
   return result.toUIMessageStreamResponse();
 }

--- a/examples/with-artifacts/app/page.tsx
+++ b/examples/with-artifacts/app/page.tsx
@@ -5,100 +5,26 @@ import {
   AssistantRuntimeProvider,
   Tools,
   useAui,
-  useAuiState,
   AuiProvider,
   Suggestions,
 } from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
-import type { ToolCallMessagePart } from "@assistant-ui/react";
-import { CodeIcon, EyeIcon } from "lucide-react";
-import { useState } from "react";
 import toolkit from "./toolkit";
-
-function ArtifactsView() {
-  const [tab, setTab] = useState<"source" | "preview">("source");
-
-  const lastToolCall = useAuiState((s) => {
-    const messages = s.thread.messages;
-    return messages
-      .flatMap((m) =>
-        m.content.filter(
-          (c): c is ToolCallMessagePart =>
-            c.type === "tool-call" && c.toolName === "render_html",
-        ),
-      )
-      .at(-1);
-  });
-
-  const code = lastToolCall?.args.code as string | undefined;
-  const isComplete = lastToolCall?.result !== undefined;
-
-  if (!code) return null;
-
-  return (
-    <div className="flex flex-grow basis-full justify-stretch p-3">
-      <div className="flex h-full w-full flex-col overflow-hidden rounded-lg border">
-        <div className="flex border-b">
-          <button
-            type="button"
-            onClick={() => setTab("source")}
-            className={`inline-flex flex-1 items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors ${
-              tab === "source"
-                ? "bg-background text-foreground"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            <CodeIcon className="size-4" />
-            Source Code
-          </button>
-          <button
-            type="button"
-            onClick={() => isComplete && setTab("preview")}
-            disabled={!isComplete}
-            className={`inline-flex flex-1 items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors ${
-              !isComplete
-                ? "cursor-not-allowed opacity-50"
-                : tab === "preview"
-                  ? "bg-background text-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            <EyeIcon className="size-4" />
-            Preview
-          </button>
-        </div>
-        {tab === "source" || !isComplete ? (
-          <div className="h-full overflow-y-auto px-4 py-2 font-mono text-sm break-words whitespace-pre-line">
-            {code}
-          </div>
-        ) : (
-          <div className="flex h-full flex-grow px-4 py-2">
-            <iframe
-              className="h-full w-full"
-              title="Artifact Preview"
-              srcDoc={code}
-            />
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
 
 function ThreadWithSuggestions() {
   const aui = useAui({
     suggestions: Suggestions([
       {
         title: "Build a landing page",
-        label: "with modern styling",
+        label: "as an HTML artifact",
         prompt:
-          "Build a beautiful landing page for a coffee shop with modern CSS.",
+          "Build a beautiful landing page for a coffee shop as an HTML artifact.",
       },
       {
-        title: "Create a calculator",
-        label: "with HTML and JavaScript",
+        title: "Create an interactive counter",
+        label: "as a React artifact",
         prompt:
-          "Create a calculator app with HTML, CSS, and JavaScript that supports basic arithmetic.",
+          "Create an interactive counter with a styled button as a React artifact.",
       },
     ]),
   });
@@ -117,11 +43,8 @@ export default function Home() {
 
   return (
     <AssistantRuntimeProvider aui={aui} runtime={runtime}>
-      <main className="flex h-full justify-stretch">
-        <div className="flex-grow basis-full">
-          <ThreadWithSuggestions />
-        </div>
-        <ArtifactsView />
+      <main className="mx-auto h-full w-full max-w-3xl">
+        <ThreadWithSuggestions />
       </main>
     </AssistantRuntimeProvider>
   );

--- a/examples/with-artifacts/app/toolkit.tsx
+++ b/examples/with-artifacts/app/toolkit.tsx
@@ -1,22 +1,12 @@
-"use generative";
+"use client";
 
-import { defineToolkit, externalTool } from "@assistant-ui/react";
-import { TerminalIcon } from "lucide-react";
-import { z } from "zod";
+import {
+  defineToolkit,
+  htmlArtifact,
+  reactArtifact,
+} from "@assistant-ui/react";
 
 export default defineToolkit({
-  render_html: {
-    parameters: z.object({
-      code: z.string(),
-    }),
-    execute: externalTool(),
-    render: () => {
-      return (
-        <div className="bg-primary text-primary-foreground my-2 inline-flex items-center gap-2 rounded-full border px-4 py-2">
-          <TerminalIcon className="size-4" />
-          render_html(&#123; code: &quot;...&quot; &#125;)
-        </div>
-      );
-    },
-  },
+  create_html_artifact: htmlArtifact(),
+  create_react_artifact: reactArtifact(),
 });

--- a/examples/with-artifacts/next.config.js
+++ b/examples/with-artifacts/next.config.js
@@ -1,4 +1,3 @@
-import { withAui } from "@assistant-ui/next";
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: [
@@ -8,4 +7,4 @@ const nextConfig = {
   ],
 };
 
-export default withAui(nextConfig);
+export default nextConfig;

--- a/packages/react/src/artifacts/buildReactArtifactHtml.test.ts
+++ b/packages/react/src/artifacts/buildReactArtifactHtml.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { buildReactArtifactHtml } from "./buildReactArtifactHtml";
+import { claudeParityImportMap, minimalImportMap } from "./defaultImportMap";
+
+describe("buildReactArtifactHtml", () => {
+  it("embeds the source, babel, the default import map, and the status/size protocol", () => {
+    const html = buildReactArtifactHtml("export default () => null");
+    expect(html).toContain("export default () => null");
+    expect(html).toContain("@babel/standalone");
+    expect(html).toContain(minimalImportMap.react);
+    expect(html).toContain("aui-artifact:status");
+    expect(html).toContain("aui-artifact:size");
+  });
+
+  it("escapes </script in the source so the stash block isn't closed early", () => {
+    const html = buildReactArtifactHtml('const x = "</script>";');
+    expect(html).toContain('const x = "<\\/script>";');
+  });
+
+  it("honors a custom import map and disabling tailwind", () => {
+    const html = buildReactArtifactHtml("export default () => null", {
+      importMap: claudeParityImportMap,
+      tailwind: false,
+    });
+    expect(html).toContain(claudeParityImportMap["lucide-react"]!);
+    expect(html).not.toContain("cdn.tailwindcss.com");
+  });
+});

--- a/packages/react/src/artifacts/buildReactArtifactHtml.ts
+++ b/packages/react/src/artifacts/buildReactArtifactHtml.ts
@@ -1,0 +1,206 @@
+import { minimalImportMap } from "./defaultImportMap";
+
+export interface BuildReactArtifactHtmlOptions {
+  /**
+   * Import map injected into the iframe document. Defaults to
+   * {@link minimalImportMap}. Pass {@link claudeParityImportMap} (or a custom
+   * map) to widen the set of libraries the model can `import`.
+   */
+  importMap?: Record<string, string>;
+  /**
+   * Load the Tailwind Play CDN inside the iframe so model-authored components
+   * pick up Tailwind utility classes. Default: `true`. Set `false` if you
+   * supply your own CSS.
+   */
+  tailwind?: boolean;
+  /** CSS classes applied to the iframe's `<body>`. */
+  bodyClassName?: string;
+  /**
+   * URL of `@babel/standalone`. Must be the IIFE bundle (NOT an ES module),
+   * because it is loaded via a classic `<script>` tag and registers a global
+   * `Babel`. Override to pin a different version or host. Default: unpkg.
+   */
+  babelUrl?: string;
+  /** URL of the Tailwind Play CDN script. Override to pin a version or host. */
+  tailwindCdnUrl?: string;
+}
+
+// `@babel/standalone` is a UMD/IIFE bundle that registers a global `Babel`. It
+// must not be served as an ES module (esm.sh) here because it is loaded via a
+// non-module <script> tag; unpkg/jsdelivr serve the original IIFE bundle.
+const DEFAULT_BABEL_URL =
+  "https://unpkg.com/@babel/standalone@7.25.7/babel.min.js";
+const DEFAULT_TAILWIND_URL = "https://cdn.tailwindcss.com";
+
+/**
+ * Wrap a model-authored single-file React component (TSX/JSX with an
+ * `export default`) into a complete HTML document for
+ * `SafeContentFrame.renderHtml`.
+ *
+ * The document loads an import map and `@babel/standalone` from a CDN
+ * (Babel runs inside the sandboxed iframe, so it never enters the host
+ * bundle), stashes the source in a `<script type="text/plain">` block,
+ * compiles it, blob-URL-imports the compiled module, and mounts its default
+ * export into `#root`. It reports its outcome to the host by posting an
+ * `aui-artifact:status` message ({@link reportStatus}: `{ ok }` on a clean
+ * mount, `{ ok: false, error }` on a compile/runtime error) and its content
+ * height via `aui-artifact:size`. Both post to `"*"`; the host's
+ * SandboxHost validates the source/origin on receipt.
+ */
+export function buildReactArtifactHtml(
+  source: string,
+  opts: BuildReactArtifactHtmlOptions = {},
+): string {
+  const importMap = opts.importMap ?? minimalImportMap;
+  const tailwind = opts.tailwind ?? true;
+  const babelUrl = opts.babelUrl ?? DEFAULT_BABEL_URL;
+  const tailwindUrl = opts.tailwindCdnUrl ?? DEFAULT_TAILWIND_URL;
+  const bodyClass = opts.bodyClassName ?? "";
+
+  // The source lives in a <script type="text/plain"> block; the parser ends
+  // that element at the first literal `</script` token, so escape the prefix.
+  const userSource = source.replace(/<\/script/gi, "<\\/script");
+  const importMapJson = JSON.stringify({ imports: importMap });
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>React artifact</title>
+    ${tailwind ? `<script src="${escapeAttr(tailwindUrl)}"></script>` : ""}
+    <script type="importmap">${importMapJson}</script>
+    <script src="${escapeAttr(babelUrl)}"></script>
+    <style>
+      html, body { height: 100%; margin: 0; }
+      body { font-family: ui-sans-serif, system-ui, -apple-system, sans-serif; }
+      #aui-error {
+        position: fixed; inset: 0; padding: 1rem; margin: 0;
+        font: 13px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: #b91c1c; background: #fef2f2;
+        white-space: pre-wrap; word-break: break-word;
+        overflow: auto; z-index: 2147483647;
+      }
+    </style>
+  </head>
+  <body class="${escapeAttr(bodyClass)}">
+    <div id="root"></div>
+    <script type="text/plain" id="aui-react-source">${userSource}</script>
+    <script type="module">
+      function post(message) {
+        try { window.parent.postMessage(message, "*"); } catch (_) {}
+      }
+
+      function reportSize() {
+        post({ type: "aui-artifact:size", height: Math.ceil(document.documentElement.scrollHeight) });
+      }
+      if (typeof ResizeObserver !== "undefined") {
+        new ResizeObserver(reportSize).observe(document.documentElement);
+      }
+      addEventListener("load", reportSize);
+
+      let statusReported = false;
+      function reportStatus(payload) {
+        if (statusReported) return;
+        statusReported = true;
+        post({ type: "aui-artifact:status", ...payload });
+      }
+
+      function serializeError(err) {
+        if (!err) return { message: "Unknown error" };
+        if (typeof err === "string") return { message: err };
+        return { message: err.message || String(err), stack: err.stack || undefined, name: err.name || undefined };
+      }
+
+      function showError(err) {
+        const pre = document.getElementById("aui-error") || document.createElement("pre");
+        pre.id = "aui-error";
+        pre.textContent = (err && (err.stack || err.message)) || String(err);
+        if (!pre.parentNode) document.body.appendChild(pre);
+        try { console.error("[aui-react-artifact]", err); } catch (_) {}
+        reportStatus({ ok: false, error: serializeError(err) });
+      }
+
+      // Benign warnings we ignore so they do not cover the component with the
+      // error overlay or trip the feedback loop.
+      function isBenignError(msg) {
+        if (!msg) return false;
+        return msg.indexOf("ResizeObserver loop") !== -1 || msg.indexOf("Non-Error promise rejection captured") !== -1;
+      }
+      window.addEventListener("error", (e) => {
+        if (isBenignError(e.message)) return;
+        showError(e.error || new Error(e.message + " @ " + e.filename + ":" + e.lineno));
+      });
+      window.addEventListener("unhandledrejection", (e) => {
+        const reason = e.reason;
+        if (isBenignError(reason && (reason.message || String(reason)))) return;
+        showError(reason || new Error("Unhandled rejection"));
+      });
+
+      const sourceEl = document.getElementById("aui-react-source");
+      const source = sourceEl ? sourceEl.textContent || "" : "";
+
+      try {
+        if (typeof Babel === "undefined") {
+          throw new Error("Babel standalone failed to load from " + ${JSON.stringify(babelUrl)});
+        }
+        const compiled = Babel.transform(source, {
+          filename: "artifact.tsx",
+          presets: [
+            ["env", { modules: false, targets: { esmodules: true } }],
+            ["react", { runtime: "automatic" }],
+            "typescript",
+          ],
+        }).code;
+
+        const blob = new Blob([compiled], { type: "text/javascript" });
+        const url = URL.createObjectURL(blob);
+        let mod;
+        try { mod = await import(url); } finally { URL.revokeObjectURL(url); }
+
+        const App = mod.default;
+        if (typeof App !== "function") {
+          throw new Error("React artifact must \`export default\` a component function or class. Got: " + typeof App);
+        }
+
+        const [{ default: React }, { createRoot }] = await Promise.all([
+          import("react"),
+          import("react-dom/client"),
+        ]);
+
+        // React 18 renders concurrently, so a render-time throw surfaces after
+        // root.render() returns. The error boundary routes render/lifecycle
+        // throws to a failed status; SuccessProbe reports ok only from an
+        // effect that commits when the subtree rendered cleanly. The one-shot
+        // guard makes whichever fires first authoritative.
+        class ArtifactErrorBoundary extends React.Component {
+          constructor(props) { super(props); this.state = { hasError: false }; }
+          static getDerivedStateFromError() { return { hasError: true }; }
+          componentDidCatch(error) { showError(error); }
+          render() { return this.state.hasError ? null : this.props.children; }
+        }
+
+        function SuccessProbe() {
+          React.useEffect(() => { reportStatus({ ok: true }); }, []);
+          return null;
+        }
+
+        createRoot(document.getElementById("root")).render(
+          React.createElement(
+            ArtifactErrorBoundary,
+            null,
+            React.createElement(App),
+            React.createElement(SuccessProbe),
+          ),
+        );
+      } catch (err) {
+        showError(err);
+      }
+    </script>
+  </body>
+</html>`;
+}
+
+function escapeAttr(v: string): string {
+  return v.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}

--- a/packages/react/src/artifacts/defaultImportMap.ts
+++ b/packages/react/src/artifacts/defaultImportMap.ts
@@ -1,0 +1,52 @@
+/**
+ * Import maps for the React artifact iframe.
+ *
+ * The SafeContentFrame iframe is a fresh document on a content-hashed origin
+ * with no module resolution; a `<script type="importmap">` in the rendered
+ * HTML tells the browser where to fetch each ESM specifier. Entries are URL
+ * strings only and are not preloaded; the browser fetches each lazily when the
+ * model's source `import`s the specifier, so a large map costs only the JSON
+ * bytes in the document. Identical artifact content reuses the same origin, so
+ * the browser caches these across re-renders.
+ */
+
+/**
+ * The bare minimum to render a React component: `react`, `react-dom`, and
+ * `clsx` (commonly used by hand-written components).
+ */
+export const minimalImportMap: Record<string, string> = {
+  react: "https://esm.sh/react@18.3.1",
+  "react/jsx-runtime": "https://esm.sh/react@18.3.1/jsx-runtime",
+  "react/jsx-dev-runtime": "https://esm.sh/react@18.3.1/jsx-dev-runtime",
+  "react-dom": "https://esm.sh/react-dom@18.3.1",
+  "react-dom/client": "https://esm.sh/react-dom@18.3.1/client",
+  clsx: "https://esm.sh/clsx@2.1.1",
+};
+
+/**
+ * Mirrors the library set available inside Claude's React artifacts (lucide,
+ * recharts, framer-motion, d3, three / r3f, react-router), giving the model a
+ * familiar palette.
+ *
+ * Every React-consuming library is loaded with `?external=react,react-dom` so
+ * esm.sh does not bundle its own React copy; without it each library ships its
+ * own instance and the artifact crashes with React error #31 (the element
+ * symbol differs across instances).
+ */
+export const claudeParityImportMap: Record<string, string> = {
+  ...minimalImportMap,
+  classnames: "https://esm.sh/classnames@2.5.1",
+  "lucide-react":
+    "https://esm.sh/lucide-react@0.469.0?external=react,react-dom",
+  recharts: "https://esm.sh/recharts@2.13.3?external=react,react-dom",
+  "framer-motion":
+    "https://esm.sh/framer-motion@11.15.0?external=react,react-dom",
+  d3: "https://esm.sh/d3@7.9.0",
+  three: "https://esm.sh/three@0.171.0",
+  "@react-three/fiber":
+    "https://esm.sh/@react-three/fiber@8.17.10?external=react,react-dom,three",
+  "@react-three/drei":
+    "https://esm.sh/@react-three/drei@9.121.4?external=react,react-dom,three,@react-three/fiber",
+  "react-router-dom":
+    "https://esm.sh/react-router-dom@6.28.0?external=react,react-dom",
+};

--- a/packages/react/src/artifacts/index.ts
+++ b/packages/react/src/artifacts/index.ts
@@ -3,3 +3,14 @@ export {
   type HtmlArtifactArgs,
   type HtmlArtifactOptions,
 } from "./htmlArtifact";
+export {
+  reactArtifact,
+  type ReactArtifactArgs,
+  type ReactArtifactOptions,
+  type ReactArtifactResult,
+} from "./reactArtifact";
+export {
+  buildReactArtifactHtml,
+  type BuildReactArtifactHtmlOptions,
+} from "./buildReactArtifactHtml";
+export { minimalImportMap, claudeParityImportMap } from "./defaultImportMap";

--- a/packages/react/src/artifacts/reactArtifact.test.tsx
+++ b/packages/react/src/artifacts/reactArtifact.test.tsx
@@ -125,6 +125,23 @@ describe("reactArtifact", () => {
       expect(addResult).toHaveBeenCalledWith({ ok: true });
     });
 
+    it("mounts and settles at requires-action, before the tool reaches complete", async () => {
+      // Regression: a human tool sits at "requires-action" (input done, awaiting
+      // the render's result) and never reaches "complete" until addResult, so
+      // gating render on "complete" deadlocks. It must mount at requires-action.
+      const addResult = vi.fn();
+      await mount(
+        partProps({
+          args: { code: "export default () => null" },
+          status: { type: "requires-action", reason: "interrupt" },
+          addResult,
+        }),
+      );
+      expect(renderHtmlMock).toHaveBeenCalledTimes(1);
+      await dispatch({ type: "aui-artifact:status", ok: true });
+      expect(addResult).toHaveBeenCalledWith({ ok: true });
+    });
+
     it("reports the error message when the iframe signals a failed mount", async () => {
       const addResult = vi.fn();
       await mount(

--- a/packages/react/src/artifacts/reactArtifact.test.tsx
+++ b/packages/react/src/artifacts/reactArtifact.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolCallMessagePartProps } from "@assistant-ui/core/react";
+
+const { renderHtmlMock } = vi.hoisted(() => ({ renderHtmlMock: vi.fn() }));
+
+vi.mock("safe-content-frame", () => ({
+  SafeContentFrame: class {
+    renderHtml = renderHtmlMock;
+  },
+}));
+
+import { reactArtifact, type ReactArtifactArgs } from "./reactArtifact";
+
+type Result = { ok: boolean; error?: string };
+
+function fakeRendered() {
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  return {
+    iframe,
+    origin: "https://fake.scf.test",
+    sendMessage: vi.fn(),
+    dispose: vi.fn(),
+    fullyLoadedPromiseWithTimeout: vi.fn(),
+  };
+}
+
+const flush = () =>
+  act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+function partProps(
+  overrides: Partial<ToolCallMessagePartProps<ReactArtifactArgs, Result>>,
+): ToolCallMessagePartProps<ReactArtifactArgs, Result> {
+  return {
+    type: "tool-call",
+    toolCallId: "tool-1",
+    toolName: "create_react_artifact",
+    argsText: "",
+    args: { code: "" },
+    status: { type: "complete" },
+    result: undefined,
+    addResult: vi.fn(),
+    resume: vi.fn(),
+    respondToApproval: vi.fn(),
+    ...overrides,
+  } as unknown as ToolCallMessagePartProps<ReactArtifactArgs, Result>;
+}
+
+describe("reactArtifact", () => {
+  it("is a standalone human tool with no execute", () => {
+    const tool = reactArtifact();
+    expect(tool.type).toBe("human");
+    expect(tool.execute).toBeUndefined();
+    expect(tool.parameters).toBeDefined();
+    expect(typeof tool.render).toBe("function");
+  });
+
+  describe("render", () => {
+    let container: HTMLDivElement;
+    let root: Root;
+    let rendered: ReturnType<typeof fakeRendered>;
+
+    beforeEach(() => {
+      container = document.createElement("div");
+      document.body.appendChild(container);
+      root = createRoot(container);
+      rendered = fakeRendered();
+      renderHtmlMock.mockReset();
+      renderHtmlMock.mockResolvedValue(rendered);
+    });
+
+    afterEach(() => {
+      act(() => {
+        try {
+          root.unmount();
+        } catch {
+          // ignore
+        }
+      });
+      container.remove();
+    });
+
+    async function mount(
+      props: ToolCallMessagePartProps<ReactArtifactArgs, Result>,
+    ) {
+      const Render = reactArtifact().render!;
+      await act(async () => {
+        root.render(<Render {...props} />);
+      });
+      await flush();
+    }
+
+    function dispatch(data: unknown) {
+      return act(async () => {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            data,
+            origin: rendered.origin,
+            source: rendered.iframe.contentWindow,
+          }),
+        );
+      });
+    }
+
+    it("compiles the source into the sandbox host", async () => {
+      await mount(partProps({ args: { code: "export default () => null" } }));
+      expect(renderHtmlMock).toHaveBeenCalledTimes(1);
+      const html = renderHtmlMock.mock.calls[0]![0] as string;
+      expect(html).toContain("export default () => null");
+      expect(html).toContain("@babel/standalone");
+    });
+
+    it("reports ok via addResult when the iframe signals a clean mount", async () => {
+      const addResult = vi.fn();
+      await mount(
+        partProps({ args: { code: "export default () => null" }, addResult }),
+      );
+      await dispatch({ type: "aui-artifact:status", ok: true });
+      expect(addResult).toHaveBeenCalledTimes(1);
+      expect(addResult).toHaveBeenCalledWith({ ok: true });
+    });
+
+    it("reports the error message when the iframe signals a failed mount", async () => {
+      const addResult = vi.fn();
+      await mount(
+        partProps({ args: { code: "export default () => null" }, addResult }),
+      );
+      await dispatch({
+        type: "aui-artifact:status",
+        ok: false,
+        error: { message: "boom" },
+      });
+      expect(addResult).toHaveBeenCalledWith({ ok: false, error: "boom" });
+    });
+
+    it("auto-resizes from the iframe's reported height", async () => {
+      await mount(partProps({ args: { code: "export default () => null" } }));
+      await dispatch({ type: "aui-artifact:size", height: 321 });
+      const div = container.firstElementChild as HTMLDivElement;
+      expect(div.style.height).toBe("321px");
+    });
+
+    it("does not render or settle while the source is still streaming", async () => {
+      const addResult = vi.fn();
+      await mount(
+        partProps({
+          args: { code: "export def" },
+          status: { type: "running" },
+          addResult,
+        }),
+      );
+      expect(renderHtmlMock).not.toHaveBeenCalled();
+      expect(addResult).not.toHaveBeenCalled();
+      expect(container.firstElementChild).toBeNull();
+    });
+  });
+});

--- a/packages/react/src/artifacts/reactArtifact.tsx
+++ b/packages/react/src/artifacts/reactArtifact.tsx
@@ -52,9 +52,15 @@ function createReactArtifactRender(options: ReactArtifactOptions) {
   }: ToolCallMessagePartProps<ReactArtifactArgs, ReactArtifactResult>) => {
     const settledRef = useRef(false);
 
-    // Compile once the source has fully arrived; partial source would fail to
-    // compile and report a spurious error.
-    if (status.type !== "complete" || typeof args.code !== "string")
+    // Compile once the source has fully arrived. A human tool sits at
+    // "requires-action" (input complete, awaiting the render's result) before
+    // it ever reaches "complete", so gating on "complete" alone would deadlock:
+    // the iframe would never mount, never report status, and never call
+    // addResult. Render at both, but not while the args are still streaming.
+    if (
+      (status.type !== "requires-action" && status.type !== "complete") ||
+      typeof args.code !== "string"
+    )
       return null;
 
     const settle = (r: ReactArtifactResult) => {

--- a/packages/react/src/artifacts/reactArtifact.tsx
+++ b/packages/react/src/artifacts/reactArtifact.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useRef } from "react";
+import { z } from "zod";
+import type {
+  ToolCallMessagePartProps,
+  ToolDefinition,
+} from "@assistant-ui/core/react";
+import {
+  SandboxHost,
+  type SandboxHostConfig,
+} from "../sandbox-host/SandboxHost";
+import { isRecord } from "../utils/json/is-json";
+import { buildReactArtifactHtml } from "./buildReactArtifactHtml";
+
+const reactArtifactParameters = z.object({
+  title: z
+    .string()
+    .describe("A short human-readable title for the artifact.")
+    .optional(),
+  code: z
+    .string()
+    .describe(
+      "A single-file React component as TSX/JSX with a default export. It may " +
+        "import react, react-dom, and the libraries the host allows; it is " +
+        "compiled and rendered in a sandboxed iframe.",
+    ),
+});
+
+export type ReactArtifactArgs = z.infer<typeof reactArtifactParameters>;
+
+export type ReactArtifactResult = { ok: boolean; error?: string };
+
+export type ReactArtifactOptions = {
+  /** Sandbox + container styling, forwarded to the underlying SafeContentFrame host. */
+  sandbox?: SandboxHostConfig;
+  /** Upper bound (px) the auto-resize height is clamped to. Defaults to 800. */
+  maxHeight?: number;
+  /** Import map injected into the iframe. Defaults to the minimal React map. */
+  importMap?: Record<string, string>;
+  /** Load the Tailwind Play CDN in the iframe. Defaults to `true`. */
+  tailwind?: boolean;
+};
+
+function createReactArtifactRender(options: ReactArtifactOptions) {
+  const ReactArtifact = ({
+    args,
+    status,
+    result,
+    toolCallId,
+    addResult,
+  }: ToolCallMessagePartProps<ReactArtifactArgs, ReactArtifactResult>) => {
+    const settledRef = useRef(false);
+
+    // Compile once the source has fully arrived; partial source would fail to
+    // compile and report a spurious error.
+    if (status.type !== "complete" || typeof args.code !== "string")
+      return null;
+
+    const settle = (r: ReactArtifactResult) => {
+      if (settledRef.current || result !== undefined) return;
+      settledRef.current = true;
+      addResult(r);
+    };
+
+    return (
+      <SandboxHost
+        content={{
+          html: buildReactArtifactHtml(args.code, {
+            ...(options.importMap !== undefined && {
+              importMap: options.importMap,
+            }),
+            ...(options.tailwind !== undefined && {
+              tailwind: options.tailwind,
+            }),
+          }),
+        }}
+        contentKey={toolCallId}
+        sandbox={options.sandbox}
+        maxHeight={options.maxHeight}
+        containerProps={{ "data-artifact-title": args.title }}
+        onError={(err) => settle({ ok: false, error: err.message })}
+        createBridge={(_frame, host) => ({
+          onMessage: (event) => {
+            const data = event.data;
+            if (!isRecord(data)) return;
+            if (
+              data.type === "aui-artifact:size" &&
+              typeof data.height === "number"
+            ) {
+              host.setHeight(data.height);
+            } else if (data.type === "aui-artifact:status") {
+              if (data.ok === true) {
+                settle({ ok: true });
+              } else {
+                const message =
+                  isRecord(data.error) && typeof data.error.message === "string"
+                    ? data.error.message
+                    : "React artifact failed to render";
+                settle({ ok: false, error: message });
+              }
+            }
+          },
+          dispose: () => {},
+        })}
+      />
+    );
+  };
+  ReactArtifact.displayName = "ReactArtifact";
+  return ReactArtifact;
+}
+
+/**
+ * Generative-UI tool that renders a model-authored single-file React component
+ * as an artifact, compiled (Babel-in-iframe) and shown on its own surface in a
+ * sandboxed iframe (the shared SafeContentFrame host).
+ *
+ * Unlike {@link htmlArtifact} (a frontend tool that resolves immediately), this
+ * is a human-in-the-loop tool whose render is the source of the result: the
+ * iframe reports whether it mounted cleanly, and the render calls `addResult`
+ * with `{ ok: true }` or `{ ok: false, error }`, so a compile/runtime error
+ * feeds back to the model. Human tools render standalone by default. Compose it
+ * into a `defineToolkit`:
+ *
+ * ```tsx
+ * defineToolkit({ create_react_artifact: reactArtifact() });
+ * ```
+ */
+export function reactArtifact(
+  options: ReactArtifactOptions = {},
+): ToolDefinition<ReactArtifactArgs, ReactArtifactResult> {
+  return {
+    type: "human",
+    description:
+      "Render a React artifact: a single-file React component (TSX/JSX with a " +
+      "default export) compiled and shown on its own surface in a sandboxed " +
+      "iframe. The render reports whether it mounted cleanly or hit a " +
+      "compile/runtime error.",
+    parameters: reactArtifactParameters,
+    render: createReactArtifactRender(options),
+  };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -451,4 +451,12 @@ export {
   htmlArtifact,
   type HtmlArtifactArgs,
   type HtmlArtifactOptions,
+  reactArtifact,
+  type ReactArtifactArgs,
+  type ReactArtifactOptions,
+  type ReactArtifactResult,
+  buildReactArtifactHtml,
+  type BuildReactArtifactHtmlOptions,
+  minimalImportMap,
+  claudeParityImportMap,
 } from "./artifacts";


### PR DESCRIPTION
## summary

- adds `reactArtifact()`, the flagship artifact kind: the model authors a single-file React component (TSX/JSX, default export) and it renders as a standalone artifact in the shared `SandboxHost`.
- the component is compiled by `@babel/standalone` **loaded inside the sandboxed iframe from a CDN**, so there is no Babel dependency in the `@assistant-ui/react` bundle. `buildReactArtifactHtml()` is pure string templating (import map + Babel script + source stash + blob-import bootstrap + error boundary + success probe).
- unlike `htmlArtifact` (a frontend tool that resolves immediately), this is a **human tool** whose render is the source of the result: the iframe posts an `aui-artifact:status` message and the render calls `addResult({ ok } / { ok: false, error })`, so a compile/runtime error feeds back to the model. human tools render standalone by default.
- ships `minimalImportMap` (default) + `claudeParityImportMap` (opt-in, lucide/recharts/framer-motion/d3/three/react-router, all `?external=react,react-dom`), and exports `buildReactArtifactHtml`.
- compose it: `defineToolkit({ create_react_artifact: reactArtifact() })`.

## design notes

- builds on `SandboxHost` (#4298): the iframe's `aui-artifact:status` / `aui-artifact:size` messages post to `"*"` and SandboxHost's cross-origin guard validates source/origin on receipt, so this does not reinvent #4108's bespoke origin handshake.
- safe-content-frame injects no CSP, so the sandboxed iframe can load Babel / esm.sh / Tailwind from CDNs.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react exec tsc --noEmit` -> no artifact type errors (only the pre-existing, unrelated `replayBoundaryStream.test.ts`). this is the gate `aui-build` doesn't provide; it caught two real issues pre-push.
- [x] `pnpm turbo test --filter=@assistant-ui/react` -> 362/362 (`reactArtifact` 6, `buildReactArtifactHtml` 3, covering tool shape, compile-into-host, status->addResult ok/error, auto-resize, streaming guard).
- [x] `pnpm --filter @assistant-ui/react build` + oxlint/oxfmt clean.

### reviewer should verify

- [ ] in a real browser: create a React artifact, confirm it compiles + mounts + auto-resizes; force a compile/runtime error and confirm `{ ok: false, error }` feeds back to the model. (jsdom can't run the SCF iframe + CDN Babel, so the actual compile path is browser-only.)

## notes

- scope is the React render kind only. no panel/versioning/update-rewrite yet (a later slice); the artifact renders standalone via the existing `display` routing.
- the `vi.mock("safe-content-frame")` + `fakeRendered`/`flush` helpers are now shared in spirit across three artifact test files; a shared fixture is a reasonable follow-up (low priority).