### PR TITLE
feat: add message delete runtime support

### DIFF
--- a/.changeset/message-delete-runtime.md
+++ b/.changeset/message-delete-runtime.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-ai-sdk": patch
+---
+
+feat: add runtime support for deleting messages

--- a/packages/core/src/adapters/thread-history.ts
+++ b/packages/core/src/adapters/thread-history.ts
@@ -43,6 +43,7 @@ export type GenericThreadHistoryAdapter<TMessage> = {
     item: MessageFormatItem<TMessage>,
     localMessageId: string,
   ): Promise<void>;
+  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
   reportTelemetry?(
     items: MessageFormatItem<TMessage>[],
     options?: {
@@ -58,6 +59,7 @@ export type ThreadHistoryAdapter = {
     options: ChatModelRunOptions,
   ): AsyncGenerator<ChatModelRunResult, void, unknown>;
   append(item: ExportedMessageRepositoryItem): Promise<void>;
+  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
   /** Required when used with `useAISDKRuntime` / `useChatRuntime`. */
   withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(
     formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>,

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -57,6 +57,11 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
         if (!remoteId) return;
         await formatted.update?.(remoteId, item, localMessageId);
       },
+      async delete() {
+        throw new Error(
+          "Assistant Cloud does not support deleting thread messages yet.",
+        );
+      },
       reportTelemetry(
         items: MessageFormatItem<TMessage>[],
         options?: {
@@ -95,6 +100,12 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     if (this.cloudRef.current.telemetry.enabled) {
       this._maybeReportRun(remoteId, "aui/v0", encoded);
     }
+  }
+
+  async delete() {
+    throw new Error(
+      "Assistant Cloud does not support deleting thread messages yet.",
+    );
   }
 
   async load() {

--- a/packages/core/src/runtime/api/message-runtime.ts
+++ b/packages/core/src/runtime/api/message-runtime.ts
@@ -101,7 +101,7 @@ export type MessageRuntime = {
   readonly composer: EditComposerRuntime;
 
   getState(): MessageState;
-  delete(): void;
+  delete(): void | Promise<void>;
   reload(config?: ReloadConfig): void;
   /**
    * @deprecated This API is still under active development and might change without notice.
@@ -184,7 +184,7 @@ export class MessageRuntimeImpl implements MessageRuntime {
 
   public delete() {
     const state = this._core.getState();
-    this._threadBinding.getState().deleteMessage(state.id);
+    return this._threadBinding.getState().deleteMessage(state.id);
   }
 
   public reload(reloadConfig: ReloadConfig = {}) {

--- a/packages/core/src/runtime/api/message-runtime.ts
+++ b/packages/core/src/runtime/api/message-runtime.ts
@@ -101,6 +101,7 @@ export type MessageRuntime = {
   readonly composer: EditComposerRuntime;
 
   getState(): MessageState;
+  delete(): void;
   reload(config?: ReloadConfig): void;
   /**
    * @deprecated This API is still under active development and might change without notice.
@@ -155,6 +156,7 @@ export class MessageRuntimeImpl implements MessageRuntime {
 
   protected __internal_bindMethods() {
     this.reload = this.reload.bind(this);
+    this.delete = this.delete.bind(this);
     this.getState = this.getState.bind(this);
     this.subscribe = this.subscribe.bind(this);
     this.getMessagePartByIndex = this.getMessagePartByIndex.bind(this);
@@ -178,6 +180,11 @@ export class MessageRuntimeImpl implements MessageRuntime {
 
   public getState() {
     return this._core.getState();
+  }
+
+  public delete() {
+    const state = this._core.getState();
+    this._threadBinding.getState().deleteMessage(state.id);
   }
 
   public reload(reloadConfig: ReloadConfig = {}) {

--- a/packages/core/src/runtime/api/thread-runtime.ts
+++ b/packages/core/src/runtime/api/thread-runtime.ts
@@ -252,7 +252,7 @@ export type ThreadRuntime = {
    */
   append(message: CreateAppendMessage): void;
 
-  deleteMessage(messageId: string): void;
+  deleteMessage(messageId: string): void | Promise<void>;
 
   /**
    * Start a new run with the given configuration.
@@ -415,7 +415,7 @@ export class ThreadRuntimeImpl implements ThreadRuntime {
   }
 
   public deleteMessage(messageId: string) {
-    this._threadBinding.getState().deleteMessage(messageId);
+    return this._threadBinding.getState().deleteMessage(messageId);
   }
 
   public subscribe(callback: () => void) {

--- a/packages/core/src/runtime/api/thread-runtime.ts
+++ b/packages/core/src/runtime/api/thread-runtime.ts
@@ -252,6 +252,8 @@ export type ThreadRuntime = {
    */
   append(message: CreateAppendMessage): void;
 
+  deleteMessage(messageId: string): void;
+
   /**
    * Start a new run with the given configuration.
    * @param config The configuration for starting the run
@@ -374,6 +376,7 @@ export class ThreadRuntimeImpl implements ThreadRuntime {
 
   protected __internal_bindMethods() {
     this.append = this.append.bind(this);
+    this.deleteMessage = this.deleteMessage.bind(this);
     this.resumeRun = this.resumeRun.bind(this);
     this.importExternalState = this.importExternalState.bind(this);
     this.exportExternalState = this.exportExternalState.bind(this);
@@ -409,6 +412,10 @@ export class ThreadRuntimeImpl implements ThreadRuntime {
       .append(
         toAppendMessage(this._threadBinding.getState().messages, message),
       );
+  }
+
+  public deleteMessage(messageId: string) {
+    this._threadBinding.getState().deleteMessage(messageId);
   }
 
   public subscribe(callback: () => void) {

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -56,7 +56,7 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
 
   public abstract get capabilities(): RuntimeCapabilities;
   public abstract append(message: AppendMessage): void;
-  public abstract deleteMessage(messageId: string): void;
+  public abstract deleteMessage(messageId: string): void | Promise<void>;
   public abstract startRun(config: StartRunConfig): void;
   public abstract resumeRun(config: ResumeRunConfig): void;
   public abstract addToolResult(options: AddToolResultOptions): void;

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -56,6 +56,7 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
 
   public abstract get capabilities(): RuntimeCapabilities;
   public abstract append(message: AppendMessage): void;
+  public abstract deleteMessage(messageId: string): void;
   public abstract startRun(config: StartRunConfig): void;
   public abstract resumeRun(config: ResumeRunConfig): void;
   public abstract addToolResult(options: AddToolResultOptions): void;

--- a/packages/core/src/runtime/interfaces/thread-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-runtime-core.ts
@@ -147,7 +147,7 @@ export type ThreadRuntimeCore = Readonly<{
   switchToBranch: (branchId: string) => void;
 
   append: (message: AppendMessage) => void;
-  deleteMessage: (messageId: string) => void;
+  deleteMessage: (messageId: string) => void | Promise<void>;
   startRun: (config: StartRunConfig) => void;
   resumeRun: (config: ResumeRunConfig) => void;
   cancelRun: () => void;

--- a/packages/core/src/runtime/interfaces/thread-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-runtime-core.ts
@@ -23,6 +23,7 @@ export type RuntimeCapabilities = {
   readonly switchBranchDuringRun: boolean;
   readonly edit: boolean;
   readonly reload: boolean;
+  readonly delete: boolean;
   readonly cancel: boolean;
   readonly unstable_copy: boolean;
   readonly speech: boolean;
@@ -146,6 +147,7 @@ export type ThreadRuntimeCore = Readonly<{
   switchToBranch: (branchId: string) => void;
 
   append: (message: AppendMessage) => void;
+  deleteMessage: (messageId: string) => void;
   startRun: (config: StartRunConfig) => void;
   resumeRun: (config: ResumeRunConfig) => void;
   cancelRun: () => void;

--- a/packages/core/src/runtimes/external-store/external-store-adapter.ts
+++ b/packages/core/src/runtimes/external-store/external-store-adapter.ts
@@ -109,6 +109,7 @@ type ExternalStoreAdapterBase<T> = {
   /** Opt in to message queuing. Typically produced by `createMessageQueue`. */
   queue?: ExternalThreadQueueAdapter | undefined;
   onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
+  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
   onReload?: // TODO: remove parentId in 0.12.0
     | ((parentId: string | null, config: StartRunConfig) => Promise<void>)
     | undefined;

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -60,6 +60,7 @@ export class ExternalStoreThreadRuntimeCore
     switchToBranch: false,
     switchBranchDuringRun: false,
     edit: false,
+    delete: false,
     reload: false,
     cancel: false,
     unstable_copy: false,
@@ -148,6 +149,9 @@ export class ExternalStoreThreadRuntimeCore
       switchToBranch: this._store.setMessages !== undefined,
       switchBranchDuringRun: false,
       edit: this._store.onEdit !== undefined,
+      delete:
+        this._store.onDelete !== undefined ||
+        this._store.setMessages !== undefined,
       reload: this._store.onReload !== undefined,
       cancel: this._store.onCancel !== undefined,
       speech: this._store.adapters?.speech !== undefined,
@@ -417,6 +421,26 @@ export class ExternalStoreThreadRuntimeCore
     } else {
       await this._store.onNew(message);
     }
+  }
+
+  public async deleteMessage(messageId: string): Promise<void> {
+    if (this._store.onDelete) {
+      await this._store.onDelete(messageId);
+      return;
+    }
+
+    if (!this._store.setMessages)
+      throw new Error("Runtime does not support deleting messages.");
+
+    if (this._store.isRunning) {
+      await this._toolInvocations?.abort();
+    }
+
+    const messages = this.repository.getMessages();
+    const messageIndex = messages.findIndex((m) => m.id === messageId);
+    if (messageIndex === -1) throw new Error("Message not found.");
+
+    this.updateMessages(messages.slice(0, messageIndex));
   }
 
   public getQueueItems() {

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -440,7 +440,7 @@ export class ExternalStoreThreadRuntimeCore
     const messageIndex = messages.findIndex((m) => m.id === messageId);
     if (messageIndex === -1) throw new Error("Message not found.");
 
-    this.updateMessages(messages.slice(0, messageIndex));
+    this.updateMessages(messages.filter((message) => message.id !== messageId));
   }
 
   public getQueueItems() {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -291,13 +291,12 @@ export class LocalThreadRuntimeCore
     const messageIndex = messages.findIndex((m) => m.id === messageId);
     if (messageIndex === -1) throw new Error("Message not found.");
 
-    const items = messages.slice(messageIndex).map((message, idx) => ({
-      parentId:
-        idx === 0
-          ? (messages[messageIndex - 1]?.id ?? null)
-          : messages[messageIndex + idx - 1]!.id,
-      message,
-    }));
+    let parentId = messages[messageIndex - 1]?.id ?? null;
+    const items = messages.slice(messageIndex).map((message) => {
+      const item = { parentId, message };
+      parentId = message.id;
+      return item;
+    });
 
     await adapter.delete(items);
 

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -49,6 +49,7 @@ export class LocalThreadRuntimeCore
     switchToBranch: true,
     switchBranchDuringRun: true,
     edit: true,
+    delete: false,
     reload: true,
     cancel: true,
     unstable_copy: true,
@@ -147,6 +148,12 @@ export class LocalThreadRuntimeCore
     const canFeedback = options.adapters?.feedback !== undefined;
     if (this.capabilities.feedback !== canFeedback) {
       this.capabilities.feedback = canFeedback;
+      hasUpdates = true;
+    }
+
+    const canDelete = options.adapters?.history?.delete !== undefined;
+    if (this.capabilities.delete !== canDelete) {
+      this.capabilities.delete = canDelete;
       hasUpdates = true;
     }
 
@@ -273,6 +280,30 @@ export class LocalThreadRuntimeCore
       this.repository.resetHead(newMessage.id);
       this._notifySubscribers();
     }
+  }
+
+  public async deleteMessage(messageId: string): Promise<void> {
+    const adapter = this._options.adapters.history;
+    if (!adapter?.delete)
+      throw new Error("Runtime does not support deleting messages.");
+
+    const messages = this.repository.getMessages();
+    const messageIndex = messages.findIndex((m) => m.id === messageId);
+    if (messageIndex === -1) throw new Error("Message not found.");
+
+    const items = messages.slice(messageIndex).map((message, idx) => ({
+      parentId:
+        idx === 0
+          ? (messages[messageIndex - 1]?.id ?? null)
+          : messages[messageIndex + idx - 1]!.id,
+      message,
+    }));
+
+    await adapter.delete(items);
+
+    const previousMessage = messages[messageIndex - 1];
+    this.repository.resetHead(previousMessage?.id ?? null);
+    this._notifySubscribers();
   }
 
   public resumeRun({ stream, ...startConfig }: ResumeRunConfig): Promise<void> {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -291,17 +291,13 @@ export class LocalThreadRuntimeCore
     const messageIndex = messages.findIndex((m) => m.id === messageId);
     if (messageIndex === -1) throw new Error("Message not found.");
 
-    let parentId = messages[messageIndex - 1]?.id ?? null;
-    const items = messages.slice(messageIndex).map((message) => {
-      const item = { parentId, message };
-      parentId = message.id;
-      return item;
-    });
+    const message = messages[messageIndex]!;
+    const parentId = messages[messageIndex - 1]?.id ?? null;
+    const items = [{ parentId, message }];
 
     await adapter.delete(items);
 
-    const previousMessage = messages[messageIndex - 1];
-    this.repository.resetHead(previousMessage?.id ?? null);
+    this.repository.deleteMessage(messageId);
     this._notifySubscribers();
   }
 

--- a/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
+++ b/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
@@ -47,6 +47,10 @@ export class ReadonlyThreadRuntimeCore
     throw READONLY_THREAD_ERROR;
   }
 
+  deleteMessage(): void {
+    throw READONLY_THREAD_ERROR;
+  }
+
   startRun(): void {
     throw READONLY_THREAD_ERROR;
   }
@@ -202,6 +206,7 @@ export class ReadonlyThreadRuntimeCore
     switchToBranch: false,
     switchBranchDuringRun: false,
     edit: false,
+    delete: false,
     reload: false,
     cancel: false,
     unstable_copy: false,

--- a/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
+++ b/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
@@ -20,6 +20,10 @@ export const EMPTY_THREAD_CORE: ThreadRuntimeCore = {
     throw EMPTY_THREAD_ERROR;
   },
 
+  deleteMessage() {
+    throw EMPTY_THREAD_ERROR;
+  },
+
   startRun() {
     throw EMPTY_THREAD_ERROR;
   },
@@ -183,6 +187,7 @@ export const EMPTY_THREAD_CORE: ThreadRuntimeCore = {
     switchToBranch: false,
     switchBranchDuringRun: false,
     edit: false,
+    delete: false,
     reload: false,
     cancel: false,
     unstable_copy: false,

--- a/packages/core/src/store/clients/thread-message-client.ts
+++ b/packages/core/src/store/clients/thread-message-client.ts
@@ -137,6 +137,9 @@ export const ThreadMessageClient = resource(function ThreadMessageClient({
         return attachments.get(selector);
       }
     },
+    delete: () => {
+      throw new Error("Not supported in ThreadMessageProvider");
+    },
     reload: () => {
       throw new Error("Not supported in ThreadMessageProvider");
     },

--- a/packages/core/src/store/runtime-clients/message-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/message-runtime-client.ts
@@ -117,6 +117,7 @@ export const MessageClient = resource(function MessageClient({
 
     composer: () => composer.methods,
 
+    delete: () => runtime.delete(),
     reload: (config) => runtime.reload(config),
     speak: () => runtime.speak(),
     stopSpeaking: () => runtime.stopSpeaking(),

--- a/packages/core/src/store/runtime-clients/thread-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-runtime-client.ts
@@ -109,6 +109,7 @@ export const ThreadClient = resource(function ThreadClient({
     getState: () => state,
     composer: () => composer.methods,
     append: runtime.append,
+    deleteMessage: runtime.deleteMessage,
     startRun: runtime.startRun,
     resumeRun: runtime.resumeRun,
     cancelRun: runtime.cancelRun,

--- a/packages/core/src/store/scopes/message.ts
+++ b/packages/core/src/store/scopes/message.ts
@@ -42,6 +42,7 @@ export type MessageMethods = {
    */
   getState(): MessageState;
   composer(): ComposerMethods;
+  delete(): void;
   reload(config?: { runConfig?: RunConfig }): void;
   /** @deprecated This API is still under active development and might change without notice. */
   speak(): void;

--- a/packages/core/src/store/scopes/message.ts
+++ b/packages/core/src/store/scopes/message.ts
@@ -42,7 +42,7 @@ export type MessageMethods = {
    */
   getState(): MessageState;
   composer(): ComposerMethods;
-  delete(): void;
+  delete(): void | Promise<void>;
   reload(config?: { runConfig?: RunConfig }): void;
   /** @deprecated This API is still under active development and might change without notice. */
   speak(): void;

--- a/packages/core/src/store/scopes/thread.ts
+++ b/packages/core/src/store/scopes/thread.ts
@@ -88,6 +88,7 @@ export type ThreadMethods = {
    * ```
    */
   append(message: CreateAppendMessage): void;
+  deleteMessage(messageId: string): void | Promise<void>;
   /**
    * Start a new run with the given configuration.
    * @param config The configuration for starting the run

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -49,6 +49,15 @@ describe("ExternalStoreThreadRuntimeCore - state reference stability", () => {
       expect(runtime.capabilities).not.toBe(capsBefore);
     });
 
+    it("enables delete when setMessages is provided", () => {
+      const runtime = new ExternalStoreThreadRuntimeCore(
+        mockContextProvider,
+        makeStore({ setMessages: vi.fn() }),
+      );
+
+      expect(runtime.capabilities.delete).toBe(true);
+    });
+
     it("should maintain stable reference across repeated setAdapter calls", () => {
       const runtime = new ExternalStoreThreadRuntimeCore(
         mockContextProvider,
@@ -151,6 +160,53 @@ describe("ExternalStoreThreadRuntimeCore - state reference stability", () => {
     runtime.__internal_setAdapter(store);
 
     expect(runtime.capabilities).toBe(capsBefore);
+  });
+
+  describe("deleteMessage", () => {
+    it("removes the selected message and later messages from the active branch", async () => {
+      const setMessages = vi.fn();
+      const runtime = new ExternalStoreThreadRuntimeCore(
+        mockContextProvider,
+        makeStore({
+          messages: [
+            {
+              id: "u1",
+              role: "user",
+              content: [{ type: "text", text: "first" }],
+            },
+            {
+              id: "a1",
+              role: "assistant",
+              content: [{ type: "text", text: "answer" }],
+            },
+            {
+              id: "u2",
+              role: "user",
+              content: [{ type: "text", text: "second" }],
+            },
+          ],
+          setMessages,
+        }),
+      );
+
+      await runtime.deleteMessage("a1");
+
+      expect(setMessages).toHaveBeenCalledWith([
+        expect.objectContaining({ id: "u1" }),
+      ]);
+    });
+
+    it("delegates to onDelete when provided", async () => {
+      const onDelete = vi.fn();
+      const runtime = new ExternalStoreThreadRuntimeCore(
+        mockContextProvider,
+        makeStore({ onDelete }),
+      );
+
+      await runtime.deleteMessage("m1");
+
+      expect(onDelete).toHaveBeenCalledWith("m1");
+    });
   });
 });
 describe("ExternalStoreThreadRuntimeCore - optimistic message reconciliation", () => {

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -163,7 +163,7 @@ describe("ExternalStoreThreadRuntimeCore - state reference stability", () => {
   });
 
   describe("deleteMessage", () => {
-    it("removes the selected message and later messages from the active branch", async () => {
+    it("removes only the selected message", async () => {
       const setMessages = vi.fn();
       const runtime = new ExternalStoreThreadRuntimeCore(
         mockContextProvider,
@@ -193,6 +193,7 @@ describe("ExternalStoreThreadRuntimeCore - state reference stability", () => {
 
       expect(setMessages).toHaveBeenCalledWith([
         expect.objectContaining({ id: "u1" }),
+        expect.objectContaining({ id: "u2" }),
       ]);
     });
 

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
@@ -285,7 +285,7 @@ describe("useAISDKRuntime", () => {
     );
   });
 
-  it("deletes a message and later messages from AI SDK state", async () => {
+  it("deletes only the selected message from AI SDK state", async () => {
     const deleteMessage = vi.fn().mockResolvedValue(undefined);
     vi.mocked(useExternalHistory).mockReturnValue({
       isLoading: false,
@@ -320,6 +320,7 @@ describe("useAISDKRuntime", () => {
     expect(chat.messages.map((message: any) => message.id)).toEqual([
       "u1",
       "a1",
+      "a2",
     ]);
   });
 

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
@@ -8,10 +8,14 @@ import { validateUIMessages } from "ai";
 // in isolation). Every other dependency — useExternalStoreRuntime,
 // useToolInvocations, the message converter — runs for real.
 vi.mock("./useExternalHistory", () => ({
-  useExternalHistory: vi.fn(() => false),
+  useExternalHistory: vi.fn(() => ({
+    isLoading: false,
+    deleteMessage: vi.fn().mockResolvedValue(undefined),
+  })),
   toExportedMessageRepository: vi.fn(),
 }));
 
+import { useExternalHistory } from "./useExternalHistory";
 import { useAISDKRuntime } from "./useAISDKRuntime";
 
 const createChatHelpers = (messages: any[] = []) => {
@@ -46,6 +50,10 @@ const textOf = (message: any): string =>
 describe("useAISDKRuntime", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useExternalHistory).mockReturnValue({
+      isLoading: false,
+      deleteMessage: vi.fn().mockResolvedValue(undefined),
+    });
   });
 
   it("sends a new user message through the runtime", async () => {
@@ -275,6 +283,44 @@ describe("useAISDKRuntime", () => {
         ]),
       }),
     );
+  });
+
+  it("deletes a message and later messages from AI SDK state", async () => {
+    const deleteMessage = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(useExternalHistory).mockReturnValue({
+      isLoading: false,
+      deleteMessage,
+    });
+    const chat = createChatHelpers([
+      { id: "u1", role: "user", parts: [{ type: "text", text: "first" }] },
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [{ type: "text", text: "first-answer" }],
+      },
+      { id: "u2", role: "user", parts: [{ type: "text", text: "second" }] },
+      {
+        id: "a2",
+        role: "assistant",
+        parts: [{ type: "text", text: "second-answer" }],
+      },
+    ]);
+
+    const { result } = renderHook(() => useAISDKRuntime(chat));
+
+    await waitFor(() => {
+      expect(result.current.thread.getState().messages).toHaveLength(4);
+    });
+
+    await act(async () => {
+      result.current.thread.getMessageById("u2").delete();
+    });
+
+    expect(deleteMessage).toHaveBeenCalledWith("u2");
+    expect(chat.messages.map((message: any) => message.id)).toEqual([
+      "u1",
+      "a1",
+    ]);
   });
 
   it("edit slices history to parentId and sends the edited message", async () => {

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -325,10 +325,9 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       await deleteHistoryMessage(messageId);
 
       const deleteIds = new Set(
-        threadMessages
-          .slice(messageIndex)
-          .flatMap((message) => getExternalStoreMessages<UI_MESSAGE>(message))
-          .map((message) => message.id),
+        getExternalStoreMessages<UI_MESSAGE>(threadMessages[messageIndex]!).map(
+          (message) => message.id,
+        ),
       );
       chatHelpers.setMessages((current) =>
         current.filter((message) => !deleteIds.has(message.id)),

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -158,7 +158,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     },
   }));
 
-  const isLoading = useExternalHistory(
+  const { isLoading, deleteMessage: deleteHistoryMessage } = useExternalHistory(
     runtimeRef,
     adapters?.history ?? contextAdapters?.history,
     AISDKMessageConverter.toThreadMessages as (
@@ -314,6 +314,25 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       await chatHelpers.sendMessage(createMessage, {
         metadata: message.runConfig,
       });
+    },
+    onDelete: async (messageId) => {
+      const threadMessages = runtimeRef.current.thread.getState().messages;
+      const messageIndex = threadMessages.findIndex(
+        (message) => message.id === messageId,
+      );
+      if (messageIndex === -1) return;
+
+      await deleteHistoryMessage(messageId);
+
+      const deleteIds = new Set(
+        threadMessages
+          .slice(messageIndex)
+          .flatMap((message) => getExternalStoreMessages<UI_MESSAGE>(message))
+          .map((message) => message.id),
+      );
+      chatHelpers.setMessages((current) =>
+        current.filter((message) => !deleteIds.has(message.id)),
+      );
     },
     onReload: async (parentId: string | null, config) => {
       lastRunConfigRef.current = config.runConfig;

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -300,12 +300,20 @@ export const useExternalHistory = <TMessage>(
       const messageIndex = messages.findIndex((m) => m.id === messageId);
       if (messageIndex === -1) return;
 
-      const itemsToDelete = messages.slice(messageIndex).flatMap((message) =>
-        getExternalStoreMessages<TMessage>(message).map((innerMessage) => ({
-          parentId: null,
-          message: innerMessage,
-        })),
-      );
+      const previousInnerMessages = messages
+        .slice(0, messageIndex)
+        .flatMap(getExternalStoreMessages<TMessage>);
+      let parentId = previousInnerMessages.at(-1)
+        ? storageFormatAdapter.getId(previousInnerMessages.at(-1)!)
+        : null;
+      const itemsToDelete = messages
+        .slice(messageIndex)
+        .flatMap(getExternalStoreMessages<TMessage>)
+        .map((message) => {
+          const item = { parentId, message };
+          parentId = storageFormatAdapter.getId(message);
+          return item;
+        });
 
       await formatAdapter.delete(itemsToDelete);
 
@@ -313,7 +321,7 @@ export const useExternalHistory = <TMessage>(
         historyIds.current.delete(message.id);
       }
     },
-    [formatAdapter, runtimeRef],
+    [formatAdapter, runtimeRef, storageFormatAdapter],
   );
 
   return { isLoading, deleteMessage };

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -292,5 +292,29 @@ export const useExternalHistory = <TMessage>(
     };
   }, [formatAdapter, storageFormatAdapter, runtimeRef]);
 
-  return isLoading;
+  const deleteMessage = useCallback(
+    async (messageId: string) => {
+      if (!formatAdapter?.delete) return;
+
+      const messages = runtimeRef.current.thread.getState().messages;
+      const messageIndex = messages.findIndex((m) => m.id === messageId);
+      if (messageIndex === -1) return;
+
+      const itemsToDelete = messages.slice(messageIndex).flatMap((message) =>
+        getExternalStoreMessages<TMessage>(message).map((innerMessage) => ({
+          parentId: null,
+          message: innerMessage,
+        })),
+      );
+
+      await formatAdapter.delete(itemsToDelete);
+
+      for (const message of messages.slice(messageIndex)) {
+        historyIds.current.delete(message.id);
+      }
+    },
+    [formatAdapter, runtimeRef],
+  );
+
+  return { isLoading, deleteMessage };
 };

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -306,20 +306,17 @@ export const useExternalHistory = <TMessage>(
       let parentId = previousInnerMessages.at(-1)
         ? storageFormatAdapter.getId(previousInnerMessages.at(-1)!)
         : null;
-      const itemsToDelete = messages
-        .slice(messageIndex)
-        .flatMap(getExternalStoreMessages<TMessage>)
-        .map((message) => {
-          const item = { parentId, message };
-          parentId = storageFormatAdapter.getId(message);
-          return item;
-        });
+      const itemsToDelete = getExternalStoreMessages<TMessage>(
+        messages[messageIndex]!,
+      ).map((message) => {
+        const item = { parentId, message };
+        parentId = storageFormatAdapter.getId(message);
+        return item;
+      });
 
       await formatAdapter.delete(itemsToDelete);
 
-      for (const message of messages.slice(messageIndex)) {
-        historyIds.current.delete(message.id);
-      }
+      historyIds.current.delete(messageId);
     },
     [formatAdapter, runtimeRef, storageFormatAdapter],
   );

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -572,6 +572,7 @@ export const ExternalThread = resource(function ExternalThread({
         onNew?.(appendMessage);
       }
     },
+    deleteMessage: () => {},
     startRun: () => {
       onStartRun?.();
     },

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -151,6 +151,7 @@ const MessageClient = resource(function MessageClient({
   return {
     getState: () => state,
     composer: () => composerClient.methods,
+    delete: () => {},
     reload: () => {
       onReload?.();
     },
@@ -509,6 +510,7 @@ export const ExternalThread = resource(function ExternalThread({
       isRunning,
       capabilities: {
         edit: false,
+        delete: false,
         reload: false,
         cancel: isRunning,
         speech: false,


### PR DESCRIPTION
Closes #4311

## Summary
- add optional delete support to thread history adapters and expose `message.delete()`
- add delete capability handling for local, external-store, and AI SDK runtimes
- add temporary Assistant Cloud history delete methods that throw until cloud support lands

## Testing
- pnpm --filter @assistant-ui/core exec vitest run src/tests/external-store-thread-runtime-core.test.ts
- pnpm --filter @assistant-ui/react-ai-sdk exec vitest run src/ui/use-chat/useAISDKRuntime.test.ts src/ui/use-chat/useExternalHistory.test.ts
- pnpm lint
- pnpm build