### PR TITLE
fix(react-ag-ui): mark the assistant placeholder optimistic so the id swap doesn't leave a phantom branch

### DIFF
--- a/.changeset/loud-pugs-smile.md
+++ b/.changeset/loud-pugs-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: mark the streaming assistant placeholder with `metadata.isOptimistic` so the message repository evicts it after the client→server id swap, instead of leaving a phantom empty sibling branch on every run

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -722,9 +722,6 @@ export class AgUiThreadRuntimeCore {
         unstable_annotations: [],
         unstable_data: [],
         steps: [],
-        // Marks the placeholder for MessageRepository's off-branch eviction;
-        // without it, the client->server id swap leaves a phantom sibling
-        // branch in the external-store repository.
         isOptimistic: true,
         custom: {},
       },
@@ -746,8 +743,6 @@ export class AgUiThreadRuntimeCore {
       );
       this.messages = this.messages.filter((m) => m.id !== oldId);
     } else {
-      // The message is real once it has a server/stable id — drop the
-      // optimistic marker so the repository no longer treats it as evictable.
       this.messages = this.messages.map((m) => {
         if (m.id !== oldId) return m;
         const { isOptimistic: _, ...metadata } = m.metadata;

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -722,6 +722,10 @@ export class AgUiThreadRuntimeCore {
         unstable_annotations: [],
         unstable_data: [],
         steps: [],
+        // Marks the placeholder for MessageRepository's off-branch eviction;
+        // without it, the client->server id swap leaves a phantom sibling
+        // branch in the external-store repository.
+        isOptimistic: true,
         custom: {},
       },
     };
@@ -742,9 +746,13 @@ export class AgUiThreadRuntimeCore {
       );
       this.messages = this.messages.filter((m) => m.id !== oldId);
     } else {
-      this.messages = this.messages.map((m) =>
-        m.id === oldId ? { ...m, id: newId } : m,
-      );
+      // The message is real once it has a server/stable id — drop the
+      // optimistic marker so the repository no longer treats it as evictable.
+      this.messages = this.messages.map((m) => {
+        if (m.id !== oldId) return m;
+        const { isOptimistic: _, ...metadata } = m.metadata;
+        return { ...m, id: newId, metadata } as ThreadMessage;
+      });
     }
 
     const pendingParent = this.assistantHistoryParents.get(oldId);
@@ -869,6 +877,7 @@ export class AgUiThreadRuntimeCore {
       unstable_annotations: annotations,
       unstable_data: data,
       steps,
+      ...(current.isOptimistic ? { isOptimistic: true } : {}),
       ...(incoming.timing ? { timing: incoming.timing } : {}),
       custom: incoming.custom
         ? { ...current.custom, ...incoming.custom }

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1917,4 +1917,51 @@ describe("AGUIThreadRuntimeCore", () => {
       .filter((m) => m.id.startsWith("__optimistic__"));
     expect(optimisticLingerers).toHaveLength(0);
   });
+
+  it("marks the placeholder as optimistic and clears the flag once the server id arrives", async () => {
+    const serverId = "srv-optimistic-flag";
+    let midRunAssistant: ThreadAssistantMessage | undefined;
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onTextMessageContentEvent?.({
+          event: { type: "TEXT_MESSAGE_CONTENT", delta: "partial" },
+        });
+        midRunAssistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+        subscriber.onTextMessageStartEvent?.({
+          event: { type: "TEXT_MESSAGE_START", messageId: serverId },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    expect(midRunAssistant?.id.startsWith("__optimistic__")).toBe(true);
+    expect(midRunAssistant?.metadata.isOptimistic).toBe(true);
+
+    const assistant = core
+      .getMessages()
+      .find((m) => m.id === serverId) as ThreadAssistantMessage;
+    expect(assistant).toBeDefined();
+    expect(assistant.metadata.isOptimistic).toBeUndefined();
+  });
+
+  it("clears the optimistic flag when the id stabilizes without a server id", async () => {
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onTextMessageContentEvent?.({
+          event: { type: "TEXT_MESSAGE_CONTENT", delta: "ok" },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.id.startsWith("__optimistic__")).toBe(false);
+    expect(assistant.metadata.isOptimistic).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## The bug

Every run in an AG-UI runtime leaves an empty phantom assistant message as a sibling branch of the real response — the UI shows "branches 2/2" on each turn, with branch 1 being a blank assistant message.

### Mechanism

1. `AgUiThreadRuntimeCore` appends an `__optimistic__…` assistant placeholder when a run starts, and renames it in place to the server's message id when `TEXT_MESSAGE_START` arrives (`reassignAssistantId`).
2. The external-store sync sees a new id at the same position and adds it to the `MessageRepository` as a **second child** of the user message. The old placeholder node stays in the repository.
3. Since #4162 (core ≥0.2.8), the repository cleans up exactly this case via `evictOffBranchOptimisticMessages` — but eviction is keyed on `metadata.isOptimistic`, which `react-ag-ui` never sets on its placeholder. The eviction never fires and the phantom sibling survives permanently.

The repro is most reliable when `RUN_STARTED` / `STATE_SNAPSHOT` and the first token arrive in separate batches (the placeholder renders before the swap), but the stale repository node is created on any transport.

## The fix

Opt the placeholder into the eviction mechanism core already provides:

- `insertAssistantPlaceholder` sets `metadata.isOptimistic: true`.
- `mergeAssistantMetadata` carries the flag through mid-run metadata updates (it rebuilds metadata from scratch, so the flag would otherwise be dropped on the first update that includes metadata).
- `reassignAssistantId` strips the flag when the message gets its server/stable id — both the server-id swap and the settle-time stabilization go through it — so the now-real message is never treated as evictable and `export()` persists it normally.

`fromThreadMessageLike` already passes `isOptimistic` through, so no core changes are needed.

## Tests

- placeholder carries `metadata.isOptimistic` mid-run; the flag is gone after the server-id reassignment
- the flag is also cleared when the id stabilizes at terminal state without a server id

`pnpm test` in `packages/react-ag-ui`: 51/51 passing.