### PR TITLE
feat(docs): live traction stats, rolling downloads, bot contributors

### DIFF
--- a/apps/docs/app/(home)/traction/page.tsx
+++ b/apps/docs/app/(home)/traction/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import {
   ArrowRight,
   ArrowUpRight,
+  Bot,
   GitFork,
   GitCommit,
   Network,
@@ -15,9 +16,10 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { GitHubIcon } from "@/components/icons/github";
 import { createOgMetadata } from "@/lib/og";
 import {
-  PROJECT_FACTS,
+  PACKAGES,
   TIMELINE_PACKAGES,
   daysSince,
+  fetchAiContributors,
   fetchCommitActivity,
   fetchContributors,
   fetchNpmDownloads,
@@ -25,7 +27,7 @@ import {
   fetchStarHistory,
   fetchTimelineSeries,
 } from "@/lib/traction";
-import { getDependents, getRepo } from "@/lib/github";
+import { getCommitStats, getDependents, getRepo } from "@/lib/github";
 import { formatCompact, formatNumber } from "@/lib/format";
 import { ActivityHeatmap } from "@/components/traction/activity-heatmap";
 import { DownloadsChart } from "@/components/traction/downloads-chart";
@@ -46,7 +48,7 @@ const REPO_URL = "https://github.com/assistant-ui/assistant-ui";
 
 type HeroStat = {
   label: string;
-  value: string;
+  value: string | null;
   caption: string;
   icon: typeof Star;
 };
@@ -68,32 +70,36 @@ export default async function TractionPage({
     starHistory,
     downloadsTimeline,
     contributors,
+    aiContributors,
     dependents,
     commitActivity,
     releaseActivity,
+    commitStats,
   ] = await Promise.all([
     fetchNpmDownloads(revalidate),
-    fetchStarHistory(repo.stars, revalidate),
+    fetchStarHistory(repo?.stars ?? 0, revalidate),
     fetchTimelineSeries(TIMELINE_PACKAGES, revalidate),
     fetchContributors(revalidate),
+    fetchAiContributors(revalidate),
     getDependents(revalidate),
     fetchCommitActivity(revalidate),
     fetchReleaseActivity(revalidate),
+    getCommitStats(revalidate),
   ]);
 
-  const days = daysSince(PROJECT_FACTS.firstCommitDate);
   const flagshipWeekly = npm.perPackage[FLAGSHIP_PACKAGE]?.weekly ?? 0;
+  const publicPackages = PACKAGES.filter((pkg) => !pkg.deprecated).length;
 
   const heroStats: HeroStat[] = [
     {
       label: "GitHub stars",
-      value: formatCompact(repo.stars),
+      value: repo ? formatCompact(repo.stars) : null,
       caption: "and counting",
       icon: Star,
     },
     {
       label: "Public packages",
-      value: PROJECT_FACTS.publicPackages.toString(),
+      value: publicPackages.toString(),
       caption: "shipped on npm",
       icon: Package,
     },
@@ -105,10 +111,7 @@ export default async function TractionPage({
     },
     {
       label: "Contributors",
-      value:
-        contributors.length > 0
-          ? contributors.length.toString()
-          : `${PROJECT_FACTS.uniqueAuthors}+`,
+      value: contributors ? contributors.length.toString() : null,
       caption: "from the community",
       icon: Users,
     },
@@ -117,17 +120,20 @@ export default async function TractionPage({
   const detailStats = [
     {
       label: "Forks",
-      value: formatNumber(repo.forks),
+      value: repo ? formatNumber(repo.forks) : null,
       icon: GitFork,
     },
     {
       label: "Total commits",
-      value: PROJECT_FACTS.totalCommits.toLocaleString(),
+      value:
+        commitStats.total != null ? commitStats.total.toLocaleString() : null,
       icon: GitCommit,
     },
     {
       label: "Days building in the open",
-      value: days.toLocaleString(),
+      value: commitStats.firstCommitDate
+        ? daysSince(commitStats.firstCommitDate).toLocaleString()
+        : null,
       icon: Sparkles,
     },
     ...(dependents && dependents.repos > 0
@@ -196,7 +202,7 @@ export default async function TractionPage({
               >
                 <Icon className="text-muted-foreground size-4" />
                 <div className="text-3xl font-medium tracking-tight tabular-nums md:text-4xl">
-                  {stat.value}
+                  {stat.value ?? "—"}
                 </div>
                 <div className="flex flex-col gap-0.5">
                   <span className="text-sm">{stat.label}</span>
@@ -278,7 +284,7 @@ export default async function TractionPage({
                 <Icon className="text-muted-foreground mt-1 size-4" />
                 <div className="flex flex-col">
                   <span className="text-2xl font-medium tracking-tight tabular-nums">
-                    {stat.value}
+                    {stat.value ?? "—"}
                   </span>
                   <span className="text-muted-foreground text-sm">
                     {stat.label}
@@ -290,7 +296,7 @@ export default async function TractionPage({
         </div>
       </section>
 
-      {contributors.length > 0 ? (
+      {contributors && contributors.length > 0 ? (
         <section className="mb-20">
           <div className="mb-8 flex flex-col gap-1">
             <h2 className="text-xl font-medium tracking-tight">
@@ -322,6 +328,36 @@ export default async function TractionPage({
               </a>
             ))}
           </div>
+          {aiContributors.length > 0 ? (
+            <div className="mt-8 flex flex-col gap-3">
+              <div className="text-muted-foreground flex items-center gap-1.5 text-sm">
+                <Bot className="size-4" />
+                <span>With bot</span>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {aiContributors.map((c) => (
+                  <a
+                    key={c.login}
+                    href={c.htmlUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={`${c.login} · ${c.contributions.toLocaleString()} commit${c.contributions === 1 ? "" : "s"}`}
+                    className="block transition-transform hover:scale-110"
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={c.avatarUrl}
+                      alt={c.login}
+                      width={32}
+                      height={32}
+                      loading="lazy"
+                      className="border-border size-8 rounded-full border"
+                    />
+                  </a>
+                ))}
+              </div>
+            </div>
+          ) : null}
         </section>
       ) : null}
 
@@ -370,7 +406,7 @@ export default async function TractionPage({
             className={buttonVariants({ variant: "outline" })}
           >
             <GitHubIcon className="size-4" />
-            {formatCompact(repo.stars)} on GitHub
+            {repo ? `${formatCompact(repo.stars)} on GitHub` : "Star on GitHub"}
           </a>
         </div>
       </section>

--- a/apps/docs/app/api/github/repo/route.ts
+++ b/apps/docs/app/api/github/repo/route.ts
@@ -4,6 +4,12 @@ export const revalidate = 3600;
 
 export async function GET() {
   const repo = await getRepo();
+  if (!repo) {
+    return Response.json(
+      { error: "Repository data unavailable" },
+      { status: 503 },
+    );
+  }
   return Response.json(repo, {
     headers: {
       "Cache-Control":

--- a/apps/docs/components/traction/weekly-downloads-stat.tsx
+++ b/apps/docs/components/traction/weekly-downloads-stat.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { ArrowLeftRight, ArrowUpRight } from "lucide-react";
-import { formatCompact } from "@/lib/format";
+import { NumberRoll } from "@/components/assistant-ui/number-roll";
 
 type Mode = { value: number; caption: string };
 
@@ -19,7 +19,15 @@ export function WeeklyDownloadsStat({
     <div className="bg-background flex flex-col gap-3 p-6">
       <ArrowUpRight className="text-muted-foreground size-4" />
       <div className="text-3xl font-medium tracking-tight tabular-nums md:text-4xl">
-        {current.value > 0 ? formatCompact(current.value) : "—"}
+        {current.value > 0 ? (
+          <NumberRoll
+            value={current.value}
+            locales="en-US"
+            format={{ notation: "compact", maximumFractionDigits: 1 }}
+          />
+        ) : (
+          "—"
+        )}
       </div>
       <div className="flex flex-col gap-0.5">
         <span className="text-sm">Weekly downloads</span>

--- a/apps/docs/lib/github.ts
+++ b/apps/docs/lib/github.ts
@@ -56,28 +56,22 @@ export type RepoStats = {
   watchers: number;
 };
 
-const REPO_FALLBACK: RepoStats = {
-  stars: 9700,
-  forks: 990,
-  openIssues: 60,
-  watchers: 80,
-};
-
 export async function getRepo(
   revalidate: number = REVALIDATE.WARM,
-): Promise<RepoStats> {
+): Promise<RepoStats | null> {
   try {
     const res = await ghFetch("", revalidate);
-    if (!res.ok) return REPO_FALLBACK;
+    if (!res.ok) return null;
     const data = await res.json();
+    if (typeof data?.stargazers_count !== "number") return null;
     return {
-      stars: data.stargazers_count ?? REPO_FALLBACK.stars,
-      forks: data.forks_count ?? REPO_FALLBACK.forks,
-      openIssues: data.open_issues_count ?? REPO_FALLBACK.openIssues,
-      watchers: data.subscribers_count ?? REPO_FALLBACK.watchers,
+      stars: data.stargazers_count,
+      forks: data.forks_count,
+      openIssues: data.open_issues_count,
+      watchers: data.subscribers_count,
     };
   } catch {
-    return REPO_FALLBACK;
+    return null;
   }
 }
 
@@ -161,6 +155,40 @@ export async function getCommitsSince(
   return all;
 }
 
+export type CommitStats = {
+  total: number | null;
+  firstCommitDate: string | null;
+};
+
+const commitDate = (item: CommitListItem | undefined): string | null =>
+  item?.commit?.author?.date ?? item?.commit?.committer?.date ?? null;
+
+export async function getCommitStats(
+  revalidate: number = REVALIDATE.COOL,
+): Promise<CommitStats> {
+  try {
+    const res = await ghFetch("/commits?per_page=1", revalidate);
+    if (!res.ok) return { total: null, firstCommitDate: null };
+    // With per_page=1 the last page number equals the total number of commits on the default branch (every author, bots included).
+    const last = parseLastPage(res.headers.get("Link"));
+    const page1 = (await res.json()) as CommitListItem[];
+    const total = last ?? (Array.isArray(page1) ? page1.length : null);
+
+    if (last == null || last <= 1) {
+      return { total, firstCommitDate: commitDate(page1[0]) };
+    }
+    const oldest = await ghFetch(
+      `/commits?per_page=1&page=${last}`,
+      revalidate,
+    );
+    if (!oldest.ok) return { total, firstCommitDate: null };
+    const data = (await oldest.json()) as CommitListItem[];
+    return { total, firstCommitDate: commitDate(data[0]) };
+  } catch {
+    return { total: null, firstCommitDate: null };
+  }
+}
+
 export type GitHubContributor = {
   login: string;
   avatar_url: string;
@@ -172,22 +200,27 @@ export type GitHubContributor = {
 export async function getContributors(
   maxPages = 2,
   revalidate: number = REVALIDATE.COOL,
-): Promise<GitHubContributor[]> {
-  const all: GitHubContributor[] = [];
+): Promise<GitHubContributor[] | null> {
   try {
+    const all: GitHubContributor[] = [];
     for (let page = 1; page <= maxPages; page++) {
       const res = await ghFetch(
         `/contributors?per_page=100&page=${page}`,
         revalidate,
       );
-      if (!res.ok) break;
+      if (!res.ok) {
+        if (page === 1) return null;
+        break;
+      }
       const batch = (await res.json()) as GitHubContributor[];
       if (batch.length === 0) break;
       all.push(...batch);
       if (batch.length < 100) break;
     }
-  } catch {}
-  return all;
+    return all;
+  } catch {
+    return null;
+  }
 }
 
 export type StargazerEntry = { starred_at: string };

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -1,4 +1,5 @@
 import {
+  type GitHubContributor,
   getCommitActivityStats,
   getCommitsSince,
   getContributors,
@@ -376,18 +377,52 @@ export async function fetchReleaseActivity(
   return Array.from(counts.entries()).map(([date, count]) => ({ date, count }));
 }
 
+const isBot = (login: string, type?: string) =>
+  type === "Bot" || /\[bot\]$/i.test(login);
+
+/* Bot accounts that are AI coding/docs agents, as opposed to CI and release automation (github-actions, blacksmith, dependabot, renovate, ...). Surfaced as "With AI" collaborators on the traction page; extend as new agents ship code. */
+const AI_BOT_LOGINS = new Set(
+  [
+    "Copilot",
+    "devin-ai-integration[bot]",
+    "promptless[bot]",
+    "dosubot[bot]",
+    "claude[bot]",
+    "cursor[bot]",
+    "coderabbitai[bot]",
+    "codegen-sh[bot]",
+    "sweep-ai[bot]",
+    "greptile-apps[bot]",
+    "ellipsis-dev[bot]",
+    "qodo-merge-pro[bot]",
+  ].map((login) => login.toLowerCase()),
+);
+
+const toContributor = (c: GitHubContributor): Contributor => ({
+  login: c.login,
+  avatarUrl: c.avatar_url,
+  htmlUrl: c.html_url,
+  contributions: c.contributions,
+});
+
 export async function fetchContributors(
+  revalidate?: number,
+): Promise<Contributor[] | null> {
+  const raw = await getContributors(undefined, revalidate);
+  if (raw === null) return null;
+  return raw.filter((c) => !isBot(c.login, c.type)).map(toContributor);
+}
+
+export async function fetchAiContributors(
   revalidate?: number,
 ): Promise<Contributor[]> {
   const raw = await getContributors(undefined, revalidate);
+  if (raw === null) return [];
   return raw
-    .filter((c) => c.type !== "Bot" && !/\[bot\]$/i.test(c.login))
-    .map((c) => ({
-      login: c.login,
-      avatarUrl: c.avatar_url,
-      htmlUrl: c.html_url,
-      contributions: c.contributions,
-    }));
+    .filter(
+      (c) => isBot(c.login, c.type) && AI_BOT_LOGINS.has(c.login.toLowerCase()),
+    )
+    .map(toContributor);
 }
 
 const EMPTY_DOWNLOADS: PackageDownloads = {
@@ -724,15 +759,6 @@ function resampleMonthly(anchors: TimelinePoint[]): TimelinePoint[] {
 
   return out;
 }
-
-export const PROJECT_FACTS = {
-  firstCommitDate: "2024-04-21",
-  totalCommits: 3062,
-  uniqueAuthors: 100,
-  publicPackages: PACKAGES.filter((pkg) => !pkg.deprecated).length,
-  examples: 30,
-  showcased: 8,
-} as const;
 
 export function daysSince(isoDate: string): number {
   const start = new Date(isoDate).getTime();


### PR DESCRIPTION
## summary

- traction page numbers are now fetched live from GitHub on every revalidation: total commits and "days building in the open" come from the real commit history (via the commits Link rel=last trick, bot commits included) instead of hardcoded constants.
- the weekly-downloads card rolls its digits with NumberRoll when you toggle between the flagship package and the ecosystem total.
- added a "with bot" group under contributors that lists curated agent bots (Copilot, devin, promptless, dosubot) with a Bot icon; CI and release automation (github-actions, blacksmith) is intentionally excluded.
- removed every hardcoded fallback: deleted PROJECT_FACTS and REPO_FALLBACK. getRepo and getContributors return null on failure, and any stat that can't be fetched renders "—" instead of a fabricated number. /api/github/repo returns 503 when repo data is unavailable.

## test plan

### already verified

- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` on the changed files: clean
- [x] `tsc --noEmit -p apps/docs/tsconfig.json`: passes
- [x] confirmed live values via `gh`: total commits 3429 (incl. bots), first commit 2024-04-21, bot contributors list

### reviewer should verify

- [ ] load /traction: stars, forks, total commits, days building, contributor count all render real numbers; the weekly-downloads caption toggle rolls the number; the "with bot" row shows the agent avatars
- [ ] simulate a GitHub fetch failure (bad GITHUB_TOKEN or offline): affected stats show "—" instead of stale numbers, and /api/github/repo responds 503

## notes

- the "with bot" set is an explicit allowlist (AI_BOT_LOGINS in lib/traction.ts), so new agents auto-appear once added; today it resolves to Copilot, devin, promptless, dosubot.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

