### PR TITLE
feat: add opt-in defer prop to markdown text primitives

### DIFF
--- a/.changeset/markdown-defer-prop.md
+++ b/.changeset/markdown-defer-prop.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/react-streamdown": patch
+"@assistant-ui/react-markdown": patch
+---
+
+feat: opt-in `defer` prop on the markdown text primitives
+
+`StreamdownTextPrimitive` and `MarkdownTextPrimitive` accept a `defer` flag that routes the streamed text through `useDeferredValue`, so re-parsing the growing message runs at a lower priority and typing/scrolling stay responsive while a long message streams in. intermediate streaming states may be skipped under load; the final text always renders. default off; the shadcn kit's markdown-text turns it on.

--- a/apps/docs/content/docs/ui/streamdown.mdx
+++ b/apps/docs/content/docs/ui/streamdown.mdx
@@ -119,6 +119,7 @@ const StreamdownText = () => (
 | `components` | `object` | - | Custom components including `SyntaxHighlighter` and `CodeHeader` |
 | `componentsByLanguage` | `object` | - | Language-specific component overrides |
 | `preprocess` | `(text: string) => string` | - | Text preprocessing function |
+| `defer` | `boolean` | `false` | Defer markdown parsing to a lower priority via `useDeferredValue` so typing and scrolling stay responsive during streaming |
 | `controls` | `boolean \| object` | `true` | Enable/disable UI controls for code blocks and tables |
 | `caret` | `"block" \| "circle"` | - | Streaming caret style |
 | `mermaid` | `MermaidOptions` | - | Mermaid diagram configuration |

--- a/packages/react-markdown/src/primitives/MarkdownText.tsx
+++ b/packages/react-markdown/src/primitives/MarkdownText.tsx
@@ -8,6 +8,7 @@ import {
   forwardRef,
   type ForwardRefExoticComponent,
   type RefAttributes,
+  useDeferredValue,
   useMemo,
   type ComponentPropsWithoutRef,
   type ComponentType,
@@ -62,6 +63,15 @@ export type MarkdownTextPrimitiveProps = Omit<
     | undefined;
   smooth?: boolean | undefined;
   /**
+   * Defers markdown parsing and rendering to a lower priority via React's
+   * `useDeferredValue`, so urgent work (typing, scrolling) is not blocked by
+   * re-parsing the growing message on every streamed token. Intermediate
+   * streaming states may be skipped under load; the final text always renders.
+   *
+   * @default false
+   */
+  defer?: boolean | undefined;
+  /**
    * Function to transform text before markdown processing.
    */
   preprocess?: (text: string) => string;
@@ -71,6 +81,7 @@ const MarkdownTextInner: FC<MarkdownTextPrimitiveProps> = ({
   components: userComponents,
   componentsByLanguage,
   smooth = true,
+  defer = false,
   preprocess,
   ...rest
 }) => {
@@ -86,6 +97,9 @@ const MarkdownTextInner: FC<MarkdownTextPrimitiveProps> = ({
   }, [messagePartText, preprocess]);
 
   const { text } = useSmooth(processedMessagePart, smooth);
+
+  const deferredText = useDeferredValue(text);
+  const resolvedText = defer ? deferredText : text;
 
   const {
     pre = DefaultPre,
@@ -121,7 +135,7 @@ const MarkdownTextInner: FC<MarkdownTextPrimitiveProps> = ({
 
   return (
     <ReactMarkdown components={components} {...rest}>
-      {text}
+      {resolvedText}
     </ReactMarkdown>
   );
 };

--- a/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
+++ b/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
@@ -59,6 +59,35 @@ describe("StreamdownTextPrimitive", () => {
     ).toBe(false);
   });
 
+  it("settles on the latest text when defer is enabled", async () => {
+    const { rerender } = render(
+      <TextMessagePartProvider text="first chunk" isRunning>
+        <StreamdownTextPrimitive defer />
+      </TextMessagePartProvider>,
+    );
+
+    expect(await screen.findByText("first chunk")).toBeTruthy();
+
+    rerender(
+      <TextMessagePartProvider text="first chunk second chunk" isRunning>
+        <StreamdownTextPrimitive defer />
+      </TextMessagePartProvider>,
+    );
+
+    expect(await screen.findByText("first chunk second chunk")).toBeTruthy();
+
+    rerender(
+      <TextMessagePartProvider
+        text="first chunk second chunk"
+        isRunning={false}
+      >
+        <StreamdownTextPrimitive defer />
+      </TextMessagePartProvider>,
+    );
+
+    expect(await screen.findByText("first chunk second chunk")).toBeTruthy();
+  });
+
   describe("code adapter with custom components", () => {
     const fencedMarkdown = "```ts\nconst x = 1;\n```";
 

--- a/packages/react-streamdown/src/primitives/StreamdownText.tsx
+++ b/packages/react-streamdown/src/primitives/StreamdownText.tsx
@@ -5,7 +5,12 @@ import { harden } from "rehype-harden";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
 import { Streamdown, type StreamdownProps } from "streamdown";
-import { type ComponentRef, forwardRef, useMemo } from "react";
+import {
+  type ComponentRef,
+  forwardRef,
+  useDeferredValue,
+  useMemo,
+} from "react";
 import { useAdaptedComponents } from "../adapters/components-adapter";
 import { DEFAULT_SHIKI_THEME, mergePlugins } from "../defaults";
 import type { SecurityConfig, StreamdownTextPrimitiveProps } from "../types";
@@ -84,6 +89,7 @@ export const StreamdownTextPrimitive = forwardRef<
       components,
       componentsByLanguage,
       preprocess,
+      defer = false,
 
       // plugin configuration
       plugins: userPlugins,
@@ -115,9 +121,12 @@ export const StreamdownTextPrimitive = forwardRef<
   ) => {
     const { text, status } = useMessagePartText();
 
+    const deferredText = useDeferredValue(text);
+    const resolvedText = defer ? deferredText : text;
+
     const processedText = useMemo(
-      () => (preprocess ? preprocess(text) : text),
-      [text, preprocess],
+      () => (preprocess ? preprocess(resolvedText) : resolvedText),
+      [resolvedText, preprocess],
     );
 
     const resolvedPlugins = useMemo(() => {

--- a/packages/react-streamdown/src/types.ts
+++ b/packages/react-streamdown/src/types.ts
@@ -275,6 +275,16 @@ export type StreamdownTextPrimitiveProps = Omit<
   preprocess?: ((text: string) => string) | undefined;
 
   /**
+   * Defers markdown parsing and rendering to a lower priority via React's
+   * `useDeferredValue`, so urgent work (typing, scrolling) is not blocked by
+   * re-parsing the growing message on every streamed token. Intermediate
+   * streaming states may be skipped under load; the final text always renders.
+   *
+   * @default false
+   */
+  defer?: boolean | undefined;
+
+  /**
    * Container element props.
    */
   containerProps?:

--- a/packages/ui/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/ui/src/components/assistant-ui/markdown-text.tsx
@@ -22,6 +22,7 @@ const MarkdownTextImpl = () => {
       remarkPlugins={[remarkGfm]}
       className="aui-md"
       components={defaultComponents}
+      defer
     />
   );
 };

--- a/templates/minimal/components/assistant-ui/markdown-text.tsx
+++ b/templates/minimal/components/assistant-ui/markdown-text.tsx
@@ -21,6 +21,7 @@ const MarkdownTextImpl = () => {
       remarkPlugins={[remarkGfm]}
       className="aui-md"
       components={defaultComponents}
+      defer
     />
   );
 };


### PR DESCRIPTION
## what

adds an opt-in `defer` prop to `StreamdownTextPrimitive` (react-streamdown) and `MarkdownTextPrimitive` (react-markdown). when enabled, the streamed text is routed through `useDeferredValue` before it reaches the markdown pipeline, so re-parsing the growing message runs at a lower priority and urgent work (typing, scrolling) is not blocked by it. the shadcn kit's `markdown-text.tsx` (and the minimal template's diverged copy) turn it on.

## why

re-parsing the whole growing message on every streamed token is the dominant main-thread cost on long streaming messages. hermes-agent's desktop app hit this on large sessions and built exactly this wrapper in userland on the public API (`useMessagePartText` + `useDeferredValue` + `TextMessagePartProvider`); their profiling A/B on a 34MB session showed avgFps 54.3 to 58.5 and p99 frame 41ms to 31ms, with type-while-streaming latency unchanged. `useDeferredValue` does not reduce the parse cost, it stops the parse from blocking urgent updates; under load React may skip intermediate streaming states and commit only the latest text, which is the desired behavior.

upstreaming it as a one-prop opt-in removes the need for that wrapper and gives the same lever to every consumer of both markdown primitives.

## notes

- default off on both primitives, so no behavior change for existing consumers; the ui kit opts in
- in react-markdown the deferral applies after `useSmooth`, so `smooth` and `defer` compose: smooth controls the reveal rate, defer controls the parse priority
- `data-status` and streamdown's `isAnimating` stay bound to the live status; only the text value is deferred
- react-markdown has no DOM test harness (node environment), so the render-level test lives in react-streamdown, which exercises the same pattern

## testing

- `pnpm vitest run` in react-streamdown (94 passing, includes a new defer test: settles on the latest text across streaming rerenders and completion) and react-markdown (3 passing)
- `pnpm lint`, `pnpm turbo build --filter=@assistant-ui/react-streamdown --filter=@assistant-ui/react-markdown --filter=@assistant-ui/ui` (15 tasks green)
- `pnpm sync-templates` clean (minimal's markdown-text is an intentional OVERRIDES divergence and was updated by hand)
