### PR TITLE
refactor: migrate in-repo usages off deprecated tool ui apis

### DIFF
--- a/.changeset/hook-form-drop-deprecated-tool-ui.md
+++ b/.changeset/hook-form-drop-deprecated-tool-ui.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-hook-form": patch
+---
+
+refactor: replace deprecated useAssistantToolUI with the tools client API

--- a/.changeset/skill-toolkit-tool-ui.md
+++ b/.changeset/skill-toolkit-tool-ui.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+docs: teach defineToolkit instead of deprecated makeAssistantToolUI in the assistant-ui skill

--- a/examples/with-react-ink/src/app.tsx
+++ b/examples/with-react-ink/src/app.tsx
@@ -4,10 +4,12 @@ import {
   AssistantRuntimeProvider,
   useLocalRuntime,
   StatusBarPrimitive,
+  Tools,
+  useAui,
 } from "@assistant-ui/react-ink";
 import { Thread } from "./components/thread.js";
 import { createScriptedAdapter, MODEL_NAME } from "./scripted-adapter.js";
-import { ApplyPatchToolUI } from "./tools.js";
+import toolkit from "./tools.js";
 
 const StatusBar = () => (
   <StatusBarPrimitive.Root>
@@ -21,10 +23,12 @@ const StatusBar = () => (
 export const App = () => {
   const adapter = useMemo(() => createScriptedAdapter(), []);
   const runtime = useLocalRuntime(adapter);
+  const aui = useAui({
+    tools: Tools({ toolkit }),
+  });
 
   return (
-    <AssistantRuntimeProvider runtime={runtime}>
-      <ApplyPatchToolUI />
+    <AssistantRuntimeProvider aui={aui} runtime={runtime}>
       <Box flexDirection="column" padding={1}>
         <Box>
           <Text bold color="cyan">

--- a/examples/with-react-ink/src/tools.tsx
+++ b/examples/with-react-ink/src/tools.tsx
@@ -1,18 +1,26 @@
 import { Box, Text } from "ink";
-import { makeAssistantToolUI, DiffView } from "@assistant-ui/react-ink";
+import {
+  defineToolkit,
+  DiffView,
+  type ToolCallMessagePartComponent,
+} from "@assistant-ui/react-ink";
 
-export const ApplyPatchToolUI = makeAssistantToolUI<
+const ApplyPatchToolUI: ToolCallMessagePartComponent<
   { path: string; patch: string },
   unknown
->({
-  toolName: "apply_patch",
-  render: ({ args }) => {
-    if (!args?.patch) return null;
-    return (
-      <Box flexDirection="column" marginBottom={1}>
-        <Text color="cyan">edit {args.path}</Text>
-        <DiffView patch={args.patch} showLineNumbers />
-      </Box>
-    );
+> = ({ args }) => {
+  if (!args?.patch) return null;
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text color="cyan">edit {args.path}</Text>
+      <DiffView patch={args.patch} showLineNumbers />
+    </Box>
+  );
+};
+
+export default defineToolkit({
+  apply_patch: {
+    type: "backend",
+    render: ApplyPatchToolUI,
   },
 });

--- a/packages/cli/plugin/skills/assistant-ui/SKILL.md
+++ b/packages/cli/plugin/skills/assistant-ui/SKILL.md
@@ -124,32 +124,45 @@ const result = streamText({
 
 ### Frontend tool UI:
 
+Create a toolkit with a renderer for the tool. The tool executes on the backend, so the entry uses `externalTool()` and only attaches UI:
+
 ```tsx
-"use client";
+// app/toolkit.tsx
+"use generative";
 
-import { makeAssistantToolUI } from "@assistant-ui/react";
+import { defineToolkit, externalTool } from "@assistant-ui/react";
 
-export const WeatherToolUI = makeAssistantToolUI({
-  toolName: "get_weather",
-  render: ({ args, result }) => {
-    return (
-      <div>
-        <p>Weather for {args?.location}</p>
-        {result && <p>{result.temperature}F, {result.condition}</p>}
-      </div>
-    );
+export default defineToolkit({
+  get_weather: {
+    execute: externalTool(),
+    render: ({ args, result }) => {
+      return (
+        <div>
+          <p>Weather for {args?.location}</p>
+          {result && <p>{result.temperature}F, {result.condition}</p>}
+        </div>
+      );
+    },
   },
 });
 ```
 
-Register the tool UI in your assistant component:
+Register the toolkit in your assistant component:
 
 ```tsx
-<AssistantRuntimeProvider runtime={runtime}>
-  <WeatherToolUI />
+import { AssistantRuntimeProvider, Tools, useAui } from "@assistant-ui/react";
+import toolkit from "@/app/toolkit";
+
+const aui = useAui({
+  tools: Tools({ toolkit }),
+});
+
+<AssistantRuntimeProvider aui={aui} runtime={runtime}>
   <Thread />
 </AssistantRuntimeProvider>
 ```
+
+Do not use `makeAssistantToolUI`, `useAssistantToolUI`, `makeAssistantTool`, or `useAssistantTool`; they are deprecated in favor of toolkits.
 
 ## Key Packages
 

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -2,10 +2,7 @@
 
 import { type ModelContext, tool } from "@assistant-ui/core";
 import type {} from "@assistant-ui/core/store";
-import {
-  type ToolCallMessagePartComponent,
-  useAssistantToolUI,
-} from "@assistant-ui/core/react";
+import { type ToolCallMessagePartComponent } from "@assistant-ui/core/react";
 import { useAui } from "@assistant-ui/store";
 import { useEffect } from "react";
 import {
@@ -150,34 +147,22 @@ export const useAssistantForm = <
   }, [control, setValue, getValues, aui, reset, isSubmitting]);
 
   const renderFormFieldTool = props?.assistant?.tools?.set_form_field?.render;
-  useAssistantToolUI(
-    renderFormFieldTool
-      ? {
-          toolName: "set_form_field",
-          render: renderFormFieldTool,
-        }
-      : null,
-  );
+  useEffect(() => {
+    if (!renderFormFieldTool) return undefined;
+    return aui.tools().setToolUI("set_form_field", renderFormFieldTool);
+  }, [aui, renderFormFieldTool]);
 
   const renderSubmitFormTool = props?.assistant?.tools?.submit_form?.render;
-  useAssistantToolUI(
-    renderSubmitFormTool
-      ? {
-          toolName: "submit_form",
-          render: renderSubmitFormTool,
-        }
-      : null,
-  );
+  useEffect(() => {
+    if (!renderSubmitFormTool) return undefined;
+    return aui.tools().setToolUI("submit_form", renderSubmitFormTool);
+  }, [aui, renderSubmitFormTool]);
 
   const renderResetFormTool = props?.assistant?.tools?.reset_form?.render;
-  useAssistantToolUI(
-    renderResetFormTool
-      ? {
-          toolName: "reset_form",
-          render: renderResetFormTool,
-        }
-      : null,
-  );
+  useEffect(() => {
+    if (!renderResetFormTool) return undefined;
+    return aui.tools().setToolUI("reset_form", renderResetFormTool);
+  }, [aui, renderResetFormTool]);
 
   return form;
 };


### PR DESCRIPTION
`makeAssistantToolUI` / `useAssistantToolUI` are deprecated in favor of toolkits. this migrates the three remaining real usages in the repo:

- `examples/with-react-ink`: the apply_patch renderer becomes a `defineToolkit` entry registered via `useAui({ tools: Tools({ toolkit }) })`. the example builds with plain tsc (no `"use generative"` compiler), so the entry is authored directly as `{ type: "backend", render }`, the same shape `externalTool()` compiles to.
- `packages/cli` skill: SKILL.md taught `makeAssistantToolUI`; it now teaches the toolkit pattern (`"use generative"` + `externalTool()` + `Tools({ toolkit })`), which works in all scaffolded templates since they wire `withAui`.
- `packages/react-hook-form`: the three renderers are dynamic (passed via props), so a static toolkit cannot express them. `useAssistantToolUI` is a thin wrapper over the public client api, so the calls become `aui.tools().setToolUI(...)` effects with identical behavior.

left alone on purpose: the deprecated re-exports in packages/react, react-ink, react-native, and core (the deprecation surface itself, scheduled for removal in v0.15), historical changelogs, migration docs, and reference pages that already carry deprecation notes.

changesets: patch for `assistant-ui` (cli skill) and `@assistant-ui/react-hook-form`. verified: react-hook-form build clean, with-react-ink tsc build clean, repo lint and format green.