### PR TITLE
docs: add machine-readable pricing

### DIFF
--- a/apps/docs/app/(home)/pricing.md/route.ts
+++ b/apps/docs/app/(home)/pricing.md/route.ts
@@ -34,8 +34,7 @@ export function GET() {
   return new Response(`${markdown}\n`, {
     headers: {
       "Content-Type": "text/markdown; charset=utf-8",
-      "X-Robots-Tag": "index, follow",
+      "X-Robots-Tag": "noindex, follow",
     },
   });
 }
-

--- a/apps/docs/app/(home)/pricing.md/route.ts
+++ b/apps/docs/app/(home)/pricing.md/route.ts
@@ -1,0 +1,41 @@
+import { pricingPlans } from "../pricing/pricing-data";
+
+export const revalidate = false;
+
+const formatPlan = (plan: (typeof pricingPlans)[number]) => {
+  const price = plan.period ? `${plan.price}${plan.period}` : plan.price;
+
+  return [
+    `## ${plan.name}`,
+    "",
+    `Price: ${price}`,
+    `Description: ${plan.description}`,
+    "",
+    "Included:",
+    ...plan.features.map((feature) => `- ${feature}`),
+    "",
+    `CTA: ${plan.cta}`,
+    `URL: ${plan.href}`,
+  ].join("\n");
+};
+
+export function GET() {
+  const markdown = [
+    "# assistant-ui pricing",
+    "",
+    "assistant-ui is a free, MIT-licensed TypeScript/React library for AI chat. The commercial pricing below is for assistant-cloud, the fully managed backend for AI chat applications.",
+    "",
+    "MAU means Monthly Active Users who send at least one message.",
+    "B2C pricing is available by contacting b2c-pricing@assistant.dev.",
+    "",
+    ...pricingPlans.map(formatPlan),
+  ].join("\n\n");
+
+  return new Response(`${markdown}\n`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "X-Robots-Tag": "index, follow",
+    },
+  });
+}
+

--- a/apps/docs/app/(home)/pricing/page.tsx
+++ b/apps/docs/app/(home)/pricing/page.tsx
@@ -3,6 +3,7 @@ import { createOgMetadata } from "@/lib/og";
 import { Check } from "lucide-react";
 import { GitHubIcon } from "@/components/icons/github";
 import { PricingPlanCard } from "./pricing-plan-card";
+import { pricingPlans } from "./pricing-data";
 
 const title = "Pricing";
 const description = "Fully managed backend for AI chat applications";
@@ -12,50 +13,6 @@ export const metadata: Metadata = {
   description,
   ...createOgMetadata(title, description),
 };
-
-const plans = [
-  {
-    name: "Free",
-    price: "$0",
-    description: "Get started with the basics",
-    features: ["200 MAU included", "Chat history", "Thread management"],
-    cta: "Start free",
-    href: "https://cloud.assistant-ui.com/",
-    highlighted: false,
-  },
-  {
-    name: "Pro",
-    price: "$50",
-    period: "/mo",
-    description: "For growing applications",
-    features: [
-      "500 MAU included",
-      "$0.10 per additional MAU",
-      "Chat history",
-      "Thread management",
-      "Early access to new features",
-    ],
-    cta: "Get started",
-    href: "https://cloud.assistant-ui.com/",
-    highlighted: true,
-  },
-  {
-    name: "Enterprise",
-    price: "Custom",
-    description: "For large-scale deployments",
-    features: [
-      "Custom MAU pricing",
-      "Your own backend integration",
-      "Data replication",
-      "Dedicated support",
-      "99.99% uptime SLA",
-      "On-premises deployment",
-    ],
-    cta: "Contact sales",
-    href: "https://cal.com/simon-farshid/assistant-ui",
-    highlighted: false,
-  },
-];
 
 export default function PricingPage() {
   return (
@@ -82,7 +39,7 @@ export default function PricingPage() {
         </div>
 
         <div className="grid gap-6 md:grid-cols-3">
-          {plans.map((plan) => (
+          {pricingPlans.map((plan) => (
             <PricingPlanCard key={plan.name} plan={plan} />
           ))}
         </div>

--- a/apps/docs/app/(home)/pricing/pricing-data.ts
+++ b/apps/docs/app/(home)/pricing/pricing-data.ts
@@ -1,0 +1,54 @@
+export type PricingPlan = {
+  name: string;
+  price: string;
+  period?: string;
+  description: string;
+  features: string[];
+  cta: string;
+  href: string;
+  highlighted: boolean;
+};
+
+export const pricingPlans = [
+  {
+    name: "Free",
+    price: "$0",
+    description: "Get started with the basics",
+    features: ["200 MAU included", "Chat history", "Thread management"],
+    cta: "Start free",
+    href: "https://cloud.assistant-ui.com/",
+    highlighted: false,
+  },
+  {
+    name: "Pro",
+    price: "$50",
+    period: "/mo",
+    description: "For growing applications",
+    features: [
+      "500 MAU included",
+      "$0.10 per additional MAU",
+      "Chat history",
+      "Thread management",
+      "Early access to new features",
+    ],
+    cta: "Get started",
+    href: "https://cloud.assistant-ui.com/",
+    highlighted: true,
+  },
+  {
+    name: "Enterprise",
+    price: "Custom",
+    description: "For large-scale deployments",
+    features: [
+      "Custom MAU pricing",
+      "Your own backend integration",
+      "Data replication",
+      "Dedicated support",
+      "99.99% uptime SLA",
+      "On-premises deployment",
+    ],
+    cta: "Contact sales",
+    href: "https://cal.com/simon-farshid/assistant-ui",
+    highlighted: false,
+  },
+] satisfies PricingPlan[];

--- a/apps/docs/app/(home)/pricing/pricing-plan-card.tsx
+++ b/apps/docs/app/(home)/pricing/pricing-plan-card.tsx
@@ -4,17 +4,7 @@ import Link from "next/link";
 import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { analytics } from "@/lib/analytics";
-
-interface PricingPlan {
-  name: string;
-  price: string;
-  period?: string;
-  description: string;
-  features: string[];
-  cta: string;
-  href: string;
-  highlighted: boolean;
-}
+import type { PricingPlan } from "./pricing-data";
 
 export function PricingPlanCard({ plan }: { plan: PricingPlan }) {
   const handleClick = () => {

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -46,6 +46,13 @@ const config: NextConfig = {
         destination: "/llms.txt",
       },
       {
+        source: "/pricing",
+        has: [
+          { type: "header", key: "accept", value: "(?:.*text/markdown.*)" },
+        ],
+        destination: "/pricing.md",
+      },
+      {
         source: "/docs/:path*",
         has: [
           { type: "header", key: "accept", value: "(?:.*text/markdown.*)" },


### PR DESCRIPTION
## Summary
- add a /pricing.md route with the assistant-cloud pricing details in Markdown
- serve that Markdown from /pricing when clients request text/markdown
- share pricing plan data between the human pricing page and the Markdown endpoint

## Validation
- pnpm lint
- pnpm build

No changeset: docs app is private.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

