### PR TITLE
feat(react): add unstable_useLiveCompletionAdapter for async trigger completions

### DIFF
--- a/.changeset/unstable-live-completion-adapter.md
+++ b/.changeset/unstable-live-completion-adapter.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: add `unstable_useLiveCompletionAdapter` for async trigger completions
+
+bridges an async completion source (a server search, a gateway RPC) into the synchronous `Unstable_TriggerAdapter`. `search` returns cached items synchronously and schedules a debounced fetch with stale-request cancellation; when results land the adapter re-creates so the popover re-renders. also adds an `isLoading` prop on `ComposerPrimitive.Unstable_TriggerPopover` (surfaced on the popover scope) so async sources can render a loading state.

--- a/apps/docs/content/docs/guides/mentions.mdx
+++ b/apps/docs/content/docs/guides/mentions.mdx
@@ -85,7 +85,35 @@ const myAdapter: Unstable_TriggerAdapter = {
 
 ### Async Mention Search
 
-The adapter interface is synchronous, but the data it reads can come from any async source. Load results into React state (or a query cache) and read the current snapshot inside the adapter methods. The adapter re-creates on each render, so the popover always sees the latest results.
+The built-in `unstable_useLiveCompletionAdapter` wraps an async fetcher with debouncing, stale-request cancellation (results for an outdated query are dropped), and a single-entry cache. Its `search` returns the last results synchronously and schedules a debounced fetch when the query changes; when results arrive the returned `adapter` re-creates, which re-runs the popover lookup so the fresh items render. It also reports `isLoading`, which you pass to the popover to show a loading state.
+
+```tsx
+import {
+  unstable_useLiveCompletionAdapter,
+  unstable_defaultDirectiveFormatter,
+} from "@assistant-ui/react";
+import { ComposerTriggerPopover } from "@/components/assistant-ui/composer-trigger-popover";
+
+function MentionPopover() {
+  const mentions = unstable_useLiveCompletionAdapter({
+    fetcher: async (query) => {
+      const users = await fetchUsers(query);
+      return users.map((u) => ({ id: u.id, type: "user", label: u.name }));
+    },
+  });
+
+  return (
+    <ComposerTriggerPopover
+      char="@"
+      adapter={mentions.adapter}
+      isLoading={mentions.isLoading}
+      directive={{ formatter: unstable_defaultDirectiveFormatter }}
+    />
+  );
+}
+```
+
+The adapter interface is itself synchronous, so you can also wire async data by hand when you need a custom cache, no debounce, or an existing query client. Load results into React state (or a query cache) and read the current snapshot inside the adapter methods. The adapter re-creates on each render, so the popover always sees the latest results.
 
 **With React state and `useEffect`:**
 

--- a/apps/docs/content/docs/ui/composer-trigger-popover.mdx
+++ b/apps/docs/content/docs/ui/composer-trigger-popover.mdx
@@ -185,6 +185,8 @@ The popover implements the WAI-ARIA editable combobox pattern.
 | `backLabel` | `string` | `"Back"` | Back button label |
 | `emptyCategoriesLabel` | `string` | `"No items available"` | Shown when no categories are available |
 | `emptyItemsLabel` | `string` | `"No matching items"` | Shown when no items match |
+| `isLoading` | `boolean` | `false` | Whether the adapter is resolving items (async sources). Pair with `unstable_useLiveCompletionAdapter`. |
+| `loadingLabel` | `string` | `"Loading…"` | Shown in place of `emptyItemsLabel` while `isLoading` and no items are present |
 
 All other props (`className`, etc.) forward to the underlying popover `div`.
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -414,6 +414,12 @@ export {
   type Unstable_UseSlashCommandAdapterOptions,
 } from "./unstable/useSlashCommandAdapter";
 
+// Unstable - live (async) completion adapter helper
+export {
+  unstable_useLiveCompletionAdapter,
+  type Unstable_UseLiveCompletionAdapterOptions,
+} from "./unstable/useLiveCompletionAdapter";
+
 export type { ToolExecutionStatus } from "./internal";
 
 // Unstable - trigger popover (unified root for @ mentions, / slash commands, etc.)

--- a/packages/react/src/primitives/composer/trigger/TriggerPopover.tsx
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopover.tsx
@@ -72,6 +72,8 @@ export namespace ComposerPrimitiveTriggerPopover {
     readonly char: string;
     /** Adapter providing categories and items. */
     readonly adapter?: Unstable_TriggerAdapter | undefined;
+    /** Whether the adapter is resolving items, surfaced to the popover scope for async sources. @default false */
+    readonly isLoading?: boolean | undefined;
   };
 }
 
@@ -107,7 +109,14 @@ export const ComposerPrimitiveTriggerPopover = forwardRef<
   ComposerPrimitiveTriggerPopover.Props
 >(
   (
-    { char, adapter, "aria-label": ariaLabel, children, ...props },
+    {
+      char,
+      adapter,
+      isLoading = false,
+      "aria-label": ariaLabel,
+      children,
+      ...props
+    },
     forwardedRef,
   ) => {
     const aui = useAui();
@@ -159,6 +168,7 @@ export const ComposerPrimitiveTriggerPopover = forwardRef<
         behavior: behavior ?? undefined,
         aui,
         popoverId,
+        isLoading,
       }),
     );
 

--- a/packages/react/src/primitives/composer/trigger/TriggerPopoverResource.ts
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopoverResource.ts
@@ -29,6 +29,8 @@ export type TriggerPopoverResourceOutput = {
   readonly items: readonly Unstable_TriggerItem[];
   readonly highlightedIndex: number;
   readonly isSearchMode: boolean;
+  /** Whether the adapter is currently resolving items (async sources). */
+  readonly isLoading: boolean;
   /** Stable ID prefix for generating accessible element IDs. */
   readonly popoverId: string;
   /** ID of the currently highlighted item (for aria-activedescendant). */
@@ -58,6 +60,7 @@ const useTriggerPopoverResource = ({
   behavior,
   aui,
   popoverId,
+  isLoading,
 }: {
   adapter: Unstable_TriggerAdapter | undefined;
   text: string;
@@ -66,6 +69,7 @@ const useTriggerPopoverResource = ({
   aui: AssistantClient;
   /** Stable ID for accessible element IDs (pass React's useId() from component layer). */
   popoverId: string;
+  isLoading: boolean;
 }): TriggerPopoverResourceOutput => {
   const detection = useResource(
     TriggerDetectionResource({ text, triggerChar }),
@@ -122,6 +126,7 @@ const useTriggerPopoverResource = ({
     items: navigation.items,
     highlightedIndex: keyboard.highlightedIndex,
     isSearchMode: navigation.isSearchMode,
+    isLoading,
     popoverId,
     highlightedItemId: keyboard.highlightedItemId,
     selectCategory: navigation.selectCategory,

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -128,4 +128,49 @@ describe("unstable_useLiveCompletionAdapter", () => {
     });
     expect(result.current.adapter.search!("ab")).toEqual([item("ab")]);
   });
+
+  it("drops an in-flight fetch when the query returns to a cached value", async () => {
+    const resolvers: Record<
+      string,
+      (value: readonly Unstable_TriggerItem[]) => void
+    > = {};
+    const fetcher = vi.fn(
+      (q: string) =>
+        new Promise<readonly Unstable_TriggerItem[]>((r) => {
+          resolvers[q] = r;
+        }),
+    );
+    const { result } = renderHook(() =>
+      unstable_useLiveCompletionAdapter({ fetcher, debounceMs: 0 }),
+    );
+
+    await act(async () => {
+      result.current.adapter.search!("ab");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      resolvers["ab"]!([item("ab")]);
+    });
+    expect(result.current.adapter.search!("ab")).toEqual([item("ab")]);
+
+    // type "abc": a fetch goes in flight
+    await act(async () => {
+      result.current.adapter.search!("abc");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(resolvers["abc"]).toBeTypeOf("function");
+
+    // delete back to the cached "ab": the in-flight "abc" must be invalidated
+    await act(async () => {
+      result.current.adapter.search!("ab");
+    });
+    await act(async () => {
+      resolvers["abc"]!([item("abc")]);
+    });
+    expect(result.current.adapter.search!("ab")).toEqual([item("ab")]);
+  });
 });

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -27,15 +27,15 @@ describe("unstable_useLiveCompletionAdapter", () => {
     );
 
     let returned: readonly Unstable_TriggerItem[] = [];
-    act(() => {
+    await act(async () => {
       returned = result.current.adapter.search!("ab");
     });
     expect(returned).toEqual([]);
     expect(result.current.isLoading).toBe(true);
     expect(fetcher).not.toHaveBeenCalled();
 
-    act(() => {
-      vi.advanceTimersByTime(50);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
     });
     expect(fetcher).toHaveBeenCalledTimes(1);
     expect(fetcher).toHaveBeenCalledWith("ab");
@@ -48,23 +48,45 @@ describe("unstable_useLiveCompletionAdapter", () => {
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
-  it("does not fetch when disabled", () => {
-    const fetcher = vi.fn(async () => [item("a")]);
+  it("defers its state update out of search() so it is safe to call during render", () => {
+    const fetcher = vi.fn(async () => []);
     const { result } = renderHook(() =>
-      unstable_useLiveCompletionAdapter({
-        fetcher,
-        enabled: false,
-        debounceMs: 0,
-      }),
+      unstable_useLiveCompletionAdapter({ fetcher, debounceMs: 0 }),
     );
 
-    act(() => {
+    const returned = result.current.adapter.search!("ab");
+    expect(returned).toEqual([]);
+    // the fetch (and its setIsLoading) is queued, not run synchronously
+    expect(result.current.isLoading).toBe(false);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when disabled and clears cached items", async () => {
+    const fetcher = vi.fn(async () => [item("a")]);
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        unstable_useLiveCompletionAdapter({ fetcher, enabled, debounceMs: 0 }),
+      { initialProps: { enabled: true } },
+    );
+
+    await act(async () => {
       result.current.adapter.search!("ab");
-      vi.advanceTimersByTime(100);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.adapter.search!("ab")).toEqual([item("a")]);
+
+    fetcher.mockClear();
+    await act(async () => {
+      rerender({ enabled: false });
+    });
+    expect(result.current.adapter.search!("ab")).toEqual([]);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
     });
     expect(fetcher).not.toHaveBeenCalled();
     expect(result.current.isLoading).toBe(false);
-    expect(result.current.adapter.search!("ab")).toEqual([]);
   });
 
   it("drops a stale in-flight result when the query changes", async () => {
@@ -82,14 +104,19 @@ describe("unstable_useLiveCompletionAdapter", () => {
       unstable_useLiveCompletionAdapter({ fetcher, debounceMs: 0 }),
     );
 
-    act(() => {
+    await act(async () => {
       result.current.adapter.search!("a");
-      vi.advanceTimersByTime(0);
     });
-    act(() => {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
       result.current.adapter.search!("ab");
-      vi.advanceTimersByTime(0);
     });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
 
     await act(async () => {
       resolvers["a"]!([item("a")]);

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -1,0 +1,104 @@
+/** @vitest-environment jsdom */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Unstable_TriggerItem } from "@assistant-ui/core";
+import { unstable_useLiveCompletionAdapter } from "./useLiveCompletionAdapter";
+
+const item = (id: string): Unstable_TriggerItem => ({
+  id,
+  type: "x",
+  label: id,
+});
+
+describe("unstable_useLiveCompletionAdapter", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("returns cached items synchronously and schedules a debounced fetch", async () => {
+    let resolve!: (value: readonly Unstable_TriggerItem[]) => void;
+    const fetcher = vi.fn(
+      () =>
+        new Promise<readonly Unstable_TriggerItem[]>((r) => {
+          resolve = r;
+        }),
+    );
+    const { result } = renderHook(() =>
+      unstable_useLiveCompletionAdapter({ fetcher, debounceMs: 50 }),
+    );
+
+    let returned: readonly Unstable_TriggerItem[] = [];
+    act(() => {
+      returned = result.current.adapter.search!("ab");
+    });
+    expect(returned).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+    expect(fetcher).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith("ab");
+
+    await act(async () => {
+      resolve([item("ab")]);
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.adapter.search!("ab")).toEqual([item("ab")]);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fetch when disabled", () => {
+    const fetcher = vi.fn(async () => [item("a")]);
+    const { result } = renderHook(() =>
+      unstable_useLiveCompletionAdapter({
+        fetcher,
+        enabled: false,
+        debounceMs: 0,
+      }),
+    );
+
+    act(() => {
+      result.current.adapter.search!("ab");
+      vi.advanceTimersByTime(100);
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.adapter.search!("ab")).toEqual([]);
+  });
+
+  it("drops a stale in-flight result when the query changes", async () => {
+    const resolvers: Record<
+      string,
+      (value: readonly Unstable_TriggerItem[]) => void
+    > = {};
+    const fetcher = vi.fn(
+      (q: string) =>
+        new Promise<readonly Unstable_TriggerItem[]>((r) => {
+          resolvers[q] = r;
+        }),
+    );
+    const { result } = renderHook(() =>
+      unstable_useLiveCompletionAdapter({ fetcher, debounceMs: 0 }),
+    );
+
+    act(() => {
+      result.current.adapter.search!("a");
+      vi.advanceTimersByTime(0);
+    });
+    act(() => {
+      result.current.adapter.search!("ab");
+      vi.advanceTimersByTime(0);
+    });
+
+    await act(async () => {
+      resolvers["a"]!([item("a")]);
+    });
+    expect(result.current.adapter.search!("ab")).toEqual([]);
+
+    await act(async () => {
+      resolvers["ab"]!([item("ab")]);
+    });
+    expect(result.current.adapter.search!("ab")).toEqual([item("ab")]);
+  });
+});

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -101,16 +101,20 @@ export function unstable_useLiveCompletionAdapter(
     [enabled, debounceMs, cancelTimer],
   );
 
-  useEffect(() => {
-    if (enabled) return;
+  const invalidatePending = useCallback(() => {
     cancelTimer();
     pendingQueryRef.current = null;
     tokenRef.current += 1;
     setIsLoading(false);
+  }, [cancelTimer]);
+
+  useEffect(() => {
+    if (enabled) return;
+    invalidatePending();
     setState((s) =>
       s.query === NO_QUERY ? s : { query: NO_QUERY, items: [] },
     );
-  }, [enabled, cancelTimer]);
+  }, [enabled, invalidatePending]);
 
   useEffect(() => cancelTimer, [cancelTimer]);
 
@@ -119,13 +123,22 @@ export function unstable_useLiveCompletionAdapter(
       categories: () => [],
       categoryItems: () => [],
       search: (query: string) => {
-        // search() runs inside the popover's render; defer the fetch so its
-        // state updates are not dispatched while another component renders.
-        if (query !== state.query) queueMicrotask(() => scheduleFetch(query));
+        // search() runs inside the popover's render; defer state updates with
+        // queueMicrotask so they are not dispatched while another component renders.
+        if (query !== state.query) {
+          queueMicrotask(() => scheduleFetch(query));
+        } else if (
+          pendingQueryRef.current !== null &&
+          pendingQueryRef.current !== query
+        ) {
+          // the query returned to a cached value while a fetch for a different
+          // query is in flight; drop it so its result cannot overwrite the cache
+          queueMicrotask(invalidatePending);
+        }
         return state.items;
       },
     }),
-    [state, scheduleFetch],
+    [state, scheduleFetch, invalidatePending],
   );
 
   return useMemo(() => ({ adapter, isLoading }), [adapter, isLoading]);

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -1,0 +1,127 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  Unstable_TriggerAdapter,
+  Unstable_TriggerItem,
+} from "@assistant-ui/core";
+
+export type Unstable_UseLiveCompletionAdapterOptions = {
+  /**
+   * Fetches the items for a query from an async source. Called debounced; the
+   * resolved items are cached and returned synchronously to the popover on the
+   * next render.
+   */
+  readonly fetcher: (query: string) => Promise<readonly Unstable_TriggerItem[]>;
+  /** Debounce applied before a fetch fires, in milliseconds. @default 60 */
+  readonly debounceMs?: number | undefined;
+  /** When `false`, no fetch is scheduled and the adapter stays empty. @default true */
+  readonly enabled?: boolean | undefined;
+};
+
+/** Sentinel that no real query (including the empty string) equals, so the first query always fetches. */
+const NO_QUERY = "\u0000";
+
+/**
+ * @deprecated Under active development and may change without notice.
+ *
+ * Bridges an async completion source (a server search, a gateway RPC) into the
+ * synchronous `Unstable_TriggerAdapter` that `ComposerTriggerPopover` consumes.
+ * `search(query)` returns the last fetched items synchronously and schedules a
+ * debounced fetch when the query changes; when results arrive the returned
+ * `adapter` identity changes, which re-runs the popover's lookup so the fresh
+ * items render. This is a search-only adapter (`categories` are empty).
+ *
+ * `isLoading` is `true` while a fetch is in flight. Pass it to the popover's
+ * `isLoading` prop to render a loading state.
+ *
+ * @example
+ * ```tsx
+ * const mentions = unstable_useLiveCompletionAdapter({
+ *   fetcher: (query) => searchUsers(query),
+ * });
+ *
+ * <ComposerTriggerPopover
+ *   char="@"
+ *   adapter={mentions.adapter}
+ *   isLoading={mentions.isLoading}
+ *   directive={{ onInserted }}
+ * />
+ * ```
+ */
+export function unstable_useLiveCompletionAdapter(
+  options: Unstable_UseLiveCompletionAdapterOptions,
+): { adapter: Unstable_TriggerAdapter; isLoading: boolean } {
+  const { fetcher, debounceMs = 60, enabled = true } = options;
+
+  const [state, setState] = useState<{
+    query: string;
+    items: readonly Unstable_TriggerItem[];
+  }>({ query: NO_QUERY, items: [] });
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tokenRef = useRef(0);
+  const pendingQueryRef = useRef<string | null>(null);
+
+  const cancelTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const scheduleFetch = useCallback(
+    (query: string) => {
+      if (!enabled) return;
+      if (pendingQueryRef.current === query) return;
+      pendingQueryRef.current = query;
+      cancelTimer();
+      const token = ++tokenRef.current;
+      setIsLoading(true);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        fetcherRef.current(query).then(
+          (items) => {
+            if (token !== tokenRef.current) return;
+            setState({ query, items });
+            setIsLoading(false);
+          },
+          () => {
+            if (token !== tokenRef.current) return;
+            setState({ query, items: [] });
+            setIsLoading(false);
+          },
+        );
+      }, debounceMs);
+    },
+    [enabled, debounceMs, cancelTimer],
+  );
+
+  useEffect(() => {
+    if (enabled) return;
+    cancelTimer();
+    pendingQueryRef.current = null;
+    tokenRef.current += 1;
+    setIsLoading(false);
+  }, [enabled, cancelTimer]);
+
+  useEffect(() => cancelTimer, [cancelTimer]);
+
+  const adapter = useMemo<Unstable_TriggerAdapter>(
+    () => ({
+      categories: () => [],
+      categoryItems: () => [],
+      search: (query: string) => {
+        if (query !== state.query) scheduleFetch(query);
+        return state.items;
+      },
+    }),
+    [state, scheduleFetch],
+  );
+
+  return useMemo(() => ({ adapter, isLoading }), [adapter, isLoading]);
+}

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -141,5 +141,5 @@ export function unstable_useLiveCompletionAdapter(
     [state, scheduleFetch, invalidatePending],
   );
 
-  return useMemo(() => ({ adapter, isLoading }), [adapter, isLoading]);
+  return { adapter, isLoading };
 }

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -107,6 +107,9 @@ export function unstable_useLiveCompletionAdapter(
     pendingQueryRef.current = null;
     tokenRef.current += 1;
     setIsLoading(false);
+    setState((s) =>
+      s.query === NO_QUERY ? s : { query: NO_QUERY, items: [] },
+    );
   }, [enabled, cancelTimer]);
 
   useEffect(() => cancelTimer, [cancelTimer]);
@@ -116,7 +119,9 @@ export function unstable_useLiveCompletionAdapter(
       categories: () => [],
       categoryItems: () => [],
       search: (query: string) => {
-        if (query !== state.query) scheduleFetch(query);
+        // search() runs inside the popover's render; defer the fetch so its
+        // state updates are not dispatched while another component renders.
+        if (query !== state.query) queueMicrotask(() => scheduleFetch(query));
         return state.items;
       },
     }),

--- a/packages/ui/src/components/assistant-ui/composer-trigger-popover.tsx
+++ b/packages/ui/src/components/assistant-ui/composer-trigger-popover.tsx
@@ -4,6 +4,7 @@ import { memo, useRef, type ComponentPropsWithoutRef, type FC } from "react";
 import {
   ComposerPrimitive,
   unstable_defaultDirectiveFormatter,
+  unstable_useTriggerPopoverScopeContext,
   type Unstable_DirectiveFormatter,
   type Unstable_TriggerItem,
 } from "@assistant-ui/react";
@@ -45,6 +46,8 @@ type ComposerTriggerPopoverBaseProps = Omit<
   emptyCategoriesLabel?: string;
   /** Label shown when no items match. @default "No matching items" */
   emptyItemsLabel?: string;
+  /** Label shown while an async adapter is resolving items. @default "Loading…" */
+  loadingLabel?: string;
 };
 
 type ComposerTriggerPopoverProps = ComposerTriggerPopoverBaseProps &
@@ -118,6 +121,7 @@ type ItemsProps = {
   fallbackIcon: IconComponent;
   backLabel: string;
   emptyLabel: string;
+  loadingLabel: string;
 };
 
 const Items: FC<ItemsProps> = ({
@@ -125,7 +129,9 @@ const Items: FC<ItemsProps> = ({
   fallbackIcon,
   backLabel,
   emptyLabel,
+  loadingLabel,
 }) => {
+  const { isLoading } = unstable_useTriggerPopoverScopeContext();
   return (
     <ComposerPrimitive.Unstable_TriggerPopoverItems>
       {(items) => (
@@ -166,7 +172,7 @@ const Items: FC<ItemsProps> = ({
             })}
             {items.length === 0 && (
               <div className="text-muted-foreground px-3 py-2 text-sm">
-                {emptyLabel}
+                {isLoading ? loadingLabel : emptyLabel}
               </div>
             )}
           </div>
@@ -186,6 +192,7 @@ const ComposerTriggerPopoverImpl: FC<ComposerTriggerPopoverProps> = ({
   backLabel = "Back",
   emptyCategoriesLabel = "No items available",
   emptyItemsLabel = "No matching items",
+  loadingLabel = "Loading…",
   className,
   directive,
   action,
@@ -234,6 +241,7 @@ const ComposerTriggerPopoverImpl: FC<ComposerTriggerPopoverProps> = ({
         fallbackIcon={fallbackIcon}
         backLabel={backLabel}
         emptyLabel={emptyItemsLabel}
+        loadingLabel={loadingLabel}
       />
     </ComposerPrimitive.Unstable_TriggerPopover>
   );


### PR DESCRIPTION
## what

adds `unstable_useLiveCompletionAdapter`, a helper that bridges an async completion source (a server search, a gateway RPC) into the synchronous `Unstable_TriggerAdapter` that `ComposerTriggerPopover` consumes:

```tsx
const mentions = unstable_useLiveCompletionAdapter({
  fetcher: (query) => searchUsers(query), // Promise<readonly Unstable_TriggerItem[]>
});

<ComposerTriggerPopover char="@" adapter={mentions.adapter} isLoading={mentions.isLoading} directive={{ onInserted }} />
```

`search(query)` returns the last fetched items synchronously and schedules a debounced (60ms) fetch when the query changes, with a single-entry cache, a generation-counter stale-request guard, and a pending-query dedup. when results land, the returned `adapter` identity changes, which re-runs the popover lookup so the fresh items render.

## why / design

today `Unstable_TriggerAdapter` is sync-only (`packages/core/src/adapters/trigger.ts`), so any consumer whose completions come from a server has to hand-roll the debounce + cache + stale-guard bridge. this packages that pattern.

notably this needs **no change to the adapter interface**: async data already flows against the sync interface via the reference-swap (the navigation memos in `triggerNavigationResource.ts` depend on `adapter`, so swapping its identity re-runs `search()`). widening the interface to return `Promise` would instead force those memos into async effects and break every existing sync adapter, so that path was rejected.

loading state is surfaced as an **additive** `isLoading` prop on `ComposerPrimitive.Unstable_TriggerPopover`, threaded onto the popover scope output (`TriggerPopoverResourceOutput.isLoading`) so any primitive can read it via `unstable_useTriggerPopoverScopeContext()`. the prebuilt `ComposerTriggerPopover` gains `isLoading` (auto-inherited) + a `loadingLabel` and renders a loading state when fetching with no items yet.

## scope
- new `unstable_useLiveCompletionAdapter` + 3 unit tests (debounced fetch + sync cache, disabled, stale-result drop)
- additive `isLoading` on the trigger popover primitive + resource output
- `isLoading`/`loadingLabel` on the prebuilt `ComposerTriggerPopover`
- docs: leads the mentions guide "Async Mention Search" section with the helper; component props table updated

fully backward compatible, no change to `@assistant-ui/core`. patch changeset for `@assistant-ui/react` (`ui` and docs are private).

## testing
`@assistant-ui/react` 386 tests pass (3 new), both packages typecheck, oxlint + oxfmt clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

