### PR TITLE
feat: export math-delimiter preprocess helpers for the markdown text primitives

### DIFF
--- a/.changeset/math-delimiter-preprocess-helpers.md
+++ b/.changeset/math-delimiter-preprocess-helpers.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-streamdown": patch
+---
+
+feat: export math-delimiter preprocess helpers for the markdown text primitives
+
+adds `normalizeMathDelimiters`, `rewriteLatexBracketDelimiters`, `rewriteCustomMathTags`, and `escapeCurrencyDollars` so you can pass them to the `preprocess` prop instead of copy-pasting a regex blob. they rewrite the `\(...\)` / `\[...\]` brackets and `[/math]` / `[/inline]` tags that models emit to the `$...$` / `$$...$$` form remark-math parses, and escape `$5`-style currency so single-dollar math doesn't eat it.

--- a/apps/docs/content/docs/guides/latex.mdx
+++ b/apps/docs/content/docs/guides/latex.mdx
@@ -106,47 +106,53 @@ By default, remark-math (react-markdown path) supports:
 
 ## Supporting Alternative LaTeX Delimiters
 
-Many language models generate LaTeX using different delimiter formats:
-- `\(...\)` for inline math
-- `\[...\]` for display math
-- Custom formats like `[/math]...[/math]`
+Many language models emit math in delimiters that remark-math does not recognize:
+- `\(...\)` for inline math and `\[...\]` for display math
+- custom tags like `[/math]...[/math]` and `[/inline]...[/inline]`
 
-You can use the `preprocess` prop on `MarkdownTextPrimitive` to normalize these formats before parsing:
+`@assistant-ui/react-markdown` exports `normalizeMathDelimiters`, which rewrites these to the `$...$` and `$$...$$` form remark-math parses. Pass it to the `preprocess` prop of `MarkdownTextPrimitive`:
 
 ```tsx title="/components/assistant-ui/markdown-text.tsx"
-import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
+import {
+  MarkdownTextPrimitive,
+  normalizeMathDelimiters, // [!code ++]
+} from "@assistant-ui/react-markdown";
 
 const MarkdownTextImpl = () => {
   return (
     <MarkdownTextPrimitive
       remarkPlugins={[remarkGfm, remarkMath]}
       rehypePlugins={[rehypeKatex]}
-      preprocess={normalizeCustomMathTags} // [!code ++]
+      preprocess={normalizeMathDelimiters} // [!code ++]
       className="aui-md"
       components={defaultComponents}
     />
   );
 };
+```
 
-// Your LaTeX preprocessing function
-function normalizeCustomMathTags(input: string): string {
-  return (
-    input
-      // Convert [/math]...[/math] to $$...$$
-      .replace(/\[\/math\]([\s\S]*?)\[\/math\]/g, (_, content) => `$$${content.trim()}$$`)
+The individual transforms `rewriteLatexBracketDelimiters` and `rewriteCustomMathTags` are exported too, for finer control over which delimiters are normalized.
 
-      // Convert [/inline]...[/inline] to $...$
-      .replace(/\[\/inline\]([\s\S]*?)\[\/inline\]/g, (_, content) => `$${content.trim()}$`)
+<Callout type="info">
+  Using [Streamdown](/docs/ui/streamdown) as your renderer? The same helpers are exported from `@assistant-ui/react-streamdown` and accepted by the `preprocess` prop of `StreamdownTextPrimitive`.
+</Callout>
 
-      // Convert \( ... \) to $...$ (inline math) - handles both single and double backslashes
-      .replace(/\\{1,2}\(([\s\S]*?)\\{1,2}\)/g, (_, content) => `$${content.trim()}$`)
+### Currency amounts
 
-      // Convert \[ ... \] to $$...$$ (block math) - handles both single and double backslashes
-      .replace(/\\{1,2}\[([\s\S]*?)\\{1,2}\]/g, (_, content) => `$$${content.trim()}$$`)
-  );
-}
+With single-dollar inline math enabled (the default on the react-markdown path), remark-math reads a lone `$` as a math delimiter, so prose such as `$5 ... $10` is parsed as math. `escapeCurrencyDollars` escapes a `$` immediately followed by a digit so currency survives, while leaving the `$$` of display math intact. Compose it with the delimiter normalization:
+
+```tsx title="/components/assistant-ui/markdown-text.tsx"
+import {
+  normalizeMathDelimiters,
+  escapeCurrencyDollars, // [!code ++]
+} from "@assistant-ui/react-markdown";
+
+<MarkdownTextPrimitive
+  preprocess={(text) => escapeCurrencyDollars(normalizeMathDelimiters(text))} // [!code ++]
+  // ...
+/>;
 ```
 
 <Callout type="tip">
-Inside `MarkdownTextPrimitive`, the streamed text first passes through `preprocess` (delimiter normalization) and then through `useSmooth` (character-by-character accumulation), and only then reaches the markdown parser. Both run before remark-math sees the text, so delimiter replacement and the streaming smoothing are streaming-safe — partially-received delimiters are accumulated in the smoothing buffer rather than parsed mid-fragment.
+Inside `MarkdownTextPrimitive`, the streamed text first passes through `preprocess` (delimiter normalization) and then through `useSmooth` (character by character accumulation), and only then reaches the markdown parser. Both run before remark-math sees the text, so delimiter replacement and the streaming smoothing stay streaming safe; a partially received delimiter is accumulated in the smoothing buffer rather than parsed mid fragment.
 </Callout>

--- a/packages/react-markdown/src/index.ts
+++ b/packages/react-markdown/src/index.ts
@@ -10,3 +10,10 @@ export type {
 
 export { useIsMarkdownCodeBlock } from "./overrides/PreOverride";
 export { memoizeMarkdownComponents as unstable_memoizeMarkdownComponents } from "./memoization";
+
+export {
+  rewriteLatexBracketDelimiters,
+  rewriteCustomMathTags,
+  normalizeMathDelimiters,
+  escapeCurrencyDollars,
+} from "./preprocess";

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  rewriteLatexBracketDelimiters,
+  rewriteCustomMathTags,
+  normalizeMathDelimiters,
+  escapeCurrencyDollars,
+} from "./preprocess";
+
+describe("rewriteLatexBracketDelimiters", () => {
+  it("rewrites inline brackets to single dollars", () => {
+    expect(rewriteLatexBracketDelimiters("a \\(x^2\\) b")).toBe("a $x^2$ b");
+  });
+
+  it("rewrites display brackets to double dollars", () => {
+    expect(rewriteLatexBracketDelimiters("\\[a + b\\]")).toBe("$$a + b$$");
+  });
+
+  it("accepts a double leading backslash", () => {
+    expect(rewriteLatexBracketDelimiters("\\\\(x\\\\)")).toBe("$x$");
+  });
+
+  it("trims the captured body", () => {
+    expect(rewriteLatexBracketDelimiters("\\( x \\)")).toBe("$x$");
+  });
+
+  it("spans newlines only for display math", () => {
+    expect(rewriteLatexBracketDelimiters("\\[a\nb\\]")).toBe("$$a\nb$$");
+    expect(rewriteLatexBracketDelimiters("\\(a\nb\\)")).toBe("\\(a\nb\\)");
+  });
+
+  it("leaves text without bracket delimiters untouched", () => {
+    expect(rewriteLatexBracketDelimiters("plain $x$ text")).toBe(
+      "plain $x$ text",
+    );
+  });
+});
+
+describe("rewriteCustomMathTags", () => {
+  it("rewrites [/math] to display dollars and [/inline] to inline dollars", () => {
+    expect(
+      rewriteCustomMathTags("[/math]a+b[/math] and [/inline]c[/inline]"),
+    ).toBe("$$a+b$$ and $c$");
+  });
+});
+
+describe("normalizeMathDelimiters", () => {
+  it("normalizes both bracket delimiters and custom tags", () => {
+    expect(normalizeMathDelimiters("\\(x\\) [/math]y[/math]")).toBe(
+      "$x$ $$y$$",
+    );
+  });
+});
+
+describe("escapeCurrencyDollars", () => {
+  it("escapes a dollar followed by a digit", () => {
+    expect(escapeCurrencyDollars("it costs $5 and $10.")).toBe(
+      "it costs \\$5 and \\$10.",
+    );
+  });
+
+  it("escapes currency at the start of the string", () => {
+    expect(escapeCurrencyDollars("$1,299 total")).toBe("\\$1,299 total");
+  });
+
+  it("leaves display math intact", () => {
+    expect(escapeCurrencyDollars("$$5x$$")).toBe("$$5x$$");
+  });
+
+  it("does not touch a dollar followed by a letter", () => {
+    expect(escapeCurrencyDollars("$x$")).toBe("$x$");
+  });
+
+  it("does not double-escape an already escaped dollar", () => {
+    expect(escapeCurrencyDollars("already \\$5")).toBe("already \\$5");
+  });
+});

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -73,4 +73,8 @@ describe("escapeCurrencyDollars", () => {
   it("does not double-escape an already escaped dollar", () => {
     expect(escapeCurrencyDollars("already \\$5")).toBe("already \\$5");
   });
+
+  it("escapes currency after an escaped backslash", () => {
+    expect(escapeCurrencyDollars("\\\\$5")).toBe("\\\\\\$5");
+  });
 });

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -54,18 +54,19 @@ export function normalizeMathDelimiters(text: string): string {
   return rewriteLatexBracketDelimiters(rewriteCustomMathTags(text));
 }
 
-const CURRENCY_DOLLAR = /(^|[^\\$])\$(?=\d)/g;
+const CURRENCY_DOLLAR = /(^|[^\\$])((?:\\\\)*)\$(?=\d)/g;
 
 /**
  * Escapes a `$` immediately followed by a digit (`$5`, `$19.99`, `$1,299`) so that
  * remark-math with single-dollar math enabled does not consume currency amounts in
  * prose as math delimiters. A math expression almost always opens with a letter or a
  * `\command`, so a digit after `$` is treated as currency. The `$$` of display math
- * is left intact.
+ * is left intact, and an already-escaped `\$` is not escaped twice (the even run of
+ * backslashes before the `$` is preserved).
  *
  * Trade-off: an expression that genuinely opens with a digit (`$5x = 10$`) has its
  * leading `$` escaped as well. This is rare in practice.
  */
 export function escapeCurrencyDollars(text: string): string {
-  return text.replace(CURRENCY_DOLLAR, "$1\\$");
+  return text.replace(CURRENCY_DOLLAR, "$1$2\\$");
 }

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -1,0 +1,71 @@
+/**
+ * Text transforms for the `preprocess` prop of `MarkdownTextPrimitive`.
+ *
+ * Language models routinely emit math in delimiters that remark-math does not
+ * recognize (LaTeX `\(...\)` / `\[...\]` brackets, `[/math]` / `[/inline]` tags),
+ * and they write currency amounts (`$5`) that single-dollar math otherwise eats.
+ * These helpers normalize that output to the `$...$` / `$$...$$` form remark-math
+ * parses, and are streaming safe (each runs on the full accumulated text before
+ * the parser sees it). Compose them in `preprocess`.
+ */
+
+const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
+const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
+
+/**
+ * Rewrites LaTeX bracket delimiters to dollar delimiters: `\(...\)` becomes
+ * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display). A single or double
+ * leading backslash is accepted, since models emit both depending on escaping.
+ * remark-math only recognizes the dollar form, so without this rewrite bracket
+ * math renders as plain text.
+ */
+export function rewriteLatexBracketDelimiters(text: string): string {
+  return text
+    .replace(LATEX_INLINE_DELIMITER, (_, body: string) => `$${body.trim()}$`)
+    .replace(
+      LATEX_DISPLAY_DELIMITER,
+      (_, body: string) => `$$${body.trim()}$$`,
+    );
+}
+
+const MATH_TAG = /\[\/math\]([\s\S]*?)\[\/math\]/g;
+const INLINE_TAG = /\[\/inline\]([\s\S]*?)\[\/inline\]/g;
+
+/**
+ * Rewrites the custom math tags some models emit to dollar delimiters:
+ * `[/math]...[/math]` becomes `$$...$$` and `[/inline]...[/inline]` becomes `$...$`.
+ */
+export function rewriteCustomMathTags(text: string): string {
+  return text
+    .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
+    .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`);
+}
+
+/**
+ * Normalizes the alternative math delimiters language models commonly emit (LaTeX
+ * `\(...\)` / `\[...\]` brackets and `[/math]` / `[/inline]` tags) to the `$...$` /
+ * `$$...$$` delimiters remark-math parses. Pass it to the `preprocess` prop of
+ * `MarkdownTextPrimitive`.
+ *
+ * It does not touch currency. Compose it with {@link escapeCurrencyDollars} when
+ * single-dollar math is enabled and your content includes prices.
+ */
+export function normalizeMathDelimiters(text: string): string {
+  return rewriteLatexBracketDelimiters(rewriteCustomMathTags(text));
+}
+
+const CURRENCY_DOLLAR = /(^|[^\\$])\$(?=\d)/g;
+
+/**
+ * Escapes a `$` immediately followed by a digit (`$5`, `$19.99`, `$1,299`) so that
+ * remark-math with single-dollar math enabled does not consume currency amounts in
+ * prose as math delimiters. A math expression almost always opens with a letter or a
+ * `\command`, so a digit after `$` is treated as currency. The `$$` of display math
+ * is left intact.
+ *
+ * Trade-off: an expression that genuinely opens with a digit (`$5x = 10$`) has its
+ * leading `$` escaped as well. This is rare in practice.
+ */
+export function escapeCurrencyDollars(text: string): string {
+  return text.replace(CURRENCY_DOLLAR, "$1\\$");
+}

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  rewriteLatexBracketDelimiters,
+  rewriteCustomMathTags,
+  normalizeMathDelimiters,
+  escapeCurrencyDollars,
+} from "../preprocess";
+
+describe("rewriteLatexBracketDelimiters", () => {
+  it("rewrites inline brackets to single dollars", () => {
+    expect(rewriteLatexBracketDelimiters("a \\(x^2\\) b")).toBe("a $x^2$ b");
+  });
+
+  it("rewrites display brackets to double dollars", () => {
+    expect(rewriteLatexBracketDelimiters("\\[a + b\\]")).toBe("$$a + b$$");
+  });
+
+  it("accepts a double leading backslash", () => {
+    expect(rewriteLatexBracketDelimiters("\\\\(x\\\\)")).toBe("$x$");
+  });
+
+  it("trims the captured body", () => {
+    expect(rewriteLatexBracketDelimiters("\\( x \\)")).toBe("$x$");
+  });
+
+  it("spans newlines only for display math", () => {
+    expect(rewriteLatexBracketDelimiters("\\[a\nb\\]")).toBe("$$a\nb$$");
+    expect(rewriteLatexBracketDelimiters("\\(a\nb\\)")).toBe("\\(a\nb\\)");
+  });
+
+  it("leaves text without bracket delimiters untouched", () => {
+    expect(rewriteLatexBracketDelimiters("plain $x$ text")).toBe(
+      "plain $x$ text",
+    );
+  });
+});
+
+describe("rewriteCustomMathTags", () => {
+  it("rewrites [/math] to display dollars and [/inline] to inline dollars", () => {
+    expect(
+      rewriteCustomMathTags("[/math]a+b[/math] and [/inline]c[/inline]"),
+    ).toBe("$$a+b$$ and $c$");
+  });
+});
+
+describe("normalizeMathDelimiters", () => {
+  it("normalizes both bracket delimiters and custom tags", () => {
+    expect(normalizeMathDelimiters("\\(x\\) [/math]y[/math]")).toBe(
+      "$x$ $$y$$",
+    );
+  });
+});
+
+describe("escapeCurrencyDollars", () => {
+  it("escapes a dollar followed by a digit", () => {
+    expect(escapeCurrencyDollars("it costs $5 and $10.")).toBe(
+      "it costs \\$5 and \\$10.",
+    );
+  });
+
+  it("escapes currency at the start of the string", () => {
+    expect(escapeCurrencyDollars("$1,299 total")).toBe("\\$1,299 total");
+  });
+
+  it("leaves display math intact", () => {
+    expect(escapeCurrencyDollars("$$5x$$")).toBe("$$5x$$");
+  });
+
+  it("does not touch a dollar followed by a letter", () => {
+    expect(escapeCurrencyDollars("$x$")).toBe("$x$");
+  });
+
+  it("does not double-escape an already escaped dollar", () => {
+    expect(escapeCurrencyDollars("already \\$5")).toBe("already \\$5");
+  });
+});

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -73,4 +73,8 @@ describe("escapeCurrencyDollars", () => {
   it("does not double-escape an already escaped dollar", () => {
     expect(escapeCurrencyDollars("already \\$5")).toBe("already \\$5");
   });
+
+  it("escapes currency after an escaped backslash", () => {
+    expect(escapeCurrencyDollars("\\\\$5")).toBe("\\\\\\$5");
+  });
 });

--- a/packages/react-streamdown/src/index.ts
+++ b/packages/react-streamdown/src/index.ts
@@ -6,6 +6,13 @@ export {
 export { DEFAULT_SHIKI_THEME } from "./defaults";
 export { memoCompareNodes } from "./memoization";
 
+export {
+  rewriteLatexBracketDelimiters,
+  rewriteCustomMathTags,
+  normalizeMathDelimiters,
+  escapeCurrencyDollars,
+} from "./preprocess";
+
 export type {
   StreamdownTextPrimitiveProps,
   SyntaxHighlighterProps,

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -1,5 +1,5 @@
 /**
- * Text transforms for the `preprocess` prop of `MarkdownTextPrimitive`.
+ * Text transforms for the `preprocess` prop of `StreamdownTextPrimitive`.
  *
  * Language models routinely emit math in delimiters that remark-math does not
  * recognize (LaTeX `\(...\)` / `\[...\]` brackets, `[/math]` / `[/inline]` tags),
@@ -45,7 +45,7 @@ export function rewriteCustomMathTags(text: string): string {
  * Normalizes the alternative math delimiters language models commonly emit (LaTeX
  * `\(...\)` / `\[...\]` brackets and `[/math]` / `[/inline]` tags) to the `$...$` /
  * `$$...$$` delimiters remark-math parses. Pass it to the `preprocess` prop of
- * `MarkdownTextPrimitive`.
+ * `StreamdownTextPrimitive`.
  *
  * It does not touch currency. Compose it with {@link escapeCurrencyDollars} when
  * single-dollar math is enabled and your content includes prices.
@@ -54,18 +54,19 @@ export function normalizeMathDelimiters(text: string): string {
   return rewriteLatexBracketDelimiters(rewriteCustomMathTags(text));
 }
 
-const CURRENCY_DOLLAR = /(^|[^\\$])\$(?=\d)/g;
+const CURRENCY_DOLLAR = /(^|[^\\$])((?:\\\\)*)\$(?=\d)/g;
 
 /**
  * Escapes a `$` immediately followed by a digit (`$5`, `$19.99`, `$1,299`) so that
  * remark-math with single-dollar math enabled does not consume currency amounts in
  * prose as math delimiters. A math expression almost always opens with a letter or a
  * `\command`, so a digit after `$` is treated as currency. The `$$` of display math
- * is left intact.
+ * is left intact, and an already-escaped `\$` is not escaped twice (the even run of
+ * backslashes before the `$` is preserved).
  *
  * Trade-off: an expression that genuinely opens with a digit (`$5x = 10$`) has its
  * leading `$` escaped as well. This is rare in practice.
  */
 export function escapeCurrencyDollars(text: string): string {
-  return text.replace(CURRENCY_DOLLAR, "$1\\$");
+  return text.replace(CURRENCY_DOLLAR, "$1$2\\$");
 }

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -1,0 +1,71 @@
+/**
+ * Text transforms for the `preprocess` prop of `MarkdownTextPrimitive`.
+ *
+ * Language models routinely emit math in delimiters that remark-math does not
+ * recognize (LaTeX `\(...\)` / `\[...\]` brackets, `[/math]` / `[/inline]` tags),
+ * and they write currency amounts (`$5`) that single-dollar math otherwise eats.
+ * These helpers normalize that output to the `$...$` / `$$...$$` form remark-math
+ * parses, and are streaming safe (each runs on the full accumulated text before
+ * the parser sees it). Compose them in `preprocess`.
+ */
+
+const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
+const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
+
+/**
+ * Rewrites LaTeX bracket delimiters to dollar delimiters: `\(...\)` becomes
+ * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display). A single or double
+ * leading backslash is accepted, since models emit both depending on escaping.
+ * remark-math only recognizes the dollar form, so without this rewrite bracket
+ * math renders as plain text.
+ */
+export function rewriteLatexBracketDelimiters(text: string): string {
+  return text
+    .replace(LATEX_INLINE_DELIMITER, (_, body: string) => `$${body.trim()}$`)
+    .replace(
+      LATEX_DISPLAY_DELIMITER,
+      (_, body: string) => `$$${body.trim()}$$`,
+    );
+}
+
+const MATH_TAG = /\[\/math\]([\s\S]*?)\[\/math\]/g;
+const INLINE_TAG = /\[\/inline\]([\s\S]*?)\[\/inline\]/g;
+
+/**
+ * Rewrites the custom math tags some models emit to dollar delimiters:
+ * `[/math]...[/math]` becomes `$$...$$` and `[/inline]...[/inline]` becomes `$...$`.
+ */
+export function rewriteCustomMathTags(text: string): string {
+  return text
+    .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
+    .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`);
+}
+
+/**
+ * Normalizes the alternative math delimiters language models commonly emit (LaTeX
+ * `\(...\)` / `\[...\]` brackets and `[/math]` / `[/inline]` tags) to the `$...$` /
+ * `$$...$$` delimiters remark-math parses. Pass it to the `preprocess` prop of
+ * `MarkdownTextPrimitive`.
+ *
+ * It does not touch currency. Compose it with {@link escapeCurrencyDollars} when
+ * single-dollar math is enabled and your content includes prices.
+ */
+export function normalizeMathDelimiters(text: string): string {
+  return rewriteLatexBracketDelimiters(rewriteCustomMathTags(text));
+}
+
+const CURRENCY_DOLLAR = /(^|[^\\$])\$(?=\d)/g;
+
+/**
+ * Escapes a `$` immediately followed by a digit (`$5`, `$19.99`, `$1,299`) so that
+ * remark-math with single-dollar math enabled does not consume currency amounts in
+ * prose as math delimiters. A math expression almost always opens with a letter or a
+ * `\command`, so a digit after `$` is treated as currency. The `$$` of display math
+ * is left intact.
+ *
+ * Trade-off: an expression that genuinely opens with a digit (`$5x = 10$`) has its
+ * leading `$` escaped as well. This is rare in practice.
+ */
+export function escapeCurrencyDollars(text: string): string {
+  return text.replace(CURRENCY_DOLLAR, "$1\\$");
+}


### PR DESCRIPTION
## what

exports four pure preprocess helpers from both markdown text packages (`@assistant-ui/react-markdown` and `@assistant-ui/react-streamdown`), so users can pass them to the `preprocess` prop instead of copy-pasting a regex blob:

- `normalizeMathDelimiters(text)` rewrites the alternative math delimiters models commonly emit (`\(...\)` / `\[...\]` brackets and `[/math]` / `[/inline]` tags) to the `$...$` / `$$...$$` form remark-math parses
- `rewriteLatexBracketDelimiters(text)` and `rewriteCustomMathTags(text)` are the individual transforms, for finer control
- `escapeCurrencyDollars(text)` escapes a `$` immediately followed by a digit (`$5`, `$19.99`, `$1,299`) so single-dollar math doesn't eat currency in prose, while leaving the `$$` of display math intact

## why

the latex guide currently tells users to paste a `normalizeCustomMathTags` regex function into their own `markdown-text.tsx`. teaching a copy-paste is the canonical signal it should be a library export, and the documented version is also incomplete: it has no currency handling, so a `$5 ... $10` price gets parsed as math under single-dollar mode (remark-math's default on the react-markdown path).

helpers are mirrored into both packages on purpose. `@streamdown/math` is just `remark-math` + `rehype-katex` with `singleDollarTextMath` defaulting to false (verified against vercel/streamdown `packages/streamdown-math/index.ts`), so it does not normalize bracket delimiters either. exporting from `react-streamdown` as well lets a streamdown consumer adopt these without cross-importing `react-markdown`, matching how both packages already ship their own parallel `memoization` util.

## docs

rewrites the "supporting alternative latex delimiters" section of `guides/latex.mdx` to import the helpers (and adds a currency subsection + a note that the same exports work for `StreamdownTextPrimitive`).

## testing

- new unit tests for all four helpers in each package (bracket + display + double-backslash + trim + newline scoping; currency escaping incl. display-math protection and idempotence)
- `react-markdown` 16 passed, `react-streamdown` 109 passed, typecheck + oxlint + oxfmt clean

patch changeset for both packages.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

