### PR TITLE
feat: add smooth prop to StreamdownTextPrimitive

### DIFF
--- a/.changeset/streamdown-smooth.md
+++ b/.changeset/streamdown-smooth.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-streamdown": patch
+---
+
+feat: `smooth` prop on `StreamdownTextPrimitive`
+
+opt-in typewriter reveal via the now-public `useSmooth`, accepting `boolean | SmoothOptions`. the pipeline runs preprocess, then smooth, then the existing `defer` deferral, and `data-status`/`isAnimating` derive from the smooth status so the caret keeps blinking and the copy/download controls stay disabled until the reveal catches up. default off; streamdown's block memoization bounds the per-frame cost to linear string scans plus the tail block parse. the `@assistant-ui/react` peer floor moves to the release that ships `SmoothOptions`.

--- a/apps/docs/content/docs/ui/streamdown.mdx
+++ b/apps/docs/content/docs/ui/streamdown.mdx
@@ -120,6 +120,7 @@ const StreamdownText = () => (
 | `componentsByLanguage` | `object` | - | Language-specific component overrides |
 | `preprocess` | `(text: string) => string` | - | Text preprocessing function |
 | `defer` | `boolean` | `false` | Defer markdown parsing to a lower priority via `useDeferredValue` so typing and scrolling stay responsive during streaming |
+| `smooth` | `boolean \| SmoothOptions` | `false` | Typewriter-style reveal via `useSmooth`; the caret and controls stay active until the reveal catches up. Prefer the native `animated` prop for entrance animations |
 | `controls` | `boolean \| object` | `true` | Enable/disable UI controls for code blocks and tables |
 | `caret` | `"block" \| "circle"` | - | Streaming caret style |
 | `mermaid` | `MermaidOptions` | - | Mermaid diagram configuration |

--- a/packages/react-streamdown/package.json
+++ b/packages/react-streamdown/package.json
@@ -40,7 +40,7 @@
     "streamdown": "^2.5.0"
   },
   "peerDependencies": {
-    "@assistant-ui/react": "^0.14.14",
+    "@assistant-ui/react": "^0.14.18",
     "@streamdown/code": "^1.0.0",
     "@streamdown/cjk": "^1.0.0",
     "@streamdown/math": "^1.0.0",

--- a/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
+++ b/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
@@ -88,6 +88,31 @@ describe("StreamdownTextPrimitive", () => {
     expect(await screen.findByText("first chunk second chunk")).toBeTruthy();
   });
 
+  it("renders settled text in full when smooth is enabled", async () => {
+    render(
+      <TextMessagePartProvider text="hello smooth" isRunning={false}>
+        <StreamdownTextPrimitive smooth />
+      </TextMessagePartProvider>,
+    );
+
+    expect(await screen.findByText("hello smooth")).toBeTruthy();
+  });
+
+  it("accepts a SmoothOptions object and keeps data-status smooth-aware", async () => {
+    const { container } = render(
+      <TextMessagePartProvider text="tuned reveal" isRunning={false}>
+        <StreamdownTextPrimitive
+          smooth={{ drainMs: 500, maxCharsPerFrame: 30 }}
+        />
+      </TextMessagePartProvider>,
+    );
+
+    expect(await screen.findByText("tuned reveal")).toBeTruthy();
+    expect(
+      container.querySelector("[data-status]")?.getAttribute("data-status"),
+    ).toBe("complete");
+  });
+
   describe("code adapter with custom components", () => {
     const fencedMarkdown = "```ts\nconst x = 1;\n```";
 

--- a/packages/react-streamdown/src/primitives/StreamdownText.tsx
+++ b/packages/react-streamdown/src/primitives/StreamdownText.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMessagePartText } from "@assistant-ui/react";
+import { useMessagePartText, useSmooth } from "@assistant-ui/react";
 import { harden } from "rehype-harden";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
@@ -90,6 +90,7 @@ export const StreamdownTextPrimitive = forwardRef<
       componentsByLanguage,
       preprocess,
       defer = false,
+      smooth = false,
 
       // plugin configuration
       plugins: userPlugins,
@@ -119,15 +120,20 @@ export const StreamdownTextPrimitive = forwardRef<
     },
     ref,
   ) => {
-    const { text, status } = useMessagePartText();
+    const messagePart = useMessagePartText();
+
+    const processedPart = useMemo(
+      () =>
+        preprocess
+          ? { ...messagePart, text: preprocess(messagePart.text) }
+          : messagePart,
+      [messagePart, preprocess],
+    );
+
+    const { text, status } = useSmooth(processedPart, smooth);
 
     const deferredText = useDeferredValue(text);
-    const resolvedText = defer ? deferredText : text;
-
-    const processedText = useMemo(
-      () => (preprocess ? preprocess(resolvedText) : resolvedText),
-      [resolvedText, preprocess],
-    );
+    const processedText = defer ? deferredText : text;
 
     const resolvedPlugins = useMemo(() => {
       const merged = mergePlugins(userPlugins, {});

--- a/packages/react-streamdown/src/types.ts
+++ b/packages/react-streamdown/src/types.ts
@@ -1,3 +1,4 @@
+import type { SmoothOptions } from "@assistant-ui/react";
 import type { Element } from "hast";
 import type { ComponentPropsWithoutRef, ComponentType, ReactNode } from "react";
 import type { Options as RemarkRehypeOptions } from "remark-rehype";
@@ -283,6 +284,17 @@ export type StreamdownTextPrimitiveProps = Omit<
    * @default false
    */
   defer?: boolean | undefined;
+
+  /**
+   * Animates the streamed text with a typewriter-style reveal via
+   * `useSmooth`; pass a `SmoothOptions` object to tune the reveal rate.
+   * The caret and streaming controls stay active until the reveal catches
+   * up. Composes with `defer`. For entrance animations at token cadence,
+   * prefer Streamdown's native `animated` prop instead.
+   *
+   * @default false
+   */
+  smooth?: boolean | SmoothOptions | undefined;
 
   /**
    * Container element props.


### PR DESCRIPTION
## what

adds an opt-in `smooth` prop (`boolean | SmoothOptions`) to `StreamdownTextPrimitive`, completing capability parity with `MarkdownTextPrimitive` now that `useSmooth` is public and tunable (#4350). the pipeline order is preprocess, then smooth, then the existing `defer` deferral, matching the react-markdown path.

## design notes (from reading streamdown 2.5.0 source, the exact pinned version)

- `data-status` and the default `isAnimating` now derive from the smooth-returned status instead of the raw part status. this is load-bearing upstream: the streaming caret only renders while `caret && isAnimating` (index.tsx:749) and the code block copy/download controls are disabled while `isAnimating`, so with the raw status the caret would vanish and controls would enable while the reveal is still draining. consumer `isAnimating` overrides keep working because `{...streamdownProps}` spreads last.
- per-frame cost is bounded by streamdown's architecture: the full-text work per smooth frame is remend plus the marked lexer block split (linear string scans, no AST), and the heavy unified parse stays confined to the tail block by the `Block` memo's per-content comparison. this is why char-level smoothing is viable here without the full-text re-parse problem the react-markdown path has.
- streamdown ships its own `animated` prop (rehype-level entrance animation, word or char granularity, with prev-length tracking to avoid re-animating). it already passes through this primitive. the two are different semantics: `animated` animates the appearance of newly arrived content at token cadence, `smooth` paces the reveal itself. the prop JSDoc and docs table point users to `animated` for entrance animations rather than combining both.
- default off: react-markdown's `smooth` defaults on for historical reasons, but flipping every existing streamdown consumer to a typewriter reveal in a patch would be a behavior change.

## peer note

`@assistant-ui/react` peer floor moves to `^0.14.18` for the `SmoothOptions` type import, same caveat as #4350: it must match the react release that ships the export.

## testing

full react-streamdown suite passes (96 tests, 8 files, including two new smooth cases: settled full render and SmoothOptions acceptance with smooth-aware `data-status`); the pre-existing suite now also exercises the `useSmooth` hook path under `TextMessagePartProvider`. `pnpm lint`, `pnpm turbo build --filter=@assistant-ui/react-streamdown`.
