### PR TITLE
feat(react-ag-ui): forward the full ExternalStoreThreadListAdapter through adapters.threadList

### DIFF
--- a/.changeset/agui-forward-threadlist-adapter.md
+++ b/.changeset/agui-forward-threadlist-adapter.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-ag-ui": patch
 ---
 
-feat: forward the full ExternalStoreThreadListAdapter (threads, archivedThreads, onRename, onArchive, ...) through adapters.threadList so server-persisted threads can be registered and switched to; clear messages before onSwitchToThread so the previous thread's messages no longer merge in as a phantom sibling branch; onSwitchToThread can return unstable_resume to reattach to an in-flight run after switching
+feat: forward the full ExternalStoreThreadListAdapter (threads, archivedThreads, onRename, onArchive, ...) through adapters.threadList so server-persisted threads can be registered and switched to; clear messages before onSwitchToThread so the previous thread's messages no longer merge in as a phantom sibling branch; onSwitchToThread can return unstable_resume to reattach to an in-flight run after switching (resumes in the background and requires a ThreadHistoryAdapter with resume(), otherwise it reports through onError instead of re-running the agent)

--- a/.changeset/agui-forward-threadlist-adapter.md
+++ b/.changeset/agui-forward-threadlist-adapter.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: forward the full ExternalStoreThreadListAdapter (threads, archivedThreads, onRename, onArchive, ...) through adapters.threadList so server-persisted threads can be registered and switched to; clear messages before onSwitchToThread so the previous thread's messages no longer merge in as a phantom sibling branch; onSwitchToThread can return unstable_resume to reattach to an in-flight run after switching

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -215,15 +215,28 @@ export class AgUiThreadRuntimeCore {
     );
   }
 
-  /**
-   * Resume a run that was in flight when the thread was hydrated externally
-   * (thread switch). Mirrors the `unstable_resume` path of `__internal_load`,
-   * including the history adapter's resume stream.
-   */
   async resumeInFlightRun(messages: readonly ThreadMessage[]): Promise<void> {
-    const parentId = messages.at(-1)?.id ?? null;
+    // Without a resume stream startRun would re-run the agent from scratch.
     const resumeStream = this.history?.resume?.bind(this.history);
-    await this.startRun(parentId, this.lastRunConfig, undefined, resumeStream);
+    if (!resumeStream) {
+      const error = new Error(
+        "[agui] unstable_resume requires a ThreadHistoryAdapter with a resume() method; skipping resume after thread switch",
+      );
+      this.logger.error?.(error.message);
+      this.onError?.(error);
+      return;
+    }
+    const parentId = messages.at(-1)?.id ?? null;
+    try {
+      await this.startRun(
+        parentId,
+        this.lastRunConfig,
+        undefined,
+        resumeStream,
+      );
+    } catch {
+      // startRun already reported via onError; don't reject the switch.
+    }
   }
 
   private assertNoPendingInterrupts(): void {

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -215,6 +215,17 @@ export class AgUiThreadRuntimeCore {
     );
   }
 
+  /**
+   * Resume a run that was in flight when the thread was hydrated externally
+   * (thread switch). Mirrors the `unstable_resume` path of `__internal_load`,
+   * including the history adapter's resume stream.
+   */
+  async resumeInFlightRun(messages: readonly ThreadMessage[]): Promise<void> {
+    const parentId = messages.at(-1)?.id ?? null;
+    const resumeStream = this.history?.resume?.bind(this.history);
+    await this.startRun(parentId, this.lastRunConfig, undefined, resumeStream);
+  }
+
   private assertNoPendingInterrupts(): void {
     if (!this.getPendingInterrupts()) return;
     throw new Error(

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -2,6 +2,7 @@ import type {
   AttachmentAdapter,
   DictationAdapter,
   ExternalStoreSharedOptions,
+  ExternalStoreThreadListAdapter,
   FeedbackAdapter,
   RealtimeVoiceAdapter,
   SpeechSynthesisAdapter,
@@ -14,17 +15,29 @@ import type { ReadonlyJSONValue } from "assistant-stream/utils";
 
 /**
  * @experimental This API is still under active development and might change without notice.
+ *
+ * Same as ExternalStoreThreadListAdapter, except `onSwitchToThread` returns
+ * the messages (and optional state) to hydrate the thread with.
  */
-export type UseAgUiThreadListAdapter = {
-  threadId?: string | undefined;
-  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
+type SwitchToThreadResult = {
+  messages: readonly ThreadMessage[];
+  state?: ReadonlyJSONValue;
+  /**
+   * Set when the thread has a run in flight. The runtime resumes the run
+   * after hydrating, the same way `ThreadHistoryAdapter.load()` does when it
+   * returns `unstable_resume: true`.
+   */
+  unstable_resume?: boolean;
+};
+
+export type UseAgUiThreadListAdapter = Omit<
+  ExternalStoreThreadListAdapter,
+  "onSwitchToThread"
+> & {
   onSwitchToThread?:
-    | ((threadId: string) =>
-        | Promise<{
-            messages: readonly ThreadMessage[];
-            state?: ReadonlyJSONValue;
-          }>
-        | { messages: readonly ThreadMessage[]; state?: ReadonlyJSONValue })
+    | ((
+        threadId: string,
+      ) => Promise<SwitchToThreadResult> | SwitchToThreadResult)
     | undefined;
 };
 

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -96,7 +96,7 @@ export function useAgUiRuntime(
               core.loadExternalState(result.state);
             }
             if (result.unstable_resume) {
-              await core.resumeInFlightRun(result.messages);
+              void core.resumeInFlightRun(result.messages);
             }
           }
         : undefined,

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -74,10 +74,11 @@ export function useAgUiRuntime(
   const threadList = useMemo(() => {
     if (!threadListAdapter) return undefined;
 
-    const { onSwitchToNewThread, onSwitchToThread } = threadListAdapter;
+    const { onSwitchToNewThread, onSwitchToThread, ...rest } =
+      threadListAdapter;
 
     return {
-      threadId: threadListAdapter.threadId,
+      ...rest,
       onSwitchToNewThread: onSwitchToNewThread
         ? async () => {
             await onSwitchToNewThread();
@@ -86,10 +87,16 @@ export function useAgUiRuntime(
         : undefined,
       onSwitchToThread: onSwitchToThread
         ? async (threadId: string) => {
+            // Clear before the thread id flips, or the old messages leak
+            // into the new thread as a sibling branch.
+            core.applyExternalMessages([]);
             const result = await onSwitchToThread(threadId);
             core.applyExternalMessages(result.messages);
             if (result.state) {
               core.loadExternalState(result.state);
+            }
+            if (result.unstable_resume) {
+              await core.resumeInFlightRun(result.messages);
             }
           }
         : undefined,

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1123,6 +1123,78 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(assistant.status).toMatchObject({ type: "complete" });
   });
 
+  it("resumeInFlightRun feeds history.resume() stream instead of re-running", async () => {
+    const runAgent = vi.fn(async (_input, subscriber) => {
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const userMessage: ThreadMessage = {
+      id: "msg-1",
+      role: "user",
+      createdAt: new Date(),
+      content: [{ type: "text", text: "Hello" }],
+      metadata: { custom: {} },
+    };
+
+    const resume = vi.fn(async function* (): AsyncGenerator<
+      ChatModelRunResult,
+      void,
+      unknown
+    > {
+      yield {
+        content: [{ type: "text", text: "recovered" }],
+        status: { type: "complete", reason: "unknown" },
+      };
+    });
+
+    const historyAdapter: ThreadHistoryAdapter = {
+      load: vi.fn().mockResolvedValue(null),
+      resume,
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const core = createCore(agent, { history: historyAdapter });
+    core.applyExternalMessages([userMessage]);
+
+    await core.resumeInFlightRun([userMessage]);
+
+    expect(resume).toHaveBeenCalledTimes(1);
+    expect(runAgent).not.toHaveBeenCalled();
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.content.at(-1)).toMatchObject({
+      type: "text",
+      text: "recovered",
+    });
+    expect(assistant.status).toMatchObject({ type: "complete" });
+  });
+
+  it("resumeInFlightRun without a resume adapter skips the run and reports onError", async () => {
+    const runAgent = vi.fn(async (_input, subscriber) => {
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const onError = vi.fn();
+    const core = createCore(agent, { onError });
+
+    const userMessage: ThreadMessage = {
+      id: "msg-1",
+      role: "user",
+      createdAt: new Date(),
+      content: [{ type: "text", text: "Hello" }],
+      metadata: { custom: {} },
+    };
+    core.applyExternalMessages([userMessage]);
+
+    await core.resumeInFlightRun([userMessage]);
+
+    expect(runAgent).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+  });
+
   it("omits the placeholder assistant message from run input history", async () => {
     const runAgent = vi.fn(async (_input, subscriber) => {
       subscriber.onRunFinalized?.();


### PR DESCRIPTION
## Motivation

`useAgUiRuntime`'s `threadList` adapter currently forwards only `threadId`, `onSwitchToNewThread`, and `onSwitchToThread` to the underlying external-store runtime. As a result the thread registry never learns about threads the runtime didn't create itself:

- `switchToThread(id)` on a **server-persisted thread** silently no-ops — the registry doesn't know the id, so `onSwitchToThread` is unreachable for any remote conversation.
- `ThreadListPrimitive` has nothing to render — apps can't drive the canonical thread-list UI from their backend's conversation list.

The `with-ag-ui` example sidesteps this by only supporting threads created in-session (the `threadsRef` map starts empty); restoring previously persisted threads is impossible today.

## Change

1. **Forward the rest of the adapter.** `UseAgUiThreadListAdapter` becomes `Omit<ExternalStoreThreadListAdapter, "onSwitchToThread"> & { onSwitchToThread?: ... }`. Only `onSwitchToThread` differs from the ExternalStore contract (it returns the `{ messages, state }` to hydrate with — the reason this wrapper exists); `onSwitchToNewThread`'s signature is identical, so everything else (`threads`, `archivedThreads`, `isLoading`, `onRename`, `onArchive`, `onUnarchive`, `onDelete`, `onUpdateCustom`) now passes straight through via a spread. Strictly a widening — existing adapters compile unchanged. If the original narrowing was deliberate, happy to adjust.

2. **Fix cross-thread message bleed on switch** (reachable only once switching works, so bundled here). The host's `threadId` flip and `core.applyExternalMessages(result.messages)` land in **separate React commits**: the fresh thread core created on the id flip first hydrates with the *previous* thread's messages, then the real ones merge into the repository as a sibling branch — manifesting as a phantom `2/2` branch picker showing thread A's conversation inside thread B. Fixed by clearing messages before invoking the host callback, mirroring what `onSwitchToNewThread` already does.

3. **`unstable_resume` on switch.** `onSwitchToThread` can now return `unstable_resume: true` when the target thread has a run in flight; the runtime resumes it after hydrating — the same contract `ThreadHistoryAdapter.load()` already has. Without this, switching to a thread mid-run leaves the stream detached even though the history said it was running.

## Verification

- Browser-verified on a locally modified copy of the `with-ag-ui` example (seeded two pre-existing threads + the canonical `<ThreadList />` component; not included — the change is purely additive): the sidebar renders the pre-seeded threads from the registry, `ThreadListItemPrimitive.Trigger` switches and hydrates them, and round-trips (A→B→A, new→back) show no message bleed and no phantom branches.
- `pnpm vitest run`: 148/148 passing; package build clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




