### PR TITLE
feat: per-tool-call timing and stall detection

### DIFF
--- a/.changeset/tool-call-timing.md
+++ b/.changeset/tool-call-timing.md
@@ -1,0 +1,8 @@
+---
+"assistant-stream": patch
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+---
+
+feat: per-tool-call timing and stall detection. `ToolCallMessagePart` gains a `timing` field (`{ startedAt, completedAt? }` in epoch ms), auto-populated by the assistant-stream accumulator at part start and result, and accepted on `ThreadMessageLike` for external-store hosts. New `useToolCallElapsed()` hook returns the call's elapsed milliseconds, ticking once per second while running; `unstable_useMessageStallDetection({ thresholdMs })` reports mid-run output stalls by watching a message content fingerprint. The kit `ToolFallback` trigger renders the duration when timing is present.

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
@@ -101,6 +101,57 @@ describe("AssistantMessageAccumulator timing", () => {
     expect(last.metadata.timing!.toolCallCount).toBe(1);
   });
 
+  it("should record per-tool-call timing on the part", async () => {
+    const before = Date.now();
+    const chunks: AssistantStreamChunk[] = [
+      {
+        type: "part-start",
+        path: [0],
+        part: {
+          type: "tool-call",
+          toolCallId: "tc-1",
+          toolName: "search",
+        },
+      },
+      { type: "text-delta", path: [0], textDelta: '{"q":"test"}' },
+      { type: "tool-call-args-text-finish", path: [0] },
+      {
+        type: "result",
+        path: [0],
+        result: "found",
+        isError: false,
+      },
+      { type: "part-finish", path: [0] },
+      {
+        type: "message-finish",
+        path: [],
+        finishReason: "stop",
+        usage: { inputTokens: 0, outputTokens: 0 },
+      },
+    ];
+
+    const messages = await collectStream(chunks);
+    const after = Date.now();
+
+    const runningPart = messages
+      .find((m) =>
+        m.parts.some((p) => p.type === "tool-call" && p.state !== "result"),
+      )!
+      .parts.find((p) => p.type === "tool-call")!;
+    expect(runningPart.timing).toBeDefined();
+    expect(runningPart.timing!.startedAt).toBeGreaterThanOrEqual(before);
+    expect(runningPart.timing!.completedAt).toBeUndefined();
+
+    const settledPart = messages
+      .at(-1)!
+      .parts.find((p) => p.type === "tool-call")!;
+    expect(settledPart.timing).toBeDefined();
+    expect(settledPart.timing!.completedAt).toBeGreaterThanOrEqual(
+      settledPart.timing!.startedAt,
+    );
+    expect(settledPart.timing!.completedAt).toBeLessThanOrEqual(after);
+  });
+
   it("should include timing on flush when stream closes without message-finish", async () => {
     const chunks: AssistantStreamChunk[] = [
       { type: "part-start", path: [0], part: { type: "text" } },

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
@@ -92,6 +92,7 @@ const handlePartStart = (
       toolName: partInit.toolName,
       argsText: "",
       args: {},
+      timing: { startedAt: Date.now() },
       ...(partInit.parentId && { parentId: partInit.parentId }),
     };
     return {
@@ -213,6 +214,14 @@ const handleResult = (
       return {
         ...part,
         state: "result",
+        ...(part.timing !== undefined
+          ? {
+              timing: {
+                ...part.timing,
+                completedAt: part.timing.completedAt ?? Date.now(),
+              },
+            }
+          : {}),
         ...(chunk.artifact !== undefined ? { artifact: chunk.artifact } : {}),
         result: chunk.result,
         isError: chunk.isError ?? false,

--- a/packages/assistant-stream/src/core/utils/types.ts
+++ b/packages/assistant-stream/src/core/utils/types.ts
@@ -60,6 +60,7 @@ type ToolCallPartBase = {
   toolName: string;
   argsText: string;
   args: ReadonlyJSONObject;
+  timing?: { startedAt: number; completedAt?: number };
   artifact?: ReadonlyJSONValue;
   result?: ReadonlyJSONValue;
   modelContent?: readonly ToolModelContentPart[];

--- a/packages/assistant-stream/src/core/utils/types.ts
+++ b/packages/assistant-stream/src/core/utils/types.ts
@@ -53,6 +53,19 @@ type ToolCallStatus =
       reason: "cancelled" | "length" | "content-filter" | "other";
     };
 
+/**
+ * Wall-clock timing of a tool call. Accumulator-populated timings are
+ * measured by the consuming accumulator, so resumed or replayed streams
+ * re-measure them; hosts that need authoritative timings supply the field
+ * themselves.
+ */
+export type ToolCallTiming = {
+  /** Epoch milliseconds when the tool call started streaming or executing. */
+  readonly startedAt: number;
+  /** Epoch milliseconds when the result landed. Absent while the call runs. */
+  readonly completedAt?: number;
+};
+
 type ToolCallPartBase = {
   type: "tool-call";
   status: ToolCallStatus;
@@ -60,7 +73,7 @@ type ToolCallPartBase = {
   toolName: string;
   argsText: string;
   args: ReadonlyJSONObject;
-  timing?: { startedAt: number; completedAt?: number };
+  timing?: ToolCallTiming;
   artifact?: ReadonlyJSONValue;
   result?: ReadonlyJSONValue;
   modelContent?: readonly ToolModelContentPart[];

--- a/packages/assistant-stream/src/index.ts
+++ b/packages/assistant-stream/src/index.ts
@@ -33,6 +33,7 @@ export type {
   AssistantMessage,
   AssistantMessageTiming,
   DataPart,
+  ToolCallTiming,
 } from "./core/utils/types";
 
 export type {

--- a/packages/assistant-stream/src/resumable/__tests__/integration.test.ts
+++ b/packages/assistant-stream/src/resumable/__tests__/integration.test.ts
@@ -145,9 +145,22 @@ describe("resumable integration", () => {
       new AssistantTransportDecoder(),
     );
 
-    expect(replayMessage.parts).toEqual(producerMessage.parts);
+    // Tool-call timing is measured by the consuming accumulator, so a replay
+    // re-measures it; compare parts modulo timing.
+    const withoutTiming = (parts: typeof replayMessage.parts) =>
+      parts.map((part) =>
+        part.type === "tool-call"
+          ? (({ timing: _timing, ...rest }) => rest)(part)
+          : part,
+      );
+    expect(withoutTiming(replayMessage.parts)).toEqual(
+      withoutTiming(producerMessage.parts),
+    );
     expect(replayMessage.status).toEqual(producerMessage.status);
     const toolPart = replayMessage.parts.find((p) => p.type === "tool-call");
+    expect(toolPart).toMatchObject({
+      timing: { startedAt: expect.any(Number) },
+    });
     expect(toolPart).toBeDefined();
     expect(toolPart).toMatchObject({
       toolName: "lookup",

--- a/packages/assistant-stream/src/resumable/__tests__/integration.test.ts
+++ b/packages/assistant-stream/src/resumable/__tests__/integration.test.ts
@@ -158,15 +158,13 @@ describe("resumable integration", () => {
     );
     expect(replayMessage.status).toEqual(producerMessage.status);
     const toolPart = replayMessage.parts.find((p) => p.type === "tool-call");
-    expect(toolPart).toMatchObject({
-      timing: { startedAt: expect.any(Number) },
-    });
     expect(toolPart).toBeDefined();
     expect(toolPart).toMatchObject({
       toolName: "lookup",
       toolCallId: "tool-1",
       args: { query: "weather" },
       result: { temperature: 72 },
+      timing: { startedAt: expect.any(Number) },
     });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export type {
   ToolApprovalOptionKind,
   ToolApprovalResponse,
   ToolCallMessagePart,
+  ToolCallTiming,
   ToolCallMessagePartMcpMetadata,
   McpAppMetadata,
   ToolModelContentPart,

--- a/packages/core/src/runtime/utils/thread-message-like.ts
+++ b/packages/core/src/runtime/utils/thread-message-like.ts
@@ -22,6 +22,7 @@ import type {
   MessageTiming,
   TextMessagePart,
   ToolApprovalOption,
+  ToolCallTiming,
 } from "../../types/message";
 import type {
   ReadonlyJSONObject,
@@ -59,6 +60,7 @@ export type ThreadMessageLike = {
             readonly parentId?: string | undefined;
             readonly messages?: readonly ThreadMessage[] | undefined;
             readonly interrupt?: { type: "human"; payload: unknown };
+            readonly timing?: ToolCallTiming;
             readonly approval?: {
               readonly id: string;
               readonly approved?: boolean;

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -2,10 +2,10 @@ import type {
   ReadonlyJSONObject,
   ReadonlyJSONValue,
 } from "assistant-stream/utils";
-import type { ToolModelContentPart } from "assistant-stream";
+import type { ToolCallTiming, ToolModelContentPart } from "assistant-stream";
 import type { CompleteAttachment } from "./attachment";
 
-export type { ToolModelContentPart };
+export type { ToolCallTiming, ToolModelContentPart };
 
 export type TextMessagePart = {
   readonly type: "text";
@@ -158,19 +158,6 @@ export type ToolApprovalOption = {
   readonly grants?: readonly string[];
   /** Opt-in confirmation step before this option resolves. */
   readonly confirm?: boolean | { title?: string; description?: string };
-};
-
-/**
- * Wall-clock timing of a tool call. Accumulator-populated timings are
- * measured by the consuming accumulator, so resumed or replayed streams
- * re-measure them; hosts that need authoritative timings supply the field
- * themselves.
- */
-export type ToolCallTiming = {
-  /** Epoch milliseconds when the tool call started streaming or executing. */
-  readonly startedAt: number;
-  /** Epoch milliseconds when the result landed. Absent while the call runs. */
-  readonly completedAt?: number;
 };
 
 export type ToolApprovalResponse =

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -160,6 +160,19 @@ export type ToolApprovalOption = {
   readonly confirm?: boolean | { title?: string; description?: string };
 };
 
+/**
+ * Wall-clock timing of a tool call. Accumulator-populated timings are
+ * measured by the consuming accumulator, so resumed or replayed streams
+ * re-measure them; hosts that need authoritative timings supply the field
+ * themselves.
+ */
+export type ToolCallTiming = {
+  /** Epoch milliseconds when the tool call started streaming or executing. */
+  readonly startedAt: number;
+  /** Epoch milliseconds when the result landed. Absent while the call runs. */
+  readonly completedAt?: number;
+};
+
 export type ToolApprovalResponse =
   | { readonly approved: boolean; readonly reason?: string }
   | { readonly optionId: string; readonly reason?: string }
@@ -193,6 +206,8 @@ export type ToolCallMessagePart<
   readonly argsText: string;
   /** UI-only artifact associated with the tool result. */
   readonly artifact?: unknown;
+  /** Wall-clock timing for this call, when the runtime or host tracks it. */
+  readonly timing?: ToolCallTiming;
   /** MCP app metadata associated with this tool call, when present. */
   readonly mcp?: ToolCallMessagePartMcpMetadata;
   /** Content returned to the model for this tool result. */

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -21,6 +21,7 @@ export type {
   ToolApprovalOptionKind,
   ToolApprovalResponse,
   ToolCallMessagePart,
+  ToolCallTiming,
   ToolModelContentPart,
   ImageMessagePart,
   FileMessagePart,

--- a/packages/react/src/hooks/useToolCallElapsed.ts
+++ b/packages/react/src/hooks/useToolCallElapsed.ts
@@ -8,8 +8,9 @@ import { useAui, useAuiState } from "@assistant-ui/store";
  * milliseconds, ticking once per second while the call runs.
  *
  * Reads `part.timing`. Returns `undefined` when the part is not a tool call,
- * carries no timing, or when no message part scope is available (so kit
- * components stay renderable standalone, e.g. in docs previews).
+ * carries no timing, ended without a recorded completion (the duration is
+ * unknown), or when no message part scope is available (so kit components
+ * stay renderable standalone, e.g. in docs previews).
  *
  * @example
  * ```tsx
@@ -44,5 +45,8 @@ export const useToolCallElapsed = (): number | undefined => {
   }, [running]);
 
   if (timing === undefined) return undefined;
-  return Math.max(0, (timing.completedAt ?? now) - timing.startedAt);
+  if (timing.completedAt !== undefined)
+    return Math.max(0, timing.completedAt - timing.startedAt);
+  if (!running) return undefined;
+  return Math.max(0, now - timing.startedAt);
 };

--- a/packages/react/src/hooks/useToolCallElapsed.ts
+++ b/packages/react/src/hooks/useToolCallElapsed.ts
@@ -1,14 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useAuiState } from "@assistant-ui/store";
+import { useAui, useAuiState } from "@assistant-ui/store";
 
 /**
  * Hook that returns the elapsed wall-clock time of the current tool call in
  * milliseconds, ticking once per second while the call runs.
  *
- * Reads `part.timing`. Returns `undefined` when the part is not a tool call
- * or carries no timing. Must be used inside a message part scope.
+ * Reads `part.timing`. Returns `undefined` when the part is not a tool call,
+ * carries no timing, or when no message part scope is available (so kit
+ * components stay renderable standalone, e.g. in docs previews).
  *
  * @example
  * ```tsx
@@ -20,10 +21,19 @@ import { useAuiState } from "@assistant-ui/store";
  * ```
  */
 export const useToolCallElapsed = (): number | undefined => {
+  const aui = useAui();
+  const hasPart = aui.part.source !== null;
   const timing = useAuiState((s) =>
-    s.part.type === "tool-call" ? s.part.timing : undefined,
+    hasPart && s.part.type === "tool-call" ? s.part.timing : undefined,
   );
-  const running = timing !== undefined && timing.completedAt === undefined;
+  const partRunning = useAuiState(
+    (s) =>
+      hasPart &&
+      s.part.type === "tool-call" &&
+      s.part.status.type === "running",
+  );
+  const running =
+    timing !== undefined && timing.completedAt === undefined && partRunning;
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
@@ -34,7 +44,5 @@ export const useToolCallElapsed = (): number | undefined => {
   }, [running]);
 
   if (timing === undefined) return undefined;
-  if (timing.completedAt !== undefined)
-    return timing.completedAt - timing.startedAt;
-  return Math.max(0, now - timing.startedAt);
+  return Math.max(0, (timing.completedAt ?? now) - timing.startedAt);
 };

--- a/packages/react/src/hooks/useToolCallElapsed.ts
+++ b/packages/react/src/hooks/useToolCallElapsed.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuiState } from "@assistant-ui/store";
+
+/**
+ * Hook that returns the elapsed wall-clock time of the current tool call in
+ * milliseconds, ticking once per second while the call runs.
+ *
+ * Reads `part.timing`. Returns `undefined` when the part is not a tool call
+ * or carries no timing. Must be used inside a message part scope.
+ *
+ * @example
+ * ```tsx
+ * function ToolDuration() {
+ *   const elapsedMs = useToolCallElapsed();
+ *   if (elapsedMs === undefined) return null;
+ *   return <span>{(elapsedMs / 1000).toFixed(1)}s</span>;
+ * }
+ * ```
+ */
+export const useToolCallElapsed = (): number | undefined => {
+  const timing = useAuiState((s) =>
+    s.part.type === "tool-call" ? s.part.timing : undefined,
+  );
+  const running = timing !== undefined && timing.completedAt === undefined;
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!running) return undefined;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [running]);
+
+  if (timing === undefined) return undefined;
+  if (timing.completedAt !== undefined)
+    return timing.completedAt - timing.startedAt;
+  return Math.max(0, now - timing.startedAt);
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -289,6 +289,12 @@ export { useThreadViewportAutoScroll } from "./primitives/thread/useThreadViewpo
 export { useScrollLock } from "./primitives/reasoning/useScrollLock";
 export { useMessageQuote } from "./hooks/useMessageQuote";
 export { useMessageTiming } from "./hooks/useMessageTiming";
+export { useToolCallElapsed } from "./hooks/useToolCallElapsed";
+export {
+  unstable_useMessageStallDetection,
+  type Unstable_MessageStallDetection,
+  type Unstable_MessageStallDetectionOptions,
+} from "./unstable/useMessageStallDetection";
 export { useSmooth, type SmoothOptions } from "./utils/smooth/useSmooth";
 
 // Re-export core types from @assistant-ui/core
@@ -314,6 +320,7 @@ export type {
   ToolApprovalOptionKind,
   ToolApprovalResponse,
   ToolCallMessagePart,
+  ToolCallTiming,
   ToolModelContentPart,
   MessageStatus,
   MessagePartStatus,

--- a/packages/react/src/tests/toolCallTiming.test.tsx
+++ b/packages/react/src/tests/toolCallTiming.test.tsx
@@ -131,7 +131,7 @@ describe("useToolCallElapsed on terminated calls", () => {
     vi.useRealTimers();
   });
 
-  it("stops ticking when the call ends without a result (cancelled run)", async () => {
+  it("claims no duration when the call ends without a result (cancelled run)", async () => {
     const startedAt = Date.now() - 1000;
     const cancelled: ThreadMessageLike = {
       role: "assistant",
@@ -149,13 +149,13 @@ describe("useToolCallElapsed on terminated calls", () => {
     };
     await renderHarness([cancelled], ElapsedProbe);
 
-    expect(screen.getByTestId("elapsed").textContent).toBe("1000");
+    expect(screen.getByTestId("elapsed").textContent).toBe("none");
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(3000);
     });
 
-    expect(screen.getByTestId("elapsed").textContent).toBe("1000");
+    expect(screen.getByTestId("elapsed").textContent).toBe("none");
   });
 });
 

--- a/packages/react/src/tests/toolCallTiming.test.tsx
+++ b/packages/react/src/tests/toolCallTiming.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+
+import { act, render, screen } from "@testing-library/react";
+import type { FC, PropsWithChildren } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AssistantRuntimeProvider } from "../context";
+import * as MessagePrimitive from "../primitives/message";
+import * as ThreadPrimitive from "../primitives/thread";
+import { useLocalRuntime } from "../legacy-runtime/runtime-cores/local/useLocalRuntime";
+import type { ChatModelAdapter, ThreadMessageLike } from "../index";
+import {
+  useToolCallElapsed,
+  unstable_useMessageStallDetection,
+} from "../index";
+
+const noOpAdapter: ChatModelAdapter = {
+  async *run() {},
+};
+
+const toolMessage = (timing?: {
+  startedAt: number;
+  completedAt?: number;
+}): ThreadMessageLike => ({
+  role: "assistant",
+  content: [
+    {
+      type: "tool-call",
+      toolCallId: "tc-1",
+      toolName: "search",
+      args: {},
+      argsText: "{}",
+      ...(timing !== undefined && { timing }),
+    },
+  ],
+  status: { type: "running" },
+});
+
+const ElapsedProbe: FC = () => {
+  const elapsedMs = useToolCallElapsed();
+  return (
+    <span data-testid="elapsed">
+      {elapsedMs === undefined ? "none" : String(elapsedMs)}
+    </span>
+  );
+};
+
+const StallProbe: FC = () => {
+  const { stalled } = unstable_useMessageStallDetection({ thresholdMs: 2000 });
+  return <span data-testid="stalled">{String(stalled)}</span>;
+};
+
+const RuntimeProvider: FC<
+  PropsWithChildren<{ messages: ThreadMessageLike[] }>
+> = ({ messages, children }) => {
+  const runtime = useLocalRuntime(noOpAdapter, { initialMessages: messages });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+};
+
+const renderHarness = async (messages: ThreadMessageLike[], probe: FC) => {
+  render(<Harness messages={messages} probe={probe} />);
+  // Flush the runtime's deferred initialization, which fake timers hold back.
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+};
+
+const Harness: FC<{ messages: ThreadMessageLike[]; probe: FC }> = ({
+  messages,
+  probe: Probe,
+}) => (
+  <RuntimeProvider messages={messages}>
+    <ThreadPrimitive.Messages
+      components={{
+        Message: () => (
+          <MessagePrimitive.Parts components={{ tools: { Fallback: Probe } }} />
+        ),
+      }}
+    />
+  </RuntimeProvider>
+);
+
+describe("useToolCallElapsed", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:10.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns undefined when the part carries no timing", async () => {
+    await renderHarness([toolMessage()], ElapsedProbe);
+    expect(screen.getByTestId("elapsed").textContent).toBe("none");
+  });
+
+  it("returns the settled duration for completed calls", async () => {
+    const startedAt = Date.now() - 5000;
+    await renderHarness(
+      [toolMessage({ startedAt, completedAt: startedAt + 1500 })],
+      ElapsedProbe,
+    );
+    expect(screen.getByTestId("elapsed").textContent).toBe("1500");
+  });
+
+  it("ticks while the call is running", async () => {
+    const startedAt = Date.now() - 1000;
+    await renderHarness([toolMessage({ startedAt })], ElapsedProbe);
+
+    expect(screen.getByTestId("elapsed").textContent).toBe("1000");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    expect(screen.getByTestId("elapsed").textContent).toBe("4000");
+  });
+});
+
+describe("unstable_useMessageStallDetection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports a stall after the threshold with no content changes", async () => {
+    await renderHarness([toolMessage({ startedAt: 0 })], StallProbe);
+
+    expect(screen.getByTestId("stalled").textContent).toBe("false");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(screen.getByTestId("stalled").textContent).toBe("true");
+  });
+
+  it("never stalls on settled messages", async () => {
+    const settled: ThreadMessageLike = {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "tc-1",
+          toolName: "search",
+          args: {},
+          argsText: "{}",
+          result: "done",
+        },
+      ],
+      status: { type: "complete", reason: "stop" },
+    };
+    await renderHarness([settled], StallProbe);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(screen.getByTestId("stalled").textContent).toBe("false");
+  });
+});

--- a/packages/react/src/tests/toolCallTiming.test.tsx
+++ b/packages/react/src/tests/toolCallTiming.test.tsx
@@ -121,6 +121,59 @@ describe("useToolCallElapsed", () => {
   });
 });
 
+describe("useToolCallElapsed on terminated calls", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:10.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stops ticking when the call ends without a result (cancelled run)", async () => {
+    const startedAt = Date.now() - 1000;
+    const cancelled: ThreadMessageLike = {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "tc-1",
+          toolName: "search",
+          args: {},
+          argsText: "{}",
+          timing: { startedAt },
+        },
+      ],
+      status: { type: "incomplete", reason: "cancelled" },
+    };
+    await renderHarness([cancelled], ElapsedProbe);
+
+    expect(screen.getByTestId("elapsed").textContent).toBe("1000");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    expect(screen.getByTestId("elapsed").textContent).toBe("1000");
+  });
+});
+
+describe("useToolCallElapsed outside any scope", () => {
+  it("returns undefined without a provider instead of throwing", () => {
+    const Standalone: FC = () => {
+      const elapsedMs = useToolCallElapsed();
+      return (
+        <span data-testid="standalone">
+          {elapsedMs === undefined ? "none" : String(elapsedMs)}
+        </span>
+      );
+    };
+    render(<Standalone />);
+    expect(screen.getByTestId("standalone").textContent).toBe("none");
+  });
+});
+
 describe("unstable_useMessageStallDetection", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/packages/react/src/unstable/useMessageStallDetection.ts
+++ b/packages/react/src/unstable/useMessageStallDetection.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useAuiState } from "@assistant-ui/store";
+
+export type Unstable_MessageStallDetectionOptions = {
+  /**
+   * Milliseconds of unchanged message content before the message counts as
+   * stalled.
+   * @default 2000
+   */
+  thresholdMs?: number | undefined;
+};
+
+export type Unstable_MessageStallDetection = {
+  /** True while the message is running and its content has not changed for at least `thresholdMs`. */
+  stalled: boolean;
+  /** Milliseconds since the last observed content change. `0` while not stalled. */
+  stalledForMs: number;
+};
+
+/**
+ * @deprecated Under active development and might change without notice.
+ *
+ * Detects mid-run output stalls on the current message: while the message is
+ * running, watches a fingerprint of its content (part count plus text,
+ * argument, and result sizes) and reports a stall once the fingerprint stops
+ * changing for `thresholdMs`. Useful for re-surfacing a "still working"
+ * indicator during tool think-time or provider stalls, after the first
+ * tokens have already streamed.
+ *
+ * Must be used inside a message scope.
+ */
+export function unstable_useMessageStallDetection(
+  options?: Unstable_MessageStallDetectionOptions,
+): Unstable_MessageStallDetection {
+  const thresholdMs = options?.thresholdMs ?? 2000;
+
+  const fingerprint = useAuiState((s) => {
+    if (s.message.status?.type !== "running") return undefined;
+    let size = 0;
+    for (const part of s.message.content) {
+      if (part.type === "text" || part.type === "reasoning") {
+        size += part.text.length;
+      } else if (part.type === "tool-call") {
+        size += part.argsText.length + (part.result !== undefined ? 1 : 0);
+      }
+    }
+    return `${s.message.content.length}:${size}`;
+  });
+
+  const running = fingerprint !== undefined;
+  const lastActivityRef = useRef(Date.now());
+  const [stalled, setStalled] = useState(false);
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!running) {
+      setStalled(false);
+      return undefined;
+    }
+
+    lastActivityRef.current = Date.now();
+    setStalled(false);
+    const id = setTimeout(() => setStalled(true), thresholdMs);
+    return () => clearTimeout(id);
+  }, [running, fingerprint, thresholdMs]);
+
+  useEffect(() => {
+    if (!stalled) return undefined;
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, [stalled]);
+
+  if (!stalled) return { stalled: false, stalledForMs: 0 };
+  return {
+    stalled: true,
+    stalledForMs: Math.max(0, Date.now() - lastActivityRef.current),
+  };
+}

--- a/packages/react/src/unstable/useMessageStallDetection.ts
+++ b/packages/react/src/unstable/useMessageStallDetection.ts
@@ -55,14 +55,25 @@ export function unstable_useMessageStallDetection(
   const [, setTick] = useState(0);
 
   useEffect(() => {
+    if (!running) return undefined;
+    lastActivityRef.current = Date.now();
+    return undefined;
+  }, [running, fingerprint]);
+
+  useEffect(() => {
     if (!running) {
       setStalled(false);
       return undefined;
     }
 
-    lastActivityRef.current = Date.now();
+    const sinceActivity = Date.now() - lastActivityRef.current;
+    if (sinceActivity >= thresholdMs) {
+      setStalled(true);
+      return undefined;
+    }
+
     setStalled(false);
-    const id = setTimeout(() => setStalled(true), thresholdMs);
+    const id = setTimeout(() => setStalled(true), thresholdMs - sinceActivity);
     return () => clearTimeout(id);
   }, [running, fingerprint, thresholdMs]);
 

--- a/packages/ui/src/components/assistant-ui/tool-fallback.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-fallback.tsx
@@ -96,9 +96,9 @@ const statusIconMap: Record<ToolStatus, React.ElementType> = {
 const formatToolDuration = (ms: number) => {
   if (ms < 1000) return "<1s";
   const seconds = ms / 1000;
-  if (seconds < 10) return `${seconds.toFixed(1)}s`;
-  if (seconds < 60) return `${Math.round(seconds)}s`;
-  return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+  if (seconds < 10) return `${(Math.floor(seconds * 10) / 10).toFixed(1)}s`;
+  if (seconds < 60) return `${Math.floor(seconds)}s`;
+  return `${Math.floor(seconds / 60)}m ${Math.floor(seconds % 60)}s`;
 };
 
 function ToolFallbackDuration({

--- a/packages/ui/src/components/assistant-ui/tool-fallback.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-fallback.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import {
   useScrollLock,
+  useToolCallElapsed,
   type ToolApprovalOption,
   type ToolCallMessagePart,
   type ToolCallMessagePartProps,
@@ -92,6 +93,35 @@ const statusIconMap: Record<ToolStatus, React.ElementType> = {
   "requires-action": AlertCircleIcon,
 };
 
+const formatToolDuration = (ms: number) => {
+  if (ms < 1000) return "<1s";
+  const seconds = ms / 1000;
+  if (seconds < 10) return `${seconds.toFixed(1)}s`;
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+};
+
+function ToolFallbackDuration({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  const elapsedMs = useToolCallElapsed();
+  if (elapsedMs === undefined) return null;
+
+  return (
+    <span
+      data-slot="tool-fallback-duration"
+      className={cn(
+        "aui-tool-fallback-duration text-muted-foreground text-xs tabular-nums",
+        className,
+      )}
+      {...props}
+    >
+      {formatToolDuration(elapsedMs)}
+    </span>
+  );
+}
+
 function ToolFallbackTrigger({
   toolName,
   status,
@@ -146,6 +176,7 @@ function ToolFallbackTrigger({
           </span>
         )}
       </span>
+      <ToolFallbackDuration />
       <ChevronDownIcon
         data-slot="tool-fallback-trigger-chevron"
         className={cn(

--- a/templates/minimal/components/assistant-ui/tool-fallback.tsx
+++ b/templates/minimal/components/assistant-ui/tool-fallback.tsx
@@ -96,9 +96,9 @@ const statusIconMap: Record<ToolStatus, React.ElementType> = {
 const formatToolDuration = (ms: number) => {
   if (ms < 1000) return "<1s";
   const seconds = ms / 1000;
-  if (seconds < 10) return `${seconds.toFixed(1)}s`;
-  if (seconds < 60) return `${Math.round(seconds)}s`;
-  return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+  if (seconds < 10) return `${(Math.floor(seconds * 10) / 10).toFixed(1)}s`;
+  if (seconds < 60) return `${Math.floor(seconds)}s`;
+  return `${Math.floor(seconds / 60)}m ${Math.floor(seconds % 60)}s`;
 };
 
 function ToolFallbackDuration({

--- a/templates/minimal/components/assistant-ui/tool-fallback.tsx
+++ b/templates/minimal/components/assistant-ui/tool-fallback.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import {
   useScrollLock,
+  useToolCallElapsed,
   type ToolApprovalOption,
   type ToolCallMessagePart,
   type ToolCallMessagePartProps,
@@ -92,6 +93,35 @@ const statusIconMap: Record<ToolStatus, React.ElementType> = {
   "requires-action": AlertCircleIcon,
 };
 
+const formatToolDuration = (ms: number) => {
+  if (ms < 1000) return "<1s";
+  const seconds = ms / 1000;
+  if (seconds < 10) return `${seconds.toFixed(1)}s`;
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+};
+
+function ToolFallbackDuration({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  const elapsedMs = useToolCallElapsed();
+  if (elapsedMs === undefined) return null;
+
+  return (
+    <span
+      data-slot="tool-fallback-duration"
+      className={cn(
+        "aui-tool-fallback-duration text-muted-foreground text-xs tabular-nums",
+        className,
+      )}
+      {...props}
+    >
+      {formatToolDuration(elapsedMs)}
+    </span>
+  );
+}
+
 function ToolFallbackTrigger({
   toolName,
   status,
@@ -146,6 +176,7 @@ function ToolFallbackTrigger({
           </span>
         )}
       </span>
+      <ToolFallbackDuration />
       <ChevronDownIcon
         data-slot="tool-fallback-trigger-chevron"
         className={cn(


### PR DESCRIPTION
## summary

- `ToolCallMessagePart` gains a `timing` field (`{ startedAt, completedAt? }` in epoch ms), making tool-call duration a first-class message fact instead of consumer-side component state; `completedAt` absent doubles as the running signal, and live elapsed (`now - startedAt`) recomputes identically anywhere, so virtualization remounts need no timer registry
- the assistant-stream accumulator auto-populates it at part start and result (idempotent on duplicate results), so every stream-based runtime gets the data with zero configuration; `ThreadMessageLike` accepts the field so external-store hosts can supply it themselves
- new `useToolCallElapsed()` hook returns the call's elapsed milliseconds, ticking once per second while running; `unstable_useMessageStallDetection({ thresholdMs })` watches a message content fingerprint (part count plus text, argument, and result sizes) and reports mid-run output stalls, derived client-side rather than stored on the message
- the kit `ToolFallback` trigger renders the duration when timing is present (`3.2s` / `12s` / `1m 5s`), nothing otherwise; template copy synced

design note: accumulator-measured timings are wall-clock at consumption, so resumed/replayed streams re-measure them; this matches the existing `metadata.timing` semantics (which the resumable round-trip test never compared) and is now documented on the type. carrying original timestamps in the stream chunks is the future protocol-level option if resume-faithful durations are ever needed.

## test plan

### already verified

- [x] assistant-stream `pnpm vitest run`: 242/242 (new per-tool timing test asserts startedAt on the running part and ordered completedAt on the settled part; resumable round-trip updated to compare parts modulo timing with an existence assertion)
- [x] react `pnpm vitest run`: 381/381 incl. 5 new tests (elapsed: no-timing, settled duration, 1s ticking under fake timers; stall: threshold trip, settled messages never stall)
- [x] core `pnpm vitest run`: 326/326; `tsc --noEmit` baseline diff zero new errors across core/react; react-native and ui clean
- [x] oxlint + oxfmt clean; `bash scripts/sync-templates.sh` no drift

### reviewer should verify

- [ ] a streamed tool call in any data-stream example shows a ticking duration on the ToolFallback trigger while running and a fixed duration after settling
- [ ] messages without timing render the trigger byte-for-byte as before

## notes

- prior art: per-tool elapsed/running indicators are standard across agent products, and hermes-agent hand-rolled this twice (desktop activity-timer registry with a 2s stall indicator, TUI 500ms tickers); the part-carried timestamp design makes their cross-remount timer registry unnecessary
- stall detection ships `unstable_` (threshold and fingerprint semantics may evolve), mirroring the `unstable_useComposerInputHistory` precedent

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

