### PR TITLE
fix(react-opencode): keep the event subscription stable across renders

### DIFF
--- a/.changeset/opencode-stable-subscribe.md
+++ b/.changeset/opencode-stable-subscribe.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix(react-opencode): stop re-subscribing to the OpenCode event stream on every render, which could drop `session.idle` and leave `isRunning` stuck at `true`

--- a/packages/react-opencode/package.json
+++ b/packages/react-opencode/package.json
@@ -63,7 +63,10 @@
     "@assistant-ui/x-buildutils": "workspace:*",
     "@types/node": "^25.9.2",
     "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.1.1",
     "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -114,6 +114,25 @@ describe("OpenCodeThreadController", () => {
     expect(eventSource.unsubscribe).toHaveBeenCalledTimes(1);
   });
 
+  it("supports detached subscribe and getState references", () => {
+    const eventSource = createEventSource();
+    const controller = new OpenCodeThreadController(
+      {} as never,
+      () => eventSource,
+      "ses_1",
+    );
+
+    const { subscribe, getState } = controller;
+    const unsubscribe = subscribe(vi.fn());
+
+    expect(eventSource.subscribe).toHaveBeenCalledTimes(1);
+    expect(getState().sessionId).toBe("ses_1");
+
+    unsubscribe();
+
+    expect(eventSource.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps forced reloads authoritative while earlier loads finish", async () => {
     const firstSession = createDeferred<{ data: unknown }>();
     const firstMessages = createDeferred<{ data: unknown[] }>();

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -186,17 +186,16 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   }
 
   public dispose() {
-    // React StrictMode can detach and then resubscribe the same controller.
     this.unsubscribeFromEvents?.();
     this.unsubscribeFromEvents = null;
     this.listeners.clear();
   }
 
-  public getState() {
+  public getState = () => {
     return this.state;
-  }
+  };
 
-  public subscribe(listener: () => void) {
+  public subscribe = (listener: () => void) => {
     this.listeners.add(listener);
     this.ensureEventSubscription();
 
@@ -207,7 +206,7 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
         this.unsubscribeFromEvents = null;
       }
     };
-  }
+  };
 
   public async load(force = false) {
     if (this.loadPromise && !force) return this.loadPromise;

--- a/packages/react-opencode/src/useOpenCodeControllerState.test.tsx
+++ b/packages/react-opencode/src/useOpenCodeControllerState.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { StrictMode, act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { OpenCodeThreadController } from "./OpenCodeThreadController";
+import { useOpenCodeControllerState } from "./useOpenCodeControllerState";
+import type { OpenCodeServerEvent, OpenCodeThreadState } from "./types";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const createEventSource = () => {
+  let listener: ((event: OpenCodeServerEvent) => void) | undefined;
+  const unsubscribe = vi.fn();
+
+  return {
+    emit(event: OpenCodeServerEvent) {
+      listener?.(event);
+    },
+    subscribe: vi.fn((nextListener: (event: OpenCodeServerEvent) => void) => {
+      listener = nextListener;
+      return unsubscribe;
+    }),
+    unsubscribe,
+  };
+};
+
+const sessionUpdated = (title: string): OpenCodeServerEvent => ({
+  type: "session.updated",
+  sessionId: "ses_1",
+  properties: {
+    info: {
+      id: "ses_1",
+      title,
+      time: {},
+    },
+  },
+  raw: {},
+});
+
+describe("useOpenCodeControllerState", () => {
+  let root: Root | undefined;
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    root = undefined;
+  });
+
+  it("keeps the event subscription across event-driven re-renders", () => {
+    const eventSource = createEventSource();
+    const controller = new OpenCodeThreadController(
+      {} as never,
+      () => eventSource,
+      "ses_1",
+    );
+
+    const snapshots: OpenCodeThreadState[] = [];
+    const Probe = () => {
+      snapshots.push(useOpenCodeControllerState(controller));
+      return null;
+    };
+
+    act(() => {
+      root = createRoot(document.createElement("div"));
+      root.render(<Probe />);
+    });
+
+    expect(eventSource.subscribe).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      eventSource.emit(sessionUpdated("First response"));
+    });
+
+    expect(snapshots.length).toBeGreaterThan(1);
+    expect(snapshots.at(-1)?.session).toMatchObject({
+      id: "ses_1",
+      title: "First response",
+    });
+    expect(eventSource.subscribe).toHaveBeenCalledTimes(1);
+    expect(eventSource.unsubscribe).not.toHaveBeenCalled();
+
+    act(() => {
+      root?.unmount();
+    });
+    root = undefined;
+
+    expect(eventSource.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays attached to events after a StrictMode double mount", () => {
+    const eventSource = createEventSource();
+    const controller = new OpenCodeThreadController(
+      {} as never,
+      () => eventSource,
+      "ses_1",
+    );
+
+    const snapshots: OpenCodeThreadState[] = [];
+    const Probe = () => {
+      snapshots.push(useOpenCodeControllerState(controller));
+      return null;
+    };
+
+    act(() => {
+      root = createRoot(document.createElement("div"));
+      root.render(
+        <StrictMode>
+          <Probe />
+        </StrictMode>,
+      );
+    });
+
+    expect(eventSource.subscribe.mock.calls.length).toBe(
+      eventSource.unsubscribe.mock.calls.length + 1,
+    );
+
+    const subscribesAfterMount = eventSource.subscribe.mock.calls.length;
+
+    act(() => {
+      eventSource.emit(sessionUpdated("Recovered"));
+    });
+
+    expect(snapshots.at(-1)?.session).toMatchObject({
+      id: "ses_1",
+      title: "Recovered",
+    });
+    expect(eventSource.subscribe.mock.calls.length).toBe(subscribesAfterMount);
+  });
+});

--- a/packages/react-opencode/src/useOpenCodeControllerState.ts
+++ b/packages/react-opencode/src/useOpenCodeControllerState.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import type {
+  OpenCodeThreadControllerLike,
+  OpenCodeThreadState,
+} from "./types";
+
+export const useOpenCodeControllerState = (
+  controller: OpenCodeThreadControllerLike,
+): OpenCodeThreadState => {
+  return useSyncExternalStore(
+    controller.subscribe,
+    controller.getState,
+    controller.getState,
+  );
+};

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -12,12 +12,7 @@ import {
   createOpencodeClient,
   type GlobalSession,
 } from "@opencode-ai/sdk/v2/client";
-import {
-  useEffect,
-  useEffectEvent,
-  useMemo,
-  useSyncExternalStore,
-} from "react";
+import { useEffect, useEffectEvent, useMemo } from "react";
 import type {
   OpenCodeRuntimeExtras,
   OpenCodeRuntimeOptions,
@@ -28,6 +23,7 @@ import { OpenCodeEventSource } from "./OpenCodeEventSource";
 import { OpenCodeThreadController } from "./OpenCodeThreadController";
 import { projectOpenCodeThreadRepository } from "./openCodeMessageProjection";
 import { createOpenCodeThreadState } from "./openCodeThreadState";
+import { useOpenCodeControllerState } from "./useOpenCodeControllerState";
 import { useOpenCodeStreamingTiming } from "./useOpenCodeStreamingTiming";
 
 type OpenCodeControllerRegistry = {
@@ -128,16 +124,6 @@ const NOOP_CONTROLLER: OpenCodeThreadControllerLike = {
 
 const NOOP_ON_NEW = () =>
   Promise.reject(new Error("OpenCode session is still initializing"));
-
-const useOpenCodeControllerState = (
-  controller: OpenCodeThreadControllerLike,
-): OpenCodeThreadState => {
-  return useSyncExternalStore(
-    (listener) => controller.subscribe(listener),
-    () => controller.getState(),
-    () => controller.getState(),
-  );
-};
 
 const isOpenCodeStateRunning = (state: OpenCodeThreadState): boolean =>
   state.runState.type === "streaming" ||

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3940,9 +3940,18 @@ importers:
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       react:
         specifier: ^19.2.7
         version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))


### PR DESCRIPTION
closes #4333

## summary

- fixes `s.thread.isRunning` getting stuck at `true` forever after an OpenCode response completes (regression introduced in 0.2.1)
- `useOpenCodeControllerState` passed a fresh inline arrow to `useSyncExternalStore` every render, so React re-subscribed on each render; since #4068 made the controller's event subscription ref-counted, every re-subscribe transiently dropped the listener count to 0, aborting the SSE connection, and a `session.idle` arriving in the reconnect gap was lost with no recovery path
- `OpenCodeThreadController.subscribe` / `getState` are now stable bound fields passed bare to `useSyncExternalStore`, matching the repo's other call sites; the hook moved to its own `useOpenCodeControllerState.ts` module
- adds regression coverage: a jsdom test asserting event-driven re-renders no longer churn the event subscription (plus StrictMode recovery), and a node test pinning the detached `subscribe` / `getState` references

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-opencode exec vitest run` -> 6 files, 35 tests passed
- [x] new jsdom tests fail against the previous inline-arrow code (subscribe called 2x instead of 1x), confirming they pin the regression
- [x] `pnpm exec tsc --noEmit -p packages/react-opencode/tsconfig.json` -> no errors
- [x] `pnpm lint` (oxlint + oxfmt) -> clean
- [x] `pnpm exec turbo run build --filter=@assistant-ui/react-opencode` -> built

### reviewer should verify

- [ ] run an app on `useOpenCodeRuntime`, send a message, and confirm `s.thread.isRunning` returns to `false` once the response finishes (repro from #4333)

## notes

- a follow-up PR will add refresh-on-reconnect so a terminal event missed during a genuine network blip cannot wedge `isRunning` either