### PR TITLE
feat(react-ag-ui): restore multimodal user input as attachments in fromAgUiMessages

### DIFF
--- a/.changeset/shiny-pots-tell.md
+++ b/.changeset/shiny-pots-tell.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-ag-ui": patch
 ---
 
-feat: restore multimodal user input (`image`, `audio`, `video`, `document` parts) as attachments in `fromAgUiMessages`, so persisted conversations reload attachments instead of dropping them and re-send them losslessly on the next run
+feat: restore multimodal user input (`image`, `audio`, `video`, `document`, and legacy `binary` parts) as attachments in `fromAgUiMessages`, so persisted conversations reload attachments instead of dropping them and re-send them on the next run

--- a/.changeset/shiny-pots-tell.md
+++ b/.changeset/shiny-pots-tell.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: restore multimodal user input (`image`, `audio`, `video`, `document` parts) as attachments in `fromAgUiMessages`, so persisted conversations reload attachments instead of dropping them and re-send them losslessly on the next run

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -66,11 +66,7 @@ messages are gone on the next page load.
 `showThinking: false`, so imported reasoning messages are dropped at conversion
 time, the same way a live run never stores them.
 
-`fromAgUiMessages` reconstructs the text, reasoning, and tool calls of each
-message. Multimodal user input (`image`, `audio`, `video`, and `document`
-parts) is restored as attachments on the user message, so a backend that
-persists multimodal messages shows them again on reload and re-sends them
-losslessly on the next run.
+`fromAgUiMessages` reconstructs the text, reasoning, and tool calls of each message. Multimodal user input (`image`, `audio`, `video`, and `document` parts, as well as legacy `binary` parts) is restored as attachments on the user message, so a backend that persists multimodal messages shows them again on reload and re-sends them on the next run. Legacy `binary` parts that only reference a file id are not restored.
 
 ## Thread list (experimental)
 

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -67,8 +67,10 @@ messages are gone on the next page load.
 time, the same way a live run never stores them.
 
 `fromAgUiMessages` reconstructs the text, reasoning, and tool calls of each
-message. Non-text message content such as images and files is not restored, so a
-backend that persists multimodal messages loads only their text on reload.
+message. Multimodal user input (`image`, `audio`, `video`, and `document`
+parts) is restored as attachments on the user message, so a backend that
+persists multimodal messages shows them again on reload and re-sends them
+losslessly on the next run.
 
 ## Thread list (experimental)
 

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -210,8 +210,7 @@ type SnapshotAttachment = NonNullable<
 
 const mediaInputTypes = new Set(["image", "audio", "video", "document"]);
 
-// Inverse of buildInputSource: collapse an AG-UI source back to the string
-// form assistant-ui message parts carry (http(s) URL or data URL).
+// Inverse of buildInputSource.
 function inputSourceToString(
   value: unknown,
 ): { value: string; mimeType?: string } | null {
@@ -233,16 +232,39 @@ function inputSourceToString(
   return null;
 }
 
-// Inverse of toInputContent: restore multimodal input parts from a snapshot
-// user message as assistant-ui attachments. The binary payload canonically
-// lives in message.attachments (buildUserContent reads it back from there),
-// so a restored message round-trips through toAgUiMessages without loss.
+// Mirrors @ag-ui/client's BackwardCompatibility_0_0_47 middleware.
+function upgradeBinaryInputPart(
+  part: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const mimeType = getString(part, "mimeType");
+  if (mimeType === undefined) return null;
+  const data = getString(part, "data");
+  const url = getString(part, "url");
+  const source = data
+    ? { type: "data", value: data, mimeType }
+    : url
+      ? { type: "url", value: url, mimeType }
+      : null;
+  if (!source) return null;
+  const filename = getString(part, "filename");
+  return {
+    type: mediaTypeForMime(mimeType),
+    source,
+    ...(filename && { metadata: { filename } }),
+  };
+}
+
 function toSnapshotAttachments(content: unknown): SnapshotAttachment[] {
   if (!Array.isArray(content)) return [];
 
   const attachments: SnapshotAttachment[] = [];
-  for (const part of content) {
-    if (!isObject(part)) continue;
+  for (const rawPart of content) {
+    if (!isObject(rawPart)) continue;
+    const part =
+      getString(rawPart, "type") === "binary"
+        ? upgradeBinaryInputPart(rawPart)
+        : rawPart;
+    if (!part) continue;
     const type = getString(part, "type");
     if (type === undefined || !mediaInputTypes.has(type)) continue;
     const source = inputSourceToString(part.source);

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -204,6 +204,93 @@ function toInputContent(
   return null;
 }
 
+type SnapshotAttachment = NonNullable<
+  CoreThreadMessageLike["attachments"]
+>[number];
+
+const mediaInputTypes = new Set(["image", "audio", "video", "document"]);
+
+// Inverse of buildInputSource: collapse an AG-UI source back to the string
+// form assistant-ui message parts carry (http(s) URL or data URL).
+function inputSourceToString(
+  value: unknown,
+): { value: string; mimeType?: string } | null {
+  if (!isObject(value)) return null;
+  const sourceValue = getString(value, "value");
+  if (sourceValue === undefined) return null;
+  const mimeType = getString(value, "mimeType");
+  const type = getString(value, "type");
+  if (type === "url") {
+    return { value: sourceValue, ...(mimeType !== undefined && { mimeType }) };
+  }
+  if (type === "data") {
+    const resolvedMimeType = mimeType ?? "application/octet-stream";
+    return {
+      value: `data:${resolvedMimeType};base64,${sourceValue}`,
+      mimeType: resolvedMimeType,
+    };
+  }
+  return null;
+}
+
+// Inverse of toInputContent: restore multimodal input parts from a snapshot
+// user message as assistant-ui attachments. The binary payload canonically
+// lives in message.attachments (buildUserContent reads it back from there),
+// so a restored message round-trips through toAgUiMessages without loss.
+function toSnapshotAttachments(content: unknown): SnapshotAttachment[] {
+  if (!Array.isArray(content)) return [];
+
+  const attachments: SnapshotAttachment[] = [];
+  for (const part of content) {
+    if (!isObject(part)) continue;
+    const type = getString(part, "type");
+    if (type === undefined || !mediaInputTypes.has(type)) continue;
+    const source = inputSourceToString(part.source);
+    if (!source) continue;
+
+    const filename = isObject(part.metadata)
+      ? getString(part.metadata, "filename")
+      : undefined;
+    const id = attachments.length.toString();
+
+    if (type === "image") {
+      attachments.push({
+        id,
+        type: "image",
+        name: filename ?? "image",
+        ...(source.mimeType !== undefined && { contentType: source.mimeType }),
+        status: { type: "complete" },
+        content: [
+          {
+            type: "image",
+            image: source.value,
+            ...(filename !== undefined && { filename }),
+          },
+        ],
+      });
+      continue;
+    }
+
+    const mimeType = source.mimeType ?? "application/octet-stream";
+    attachments.push({
+      id,
+      type: type === "document" ? "document" : "file",
+      name: filename ?? "file",
+      contentType: mimeType,
+      status: { type: "complete" },
+      content: [
+        {
+          type: "file",
+          data: source.value,
+          mimeType,
+          ...(filename !== undefined && { filename }),
+        },
+      ],
+    });
+  }
+  return attachments;
+}
+
 function buildUserContent(message: ThreadMessageLike): string | InputContent[] {
   // File parts in message.content are intentionally skipped: the canonical
   // binary payload for files always flows through message.attachments.
@@ -353,11 +440,14 @@ function toUserOrSystemSnapshotMessage(
   rawMessage: Record<string, unknown>,
 ): CoreThreadMessageLike {
   const messageName = getString(rawMessage, "name");
+  const attachments =
+    role === "user" ? toSnapshotAttachments(rawMessage.content) : [];
   return {
     id: getString(rawMessage, "id") ?? generateId(),
     role,
     content: extractText(rawMessage.content),
     ...(messageName !== undefined ? { name: messageName } : {}),
+    ...(attachments.length > 0 ? { attachments } : {}),
   };
 }
 

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -988,6 +988,159 @@ describe("adapter conversions", () => {
     });
     expect(() => UserMessageSchema.parse(roundTripped[0])).not.toThrow();
   });
+
+  it("restores a legacy binary input part and re-sends it as a modern part", () => {
+    const restored = fromAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          { type: "text", text: "old history" },
+          {
+            type: "binary",
+            mimeType: "application/pdf",
+            data: "JVBERi0xLjQK",
+            filename: "legacy.pdf",
+          },
+        ],
+      },
+    ]);
+
+    expect(restored[0]).toMatchObject({
+      role: "user",
+      content: "old history",
+      attachments: [
+        {
+          type: "document",
+          name: "legacy.pdf",
+          contentType: "application/pdf",
+          status: { type: "complete" },
+          content: [
+            {
+              type: "file",
+              data: "data:application/pdf;base64,JVBERi0xLjQK",
+              mimeType: "application/pdf",
+              filename: "legacy.pdf",
+            },
+          ],
+        },
+      ],
+    });
+
+    const roundTripped = toAgUiMessages(
+      restored as Parameters<typeof toAgUiMessages>[0],
+    );
+    expect(roundTripped[0]).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "old history" },
+        {
+          type: "document",
+          source: {
+            type: "data",
+            value: "JVBERi0xLjQK",
+            mimeType: "application/pdf",
+          },
+          metadata: { filename: "legacy.pdf" },
+        },
+      ],
+    });
+    expect(() => UserMessageSchema.parse(roundTripped[0])).not.toThrow();
+  });
+
+  it("restores a legacy binary image part with a url as an image attachment", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          {
+            type: "binary",
+            mimeType: "image/png",
+            url: "https://example.com/cat.png",
+          },
+        ],
+      },
+    ]);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: "",
+      attachments: [
+        {
+          type: "image",
+          name: "image",
+          contentType: "image/png",
+          status: { type: "complete" },
+          content: [{ type: "image", image: "https://example.com/cat.png" }],
+        },
+      ],
+    });
+  });
+
+  it("prefers data over url in legacy binary parts and routes them by mime type", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          {
+            type: "binary",
+            mimeType: "audio/mpeg",
+            data: "QUJD",
+            url: "https://example.com/memo.mp3",
+          },
+          {
+            type: "binary",
+            mimeType: "video/mp4",
+            data: "",
+            url: "https://example.com/clip.mp4",
+          },
+        ],
+      },
+    ]);
+
+    expect(result[0]!.attachments).toMatchObject([
+      {
+        type: "file",
+        contentType: "audio/mpeg",
+        content: [
+          {
+            type: "file",
+            data: "data:audio/mpeg;base64,QUJD",
+            mimeType: "audio/mpeg",
+          },
+        ],
+      },
+      {
+        type: "file",
+        contentType: "video/mp4",
+        content: [
+          {
+            type: "file",
+            data: "https://example.com/clip.mp4",
+            mimeType: "video/mp4",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("skips legacy binary parts that only carry a file id", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          { type: "text", text: "see file" },
+          { type: "binary", mimeType: "application/pdf", id: "file-1" },
+        ],
+      },
+    ]);
+
+    expect(result[0]).toMatchObject({ role: "user", content: "see file" });
+    expect(result[0]).not.toHaveProperty("attachments");
+  });
 });
 
 describe("package exports", () => {

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -804,6 +804,190 @@ describe("adapter conversions", () => {
     expect((result[0] as any).content[0].source).not.toHaveProperty("data");
     expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
   });
+
+  it("restores a document input part as a user attachment", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          { type: "text", text: "review this" },
+          {
+            type: "document",
+            source: {
+              type: "url",
+              value: "https://example.com/spec.pdf",
+              mimeType: "application/pdf",
+            },
+            metadata: { filename: "spec.pdf" },
+          },
+        ],
+      },
+    ]);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: "review this",
+      attachments: [
+        {
+          type: "document",
+          name: "spec.pdf",
+          contentType: "application/pdf",
+          status: { type: "complete" },
+          content: [
+            {
+              type: "file",
+              data: "https://example.com/spec.pdf",
+              mimeType: "application/pdf",
+              filename: "spec.pdf",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("restores an image input part with a data source as an image attachment", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "data",
+              value: "iVBORw0KGgo=",
+              mimeType: "image/png",
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: "",
+      attachments: [
+        {
+          type: "image",
+          name: "image",
+          contentType: "image/png",
+          status: { type: "complete" },
+          content: [
+            { type: "image", image: "data:image/png;base64,iVBORw0KGgo=" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("restores audio and video input parts as file attachments", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          {
+            type: "audio",
+            source: { type: "data", value: "QUJD", mimeType: "audio/mpeg" },
+            metadata: { filename: "memo.mp3" },
+          },
+          {
+            type: "video",
+            source: {
+              type: "url",
+              value: "https://example.com/clip.mp4",
+              mimeType: "video/mp4",
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result[0]!.attachments).toMatchObject([
+      {
+        type: "file",
+        name: "memo.mp3",
+        contentType: "audio/mpeg",
+        content: [
+          {
+            type: "file",
+            data: "data:audio/mpeg;base64,QUJD",
+            mimeType: "audio/mpeg",
+            filename: "memo.mp3",
+          },
+        ],
+      },
+      {
+        type: "file",
+        name: "file",
+        contentType: "video/mp4",
+        content: [
+          {
+            type: "file",
+            data: "https://example.com/clip.mp4",
+            mimeType: "video/mp4",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("does not add attachments to text-only user messages", () => {
+    const result = fromAgUiMessages([
+      { id: "u-1", role: "user", content: "Hi" },
+      {
+        id: "u-2",
+        role: "user",
+        content: [{ type: "text", text: "Hello" }],
+      },
+    ]);
+
+    expect(result[0]).not.toHaveProperty("attachments");
+    expect(result[1]).not.toHaveProperty("attachments");
+  });
+
+  it("round-trips multimodal user input through fromAgUiMessages and back", () => {
+    const original = {
+      id: "u-1",
+      role: "user",
+      content: [
+        { type: "text", text: "see attached" },
+        {
+          type: "document",
+          source: {
+            type: "data",
+            value: "JVBERi0xLjQK",
+            mimeType: "application/pdf",
+          },
+          metadata: { filename: "spec.pdf" },
+        },
+      ],
+    };
+
+    const restored = fromAgUiMessages([original]);
+    const roundTripped = toAgUiMessages(
+      restored as Parameters<typeof toAgUiMessages>[0],
+    );
+
+    expect(roundTripped[0]).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "see attached" },
+        {
+          type: "document",
+          source: {
+            type: "data",
+            value: "JVBERi0xLjQK",
+            mimeType: "application/pdf",
+          },
+          metadata: { filename: "spec.pdf" },
+        },
+      ],
+    });
+    expect(() => UserMessageSchema.parse(roundTripped[0])).not.toThrow();
+  });
 });
 
 describe("package exports", () => {


### PR DESCRIPTION
## Summary

`fromAgUiMessages` drops multimodal user input: `toUserOrSystemSnapshotMessage` calls `extractText()`, so `image` / `audio` / `video` / `document` parts vanish and only the text survives. The docs even state it as a known limitation: *"Non-text message content such as images and files is not restored, so a backend that persists multimodal messages loads only their text on reload."*

This is the missing inbound mirror of work that already landed outbound:
- #3810 / #3811 fixed `toAgUiMessages` silently dropping attachments on **send**
- #4232 upgraded that path to the current multimodal parts (`image`/`audio`/`video`/`document` with typed sources and `metadata.filename`)
- #4262 / #4264 exported `fromAgUiMessages` precisely for history-adapter restore on page load

Anyone combining those — a backend that persists multimodal AG-UI messages plus a history adapter (or a `MESSAGES_SNAPSHOT`-emitting backend) — currently loses the attachments on reload.

## What this does

User snapshot messages now restore multimodal input parts as assistant-ui **attachments**:

- `image` parts → `type: "image"` attachments (image part inside)
- `document` parts → `type: "document"` attachments, `audio`/`video` → `type: "file"` (file part inside — core's audio part only accepts mp3/wav, which would be lossy)
- `metadata.filename` → attachment `name` + part `filename`; source mime → `contentType`/`mimeType`; `status: { type: "complete" }`
- `{type: "url"}` sources stay URLs; `{type: "data"}` sources become `data:` URLs — the exact strings `buildInputSource` parses back, so restore → re-send round-trips losslessly (test included, validated against `UserMessageSchema`)

Text content is untouched (still a plain string), text-only messages get no `attachments` key, and system messages are unaffected — fully backward compatible.

### Design notes

- **Attachments, not content parts**: mirrors `react-ai-sdk`'s `convertMessage`, which restores file parts the same way, and matches `buildUserContent`'s expectation that binary payloads live in `message.attachments` — that's what makes the round trip lossless.
- **Defensive parsing** via the same `isObject`/`getString` guards the rest of `fromAgUiMessages` uses on `unknown[]` input.
- Both consumption paths benefit: history adapters (via `ExportedMessageRepository.fromArray`) and the live `MESSAGES_SNAPSHOT` handler — `fromThreadMessageLike` already passes user attachments through.
- A `url` source with no mime type falls back to `application/octet-stream` for the file part (the field is required); images keep `contentType` optional.

Docs updated: the known-limitation paragraph in `runtime-options.mdx` now describes the restored behavior.

## Test plan

- [x] 5 new cases in `conversions.spec.ts`: document restore with filename, image data-source restore (data-URL reconstruction), audio/video → file attachments, text-only messages unchanged, and a full `fromAgUiMessages` → `toAgUiMessages` round trip validated with `UserMessageSchema.parse`
- [x] `pnpm vitest run` in `packages/react-ag-ui` — 144/144 passing
- [x] `tsc --noEmit` clean, oxlint/oxfmt clean