### PR TITLE
fix(docs): redirect .md doc and example URLs to .mdx

### DIFF
--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -36,6 +36,23 @@ const config: NextConfig = {
       ],
     },
   ],
+  redirects: async () => [
+    {
+      source: "/docs/:path*.md",
+      destination: "/docs/:path*.mdx",
+      permanent: true,
+    },
+    {
+      source: "/examples.md",
+      destination: "/examples.mdx",
+      permanent: true,
+    },
+    {
+      source: "/examples/:path*.md",
+      destination: "/examples/:path*.mdx",
+      permanent: true,
+    },
+  ],
   rewrites: async () => ({
     beforeFiles: [
       {


### PR DESCRIPTION
## summary

- agents and LLMs that append `.md` to a docs or examples URL now get the raw markdown instead of a 404 HTML error page; previously only `.mdx` (and the `accept: text/markdown` header) were wired up
- adds permanent (308) redirects for `/docs/:path*.md`, `/examples.md`, and `/examples/:path*.md` to their `.mdx` equivalents, which the existing rewrites already serve as markdown via the `/llms.mdx/...` route handlers
- canonicalizes `.md` onto the `.mdx` URL (one cached/indexed raw-markdown URL per page) at the cost of one extra redirect hop

## test plan

### already verified

- [x] ran `next dev` locally: `/docs/installation.md` -> 308 -> `/docs/installation.mdx` -> 200 `text/markdown` with real content; nested `/docs/cloud.md`, `/examples.md`, `/examples/gemini.md`, `/examples/claude.md` all chain 308 -> 200 markdown
- [x] `/docs/installation.mdx` direct still 200; blog `.md` and pricing `.md` unaffected; non-existent slugs still 404 (the redirect fires, then the `.mdx` handler `notFound()`s)
- [x] `pnpm lint` (oxlint + oxfmt --check) clean

### reviewer should verify

- [ ] after deploy, `curl -sI https://www.assistant-ui.com/docs/installation.md` returns `308` with `location: /docs/installation.mdx`, and following it returns `text/markdown`

## notes

- tap docs (`/tap/docs/*.mdx`) has no markdown route or rewrite at all, so its "view as markdown" link already 404s independent of this change; left out of scope

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

