### PR TITLE
fix(react-ag-ui): attach TOOL_CALL_RESULT for a prior run's tool call to its owning message

### DIFF
--- a/.changeset/agui-result-only-resume.md
+++ b/.changeset/agui-result-only-resume.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: attach a TOOL_CALL_RESULT for a prior run's tool call to its owning message instead of synthesizing a duplicate empty-args part

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -22,6 +22,7 @@ import {
   AG_UI_METADATA_NAMESPACE,
   type AgUiCustomMetadata,
   RunAggregator,
+  tryParseJSON,
 } from "./adapter/run-aggregator";
 import {
   fromAgUiMessages,
@@ -908,9 +909,44 @@ export class AgUiThreadRuntimeCore {
         this.importMessagesSnapshot(event.messages);
         return;
       }
+      case "TOOL_CALL_RESULT": {
+        // Results for tool calls the current run never opened (e.g. resume
+        // after an interrupt) belong to a prior message.
+        if (!aggregator.hasToolCall(event.toolCallId)) {
+          const messageId = this.findMessageIdForToolCall(event.toolCallId);
+          if (messageId !== undefined) {
+            this.applyCrossRunToolResult(messageId, event);
+            return;
+          }
+        }
+        aggregator.handle(event);
+        return;
+      }
       default:
         aggregator.handle(event);
     }
+  }
+
+  private applyCrossRunToolResult(
+    messageId: string,
+    event: Extract<AgUiEvent, { type: "TOOL_CALL_RESULT" }>,
+  ): void {
+    const owner = this.messages.find((m) => m.id === messageId);
+    const part =
+      owner?.role === "assistant"
+        ? owner.content.find(
+            (p): p is ToolCallMessagePart =>
+              p.type === "tool-call" && p.toolCallId === event.toolCallId,
+          )
+        : undefined;
+    this.addToolResult({
+      messageId,
+      toolCallId: event.toolCallId,
+      toolName: part?.toolName ?? "tool",
+      result: tryParseJSON(event.content ?? "") as ReadonlyJSONValue,
+      // mirror finishToolCall: a missing role leaves isError unset
+      isError: event.role === "tool" ? false : undefined,
+    } as AddToolResultOptions);
   }
 
   private importMessagesSnapshot(rawMessages: readonly unknown[]) {

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -397,27 +397,37 @@ export class AgUiThreadRuntimeCore {
     this.maybeResumeAfterToolResults(options.messageId);
   }
 
-  // Re-evaluate whether every tool call on the assistant message now has a
-  // result and, if so, drive the follow-up run. Centralizing this lets the
-  // continuation fire whether the frontend result lands before RUN_FINISHED
-  // (status flips to requires-action only later, while a run is still draining)
-  // or after it. Idempotent: once the message is marked complete it no-ops.
+  // The continuation fires whether the frontend result lands before
+  // RUN_FINISHED (the status flips to requires-action only later, while the
+  // run is still draining) or after it.
   private maybeResumeAfterToolResults(messageId: string): void {
+    if (!this.maybeCompleteAfterToolResults(messageId)) return;
+
+    if (this.isRunningFlag) {
+      // A run is still draining (RUN_FINISHED arrived but the stream has not
+      // closed). Defer until startRun's tail so we never start two runs.
+      this.pendingResumeMessageId = messageId;
+      return;
+    }
+    this.startResumeRun(messageId);
+  }
+
+  private maybeCompleteAfterToolResults(messageId: string): boolean {
     const message = this.messages.find((m) => m.id === messageId);
-    if (!message || message.role !== "assistant") return;
+    if (!message || message.role !== "assistant") return false;
     const assistant = message as ThreadAssistantMessage;
     if (
       assistant.status?.type !== "requires-action" ||
       assistant.status.reason !== "tool-calls"
     ) {
-      return;
+      return false;
     }
     const allResolved = assistant.content.every(
       (part) =>
         part.type !== "tool-call" ||
         ("result" in part && part.result !== undefined),
     );
-    if (!allResolved) return;
+    if (!allResolved) return false;
 
     this.messages = this.messages.map((m) =>
       m.id === messageId && m.role === "assistant"
@@ -429,14 +439,7 @@ export class AgUiThreadRuntimeCore {
     );
     this.notifyUpdate();
     this.persistAssistantHistory(messageId);
-
-    if (this.isRunningFlag) {
-      // A run is still draining (RUN_FINISHED arrived but the stream has not
-      // closed). Defer until startRun's tail so we never start two runs.
-      this.pendingResumeMessageId = messageId;
-      return;
-    }
-    this.startResumeRun(messageId);
+    return true;
   }
 
   private startResumeRun(messageId: string): void {
@@ -910,8 +913,6 @@ export class AgUiThreadRuntimeCore {
         return;
       }
       case "TOOL_CALL_RESULT": {
-        // Results for tool calls the current run never opened (e.g. resume
-        // after an interrupt) belong to a prior message.
         if (!aggregator.hasToolCall(event.toolCallId)) {
           const messageId = this.findMessageIdForToolCall(event.toolCallId);
           if (messageId !== undefined) {
@@ -931,22 +932,35 @@ export class AgUiThreadRuntimeCore {
     messageId: string,
     event: Extract<AgUiEvent, { type: "TOOL_CALL_RESULT" }>,
   ): void {
-    const owner = this.messages.find((m) => m.id === messageId);
-    const part =
-      owner?.role === "assistant"
-        ? owner.content.find(
-            (p): p is ToolCallMessagePart =>
-              p.type === "tool-call" && p.toolCallId === event.toolCallId,
-          )
-        : undefined;
-    this.addToolResult({
-      messageId,
-      toolCallId: event.toolCallId,
-      toolName: part?.toolName ?? "tool",
-      result: tryParseJSON(event.content ?? "") as ReadonlyJSONValue,
-      // mirror finishToolCall: a missing role leaves isError unset
-      isError: event.role === "tool" ? false : undefined,
-    } as AddToolResultOptions);
+    let updated = false;
+    this.messages = this.messages.map((message) => {
+      if (message.id !== messageId || message.role !== "assistant")
+        return message;
+      const assistant = message as ThreadAssistantMessage;
+      let matchedToolCall = false;
+      const content = assistant.content.map((part) => {
+        if (part.type !== "tool-call" || part.toolCallId !== event.toolCallId)
+          return part;
+        matchedToolCall = true;
+        return {
+          ...part,
+          result: tryParseJSON(event.content ?? "") as ReadonlyJSONValue,
+          ...(event.role === "tool" ? { isError: false } : {}),
+          ...(event.messageId
+            ? { unstable_toolMessageId: event.messageId }
+            : {}),
+        };
+      });
+      if (!matchedToolCall) return message;
+      updated = true;
+      return { ...assistant, content };
+    });
+
+    if (!updated) return;
+    this.notifyUpdate();
+    // Not maybeResumeAfterToolResults: the delivering run is already in
+    // flight, and a resume from the owner would reset the head past it.
+    this.maybeCompleteAfterToolResults(messageId);
   }
 
   private importMessagesSnapshot(rawMessages: readonly unknown[]) {

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -82,6 +82,10 @@ export class RunAggregator {
     this.onServerMessageId = options.onServerMessageId;
   }
 
+  hasToolCall(toolCallId: string): boolean {
+    return this.toolCalls.has(toolCallId);
+  }
+
   handle(event: AgUiEvent): void {
     switch (event.type) {
       case "RUN_STARTED": {
@@ -388,21 +392,12 @@ export class RunAggregator {
     ) {
       this.partOrder.push({ kind: "tool-call", toolCallId: id });
     }
-    entry.result = this.tryParseJSON(content);
+    entry.result = tryParseJSON(content);
     entry.isError = isError;
     if (toolMessageId) {
       entry.toolMessageId = toolMessageId;
     }
     this.lastResolvedToolCallId = id;
-  }
-
-  private tryParseJSON(value: string): unknown {
-    if (!value) return value;
-    try {
-      return JSON.parse(value);
-    } catch {
-      return value;
-    }
   }
 
   private emit(): void {
@@ -540,5 +535,14 @@ export class RunAggregator {
     if (!this.showThinking) return;
     this.activeReasoningKey = undefined;
     this.emit();
+  }
+}
+
+export function tryParseJSON(value: string): unknown {
+  if (!value) return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
   }
 }

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1374,6 +1374,127 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(assistant.metadata.custom.agui).toBeUndefined();
   });
 
+  it("attaches a TOOL_CALL_RESULT for a prior run's tool call to its owning message", async () => {
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "call-1",
+            toolCallName: "ask_question",
+          },
+        });
+        subscriber.onToolCallArgsEvent?.({
+          event: {
+            type: "TOOL_CALL_ARGS",
+            toolCallId: "call-1",
+            delta: '{"question":"approve?"}',
+          },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+        });
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: {
+              type: "interrupt",
+              interrupts: [
+                { id: "int-1", reason: "tool_call", toolCallId: "call-1" },
+              ],
+            },
+          },
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onToolCallResultEvent?.({
+        event: {
+          type: "TOOL_CALL_RESULT",
+          messageId: "tool-msg-1",
+          toolCallId: "call-1",
+          content: '{"answer":"yes"}',
+          role: "tool",
+        },
+      });
+      subscriber.onTextMessageContentEvent?.({
+        event: { type: "TEXT_MESSAGE_CONTENT", delta: "Done." },
+      });
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+    await core.submitInterruptResponses([
+      { interruptId: "int-1", status: "resolved", payload: { ok: true } },
+    ]);
+
+    const assistants = core
+      .getMessages()
+      .filter((m) => m.role === "assistant") as ThreadAssistantMessage[];
+    expect(assistants).toHaveLength(2);
+
+    const [first, second] = assistants;
+    const toolPart = first!.content.find((p) => p.type === "tool-call");
+    expect(toolPart).toMatchObject({
+      toolCallId: "call-1",
+      toolName: "ask_question",
+      result: { answer: "yes" },
+    });
+    expect(second!.content.filter((p) => p.type === "tool-call")).toHaveLength(
+      0,
+    );
+    expect(second!.content).toContainEqual(
+      expect.objectContaining({ type: "text", text: "Done." }),
+    );
+  });
+
+  it("falls back to the aggregator when a TOOL_CALL_RESULT has no owning message", async () => {
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onToolCallResultEvent?.({
+        event: {
+          type: "TOOL_CALL_RESULT",
+          toolCallId: "orphan-1",
+          content: "ok",
+          role: "tool",
+        },
+      });
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const assistant = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    const toolPart = assistant.content.find((p) => p.type === "tool-call");
+    expect(toolPart).toMatchObject({
+      toolCallId: "orphan-1",
+      toolName: "tool",
+      result: "ok",
+    });
+  });
+
   it("rejects interrupt resume that does not cover every open interrupt", async () => {
     const runAgent = vi.fn(async (input: any, subscriber: any) => {
       subscriber.onRunFinishedEvent?.({

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1440,6 +1440,7 @@ describe("AGUIThreadRuntimeCore", () => {
       { interruptId: "int-1", status: "resolved", payload: { ok: true } },
     ]);
 
+    expect(runAgent).toHaveBeenCalledTimes(2);
     const assistants = core
       .getMessages()
       .filter((m) => m.role === "assistant") as ThreadAssistantMessage[];
@@ -1451,6 +1452,7 @@ describe("AGUIThreadRuntimeCore", () => {
       toolCallId: "call-1",
       toolName: "ask_question",
       result: { answer: "yes" },
+      unstable_toolMessageId: "tool-msg-1",
     });
     expect(second!.content.filter((p) => p.type === "tool-call")).toHaveLength(
       0,
@@ -1493,6 +1495,95 @@ describe("AGUIThreadRuntimeCore", () => {
       toolName: "tool",
       result: "ok",
     });
+  });
+
+  it("completes a requires-action message via a cross-run result without starting a resume run", async () => {
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "call-1",
+            toolCallName: "lookup",
+          },
+        });
+        subscriber.onToolCallArgsEvent?.({
+          event: { type: "TOOL_CALL_ARGS", toolCallId: "call-1", delta: "{}" },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+        });
+        subscriber.onRunFinishedEvent?.({
+          event: { type: "RUN_FINISHED", runId: input.runId },
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onToolCallResultEvent?.({
+        event: {
+          type: "TOOL_CALL_RESULT",
+          messageId: "tool-msg-1",
+          toolCallId: "call-1",
+          content: "42",
+          role: "tool",
+        },
+      });
+      subscriber.onTextMessageContentEvent?.({
+        event: { type: "TEXT_MESSAGE_CONTENT", delta: "It is 42." },
+      });
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const owner = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    expect(owner.status).toMatchObject({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+
+    await core.append(
+      createAppendMessage({ parentId: core.getMessages().at(-1)!.id }),
+    );
+
+    expect(runAgent).toHaveBeenCalledTimes(2);
+    const messages = core.getMessages();
+    expect(messages.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+
+    const first = messages[1] as ThreadAssistantMessage;
+    expect(first.status).toMatchObject({ type: "complete" });
+    expect(first.content.find((p) => p.type === "tool-call")).toMatchObject({
+      toolCallId: "call-1",
+      toolName: "lookup",
+      result: 42,
+      isError: false,
+    });
+
+    const second = messages[3] as ThreadAssistantMessage;
+    expect(second.content.filter((p) => p.type === "tool-call")).toHaveLength(
+      0,
+    );
+    expect(second.content).toContainEqual(
+      expect.objectContaining({ type: "text", text: "It is 42." }),
+    );
   });
 
   it("rejects interrupt resume that does not cover every open interrupt", async () => {


### PR DESCRIPTION
## Problem

When a backend emits a `TOOL_CALL_RESULT` for a `toolCallId` that the **current** run never opened, the `RunAggregator` synthesizes a brand-new tool-call part named `"tool"` with empty args on the current assistant message — while the original tool-call part on the earlier message stays result-less forever.

This is a spec-mandated flow: the interrupt documentation (`docs/concepts/interrupts.mdx`) states that a resumed run does not re-emit `TOOL_CALL_START`/`ARGS`/`END` and only emits `TOOL_CALL_RESULT` against the original `toolCallId`, and the `a2a` integration produces exactly this shape by design (`aws-strands` drives the same flow through the `RUN_FINISHED` interrupt outcome). The protocol layer agrees: `verifyEvents` has no rule for `TOOL_CALL_RESULT`, and `@ag-ui/client`'s `defaultApplyEvents` splices the result after the owning assistant message across the whole persisted list. But `react-ag-ui` renders from its own per-run aggregator (a fresh one per `startRun`, `RUN_STARTED` clears its tool-call map), so any spec-following backend that resumes this way renders a duplicate empty-args "tool" card. (The current `@ag-ui/langgraph` adapter happens to re-emit `TOOL_CALL_START` before the result on its mainline resume path, which masks the bug there today; its TS Command path can still produce a result-only sequence.)

## Fix

In `AgUiThreadRuntimeCore.handleEvent`, intercept `TOOL_CALL_RESULT`: if the current run's aggregator doesn't know the id and `findMessageIdForToolCall` locates an owning message, patch the result onto that message's tool-call part directly, carrying the event's `messageId` as `unstable_toolMessageId` like the aggregator does. Otherwise fall through to the aggregator unchanged (orphan results keep today's synthesize behavior).

The cross-run attach deliberately bypasses `addToolResult`'s continuation machinery: the run delivering the result is already in flight, and `maybeResumeAfterToolResults` on an owner stuck at `requires-action`/`"tool-calls"` would schedule a deferred resume run whose `resetHead(owner)` drops every newer message and re-invokes the agent unprompted. The attach completes the owner's status once all its tool calls are resolved (`maybeCompleteAfterToolResults`) but never starts a run.

## Tests

- resume scenario: run 1 opens `call-1` and interrupts; run 2 emits result-only → result lands on run 1's part (name and `unstable_toolMessageId` preserved), no tool-call part on run 2's message, exactly 2 runs
- regression: owner stuck at `requires-action`/`"tool-calls"` (bare `RUN_FINISHED` with an unresolved call), then a follow-up user message whose run delivers the result → result attaches, owner completes, exactly 2 runs and no message loss (fails with 3 runs when routed through `addToolResult`)
- orphan result with no owning message still falls back to the aggregator

🤖 Generated with [Claude Code](https://claude.com/claude-code)