### PR TITLE
fix(example): disable Nitro wasm condition to fix with-tanstack SSR build

### DIFF
--- a/examples/with-tanstack/vite.config.ts
+++ b/examples/with-tanstack/vite.config.ts
@@ -11,6 +11,12 @@ const config = defineConfig({
       output: {
         dir: "dist",
       },
+      // Nitro enables wasm by default, which adds the "unwasm" export
+      // condition. That routes `shiki/wasm` to its raw `onig.wasm` file, which
+      // Vite/Rolldown cannot load during the SSR build ([UNLOADABLE_DEPENDENCY]).
+      // Disabling it resolves `shiki/wasm` to its base64-inlined default — same
+      // Oniguruma engine, no separate .wasm asset.
+      wasm: false,
     }),
     viteTsConfigPaths({
       projects: ["./tsconfig.json", "../../packages/ui/tsconfig.json"],


### PR DESCRIPTION
Nitro enables wasm handling by default, which adds the 'unwasm' export
condition to its SSR Vite environment. That routes shiki/wasm to its raw
onig.wasm file, which Vite 8/Rolldown cannot load during the SSR build
([UNLOADABLE_DEPENDENCY]). Setting wasm: false resolves shiki/wasm to its
base64-inlined default instead -- same Oniguruma engine, no separate .wasm
asset.