### PR TITLE
fix(react-ag-ui): don't finalize a failed run as successful

### DIFF
--- a/.changeset/agui-run-failed-finalize.md
+++ b/.changeset/agui-run-failed-finalize.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: do not synthesize RUN_FINISHED when the finalize hook follows a failed run — the error status was overwritten and the run rendered as successful

--- a/.changeset/agui-run-failed-finalize.md
+++ b/.changeset/agui-run-failed-finalize.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-ag-ui": patch
 ---
 
-fix: do not synthesize RUN_FINISHED when the finalize hook follows a failed run — the error status was overwritten and the run rendered as successful
+fix: keep failed and aborted runs visible. the synthetic RUN_FINISHED from onRunFinalized used to overwrite RUN_ERROR with a successful status, so failed runs rendered as complete and MessagePrimitive.Error never showed. aborts (which @ag-ui/client routes through onRunFailed) now map to RUN_CANCELLED instead of RUN_ERROR, so the run lands as incomplete/cancelled.

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -38,6 +38,16 @@ type Subscriber = {
   onRunFailed?: (payload: { error: Error }) => void;
 };
 
+const isAbortError = (error: Error): boolean => {
+  if (error.name === "AbortError") return true;
+  const message = typeof error.message === "string" ? error.message : "";
+  return (
+    message === "Fetch is aborted" ||
+    message === "signal is aborted without reason" ||
+    message === "component unmounted"
+  );
+};
+
 const ensureEvent = (
   raw: unknown,
   type: AgUiEvent["type"],
@@ -143,11 +153,12 @@ export const createAgUiSubscriber = (
       dispatch({ type: "RUN_FINISHED", runId });
     },
     onRunFailed: ({ error }) => {
-      // The finalize hook fires after onRunFailed; without this flag it
-      // synthesizes a RUN_FINISHED that overwrites the error status, so the
-      // failed run renders as successful.
       runFinishedDispatched = true;
       onRunFailed?.(error);
+      if (isAbortError(error)) {
+        dispatch({ type: "RUN_CANCELLED" } satisfies AgUiEvent);
+        return;
+      }
       const message =
         typeof error.message === "string" ? error.message : "Run failed";
       const code =

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -143,6 +143,10 @@ export const createAgUiSubscriber = (
       dispatch({ type: "RUN_FINISHED", runId });
     },
     onRunFailed: ({ error }) => {
+      // The finalize hook fires after onRunFailed; without this flag it
+      // synthesizes a RUN_FINISHED that overwrites the error status, so the
+      // failed run renders as successful.
+      runFinishedDispatched = true;
       onRunFailed?.(error);
       const message =
         typeof error.message === "string" ? error.message : "Run failed";

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { ChatModelRunResult } from "@assistant-ui/core";
 import { RunAggregator } from "../src/runtime/adapter/run-aggregator";
+import { createAgUiSubscriber } from "../src/runtime/adapter/subscriber";
 import type { AgUiEvent } from "../src/runtime/types";
 
 const makeLogger = () => ({
@@ -483,6 +484,46 @@ describe("RunAggregator", () => {
       type: "incomplete",
       reason: "error",
       error: "boom",
+    });
+  });
+
+  it("preserves incomplete/error status when subscriber finalize follows a failed run", () => {
+    const aggregator = createAggregator(false);
+    const subscriber = createAgUiSubscriber({
+      dispatch: (evt) => aggregator.handle(evt),
+      runId: "r1",
+    });
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    subscriber.onRunFailed?.({ error: new Error("boom") });
+    subscriber.onRunFinalized?.();
+
+    const last = results.at(-1);
+    expect(last?.status).toMatchObject({
+      type: "incomplete",
+      reason: "error",
+      error: "boom",
+    });
+  });
+
+  it("preserves incomplete/cancelled status when subscriber finalize follows an aborted run", () => {
+    const aggregator = createAggregator(false);
+    const subscriber = createAgUiSubscriber({
+      dispatch: (evt) => aggregator.handle(evt),
+      runId: "r1",
+    });
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    const abortError = Object.assign(new Error("aborted"), {
+      name: "AbortError",
+    });
+    subscriber.onRunFailed?.({ error: abortError });
+    subscriber.onRunFinalized?.();
+
+    const last = results.at(-1);
+    expect(last?.status).toMatchObject({
+      type: "incomplete",
+      reason: "cancelled",
     });
   });
 

--- a/packages/react-ag-ui/test/subscriber.spec.ts
+++ b/packages/react-ag-ui/test/subscriber.spec.ts
@@ -41,6 +41,22 @@ describe("createAgUiSubscriber", () => {
     expect(events[0]).toMatchObject({ type: "RUN_ERROR", message: "boom" });
   });
 
+  it("does not synthesize RUN_FINISHED when finalize follows a failed run", () => {
+    const events: AgUiEvent[] = [];
+    const subscriber = createAgUiSubscriber({
+      dispatch: (evt) => events.push(evt),
+      runId: "run",
+    });
+
+    subscriber.onRunFailed?.({ error: new Error("boom") });
+    // onRunFinalized fires after onRunFailed in real ag-ui flows; a synthetic
+    // RUN_FINISHED here would overwrite the error status with a successful one.
+    subscriber.onRunFinalized?.();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "RUN_ERROR", message: "boom" });
+  });
+
   it("dispatches RUN_FINISHED with outcome from onRunFinishedEvent", () => {
     const events: AgUiEvent[] = [];
     const subscriber = createAgUiSubscriber({

--- a/packages/react-ag-ui/test/subscriber.spec.ts
+++ b/packages/react-ag-ui/test/subscriber.spec.ts
@@ -49,12 +49,53 @@ describe("createAgUiSubscriber", () => {
     });
 
     subscriber.onRunFailed?.({ error: new Error("boom") });
-    // onRunFinalized fires after onRunFailed in real ag-ui flows; a synthetic
-    // RUN_FINISHED here would overwrite the error status with a successful one.
     subscriber.onRunFinalized?.();
 
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({ type: "RUN_ERROR", message: "boom" });
+  });
+
+  it.each([
+    [
+      "AbortError name",
+      Object.assign(new Error("aborted"), { name: "AbortError" }),
+    ],
+    ["Fetch is aborted", new Error("Fetch is aborted")],
+    [
+      "signal is aborted without reason",
+      new Error("signal is aborted without reason"),
+    ],
+    ["component unmounted", new Error("component unmounted")],
+  ])(
+    "dispatches RUN_CANCELLED instead of RUN_ERROR for abort-shaped errors (%s)",
+    (_label, error) => {
+      const events: AgUiEvent[] = [];
+      const subscriber = createAgUiSubscriber({
+        dispatch: (evt) => events.push(evt),
+        runId: "run",
+      });
+
+      subscriber.onRunFailed?.({ error });
+      subscriber.onRunFinalized?.();
+
+      expect(events).toEqual([{ type: "RUN_CANCELLED" }]);
+    },
+  );
+
+  it("still forwards abort errors to the onRunFailed callback", () => {
+    const onRunFailed = vi.fn();
+    const events: AgUiEvent[] = [];
+    const subscriber = createAgUiSubscriber({
+      dispatch: (evt) => events.push(evt),
+      runId: "run",
+      onRunFailed,
+    });
+
+    const error = Object.assign(new Error("aborted"), { name: "AbortError" });
+    subscriber.onRunFailed?.({ error });
+
+    expect(onRunFailed).toHaveBeenCalledWith(error);
+    expect(events).toEqual([{ type: "RUN_CANCELLED" }]);
   });
 
   it("dispatches RUN_FINISHED with outcome from onRunFinishedEvent", () => {
@@ -74,8 +115,6 @@ describe("createAgUiSubscriber", () => {
         },
       },
     });
-    // onRunFinalized fires after onRunFinishedEvent in real ag-ui flows;
-    // we should not double-dispatch.
     subscriber.onRunFinalized?.();
 
     expect(events).toHaveLength(1);


### PR DESCRIPTION
## Bug

`@ag-ui/client`'s finalize hook fires after `onRunFailed`. The subscriber's `onRunFailed` dispatches `RUN_ERROR` but never sets `runFinishedDispatched`, so `onRunFinalized` then synthesizes a `RUN_FINISHED` that overwrites the aggregator's `incomplete`/error status with `complete` — the failed run renders as successful and the error UI (`MessagePrimitive.Error`) never shows.

Sequence today:
1. backend run fails → client invokes `onRunFailed` → `RUN_ERROR` dispatched, assistant message gets error status ✓
2. client invokes `onRunFinalized` → `runFinishedDispatched` is still false → synthetic `RUN_FINISHED` dispatched → error status clobbered ✗

## Fix

Set `runFinishedDispatched` in `onRunFailed` — a failed run already dispatched its terminal event, so finalize must not synthesize one. One line, plus a unit test reproducing the failed-then-finalized sequence.

## Verification

- New test fails without the fix, passes with it; `pnpm vitest run`: 149/149.
- We've been carrying this as a patch in production — it's what makes backend `RUN_ERROR`s actually surface in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

