### PR TITLE
fix(with-react-ink-web): deploy as static export to bypass vercel's next builder

### DIFF
--- a/examples/with-react-ink-web/next.config.ts
+++ b/examples/with-react-ink-web/next.config.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { NextConfig } from "next";
 
 const config: NextConfig = {
+  output: "export",
   transpilePackages: ["ink-web"],
   turbopack: {
     // Pin the workspace root; vercel build's environment makes Turbopack's
@@ -15,18 +16,6 @@ const config: NextConfig = {
       },
     },
   },
-  headers: async () => [
-    {
-      source: "/(.*)",
-      headers: [
-        {
-          key: "Content-Security-Policy",
-          value:
-            "frame-ancestors 'self' https://*.assistant-ui.com https://*.vercel.app http://localhost:*;",
-        },
-      ],
-    },
-  ],
 };
 
 export default config;

--- a/examples/with-react-ink-web/vercel.json
+++ b/examples/with-react-ink-web/vercel.json
@@ -1,5 +1,18 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "bash ../../scripts/vercel-ignore-changeset-release.sh",
-  "buildCommand": "cd ../.. && pnpm turbo build --filter=@assistant-ui/react-ink --filter=@assistant-ui/react-ink-markdown --filter=@assistant-ui/react-ai-sdk && cd examples/with-react-ink-web && pnpm run build"
+  "buildCommand": "cd ../.. && pnpm turbo build --filter=@assistant-ui/react-ink --filter=@assistant-ui/react-ink-markdown --filter=@assistant-ui/react-ai-sdk && cd examples/with-react-ink-web && pnpm run build",
+  "outputDirectory": "out",
+  "framework": null,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "frame-ancestors 'self' https://*.assistant-ui.com https://*.vercel.app http://localhost:*;"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
the Deploy Ink Example runs kept failing after #4376: vercel build injects `outputFileTracingRoot` pointed at the app directory (the project's root directory), which overrides `turbopack.root` and re-breaks resolution of pnpm-symlinked workspace packages (runs 27407660213, 27408193770).

every route in this app is already statically prerendered, so the clean fix is the with-expo deployment shape: `output: "export"` plus `framework: null` and `outputDirectory: "out"` in vercel.json. with no framework builder involved, vercel build just runs the build command and packages the static output, and `next build` behaves exactly as it does locally. the frame-ancestors CSP moves from next.config headers (unsupported with static export) to vercel.json headers.

verified with a clean local build producing out/ with the prerendered pages.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

