### PR TITLE
ci(npm-publish): fail fast on pending changesets and skip git hooks

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -245,6 +245,17 @@ jobs:
             exit 1
           fi
 
+      - name: Validate no pending changesets
+        run: |
+          pending=$(find .changeset -name '*.md' ! -name 'README.md' | sort)
+          if [ -n "$pending" ]; then
+            echo "::error::Release SHA has pending changesets, so changesets/action would update the version PR instead of publishing."
+            echo "::error::Merge the version PR first, then dispatch with its merge commit as releaseSha."
+            echo "Pending changesets:"
+            echo "$pending"
+            exit 1
+          fi
+
       - name: Resolve publish targets
         id: targets
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -795,6 +806,8 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The action's fallback version path commits without ci:version's lockfile refresh, so the pre-commit hook's pnpm run fails on the stale lockfile.
+          HUSKY: 0
 
       - name: Recovery guidance
         if: failure()


### PR DESCRIPTION
## summary

- dispatching a publish at a SHA that still has pending changesets made changesets/action silently take its version-PR branch instead of publishing, then crash inside its `git commit`: the action's bare `changeset version` (unlike `ci:version` in changeset.yaml) leaves pnpm-lock.yaml stale, so the pre-commit hook's pnpm run fails; this is how run 27255036229 died and why the version PR stopped refreshing
- the summary job now validates that the release SHA has no pending changesets and fails fast with recovery guidance (merge the version PR, dispatch with its merge commit as releaseSha), before the `npm Publish` environment approval gate so a doomed run never asks for approval
- `HUSKY: 0` on the changesets step as defense in depth, so any git operation the action performs skips repo hooks even if the guard is ever bypassed

## test plan

### already verified

- [x] yaml lint on the workflow file passes
- [x] failure chain reproduced from the logs of run 27255036229: pending changesets present at the dispatched SHA (`git ls-tree 5b6fabffb .changeset/` shows 2 entries), version-PR path taken, `husky - pre-commit script failed (code 1)` on the action's internal commit

### reviewer should verify

- [ ] after merge, a workflow_dispatch at a SHA with pending changesets fails in the "Release summary" job with the new error and never reaches the approval gate
- [ ] a dispatch at the next version commit (zero pending changesets) passes the guard and proceeds to publish

## notes

- the other recent failure (run 27247979726, the auto-dispatch at the 0.14.17 version commit) died at the `npm Publish` environment approval gate ("deployment was rejected"), not in the workflow logic; nothing to fix in code there, the next publish just needs the approval
- react 0.14.17, core 0.2.13, and tap 0.7.0 are still unpublished; recovery path after this merges: let changeset.yaml refresh the version PR, merge it, approve the auto-dispatched publish run