### PR TITLE
feat(docs): traction bot co-authors, cross-section nav, ui polish

### DIFF
--- a/apps/docs/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/(docs)/docs/[[...slug]]/page.tsx
@@ -4,7 +4,8 @@ import { notFound } from "next/navigation";
 import { createOgMetadata } from "@/lib/og";
 import { getMDXComponents } from "@/mdx-components";
 import { source } from "@/lib/source";
-import { getPageTreePeers, findNeighbour } from "fumadocs-core/page-tree";
+import { getPageTreePeers } from "fumadocs-core/page-tree";
+import { getDocsNeighbours } from "@/lib/docs-neighbours";
 import { Card, Cards } from "@/components/docs/fumadocs/card";
 import { TableOfContents } from "@/components/docs/layout/table-of-contents";
 import { DocsFooter } from "@/components/docs/layout/docs-footer";
@@ -43,13 +44,9 @@ export default async function Page(props: {
   const markdownUrl = `${page.url}.mdx`;
   const githubEditUrl = `https://github.com/assistant-ui/assistant-ui/edit/main/${path}`;
 
-  const neighbours = findNeighbour(source.pageTree, page.url);
-  const footerPrevious = neighbours.previous
-    ? { name: neighbours.previous.name, url: neighbours.previous.url }
-    : undefined;
-  const footerNext = neighbours.next
-    ? { name: neighbours.next.name, url: neighbours.next.url }
-    : undefined;
+  const neighbours = getDocsNeighbours(source.pageTree, page.url);
+  const footerPrevious = neighbours.previous;
+  const footerNext = neighbours.next;
 
   return (
     <DocsPage

--- a/apps/docs/app/(home)/traction/page.tsx
+++ b/apps/docs/app/(home)/traction/page.tsx
@@ -19,7 +19,7 @@ import {
   PACKAGES,
   TIMELINE_PACKAGES,
   daysSince,
-  fetchAiContributors,
+  fetchBotCoAuthors,
   fetchCommitActivity,
   fetchContributors,
   fetchNpmDownloads,
@@ -70,7 +70,7 @@ export default async function TractionPage({
     starHistory,
     downloadsTimeline,
     contributors,
-    aiContributors,
+    botCoAuthors,
     dependents,
     commitActivity,
     releaseActivity,
@@ -80,7 +80,7 @@ export default async function TractionPage({
     fetchStarHistory(repo?.stars ?? 0, revalidate),
     fetchTimelineSeries(TIMELINE_PACKAGES, revalidate),
     fetchContributors(revalidate),
-    fetchAiContributors(revalidate),
+    fetchBotCoAuthors(revalidate),
     getDependents(revalidate),
     fetchCommitActivity(revalidate),
     fetchReleaseActivity(revalidate),
@@ -328,20 +328,20 @@ export default async function TractionPage({
               </a>
             ))}
           </div>
-          {aiContributors.length > 0 ? (
+          {botCoAuthors.length > 0 ? (
             <div className="mt-8 flex flex-col gap-3">
               <div className="text-muted-foreground flex items-center gap-1.5 text-sm">
                 <Bot className="size-4" />
                 <span>With bot</span>
               </div>
               <div className="flex flex-wrap gap-2">
-                {aiContributors.map((c) => (
+                {botCoAuthors.map((c) => (
                   <a
                     key={c.login}
                     href={c.htmlUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    title={`${c.login} · ${c.contributions.toLocaleString()} commit${c.contributions === 1 ? "" : "s"}`}
+                    title={`${c.login} · co-authored ${c.contributions.toLocaleString()} commit${c.contributions === 1 ? "" : "s"}`}
                     className="block transition-transform hover:scale-110"
                   >
                     {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/apps/docs/components/docs/assistant/floating-composer.tsx
+++ b/apps/docs/components/docs/assistant/floating-composer.tsx
@@ -8,7 +8,7 @@ import {
 import { useAssistantPanel } from "@/components/docs/assistant/context";
 import { ModelSelector } from "@/components/assistant-ui/model-selector";
 import { MODELS } from "@/constants/model";
-import { SparklesIcon } from "lucide-react";
+import { SparklesIcon, XIcon } from "lucide-react";
 import Image from "next/image";
 import { ComposerPrimitive, useAuiState } from "@assistant-ui/react";
 import {
@@ -20,6 +20,7 @@ import {
   type ReactNode,
 } from "react";
 import { cn } from "@/lib/utils";
+import { usePersistentBoolean } from "@/hooks/use-persistent-boolean";
 
 const models = MODELS.map((m) => ({
   id: m.value,
@@ -82,10 +83,13 @@ export function FloatingComposer(): ReactNode {
   const { modelValue, onModelChange } = useSharedDocsModelSelection();
   const [expanded, setExpanded] = useState(false);
   const [modelSelectorOpen, setModelSelectorOpen] = useState(false);
+  const [dismissed, setDismissed] = usePersistentBoolean(
+    "floating-composer-dismissed",
+  );
   const containerRef = useRef<HTMLDivElement>(null);
 
   const hasScrolled = useHasScrolled(100);
-  const visible = hasScrolled && !open;
+  const visible = hasScrolled && !open && !dismissed;
 
   // Reset expanded state when floating composer becomes hidden
   useEffect(() => {
@@ -123,7 +127,15 @@ export function FloatingComposer(): ReactNode {
             : "pointer-events-none translate-y-full opacity-0",
       )}
     >
-      <div ref={containerRef}>
+      <div ref={containerRef} className="group relative">
+        <button
+          type="button"
+          aria-label="Dismiss"
+          onClick={() => setDismissed(true)}
+          className="border-border/60 bg-background text-muted-foreground hover:text-foreground absolute -top-2 -right-2 z-10 flex size-5 items-center justify-center rounded-full border opacity-0 transition-opacity group-hover:opacity-100"
+        >
+          <XIcon className="size-3" />
+        </button>
         <ComposerPrimitive.Root onSubmit={handleSubmit}>
           <div
             className={cn(

--- a/apps/docs/components/docs/assistant/floating-composer.tsx
+++ b/apps/docs/components/docs/assistant/floating-composer.tsx
@@ -132,7 +132,7 @@ export function FloatingComposer(): ReactNode {
           type="button"
           aria-label="Dismiss"
           onClick={() => setDismissed(true)}
-          className="border-border/60 bg-background text-muted-foreground hover:text-foreground absolute -top-2 -right-2 z-10 flex size-5 items-center justify-center rounded-full border opacity-0 transition-opacity group-hover:opacity-100"
+          className="border-border/60 bg-background text-muted-foreground hover:text-foreground absolute -top-2 -right-2 z-10 flex size-5 items-center justify-center rounded-full border opacity-0 transition-opacity group-hover:opacity-100 [@media(hover:none)]:opacity-100"
         >
           <XIcon className="size-3" />
         </button>

--- a/apps/docs/components/docs/assistant/messages.tsx
+++ b/apps/docs/components/docs/assistant/messages.tsx
@@ -63,7 +63,7 @@ export function AssistantMessage({
           }
         >
           <div className="text-muted-foreground flex items-center gap-2 py-1">
-            <DotMatrix state="connecting" label="Connecting" />
+            <DotMatrix state="connecting" aria-hidden />
             <span className="text-sm">Connecting</span>
           </div>
         </AuiIf>

--- a/apps/docs/components/docs/assistant/messages.tsx
+++ b/apps/docs/components/docs/assistant/messages.tsx
@@ -27,6 +27,7 @@ import {
 } from "react";
 import { cn } from "@/lib/utils";
 import { Reasoning } from "@/components/assistant-ui/reasoning";
+import { DotMatrix } from "@/components/assistant-ui/dot-matrix";
 
 export function UserMessage(): ReactNode {
   return (
@@ -62,8 +63,8 @@ export function AssistantMessage({
           }
         >
           <div className="text-muted-foreground flex items-center gap-2 py-1">
-            <LoaderIcon className="size-3 animate-spin" />
-            <span className="text-sm">Thinking...</span>
+            <DotMatrix state="connecting" label="Connecting" />
+            <span className="text-sm">Connecting</span>
           </div>
         </AuiIf>
         <MessageError />

--- a/apps/docs/components/docs/fumadocs/card.tsx
+++ b/apps/docs/components/docs/fumadocs/card.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ArrowRight, ArrowUpRight } from "lucide-react";
 import type { ReactNode } from "react";
 
 type CardProps = {
@@ -9,6 +10,9 @@ type CardProps = {
   icon?: ReactNode;
   external?: boolean;
 };
+
+const base =
+  "flex flex-col gap-1.5 rounded-xl border border-fd-border bg-fd-card p-4";
 
 export function Card({
   title,
@@ -22,20 +26,25 @@ export function Card({
     <>
       <span className="flex items-center gap-2 text-sm font-medium">
         {icon}
-        {title}
+        <span className="flex-1">{title}</span>
+        {href ? (
+          external ? (
+            <ArrowUpRight className="text-fd-muted-foreground size-4 shrink-0 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+          ) : (
+            <ArrowRight className="text-fd-muted-foreground size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
+          )
+        ) : null}
       </span>
       {(description || children) && (
-        <span className="text-muted-foreground text-sm">
+        <span className="text-fd-muted-foreground text-sm">
           {description ?? children}
         </span>
       )}
     </>
   );
 
-  const className =
-    "flex flex-col gap-1 rounded-lg bg-fd-muted/50 p-4 transition-colors hover:bg-fd-muted";
-
   if (href) {
+    const className = `group ${base} transition-colors hover:border-fd-foreground/15 hover:bg-fd-muted/50`;
     if (external) {
       return (
         <a
@@ -55,7 +64,7 @@ export function Card({
     );
   }
 
-  return <div className={className}>{content}</div>;
+  return <div className={base}>{content}</div>;
 }
 
 export function Cards({ children }: { children: ReactNode }) {

--- a/apps/docs/components/docs/fumadocs/install/package-manager-tabs.tsx
+++ b/apps/docs/components/docs/fumadocs/install/package-manager-tabs.tsx
@@ -76,7 +76,7 @@ function CommandTabs({
   } = useAnimatedTabs({ activeIndex });
 
   return (
-    <div className="not-prose my-4 overflow-hidden rounded-xl bg-[oklch(0.97_0_0)] dark:bg-[oklch(0.16_0_0)]">
+    <div className="not-prose border-border bg-background my-4 overflow-hidden rounded-xl border">
       <div
         ref={containerRef}
         className="relative flex items-center gap-1 px-3 py-2"
@@ -127,7 +127,7 @@ function CommandTabs({
           </button>
         ))}
       </div>
-      <div className="[&_figure]:my-0! [&_figure]:rounded-none! [&_figure]:bg-transparent!">
+      <div className="bg-muted overflow-hidden rounded-t-lg [&_figure]:my-0! [&_figure]:rounded-none! [&_figure]:border-none! [&_figure]:bg-transparent!">
         <DynamicCodeBlock lang="bash" code={getCommand(pm)} />
       </div>
     </div>

--- a/apps/docs/components/docs/layout/docs-footer.tsx
+++ b/apps/docs/components/docs/layout/docs-footer.tsx
@@ -23,10 +23,10 @@ export function DocsFooter({ previous, next }: DocsFooterProps) {
       {previous ? (
         <Link
           href={previous.url}
-          className="group text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 transition-colors"
+          className="group text-muted-foreground hover:text-foreground inline-flex min-w-0 items-center gap-1.5 transition-colors"
         >
           <ChevronLeft className="size-4 shrink-0 transition-transform group-hover:-translate-x-0.5" />
-          <span>
+          <span className="min-w-0 truncate">
             {previous.section ? (
               <span className="opacity-60">{previous.section} / </span>
             ) : null}
@@ -40,9 +40,9 @@ export function DocsFooter({ previous, next }: DocsFooterProps) {
       {next ? (
         <Link
           href={next.url}
-          className="group text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 transition-colors"
+          className="group text-muted-foreground hover:text-foreground inline-flex min-w-0 items-center gap-1.5 transition-colors"
         >
-          <span>
+          <span className="min-w-0 truncate">
             {next.section ? (
               <span className="opacity-60">{next.section} / </span>
             ) : null}

--- a/apps/docs/components/docs/layout/docs-footer.tsx
+++ b/apps/docs/components/docs/layout/docs-footer.tsx
@@ -7,6 +7,7 @@ import type { ReactNode } from "react";
 type FooterItem = {
   name: ReactNode;
   url: string;
+  section?: ReactNode;
 };
 
 type DocsFooterProps = {
@@ -18,29 +19,39 @@ export function DocsFooter({ previous, next }: DocsFooterProps) {
   if (!previous && !next) return null;
 
   return (
-    <nav className="not-prose mt-16 grid grid-cols-1 gap-2 text-sm sm:grid-cols-2 sm:gap-3">
+    <nav className="not-prose mt-16 flex items-center justify-between gap-4 text-sm">
       {previous ? (
         <Link
           href={previous.url}
-          className="group bg-muted/50 hover:bg-muted flex items-center gap-2 rounded-lg px-4 py-3 transition-colors"
+          className="group text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 transition-colors"
         >
-          <ChevronLeft className="text-muted-foreground size-4 shrink-0 transition-transform group-hover:-translate-x-0.5" />
-          <span className="truncate">{previous.name}</span>
+          <ChevronLeft className="size-4 shrink-0 transition-transform group-hover:-translate-x-0.5" />
+          <span>
+            {previous.section ? (
+              <span className="opacity-60">{previous.section} / </span>
+            ) : null}
+            {previous.name}
+          </span>
         </Link>
       ) : (
-        <div />
+        <span />
       )}
 
       {next ? (
         <Link
           href={next.url}
-          className="group bg-muted/50 hover:bg-muted flex items-center justify-end gap-2 rounded-lg px-4 py-3 text-right transition-colors"
+          className="group text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 transition-colors"
         >
-          <span className="truncate">{next.name}</span>
-          <ChevronRight className="text-muted-foreground size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
+          <span>
+            {next.section ? (
+              <span className="opacity-60">{next.section} / </span>
+            ) : null}
+            {next.name}
+          </span>
+          <ChevronRight className="size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
         </Link>
       ) : (
-        <div />
+        <span />
       )}
     </nav>
   );

--- a/apps/docs/components/docs/layout/toc-hiring-banner.tsx
+++ b/apps/docs/components/docs/layout/toc-hiring-banner.tsx
@@ -15,7 +15,7 @@ export const TOCHiringBanner = () => {
     <div className="group relative">
       <Link
         href="/careers"
-        className="bg-muted hover:bg-accent block rounded-xl px-3.5 py-3 transition-colors"
+        className="border-border/60 bg-muted/30 hover:border-border hover:bg-muted/50 block rounded-xl border px-3.5 py-3 transition-colors"
       >
         <p className="shimmer text-foreground/80 text-[11px] font-medium tracking-wide uppercase">
           We are hiring
@@ -31,7 +31,7 @@ export const TOCHiringBanner = () => {
           e.preventDefault();
           setDismissed(true);
         }}
-        className="bg-background text-muted-foreground hover:text-foreground absolute -top-1.5 -right-1.5 flex size-5 items-center justify-center rounded-full opacity-0 shadow-sm transition-all group-hover:opacity-100"
+        className="border-border/60 bg-background text-muted-foreground hover:text-foreground absolute -top-1.5 -right-1.5 flex size-5 items-center justify-center rounded-full border opacity-0 transition-all group-hover:opacity-100"
       >
         <X className="size-3" />
       </button>

--- a/apps/docs/components/examples/base.tsx
+++ b/apps/docs/components/examples/base.tsx
@@ -6,6 +6,7 @@ import {
   UserMessageAttachments,
 } from "@/components/assistant-ui/attachment";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import { DotMatrix } from "@/components/assistant-ui/dot-matrix";
 import { MessageTiming } from "@/components/assistant-ui/message-timing";
 import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
 import {
@@ -656,6 +657,31 @@ const MessageError: FC = () => {
   );
 };
 
+const AssistantWorkingIndicator: FC = () => {
+  const isEmpty = useAuiState((s) => s.message.content.length === 0);
+  if (isEmpty) {
+    return (
+      <span
+        data-slot="aui_assistant-message-indicator"
+        className="text-muted-foreground inline-flex items-center gap-2 align-middle"
+        aria-label="Connecting"
+      >
+        <DotMatrix state="connecting" label="Connecting" />
+        <span className="text-sm">Connecting</span>
+      </span>
+    );
+  }
+  return (
+    <span
+      data-slot="aui_assistant-message-indicator"
+      className="animate-pulse font-sans"
+      aria-label="Assistant is working"
+    >
+      {"●"}
+    </span>
+  );
+};
+
 const AssistantMessage: FC = () => {
   // reserves space for action bar and compensates with `-mb` for consistent msg spacing
   // keeps hovered action bar from shifting layout (autohide doesn't support absolute positioning well)
@@ -712,15 +738,7 @@ const AssistantMessage: FC = () => {
               case "tool-call":
                 return part.toolUI ?? <ToolFallback {...part} />;
               case "indicator":
-                return (
-                  <span
-                    data-slot="aui_assistant-message-indicator"
-                    className="animate-pulse font-sans"
-                    aria-label="Assistant is working"
-                  >
-                    {"●"}
-                  </span>
-                );
+                return <AssistantWorkingIndicator />;
               case "data":
                 return part.dataRendererUI;
               default:

--- a/apps/docs/components/examples/base.tsx
+++ b/apps/docs/components/examples/base.tsx
@@ -664,9 +664,8 @@ const AssistantWorkingIndicator: FC = () => {
       <span
         data-slot="aui_assistant-message-indicator"
         className="text-muted-foreground inline-flex items-center gap-2 align-middle"
-        aria-label="Connecting"
       >
-        <DotMatrix state="connecting" label="Connecting" />
+        <DotMatrix state="connecting" aria-hidden />
         <span className="text-sm">Connecting</span>
       </span>
     );

--- a/apps/docs/content/docs/(docs)/architecture.mdx
+++ b/apps/docs/content/docs/(docs)/architecture.mdx
@@ -7,18 +7,19 @@ import { Sparkles, PanelsTopLeft, Database, Terminal } from "lucide-react";
 
 ## assistant-ui is built on these main pillars:
 
-<div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-    <Card title='1. Frontend components'>
-        Shadcn UI chat components with built-in state management
-    </Card>
-
-    <Card title='2. Runtime'>
-        State management layer connecting UI to LLMs and backend services
-    </Card>
-
-    <Card title='3. Assistant Cloud'>
-        Hosted service for thread persistence, history, and user management
-    </Card>
+<div className="not-prose grid grid-cols-1 gap-4 md:grid-cols-3">
+  <Card
+    title="1. Frontend components"
+    description="Shadcn UI chat components with built-in state management"
+  />
+  <Card
+    title="2. Runtime"
+    description="State management layer connecting UI to LLMs and backend services"
+  />
+  <Card
+    title="3. Assistant Cloud"
+    description="Hosted service for thread persistence, history, and user management"
+  />
 </div>
 
 

--- a/apps/docs/lib/docs-neighbours.ts
+++ b/apps/docs/lib/docs-neighbours.ts
@@ -1,0 +1,66 @@
+import type { Node, Root } from "fumadocs-core/page-tree";
+import type { ReactNode } from "react";
+
+export type DocsNeighbour = {
+  name: ReactNode;
+  url: string;
+  section?: ReactNode;
+};
+
+type Section = { id: string; name: ReactNode } | undefined;
+type FlatPage = { name: ReactNode; url: string; section: Section };
+
+/* fumadocs findNeighbour stops at root:true folder boundaries, so the last page of a section has no next. Flatten every section into one ordered list so navigation continues across sections, tagging each page with the section it belongs to. */
+function flatten(tree: Root): FlatPage[] {
+  const pages: FlatPage[] = [];
+  let rootCount = 0;
+  const walk = (nodes: Node[], section: Section) => {
+    for (const node of nodes) {
+      if (node.type === "page") {
+        pages.push({ name: node.name, url: node.url, section });
+      } else if (node.type === "folder") {
+        const childSection: Section = node.root
+          ? { id: `root-${rootCount++}`, name: node.name }
+          : section;
+        if (node.index) {
+          pages.push({
+            name: node.index.name,
+            url: node.index.url,
+            section: childSection,
+          });
+        }
+        walk(node.children, childSection);
+      }
+    }
+  };
+  walk(tree.children, undefined);
+  return pages;
+}
+
+export function getDocsNeighbours(
+  tree: Root,
+  url: string,
+): { previous?: DocsNeighbour | undefined; next?: DocsNeighbour | undefined } {
+  const pages = flatten(tree);
+  const index = pages.findIndex((page) => page.url === url);
+  if (index === -1) return {};
+  const current = pages[index]!;
+
+  const toNeighbour = (
+    page: FlatPage | undefined,
+  ): DocsNeighbour | undefined => {
+    if (!page) return undefined;
+    const crossesSection =
+      page.section != null && page.section.id !== current.section?.id;
+    return {
+      name: page.name,
+      url: page.url,
+      ...(crossesSection ? { section: page.section!.name } : {}),
+    };
+  };
+
+  return {
+    previous: toNeighbour(pages[index - 1]),
+    next: toNeighbour(pages[index + 1]),
+  };
+}

--- a/apps/docs/lib/github.ts
+++ b/apps/docs/lib/github.ts
@@ -128,6 +128,7 @@ export async function getCommitActivityStats(
 
 export type CommitListItem = {
   commit?: {
+    message?: string;
     author?: { date?: string };
     committer?: { date?: string };
   };
@@ -188,6 +189,117 @@ export async function getCommitStats(
     return { total: null, firstCommitDate: null };
   }
 }
+
+export type CoAuthor = {
+  name: string;
+  email: string;
+  id: number | null;
+  login: string | null;
+  count: number;
+};
+
+const CO_AUTHOR_RE = /co-authored-by:\s*([^<\n]+?)\s*<([^>]+)>/gi;
+const NOREPLY_RE = /^(?:(\d+)\+)?(.+)@users\.noreply\.github\.com$/i;
+
+const COMMIT_PAGE_CONCURRENCY = 8;
+const MAX_COMMIT_PAGES = 60;
+
+export async function getCommitCoAuthors(
+  revalidate: number = REVALIDATE.COOL,
+): Promise<CoAuthor[] | null> {
+  try {
+    const first = await ghFetch("/commits?per_page=100&page=1", revalidate);
+    if (!first.ok) return null;
+    const lastPage = Math.min(
+      parseLastPage(first.headers.get("Link")) ?? 1,
+      MAX_COMMIT_PAGES,
+    );
+    const pages: CommitListItem[][] = [
+      (await first.json()) as CommitListItem[],
+    ];
+
+    const rest: number[] = [];
+    for (let page = 2; page <= lastPage; page++) rest.push(page);
+    for (let i = 0; i < rest.length; i += COMMIT_PAGE_CONCURRENCY) {
+      const batch = await Promise.all(
+        rest.slice(i, i + COMMIT_PAGE_CONCURRENCY).map(async (page) => {
+          const res = await ghFetch(
+            `/commits?per_page=100&page=${page}`,
+            revalidate,
+          );
+          return res.ok ? ((await res.json()) as CommitListItem[]) : [];
+        }),
+      );
+      pages.push(...batch);
+    }
+
+    const byEmail = new Map<string, CoAuthor>();
+    for (const batch of pages) {
+      for (const item of batch) {
+        const message = item.commit?.message;
+        if (!message) continue;
+        for (const match of message.matchAll(CO_AUTHOR_RE)) {
+          const name = match[1]!.trim();
+          const email = match[2]!.trim().toLowerCase();
+          const existing = byEmail.get(email);
+          if (existing) {
+            existing.count++;
+          } else {
+            const noreply = email.match(NOREPLY_RE);
+            byEmail.set(email, {
+              name,
+              email,
+              id: noreply?.[1] ? Number(noreply[1]) : null,
+              login: noreply ? noreply[2]! : null,
+              count: 1,
+            });
+          }
+        }
+      }
+    }
+    return Array.from(byEmail.values());
+  } catch {
+    return null;
+  }
+}
+
+export type GitHubUser = {
+  login: string;
+  type: string;
+  avatarUrl: string;
+  htmlUrl: string;
+};
+
+async function fetchGitHubUser(
+  path: string,
+  revalidate: number,
+): Promise<GitHubUser | null> {
+  try {
+    const res = await fetch(
+      `https://api.github.com/${path}`,
+      revalidate === 0
+        ? { headers: ghHeaders(), cache: "no-store" }
+        : { headers: ghHeaders(), next: { revalidate } },
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (typeof data?.login !== "string") return null;
+    return {
+      login: data.login,
+      type: data.type,
+      avatarUrl: data.avatar_url,
+      htmlUrl: data.html_url,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export const getUser = (login: string, revalidate: number = REVALIDATE.COOL) =>
+  fetchGitHubUser(`users/${encodeURIComponent(login)}`, revalidate);
+
+export const getUserById = (id: number, revalidate: number = REVALIDATE.COOL) =>
+  fetchGitHubUser(`user/${id}`, revalidate);
 
 export type GitHubContributor = {
   login: string;

--- a/apps/docs/lib/github.ts
+++ b/apps/docs/lib/github.ts
@@ -28,19 +28,25 @@ function ghHeaders(extra?: HeadersInit): HeadersInit {
   return h;
 }
 
+const cacheInit = (
+  revalidate: number,
+): { cache: "no-store" } | { next: { revalidate: number } } =>
+  revalidate === 0 ? { cache: "no-store" } : { next: { revalidate } };
+
 async function ghFetch(
   path: string,
   revalidate: number,
   init?: RequestInit & { headers?: Record<string, string> },
 ): Promise<Response> {
   const { next: initNext, ...rest } = init ?? {};
-  const common = { ...rest, headers: ghHeaders(init?.headers) };
-  return fetch(
-    `${API_BASE}${path}`,
-    revalidate === 0
-      ? { ...common, cache: "no-store" }
-      : { ...common, next: { revalidate, ...(initNext ?? {}) } },
-  );
+  const cache = cacheInit(revalidate);
+  return fetch(`${API_BASE}${path}`, {
+    ...rest,
+    headers: ghHeaders(init?.headers),
+    ...("next" in cache
+      ? { next: { ...cache.next, ...(initNext ?? {}) } }
+      : cache),
+  });
 }
 
 function parseLastPage(linkHeader: string | null): number | null {
@@ -275,12 +281,10 @@ async function fetchGitHubUser(
   revalidate: number,
 ): Promise<GitHubUser | null> {
   try {
-    const res = await fetch(
-      `https://api.github.com/${path}`,
-      revalidate === 0
-        ? { headers: ghHeaders(), cache: "no-store" }
-        : { headers: ghHeaders(), next: { revalidate } },
-    );
+    const res = await fetch(`https://api.github.com/${path}`, {
+      headers: ghHeaders(),
+      ...cacheInit(revalidate),
+    });
     if (!res.ok) return null;
     const data = await res.json();
     if (typeof data?.login !== "string") return null;
@@ -367,9 +371,7 @@ export async function getDependents(
   try {
     const res = await fetch(`${HTML_BASE}/network/dependents`, {
       headers: { "User-Agent": "Mozilla/5.0 (assistant-ui-traction)" },
-      ...(revalidate === 0
-        ? { cache: "no-store" as const }
-        : { next: { revalidate } }),
+      ...cacheInit(revalidate),
     });
     if (!res.ok) return null;
     const html = await res.text();

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -1,10 +1,13 @@
 import {
   type GitHubContributor,
   getCommitActivityStats,
+  getCommitCoAuthors,
   getCommitsSince,
   getContributors,
   getReleases,
   getStargazersPage,
+  getUser,
+  getUserById,
 } from "./github";
 import { getDownloadsRange } from "./npm";
 
@@ -380,24 +383,6 @@ export async function fetchReleaseActivity(
 const isBot = (login: string, type?: string) =>
   type === "Bot" || /\[bot\]$/i.test(login);
 
-/* Bot accounts that are AI coding/docs agents, as opposed to CI and release automation (github-actions, blacksmith, dependabot, renovate, ...). Surfaced as "With AI" collaborators on the traction page; extend as new agents ship code. */
-const AI_BOT_LOGINS = new Set(
-  [
-    "Copilot",
-    "devin-ai-integration[bot]",
-    "promptless[bot]",
-    "dosubot[bot]",
-    "claude[bot]",
-    "cursor[bot]",
-    "coderabbitai[bot]",
-    "codegen-sh[bot]",
-    "sweep-ai[bot]",
-    "greptile-apps[bot]",
-    "ellipsis-dev[bot]",
-    "qodo-merge-pro[bot]",
-  ].map((login) => login.toLowerCase()),
-);
-
 const toContributor = (c: GitHubContributor): Contributor => ({
   login: c.login,
   avatarUrl: c.avatar_url,
@@ -413,16 +398,79 @@ export async function fetchContributors(
   return raw.filter((c) => !isBot(c.login, c.type)).map(toContributor);
 }
 
-export async function fetchAiContributors(
+/* Claude has no GitHub account, so it never resolves as a "Bot"; it is matched by the co-author email every model variant shares. */
+const CLAUDE_CO_AUTHOR_EMAIL = "noreply@anthropic.com";
+
+export async function fetchBotCoAuthors(
   revalidate?: number,
 ): Promise<Contributor[]> {
-  const raw = await getContributors(undefined, revalidate);
-  if (raw === null) return [];
-  return raw
-    .filter(
-      (c) => isBot(c.login, c.type) && AI_BOT_LOGINS.has(c.login.toLowerCase()),
-    )
-    .map(toContributor);
+  const coAuthors = await getCommitCoAuthors(revalidate);
+  if (coAuthors === null) return [];
+
+  let claudeCount = 0;
+  const accounts = new Map<
+    string,
+    { id: number | null; login: string | null; count: number }
+  >();
+  for (const author of coAuthors) {
+    if (author.email === CLAUDE_CO_AUTHOR_EMAIL) {
+      claudeCount += author.count;
+      continue;
+    }
+    if (author.id == null && author.login == null) continue;
+    const key =
+      author.id != null
+        ? `id:${author.id}`
+        : `login:${author.login!.toLowerCase()}`;
+    const entry = accounts.get(key);
+    if (entry) entry.count += author.count;
+    else
+      accounts.set(key, {
+        id: author.id,
+        login: author.login,
+        count: author.count,
+      });
+  }
+
+  const resolved = await Promise.all(
+    Array.from(accounts.values()).map(async ({ id, login, count }) => {
+      const user =
+        id != null
+          ? await getUserById(id, revalidate)
+          : await getUser(login!, revalidate);
+      if (!user || user.type !== "Bot") return null;
+      return {
+        login: user.login,
+        avatarUrl: user.avatarUrl,
+        htmlUrl: user.htmlUrl,
+        contributions: count,
+      } satisfies Contributor;
+    }),
+  );
+
+  // distinct app accounts can resolve to the same login (e.g. Copilot reviewer + swe-agent), so merge by login.
+  const byLogin = new Map<string, Contributor>();
+  for (const bot of resolved) {
+    if (!bot) continue;
+    const entry = byLogin.get(bot.login);
+    if (entry) entry.contributions += bot.contributions;
+    else byLogin.set(bot.login, { ...bot });
+  }
+  const result = Array.from(byLogin.values());
+
+  if (claudeCount > 0) {
+    const anthropic = await getUser("anthropics", revalidate);
+    if (anthropic) {
+      result.push({
+        login: "Claude",
+        avatarUrl: anthropic.avatarUrl,
+        htmlUrl: "https://claude.com",
+        contributions: claudeCount,
+      });
+    }
+  }
+
+  return result.sort((a, b) => b.contributions - a.contributions);
 }
 
 const EMPTY_DOWNLOADS: PackageDownloads = {

--- a/apps/docs/lib/traction.ts
+++ b/apps/docs/lib/traction.ts
@@ -460,14 +460,12 @@ export async function fetchBotCoAuthors(
 
   if (claudeCount > 0) {
     const anthropic = await getUser("anthropics", revalidate);
-    if (anthropic) {
-      result.push({
-        login: "Claude",
-        avatarUrl: anthropic.avatarUrl,
-        htmlUrl: "https://claude.com",
-        contributions: claudeCount,
-      });
-    }
+    result.push({
+      login: "Claude",
+      avatarUrl: anthropic?.avatarUrl ?? "/icons/anthropic.svg",
+      htmlUrl: "https://claude.com",
+      contributions: claudeCount,
+    });
   }
 
   return result.sort((a, b) => b.contributions - a.contributions);

--- a/apps/docs/styles/fumadocs.css
+++ b/apps/docs/styles/fumadocs.css
@@ -356,9 +356,9 @@ figure.shiki {
   margin-top: 1.25rem !important;
   margin-bottom: 1.25rem !important;
   border-radius: 0.75rem !important;
-  border: none !important;
+  border: 1px solid var(--border) !important;
   box-shadow: none !important;
-  background: var(--muted) !important;
+  background: var(--background) !important;
   overflow: hidden;
 
   /* Header with title */
@@ -366,7 +366,7 @@ figure.shiki {
     height: 2.25rem !important;
     padding-inline: 0.875rem !important;
     border-bottom: none !important;
-    background: transparent !important;
+    background: var(--background) !important;
   }
 
   & figcaption {
@@ -415,6 +415,13 @@ figure.shiki {
     padding-bottom: 0.875rem !important;
     font-size: 0.8125rem !important;
     line-height: 1.65 !important;
+    background: var(--muted) !important;
+  }
+
+  /* Code region top corners, when a title header sits above it */
+  &:has(figcaption) > div[role="region"] {
+    border-top-left-radius: 0.5rem !important;
+    border-top-right-radius: 0.5rem !important;
   }
 
   & pre {


### PR DESCRIPTION
## summary

- the /traction "with bot" row now derives bot collaborators from `co-authored-by:` commit trailers, resolving each one to a real GitHub bot account (by id or login) and surfacing Claude via the shared anthropic noreply email, replacing the hardcoded AI bot allowlist that went stale as new agents shipped.
- docs prev/next navigation now continues past section boundaries: the last page of a section links into the first page of the next, labelled with the section it crosses into, instead of dead-ending where fumadocs `findNeighbour` stops at root folders.
- the floating composer gained a hover-revealed dismiss button (persisted), and the assistant/example messages now use the DotMatrix connecting indicator instead of the spinner placeholder.
- refined cards (hairline border + directional arrow), code blocks, package-manager tabs, and the hiring banner onto the bordered token palette for a cleaner, more consistent docs surface.

## test plan

### already verified

- [x] `oxlint` + `oxfmt --check` clean across all 14 changed files
- [x] `tsc --noEmit -p apps/docs/tsconfig.json` -> 0 errors

### reviewer should verify

- [ ] /traction "with bot" row lists bot co-authors (including Claude) resolved from commit trailers, sorted by co-authored commit count
- [ ] the last page of a docs section shows a next link into the following section, prefixed with that section's name
- [ ] dismissing the floating composer hides it and the choice survives a reload

## notes

- co-author resolution scans up to the latest 6000 commits (60 pages of 100, fetched 8 at a time) and resolves each distinct account through the GitHub users API; results are cached on the page's revalidate window.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

