### PR TITLE
fix: stable identity for grouped message parts across reorders

### DIFF
--- a/.changeset/toolgroup-identity-keys.md
+++ b/.changeset/toolgroup-identity-keys.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: stable identity for grouped message parts across reorders
+
+tool groups (and chain-of-thought groups) in `MessagePrimitive.Parts` and group nodes in `MessagePrimitive.GroupedParts` are now keyed by the id of their first part (`toolCallId`) instead of their positional index, and tool parts inside a group are keyed by their own id. when a message's parts array re-orders between live streaming and the settled shape, group and part React identity now survives the re-slice, so collapse/open state no longer resets. groups whose first part has no id keep their structural key, and duplicate ids fall back to structural keys, so keys stay unique.

--- a/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
@@ -181,9 +181,14 @@ const renderNode = <TKey extends `group-${string}`>(
   render: (info: MessagePrimitiveGroupedParts.RenderInfo<TKey>) => ReactNode,
 ): ReactNode => {
   if (node.type === "part") {
-    // Key by absolute part index, not structural nodeKey — prevents zombie fiber subscriptions when parts reshape (#4051).
+    // Key by part identity when available, else absolute part index — never
+    // the structural nodeKey, which leaves zombie fiber subscriptions when
+    // parts reshape (#4051).
     return (
-      <MessagePartChildren key={`part-${node.index}`} index={node.index}>
+      <MessagePartChildren
+        key={node.idKey ? `part-${node.idKey}` : `part-${node.index}`}
+        index={node.index}
+      >
         {({ part }) => render({ part, children: <PartChildrenSentinel /> })}
       </MessagePartChildren>
     );
@@ -197,7 +202,7 @@ const renderNode = <TKey extends `group-${string}`>(
   };
 
   return (
-    <Fragment key={node.nodeKey}>
+    <Fragment key={node.idKey ?? node.nodeKey}>
       {render({
         part: groupPart,
         children: (
@@ -266,7 +271,12 @@ export const MessagePrimitiveGroupedParts = <TKey extends `group-${string}`>({
   const memoDep = memoKey ?? groupBy;
   const tree = useMemo(() => {
     const context: GroupByContext = { toolUIs };
-    return buildGroupTree(parts.map((part) => groupBy(part, context) ?? []));
+    return buildGroupTree(
+      parts.map((part) => groupBy(part, context) ?? []),
+      parts.map((part) =>
+        part.type === "tool-call" ? part.toolCallId : undefined,
+      ),
+    );
     // oxlint-disable-next-line react/exhaustive-deps -- groupBy is captured via memoDep (either its identity or the helper's memoKey fingerprint); listing it directly would defeat the helper-tagged memo path
   }, [parts, memoDep, toolUIs]);
 

--- a/packages/core/src/react/primitives/message/MessageParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageParts.tsx
@@ -44,9 +44,24 @@ import { useShallow } from "zustand/shallow";
 
 type MessagePartRange =
   | { type: "single"; index: number }
-  | { type: "toolGroup"; startIndex: number; endIndex: number }
-  | { type: "reasoningGroup"; startIndex: number; endIndex: number }
-  | { type: "chainOfThoughtGroup"; startIndex: number; endIndex: number };
+  | {
+      type: "toolGroup";
+      startIndex: number;
+      endIndex: number;
+      idKey?: string | undefined;
+    }
+  | {
+      type: "reasoningGroup";
+      startIndex: number;
+      endIndex: number;
+      idKey?: string | undefined;
+    }
+  | {
+      type: "chainOfThoughtGroup";
+      startIndex: number;
+      endIndex: number;
+      idKey?: string | undefined;
+    };
 
 /**
  * Creates a group state manager for a specific part type.
@@ -91,10 +106,13 @@ const createGroupState = <
  * Groups consecutive tool-call and reasoning message parts into ranges.
  * Always groups tool calls and reasoning parts, even if there's only one.
  * When useChainOfThought is true, groups tool-call and reasoning parts together.
+ * `partIds[i]` optionally carries a stable identity for part `i`; group
+ * ranges derive an `idKey` from their first part's id (first claim wins).
  */
-const groupMessageParts = (
+export const groupMessageParts = (
   messageTypes: readonly string[],
   useChainOfThought: boolean,
+  partIds?: readonly (string | undefined)[],
 ): MessagePartRange[] => {
   const ranges: MessagePartRange[] = [];
 
@@ -137,22 +155,44 @@ const groupMessageParts = (
     reasoningGroup.finalize(messageTypes.length - 1, ranges);
   }
 
+  if (partIds) {
+    const claimed = new Set<string>();
+    for (const range of ranges) {
+      if (range.type === "single") continue;
+      const id = partIds[range.startIndex];
+      if (id !== undefined && !claimed.has(id)) {
+        claimed.add(id);
+        range.idKey = `id:${id}`;
+      }
+    }
+  }
+
   return ranges;
 };
 
 const useMessagePartsGroups = (
   useChainOfThought: boolean,
-): MessagePartRange[] => {
+): { ranges: MessagePartRange[]; partIds: (string | undefined)[] } => {
   const messageTypes = useAuiState(
     useShallow((s) => s.message.parts.map((c: any) => c.type)),
+  );
+  const partIds = useAuiState(
+    useShallow((s) =>
+      s.message.parts.map((c: any) =>
+        c.type === "tool-call" ? c.toolCallId : undefined,
+      ),
+    ),
   );
 
   return useMemo(() => {
     if (messageTypes.length === 0) {
-      return [];
+      return { ranges: [], partIds };
     }
-    return groupMessageParts(messageTypes, useChainOfThought);
-  }, [messageTypes, useChainOfThought]);
+    return {
+      ranges: groupMessageParts(messageTypes, useChainOfThought, partIds),
+      partIds,
+    };
+  }, [messageTypes, partIds, useChainOfThought]);
 };
 
 export namespace MessagePrimitiveParts {
@@ -795,12 +835,23 @@ const MessagePrimitivePartsCompat: FC<{
 }> = ({ components, unstable_showEmptyOnNonTextEnd }) => {
   const contentLength = useAuiState((s) => s.message.parts.length);
   const useChainOfThought = !!components?.ChainOfThought;
-  const messageRanges = useMessagePartsGroups(useChainOfThought);
+  const { ranges: messageRanges, partIds } =
+    useMessagePartsGroups(useChainOfThought);
 
   const partsElements = useMemo(() => {
     if (contentLength === 0) {
       return <EmptyParts components={components} />;
     }
+
+    const claimed = new Set<string>();
+    const toolLeafKey = (partIndex: number) => {
+      const id = partIds[partIndex];
+      if (id !== undefined && !claimed.has(id)) {
+        claimed.add(id);
+        return `part-id:${id}`;
+      }
+      return `part-${partIndex}`;
+    };
 
     return messageRanges.map((range) => {
       if (range.type === "single") {
@@ -816,7 +867,7 @@ const MessagePrimitivePartsCompat: FC<{
         if (!ChainOfThoughtComponent) return null;
         return (
           <ChainOfThoughtByIndicesProvider
-            key={`chainOfThought-${range.startIndex}`}
+            key={`chainOfThought-${range.idKey ?? range.startIndex}`}
             startIndex={range.startIndex}
             endIndex={range.endIndex}
           >
@@ -828,7 +879,7 @@ const MessagePrimitivePartsCompat: FC<{
           components?.ToolGroup ?? defaultComponents.ToolGroup;
         return (
           <ToolGroupComponent
-            key={`tool-${range.startIndex}`}
+            key={`tool-${range.idKey ?? range.startIndex}`}
             startIndex={range.startIndex}
             endIndex={range.endIndex}
           >
@@ -838,7 +889,7 @@ const MessagePrimitivePartsCompat: FC<{
                 const partIndex = range.startIndex + i;
                 return (
                   <MessagePrimitivePartByIndex
-                    key={`part-${partIndex}`}
+                    key={toolLeafKey(partIndex)}
                     index={partIndex}
                     components={components}
                   />
@@ -874,7 +925,7 @@ const MessagePrimitivePartsCompat: FC<{
         );
       }
     });
-  }, [messageRanges, components, contentLength]);
+  }, [messageRanges, partIds, components, contentLength]);
 
   return (
     <>

--- a/packages/core/src/react/utils/groupParts.ts
+++ b/packages/core/src/react/utils/groupParts.ts
@@ -119,6 +119,11 @@ export interface GroupNodeGroup {
   readonly key: string;
   /** Structural React key: sibling-index path, e.g. `"0.1.0"`. */
   readonly nodeKey: string;
+  /**
+   * Identity key (`"id:<partId>"`) from the group's first part; undefined
+   * when absent or already claimed by an earlier sibling.
+   */
+  readonly idKey: string | undefined;
   /** Indices of parts in this subtree, in order. */
   readonly indices: readonly number[];
   readonly children: readonly GroupNode[];
@@ -130,6 +135,11 @@ export interface GroupNodePart {
   readonly index: number;
   /** Structural React key: sibling-index path within parent. */
   readonly nodeKey: string;
+  /**
+   * Identity key (`"id:<partId>"`); undefined when absent or already
+   * claimed by an earlier sibling.
+   */
+  readonly idKey: string | undefined;
 }
 
 interface BuildFrame {
@@ -138,6 +148,7 @@ interface BuildFrame {
   indices: number[];
   children: GroupNode[];
   nextChildIdx: number;
+  claimed: Set<string>;
 }
 
 const makeChildNodeKey = (parent: BuildFrame): string => {
@@ -145,13 +156,25 @@ const makeChildNodeKey = (parent: BuildFrame): string => {
   return parent.nodeKey === "" ? String(idx) : `${parent.nodeKey}.${idx}`;
 };
 
+const claimIdKey = (
+  frame: BuildFrame,
+  id: string | undefined,
+): string | undefined => {
+  if (id === undefined || frame.claimed.has(id)) return undefined;
+  frame.claimed.add(id);
+  return `id:${id}`;
+};
+
 /**
  * Build the group tree from an array of normalized group paths.
  * `paths[i]` is the path for part `i`. The output tree contains one
  * `part` node per part and one `group` node per coalesced run.
+ * `partIds[i]` optionally carries a stable identity for part `i` (e.g. a
+ * tool call id), from which nodes derive an `idKey`.
  */
 export const buildGroupTree = (
   paths: readonly (readonly string[])[],
+  partIds?: readonly (string | undefined)[],
 ): readonly GroupNode[] => {
   const root: BuildFrame = {
     key: "",
@@ -159,6 +182,7 @@ export const buildGroupTree = (
     indices: [],
     children: [],
     nextChildIdx: 0,
+    claimed: new Set(),
   };
   const stack: BuildFrame[] = [root];
 
@@ -169,6 +193,7 @@ export const buildGroupTree = (
       type: "group",
       key: closing.key,
       nodeKey: closing.nodeKey,
+      idKey: claimIdKey(parent, partIds?.[closing.indices[0]!]),
       indices: closing.indices,
       children: closing.children,
     });
@@ -202,6 +227,7 @@ export const buildGroupTree = (
         indices: [],
         children: [],
         nextChildIdx: 0,
+        claimed: new Set(),
       });
     }
 
@@ -211,6 +237,7 @@ export const buildGroupTree = (
       type: "part",
       index: i,
       nodeKey: makeChildNodeKey(top),
+      idKey: claimIdKey(top, partIds?.[i]),
     });
 
     // Record the part index in every open ancestor group.

--- a/packages/core/src/tests/groupMessageParts.test.ts
+++ b/packages/core/src/tests/groupMessageParts.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { groupMessageParts } from "../react/primitives/message/MessageParts";
+
+describe("groupMessageParts idKey", () => {
+  it("leaves idKey undefined when partIds is not provided", () => {
+    const ranges = groupMessageParts(["tool-call", "tool-call"], false);
+    expect(ranges).toEqual([{ type: "toolGroup", startIndex: 0, endIndex: 1 }]);
+  });
+
+  it("derives a tool group's idKey from its first part", () => {
+    const ranges = groupMessageParts(
+      ["text", "tool-call", "tool-call"],
+      false,
+      [undefined, "t1", "t2"],
+    );
+    expect(ranges).toEqual([
+      { type: "single", index: 0 },
+      { type: "toolGroup", startIndex: 1, endIndex: 2, idKey: "id:t1" },
+    ]);
+  });
+
+  it("keeps a group's idKey stable when the group shifts to a new index", () => {
+    const live = groupMessageParts(["text", "tool-call", "tool-call"], false, [
+      undefined,
+      "t1",
+      "t2",
+    ]);
+    const settled = groupMessageParts(
+      ["reasoning", "text", "tool-call", "tool-call"],
+      false,
+      [undefined, undefined, "t1", "t2"],
+    );
+    const liveGroup = live.find((r) => r.type === "toolGroup")!;
+    const settledGroup = settled.find((r) => r.type === "toolGroup")!;
+    expect(liveGroup.idKey).toBe("id:t1");
+    expect(settledGroup.idKey).toBe("id:t1");
+    expect(settledGroup).toMatchObject({ startIndex: 2, endIndex: 3 });
+  });
+
+  it("demotes a duplicate id in a later range to undefined", () => {
+    const ranges = groupMessageParts(
+      ["tool-call", "text", "tool-call"],
+      false,
+      ["t1", undefined, "t1"],
+    );
+    const groups = ranges.filter((r) => r.type === "toolGroup");
+    expect(groups.map((r) => r.idKey)).toEqual(["id:t1", undefined]);
+  });
+
+  it("does not assign an idKey to reasoning groups", () => {
+    const ranges = groupMessageParts(["reasoning", "reasoning"], false, [
+      undefined,
+      undefined,
+    ]);
+    expect(ranges).toEqual([
+      { type: "reasoningGroup", startIndex: 0, endIndex: 1 },
+    ]);
+  });
+
+  it("keeps a chain-of-thought group structural when it opens with reasoning", () => {
+    const ranges = groupMessageParts(["reasoning", "tool-call"], true, [
+      undefined,
+      "t1",
+    ]);
+    expect(ranges).toEqual([
+      { type: "chainOfThoughtGroup", startIndex: 0, endIndex: 1 },
+    ]);
+  });
+
+  it("derives a chain-of-thought group's idKey when it opens with a tool call", () => {
+    const ranges = groupMessageParts(["tool-call", "reasoning"], true, [
+      "t1",
+      undefined,
+    ]);
+    expect(ranges).toEqual([
+      {
+        type: "chainOfThoughtGroup",
+        startIndex: 0,
+        endIndex: 1,
+        idKey: "id:t1",
+      },
+    ]);
+  });
+});

--- a/packages/core/src/tests/groupParts.test.ts
+++ b/packages/core/src/tests/groupParts.test.ts
@@ -268,3 +268,58 @@ describe("groupPartByType", () => {
     expect(keyA).not.toBe(keyB);
   });
 });
+
+describe("buildGroupTree idKey", () => {
+  const ids = (values: readonly (string | undefined)[]) => values;
+
+  it("leaves idKey undefined when partIds is not provided", () => {
+    const tree = buildGroupTree(asPaths([["a"], ["a"]]));
+    const group = tree[0]!;
+    expect(group.idKey).toBeUndefined();
+    if (group.type === "group") {
+      expect(group.children.every((c) => c.idKey === undefined)).toBe(true);
+    }
+  });
+
+  it("derives group idKey from the first part of the group", () => {
+    const tree = buildGroupTree(asPaths([["a"], ["a"]]), ids(["t1", "t2"]));
+    const group = tree[0]!;
+    expect(group.idKey).toBe("id:t1");
+  });
+
+  it("keeps group idKey undefined when the first part has no id", () => {
+    const tree = buildGroupTree(
+      asPaths([["a"], ["a"]]),
+      ids([undefined, "t2"]),
+    );
+    expect(tree[0]!.idKey).toBeUndefined();
+  });
+
+  it("assigns leaf idKeys and lets a group and its first leaf share an id across levels", () => {
+    const tree = buildGroupTree(asPaths([["a"], ["a"]]), ids(["t1", "t2"]));
+    const group = tree[0]!;
+    if (group.type !== "group") throw new Error("expected group");
+    expect(group.idKey).toBe("id:t1");
+    expect(group.children.map((c) => c.idKey)).toEqual(["id:t1", "id:t2"]);
+  });
+
+  it("demotes duplicate ids among siblings to undefined", () => {
+    const tree = buildGroupTree(asPaths([[], [], []]), ids(["t1", "t1", "t2"]));
+    expect(tree.map((n) => n.idKey)).toEqual(["id:t1", undefined, "id:t2"]);
+  });
+
+  it("keeps a group's idKey stable when parts reorder across rebuilds", () => {
+    const live = buildGroupTree(
+      asPaths([[], ["a"], [], ["a"]]),
+      ids([undefined, "t1", undefined, "t2"]),
+    );
+    const settled = buildGroupTree(
+      asPaths([[], [], ["a"], ["a"]]),
+      ids([undefined, undefined, "t1", "t2"]),
+    );
+    const liveFirstGroup = live.find((n) => n.type === "group")!;
+    const settledGroup = settled.find((n) => n.type === "group")!;
+    expect(liveFirstGroup.idKey).toBe("id:t1");
+    expect(settledGroup.idKey).toBe("id:t1");
+  });
+});


### PR DESCRIPTION
## what

grouped message parts now derive React identity from their parts' ids instead of positional indices. `groupMessageParts` (the `components.ToolGroup`/`ChainOfThought` compat path in `MessagePrimitive.Parts`) and `buildGroupTree` (`MessagePrimitive.GroupedParts`) accept an optional `partIds` array; group ranges/nodes get an `idKey` derived from their **first part's** id (`"id:<toolCallId>"`), and tool leaves get their own. keying falls back to the existing positional/structural keys when no id exists.

## why

groups were sliced by adjacency and keyed positionally (`tool-${range.startIndex}`, `part-${partIndex}`, structural `nodeKey`s), so group identity had no stability guarantee across a parts-array re-slice. runtimes whose parts array re-orders between live streaming and the settled message (hermes-agent's desktop streams text/reasoning interleaved with tool calls, then settles to `[reasoning, text, ...tool calls]`) lose every Collapsible's open state at the transition; hermes documented this in their `ToolGroupSlot` and gave up on grouped rendering entirely, rendering tools flat.

first-part-id (rather than first-tool-id-in-subtree) is deliberate: a group that opens with reasoning keeps a structural key forever instead of remounting mid-stream the moment its first tool call arrives on the default append-only path.

## notes

- duplicate ids are demoted to structural keys via first-claim-wins, so duplicate React keys are impossible even with duplicate `toolCallId`s
- a group and its first leaf may share the same `id:` key; they live in different sibling lists, so React identity is unambiguous
- `idKey` is assigned during the existing single-pass builds (no post-pass mutation of constructed nodes); reasoning group keying is untouched (reasoning parts carry no ids)
- changeset bumps `@assistant-ui/core` only; react/react-native/react-ink re-export core's primitives unchanged, and `packages/ui` needs no change (ToolGroupRoot's uncontrolled open state is preserved purely by upstream key stability)

## testing

6 new `buildGroupTree` cases and a new `groupMessageParts` suite (7 cases) covering id derivation, the live-to-settled reorder keeping `idKey` stable across rebuilds, duplicate demotion, reasoning groups, and both chain-of-thought opening orders. full `@assistant-ui/core` suite passes (315 tests, 35 files); `pnpm lint`; `pnpm turbo build` for core, react, react-native, react-ink.
