### PR TITLE
fix(tap): buffer dispatches that arrive before a resource's first commit

### DIFF
--- a/.changeset/pre-mount-dispatch-buffer.md
+++ b/.changeset/pre-mount-dispatch-buffer.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: buffer dispatches that arrive before a resource's first commit instead of throwing "Resource updated before mount". React flushes passive effects child-first, so a descendant's mount effect can legitimately dispatch on a resource before its ancestor host commits it; such dispatches are now replayed in FIFO order at first commit.

--- a/packages/tap/src/__tests__/react/pre-mount-dispatch.test.tsx
+++ b/packages/tap/src/__tests__/react/pre-mount-dispatch.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import {
+  Component,
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from "react";
+import { resource } from "../../core/resource";
+import { useState as useResourceState } from "../../react-hooks/useState";
+import { useResource, useTapRoot } from "../../index";
+import { cleanupAllResources } from "../test-utils";
+
+afterEach(() => {
+  cleanupAllResources();
+  cleanup();
+});
+
+// Reproduces the docs `/docs/tools/interactables` crash:
+//   "Resource updated before mount" (tap/react-hooks/useReducer.ts).
+//
+// Shape of the real bug:
+//   - An ancestor hosts a tap resource (via useAui -> useTapRoot, or
+//     useClientResource -> useResource). The resource's fiber is committed
+//     ("mounted") in a *passive effect* on that ancestor component.
+//   - A descendant registers itself from its own mount effect, which
+//     synchronously dispatches a state update on the hosted resource
+//     (Interactables.register -> setState).
+//   - React flushes passive effects child-first, so the descendant's register
+//     effect runs BEFORE the ancestor's commit effect. The dispatch lands while
+//     the fiber is still `isNeverMounted`, and tap's reducer guard throws.
+//
+// `useRegistry` stands in for the Interactables resource; `register` mirrors
+// Interactables.register (a method that synchronously dispatches setState).
+
+const useRegistry = () => {
+  const [ids, setIds] = useResourceState<readonly string[]>([]);
+  const register = (id: string) =>
+    setIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
+  return { ids, register };
+};
+const Registry = resource(useRegistry);
+
+type RegistryApi = ReturnType<typeof useRegistry>;
+
+// Records errors thrown during render or in a child's passive effect so a throw
+// surfaces as an assertable value instead of an unhandled error.
+class Boundary extends Component<
+  { onError: (e: unknown) => void; children: ReactNode },
+  { failed: boolean }
+> {
+  override state = { failed: false };
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  override componentDidCatch(error: unknown) {
+    this.props.onError(error);
+  }
+  override render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
+const collectErrors = (ui: ReactNode) => {
+  const errors: unknown[] = [];
+  try {
+    render(<Boundary onError={(e) => errors.push(e)}>{ui}</Boundary>);
+  } catch (e) {
+    errors.push(e);
+  }
+  return errors.map((e) => (e instanceof Error ? e.message : String(e)));
+};
+
+describe("dispatch from a descendant effect before the host commits", () => {
+  // --- Host A: useResource (mirrors store's useClientResource) ----------------
+  describe("useResource host", () => {
+    const Ctx = createContext<RegistryApi | null>(null);
+
+    function Host({ children }: { children: ReactNode }) {
+      const api = useResource(Registry());
+      return <Ctx.Provider value={api}>{children}</Ctx.Provider>;
+    }
+
+    function Consumer() {
+      const api = useContext(Ctx)!;
+      const apiRef = useRef(api);
+      apiRef.current = api;
+      // Mirrors useAssistantInteractable: register once per mount (its real
+      // deps — the aui client etc. — are stable). Depending on `api` itself
+      // would re-register on every registry render, which is a consumer bug
+      // (useRegistry returns a fresh object each render).
+      useEffect(() => {
+        apiRef.current.register("taskBoard");
+      }, []);
+      return null;
+    }
+
+    it("a descendant can register without 'Resource updated before mount'", () => {
+      const messages = collectErrors(
+        <Host>
+          <Consumer />
+        </Host>,
+      );
+      expect(messages.join("\n")).not.toMatch(/Resource updated before mount/);
+    });
+  });
+
+  // --- Host B: useTapRoot (exactly what useAui uses) --------------------------
+  describe("useTapRoot host", () => {
+    type Store = ReturnType<typeof useTapRoot<RegistryApi>>;
+    const Ctx = createContext<Store | null>(null);
+
+    let hostedStore: Store | null = null;
+
+    function Host({ children }: { children: ReactNode }) {
+      const store = useTapRoot(function RegistryRoot() {
+        return useRegistry();
+      });
+      hostedStore = store;
+      return <Ctx.Provider value={store}>{children}</Ctx.Provider>;
+    }
+
+    function Consumer() {
+      const store = useContext(Ctx)!;
+      // useAui exposes client methods the consumer calls in its mount effect.
+      useEffect(() => {
+        store.getValue().register("taskBoard");
+      }, [store]);
+      return null;
+    }
+
+    it("a descendant can register without 'Resource updated before mount'", () => {
+      const messages = collectErrors(
+        <Host>
+          <Consumer />
+        </Host>,
+      );
+      expect(messages.join("\n")).not.toMatch(/Resource updated before mount/);
+    });
+
+    it("the registration is observable once dispatch is allowed", async () => {
+      collectErrors(
+        <Host>
+          <Consumer />
+        </Host>,
+      );
+      // The replayed dispatch goes through the root's macrotask scheduler
+      // (MessageChannel), so yield a macrotask before observing.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(hostedStore?.getValue().ids).toContain("taskBoard");
+    });
+  });
+});

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -21,6 +21,7 @@ export function createResourceFiber<R, A extends readonly unknown[]>(
     isFirstRender: true,
     isMounted: false,
     isNeverMounted: true,
+    preMountQueue: undefined,
   };
 }
 
@@ -70,4 +71,10 @@ export function commitResourceFiber<R, A extends readonly unknown[]>(
 
   fiber.isNeverMounted = false;
   commitAllEffects(result);
+
+  const queue = fiber.preMountQueue;
+  if (queue) {
+    fiber.preMountQueue = undefined;
+    for (const replay of queue) replay();
+  }
 }

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -77,4 +77,12 @@ export interface ResourceFiber<R, A extends readonly unknown[] = any[]> {
   isMounted: boolean;
   isFirstRender: boolean;
   isNeverMounted: boolean;
+
+  /**
+   * Dispatches that arrived before the first commit (React flushes passive
+   * effects child-first, so a descendant's mount effect can dispatch before
+   * the ancestor host commits this fiber). Replayed in FIFO order after the
+   * first commit.
+   */
+  preMountQueue: (() => void)[] | undefined;
 }

--- a/packages/tap/src/react-hooks/useReducer.ts
+++ b/packages/tap/src/react-hooks/useReducer.ts
@@ -14,7 +14,12 @@ const dispatchOnFiber = (
     throw new Error("Resource updated during render");
   }
   if (fiber.isNeverMounted) {
-    throw new Error("Resource updated before mount");
+    // The fiber's host commits it in a passive effect, but React flushes
+    // passive effects child-first — a descendant's mount effect can dispatch
+    // before the ancestor host commits. Buffer the dispatch and replay it
+    // after the first commit; FIFO order preserves dispatch sequences.
+    (fiber.preMountQueue ??= []).push(() => dispatchOnFiber(fiber, callback));
+    return;
   }
 
   fiber.root.dispatchUpdate(() => {


### PR DESCRIPTION
## Problem

Visiting `/docs/tools/interactables` crashed with:

> Error: Resource updated before mount

Any component calling `useAssistantInteractable` (or otherwise dispatching into a tap resource from its mount effect) hit this. The resource is hosted by an ancestor (`useAui` → `useTapRoot`), which commits the resource's fiber in a **passive effect on the ancestor**. The consumer registers from a **passive effect on a descendant**. React flushes passive effects child-first, so the registration dispatch always lands before the resource is committed — and tap's `dispatchOnFiber` threw on pre-mount updates.

This ordering is inherent: every effect phase (layout included) runs child-first, so no consumer-side restructuring can avoid it.

## Fix

`dispatchOnFiber` now buffers pre-mount dispatches on the fiber (`preMountQueue`) and `commitResourceFiber` replays them in FIFO order immediately after the first commit:

- **FIFO replay** preserves StrictMode's `register → unregister → register` double-mount sequence, landing on the correct end state.
- Buffered entries are **self-contained thunks** that re-enter `dispatchOnFiber`, so tap core doesn't import from react-hooks.
- Replay runs after the final `commitAllEffects` (after the dev StrictMode double-commit pass), the same position from which resource mount effects may already dispatch.

Fixed in tap rather than in `Interactables` because the race applies to any resource method dispatching from a descendant's mount effect — `dispatchOnFiber` is the single choke point (the only `isNeverMounted` check in the codebase).

## Tests

New `pre-mount-dispatch.test.tsx` reproduces the crash through both hosting paths (`useResource` and `useTapRoot`) plus an observability check that the buffered registration actually applies. All three fail with the original error without the fix. Full tap suite: 144/144; store suite green.
