### PR TITLE
feat: precompile packages with React Compiler

### DIFF
--- a/.changeset/tap-compiler-runtime-shim.md
+++ b/.changeset/tap-compiler-runtime-shim.md
@@ -1,0 +1,19 @@
+---
+"@assistant-ui/x-buildutils": patch
+"@assistant-ui/tap": patch
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/store": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+"@assistant-ui/react-devtools": patch
+"@assistant-ui/react-mcp": patch
+"@assistant-ui/react-o11y": patch
+---
+
+feat: precompile packages with React Compiler
+
+- aui-build runs React Compiler over packages that depend on tap and remaps `react/compiler-runtime` to the tap shim subpath, so compiled hooks and components work both in React components and inside tap resource renders
+- `@assistant-ui/tap/react-shim` exports `useMemoCache` (tap inside a resource render, `React.__COMPILER_RUNTIME.c` otherwise, with a React 18 polyfill); new `@assistant-ui/tap/react-shim/compiler-runtime` subpath mirrors `react/compiler-runtime`'s `c` export
+- tap implements `useSyncExternalStore` and a no-op `useDebugValue`; `useSubscribable` now builds on `useSyncExternalStore` so its store reads stay visible to the compiler
+- `AssistantProviderBase` opts out via `"use no memo"` because the runtime receives options through an effect inside a re-rendered child element

--- a/packages/core/src/react/AssistantProvider.tsx
+++ b/packages/core/src/react/AssistantProvider.tsx
@@ -21,6 +21,13 @@ export type AssistantProviderBaseProps = PropsWithChildren<{
 
 export const AssistantProviderBase: FC<AssistantProviderBaseProps> = memo(
   ({ runtime, aui: parent = null, children }) => {
+    // The runtime has a stable identity but mutates in place: its options are
+    // pushed in by an unconditional effect inside <RenderComponent />, so that
+    // element must be re-created every commit for React to re-render it and
+    // re-run the effect. React Compiler caches <RenderComponent /> on the
+    // stable RenderComponent type, which silences the effect and stops option
+    // changes (e.g. unstable_enableMessageQueue) from reaching the runtime.
+    "use no memo";
     const aui = useAui({ threads: RuntimeAdapter(runtime) }, { parent });
     const RenderComponent = getRenderComponent(runtime);
     const inner = (

--- a/packages/core/src/store/runtime-clients/useSubscribable.ts
+++ b/packages/core/src/store/runtime-clients/useSubscribable.ts
@@ -1,16 +1,8 @@
-import { useState, useEffect } from "react";
+import { useSyncExternalStore } from "react";
 import type { SubscribableWithState } from "../../subscribable/subscribable";
 
 export const useSubscribable = <T>(
   subscribable: Omit<SubscribableWithState<T, any>, "path">,
 ) => {
-  const [, setState] = useState(subscribable.getState);
-  useEffect(() => {
-    setState(subscribable.getState());
-    return subscribable.subscribe(() => {
-      setState(subscribable.getState());
-    });
-  }, [subscribable]);
-
-  return subscribable.getState();
+  return useSyncExternalStore(subscribable.subscribe, subscribable.getState);
 };

--- a/packages/tap/package.json
+++ b/packages/tap/package.json
@@ -20,6 +20,10 @@
     "./react-shim": {
       "types": null,
       "default": "./dist/react-shim/index.js"
+    },
+    "./react-shim/compiler-runtime": {
+      "types": null,
+      "default": "./dist/react-shim/compiler-runtime.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/tap/react-shim/compiler-runtime/package.json
+++ b/packages/tap/react-shim/compiler-runtime/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "../../dist/react-shim/compiler-runtime.js"
+}

--- a/packages/tap/src/__tests__/basic/useSyncExternalStore.test.ts
+++ b/packages/tap/src/__tests__/basic/useSyncExternalStore.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { useSyncExternalStore } from "../../react-hooks/useSyncExternalStore";
+import { useCallback } from "../../react-hooks/useCallback";
+import {
+  createTestResource,
+  renderTest,
+  cleanupAllResources,
+  waitForNextTick,
+  getCommittedOutput,
+} from "../test-utils";
+
+const createStore = <T>(initial: T) => {
+  let state = initial;
+  const listeners = new Set<() => void>();
+  const store = {
+    subscribeCalls: 0,
+    unsubscribeCalls: 0,
+    getState: () => state,
+    setState: (next: T) => {
+      state = next;
+      for (const listener of listeners) listener();
+    },
+    subscribe: (listener: () => void) => {
+      store.subscribeCalls++;
+      listeners.add(listener);
+      return () => {
+        store.unsubscribeCalls++;
+        listeners.delete(listener);
+      };
+    },
+  };
+  return store;
+};
+
+const useStore = <T>(store: ReturnType<typeof createStore<T>>) =>
+  useSyncExternalStore(
+    useCallback((cb) => store.subscribe(cb), [store]),
+    useCallback(() => store.getState(), [store]),
+  );
+
+describe("useSyncExternalStore", () => {
+  afterEach(() => {
+    cleanupAllResources();
+  });
+
+  it("reads the current snapshot during render", () => {
+    const store = createStore(1);
+    const testFiber = createTestResource(() => useStore(store));
+
+    expect(renderTest(testFiber)).toBe(1);
+  });
+
+  it("re-renders when the store changes", async () => {
+    const store = createStore(1);
+    const testFiber = createTestResource(() => useStore(store));
+
+    renderTest(testFiber);
+    store.setState(2);
+    await waitForNextTick();
+    expect(getCommittedOutput(testFiber)).toBe(2);
+  });
+
+  it("does not re-render when the snapshot is Object.is-equal", async () => {
+    const store = createStore(1);
+    let renders = 0;
+    const testFiber = createTestResource(() => {
+      renders++;
+      return useStore(store);
+    });
+
+    renderTest(testFiber);
+    const rendersAfterMount = renders;
+    store.setState(1);
+    await waitForNextTick();
+    expect(renders).toBe(rendersAfterMount);
+  });
+
+  it("uses getServerSnapshot for the first render and corrects to getSnapshot on mount", async () => {
+    const store = createStore("client");
+    const testFiber = createTestResource(() =>
+      useSyncExternalStore(
+        (cb) => store.subscribe(cb),
+        () => store.getState(),
+        () => "server",
+      ),
+    );
+
+    // the first render itself returns the server snapshot
+    expect(renderTest(testFiber)).toBe("server");
+    // the mount effect detects the mismatch and re-renders with the client read
+    await waitForNextTick();
+    expect(getCommittedOutput(testFiber)).toBe("client");
+  });
+
+  it("does not re-render when server and client snapshots match", async () => {
+    const store = createStore("same");
+    let renders = 0;
+    const testFiber = createTestResource(() => {
+      renders++;
+      return useSyncExternalStore(
+        (cb) => store.subscribe(cb),
+        () => store.getState(),
+        () => "same",
+      );
+    });
+
+    expect(renderTest(testFiber)).toBe("same");
+    await waitForNextTick();
+    expect(renders).toBe(1);
+  });
+
+  it("uses getSnapshot on re-renders after the first", () => {
+    const store = createStore("client");
+    const testFiber = createTestResource((_p: { n: number }) =>
+      useSyncExternalStore(
+        (cb) => store.subscribe(cb),
+        () => store.getState(),
+        () => "server",
+      ),
+    );
+
+    renderTest(testFiber, { n: 1 });
+    expect(renderTest(testFiber, { n: 2 })).toBe("client");
+  });
+
+  it("re-subscribes when the store changes identity and unsubscribes on unmount", async () => {
+    const storeA = createStore("a");
+    const storeB = createStore("b");
+    const testFiber = createTestResource(
+      (p: { store: ReturnType<typeof createStore<string>> }) =>
+        useStore(p.store),
+    );
+
+    expect(renderTest(testFiber, { store: storeA })).toBe("a");
+    expect(renderTest(testFiber, { store: storeB })).toBe("b");
+    await waitForNextTick();
+    expect(storeA.unsubscribeCalls).toBe(1);
+    expect(storeB.subscribeCalls).toBe(1);
+
+    // storeA changes no longer reach the resource
+    storeA.setState("a2");
+    await waitForNextTick();
+    expect(getCommittedOutput(testFiber)).toBe("b");
+
+    storeB.setState("b2");
+    await waitForNextTick();
+    expect(getCommittedOutput(testFiber)).toBe("b2");
+
+    cleanupAllResources();
+    expect(storeB.unsubscribeCalls).toBe(1);
+  });
+});

--- a/packages/tap/src/__tests__/react/react-shim.test.tsx
+++ b/packages/tap/src/__tests__/react/react-shim.test.tsx
@@ -7,7 +7,10 @@ import {
   getCommittedOutput,
   waitForNextTick,
 } from "../test-utils";
-import { useState, useEffect } from "../../react-shim";
+import { useState, useEffect, useMemoCache } from "../../react-shim";
+import { c as _c } from "../../react-shim/compiler-runtime";
+
+const SENTINEL = Symbol.for("react.memo_cache_sentinel");
 
 describe("@assistant-ui/tap/react-shim", () => {
   afterEach(() => {
@@ -38,6 +41,31 @@ describe("@assistant-ui/tap/react-shim", () => {
       expect(getCommittedOutput(testFiber)).toBe(5);
       expect(effectLog).toEqual([0, 5]);
     });
+
+    it("useMemoCache persists the memo cache across renders", () => {
+      let computes = 0;
+      const testFiber = createTestResource((p: { x: number }) => {
+        // exactly what React Compiler emits: const $ = _c(n)
+        const $ = _c(2);
+        let double;
+        if ($[0] !== p.x) {
+          computes++;
+          double = p.x * 2;
+          $[0] = p.x;
+          $[1] = double;
+        } else {
+          double = $[1];
+        }
+        return double;
+      });
+
+      expect(renderTest(testFiber, { x: 2 })).toBe(4);
+      expect(computes).toBe(1);
+      expect(renderTest(testFiber, { x: 2 })).toBe(4);
+      expect(computes).toBe(1);
+      expect(renderTest(testFiber, { x: 3 })).toBe(6);
+      expect(computes).toBe(2);
+    });
   });
 
   describe("inside a React component", () => {
@@ -60,6 +88,32 @@ describe("@assistant-ui/tap/react-shim", () => {
       expect(btn.textContent).toBe("0");
       act(() => btn.click());
       expect(btn.textContent).toBe("1");
+    });
+
+    it("useMemoCache routes to React's compiler runtime", () => {
+      let computes = 0;
+      function Compiled({ x }: { x: number }) {
+        const $ = useMemoCache(2);
+        let double;
+        if ($[0] === SENTINEL || $[0] !== x) {
+          computes++;
+          double = x * 2;
+          $[0] = x;
+          $[1] = double;
+        } else {
+          double = $[1];
+        }
+        return <div data-testid="out">{double as number}</div>;
+      }
+
+      const { rerender } = render(<Compiled x={2} />);
+      expect(screen.getByTestId("out").textContent).toBe("4");
+      expect(computes).toBe(1);
+      rerender(<Compiled x={2} />);
+      expect(computes).toBe(1);
+      rerender(<Compiled x={3} />);
+      expect(screen.getByTestId("out").textContent).toBe("6");
+      expect(computes).toBe(2);
     });
   });
 });

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -23,8 +23,8 @@ export function createTestResource<R, A extends readonly unknown[]>(
     if (activeResources.has(fiber)) {
       const lastArgs = propsMap.get(fiber);
       const result = renderResourceFiber(fiber, lastArgs);
-      commitResourceFiber(fiber, result);
       lastRenderResultMap.set(fiber, result);
+      commitResourceFiber(fiber, result);
     }
   };
 
@@ -56,10 +56,12 @@ export function renderTest<R, A extends readonly unknown[]>(
   // Track resource for cleanup
   activeResources.add(fiber);
 
-  // Render with new args
+  // Render with new args. Record the result before committing: the commit can
+  // synchronously trigger a nested re-render whose newer result must not be
+  // clobbered afterwards.
   const result = renderResourceFiber(fiber, args);
-  commitResourceFiber(fiber, result);
   lastRenderResultMap.set(fiber, result);
+  commitResourceFiber(fiber, result);
 
   // Return the committed state from the result
   // This accounts for any re-renders that happened during commit

--- a/packages/tap/src/core/react-dispatcher.ts
+++ b/packages/tap/src/core/react-dispatcher.ts
@@ -9,6 +9,8 @@ import { useEffect } from "../react-hooks/useEffect";
 import { useEffectEvent } from "../react-hooks/useEffectEvent";
 import { use } from "../react-hooks/use";
 import { useMemoCache } from "../react-hooks/useMemoCache";
+import { useSyncExternalStore } from "../react-hooks/useSyncExternalStore";
+import { useDebugValue } from "../react-hooks/useDebugValue";
 
 // The dispatcher React reads while a resource renders, so hooks imported from
 // "react" route to tap with no build step. Hooks tap has no equivalent for are
@@ -27,6 +29,8 @@ const tapDispatcher = {
   useContext: use,
   use,
   useMemoCache,
+  useSyncExternalStore,
+  useDebugValue,
 };
 
 // React's live dispatcher slot differs by version: React 19 exposes it as `H` on

--- a/packages/tap/src/react-hooks/index.ts
+++ b/packages/tap/src/react-hooks/index.ts
@@ -7,6 +7,8 @@ export { useEffect } from "./useEffect";
 export { useEffectEvent } from "./useEffectEvent";
 export { use } from "./use";
 export { useMemoCache } from "./useMemoCache";
+export { useSyncExternalStore } from "./useSyncExternalStore";
+export { useDebugValue } from "./useDebugValue";
 export { useResource } from "../hooks/useResource";
 export { useResources } from "../hooks/useResources";
 export { useTapRoot } from "../hooks/useTapRoot";

--- a/packages/tap/src/react-hooks/useDebugValue.ts
+++ b/packages/tap/src/react-hooks/useDebugValue.ts
@@ -1,0 +1,5 @@
+// no-op for now
+export const useDebugValue = <T>(
+  _value: T,
+  _format?: (value: T) => unknown,
+): void => {};

--- a/packages/tap/src/react-hooks/useSyncExternalStore.ts
+++ b/packages/tap/src/react-hooks/useSyncExternalStore.ts
@@ -1,0 +1,27 @@
+import { useState } from "./useState";
+import { useEffect } from "./useEffect";
+import { useEffectEvent } from "./useEffectEvent";
+import { useRef } from "./useRef";
+
+export const useSyncExternalStore = <T>(
+  subscribe: (onStoreChange: () => void) => () => void,
+  getSnapshot: () => T,
+  getServerSnapshot: () => T = getSnapshot,
+): T => {
+  const isFirstRender = useRef(true);
+  const value = isFirstRender.current ? getServerSnapshot() : getSnapshot();
+  isFirstRender.current = false;
+
+  const [, forceUpdate] = useState(0);
+
+  const onStoreChange = useEffectEvent(() => {
+    if (!Object.is(value, getSnapshot())) forceUpdate((c) => c + 1);
+  });
+
+  useEffect(() => {
+    onStoreChange();
+    return subscribe(onStoreChange);
+  }, [subscribe]);
+
+  return value;
+};

--- a/packages/tap/src/react-shim/compiler-runtime.ts
+++ b/packages/tap/src/react-shim/compiler-runtime.ts
@@ -1,0 +1,5 @@
+// Runtime drop-in for "react/compiler-runtime": React Compiler output calls
+// `c(size)` for its memo cache, which the shimmed useMemoCache routes to tap
+// inside a resource render and to React's own compiler runtime otherwise.
+// Aliased the same way as the "react" shim (x-buildutils `output.paths`).
+export { useMemoCache as c } from "./index";

--- a/packages/tap/src/react-shim/index.ts
+++ b/packages/tap/src/react-shim/index.ts
@@ -20,8 +20,18 @@ export { default } from "react";
 const inTap = () => peekResourceFiber() !== null;
 const ReactRuntime = React as any;
 
-// --- hooks with a tap equivalent: override the star-exported react hooks ---
+// React 18 lacks `__COMPILER_RUNTIME` (its dispatcher has no useMemoCache), so
+// mirror Meta's react-compiler-runtime polyfill: a once-per-mount memo cell.
+const MEMO_CACHE_SENTINEL = Symbol.for("react.memo_cache_sentinel");
+const useMemoCachePolyfill = (size: number): unknown[] =>
+  ReactRuntime.useMemo(() => {
+    const $: unknown[] = new Array(size).fill(MEMO_CACHE_SENTINEL);
+    // tells react devtools this array is a memo cache
+    ($ as any)[MEMO_CACHE_SENTINEL] = true;
+    return $;
+  }, []);
 
+// --- hooks with a tap equivalent: override the star-exported react hooks ---
 export const useState = (initialState?: any) =>
   inTap() ? hooks.useState(initialState) : ReactRuntime.useState(initialState);
 
@@ -57,6 +67,29 @@ export const useEffectEvent = (callback: any) =>
   inTap()
     ? hooks.useEffectEvent(callback)
     : ReactRuntime.useEffectEvent(callback);
+
+export const useSyncExternalStore = (
+  subscribe: any,
+  getSnapshot: any,
+  getServerSnapshot?: any,
+) =>
+  inTap()
+    ? hooks.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+    : ReactRuntime.useSyncExternalStore(
+        subscribe,
+        getSnapshot,
+        getServerSnapshot,
+      );
+
+export const useDebugValue = (value: any, format?: any) =>
+  inTap()
+    ? hooks.useDebugValue(value, format)
+    : ReactRuntime.useDebugValue(value, format);
+
+export const useMemoCache = (size: number): unknown[] =>
+  inTap()
+    ? hooks.useMemoCache(size)
+    : (ReactRuntime.__COMPILER_RUNTIME?.c ?? useMemoCachePolyfill)(size);
 
 // `use(usable)` reads tap resource context when handed a tap context (routed by
 // its brand, not by ambient render state), and falls back to React's `use`

--- a/packages/x-buildutils/package.json
+++ b/packages/x-buildutils/package.json
@@ -24,13 +24,16 @@
   },
   "sideEffects": false,
   "dependencies": {
+    "@babel/core": "^7.29.7",
     "@tsconfig/strictest": "^2.0.8",
+    "babel-plugin-react-compiler": "^1.0.0",
     "jiti": "^2.7.0",
     "rolldown": "1.0.2",
     "tsdown": "^0.22.2",
     "typescript": "^6.0.3"
   },
   "devDependencies": {
+    "@types/babel__core": "^7.20.5",
     "@types/node": "^25.9.2"
   },
   "homepage": "https://www.assistant-ui.com/",

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -2,6 +2,7 @@ import { readFileSync, readdirSync, writeFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { build } from "tsdown";
 import { preserveReferenceDirectives } from "./reference-directives";
+import { reactCompiler } from "./react-compiler";
 
 const isDev = process.argv.slice(2).includes("dev");
 
@@ -19,8 +20,10 @@ if (isDev && pkg.scripts?.start) onSuccess = pkg.scripts.start;
 // import hooks from "react" and have them resolve to tap inside a resource
 // render. Done with output `paths` (remap of the external specifier) so the
 // import stays external and only the specifier is rewritten — `alias` does not
-// affect unbundled external imports. Exact "react" only, so "react/jsx-runtime"
-// and "react-dom" are untouched.
+// affect unbundled external imports. Exact specifiers only ("react" and
+// "react/compiler-runtime", the latter so React Compiler output's memo cache
+// routes to tap inside a resource render), so "react/jsx-runtime" and
+// "react-dom" are untouched.
 //
 // Only applied to packages that actually depend on `@assistant-ui/tap` (so the
 // remapped `@assistant-ui/tap/react-shim` specifier resolves for consumers).
@@ -43,6 +46,8 @@ await build({
           paths: {
             ...(options.paths as Record<string, string>),
             react: "@assistant-ui/tap/react-shim",
+            "react/compiler-runtime":
+              "@assistant-ui/tap/react-shim/compiler-runtime",
           },
         }),
       }
@@ -55,7 +60,14 @@ await build({
   sourcemap: true,
   watch: isDev,
   ...(onSuccess ? { onSuccess } : {}),
-  plugins: [preserveReferenceDirectives()],
+  // React Compiler shares the remap gate: compiled output's memo cache only
+  // works inside tap renders through the shimmed `react/compiler-runtime`, and
+  // tap itself (which implements the hooks the compiler output runs on) must
+  // never be compiled.
+  plugins: [
+    ...(remapReactToShim ? [reactCompiler()] : []),
+    preserveReferenceDirectives(),
+  ],
 });
 
 // `output.paths` rewrites the `react` specifier in BOTH the emitted JS and the
@@ -71,6 +83,14 @@ if (remapReactToShim && !isDev && existsSync("dist")) {
     const file = resolve("dist", rel);
     const src = readFileSync(file, "utf8");
     const out = src
+      .replaceAll(
+        '"@assistant-ui/tap/react-shim/compiler-runtime"',
+        '"react/compiler-runtime"',
+      )
+      .replaceAll(
+        "'@assistant-ui/tap/react-shim/compiler-runtime'",
+        "'react/compiler-runtime'",
+      )
       .replaceAll('"@assistant-ui/tap/react-shim"', '"react"')
       .replaceAll("'@assistant-ui/tap/react-shim'", "'react'");
     if (out !== src) writeFileSync(file, out);

--- a/packages/x-buildutils/src/react-compiler.ts
+++ b/packages/x-buildutils/src/react-compiler.ts
@@ -1,0 +1,42 @@
+import { transformAsync } from "@babel/core";
+import type { Plugin, SourceMapInput } from "rolldown";
+
+/**
+ * Runs React Compiler over source files before rolldown's own TS transform.
+ * Infer mode: only `use*`-named hooks and PascalCase components are compiled;
+ * anonymous resource bodies are left alone. Compiled output allocates its memo
+ * cache through `react/compiler-runtime`, which the `output.paths` remap routes
+ * to `@assistant-ui/tap/react-shim/compiler-runtime` so it works inside tap
+ * resource renders too. Babel only parses TS here (no transform), so the code
+ * handed back to rolldown is still TS.
+ */
+export function reactCompiler(): Plugin {
+  return {
+    name: "react-compiler",
+    transform: {
+      filter: { id: { include: /\.tsx?$/, exclude: /\.d\.ts$/ } },
+      async handler(code, id) {
+        const result = await transformAsync(code, {
+          filename: id,
+          babelrc: false,
+          configFile: false,
+          browserslistConfigFile: false,
+          parserOpts: {
+            plugins: id.endsWith(".tsx")
+              ? ["typescript", "jsx"]
+              : ["typescript"],
+          },
+          plugins: ["babel-plugin-react-compiler"],
+          sourceMaps: true,
+        });
+        if (result?.code == null) return null;
+        return {
+          code: result.code,
+          // babel's optional `sourcesContent` doesn't satisfy rolldown's map
+          // type under exactOptionalPropertyTypes; shapes are compatible.
+          map: (result.map ?? null) as SourceMapInput,
+        };
+      },
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4384,9 +4384,15 @@ importers:
 
   packages/x-buildutils:
     dependencies:
+      '@babel/core':
+        specifier: ^7.29.7
+        version: 7.29.7
       '@tsconfig/strictest':
         specifier: ^2.0.8
         version: 2.0.8
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
@@ -4400,6 +4406,9 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
     devDependencies:
+      '@types/babel__core':
+        specifier: ^7.20.5
+        version: 7.20.5
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
@@ -9752,8 +9761,14 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
   '@types/babel__generator@7.27.0':
     resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
 
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
@@ -22570,8 +22585,21 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
   '@types/babel__generator@7.27.0':
     dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':


### PR DESCRIPTION
## Summary

Enables React Compiler across all published packages that depend on `@assistant-ui/tap`, so shipped code is precompiled with memoization.

The challenge: compiled output allocates its memo cache through `react/compiler-runtime`'s `c()`, which calls `ReactSharedInternals.H.useMemoCache` directly. Inside a tap resource render, that dispatcher slot is tap's, which had no `useMemoCache`. This wires the compiler output to resolve correctly in both contexts.

## What changed

- **aui-build (`@assistant-ui/x-buildutils`)** runs `babel-plugin-react-compiler` (infer mode) over packages that depend on tap, and remaps both `react` → `@assistant-ui/tap/react-shim` and `react/compiler-runtime` → `@assistant-ui/tap/react-shim/compiler-runtime`. tap itself is never compiled (it implements the hooks compiled output runs on).
- **`@assistant-ui/tap`** gains:
  - `useMemoCache` in the react-shim (routes to tap inside a resource render; `React.__COMPILER_RUNTIME.c` otherwise, with a React 18 `useMemo`-based polyfill).
  - a new `@assistant-ui/tap/react-shim/compiler-runtime` subpath mirroring `react/compiler-runtime`'s `c` export.
  - `useSyncExternalStore` (synchronous, no tearing handling needed; supports `getServerSnapshot` for the first render) and a no-op `useDebugValue`.
- **`useSubscribable`** is rebuilt on `useSyncExternalStore` so its store reads are visible to the compiler as dataflow (was a bare render-time `getState()` that the compiler would freeze on the stable subscribable identity).
- **`AssistantProviderBase`** keeps `"use no memo"`: the runtime has a stable identity but receives new options through an unconditional effect inside `<RenderComponent />`, which must be re-created each commit for that effect to re-run. Confirmed by tracing that the `<RenderComponent />` element freeze is the only fatal case (the `RuntimeAdapter` element freeze is benign because the output path now flows through the `useSyncExternalStore` subscription).

## Testing

- Full monorepo build (83 tasks) and test suite (68 tasks) pass.
- New tap tests for `useSyncExternalStore` (snapshot reads, change-driven re-render, server snapshot, re-subscribe/unsubscribe) and for the `useMemoCache` shim + `compiler-runtime` subpath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

