### PR TITLE
feat: add NumberRoll rolling number component

### DIFF
--- a/apps/docs/components/docs/samples/number-roll.tsx
+++ b/apps/docs/components/docs/samples/number-roll.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { MinusIcon, PauseIcon, PlayIcon, PlusIcon } from "lucide-react";
+import { NumberRoll } from "@/components/assistant-ui/number-roll";
+import { Button } from "@/components/ui/button";
+import { SampleFrame } from "@/components/docs/samples/sample-frame";
+
+export function NumberRollSample() {
+  const [value, setValue] = useState(12);
+
+  return (
+    <SampleFrame className="flex h-auto flex-col items-center justify-center gap-6 p-10">
+      <NumberRoll
+        value={value}
+        locales="en-US"
+        className="text-5xl font-semibold"
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon"
+          aria-label="Decrement"
+          onClick={() => setValue((v) => v - 1)}
+        >
+          <MinusIcon />
+        </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          aria-label="Increment"
+          onClick={() => setValue((v) => v + 1)}
+        >
+          <PlusIcon />
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => setValue(Math.floor(Math.random() * 9000) + 100)}
+        >
+          Random
+        </Button>
+      </div>
+    </SampleFrame>
+  );
+}
+
+export function NumberRollCompactSample() {
+  const [value, setValue] = useState(700);
+
+  return (
+    <SampleFrame className="flex h-auto flex-col items-center justify-center gap-6 p-10">
+      <NumberRoll
+        value={value}
+        locales="en-US"
+        format={{ notation: "compact" }}
+        className="text-5xl font-semibold"
+      />
+      <div className="flex items-center gap-2">
+        <Button variant="outline" onClick={() => setValue((v) => v - 400)}>
+          -400
+        </Button>
+        <Button variant="outline" onClick={() => setValue((v) => v + 400)}>
+          +400
+        </Button>
+      </div>
+      <span className="text-muted-foreground font-mono text-xs tabular-nums">
+        value = {value}
+      </span>
+    </SampleFrame>
+  );
+}
+
+export function NumberRollFormatSample() {
+  const [index, setIndex] = useState(0);
+  const values = [1234.56, 98765.43, 412.07];
+  const value = values[index % values.length]!;
+
+  return (
+    <SampleFrame className="flex h-auto flex-col items-center gap-6 p-10">
+      <div className="grid grid-cols-[auto_1fr] items-baseline gap-x-8 gap-y-3 text-xl">
+        <span className="text-muted-foreground text-xs">Currency</span>
+        <NumberRoll
+          value={value}
+          locales="en-US"
+          format={{ style: "currency", currency: "USD" }}
+        />
+        <span className="text-muted-foreground text-xs">Percent</span>
+        <NumberRoll
+          value={value / 100000}
+          locales="en-US"
+          format={{ style: "percent" }}
+        />
+        <span className="text-muted-foreground text-xs">zh-CN compact</span>
+        <NumberRoll
+          value={value * 100}
+          locales="zh-CN"
+          format={{ notation: "compact" }}
+        />
+        <span className="text-muted-foreground text-xs">Suffix</span>
+        <NumberRoll value={value} locales="en-US" suffix=" tokens" />
+      </div>
+      <Button variant="outline" onClick={() => setIndex((i) => i + 1)}>
+        Shuffle
+      </Button>
+    </SampleFrame>
+  );
+}
+
+export function NumberRollLiveSample() {
+  const [running, setRunning] = useState(false);
+  const [tokens, setTokens] = useState(0);
+
+  useEffect(() => {
+    if (!running) return;
+    const interval = setInterval(() => {
+      setTokens((t) => t + Math.floor(Math.random() * 120) + 20);
+    }, 400);
+    return () => clearInterval(interval);
+  }, [running]);
+
+  return (
+    <SampleFrame className="flex h-auto flex-col items-center justify-center gap-6 p-10">
+      <div className="text-muted-foreground flex items-baseline gap-2 text-sm">
+        <NumberRoll
+          value={tokens}
+          locales="en-US"
+          format={{ notation: "compact", maximumFractionDigits: 1 }}
+          className="text-foreground text-3xl font-semibold"
+        />
+        tokens
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon"
+          aria-label={running ? "Pause" : "Play"}
+          onClick={() => setRunning((r) => !r)}
+        >
+          {running ? <PauseIcon /> : <PlayIcon />}
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => {
+            setRunning(false);
+            setTokens(0);
+          }}
+        >
+          Reset
+        </Button>
+      </div>
+    </SampleFrame>
+  );
+}

--- a/apps/docs/content/docs/ui/meta.json
+++ b/apps/docs/content/docs/ui/meta.json
@@ -34,6 +34,7 @@
     "accordion",
     "badge",
     "diff-viewer",
+    "number-roll",
     "select",
     "tabs",
     "---Experimental---",

--- a/apps/docs/content/docs/ui/number-roll.mdx
+++ b/apps/docs/content/docs/ui/number-roll.mdx
@@ -1,0 +1,154 @@
+---
+title: Number Roll
+description: Animated number that rolls digits odometer-style when the value changes.
+platforms: ["react"]
+---
+
+import { PreviewCode } from "@/components/docs/preview-code.server";
+import {
+  NumberRollSample,
+  NumberRollCompactSample,
+  NumberRollFormatSample,
+  NumberRollLiveSample,
+} from "@/components/docs/samples/number-roll";
+
+<Callout>
+  This is a **standalone component** that does not depend on the assistant-ui runtime. Use it anywhere in your application.
+</Callout>
+
+<NumberRollSample />
+
+## Installation
+
+<InstallCommand shadcn={["number-roll"]} />
+
+This adds a `/components/assistant-ui/number-roll.tsx` file to your project, which you can adjust as needed. The component has no dependencies beyond React.
+
+## Usage
+
+```tsx
+import { NumberRoll } from "@/components/assistant-ui/number-roll";
+
+export function TokenCounter({ count }: { count: number }) {
+  return <NumberRoll value={count} format={{ notation: "compact" }} />;
+}
+```
+
+When `value` changes, each digit rolls in place to its new value. Formatting is handled by `Intl.NumberFormat`, so structural changes animate too: when `700` becomes `1.1K` with compact notation, the surviving ones digit rolls from 0 to 1 while the leading `70` slides out and the decimal point, fraction digit, and `K` suffix slide in.
+
+## Examples
+
+### Compact Notation
+
+Pass any `Intl.NumberFormatOptions` via the `format` prop. Crossing a compact-notation threshold animates the formatting change instead of remounting the whole string.
+
+<PreviewCode file="components/docs/samples/number-roll" name="NumberRollCompactSample">
+  <NumberRollCompactSample />
+</PreviewCode>
+
+### Formats and Locales
+
+Currencies, percentages, suffixes, and non-English locales all work through the same `Intl.NumberFormat` pipeline. Compact thresholds and suffixes are locale-dependent (`1.2万` in `zh-CN`), so never hardcode them.
+
+<PreviewCode file="components/docs/samples/number-roll" name="NumberRollFormatSample">
+  <NumberRollFormatSample />
+</PreviewCode>
+
+### Live Counter
+
+Rapid successive updates retarget the in-flight roll smoothly, which makes the component suitable for streaming token counts and other live metrics.
+
+<PreviewCode file="components/docs/samples/number-roll" name="NumberRollLiveSample">
+  <NumberRollLiveSample />
+</PreviewCode>
+
+## How It Works
+
+The value is formatted with `Intl.NumberFormat.formatToParts` and split into keyed parts. Integer digits are keyed by place value counted from the right, so when `999` becomes `1,000` the existing columns keep their identity and roll in place while only the new leading digit and separator enter. Symbols (decimal point, group separators, currency signs, compact suffixes) cross-fade and collapse via animated `grid-template-columns`.
+
+Each digit renders a strip of 0 to 9 and animates a registered CSS custom property; CSS `mod()` math wraps the strip into an endless ribbon, so rolling from 9 to 0 continues in the trend direction instead of spinning backwards. There is no JavaScript animation loop and no animation library dependency.
+
+In browsers without CSS `mod()` support, and during server rendering, the component renders the plain formatted string. With `prefers-reduced-motion`, values swap instantly without rolling. When server rendering, pass an explicit `locales`: the server's default locale can differ from the visitor's browser locale, and a mismatched formatted string causes a React hydration error. Locales whose default numbering system is non-Latin (such as `ar-EG`) cross-fade their digits as symbols instead of rolling.
+
+The formatted value is exposed to screen readers as plain text while the animated digits are `aria-hidden`. Value changes are not announced automatically; wrap the component in an `aria-live` region if you need announcements.
+
+## API Reference
+
+### NumberRoll
+
+<ParametersTable
+  type="NumberRollProps"
+  parameters={[
+    {
+      name: "value",
+      type: "number",
+      required: true,
+      description: "The number to display.",
+    },
+    {
+      name: "format",
+      type: "Intl.NumberFormatOptions",
+      description:
+        "Number formatting options, e.g. `{ notation: \"compact\" }` or `{ style: \"currency\", currency: \"USD\" }`.",
+    },
+    {
+      name: "locales",
+      type: "Intl.LocalesArgument",
+      description:
+        "Locale(s) passed to `Intl.NumberFormat`. Pass an explicit value in server-rendered apps so the server and client format identically.",
+    },
+    {
+      name: "prefix",
+      type: "string",
+      description: "Static text rendered before the number.",
+    },
+    {
+      name: "suffix",
+      type: "string",
+      description: "Static text rendered after the number.",
+    },
+    {
+      name: "trend",
+      type: '"auto" | "up" | "down"',
+      default: '"auto"',
+      description:
+        "Roll direction. `auto` follows the sign of the value change; `up` and `down` force a direction, wrapping digits through 9/0 as needed.",
+    },
+    {
+      name: "duration",
+      type: "number",
+      default: "500",
+      description:
+        "Digit roll duration in milliseconds. Enter/exit fades run at 60% of this value.",
+    },
+    {
+      name: "className",
+      type: "string",
+      description: "Additional CSS classes.",
+    },
+  ]}
+/>
+
+### Styling
+
+The root applies `tabular-nums` so digits keep a constant width while rolling; the font you use must provide tabular figures for the layout to stay stable. Size and color are inherited from the surrounding text, so style it like any span:
+
+```tsx
+<NumberRoll value={value} className="text-4xl font-semibold" />
+```
+
+Change the animation speed via the `duration` prop; it drives both the CSS timing and the cleanup that unmounts exited characters, so overriding the duration variable in CSS alone would remove them mid-fade. The fade and easing variables are safe to override via the `style` prop (the defaults are set as inline styles, so plain `className` overrides do not apply):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `--aui-number-roll-duration` | `500ms` (from the `duration` prop) | Digit roll duration. |
+| `--aui-number-roll-fade` | 60% of the duration | Enter/exit fade and width-collapse duration. |
+| `--aui-number-roll-ease` | `cubic-bezier(0.23, 1, 0.32, 1)` | Digit roll easing. |
+
+Parts are targetable via data attributes: `[data-slot="number-roll"]`, `[data-slot="number-roll-part"]`, `[data-slot="number-roll-digit"]`, and `[data-slot="number-roll-symbol"]`.
+
+## Related Components
+
+- [Context Display](/docs/ui/context-display) - Live token usage ring and bar
+- [Message Timing](/docs/ui/message-timing) - Streaming stats badge
+- [Badge](/docs/ui/badge) - Small status and metadata labels

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -560,6 +560,20 @@ export const registry: RegistryItem[] = [
     registryDependencies: [],
   },
   {
+    name: "number-roll",
+    type: "registry:component",
+    files: [
+      {
+        type: "registry:component",
+        path: "components/assistant-ui/number-roll.tsx",
+        sourcePath:
+          "../../packages/ui/src/components/assistant-ui/number-roll.tsx",
+      },
+    ],
+    dependencies: [],
+    registryDependencies: [],
+  },
+  {
     name: "heat-graph",
     type: "registry:component",
     files: [

--- a/packages/ui/src/components/assistant-ui/number-roll.tsx
+++ b/packages/ui/src/components/assistant-ui/number-roll.tsx
@@ -57,7 +57,7 @@ const getFormatter = (
 type DigitPart = { type: "digit"; key: string; digit: number };
 type SymbolPart = { type: "symbol"; key: string; value: string };
 type Part = DigitPart | SymbolPart;
-type RenderedPart = Part & { exiting?: boolean };
+type RenderedPart = Part & { exiting?: boolean; entered?: boolean };
 
 const toParts = (
   value: number,
@@ -144,8 +144,10 @@ const merge = (prev: RenderedPart[], next: Part[]): RenderedPart[] => {
     if (prevKeys.has(part.key)) {
       emitExited(part.key);
       i++;
+      out.push(part);
+    } else {
+      out.push({ ...part, entered: true });
     }
-    out.push(part);
   }
   emitExited(undefined);
   return out;
@@ -195,7 +197,8 @@ function NumberRollPart({ part, dir }: { part: RenderedPart; dir: number }) {
       data-slot="number-roll-part"
       className={cn(
         "inline-grid grid-cols-[1fr] transition-[grid-template-columns,opacity,translate] duration-(--aui-number-roll-fade) ease-out motion-reduce:transition-none",
-        "starting:translate-y-(--aui-number-roll-shift) starting:grid-cols-[0fr] starting:opacity-0",
+        part.entered &&
+          "starting:translate-y-(--aui-number-roll-shift) starting:grid-cols-[0fr] starting:opacity-0",
         part.exiting &&
           "pointer-events-none translate-y-[calc(var(--aui-number-roll-shift)*-1)] grid-cols-[0fr] opacity-0",
       )}
@@ -261,27 +264,19 @@ function NumberRoll({
     () => toParts(value, formatter, prefix, suffix),
     [value, formatter, prefix, suffix],
   );
-  const signature = useMemo(
-    () =>
-      parts
-        .map((part) =>
-          part.type === "digit" ? `${part.key}=${part.digit}` : part.key,
-        )
-        .join("|"),
-    [parts],
-  );
+  const formatted = `${prefix ?? ""}${formatter.format(value)}${suffix ?? ""}`;
 
   const [display, setDisplay] = useState<{
     value: number;
-    signature: string;
+    formatted: string;
     rendered: RenderedPart[];
     dir: number;
-  }>(() => ({ value, signature, rendered: parts, dir: 0 }));
+  }>(() => ({ value, formatted, rendered: parts, dir: 0 }));
 
-  if (display.signature !== signature) {
+  if (display.formatted !== formatted) {
     setDisplay({
       value,
-      signature,
+      formatted,
       rendered: merge(display.rendered, parts),
       dir:
         trend === "up"
@@ -292,13 +287,9 @@ function NumberRoll({
     });
   }
 
-  /* Each exiting part gets its own removal timer so a new exit batch does not extend the lifetime of parts already mid-exit. */
+  /* Each exiting part gets its own removal timer so a new exit batch does not extend the lifetime of parts already mid-exit. The body is idempotent, so extra runs from unrelated display changes are no-ops. */
   const exitTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
   const lastDuration = useRef(duration);
-  const exitingKeys = display.rendered
-    .filter((part) => part.exiting)
-    .map((part) => part.key)
-    .join("\u0000");
   useEffect(() => {
     const timers = exitTimers.current;
     if (lastDuration.current !== duration) {
@@ -306,7 +297,9 @@ function NumberRoll({
       for (const timer of timers.values()) clearTimeout(timer);
       timers.clear();
     }
-    const exiting = new Set(exitingKeys ? exitingKeys.split("\u0000") : []);
+    const exiting = new Set(
+      display.rendered.filter((part) => part.exiting).map((part) => part.key),
+    );
     for (const [key, timer] of timers) {
       if (!exiting.has(key)) {
         clearTimeout(timer);
@@ -328,7 +321,7 @@ function NumberRoll({
         }, duration),
       );
     }
-  }, [exitingKeys, duration]);
+  }, [display.rendered, duration]);
   useEffect(() => {
     const timers = exitTimers.current;
     return () => {
@@ -336,8 +329,6 @@ function NumberRoll({
       timers.clear();
     };
   }, []);
-
-  const formatted = `${prefix ?? ""}${formatter.format(value)}${suffix ?? ""}`;
 
   return (
     <span

--- a/packages/ui/src/components/assistant-ui/number-roll.tsx
+++ b/packages/ui/src/components/assistant-ui/number-roll.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type ComponentProps,
+  type CSSProperties,
+} from "react";
+import { cn } from "@/lib/utils";
+
+const DEFAULT_DURATION = 500;
+const DIGIT_CELLS = Array.from({ length: 10 }, (_, i) => i);
+
+if (typeof CSS !== "undefined" && typeof CSS.registerProperty === "function") {
+  try {
+    CSS.registerProperty({
+      name: "--aui-number-roll-pos",
+      syntax: "<number>",
+      inherits: true,
+      initialValue: "0",
+    });
+  } catch {
+    /* Already registered by another copy of this component. */
+  }
+}
+
+let supportsRoll: boolean | undefined;
+const canAnimate = () =>
+  (supportsRoll ??=
+    typeof CSS !== "undefined" &&
+    typeof CSS.registerProperty === "function" &&
+    CSS.supports(
+      "transform",
+      "translateY(clamp(-1lh, calc((mod(7.5, 10) - 5) * 1lh), 1lh))",
+    ));
+
+type DigitPart = { type: "digit"; key: string; digit: number };
+type SymbolPart = { type: "symbol"; key: string; value: string };
+type Part = DigitPart | SymbolPart;
+type RenderedPart = Part & { exiting?: boolean };
+
+const toParts = (
+  value: number,
+  formatter: Intl.NumberFormat,
+  prefix: string | undefined,
+  suffix: string | undefined,
+): Part[] => {
+  type Atom =
+    | { kind: "integer"; digit: number }
+    | { kind: "group"; value: string }
+    | { kind: "fraction"; digit: number }
+    | { kind: "symbol"; type: string; value: string };
+
+  const atoms: Atom[] = [];
+  if (prefix) atoms.push({ kind: "symbol", type: "prefix", value: prefix });
+  for (const part of formatter.formatToParts(value)) {
+    if (part.type === "integer" || part.type === "fraction") {
+      for (const char of part.value) {
+        const digit = char.charCodeAt(0) - 48;
+        if (digit >= 0 && digit <= 9) {
+          atoms.push({ kind: part.type, digit });
+        } else {
+          atoms.push({ kind: "symbol", type: part.type, value: char });
+        }
+      }
+    } else if (part.type === "group") {
+      atoms.push({ kind: "group", value: part.value });
+    } else {
+      const type =
+        part.type === "minusSign" || part.type === "plusSign"
+          ? "sign"
+          : part.type;
+      atoms.push({ kind: "symbol", type, value: part.value });
+    }
+  }
+  if (suffix) atoms.push({ kind: "symbol", type: "suffix", value: suffix });
+
+  const counts = new Map<string, number>();
+  const nextKey = (type: string) => {
+    const count = counts.get(type) ?? 0;
+    counts.set(type, count + 1);
+    return `${type}:${count}`;
+  };
+
+  /* Integer digits and group separators are keyed right to left so the ones digit is always int:0. When the digit count changes (999 -> 1,000), the surviving places keep their identity and only the new leading parts enter, instead of every column being re-assigned a new meaning. */
+  const parts: Part[] = new Array(atoms.length);
+  for (let i = atoms.length - 1; i >= 0; i--) {
+    const atom = atoms[i]!;
+    if (atom.kind === "integer") {
+      parts[i] = { type: "digit", key: nextKey("int"), digit: atom.digit };
+    } else if (atom.kind === "group") {
+      parts[i] = { type: "symbol", key: nextKey("group"), value: atom.value };
+    }
+  }
+  for (let i = 0; i < atoms.length; i++) {
+    const atom = atoms[i]!;
+    if (atom.kind === "fraction") {
+      parts[i] = { type: "digit", key: nextKey("fraction"), digit: atom.digit };
+    } else if (atom.kind === "symbol") {
+      parts[i] = {
+        type: "symbol",
+        key: `${nextKey(atom.type)}:${atom.value}`,
+        value: atom.value,
+      };
+    }
+  }
+  return parts;
+};
+
+const merge = (prev: RenderedPart[], next: Part[]): RenderedPart[] => {
+  const nextKeys = new Set(next.map((part) => part.key));
+  const prevKeys = new Set(prev.map((part) => part.key));
+  const out: RenderedPart[] = [];
+  let i = 0;
+  const emitExited = (until: string | undefined) => {
+    while (i < prev.length && prev[i]!.key !== until) {
+      const old = prev[i++]!;
+      if (!nextKeys.has(old.key)) {
+        out.push(old.exiting ? old : { ...old, exiting: true });
+      }
+    }
+  };
+  for (const part of next) {
+    if (prevKeys.has(part.key)) {
+      emitExited(part.key);
+      i++;
+    }
+    out.push(part);
+  }
+  emitExited(undefined);
+  return out;
+};
+
+const rollDelta = (from: number, to: number, dir: number) => {
+  const up = (((to - from) % 10) + 10) % 10;
+  if (dir > 0) return up;
+  if (dir < 0) return up - 10;
+  return up > 5 ? up - 10 : up;
+};
+
+function NumberRollDigit({ digit, dir }: { digit: number; dir: number }) {
+  const [state, setState] = useState({ digit, roll: digit });
+  if (state.digit !== digit) {
+    setState({ digit, roll: state.roll + rollDelta(state.digit, digit, dir) });
+  }
+
+  return (
+    <span
+      data-slot="number-roll-digit"
+      className="relative inline-block overflow-clip [transition-property:--aui-number-roll-pos] duration-(--aui-number-roll-duration) ease-(--aui-number-roll-ease) motion-reduce:transition-none"
+      style={{ "--aui-number-roll-pos": state.roll } as CSSProperties}
+    >
+      {/* Digit glyphs render through ::before so find-in-page and copy never see the strip. overflow-clip (not hidden) keeps the inline-block's baseline on the text instead of the box bottom edge. */}
+      <span
+        data-d={digit}
+        className="invisible before:content-[attr(data-d)]"
+      />
+      {DIGIT_CELLS.map((cell) => (
+        <span
+          key={cell}
+          data-d={cell}
+          className="absolute inset-0 text-center before:content-[attr(data-d)]"
+          style={{
+            transform: `translateY(clamp(-1lh, calc((mod(mod(${cell} - var(--aui-number-roll-pos), 10) + 5, 10) - 5) * 1lh), 1lh))`,
+          }}
+        />
+      ))}
+    </span>
+  );
+}
+
+function NumberRollPart({ part, dir }: { part: RenderedPart; dir: number }) {
+  return (
+    <span
+      data-slot="number-roll-part"
+      className={cn(
+        "inline-grid grid-cols-[1fr] transition-[grid-template-columns,opacity,translate] duration-(--aui-number-roll-fade) ease-out motion-reduce:transition-none",
+        "starting:translate-y-(--aui-number-roll-shift) starting:grid-cols-[0fr] starting:opacity-0",
+        part.exiting &&
+          "pointer-events-none translate-y-[calc(var(--aui-number-roll-shift)*-1)] grid-cols-[0fr] opacity-0",
+      )}
+      style={
+        {
+          "--aui-number-roll-shift":
+            dir === 0 ? "0%" : dir > 0 ? "35%" : "-35%",
+        } as CSSProperties
+      }
+    >
+      <span className="min-w-0 overflow-hidden">
+        {part.type === "digit" ? (
+          <NumberRollDigit digit={part.digit} dir={dir} />
+        ) : (
+          <span data-slot="number-roll-symbol" className="whitespace-pre">
+            {part.value}
+          </span>
+        )}
+      </span>
+    </span>
+  );
+}
+
+export type NumberRollProps = Omit<
+  ComponentProps<"span">,
+  "children" | "prefix"
+> & {
+  value: number;
+  format?: Intl.NumberFormatOptions;
+  locales?: Intl.LocalesArgument;
+  prefix?: string;
+  suffix?: string;
+  trend?: "auto" | "up" | "down";
+  duration?: number;
+};
+
+/**
+ * Animated number that rolls digits odometer-style when the value changes. Formatting is driven by `Intl.NumberFormat`, so compact notation ("1.1K"), currencies, percentages, and locale-specific output animate gracefully: digits spin in place while entering and exiting characters slide and fade. Renders the plain formatted value on the server and in browsers without CSS `mod()` support; when server rendering, pass an explicit `locales` so the server and client format identically.
+ *
+ * ```tsx
+ * <NumberRoll value={count} format={{ notation: "compact" }} />
+ * ```
+ */
+function NumberRoll({
+  value,
+  format,
+  locales,
+  prefix,
+  suffix,
+  trend = "auto",
+  duration = DEFAULT_DURATION,
+  className,
+  style,
+  ...props
+}: NumberRollProps) {
+  const [enhanced, setEnhanced] = useState(false);
+  useEffect(() => {
+    if (canAnimate()) setEnhanced(true);
+  }, []);
+
+  const formatter = useMemo(
+    () => new Intl.NumberFormat(locales, format),
+    [locales, format],
+  );
+  const parts = useMemo(
+    () => toParts(value, formatter, prefix, suffix),
+    [value, formatter, prefix, suffix],
+  );
+  const signature = useMemo(
+    () =>
+      parts
+        .map((part) =>
+          part.type === "digit" ? `${part.key}=${part.digit}` : part.key,
+        )
+        .join("|"),
+    [parts],
+  );
+
+  const [display, setDisplay] = useState<{
+    value: number;
+    signature: string;
+    rendered: RenderedPart[];
+    dir: number;
+  }>(() => ({ value, signature, rendered: parts, dir: 0 }));
+
+  if (display.signature !== signature) {
+    setDisplay({
+      value,
+      signature,
+      rendered: merge(display.rendered, parts),
+      dir:
+        trend === "up"
+          ? 1
+          : trend === "down"
+            ? -1
+            : Math.sign(value - display.value),
+    });
+  }
+
+  const exitingKeys = display.rendered
+    .filter((part) => part.exiting)
+    .map((part) => part.key)
+    .join("|");
+  useEffect(() => {
+    if (!exitingKeys) return;
+    const timeout = setTimeout(() => {
+      setDisplay((current) => ({
+        ...current,
+        rendered: current.rendered.filter((part) => !part.exiting),
+      }));
+    }, duration);
+    return () => clearTimeout(timeout);
+  }, [exitingKeys, duration]);
+
+  const formatted = `${prefix ?? ""}${formatter.format(value)}${suffix ?? ""}`;
+
+  return (
+    <span
+      data-slot="number-roll"
+      className={cn("inline-block whitespace-nowrap tabular-nums", className)}
+      style={
+        {
+          "--aui-number-roll-duration": `${duration}ms`,
+          "--aui-number-roll-fade":
+            "calc(var(--aui-number-roll-duration) * 0.6)",
+          "--aui-number-roll-ease": "cubic-bezier(0.23, 1, 0.32, 1)",
+          ...style,
+        } as CSSProperties
+      }
+      {...props}
+    >
+      <span className="sr-only">{formatted}</span>
+      {enhanced ? (
+        <span aria-hidden className="inline-block select-none">
+          {display.rendered.map((part) => (
+            <NumberRollPart key={part.key} part={part} dir={display.dir} />
+          ))}
+        </span>
+      ) : (
+        <span aria-hidden>{formatted}</span>
+      )}
+    </span>
+  );
+}
+
+export { NumberRoll };

--- a/packages/ui/src/components/assistant-ui/number-roll.tsx
+++ b/packages/ui/src/components/assistant-ui/number-roll.tsx
@@ -3,6 +3,7 @@
 import {
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ComponentProps,
   type CSSProperties,
@@ -34,6 +35,21 @@ const canAnimate = () =>
       "transform",
       "translateY(clamp(-1lh, calc((mod(7.5, 10) - 5) * 1lh), 1lh))",
     ));
+
+/* Cached because Intl.NumberFormat construction is expensive and inline format/locales props change identity on every parent render. */
+const formatterCache = new Map<string, Intl.NumberFormat>();
+const getFormatter = (
+  locales: Intl.LocalesArgument,
+  format: Intl.NumberFormatOptions | undefined,
+) => {
+  const key = `${String(locales)}\u0000${JSON.stringify(format)}`;
+  let formatter = formatterCache.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locales, format);
+    formatterCache.set(key, formatter);
+  }
+  return formatter;
+};
 
 type DigitPart = { type: "digit"; key: string; digit: number };
 type SymbolPart = { type: "symbol"; key: string; value: string };
@@ -237,10 +253,7 @@ function NumberRoll({
     if (canAnimate()) setEnhanced(true);
   }, []);
 
-  const formatter = useMemo(
-    () => new Intl.NumberFormat(locales, format),
-    [locales, format],
-  );
+  const formatter = getFormatter(locales, format);
   const parts = useMemo(
     () => toParts(value, formatter, prefix, suffix),
     [value, formatter, prefix, suffix],
@@ -276,20 +289,44 @@ function NumberRoll({
     });
   }
 
+  /* Each exiting part gets its own removal timer so a new exit batch does not extend the lifetime of parts already mid-exit. */
+  const exitTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
   const exitingKeys = display.rendered
     .filter((part) => part.exiting)
     .map((part) => part.key)
-    .join("|");
+    .join("\u0000");
   useEffect(() => {
-    if (!exitingKeys) return;
-    const timeout = setTimeout(() => {
-      setDisplay((current) => ({
-        ...current,
-        rendered: current.rendered.filter((part) => !part.exiting),
-      }));
-    }, duration);
-    return () => clearTimeout(timeout);
+    const timers = exitTimers.current;
+    const exiting = new Set(exitingKeys ? exitingKeys.split("\u0000") : []);
+    for (const [key, timer] of timers) {
+      if (!exiting.has(key)) {
+        clearTimeout(timer);
+        timers.delete(key);
+      }
+    }
+    for (const key of exiting) {
+      if (timers.has(key)) continue;
+      timers.set(
+        key,
+        setTimeout(() => {
+          timers.delete(key);
+          setDisplay((current) => ({
+            ...current,
+            rendered: current.rendered.filter(
+              (part) => !(part.exiting && part.key === key),
+            ),
+          }));
+        }, duration),
+      );
+    }
   }, [exitingKeys, duration]);
+  useEffect(() => {
+    const timers = exitTimers.current;
+    return () => {
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
+    };
+  }, []);
 
   const formatted = `${prefix ?? ""}${formatter.format(value)}${suffix ?? ""}`;
 

--- a/packages/ui/src/components/assistant-ui/number-roll.tsx
+++ b/packages/ui/src/components/assistant-ui/number-roll.tsx
@@ -13,28 +13,31 @@ import { cn } from "@/lib/utils";
 const DEFAULT_DURATION = 500;
 const DIGIT_CELLS = Array.from({ length: 10 }, (_, i) => i);
 
-if (typeof CSS !== "undefined" && typeof CSS.registerProperty === "function") {
-  try {
-    CSS.registerProperty({
-      name: "--aui-number-roll-pos",
-      syntax: "<number>",
-      inherits: true,
-      initialValue: "0",
-    });
-  } catch {
-    /* Already registered by another copy of this component. */
-  }
-}
-
 let supportsRoll: boolean | undefined;
-const canAnimate = () =>
-  (supportsRoll ??=
-    typeof CSS !== "undefined" &&
-    typeof CSS.registerProperty === "function" &&
-    CSS.supports(
-      "transform",
-      "translateY(clamp(-1lh, calc((mod(7.5, 10) - 5) * 1lh), 1lh))",
-    ));
+const canAnimate = () => {
+  if (supportsRoll === undefined) {
+    supportsRoll =
+      typeof CSS !== "undefined" &&
+      typeof CSS.registerProperty === "function" &&
+      CSS.supports(
+        "transform",
+        "translateY(clamp(-1lh, calc((mod(7.5, 10) - 5) * 1lh), 1lh))",
+      );
+    if (supportsRoll) {
+      try {
+        CSS.registerProperty({
+          name: "--aui-number-roll-pos",
+          syntax: "<number>",
+          inherits: true,
+          initialValue: "0",
+        });
+      } catch {
+        /* Already registered by another copy of this component. */
+      }
+    }
+  }
+  return supportsRoll;
+};
 
 /* Cached because Intl.NumberFormat construction is expensive and inline format/locales props change identity on every parent render. */
 const formatterCache = new Map<string, Intl.NumberFormat>();
@@ -291,12 +294,18 @@ function NumberRoll({
 
   /* Each exiting part gets its own removal timer so a new exit batch does not extend the lifetime of parts already mid-exit. */
   const exitTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+  const lastDuration = useRef(duration);
   const exitingKeys = display.rendered
     .filter((part) => part.exiting)
     .map((part) => part.key)
     .join("\u0000");
   useEffect(() => {
     const timers = exitTimers.current;
+    if (lastDuration.current !== duration) {
+      lastDuration.current = duration;
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
+    }
     const exiting = new Set(exitingKeys ? exitingKeys.split("\u0000") : []);
     for (const [key, timer] of timers) {
       if (!exiting.has(key)) {


### PR DESCRIPTION
## summary

- new `NumberRoll` component in the shadcn kit: an animated number that rolls digits odometer-style when the value changes. formatting goes through `Intl.NumberFormat`, so structural changes animate too; when 700 becomes 1.1K with compact notation, the surviving ones digit rolls in place while the leading digits slide out and the decimal point, fraction digit, and K suffix slide in. currencies, percentages, prefixes/suffixes, and locale-specific output (e.g. 1.2万 in zh-CN) all work through the same pipeline
- pure CSS animation, matching the packages/ui convention of no JS animation libraries: each digit renders a 10-cell strip positioned by CSS `mod()` math over a single `@property`-registered custom property, so one transitioned value drives the whole roll with no JS animation loop and smooth retargeting mid-flight. width changes animate via `grid-template-columns` 0fr/1fr, entries via `@starting-style`. zero npm dependencies
- graceful degradation: SSR and browsers without CSS `mod()` render the plain formatted string and upgrade after mount; `prefers-reduced-motion` swaps instantly. the formatted value is exposed to screen readers via sr-only text, the animated guts are aria-hidden, and strip glyphs render through `::before` generated content so find-in-page and copy never see them
- registered in the shadcn registry as `number-roll` and documented at /docs/ui/number-roll with four interactive samples (counter, compact threshold crossing, formats/locales, simulated live token counter)

## test plan

### already verified

- [x] `pnpm lint` green, `tsc --noEmit` green in packages/ui and apps/registry, `pnpm --filter @assistant-ui/shadcn-registry build` emits dist/number-roll.json, `pnpm sync-templates` passes
- [x] verified live in Chrome on the docs page: sampled `--aui-number-roll-pos` interpolating 2 to 3 on increment with the custom easing; 700 to 1.1K shows exiting digits collapsing while `.1K` expands from 0fr and the ones digit keeps its place-value identity; exited parts are removed from the DOM about one duration after settling
- [x] sustained updates every 400ms across the 1K boundary (live counter sample) leave no stale zero-width parts in the DOM
- [x] digit and symbol baselines align ($1,234.56, 1%, 12万, suffix text); no console errors or hydration warnings

### reviewer should verify

- [ ] open /docs/ui/number-roll, click the increment/random/+400 buttons and play the live counter; rolls should be smooth and the layout should not shift horizontally mid-roll
- [ ] Safari: digit rolls and exits work from 16.4, enter animations need 17.5+ for `@starting-style` and pop in without it (intended degradation)

## notes

- non-Latin numbering systems (e.g. ar-EG) cross-fade digits as symbols instead of rolling; documented in the page
- server-rendered apps should pass an explicit `locales` so server and client format identically; documented on the `locales` prop and in How It Works, and all docs samples do so
- no changeset: only private packages are touched (@assistant-ui/ui, @assistant-ui/shadcn-registry, @assistant-ui/docs)