### PR TITLE
feat(tap): useTapHost passive-commit React host

### DIFF
--- a/.changeset/store-use-tap-host.md
+++ b/.changeset/store-use-tap-host.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+feat: host the assistant client with useTapHost so the tap commit runs in the passive phase (no paint blocking); AuiProvider mounts the host's commit effects ahead of its children's effects

--- a/.changeset/tap-use-tap-host.md
+++ b/.changeset/tap-use-tap-host.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+feat: add useTapHost, a React host that commits the resource in the passive phase without blocking paint; the returned per-render effects callback lets descendant consumers mount the commit ahead of their own effects via useEffect(effects). The React bridge hosts (useResource, useResources, useTapRoot) now also commit in useEffect instead of useLayoutEffect.

--- a/apps/docs/content/tap-docs/tap/api-reference.mdx
+++ b/apps/docs/content/tap-docs/tap/api-reference.mdx
@@ -79,6 +79,38 @@ handle.getValue();
 handle.subscribe(() => {});
 ```
 
+## useTapHost
+
+Hosts a resource tree inside a React component. The tree renders with the
+component and commits in a passive effect, so it never blocks paint. Returns
+`{ value, effects }`.
+
+`effects` is a per-render callback (not a hook) that performs the commit. The
+host mounts it itself, but parent effects run after children's, so a child
+effect that subscribes to the tree would run before the commit. To commit
+ahead of a subtree, render a component before it that passes `effects` to a
+deps-less `useEffect`; the first instance to run wins. Consumers of `effects`
+must be descendants of the host component.
+
+```tsx
+function CounterProvider({ children }: { children: ReactNode }) {
+  const { value, effects } = useTapHost(function CounterHost() {
+    return useResource(Counter({ initialValue: 0 }));
+  });
+  return (
+    <CounterContext.Provider value={value}>
+      <TapEffects effects={effects} />
+      {children}
+    </CounterContext.Provider>
+  );
+}
+
+function TapEffects({ effects }: { effects: () => void }) {
+  useEffect(effects);
+  return null;
+}
+```
+
 ## createTapRoot
 
 Hosts a resource tree [outside React](/tap/docs/tap/outside-react). Takes a render

--- a/packages/core/src/react/AssistantProvider.tsx
+++ b/packages/core/src/react/AssistantProvider.tsx
@@ -23,11 +23,13 @@ export const AssistantProviderBase: FC<AssistantProviderBaseProps> = memo(
   ({ runtime, aui: parent = null, children }) => {
     const aui = useAui({ threads: RuntimeAdapter(runtime) }, { parent });
     const RenderComponent = getRenderComponent(runtime);
-    return (
+    const inner = (
       <AuiProvider value={aui}>
         {RenderComponent && <RenderComponent />}
         {children}
       </AuiProvider>
     );
+    if (!parent) return inner;
+    return <AuiProvider value={parent}>{inner}</AuiProvider>;
   },
 );

--- a/packages/store/src/__tests__/useAuiHost.test.tsx
+++ b/packages/store/src/__tests__/useAuiHost.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { flushTapSync, resource } from "@assistant-ui/tap";
+import { AuiProvider } from "../utils/react-assistant-context";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+
+const makeTestClient = (log: string[]) => {
+  // Runs inside the tap host; "react" imports route to tap's dispatcher.
+  const useTestClient = () => {
+    const [count, setCount] = useState(0);
+    useEffect(() => {
+      log.push("tap effect");
+      return () => {
+        log.push("tap cleanup");
+      };
+    }, []);
+    return {
+      getState: () => ({ count }),
+      setCount: (n: number) => setCount(n),
+    };
+  };
+  return resource(useTestClient);
+};
+
+const Provider = ({
+  client,
+  children,
+}: {
+  client: ReturnType<ReturnType<typeof makeTestClient>>;
+  children: ReactNode;
+}) => {
+  const aui = useAui({ thread: client } as unknown as useAui.Props);
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+};
+
+describe("useAui tap host", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("commits client effects passively, ahead of consumer effects", () => {
+    const log: string[] = [];
+    const TestClient = makeTestClient(log);
+
+    function Consumer() {
+      useLayoutEffect(() => {
+        log.push("consumer layout");
+      }, []);
+      useEffect(() => {
+        log.push("consumer effect");
+      }, []);
+      return null;
+    }
+
+    render(
+      <Provider client={TestClient()}>
+        <Consumer />
+      </Provider>,
+    );
+
+    // "consumer layout" first: the commit no longer blocks paint.
+    // "tap effect" before "consumer effect": AuiProvider mounts the host's
+    // commit ahead of its children's effects, with no opt-in by the child.
+    expect(log).toEqual(["consumer layout", "tap effect", "consumer effect"]);
+  });
+
+  it("commits via the host's own fallback without an AuiProvider", () => {
+    const log: string[] = [];
+    const TestClient = makeTestClient(log);
+    const client = TestClient();
+
+    function HostOnly() {
+      useAui({ thread: client } as unknown as useAui.Props);
+      return null;
+    }
+
+    render(<HostOnly />);
+    expect(log).toEqual(["tap effect"]);
+  });
+
+  it("updates flow through to useAuiState consumers", () => {
+    const log: string[] = [];
+    const TestClient = makeTestClient(log);
+
+    let api!: { setCount: (n: number) => void };
+    let observed!: number;
+    function Consumer() {
+      const aui = useAui();
+      api = (aui as any).thread();
+      observed = useAuiState((s) => (s as any).thread.count);
+      return null;
+    }
+
+    render(
+      <Provider client={TestClient()}>
+        <Consumer />
+      </Provider>,
+    );
+    expect(observed).toBe(0);
+
+    act(() => flushTapSync(() => api.setCount(7)));
+    expect(observed).toBe(7);
+  });
+
+  it("cleans up client effects when the host unmounts", () => {
+    const log: string[] = [];
+    const TestClient = makeTestClient(log);
+
+    const { unmount } = render(
+      <Provider client={TestClient()}>{null}</Provider>,
+    );
+    unmount();
+    expect(log).toEqual(["tap effect", "tap cleanup"]);
+  });
+});

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -3,6 +3,7 @@
 import {
   useResource,
   useResources,
+  useTapHost,
   useTapRoot,
   resource,
   withKey,
@@ -21,6 +22,7 @@ import {
   useAssistantContextValue,
   DefaultAssistantClient,
   createRootAssistantClient,
+  AUI_USE_EFFECTS_SYMBOL,
 } from "./utils/react-assistant-context";
 import {
   type DerivedClients,
@@ -362,6 +364,19 @@ const useAssistantClient = ({
   return client;
 };
 
+const useHostedAssistantClient = (props: {
+  parent: AssistantClient;
+  clients: useAui.Props;
+}): AssistantClient => {
+  const { value: client, effects } = useTapHost(function AssistantClientHost() {
+    return useAssistantClient(props);
+  });
+
+  (client as Record<symbol, unknown>)[AUI_USE_EFFECTS_SYMBOL] = effects;
+
+  return client;
+};
+
 export namespace useAui {
   export type Props = {
     [K in ClientNames]?: ClientElement<K> | DerivedElement<K>;
@@ -441,7 +456,7 @@ export function useAui(
   },
 ): AssistantClient {
   if (clients) {
-    return useAssistantClient({
+    return useHostedAssistantClient({
       parent: parent ?? DefaultAssistantClient,
       clients,
     });

--- a/packages/store/src/utils/react-assistant-context.tsx
+++ b/packages/store/src/utils/react-assistant-context.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { createContext, useContext } from "react";
+import { createContext, useContext, useEffect } from "react";
 import type { AssistantClient, AssistantClientAccessor } from "../types/client";
 import {
   createProxiedAssistantState,
@@ -80,6 +80,29 @@ export const createRootAssistantClient = (): AssistantClient =>
  */
 const AssistantContext = createContext<AssistantClient>(DefaultAssistantClient);
 
+/**
+ * Carries the tap host's effects callback on the client so AuiProvider can
+ * mount the host's commit ahead of its children's effects.
+ */
+export const AUI_USE_EFFECTS_SYMBOL = Symbol("assistant-ui.store.useEffects");
+
+const NOOP_EFFECT = () => {};
+
+const getTapEffects = (client: AssistantClient): (() => void) => {
+  return (
+    (client as Record<symbol, never>)[AUI_USE_EFFECTS_SYMBOL] ?? NOOP_EFFECT
+  );
+};
+
+const UseTapEffects = () => {
+  "use no memo";
+
+  const aui = useAssistantContextValue();
+  // oxlint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(getTapEffects(aui));
+  return null;
+};
+
 export const useAssistantContextValue = (): AssistantClient => {
   return useContext(AssistantContext);
 };
@@ -114,8 +137,11 @@ export const AuiProvider = ({
   /** Subtree that may read from the client. */
   children: React.ReactNode;
 }): React.ReactElement => {
+  // The <UseTapEffects /> element must be created fresh each render
+  "use no memo";
   return (
     <AssistantContext.Provider value={value}>
+      <UseTapEffects />
       {children}
     </AssistantContext.Provider>
   );

--- a/packages/tap/src/__tests__/errors/errors.render-errors.test.ts
+++ b/packages/tap/src/__tests__/errors/errors.render-errors.test.ts
@@ -50,7 +50,7 @@ describe("Errors - Render Errors", () => {
       return count;
     });
 
-    expect(renderResourceFiber(resource, []).output).toBe(5);
+    expect(renderResourceFiber(resource, []).value).toBe(5);
   });
 
   it("should throw when updating a different resource during render", () => {

--- a/packages/tap/src/__tests__/react/useTapHost.test.tsx
+++ b/packages/tap/src/__tests__/react/useTapHost.test.tsx
@@ -1,0 +1,233 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import { StrictMode, useEffect, useLayoutEffect } from "react";
+import { useState as useTapState } from "../../react-hooks/useState";
+import { useEffect as useTapEffect } from "../../react-hooks/useEffect";
+import { useTapHost } from "../../index";
+
+const countOf = (log: string[], entry: string) =>
+  log.filter((e) => e === entry).length;
+
+describe("useTapHost", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("returns the resource value and re-renders on dispatch", () => {
+    let api!: { count: number; setCount: (n: number) => void };
+    function App() {
+      const { value } = useTapHost(function TapHost() {
+        const [count, setCount] = useTapState(0);
+        return { count, setCount };
+      });
+      api = value;
+      return <div data-testid="count">{value.count}</div>;
+    }
+
+    render(<App />);
+    expect(screen.getByTestId("count").textContent).toBe("0");
+    act(() => api.setCount(3));
+    expect(screen.getByTestId("count").textContent).toBe("3");
+  });
+
+  it("commits in the passive phase, before the effects of a consumer that mounts effects", () => {
+    const log: string[] = [];
+    function Child({ effects }: { effects: () => void }) {
+      useEffect(effects);
+      useLayoutEffect(() => {
+        log.push("child layout");
+      }, []);
+      useEffect(() => {
+        log.push("child effect");
+      }, []);
+      return null;
+    }
+    function App() {
+      const { effects } = useTapHost(function TapHost() {
+        useTapEffect(() => {
+          log.push("tap effect");
+        });
+        return null;
+      });
+      useEffect(() => {
+        log.push("host effect");
+      }, []);
+      return <Child effects={effects} />;
+    }
+
+    render(<App />);
+    // "child layout" first proves the commit is passive (does not block
+    // paint); "tap effect" before "child effect" proves the consumer's
+    // instance won the commit over the host's own fallback instance.
+    expect(log).toEqual([
+      "child layout",
+      "tap effect",
+      "child effect",
+      "host effect",
+    ]);
+  });
+
+  it("falls back to the host's own instance when no consumer mounts effects", () => {
+    const log: string[] = [];
+    function Child() {
+      useEffect(() => {
+        log.push("child effect");
+      }, []);
+      return null;
+    }
+    function App() {
+      useTapHost(function TapHost() {
+        useTapEffect(() => {
+          log.push("tap effect");
+        });
+        return null;
+      });
+      return <Child />;
+    }
+
+    render(<App />);
+    expect(log).toEqual(["child effect", "tap effect"]);
+  });
+
+  it("commits exactly once per pass with multiple consumers", () => {
+    const log: string[] = [];
+    let api!: { bump: () => void };
+    function Child({ effects }: { effects: () => void }) {
+      useEffect(effects);
+      return null;
+    }
+    function App() {
+      const { value, effects } = useTapHost(function TapHost() {
+        const [count, setCount] = useTapState(0);
+        useTapEffect(() => {
+          log.push("tap effect");
+        });
+        return { count, bump: () => setCount(count + 1) };
+      });
+      api = value;
+      return (
+        <>
+          <Child effects={effects} />
+          <Child effects={effects} />
+        </>
+      );
+    }
+
+    render(<App />);
+    expect(countOf(log, "tap effect")).toBe(1);
+
+    act(() => api.bump());
+    expect(countOf(log, "tap effect")).toBe(2);
+  });
+
+  it("hands responsibility to the next instance when the winner unmounts", () => {
+    const log: string[] = [];
+    let api!: { count: number; bump: () => void };
+    function Child({ name, effects }: { name: string; effects: () => void }) {
+      useEffect(effects);
+      useEffect(() => {
+        log.push(`${name} effect`);
+      });
+      return null;
+    }
+    function App({ showA }: { showA: boolean }) {
+      const { value, effects } = useTapHost(function TapHost() {
+        const [count, setCount] = useTapState(0);
+        useTapEffect(() => {
+          log.push(`tap effect ${count}`);
+          return () => {
+            log.push("tap cleanup");
+          };
+        });
+        return { count, bump: () => setCount(count + 1) };
+      });
+      api = value;
+      return (
+        <>
+          {showA && <Child name="a" effects={effects} />}
+          <Child name="b" effects={effects} />
+        </>
+      );
+    }
+
+    const { rerender } = render(<App showA={true} />);
+    expect(log).toEqual(["tap effect 0", "a effect", "b effect"]);
+
+    log.length = 0;
+    rerender(<App showA={false} />);
+    // The winner's unmount removes only its instance, not the resource: the
+    // no-deps tap effect re-fires as a cleanup/setup pair, not a final
+    // cleanup, and the commit still lands before b's own effect.
+    expect(log).toEqual(["tap cleanup", "tap effect 0", "b effect"]);
+
+    log.length = 0;
+    act(() => api.bump());
+    expect(api.count).toBe(1);
+    // Next in line (b) now commits, still ahead of its own effects.
+    expect(log).toEqual(["tap cleanup", "tap effect 1", "b effect"]);
+  });
+
+  it("unmounting the host cleans up exactly once", () => {
+    // effects consumers must be descendants of the host component, so
+    // they unmount with it and no flush can fire after the deletion.
+    const log: string[] = [];
+    function Child({ effects }: { effects: () => void }) {
+      useEffect(effects);
+      return null;
+    }
+    function HostComp() {
+      const { effects } = useTapHost(function TapHost() {
+        useTapEffect(() => {
+          log.push("tap effect");
+          return () => {
+            log.push("tap cleanup");
+          };
+        }, []);
+        return null;
+      });
+      return <Child effects={effects} />;
+    }
+    function App({ showHost }: { showHost: boolean }) {
+      return showHost ? <HostComp /> : null;
+    }
+
+    const { rerender } = render(<App showHost={true} />);
+    expect(log).toEqual(["tap effect"]);
+
+    rerender(<App showHost={false} />);
+    expect(log).toEqual(["tap effect", "tap cleanup"]);
+  });
+
+  it("remounts through a StrictMode effect cycle", () => {
+    const log: string[] = [];
+    let api!: { count: number; setCount: (n: number) => void };
+    function App() {
+      const { value } = useTapHost(function TapHost() {
+        const [count, setCount] = useTapState(0);
+        useTapEffect(() => {
+          log.push("tap mount");
+          return () => {
+            log.push("tap unmount");
+          };
+        }, []);
+        return { count, setCount };
+      });
+      api = value;
+      return <div data-testid="count">{value.count}</div>;
+    }
+
+    render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+    // setup, simulated unmount, setup: same as inlined hooks in StrictMode.
+    expect(countOf(log, "tap mount")).toBe(2);
+    expect(countOf(log, "tap unmount")).toBe(1);
+
+    act(() => api.setCount(5));
+    expect(screen.getByTestId("count").textContent).toBe("5");
+    expect(countOf(log, "tap mount")).toBe(2);
+    expect(countOf(log, "tap unmount")).toBe(1);
+  });
+});

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -63,7 +63,7 @@ export function renderTest<R, A extends readonly unknown[]>(
 
   // Return the committed state from the result
   // This accounts for any re-renders that happened during commit
-  return result.output;
+  return result.value;
 }
 
 /**
@@ -99,7 +99,7 @@ export function getCommittedOutput<R, A extends readonly unknown[]>(
       "No render result found for fiber. Make sure to call renderResource first.",
     );
   }
-  return lastResult.output;
+  return lastResult.value;
 }
 
 /**
@@ -117,7 +117,7 @@ export class TestSubscriber<T> {
     const lastArgs = propsMap.get(fiber) ?? [];
     const initialResult = renderResourceFiber(fiber, lastArgs as any);
     commitResourceFiber(fiber, initialResult);
-    this.lastState = initialResult.output;
+    this.lastState = initialResult.value;
     lastRenderResultMap.set(fiber, initialResult);
     activeResources.add(fiber);
   }
@@ -150,7 +150,7 @@ export class TestResourceManager<R, A extends readonly unknown[]> {
     const result = renderResourceFiber(this.fiber, args);
     commitResourceFiber(this.fiber, result);
     lastRenderResultMap.set(this.fiber, result);
-    return result.output;
+    return result.value;
   }
 
   cleanup() {

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -57,13 +57,13 @@ export function renderResourceFiber<R, A extends readonly unknown[]>(
 
     result = {
       effectTasks: [],
-      output: undefined as R | undefined,
+      value: undefined as R | undefined,
     };
 
     withResourceFiber(fiber, () => {
       fiber.renderContext = result;
       try {
-        result.output = withReactDispatcher(() => fiber.hook(...args));
+        result.value = withReactDispatcher(() => fiber.hook(...args));
       } finally {
         fiber.renderContext = undefined;
       }

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -34,7 +34,7 @@ export const createTapRoot = <R>(
   const rendered = renderResourceFiber(fiber, [render]);
   flushTapSync(() => commitResourceFiber(fiber, rendered));
 
-  const root = rendered.output as useTapRoot.Root<R>;
+  const root = rendered.value as useTapRoot.Root<R>;
 
   return {
     ...root,

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -51,7 +51,7 @@ export interface EffectTask {
 }
 
 export interface RenderResult {
-  output: any;
+  value: any;
   effectTasks: EffectTask[];
 }
 

--- a/packages/tap/src/hooks/useResource.ts
+++ b/packages/tap/src/hooks/useResource.ts
@@ -5,7 +5,7 @@ import {
   commitResourceFiber,
 } from "../core/ResourceFiber";
 import { useResourceFiberHost } from "./utils/useResourceFiberHostUtils";
-import { useLayoutEffect, useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useRenderMemo } from "./utils/useRenderMemo";
 
 export function useResource<E extends ResourceElement<any, any[]>>(
@@ -31,10 +31,10 @@ export function useResource<E extends ResourceElement<any, any[]>>(
     [fiber, version, ...identity],
   );
 
-  useLayoutEffect(() => () => unmountResourceFiber(fiber), [fiber]);
-  useLayoutEffect(() => {
+  useEffect(() => () => unmountResourceFiber(fiber), [fiber]);
+  useEffect(() => {
     commitResourceFiber(fiber, result);
   }, [fiber, result]);
 
-  return result.output;
+  return result.value;
 }

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -10,7 +10,7 @@ import {
   commitResourceFiber,
 } from "../core/ResourceFiber";
 import { useResourceFiberHost } from "./utils/useResourceFiberHostUtils";
-import { useCallback, useLayoutEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useRenderMemo } from "./utils/useRenderMemo";
 
 type FiberState = {
@@ -65,15 +65,15 @@ export function useResources<E extends ResourceElement<any, any[]>>(
         };
         newCount++;
         fibers.set(elementKey, state);
-        results.push(result.output);
+        results.push(result.value);
       } else if (state.fiber.hook !== element.hook) {
         const fiber = createFiber(element.hook, element.key);
         const result = renderResourceFiber(fiber, element.args);
         state.next = [fiber, result];
-        results.push(result.output);
+        results.push(result.value);
       } else {
         state.next = renderResourceFiber(state.fiber, element.args);
-        results.push(state.next.output);
+        results.push(state.next.value);
       }
     }
 
@@ -90,7 +90,7 @@ export function useResources<E extends ResourceElement<any, any[]>>(
   }, [getElementsMemo, fibers, createFiber, version]);
 
   // Cleanup on unmount
-  useLayoutEffect(() => {
+  useEffect(() => {
     return () => {
       for (const key of fibers.keys()) {
         const fiber = fibers.get(key)!.fiber;
@@ -99,7 +99,7 @@ export function useResources<E extends ResourceElement<any, any[]>>(
     };
   }, [fibers]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     void res; // as a performance optimization, we only run if the results have changed
 
     for (const [key, state] of fibers.entries()) {

--- a/packages/tap/src/hooks/useTapHost.ts
+++ b/packages/tap/src/hooks/useTapHost.ts
@@ -1,0 +1,60 @@
+import {
+  unmountResourceFiber,
+  renderResourceFiber,
+  commitResourceFiber,
+} from "../core/ResourceFiber";
+import { useResourceFiberHost } from "./utils/useResourceFiberHostUtils";
+import { useEffect, useMemo } from "react";
+
+export namespace useTapHost {
+  export interface Result<R> {
+    /**
+     * The current render output of the host resource.
+     */
+    value: R;
+
+    /**
+     * Commits the host's pending render result. Pass to a deps-less
+     * useEffect in a descendant component to land the commit ahead of
+     * the descendants' own effects; the first instance to run wins. A
+     * plain callback (not a hook) so React Compiler can compile the
+     * consumer; its identity changes on every host render.
+     */
+    effects: () => void;
+  }
+}
+
+const useHostRender = <R>(render: () => R): R => render();
+
+export const useTapHost = <R>(callback: () => R): useTapHost.Result<R> => {
+  const { createFiber } = useResourceFiberHost();
+  const fiber = useMemo(
+    () => createFiber(useHostRender<R>, undefined),
+    [createFiber],
+  );
+
+  const render = renderResourceFiber(fiber, [callback]);
+
+  useEffect(() => {
+    return () => {
+      unmountResourceFiber(fiber);
+    };
+  }, [fiber]);
+
+  let renderCommitted = false;
+  const effects = () => {
+    // !isMounted: StrictMode/Activity replays effects without a re-render
+    // after unmounting the fiber; the replay must recommit it.
+    if (renderCommitted && fiber.isMounted) return;
+    renderCommitted = true;
+
+    commitResourceFiber(fiber, render);
+  };
+
+  useEffect(effects);
+
+  return {
+    value: render.value as R,
+    effects,
+  };
+};

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -11,7 +11,7 @@ import {
   createResourceFiberRoot,
   setRootVersion,
 } from "../core/helpers/root";
-import { useEffectEvent, useLayoutEffect, useMemo, useRef } from "react";
+import { useEffect, useEffectEvent, useMemo, useRef } from "react";
 import { useDevStrictMode } from "./utils/useDevStrictMode";
 
 export namespace useTapRoot {
@@ -61,7 +61,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
   const isMountedRef = useRef(false);
   const committedArgsRef = useRef([render] as const);
-  const valueRef = useRef<R>(render2.output);
+  const valueRef = useRef<R>(render2.value);
   const subscribers = useMemo(() => new Set<() => void>(), []);
 
   const publish = (output: R) => {
@@ -102,10 +102,10 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
       commitResourceFiber(fiber, render);
     }
 
-    publish(render.output);
+    publish(render.value);
   });
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
@@ -113,13 +113,13 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     };
   }, [fiber]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     committedArgsRef.current = [render];
     commitRoot(fiber.root);
     queue.splice(0, drainedCount);
     commitResourceFiber(fiber, render2);
 
-    publish(render2.output);
+    publish(render2.value);
   });
 
   return useMemo(

--- a/packages/tap/src/hooks/utils/useRenderMemo.ts
+++ b/packages/tap/src/hooks/utils/useRenderMemo.ts
@@ -1,4 +1,4 @@
-import { useState, useLayoutEffect } from "react";
+import { useState, useEffect } from "react";
 import { depsShallowEqual } from "./depsShallowEqual";
 
 export const useRenderMemo = <T>(callback: () => T, deps: unknown[]) => {
@@ -12,7 +12,7 @@ export const useRenderMemo = <T>(callback: () => T, deps: unknown[]) => {
   state.wipDeps = state.currentDeps;
   state.wip = state.current;
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     state.currentDeps = state.wipDeps;
     state.current = state.wip;
   });

--- a/packages/tap/src/index.ts
+++ b/packages/tap/src/index.ts
@@ -12,6 +12,7 @@ export { createResourceContext, withContextProvider } from "./core/context";
 export { useResource } from "./hooks/useResource";
 export { useResources } from "./hooks/useResources";
 export { useTapRoot } from "./hooks/useTapRoot";
+export { useTapHost } from "./hooks/useTapHost";
 
 // types
 export type {


### PR DESCRIPTION
## Summary

- Adds `useTapHost`, a React host for tap resource trees that commits in the **passive phase** instead of `useLayoutEffect`, so tap never blocks paint.
- It returns `{ value, effects }` where `effects` is a **per-render commit callback**: descendant components mount it via a deps-less `useEffect` to pull the commit ahead of their own effects. The first instance to run wins; the host mounts its own instance as the always-last fallback. The per-render closure makes aborted React renders safe (a discarded pass's result is only reachable from that pass's discarded effect closures), and an `isMounted` check handles StrictMode/Activity effect replays, which re-run effects without a re-render.
- Switches all React bridge hosts (`useResource`, `useResources`, `useTapRoot`, `useRenderMemo`) from `useLayoutEffect` to `useEffect` commits.
- Renames `RenderResult.output` to `value`.
- The store now hosts the assistant client with `useTapHost`: `AuiProvider` renders a `UseTapEffects` child before `{children}`, so the tap commit lands ahead of the entire subtree's effects with no opt-in by consumers.

## React Compiler

`UseTapEffects` and `AuiProvider` carry `"use no memo"`: the client keeps its identity across host renders while the commit closure is replaced each render, so a memoized symbol read (or a cached `<UseTapEffects />` element) would pin a stale closure and silently disable the early-commit ordering. Verified empirically against babel-plugin-react-compiler 1.0.0; the directives produce clean skips and the remaining tap call-site bailouts (hooks in render closures) preserve semantics.

## Test plan

- tap: 425 tests incl. dev+prod parity suite and a new `useTapHost` suite (passive commit ordering, first-mounted-wins, fallback, winner handoff, unmount cleanup, StrictMode remount)
- store: new integration suite pinning commit-before-consumer-effects ordering through `AuiProvider`, fallback without a provider, update flow, unmount cleanup
- react: 376 tests, full `pnpm turbo build`, `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)