### PR TITLE
feat(ui): streaming disclosure for reasoning

### DIFF
--- a/apps/docs/components/examples/base.tsx
+++ b/apps/docs/components/examples/base.tsx
@@ -697,7 +697,7 @@ const AssistantMessage: FC = () => {
               case "group-reasoning": {
                 const running = part.status.type === "running";
                 return (
-                  <ReasoningRoot defaultOpen={running}>
+                  <ReasoningRoot streaming={running}>
                     <ReasoningTrigger active={running} />
                     <ReasoningContent aria-busy={running}>
                       <ReasoningText>{children}</ReasoningText>

--- a/apps/docs/content/docs/guides/chain-of-thought.mdx
+++ b/apps/docs/content/docs/guides/chain-of-thought.mdx
@@ -60,7 +60,7 @@ const AssistantMessage: FC = () => {
             case "group-reasoning": {
               const running = part.status.type === "running";
               return (
-                <ReasoningRoot defaultOpen={running}>
+                <ReasoningRoot streaming={running}>
                   <ReasoningTrigger active={running} />
                   <ReasoningContent aria-busy={running}>
                     <ReasoningText>{children}</ReasoningText>

--- a/apps/docs/content/docs/ui/reasoning.mdx
+++ b/apps/docs/content/docs/ui/reasoning.mdx
@@ -28,7 +28,7 @@ Previously, reasoning parts were rendered via `components.Reasoning` and grouped
 
 Render reasoning parts through `MessagePrimitive.GroupedParts`. Group consecutive reasoning parts with `"group-reasoning"`, then compose `ReasoningRoot`, `ReasoningTrigger`, `ReasoningContent`, and `ReasoningText` around the grouped children.
 
-While reasoning is streaming, `part.status.type === "running"`. Pass that to `defaultOpen` so the accordion auto-opens during streaming and lets the user collapse it once the model moves on.
+While reasoning is streaming, `part.status.type === "running"`. Pass that to `streaming` so the accordion auto-opens during streaming with a bottom-pinned live preview of the newest tokens, auto-collapses when the model moves on, and permanently defers to the first manual toggle. When `streaming` is provided it supersedes `defaultOpen`.
 
 ```tsx title="/app/components/assistant-ui/thread.tsx"
 import { MessagePrimitive, groupPartByType } from "@assistant-ui/react";
@@ -56,7 +56,7 @@ const AssistantMessage: FC = () => {
               case "group-reasoning": { // [!code ++]
                 const running = part.status.type === "running"; // [!code ++]
                 return ( // [!code ++]
-                  <ReasoningRoot defaultOpen={running}> // [!code ++]
+                  <ReasoningRoot streaming={running}> // [!code ++]
                     <ReasoningTrigger active={running} /> // [!code ++]
                     <ReasoningContent aria-busy={running}> // [!code ++]
                       <ReasoningText>{children}</ReasoningText> // [!code ++]
@@ -139,7 +139,7 @@ const ReasoningGroupImpl: ReasoningGroupComponent = ({
   });
 
   return (
-    <ReasoningRoot defaultOpen={isReasoningStreaming}>
+    <ReasoningRoot streaming={isReasoningStreaming}>
       <ReasoningTrigger active={isReasoningStreaming} />
       <ReasoningContent aria-busy={isReasoningStreaming}>
         <ReasoningText>{children}</ReasoningText>

--- a/examples/with-generative-ui/components/assistant-message-gui.tsx
+++ b/examples/with-generative-ui/components/assistant-message-gui.tsx
@@ -140,7 +140,7 @@ export const AssistantMessageGui: FC<AssistantMessageGuiProps> = ({
               case "group-reasoning": {
                 const running = part.status.type === "running";
                 return (
-                  <ReasoningRoot defaultOpen={running}>
+                  <ReasoningRoot streaming={running}>
                     <ReasoningTrigger active={running} />
                     <ReasoningContent aria-busy={running}>
                       <ReasoningText>{children}</ReasoningText>

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -78,11 +79,11 @@ function ReasoningRoot({
   const isOpen = isControlled
     ? controlledOpen
     : (userOpen ?? streaming ?? initialOpenRef.current);
-  const isPreview =
-    streaming === true && isOpen && (isControlled || userOpen === null);
+  const isAutoMode = isControlled || userOpen === null;
+  const isPreview = streaming === true && isOpen && isAutoMode;
 
   const prevStreamingRef = useRef(streaming);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (prevStreamingRef.current === streaming) return;
     prevStreamingRef.current = streaming;
     if (!isControlled && userOpen === null) lockScroll();

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { memo, useCallback, useRef, useState } from "react";
+import {
+  createContext,
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { BrainIcon, ChevronDownIcon } from "lucide-react";
 import {
@@ -18,6 +26,8 @@ import {
 import { cn } from "@/lib/utils";
 
 const ANIMATION_DURATION = 200;
+
+const ReasoningPreviewContext = createContext(false);
 
 const reasoningVariants = cva("aui-reasoning-root mb-4 w-full", {
   variants: {
@@ -40,6 +50,13 @@ export type ReasoningRootProps = Omit<
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
     defaultOpen?: boolean;
+    /**
+     * Whether the reasoning is currently streaming. When provided, it
+     * supersedes `defaultOpen`: the disclosure auto-opens while streaming
+     * with a bottom-pinned live preview, auto-collapses when streaming
+     * ends, and the first manual toggle takes over permanently.
+     */
+    streaming?: boolean;
   };
 
 function ReasoningRoot({
@@ -48,21 +65,34 @@ function ReasoningRoot({
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
   defaultOpen = false,
+  streaming,
   children,
   ...props
 }: ReasoningRootProps) {
   const collapsibleRef = useRef<HTMLDivElement>(null);
-  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const initialOpenRef = useRef(defaultOpen);
+  const [userOpen, setUserOpen] = useState<boolean | null>(null);
   const lockScroll = useScrollLock(collapsibleRef, ANIMATION_DURATION);
 
   const isControlled = controlledOpen !== undefined;
-  const isOpen = isControlled ? controlledOpen : uncontrolledOpen;
+  const isOpen = isControlled
+    ? controlledOpen
+    : (userOpen ?? streaming ?? initialOpenRef.current);
+  const isPreview =
+    streaming === true && isOpen && (isControlled || userOpen === null);
+
+  const prevStreamingRef = useRef(streaming);
+  useEffect(() => {
+    if (prevStreamingRef.current === streaming) return;
+    prevStreamingRef.current = streaming;
+    if (!isControlled && userOpen === null) lockScroll();
+  }, [streaming, isControlled, userOpen, lockScroll]);
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
       lockScroll();
       if (!isControlled) {
-        setUncontrolledOpen(open);
+        setUserOpen(open);
       }
       controlledOnOpenChange?.(open);
     },
@@ -87,12 +117,35 @@ function ReasoningRoot({
       }
       {...props}
     >
-      {children}
+      <ReasoningPreviewContext.Provider value={isPreview}>
+        {children}
+      </ReasoningPreviewContext.Provider>
     </Collapsible>
   );
 }
 
-function ReasoningFade({ className, ...props }: React.ComponentProps<"div">) {
+function ReasoningFade({
+  side = "bottom",
+  className,
+  ...props
+}: React.ComponentProps<"div"> & { side?: "top" | "bottom" }) {
+  if (side === "top") {
+    return (
+      <div
+        data-slot="reasoning-fade"
+        className={cn(
+          "aui-reasoning-fade pointer-events-none absolute inset-x-0 top-0 z-10 h-8",
+          "bg-[linear-gradient(to_bottom,var(--color-background),transparent)]",
+          "group-data-[variant=muted]/reasoning-root:bg-[linear-gradient(to_bottom,hsl(var(--muted)/0.5),transparent)]",
+          "fade-in-0 animate-in",
+          "duration-(--animation-duration)",
+          className,
+        )}
+        {...props}
+      />
+    );
+  }
+
   return (
     <div
       data-slot="reasoning-fade"
@@ -171,6 +224,8 @@ function ReasoningContent({
   children,
   ...props
 }: React.ComponentProps<typeof CollapsibleContent>) {
+  const isPreview = useContext(ReasoningPreviewContext);
+
   return (
     <CollapsibleContent
       data-slot="reasoning-content"
@@ -187,18 +242,42 @@ function ReasoningContent({
       )}
       {...props}
     >
+      {isPreview ? <ReasoningFade side="top" /> : null}
       {children}
       <ReasoningFade />
     </CollapsibleContent>
   );
 }
 
-function ReasoningText({ className, ...props }: React.ComponentProps<"div">) {
+function ReasoningText({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  const isPreview = useContext(ReasoningPreviewContext);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isPreview) return;
+    const scrollEl = scrollRef.current;
+    const contentEl = contentRef.current;
+    if (!scrollEl || !contentEl) return;
+    const pin = () => {
+      scrollEl.scrollTop = scrollEl.scrollHeight;
+    };
+    pin();
+    const observer = new ResizeObserver(pin);
+    observer.observe(contentEl);
+    return () => observer.disconnect();
+  }, [isPreview]);
+
   return (
     <div
+      ref={scrollRef}
       data-slot="reasoning-text"
       className={cn(
-        "aui-reasoning-text relative z-0 max-h-64 space-y-4 overflow-y-auto ps-6 pt-2 pb-2 leading-relaxed",
+        "aui-reasoning-text relative z-0 max-h-64 overflow-y-auto ps-6 pt-2 pb-2 leading-relaxed",
         "transform-gpu transition-[transform,opacity]",
         "group-data-[state=open]/collapsible-content:animate-in",
         "group-data-[state=closed]/collapsible-content:animate-out",
@@ -211,7 +290,11 @@ function ReasoningText({ className, ...props }: React.ComponentProps<"div">) {
         className,
       )}
       {...props}
-    />
+    >
+      <div ref={contentRef} className="aui-reasoning-text-content space-y-4">
+        {children}
+      </div>
+    </div>
   );
 }
 
@@ -232,7 +315,7 @@ const ReasoningGroupImpl: ReasoningGroupComponent = ({
   });
 
   return (
-    <ReasoningRoot defaultOpen={isReasoningStreaming}>
+    <ReasoningRoot streaming={isReasoningStreaming}>
       <ReasoningTrigger active={isReasoningStreaming} />
       <ReasoningContent aria-busy={isReasoningStreaming}>
         <ReasoningText>{children}</ReasoningText>

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -376,7 +376,7 @@ const AssistantMessage: FC = () => {
                 }
                 const running = part.status.type === "running";
                 return (
-                  <ReasoningRoot defaultOpen={running}>
+                  <ReasoningRoot streaming={running}>
                     <ReasoningTrigger active={running} />
                     <ReasoningContent aria-busy={running}>
                       <ReasoningText>{children}</ReasoningText>


### PR DESCRIPTION
## what

adds a `streaming` prop to the kit's `ReasoningRoot` that drives a full streaming disclosure state machine: auto-open while the reasoning part streams, a bottom-pinned live preview of the newest tokens inside the existing `max-h-64` window (ResizeObserver pins the inner content wrapper's scroll), a top fade while previewing, auto-collapse when streaming ends, and permanent takeover by the first manual toggle. all call sites (kit thread, deprecated `ReasoningGroup` wrapper, docs example, with-generative-ui example, chain-of-thought guide snippet) swap `defaultOpen={running}` for `streaming={running}`, and the reasoning docs teach the new behavior.

## why

the previous pattern (`defaultOpen={running}`) auto-opens but can never auto-collapse: `useState(defaultOpen)` is initial-mount-only, so a finished reasoning block stays expanded and pushes the answer down. there was also no way to watch the newest tokens (the body stays scrolled to the top) and no takeover semantics. hermes-agent's `ThinkingDisclosure` is the consumer-proven reference for the `userOpen ?? streaming` machine, the ResizeObserver pin, and the preview fade; this upstreams that design into the kit.

## behavior notes

- when `streaming` is provided it supersedes `defaultOpen` (documented on the prop and in the docs); omitting `streaming` preserves the old behavior exactly, and controlled `open`/`onOpenChange` semantics are unchanged
- auto transitions fire the same `useScrollLock` protection manual toggles get, so the 200ms collapse cannot yank the thread viewport; the preview pin writes a descendant scroller's `scrollTop`, which is provably disjoint from `useScrollLock` (it pins the ancestor viewport; scroll events do not bubble)
- takeover is per component instance: reasoning groups keep their structural key across regenerate (only tool calls carry idKeys), so a user-collapsed disclosure stays collapsed across regenerate; a new message mounts fresh and re-enters auto mode
- the interactive docs demo stays on controlled `open`/`onOpenChange` deliberately, as the controlled-mode regression check

## testing

`pnpm lint`, `pnpm sync-templates` (no template carries reasoning.tsx), `pnpm turbo build` for @assistant-ui/ui, with-generative-ui, and @assistant-ui/docs (23 tasks green; docs build exercises the mdx changes and the registry mirror is sourcePath-based so no registry edit is needed). manual verification of the streaming behavior in the docs example is the release gate. all touched packages are private, no changeset.
