### PR TITLE
fix(react-opencode): re-sync state after the event stream reconnects

### DIFF
--- a/.changeset/opencode-reconnect-refresh.md
+++ b/.changeset/opencode-reconnect-refresh.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix(react-opencode): re-sync thread history and session status after the event stream reconnects, so events lost while disconnected (e.g. `session.idle`) cannot leave `isRunning` stuck

--- a/.changeset/opencode-reconnect-refresh.md
+++ b/.changeset/opencode-reconnect-refresh.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-opencode": patch
 ---
 
-fix(react-opencode): re-sync thread history and session status after the event stream reconnects, so events lost while disconnected (e.g. `session.idle`) cannot leave `isRunning` stuck
+fix(react-opencode): re-sync thread history, session status, and pending permissions/questions after the event stream reconnects, so events lost while disconnected (e.g. `session.idle` or `permission.asked`) cannot leave `isRunning` stuck or deadlock a run

--- a/packages/react-opencode/src/OpenCodeEventSource.test.ts
+++ b/packages/react-opencode/src/OpenCodeEventSource.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import { OpenCodeEventSource } from "./OpenCodeEventSource";
+import {
+  OpenCodeEventSource,
+  STREAM_RECONNECTED_EVENT_TYPE,
+} from "./OpenCodeEventSource";
 
 const waitFor = async (assertion: () => void) => {
   let lastError: unknown;
@@ -58,6 +61,38 @@ describe("OpenCodeEventSource", () => {
     await waitFor(() => {
       expect(client.event.subscribe).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it("notifies listeners on reconnect but not on the first connection", async () => {
+    const client = {
+      event: {
+        subscribe: vi.fn((_: unknown, options: { signal: AbortSignal }) =>
+          Promise.resolve({
+            stream: createAbortableStream(options.signal),
+          }),
+        ),
+      },
+    };
+    const source = new OpenCodeEventSource(client as never);
+
+    const firstListener = vi.fn();
+    const unsubscribe = source.subscribe(firstListener);
+
+    await waitFor(() => {
+      expect(client.event.subscribe).toHaveBeenCalledTimes(1);
+    });
+    expect(firstListener).not.toHaveBeenCalled();
+
+    unsubscribe();
+    const secondListener = vi.fn();
+    source.subscribe(secondListener);
+
+    await waitFor(() => {
+      expect(secondListener).toHaveBeenCalledWith(
+        expect.objectContaining({ type: STREAM_RECONNECTED_EVENT_TYPE }),
+      );
+    });
+    expect(secondListener).toHaveBeenCalledTimes(1);
   });
 
   it("continues notifying listeners when one throws", () => {

--- a/packages/react-opencode/src/OpenCodeEventSource.ts
+++ b/packages/react-opencode/src/OpenCodeEventSource.ts
@@ -69,6 +69,8 @@ const normalizeEventPayload = (event: unknown): OpenCodeServerEvent | null => {
   return normalized;
 };
 
+export const STREAM_RECONNECTED_EVENT_TYPE = "stream.reconnected";
+
 export class OpenCodeEventSource {
   private readonly listeners = new Set<Listener>();
   private readonly reconnectDelayMs = 1_000;
@@ -77,6 +79,7 @@ export class OpenCodeEventSource {
   private connectionPromise: Promise<void> | null = null;
   private stopped = false;
   private nextReconnectDelayMs = this.reconnectDelayMs;
+  private hadConnection = false;
 
   constructor(private readonly client: OpencodeClient) {}
 
@@ -141,6 +144,16 @@ export class OpenCodeEventSource {
         });
         failedToConnect = false;
         this.nextReconnectDelayMs = this.reconnectDelayMs;
+
+        if (this.hadConnection) {
+          this.emit({
+            type: STREAM_RECONNECTED_EVENT_TYPE,
+            sessionId: undefined,
+            raw: undefined,
+            properties: {},
+          });
+        }
+        this.hadConnection = true;
 
         for await (const event of subscription.stream) {
           if (abortController.signal.aborted || this.stopped) {

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -31,6 +31,29 @@ const createEventSource = () => {
   };
 };
 
+const streamReconnected: OpenCodeServerEvent = {
+  type: STREAM_RECONNECTED_EVENT_TYPE,
+  sessionId: undefined,
+  raw: undefined,
+  properties: {},
+};
+
+const createReconnectClient = ({
+  status = vi.fn().mockResolvedValue({ data: {} }),
+  permissions = vi.fn().mockResolvedValue({ data: [] }),
+  questions = vi.fn().mockResolvedValue({ data: [] }),
+} = {}) => ({
+  session: {
+    get: vi
+      .fn()
+      .mockResolvedValue({ data: { id: "ses_1", title: "t", time: {} } }),
+    messages: vi.fn().mockResolvedValue({ data: [] }),
+    status,
+  },
+  permission: { list: permissions },
+  question: { list: questions },
+});
+
 describe("OpenCodeThreadController", () => {
   it("re-subscribes through the provider after dispose", () => {
     let eventSource = createEventSource();
@@ -136,15 +159,7 @@ describe("OpenCodeThreadController", () => {
 
   it("re-syncs history and status when the stream reconnects", async () => {
     const eventSource = createEventSource();
-    const client = {
-      session: {
-        get: vi
-          .fn()
-          .mockResolvedValue({ data: { id: "ses_1", title: "t", time: {} } }),
-        messages: vi.fn().mockResolvedValue({ data: [] }),
-        status: vi.fn().mockResolvedValue({ data: {} }),
-      },
-    };
+    const client = createReconnectClient();
     const controller = new OpenCodeThreadController(
       client as never,
       () => eventSource,
@@ -163,12 +178,7 @@ describe("OpenCodeThreadController", () => {
       type: "busy",
     });
 
-    eventSource.emit({
-      type: STREAM_RECONNECTED_EVENT_TYPE,
-      sessionId: undefined,
-      raw: undefined,
-      properties: {},
-    });
+    eventSource.emit(streamReconnected);
 
     await vi.waitFor(() => {
       expect(controller.getState().sessionStatus).toMatchObject({
@@ -183,17 +193,9 @@ describe("OpenCodeThreadController", () => {
 
   it("keeps a busy status the server still reports after reconnect", async () => {
     const eventSource = createEventSource();
-    const client = {
-      session: {
-        get: vi
-          .fn()
-          .mockResolvedValue({ data: { id: "ses_1", title: "t", time: {} } }),
-        messages: vi.fn().mockResolvedValue({ data: [] }),
-        status: vi
-          .fn()
-          .mockResolvedValue({ data: { ses_1: { type: "busy" } } }),
-      },
-    };
+    const client = createReconnectClient({
+      status: vi.fn().mockResolvedValue({ data: { ses_1: { type: "busy" } } }),
+    });
     const controller = new OpenCodeThreadController(
       client as never,
       () => eventSource,
@@ -201,12 +203,7 @@ describe("OpenCodeThreadController", () => {
     );
     controller.subscribe(vi.fn());
 
-    eventSource.emit({
-      type: STREAM_RECONNECTED_EVENT_TYPE,
-      sessionId: undefined,
-      raw: undefined,
-      properties: {},
-    });
+    eventSource.emit(streamReconnected);
 
     await vi.waitFor(() => {
       expect(controller.getState().sessionStatus).toMatchObject({
@@ -220,15 +217,9 @@ describe("OpenCodeThreadController", () => {
 
   it("keeps current state when the status endpoint is unavailable", async () => {
     const eventSource = createEventSource();
-    const client = {
-      session: {
-        get: vi
-          .fn()
-          .mockResolvedValue({ data: { id: "ses_1", title: "t", time: {} } }),
-        messages: vi.fn().mockResolvedValue({ data: [] }),
-        status: vi.fn().mockRejectedValue(new Error("404")),
-      },
-    };
+    const client = createReconnectClient({
+      status: vi.fn().mockRejectedValue(new Error("404")),
+    });
     const controller = new OpenCodeThreadController(
       client as never,
       () => eventSource,
@@ -243,12 +234,7 @@ describe("OpenCodeThreadController", () => {
       raw: {},
     });
 
-    eventSource.emit({
-      type: STREAM_RECONNECTED_EVENT_TYPE,
-      sessionId: undefined,
-      raw: undefined,
-      properties: {},
-    });
+    eventSource.emit(streamReconnected);
 
     await vi.waitFor(() => {
       expect(client.session.get).toHaveBeenCalledTimes(1);
@@ -258,6 +244,87 @@ describe("OpenCodeThreadController", () => {
 
     expect(controller.getState().sessionStatus).toMatchObject({
       type: "busy",
+    });
+  });
+
+  it("re-surfaces pending permissions and questions after reconnect", async () => {
+    const eventSource = createEventSource();
+    const client = createReconnectClient({
+      permissions: vi.fn().mockResolvedValue({
+        data: [
+          {
+            id: "perm_1",
+            sessionID: "ses_1",
+            permission: "fs.write",
+            metadata: {},
+          },
+          {
+            id: "perm_2",
+            sessionID: "ses_other",
+            permission: "fs.write",
+            metadata: {},
+          },
+        ],
+      }),
+      questions: vi.fn().mockResolvedValue({
+        data: [
+          { id: "q_1", sessionID: "ses_1", questions: [] },
+          { id: "q_2", sessionID: "ses_other", questions: [] },
+        ],
+      }),
+    });
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_1",
+    );
+    controller.subscribe(vi.fn());
+
+    eventSource.emit(streamReconnected);
+
+    await vi.waitFor(() => {
+      expect(
+        Object.keys(controller.getState().interactions.permissions.pending),
+      ).toEqual(["perm_1"]);
+      expect(
+        Object.keys(controller.getState().interactions.questions.pending),
+      ).toEqual(["q_1"]);
+    });
+  });
+
+  it("ignores stale status responses from a superseded reconnect", async () => {
+    const eventSource = createEventSource();
+    const firstStatus = createDeferred<{ data: Record<string, unknown> }>();
+    const secondStatus = createDeferred<{ data: Record<string, unknown> }>();
+    const client = createReconnectClient({
+      status: vi
+        .fn()
+        .mockImplementationOnce(() => firstStatus.promise)
+        .mockImplementationOnce(() => secondStatus.promise),
+    });
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_1",
+    );
+    controller.subscribe(vi.fn());
+
+    eventSource.emit(streamReconnected);
+    eventSource.emit(streamReconnected);
+
+    secondStatus.resolve({ data: {} });
+
+    await vi.waitFor(() => {
+      expect(controller.getState().sessionStatus).toMatchObject({
+        type: "idle",
+      });
+    });
+
+    firstStatus.resolve({ data: { ses_1: { type: "busy" } } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(controller.getState().sessionStatus).toMatchObject({
+      type: "idle",
     });
   });
 

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { OpenCodeThreadController } from "./OpenCodeThreadController";
+import { STREAM_RECONNECTED_EVENT_TYPE } from "./OpenCodeEventSource";
 import type { OpenCodeServerEvent } from "./types";
 
 const createDeferred = <T>() => {
@@ -131,6 +132,133 @@ describe("OpenCodeThreadController", () => {
     unsubscribe();
 
     expect(eventSource.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-syncs history and status when the stream reconnects", async () => {
+    const eventSource = createEventSource();
+    const client = {
+      session: {
+        get: vi
+          .fn()
+          .mockResolvedValue({ data: { id: "ses_1", title: "t", time: {} } }),
+        messages: vi.fn().mockResolvedValue({ data: [] }),
+        status: vi.fn().mockResolvedValue({ data: {} }),
+      },
+    };
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_1",
+    );
+    controller.subscribe(vi.fn());
+
+    eventSource.emit({
+      type: "session.status",
+      sessionId: "ses_1",
+      properties: { status: { type: "busy" } },
+      raw: {},
+    });
+
+    expect(controller.getState().sessionStatus).toMatchObject({
+      type: "busy",
+    });
+
+    eventSource.emit({
+      type: STREAM_RECONNECTED_EVENT_TYPE,
+      sessionId: undefined,
+      raw: undefined,
+      properties: {},
+    });
+
+    await vi.waitFor(() => {
+      expect(controller.getState().sessionStatus).toMatchObject({
+        type: "idle",
+      });
+    });
+    expect(controller.getState().runState).toMatchObject({ type: "idle" });
+    expect(client.session.status).toHaveBeenCalledTimes(1);
+    expect(client.session.get).toHaveBeenCalledTimes(1);
+    expect(client.session.messages).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a busy status the server still reports after reconnect", async () => {
+    const eventSource = createEventSource();
+    const client = {
+      session: {
+        get: vi
+          .fn()
+          .mockResolvedValue({ data: { id: "ses_1", title: "t", time: {} } }),
+        messages: vi.fn().mockResolvedValue({ data: [] }),
+        status: vi
+          .fn()
+          .mockResolvedValue({ data: { ses_1: { type: "busy" } } }),
+      },
+    };
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_1",
+    );
+    controller.subscribe(vi.fn());
+
+    eventSource.emit({
+      type: STREAM_RECONNECTED_EVENT_TYPE,
+      sessionId: undefined,
+      raw: undefined,
+      properties: {},
+    });
+
+    await vi.waitFor(() => {
+      expect(controller.getState().sessionStatus).toMatchObject({
+        type: "busy",
+      });
+    });
+    expect(controller.getState().runState).toMatchObject({
+      type: "streaming",
+    });
+  });
+
+  it("keeps current state when the status endpoint is unavailable", async () => {
+    const eventSource = createEventSource();
+    const client = {
+      session: {
+        get: vi
+          .fn()
+          .mockResolvedValue({ data: { id: "ses_1", title: "t", time: {} } }),
+        messages: vi.fn().mockResolvedValue({ data: [] }),
+        status: vi.fn().mockRejectedValue(new Error("404")),
+      },
+    };
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_1",
+    );
+    controller.subscribe(vi.fn());
+
+    eventSource.emit({
+      type: "session.status",
+      sessionId: "ses_1",
+      properties: { status: { type: "busy" } },
+      raw: {},
+    });
+
+    eventSource.emit({
+      type: STREAM_RECONNECTED_EVENT_TYPE,
+      sessionId: undefined,
+      raw: undefined,
+      properties: {},
+    });
+
+    await vi.waitFor(() => {
+      expect(client.session.get).toHaveBeenCalledTimes(1);
+      expect(client.session.status).toHaveBeenCalledTimes(1);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(controller.getState().sessionStatus).toMatchObject({
+      type: "busy",
+    });
   });
 
   it("keeps forced reloads authoritative while earlier loads finish", async () => {

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -2,6 +2,7 @@ import type { AppendMessage, ThreadUserMessagePart } from "@assistant-ui/react";
 import type {
   OpencodeClient,
   PermissionRequest,
+  QuestionRequest,
   SessionStatus,
 } from "@opencode-ai/sdk/v2/client";
 import {
@@ -81,10 +82,9 @@ const getRecordValue = (
   return undefined;
 };
 
-const extractPermissionRequest = (
-  event: OpenCodeServerEvent,
+const toPermissionRequest = (
+  request: PermissionRequest,
 ): OpenCodePermissionRequest | null => {
-  const request = event.properties as PermissionRequest;
   if (typeof request.id !== "string" || typeof request.sessionID !== "string") {
     return null;
   }
@@ -125,19 +125,28 @@ const extractPermissionRequest = (
   };
 };
 
-const extractQuestionRequest = (
+const extractPermissionRequest = (
   event: OpenCodeServerEvent,
+): OpenCodePermissionRequest | null =>
+  toPermissionRequest(event.properties as PermissionRequest);
+
+const toQuestionRequest = (
+  request: QuestionRequest,
 ): OpenCodeQuestionRequest | null => {
-  const request = event.properties;
   if (typeof request.id !== "string" || typeof request.sessionID !== "string") {
     return null;
   }
 
   return {
-    ...(request as OpenCodeQuestionRequest),
+    ...request,
     askedAt: Date.now(),
   };
 };
+
+const extractQuestionRequest = (
+  event: OpenCodeServerEvent,
+): OpenCodeQuestionRequest | null =>
+  toQuestionRequest(event.properties as unknown as QuestionRequest);
 
 const normalizeUnhandledEvent = (
   event: OpenCodeServerEvent,
@@ -169,6 +178,7 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   private readonly getEventSource: OpenCodeEventSourceProvider;
   private unsubscribeFromEvents: (() => void) | null = null;
   private loadPromise: Promise<void> | null = null;
+  private reconnectSyncToken = 0;
 
   constructor(
     private readonly client: OpencodeClient,
@@ -194,16 +204,48 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
 
   private handleStreamReconnect() {
     this.refreshInBackground();
+    const token = ++this.reconnectSyncToken;
+
     void this.client.session
       .status()
       .catch(() => null)
       .then((response) => {
-        if (!response) return;
+        if (!response || token !== this.reconnectSyncToken) return;
         const status = response.data?.[this.sessionId];
         if (status) {
           this.dispatch({ type: "session.status", status });
         } else {
           this.dispatch({ type: "session.idle", sessionId: this.sessionId });
+        }
+      });
+
+    void this.client.permission
+      .list()
+      .catch(() => null)
+      .then((response) => {
+        if (!response || token !== this.reconnectSyncToken) return;
+        for (const item of response.data ?? []) {
+          const request = toPermissionRequest(item);
+          if (!request || request.sessionId !== this.sessionId) continue;
+          if (request.id in this.state.interactions.permissions.pending) {
+            continue;
+          }
+          this.dispatch({ type: "permission.asked", request });
+        }
+      });
+
+    void this.client.question
+      .list()
+      .catch(() => null)
+      .then((response) => {
+        if (!response || token !== this.reconnectSyncToken) return;
+        for (const item of response.data ?? []) {
+          const request = toQuestionRequest(item);
+          if (!request || request.sessionID !== this.sessionId) continue;
+          if (request.id in this.state.interactions.questions.pending) {
+            continue;
+          }
+          this.dispatch({ type: "question.asked", request });
         }
       });
   }

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -21,7 +21,10 @@ import type {
   OpenCodeUserMessageOptions,
   PendingUserMessage,
 } from "./types";
-import type { OpenCodeEventSource } from "./OpenCodeEventSource";
+import {
+  STREAM_RECONNECTED_EVENT_TYPE,
+  type OpenCodeEventSource,
+} from "./OpenCodeEventSource";
 import { serializeUserParts } from "./serializeUserParts";
 
 type OpenCodeEventSourceProvider = () => Pick<OpenCodeEventSource, "subscribe">;
@@ -180,9 +183,29 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     if (this.unsubscribeFromEvents) return;
 
     this.unsubscribeFromEvents = this.getEventSource().subscribe((event) => {
+      if (event.type === STREAM_RECONNECTED_EVENT_TYPE) {
+        this.handleStreamReconnect();
+        return;
+      }
       if (event.sessionId !== this.sessionId) return;
       this.handleServerEvent(event);
     });
+  }
+
+  private handleStreamReconnect() {
+    this.refreshInBackground();
+    void this.client.session
+      .status()
+      .catch(() => null)
+      .then((response) => {
+        if (!response) return;
+        const status = response.data?.[this.sessionId];
+        if (status) {
+          this.dispatch({ type: "session.status", status });
+        } else {
+          this.dispatch({ type: "session.idle", sessionId: this.sessionId });
+        }
+      });
   }
 
   public dispose() {

--- a/packages/react-opencode/src/index.ts
+++ b/packages/react-opencode/src/index.ts
@@ -9,7 +9,10 @@ export {
 
 export { useOpenCodeStreamingTiming } from "./useOpenCodeStreamingTiming";
 
-export { OpenCodeEventSource } from "./OpenCodeEventSource";
+export {
+  OpenCodeEventSource,
+  STREAM_RECONNECTED_EVENT_TYPE,
+} from "./OpenCodeEventSource";
 export { OpenCodeThreadController } from "./OpenCodeThreadController";
 export {
   createOpenCodeThreadState,


### PR DESCRIPTION
## summary

- after the OpenCode SSE event stream reconnects, controllers now re-fetch history, the authoritative session status, and pending permissions/questions; events emitted while disconnected are lost permanently (the server keeps no replay buffer), so a lost `session.idle` previously left `isRunning` stuck at `true` until the next completed run, and a lost `permission.asked` silently deadlocked the run with no prompt to respond to
- `OpenCodeEventSource` emits a synthetic `stream.reconnected` event (exported as `STREAM_RECONNECTED_EVENT_TYPE`) on every connection after the first; `OpenCodeThreadController` handles it by refreshing history, fetching `GET /session/status` (dispatching the returned status, or `session.idle` when the session is absent from the map, matching the server's own semantics, which removes idle sessions from the status map), and re-surfacing pending `permission.asked` / `question.asked` requests from `client.permission.list()` / `client.question.list()` that were dropped mid-disconnect
- all reconnect fetches are guarded by a per-reconnect token, so out-of-order responses from rapid consecutive reconnects cannot apply a stale snapshot over a newer one
- older servers without these endpoints are tolerated; failed fetches are skipped and the history refresh still applies

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-opencode exec vitest run` -> 6 files, 41 tests passed
- [x] mutation checks: disabling the reconnect emission fails the new event-source test, stubbing the controller's reconnect handler fails the controller reconnect tests, and removing the staleness token check fails the superseded-reconnect test
- [x] `pnpm exec tsc --noEmit -p packages/react-opencode/tsconfig.json` -> no errors
- [x] `pnpm lint` (oxlint + oxfmt) -> clean
- [x] `pnpm exec turbo run build --filter=@assistant-ui/react-opencode` -> built

### reviewer should verify

- [ ] with an app on `useOpenCodeRuntime`, restart the OpenCode server mid-run (or toggle the network); after the stream reconnects, the thread re-syncs, `s.thread.isRunning` reflects the server's actual status, and a permission prompt raised during the disconnect reappears

## notes

- follow-up to #4334 (issue #4333): that PR removed the render churn that artificially dropped the connection; this one heals genuinely lost events on any reconnect
- the reconnect refresh reuses existing `refresh()` semantics, which briefly sets `isLoading` on the visible thread; pre-existing behavior shared with `session.compacted` refreshes