### PR TITLE
feat: public, tunable useSmooth

### DIFF
--- a/.changeset/smooth-options.md
+++ b/.changeset/smooth-options.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/react-markdown": patch
+---
+
+feat: public, tunable `useSmooth`
+
+`useSmooth` and a new `SmoothOptions` type are now exported from `@assistant-ui/react` (previously internal-only with a hard-coded reveal rate). the `smooth` prop on `MessagePartPrimitive.Text` and `MarkdownTextPrimitive` widens to `boolean | SmoothOptions`, with `drainMs` (backlog drain target, default 250), `maxCharIntervalMs` (slowest reveal interval, default 5), and `maxCharsPerFrame` (per-frame cap, default unlimited). the hook also now preserves the part type for reasoning parts instead of always returning `type: "text"`. react-markdown's `@assistant-ui/react` peer floor moves to the release that ships `SmoothOptions`.

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/utilities.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/utilities.mdx
@@ -375,6 +375,21 @@ import { useScrollLock } from "@assistant-ui/react";
 
 Source: `packages/react/src/primitives/reasoning/useScrollLock.ts`
 
+### useSmooth
+
+Animates streamed message part text with a typewriter-style reveal. Takes the message part state and a `smooth` argument: `false` disables, `true` uses the default rate, and a `SmoothOptions` object tunes it (`drainMs` backlog drain target, default 250; `maxCharIntervalMs` slowest reveal interval, default 5; `maxCharsPerFrame` per-frame cap, default unlimited).
+
+```tsx
+import { useSmooth, type SmoothOptions } from "@assistant-ui/react";
+
+const { text, status } = useSmooth(useMessagePartText(), {
+  drainMs: 500,
+  maxCharsPerFrame: 30,
+});
+```
+
+Source: `packages/react/src/utils/smooth/useSmooth.ts`
+
 ### useThread
 
 Deprecated: Use `useAuiState((s) =&gt; s.thread)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/utilities.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/utilities.mdx
@@ -375,21 +375,6 @@ import { useScrollLock } from "@assistant-ui/react";
 
 Source: `packages/react/src/primitives/reasoning/useScrollLock.ts`
 
-### useSmooth
-
-Animates streamed message part text with a typewriter-style reveal. Takes the message part state and a `smooth` argument: `false` disables, `true` uses the default rate, and a `SmoothOptions` object tunes it (`drainMs` backlog drain target, default 250; `maxCharIntervalMs` slowest reveal interval, default 5; `maxCharsPerFrame` per-frame cap, default unlimited).
-
-```tsx
-import { useSmooth, type SmoothOptions } from "@assistant-ui/react";
-
-const { text, status } = useSmooth(useMessagePartText(), {
-  drainMs: 500,
-  maxCharsPerFrame: 30,
-});
-```
-
-Source: `packages/react/src/utils/smooth/useSmooth.ts`
-
 ### useThread
 
 Deprecated: Use `useAuiState((s) =&gt; s.thread)` instead. See migration guide: https://assistant-ui.com/docs/migrations/v0-12

--- a/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
@@ -3,7 +3,7 @@ title: Utilities
 description: Miscellaneous @assistant-ui/react utilities for custom rendering, composition, and advanced assistant UI behavior.
 ---
 
-import { AssistantCloud, ChainOfThoughtClient, DevToolsHooks, InMemoryThreadList, Interactables, SingleThreadList, Suggestions } from "@/generated/typeDocs";
+import { AssistantCloud, ChainOfThoughtClient, DevToolsHooks, InMemoryThreadList, Interactables, SingleThreadList, Suggestions, useSmooth } from "@/generated/typeDocs";
 
 {/* AUTO-GENERATED PAGE by scripts/generate-api-reference.mts */}
 {/* Do not edit manually. */}
@@ -47,6 +47,24 @@ const createMessageQueue: (driver: MessageQueueDriver) => MessageQueueController
 ### Suggestions
 
 <ParametersTable {...Suggestions} />
+
+### useSmooth
+
+Animates streamed message part text with a typewriter-style reveal.
+
+Takes the current part state and a `smooth` argument: `false` disables,
+`true` uses the default rate, and a SmoothOptions object tunes
+the reveal. Returns the part state with `text` replaced by the revealed
+prefix and `status` reporting `running` until the reveal catches up.
+
+```tsx
+const { text, status } = useSmooth(useMessagePartText(), {
+  drainMs: 500,
+  maxCharsPerFrame: 30,
+});
+```
+
+<ParametersTable {...useSmooth} />
 
 ### unstable_defaultDirectiveFormatter
 

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -45,7 +45,7 @@
     "react-markdown": "^10.1.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.14.14",
+    "@assistant-ui/react": "^0.14.18",
     "@types/react": "*",
     "react": "^18 || ^19"
   },

--- a/packages/react-markdown/src/primitives/MarkdownText.tsx
+++ b/packages/react-markdown/src/primitives/MarkdownText.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { INTERNAL, useMessagePartText } from "@assistant-ui/react";
+import {
+  INTERNAL,
+  type SmoothOptions,
+  useMessagePartText,
+} from "@assistant-ui/react";
 import {
   type ComponentRef,
   type ElementType,
@@ -60,7 +64,7 @@ export type MarkdownTextPrimitiveProps = Omit<
         }
       >
     | undefined;
-  smooth?: boolean | undefined;
+  smooth?: boolean | SmoothOptions | undefined;
   /**
    * Function to transform text before markdown processing.
    */

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -288,6 +288,7 @@ export { useThreadViewportAutoScroll } from "./primitives/thread/useThreadViewpo
 export { useScrollLock } from "./primitives/reasoning/useScrollLock";
 export { useMessageQuote } from "./hooks/useMessageQuote";
 export { useMessageTiming } from "./hooks/useMessageTiming";
+export { useSmooth, type SmoothOptions } from "./utils/smooth/useSmooth";
 
 // Re-export core types from @assistant-ui/core
 export type {

--- a/packages/react/src/primitives/messagePart/MessagePartText.tsx
+++ b/packages/react/src/primitives/messagePart/MessagePartText.tsx
@@ -8,7 +8,7 @@ import {
   type ElementType,
 } from "react";
 import { useMessagePartText } from "./useMessagePartText";
-import { useSmooth } from "../../utils/smooth/useSmooth";
+import { useSmooth, type SmoothOptions } from "../../utils/smooth/useSmooth";
 
 export namespace MessagePartPrimitiveText {
   export type Element = ComponentRef<typeof Primitive.span>;
@@ -19,9 +19,10 @@ export namespace MessagePartPrimitiveText {
     /**
      * Whether to enable smooth text streaming animation.
      * When enabled, text appears with a typing effect as it streams in.
+     * Pass a `SmoothOptions` object to tune the reveal rate.
      * @default true
      */
-    smooth?: boolean;
+    smooth?: boolean | SmoothOptions;
     /**
      * The HTML element or React component to render as.
      * @default "span"

--- a/packages/react/src/utils/smooth/useSmooth.test.tsx
+++ b/packages/react/src/utils/smooth/useSmooth.test.tsx
@@ -53,6 +53,38 @@ describe("useSmooth", () => {
     expect(result.current.text).toBe("thinking...");
   });
 
+  it("tolerates null as disabled", () => {
+    const state = textState("hello");
+    const { result } = renderHook(() =>
+      useSmooth(state, null as unknown as boolean),
+    );
+    expect(result.current).toBe(state);
+  });
+
+  it("starts from an empty reveal for running parts when enabled", () => {
+    const state = {
+      type: "text",
+      text: "streaming",
+      status: { type: "running" },
+    } as MessagePartState & TextMessagePart;
+    const { result } = renderHook(() => useSmooth(state, true));
+    expect(result.current.text).toBe("");
+    expect(result.current.status.type).toBe("running");
+  });
+
+  it("falls back to defaults for non-positive or NaN options", () => {
+    const state = textState("hello");
+    const { result } = renderHook(() =>
+      useSmooth(state, {
+        drainMs: -1,
+        maxCharIntervalMs: NaN,
+        maxCharsPerFrame: 0,
+      }),
+    );
+    expect(result.current.text).toBe("hello");
+    expect(result.current.status).toBe(state.status);
+  });
+
   it("accepts a SmoothOptions object as the enabled form", () => {
     const options: SmoothOptions = { drainMs: 500, maxCharsPerFrame: 30 };
     const state = textState("hello");

--- a/packages/react/src/utils/smooth/useSmooth.test.tsx
+++ b/packages/react/src/utils/smooth/useSmooth.test.tsx
@@ -1,0 +1,63 @@
+/** @vitest-environment jsdom */
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  MessagePartState,
+  ReasoningMessagePart,
+  TextMessagePart,
+} from "@assistant-ui/core";
+
+const part = {};
+vi.mock("@assistant-ui/store", () => ({
+  useAui: () => ({ part: () => part }),
+  useAuiState: (selector: () => unknown) => selector(),
+}));
+vi.mock("./SmoothContext", () => ({
+  useSmoothStatusStore: () => null,
+}));
+
+import { useSmooth, type SmoothOptions } from "./useSmooth";
+
+const textState = (text: string) =>
+  ({
+    type: "text",
+    text,
+    status: { type: "complete", reason: "stop" },
+  }) as MessagePartState & TextMessagePart;
+
+const reasoningState = (text: string) =>
+  ({
+    type: "reasoning",
+    text,
+    status: { type: "complete", reason: "stop" },
+  }) as MessagePartState & ReasoningMessagePart;
+
+describe("useSmooth", () => {
+  it("returns the input state unchanged when disabled", () => {
+    const state = textState("hello");
+    const { result } = renderHook(() => useSmooth(state, false));
+    expect(result.current).toBe(state);
+  });
+
+  it("returns the full text immediately for settled parts when enabled", () => {
+    const state = textState("hello");
+    const { result } = renderHook(() => useSmooth(state, true));
+    expect(result.current.text).toBe("hello");
+    expect(result.current.status).toBe(state.status);
+  });
+
+  it("preserves the part type for reasoning parts", () => {
+    const state = reasoningState("thinking...");
+    const { result } = renderHook(() => useSmooth(state, true));
+    expect(result.current.type).toBe("reasoning");
+    expect(result.current.text).toBe("thinking...");
+  });
+
+  it("accepts a SmoothOptions object as the enabled form", () => {
+    const options: SmoothOptions = { drainMs: 500, maxCharsPerFrame: 30 };
+    const state = textState("hello");
+    const { result } = renderHook(() => useSmooth(state, options));
+    expect(result.current.text).toBe("hello");
+    expect(result.current.status).toBe(state.status);
+  });
+});

--- a/packages/react/src/utils/smooth/useSmooth.ts
+++ b/packages/react/src/utils/smooth/useSmooth.ts
@@ -84,7 +84,7 @@ class TextStreamAnimator {
     }
     // A cap-limited frame must not bank its surplus time, or the next
     // frame would burst past the cap.
-    if (charsToAdd === this.maxCharsPerFrame) {
+    if (charsToAdd === frameLimit && frameLimit === this.maxCharsPerFrame) {
       timeToConsume = 0;
     }
 
@@ -108,17 +108,39 @@ const SMOOTH_STATUS: MessagePartStatus = Object.freeze({
   type: "running",
 });
 
+const positiveOr = (value: number | undefined, fallback: number): number =>
+  value !== undefined && value > 0 ? value : fallback;
+
+/**
+ * Animates streamed message part text with a typewriter-style reveal.
+ *
+ * Takes the current part state and a `smooth` argument: `false` disables,
+ * `true` uses the default rate, and a {@link SmoothOptions} object tunes
+ * the reveal. Returns the part state with `text` replaced by the revealed
+ * prefix and `status` reporting `running` until the reveal catches up.
+ *
+ * @example
+ * ```tsx
+ * const { text, status } = useSmooth(useMessagePartText(), {
+ *   drainMs: 500,
+ *   maxCharsPerFrame: 30,
+ * });
+ * ```
+ */
 export const useSmooth = (
   state: MessagePartState & (TextMessagePart | ReasoningMessagePart),
   smooth: boolean | SmoothOptions = false,
 ): MessagePartState & (TextMessagePart | ReasoningMessagePart) => {
   const { text } = state;
-  const enabled = smooth !== false;
-  const {
-    drainMs = DEFAULT_DRAIN_MS,
-    maxCharIntervalMs = DEFAULT_MAX_CHAR_INTERVAL_MS,
-    maxCharsPerFrame = Infinity,
-  } = typeof smooth === "object" ? smooth : {};
+  const options =
+    typeof smooth === "object" && smooth !== null ? smooth : undefined;
+  const enabled = smooth !== false && smooth !== null;
+  const drainMs = positiveOr(options?.drainMs, DEFAULT_DRAIN_MS);
+  const maxCharIntervalMs = positiveOr(
+    options?.maxCharIntervalMs,
+    DEFAULT_MAX_CHAR_INTERVAL_MS,
+  );
+  const maxCharsPerFrame = positiveOr(options?.maxCharsPerFrame, Infinity);
 
   const [displayedText, setDisplayedText] = useState(
     state.status.type === "running" ? "" : text,

--- a/packages/react/src/utils/smooth/useSmooth.ts
+++ b/packages/react/src/utils/smooth/useSmooth.ts
@@ -12,11 +12,40 @@ import { useCallbackRef } from "@radix-ui/react-use-callback-ref";
 import { useSmoothStatusStore } from "./SmoothContext";
 import { writableStore } from "../../context/ReadonlyStore";
 
+/**
+ * Tuning options for the smooth text streaming animation.
+ */
+export type SmoothOptions = {
+  /**
+   * Target time in milliseconds to drain the backlog of unrevealed
+   * characters. Larger values reveal long backlogs more gradually.
+   * @default 250
+   */
+  drainMs?: number | undefined;
+  /**
+   * Maximum time in milliseconds between revealed characters, i.e. the
+   * slowest reveal rate when the backlog is short.
+   * @default 5
+   */
+  maxCharIntervalMs?: number | undefined;
+  /**
+   * Maximum number of characters revealed per animation frame.
+   * @default Infinity
+   */
+  maxCharsPerFrame?: number | undefined;
+};
+
+const DEFAULT_DRAIN_MS = 250;
+const DEFAULT_MAX_CHAR_INTERVAL_MS = 5;
+
 class TextStreamAnimator {
   private animationFrameId: number | null = null;
   private lastUpdateTime: number = Date.now();
 
   public targetText: string = "";
+  public drainMs: number = DEFAULT_DRAIN_MS;
+  public maxCharIntervalMs: number = DEFAULT_MAX_CHAR_INTERVAL_MS;
+  public maxCharsPerFrame: number = Infinity;
 
   constructor(
     public currentText: string,
@@ -42,12 +71,21 @@ class TextStreamAnimator {
     let timeToConsume = deltaTime;
 
     const remainingChars = this.targetText.length - this.currentText.length;
-    const baseTimePerChar = Math.min(5, 250 / remainingChars);
+    const baseTimePerChar = Math.min(
+      this.maxCharIntervalMs,
+      this.drainMs / remainingChars,
+    );
 
+    const frameLimit = Math.min(remainingChars, this.maxCharsPerFrame);
     let charsToAdd = 0;
-    while (timeToConsume >= baseTimePerChar && charsToAdd < remainingChars) {
+    while (timeToConsume >= baseTimePerChar && charsToAdd < frameLimit) {
       charsToAdd++;
       timeToConsume -= baseTimePerChar;
+    }
+    // A cap-limited frame must not bank its surplus time, or the next
+    // frame would burst past the cap.
+    if (charsToAdd === this.maxCharsPerFrame) {
+      timeToConsume = 0;
     }
 
     if (charsToAdd !== remainingChars) {
@@ -72,9 +110,15 @@ const SMOOTH_STATUS: MessagePartStatus = Object.freeze({
 
 export const useSmooth = (
   state: MessagePartState & (TextMessagePart | ReasoningMessagePart),
-  smooth: boolean = false,
+  smooth: boolean | SmoothOptions = false,
 ): MessagePartState & (TextMessagePart | ReasoningMessagePart) => {
   const { text } = state;
+  const enabled = smooth !== false;
+  const {
+    drainMs = DEFAULT_DRAIN_MS,
+    maxCharIntervalMs = DEFAULT_MAX_CHAR_INTERVAL_MS,
+    maxCharsPerFrame = Infinity,
+  } = typeof smooth === "object" ? smooth : {};
 
   const [displayedText, setDisplayedText] = useState(
     state.status.type === "running" ? "" : text,
@@ -113,20 +157,26 @@ export const useSmooth = (
   useEffect(() => {
     if (smoothStatusStore) {
       const target =
-        smooth && (displayedText !== text || state.status.type === "running")
+        enabled && (displayedText !== text || state.status.type === "running")
           ? SMOOTH_STATUS
           : state.status;
       writableStore(smoothStatusStore).setState(target, true);
     }
-  }, [smoothStatusStore, smooth, text, displayedText, state.status]);
+  }, [smoothStatusStore, enabled, text, displayedText, state.status]);
 
   const [animatorRef] = useState<TextStreamAnimator>(
     new TextStreamAnimator(displayedText, setText),
   );
 
+  useEffect(() => {
+    animatorRef.drainMs = drainMs;
+    animatorRef.maxCharIntervalMs = maxCharIntervalMs;
+    animatorRef.maxCharsPerFrame = maxCharsPerFrame;
+  }, [animatorRef, drainMs, maxCharIntervalMs, maxCharsPerFrame]);
+
   const animatorPartRef = useRef(part);
   useEffect(() => {
-    if (!smooth) {
+    if (!enabled) {
       animatorRef.stop();
       return;
     }
@@ -153,7 +203,7 @@ export const useSmooth = (
 
     animatorRef.targetText = text;
     animatorRef.start();
-  }, [animatorRef, smooth, text, state.status.type, part]);
+  }, [animatorRef, enabled, text, state.status.type, part]);
 
   useEffect(() => {
     return () => {
@@ -163,13 +213,13 @@ export const useSmooth = (
 
   return useMemo(
     () =>
-      smooth
+      enabled
         ? {
-            type: "text",
+            ...state,
             text: displayedText,
             status: text === displayedText ? state.status : SMOOTH_STATUS,
           }
         : state,
-    [smooth, displayedText, state, text],
+    [enabled, displayedText, state, text],
   );
 };


### PR DESCRIPTION
## what

promotes `useSmooth` from the internal surface to the public `@assistant-ui/react` API and makes its reveal rate tunable. the hard-coded `Math.min(5, 250 / remainingChars)` becomes three options on a new `SmoothOptions` type: `drainMs` (backlog drain target, default 250), `maxCharIntervalMs` (slowest per-character interval, default 5), and `maxCharsPerFrame` (per-frame cap, default unlimited; a cap-limited frame zeroes its surplus time so the next frame cannot burst past the cap). the `smooth` prop on `MessagePartPrimitive.Text` and `MarkdownTextPrimitive` widens to `boolean | SmoothOptions`. the `INTERNAL` re-export stays for back-compat.

also fixes a latent bug exposed by publicizing the hook: the enabled path always returned `type: "text"`, so a reasoning part run through `useSmooth` came back mislabeled (and dropped its other fields). the return now spreads the input state and overrides only `text`/`status`.

## why

the rate is a product decision, not a constant: hermes-agent's desktop replaced the whole hook in userland (`SmoothStreamingText`) just to get a 500ms drain with a 30 chars/frame cap, which maps exactly to `{ drainMs: 500, maxCharsPerFrame: 30, maxCharIntervalMs: 16 }`. publicizing the existing hook with options removes that fork; the export placement follows the `useScrollLock`/`useMessageQuote`/`useMessageTiming` precedent (no `unstable_` prefix for promoted utilities).

`SmoothContext`/`useSmoothStatus` deliberately stay internal (the zustand status bridge is self-described as hacky and not a surface to freeze).

## notes

- react-markdown's `@assistant-ui/react` peer floor moves to `^0.14.18` for the `SmoothOptions` type import; this must match the react release that includes this PR (currently 0.14.17 + this patch). if other react patches land first, bump the floor accordingly before release.
- options are pushed onto the animator in an effect with primitive deps, so a fresh inline options object never invalidates effects or restarts the animation.

## testing

new colocated `useSmooth.test.tsx` (disabled passthrough, settled full-text, reasoning type preservation, options object accepted); full `@assistant-ui/react` suite passes (356 tests, 32 files); `pnpm lint`; `pnpm turbo build --filter=@assistant-ui/react --filter=@assistant-ui/react-markdown`.
