### PR TITLE
feat(docs): show homepage hiring banner only from second visit

### DIFF
--- a/apps/docs/components/shared/header.tsx
+++ b/apps/docs/components/shared/header.tsx
@@ -74,10 +74,20 @@ export function Header() {
   const [dismissed, setDismissed] = usePersistentBoolean(
     "homepage-hiring-banner-dismissed",
   );
+  const [visited, setVisited] = usePersistentBoolean("homepage-visited");
+  const [returningVisitor, setReturningVisitor] = useState(false);
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    if (pathname !== "/") return;
+    // Show the banner only from the second homepage visit onward.
+    setReturningVisitor(visited);
+    if (!visited) setVisited(true);
+    // oxlint-disable-next-line react/exhaustive-deps
+  }, [pathname]);
 
   useEffect(() => {
     fetch("/api/github/repo")
@@ -91,7 +101,7 @@ export function Header() {
   }, []);
 
   const isHome = pathname === "/";
-  const showBanner = mounted && isHome && !dismissed;
+  const showBanner = mounted && isHome && returningVisitor && !dismissed;
 
   return (
     <header className="sticky top-0 z-50 w-full">


### PR DESCRIPTION
## Summary
The homepage hiring banner now appears only from a visitor's **second** homepage visit onward, instead of on the very first landing.

## How it works
- Added a persistent `homepage-visited` flag (localStorage via the existing `usePersistentBoolean`).
- On landing on `/`, the effect reads the flag *before* writing it: `returningVisitor` captures the prior value, then the flag is marked `true`. This avoids the banner flashing on the same first visit.
- Banner condition is now `mounted && isHome && returningVisitor && !dismissed`.

First visit: flag set, banner hidden. Subsequent visits: banner shows (unless previously dismissed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

