### PR TITLE
fix(ci): template sync override + redundant-copy guard for examples

### DIFF
--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 # Verifies that shared assistant-ui components in templates/* are byte-equal
-# with the canonical source in packages/ui/src/components/assistant-ui.
+# with the canonical source in packages/ui/src/components/assistant-ui, and
+# that examples/* don't carry redundant byte-equal copies (examples resolve
+# `@/components/assistant-ui/*` to packages/ui via tsconfig paths, so an
+# identical local copy is dead weight that silently drifts).
 #
 # Usage:
 #   bash scripts/sync-templates.sh            # check (CI mode), exits 1 on drift
@@ -16,6 +19,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$SCRIPT_DIR/.."
 SOURCE_DIR="$ROOT_DIR/packages/ui/src/components/assistant-ui"
 TEMPLATES_ROOT="$ROOT_DIR/templates"
+EXAMPLES_ROOT="$ROOT_DIR/examples"
 
 TEMPLATES=(default minimal cloud cloud-clerk langgraph mcp)
 
@@ -23,9 +27,20 @@ OVERRIDES=(
     # minimal intentionally ships a slim thread.tsx without GroupedParts /
     # reasoning / tool-group, since it doesn't bundle those companion files.
     "minimal/thread.tsx"
+    # minimal ships without react-shiki, so its markdown-text.tsx omits the
+    # SyntaxHighlighter wiring.
+    "minimal/markdown-text.tsx"
 )
 
 MODE="${1:-check}"
+
+annotate() {
+    # GitHub Actions error annotation; plain echo elsewhere.
+    local file="$1" message="$2"
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+        echo "::error file=$file::$message"
+    fi
+}
 
 drift=()
 
@@ -55,8 +70,25 @@ for tpl in "${TEMPLATES[@]}"; do
     done < <(find "$tpl_dir" -maxdepth 1 -type f \( -name "*.tsx" -o -name "*.ts" \) -print0)
 done
 
-if [[ ${#drift[@]} -eq 0 ]]; then
+# Examples must NOT hold byte-equal copies of packages/ui components: their
+# tsconfig already aliases `@/components/assistant-ui/*` to packages/ui, so a
+# local file is only justified as an intentional fork (which diverges by
+# definition). A byte-equal copy means someone duplicated instead of aliasing.
+redundant=()
+
+while IFS= read -r -d '' ex_file; do
+    file="$(basename "$ex_file")"
+    src_file="$SOURCE_DIR/$file"
+    [[ -f "$src_file" ]] || continue
+
+    if cmp -s "$src_file" "$ex_file"; then
+        redundant+=("${ex_file#"$ROOT_DIR"/}")
+    fi
+done < <(find "$EXAMPLES_ROOT" -path "*/components/assistant-ui/*" -maxdepth 4 -type f \( -name "*.tsx" -o -name "*.ts" \) -not -path "*/node_modules/*" -print0)
+
+if [[ ${#drift[@]} -eq 0 && ${#redundant[@]} -eq 0 ]]; then
     echo "✓ all template components are in sync with packages/ui"
+    echo "✓ no redundant packages/ui copies in examples"
     exit 0
 fi
 
@@ -67,16 +99,32 @@ if [[ "$MODE" == "--write" ]]; then
         cp "$SOURCE_DIR/$file" "$TEMPLATES_ROOT/$tpl/components/assistant-ui/$file"
         echo "synced $d"
     done
+    for r in "${redundant[@]}"; do
+        rm "$ROOT_DIR/$r"
+        echo "removed redundant copy $r (resolved from packages/ui via tsconfig paths)"
+    done
     echo ""
-    echo "synced ${#drift[@]} file(s)"
+    echo "fixed $(( ${#drift[@]} + ${#redundant[@]} )) file(s)"
     exit 0
 fi
 
-echo "✗ drift detected in ${#drift[@]} template file(s) vs packages/ui:"
-for d in "${drift[@]}"; do
-    echo "    templates/$d"
-done
+if [[ ${#drift[@]} -gt 0 ]]; then
+    echo "✗ drift detected in ${#drift[@]} template file(s) vs packages/ui:"
+    for d in "${drift[@]}"; do
+        echo "    templates/$d"
+        annotate "templates/$d/components/assistant-ui/${d##*/}" "out of sync with packages/ui/src/components/assistant-ui/${d##*/}; run 'pnpm sync-templates --write' or add an OVERRIDES entry"
+    done
+fi
+
+if [[ ${#redundant[@]} -gt 0 ]]; then
+    echo "✗ ${#redundant[@]} redundant packages/ui copy(ies) in examples (use the @/components/assistant-ui tsconfig alias instead):"
+    for r in "${redundant[@]}"; do
+        echo "    $r"
+        annotate "$r" "byte-equal copy of the packages/ui component; delete it and rely on the tsconfig path alias"
+    done
+fi
+
 echo ""
 echo "to fix, run:    pnpm sync-templates --write"
-echo "if the divergence is intentional, add '<tpl>/<file>' to OVERRIDES in scripts/sync-templates.sh"
+echo "if a template divergence is intentional, add '<tpl>/<file>' to OVERRIDES in scripts/sync-templates.sh"
 exit 1


### PR DESCRIPTION
**fixes the red template sync on main**: #4330 added syntax highlighting to the canonical `markdown-text.tsx`, but `templates/minimal` intentionally ships without `react-shiki`, so its copy can't stay byte-equal. the divergence is now an explicit override, same as the existing `minimal/thread.tsx` slim variant. (the failure slipped through because the pr was admin-merged — mea culpa.)

**extends the check to examples**: examples resolve `@/components/assistant-ui/*` to packages/ui via tsconfig paths, so a local file under that directory is only justified as an intentional fork — which diverges by definition. the script now fails on byte-equal copies in `examples/*` (they're dead weight that silently drifts) and `--write` removes them.

**actionable ci output**: drift and redundancy now emit github actions `::error file=...` annotations, so the failing file shows up inline in the pr instead of only in the job log.