### PR TITLE
fix tap context tracking across roots

### DIFF
--- a/.changeset/tap-peer-ranges.md
+++ b/.changeset/tap-peer-ranges.md
@@ -1,0 +1,10 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/store": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+"@assistant-ui/react-devtools": patch
+---
+
+chore: update peer and dependency ranges for @assistant-ui/tap 0.9

--- a/.changeset/tap-root-context.md
+++ b/.changeset/tap-root-context.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/tap": patch
+"@assistant-ui/store": patch
+---
+
+fix: preserve tap context across nested tap root rerenders

--- a/.changeset/tap-root-context.md
+++ b/.changeset/tap-root-context.md
@@ -3,4 +3,4 @@
 "@assistant-ui/store": patch
 ---
 
-fix: preserve tap context across nested tap root rerenders
+fix: preserve tap context across nested tap root rerenders and mark tap context as supported

--- a/apps/docs/content/tap-docs/overview/roadmap.mdx
+++ b/apps/docs/content/tap-docs/overview/roadmap.mdx
@@ -7,4 +7,4 @@ description: Upcoming features and improvements.
 
 | Feature | Status | Description |
 |---|---|---|
-| Context API (stable) | Planned | The current Context API is experimental. A stable version will finalize the API for passing values through resource trees. |
+| Context API (stable) | Shipped in `@assistant-ui/tap` 0.9 | Tap context is no longer deprecated and preserves context across tap root boundaries. |

--- a/apps/docs/content/tap-docs/tap/api-reference.mdx
+++ b/apps/docs/content/tap-docs/tap/api-reference.mdx
@@ -133,29 +133,23 @@ trees (`createTapRoot` / `useTapRoot`); for `useResource` trees use
 flushTapSync(() => handle.getValue().increment());
 ```
 
-## createResourceContext
+## Context
 
-<Callout type="warn">
-The context API is experimental and may change.
-</Callout>
+Tap context uses regular React contexts and is supported as of `@assistant-ui/tap` 0.9.
 
-Creates a [context](/tap/docs/tap/context) with a default value. Read it
-with `use` / `useContext` from `"react"`.
+Create a [context](/tap/docs/tap/context) with `createContext` from `"react"`.
+Read it with `use` / `useContext` from `"react"`.
 
 ```ts
-const ThemeContext = createResourceContext("light");
+const ThemeContext = createContext("light");
 ```
 
-## withContextProvider
-
-<Callout type="warn">
-The context API is experimental and may change.
-</Callout>
+## useContextProvider
 
 Provides a context value to every resource rendered inside the callback.
 
 ```ts
-withContextProvider(ThemeContext, "dark", () => useResource(Button()));
+useContextProvider(ThemeContext, "dark", () => useResource(Button()));
 ```
 
 ## Types

--- a/apps/docs/content/tap-docs/tap/composition.mdx
+++ b/apps/docs/content/tap-docs/tap/composition.mdx
@@ -38,7 +38,7 @@ const Timer = resource(useTimer);
 The child re-renders when the element identity changes. The [React Compiler](https://react.dev/learn/react-compiler) keeps the element stable across renders when its props are unchanged, so the child only re-renders when its inputs actually change, no manual dependency tracking required.
 
 ```ts
-const result = useResource(Counter({ incrementBy }));
+const value = useResource(Counter({ incrementBy }));
 ```
 
 ## useResources

--- a/apps/docs/content/tap-docs/tap/context.mdx
+++ b/apps/docs/content/tap-docs/tap/context.mdx
@@ -3,20 +3,20 @@ title: Context
 description: Pass values through resource boundaries without prop drilling.
 ---
 
-<Callout type="warn">
-The context API is experimental and not yet stable. It may change significantly in a future version.
+<Callout type="info">
+Tap context is supported as of `@assistant-ui/tap` 0.9 and is no longer deprecated.
 </Callout>
 
 Context lets you pass values through the resource tree without threading props through every level, the same idea as React's `createContext` / `useContext`.
 
-## createResourceContext
+## createContext
 
 Create a context with a default value.
 
 ```ts
-import { createResourceContext } from "@assistant-ui/tap";
+import { createContext } from "react";
 
-const ThemeContext = createResourceContext("light");
+const ThemeContext = createContext("light");
 ```
 
 ## Reading context
@@ -34,15 +34,15 @@ const useButton = () => {
 const Button = resource(useButton);
 ```
 
-## withContextProvider
+## useContextProvider
 
 Provide a context value to all resources rendered within the callback.
 
 ```ts
-import { useResource, withContextProvider } from "@assistant-ui/tap";
+import { useContextProvider, useResource } from "@assistant-ui/tap";
 
 const useApp = () => {
-  const child = withContextProvider(ThemeContext, "dark", () => {
+  const child = useContextProvider(ThemeContext, "dark", () => {
     return useResource(Button());
   });
 
@@ -53,7 +53,3 @@ const App = resource(useApp);
 ```
 
 Any resource rendered inside the callback (including deeply nested children) reads `"dark"` from `ThemeContext`.
-
-<Callout type="warn">
-Context is not properly persisted across `useTapRoot` boundaries. If a child resource is wrapped with `useTapRoot`, it may not see context values provided by its ancestors. This is a known bug.
-</Callout>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "@assistant-ui/store": "^0.2.13",
-    "@assistant-ui/tap": "^0.8.0",
+    "@assistant-ui/tap": "^0.9.0",
     "@types/react": "*",
     "react": "^18 || ^19",
     "assistant-cloud": "^0.1.31",

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "@assistant-ui/react": "^0.14.14",
-    "@assistant-ui/tap": "^0.8.0",
+    "@assistant-ui/tap": "^0.9.0",
     "@types/react": "*",
     "@types/react-dom": "*",
     "react": "^18 || ^19",

--- a/packages/react-ink/package.json
+++ b/packages/react-ink/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@assistant-ui/core": "^0.2.15",
     "@assistant-ui/store": "^0.2.17",
-    "@assistant-ui/tap": "^0.8.1",
+    "@assistant-ui/tap": "^0.9.0",
     "assistant-stream": "^0.3.22",
     "diff": "^9.0.0",
     "ink-spinner": "^5.0.0",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@assistant-ui/core": "^0.2.15",
     "@assistant-ui/store": "^0.2.17",
-    "@assistant-ui/tap": "^0.8.1",
+    "@assistant-ui/tap": "^0.9.0",
     "assistant-stream": "^0.3.22",
     "zustand": "^5.0.14"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@assistant-ui/core": "^0.2.15",
     "@assistant-ui/store": "^0.2.17",
-    "@assistant-ui/tap": "^0.8.1",
+    "@assistant-ui/tap": "^0.9.0",
     "@radix-ui/primitive": "^1.1.4",
     "@radix-ui/react-compose-refs": "^1.1.3",
     "@radix-ui/react-context": "^1.1.4",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -35,7 +35,7 @@
     "use-effect-event": "^2.0.3"
   },
   "peerDependencies": {
-    "@assistant-ui/tap": "^0.8.0",
+    "@assistant-ui/tap": "^0.9.0",
     "@types/react": "*",
     "react": "^18 || ^19"
   },

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -36,7 +36,7 @@ import {
   type AssistantEventSelector,
 } from "./types/events";
 import { NotificationManager } from "./utils/NotificationManager";
-import { withAssistantTapContextProvider } from "./utils/tap-assistant-context";
+import { useAssistantTapContextProvider } from "./utils/tap-assistant-context";
 import { useClientResource } from "./useClientResource";
 import { getClientIndex } from "./utils/tap-client-stack-context";
 import {
@@ -58,7 +58,7 @@ const useRootClientResource = <K extends ClientNames>({
   emit: NotificationManager["emit"];
   clientRef: { parent: AssistantClient; current: AssistantClient | null };
 }) => {
-  const { methods, state } = withAssistantTapContextProvider(
+  const { methods, state } = useAssistantTapContextProvider(
     { clientRef, emit },
     function WithTapContext() {
       return useClientResource(element);

--- a/packages/store/src/useClientResource.ts
+++ b/packages/store/src/useClientResource.ts
@@ -3,7 +3,7 @@ import { resource, useResource, type ResourceElement } from "@assistant-ui/tap";
 import type { ClientMethods } from "./types/client";
 import {
   useClientStack,
-  useWithClientStack,
+  useClientStackProvider,
   SYMBOL_CLIENT_INDEX,
 } from "./utils/tap-client-stack-context";
 import {
@@ -144,7 +144,7 @@ export const useClientResource = <TMethods extends ClientMethods>(
     [index],
   );
 
-  const value = useWithClientStack(methods, function WithClientStack() {
+  const value = useClientStackProvider(methods, function WithClientStack() {
     return useResource(element);
   });
 

--- a/packages/store/src/utils/tap-assistant-context.ts
+++ b/packages/store/src/utils/tap-assistant-context.ts
@@ -1,6 +1,5 @@
-import { useEffectEvent, use } from "react";
-
-import { createResourceContext, withContextProvider } from "@assistant-ui/tap";
+import { useEffectEvent, use, createContext } from "react";
+import { useContextProvider } from "@assistant-ui/tap";
 import type {
   AssistantEventName,
   AssistantEventPayload,
@@ -19,14 +18,15 @@ export type AssistantTapContextValue = {
   emit: EmitFn;
 };
 
-const AssistantTapContext =
-  createResourceContext<AssistantTapContextValue | null>(null);
+const AssistantTapContext = createContext<AssistantTapContextValue | null>(
+  null,
+);
 
-export const withAssistantTapContextProvider = <TResult>(
+export const useAssistantTapContextProvider = <TResult>(
   value: AssistantTapContextValue,
   fn: () => TResult,
 ) => {
-  return withContextProvider(AssistantTapContext, value, fn);
+  return useContextProvider(AssistantTapContext, value, fn);
 };
 
 const useAssistantTapContext = () => {

--- a/packages/store/src/utils/tap-client-stack-context.ts
+++ b/packages/store/src/utils/tap-client-stack-context.ts
@@ -1,6 +1,6 @@
-import { useMemo, use } from "react";
+import { useMemo, use, createContext } from "react";
 
-import { createResourceContext, withContextProvider } from "@assistant-ui/tap";
+import { useContextProvider } from "@assistant-ui/tap";
 import type { ClientMethods } from "../types/client";
 
 /**
@@ -22,7 +22,7 @@ export const getClientIndex = (client: ClientMethods): number => {
  */
 export type ClientStack = readonly ClientMethods[];
 
-const ClientStackContext = createResourceContext<ClientStack>([]);
+const ClientStackContext = createContext<ClientStack>([]);
 
 /**
  * Get the current client stack inside a tap resource.
@@ -35,7 +35,7 @@ export const useClientStack = (): ClientStack => {
  * Execute a callback with a client pushed onto the stack.
  * The stack is duplicated, not mutated.
  */
-export const useWithClientStack = <T>(
+export const useClientStackProvider = <T>(
   client: ClientMethods,
   callback: () => T,
 ): T => {
@@ -44,5 +44,5 @@ export const useWithClientStack = <T>(
     () => [...currentStack, client],
     [currentStack, client],
   );
-  return withContextProvider(ClientStackContext, newStack, callback);
+  return useContextProvider(ClientStackContext, newStack, callback);
 };

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -60,7 +60,7 @@ function CounterButton() {
 
 ## Hooks
 
-Inside a resource you use React's hooks (`useState`, `useEffect`, `useMemo`, `useCallback`, `useRef`, `use`, ...) imported from `"react"`. tap adds `useResource` / `useResources` / `useTapRoot` for composition and `createResourceContext` / `withContextProvider` for context.
+Inside a resource you use React's hooks (`useState`, `useEffect`, `useMemo`, `useCallback`, `useRef`, `use`, ...) imported from `"react"`. tap adds `useResource` / `useResources` / `useTapRoot` for composition and `useContextProvider` for context.
 
 Full API reference at [assistant-ui.com/tap/docs](https://www.assistant-ui.com/tap/docs).
 

--- a/packages/tap/package.json
+++ b/packages/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/tap",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Reactive state management inspired by React hooks",
   "keywords": [
     "state-management",

--- a/packages/tap/src/__tests__/basic/tapReducer.basic.test.ts
+++ b/packages/tap/src/__tests__/basic/tapReducer.basic.test.ts
@@ -6,7 +6,7 @@ import {
   renderTest,
   cleanupAllResources,
   waitForNextTick,
-  getCommittedOutput,
+  getCommittedValue,
 } from "../test-utils";
 
 describe("useReducer - Basic Functionality", () => {
@@ -23,8 +23,8 @@ describe("useReducer - Basic Functionality", () => {
         return count;
       });
 
-      const result = renderTest(testFiber);
-      expect(result).toBe(0);
+      const value = renderTest(testFiber);
+      expect(value).toBe(0);
     });
 
     it("should initialize with init function", () => {
@@ -39,8 +39,8 @@ describe("useReducer - Basic Functionality", () => {
         return count;
       });
 
-      const result = renderTest(testFiber);
-      expect(result).toBe(20);
+      const value = renderTest(testFiber);
+      expect(value).toBe(20);
       expect(initCalled).toBe(1);
 
       // Re-render should not call init again
@@ -74,19 +74,19 @@ describe("useReducer - Basic Functionality", () => {
       });
 
       renderTest(testFiber);
-      expect(getCommittedOutput(testFiber)).toBe(0);
+      expect(getCommittedValue(testFiber)).toBe(0);
 
       dispatchFn!({ type: "increment" });
       await waitForNextTick();
-      expect(getCommittedOutput(testFiber)).toBe(1);
+      expect(getCommittedValue(testFiber)).toBe(1);
 
       dispatchFn!({ type: "increment" });
       await waitForNextTick();
-      expect(getCommittedOutput(testFiber)).toBe(2);
+      expect(getCommittedValue(testFiber)).toBe(2);
 
       dispatchFn!({ type: "decrement" });
       await waitForNextTick();
-      expect(getCommittedOutput(testFiber)).toBe(1);
+      expect(getCommittedValue(testFiber)).toBe(1);
     });
   });
 
@@ -139,19 +139,19 @@ describe("useReducer - Basic Functionality", () => {
       });
 
       renderTest(testFiber);
-      expect(getCommittedOutput(testFiber)).toBe(0);
+      expect(getCommittedValue(testFiber)).toBe(0);
 
       // Dispatch with multiplier=1
       dispatchFn!(5);
       await waitForNextTick();
-      expect(getCommittedOutput(testFiber)).toBe(5);
+      expect(getCommittedValue(testFiber)).toBe(5);
 
       // Change multiplier and dispatch
       multiplier = 10;
       renderTest(testFiber); // re-render to update reducer
       dispatchFn!(5);
       await waitForNextTick();
-      expect(getCommittedOutput(testFiber)).toBe(55); // 5 + 5*10
+      expect(getCommittedValue(testFiber)).toBe(55); // 5 + 5*10
     });
   });
 
@@ -171,14 +171,14 @@ describe("useReducer - Basic Functionality", () => {
       });
 
       renderTest(testFiber);
-      expect(getCommittedOutput(testFiber)).toBe(0);
+      expect(getCommittedValue(testFiber)).toBe(0);
 
       // Multiple dispatches
       dispatchFn!(1);
       dispatchFn!(2);
       dispatchFn!(3);
       await waitForNextTick();
-      expect(getCommittedOutput(testFiber)).toBe(6);
+      expect(getCommittedValue(testFiber)).toBe(6);
     });
   });
 

--- a/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
+++ b/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
@@ -65,8 +65,8 @@ describe("useResources - Basic Functionality", () => {
         return results;
       });
 
-      const result = renderTest(testFiber);
-      expect(result).toEqual([{ count: 10 }, { count: 20 }, { count: 30 }]);
+      const value = renderTest(testFiber);
+      expect(value).toEqual([{ count: 10 }, { count: 20 }, { count: 30 }]);
     });
 
     it("should work with resource constructor syntax", () => {
@@ -93,8 +93,8 @@ describe("useResources - Basic Functionality", () => {
         return results;
       });
 
-      const result = renderTest(testFiber);
-      expect(result).toEqual([
+      const value = renderTest(testFiber);
+      expect(value).toEqual([
         { count: 5, double: 10 },
         { count: 10, double: 20 },
         { count: 15, double: 30 },

--- a/packages/tap/src/__tests__/basic/tapState.basic.test.ts
+++ b/packages/tap/src/__tests__/basic/tapState.basic.test.ts
@@ -6,7 +6,7 @@ import {
   renderTest,
   cleanupAllResources,
   waitForNextTick,
-  getCommittedOutput,
+  getCommittedValue,
 } from "../test-utils";
 
 describe("useState - Basic Functionality", () => {
@@ -21,8 +21,8 @@ describe("useState - Basic Functionality", () => {
         return count;
       });
 
-      const result = renderTest(testFiber);
-      expect(result).toBe(42);
+      const value = renderTest(testFiber);
+      expect(value).toBe(42);
     });
 
     it("should initialize with lazy value function", () => {
@@ -37,8 +37,8 @@ describe("useState - Basic Functionality", () => {
       });
 
       // First render
-      const result = renderTest(testFiber);
-      expect(result).toBe(100);
+      const value = renderTest(testFiber);
+      expect(value).toBe(100);
       expect(initCalled).toBe(1);
 
       // Re-render should not call initializer again
@@ -52,8 +52,8 @@ describe("useState - Basic Functionality", () => {
         return value;
       });
 
-      const result = renderTest(testFiber);
-      expect(result).toBeUndefined();
+      const value = renderTest(testFiber);
+      expect(value).toBeUndefined();
     });
   });
 
@@ -85,7 +85,7 @@ describe("useState - Basic Functionality", () => {
       await waitForNextTick();
 
       // Check that state was updated
-      expect(getCommittedOutput(testFiber)).toEqual({
+      expect(getCommittedValue(testFiber)).toEqual({
         count: 10,
         renderCount: 2,
       });
@@ -136,19 +136,19 @@ describe("useState - Basic Functionality", () => {
 
       // Initial render
       renderTest(testFiber);
-      expect(getCommittedOutput(testFiber)).toBe(10);
+      expect(getCommittedValue(testFiber)).toBe(10);
 
       // Functional update
       setCountFn!((prev) => prev * 2);
 
       await waitForNextTick();
-      expect(getCommittedOutput(testFiber)).toBe(20);
+      expect(getCommittedValue(testFiber)).toBe(20);
 
       // Another functional update
       setCountFn!((prev) => prev + 5);
 
       await waitForNextTick();
-      expect(getCommittedOutput(testFiber)).toBe(25);
+      expect(getCommittedValue(testFiber)).toBe(25);
     });
   });
 
@@ -167,8 +167,8 @@ describe("useState - Basic Functionality", () => {
         };
       });
 
-      const result = renderTest(testFiber);
-      expect(result).toMatchObject({
+      const value = renderTest(testFiber);
+      expect(value).toMatchObject({
         count1: 1,
         count2: 2,
         text: "hello",
@@ -192,18 +192,18 @@ describe("useState - Basic Functionality", () => {
 
       // Initial render
       renderTest(testFiber);
-      expect(getCommittedOutput(testFiber)).toEqual({ a: "a", b: "b", c: "c" });
+      expect(getCommittedValue(testFiber)).toEqual({ a: "a", b: "b", c: "c" });
 
       // Update only B
       setters.setB("B");
       await waitForNextTick();
-      expect(getCommittedOutput(testFiber)).toEqual({ a: "a", b: "B", c: "c" });
+      expect(getCommittedValue(testFiber)).toEqual({ a: "a", b: "B", c: "c" });
 
       // Update A and C
       setters.setA("A");
       setters.setC("C");
       await waitForNextTick();
-      expect(getCommittedOutput(testFiber)).toEqual({ a: "A", b: "B", c: "C" });
+      expect(getCommittedValue(testFiber)).toEqual({ a: "A", b: "B", c: "C" });
     });
   });
 

--- a/packages/tap/src/__tests__/basic/useSyncExternalStore.test.ts
+++ b/packages/tap/src/__tests__/basic/useSyncExternalStore.test.ts
@@ -6,7 +6,7 @@ import {
   renderTest,
   cleanupAllResources,
   waitForNextTick,
-  getCommittedOutput,
+  getCommittedValue,
 } from "../test-utils";
 
 const createStore = <T>(initial: T) => {
@@ -57,7 +57,7 @@ describe("useSyncExternalStore", () => {
     renderTest(testFiber);
     store.setState(2);
     await waitForNextTick();
-    expect(getCommittedOutput(testFiber)).toBe(2);
+    expect(getCommittedValue(testFiber)).toBe(2);
   });
 
   it("does not re-render when the snapshot is Object.is-equal", async () => {
@@ -89,7 +89,7 @@ describe("useSyncExternalStore", () => {
     expect(renderTest(testFiber)).toBe("server");
     // the mount effect detects the mismatch and re-renders with the client read
     await waitForNextTick();
-    expect(getCommittedOutput(testFiber)).toBe("client");
+    expect(getCommittedValue(testFiber)).toBe("client");
   });
 
   it("does not re-render when server and client snapshots match", async () => {
@@ -140,11 +140,11 @@ describe("useSyncExternalStore", () => {
     // storeA changes no longer reach the resource
     storeA.setState("a2");
     await waitForNextTick();
-    expect(getCommittedOutput(testFiber)).toBe("b");
+    expect(getCommittedValue(testFiber)).toBe("b");
 
     storeB.setState("b2");
     await waitForNextTick();
-    expect(getCommittedOutput(testFiber)).toBe("b2");
+    expect(getCommittedValue(testFiber)).toBe("b2");
 
     cleanupAllResources();
     expect(storeB.unsubscribeCalls).toBe(1);

--- a/packages/tap/src/__tests__/bench/memo-hooks.bench.tsx
+++ b/packages/tap/src/__tests__/bench/memo-hooks.bench.tsx
@@ -11,7 +11,7 @@ import { createElement, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { flushSync } from "react-dom";
 import { createTapRoot, flushTapSync } from "@assistant-ui/tap";
-import { c } from "@assistant-ui/tap/react-shim/compiler-runtime";
+import { c } from "../../react-shim/compiler-runtime";
 import { useRenderMemo } from "../../hooks/utils/useRenderMemo";
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = false;
@@ -172,7 +172,7 @@ const reactUseRenderMemoStable = (): Host => {
 
     let sum = 0;
     for (let i = 0; i < N; i++) {
-      sum += useRenderMemo(() => i, [i]);
+      sum += useRenderMemo(() => i, [i], false);
     }
     return sum;
   }
@@ -195,7 +195,7 @@ const tapUseRenderMemoStable = (): Host => {
 
     let sum = 0;
     for (let i = 0; i < N; i++) {
-      sum += useRenderMemo(() => i, [i]);
+      sum += useRenderMemo(() => i, [i], false);
     }
     return sum;
   });

--- a/packages/tap/src/__tests__/errors/errors.effect-errors.test.ts
+++ b/packages/tap/src/__tests__/errors/errors.effect-errors.test.ts
@@ -39,15 +39,15 @@ describe("Errors - Effect Errors", () => {
     });
 
     // First render and commit - establishes the effect
-    const ctx1 = renderResourceFiber(resource, []);
-    commitResourceFiber(resource, ctx1);
+    renderResourceFiber(resource, []);
+    commitResourceFiber(resource);
 
     // Change dep to trigger cleanup on next render
     dep = 1;
 
     // Second render with different dep should trigger cleanup that throws
-    const ctx2 = renderResourceFiber(resource, []);
-    expect(() => commitResourceFiber(resource, ctx2)).toThrow(error);
+    renderResourceFiber(resource, []);
+    expect(() => commitResourceFiber(resource)).toThrow(error);
   });
 
   it("should throw on invalid effect return value", () => {

--- a/packages/tap/src/__tests__/errors/errors.render-errors.test.ts
+++ b/packages/tap/src/__tests__/errors/errors.render-errors.test.ts
@@ -50,7 +50,7 @@ describe("Errors - Render Errors", () => {
       return count;
     });
 
-    expect(renderResourceFiber(resource, []).value).toBe(5);
+    expect(renderResourceFiber(resource, [])).toBe(5);
   });
 
   it("should throw when updating a different resource during render", () => {
@@ -117,9 +117,9 @@ describe("Errors - Render Errors", () => {
       return count;
     });
 
-    const ctx = renderResourceFiber(resource, []);
+    renderResourceFiber(resource, []);
     // This should not throw - setState in effects is allowed
-    expect(() => commitResourceFiber(resource, ctx)).not.toThrow();
+    expect(() => commitResourceFiber(resource)).not.toThrow();
     unmountResourceFiber(resource);
   });
 
@@ -160,8 +160,8 @@ describe("Errors - Render Errors", () => {
     });
 
     // First successful render
-    const result = renderTest(resource);
-    expect(result).toBe(42);
+    const value = renderTest(resource);
+    expect(value).toBe(42);
 
     // Failed render
     shouldThrow = true;
@@ -227,7 +227,7 @@ describe("Errors - Render Errors", () => {
       return feature;
     });
 
-    const result = renderTest(resource);
-    expect(result).toBe("feature");
+    const value = renderTest(resource);
+    expect(value).toBe("feature");
   });
 });

--- a/packages/tap/src/__tests__/lifecycle/lifecycle.dependencies.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/lifecycle.dependencies.test.ts
@@ -78,8 +78,8 @@ describe("Lifecycle - Dependencies", () => {
 
     // Change dep
     setDep(2);
-    const ctx = renderResourceFiber(resource, []);
-    commitResourceFiber(resource, ctx);
+    renderResourceFiber(resource, []);
+    commitResourceFiber(resource);
 
     expect(log).toEqual(["effect-1", "cleanup-1", "effect-2"]);
   });
@@ -124,8 +124,8 @@ describe("Lifecycle - Dependencies", () => {
 
     // Re-render
     triggerRerender(1);
-    const ctx = renderResourceFiber(resource, []);
-    commitResourceFiber(resource, ctx);
+    renderResourceFiber(resource, []);
+    commitResourceFiber(resource);
 
     expect(effect).toHaveBeenCalledTimes(1); // Should not re-run
   });
@@ -145,27 +145,27 @@ describe("Lifecycle - Dependencies", () => {
     });
 
     // Initial render
-    let ctx = renderResourceFiber(resource, []);
-    commitResourceFiber(resource, ctx);
+    renderResourceFiber(resource, []);
+    commitResourceFiber(resource);
     expect(effect).toHaveBeenCalledTimes(1);
 
     // Change first dep
     setDep1("b");
-    ctx = renderResourceFiber(resource, []);
-    commitResourceFiber(resource, ctx);
+    renderResourceFiber(resource, []);
+    commitResourceFiber(resource);
     expect(effect).toHaveBeenCalledTimes(2);
 
     // Change second dep
     setDep2(2);
-    ctx = renderResourceFiber(resource, []);
-    commitResourceFiber(resource, ctx);
+    renderResourceFiber(resource, []);
+    commitResourceFiber(resource);
     expect(effect).toHaveBeenCalledTimes(3);
 
     // Change both deps
     setDep1("c");
     setDep2(3);
-    ctx = renderResourceFiber(resource, []);
-    commitResourceFiber(resource, ctx);
+    renderResourceFiber(resource, []);
+    commitResourceFiber(resource);
     expect(effect).toHaveBeenCalledTimes(4);
 
     unmountResourceFiber(resource);
@@ -188,8 +188,8 @@ describe("Lifecycle - Dependencies", () => {
 
     // Set to new object with same shape
     setObj({ value: 1 });
-    const ctx = renderResourceFiber(resource, []);
-    commitResourceFiber(resource, ctx);
+    renderResourceFiber(resource, []);
+    commitResourceFiber(resource);
 
     expect(effect).toHaveBeenCalledTimes(2); // Should re-run (different object)
   });
@@ -210,9 +210,9 @@ describe("Lifecycle - Dependencies", () => {
     expect(effect).toHaveBeenCalledTimes(1);
 
     // Set to NaN again
-    const ctx = renderResourceFiber(resource, []);
+    renderResourceFiber(resource, []);
     setValue(NaN);
-    commitResourceFiber(resource, ctx);
+    commitResourceFiber(resource);
 
     expect(effect).toHaveBeenCalledTimes(1); // Should not re-run (NaN === NaN in Object.is)
   });

--- a/packages/tap/src/__tests__/lifecycle/lifecycle.mount-unmount.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/lifecycle.mount-unmount.test.ts
@@ -120,17 +120,17 @@ describe("Lifecycle - Mount/Unmount", () => {
     });
 
     // Initial render
-    const ctx = renderResourceFiber(resource, []);
+    renderResourceFiber(resource, []);
     expect(log).toEqual(["render"]);
 
     // Commit - effects will run
-    commitResourceFiber(resource, ctx);
+    commitResourceFiber(resource);
     // After commit: initial render + effects
     expect(log).toEqual(["render", "effect-1", "effect-2"]);
 
     // The setState in effect schedules a re-render; trigger it manually
-    const ctx2 = renderResourceFiber(resource, []);
-    commitResourceFiber(resource, ctx2);
+    renderResourceFiber(resource, []);
+    commitResourceFiber(resource);
 
     // Now we should see the re-render and cleanup/re-run of effects
     expect(log).toEqual([
@@ -200,8 +200,8 @@ describe("Lifecycle - Mount/Unmount", () => {
       return null;
     });
 
-    const ctx = renderResourceFiber(resource, []);
-    commitResourceFiber(resource, ctx);
+    renderResourceFiber(resource, []);
+    commitResourceFiber(resource);
     unmountResourceFiber(resource);
 
     expect(effect).toHaveBeenCalledTimes(1);

--- a/packages/tap/src/__tests__/parity/parity.basics.test.tsx
+++ b/packages/tap/src/__tests__/parity/parity.basics.test.tsx
@@ -67,9 +67,9 @@ const scenarios: Scenario[] = [
       const countRef = useRef(0);
       const [state, dispatch] = useReducer((s: number, _a: number) => {
         countRef.current++;
-        const result = countRef.current * 100;
-        log(`reducer-${countRef.current} state=${s} -> ${result}`);
-        return result;
+        const value = countRef.current * 100;
+        log(`reducer-${countRef.current} state=${s} -> ${value}`);
+        return value;
       }, 0);
       log(`render state=${state}`);
       return { dispatch };

--- a/packages/tap/src/__tests__/react-dispatcher.test.ts
+++ b/packages/tap/src/__tests__/react-dispatcher.test.ts
@@ -9,7 +9,7 @@ import type { MemoCell } from "../core/types";
 import {
   createTestResource,
   renderTest,
-  getCommittedOutput,
+  getCommittedValue,
   cleanupAllResources,
   waitForNextTick,
 } from "./test-utils";
@@ -33,7 +33,7 @@ describe("react dispatcher", () => {
     expect(renderTest(fiber)).toBe(10);
     set(42);
     await waitForNextTick();
-    expect(getCommittedOutput(fiber)).toBe(42);
+    expect(getCommittedValue(fiber)).toBe(42);
   });
 
   it("routes React.useMemo with deps memoization", () => {
@@ -68,7 +68,7 @@ describe("react dispatcher", () => {
     expect(renderTest(fiber, { x: 1 })).toEqual({ run: 1, value: 1 });
 
     setRootVersion(fiber.root, 1);
-    expect(renderResourceFiber(fiber, [{ x: 2 }]).value).toEqual({
+    expect(renderResourceFiber(fiber, [{ x: 2 }])).toEqual({
       run: 2,
       value: 2,
     });
@@ -91,16 +91,16 @@ describe("react dispatcher", () => {
 
     expect(renderTest(fiber, { x: 1 })).toEqual({ run: 1, value: 1 });
 
-    expect(renderResourceFiber(fiber, [{ x: 2 }]).value).toEqual({
+    expect(renderResourceFiber(fiber, [{ x: 2 }])).toEqual({
       run: 2,
       value: 2,
     });
     const replayed = renderResourceFiber(fiber, [{ x: 2 }]);
-    commitResourceFiber(fiber, replayed);
+    commitResourceFiber(fiber);
 
     const cell = fiber.cells[0] as MemoCell;
     expect(cell.isDirty).toBe(false);
-    expect(cell.current).toBe(replayed.value);
+    expect(cell.current).toBe(replayed);
     expect(cell.currentDeps).toEqual([2]);
   });
 

--- a/packages/tap/src/__tests__/react/concurrent-mode.test.tsx
+++ b/packages/tap/src/__tests__/react/concurrent-mode.test.tsx
@@ -24,8 +24,8 @@ describe("Concurrent Mode with useResource", () => {
     });
 
     function Suspender() {
-      const result = use(suspendPromise);
-      return result;
+      const value = use(suspendPromise);
+      return value;
     }
 
     function App() {
@@ -86,8 +86,8 @@ describe("Concurrent Mode with useResource", () => {
     });
 
     function Suspender() {
-      const result = use(suspendPromise);
-      return result;
+      const value = use(suspendPromise);
+      return value;
     }
 
     function App() {
@@ -156,8 +156,8 @@ describe("Concurrent Mode with useResource", () => {
     const TestResource = resource(useTestResource);
 
     function Inner({ id }: { id: number }) {
-      const result = useResource(TestResource({ id }));
-      return <div data-testid="result">{result.value}</div>;
+      const value = useResource(TestResource({ id }));
+      return <div data-testid="result">{value.value}</div>;
     }
 
     function App() {
@@ -204,8 +204,8 @@ describe("Concurrent Mode with useResource", () => {
     });
 
     function Suspender() {
-      const result = use(suspendPromise);
-      return result;
+      const value = use(suspendPromise);
+      return value;
     }
 
     function App() {

--- a/packages/tap/src/__tests__/react/react-shim.test.tsx
+++ b/packages/tap/src/__tests__/react/react-shim.test.tsx
@@ -1,4 +1,5 @@
-import { describe, it, expect, afterEach } from "vitest";
+import React from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, screen, act, cleanup } from "@testing-library/react";
 import {
   createTestResource,
@@ -9,17 +10,21 @@ import {
 } from "../test-utils";
 import {
   createContext,
+  use,
   useContext,
   useState,
   useEffect,
 } from "../../react-shim";
 import { useContextProvider } from "../../core/context";
+import { renderResourceFiber } from "../../core/ResourceFiber";
+import { use as tapUse } from "../../react-hooks/use";
 import { c as _c } from "../../react-shim/compiler-runtime";
 
 const SENTINEL = Symbol.for("react.memo_cache_sentinel");
 
 describe("@assistant-ui/tap/react-shim", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     cleanupAllResources();
     cleanup();
   });
@@ -37,6 +42,38 @@ describe("@assistant-ui/tap/react-shim", () => {
 
       expect(renderTest(defaultFiber)).toBe("default");
       expect(renderTest(providedFiber, "tap")).toBe("tap");
+    });
+
+    it("registers provided React contexts created outside the shim", () => {
+      const TestContext = React.createContext("default");
+      const defaultFiber = createTestResource(() => use(TestContext));
+      const testFiber = createTestResource((value: string) => {
+        return useContextProvider(TestContext, value, () => use(TestContext));
+      });
+
+      expect(renderTest(defaultFiber)).toBe("default");
+      expect(renderTest(testFiber, "tap")).toBe("tap");
+    });
+
+    it("forwards non-context use values to React.use", () => {
+      const promise = Promise.resolve("react");
+      const useSpy = vi
+        .spyOn(React, "use")
+        .mockImplementation(() => "react-use");
+      const testFiber = createTestResource(() => use(promise));
+
+      expect(renderTest(testFiber)).toBe("react-use");
+      expect(useSpy).toHaveBeenCalledWith(promise);
+
+      useSpy.mockRestore();
+    });
+
+    it("rejects non-context values in tap's direct use hook", () => {
+      const testFiber = createTestResource(() => tapUse(Promise.resolve()));
+
+      expect(() => renderResourceFiber(testFiber, [])).toThrow(
+        "A tap resource's `use()` only accepts a tap context.",
+      );
     });
 
     it("useState routes to useState and useEffect to useEffect", async () => {

--- a/packages/tap/src/__tests__/react/react-shim.test.tsx
+++ b/packages/tap/src/__tests__/react/react-shim.test.tsx
@@ -5,7 +5,7 @@ import {
   createTestResource,
   renderTest,
   cleanupAllResources,
-  getCommittedOutput,
+  getCommittedValue,
   waitForNextTick,
 } from "../test-utils";
 import {
@@ -53,6 +53,19 @@ describe("@assistant-ui/tap/react-shim", () => {
 
       expect(renderTest(defaultFiber)).toBe("default");
       expect(renderTest(testFiber, "tap")).toBe("tap");
+
+      const ProviderFirstContext = React.createContext("default");
+      const providerFirstFiber = createTestResource((value: string) => {
+        return useContextProvider(ProviderFirstContext, value, () =>
+          use(ProviderFirstContext),
+        );
+      });
+      const providerFirstDefaultFiber = createTestResource(() =>
+        use(ProviderFirstContext),
+      );
+
+      expect(renderTest(providerFirstFiber, "tap")).toBe("tap");
+      expect(renderTest(providerFirstDefaultFiber)).toBe("default");
     });
 
     it("forwards non-context use values to React.use", () => {
@@ -90,12 +103,12 @@ describe("@assistant-ui/tap/react-shim", () => {
       });
 
       renderTest(testFiber);
-      expect(getCommittedOutput(testFiber)).toBe(0);
+      expect(getCommittedValue(testFiber)).toBe(0);
       expect(effectLog).toEqual([0]);
 
       setCount!(5);
       await waitForNextTick();
-      expect(getCommittedOutput(testFiber)).toBe(5);
+      expect(getCommittedValue(testFiber)).toBe(5);
       expect(effectLog).toEqual([0, 5]);
     });
 

--- a/packages/tap/src/__tests__/react/react-shim.test.tsx
+++ b/packages/tap/src/__tests__/react/react-shim.test.tsx
@@ -7,7 +7,13 @@ import {
   getCommittedOutput,
   waitForNextTick,
 } from "../test-utils";
-import { useState, useEffect } from "../../react-shim";
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+} from "../../react-shim";
+import { useContextProvider } from "../../core/context";
 import { c as _c } from "../../react-shim/compiler-runtime";
 
 const SENTINEL = Symbol.for("react.memo_cache_sentinel");
@@ -19,6 +25,21 @@ describe("@assistant-ui/tap/react-shim", () => {
   });
 
   describe("inside a tap resource", () => {
+    it("uses shim-created React contexts as tap contexts", () => {
+      const TestContext = createContext("default");
+
+      const testFiber = createTestResource((value: string | null) => {
+        if (value === null) return useContext(TestContext);
+
+        return useContextProvider(TestContext, value, () =>
+          useContext(TestContext),
+        );
+      });
+
+      expect(renderTest(testFiber, null)).toBe("default");
+      expect(renderTest(testFiber, "tap")).toBe("tap");
+    });
+
     it("useState routes to useState and useEffect to useEffect", async () => {
       let setCount: ((n: number) => void) | null = null;
       const effectLog: number[] = [];
@@ -69,6 +90,31 @@ describe("@assistant-ui/tap/react-shim", () => {
   });
 
   describe("inside a React component", () => {
+    it("uses shim-created contexts as regular React contexts", () => {
+      const TestContext = createContext("default");
+
+      function App({ value }: { value?: string }) {
+        const text = useContext(TestContext);
+        if (value === undefined) return <div data-testid="out">{text}</div>;
+
+        return (
+          <TestContext.Provider value={value}>
+            <Child />
+          </TestContext.Provider>
+        );
+      }
+
+      function Child() {
+        return <div data-testid="out">{useContext(TestContext)}</div>;
+      }
+
+      const { rerender } = render(<App />);
+      expect(screen.getByTestId("out").textContent).toBe("default");
+
+      rerender(<App value="react" />);
+      expect(screen.getByTestId("out").textContent).toBe("react");
+    });
+
     it("useState routes to React.useState", () => {
       function Counter() {
         const [count, setCount] = useState(0);

--- a/packages/tap/src/__tests__/react/react-shim.test.tsx
+++ b/packages/tap/src/__tests__/react/react-shim.test.tsx
@@ -28,16 +28,15 @@ describe("@assistant-ui/tap/react-shim", () => {
     it("uses shim-created React contexts as tap contexts", () => {
       const TestContext = createContext("default");
 
-      const testFiber = createTestResource((value: string | null) => {
-        if (value === null) return useContext(TestContext);
-
+      const defaultFiber = createTestResource(() => useContext(TestContext));
+      const providedFiber = createTestResource((value: string) => {
         return useContextProvider(TestContext, value, () =>
           useContext(TestContext),
         );
       });
 
-      expect(renderTest(testFiber, null)).toBe("default");
-      expect(renderTest(testFiber, "tap")).toBe("tap");
+      expect(renderTest(defaultFiber)).toBe("default");
+      expect(renderTest(providedFiber, "tap")).toBe("tap");
     });
 
     it("useState routes to useState and useEffect to useEffect", async () => {

--- a/packages/tap/src/__tests__/react/useResource.test.tsx
+++ b/packages/tap/src/__tests__/react/useResource.test.tsx
@@ -181,6 +181,27 @@ describe("@assistant-ui/tap/react resource API", () => {
       expect(values).toEqual([5, 0]);
       expect(renders).toEqual({ a: 2, b: 1 });
     });
+
+    it("re-renders a child with unchanged deps when its tap context changes", () => {
+      const TestContext = createContext("default");
+      let renders = 0;
+
+      const useItem = () => {
+        renders++;
+        return useResourceContext(TestContext);
+      };
+      const Item = resource(useItem);
+
+      const parent = createTestResource((value: string) =>
+        useContextProvider(TestContext, value, () =>
+          useResources([withKey("item", Item(), [])]),
+        ),
+      );
+
+      expect(renderTest(parent, "a")).toEqual(["a"]);
+      expect(renderTest(parent, "b")).toEqual(["b"]);
+      expect(renders).toBe(2);
+    });
   });
 
   describe("useTapRoot", () => {

--- a/packages/tap/src/__tests__/react/useResource.test.tsx
+++ b/packages/tap/src/__tests__/react/useResource.test.tsx
@@ -15,7 +15,10 @@ import {
   useResources,
   useTapRoot,
   flushTapSync,
+  useContextProvider,
 } from "../../index";
+import { use as useResourceContext } from "../../react-hooks/use";
+import { createContext } from "../../react-shim";
 
 describe("@assistant-ui/tap/react resource API", () => {
   afterEach(() => {
@@ -193,6 +196,39 @@ describe("@assistant-ui/tap/react resource API", () => {
         }).getValue(),
       );
       expect(renderTest(parent)).toBe(7);
+    });
+
+    it("rerenders nested tap roots in their last committed tap context", () => {
+      const TestContext = createContext("default");
+
+      let increment: (() => void) | null = null;
+      const useRoot = () => {
+        const context = useResourceContext(TestContext) as string;
+        const [count, setCount] = useResourceState(0);
+        increment = () => setCount((c: number) => c + 1);
+        return `${context}:${count}`;
+      };
+
+      let store: useTapRoot.Root<string> | null = null;
+      const parent = createTestResource((context: string) =>
+        useContextProvider(TestContext, context, () => {
+          store = useTapRoot(function Root() {
+            return useRoot();
+          });
+          return store.getValue();
+        }),
+      );
+
+      expect(renderTest(parent, "a")).toBe("a:0");
+
+      flushTapSync(() => increment!());
+      expect(store!.getValue()).toBe("a:1");
+
+      renderTest(parent, "b");
+      expect(store!.getValue()).toBe("b:1");
+
+      flushTapSync(() => increment!());
+      expect(store!.getValue()).toBe("b:2");
     });
 
     // A root is push-based: host it in one place and observe it via getValue/

--- a/packages/tap/src/__tests__/react/useResource.test.tsx
+++ b/packages/tap/src/__tests__/react/useResource.test.tsx
@@ -199,7 +199,9 @@ describe("@assistant-ui/tap/react resource API", () => {
       );
 
       expect(renderTest(parent, "a")).toEqual(["a"]);
+      expect(parent.contextDeps).toBeNull();
       expect(renderTest(parent, "b")).toEqual(["b"]);
+      expect(parent.contextDeps).toBeNull();
       expect(renders).toBe(2);
     });
   });

--- a/packages/tap/src/__tests__/rules/rules.hook-order.test.ts
+++ b/packages/tap/src/__tests__/rules/rules.hook-order.test.ts
@@ -93,8 +93,8 @@ describe("Rules of Hooks - Hook Order", () => {
       return states;
     });
 
-    const result = renderTest(resource);
-    expect(result).toEqual([1, 2, 3]);
+    const value = renderTest(resource);
+    expect(value).toEqual([1, 2, 3]);
 
     // Re-render should work fine
     expect(() => renderResourceFiber(resource, [])).not.toThrow();
@@ -131,12 +131,12 @@ describe("Rules of Hooks - Hook Order", () => {
       return { a, b, c };
     });
 
-    const result = renderTest(resource);
-    expect(result).toEqual({ a: 1, b: 2, c: 3 });
+    const value = renderTest(resource);
+    expect(value).toEqual({ a: 1, b: 2, c: 3 });
 
     // Re-render should maintain same order
-    const ctx = renderResourceFiber(resource, []);
-    expect(() => commitResourceFiber(resource, ctx)).not.toThrow();
+    renderResourceFiber(resource, []);
+    expect(() => commitResourceFiber(resource)).not.toThrow();
   });
 
   it("should detect early return causing different hook counts", () => {

--- a/packages/tap/src/__tests__/strictmode/strictmode-parity.test.tsx
+++ b/packages/tap/src/__tests__/strictmode/strictmode-parity.test.tsx
@@ -173,9 +173,9 @@ const scenarios: Scenario[] = [
       const countRef = useRef(0);
       const [state, dispatch] = useReducer((s: number, _a: number) => {
         countRef.current++;
-        const result = countRef.current * 100;
-        log(`reducer-${countRef.current} state=${s} -> ${result}`);
-        return result;
+        const value = countRef.current * 100;
+        log(`reducer-${countRef.current} state=${s} -> ${value}`);
+        return value;
       }, 0);
       log(`render state=${state}`);
       return { dispatch };

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -23,9 +23,9 @@ export function createTestResource<R, A extends readonly unknown[]>(
     // Re-render when state changes
     if (activeResources.has(fiber)) {
       const lastArgs = propsMap.get(fiber);
-      const result = renderResourceFiber(fiber, lastArgs);
-      lastRenderResultMap.set(fiber, result);
-      commitResourceFiber(fiber, result);
+      const value = renderResourceFiber(fiber, lastArgs);
+      lastRenderValueMap.set(fiber, value);
+      commitResourceFiber(fiber);
     }
   };
 
@@ -41,7 +41,7 @@ export function createTestResource<R, A extends readonly unknown[]>(
 // Track resources for cleanup
 const activeResources = new Set<ResourceFiber<any, any>>();
 const propsMap = new WeakMap<ResourceFiber<any, any>, any>();
-const lastRenderResultMap = new WeakMap<ResourceFiber<any, any>, any>();
+const lastRenderValueMap = new WeakMap<ResourceFiber<any, any>, any>();
 
 /**
  * Renders a test resource fiber with the given props and manages its lifecycle.
@@ -60,13 +60,13 @@ export function renderTest<R, A extends readonly unknown[]>(
   // Render with new args. Record the result before committing: the commit can
   // synchronously trigger a nested re-render whose newer result must not be
   // clobbered afterwards.
-  const result = renderResourceFiber(fiber, args);
-  lastRenderResultMap.set(fiber, result);
-  commitResourceFiber(fiber, result);
+  const value = renderResourceFiber(fiber, args);
+  lastRenderValueMap.set(fiber, value);
+  commitResourceFiber(fiber);
 
   // Return the committed state from the result
   // This accounts for any re-renders that happened during commit
-  return result.value;
+  return value;
 }
 
 /**
@@ -93,16 +93,15 @@ export function cleanupAllResources() {
  * Gets the current committed state of a resource fiber.
  * Returns the state from the last render/commit cycle.
  */
-export function getCommittedOutput<R, A extends readonly unknown[]>(
+export function getCommittedValue<R, A extends readonly unknown[]>(
   fiber: ResourceFiber<R, A>,
 ): R {
-  const lastResult = lastRenderResultMap.get(fiber);
-  if (!lastResult) {
+  if (!lastRenderValueMap.has(fiber)) {
     throw new Error(
       "No render result found for fiber. Make sure to call renderResource first.",
     );
   }
-  return lastResult.value;
+  return lastRenderValueMap.get(fiber);
 }
 
 /**
@@ -118,10 +117,10 @@ export class TestSubscriber<T> {
     this.fiber = fiber;
     // Need to render once to get initial state
     const lastArgs = propsMap.get(fiber) ?? [];
-    const initialResult = renderResourceFiber(fiber, lastArgs as any);
-    commitResourceFiber(fiber, initialResult);
-    this.lastState = initialResult.value;
-    lastRenderResultMap.set(fiber, initialResult);
+    const initialValue = renderResourceFiber(fiber, lastArgs as any);
+    commitResourceFiber(fiber);
+    this.lastState = initialValue;
+    lastRenderValueMap.set(fiber, initialValue);
     activeResources.add(fiber);
   }
 
@@ -150,10 +149,10 @@ export class TestResourceManager<R, A extends readonly unknown[]> {
     this.isActive = true;
     activeResources.add(this.fiber);
     propsMap.set(this.fiber, args);
-    const result = renderResourceFiber(this.fiber, args);
-    commitResourceFiber(this.fiber, result);
-    lastRenderResultMap.set(this.fiber, result);
-    return result.value;
+    const value = renderResourceFiber(this.fiber, args);
+    commitResourceFiber(this.fiber);
+    lastRenderValueMap.set(this.fiber, value);
+    return value;
   }
 
   cleanup() {

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -1,5 +1,5 @@
 import type { ResourceFiber, RenderResult, TapRoot } from "./types";
-import { withTapRootContext } from "./context";
+import { bubbleContextDeps } from "./context";
 import {
   commitAllCallbacks,
   createCommitCallbacks,
@@ -22,6 +22,8 @@ export function createResourceFiber<R, A extends readonly unknown[]>(
     markDirty,
     devStrictMode: strictMode,
     cells: [],
+    contextDeps: null,
+    wipContextDeps: null,
     memoCache: {
       current: null,
       workInProgress: null,
@@ -49,7 +51,6 @@ export function unmountResourceFiber<R, A extends readonly unknown[]>(
 export function renderResourceFiber<R, A extends readonly unknown[]>(
   fiber: ResourceFiber<R, A>,
   args: Readonly<A>,
-  context = fiber.root.context,
 ): RenderResult {
   fiber.memoCache.workInProgress = null;
 
@@ -71,22 +72,21 @@ export function renderResourceFiber<R, A extends readonly unknown[]>(
 
     result = {
       commitCallbacks: createCommitCallbacks(),
-      context,
       value: undefined as R | undefined,
     };
     fiber.memoCache.index = 0;
 
-    withTapRootContext(fiber.root, context, () => {
-      withResourceFiber(fiber, () => {
-        fiber.renderContext = result;
-        try {
-          result.value = withReactDispatcher(() => fiber.hook(...args));
-        } finally {
-          fiber.renderContext = undefined;
-        }
-      });
+    withResourceFiber(fiber, () => {
+      fiber.renderContext = result;
+      try {
+        result.value = withReactDispatcher(() => fiber.hook(...args));
+      } finally {
+        fiber.renderContext = undefined;
+      }
     });
   } while ((fiber.renderPendingCells?.size ?? 0) > 0);
+
+  bubbleContextDeps(fiber);
 
   return result;
 }
@@ -96,6 +96,7 @@ export function commitResourceFiber<R, A extends readonly unknown[]>(
   result: RenderResult,
 ): void {
   fiber.isMounted = true;
+  fiber.contextDeps = fiber.wipContextDeps;
   commitRoot(fiber.root);
 
   if (fiber.memoCache.workInProgress !== null) {

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -1,4 +1,5 @@
-import type { ResourceFiber, RenderResult, ResourceFiberRoot } from "./types";
+import type { ResourceFiber, RenderResult, TapRoot } from "./types";
+import { withTapRootContext } from "./context";
 import {
   commitAllCallbacks,
   createCommitCallbacks,
@@ -11,7 +12,7 @@ import { commitRoot } from "./helpers/root";
 
 export function createResourceFiber<R, A extends readonly unknown[]>(
   hook: (...args: A) => R,
-  root: ResourceFiberRoot,
+  root: TapRoot,
   markDirty: (() => void) | undefined = undefined,
   strictMode: "root" | "child" | null,
 ): ResourceFiber<R, A> {
@@ -48,6 +49,7 @@ export function unmountResourceFiber<R, A extends readonly unknown[]>(
 export function renderResourceFiber<R, A extends readonly unknown[]>(
   fiber: ResourceFiber<R, A>,
   args: Readonly<A>,
+  context = fiber.root.context,
 ): RenderResult {
   fiber.memoCache.workInProgress = null;
 
@@ -69,17 +71,20 @@ export function renderResourceFiber<R, A extends readonly unknown[]>(
 
     result = {
       commitCallbacks: createCommitCallbacks(),
+      context,
       value: undefined as R | undefined,
     };
     fiber.memoCache.index = 0;
 
-    withResourceFiber(fiber, () => {
-      fiber.renderContext = result;
-      try {
-        result.value = withReactDispatcher(() => fiber.hook(...args));
-      } finally {
-        fiber.renderContext = undefined;
-      }
+    withTapRootContext(fiber.root, context, () => {
+      withResourceFiber(fiber, () => {
+        fiber.renderContext = result;
+        try {
+          result.value = withReactDispatcher(() => fiber.hook(...args));
+        } finally {
+          fiber.renderContext = undefined;
+        }
+      });
     });
   } while ((fiber.renderPendingCells?.size ?? 0) > 0);
 

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -1,10 +1,6 @@
-import type { ResourceFiber, RenderResult, TapRoot } from "./types";
+import type { ResourceFiber, TapRoot } from "./types";
 import { bubbleContextDeps } from "./context";
-import {
-  commitAllCallbacks,
-  createCommitCallbacks,
-  cleanupAllEffects,
-} from "./helpers/commit";
+import { commitAllCallbacks, cleanupAllEffects } from "./helpers/commit";
 import { withResourceFiber } from "./helpers/execution-context";
 import { withReactDispatcher } from "./react-dispatcher";
 import { isDevelopment } from "./helpers/env";
@@ -24,6 +20,8 @@ export function createResourceFiber<R, A extends readonly unknown[]>(
     cells: [],
     contextDeps: null,
     wipContextDeps: null,
+    commitCallbacks: null,
+    wipCommitCallbacks: null,
     memoCache: {
       current: null,
       workInProgress: null,
@@ -31,7 +29,6 @@ export function createResourceFiber<R, A extends readonly unknown[]>(
     },
     renderPendingCells: null,
     currentIndex: 0,
-    renderContext: undefined,
     isFirstRender: true,
     isMounted: false,
     isNeverMounted: true,
@@ -51,7 +48,7 @@ export function unmountResourceFiber<R, A extends readonly unknown[]>(
 export function renderResourceFiber<R, A extends readonly unknown[]>(
   fiber: ResourceFiber<R, A>,
   args: Readonly<A>,
-): RenderResult {
+): R {
   fiber.memoCache.workInProgress = null;
 
   // Discard render-phase actions left by a previous render
@@ -61,7 +58,7 @@ export function renderResourceFiber<R, A extends readonly unknown[]>(
   }
 
   let passes = 0;
-  let result: RenderResult;
+  let value: R;
   do {
     if (++passes > 25) {
       throw new Error(
@@ -69,32 +66,26 @@ export function renderResourceFiber<R, A extends readonly unknown[]>(
           "an infinite loop.",
       );
     }
-
-    result = {
-      commitCallbacks: createCommitCallbacks(),
-      value: undefined as R | undefined,
-    };
     fiber.memoCache.index = 0;
 
     withResourceFiber(fiber, () => {
-      fiber.renderContext = result;
-      try {
-        result.value = withReactDispatcher(() => fiber.hook(...args));
-      } finally {
-        fiber.renderContext = undefined;
-      }
+      value = withReactDispatcher(() => fiber.hook(...args));
     });
   } while ((fiber.renderPendingCells?.size ?? 0) > 0);
 
   bubbleContextDeps(fiber);
 
-  return result;
+  return value!;
 }
 
 export function commitResourceFiber<R, A extends readonly unknown[]>(
   fiber: ResourceFiber<R, A>,
-  result: RenderResult,
 ): void {
+  const commitCallbacks =
+    fiber.wipCommitCallbacks ?? fiber.commitCallbacks ?? [];
+  fiber.wipCommitCallbacks = null;
+  fiber.commitCallbacks = commitCallbacks;
+
   fiber.isMounted = true;
   fiber.contextDeps = fiber.wipContextDeps;
   commitRoot(fiber.root);
@@ -107,10 +98,10 @@ export function commitResourceFiber<R, A extends readonly unknown[]>(
   if (isDevelopment && fiber.isNeverMounted && fiber.devStrictMode === "root") {
     fiber.isNeverMounted = false;
 
-    commitAllCallbacks(result.commitCallbacks);
+    commitAllCallbacks(commitCallbacks);
     cleanupAllEffects(fiber);
   }
 
   fiber.isNeverMounted = false;
-  commitAllCallbacks(result.commitCallbacks);
+  commitAllCallbacks(commitCallbacks);
 }

--- a/packages/tap/src/core/context.ts
+++ b/packages/tap/src/core/context.ts
@@ -25,7 +25,7 @@ const asTap = <T>(context: ReactContext<T>): TapContext<T> =>
   context as unknown as TapContext<T>;
 
 let currentContext: ResourceContext = new Map();
-const changedContexts = new Map<object, true>();
+const changedContexts = new Set<object>();
 
 export const cloneCurrentTapContext = (): ResourceContext =>
   new Map(currentContext);
@@ -98,7 +98,7 @@ export const useContextProvider = <T, TResult>(
 ) => {
   if (typeof context !== "object" || context === null)
     throw new Error("useContextProvider only accepts a React context.");
-  if (!isTapContext(context)) attachDefaultValueToContext(context, value);
+  assertTapContext(context);
 
   const key = context as object;
   const currentFiber = getCurrentResourceFiber();
@@ -134,7 +134,7 @@ const withChangedContext = <T>(
   const restoreChangedContext = changedContexts.has(context);
 
   if (didChange) {
-    changedContexts.set(context, true);
+    changedContexts.add(context);
   } else {
     changedContexts.delete(context);
   }
@@ -143,7 +143,7 @@ const withChangedContext = <T>(
     return fn();
   } finally {
     if (restoreChangedContext) {
-      changedContexts.set(context, true);
+      changedContexts.add(context);
     } else {
       changedContexts.delete(context);
     }

--- a/packages/tap/src/core/context.ts
+++ b/packages/tap/src/core/context.ts
@@ -1,50 +1,97 @@
 import type { Context as ReactContext } from "react";
+import type { ResourceContext, TapRoot } from "./types";
+import { peekResourceFiber } from "./helpers/execution-context";
 
-const contextValue: unique symbol = Symbol("tap.Context");
-type TapContext<T> = {
-  [contextValue]: T;
+const defaultContextValue: unique symbol = Symbol("tap.Context.defaultValue");
+type TapContext<T> = ReactContext<T> & {
+  [defaultContextValue]: T;
 };
 
 const asTap = <T>(context: ReactContext<T>): TapContext<T> =>
   context as unknown as TapContext<T>;
 
-// A tap resource context is typed as a React `Context<T>` purely so React's
-// `use(context)` accepts it (the type is erased, so this adds no runtime react
-// dependency). At runtime it is only a branded `{ [contextValue]: T }` and is
-// not a usable React context — `use()` routes it to `useResourceContext()` via the brand.
+let ambientContext: ResourceContext = new Map();
+
+const getCurrentTapContext = (): ResourceContext => {
+  const fiber = peekResourceFiber();
+  if (fiber) return fiber.root.context;
+
+  return ambientContext;
+};
+
+export const cloneCurrentTapContext = (): ResourceContext =>
+  new Map(getCurrentTapContext());
+
+export const withTapRootContext = <TResult>(
+  root: TapRoot,
+  context: ResourceContext,
+  fn: () => TResult,
+) => {
+  const previousContext = root.context;
+  root.context = context;
+  try {
+    return fn();
+  } finally {
+    root.context = previousContext;
+  }
+};
+
+// Tap uses regular React contexts. The shim attaches the default value here so
+// the same context object can be read from tap renders without involving
+// React's context stack.
+export const attachDefaultValueToContext = <T>(
+  context: ReactContext<T>,
+  defaultValue: T,
+) => {
+  (context as TapContext<T>)[defaultContextValue] = defaultValue;
+};
+
+const ensureTapContext = (context: unknown) => {
+  // TODO fitler out promises and stores
+  if (
+    typeof context === "object" &&
+    context !== null &&
+    defaultContextValue in context
+  )
+    return;
+
+  attachDefaultValueToContext(
+    context as ReactContext<unknown>,
+    (context as any)._currentValue2,
+  );
+};
+
 /**
  * @deprecated experimental — the resource context API is not yet stable and may
  * change or be removed in a future release.
  */
-export const createResourceContext = <T>(defaultValue: T): ReactContext<T> => {
-  return {
-    [contextValue]: defaultValue,
-  } as unknown as ReactContext<T>;
-};
-
-export const isResourceContext = (value: unknown): boolean => {
-  return typeof value === "object" && value !== null && contextValue in value;
-};
-
-/**
- * @deprecated experimental — the resource context API is not yet stable and may
- * change or be removed in a future release.
- */
-export const withContextProvider = <T, TResult>(
+export const useContextProvider = <T, TResult>(
   context: ReactContext<T>,
   value: T,
   fn: () => TResult,
 ) => {
-  const tapContext = asTap(context);
-  const previousValue = tapContext[contextValue];
-  tapContext[contextValue] = value;
+  const resourceContext = getCurrentTapContext();
+  const key = context as object;
+  const previousValue = resourceContext.get(key);
+  const hadPreviousValue = previousValue || resourceContext.has(key);
+
+  resourceContext.set(key, value);
   try {
     return fn();
   } finally {
-    tapContext[contextValue] = previousValue;
+    if (hadPreviousValue) {
+      resourceContext.set(key, previousValue);
+    } else {
+      resourceContext.delete(key);
+    }
   }
 };
 
-export const useResourceContext = <T>(context: ReactContext<T>) => {
-  return asTap(context)[contextValue];
+export const useTapContext = <T>(context: ReactContext<T>) => {
+  ensureTapContext(context);
+
+  const resourceContext = getCurrentTapContext();
+  return resourceContext.has(context as object)
+    ? (resourceContext.get(context as object) as T)
+    : asTap(context)[defaultContextValue];
 };

--- a/packages/tap/src/core/context.ts
+++ b/packages/tap/src/core/context.ts
@@ -1,6 +1,9 @@
 import type { Context as ReactContext } from "react";
-import type { ResourceContext, TapRoot } from "./types";
-import { peekResourceFiber } from "./helpers/execution-context";
+import type { ResourceContext, ResourceFiber, TapRoot } from "./types";
+import {
+  getCurrentResourceFiber,
+  peekResourceFiber,
+} from "./helpers/execution-context";
 
 const defaultContextValue: unique symbol = Symbol("tap.Context.defaultValue");
 type TapContext<T> = ReactContext<T> & {
@@ -10,29 +13,21 @@ type TapContext<T> = ReactContext<T> & {
 const asTap = <T>(context: ReactContext<T>): TapContext<T> =>
   context as unknown as TapContext<T>;
 
-let ambientContext: ResourceContext = new Map();
-
-const getCurrentTapContext = (): ResourceContext => {
-  const fiber = peekResourceFiber();
-  if (fiber) return fiber.root.context;
-
-  return ambientContext;
-};
+let currentContext: ResourceContext = new Map();
 
 export const cloneCurrentTapContext = (): ResourceContext =>
-  new Map(getCurrentTapContext());
+  new Map(currentContext);
 
-export const withTapRootContext = <TResult>(
-  root: TapRoot,
+export const withTapContextRoot = <TResult>(
   context: ResourceContext,
   fn: () => TResult,
 ) => {
-  const previousContext = root.context;
-  root.context = context;
+  const previousContext = currentContext;
+  currentContext = context;
   try {
     return fn();
   } finally {
-    root.context = previousContext;
+    currentContext = previousContext;
   }
 };
 
@@ -70,19 +65,19 @@ export const useContextProvider = <T, TResult>(
   value: T,
   fn: () => TResult,
 ) => {
-  const resourceContext = getCurrentTapContext();
   const key = context as object;
-  const previousValue = resourceContext.get(key);
-  const hadPreviousValue = previousValue || resourceContext.has(key);
+  const previousValue = currentContext.get(key);
+  const hadPreviousValue =
+    previousValue !== undefined || currentContext.has(key);
 
-  resourceContext.set(key, value);
+  currentContext.set(key, value);
   try {
     return fn();
   } finally {
     if (hadPreviousValue) {
-      resourceContext.set(key, previousValue);
+      currentContext.set(key, previousValue);
     } else {
-      resourceContext.delete(key);
+      currentContext.delete(key);
     }
   }
 };
@@ -90,8 +85,33 @@ export const useContextProvider = <T, TResult>(
 export const useTapContext = <T>(context: ReactContext<T>) => {
   ensureTapContext(context);
 
-  const resourceContext = getCurrentTapContext();
-  return resourceContext.has(context as object)
-    ? (resourceContext.get(context as object) as T)
+  const key = context as object;
+  const value = currentContext.has(key)
+    ? currentContext.get(key)
     : asTap(context)[defaultContextValue];
+  const currentFiber = getCurrentResourceFiber();
+  (currentFiber.wipContextDeps ??= new Map()).set(key, value);
+  return value as T;
+};
+
+export const bubbleContextDeps = (fiber: ResourceFiber<any>) => {
+  const currentFiber = peekResourceFiber();
+  if (!currentFiber?.wipContextDeps || !fiber.wipContextDeps) return;
+
+  for (const [context, value] of fiber.wipContextDeps) {
+    // TODO instead of always forwarding, there should be context source tracking
+    // if context source of a context dep is this current fiber, don't bubble it up
+    currentFiber?.wipContextDeps.set(context, value);
+  }
+};
+
+export const hasContextDepsChanged = (fiber: ResourceFiber<any, any[]>) => {
+  if (!fiber.contextDeps) return false;
+
+  for (const [context, previousValue] of fiber.contextDeps) {
+    const currentValue = currentContext.get(context);
+    if (!Object.is(previousValue, currentValue)) return true;
+  }
+
+  return false;
 };

--- a/packages/tap/src/core/context.ts
+++ b/packages/tap/src/core/context.ts
@@ -63,10 +63,6 @@ const ensureTapContext = (context: unknown) => {
   );
 };
 
-/**
- * @deprecated experimental — the resource context API is not yet stable and may
- * change or be removed in a future release.
- */
 export const useContextProvider = <T, TResult>(
   context: ReactContext<T>,
   value: T,
@@ -91,7 +87,7 @@ export const useContextProvider = <T, TResult>(
     return withChangedContext(key, didChange, fn);
   } finally {
     if (hadPreviousValue) {
-      currentContext.set(key, previousValue);
+      currentContext.set(key, previousValue!);
     } else {
       currentContext.delete(key);
     }

--- a/packages/tap/src/core/context.ts
+++ b/packages/tap/src/core/context.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import type {
   ResourceContext,
   ResourceContextDeps,
+  ResourceContextValue,
   ResourceFiber,
 } from "./types";
 import {
@@ -72,6 +73,7 @@ export const useContextProvider = <T, TResult>(
   fn: () => TResult,
 ) => {
   const key = context as object;
+  const currentFiber = getCurrentResourceFiber();
   const committedValueRef = useRef<{ value: T } | undefined>(undefined);
   const didChange =
     committedValueRef.current === undefined ||
@@ -83,7 +85,7 @@ export const useContextProvider = <T, TResult>(
   const previousValue = currentContext.get(key);
   const hadPreviousValue =
     previousValue !== undefined || currentContext.has(key);
-  currentContext.set(key, value);
+  currentContext.set(key, { value, source: currentFiber });
 
   try {
     return withChangedContext(key, didChange, fn);
@@ -124,26 +126,35 @@ export const useTapContext = <T>(context: ReactContext<T>) => {
   ensureTapContext(context);
 
   const key = context as object;
-  const value = getCurrentContextValue(key);
+  const contextValue = getCurrentContextValue(key, context);
   const currentFiber = getCurrentResourceFiber();
-  (currentFiber.wipContextDeps ??= new Set()).add(key);
-  return value as T;
+  (currentFiber.wipContextDeps ??= new Map()).set(key, contextValue.source);
+  return contextValue.value as T;
 };
 
-const getCurrentContextValue = (context: object) =>
-  currentContext.has(context)
-    ? currentContext.get(context)
-    : asTap(context as ReactContext<unknown>)[defaultContextValue];
+const getCurrentContextValue = <T>(
+  key: object,
+  context: ReactContext<T>,
+): ResourceContextValue =>
+  currentContext.get(key) ?? {
+    value: asTap(context)[defaultContextValue],
+    source: null,
+  };
 
 const mergeContextDeps = (
+  targetFiber: ResourceFiber<any>,
+  sourceFiber: ResourceFiber<any>,
   target: ResourceContextDeps | null,
   source: ResourceContextDeps | null,
 ) => {
   if (!source) return target;
 
-  const next = target ?? new Set();
-  for (const context of source) {
-    next.add(context);
+  let next = target;
+  for (const [context, providerFiber] of source) {
+    if (providerFiber === sourceFiber || providerFiber === targetFiber) {
+      continue;
+    }
+    (next ??= new Map()).set(context, providerFiber);
   }
   return next;
 };
@@ -155,9 +166,9 @@ export const bubbleContextDeps = (
   const currentFiber = peekResourceFiber();
   if (!currentFiber || !contextDeps) return;
 
-  // TODO instead of always forwarding, there should be context source tracking
-  // if context source of a context dep is this current fiber, don't bubble it up
   currentFiber.wipContextDeps = mergeContextDeps(
+    currentFiber,
+    fiber,
     currentFiber.wipContextDeps,
     contextDeps,
   );

--- a/packages/tap/src/core/context.ts
+++ b/packages/tap/src/core/context.ts
@@ -1,5 +1,10 @@
 import type { Context as ReactContext } from "react";
-import type { ResourceContext, ResourceFiber, TapRoot } from "./types";
+import { useEffect, useRef } from "react";
+import type {
+  ResourceContext,
+  ResourceContextDeps,
+  ResourceFiber,
+} from "./types";
 import {
   getCurrentResourceFiber,
   peekResourceFiber,
@@ -14,6 +19,7 @@ const asTap = <T>(context: ReactContext<T>): TapContext<T> =>
   context as unknown as TapContext<T>;
 
 let currentContext: ResourceContext = new Map();
+const changedContexts = new Map<object, true>();
 
 export const cloneCurrentTapContext = (): ResourceContext =>
   new Map(currentContext);
@@ -66,13 +72,21 @@ export const useContextProvider = <T, TResult>(
   fn: () => TResult,
 ) => {
   const key = context as object;
+  const committedValueRef = useRef<{ value: T } | undefined>(undefined);
+  const didChange =
+    committedValueRef.current === undefined ||
+    !Object.is(committedValueRef.current.value, value);
+  useEffect(() => {
+    committedValueRef.current = { value };
+  }, [value]);
+
   const previousValue = currentContext.get(key);
   const hadPreviousValue =
     previousValue !== undefined || currentContext.has(key);
-
   currentContext.set(key, value);
+
   try {
-    return fn();
+    return withChangedContext(key, didChange, fn);
   } finally {
     if (hadPreviousValue) {
       currentContext.set(key, previousValue);
@@ -82,35 +96,80 @@ export const useContextProvider = <T, TResult>(
   }
 };
 
+const withChangedContext = <T>(
+  context: object,
+  didChange: boolean,
+  fn: () => T,
+) => {
+  const restoreChangedContext = changedContexts.has(context);
+
+  if (didChange) {
+    changedContexts.set(context, true);
+  } else {
+    changedContexts.delete(context);
+  }
+
+  try {
+    return fn();
+  } finally {
+    if (restoreChangedContext) {
+      changedContexts.set(context, true);
+    } else {
+      changedContexts.delete(context);
+    }
+  }
+};
+
 export const useTapContext = <T>(context: ReactContext<T>) => {
   ensureTapContext(context);
 
   const key = context as object;
-  const value = currentContext.has(key)
-    ? currentContext.get(key)
-    : asTap(context)[defaultContextValue];
+  const value = getCurrentContextValue(key);
   const currentFiber = getCurrentResourceFiber();
-  (currentFiber.wipContextDeps ??= new Map()).set(key, value);
+  (currentFiber.wipContextDeps ??= new Set()).add(key);
   return value as T;
 };
 
-export const bubbleContextDeps = (fiber: ResourceFiber<any>) => {
-  const currentFiber = peekResourceFiber();
-  if (!currentFiber?.wipContextDeps || !fiber.wipContextDeps) return;
+const getCurrentContextValue = (context: object) =>
+  currentContext.has(context)
+    ? currentContext.get(context)
+    : asTap(context as ReactContext<unknown>)[defaultContextValue];
 
-  for (const [context, value] of fiber.wipContextDeps) {
-    // TODO instead of always forwarding, there should be context source tracking
-    // if context source of a context dep is this current fiber, don't bubble it up
-    currentFiber?.wipContextDeps.set(context, value);
+const mergeContextDeps = (
+  target: ResourceContextDeps | null,
+  source: ResourceContextDeps | null,
+) => {
+  if (!source) return target;
+
+  const next = target ?? new Set();
+  for (const context of source) {
+    next.add(context);
   }
+  return next;
 };
 
-export const hasContextDepsChanged = (fiber: ResourceFiber<any, any[]>) => {
-  if (!fiber.contextDeps) return false;
+export const bubbleContextDeps = (
+  fiber: ResourceFiber<any>,
+  contextDeps: ResourceContextDeps | null = fiber.wipContextDeps,
+) => {
+  const currentFiber = peekResourceFiber();
+  if (!currentFiber || !contextDeps) return;
 
-  for (const [context, previousValue] of fiber.contextDeps) {
-    const currentValue = currentContext.get(context);
-    if (!Object.is(previousValue, currentValue)) return true;
+  // TODO instead of always forwarding, there should be context source tracking
+  // if context source of a context dep is this current fiber, don't bubble it up
+  currentFiber.wipContextDeps = mergeContextDeps(
+    currentFiber.wipContextDeps,
+    contextDeps,
+  );
+};
+
+export const hasChangedContexts = () => changedContexts.size > 0;
+
+export const hasContextDepsChanged = (fiber: ResourceFiber<any, any[]>) => {
+  if (!fiber.contextDeps || !hasChangedContexts()) return false;
+
+  for (const context of changedContexts.keys()) {
+    if (fiber.contextDeps.has(context)) return true;
   }
 
   return false;

--- a/packages/tap/src/core/context.ts
+++ b/packages/tap/src/core/context.ts
@@ -16,6 +16,11 @@ type TapContext<T> = ReactContext<T> & {
   [defaultContextValue]: T;
 };
 
+type ReactContextWithDefault<T> = ReactContext<T> & {
+  _currentValue?: T;
+  _currentValue2?: T;
+};
+
 const asTap = <T>(context: ReactContext<T>): TapContext<T> =>
   context as unknown as TapContext<T>;
 
@@ -48,19 +53,42 @@ export const attachDefaultValueToContext = <T>(
   (context as TapContext<T>)[defaultContextValue] = defaultValue;
 };
 
-const ensureTapContext = (context: unknown) => {
-  // TODO fitler out promises and stores
-  if (
-    typeof context === "object" &&
-    context !== null &&
-    defaultContextValue in context
-  )
-    return;
+export const isTapContext = (
+  context: unknown,
+): context is TapContext<unknown> =>
+  typeof context === "object" &&
+  context !== null &&
+  defaultContextValue in context;
 
-  attachDefaultValueToContext(
-    context as ReactContext<unknown>,
-    (context as any)._currentValue2,
-  );
+const isReactContext = (
+  context: unknown,
+): context is ReactContextWithDefault<unknown> =>
+  typeof context === "object" &&
+  context !== null &&
+  "$$typeof" in context &&
+  (context as { $$typeof: unknown }).$$typeof === Symbol.for("react.context");
+
+export const isReadableTapContext = (
+  context: unknown,
+): context is ReactContext<unknown> =>
+  isTapContext(context) || isReactContext(context);
+
+const assertTapContext: (
+  context: unknown,
+) => asserts context is TapContext<unknown> = (context) => {
+  if (isTapContext(context)) return;
+  if (isReactContext(context)) {
+    // React stores the createContext default on the context object. There is no
+    // public accessor, so this guarded fallback only runs for actual React
+    // contexts that were created before the tap shim could attach the marker.
+    attachDefaultValueToContext(
+      context,
+      context._currentValue ?? context._currentValue2,
+    );
+    return;
+  }
+
+  throw new Error("A tap resource's `use()` only accepts a tap context.");
 };
 
 export const useContextProvider = <T, TResult>(
@@ -68,6 +96,10 @@ export const useContextProvider = <T, TResult>(
   value: T,
   fn: () => TResult,
 ) => {
+  if (typeof context !== "object" || context === null)
+    throw new Error("useContextProvider only accepts a React context.");
+  if (!isTapContext(context)) attachDefaultValueToContext(context, value);
+
   const key = context as object;
   const currentFiber = getCurrentResourceFiber();
   const committedValueRef = useRef<{ value: T } | undefined>(undefined);
@@ -119,7 +151,7 @@ const withChangedContext = <T>(
 };
 
 export const useTapContext = <T>(context: ReactContext<T>) => {
-  ensureTapContext(context);
+  assertTapContext(context);
 
   const key = context as object;
   const contextValue = getCurrentContextValue(key, context);

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -33,9 +33,9 @@ export const createTapRoot = <R>(
   }
 
   const rendered = renderResourceFiber(fiber, [render]);
-  flushTapSync(() => commitResourceFiber(fiber, rendered));
+  flushTapSync(() => commitResourceFiber(fiber));
 
-  const root = rendered.value as useTapRoot.Root<R>;
+  const root = rendered as useTapRoot.Root<R>;
 
   return {
     ...root,

--- a/packages/tap/src/core/helpers/execution-context.ts
+++ b/packages/tap/src/core/helpers/execution-context.ts
@@ -7,6 +7,7 @@ export function withResourceFiber<R, A extends readonly unknown[]>(
   fn: () => void,
 ): void {
   fiber.currentIndex = 0;
+  fiber.wipContextDeps = null;
 
   const previousContext = currentResourceFiber;
   currentResourceFiber = fiber;

--- a/packages/tap/src/core/helpers/execution-context.ts
+++ b/packages/tap/src/core/helpers/execution-context.ts
@@ -8,6 +8,7 @@ export function withResourceFiber<R, A extends readonly unknown[]>(
 ): void {
   fiber.currentIndex = 0;
   fiber.wipContextDeps = null;
+  fiber.wipCommitCallbacks = [];
 
   const previousContext = currentResourceFiber;
   currentResourceFiber = fiber;

--- a/packages/tap/src/core/helpers/root.ts
+++ b/packages/tap/src/core/helpers/root.ts
@@ -68,7 +68,7 @@ export const addCommit = (
   priority: CommitPriority,
   callback: () => void,
 ): void => {
-  const callbacks = fiber.renderContext!.commitCallbacks;
+  const callbacks = fiber.wipCommitCallbacks!;
   (callbacks[priority] ??= []).push(callback);
 };
 

--- a/packages/tap/src/core/helpers/root.ts
+++ b/packages/tap/src/core/helpers/root.ts
@@ -2,32 +2,31 @@ import type {
   ChangelogRecord,
   ReducerCell,
   ResourceFiber,
-  ResourceFiberRoot,
+  TapRoot,
 } from "../types";
+import { cloneCurrentTapContext } from "../context";
 import { CommitPriority } from "./commit";
 
 export const createResourceFiberRoot = (
   dispatchUpdate: (evaluate: () => boolean, apply: () => boolean) => void,
-): ResourceFiberRoot => {
+): TapRoot => {
   return {
     version: 0,
     committedVersion: 0,
+    context: cloneCurrentTapContext(),
     dispatchUpdate,
     changelog: [],
     rollbackCallbacks: [],
   };
 };
 
-export const commitRoot = (root: ResourceFiberRoot): void => {
+export const commitRoot = (root: TapRoot): void => {
   root.committedVersion = root.version;
   root.changelog.length = 0;
   root.rollbackCallbacks.length = 0;
 };
 
-export const setRootVersion = (
-  root: ResourceFiberRoot,
-  version: number,
-): void => {
+export const setRootVersion = (root: TapRoot, version: number): void => {
   const rollback = root.version > version;
   root.version = version;
   if (rollback) {
@@ -73,10 +72,7 @@ export const addCommit = (
   (callbacks[priority] ??= []).push(callback);
 };
 
-export const addRollback = (
-  root: ResourceFiberRoot,
-  callback: () => void,
-): void => {
+export const addRollback = (root: TapRoot, callback: () => void): void => {
   root.rollbackCallbacks.push(callback);
 };
 

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -100,10 +100,10 @@ export const flushTapSync = <T>(callback: () => T): T => {
   };
 
   try {
-    const result = callback();
+    const value = callback();
     flushScheduled();
 
-    return result;
+    return value;
   } finally {
     flushState = prev;
   }

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -68,7 +68,7 @@ export interface RenderResult {
 }
 
 export type ResourceContext = Map<object, unknown>;
-export type ResourceContextDeps = Map<object, unknown>;
+export type ResourceContextDeps = Set<object>;
 
 export interface TapRoot {
   version: number;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -62,11 +62,6 @@ export type Cell = ReducerCell | MemoCell | EffectCell;
 export type CommitCallback = () => void;
 export type CommitCallbacks = Array<CommitCallback[] | undefined>;
 
-export interface RenderResult {
-  value: any;
-  readonly commitCallbacks: CommitCallbacks;
-}
-
 export type ResourceContext = Map<object, ResourceContextValue>;
 export type ResourceContextDeps = Map<object, ResourceFiber<any> | null>;
 
@@ -98,6 +93,8 @@ export interface ResourceFiber<R, A extends readonly unknown[] = any[]> {
 
   wipContextDeps: ResourceContextDeps | null;
   contextDeps: ResourceContextDeps | null;
+  commitCallbacks: CommitCallbacks | null;
+  wipCommitCallbacks: CommitCallbacks | null;
 
   currentIndex: number;
   memoCache: {
@@ -107,8 +104,6 @@ export interface ResourceFiber<R, A extends readonly unknown[] = any[]> {
   };
 
   renderPendingCells: Set<ReducerCell> | null;
-
-  renderContext: RenderResult | undefined; // set during render
 
   isMounted: boolean;
   isFirstRender: boolean;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -68,6 +68,7 @@ export interface RenderResult {
 }
 
 export type ResourceContext = Map<object, unknown>;
+export type ResourceContextDeps = Map<object, unknown>;
 
 export interface TapRoot {
   version: number;
@@ -89,6 +90,10 @@ export interface ResourceFiber<R, A extends readonly unknown[] = any[]> {
   readonly devStrictMode: "root" | "child" | null;
 
   cells: Cell[];
+
+  wipContextDeps: ResourceContextDeps | null;
+  contextDeps: ResourceContextDeps | null;
+
   currentIndex: number;
   memoCache: {
     current: unknown[][] | null;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -67,9 +67,12 @@ export interface RenderResult {
   readonly commitCallbacks: CommitCallbacks;
 }
 
-export interface ResourceFiberRoot {
+export type ResourceContext = Map<object, unknown>;
+
+export interface TapRoot {
   version: number;
   committedVersion: number;
+  context: ResourceContext;
   readonly changelog: ChangelogRecord[];
   readonly dispatchUpdate: (
     evaluate: () => boolean,
@@ -80,7 +83,7 @@ export interface ResourceFiberRoot {
 }
 
 export interface ResourceFiber<R, A extends readonly unknown[] = any[]> {
-  readonly root: ResourceFiberRoot;
+  readonly root: TapRoot;
   readonly hook: (...args: A) => R;
   readonly markDirty: (() => void) | undefined;
   readonly devStrictMode: "root" | "child" | null;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -67,8 +67,13 @@ export interface RenderResult {
   readonly commitCallbacks: CommitCallbacks;
 }
 
-export type ResourceContext = Map<object, unknown>;
-export type ResourceContextDeps = Set<object>;
+export type ResourceContext = Map<object, ResourceContextValue>;
+export type ResourceContextDeps = Map<object, ResourceFiber<any> | null>;
+
+export interface ResourceContextValue {
+  value: unknown;
+  source: ResourceFiber<any> | null;
+}
 
 export interface TapRoot {
   version: number;

--- a/packages/tap/src/hooks/useResource.ts
+++ b/packages/tap/src/hooks/useResource.ts
@@ -4,6 +4,7 @@ import {
   renderResourceFiber,
   commitResourceFiber,
 } from "../core/ResourceFiber";
+import { hasContextDepsChanged } from "../core/context";
 import { useResourceFiberHost } from "./utils/useResourceFiberHostUtils";
 import { useEffect, useMemo } from "react";
 import { useRenderMemo } from "./utils/useRenderMemo";
@@ -18,7 +19,8 @@ export function useResource<E extends ResourceElement<any, any[]>>(
 
   const result = useRenderMemo(
     () => renderResourceFiber(fiber, element.args),
-    [fiber, version, element.args],
+    [fiber, version, ...element.args],
+    hasContextDepsChanged(fiber),
   );
 
   useEffect(() => () => unmountResourceFiber(fiber), [fiber]);

--- a/packages/tap/src/hooks/useResource.ts
+++ b/packages/tap/src/hooks/useResource.ts
@@ -19,7 +19,7 @@ export function useResource<E extends ResourceElement<any, any[]>>(
 
   const result = useRenderMemo(
     () => renderResourceFiber(fiber, element.args),
-    [fiber, version, ...element.args],
+    [fiber, version, element.args],
     hasContextDepsChanged(fiber),
   );
 

--- a/packages/tap/src/hooks/useResource.ts
+++ b/packages/tap/src/hooks/useResource.ts
@@ -18,14 +18,15 @@ export function useResource<E extends ResourceElement<any, any[]>>(
   }, [element.hook, element.key, createFiber]);
 
   const result = useRenderMemo(
-    () => renderResourceFiber(fiber, element.args),
+    () => ({ value: renderResourceFiber(fiber, element.args) }),
     [fiber, version, element.args],
     hasContextDepsChanged(fiber),
   );
 
   useEffect(() => () => unmountResourceFiber(fiber), [fiber]);
   useEffect(() => {
-    commitResourceFiber(fiber, result);
+    void result;
+    commitResourceFiber(fiber);
   }, [fiber, result]);
 
   return result.value;

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -9,7 +9,11 @@ import {
   renderResourceFiber,
   commitResourceFiber,
 } from "../core/ResourceFiber";
-import { hasContextDepsChanged } from "../core/context";
+import {
+  bubbleContextDeps,
+  hasChangedContexts,
+  hasContextDepsChanged,
+} from "../core/context";
 import { useResourceFiberHost } from "./utils/useResourceFiberHostUtils";
 import { useEffect, useMemo } from "react";
 import { useRenderMemo } from "./utils/useRenderMemo";
@@ -55,6 +59,18 @@ const canReuse = (state: FiberState, deps: readonly unknown[] | undefined) =>
   state.committedDeps !== undefined &&
   depsShallowEqual(state.committedDeps, deps);
 
+const hasAnyChildContextDepsChanged = (
+  fibers: Map<string | number, FiberState>,
+) => {
+  if (!hasChangedContexts()) return false;
+
+  for (const { fiber } of fibers.values()) {
+    if (hasContextDepsChanged(fiber)) return true;
+  }
+
+  return false;
+};
+
 export function useResources<E extends ResourceElement<any, any[]>>(
   elements: readonly E[],
 ): ExtractResourceReturnType<E>[] {
@@ -63,9 +79,7 @@ export function useResources<E extends ResourceElement<any, any[]>>(
   // Process each element
 
   const { version, createFiber } = useResourceFiberHost();
-  const hasAnyContextDepsChanged = Array.from(fibers.values()).some((state) =>
-    hasContextDepsChanged(state.fiber),
-  );
+  const hasAnyContextDepsChanged = hasAnyChildContextDepsChanged(fibers);
 
   const res = useRenderMemo(
     () => {
@@ -76,7 +90,6 @@ export function useResources<E extends ResourceElement<any, any[]>>(
       const results: any[] = [];
       let newCount = 0;
 
-      // Create/update fibers and render
       for (let i = 0; i < elements.length; i++) {
         const element = elements[i]!;
 
@@ -113,14 +126,14 @@ export function useResources<E extends ResourceElement<any, any[]>>(
           const result = renderResourceFiber(fiber, element.args);
           state.next = { result, deps: element.deps, remount: fiber };
         } else if (canReuse(state, element.deps)) {
+          if (state.fiber.contextDeps) {
+            bubbleContextDeps(state.fiber, state.fiber.contextDeps);
+          }
           state.next = "skip";
         } else {
           const result = renderResourceFiber(state.fiber, element.args);
           state.next = { result, deps: element.deps };
         }
-
-        // Reused children serve their committed value; everything else its render.
-        // TODO merge all fiber's context usage for fast lookup
 
         results.push(
           typeof state.next === "object"

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -9,6 +9,7 @@ import {
   renderResourceFiber,
   commitResourceFiber,
 } from "../core/ResourceFiber";
+import { hasContextDepsChanged } from "../core/context";
 import { useResourceFiberHost } from "./utils/useResourceFiberHostUtils";
 import { useEffect, useMemo } from "react";
 import { useRenderMemo } from "./utils/useRenderMemo";
@@ -49,6 +50,7 @@ const markChildDirty = (
 // A child is reused when its deps are unchanged and it has no pending work.
 const canReuse = (state: FiberState, deps: readonly unknown[] | undefined) =>
   !state.isDirty &&
+  !hasContextDepsChanged(state.fiber) &&
   deps !== undefined &&
   state.committedDeps !== undefined &&
   depsShallowEqual(state.committedDeps, deps);
@@ -61,75 +63,86 @@ export function useResources<E extends ResourceElement<any, any[]>>(
   // Process each element
 
   const { version, createFiber } = useResourceFiberHost();
-  const res = useRenderMemo(() => {
-    void version;
+  const hasAnyContextDepsChanged = Array.from(fibers.values()).some((state) =>
+    hasContextDepsChanged(state.fiber),
+  );
 
-    const seenKeys = new Set<string | number>();
-    const results: any[] = [];
-    let newCount = 0;
+  const res = useRenderMemo(
+    () => {
+      void version;
+      void hasAnyContextDepsChanged;
 
-    // Create/update fibers and render
-    for (let i = 0; i < elements.length; i++) {
-      const element = elements[i]!;
+      const seenKeys = new Set<string | number>();
+      const results: any[] = [];
+      let newCount = 0;
 
-      const elementKey = element.key;
-      if (elementKey === undefined) {
-        throw new Error(
-          `useResources did not provide a key for array at index ${i}`,
+      // Create/update fibers and render
+      for (let i = 0; i < elements.length; i++) {
+        const element = elements[i]!;
+
+        const elementKey = element.key;
+        if (elementKey === undefined) {
+          throw new Error(
+            `useResources did not provide a key for array at index ${i}`,
+          );
+        }
+
+        if (seenKeys.has(elementKey))
+          throw new Error(`Duplicate key ${elementKey} in useResources`);
+        seenKeys.add(elementKey);
+
+        let state = fibers.get(elementKey);
+        if (!state) {
+          const fiber = createFiber(element.hook, element.key, () =>
+            markChildDirty(fibers, elementKey),
+          );
+          const result = renderResourceFiber(fiber, element.args);
+          state = {
+            fiber,
+            next: { result, deps: element.deps },
+            isDirty: false,
+            committedDeps: undefined,
+            committedValue: undefined,
+          };
+          newCount++;
+          fibers.set(elementKey, state);
+        } else if (state.fiber.hook !== element.hook) {
+          const fiber = createFiber(element.hook, element.key, () =>
+            markChildDirty(fibers, elementKey),
+          );
+          const result = renderResourceFiber(fiber, element.args);
+          state.next = { result, deps: element.deps, remount: fiber };
+        } else if (canReuse(state, element.deps)) {
+          state.next = "skip";
+        } else {
+          const result = renderResourceFiber(state.fiber, element.args);
+          state.next = { result, deps: element.deps };
+        }
+
+        // Reused children serve their committed value; everything else its render.
+        // TODO merge all fiber's context usage for fast lookup
+
+        results.push(
+          typeof state.next === "object"
+            ? state.next.result.value
+            : state.committedValue,
         );
       }
 
-      if (seenKeys.has(elementKey))
-        throw new Error(`Duplicate key ${elementKey} in useResources`);
-      seenKeys.add(elementKey);
-
-      let state = fibers.get(elementKey);
-      if (!state) {
-        const fiber = createFiber(element.hook, element.key, () =>
-          markChildDirty(fibers, elementKey),
-        );
-        const result = renderResourceFiber(fiber, element.args);
-        state = {
-          fiber,
-          next: { result, deps: element.deps },
-          isDirty: false,
-          committedDeps: undefined,
-          committedValue: undefined,
-        };
-        newCount++;
-        fibers.set(elementKey, state);
-      } else if (state.fiber.hook !== element.hook) {
-        const fiber = createFiber(element.hook, element.key, () =>
-          markChildDirty(fibers, elementKey),
-        );
-        const result = renderResourceFiber(fiber, element.args);
-        state.next = { result, deps: element.deps, remount: fiber };
-      } else if (canReuse(state, element.deps)) {
-        state.next = "skip";
-      } else {
-        const result = renderResourceFiber(state.fiber, element.args);
-        state.next = { result, deps: element.deps };
-      }
-
-      // Reused children serve their committed value; everything else its render.
-      results.push(
-        typeof state.next === "object"
-          ? state.next.result.value
-          : state.committedValue,
-      );
-    }
-
-    // Clean up removed fibers (only if there might be stale ones)
-    if (fibers.size > results.length - newCount) {
-      for (const key of fibers.keys()) {
-        if (!seenKeys.has(key)) {
-          fibers.get(key)!.next = "delete";
+      // Clean up removed fibers (only if there might be stale ones)
+      if (fibers.size > results.length - newCount) {
+        for (const key of fibers.keys()) {
+          if (!seenKeys.has(key)) {
+            fibers.get(key)!.next = "delete";
+          }
         }
       }
-    }
 
-    return results;
-  }, [elements, fibers, createFiber, version]);
+      return results;
+    },
+    [elements, fibers, createFiber, version],
+    hasAnyContextDepsChanged,
+  );
 
   // Cleanup on unmount
   useEffect(() => {

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -1,6 +1,5 @@
 import type {
   ExtractResourceReturnType,
-  RenderResult,
   ResourceElement,
   ResourceFiber,
 } from "../core/types";
@@ -25,7 +24,7 @@ import { depsShallowEqual } from "./utils/depsShallowEqual";
 //   "delete"  removed from the list; unmount
 type Pending =
   | {
-      result: RenderResult;
+      value: any;
       deps: readonly unknown[] | undefined;
       remount?: ResourceFiber<unknown>;
     }
@@ -81,13 +80,12 @@ export function useResources<E extends ResourceElement<any, any[]>>(
   const { version, createFiber } = useResourceFiberHost();
   const hasAnyContextDepsChanged = hasAnyChildContextDepsChanged(fibers);
 
-  const res = useRenderMemo(
+  const val = useRenderMemo(
     () => {
       void version;
-      void hasAnyContextDepsChanged;
 
       const seenKeys = new Set<string | number>();
-      const results: any[] = [];
+      const values: any[] = [];
       let newCount = 0;
 
       for (let i = 0; i < elements.length; i++) {
@@ -109,10 +107,10 @@ export function useResources<E extends ResourceElement<any, any[]>>(
           const fiber = createFiber(element.hook, element.key, () =>
             markChildDirty(fibers, elementKey),
           );
-          const result = renderResourceFiber(fiber, element.args);
+          const value = renderResourceFiber(fiber, element.args);
           state = {
             fiber,
-            next: { result, deps: element.deps },
+            next: { value: value, deps: element.deps },
             isDirty: false,
             committedDeps: undefined,
             committedValue: undefined,
@@ -123,27 +121,27 @@ export function useResources<E extends ResourceElement<any, any[]>>(
           const fiber = createFiber(element.hook, element.key, () =>
             markChildDirty(fibers, elementKey),
           );
-          const result = renderResourceFiber(fiber, element.args);
-          state.next = { result, deps: element.deps, remount: fiber };
+          const value = renderResourceFiber(fiber, element.args);
+          state.next = { value: value, deps: element.deps, remount: fiber };
         } else if (canReuse(state, element.deps)) {
           if (state.fiber.contextDeps) {
             bubbleContextDeps(state.fiber, state.fiber.contextDeps);
           }
           state.next = "skip";
         } else {
-          const result = renderResourceFiber(state.fiber, element.args);
-          state.next = { result, deps: element.deps };
+          const value = renderResourceFiber(state.fiber, element.args);
+          state.next = { value: value, deps: element.deps };
         }
 
-        results.push(
+        values.push(
           typeof state.next === "object"
-            ? state.next.result.value
+            ? state.next.value
             : state.committedValue,
         );
       }
 
       // Clean up removed fibers (only if there might be stale ones)
-      if (fibers.size > results.length - newCount) {
+      if (fibers.size > values.length - newCount) {
         for (const key of fibers.keys()) {
           if (!seenKeys.has(key)) {
             fibers.get(key)!.next = "delete";
@@ -151,7 +149,7 @@ export function useResources<E extends ResourceElement<any, any[]>>(
         }
       }
 
-      return results;
+      return values;
     },
     [elements, fibers, createFiber, version],
     hasAnyContextDepsChanged,
@@ -168,7 +166,7 @@ export function useResources<E extends ResourceElement<any, any[]>>(
   }, [fibers]);
 
   useEffect(() => {
-    void res; // as a performance optimization, we only run if the results have changed
+    void val; // as a performance optimization, we only run if the results have changed
 
     for (const [key, state] of fibers.entries()) {
       const next = state.next;
@@ -184,13 +182,13 @@ export function useResources<E extends ResourceElement<any, any[]>>(
           unmountResourceFiber(state.fiber);
           state.fiber = next.remount;
         }
-        commitResourceFiber(state.fiber, next.result);
+        commitResourceFiber(state.fiber);
         state.committedDeps = next.deps;
-        state.committedValue = next.result.value;
+        state.committedValue = next.value;
         state.isDirty = false;
       }
     }
-  }, [res, fibers]);
+  }, [val, fibers]);
 
-  return res;
+  return val;
 }

--- a/packages/tap/src/hooks/useTapHost.ts
+++ b/packages/tap/src/hooks/useTapHost.ts
@@ -48,13 +48,13 @@ export const useTapHost = <R>(callback: () => R): useTapHost.Result<R> => {
     if (renderCommitted && fiber.isMounted) return;
     renderCommitted = true;
 
-    commitResourceFiber(fiber, render);
+    commitResourceFiber(fiber);
   };
 
   useEffect(effects);
 
   return {
-    value: render.value as R,
+    value: render as R,
     effects,
   };
 };

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -69,7 +69,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
   const isMountedRef = useRef(false);
   const committedArgsRef = useRef([render] as const);
-  const valueRef = useRef<R>(render2.value);
+  const valueRef = useRef<R>(render2);
   const subscribers = useMemo(() => new Set<() => void>(), []);
 
   const publish = (output: R) => {
@@ -95,12 +95,12 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     );
 
     if (isDevelopment && fiber.devStrictMode) {
-      void withTapContextRoot(context, () => {
+      void withTapContextRoot(fiber.root.context, () => {
         return renderResourceFiber(fiber, committedArgsRef.current);
       });
     }
 
-    const render = withTapContextRoot(context, () => {
+    const render = withTapContextRoot(fiber.root.context, () => {
       return renderResourceFiber(fiber, committedArgsRef.current);
     });
 
@@ -111,10 +111,10 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     queue.length = 0;
 
     if (isMountedRef.current) {
-      commitResourceFiber(fiber, render);
+      commitResourceFiber(fiber);
     }
 
-    publish(render.value);
+    publish(render);
   });
 
   useEffect(() => {
@@ -130,9 +130,9 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     commitRoot(fiber.root);
     queue.splice(0, drainedCount);
     fiber.root.context = context;
-    commitResourceFiber(fiber, render2);
+    commitResourceFiber(fiber);
 
-    publish(render2.value);
+    publish(render2);
   });
 
   return useMemo(

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -11,6 +11,7 @@ import {
   createResourceFiberRoot,
   setRootVersion,
 } from "../core/helpers/root";
+import { cloneCurrentTapContext } from "../core/context";
 import { useEffect, useEffectEvent, useMemo, useRef } from "react";
 import { useDevStrictMode } from "./utils/useDevStrictMode";
 
@@ -59,8 +60,10 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     );
   }, [queue, scheduler, getDevStrictMode]);
 
+  const context = cloneCurrentTapContext();
+
   const drainedCount = fiber.root.version - fiber.root.committedVersion;
-  const render2 = renderResourceFiber(fiber, [render]);
+  const render2 = renderResourceFiber(fiber, [render], context);
 
   const isMountedRef = useRef(false);
   const committedArgsRef = useRef([render] as const);
@@ -90,10 +93,14 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     );
 
     if (isDevelopment && fiber.devStrictMode) {
-      void renderResourceFiber(fiber, committedArgsRef.current);
+      void renderResourceFiber(fiber, committedArgsRef.current, context);
     }
 
-    const render = renderResourceFiber(fiber, committedArgsRef.current);
+    const render = renderResourceFiber(
+      fiber,
+      committedArgsRef.current,
+      context,
+    );
 
     if (scheduler.isDirty)
       throw new Error("Scheduler is dirty, this should never happen");
@@ -120,6 +127,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     committedArgsRef.current = [render];
     commitRoot(fiber.root);
     queue.splice(0, drainedCount);
+    fiber.root.context = context;
     commitResourceFiber(fiber, render2);
 
     publish(render2.value);

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -11,7 +11,7 @@ import {
   createResourceFiberRoot,
   setRootVersion,
 } from "../core/helpers/root";
-import { cloneCurrentTapContext } from "../core/context";
+import { cloneCurrentTapContext, withTapContextRoot } from "../core/context";
 import { useEffect, useEffectEvent, useMemo, useRef } from "react";
 import { useDevStrictMode } from "./utils/useDevStrictMode";
 
@@ -63,7 +63,9 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   const context = cloneCurrentTapContext();
 
   const drainedCount = fiber.root.version - fiber.root.committedVersion;
-  const render2 = renderResourceFiber(fiber, [render], context);
+  const render2 = withTapContextRoot(context, () => {
+    return renderResourceFiber(fiber, [render]);
+  });
 
   const isMountedRef = useRef(false);
   const committedArgsRef = useRef([render] as const);
@@ -93,14 +95,14 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     );
 
     if (isDevelopment && fiber.devStrictMode) {
-      void renderResourceFiber(fiber, committedArgsRef.current, context);
+      void withTapContextRoot(context, () => {
+        return renderResourceFiber(fiber, committedArgsRef.current);
+      });
     }
 
-    const render = renderResourceFiber(
-      fiber,
-      committedArgsRef.current,
-      context,
-    );
+    const render = withTapContextRoot(context, () => {
+      return renderResourceFiber(fiber, committedArgsRef.current);
+    });
 
     if (scheduler.isDirty)
       throw new Error("Scheduler is dirty, this should never happen");

--- a/packages/tap/src/hooks/utils/useRenderMemo.ts
+++ b/packages/tap/src/hooks/utils/useRenderMemo.ts
@@ -1,7 +1,11 @@
 import { useEffect, useRef } from "react";
 import { depsShallowEqual } from "./depsShallowEqual";
 
-export const useRenderMemo = <T>(callback: () => T, deps: unknown[]) => {
+export const useRenderMemo = <T>(
+  callback: () => T,
+  deps: unknown[],
+  disableMemo: boolean,
+) => {
   const stateRef = useRef<{
     wipDeps: unknown[] | null;
     wip: T | null;
@@ -25,7 +29,11 @@ export const useRenderMemo = <T>(callback: () => T, deps: unknown[]) => {
     state.current = state.wip;
   });
 
-  if (state.currentDeps && depsShallowEqual(state.currentDeps, deps))
+  if (
+    !disableMemo &&
+    state.currentDeps &&
+    depsShallowEqual(state.currentDeps, deps)
+  )
     return state.current as T;
 
   state.wipDeps = deps;

--- a/packages/tap/src/hooks/utils/useResourceFiberHostUtils.ts
+++ b/packages/tap/src/hooks/utils/useResourceFiberHostUtils.ts
@@ -8,7 +8,6 @@ import {
   setRootVersion,
 } from "../../core/helpers/root";
 import { createResourceFiber } from "../../core/ResourceFiber";
-import type { ResourceFiberRoot } from "../../core/types";
 import { useDevStrictMode } from "./useDevStrictMode";
 
 const useResourceFiberHostUtilsTap = () => {
@@ -27,7 +26,7 @@ const useResourceFiberHostUtilsTap = () => {
 };
 
 const useResourceFiberHostUtilsReact = () => {
-  const root = useMemo<ResourceFiberRoot>(() => {
+  const root = useMemo(() => {
     return createResourceFiberRoot((evaluateUpdate, applyUpdate) => {
       let eagerBail = false;
 

--- a/packages/tap/src/index.ts
+++ b/packages/tap/src/index.ts
@@ -6,7 +6,7 @@ export { createTapRoot } from "./core/createTapRoot";
 export { flushTapSync } from "./core/scheduler";
 
 // context
-export { createResourceContext, withContextProvider } from "./core/context";
+export { useContextProvider } from "./core/context";
 
 // hooks
 export { useResource } from "./hooks/useResource";

--- a/packages/tap/src/react-hooks/use.ts
+++ b/packages/tap/src/react-hooks/use.ts
@@ -1,8 +1,8 @@
 import { isReadableTapContext, useTapContext } from "../core/context";
 
 /**
- * Reads a resource context from inside a resource render, the tap equivalent of
- * React's `use(Context)`. Only resource contexts are supported.
+ * Reads a context from inside a resource render, the tap equivalent of React's
+ * `use(Context)` / `useContext(Context)`. Accepts React contexts.
  */
 export const use = (usable: unknown): unknown => {
   if (!isReadableTapContext(usable))

--- a/packages/tap/src/react-hooks/use.ts
+++ b/packages/tap/src/react-hooks/use.ts
@@ -1,13 +1,9 @@
-import { isResourceContext, useResourceContext } from "../core/context";
+import { useTapContext } from "../core/context";
 
 /**
  * Reads a resource context from inside a resource render, the tap equivalent of
  * React's `use(Context)`. Only resource contexts are supported.
  */
 export const use = (usable: unknown): unknown => {
-  if (!isResourceContext(usable))
-    throw new Error(
-      "A tap resource's `use()` only accepts a resource context.",
-    );
-  return useResourceContext(usable as never);
+  return useTapContext(usable as never);
 };

--- a/packages/tap/src/react-hooks/use.ts
+++ b/packages/tap/src/react-hooks/use.ts
@@ -1,9 +1,12 @@
-import { useTapContext } from "../core/context";
+import { isReadableTapContext, useTapContext } from "../core/context";
 
 /**
  * Reads a resource context from inside a resource render, the tap equivalent of
  * React's `use(Context)`. Only resource contexts are supported.
  */
 export const use = (usable: unknown): unknown => {
+  if (!isReadableTapContext(usable))
+    throw new Error("A tap resource's `use()` only accepts a tap context.");
+
   return useTapContext(usable as never);
 };

--- a/packages/tap/src/react-hooks/useEffectEvent.ts
+++ b/packages/tap/src/react-hooks/useEffectEvent.ts
@@ -1,7 +1,10 @@
 import { useRef } from "./useRef";
 import { isDevelopment } from "../core/helpers/env";
 import { useCallback } from "./useCallback";
-import { getCurrentResourceFiber } from "../core/helpers/execution-context";
+import {
+  getCurrentResourceFiber,
+  peekResourceFiber,
+} from "../core/helpers/execution-context";
 import { CommitPriority } from "../core/helpers/commit";
 import { addCommit } from "../core/helpers/root";
 
@@ -34,10 +37,10 @@ export function useEffectEvent<T extends (...args: any[]) => any>(
 
   return useCallback(
     ((...args: Parameters<T>) => {
-      if (isDevelopment && fiber.renderContext)
+      if (isDevelopment && peekResourceFiber())
         throw new Error("useEffectEvent cannot be called during render");
       return callbackRef.current(...args);
     }) as T,
-    [fiber],
+    [],
   );
 }

--- a/packages/tap/src/react-shim/index.ts
+++ b/packages/tap/src/react-shim/index.ts
@@ -11,7 +11,7 @@
 import React from "react";
 import { peekResourceFiber } from "../core/helpers/execution-context";
 import * as hooks from "../react-hooks";
-import { useResourceContext, isResourceContext } from "../core/context";
+import { attachDefaultValueToContext } from "../core/context";
 
 // @ts-expect-error -- @types/react uses `export =`; this is valid at runtime.
 export * from "react";
@@ -75,18 +75,14 @@ export const useDebugValue = (value: any, format?: any) =>
     ? hooks.useDebugValue(value, format)
     : ReactRuntime.useDebugValue(value, format);
 
-// `use(usable)` reads tap resource context when handed a tap context (routed by
-// its brand, not by ambient render state), and falls back to React's `use`
-// (promises / React context) for everything else. The non-tap fallback requires
-// React 19.
-export const use = (usable: any) =>
-  isResourceContext(usable)
-    ? useResourceContext(usable)
-    : ReactRuntime.use(usable);
+export const createContext = (defaultValue: any) => {
+  const context = ReactRuntime.createContext(defaultValue);
+  attachDefaultValueToContext(context, defaultValue);
+  return context;
+};
 
-// `useContext(context)` reads tap resource context when handed a tap context
-// (routed by its brand), and falls back to React's `useContext` otherwise.
+export const use = (usable: any) =>
+  inTap() ? hooks.use(usable) : ReactRuntime.use(usable);
+
 export const useContext = (context: any) =>
-  isResourceContext(context)
-    ? useResourceContext(context)
-    : ReactRuntime.useContext(context);
+  inTap() ? hooks.use(context) : ReactRuntime.useContext(context);

--- a/packages/tap/src/react-shim/index.ts
+++ b/packages/tap/src/react-shim/index.ts
@@ -11,7 +11,10 @@
 import React from "react";
 import { peekResourceFiber } from "../core/helpers/execution-context";
 import * as hooks from "../react-hooks";
-import { attachDefaultValueToContext } from "../core/context";
+import {
+  attachDefaultValueToContext,
+  isReadableTapContext,
+} from "../core/context";
 
 // @ts-expect-error -- @types/react uses `export =`; this is valid at runtime.
 export * from "react";
@@ -82,7 +85,11 @@ export const createContext = (defaultValue: any) => {
 };
 
 export const use = (usable: any) =>
-  inTap() ? hooks.use(usable) : ReactRuntime.use(usable);
+  inTap() && isReadableTapContext(usable)
+    ? hooks.use(usable)
+    : ReactRuntime.use(usable);
 
 export const useContext = (context: any) =>
-  inTap() ? hooks.use(context) : ReactRuntime.useContext(context);
+  inTap() && isReadableTapContext(context)
+    ? hooks.use(context)
+    : ReactRuntime.useContext(context);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3436,7 +3436,7 @@ importers:
         specifier: ^0.2.17
         version: link:../store
       '@assistant-ui/tap':
-        specifier: ^0.8.1
+        specifier: ^0.9.0
         version: link:../tap
       '@radix-ui/primitive':
         specifier: ^1.1.4
@@ -3781,7 +3781,7 @@ importers:
         specifier: ^0.2.17
         version: link:../store
       '@assistant-ui/tap':
-        specifier: ^0.8.1
+        specifier: ^0.9.0
         version: link:../tap
       assistant-stream:
         specifier: ^0.3.22
@@ -4067,7 +4067,7 @@ importers:
         specifier: ^0.2.17
         version: link:../store
       '@assistant-ui/tap':
-        specifier: ^0.8.1
+        specifier: ^0.9.0
         version: link:../tap
       assistant-stream:
         specifier: ^0.3.22


### PR DESCRIPTION
## Summary
- store tap context on fiber roots and clone it when rendering across tap root boundaries
- make shim-created React contexts readable from tap while preserving normal React context behavior
- update store tap contexts to use the shimmed context creation path

## Validation
- pnpm --filter @assistant-ui/tap build
- pnpm --filter @assistant-ui/store build
- pnpm --filter @assistant-ui/tap test
- pnpm --filter @assistant-ui/store test
- pnpm lint

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

