### PR TITLE
feat(core): expose lastMessageAt on thread list items

### DIFF
--- a/.changeset/thread-list-last-message-at.md
+++ b/.changeset/thread-list-last-message-at.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat: expose `lastMessageAt` on thread list items, populated from the cloud thread list adapter

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -296,6 +296,7 @@ export class RemoteThreadListThreadListRuntimeCore
           externalId: remoteMetadata.externalId,
           status: remoteMetadata.status,
           title: remoteMetadata.title,
+          lastMessageAt: remoteMetadata.lastMessageAt,
           custom: remoteMetadata.custom,
         } as RemoteThreadData,
       };

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -94,6 +94,9 @@ export const useCloudThreadListAdapter = (
           status: t.is_archived ? "archived" : "regular",
           remoteId: t.id,
           title: t.title,
+          lastMessageAt: t.last_message_at
+            ? new Date(t.last_message_at)
+            : undefined,
           externalId: t.external_id ?? undefined,
           custom: toCustom(t.metadata),
         })),
@@ -153,6 +156,9 @@ export const useCloudThreadListAdapter = (
         status: thread.is_archived ? "archived" : "regular",
         remoteId: thread.id,
         title: thread.title,
+        lastMessageAt: thread.last_message_at
+          ? new Date(thread.last_message_at)
+          : undefined,
         externalId: thread.external_id ?? undefined,
         custom: toCustom(thread.metadata),
       };

--- a/packages/core/src/runtime/api/bindings.ts
+++ b/packages/core/src/runtime/api/bindings.ts
@@ -42,5 +42,6 @@ export type ThreadListItemState = {
   readonly externalId: string | undefined;
   readonly status: import("../interfaces/thread-list-runtime-core").ThreadListItemStatus;
   readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
   readonly custom?: Record<string, unknown> | undefined;
 };

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -88,6 +88,7 @@ const getThreadListItemState = (
     externalId: threadData.externalId,
     title: threadData.title,
     status: threadData.status,
+    lastMessageAt: threadData.lastMessageAt,
     custom: threadData.custom,
     isMain: threadData.id === threadList.mainThreadId,
   };

--- a/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
@@ -10,6 +10,7 @@ export type ThreadListItemCoreState = {
 
   readonly status: ThreadListItemStatus;
   readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
   readonly custom?: Record<string, unknown> | undefined;
 
   readonly runtime?: ThreadRuntimeCore | undefined;

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -28,6 +28,7 @@ export type RemoteThreadData =
       readonly externalId: string | undefined;
       readonly status: "regular" | "archived";
       readonly title?: string | undefined;
+      readonly lastMessageAt?: Date | undefined;
       readonly custom?: Record<string, unknown> | undefined;
     };
 
@@ -75,6 +76,7 @@ export const classifyThreads = (
       externalId: thread.externalId,
       status: thread.status,
       title: thread.title,
+      lastMessageAt: thread.lastMessageAt,
       custom: thread.custom,
       initializeTask: Promise.resolve({
         remoteId: thread.remoteId,

--- a/packages/core/src/runtimes/remote-thread-list/types.ts
+++ b/packages/core/src/runtimes/remote-thread-list/types.ts
@@ -13,6 +13,7 @@ export type RemoteThreadMetadata = {
   readonly remoteId: string;
   readonly externalId?: string | undefined;
   readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
   readonly custom?: Record<string, unknown> | undefined;
 };
 

--- a/packages/core/src/store/scopes/thread-list-item.ts
+++ b/packages/core/src/store/scopes/thread-list-item.ts
@@ -6,6 +6,7 @@ export type ThreadListItemState = {
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
   readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
   readonly status: ThreadListItemStatus;
   readonly custom?: Record<string, unknown> | undefined;
 };


### PR DESCRIPTION
the cloud api returns `last_message_at` for threads but the runtime pipeline dropped it. this threads an optional `lastMessageAt` through the remote thread list (adapter → remote state → runtime → store scope) so UIs can sort and group threads by recency (e.g. Today / Yesterday / Earlier sections).

- `RemoteThreadMetadata`, `RemoteThreadData`, `ThreadListItemCoreState`, and the runtime + store `ThreadListItemState` gain an optional `lastMessageAt?: Date`
- the cloud thread list adapter maps `last_message_at` in `list()` and `fetch()`, with a `new Date()` guard since the json payload arrives as a string despite the typed `Date`
- adapters that don't provide timestamps simply leave it undefined, so existing consumers are unaffected