### PR TITLE
refactor(tap): drop the tap-root pending-update queue

### DIFF
--- a/.changeset/tap-root-queue-removal.md
+++ b/.changeset/tap-root-queue-removal.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+refactor: tap-scheduled roots apply updates directly to cells instead of holding a separate pending-callback queue. Dispatches now apply immediately and the scheduler only batches the re-render; commitRoot keeps cells with unprocessed entries dirty so updates dispatched during a commit survive until the next render.

--- a/packages/tap/src/core/helpers/root.ts
+++ b/packages/tap/src/core/helpers/root.ts
@@ -13,14 +13,22 @@ export const createResourceFiberRoot = (
 };
 
 export const commitRoot = (root: ResourceFiberRoot): void => {
+  // A cell whose queue still holds entries was updated after the committed
+  // render (e.g. a dispatch from an effect during this commit). It stays
+  // dirty so the next render processes it.
+  const pending: (Cell & { type: "reducer" })[] = [];
   for (const cell of root.dirtyCells) {
-    cell.dirty = false;
-    cell.queue.clear();
     cell.current = cell.workInProgress;
+    if (cell.queue.size > 0) {
+      pending.push(cell);
+    } else {
+      cell.dirty = false;
+    }
   }
   root.committedVersion = root.version;
   root.changelog.length = 0;
   root.dirtyCells.length = 0;
+  root.dirtyCells.push(...pending);
 };
 
 export const setRootVersion = (

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -7,11 +7,7 @@ import {
 import { UpdateScheduler } from "../core/scheduler";
 import type { RenderResult } from "../core/types";
 import { isDevelopment } from "../core/helpers/env";
-import {
-  commitRoot,
-  createResourceFiberRoot,
-  setRootVersion,
-} from "../core/helpers/root";
+import { commitRoot, createResourceFiberRoot } from "../core/helpers/root";
 import { useEffect, useEffectEvent, useMemo, useRef } from "react";
 import { useDevStrictMode } from "./utils/useDevStrictMode";
 
@@ -38,24 +34,24 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     () => new UpdateScheduler(() => handleUpdate(null)),
     [],
   );
-  const queue = useMemo(() => [] as (() => void)[], []);
 
   const getDevStrictMode = useDevStrictMode();
   const fiber = useMemo(() => {
     return createResourceFiber(
       useHostRoot<R>,
+      // Updates apply immediately: the cells hold the pending entries (and the
+      // root's changelog records them), so the scheduler only batches the
+      // re-render. A `false` return is the eager same-state bailout.
       createResourceFiberRoot((callback) => {
-        if (!scheduler.isDirty && !callback()) return;
-        queue.push(callback);
+        if (!callback()) return;
         scheduler.markDirty();
       }),
       undefined,
       getDevStrictMode(),
     );
-  }, [queue, scheduler, getDevStrictMode]);
+  }, [scheduler, getDevStrictMode]);
 
   // TODO I think dev mode only should double render!
-  setRootVersion(fiber.root, fiber.root.committedVersion);
   const render2 = renderResourceFiber(fiber, [render]);
 
   const isMountedRef = useRef(false);
@@ -64,17 +60,6 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   const subscribers = useMemo(() => new Set<() => void>(), []);
   const handleUpdate = useEffectEvent((render: RenderResult | null) => {
     if (render === null) {
-      setRootVersion(fiber.root, 2);
-      setRootVersion(fiber.root, 1);
-
-      queue.forEach((callback) => {
-        if (isDevelopment && fiber.devStrictMode) {
-          callback();
-        }
-
-        callback();
-      });
-
       if (isDevelopment && fiber.devStrictMode) {
         void renderResourceFiber(fiber, committedArgsRef.current);
       }
@@ -86,7 +71,6 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
       throw new Error("Scheduler is dirty, this should never happen");
 
     commitRoot(fiber.root);
-    queue.length = 0;
 
     if (isMountedRef.current) {
       commitResourceFiber(fiber, render);


### PR DESCRIPTION
Tap-scheduled roots (useTapRoot / createTapRoot) kept three callback lists: the render-to-commit effectTasks, the root changelog (rollback/fast-forward replay for React-hosted roots), and a host-level queue of pending dispatch callbacks that were re-applied at flush after a version-rollback dance. This removes the third.

Dispatches now apply immediately, the reducer cells hold the pending entries, and the scheduler only batches the re-render, so the flush is just (ghost render in dev strict mode +) render + commit. The version dance, the queue, and the flush-time re-application all go away.

The one piece of real work the queue was doing: pending updates had to survive an intermediate commit, because commitRoot cleared cell queues (updates dispatched from effects during a commit were exactly this case, caught by the StrictMode parity suite). commitRoot now keeps cells with unprocessed entries dirty instead of discarding them, which also closes the stale-eager hazard since the eager dispatch path checks for dirty cells.

Validated by the differential StrictMode parity suite (all three worlds), the concurrent-mode/Activity tests, store/react/core suites, and a live run of the docs demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)