### PR TITLE
feat: add DotMatrix status indicator component

### DIFF
--- a/apps/docs/components/docs/samples/dot-matrix.tsx
+++ b/apps/docs/components/docs/samples/dot-matrix.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  DotMatrix,
+  dotMatrixStates,
+  type DotMatrixState,
+} from "@/components/assistant-ui/dot-matrix";
+import { Button } from "@/components/ui/button";
+import { SampleFrame } from "@/components/docs/samples/sample-frame";
+
+export function DotMatrixSample() {
+  return (
+    <SampleFrame className="grid h-auto grid-cols-3 gap-x-4 gap-y-8 p-10 sm:grid-cols-5">
+      {dotMatrixStates.map((state) => (
+        <div key={state} className="flex flex-col items-center gap-3">
+          <DotMatrix state={state} className="size-8" />
+          <span className="text-muted-foreground font-mono text-xs">
+            {state}
+          </span>
+        </div>
+      ))}
+    </SampleFrame>
+  );
+}
+
+export function DotMatrixLifecycleSample() {
+  const lifecycle = [
+    "idle",
+    "connecting",
+    "loading",
+    "thinking",
+    "streaming",
+    "success",
+  ] as const satisfies readonly DotMatrixState[];
+  const [step, setStep] = useState(0);
+  const state = lifecycle[step % lifecycle.length]!;
+
+  return (
+    <SampleFrame className="flex h-auto flex-col items-center justify-center gap-6 p-10">
+      <div className="flex items-center gap-3">
+        <DotMatrix state={state} className="size-10" />
+        <span className="text-muted-foreground font-mono text-sm">{state}</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" onClick={() => setStep((s) => s + 1)}>
+          Next state
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => setStep(0)}
+          disabled={state === "idle"}
+        >
+          Reset
+        </Button>
+      </div>
+    </SampleFrame>
+  );
+}
+
+export function DotMatrixInlineSample() {
+  const [running, setRunning] = useState(true);
+
+  useEffect(() => {
+    const interval = setInterval(() => setRunning((r) => !r), 3000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <SampleFrame className="flex h-auto flex-col items-center justify-center gap-6 p-10">
+      <div className="flex items-center gap-2 text-sm">
+        <DotMatrix state={running ? "loading" : "success"} />
+        {running ? "Generating response…" : "Done"}
+      </div>
+      <div className="bg-foreground text-background flex items-center gap-2 rounded-lg px-4 py-3 text-sm">
+        <DotMatrix state={running ? "thinking" : "success"} />
+        {running ? "Thinking…" : "Done"}
+      </div>
+      <div className="flex items-center gap-2 text-sm">
+        <DotMatrix state={running ? "recording" : "stopped"} />
+        {running ? "Recording…" : "Stopped"}
+      </div>
+    </SampleFrame>
+  );
+}
+
+export function DotMatrixSizesSample() {
+  return (
+    <SampleFrame className="flex h-auto items-end justify-center gap-8 p-10">
+      {(["size-4", "size-6", "size-10", "size-16"] as const).map((size) => (
+        <div key={size} className="flex flex-col items-center gap-3">
+          <DotMatrix state="loading" className={size} />
+          <span className="text-muted-foreground font-mono text-xs">
+            {size}
+          </span>
+        </div>
+      ))}
+    </SampleFrame>
+  );
+}

--- a/apps/docs/content/docs/ui/dot-matrix.mdx
+++ b/apps/docs/content/docs/ui/dot-matrix.mdx
@@ -22,7 +22,7 @@ import {
 
 <InstallCommand shadcn={["dot-matrix"]} />
 
-This adds a `/components/assistant-ui/dot-matrix.tsx` file to your project, which you can adjust as needed. The component has no dependencies beyond React and class-variance-authority.
+This adds a `/components/assistant-ui/dot-matrix.tsx` file to your project, which you can adjust as needed. The component has no dependencies beyond React.
 
 ## Usage
 

--- a/apps/docs/content/docs/ui/dot-matrix.mdx
+++ b/apps/docs/content/docs/ui/dot-matrix.mdx
@@ -1,0 +1,133 @@
+---
+title: Dot Matrix
+description: Tiny 5x5 dot-matrix indicator with 20 state-specific blink patterns.
+platforms: ["react"]
+---
+
+import { PreviewCode } from "@/components/docs/preview-code.server";
+import {
+  DotMatrixSample,
+  DotMatrixLifecycleSample,
+  DotMatrixInlineSample,
+  DotMatrixSizesSample,
+} from "@/components/docs/samples/dot-matrix";
+
+<Callout>
+  This is a **standalone component** that does not depend on the assistant-ui runtime. Use it anywhere in your application.
+</Callout>
+
+<DotMatrixSample />
+
+## Installation
+
+<InstallCommand shadcn={["dot-matrix"]} />
+
+This adds a `/components/assistant-ui/dot-matrix.tsx` file to your project, which you can adjust as needed. The component has no dependencies beyond React and class-variance-authority.
+
+## Usage
+
+```tsx
+import { DotMatrix } from "@/components/assistant-ui/dot-matrix";
+
+export function RunIndicator({ isRunning }: { isRunning: boolean }) {
+  return <DotMatrix state={isRunning ? "loading" : "success"} />;
+}
+```
+
+Dots inherit the surrounding text color, so the matrix renders dark dots on light backgrounds and light dots on dark backgrounds without configuration. Every state is a combination of a dot pattern, a motion, and a color, and switching states cross-fades each dot into its new pattern.
+
+## States
+
+| State | Pattern |
+|-------|---------|
+| `idle` | Dim static grid |
+| `loading` | Randomized twinkle (default) |
+| `thinking` | Diagonal wave |
+| `streaming` | Falling rain, per-column streaks |
+| `searching` | Horizontal sweep |
+| `syncing` | Rotating sweep around the center |
+| `connecting` | Ripple expanding from the center |
+| `waiting` | Ellipsis dots blinking in sequence |
+| `uploading` | Wave rising upward |
+| `downloading` | Wave falling downward |
+| `listening` | Slow equalizer columns |
+| `speaking` | Fast equalizer columns |
+| `recording` | Red center dot breathing |
+| `success` | Green check glyph, static |
+| `error` | Red cross glyph, blinking |
+| `warning` | Amber exclamation glyph, slow blink |
+| `info` | Blue info glyph, static |
+| `paused` | Pause bars glyph, static |
+| `stopped` | Square glyph, static |
+| `offline` | Very dim static grid |
+
+The component exports `dotMatrixStates` (the ordered list above) and the `DotMatrixState` union type, so UIs can enumerate or map states without duplicating the list. New states are added by extending the `STATES` record in the component source with a glyph and a per-dot blink function.
+
+## Examples
+
+### State Lifecycle
+
+Drive the `state` prop from your run status; the matrix morphs between patterns instead of swapping components.
+
+<PreviewCode file="components/docs/samples/dot-matrix" name="DotMatrixLifecycleSample">
+  <DotMatrixLifecycleSample />
+</PreviewCode>
+
+### Inline With Text
+
+At the default `size-4` the matrix aligns with text like an icon, and the dots adapt to inverted surfaces through `currentColor`.
+
+<PreviewCode file="components/docs/samples/dot-matrix" name="DotMatrixInlineSample">
+  <DotMatrixInlineSample />
+</PreviewCode>
+
+### Sizes
+
+The matrix is an SVG, so any size utility scales it crisply.
+
+<DotMatrixSizesSample />
+
+## How It Works
+
+The grid is a 5x5 SVG of `currentColor` circles. Blinking is a single CSS keyframe animation whose high/low opacity bounds come from registered per-dot CSS variables; the animation runs in every state (static states collapse the bounds) and the bounds carry a transition, which is what makes state changes cross-fade per dot. The randomized loading rhythm uses deterministic per-dot delays and durations, so server and client render identical markup and no JavaScript runs after render. With `prefers-reduced-motion`, the dots hold their resting opacity instead of blinking.
+
+The root is a `role="status"` live region whose text content is the state name (or the `label` prop), so screen readers announce state changes; the SVG itself is `aria-hidden`.
+
+## API Reference
+
+### DotMatrix
+
+<ParametersTable
+  type="DotMatrixProps"
+  parameters={[
+    {
+      name: "state",
+      type: "DotMatrixState",
+      default: '"loading"',
+      description:
+        "One of the 20 built-in states listed above, controlling pattern, motion, and color.",
+    },
+    {
+      name: "label",
+      type: "string",
+      description:
+        "Accessible label announced by screen readers. Defaults to the state name.",
+    },
+    {
+      name: "className",
+      type: "string",
+      description:
+        "Additional CSS classes. Use size utilities to scale and text color utilities to recolor.",
+    },
+  ]}
+/>
+
+### Styling
+
+Color follows `currentColor`, so `className="text-blue-500"` recolors the whole matrix; the outcome states (`success`, `error`, `warning`, `info`, `recording`, and the muted static states) set their own color which a `className` can override. Dots are targetable via `[data-slot="dot-matrix"]` and `[data-slot="dot-matrix-dot"]`, and the current state is exposed as `data-state` on the root.
+
+## Related Components
+
+- [Number Roll](/docs/ui/number-roll) - Animated rolling number
+- [Badge](/docs/ui/badge) - Small status and metadata labels
+- [Voice](/docs/ui/voice) - Voice activity visualization

--- a/apps/docs/content/docs/ui/meta.json
+++ b/apps/docs/content/docs/ui/meta.json
@@ -34,6 +34,7 @@
     "accordion",
     "badge",
     "diff-viewer",
+    "dot-matrix",
     "number-roll",
     "select",
     "tabs",

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -570,7 +570,7 @@ export const registry: RegistryItem[] = [
           "../../packages/ui/src/components/assistant-ui/dot-matrix.tsx",
       },
     ],
-    dependencies: ["class-variance-authority"],
+    dependencies: [],
     registryDependencies: [],
   },
   {

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -560,6 +560,20 @@ export const registry: RegistryItem[] = [
     registryDependencies: [],
   },
   {
+    name: "dot-matrix",
+    type: "registry:component",
+    files: [
+      {
+        type: "registry:component",
+        path: "components/assistant-ui/dot-matrix.tsx",
+        sourcePath:
+          "../../packages/ui/src/components/assistant-ui/dot-matrix.tsx",
+      },
+    ],
+    dependencies: ["class-variance-authority"],
+    registryDependencies: [],
+  },
+  {
     name: "number-roll",
     type: "registry:component",
     files: [

--- a/packages/ui/src/components/assistant-ui/dot-matrix.tsx
+++ b/packages/ui/src/components/assistant-ui/dot-matrix.tsx
@@ -1,5 +1,4 @@
 import type { ComponentProps, CSSProperties } from "react";
-import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const GRID = 5;
@@ -78,43 +77,11 @@ const ELLIPSIS = glyph([
   [2, 4],
 ]);
 
-const dotMatrixVariants = cva("inline-block size-4 shrink-0", {
-  variants: {
-    state: {
-      idle: "text-muted-foreground",
-      loading: "",
-      thinking: "",
-      streaming: "",
-      searching: "",
-      syncing: "",
-      connecting: "",
-      waiting: "",
-      uploading: "",
-      downloading: "",
-      listening: "",
-      speaking: "",
-      recording: "text-red-500",
-      success: "text-emerald-500",
-      error: "text-red-500",
-      warning: "text-amber-500",
-      info: "text-blue-500",
-      paused: "text-muted-foreground",
-      stopped: "text-muted-foreground",
-      offline: "text-muted-foreground",
-    },
-  },
-  defaultVariants: {
-    state: "loading",
-  },
-});
-
-export type DotMatrixState = NonNullable<
-  VariantProps<typeof dotMatrixVariants>["state"]
->;
-
 type Blink = { duration: number; delay: number; lo: number };
 
 type StateConfig = {
+  /** Text color class; dots inherit the surrounding color when omitted. */
+  color?: string;
   /** Dots that render at full opacity; all others rest at `dim`. Omit for the full grid. */
   glyph?: Set<number>;
   /** Resting opacity of on dots. */
@@ -125,8 +92,8 @@ type StateConfig = {
   blink?: (i: number, row: number, col: number) => Blink;
 };
 
-const STATES: Record<DotMatrixState, StateConfig> = {
-  idle: { base: 0.3 },
+const STATES = {
+  idle: { color: "text-muted-foreground", base: 0.3 },
   loading: {
     blink: (i) => ({
       duration: 0.9 + hash(i, 2, 700),
@@ -198,31 +165,36 @@ const STATES: Record<DotMatrixState, StateConfig> = {
     }),
   },
   recording: {
+    color: "text-red-500",
     glyph: RECORD,
     dim: 0.12,
     blink: () => ({ duration: 1.4, delay: 0, lo: 0.3 }),
   },
-  success: { glyph: CHECK },
+  success: { color: "text-emerald-500", glyph: CHECK },
   error: {
+    color: "text-red-500",
     glyph: CROSS,
     blink: () => ({ duration: 1.1, delay: 0, lo: 0.4 }),
   },
   warning: {
+    color: "text-amber-500",
     glyph: BANG,
     blink: () => ({ duration: 1.6, delay: 0, lo: 0.45 }),
   },
-  info: { glyph: INFO },
-  paused: { glyph: PAUSE },
-  stopped: { glyph: STOP },
-  offline: { base: 0.15 },
+  info: { color: "text-blue-500", glyph: INFO },
+  paused: { color: "text-muted-foreground", glyph: PAUSE },
+  stopped: { color: "text-muted-foreground", glyph: STOP },
+  offline: { color: "text-muted-foreground", base: 0.15 },
+} satisfies Record<string, StateConfig>;
+
+export type DotMatrixState = keyof typeof STATES;
+
+const dotMatrixStates = Object.keys(STATES) as readonly DotMatrixState[];
+
+export type DotMatrixProps = Omit<ComponentProps<"span">, "children"> & {
+  state?: DotMatrixState;
+  label?: string;
 };
-
-const dotMatrixStates = Object.keys(STATES) as DotMatrixState[];
-
-export type DotMatrixProps = Omit<ComponentProps<"span">, "children"> &
-  VariantProps<typeof dotMatrixVariants> & {
-    label?: string;
-  };
 
 /* The blink animation runs on every dot in every state (static states set hi = lo) and the registered hi/lo custom properties carry a transition, because removing or adding an animation never triggers a CSS transition on the animated property itself; transitioning the amplitude bounds is what makes state changes cross-fade. */
 const DOT_MATRIX_CSS =
@@ -237,13 +209,13 @@ const DOT_MATRIX_CSS =
  */
 function DotMatrix({ className, state, label, ...props }: DotMatrixProps) {
   const resolvedState = state ?? "loading";
-  const config = STATES[resolvedState];
+  const config: StateConfig = STATES[resolvedState];
   return (
     <span
       data-slot="dot-matrix"
       data-state={resolvedState}
       role="status"
-      className={cn(dotMatrixVariants({ state: resolvedState }), className)}
+      className={cn("inline-block size-4 shrink-0", config.color, className)}
       {...props}
     >
       <span className="sr-only">{label ?? resolvedState}</span>
@@ -267,7 +239,7 @@ function DotMatrix({ className, state, label, ...props }: DotMatrixProps) {
               cx={2 + (i % GRID) * 4}
               cy={2 + Math.floor(i / GRID) * 4}
               r={1.3}
-              className="[transition-property:--aui-dot-matrix-hi,--aui-dot-matrix-lo] duration-300 [animation-iteration-count:infinite] [animation-name:aui-dot-matrix-blink] [animation-timing-function:ease-in-out] motion-reduce:[animation-name:none]"
+              className="[transition-property:--aui-dot-matrix-hi,--aui-dot-matrix-lo,opacity] duration-300 [animation-iteration-count:infinite] [animation-name:aui-dot-matrix-blink] [animation-timing-function:ease-in-out] motion-reduce:[animation-name:none]"
               style={
                 {
                   opacity: hi,

--- a/packages/ui/src/components/assistant-ui/dot-matrix.tsx
+++ b/packages/ui/src/components/assistant-ui/dot-matrix.tsx
@@ -207,18 +207,22 @@ const DOT_MATRIX_CSS =
  * <DotMatrix state={isRunning ? "loading" : "success"} />
  * ```
  */
-function DotMatrix({ className, state, label, ...props }: DotMatrixProps) {
-  const resolvedState = state ?? "loading";
-  const config: StateConfig = STATES[resolvedState];
+function DotMatrix({
+  className,
+  state = "loading",
+  label,
+  ...props
+}: DotMatrixProps) {
+  const config: StateConfig = STATES[state];
   return (
     <span
       data-slot="dot-matrix"
-      data-state={resolvedState}
+      data-state={state}
       role="status"
       className={cn("inline-block size-4 shrink-0", config.color, className)}
       {...props}
     >
-      <span className="sr-only">{label ?? resolvedState}</span>
+      <span className="sr-only">{label ?? state}</span>
       <svg
         aria-hidden
         viewBox="0 0 20 20"
@@ -227,17 +231,17 @@ function DotMatrix({ className, state, label, ...props }: DotMatrixProps) {
       >
         <style>{DOT_MATRIX_CSS}</style>
         {DOT_INDEXES.map((i) => {
+          const row = Math.floor(i / GRID);
+          const col = i % GRID;
           const on = !config.glyph || config.glyph.has(i);
           const hi = on ? (config.base ?? 1) : (config.dim ?? 0.15);
-          const blink = on
-            ? config.blink?.(i, Math.floor(i / GRID), i % GRID)
-            : undefined;
+          const blink = on ? config.blink?.(i, row, col) : undefined;
           return (
             <circle
               key={i}
               data-slot="dot-matrix-dot"
-              cx={2 + (i % GRID) * 4}
-              cy={2 + Math.floor(i / GRID) * 4}
+              cx={2 + col * 4}
+              cy={2 + row * 4}
               r={1.3}
               className="[transition-property:--aui-dot-matrix-hi,--aui-dot-matrix-lo,opacity] duration-300 [animation-iteration-count:infinite] [animation-name:aui-dot-matrix-blink] [animation-timing-function:ease-in-out] motion-reduce:[animation-name:none]"
               style={

--- a/packages/ui/src/components/assistant-ui/dot-matrix.tsx
+++ b/packages/ui/src/components/assistant-ui/dot-matrix.tsx
@@ -5,7 +5,7 @@ const GRID = 5;
 const CENTER = (GRID - 1) / 2;
 const DOT_INDEXES = Array.from({ length: GRID * GRID }, (_, i) => i);
 
-/* Deterministic bit-mixing hash so server and client render identical markup. A plain (i * prime) % range correlates indexes a grid-stride apart and renders as column-synchronized waves instead of a twinkle. */
+/* Deterministic bit-mixing hash so server and client render identical markup; takes a range in milliseconds and returns seconds. A plain (i * prime) % range correlates indexes a grid-stride apart and renders as column-synchronized waves instead of a twinkle. */
 const hash = (n: number, salt: number, range: number) => {
   let h = (Math.imul(n, 374761393) + Math.imul(salt, 668265263)) >>> 0;
   h = Math.imul(h ^ (h >>> 13), 1274126177) >>> 0;
@@ -223,13 +223,16 @@ function DotMatrix({
       {...props}
     >
       <span className="sr-only">{label ?? state}</span>
+      {/* Hoisted and deduplicated across instances by React; must live in HTML scope, inside the SVG it would be an SVG-namespace element React does not hoist. */}
+      <style href="aui-dot-matrix" precedence="low">
+        {DOT_MATRIX_CSS}
+      </style>
       <svg
         aria-hidden
         viewBox="0 0 20 20"
         fill="currentColor"
         className="size-full"
       >
-        <style>{DOT_MATRIX_CSS}</style>
         {DOT_INDEXES.map((i) => {
           const row = Math.floor(i / GRID);
           const col = i % GRID;

--- a/packages/ui/src/components/assistant-ui/dot-matrix.tsx
+++ b/packages/ui/src/components/assistant-ui/dot-matrix.tsx
@@ -1,0 +1,288 @@
+import type { ComponentProps, CSSProperties } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const GRID = 5;
+const CENTER = (GRID - 1) / 2;
+const DOT_INDEXES = Array.from({ length: GRID * GRID }, (_, i) => i);
+
+/* Deterministic bit-mixing hash so server and client render identical markup. A plain (i * prime) % range correlates indexes a grid-stride apart and renders as column-synchronized waves instead of a twinkle. */
+const hash = (n: number, salt: number, range: number) => {
+  let h = (Math.imul(n, 374761393) + Math.imul(salt, 668265263)) >>> 0;
+  h = Math.imul(h ^ (h >>> 13), 1274126177) >>> 0;
+  return ((h ^ (h >>> 16)) % range) / 1000;
+};
+
+const glyph = (dots: [number, number][]) =>
+  new Set(dots.map(([row, col]) => row * GRID + col));
+
+const CHECK = glyph([
+  [1, 4],
+  [2, 3],
+  [3, 0],
+  [3, 2],
+  [4, 1],
+]);
+const CROSS = glyph([
+  [0, 0],
+  [0, 4],
+  [1, 1],
+  [1, 3],
+  [2, 2],
+  [3, 1],
+  [3, 3],
+  [4, 0],
+  [4, 4],
+]);
+const BANG = glyph([
+  [0, 2],
+  [1, 2],
+  [2, 2],
+  [4, 2],
+]);
+const INFO = glyph([
+  [0, 2],
+  [2, 2],
+  [3, 2],
+  [4, 2],
+]);
+const PAUSE = glyph([
+  [1, 1],
+  [2, 1],
+  [3, 1],
+  [1, 3],
+  [2, 3],
+  [3, 3],
+]);
+const STOP = glyph([
+  [1, 1],
+  [1, 2],
+  [1, 3],
+  [2, 1],
+  [2, 2],
+  [2, 3],
+  [3, 1],
+  [3, 2],
+  [3, 3],
+]);
+const RECORD = glyph([
+  [1, 2],
+  [2, 1],
+  [2, 2],
+  [2, 3],
+  [3, 2],
+]);
+const ELLIPSIS = glyph([
+  [2, 0],
+  [2, 2],
+  [2, 4],
+]);
+
+const dotMatrixVariants = cva("inline-block size-4 shrink-0", {
+  variants: {
+    state: {
+      idle: "text-muted-foreground",
+      loading: "",
+      thinking: "",
+      streaming: "",
+      searching: "",
+      syncing: "",
+      connecting: "",
+      waiting: "",
+      uploading: "",
+      downloading: "",
+      listening: "",
+      speaking: "",
+      recording: "text-red-500",
+      success: "text-emerald-500",
+      error: "text-red-500",
+      warning: "text-amber-500",
+      info: "text-blue-500",
+      paused: "text-muted-foreground",
+      stopped: "text-muted-foreground",
+      offline: "text-muted-foreground",
+    },
+  },
+  defaultVariants: {
+    state: "loading",
+  },
+});
+
+export type DotMatrixState = NonNullable<
+  VariantProps<typeof dotMatrixVariants>["state"]
+>;
+
+type Blink = { duration: number; delay: number; lo: number };
+
+type StateConfig = {
+  /** Dots that render at full opacity; all others rest at `dim`. Omit for the full grid. */
+  glyph?: Set<number>;
+  /** Resting opacity of on dots. */
+  base?: number;
+  /** Resting opacity of off dots when a glyph is set. */
+  dim?: number;
+  /** Blink parameters per on dot, keyed by index and grid position. */
+  blink?: (i: number, row: number, col: number) => Blink;
+};
+
+const STATES: Record<DotMatrixState, StateConfig> = {
+  idle: { base: 0.3 },
+  loading: {
+    blink: (i) => ({
+      duration: 0.9 + hash(i, 2, 700),
+      delay: -hash(i, 1, 1200),
+      lo: 0.15,
+    }),
+  },
+  thinking: {
+    blink: (_i, row, col) => ({
+      duration: 1.2,
+      delay: -(row + col) * 0.09,
+      lo: 0.2,
+    }),
+  },
+  streaming: {
+    blink: (_i, row, col) => ({
+      duration: 0.9,
+      delay: -(row * 0.12 + hash(col, 3, 900)),
+      lo: 0.15,
+    }),
+  },
+  searching: {
+    blink: (_i, _row, col) => ({ duration: 1.1, delay: -col * 0.12, lo: 0.2 }),
+  },
+  syncing: {
+    blink: (_i, row, col) => {
+      const turn =
+        (Math.atan2(row - CENTER, col - CENTER) + Math.PI) / (2 * Math.PI);
+      return { duration: 1.3, delay: -turn * 1.3, lo: 0.2 };
+    },
+  },
+  connecting: {
+    blink: (_i, row, col) => ({
+      duration: 1.4,
+      delay: -Math.max(Math.abs(row - CENTER), Math.abs(col - CENTER)) * 0.18,
+      lo: 0.15,
+    }),
+  },
+  waiting: {
+    glyph: ELLIPSIS,
+    blink: (_i, _row, col) => ({
+      duration: 1.2,
+      delay: -col * 0.09,
+      lo: 0.2,
+    }),
+  },
+  uploading: {
+    blink: (_i, row) => ({
+      duration: 1,
+      delay: -(GRID - 1 - row) * 0.12,
+      lo: 0.2,
+    }),
+  },
+  downloading: {
+    blink: (_i, row) => ({ duration: 1, delay: -row * 0.12, lo: 0.2 }),
+  },
+  listening: {
+    blink: (_i, _row, col) => ({
+      duration: 0.7 + hash(col, 4, 500),
+      delay: -hash(col, 5, 900),
+      lo: 0.25,
+    }),
+  },
+  speaking: {
+    blink: (_i, _row, col) => ({
+      duration: 0.4 + hash(col, 6, 350),
+      delay: -hash(col, 7, 700),
+      lo: 0.2,
+    }),
+  },
+  recording: {
+    glyph: RECORD,
+    dim: 0.12,
+    blink: () => ({ duration: 1.4, delay: 0, lo: 0.3 }),
+  },
+  success: { glyph: CHECK },
+  error: {
+    glyph: CROSS,
+    blink: () => ({ duration: 1.1, delay: 0, lo: 0.4 }),
+  },
+  warning: {
+    glyph: BANG,
+    blink: () => ({ duration: 1.6, delay: 0, lo: 0.45 }),
+  },
+  info: { glyph: INFO },
+  paused: { glyph: PAUSE },
+  stopped: { glyph: STOP },
+  offline: { base: 0.15 },
+};
+
+const dotMatrixStates = Object.keys(STATES) as DotMatrixState[];
+
+export type DotMatrixProps = Omit<ComponentProps<"span">, "children"> &
+  VariantProps<typeof dotMatrixVariants> & {
+    label?: string;
+  };
+
+/* The blink animation runs on every dot in every state (static states set hi = lo) and the registered hi/lo custom properties carry a transition, because removing or adding an animation never triggers a CSS transition on the animated property itself; transitioning the amplitude bounds is what makes state changes cross-fade. */
+const DOT_MATRIX_CSS =
+  '@property --aui-dot-matrix-hi{syntax:"<number>";inherits:false;initial-value:1}@property --aui-dot-matrix-lo{syntax:"<number>";inherits:false;initial-value:0.15}@keyframes aui-dot-matrix-blink{0%,100%{opacity:var(--aui-dot-matrix-hi,1)}50%{opacity:var(--aui-dot-matrix-lo,0.15)}}';
+
+/**
+ * Tiny 5x5 dot-matrix status indicator with 20 built-in states. Dots inherit the text color and animate in state-specific patterns: twinkle, waves, ripples, sweeps, equalizer columns, and check/cross/bang glyphs. State changes cross-fade per dot.
+ *
+ * ```tsx
+ * <DotMatrix state={isRunning ? "loading" : "success"} />
+ * ```
+ */
+function DotMatrix({ className, state, label, ...props }: DotMatrixProps) {
+  const resolvedState = state ?? "loading";
+  const config = STATES[resolvedState];
+  return (
+    <span
+      data-slot="dot-matrix"
+      data-state={resolvedState}
+      role="status"
+      className={cn(dotMatrixVariants({ state: resolvedState }), className)}
+      {...props}
+    >
+      <span className="sr-only">{label ?? resolvedState}</span>
+      <svg
+        aria-hidden
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        className="size-full"
+      >
+        <style>{DOT_MATRIX_CSS}</style>
+        {DOT_INDEXES.map((i) => {
+          const on = !config.glyph || config.glyph.has(i);
+          const hi = on ? (config.base ?? 1) : (config.dim ?? 0.15);
+          const blink = on
+            ? config.blink?.(i, Math.floor(i / GRID), i % GRID)
+            : undefined;
+          return (
+            <circle
+              key={i}
+              data-slot="dot-matrix-dot"
+              cx={2 + (i % GRID) * 4}
+              cy={2 + Math.floor(i / GRID) * 4}
+              r={1.3}
+              className="[transition-property:--aui-dot-matrix-hi,--aui-dot-matrix-lo] duration-300 [animation-iteration-count:infinite] [animation-name:aui-dot-matrix-blink] [animation-timing-function:ease-in-out] motion-reduce:[animation-name:none]"
+              style={
+                {
+                  opacity: hi,
+                  animationDuration: `${blink?.duration ?? 1}s`,
+                  animationDelay: `${blink?.delay ?? 0}s`,
+                  "--aui-dot-matrix-hi": hi,
+                  "--aui-dot-matrix-lo": blink?.lo ?? hi,
+                } as CSSProperties
+              }
+            />
+          );
+        })}
+      </svg>
+    </span>
+  );
+}
+
+export { DotMatrix, dotMatrixStates };


### PR DESCRIPTION
## summary

- new `DotMatrix` component in the shadcn kit: a tiny 5x5 dot-matrix status indicator with 20 built-in states. every state is a combination of a dot pattern, a motion, and a color: activity states animate the full grid (randomized twinkle for `loading`, diagonal wave for `thinking`, per-column rain for `streaming`, horizontal sweep for `searching`, rotating sweep for `syncing`, center ripple for `connecting`, rising/falling waves for `uploading`/`downloading`, equalizer columns for `listening`/`speaking`), outcome states settle into glyphs (green check, red cross, amber bang, blue info, pause bars, stop square, breathing record dot, ellipsis), and `idle`/`offline` dim the grid
- dots inherit `currentColor`, so the matrix renders dark dots on light themes and light dots on dark themes with no configuration; outcome states set their own color which `className` overrides
- pure CSS, zero JS after render: a single keyframe animation runs on every dot in every state, with `@property`-registered amplitude-bound variables (`--hi`/`--lo`) carried by a transition, so state changes genuinely cross-fade per dot (removing/adding an animation never triggers a CSS transition, so transitioning the bounds is the only zero-JS way to get this). per-dot phases come from a deterministic bit-mixing hash, so server and client render identical markup
- accessibility: the root is a `role="status"` live region whose text content is the state name (or `label`), and the SVG is `aria-hidden`; `prefers-reduced-motion` holds dots at resting opacity
- the component exports `dotMatrixStates` and the `DotMatrixState` union, the docs hero sample enumerates all 20 states from it, and the page documents every state in a table; registered in the shadcn registry as `dot-matrix`

## test plan

### already verified

- [x] `pnpm lint`, `tsc --noEmit` in packages/ui, registry build emits dist/dot-matrix.json, `pnpm sync-templates` passes
- [x] verified live in Chrome on /docs/ui/dot-matrix: all 20 states render with the intended animation footprint (static glyph states animate 0 dots at rest; waiting 3, recording 5, error 9, warning 4, full-grid motions 25)
- [x] loading twinkle is genuinely decorrelated: per-column opacity spread sampled at 20 to 82 percent (a naive `(i * prime) % range` hash produced column-synchronized waves; replaced with a bit-mixing hash after an adversarial review caught it)
- [x] cross-fade verified on the blink-to-static path (streaming to success): background dots converge smoothly along the amplitude envelope to 0.15 and check dots rise smoothly to 1, no per-dot snapping
- [x] dark mode renders white dots; no console errors or hydration warnings

### reviewer should verify

- [ ] open /docs/ui/dot-matrix, eyeball each of the 20 states in the hero grid and step through the lifecycle sample; transitions should cross-fade rather than snap
- [ ] Firefox before 128 ignores the `@property` registrations, so state changes snap instead of fading there (animations themselves still run); confirm this degradation is acceptable

## notes

- per-instance duplicate `<style>` injection (same `@keyframes` text) follows the existing chart.tsx precedent; cascade-safe
- no changeset: only private packages are touched (@assistant-ui/ui, @assistant-ui/shadcn-registry, @assistant-ui/docs)