### PR TITLE
feat(registry): redesign ModelSelector component

### DIFF
--- a/.changeset/model-selector-reasoning-effort.md
+++ b/.changeset/model-selector-reasoning-effort.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat: add reasoningEffort to LanguageModelConfig

--- a/apps/docs/components/docs/samples/model-selector.tsx
+++ b/apps/docs/components/docs/samples/model-selector.tsx
@@ -16,6 +16,7 @@ import {
 import { DEFAULT_MODEL_ID, getContextWindow } from "@/constants/model";
 import { docsModelOptions } from "@/components/docs/assistant/docs-model-options";
 import { SampleFrame } from "@/components/docs/samples/sample-frame";
+import { cn } from "@/lib/utils";
 
 const PROVIDER_NAMES: Record<string, string> = {
   openai: "OpenAI",
@@ -57,7 +58,7 @@ function VariantRow({
   const [effort, setEffort] = useState<string>("medium");
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col items-center gap-2">
       <span className="text-muted-foreground text-xs font-medium">{label}</span>
       <ModelSelectorRoot
         models={models}
@@ -76,11 +77,31 @@ function VariantRow({
 function ComposedRow() {
   const [value, setValue] = useState<string>(DEFAULT_MODEL_ID);
   const [effort, setEffort] = useState<string>("medium");
+  const [providerFilter, setProviderFilter] = useState<ReadonlySet<string>>(
+    new Set(),
+  );
+
+  const toggleProvider = (provider: string) => {
+    setProviderFilter((prev) => {
+      const next = new Set(prev);
+      if (next.has(provider)) {
+        next.delete(provider);
+      } else {
+        next.add(provider);
+      }
+      return next;
+    });
+  };
+
+  // An empty filter means no filtering — all providers are shown.
+  const visibleGroups = [...modelsByProvider].filter(
+    ([provider]) => providerFilter.size === 0 || providerFilter.has(provider),
+  );
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col items-center gap-2">
       <span className="text-muted-foreground text-xs font-medium">
-        Composed: search + provider groups
+        With search, provider filters + groups
       </span>
       <ModelSelectorRoot
         models={models}
@@ -92,9 +113,31 @@ function ComposedRow() {
         <ModelSelectorTrigger />
         <ModelSelectorContent>
           <ModelSelectorSearch />
+          <div className="flex flex-wrap gap-1 border-b px-3 py-2">
+            {[...modelsByProvider.keys()].map((provider) => {
+              const isActive = providerFilter.has(provider);
+              return (
+                <button
+                  key={provider}
+                  type="button"
+                  aria-pressed={isActive}
+                  data-state={isActive ? "on" : "off"}
+                  onClick={() => toggleProvider(provider)}
+                  className={cn(
+                    "rounded-full border px-2 py-0.5 text-xs transition-colors",
+                    isActive
+                      ? "bg-accent text-accent-foreground border-transparent"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {provider}
+                </button>
+              );
+            })}
+          </div>
           <ModelSelectorList>
             <ModelSelectorEmpty />
-            {[...modelsByProvider].map(([provider, providerModels]) => (
+            {visibleGroups.map(([provider, providerModels]) => (
               <ModelSelectorGroup key={provider} heading={provider}>
                 {providerModels.map((model) => (
                   <ModelSelectorItem key={model.id} model={model} />
@@ -111,10 +154,12 @@ function ComposedRow() {
 
 export function ModelSelectorSample() {
   return (
-    <SampleFrame className="flex h-auto flex-col gap-6 p-6">
-      <VariantRow label="Outline (default)" variant="outline" />
-      <VariantRow label="Ghost" variant="ghost" />
-      <VariantRow label="Muted" variant="muted" />
+    <SampleFrame className="flex h-auto flex-col items-center gap-8 p-8">
+      <div className="flex flex-wrap items-start justify-center gap-x-10 gap-y-6">
+        <VariantRow label="Outline (default)" variant="outline" />
+        <VariantRow label="Ghost" variant="ghost" />
+        <VariantRow label="Muted" variant="muted" />
+      </div>
       <ComposedRow />
     </SampleFrame>
   );

--- a/apps/docs/components/docs/samples/model-selector.tsx
+++ b/apps/docs/components/docs/samples/model-selector.tsx
@@ -31,21 +31,30 @@ function providerOf(modelId: string): string {
 
 const compactNumber = new Intl.NumberFormat("en", { notation: "compact" });
 
-const models: ModelOption[] = docsModelOptions().map((model) => ({
-  ...model,
-  description: `${compactNumber.format(getContextWindow(model.id))} context window`,
-  keywords: [PROVIDER_NAMES[providerOf(model.id)] ?? ""],
-  efforts: true,
-}));
+const EFFORT_SUPPORTED_MODELS = new Set([
+  "gpt-5.4-nano",
+  "gpt-5.4-mini",
+  "grok/grok-3-mini",
+]);
 
-const modelsByProvider = models.reduce<Map<string, ModelOption[]>>(
-  (groups, model) => {
-    const provider = PROVIDER_NAMES[providerOf(model.id)] ?? "Other";
-    groups.set(provider, [...(groups.get(provider) ?? []), model]);
-    return groups;
-  },
-  new Map(),
-);
+const models: ModelOption[] = [];
+const modelsByProvider = new Map<string, ModelOption[]>();
+for (const option of docsModelOptions()) {
+  const provider = PROVIDER_NAMES[providerOf(option.id)] ?? "Other";
+  const model: ModelOption = {
+    ...option,
+    description: `${compactNumber.format(getContextWindow(option.id))} context window`,
+    keywords: [provider],
+    ...(EFFORT_SUPPORTED_MODELS.has(option.id) ? { efforts: true } : undefined),
+  };
+  models.push(model);
+  const group = modelsByProvider.get(provider);
+  if (group) {
+    group.push(model);
+  } else {
+    modelsByProvider.set(provider, [model]);
+  }
+}
 
 function VariantRow({
   label,

--- a/apps/docs/components/docs/samples/model-selector.tsx
+++ b/apps/docs/components/docs/samples/model-selector.tsx
@@ -1,22 +1,50 @@
 "use client";
 
 import { useState } from "react";
-import { SparklesIcon } from "lucide-react";
 import {
   ModelSelectorRoot,
   ModelSelectorTrigger,
   ModelSelectorContent,
+  ModelSelectorSearch,
+  ModelSelectorList,
+  ModelSelectorEmpty,
+  ModelSelectorGroup,
+  ModelSelectorItem,
+  ModelSelectorEffort,
+  type ModelOption,
 } from "@/components/assistant-ui/model-selector";
-import { DEFAULT_MODEL_ID, MODELS } from "@/constants/model";
+import { DEFAULT_MODEL_ID, getContextWindow } from "@/constants/model";
+import { docsModelOptions } from "@/components/docs/assistant/docs-model-options";
 import { SampleFrame } from "@/components/docs/samples/sample-frame";
 
-const models = MODELS.map((model) => ({
-  id: model.value,
-  name: model.name,
-  icon: <SparklesIcon />,
-  description: `${model.disabled ? "Currently disabled" : "Available"} provider model`,
-  ...(model.disabled ? { disabled: true } : undefined),
+const PROVIDER_NAMES: Record<string, string> = {
+  openai: "OpenAI",
+  "google-ai-studio": "Google",
+  grok: "xAI",
+  groq: "Groq",
+};
+
+function providerOf(modelId: string): string {
+  return modelId.includes("/") ? modelId.split("/")[0]! : "openai";
+}
+
+const compactNumber = new Intl.NumberFormat("en", { notation: "compact" });
+
+const models: ModelOption[] = docsModelOptions().map((model) => ({
+  ...model,
+  description: `${compactNumber.format(getContextWindow(model.id))} context window`,
+  keywords: [PROVIDER_NAMES[providerOf(model.id)] ?? ""],
+  efforts: true,
 }));
+
+const modelsByProvider = models.reduce<Map<string, ModelOption[]>>(
+  (groups, model) => {
+    const provider = PROVIDER_NAMES[providerOf(model.id)] ?? "Other";
+    groups.set(provider, [...(groups.get(provider) ?? []), model]);
+    return groups;
+  },
+  new Map(),
+);
 
 function VariantRow({
   label,
@@ -26,13 +54,56 @@ function VariantRow({
   variant?: "outline" | "ghost" | "muted";
 }) {
   const [value, setValue] = useState<string>(DEFAULT_MODEL_ID);
+  const [effort, setEffort] = useState<string>("medium");
 
   return (
     <div className="flex flex-col gap-2">
       <span className="text-muted-foreground text-xs font-medium">{label}</span>
-      <ModelSelectorRoot models={models} value={value} onValueChange={setValue}>
+      <ModelSelectorRoot
+        models={models}
+        value={value}
+        onValueChange={setValue}
+        effort={effort}
+        onEffortChange={setEffort}
+      >
         <ModelSelectorTrigger variant={variant} />
         <ModelSelectorContent />
+      </ModelSelectorRoot>
+    </div>
+  );
+}
+
+function ComposedRow() {
+  const [value, setValue] = useState<string>(DEFAULT_MODEL_ID);
+  const [effort, setEffort] = useState<string>("medium");
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-muted-foreground text-xs font-medium">
+        Composed: search + provider groups
+      </span>
+      <ModelSelectorRoot
+        models={models}
+        value={value}
+        onValueChange={setValue}
+        effort={effort}
+        onEffortChange={setEffort}
+      >
+        <ModelSelectorTrigger />
+        <ModelSelectorContent>
+          <ModelSelectorSearch />
+          <ModelSelectorList>
+            <ModelSelectorEmpty />
+            {[...modelsByProvider].map(([provider, providerModels]) => (
+              <ModelSelectorGroup key={provider} heading={provider}>
+                {providerModels.map((model) => (
+                  <ModelSelectorItem key={model.id} model={model} />
+                ))}
+              </ModelSelectorGroup>
+            ))}
+          </ModelSelectorList>
+          <ModelSelectorEffort />
+        </ModelSelectorContent>
       </ModelSelectorRoot>
     </div>
   );
@@ -44,6 +115,7 @@ export function ModelSelectorSample() {
       <VariantRow label="Outline (default)" variant="outline" />
       <VariantRow label="Ghost" variant="ghost" />
       <VariantRow label="Muted" variant="muted" />
+      <ComposedRow />
     </SampleFrame>
   );
 }

--- a/apps/docs/components/docs/samples/model-selector.tsx
+++ b/apps/docs/components/docs/samples/model-selector.tsx
@@ -122,7 +122,14 @@ function ComposedRow() {
         <ModelSelectorTrigger />
         <ModelSelectorContent>
           <ModelSelectorSearch />
-          <div className="flex flex-wrap gap-1 border-b px-3 py-2">
+          <div
+            className="flex flex-wrap gap-1 border-b px-3 py-2"
+            // Keep cmdk's root handler from claiming Enter so the focused
+            // chip toggles instead of selecting the highlighted model.
+            onKeyDown={(e) => {
+              if (e.key === "Enter") e.stopPropagation();
+            }}
+          >
             {[...modelsByProvider.keys()].map((provider) => {
               const isActive = providerFilter.has(provider);
               return (

--- a/apps/docs/content/docs/ui/model-selector.mdx
+++ b/apps/docs/content/docs/ui/model-selector.mdx
@@ -1,12 +1,12 @@
 ---
 title: ModelSelector
-description: Model picker with unified overlay positioning and runtime integration.
+description: Composable model picker with reasoning effort levels, search, and runtime integration.
 platforms: ["react"]
 ---
 
 import { ModelSelectorSample } from "@/components/docs/samples/model-selector";
 
-A select component that lets users switch between AI models. Uses item-aligned positioning so the selected model overlays the trigger for a unified look. Integrates with assistant-ui's `ModelContext` system to automatically propagate the selected model to your backend.
+A composable picker that lets users switch between AI models and set a reasoning effort (thinking) level. Built on Popover + Command, so search, grouping, and filtering compose in without being built in. Integrates with assistant-ui's `ModelContext` system to automatically propagate the selected model and effort to your backend.
 
 <ModelSelectorSample />
 
@@ -36,9 +36,10 @@ const ComposerAction: FC = () => {
         models={[
           { id: "gpt-5.4-nano", name: "GPT-5.4 Nano", description: "Fast and efficient" },
           { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", description: "Balanced performance" },
-          { id: "gpt-5.5", name: "GPT-5.5", description: "Most capable" },
+          { id: "gpt-5.5", name: "GPT-5.5", description: "Most capable", efforts: true },
         ]}
         defaultValue="gpt-5.4-nano"
+        defaultEffort="medium"
         size="sm"
       />
     </div>
@@ -46,19 +47,35 @@ const ComposerAction: FC = () => {
 };
 ```
 
+Models with `efforts: true` show a "Thinking" row with Low / Medium / High levels. Pass a custom list to override the levels:
+
+```tsx
+{
+  id: "gpt-5.5",
+  name: "GPT-5.5",
+  efforts: [
+    { id: "minimal", name: "Minimal" },
+    { id: "high", name: "High" },
+  ],
+}
+```
+
   </Step>
   <Step>
 
 ### Read the model in your API route
 
-The selected model's `id` is sent as `config.modelName` in the request body:
+The selected model's `id` is sent as `config.modelName`, and the effort level as `config.reasoningEffort`:
 
-```tsx title="app/api/chat/route.ts" {2,5}
+```tsx title="app/api/chat/route.ts" {2,5-8}
 export async function POST(req: Request) {
   const { messages, config } = await req.json();
 
   const result = streamText({
     model: openai(config?.modelName ?? "gpt-5.4-nano"),
+    providerOptions: {
+      openai: { reasoningEffort: config?.reasoningEffort ?? "medium" },
+    },
     messages: await convertToModelMessages(messages),
   });
 
@@ -68,6 +85,78 @@ export async function POST(req: Request) {
 
   </Step>
 </Steps>
+
+## Search
+
+Search is opt-in. Pass `searchable` to the default component:
+
+```tsx
+<ModelSelector models={models} searchable />
+```
+
+Or compose `ModelSelector.Search` into a custom layout. Matching runs against each model's `id`, `name`, and `keywords`.
+
+## Composition
+
+All parts are exported individually. The default popover content is `List` + `Effort`; replace it to add search, provider groups, or anything else:
+
+```tsx
+import {
+  ModelSelectorRoot,
+  ModelSelectorTrigger,
+  ModelSelectorContent,
+  ModelSelectorSearch,
+  ModelSelectorList,
+  ModelSelectorEmpty,
+  ModelSelectorGroup,
+  ModelSelectorItem,
+  ModelSelectorEffort,
+} from "@/components/assistant-ui/model-selector";
+
+<ModelSelectorRoot
+  models={models}
+  value={modelId}
+  onValueChange={setModelId}
+  effort={effort}
+  onEffortChange={setEffort}
+>
+  <ModelSelectorTrigger variant="outline" />
+  <ModelSelectorContent>
+    <ModelSelectorSearch placeholder="Search models..." />
+    <ModelSelectorList>
+      <ModelSelectorEmpty />
+      <ModelSelectorGroup heading="OpenAI">
+        {openaiModels.map((model) => (
+          <ModelSelectorItem key={model.id} model={model} />
+        ))}
+      </ModelSelectorGroup>
+      <ModelSelectorGroup heading="Anthropic">
+        {anthropicModels.map((model) => (
+          <ModelSelectorItem key={model.id} model={model} />
+        ))}
+      </ModelSelectorGroup>
+    </ModelSelectorList>
+    <ModelSelectorEffort label="Thinking" />
+  </ModelSelectorContent>
+</ModelSelectorRoot>
+```
+
+`ModelSelector.List` is a Command list, so filtering and keyboard navigation work across groups automatically. Custom sorting is plain code — order the models before rendering items.
+
+| Component | Description |
+|-----------|-------------|
+| `ModelSelector` | Default export with runtime integration |
+| `ModelSelector.Root` | Presentational root (no runtime, controlled state) |
+| `ModelSelector.Trigger` | CVA-styled trigger showing the current selection |
+| `ModelSelector.Value` | Selected model name, icon, and active effort |
+| `ModelSelector.Content` | Popover content wrapping a Command |
+| `ModelSelector.Search` | Search input that filters the list |
+| `ModelSelector.List` | List of model items (renders all models by default) |
+| `ModelSelector.Empty` | Empty state shown when search has no matches |
+| `ModelSelector.Group` | Labeled group of items (e.g. by provider) |
+| `ModelSelector.Separator` | Divider between groups or items |
+| `ModelSelector.Item` | Individual model option |
+| `ModelSelector.Effort` | Thinking level row for the selected model |
 
 ## Variants
 
@@ -95,58 +184,19 @@ Use the `size` prop to control the trigger dimensions.
 <ModelSelector size="lg" />      // Large (h-10)
 ```
 
-## Model Options
-
-Each model in the `models` array supports:
-
-```tsx
-const models = [
-  {
-    id: "gpt-5.4-nano",           // Sent to backend as config.modelName
-    name: "GPT-5.4 Nano",   // Display name in trigger and items
-    description: "Fast and efficient", // Optional subtitle in items only
-    icon: <SparklesIcon />,      // Optional icon (any ReactNode)
-  },
-];
-```
-
 ## Runtime Integration
 
-The default `ModelSelector` export automatically registers the selected model with assistant-ui's `ModelContext` system. When a user selects a model:
+The default `ModelSelector` export automatically registers the selection with assistant-ui's `ModelContext` system:
 
-1. The component calls `aui.modelContext().register()` with `config.modelName`
+1. The component calls `aui.modelContext().register()` with `config.modelName` and, when the selected model supports it, `config.reasoningEffort`
 2. The `AssistantChatTransport` includes `config` in the request body
-3. Your API route reads `config.modelName` to determine which model to use
+3. Your API route reads `config.modelName` and `config.reasoningEffort`
 
 This works out of the box with `@assistant-ui/react-ai-sdk`.
 
+The effort selection is sticky: switching to a model that doesn't support the current effort level omits `reasoningEffort` instead of resetting the user's choice. The exported `resolveModelEffort(models, modelId, effort)` helper applies the same rule if you wire up your own runtime integration around `ModelSelector.Root`.
+
 ## API Reference
-
-### Composable API
-
-For custom layouts, use the sub-components directly with `ModelSelector.Root`:
-
-```tsx
-import {
-  ModelSelectorRoot,
-  ModelSelectorTrigger,
-  ModelSelectorContent,
-  ModelSelectorItem,
-} from "@/components/assistant-ui/model-selector";
-
-<ModelSelectorRoot models={models} value={modelId} onValueChange={setModelId}>
-  <ModelSelectorTrigger variant="outline" />
-  <ModelSelectorContent />
-</ModelSelectorRoot>
-```
-
-| Component | Description |
-|-----------|-------------|
-| `ModelSelector` | Default export with runtime integration |
-| `ModelSelector.Root` | Presentational root (no runtime, controlled state) |
-| `ModelSelector.Trigger` | CVA-styled trigger showing current model |
-| `ModelSelector.Content` | Select content with model items |
-| `ModelSelector.Item` | Individual model option with icon, name, description |
 
 ### ModelSelector
 
@@ -162,7 +212,7 @@ import {
     {
       name: "defaultValue",
       type: "string",
-      description: "Initial model ID for uncontrolled usage.",
+      description: "Initial model ID for uncontrolled usage. Defaults to the first model.",
     },
     {
       name: "value",
@@ -173,6 +223,27 @@ import {
       name: "onValueChange",
       type: "(value: string) => void",
       description: "Callback when selected model changes.",
+    },
+    {
+      name: "defaultEffort",
+      type: "string",
+      description: "Initial effort level ID for uncontrolled usage.",
+    },
+    {
+      name: "effort",
+      type: "string",
+      description: "Controlled effort level ID.",
+    },
+    {
+      name: "onEffortChange",
+      type: "(effort: string) => void",
+      description: "Callback when effort level changes.",
+    },
+    {
+      name: "searchable",
+      type: "boolean",
+      default: "false",
+      description: "Render a search input above the model list.",
     },
     {
       name: "variant",
@@ -220,6 +291,21 @@ import {
       name: "icon",
       type: "React.ReactNode",
       description: "Optional icon displayed before the model name.",
+    },
+    {
+      name: "disabled",
+      type: "boolean",
+      description: "Disable selection of this model.",
+    },
+    {
+      name: "keywords",
+      type: "string[]",
+      description: "Extra search terms matched by ModelSelector.Search (e.g. the provider name).",
+    },
+    {
+      name: "efforts",
+      type: "boolean | ModelSelectorEffortOption[]",
+      description: "Reasoning effort levels. true enables the default Low/Medium/High; pass a custom { id, name } list to override. Omit for models without configurable reasoning.",
     },
   ]}
 />

--- a/apps/docs/content/docs/ui/model-selector.mdx
+++ b/apps/docs/content/docs/ui/model-selector.mdx
@@ -1,5 +1,5 @@
 ---
-title: ModelSelector
+title: Model Selector
 description: Composable model picker with reasoning effort levels, search, and runtime integration.
 platforms: ["react"]
 ---
@@ -26,7 +26,7 @@ A composable picker that lets users switch between AI models and set a reasoning
 
 Place the `ModelSelector` inside your thread component, typically in the composer area:
 
-```tsx title="/components/assistant-ui/thread.tsx" {1,6-14}
+```tsx title="/components/assistant-ui/thread.tsx" {1,6-15}
 import { ModelSelector } from "@/components/assistant-ui/model-selector";
 
 const ComposerAction: FC = () => {
@@ -47,7 +47,7 @@ const ComposerAction: FC = () => {
 };
 ```
 
-Models with `efforts: true` show a "Thinking" row with Low / Medium / High levels. Pass a custom list to override the levels:
+Models with an `efforts` list show a "Thinking" row with those levels:
 
 ```tsx
 {
@@ -59,6 +59,8 @@ Models with `efforts: true` show a "Thinking" row with Low / Medium / High level
   ],
 }
 ```
+
+`efforts: true` can be used as a shorthand, it defaults to displaying Low / Medium / High.
 
   </Step>
   <Step>
@@ -157,6 +159,48 @@ import {
 | `ModelSelector.Separator` | Divider between groups or items |
 | `ModelSelector.Item` | Individual model option |
 | `ModelSelector.Effort` | Thinking level row for the selected model |
+
+### Custom effort UI
+
+`ModelSelector.Effort` lays the levels out as horizontal segments, which overflows the popover width once a model has more than a few. For those cases — or any other layout, like a slider or a sub-dropdown — build your own effort control with the `useModelSelectorEfforts` hook, which exposes the selected model's levels and the active selection:
+
+```tsx
+import { useModelSelectorEfforts } from "@/components/assistant-ui/model-selector";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+function EffortDropdown() {
+  const { efforts, effort, setEffort } = useModelSelectorEfforts();
+  if (!efforts?.length) return null;
+
+  return (
+    <div className="flex items-center justify-between gap-3 border-t px-3 py-2">
+      <span className="text-muted-foreground text-xs">Thinking</span>
+      <DropdownMenu>
+        <DropdownMenuTrigger className="text-xs">
+          {efforts.find((e) => e.id === effort)?.name ?? "Select"}
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuRadioGroup value={effort} onValueChange={setEffort}>
+            {efforts.map((option) => (
+              <DropdownMenuRadioItem key={option.id} value={option.id}>
+                {option.name}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+```
+
+Render it inside `ModelSelector.Content` in place of `ModelSelector.Effort`. The same hook supports any shape — the `with-pi` example composes in a line-graph style slider (one thin vertical line per level, with hover tooltips) built the same way; see `examples/with-pi/components/assistant-ui/thinking-level-slider.tsx`.
 
 ## Variants
 

--- a/apps/docs/content/docs/ui/model-selector.mdx
+++ b/apps/docs/content/docs/ui/model-selector.mdx
@@ -6,7 +6,7 @@ platforms: ["react"]
 
 import { ModelSelectorSample } from "@/components/docs/samples/model-selector";
 
-A composable picker that lets users switch between AI models and set a reasoning effort (thinking) level. Built on Popover + Command, so search, grouping, and filtering compose in without being built in. Integrates with assistant-ui's `ModelContext` system to automatically propagate the selected model and effort to your backend.
+A picker that lets users switch between AI models and choose a reasoning effort (thinking) level. It is built on Popover + Command, so search, provider grouping, and filtering compose in without being built in. The default export integrates with assistant-ui's `ModelContext` system, so the selection reaches your backend on every request with no extra wiring.
 
 <ModelSelectorSample />
 
@@ -24,7 +24,7 @@ A composable picker that lets users switch between AI models and set a reasoning
 
 ### Use in your application
 
-Place the `ModelSelector` inside your thread component, typically in the composer area:
+Place the `ModelSelector` inside your thread component, typically in the composer area. Each model needs an `id` and a display `name`; everything else is optional:
 
 ```tsx title="/components/assistant-ui/thread.tsx" {1,6-15}
 import { ModelSelector } from "@/components/assistant-ui/model-selector";
@@ -47,27 +47,12 @@ const ComposerAction: FC = () => {
 };
 ```
 
-Models with an `efforts` list show a "Thinking" row with those levels:
-
-```tsx
-{
-  id: "gpt-5.5",
-  name: "GPT-5.5",
-  efforts: [
-    { id: "minimal", name: "Minimal" },
-    { id: "high", name: "High" },
-  ],
-}
-```
-
-`efforts: true` can be used as a shorthand — it defaults to displaying Low / Medium / High.
-
   </Step>
   <Step>
 
-### Read the model in your API route
+### Read the selection in your API route
 
-The selected model's `id` is sent as `config.modelName`, and the effort level as `config.reasoningEffort`:
+The selected model's `id` arrives as `config.modelName`, and the effort level as `config.reasoningEffort`:
 
 ```tsx title="app/api/chat/route.ts" {2,5-11}
 export async function POST(req: Request) {
@@ -88,8 +73,73 @@ export async function POST(req: Request) {
 }
 ```
 
+`config.reasoningEffort` is only present when the selected model supports the chosen level, so the conditional spread mirrors what the component sends. See [How It Works](#how-it-works).
+
   </Step>
 </Steps>
+
+## Reasoning Efforts
+
+A model that declares `efforts` shows a "Thinking" row at the bottom of the popover. `efforts: true` enables the default Low / Medium / High levels; pass a list of `{ id, name }` objects to define your own:
+
+```tsx
+{
+  id: "gpt-5.5",
+  name: "GPT-5.5",
+  efforts: [
+    { id: "minimal", name: "Minimal" },
+    { id: "high", name: "High" },
+  ],
+}
+```
+
+Omit `efforts` for models without configurable reasoning. The row is hidden while such a model is selected.
+
+### Sticky Selection
+
+The effort selection survives model switches. Switching to a model that doesn't support the current level omits `reasoningEffort` from the request instead of resetting the user's choice, and the level applies again when the user switches back. The exported `resolveModelEffort` helper applies the same rule if you build your own runtime integration around `ModelSelector.Root`; see [`resolveModelEffort`](#resolvemodeleffort).
+
+### Custom Effort UI
+
+`ModelSelector.Effort` lays the levels out as horizontal segments, which overflows the popover width once a model has more than a few. For those cases, or for a different layout such as a slider or a sub-dropdown, build your own control with the `useModelSelectorEfforts` hook. It exposes the selected model's levels and the active selection:
+
+```tsx
+import { useModelSelectorEfforts } from "@/components/assistant-ui/model-selector";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+function EffortDropdown() {
+  const { efforts, effort, setEffort } = useModelSelectorEfforts();
+  if (!efforts?.length) return null;
+
+  return (
+    <div className="flex items-center justify-between gap-3 border-t px-3 py-2">
+      <span className="text-muted-foreground text-xs">Thinking</span>
+      <DropdownMenu>
+        <DropdownMenuTrigger className="text-xs">
+          {efforts.find((e) => e.id === effort)?.name ?? "Select"}
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuRadioGroup value={effort} onValueChange={setEffort}>
+            {efforts.map((option) => (
+              <DropdownMenuRadioItem key={option.id} value={option.id}>
+                {option.name}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+```
+
+Render it inside `ModelSelector.Content` in place of `ModelSelector.Effort`. The same hook supports any shape that reads the levels and writes the selection.
 
 ## Search
 
@@ -99,7 +149,7 @@ Search is opt-in. Pass `searchable` to the default component:
 <ModelSelector models={models} searchable />
 ```
 
-Or compose `ModelSelector.Search` into a custom layout. Matching runs against each model's `id`, `name`, and `keywords`.
+Or compose `ModelSelector.Search` into a custom layout. Matching runs against each model's `id`, `name`, and `keywords`; add the provider name to `keywords` so typing "openai" finds its models.
 
 ## Composition
 
@@ -146,10 +196,6 @@ import {
 </ModelSelectorRoot>
 ```
 
-`ModelSelector.List` is a Command list, so filtering and keyboard navigation work across groups automatically. Custom sorting is plain code — order the models before rendering items.
-
-`ModelSelector.Content` wraps a Command, whose root keydown handler claims <kbd>Enter</kbd> to select the highlighted model. Interactive elements composed inside it — filter chips, custom effort controls — should call `event.stopPropagation()` for Enter in their own `onKeyDown` so the focused control activates instead. `ModelSelector.Effort` already does this.
-
 | Component | Description |
 |-----------|-------------|
 | `ModelSelector` | Default export with runtime integration |
@@ -165,47 +211,15 @@ import {
 | `ModelSelector.Item` | Individual model option |
 | `ModelSelector.Effort` | Thinking level row for the selected model |
 
-### Custom effort UI
+`ModelSelector.List` is a Command list, so filtering and keyboard navigation work across groups automatically. Custom sorting is plain code: order the models before rendering items.
 
-`ModelSelector.Effort` lays the levels out as horizontal segments, which overflows the popover width once a model has more than a few. For those cases — or any other layout, like a slider or a sub-dropdown — build your own effort control with the `useModelSelectorEfforts` hook, which exposes the selected model's levels and the active selection:
-
-```tsx
-import { useModelSelectorEfforts } from "@/components/assistant-ui/model-selector";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-
-function EffortDropdown() {
-  const { efforts, effort, setEffort } = useModelSelectorEfforts();
-  if (!efforts?.length) return null;
-
-  return (
-    <div className="flex items-center justify-between gap-3 border-t px-3 py-2">
-      <span className="text-muted-foreground text-xs">Thinking</span>
-      <DropdownMenu>
-        <DropdownMenuTrigger className="text-xs">
-          {efforts.find((e) => e.id === effort)?.name ?? "Select"}
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuRadioGroup value={effort} onValueChange={setEffort}>
-            {efforts.map((option) => (
-              <DropdownMenuRadioItem key={option.id} value={option.id}>
-                {option.name}
-              </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
-  );
-}
-```
-
-Render it inside `ModelSelector.Content` in place of `ModelSelector.Effort`. The same hook supports any shape — sliders, sub-dropdowns, or anything else that reads the levels and writes the selection.
+<Callout type="warn">
+  `ModelSelector.Content` wraps a Command whose root keydown handler claims
+  <kbd>Enter</kbd> to select the highlighted model. Interactive elements
+  composed inside it (filter chips, custom effort controls) should stop
+  propagation for Enter in their own `onKeyDown` so the focused control
+  activates instead. `ModelSelector.Effort` already does this.
+</Callout>
 
 ## Variants
 
@@ -233,17 +247,15 @@ Use the `size` prop to control the trigger dimensions.
 <ModelSelector size="lg" />      // Large (h-10)
 ```
 
-## Runtime Integration
+## How It Works
 
-The default `ModelSelector` export automatically registers the selection with assistant-ui's `ModelContext` system:
+The default `ModelSelector` export registers the selection with assistant-ui's `ModelContext` system:
 
-1. The component calls `aui.modelContext().register()` with `config.modelName` and, when the selected model supports it, `config.reasoningEffort`
-2. The `AssistantChatTransport` includes `config` in the request body
+1. The component calls `aui.modelContext().register()` with `config.modelName`, plus `config.reasoningEffort` when the selected model supports the chosen level
+2. The `AssistantChatTransport` includes `config` in the request body of every chat request
 3. Your API route reads `config.modelName` and `config.reasoningEffort`
 
-This works out of the box with `@assistant-ui/react-ai-sdk`.
-
-The effort selection is sticky: switching to a model that doesn't support the current effort level omits `reasoningEffort` instead of resetting the user's choice. The exported `resolveModelEffort(models, modelId, effort)` helper applies the same rule if you wire up your own runtime integration around `ModelSelector.Root`.
+This works out of the box with `@assistant-ui/react-ai-sdk`. `ModelSelector.Root` performs no registration; it is purely presentational, with controlled and uncontrolled props for the value, effort, and open state.
 
 ## API Reference
 
@@ -358,3 +370,23 @@ The effort selection is sticky: switching to a model that doesn't support the cu
     },
   ]}
 />
+
+### `useModelSelectorEfforts`
+
+```tsx
+const { efforts, effort, setEffort } = useModelSelectorEfforts();
+```
+
+The selected model's effort levels and the active selection, for building a [custom effort UI](#custom-effort-ui) inside `ModelSelector.Content`. `efforts` is `undefined` for models without configurable reasoning.
+
+### `resolveModelEffort`
+
+```tsx
+resolveModelEffort(models, modelId, effort); // => string | undefined
+```
+
+Returns the effort ID when the given model supports it, otherwise `undefined`. This is the [sticky selection](#sticky-selection) rule the default component applies before registering the selection.
+
+## Related
+
+- [Model Context](/docs/copilots/model-context): How registered context (instructions, tools, config) reaches your backend

--- a/apps/docs/content/docs/ui/model-selector.mdx
+++ b/apps/docs/content/docs/ui/model-selector.mdx
@@ -73,7 +73,7 @@ export async function POST(req: Request) {
 }
 ```
 
-`config.reasoningEffort` is only present when the selected model supports the chosen level, so the conditional spread mirrors what the component sends. See [How It Works](#how-it-works).
+`config.reasoningEffort` is only present when the selected model supports the chosen level, so the route only forwards it when it exists. See [How It Works](#how-it-works).
 
   </Step>
 </Steps>
@@ -273,7 +273,7 @@ This works out of the box with `@assistant-ui/react-ai-sdk`. `ModelSelector.Root
     {
       name: "defaultValue",
       type: "string",
-      description: "Initial model ID for uncontrolled usage. Defaults to the first model.",
+      description: "Initial model ID for uncontrolled usage. Defaults to the first model, captured on first render; if models loads asynchronously, control the value instead.",
     },
     {
       name: "value",

--- a/apps/docs/content/docs/ui/model-selector.mdx
+++ b/apps/docs/content/docs/ui/model-selector.mdx
@@ -69,14 +69,17 @@ Models with an `efforts` list show a "Thinking" row with those levels:
 
 The selected model's `id` is sent as `config.modelName`, and the effort level as `config.reasoningEffort`:
 
-```tsx title="app/api/chat/route.ts" {2,5-8}
+```tsx title="app/api/chat/route.ts" {2,5-11}
 export async function POST(req: Request) {
   const { messages, config } = await req.json();
 
   const result = streamText({
     model: openai(config?.modelName ?? "gpt-5.4-nano"),
     providerOptions: {
-      openai: { reasoningEffort: config?.reasoningEffort ?? "medium" },
+      openai:
+        config?.reasoningEffort !== undefined
+          ? { reasoningEffort: config.reasoningEffort }
+          : {},
     },
     messages: await convertToModelMessages(messages),
   });
@@ -200,7 +203,7 @@ function EffortDropdown() {
 }
 ```
 
-Render it inside `ModelSelector.Content` in place of `ModelSelector.Effort`. The same hook supports any shape — the `with-pi` example composes in a line-graph style slider (one thin vertical line per level, with hover tooltips) built the same way; see `examples/with-pi/components/assistant-ui/thinking-level-slider.tsx`.
+Render it inside `ModelSelector.Content` in place of `ModelSelector.Effort`. The same hook supports any shape — sliders, sub-dropdowns, or anything else that reads the levels and writes the selection.
 
 ## Variants
 

--- a/apps/docs/content/docs/ui/model-selector.mdx
+++ b/apps/docs/content/docs/ui/model-selector.mdx
@@ -60,7 +60,7 @@ Models with an `efforts` list show a "Thinking" row with those levels:
 }
 ```
 
-`efforts: true` can be used as a shorthand, it defaults to displaying Low / Medium / High.
+`efforts: true` can be used as a shorthand — it defaults to displaying Low / Medium / High.
 
   </Step>
   <Step>
@@ -147,6 +147,8 @@ import {
 ```
 
 `ModelSelector.List` is a Command list, so filtering and keyboard navigation work across groups automatically. Custom sorting is plain code — order the models before rendering items.
+
+`ModelSelector.Content` wraps a Command, whose root keydown handler claims <kbd>Enter</kbd> to select the highlighted model. Interactive elements composed inside it — filter chips, custom effort controls — should call `event.stopPropagation()` for Enter in their own `onKeyDown` so the focused control activates instead. `ModelSelector.Effort` already does this.
 
 | Component | Description |
 |-----------|-------------|

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -487,11 +487,10 @@ export const registry: RegistryItem[] = [
     ],
     dependencies: [
       "@assistant-ui/react",
-      "radix-ui",
       "lucide-react",
       "class-variance-authority",
     ],
-    registryDependencies: ["https://r.assistant-ui.com/select.json"],
+    registryDependencies: ["command", "popover"],
   },
   {
     name: "select",

--- a/packages/core/src/model-context/types.ts
+++ b/packages/core/src/model-context/types.ts
@@ -15,6 +15,7 @@ export type LanguageModelConfig = {
   apiKey?: string;
   baseUrl?: string;
   modelName?: string;
+  reasoningEffort?: string;
 };
 
 export type ModelContext = {

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -124,6 +124,22 @@ function useModelSelectorContext() {
   return ctx;
 }
 
+/**
+ * The selected model's effort levels and the active selection. Use it to build
+ * a custom effort UI inside ModelSelector.Content (e.g. a slider or a shadcn
+ * DropdownMenu) when the built-in ModelSelector.Effort layout doesn't fit.
+ * `efforts` is undefined for models without configurable reasoning.
+ */
+export function useModelSelectorEfforts(): {
+  efforts: readonly ModelSelectorEffortOption[] | undefined;
+  effort: string | undefined;
+  setEffort: (effort: string) => void;
+} {
+  const { models, value, effort, setEffort } = useModelSelectorContext();
+  const efforts = getModelEfforts(models.find((m) => m.id === value));
+  return { efforts, effort, setEffort };
+}
+
 export type ModelSelectorRootProps = {
   models: readonly ModelOption[];
   value?: string;
@@ -182,6 +198,7 @@ function ModelSelectorRoot({
 
   return (
     <ModelSelectorContext.Provider value={contextValue}>
+      {/* `?? false` narrows away undefined for exactOptionalPropertyTypes consumers. */}
       <Popover open={open ?? false} onOpenChange={setOpen}>
         {children}
       </Popover>
@@ -230,11 +247,7 @@ function ModelSelectorTrigger({
       data-variant={variant ?? "outline"}
       data-size={size ?? "default"}
       role="combobox"
-      className={cn(
-        modelSelectorTriggerVariants({ variant, size }),
-        "aui-model-selector-trigger",
-        className,
-      )}
+      className={cn(modelSelectorTriggerVariants({ variant, size }), className)}
       {...props}
     >
       {children ?? <ModelSelectorValue />}
@@ -297,6 +310,8 @@ function ModelSelectorContent({
   children,
   ...props
 }: ModelSelectorContentProps) {
+  const { value } = useModelSelectorContext();
+
   return (
     <PopoverContent
       data-slot="model-selector-content"
@@ -308,7 +323,12 @@ function ModelSelectorContent({
       )}
       {...props}
     >
-      <Command className="bg-transparent">
+      {/* Seeding cmdk with the selected id makes it the active item, which
+          cmdk scrolls into view when the popover opens. */}
+      <Command
+        className="bg-transparent"
+        {...(value !== undefined ? { defaultValue: value } : {})}
+      >
         {children ?? (
           <>
             <ModelSelectorList />
@@ -467,8 +487,7 @@ function ModelSelectorEffort({
   className,
   ...props
 }: ModelSelectorEffortProps) {
-  const { models, value, effort, setEffort } = useModelSelectorContext();
-  const efforts = getModelEfforts(models.find((m) => m.id === value));
+  const { efforts, effort, setEffort } = useModelSelectorEfforts();
 
   if (!efforts?.length) return null;
 
@@ -483,8 +502,8 @@ function ModelSelectorEffort({
     >
       <span className="text-muted-foreground text-xs">{label}</span>
       <div
-        role="radiogroup"
-        aria-label="Reasoning effort"
+        role="group"
+        aria-label={typeof label === "string" ? label : "Reasoning effort"}
         className="flex items-center gap-0.5"
       >
         {efforts.map((option) => {
@@ -493,8 +512,7 @@ function ModelSelectorEffort({
             <button
               key={option.id}
               type="button"
-              role="radio"
-              aria-checked={isActive}
+              aria-pressed={isActive}
               data-state={isActive ? "on" : "off"}
               onClick={() => setEffort(option.id)}
               className={cn(
@@ -521,33 +539,10 @@ export type ModelSelectorProps = Omit<ModelSelectorRootProps, "children"> &
     contentClassName?: string;
   };
 
-const ModelSelectorImpl = ({
-  models,
-  value: valueProp,
-  defaultValue,
-  onValueChange,
-  effort: effortProp,
-  defaultEffort,
-  onEffortChange,
-  searchable,
-  variant,
-  size,
-  className,
-  contentClassName,
-  ...rootProps
-}: ModelSelectorProps) => {
-  const [value, setValue] = useControllableState({
-    prop: valueProp,
-    defaultProp: defaultValue ?? models[0]?.id,
-    onChange: onValueChange,
-  });
-  const [effort, setEffort] = useControllableState({
-    prop: effortProp,
-    defaultProp: defaultEffort,
-    onChange: onEffortChange,
-  });
-  const activeEffort = resolveModelEffort(models, value, effort);
-
+/** Registers the selection with assistant-ui's ModelContext system. The
+ * context's effort is already resolved against the selected model. */
+function ModelSelectorModelContext() {
+  const { value, effort } = useModelSelectorContext();
   const api = useAui();
 
   useEffect(() => {
@@ -555,25 +550,28 @@ const ModelSelectorImpl = ({
     const config = {
       config: {
         modelName: value,
-        ...(activeEffort !== undefined
-          ? { reasoningEffort: activeEffort }
-          : undefined),
+        ...(effort !== undefined ? { reasoningEffort: effort } : undefined),
       },
     };
     return api.modelContext().register({
       getModelContext: () => config,
     });
-  }, [api, value, activeEffort]);
+  }, [api, value, effort]);
 
+  return null;
+}
+
+const ModelSelectorImpl = ({
+  searchable,
+  variant,
+  size,
+  className,
+  contentClassName,
+  ...rootProps
+}: ModelSelectorProps) => {
   return (
-    <ModelSelectorRoot
-      models={models}
-      {...(value !== undefined ? { value } : undefined)}
-      onValueChange={setValue}
-      {...(effort !== undefined ? { effort } : undefined)}
-      onEffortChange={setEffort}
-      {...rootProps}
-    >
+    <ModelSelectorRoot {...rootProps}>
+      <ModelSelectorModelContext />
       <ModelSelectorTrigger
         variant={variant}
         size={size}

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -2,26 +2,44 @@
 
 import {
   memo,
-  useState,
+  useCallback,
   useEffect,
   useMemo,
+  useState,
   createContext,
   useContext,
   type ComponentPropsWithoutRef,
   type ReactNode,
 } from "react";
-import { Select as SelectPrimitive } from "radix-ui";
-import type { VariantProps } from "class-variance-authority";
-import { CheckIcon } from "lucide-react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
 import { useAui } from "@assistant-ui/react";
 import { cn } from "@/lib/utils";
 import {
-  SelectRoot,
-  SelectTrigger,
-  SelectContent,
-  type SelectItem,
-  type selectTriggerVariants,
-} from "@/components/assistant-ui/select";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+
+export type ModelSelectorEffortOption = {
+  id: string;
+  name: string;
+};
+
+export const DEFAULT_EFFORT_OPTIONS: readonly ModelSelectorEffortOption[] = [
+  { id: "low", name: "Low" },
+  { id: "medium", name: "Medium" },
+  { id: "high", name: "High" },
+];
 
 export type ModelOption = {
   id: string;
@@ -29,11 +47,67 @@ export type ModelOption = {
   description?: string;
   icon?: ReactNode;
   disabled?: boolean;
+  /** Extra terms matched by ModelSelector.Search, in addition to id and name. */
+  keywords?: readonly string[];
+  /**
+   * Reasoning effort levels the model supports. Pass `true` for the default
+   * low/medium/high levels, or a custom list. Omit for models without
+   * configurable reasoning.
+   */
+  efforts?: boolean | readonly ModelSelectorEffortOption[];
 };
 
+function getModelEfforts(
+  model: ModelOption | undefined,
+): readonly ModelSelectorEffortOption[] | undefined {
+  if (!model?.efforts) return undefined;
+  return model.efforts === true ? DEFAULT_EFFORT_OPTIONS : model.efforts;
+}
+
+/**
+ * Returns the effort id if the given model supports it, otherwise undefined.
+ * Effort selection is kept sticky across model switches; this resolves what
+ * actually applies to the current model.
+ */
+export function resolveModelEffort(
+  models: readonly ModelOption[],
+  modelId: string | undefined,
+  effort: string | undefined,
+): string | undefined {
+  if (effort === undefined) return undefined;
+  const efforts = getModelEfforts(models.find((m) => m.id === modelId));
+  return efforts?.some((e) => e.id === effort) ? effort : undefined;
+}
+
+function useControllableState<T>({
+  prop,
+  defaultProp,
+  onChange,
+}: {
+  prop: T | undefined;
+  defaultProp: T | undefined;
+  onChange: ((next: T) => void) | undefined;
+}) {
+  const [internal, setInternal] = useState(defaultProp);
+  const value = prop !== undefined ? prop : internal;
+  const setValue = useCallback(
+    (next: T) => {
+      setInternal(next);
+      onChange?.(next);
+    },
+    [onChange],
+  );
+  return [value, setValue] as const;
+}
+
 type ModelSelectorContextValue = {
-  models: ModelOption[];
+  models: readonly ModelOption[];
   value: string | undefined;
+  setValue: (value: string) => void;
+  /** Effort resolved against the selected model's supported levels. */
+  effort: string | undefined;
+  setEffort: (effort: string) => void;
+  setOpen: (open: boolean) => void;
 };
 
 const ModelSelectorContext = createContext<ModelSelectorContextValue | null>(
@@ -51,41 +125,97 @@ function useModelSelectorContext() {
 }
 
 export type ModelSelectorRootProps = {
-  models: ModelOption[];
+  models: readonly ModelOption[];
   value?: string;
-  onValueChange?: (value: string) => void;
   defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  effort?: string;
+  defaultEffort?: string;
+  onEffortChange?: (effort: string) => void;
   open?: boolean;
-  onOpenChange?: (open: boolean) => void;
   defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
   children: ReactNode;
 };
 
 function ModelSelectorRoot({
   models,
-  defaultValue: defaultValueProp,
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  effort: effortProp,
+  defaultEffort,
+  onEffortChange,
+  open: openProp,
+  defaultOpen,
+  onOpenChange,
   children,
-  value,
-  ...selectProps
 }: ModelSelectorRootProps) {
-  const defaultValue = defaultValueProp ?? models[0]?.id;
-  const contextValue = useMemo(() => ({ models, value }), [models, value]);
+  const [value, setValue] = useControllableState({
+    prop: valueProp,
+    defaultProp: defaultValue ?? models[0]?.id,
+    onChange: onValueChange,
+  });
+  const [effort, setEffort] = useControllableState({
+    prop: effortProp,
+    defaultProp: defaultEffort,
+    onChange: onEffortChange,
+  });
+  const [open, setOpen] = useControllableState({
+    prop: openProp,
+    defaultProp: defaultOpen ?? false,
+    onChange: onOpenChange,
+  });
+
+  const activeEffort = resolveModelEffort(models, value, effort);
+  const contextValue = useMemo(
+    () => ({
+      models,
+      value,
+      setValue,
+      effort: activeEffort,
+      setEffort,
+      setOpen,
+    }),
+    [models, value, setValue, activeEffort, setEffort, setOpen],
+  );
+
   return (
     <ModelSelectorContext.Provider value={contextValue}>
-      <SelectRoot
-        {...(defaultValue !== undefined ? { defaultValue } : undefined)}
-        {...(value !== undefined ? { value } : undefined)}
-        {...selectProps}
-      >
+      <Popover open={open ?? false} onOpenChange={setOpen}>
         {children}
-      </SelectRoot>
+      </Popover>
     </ModelSelectorContext.Provider>
   );
 }
 
+export const modelSelectorTriggerVariants = cva(
+  "focus-visible:ring-ring/50 flex w-fit items-center justify-between gap-2 overflow-hidden rounded-md text-sm whitespace-nowrap transition-colors outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        outline:
+          "border-input hover:bg-accent hover:text-accent-foreground border bg-transparent",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        muted: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+      },
+      size: {
+        default: "h-9 px-3 py-2",
+        sm: "h-8 px-2.5 py-1.5 text-xs",
+        lg: "h-10 px-4 py-2.5",
+      },
+    },
+    defaultVariants: {
+      variant: "outline",
+      size: "default",
+    },
+  },
+);
+
 export type ModelSelectorTriggerProps = ComponentPropsWithoutRef<
-  typeof SelectTrigger
->;
+  typeof PopoverTrigger
+> &
+  VariantProps<typeof modelSelectorTriggerVariants>;
 
 function ModelSelectorTrigger({
   className,
@@ -95,80 +225,185 @@ function ModelSelectorTrigger({
   ...props
 }: ModelSelectorTriggerProps) {
   return (
-    <SelectTrigger
+    <PopoverTrigger
       data-slot="model-selector-trigger"
-      variant={variant}
-      size={size}
-      className={cn("aui-model-selector-trigger", className)}
+      data-variant={variant ?? "outline"}
+      data-size={size ?? "default"}
+      role="combobox"
+      className={cn(
+        modelSelectorTriggerVariants({ variant, size }),
+        "aui-model-selector-trigger",
+        className,
+      )}
       {...props}
     >
       {children ?? <ModelSelectorValue />}
-    </SelectTrigger>
+      <ChevronDownIcon className="size-4 opacity-50" />
+    </PopoverTrigger>
   );
 }
 
-/**
- * Renders the selected model display in the trigger.
- *
- * Bypasses Radix Select.Value to avoid the empty-on-SSR issue caused by
- * Select items living inside a Portal (not rendered server-side).
- * Falls back to Select.Value for uncontrolled (defaultValue-only) usage.
- */
-function ModelSelectorValue() {
-  const { models, value } = useModelSelectorContext();
+export type ModelSelectorValueProps = {
+  placeholder?: ReactNode;
+  /** Show the active effort level next to the model name. */
+  showEffort?: boolean;
+  className?: string;
+};
+
+function ModelSelectorValue({
+  placeholder = "Select model",
+  showEffort = true,
+  className,
+}: ModelSelectorValueProps) {
+  const { models, value, effort } = useModelSelectorContext();
   const selectedModel =
-    value != null ? models.find((m) => m.id === value) : undefined;
+    value !== undefined ? models.find((m) => m.id === value) : undefined;
 
   if (!selectedModel) {
-    return <SelectPrimitive.Value />;
+    return <span className="text-muted-foreground">{placeholder}</span>;
   }
 
+  const effortName =
+    showEffort && effort !== undefined
+      ? getModelEfforts(selectedModel)?.find((e) => e.id === effort)?.name
+      : undefined;
+
   return (
-    <span>
-      <span className="flex items-center gap-2">
-        {selectedModel.icon && (
-          <span className="flex size-4 shrink-0 items-center justify-center [&_svg]:size-4">
-            {selectedModel.icon}
-          </span>
-        )}
-        <span className="truncate font-medium">{selectedModel.name}</span>
-      </span>
+    <span
+      data-slot="model-selector-value"
+      className={cn("flex min-w-0 items-center gap-2", className)}
+    >
+      {selectedModel.icon && (
+        <span className="flex size-4 shrink-0 items-center justify-center [&_svg]:size-4">
+          {selectedModel.icon}
+        </span>
+      )}
+      <span className="truncate font-medium">{selectedModel.name}</span>
+      {effortName && (
+        <span className="text-muted-foreground truncate">{effortName}</span>
+      )}
     </span>
   );
 }
 
 export type ModelSelectorContentProps = ComponentPropsWithoutRef<
-  typeof SelectContent
+  typeof PopoverContent
 >;
 
 function ModelSelectorContent({
   className,
+  align = "start",
+  sideOffset = 6,
   children,
   ...props
 }: ModelSelectorContentProps) {
-  const { models } = useModelSelectorContext();
-
   return (
-    <SelectContent
+    <PopoverContent
       data-slot="model-selector-content"
-      className={cn("min-w-[180px]", className)}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "bg-popover/95 w-72 min-w-(--radix-popover-trigger-width) overflow-hidden rounded-xl p-0 shadow-lg backdrop-blur-sm",
+        className,
+      )}
       {...props}
     >
-      {children ??
-        models.map((model) => (
-          <ModelSelectorItem
-            key={model.id}
-            model={model}
-            {...(model.disabled ? { disabled: true } : undefined)}
-          />
-        ))}
-    </SelectContent>
+      <Command className="bg-transparent">
+        {children ?? (
+          <>
+            <ModelSelectorList />
+            <ModelSelectorEffort />
+          </>
+        )}
+      </Command>
+    </PopoverContent>
   );
 }
 
+export type ModelSelectorSearchProps = ComponentPropsWithoutRef<
+  typeof CommandInput
+>;
+
+function ModelSelectorSearch({
+  placeholder = "Search models...",
+  className,
+  ...props
+}: ModelSelectorSearchProps) {
+  return (
+    <CommandInput
+      data-slot="model-selector-search"
+      placeholder={placeholder}
+      className={className}
+      {...props}
+    />
+  );
+}
+
+export type ModelSelectorListProps = ComponentPropsWithoutRef<
+  typeof CommandList
+>;
+
+function ModelSelectorList({
+  className,
+  children,
+  ...props
+}: ModelSelectorListProps) {
+  const { models } = useModelSelectorContext();
+
+  return (
+    <CommandList
+      data-slot="model-selector-list"
+      className={cn(
+        "[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <ModelSelectorEmpty />
+          <CommandGroup>
+            {models.map((model) => (
+              <ModelSelectorItem key={model.id} model={model} />
+            ))}
+          </CommandGroup>
+        </>
+      )}
+    </CommandList>
+  );
+}
+
+export type ModelSelectorEmptyProps = ComponentPropsWithoutRef<
+  typeof CommandEmpty
+>;
+
+function ModelSelectorEmpty({ children, ...props }: ModelSelectorEmptyProps) {
+  return (
+    <CommandEmpty data-slot="model-selector-empty" {...props}>
+      {children ?? "No models found."}
+    </CommandEmpty>
+  );
+}
+
+export type ModelSelectorGroupProps = ComponentPropsWithoutRef<
+  typeof CommandGroup
+>;
+
+function ModelSelectorGroup(props: ModelSelectorGroupProps) {
+  return <CommandGroup data-slot="model-selector-group" {...props} />;
+}
+
+export type ModelSelectorSeparatorProps = ComponentPropsWithoutRef<
+  typeof CommandSeparator
+>;
+
+function ModelSelectorSeparator(props: ModelSelectorSeparatorProps) {
+  return <CommandSeparator data-slot="model-selector-separator" {...props} />;
+}
+
 export type ModelSelectorItemProps = Omit<
-  ComponentPropsWithoutRef<typeof SelectItem>,
-  "value" | "children"
+  ComponentPropsWithoutRef<typeof CommandItem>,
+  "value"
 > & {
   model: ModelOption;
 };
@@ -176,92 +411,179 @@ export type ModelSelectorItemProps = Omit<
 function ModelSelectorItem({
   model,
   className,
+  children,
+  onSelect,
   ...props
 }: ModelSelectorItemProps) {
+  const { value, setValue, setOpen } = useModelSelectorContext();
+  const isSelected = value === model.id;
+
   return (
-    <SelectPrimitive.Item
+    <CommandItem
       data-slot="model-selector-item"
       value={model.id}
-      textValue={model.name}
-      className={cn(
-        "relative flex w-full cursor-default items-center gap-2 rounded-lg py-2 ps-3 pe-9 text-sm outline-none select-none",
-        "focus:bg-accent focus:text-accent-foreground",
-        "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-        className,
-      )}
+      keywords={[model.name, ...(model.keywords ?? [])]}
+      {...(model.disabled ? { disabled: true } : undefined)}
+      onSelect={(selectedValue) => {
+        setValue(model.id);
+        setOpen(false);
+        onSelect?.(selectedValue);
+      }}
+      className={cn("relative gap-2 rounded-lg py-2 ps-3 pe-9", className)}
       {...props}
     >
-      <span className="absolute end-3 flex size-4 items-center justify-center">
-        <SelectPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
-        </SelectPrimitive.ItemIndicator>
-      </span>
-      <SelectPrimitive.ItemText>
-        <span className="flex items-center gap-2">
+      {children ?? (
+        <>
           {model.icon && (
             <span className="flex size-4 shrink-0 items-center justify-center [&_svg]:size-4">
               {model.icon}
             </span>
           )}
-          <span className="truncate font-medium">{model.name}</span>
-        </span>
-      </SelectPrimitive.ItemText>
-      {model.description && (
-        <span className="text-muted-foreground truncate text-xs">
-          {model.description}
+          <span className="flex min-w-0 flex-col">
+            <span className="truncate font-medium">{model.name}</span>
+            {model.description && (
+              <span className="text-muted-foreground truncate text-xs">
+                {model.description}
+              </span>
+            )}
+          </span>
+        </>
+      )}
+      {isSelected && (
+        <span className="absolute end-3 flex size-4 items-center justify-center">
+          <CheckIcon className="size-4" />
         </span>
       )}
-    </SelectPrimitive.Item>
+    </CommandItem>
+  );
+}
+
+export type ModelSelectorEffortProps = ComponentPropsWithoutRef<"div"> & {
+  label?: ReactNode;
+};
+
+function ModelSelectorEffort({
+  label = "Thinking",
+  className,
+  ...props
+}: ModelSelectorEffortProps) {
+  const { models, value, effort, setEffort } = useModelSelectorContext();
+  const efforts = getModelEfforts(models.find((m) => m.id === value));
+
+  if (!efforts?.length) return null;
+
+  return (
+    <div
+      data-slot="model-selector-effort"
+      className={cn(
+        "flex items-center justify-between gap-3 border-t px-3 py-2",
+        className,
+      )}
+      {...props}
+    >
+      <span className="text-muted-foreground text-xs">{label}</span>
+      <div
+        role="radiogroup"
+        aria-label="Reasoning effort"
+        className="flex items-center gap-0.5"
+      >
+        {efforts.map((option) => {
+          const isActive = option.id === effort;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              role="radio"
+              aria-checked={isActive}
+              data-state={isActive ? "on" : "off"}
+              onClick={() => setEffort(option.id)}
+              className={cn(
+                "focus-visible:ring-ring/50 rounded-md px-2 py-1 text-xs transition-colors outline-none focus-visible:ring-2",
+                isActive
+                  ? "bg-accent text-accent-foreground font-medium"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {option.name}
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 
 export type ModelSelectorProps = Omit<ModelSelectorRootProps, "children"> &
-  VariantProps<typeof selectTriggerVariants> & {
+  VariantProps<typeof modelSelectorTriggerVariants> & {
+    /** Render a search input above the model list. */
+    searchable?: boolean;
     className?: string;
     contentClassName?: string;
   };
 
 const ModelSelectorImpl = ({
-  value: controlledValue,
-  onValueChange: controlledOnValueChange,
-  defaultValue,
   models,
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  effort: effortProp,
+  defaultEffort,
+  onEffortChange,
+  searchable,
   variant,
   size,
   className,
   contentClassName,
-  ...forwardedProps
+  ...rootProps
 }: ModelSelectorProps) => {
-  const isControlled = controlledValue !== undefined;
-  const [internalValue, setInternalValue] = useState(
-    () => defaultValue ?? models[0]?.id ?? "",
-  );
-
-  const value = isControlled ? controlledValue : internalValue;
-  const onValueChange = controlledOnValueChange ?? setInternalValue;
+  const [value, setValue] = useControllableState({
+    prop: valueProp,
+    defaultProp: defaultValue ?? models[0]?.id,
+    onChange: onValueChange,
+  });
+  const [effort, setEffort] = useControllableState({
+    prop: effortProp,
+    defaultProp: defaultEffort,
+    onChange: onEffortChange,
+  });
+  const activeEffort = resolveModelEffort(models, value, effort);
 
   const api = useAui();
 
   useEffect(() => {
-    const config = { config: { modelName: value } };
+    if (value === undefined) return;
+    const config = {
+      config: {
+        modelName: value,
+        ...(activeEffort !== undefined
+          ? { reasoningEffort: activeEffort }
+          : undefined),
+      },
+    };
     return api.modelContext().register({
       getModelContext: () => config,
     });
-  }, [api, value]);
+  }, [api, value, activeEffort]);
 
   return (
     <ModelSelectorRoot
       models={models}
-      value={value}
-      onValueChange={onValueChange}
-      {...forwardedProps}
+      {...(value !== undefined ? { value } : undefined)}
+      onValueChange={setValue}
+      {...(effort !== undefined ? { effort } : undefined)}
+      onEffortChange={setEffort}
+      {...rootProps}
     >
       <ModelSelectorTrigger
         variant={variant}
         size={size}
         className={className}
       />
-      <ModelSelectorContent className={contentClassName} />
+      <ModelSelectorContent className={contentClassName}>
+        {searchable && <ModelSelectorSearch />}
+        <ModelSelectorList />
+        <ModelSelectorEffort />
+      </ModelSelectorContent>
     </ModelSelectorRoot>
   );
 };
@@ -270,9 +592,15 @@ type ModelSelectorComponent = typeof ModelSelectorImpl & {
   displayName?: string;
   Root: typeof ModelSelectorRoot;
   Trigger: typeof ModelSelectorTrigger;
-  Content: typeof ModelSelectorContent;
-  Item: typeof ModelSelectorItem;
   Value: typeof ModelSelectorValue;
+  Content: typeof ModelSelectorContent;
+  Search: typeof ModelSelectorSearch;
+  List: typeof ModelSelectorList;
+  Empty: typeof ModelSelectorEmpty;
+  Group: typeof ModelSelectorGroup;
+  Separator: typeof ModelSelectorSeparator;
+  Item: typeof ModelSelectorItem;
+  Effort: typeof ModelSelectorEffort;
 };
 
 const ModelSelector = memo(
@@ -282,15 +610,27 @@ const ModelSelector = memo(
 ModelSelector.displayName = "ModelSelector";
 ModelSelector.Root = ModelSelectorRoot;
 ModelSelector.Trigger = ModelSelectorTrigger;
-ModelSelector.Content = ModelSelectorContent;
-ModelSelector.Item = ModelSelectorItem;
 ModelSelector.Value = ModelSelectorValue;
+ModelSelector.Content = ModelSelectorContent;
+ModelSelector.Search = ModelSelectorSearch;
+ModelSelector.List = ModelSelectorList;
+ModelSelector.Empty = ModelSelectorEmpty;
+ModelSelector.Group = ModelSelectorGroup;
+ModelSelector.Separator = ModelSelectorSeparator;
+ModelSelector.Item = ModelSelectorItem;
+ModelSelector.Effort = ModelSelectorEffort;
 
 export {
   ModelSelector,
   ModelSelectorRoot,
   ModelSelectorTrigger,
-  ModelSelectorContent,
-  ModelSelectorItem,
   ModelSelectorValue,
+  ModelSelectorContent,
+  ModelSelectorSearch,
+  ModelSelectorList,
+  ModelSelectorEmpty,
+  ModelSelectorGroup,
+  ModelSelectorSeparator,
+  ModelSelectorItem,
+  ModelSelectorEffort,
 };

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -5,10 +5,12 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   createContext,
   useContext,
   type ComponentPropsWithoutRef,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
@@ -100,12 +102,18 @@ function useControllableState<T>({
   const [internal, setInternal] = useState(defaultProp);
   const isControlled = prop !== undefined;
   const value = isControlled ? prop : internal;
+  // Read onChange through a ref so inline callbacks don't recreate the setter
+  // (and with it the memoized context value) every render.
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  });
   const setValue = useCallback(
     (next: T) => {
       if (!isControlled) setInternal(next);
-      onChange?.(next);
+      onChangeRef.current?.(next);
     },
-    [isControlled, onChange],
+    [isControlled],
   );
   return [value, setValue] as const;
 }
@@ -289,6 +297,14 @@ export type ModelSelectorValueProps = {
   className?: string;
 };
 
+function ModelIcon({ children }: { children: ReactNode }) {
+  return (
+    <span className="flex size-4 shrink-0 items-center justify-center [&_svg]:size-4">
+      {children}
+    </span>
+  );
+}
+
 function ModelSelectorValue({
   placeholder = "Select model",
   showEffort = true,
@@ -297,7 +313,14 @@ function ModelSelectorValue({
   const { selectedModel, efforts, effort } = useModelSelectorContext();
 
   if (!selectedModel) {
-    return <span className="text-muted-foreground">{placeholder}</span>;
+    return (
+      <span
+        data-slot="model-selector-value"
+        className={cn("text-muted-foreground", className)}
+      >
+        {placeholder}
+      </span>
+    );
   }
 
   const effortName =
@@ -310,11 +333,7 @@ function ModelSelectorValue({
       data-slot="model-selector-value"
       className={cn("flex min-w-0 items-center gap-2", className)}
     >
-      {selectedModel.icon && (
-        <span className="flex size-4 shrink-0 items-center justify-center [&_svg]:size-4">
-          {selectedModel.icon}
-        </span>
-      )}
+      {selectedModel.icon && <ModelIcon>{selectedModel.icon}</ModelIcon>}
       <span className="truncate font-medium">{selectedModel.name}</span>
       {effortName && (
         <span className="text-muted-foreground truncate">{effortName}</span>
@@ -476,11 +495,7 @@ function ModelSelectorItem({
     >
       {children ?? (
         <>
-          {model.icon && (
-            <span className="flex size-4 shrink-0 items-center justify-center [&_svg]:size-4">
-              {model.icon}
-            </span>
-          )}
+          {model.icon && <ModelIcon>{model.icon}</ModelIcon>}
           <span className="flex min-w-0 flex-col">
             <span className="truncate font-medium">{model.name}</span>
             {model.description && (
@@ -507,6 +522,7 @@ export type ModelSelectorEffortProps = ComponentPropsWithoutRef<"div"> & {
 function ModelSelectorEffort({
   label = "Thinking",
   className,
+  onKeyDown,
   ...props
 }: ModelSelectorEffortProps) {
   const { efforts, effort, setEffort } = useModelSelectorEfforts();
@@ -520,6 +536,12 @@ function ModelSelectorEffort({
         "flex items-center justify-between gap-3 border-t px-3 py-2",
         className,
       )}
+      onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
+        // cmdk's root keydown handler claims Enter to select the highlighted
+        // model; stop it from seeing Enter so the focused toggle activates.
+        if (e.key === "Enter") e.stopPropagation();
+        onKeyDown?.(e);
+      }}
       {...props}
     >
       <span className="text-muted-foreground text-xs">{label}</span>

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -64,6 +64,14 @@ function getModelEfforts(
   return model.efforts === true ? DEFAULT_EFFORT_OPTIONS : model.efforts;
 }
 
+function resolveEffort(
+  efforts: readonly ModelSelectorEffortOption[] | undefined,
+  effort: string | undefined,
+): string | undefined {
+  if (effort === undefined) return undefined;
+  return efforts?.some((e) => e.id === effort) ? effort : undefined;
+}
+
 /**
  * Returns the effort id if the given model supports it, otherwise undefined.
  * Effort selection is kept sticky across model switches; this resolves what
@@ -74,9 +82,10 @@ export function resolveModelEffort(
   modelId: string | undefined,
   effort: string | undefined,
 ): string | undefined {
-  if (effort === undefined) return undefined;
-  const efforts = getModelEfforts(models.find((m) => m.id === modelId));
-  return efforts?.some((e) => e.id === effort) ? effort : undefined;
+  return resolveEffort(
+    getModelEfforts(models.find((m) => m.id === modelId)),
+    effort,
+  );
 }
 
 function useControllableState<T>({
@@ -89,13 +98,14 @@ function useControllableState<T>({
   onChange: ((next: T) => void) | undefined;
 }) {
   const [internal, setInternal] = useState(defaultProp);
-  const value = prop !== undefined ? prop : internal;
+  const isControlled = prop !== undefined;
+  const value = isControlled ? prop : internal;
   const setValue = useCallback(
     (next: T) => {
-      setInternal(next);
+      if (!isControlled) setInternal(next);
       onChange?.(next);
     },
-    [onChange],
+    [isControlled, onChange],
   );
   return [value, setValue] as const;
 }
@@ -104,6 +114,10 @@ type ModelSelectorContextValue = {
   models: readonly ModelOption[];
   value: string | undefined;
   setValue: (value: string) => void;
+  /** The model matching `value`, derived once for all sub-components. */
+  selectedModel: ModelOption | undefined;
+  /** The selected model's effort levels, undefined when not configurable. */
+  efforts: readonly ModelSelectorEffortOption[] | undefined;
   /** Effort resolved against the selected model's supported levels. */
   effort: string | undefined;
   setEffort: (effort: string) => void;
@@ -135,8 +149,7 @@ export function useModelSelectorEfforts(): {
   effort: string | undefined;
   setEffort: (effort: string) => void;
 } {
-  const { models, value, effort, setEffort } = useModelSelectorContext();
-  const efforts = getModelEfforts(models.find((m) => m.id === value));
+  const { efforts, effort, setEffort } = useModelSelectorContext();
   return { efforts, effort, setEffort };
 }
 
@@ -183,17 +196,30 @@ function ModelSelectorRoot({
     onChange: onOpenChange,
   });
 
-  const activeEffort = resolveModelEffort(models, value, effort);
+  const selectedModel = models.find((m) => m.id === value);
+  const efforts = getModelEfforts(selectedModel);
+  const activeEffort = resolveEffort(efforts, effort);
   const contextValue = useMemo(
     () => ({
       models,
       value,
       setValue,
+      selectedModel,
+      efforts,
       effort: activeEffort,
       setEffort,
       setOpen,
     }),
-    [models, value, setValue, activeEffort, setEffort, setOpen],
+    [
+      models,
+      value,
+      setValue,
+      selectedModel,
+      efforts,
+      activeEffort,
+      setEffort,
+      setOpen,
+    ],
   );
 
   return (
@@ -268,9 +294,7 @@ function ModelSelectorValue({
   showEffort = true,
   className,
 }: ModelSelectorValueProps) {
-  const { models, value, effort } = useModelSelectorContext();
-  const selectedModel =
-    value !== undefined ? models.find((m) => m.id === value) : undefined;
+  const { selectedModel, efforts, effort } = useModelSelectorContext();
 
   if (!selectedModel) {
     return <span className="text-muted-foreground">{placeholder}</span>;
@@ -278,7 +302,7 @@ function ModelSelectorValue({
 
   const effortName =
     showEffort && effort !== undefined
-      ? getModelEfforts(selectedModel)?.find((e) => e.id === effort)?.name
+      ? efforts?.find((e) => e.id === effort)?.name
       : undefined;
 
   return (
@@ -346,14 +370,12 @@ export type ModelSelectorSearchProps = ComponentPropsWithoutRef<
 
 function ModelSelectorSearch({
   placeholder = "Search models...",
-  className,
   ...props
 }: ModelSelectorSearchProps) {
   return (
     <CommandInput
       data-slot="model-selector-search"
       placeholder={placeholder}
-      className={className}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

Rebuilds the `ModelSelector` registry component on Popover + Command (the shadcn combobox pattern), replacing the plain select. Two things come built in: model selection and a reasoning effort ("thinking") footer for models that declare effort levels. Search, provider grouping, and filtering aren't built in — they compose in through exported parts.

```tsx
<ModelSelector
  models={[
    { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", description: "Balanced performance" },
    { id: "gpt-5.5", name: "GPT-5.5", description: "Most capable", efforts: true },
  ]}
  defaultValue="gpt-5.4-mini"
  searchable
/>
```

Models with `efforts` show a thinking row; `efforts: true` gives the default Low/Medium/High, or pass a custom `{ id, name }` list. The selection reaches the request body through the existing config passthrough — `config.modelName` plus a new `config.reasoningEffort` field on `LanguageModelConfig`:

```ts
const result = streamText({
  model: openai(config?.modelName ?? "gpt-5.4-mini"),
  providerOptions: {
    openai: { reasoningEffort: config?.reasoningEffort ?? "medium" },
  },
  messages: await convertToModelMessages(messages),
});
```

## Composition

Every part is exported (`Root`/`Trigger`/`Value`/`Content`/`Search`/`List`/`Empty`/`Group`/`Separator`/`Item`/`Effort`). The default popover content is just `List` + `Effort`; swap it out to add search or provider groups:

```tsx
<ModelSelectorRoot models={models} value={modelId} onValueChange={setModelId}>
  <ModelSelectorTrigger variant="outline" />
  <ModelSelectorContent>
    <ModelSelectorSearch placeholder="Search models..." />
    <ModelSelectorList>
      <ModelSelectorEmpty />
      <ModelSelectorGroup heading="OpenAI">…</ModelSelectorGroup>
      <ModelSelectorGroup heading="Anthropic">…</ModelSelectorGroup>
    </ModelSelectorList>
    <ModelSelectorEffort label="Thinking" />
  </ModelSelectorContent>
</ModelSelectorRoot>
```

When the default segmented effort row doesn't fit (sliders, dropdowns, models with many levels), the `useModelSelectorEfforts()` hook exposes the selected model's levels and the active selection, so a custom control can drop in where `ModelSelector.Effort` would go.

## Notes

- Effort selection is sticky: switching to a model that doesn't support the current level omits `reasoningEffort` instead of resetting the user's choice; the exported `resolveModelEffort` helper applies the same rule for custom runtime wiring
- `ModelContext` registration moved into an internal bridge component; opening the popover scrolls the selected model into view; the effort row uses `aria-pressed` toggle buttons
- Docs page renamed to "Model Selector", with a composed example (search + provider filter chips) and the custom effort UI pattern documented
