### PR TITLE
feat(react-ag-ui): type the agent as AbstractAgent instead of HttpAgent

### DIFF
--- a/.changeset/agui-abstract-agent.md
+++ b/.changeset/agui-abstract-agent.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: accept any AbstractAgent in useAgUiRuntime instead of requiring HttpAgent

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -13,7 +13,7 @@ import type {
   ThreadMessage,
   ToolCallMessagePart,
 } from "@assistant-ui/core";
-import type { HttpAgent } from "@ag-ui/client";
+import type { AbstractAgent } from "@ag-ui/client";
 import jsonpatch, { type Operation } from "fast-json-patch";
 import type { Logger } from "./logger";
 import type { AgUiEvent, AgUiInterrupt, AgUiResumeEntry } from "./types";
@@ -49,7 +49,7 @@ type ResumeRunConfig = {
 };
 
 type CoreOptions = {
-  agent: HttpAgent;
+  agent: AbstractAgent;
   logger: Logger;
   showThinking: boolean;
   onError?: (error: Error) => void;
@@ -61,7 +61,7 @@ type CoreOptions = {
 const FALLBACK_USER_STATUS = { type: "complete", reason: "unknown" } as const;
 
 export class AgUiThreadRuntimeCore {
-  private agent: HttpAgent;
+  private agent: AbstractAgent;
   private logger: Logger;
   private showThinking: boolean;
   private onError: ((error: Error) => void) | undefined;

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -8,7 +8,7 @@ import type {
   ThreadHistoryAdapter,
   ThreadMessage,
 } from "@assistant-ui/core";
-import type { HttpAgent } from "@ag-ui/client";
+import type { AbstractAgent } from "@ag-ui/client";
 import type { Logger } from "./logger";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
 
@@ -42,7 +42,7 @@ export type UseAgUiRuntimeAdapters = {
 };
 
 export type UseAgUiRuntimeOptions = ExternalStoreSharedOptions & {
-  agent: HttpAgent;
+  agent: AbstractAgent;
   logger?: Partial<Logger>;
   showThinking?: boolean;
   onError?: (e: Error) => void;


### PR DESCRIPTION
## Motivation

`useAgUiRuntime` declares `agent: HttpAgent`, but the runtime only ever touches `AbstractAgent` members — `threadId`, `state`, and `runAgent` (the latter already invoked through an `as any` cast in `AgUiThreadRuntimeCore`). The narrow type rejects every custom `AbstractAgent` subclass at compile time: resumable/durable transports, middleware wrappers around `HttpAgent`, local in-process agents — all of which are first-class in the AG-UI ecosystem.

We currently carry a 4-hunk `d.ts` patch in our app doing exactly this widening to pass a custom resumable agent; presumably anyone else with a custom agent does something similar (or casts).

## Change

Type-only: `HttpAgent` → `AbstractAgent` in `UseAgUiRuntimeOptions`, `CoreOptions`, and the core's `agent` field. No behavior change; the existing `runAgent` call sites are untouched.

## Verification

- `pnpm vitest run`: 148/148 passing; package build clean.
- We've run this widening in production for weeks via the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

