### PR TITLE
fix(ui): render mermaid diagrams without an AuiProvider

### DIFF
--- a/packages/ui/src/components/assistant-ui/mermaid-diagram.tsx
+++ b/packages/ui/src/components/assistant-ui/mermaid-diagram.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useAuiState } from "@assistant-ui/react";
+import { useAui, useAuiState } from "@assistant-ui/react";
 import type { SyntaxHighlighterProps } from "@assistant-ui/react-markdown";
 import { renderMermaidSVG } from "beautiful-mermaid";
 import { Maximize2, Minus, Plus, RotateCcw, X } from "lucide-react";
@@ -277,7 +277,11 @@ const MermaidDiagramImpl: FC<MermaidDiagramProps> = ({
   components: _components,
   language: _language,
 }) => {
-  const isComplete = useAuiState((s) => s.part.status.type !== "running");
+  const aui = useAui();
+  const hasPart = aui.part.source !== null;
+  const isComplete = useAuiState(
+    (s) => !hasPart || s.part.status.type !== "running",
+  );
 
   const result = useMemo(() => {
     if (!isComplete) return null;


### PR DESCRIPTION
## what

gates `mermaid-diagram.tsx`'s part-scope read on `aui.part.source !== null`, so the component renders (immediately, with no streaming gate) when mounted outside an `AuiProvider`.

## why

same latent crash that #4349 fixed in the shiki highlighter: `useAuiState((s) => s.part.status...)` throws "You are using a component or hook that requires an AuiProvider" on the no-provider default client. any page that renders the kit's mermaid component standalone (docs demos, static prerendering) crashes; `/heat-graph` hit exactly this through the highlighter before its fix. without a part scope there is no streaming concept, so completing immediately is the right semantic.

## testing

`pnpm lint`, `pnpm turbo build --filter=@assistant-ui/ui`. packages/ui is private, no changeset.
