### PR TITLE
fix(docs): show demo dropdowns in fullscreen mode

### DIFF
--- a/apps/docs/components/examples/chatgpt.tsx
+++ b/apps/docs/components/examples/chatgpt.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@/lib/utils";
 import {
   ActionBarPrimitive,
+  ActionBarMorePrimitive,
   AuiIf,
   AttachmentPrimitive,
   BranchPickerPrimitive,
@@ -28,6 +29,7 @@ import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button
 import { useShallow } from "zustand/shallow";
 import {
   AudioLines,
+  Download,
   Globe,
   ImageIcon,
   Lightbulb,
@@ -335,9 +337,33 @@ const AssistantMessage: FC = () => {
           <ActionBarPrimitive.Reload className={assistantActionClassName}>
             <ReloadIcon />
           </ActionBarPrimitive.Reload>
-          <button type="button" className={assistantActionClassName}>
-            <MoreHorizontal className="size-4" />
-          </button>
+          <ActionBarMorePrimitive.Root>
+            <ActionBarMorePrimitive.Trigger asChild>
+              <button
+                type="button"
+                aria-label="More"
+                className={cn(
+                  assistantActionClassName,
+                  "data-[state=open]:bg-[#0d0d0d]/5 dark:data-[state=open]:bg-white/10",
+                )}
+              >
+                <MoreHorizontal className="size-4" />
+              </button>
+            </ActionBarMorePrimitive.Trigger>
+            <ActionBarMorePrimitive.Content
+              side="bottom"
+              align="end"
+              sideOffset={6}
+              className="bg-popover/95 text-popover-foreground data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out data-[side=bottom]:slide-in-from-top-2 z-50 min-w-40 overflow-hidden rounded-xl border p-1.5 shadow-lg backdrop-blur-sm"
+            >
+              <ActionBarPrimitive.ExportMarkdown asChild>
+                <ActionBarMorePrimitive.Item className="text-muted-foreground focus:bg-accent focus:text-accent-foreground flex cursor-pointer items-center gap-2.5 rounded-lg px-3 py-2 text-sm outline-none select-none">
+                  <Download className="size-4" />
+                  Export as Markdown
+                </ActionBarMorePrimitive.Item>
+              </ActionBarPrimitive.ExportMarkdown>
+            </ActionBarMorePrimitive.Content>
+          </ActionBarMorePrimitive.Root>
         </ActionBarPrimitive.Root>
         <BranchPicker className="ml-1" />
       </div>

--- a/apps/docs/components/home/example-showcase.tsx
+++ b/apps/docs/components/home/example-showcase.tsx
@@ -11,7 +11,7 @@ import { Grok } from "@/components/examples/grok";
 import { analytics } from "@/lib/analytics";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { ArrowUpRightIcon, Maximize2Icon, Minimize2Icon } from "lucide-react";
+import { ArrowUpRightIcon, Maximize2Icon, XIcon } from "lucide-react";
 import Link from "next/link";
 import React from "react";
 import { flushSync } from "react-dom";
@@ -177,20 +177,6 @@ export function ExampleShowcase() {
             }}
             actions={
               <>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="text-muted-foreground hover:text-foreground size-[30px]"
-                  aria-label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
-                  title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
-                  onClick={toggleFullscreen}
-                >
-                  {isFullscreen ? (
-                    <Minimize2Icon className="size-4" />
-                  ) : (
-                    <Maximize2Icon className="size-4" />
-                  )}
-                </Button>
                 {activeSlug && (
                   <Button
                     variant="ghost"
@@ -205,6 +191,20 @@ export function ExampleShowcase() {
                     </Link>
                   </Button>
                 )}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-muted-foreground hover:text-foreground size-[30px]"
+                  aria-label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+                  title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+                  onClick={toggleFullscreen}
+                >
+                  {isFullscreen ? (
+                    <XIcon className="size-4" />
+                  ) : (
+                    <Maximize2Icon className="size-4" />
+                  )}
+                </Button>
               </>
             }
           />

--- a/apps/docs/components/home/example-showcase.tsx
+++ b/apps/docs/components/home/example-showcase.tsx
@@ -140,7 +140,7 @@ export function ExampleShowcase() {
     // the overlay beneath the sticky z-50 site header.
     const stackingAncestor = sectionRef.current?.closest("main");
     if (stackingAncestor instanceof HTMLElement) {
-      stackingAncestor.style.zIndex = "100";
+      stackingAncestor.style.zIndex = "50";
     }
     return () => {
       document.removeEventListener("keydown", handleKeyDown);


### PR DESCRIPTION
## Problem

When the homepage demo is expanded to fullscreen, dropdowns/menus inside the chat examples didn't appear.

## Cause

The fullscreen toggle bumps `<main>` to `z-index: 100` to clear the sticky `z-50` site header. But the examples' dropdowns portal to `document.body` at `z-50`, so the bumped `main` stacking context painted over them.

## Fix

- Set `main` to `z-50` instead of `100`. `main` renders after the header in the DOM, so it still wins by paint order and covers the header, while staying at the same body-level z as the dropdown portals — which, appended last, layer on top. (Same pattern shadcn dialogs + dropdowns rely on.)
- Wire the ChatGPT assistant message action bar three-dots to a real `ActionBarMore` menu (**Export as Markdown**), matching the Base example. It was previously a dead placeholder `<button>` with no menu.

## Verification

Ran the docs app and confirmed in fullscreen: the composer **Tools** dropdown and the message **...** menu both render correctly above the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

