### PR TITLE
fix: collapsible and streaming interaction jank

### DIFF
--- a/.changeset/grouped-parts-empty-indicator.md
+++ b/.changeset/grouped-parts-empty-indicator.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: emit the GroupedParts streaming indicator for empty running messages, so the assistant slot shows a loading affordance immediately after sending instead of staying blank

--- a/.changeset/scroll-lock-gutter-shift.md
+++ b/.changeset/scroll-lock-gutter-shift.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: compensate scrollbar gutter in useScrollLock so collapsible animations don't shift centered content horizontally on classic scrollbars

--- a/.changeset/viewport-stale-scroll-intent.md
+++ b/.changeset/viewport-stale-scroll-intent.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: clear pending viewport bottom-scroll intent on pointer interaction, preventing collapsible expand/collapse from yanking the thread to the bottom

--- a/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
@@ -49,8 +49,9 @@ export namespace MessagePrimitiveGroupedParts {
    * which running states qualify:
    * - `"never"` — never.
    * - `"empty"` — only when the message has no parts yet.
-   * - `"no-text"` (default) — when the last part isn't `text`/`reasoning`
-   *   (e.g. it ended on a tool call, so the assistant likely isn't done).
+   * - `"no-text"` (default) — when the message has no parts yet or the last
+   *   part isn't `text`/`reasoning` (e.g. it ended on a tool call, so the
+   *   assistant likely isn't done).
    * - `"always"` — whenever the message is running, regardless of parts.
    */
   export type IndicatorMode = "never" | "empty" | "no-text" | "always";
@@ -153,7 +154,8 @@ const shouldShowIndicator = (
     case "no-text": {
       const last = parts[parts.length - 1];
       return (
-        last !== undefined && last.type !== "text" && last.type !== "reasoning"
+        last === undefined ||
+        (last.type !== "text" && last.type !== "reasoning")
       );
     }
   }

--- a/packages/react/src/primitives/reasoning/useScrollLock.ts
+++ b/packages/react/src/primitives/reasoning/useScrollLock.ts
@@ -63,11 +63,14 @@ export const useScrollLock = <T extends HTMLElement = HTMLElement>(
 
     const scrollPosition = scrollContainer.scrollTop;
     const scrollbarWidth = scrollContainer.style.scrollbarWidth;
-    const paddingRight = scrollContainer.style.paddingRight;
 
     // Hiding the scrollbar collapses its gutter on classic scrollbars, which
-    // shifts centered content horizontally; compensate with padding.
+    // shifts centered content horizontally; compensate with padding on the
+    // side the scrollbar occupies (the left side in RTL).
     const computed = getComputedStyle(scrollContainer);
+    const paddingSide =
+      computed.direction === "rtl" ? "paddingLeft" : "paddingRight";
+    const previousPadding = scrollContainer.style[paddingSide];
     const scrollbarSize =
       scrollContainer.offsetWidth -
       scrollContainer.clientWidth -
@@ -76,14 +79,14 @@ export const useScrollLock = <T extends HTMLElement = HTMLElement>(
 
     scrollContainer.style.scrollbarWidth = "none";
     if (scrollbarSize > 0) {
-      scrollContainer.style.paddingRight = `${
-        parseFloat(computed.paddingRight) + scrollbarSize
+      scrollContainer.style[paddingSide] = `${
+        parseFloat(computed[paddingSide]) + scrollbarSize
       }px`;
     }
 
     const restoreStyles = () => {
       scrollContainer.style.scrollbarWidth = scrollbarWidth;
-      scrollContainer.style.paddingRight = paddingRight;
+      scrollContainer.style[paddingSide] = previousPadding;
     };
 
     const resetPosition = () => (scrollContainer.scrollTop = scrollPosition);

--- a/packages/react/src/primitives/reasoning/useScrollLock.ts
+++ b/packages/react/src/primitives/reasoning/useScrollLock.ts
@@ -63,22 +63,42 @@ export const useScrollLock = <T extends HTMLElement = HTMLElement>(
 
     const scrollPosition = scrollContainer.scrollTop;
     const scrollbarWidth = scrollContainer.style.scrollbarWidth;
+    const paddingRight = scrollContainer.style.paddingRight;
+
+    // Hiding the scrollbar collapses its gutter on classic scrollbars, which
+    // shifts centered content horizontally; compensate with padding.
+    const computed = getComputedStyle(scrollContainer);
+    const scrollbarSize =
+      scrollContainer.offsetWidth -
+      scrollContainer.clientWidth -
+      parseFloat(computed.borderLeftWidth) -
+      parseFloat(computed.borderRightWidth);
 
     scrollContainer.style.scrollbarWidth = "none";
+    if (scrollbarSize > 0) {
+      scrollContainer.style.paddingRight = `${
+        parseFloat(computed.paddingRight) + scrollbarSize
+      }px`;
+    }
+
+    const restoreStyles = () => {
+      scrollContainer.style.scrollbarWidth = scrollbarWidth;
+      scrollContainer.style.paddingRight = paddingRight;
+    };
 
     const resetPosition = () => (scrollContainer.scrollTop = scrollPosition);
     scrollContainer.addEventListener("scroll", resetPosition);
 
     const timeoutId = setTimeout(() => {
       scrollContainer.removeEventListener("scroll", resetPosition);
-      scrollContainer.style.scrollbarWidth = scrollbarWidth;
+      restoreStyles();
       cleanupRef.current = null;
     }, animationDuration);
 
     cleanupRef.current = () => {
       clearTimeout(timeoutId);
       scrollContainer.removeEventListener("scroll", resetPosition);
-      scrollContainer.style.scrollbarWidth = scrollbarWidth;
+      restoreStyles();
     };
   }, [animationDuration, animatedElementRef]);
 

--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
@@ -180,9 +180,17 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
   });
 
   const scrollRef = useManagedRef<HTMLElement>((el) => {
+    // A pointer gesture invalidates pending bottom-scroll intent; otherwise an
+    // intent kept alive by a non-overflowing thread (see handleScroll) hijacks
+    // the next content growth, e.g. expanding a collapsible tool call.
+    const cancelPendingScrollToBottom = () => {
+      scrollingToBottomBehaviorRef.current = null;
+    };
     el.addEventListener("scroll", handleScroll);
+    el.addEventListener("pointerdown", cancelPendingScrollToBottom);
     return () => {
       el.removeEventListener("scroll", handleScroll);
+      el.removeEventListener("pointerdown", cancelPendingScrollToBottom);
     };
   });
 


### PR DESCRIPTION
three small interaction fixes found during a design pass over the chat surface, each with its own changeset:

**stale bottom-scroll intent hijacks collapsible expands** (`useThreadViewportAutoScroll`): switching to a thread that doesn't overflow the viewport keeps the pending scroll-to-bottom intent alive by design (content may still be mounting). but the intent then survives indefinitely and fires on the next content growth, e.g. expanding a tool call collapsible, yanking the thread to the bottom. a pointer gesture now clears the pending intent; the scroll-to-bottom button is unaffected since it re-plants intent on click after pointerdown.

**scroll lock shifts centered content horizontally** (`useScrollLock`): the lock hides the scrollbar during collapse/expand animations to mask thumb flicker. on classic (layout-occupying) scrollbars, hiding collapses the gutter and the centered thread shifts sideways for the lock duration, then snaps back. the lock now measures the gutter and compensates with equivalent padding, so layout width stays identical. overlay scrollbars measure 0 and behave as before.

**no streaming indicator for empty messages** (`MessageGroupedParts`): the default `"no-text"` indicator mode required a last part to exist, so a just-sent message (running, zero parts) rendered nothing — the assistant slot stayed blank until the first token. an empty running message now counts as "no text yet" and emits the indicator part.