### PR TITLE
feat(react-ag-ui): export createAgUiResumeStream for read-only run resume

### DIFF
--- a/.changeset/agui-resume-stream.md
+++ b/.changeset/agui-resume-stream.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: export createAgUiResumeStream to build a read-only ThreadHistoryAdapter.resume() from a stream of AG-UI events, reusing RunAggregator so resumed runs render identically without re-invoking the agent

--- a/packages/react-ag-ui/src/index.ts
+++ b/packages/react-ag-ui/src/index.ts
@@ -2,7 +2,10 @@ export { useAgUiRuntime } from "./useAgUiRuntime";
 export type { AgUiAssistantRuntime } from "./useAgUiRuntime";
 export { fromAgUiMessages } from "./runtime/adapter/conversions";
 export type { FromAgUiMessagesOptions } from "./runtime/adapter/conversions";
+export { createAgUiResumeStream } from "./runtime/adapter/resume-stream";
+export type { CreateAgUiResumeStreamOptions } from "./runtime/adapter/resume-stream";
 export type {
+  AgUiEvent,
   AgUiInterrupt,
   AgUiInterruptReason,
   AgUiResumeEntry,

--- a/packages/react-ag-ui/src/runtime/adapter/resume-stream.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/resume-stream.ts
@@ -1,0 +1,73 @@
+import type { ChatModelRunResult } from "@assistant-ui/core";
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
+import jsonpatch, { type Operation } from "fast-json-patch";
+import { makeLogger, type Logger } from "../logger";
+import type { AgUiEvent } from "../types";
+import { RunAggregator } from "./run-aggregator";
+
+export type CreateAgUiResumeStreamOptions = {
+  showThinking?: boolean;
+  logger?: Partial<Logger>;
+};
+
+/**
+ * Turn a stream of AG-UI events into the `ChatModelRunResult` snapshots that a
+ * `ThreadHistoryAdapter.resume()` (or any `ChatModelAdapter`) yields.
+ *
+ * This is the read-only counterpart to a live run: instead of invoking the
+ * agent, feed already-produced events (e.g. replayed from a durable/resumable
+ * transport at a cursor) and re-use the same `RunAggregator` the live runtime
+ * uses, so resumed runs render identically without re-running the model.
+ *
+ * `STATE_SNAPSHOT` / `STATE_DELTA` are folded into `metadata.unstable_state`;
+ * `MESSAGES_SNAPSHOT` is ignored here (history is hydrated on load()).
+ */
+export async function* createAgUiResumeStream(
+  events: AsyncIterable<AgUiEvent>,
+  options: CreateAgUiResumeStreamOptions = {},
+): AsyncGenerator<ChatModelRunResult, void, unknown> {
+  const logger = makeLogger(options.logger);
+  let pending: ChatModelRunResult[] = [];
+  const aggregator = new RunAggregator({
+    showThinking: options.showThinking ?? true,
+    logger,
+    emit: (update) => pending.push(update),
+  });
+
+  let stateSnapshot: ReadonlyJSONValue | undefined;
+
+  for await (const event of events) {
+    switch (event.type) {
+      case "STATE_SNAPSHOT": {
+        stateSnapshot = event.snapshot as ReadonlyJSONValue;
+        yield { metadata: { unstable_state: stateSnapshot } };
+        continue;
+      }
+      case "STATE_DELTA": {
+        if (event.delta.length === 0) continue;
+        try {
+          const result = jsonpatch.applyPatch(
+            stateSnapshot ?? {},
+            event.delta as Operation[],
+            /* validateOperation */ true,
+            /* mutateDocument */ false,
+          );
+          stateSnapshot = result.newDocument as ReadonlyJSONValue;
+          yield { metadata: { unstable_state: stateSnapshot } };
+        } catch (error) {
+          logger.error?.("[agui] failed to apply state delta on resume", error);
+        }
+        continue;
+      }
+      case "MESSAGES_SNAPSHOT":
+        continue;
+      default:
+        aggregator.handle(event);
+    }
+    if (pending.length > 0) {
+      const batch = pending;
+      pending = [];
+      for (const update of batch) yield update;
+    }
+  }
+}

--- a/packages/react-ag-ui/test/resume-stream.spec.ts
+++ b/packages/react-ag-ui/test/resume-stream.spec.ts
@@ -41,7 +41,10 @@ describe("createAgUiResumeStream", () => {
       createAgUiResumeStream(
         fromArray([
           { type: "STATE_SNAPSHOT", snapshot: { count: 1 } },
-          { type: "STATE_DELTA", delta: [{ op: "replace", path: "/count", value: 2 }] },
+          {
+            type: "STATE_DELTA",
+            delta: [{ op: "replace", path: "/count", value: 2 }],
+          },
         ]),
       ),
     );

--- a/packages/react-ag-ui/test/resume-stream.spec.ts
+++ b/packages/react-ag-ui/test/resume-stream.spec.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { describe, it, expect } from "vitest";
+import { createAgUiResumeStream } from "../src/runtime/adapter/resume-stream";
+import type { AgUiEvent } from "../src/runtime/types";
+import type { ChatModelRunResult } from "@assistant-ui/core";
+
+async function* fromArray(events: AgUiEvent[]): AsyncGenerator<AgUiEvent> {
+  for (const event of events) yield event;
+}
+
+async function collect(
+  stream: AsyncGenerator<ChatModelRunResult, void, unknown>,
+): Promise<ChatModelRunResult[]> {
+  const results: ChatModelRunResult[] = [];
+  for await (const result of stream) results.push(result);
+  return results;
+}
+
+describe("createAgUiResumeStream", () => {
+  it("replays text events into run-result snapshots", async () => {
+    const results = await collect(
+      createAgUiResumeStream(
+        fromArray([
+          { type: "RUN_STARTED", runId: "run" },
+          { type: "TEXT_MESSAGE_START", messageId: "m1" },
+          { type: "TEXT_MESSAGE_CONTENT", messageId: "m1", delta: "Hello" },
+          { type: "TEXT_MESSAGE_CONTENT", messageId: "m1", delta: " world" },
+          { type: "TEXT_MESSAGE_END", messageId: "m1" },
+          { type: "RUN_FINISHED", runId: "run" },
+        ]),
+      ),
+    );
+
+    const last = results.at(-1);
+    expect(last?.content).toEqual([{ type: "text", text: "Hello world" }]);
+  });
+
+  it("folds STATE_SNAPSHOT and STATE_DELTA into metadata.unstable_state", async () => {
+    const results = await collect(
+      createAgUiResumeStream(
+        fromArray([
+          { type: "STATE_SNAPSHOT", snapshot: { count: 1 } },
+          { type: "STATE_DELTA", delta: [{ op: "replace", path: "/count", value: 2 }] },
+        ]),
+      ),
+    );
+
+    expect(results.map((r) => r.metadata?.unstable_state)).toEqual([
+      { count: 1 },
+      { count: 2 },
+    ]);
+  });
+
+  it("ignores MESSAGES_SNAPSHOT (history is hydrated on load)", async () => {
+    const results = await collect(
+      createAgUiResumeStream(
+        fromArray([{ type: "MESSAGES_SNAPSHOT", messages: [{ id: "x" }] }]),
+      ),
+    );
+
+    expect(results).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Motivation

The AG-UI runtime already supports read-only resume: when a `ThreadHistoryAdapter` implements `resume()`, `AgUiThreadRuntimeCore` replays the returned `ChatModelRunResult` stream into the existing assistant message via `consumeResumeStream` — no agent re-invocation, the same path the data-stream runtime uses.

The missing piece is producing that stream. An AG-UI agent backed by a durable/resumable transport speaks **AG-UI events** (`TEXT_MESSAGE_CONTENT`, `TOOL_CALL_ARGS`, `STATE_DELTA`, …), not `ChatModelRunResult`s. The converter — `RunAggregator` — is internal to the package, so today the only way to resume is to re-run the agent and rely on an idempotent re-invocation, which also risks doubled content at the replay seam.

## Change

Export `createAgUiResumeStream(events)`: feed it an `AsyncIterable<AgUiEvent>` (e.g. replayed from a cursor on reconnect) and it yields the `ChatModelRunResult` snapshots `resume()` expects, reusing the same `RunAggregator` the live runtime uses — so a resumed run renders identically to the original. `STATE_SNAPSHOT`/`STATE_DELTA` fold into `metadata.unstable_state`; `MESSAGES_SNAPSHOT` is ignored (history is hydrated on `load()`). Also exports the `AgUiEvent` union it consumes.

Usage:

```ts
const historyAdapter: ThreadHistoryAdapter = {
  async load() {
    const { messages, runInFlight } = await fetchHistory(conversationId);
    return { ...ExportedMessageRepository.fromArray(messages),
             ...(runInFlight && { unstable_resume: true }) };
  },
  resume(options) {
    // reconnect to the durable stream at its cursor, parse SSE -> AgUiEvent
    return createAgUiResumeStream(reconnectFromCursor(conversationId, options));
  },
  append: async () => {},
};
```

## Verification

- New `resume-stream.spec.ts`: text replay aggregates to a final snapshot, `STATE_*` folds into `unstable_state`, `MESSAGES_SNAPSHOT` is skipped.
- `pnpm vitest run`: 151/151; package build clean, export present in dist.

No behavior change to existing paths — purely additive (one new export + the `AgUiEvent` type).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

