### PR TITLE
fix(react-ai-sdk): externalize assistant-stream as a regular dependency

### DIFF
--- a/.changeset/ai-sdk-stream-dep.md
+++ b/.changeset/ai-sdk-stream-dep.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: declare assistant-stream as a regular dependency so it is externalized instead of bundled into dist (the bundled copy broke consumers on its transitive secure-json-parse import)

--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -56,7 +56,8 @@
     "@assistant-ui/core": "^0.2.11",
     "@assistant-ui/store": "^0.2.14",
     "ai": "^6.0.197",
-    "assistant-cloud": "*"
+    "assistant-cloud": "*",
+    "assistant-stream": "^0.3.21"
   },
   "peerDependencies": {
     "@types/react": "*",
@@ -73,7 +74,6 @@
     "@types/json-schema": "^7.0.15",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "assistant-stream": "workspace:*",
     "jsdom": "^29.1.1",
     "react": "^19.2.7",
     "vitest": "^4.1.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3396,6 +3396,9 @@ importers:
       assistant-cloud:
         specifier: '*'
         version: link:../cloud
+      assistant-stream:
+        specifier: ^0.3.21
+        version: link:../assistant-stream
     devDependencies:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
@@ -3412,9 +3415,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
-      assistant-stream:
-        specifier: workspace:*
-        version: link:../assistant-stream
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1


### PR DESCRIPTION
assistant-stream was a devDependency, so the bundler inlined it into react-ai-sdk's dist. With runtime imports from assistant-stream/utils (parsePartialJsonObject), the bundled copy carries a transitive `secure-json-parse` import that consumers cannot resolve, breaking downstream builds (caught by the starter-minimal template build). Declaring it as a regular dependency externalizes it, matching @assistant-ui/react and react-generative-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)