### PR TITLE
fix: keep tap React imports compatible with React 18

### DIFF
--- a/.changeset/silver-buckets-tap.md
+++ b/.changeset/silver-buckets-tap.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/tap": patch
+"@assistant-ui/x-buildutils": patch
+---
+
+fix: keep tap React hooks compatible with React 18 builds

--- a/packages/tap/src/react-shim/index.ts
+++ b/packages/tap/src/react-shim/index.ts
@@ -15,6 +15,7 @@ import {
   attachDefaultValueToContext,
   isReadableTapContext,
 } from "../core/context";
+import { useReactEffectEvent } from "./useReactEffectEvent";
 
 // @ts-expect-error -- @types/react uses `export =`; this is valid at runtime.
 export * from "react";
@@ -54,11 +55,8 @@ export const useLayoutEffect = (effect: any, deps?: any) =>
     ? hooks.useEffect(effect, deps)
     : ReactRuntime.useLayoutEffect(effect, deps);
 
-// The non-tap fallback requires a React version that provides useEffectEvent.
 export const useEffectEvent = (callback: any) =>
-  inTap()
-    ? hooks.useEffectEvent(callback)
-    : ReactRuntime.useEffectEvent(callback);
+  inTap() ? hooks.useEffectEvent(callback) : useReactEffectEvent(callback);
 
 export const useSyncExternalStore = (
   subscribe: any,

--- a/packages/tap/src/react-shim/useReactEffectEvent.ts
+++ b/packages/tap/src/react-shim/useReactEffectEvent.ts
@@ -1,0 +1,21 @@
+import React, { useCallback, useLayoutEffect, useRef } from "react";
+
+const ReactRuntime = React as any;
+
+function useReactEffectEventShim<T extends (...args: any[]) => any>(
+  callback: T,
+): T {
+  const callbackRef = useRef(callback);
+
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  return useCallback(
+    ((...args: Parameters<T>) => callbackRef.current(...args)) as T,
+    [],
+  );
+}
+
+export const useReactEffectEvent: typeof useReactEffectEventShim =
+  ReactRuntime.useEffectEvent ?? useReactEffectEventShim;

--- a/packages/tap/src/react-shim/useReactEffectEvent.ts
+++ b/packages/tap/src/react-shim/useReactEffectEvent.ts
@@ -1,13 +1,14 @@
-import React, { useCallback, useLayoutEffect, useRef } from "react";
+import React, { useCallback, useInsertionEffect, useRef } from "react";
 
 const ReactRuntime = React as any;
 
+// Keep this local so @assistant-ui/tap stays runtime-dependency-free.
 function useReactEffectEventShim<T extends (...args: any[]) => any>(
   callback: T,
 ): T {
   const callbackRef = useRef(callback);
 
-  useLayoutEffect(() => {
+  useInsertionEffect(() => {
     callbackRef.current = callback;
   });
 

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -84,9 +84,12 @@ if (remapReactToShim && !isDev && existsSync("dist")) {
   })) {
     if (typeof rel !== "string") continue;
 
-    const isDeclaration = rel.endsWith(".d.ts");
+    const normalizedRel = rel.replaceAll("\\", "/");
+    const isDeclaration = normalizedRel.endsWith(".d.ts");
     const isTapShimRuntime =
-      isTapPackage && rel.startsWith("react-shim/") && rel.endsWith(".js");
+      isTapPackage &&
+      normalizedRel.startsWith("react-shim/") &&
+      normalizedRel.endsWith(".js");
 
     if (!isDeclaration && !isTapShimRuntime) continue;
 

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -25,13 +25,15 @@ if (isDev && pkg.scripts?.start) onSuccess = pkg.scripts.start;
 // routes to tap inside a resource render), so "react/jsx-runtime" and
 // "react-dom" are untouched.
 //
-// Only applied to packages that actually depend on `@assistant-ui/tap` (so the
-// remapped `@assistant-ui/tap/react-shim` specifier resolves for consumers).
-// `@assistant-ui/tap` itself naturally falls out — it doesn't depend on itself,
-// so it keeps the real react that its react-shim re-exports.
-const remapReactToShim = ["dependencies", "peerDependencies"].some(
+// Applied to packages that actually depend on `@assistant-ui/tap` (so the
+// remapped `@assistant-ui/tap/react-shim` specifier resolves for consumers) and
+// to `@assistant-ui/tap` itself so its React-facing hooks can share the same
+// React 18 compatibility shim.
+const dependsOnTap = ["dependencies", "peerDependencies"].some(
   (field) => pkg[field]?.["@assistant-ui/tap"],
 );
+const isTapPackage = pkg.name === "@assistant-ui/tap";
+const remapReactToShim = dependsOnTap || isTapPackage;
 
 await build({
   entry: [
@@ -60,12 +62,12 @@ await build({
   sourcemap: true,
   watch: isDev,
   ...(onSuccess ? { onSuccess } : {}),
-  // React Compiler shares the remap gate: compiled output's memo cache only
+  // React Compiler shares the dependency gate: compiled output's memo cache only
   // works inside tap renders through the shimmed `react/compiler-runtime`, and
   // tap itself (which implements the hooks the compiler output runs on) must
   // never be compiled.
   plugins: [
-    ...(remapReactToShim ? [reactCompiler()] : []),
+    ...(dependsOnTap ? [reactCompiler()] : []),
     preserveReferenceDirectives(),
   ],
 });
@@ -73,13 +75,21 @@ await build({
 // `output.paths` rewrites the `react` specifier in BOTH the emitted JS and the
 // declarations. Only the runtime (.js) should route through the shim; declared
 // types should reference real `react` (so published `.d.ts` stay clean and the
-// shim isn't an editor auto-import source). Revert the specifier in dist `.d.ts`.
+// shim isn't an editor auto-import source). When building tap itself, the
+// runtime shim files must also keep importing real `react` to avoid self-routing.
 if (remapReactToShim && !isDev && existsSync("dist")) {
   for (const rel of readdirSync("dist", {
     recursive: true,
     encoding: "utf8",
   })) {
-    if (typeof rel !== "string" || !rel.endsWith(".d.ts")) continue;
+    if (typeof rel !== "string") continue;
+
+    const isDeclaration = rel.endsWith(".d.ts");
+    const isTapShimRuntime =
+      isTapPackage && rel.startsWith("react-shim/") && rel.endsWith(".js");
+
+    if (!isDeclaration && !isTapShimRuntime) continue;
+
     const file = resolve("dist", rel);
     const src = readFileSync(file, "utf8");
     const out = src


### PR DESCRIPTION
## Summary

- route `@assistant-ui/tap`'s own non-shim React imports through `@assistant-ui/tap/react-shim`
- keep emitted `dist/react-shim/*` files importing real `react` to avoid self-routing
- add a React 18-safe `useEffectEvent` fallback in the tap react shim, while preferring the native React runtime hook when present
- add patch changesets for `@assistant-ui/tap` and `@assistant-ui/x-buildutils`

## Reproduction

Reproduced #4312 with a fresh Next 14.2.33 app using React 18.2.0 and `@assistant-ui/react@0.14.20`. The published package fails during production compilation because `@assistant-ui/tap/dist/hooks/useTapRoot.js` imports `useEffectEvent` directly from `react`.

After installing the locally built `@assistant-ui/tap` package into the same repro, `next build` passes.

## Validation

- `pnpm lint`
- `pnpm --filter @assistant-ui/tap build`
- `pnpm build`
- `npm run build` in `.test-output/repro-4312-next14-react18` after installing local `@assistant-ui/tap`

Fixes #4312


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

