### PR TITLE
feat: unstable_useComposerInputHistory

### DIFF
--- a/.changeset/composer-input-history.md
+++ b/.changeset/composer-input-history.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: `unstable_useComposerInputHistory`
+
+terminal-style input history for the thread composer: ArrowUp on an empty draft recalls previously sent user messages (newest first, derived live from thread state), ArrowDown steps back and finally restores the in-progress draft. spread the returned `{ onKeyDown }` bundle onto `ComposerPrimitive.Input`. yields to open trigger popovers, IME composition, modifiers, selections, and consumer handlers that already prevented the event; inert on edit composers.

--- a/apps/docs/content/docs/guides/input-history.mdx
+++ b/apps/docs/content/docs/guides/input-history.mdx
@@ -1,0 +1,55 @@
+---
+title: Input History
+description: Terminal-style ArrowUp/ArrowDown recall of previously sent messages in the assistant-ui React composer.
+platforms: ["react"]
+---
+
+Input history lets users press ArrowUp in an empty composer to recall previously sent messages, newest first, like a shell prompt. ArrowDown steps back toward the newest entry and finally restores the draft that was being typed when browsing started.
+
+<Callout type="warn">
+  This API is marked unstable and may change without notice.
+</Callout>
+
+## Usage
+
+Spread the hook's bundle onto `ComposerPrimitive.Input`:
+
+```tsx
+import {
+  ComposerPrimitive,
+  unstable_useComposerInputHistory,
+} from "@assistant-ui/react";
+
+const Composer = () => {
+  const history = unstable_useComposerInputHistory();
+
+  return (
+    <ComposerPrimitive.Root>
+      <ComposerPrimitive.Input {...history} />
+      <ComposerPrimitive.Send />
+    </ComposerPrimitive.Root>
+  );
+};
+```
+
+The history ring is derived live from the current thread's user messages (trimmed, with adjacent duplicates collapsed), so it needs no persistence or configuration.
+
+## Behavior
+
+- ArrowUp starts recall only when the composer is empty (whitespace-only drafts count as empty and are restored on the way back down).
+- While a recalled multi-line message is shown, arrows move the caret line by line; recall only steps when the caret is on the first line (ArrowUp) or last line (ArrowDown).
+- An open mention or slash-command popover keeps owning the arrow keys; the hook yields whenever a trigger popover is active.
+- IME composition, modifier keys, text selections, and events a preceding handler already `preventDefault`ed are left untouched.
+- Switching threads or sending a message resets the browse position.
+- The hook is inert on edit composers.
+
+To interleave your own ArrowUp handling ahead of history (for example, stepping through queued messages), compose your handler before the hook's and call `preventDefault` when you consume the key:
+
+```tsx
+<ComposerPrimitive.Input
+  onKeyDown={(e) => {
+    myHandler(e);
+    history.onKeyDown(e);
+  }}
+/>
+```

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -10,6 +10,7 @@
     "attachments",
     "mentions",
     "slash-commands",
+    "input-history",
     "quoting",
     "dictation",
     "---Messages---",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -421,6 +421,12 @@ export type {
 } from "@assistant-ui/core";
 export { unstable_defaultDirectiveFormatter } from "@assistant-ui/core";
 
+// Unstable - composer input history (terminal-style ArrowUp/ArrowDown recall)
+export {
+  unstable_useComposerInputHistory,
+  type Unstable_ComposerInputHistory,
+} from "./unstable/useComposerInputHistory";
+
 export type { Assistant } from "./augmentations";
 
 // --- mcp-apps ---

--- a/packages/react/src/unstable/useComposerInputHistory.test.tsx
+++ b/packages/react/src/unstable/useComposerInputHistory.test.tsx
@@ -1,0 +1,192 @@
+/** @vitest-environment jsdom */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fixture = {
+  messages: [] as { role: string; content: { type: string; text: string }[] }[],
+  composerType: "thread",
+  activeAria: null as object | null,
+  switchedToHandlers: [] as (() => void)[],
+};
+const setText = vi.fn();
+
+vi.mock("@assistant-ui/store", () => ({
+  useAui: () => ({
+    composer: () => ({
+      getState: () => ({ type: fixture.composerType }),
+      setText,
+    }),
+    thread: () => ({ getState: () => ({ messages: fixture.messages }) }),
+    on: (_event: string, cb: () => void) => {
+      fixture.switchedToHandlers.push(cb);
+      return () => {};
+    },
+  }),
+}));
+vi.mock("@assistant-ui/tap", () => ({
+  flushTapSync: (fn: () => void) => fn(),
+}));
+vi.mock("../primitives/composer/trigger/TriggerPopoverRootContext", () => ({
+  useTriggerPopoverRootContextOptional: () => ({
+    getActiveAria: () => fixture.activeAria,
+  }),
+}));
+
+vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+  cb(0);
+  return 0;
+});
+
+import { unstable_useComposerInputHistory } from "./useComposerInputHistory";
+
+const user = (text: string) => ({
+  role: "user",
+  content: [{ type: "text", text }],
+});
+const assistant = (text: string) => ({
+  role: "assistant",
+  content: [{ type: "text", text }],
+});
+
+function Harness() {
+  const history = unstable_useComposerInputHistory();
+  return <textarea data-testid="input" {...history} />;
+}
+
+const setup = (value = "") => {
+  const utils = render(<Harness />);
+  const textarea = screen.getByTestId("input") as HTMLTextAreaElement;
+  textarea.value = value;
+  textarea.setSelectionRange(value.length, value.length);
+  return { ...utils, textarea };
+};
+
+const arrow = (
+  textarea: HTMLTextAreaElement,
+  key: "ArrowUp" | "ArrowDown",
+  init: Record<string, unknown> = {},
+) => fireEvent.keyDown(textarea, { key, ...init });
+
+beforeEach(() => {
+  fixture.messages = [user("first"), assistant("reply"), user("second")];
+  fixture.composerType = "thread";
+  fixture.activeAria = null;
+  fixture.switchedToHandlers = [];
+  setText.mockClear();
+});
+
+describe("unstable_useComposerInputHistory", () => {
+  it("recalls the newest user message on ArrowUp in an empty composer", () => {
+    const { textarea } = setup("");
+    const notPrevented = arrow(textarea, "ArrowUp");
+    expect(notPrevented).toBe(false);
+    expect(setText).toHaveBeenCalledWith("second");
+  });
+
+  it("steps to older entries and consumes the key at the oldest", () => {
+    const { textarea } = setup("");
+    arrow(textarea, "ArrowUp");
+    textarea.value = "second";
+    arrow(textarea, "ArrowUp");
+    expect(setText).toHaveBeenLastCalledWith("first");
+
+    textarea.value = "first";
+    const notPrevented = arrow(textarea, "ArrowUp");
+    expect(notPrevented).toBe(false);
+    expect(setText).toHaveBeenCalledTimes(2);
+  });
+
+  it("restores the draft snapshot on ArrowDown past the newest", () => {
+    const { textarea } = setup("  ");
+    arrow(textarea, "ArrowUp");
+    textarea.value = "second";
+    arrow(textarea, "ArrowDown");
+    expect(setText).toHaveBeenLastCalledWith("  ");
+
+    textarea.value = "  ";
+    const notPrevented = arrow(textarea, "ArrowDown");
+    expect(notPrevented).toBe(true);
+    expect(setText).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores ArrowUp when the composer holds a typed draft", () => {
+    const { textarea } = setup("draft in progress");
+    const notPrevented = arrow(textarea, "ArrowUp");
+    expect(notPrevented).toBe(true);
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("keeps native arrows when the caret is not on the first line", () => {
+    const { textarea } = setup("");
+    arrow(textarea, "ArrowUp");
+    textarea.value = "line1\nline2";
+    fixture.messages = [user("line1\nline2"), user("other")];
+    textarea.setSelectionRange(8, 8);
+    expect(setText).toHaveBeenCalledTimes(1);
+  });
+
+  it("yields to an open trigger popover", () => {
+    fixture.activeAria = {};
+    const { textarea } = setup("");
+    const notPrevented = arrow(textarea, "ArrowUp");
+    expect(notPrevented).toBe(true);
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("ignores IME composition, modifiers, selections, and prevented events", () => {
+    const { textarea } = setup("");
+    fireEvent.keyDown(textarea, { key: "ArrowUp", isComposing: true });
+    arrow(textarea, "ArrowUp", { shiftKey: true });
+    arrow(textarea, "ArrowUp", { metaKey: true });
+    textarea.value = "ab";
+    textarea.setSelectionRange(0, 2);
+    arrow(textarea, "ArrowUp");
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("derives the ring from trimmed user texts, newest first, deduped", () => {
+    fixture.messages = [
+      user("first"),
+      user("first"),
+      assistant("noise"),
+      user("   "),
+      user("second"),
+    ];
+    const { textarea } = setup("");
+    arrow(textarea, "ArrowUp");
+    expect(setText).toHaveBeenLastCalledWith("second");
+    textarea.value = "second";
+    arrow(textarea, "ArrowUp");
+    expect(setText).toHaveBeenLastCalledWith("first");
+    textarea.value = "first";
+    arrow(textarea, "ArrowUp");
+    expect(setText).toHaveBeenCalledTimes(2);
+  });
+
+  it("starts a fresh browse after the composer was cleared externally", () => {
+    const { textarea } = setup("");
+    arrow(textarea, "ArrowUp");
+    fixture.messages = [...fixture.messages, user("third")];
+    textarea.value = "";
+    arrow(textarea, "ArrowUp");
+    expect(setText).toHaveBeenLastCalledWith("third");
+  });
+
+  it("is inert on edit composers", () => {
+    fixture.composerType = "edit";
+    const { textarea } = setup("");
+    const notPrevented = arrow(textarea, "ArrowUp");
+    expect(notPrevented).toBe(true);
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("resets browsing when the thread switches", () => {
+    const { textarea } = setup("");
+    arrow(textarea, "ArrowUp");
+    fixture.switchedToHandlers.forEach((cb) => cb());
+    textarea.value = "second";
+    const notPrevented = arrow(textarea, "ArrowDown");
+    expect(notPrevented).toBe(true);
+    expect(setText).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/unstable/useComposerInputHistory.test.tsx
+++ b/packages/react/src/unstable/useComposerInputHistory.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { fireEvent, render, screen } from "@testing-library/react";
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fixture = {
@@ -117,11 +117,14 @@ describe("unstable_useComposerInputHistory", () => {
   });
 
   it("keeps native arrows when the caret is not on the first line", () => {
+    fixture.messages = [user("other"), user("line1\nline2")];
     const { textarea } = setup("");
     arrow(textarea, "ArrowUp");
+    expect(setText).toHaveBeenLastCalledWith("line1\nline2");
     textarea.value = "line1\nline2";
-    fixture.messages = [user("line1\nline2"), user("other")];
     textarea.setSelectionRange(8, 8);
+    const notPrevented = arrow(textarea, "ArrowUp");
+    expect(notPrevented).toBe(true);
     expect(setText).toHaveBeenCalledTimes(1);
   });
 
@@ -141,6 +144,12 @@ describe("unstable_useComposerInputHistory", () => {
     textarea.value = "ab";
     textarea.setSelectionRange(0, 2);
     arrow(textarea, "ArrowUp");
+
+    textarea.value = "";
+    textarea.setSelectionRange(0, 0);
+    const prevented = createEvent.keyDown(textarea, { key: "ArrowUp" });
+    prevented.preventDefault();
+    fireEvent(textarea, prevented);
     expect(setText).not.toHaveBeenCalled();
   });
 

--- a/packages/react/src/unstable/useComposerInputHistory.ts
+++ b/packages/react/src/unstable/useComposerInputHistory.ts
@@ -1,0 +1,156 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type KeyboardEvent,
+  type KeyboardEventHandler,
+} from "react";
+import { useAui } from "@assistant-ui/store";
+import { flushTapSync } from "@assistant-ui/tap";
+import type { ThreadMessage } from "@assistant-ui/core";
+import { getThreadMessageText } from "@assistant-ui/core/internal";
+import { useTriggerPopoverRootContextOptional } from "../primitives/composer/trigger/TriggerPopoverRootContext";
+
+export type Unstable_ComposerInputHistory = {
+  /** Keydown handler to spread onto `ComposerPrimitive.Input`. */
+  onKeyDown: KeyboardEventHandler<HTMLTextAreaElement>;
+};
+
+type BrowseState = {
+  cursor: number;
+  draftSnapshot: string;
+  lastRecalledText: string;
+};
+
+const deriveHistory = (messages: readonly ThreadMessage[]): string[] => {
+  const entries: string[] = [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]!;
+    if (message.role !== "user") continue;
+    const text = getThreadMessageText(message).trim();
+    if (!text) continue;
+    if (entries[entries.length - 1] === text) continue;
+    entries.push(text);
+  }
+  return entries;
+};
+
+const isOnFirstLine = (value: string, caret: number): boolean =>
+  !value.slice(0, caret).includes("\n");
+
+const isOnLastLine = (value: string, caret: number): boolean =>
+  !value.slice(caret).includes("\n");
+
+/**
+ * @deprecated Under active development and might change without notice.
+ *
+ * Terminal-style input history for the thread composer: ArrowUp on an
+ * empty draft recalls previously sent user messages (newest first),
+ * ArrowDown steps back toward the newest and finally restores the draft
+ * that was being typed when browsing started.
+ *
+ * Recall only triggers when the caret is on the first/last line with no
+ * selection, so multi-line editing keeps native arrow behavior. The
+ * handler yields to an open mention/slash popover, to IME composition,
+ * to modifier keys, and to consumer handlers that already called
+ * `preventDefault`. It is inert on edit composers.
+ *
+ * @example
+ * ```tsx
+ * const history = unstable_useComposerInputHistory();
+ * <ComposerPrimitive.Input {...history} />
+ * ```
+ */
+export function unstable_useComposerInputHistory(): Unstable_ComposerInputHistory {
+  const aui = useAui();
+  const popoverCtx = useTriggerPopoverRootContextOptional();
+  const browseRef = useRef<BrowseState | null>(null);
+
+  useEffect(() => {
+    if (aui.composer().getState().type !== "thread") return undefined;
+
+    return aui.on("threadListItem.switchedTo", () => {
+      browseRef.current = null;
+    });
+  }, [aui]);
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.defaultPrevented) return;
+      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+      if (e.nativeEvent.isComposing) return;
+      if (e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) return;
+      if (popoverCtx && popoverCtx.getActiveAria() !== null) return;
+      if (aui.composer().getState().type !== "thread") return;
+
+      const textarea = e.currentTarget;
+      const { selectionStart, selectionEnd, value } = textarea;
+      if (selectionStart !== selectionEnd) return;
+
+      if (browseRef.current && value !== browseRef.current.lastRecalledText) {
+        browseRef.current = null;
+      }
+      const browse = browseRef.current;
+
+      const recall = (
+        text: string,
+        cursor: number,
+        draftSnapshot: string,
+      ): void => {
+        browseRef.current = { cursor, draftSnapshot, lastRecalledText: text };
+        flushTapSync(() => aui.composer().setText(text));
+        // React's controlled-value commit restores the pre-recall caret;
+        // reposition after the commit, before paint.
+        requestAnimationFrame(() => {
+          textarea.setSelectionRange(text.length, text.length);
+        });
+        e.preventDefault();
+      };
+
+      if (e.key === "ArrowUp") {
+        if (!isOnFirstLine(value, selectionStart)) return;
+
+        if (!browse) {
+          if (value.trim() !== "") return;
+          const history = deriveHistory(aui.thread().getState().messages);
+          if (history.length === 0) return;
+          recall(history[0]!, 0, value);
+          return;
+        }
+
+        const history = deriveHistory(aui.thread().getState().messages);
+        const next = browse.cursor + 1;
+        if (next >= history.length) {
+          e.preventDefault();
+          return;
+        }
+        recall(history[next]!, next, browse.draftSnapshot);
+        return;
+      }
+
+      if (!browse) return;
+      if (!isOnLastLine(value, selectionEnd)) return;
+
+      const next = browse.cursor - 1;
+      if (next < 0) {
+        const draft = browse.draftSnapshot;
+        browseRef.current = null;
+        flushTapSync(() => aui.composer().setText(draft));
+        requestAnimationFrame(() => {
+          textarea.setSelectionRange(draft.length, draft.length);
+        });
+        e.preventDefault();
+        return;
+      }
+
+      const history = deriveHistory(aui.thread().getState().messages);
+      recall(history[next]!, next, browse.draftSnapshot);
+    },
+    [aui, popoverCtx],
+  );
+
+  return useMemo(() => ({ onKeyDown }), [onKeyDown]);
+}

--- a/packages/react/src/unstable/useComposerInputHistory.ts
+++ b/packages/react/src/unstable/useComposerInputHistory.ts
@@ -95,12 +95,7 @@ export function unstable_useComposerInputHistory(): Unstable_ComposerInputHistor
       }
       const browse = browseRef.current;
 
-      const recall = (
-        text: string,
-        cursor: number,
-        draftSnapshot: string,
-      ): void => {
-        browseRef.current = { cursor, draftSnapshot, lastRecalledText: text };
+      const commitText = (text: string): void => {
         flushTapSync(() => aui.composer().setText(text));
         // React's controlled-value commit restores the pre-recall caret;
         // reposition after the commit, before paint.
@@ -110,6 +105,20 @@ export function unstable_useComposerInputHistory(): Unstable_ComposerInputHistor
         e.preventDefault();
       };
 
+      const recall = (
+        history: readonly string[],
+        cursor: number,
+        draftSnapshot: string,
+      ): void => {
+        const entry = history[cursor];
+        if (entry === undefined) {
+          e.preventDefault();
+          return;
+        }
+        browseRef.current = { cursor, draftSnapshot, lastRecalledText: entry };
+        commitText(entry);
+      };
+
       if (e.key === "ArrowUp") {
         if (!isOnFirstLine(value, selectionStart)) return;
 
@@ -117,7 +126,7 @@ export function unstable_useComposerInputHistory(): Unstable_ComposerInputHistor
           if (value.trim() !== "") return;
           const history = deriveHistory(aui.thread().getState().messages);
           if (history.length === 0) return;
-          recall(history[0]!, 0, value);
+          recall(history, 0, value);
           return;
         }
 
@@ -127,7 +136,7 @@ export function unstable_useComposerInputHistory(): Unstable_ComposerInputHistor
           e.preventDefault();
           return;
         }
-        recall(history[next]!, next, browse.draftSnapshot);
+        recall(history, next, browse.draftSnapshot);
         return;
       }
 
@@ -136,18 +145,13 @@ export function unstable_useComposerInputHistory(): Unstable_ComposerInputHistor
 
       const next = browse.cursor - 1;
       if (next < 0) {
-        const draft = browse.draftSnapshot;
         browseRef.current = null;
-        flushTapSync(() => aui.composer().setText(draft));
-        requestAnimationFrame(() => {
-          textarea.setSelectionRange(draft.length, draft.length);
-        });
-        e.preventDefault();
+        commitText(browse.draftSnapshot);
         return;
       }
 
       const history = deriveHistory(aui.thread().getState().messages);
-      recall(history[next]!, next, browse.draftSnapshot);
+      recall(history, next, browse.draftSnapshot);
     },
     [aui, popoverCtx],
   );


### PR DESCRIPTION
## what

adds `unstable_useComposerInputHistory` to `@assistant-ui/react`: terminal-style ArrowUp/ArrowDown recall of previously sent user messages in the thread composer. zero-argument hook returning a spreadable `{ onKeyDown }` bundle for `ComposerPrimitive.Input`. ships with a colocated test suite and a guides doc page.

## why

no package, hook, or example provides composer input history today, and every terminal-style consumer wants it: hermes-agent implements it twice (desktop derives the ring live from session messages with a draft snapshot and per-session cursors; the TUI persists a history file with the same browse semantics). the semantics here follow the hermes desktop variant plus zsh's up-line-or-history rules, which also match Discord-style chat conventions.

## behavior

- the ring derives live at each keypress from thread state (user texts via `getThreadMessageText`, newest first, trimmed, adjacent duplicates collapsed); no persistence, no configuration
- ArrowUp starts browsing only on an empty draft with the caret on the first line and no selection; whitespace-only drafts count as empty and are restored on the way back down
- while browsing a multi-line entry, arrows move the caret natively until the first/last line
- yields to an open trigger popover (imperative `getActiveAria()` check, no subscription), to IME composition, to modifier keys, and to events a preceding consumer handler already prevented (so callers can interleave their own ArrowUp handling, e.g. hermes's queue-edit stepping)
- recalls write through `flushTapSync(setText)` with a post-commit `requestAnimationFrame` caret-to-end placement; thread switches (`threadListItem.switchedTo`) and sends reset browsing; inert on edit composers

## scope

web (`@assistant-ui/react`) only. react-ink maps up/down to buffer cursor movement and react-native has its own composer input; both are explicitly out of scope, matching the mention/slash adapter precedent. the ring derivation is pure and can move to core when an ink consumer materializes.

## testing

11 new colocated tests (recall, stepping, oldest-entry consumption, draft restore incl. whitespace-only, typed-draft guard, multi-line caret rules, popover yield, IME/modifier/selection/prevented guards, ring derivation and dedup, external-clear re-browse, edit-composer inertness, thread-switch reset). full `@assistant-ui/react` suite passes (363 tests, 32 files); `pnpm lint`; package build green. caret placement in a real browser should be verified manually since jsdom does not model the controlled-value selection restore.
