### PR TITLE
docs: add commands and monorepo layout to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,32 @@
+## Commands
+
+```sh
+pnpm install          # Node >= 24, pnpm 11
+pnpm turbo build      # required once after install — packages import each other's dist/ outputs
+pnpm lint             # oxlint + oxfmt --check
+pnpm lint:fix         # autofix both
+pnpm test             # turbo test (vitest per package) + test:types (tsc --noEmit per package)
+```
+
+Scope work to a single package with turbo filters, or run vitest from inside the package:
+
+```sh
+pnpm turbo build --filter=@assistant-ui/react                # build one package + its deps
+cd packages/react && pnpm vitest run src/tests/foo.test.ts   # single test file
+cd packages/react && pnpm vitest run -t "test name"          # single test by name
+cd packages/react && pnpm test:watch
+```
+
+Docs site: `pnpm docs:dev`. Examples: `cd examples/<name> && pnpm dev` (build packages first — examples consume their dist outputs).
+
+## Monorepo layout
+
+- `packages/*` — published npm libraries. Built with `aui-build` (from `@assistant-ui/x-buildutils`), tested with vitest.
+- `apps/*` — deployed, never published: `docs` (assistant-ui.com), `registry` (shadcn registry), devtools extension/frame.
+- `examples/*` — runnable demos. They resolve `@/components/assistant-ui/*` to `packages/ui` via tsconfig paths, so they must not carry local copies of those components.
+- `templates/*` — starter templates used by the CLI. Shared components must stay byte-equal with the canonical source in `packages/ui/src/components/assistant-ui`; `pnpm sync-templates` checks, `bash scripts/sync-templates.sh --write` fixes drift.
+- `python/*` — uv-managed Python packages (e.g. the `assistant-stream` server library); not part of the pnpm workspace.
+
 ## Architecture
 
 ```
@@ -7,7 +36,10 @@
 @assistant-ui/react        → Web distribution (re-exports core + adds Radix primitives)
 @assistant-ui/react-native → RN distribution (re-exports core + adds RN primitives)
 @assistant-ui/react-ink    → Ink/terminal distribution
+assistant-stream           → Streaming wire protocol (TypeScript side; python/assistant-stream is the Python counterpart)
 ```
+
+Integration packages (`react-ai-sdk`, `react-langgraph`, `react-a2a`, `react-ag-ui`, …) adapt third-party backends and build on top of `@assistant-ui/react`.
 
 ## Changesets
 
@@ -43,4 +75,4 @@ Assume other coding agents are working alongside you. Before editing, check the 
 
 `@assistant-ui/ui` contains shadcn-style components that get copied into user projects. We use them directly in the monorepo to avoid duplication.
 
-There is an ongoing migration from the legacy runtime architecture to a tap-only architecture.
+There is an ongoing migration from the legacy runtime architecture to a tap-only architecture. Legacy code lives in `packages/react/src/legacy-runtime` and `packages/core/src/runtimes`; new code should use the tap architecture.


### PR DESCRIPTION
## What changed

AGENTS.md previously covered architecture, changesets, lint rules, and package boundaries, but not how to build, test, or navigate the repo. This adds the missing operational context so coding agents (and new contributors) can be productive without rediscovering it each session:

- **Commands** — install, the required initial `pnpm turbo build` (packages import each other's `dist/` outputs, per CONTRIBUTING.md), lint/autofix, the full test run, and how to scope builds/tests to a single package (turbo filters, single vitest file, `-t` by name).
- **Monorepo layout** — roles of `packages/`, `apps/`, `examples/`, `templates/`, and `python/`, including the constraint that examples resolve `@/components/assistant-ui/*` to `packages/ui` via tsconfig paths and that template components must stay byte-equal with the canonical source (`pnpm sync-templates` checks, `--write` fixes).
- **Architecture** — adds `assistant-stream` (TS/Python protocol pair) and the integration-package layer to the existing diagram, and pins down where the legacy runtime lives (`packages/react/src/legacy-runtime`, `packages/core/src/runtimes`) so the tap-migration note is actionable.

## Why

Documentation-only change; all commands and layout facts were verified against the repo (root `package.json`, `turbo.json`, `pnpm-workspace.yaml`, `scripts/sync-templates.sh`, CONTRIBUTING.md). No changeset needed since no published package is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)