### PR TITLE
fix(with-react-ink-web): pin turbopack workspace root for vercel build

### DIFF
--- a/examples/with-react-ink-web/next.config.ts
+++ b/examples/with-react-ink-web/next.config.ts
@@ -1,8 +1,13 @@
+import path from "node:path";
 import type { NextConfig } from "next";
 
 const config: NextConfig = {
   transpilePackages: ["ink-web"],
   turbopack: {
+    // Pin the workspace root; vercel build's environment makes Turbopack's
+    // lockfile-based inference resolve to the app directory instead of the
+    // monorepo root, which breaks resolution of pnpm-symlinked packages.
+    root: path.join(__dirname, "../.."),
     resolveAlias: {
       ink: "ink-web",
       "supports-hyperlinks": {


### PR DESCRIPTION
the Deploy Ink Example run on main failed in `vercel build`: Turbopack's lockfile-based workspace root inference resolved to the app directory instead of the monorepo root on the runner, so pnpm-symlinked packages (including next itself) fell outside the compile root and resolution failed (run 27407660213). local builds happened to infer correctly, which is why this slipped through.

pins `turbopack.root` to the monorepo root in the example's next config, exactly as the error message recommends. verified with a clean production build locally.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

