### PR TITLE
feat(ui): skip shiki tokenization while the message part streams

### DIFF
--- a/apps/docs/content/docs/ui/syntax-highlighting.mdx
+++ b/apps/docs/content/docs/ui/syntax-highlighting.mdx
@@ -29,7 +29,7 @@ import { SyntaxHighlightingSample } from "@/components/docs/samples/syntax-highl
 
 This adds a `/components/assistant-ui/shiki-highlighter.tsx` file to your project and
 installs the `react-shiki` dependency. The highlighter can be customized by editing
-the config in the `shiki-highlighter.tsx` file.
+the config in the `shiki-highlighter.tsx` file. While a message part is still streaming, the component renders the plain code without tokenization and highlights once the part settles, so streaming stays cheap.
 
   </Step>
   <Step>

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -351,7 +351,11 @@ export const registry: RegistryItem[] = [
           "../../packages/ui/src/components/assistant-ui/shiki-highlighter.tsx",
       },
     ],
-    dependencies: ["react-shiki"],
+    dependencies: [
+      "react-shiki",
+      "@assistant-ui/react",
+      "@assistant-ui/react-markdown",
+    ],
   },
   {
     name: "mermaid-diagram",

--- a/packages/ui/src/components/assistant-ui/shiki-highlighter.tsx
+++ b/packages/ui/src/components/assistant-ui/shiki-highlighter.tsx
@@ -33,8 +33,8 @@ const HighlightedCode: FC<{
   options: Omit<ShikiHighlighterProps, "children" | "language" | "theme">;
 }> = ({ code, language, theme, options }) => {
   const highlighted = useShikiHighlighter(code, language, theme, {
-    defaultColor: "light-dark()",
     ...options,
+    defaultColor: "light-dark()",
   });
   return <>{highlighted ?? <PlainCode code={code} />}</>;
 };

--- a/packages/ui/src/components/assistant-ui/shiki-highlighter.tsx
+++ b/packages/ui/src/components/assistant-ui/shiki-highlighter.tsx
@@ -60,6 +60,7 @@ export const SyntaxHighlighter: FC<HighlighterProps> = ({
   theme = { dark: "github-dark-default", light: "github-light-default" },
   className,
   style,
+  // Inert: useShikiHighlighter output has no default styles or language label.
   addDefaultStyles: _addDefaultStyles,
   showLanguage: _showLanguage,
   delay = 150, // the part settles before smooth streaming finishes draining, so code keeps changing for a few frames

--- a/packages/ui/src/components/assistant-ui/shiki-highlighter.tsx
+++ b/packages/ui/src/components/assistant-ui/shiki-highlighter.tsx
@@ -2,7 +2,7 @@
 
 import type { FC } from "react";
 import { useShikiHighlighter, type ShikiHighlighterProps } from "react-shiki";
-import { useAuiState } from "@assistant-ui/react";
+import { useAui, useAuiState } from "@assistant-ui/react";
 import type { SyntaxHighlighterProps as AUIProps } from "@assistant-ui/react-markdown";
 import { cn } from "@/lib/utils";
 
@@ -67,7 +67,11 @@ export const SyntaxHighlighter: FC<HighlighterProps> = ({
   components: _components,
   ...options
 }) => {
-  const isStreaming = useAuiState((s) => s.part.status.type === "running");
+  const aui = useAui();
+  const hasPart = aui.part.source !== null;
+  const isStreaming = useAuiState(
+    (s) => hasPart && s.part.status.type === "running",
+  );
   const trimmed = code.trim();
 
   return (
@@ -86,7 +90,7 @@ export const SyntaxHighlighter: FC<HighlighterProps> = ({
           code={trimmed}
           language={language}
           theme={theme}
-          options={{ delay, ...options }}
+          options={{ ...options, delay }}
         />
       )}
     </div>

--- a/packages/ui/src/components/assistant-ui/shiki-highlighter.tsx
+++ b/packages/ui/src/components/assistant-ui/shiki-highlighter.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import type { FC } from "react";
-import ShikiHighlighter, { type ShikiHighlighterProps } from "react-shiki";
+import { useShikiHighlighter, type ShikiHighlighterProps } from "react-shiki";
+import { useAuiState } from "@assistant-ui/react";
 import type { SyntaxHighlighterProps as AUIProps } from "@assistant-ui/react-markdown";
 import { cn } from "@/lib/utils";
 
@@ -16,9 +17,35 @@ export type HighlighterProps = Omit<
 } & Pick<AUIProps, "language" | "code"> &
   Partial<Pick<AUIProps, "node" | "components">>;
 
+const containerClassName =
+  "aui-shiki-base [&_pre]:border-border/50 [&_pre]:bg-muted/30! [&_.line]:px-0! [&_pre]:overflow-x-auto [&_pre]:rounded-t-none [&_pre]:rounded-b-xl [&_pre]:border [&_pre]:border-t-0 [&_pre]:p-3.5 [&_pre]:text-[13px] [&_pre]:leading-relaxed";
+
+const PlainCode: FC<{ code: string }> = ({ code }) => (
+  <pre>
+    <code>{code}</code>
+  </pre>
+);
+
+const HighlightedCode: FC<{
+  code: string;
+  language: HighlighterProps["language"];
+  theme: NonNullable<HighlighterProps["theme"]>;
+  options: Omit<ShikiHighlighterProps, "children" | "language" | "theme">;
+}> = ({ code, language, theme, options }) => {
+  const highlighted = useShikiHighlighter(code, language, theme, {
+    defaultColor: "light-dark()",
+    ...options,
+  });
+  return <>{highlighted ?? <PlainCode code={code} />}</>;
+};
+
 /**
  * SyntaxHighlighter component, using react-shiki
  * Use it by passing to `defaultComponents` in `markdown-text.tsx`
+ *
+ * Skips tokenization while the message part is streaming and renders the
+ * plain code in the same container, so streaming costs no Shiki work and
+ * settling is a color change rather than a layout shift.
  *
  * @example
  * const defaultComponents = memoizeMarkdownComponents({
@@ -32,27 +59,37 @@ export const SyntaxHighlighter: FC<HighlighterProps> = ({
   language,
   theme = { dark: "github-dark-default", light: "github-light-default" },
   className,
-  addDefaultStyles = false, // assistant-ui requires custom base styles
-  showLanguage = false, // assistant-ui/react-markdown handles language labels
+  style,
+  addDefaultStyles: _addDefaultStyles,
+  showLanguage: _showLanguage,
+  delay = 150, // the part settles before smooth streaming finishes draining, so code keeps changing for a few frames
   node: _node,
   components: _components,
-  ...props
+  ...options
 }) => {
+  const isStreaming = useAuiState((s) => s.part.status.type === "running");
+  const trimmed = code.trim();
+
   return (
-    <ShikiHighlighter
-      {...props}
-      language={language}
-      theme={theme}
-      addDefaultStyles={addDefaultStyles}
-      showLanguage={showLanguage}
-      defaultColor="light-dark()"
+    <div
       className={cn(
-        "aui-shiki-base [&_pre]:border-border/50 [&_pre]:bg-muted/30! [&_.line]:px-0! [&_pre]:overflow-x-auto [&_pre]:rounded-t-none [&_pre]:rounded-b-xl [&_pre]:border [&_pre]:border-t-0 [&_pre]:p-3.5 [&_pre]:text-[13px] [&_pre]:leading-relaxed",
+        containerClassName,
+        isStreaming && "aui-shiki-streaming",
         className,
       )}
+      style={style}
     >
-      {code.trim()}
-    </ShikiHighlighter>
+      {isStreaming ? (
+        <PlainCode code={trimmed} />
+      ) : (
+        <HighlightedCode
+          code={trimmed}
+          language={language}
+          theme={theme}
+          options={{ delay, ...options }}
+        />
+      )}
+    </div>
   );
 };
 


### PR DESCRIPTION
## what

the kit's `SyntaxHighlighter` now skips Shiki tokenization while the message part is streaming: it renders the plain code inside the same styled container, then mounts highlighting once the part settles. the settled path goes through react-shiki's `useShikiHighlighter` hook with `highlighted ?? plain` so there is no blank flash on first tokenization (the `<ShikiHighlighter>` component renders null until the first async result), and `delay` defaults to 150ms because the part status flips to complete before `useSmooth` finishes draining, so the code text keeps changing for a few frames after settle.

## why

tokenizing on every streamed token is pure waste: the result is thrown away on the next token, and on tool-heavy or code-heavy messages it is one of the dominant streaming costs. hermes-agent's desktop app ships exactly this pattern (plain code while streaming, `delay={120}` highlight throttle) on top of the copied kit component; upstreaming it makes the registry default fast.

the streaming state comes from the store (`useAuiState((s) => s.part.status.type === "running")`), the same selector precedent as `mermaid-diagram.tsx`, so it works on both the react-markdown and react-streamdown call paths and on both the tap and legacy runtime providers of the part scope.

## notes

- the shared container classes style the plain `<pre>` identically to shiki's generated one, so settling is a color change, not a layout shift; an `aui-shiki-streaming` class is present during streaming for consumers who want to style the pending state
- `addDefaultStyles`/`showLanguage` props are accepted but inert now (hook output never has default styles or a language label; the kit always disabled both)
- registry entry dependencies corrected to `["react-shiki", "@assistant-ui/react", "@assistant-ui/react-markdown"]` (the react-markdown type import was already there, undeclared)
- packages/ui and apps/registry are private, so no changeset

## testing

`pnpm lint`, `pnpm turbo build --filter=@assistant-ui/ui --filter=@assistant-ui/shadcn-registry`, `pnpm sync-templates` (no template carries this file; minimal omits it via OVERRIDES)
