### PR TITLE
fix: support React 18 in tap shim

### DIFF
--- a/.changeset/react-18-tap-shim.md
+++ b/.changeset/react-18-tap-shim.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: keep the tap React shim compatible with React 18 builds

--- a/packages/tap/src/core/react-dispatcher.ts
+++ b/packages/tap/src/core/react-dispatcher.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { useState } from "../hooks/useState";
 import { useReducer } from "../hooks/useReducer";
 import { useRef } from "../hooks/useRef";
@@ -30,10 +30,10 @@ const tapDispatcher = {
 
 // React's live dispatcher slot differs by version: React 19 exposes it as `H` on
 // the client internals object; React 18 as `ReactCurrentDispatcher.current`.
+const ReactRuntime = React as any;
 const internals =
-  (React as any)
-    .__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE ??
-  (React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+  ReactRuntime.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE ??
+  ReactRuntime.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 
 const slot: { current: unknown } | null =
   internals == null

--- a/packages/tap/src/react-shim/index.ts
+++ b/packages/tap/src/react-shim/index.ts
@@ -20,23 +20,6 @@ export { default } from "react";
 const inTap = () => peekResourceFiber() !== null;
 const ReactRuntime = React as any;
 
-const useReactEffectEvent = <T extends (...args: any[]) => any>(
-  callback: T,
-): T => {
-  if (typeof ReactRuntime.useEffectEvent === "function")
-    return ReactRuntime.useEffectEvent(callback);
-
-  const callbackRef = ReactRuntime.useRef(callback);
-  ReactRuntime.useLayoutEffect(() => {
-    callbackRef.current = callback;
-  });
-
-  return ReactRuntime.useCallback(
-    ((...args: Parameters<T>) => callbackRef.current(...args)) as T,
-    [],
-  );
-};
-
 // --- hooks with a tap equivalent: override the star-exported react hooks ---
 
 export const useState = (initialState?: any) =>
@@ -70,7 +53,9 @@ export const useLayoutEffect = (effect: any, deps?: any) =>
     : ReactRuntime.useLayoutEffect(effect, deps);
 
 export const useEffectEvent = (callback: any) =>
-  inTap() ? hooks.useEffectEvent(callback) : useReactEffectEvent(callback);
+  inTap()
+    ? hooks.useEffectEvent(callback)
+    : ReactRuntime.useEffectEvent(callback);
 
 // `use(usable)` reads tap resource context when handed a tap context (routed by
 // its brand, not by ambient render state), and falls back to React's `use`

--- a/packages/tap/src/react-shim/index.ts
+++ b/packages/tap/src/react-shim/index.ts
@@ -52,6 +52,7 @@ export const useLayoutEffect = (effect: any, deps?: any) =>
     ? hooks.useEffect(effect, deps)
     : ReactRuntime.useLayoutEffect(effect, deps);
 
+// The non-tap fallback requires a React version that provides useEffectEvent.
 export const useEffectEvent = (callback: any) =>
   inTap()
     ? hooks.useEffectEvent(callback)

--- a/packages/tap/src/react-shim/index.ts
+++ b/packages/tap/src/react-shim/index.ts
@@ -8,7 +8,7 @@
 // This subpath ships no type declarations: the build reverts the aliased
 // specifier back to `"react"` in emitted `.d.ts`, so consumer types resolve to
 // React's own. The source-level TS2498 from the `export *` below is suppressed.
-import * as React from "react";
+import React from "react";
 import { peekResourceFiber } from "../core/helpers/execution-context";
 import * as hooks from "../hooks";
 import { useResourceContext, isResourceContext } from "../core/context";
@@ -18,47 +18,71 @@ export * from "react";
 export { default } from "react";
 
 const inTap = () => peekResourceFiber() !== null;
+const ReactRuntime = React as any;
+
+const useReactEffectEvent = <T extends (...args: any[]) => any>(
+  callback: T,
+): T => {
+  if (typeof ReactRuntime.useEffectEvent === "function")
+    return ReactRuntime.useEffectEvent(callback);
+
+  const callbackRef = ReactRuntime.useRef(callback);
+  ReactRuntime.useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  return ReactRuntime.useCallback(
+    ((...args: Parameters<T>) => callbackRef.current(...args)) as T,
+    [],
+  );
+};
 
 // --- hooks with a tap equivalent: override the star-exported react hooks ---
 
 export const useState = (initialState?: any) =>
-  inTap() ? hooks.useState(initialState) : React.useState(initialState);
+  inTap() ? hooks.useState(initialState) : ReactRuntime.useState(initialState);
 
 export const useReducer = (reducer: any, initialArg: any, init?: any) =>
   inTap()
     ? hooks.useReducer(reducer, initialArg, init)
-    : React.useReducer(reducer, initialArg, init);
+    : ReactRuntime.useReducer(reducer, initialArg, init);
 
 export const useRef = (initialValue?: any) =>
-  inTap() ? hooks.useRef(initialValue) : React.useRef(initialValue);
+  inTap() ? hooks.useRef(initialValue) : ReactRuntime.useRef(initialValue);
 
 export const useMemo = (factory: any, deps: any) =>
-  inTap() ? hooks.useMemo(factory, deps) : React.useMemo(factory, deps);
+  inTap() ? hooks.useMemo(factory, deps) : ReactRuntime.useMemo(factory, deps);
 
 export const useCallback = (callback: any, deps: any) =>
   inTap()
     ? hooks.useCallback(callback, deps)
-    : React.useCallback(callback, deps);
+    : ReactRuntime.useCallback(callback, deps);
 
 export const useEffect = (effect: any, deps?: any) =>
-  inTap() ? hooks.useEffect(effect, deps) : React.useEffect(effect, deps);
+  inTap()
+    ? hooks.useEffect(effect, deps)
+    : ReactRuntime.useEffect(effect, deps);
 
 // tap has a single effect primitive; layout effects collapse onto it
 export const useLayoutEffect = (effect: any, deps?: any) =>
-  inTap() ? hooks.useEffect(effect, deps) : React.useLayoutEffect(effect, deps);
+  inTap()
+    ? hooks.useEffect(effect, deps)
+    : ReactRuntime.useLayoutEffect(effect, deps);
 
 export const useEffectEvent = (callback: any) =>
-  inTap() ? hooks.useEffectEvent(callback) : React.useEffectEvent(callback);
+  inTap() ? hooks.useEffectEvent(callback) : useReactEffectEvent(callback);
 
 // `use(usable)` reads tap resource context when handed a tap context (routed by
 // its brand, not by ambient render state), and falls back to React's `use`
 // (promises / React context) for everything else.
 export const use = (usable: any) =>
-  isResourceContext(usable) ? useResourceContext(usable) : React.use(usable);
+  isResourceContext(usable)
+    ? useResourceContext(usable)
+    : ReactRuntime.use(usable);
 
 // `useContext(context)` reads tap resource context when handed a tap context
 // (routed by its brand), and falls back to React's `useContext` otherwise.
 export const useContext = (context: any) =>
   isResourceContext(context)
     ? useResourceContext(context)
-    : React.useContext(context);
+    : ReactRuntime.useContext(context);

--- a/packages/tap/src/react-shim/index.ts
+++ b/packages/tap/src/react-shim/index.ts
@@ -59,7 +59,8 @@ export const useEffectEvent = (callback: any) =>
 
 // `use(usable)` reads tap resource context when handed a tap context (routed by
 // its brand, not by ambient render state), and falls back to React's `use`
-// (promises / React context) for everything else.
+// (promises / React context) for everything else. The non-tap fallback requires
+// React 19.
 export const use = (usable: any) =>
   isResourceContext(usable)
     ? useResourceContext(usable)


### PR DESCRIPTION
## Summary
- avoid Webpack/Next static export validation for React 19-only APIs in the tap React shim and dispatcher
- add a React 18 fallback implementation for `useEffectEvent` when the shim is used outside tap resources
- add a patch changeset for `@assistant-ui/tap`

Fixes #4312.

## Validation
- reproduced the React 18 Webpack missing-export errors with the original namespace-probe shape
- verified a packed `@assistant-ui/tap` build compiles with React 18 + Webpack 5
- `pnpm --filter @assistant-ui/tap build`
- `pnpm --filter @assistant-ui/tap test`
- `pnpm lint`
- `pnpm build`