### PR TITLE
fix(react-ai-sdk): bundle the root entry on edge, workers, browsers

### DIFF
--- a/.changeset/react-ai-sdk-root-mcp-stdio.md
+++ b/.changeset/react-ai-sdk-root-mcp-stdio.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix(react-ai-sdk): make the package root bundle on edge, cloudflare workers, deno, and browsers, not just react native. the node-only stdio MCP transport is now resolved through a package.json "imports" condition (`#mcp-stdio`), so importing `@assistant-ui/react-ai-sdk` at root carries the full server toolkit on every target with http/sse MCP working on edge, while stdio MCP throws a clear runtime error only where a subprocess cannot be spawned (browser, react native, edge, workers) instead of breaking the build via `@ai-sdk/mcp/mcp-stdio` -> `node:child_process`. node, bun, and deno keep the real stdio transport.

--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -15,6 +15,17 @@
   "author": "AgentbaseAI Inc.",
   "license": "MIT",
   "type": "module",
+  "imports": {
+    "#mcp-stdio": {
+      "types": "./src/mcp-stdio.node.ts",
+      "react-native": "./dist/mcp-stdio.unsupported.js",
+      "edge-light": "./dist/mcp-stdio.unsupported.js",
+      "workerd": "./dist/mcp-stdio.unsupported.js",
+      "browser": "./dist/mcp-stdio.unsupported.js",
+      "node": "./dist/mcp-stdio.node.js",
+      "default": "./dist/mcp-stdio.unsupported.js"
+    }
+  },
   "exports": {
     ".": {
       "react-native": {

--- a/packages/react-ai-sdk/src/generativeTools.ts
+++ b/packages/react-ai-sdk/src/generativeTools.ts
@@ -1,7 +1,7 @@
 import { jsonSchema, type ToolSet } from "ai";
 import type { MCPClient, MCPClientConfig } from "@ai-sdk/mcp";
 import { createMCPClient } from "@ai-sdk/mcp";
-import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import { Experimental_StdioMCPTransport } from "#mcp-stdio";
 import {
   toJSONSchema,
   type Tool,

--- a/packages/react-ai-sdk/src/mcp-stdio.node.ts
+++ b/packages/react-ai-sdk/src/mcp-stdio.node.ts
@@ -1,0 +1,1 @@
+export { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";

--- a/packages/react-ai-sdk/src/mcp-stdio.unsupported.ts
+++ b/packages/react-ai-sdk/src/mcp-stdio.unsupported.ts
@@ -1,0 +1,12 @@
+import type { Experimental_StdioMCPTransport as NodeStdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+
+class UnsupportedStdioMCPTransport {
+  constructor() {
+    throw new Error(
+      "stdio MCP transport requires a runtime that can spawn a subprocess, such as Node, Bun, or Deno (with --allow-run). Use an HTTP or SSE MCP server config in browser, React Native, edge, or worker runtimes.",
+    );
+  }
+}
+
+export const Experimental_StdioMCPTransport =
+  UnsupportedStdioMCPTransport as unknown as typeof NodeStdioMCPTransport;

--- a/packages/react-ai-sdk/vitest.config.ts
+++ b/packages/react-ai-sdk/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "#mcp-stdio": fileURLToPath(
+        new URL("./src/mcp-stdio.node.ts", import.meta.url),
+      ),
+    },
+  },
+});


### PR DESCRIPTION
follow-up to #4283. the react native fix in #4285 only covered metro; this extends the same isolation so the package root also bundles on edge runtimes, cloudflare workers, deno, and browsers.

## summary

- importing `@assistant-ui/react-ai-sdk` at root now bundles cleanly on edge, cloudflare workers, deno, and browsers (not just react native); it no longer drags `node:child_process` (via `@ai-sdk/mcp/mcp-stdio`) onto a non-node bundle.
- the node-only stdio MCP transport is resolved through a package.json `imports` condition (`#mcp-stdio`): the real `@ai-sdk/mcp/mcp-stdio` under `node`, a throwing stub under `react-native`/`edge-light`/`workerd`/`worker`/`browser`. the full server toolkit and http/sse MCP keep working on every target; stdio only throws at construction time, where a subprocess genuinely cannot be spawned.
- node, bun, and deno keep the real stdio transport. bun and deno both assert the `node` condition, so they are deliberately left off the stub list (deno can spawn with `--allow-run`).
- the public api on node is unchanged, so existing root importers of `AISDKToolkit` keep working.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ai-sdk build` -> clean, emits `dist/mcp-stdio.node.js` + `dist/mcp-stdio.unsupported.js`, leaves the literal `#mcp-stdio` in `dist/generativeTools.js` for the consumer to resolve.
- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` -> 75/75 green (the existing `vi.mock("@ai-sdk/mcp/mcp-stdio")` keeps working through the node re-export).
- [x] `tsc --noEmit` on a clean tree with no prebuilt dist -> 0 errors (a tsconfig `paths` redirect resolves `#mcp-stdio` to source).
- [x] `pnpm lint` -> 0.
- [x] node resolver per condition: `node` -> real transport constructs; `--conditions=workerd|edge-light|browser` -> stub throws at construction.

### reviewer should verify

- [ ] in an expo / react native app, `import { useChatRuntime } from "@assistant-ui/react-ai-sdk"` bundles for native with no `child_process` error.
- [ ] a next.js edge route (`export const runtime = "edge"`) or a cloudflare worker importing the package root builds without `child_process`, and an http/sse MCP server still works there.
- [ ] a node route still uses a `{ type: "stdio", command }` MCP server with the real transport.

## notes

- the maintainer suggestion to `async import("@ai-sdk/mcp/mcp-stdio")` was tested and does not fix the bundling: metro, webpack, esbuild and wrangler statically resolve a literal `import()` target into the build graph, and `@ai-sdk/mcp/mcp-stdio` itself statically imports `node:child_process`, so the lazy import still pulls it in. the AI SDK's own single env-compat dynamic import is double guarded (`isNodeRuntime()` + `/* webpackIgnore: true */`), which confirms a bare async import is not enough on its own.
- this mirrors how `@ai-sdk/mcp` isolates stdio behind a separate entry, applied at the consumer layer. an internal `imports` condition is used rather than a public subpath because consumers configure stdio through toolkit config and never import a transport, so the seam stays internal and out of the public api.
- the merged `react-native` exports split (`index.native.ts`) is kept as-is: it covers react native and metro < 0.82, while the `#mcp-stdio` condition covers edge/workers/browser, which still resolve the default entry.