### PR TITLE
chore(tap): bump to 0.7.0 and update dependent ranges

### DIFF
--- a/.changeset/tap-v0-7-ranges.md
+++ b/.changeset/tap-v0-7-ranges.md
@@ -1,0 +1,10 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+"@assistant-ui/store": patch
+"@assistant-ui/react-devtools": patch
+---
+
+chore: update @assistant-ui/tap dependency ranges to ^0.7.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "@assistant-ui/store": "^0.2.13",
-    "@assistant-ui/tap": "^0.6.1",
+    "@assistant-ui/tap": "^0.7.0",
     "@types/react": "*",
     "react": "^18 || ^19",
     "assistant-cloud": "^0.1.31",

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "@assistant-ui/react": "^0.14.14",
-    "@assistant-ui/tap": "^0.6.0",
+    "@assistant-ui/tap": "^0.7.0",
     "@types/react": "*",
     "@types/react-dom": "*",
     "react": "^18 || ^19",

--- a/packages/react-ink/package.json
+++ b/packages/react-ink/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@assistant-ui/core": "^0.2.11",
     "@assistant-ui/store": "^0.2.14",
-    "@assistant-ui/tap": "^0.6.0",
+    "@assistant-ui/tap": "^0.7.0",
     "assistant-stream": "^0.3.21",
     "diff": "^9.0.0",
     "ink-spinner": "^5.0.0",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@assistant-ui/core": "^0.2.11",
     "@assistant-ui/store": "^0.2.14",
-    "@assistant-ui/tap": "^0.6.0",
+    "@assistant-ui/tap": "^0.7.0",
     "assistant-stream": "^0.3.21",
     "zustand": "^5.0.14"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@assistant-ui/core": "^0.2.13",
     "@assistant-ui/store": "^0.2.15",
-    "@assistant-ui/tap": "^0.6.2",
+    "@assistant-ui/tap": "^0.7.0",
     "@radix-ui/primitive": "^1.1.4",
     "@radix-ui/react-compose-refs": "^1.1.3",
     "@radix-ui/react-context": "^1.1.4",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -35,7 +35,7 @@
     "use-effect-event": "^2.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/tap": "^0.6.0",
+    "@assistant-ui/tap": "^0.7.0",
     "@types/react": "*",
     "react": "^18 || ^19"
   },

--- a/packages/tap/package.json
+++ b/packages/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/tap",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Reactive state management inspired by React hooks",
   "keywords": [
     "state-management",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3244,7 +3244,7 @@ importers:
         specifier: ^0.2.15
         version: link:../store
       '@assistant-ui/tap':
-        specifier: ^0.6.2
+        specifier: ^0.7.0
         version: link:../tap
       '@radix-ui/primitive':
         specifier: ^1.1.4
@@ -3589,7 +3589,7 @@ importers:
         specifier: ^0.2.14
         version: link:../store
       '@assistant-ui/tap':
-        specifier: ^0.6.0
+        specifier: ^0.7.0
         version: link:../tap
       assistant-stream:
         specifier: ^0.3.21
@@ -3875,7 +3875,7 @@ importers:
         specifier: ^0.2.14
         version: link:../store
       '@assistant-ui/tap':
-        specifier: ^0.6.0
+        specifier: ^0.7.0
         version: link:../tap
       assistant-stream:
         specifier: ^0.3.21


### PR DESCRIPTION
Bumps `@assistant-ui/tap` to 0.7.0 and updates the `^0.6.x` dependency/peer ranges in `@assistant-ui/core`, `@assistant-ui/react`, `@assistant-ui/react-native`, `@assistant-ui/react-ink`, `@assistant-ui/store`, and `@assistant-ui/react-devtools` to `^0.7.0`. Includes a patch changeset for the dependents so the new ranges get published, plus the lockfile refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)