### PR TITLE
feat(docs): animate homepage demo expansion with View Transitions

### DIFF
--- a/apps/docs/components/home/example-showcase.tsx
+++ b/apps/docs/components/home/example-showcase.tsx
@@ -157,7 +157,7 @@ export function ExampleShowcase() {
     <section ref={sectionRef}>
       {/* Placeholder reserves the inline height so the page doesn't jump when
           the panel detaches to fullscreen. */}
-      <div className="relative h-192">
+      <div className="relative h-160">
         <div
           onClick={handlePanelClick}
           className={cn(

--- a/apps/docs/components/home/example-showcase.tsx
+++ b/apps/docs/components/home/example-showcase.tsx
@@ -120,6 +120,14 @@ export function ExampleShowcase() {
     document.startViewTransition(() => flushSync(apply));
   }, []);
 
+  // Inline, the demo is a static preview: clicking anywhere except the tab bar
+  // expands it to fullscreen, where it becomes interactive.
+  const handlePanelClick = (e: React.MouseEvent) => {
+    if (isFullscreen) return;
+    if ((e.target as HTMLElement).closest('[data-slot="tab-list"]')) return;
+    toggleFullscreen();
+  };
+
   React.useEffect(() => {
     if (!isFullscreen) return;
 
@@ -151,11 +159,12 @@ export function ExampleShowcase() {
           the panel detaches to fullscreen. */}
       <div className="relative h-192">
         <div
+          onClick={handlePanelClick}
           className={cn(
             "inset-0 [view-transition-name:example-demo]",
             isFullscreen
               ? "bg-background fixed z-[100] p-4 md:p-6"
-              : "absolute",
+              : "absolute cursor-zoom-in [&_[data-slot=tab-content-panel]]:pointer-events-none",
           )}
         >
           <Tab

--- a/apps/docs/components/home/example-showcase.tsx
+++ b/apps/docs/components/home/example-showcase.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 import { ArrowUpRightIcon, Maximize2Icon, Minimize2Icon } from "lucide-react";
 import Link from "next/link";
 import React from "react";
+import { flushSync } from "react-dom";
 
 const ExampleWrapper = ({ children }: { children: React.ReactNode }) => (
   <div className="not-prose h-full overflow-hidden rounded-2xl border">
@@ -94,16 +95,36 @@ const EXAMPLE_TABS = [
   },
 ];
 
+const prefersReducedMotion = () =>
+  typeof window !== "undefined" &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
 export function ExampleShowcase() {
   const sectionRef = React.useRef<HTMLElement>(null);
   const [activeIndex, setActiveIndex] = React.useState(0);
   const [isFullscreen, setIsFullscreen] = React.useState(false);
 
+  // Toggling the panel between its inline box and `fixed inset-0` is wrapped in
+  // a View Transition so the browser morphs the shared `example-demo` element
+  // between the two states. Timing lives in styles/animate.css.
+  const toggleFullscreen = React.useCallback(() => {
+    const apply = () => setIsFullscreen((value) => !value);
+    if (
+      typeof document === "undefined" ||
+      !document.startViewTransition ||
+      prefersReducedMotion()
+    ) {
+      apply();
+      return;
+    }
+    document.startViewTransition(() => flushSync(apply));
+  }, []);
+
   React.useEffect(() => {
     if (!isFullscreen) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setIsFullscreen(false);
+      if (e.key === "Escape") toggleFullscreen();
     };
     document.addEventListener("keydown", handleKeyDown);
     document.body.style.overflow = "hidden";
@@ -120,57 +141,66 @@ export function ExampleShowcase() {
         stackingAncestor.style.zIndex = "";
       }
     };
-  }, [isFullscreen]);
+  }, [isFullscreen, toggleFullscreen]);
 
   const activeSlug = EXAMPLE_TABS[activeIndex]?.slug;
 
   return (
     <section ref={sectionRef}>
-      <Tab
-        tabs={EXAMPLE_TABS}
-        className={cn(
-          "h-192",
-          isFullscreen &&
-            "bg-background fixed inset-0 z-[100] h-auto p-4 md:p-6",
-        )}
-        variant="ghost"
-        onTabChange={(label, index) => {
-          setActiveIndex(index);
-          analytics.example.tabSwitched(label);
-        }}
-        actions={
-          <>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="text-muted-foreground hover:text-foreground size-[30px]"
-              aria-label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
-              title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
-              onClick={() => setIsFullscreen((value) => !value)}
-            >
-              {isFullscreen ? (
-                <Minimize2Icon className="size-4" />
-              ) : (
-                <Maximize2Icon className="size-4" />
-              )}
-            </Button>
-            {activeSlug && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="text-muted-foreground hover:text-foreground size-[30px]"
-                aria-label="Open demo"
-                title="Open demo"
-                asChild
-              >
-                <Link href={`/demos/${activeSlug}`}>
-                  <ArrowUpRightIcon className="size-4" />
-                </Link>
-              </Button>
-            )}
-          </>
-        }
-      />
+      {/* Placeholder reserves the inline height so the page doesn't jump when
+          the panel detaches to fullscreen. */}
+      <div className="relative h-192">
+        <div
+          className={cn(
+            "inset-0 [view-transition-name:example-demo]",
+            isFullscreen
+              ? "bg-background fixed z-[100] p-4 md:p-6"
+              : "absolute",
+          )}
+        >
+          <Tab
+            tabs={EXAMPLE_TABS}
+            className="h-full"
+            variant="ghost"
+            onTabChange={(label, index) => {
+              setActiveIndex(index);
+              analytics.example.tabSwitched(label);
+            }}
+            actions={
+              <>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-muted-foreground hover:text-foreground size-[30px]"
+                  aria-label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+                  title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+                  onClick={toggleFullscreen}
+                >
+                  {isFullscreen ? (
+                    <Minimize2Icon className="size-4" />
+                  ) : (
+                    <Maximize2Icon className="size-4" />
+                  )}
+                </Button>
+                {activeSlug && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="text-muted-foreground hover:text-foreground size-[30px]"
+                    aria-label="Open demo"
+                    title="Open demo"
+                    asChild
+                  >
+                    <Link href={`/demos/${activeSlug}`}>
+                      <ArrowUpRightIcon className="size-4" />
+                    </Link>
+                  </Button>
+                )}
+              </>
+            }
+          />
+        </div>
+      </div>
     </section>
   );
 }

--- a/apps/docs/styles/animate.css
+++ b/apps/docs/styles/animate.css
@@ -11,40 +11,7 @@
   animation: marquee var(--duration) linear infinite;
 }
 
-@property --angle {
-  syntax: "<angle>";
-  inherits: false;
-  initial-value: 0deg;
-}
-
-@keyframes rotate {
-  to {
-    --angle: 360deg;
-  }
-}
-
-.rainbow-border {
-  animation: rotate 10s linear infinite;
-  background: linear-gradient(
-    var(--angle),
-    #02fcef70 0,
-    #ffb52b70 50%,
-    #a02bfe70 100%
-  );
-
-  &:after {
-    animation: rotate 10s linear infinite;
-    background: linear-gradient(
-      var(--angle),
-      #02fcef70 0,
-      #ffb52b70 50%,
-      #a02bfe70 100%
-    );
-    filter: blur(10px);
-    transition: all 0.4s ease-out;
-  }
-
-  &:hover:after {
-    transform: scale(1.1, 1.1);
-  }
+::view-transition-group(example-demo) {
+  animation-duration: 350ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
 }


### PR DESCRIPTION
## What

The homepage example demo's fullscreen toggle now animates the panel expanding/collapsing instead of snapping to a separate `fixed inset-0` overlay.

## How

- Wrap the fullscreen state flip in `document.startViewTransition` (+ `flushSync`) and give the panel a shared `view-transition-name: example-demo`, so the browser morphs it between its inline box and the fullscreen overlay.
- Transition timing lives in `styles/animate.css` via `::view-transition-group(example-demo)` (350ms, ease-out).
- A placeholder (`relative h-192`) reserves the inline height so the page doesn't jump when the panel detaches.
- Falls back to an instant toggle when View Transitions are unavailable or `prefers-reduced-motion` is set.
- Drop the unused `rainbow-border` styles (and their `--angle`/`rotate` deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

