### PR TITLE
feat: branch switching for the ExternalThread client

### DIFF
--- a/.changeset/external-thread-branches.md
+++ b/.changeset/external-thread-branches.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+feat: branch switching for the ExternalThread client
+
+`ExternalThread` accepts an optional `branches` adapter (`ExternalThreadBranchAdapter` in `@assistant-ui/core`, re-exported from `@assistant-ui/react`): `getBranches(messageId)` returns ordered sibling branch ids and `switchToBranch(branchId)` makes a sibling visible by swapping the `messages` array. messages with more than one sibling get real `branchNumber`/`branchCount`, which is what shows the branch picker; `capabilities.switchToBranch` is set for parity with the legacy external store. without the adapter, behavior is unchanged.

--- a/apps/docs/content/docs/(reference)/api-reference/external-store/runtime.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/external-store/runtime.mdx
@@ -3,7 +3,7 @@ title: External Store Runtime
 description: Runtime components, options, and adapters for using assistant-ui with externally owned chat state.
 ---
 
-import { ExternalStoreAdapter, ExternalThread, ExternalThreadProps, ExternalThreadQueueAdapter, useExternalStoreRuntime, useExternalStoreSharedOptions } from "@/generated/typeDocs";
+import { ExternalStoreAdapter, ExternalThread, ExternalThreadBranchAdapter, ExternalThreadProps, ExternalThreadQueueAdapter, useExternalStoreRuntime, useExternalStoreSharedOptions } from "@/generated/typeDocs";
 
 {/* AUTO-GENERATED PAGE by scripts/generate-api-reference.mts */}
 {/* Do not edit manually. */}
@@ -32,6 +32,12 @@ The queue surface a runtime exposes so the composer can stay usable during a
 run and render the pending messages.
 
 <ParametersTable {...ExternalThreadQueueAdapter} />
+
+### ExternalThreadBranchAdapter
+
+The branch surface a runtime exposes so the branch picker can navigate between sibling variants of a message. The consumer keeps passing the visible branch as the flat `messages` array; `getBranches(messageId)` returns ordered sibling ids (including the message's own id) and `switchToBranch(branchId)` swaps the visible branch. The picker appears when a message reports more than one sibling. Editing a message creates a branch only if the `onEdit` handler creates a sibling and `getBranches` reports it; note the edit payload carries the edited message's own id as both `parentId` and `sourceId`.
+
+<ParametersTable {...ExternalThreadBranchAdapter} />
 
 ### pickExternalStoreSharedOptions
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -287,6 +287,7 @@ export { pickExternalStoreSharedOptions } from "./runtimes/external-store/extern
 
 // Message queue
 export type { ExternalThreadQueueAdapter } from "./runtime/queue/external-thread-queue-adapter";
+export type { ExternalThreadBranchAdapter } from "./runtime/branch/external-thread-branch-adapter";
 export {
   createMessageQueue,
   type MessageQueueDriver,

--- a/packages/core/src/runtime/branch/external-thread-branch-adapter.ts
+++ b/packages/core/src/runtime/branch/external-thread-branch-adapter.ts
@@ -1,0 +1,26 @@
+/**
+ * The branch surface a runtime exposes so the branch picker can navigate
+ * between sibling variants of a message. Read during render; recreate the
+ * adapter object when branch data changes.
+ *
+ * Editing a message creates a branch only if the `onEdit` handler creates a
+ * sibling and `getBranches` reports it. Note that `ExternalThread`'s edit
+ * payload carries the edited message's own id as both `parentId` and
+ * `sourceId`.
+ */
+export type ExternalThreadBranchAdapter = {
+  /**
+   * Returns the sibling branch ids for a message in display order, including
+   * the message's own id. Return an empty array for messages without
+   * alternative branches.
+   */
+  getBranches: (messageId: string) => readonly string[];
+  /**
+   * Makes the given branch the visible one. The runtime is expected to swap
+   * the `messages` array to the selected branch. May be invoked
+   * programmatically while a run is in progress; pending queue items are not
+   * cleared, and reconciling them with the new branch is the runtime's
+   * responsibility.
+   */
+  switchToBranch: (branchId: string) => void;
+};

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -17,6 +17,7 @@ import type {
   ThreadUserMessagePart,
   ThreadMessage,
   ExternalThreadQueueAdapter,
+  ExternalThreadBranchAdapter,
 } from "@assistant-ui/core";
 import type { QueueItemState } from "@assistant-ui/core/store";
 import type { ComposerSendOptions } from "@assistant-ui/core/store";
@@ -26,6 +27,7 @@ import { Tools, DataRenderers } from "@assistant-ui/core/react";
 import { SingleThreadList } from "./SingleThreadList";
 
 const EMPTY_QUEUE_ITEMS: readonly QueueItemState[] = [];
+const EMPTY_BRANCH_IDS: readonly string[] = [];
 
 export type ExternalThreadMessage = ThreadMessage & {
   id: string;
@@ -52,6 +54,8 @@ export type ExternalThreadProps = {
   onCancel?: () => void;
   /** Queue adapter for runtimes that support message queuing and steering. */
   queue?: ExternalThreadQueueAdapter;
+  /** Branch adapter for runtimes that track sibling variants of messages. */
+  branches?: ExternalThreadBranchAdapter;
 };
 
 type MessageClientProps = {
@@ -60,6 +64,7 @@ type MessageClientProps = {
   onEdit?: (message: AppendMessage) => void;
   onReload?: () => void;
   queue?: ExternalThreadQueueAdapter | undefined;
+  branches?: ExternalThreadBranchAdapter | undefined;
 };
 
 // Message Client - minimal implementation
@@ -69,6 +74,7 @@ const useMessageClient = ({
   onEdit,
   onReload,
   queue,
+  branches,
 }: MessageClientProps): ClientOutput<"message"> => {
   const [isCopied, setIsCopied] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
@@ -125,14 +131,19 @@ const useMessageClient = ({
     }),
   );
 
+  const branchIds = branches?.getBranches(message.id) ?? EMPTY_BRANCH_IDS;
+  const branchIndex = branchIds.indexOf(message.id);
+  const branchNumber = branchIndex === -1 ? 1 : branchIndex + 1;
+  const branchCount = branchIndex === -1 ? 1 : branchIds.length;
+
   const state = useMemo(() => {
     return {
       ...message,
       attachments: message.attachments ?? [],
       parentId: null,
       isLast: false, // Will be set by thread
-      branchNumber: 1,
-      branchCount: 1,
+      branchNumber,
+      branchCount,
       speech: undefined,
       parts: partClients.state,
       isCopied,
@@ -147,6 +158,8 @@ const useMessageClient = ({
     index,
     composerClient.state,
     partClients.state,
+    branchNumber,
+    branchCount,
   ]);
 
   return {
@@ -159,7 +172,20 @@ const useMessageClient = ({
     speak: () => {},
     stopSpeaking: () => {},
     submitFeedback: () => {},
-    switchToBranch: () => {},
+    switchToBranch: ({ position, branchId }) => {
+      if (!branches) return;
+      const target =
+        branchId ??
+        (branchIndex === -1
+          ? undefined
+          : position === "previous"
+            ? branchIds[branchIndex - 1]
+            : position === "next"
+              ? branchIds[branchIndex + 1]
+              : undefined);
+      if (target !== undefined && target !== message.id)
+        branches.switchToBranch(target);
+    },
     getCopyText: () => getThreadMessageText(message),
     part: (selector) => {
       if ("index" in selector) {
@@ -458,6 +484,7 @@ const useExternalThread = ({
   onStartRun,
   onCancel,
   queue,
+  branches,
 }: ExternalThreadProps): ClientOutput<"thread"> => {
   const handleReload = (messageId: string) => {
     const messageIndex = messages.findIndex((m) => m.id === messageId);
@@ -476,11 +503,12 @@ const useExternalThread = ({
           index,
           onReload: () => handleReload(msg.id),
           queue,
+          branches,
         };
         if (onEdit) props.onEdit = onEdit;
         return withKey(msg.id, MessageClient(props));
       }),
-    [messages, onEdit, queue],
+    [messages, onEdit, queue, branches],
   );
 
   const handleCancelRun = () => {
@@ -505,6 +533,7 @@ const useExternalThread = ({
   );
 
   const hasQueue = !!queue;
+  const hasBranches = !!branches;
   const state = useMemo(() => {
     const messageStates = messageClients.state.map((s, idx, arr) => ({
       ...s,
@@ -525,7 +554,7 @@ const useExternalThread = ({
         attachments: false,
         feedback: false,
         voice: false,
-        switchToBranch: false,
+        switchToBranch: hasBranches,
         switchBranchDuringRun: false,
         unstable_copy: false,
         dictation: false,
@@ -543,6 +572,7 @@ const useExternalThread = ({
     messages,
     isRunning,
     hasQueue,
+    hasBranches,
     messageClients.state,
     composerClient.state,
   ]);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -141,6 +141,7 @@ export {
   type MessageQueueDriver,
   type MessageQueueController,
   type ExternalThreadQueueAdapter,
+  type ExternalThreadBranchAdapter,
 } from "@assistant-ui/core";
 export { useExternalStoreRuntime } from "./legacy-runtime/runtime-cores/external-store/useExternalStoreRuntime";
 export { useExternalStoreSharedOptions } from "@assistant-ui/core/react";

--- a/packages/react/src/tests/external-thread-branches.test.tsx
+++ b/packages/react/src/tests/external-thread-branches.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+import { render } from "@testing-library/react";
+import type { FC } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { useAui, AuiProvider } from "@assistant-ui/store";
+import type {
+  ExternalThreadBranchAdapter,
+  ThreadMessage,
+} from "@assistant-ui/core";
+import {
+  ExternalThread,
+  type ExternalThreadProps,
+} from "../client/ExternalThread";
+
+const message = (id: string, role: "user" | "assistant"): ThreadMessage =>
+  ({
+    id,
+    role,
+    content: [{ type: "text", text: `text of ${id}` }],
+    createdAt: new Date(1718000000000),
+    ...(role === "assistant"
+      ? { status: { type: "complete", reason: "stop" } }
+      : { attachments: [] }),
+    metadata: { custom: {} },
+  }) as ThreadMessage;
+
+const renderThread = (props: ExternalThreadProps) => {
+  const captured: { aui?: ReturnType<typeof useAui> } = {};
+  const Capture: FC = () => {
+    captured.aui = useAui();
+    return null;
+  };
+  const App: FC<{ threadProps: ExternalThreadProps }> = ({ threadProps }) => {
+    const aui = useAui({ thread: ExternalThread(threadProps) });
+    return (
+      <AuiProvider value={aui}>
+        <Capture />
+      </AuiProvider>
+    );
+  };
+  const utils = render(<App threadProps={props} />);
+  return {
+    aui: () => captured.aui!,
+    rerender: (next: ExternalThreadProps) =>
+      utils.rerender(<App threadProps={next} />),
+  };
+};
+
+const baseProps = (
+  branches?: ExternalThreadBranchAdapter,
+): ExternalThreadProps => ({
+  messages: [message("u1", "user"), message("a2", "assistant")],
+  isRunning: false,
+  ...(branches ? { branches } : {}),
+});
+
+const adapterFor = (
+  ids: readonly string[],
+  switchToBranch = vi.fn(),
+): ExternalThreadBranchAdapter => ({
+  getBranches: (messageId) => (ids.includes(messageId) ? ids : []),
+  switchToBranch,
+});
+
+describe("ExternalThread branches", () => {
+  it("defaults to single-branch state without an adapter", () => {
+    const { aui } = renderThread(baseProps());
+    const state = aui().thread().getState();
+    expect(state.messages[1]!.branchNumber).toBe(1);
+    expect(state.messages[1]!.branchCount).toBe(1);
+    expect(state.capabilities.switchToBranch).toBe(false);
+    expect(() =>
+      aui().thread().message({ index: 1 }).switchToBranch({ position: "next" }),
+    ).not.toThrow();
+  });
+
+  it("derives branchNumber and branchCount from the adapter", () => {
+    const { aui } = renderThread(baseProps(adapterFor(["a1", "a2", "a3"])));
+    const state = aui().thread().getState();
+    expect(state.messages[1]!.branchNumber).toBe(2);
+    expect(state.messages[1]!.branchCount).toBe(3);
+    expect(state.capabilities.switchToBranch).toBe(true);
+  });
+
+  it("resolves previous and next to sibling ids and no-ops at the edges", () => {
+    const switchToBranch = vi.fn();
+    const { aui } = renderThread(
+      baseProps(adapterFor(["a1", "a2", "a3"], switchToBranch)),
+    );
+    const msg = () => aui().thread().message({ index: 1 });
+
+    msg().switchToBranch({ position: "previous" });
+    expect(switchToBranch).toHaveBeenLastCalledWith("a1");
+    msg().switchToBranch({ position: "next" });
+    expect(switchToBranch).toHaveBeenLastCalledWith("a3");
+
+    switchToBranch.mockClear();
+    const edge = renderThread({
+      messages: [message("u1", "user"), message("a1", "assistant")],
+      isRunning: false,
+      branches: adapterFor(["a1", "a2"], switchToBranch),
+    });
+    edge.aui().thread().message({ index: 1 }).switchToBranch({
+      position: "previous",
+    });
+    expect(switchToBranch).not.toHaveBeenCalled();
+  });
+
+  it("forwards an explicit branchId unvalidated but ignores self-switches", () => {
+    const switchToBranch = vi.fn();
+    const { aui } = renderThread(
+      baseProps(adapterFor(["a1", "a2"], switchToBranch)),
+    );
+    const msg = () => aui().thread().message({ index: 1 });
+
+    msg().switchToBranch({ branchId: "not-in-the-list" });
+    expect(switchToBranch).toHaveBeenLastCalledWith("not-in-the-list");
+
+    switchToBranch.mockClear();
+    msg().switchToBranch({ branchId: "a2" });
+    expect(switchToBranch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to single-branch state when getBranches omits the own id", () => {
+    const switchToBranch = vi.fn();
+    const { aui } = renderThread(
+      baseProps({
+        getBranches: () => ["b1", "b2"],
+        switchToBranch,
+      }),
+    );
+    const state = aui().thread().getState();
+    expect(state.messages[1]!.branchNumber).toBe(1);
+    expect(state.messages[1]!.branchCount).toBe(1);
+
+    aui().thread().message({ index: 1 }).switchToBranch({ position: "next" });
+    expect(switchToBranch).not.toHaveBeenCalled();
+  });
+
+  it("keeps message state identity across adapter recreation with equal values", () => {
+    const messages = [message("u1", "user"), message("a2", "assistant")];
+    const { aui, rerender } = renderThread({
+      messages,
+      isRunning: false,
+      branches: adapterFor(["a1", "a2", "a3"]),
+    });
+    const before = aui().thread().getState().messages[1];
+
+    rerender({
+      messages,
+      isRunning: false,
+      branches: adapterFor(["a1", "a2", "a3"]),
+    });
+    const after = aui().thread().getState().messages[1];
+
+    expect(after!.branchNumber).toBe(2);
+    expect(before!.parts[0]).toBe(after!.parts[0]);
+  });
+});


### PR DESCRIPTION
## what

real branch support for the tap `ExternalThread` client, replacing the stubs (`branchNumber: 1`, `branchCount: 1`, `switchToBranch: () => {}`). one optional adapter prop, mirroring the queue adapter precedent exactly:

```ts
export type ExternalThreadBranchAdapter = {
  getBranches: (messageId: string) => readonly string[];
  switchToBranch: (branchId: string) => void;
};
```

the consumer keeps passing the visible branch as the flat `messages` array; the adapter supplies ordered sibling ids (including the message's own id) and one switch callback. on switch the consumer swaps `messages`. the client stays stateless: no tree handover, no new scopes, no new client state, ~30 changed lines in `ExternalThread.ts` plus a two-member type.

## design process

three competing designs were produced and judged against simplicity, paradigm fit, and consumer coverage:

- **minimal adapter (winner)**: precedent-exact with `queue?: ExternalThreadQueueAdapter` (same type tier in `core/runtime/`, same export sites, same `hasQueue`-style capability pattern), the adapter contract is the legacy `ThreadRuntimeCore.getBranches`/`switchToBranch` contract verbatim, and the position resolution copies `MessageRuntimeImpl` semantics
- branch fields on the message type: rejected for leaking tree-position metadata into the public message type (no repo precedent) and forcing consumers to spread-wrap messages, minting fresh identities and defeating consumer-side message caches
- legacy-parity tree input: self-rejected by its own design agent with evidence; true parity means re-owning the 458-line `MessageRepository`, a stateless client cannot own head selection anyway, and a `messages` XOR `tree` bifurcation threads through every handler

an adversarial vet pass then verified every line-number claim and produced five corrections, all folded in: the position-based switch is guarded when `getBranches` omits the own id (so the method agrees with the 1/1 rendering), explicit `branchId` forwards unvalidated but self-switches no-op, the capability claim is worded honestly (the picker is gated by `branchCount > 1` via `MessageIf`; `capabilities.switchToBranch` is set for parity, nothing in the primitive layer reads it), the edit-to-branch contract is documented (including the existing quirk that `ExternalThread`'s edit payload carries the edited message's own id as both `parentId` and `sourceId`), and the queue interplay divergence is on the JSDoc (programmatic mid-run switches reach the consumer instead of being silently ignored like legacy; pending queue items are not cleared).

## consumers

server-owned trees (hermes-agent style, siblings grouped by a branch-group id) expose the grouping as `getBranches` and let the server swap the visible branch; this is the post-migration shape for consumers currently on the legacy `useExternalStoreRuntime`, which remains the supported path for tree-shaped input. client-owned regenerate (ChatGPT style) keeps alternative responses per turn and flips the active one in `switchToBranch`; regenerate itself rides the existing `onReload`.

## incrementality

per-message resources stay keyed by `msg.id` in `useClientLookup`, so adapter identity changes re-render message clients without remounting them (edit composer state and `isCopied` survive), branch values are scalars in the state memo deps, and `getBranches` is called once per visible message per render (O(visible), pure-during-render, the same contract `queue.items` already imposes). a wholesale branch swap remounts only the messages whose ids changed.

## testing

new `external-thread-branches.test.tsx` (6 cases): current-behavior lock without the adapter, number/count derivation, previous/next resolution with edge no-ops, unvalidated `branchId` forwarding with the self-switch guard, the omitted-own-id fallback agreeing between rendering and the method, and part-state identity surviving adapter recreation. full `@assistant-ui/react` suite passes (376 tests, 34 files); `pnpm lint`; core/react/react-native/react-ink builds green. docs: `ExternalThreadBranchAdapter` section in the external-store runtime reference next to the queue adapter.
