### PR TITLE
docs: surface react-o11y, document thread.export(), add the live-completion hook to the api-reference

### DIFF
--- a/apps/docs/content/docs/(reference)/api-reference/hooks/composer-triggers.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/composer-triggers.mdx
@@ -3,7 +3,7 @@ title: Composer Trigger Hooks
 description: Unstable assistant-ui hooks for mention menus, slash commands, and custom composer trigger popovers.
 ---
 
-import { unstable_useMentionAdapter, unstable_useSlashCommandAdapter } from "@/generated/typeDocs";
+import { unstable_useLiveCompletionAdapter, unstable_useMentionAdapter, unstable_useSlashCommandAdapter } from "@/generated/typeDocs";
 
 {/* AUTO-GENERATED PAGE by scripts/generate-api-reference.mts */}
 {/* Do not edit manually. */}
@@ -13,6 +13,37 @@ import { unstable_useMentionAdapter, unstable_useSlashCommandAdapter } from "@/g
 {/* Do not edit this block manually. */}
 
 ## API Reference
+
+### unstable_useLiveCompletionAdapter
+
+<Callout type="warn">
+<strong>Deprecated.</strong> Under active development and may change without notice.
+</Callout>
+
+Bridges an async completion source (a server search, a gateway RPC) into the
+synchronous `Unstable_TriggerAdapter` that `ComposerTriggerPopover` consumes.
+`search(query)` returns the last fetched items synchronously and schedules a
+debounced fetch when the query changes; when results arrive the returned
+`adapter` identity changes, which re-runs the popover's lookup so the fresh
+items render. This is a search-only adapter (`categories` are empty).
+
+`isLoading` is `true` while a fetch is in flight. Pass it to the popover's
+`isLoading` prop to render a loading state.
+
+```tsx
+const mentions = unstable_useLiveCompletionAdapter({
+  fetcher: (query) => searchUsers(query),
+});
+
+<ComposerTriggerPopover
+  char="@"
+  adapter={mentions.adapter}
+  isLoading={mentions.isLoading}
+  directive={{ onInserted }}
+/>
+```
+
+<ParametersTable {...unstable_useLiveCompletionAdapter} />
 
 ### unstable_useMentionAdapter
 

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -299,6 +299,21 @@ runtime.thread.import(repo);
 
 Each message must have an explicit `id` and `parentId`; messages with the same `parentId` create branches. Parents must appear before children in the array.
 
+### Exporting a snapshot
+
+`thread.import()` has a counterpart, `thread.export()`, which captures the current thread (including its full branch tree) as a serializable `ExportedMessageRepository`. Use it to persist a conversation and re-import it later:
+
+```tsx
+// capture the current thread as a serializable snapshot
+const repo = runtime.thread.export();
+await saveToBackend(JSON.stringify(repo));
+
+// later, restore it into a runtime
+runtime.thread.import(repo);
+```
+
+The exported shape round-trips through `thread.import()` directly, so the same value is both your persistence format and what you load back.
+
 ## Tool calling
 
 Handle tool results by updating the matching tool-call entry:

--- a/apps/docs/content/docs/tools/multi-agent.mdx
+++ b/apps/docs/content/docs/tools/multi-agent.mdx
@@ -16,6 +16,10 @@ Key behaviors:
 - **Recursive** — Sub-agent messages can contain tool calls that themselves have nested messages. Just use `MessagePartPrimitive.Messages` again.
 - **Read-only** — Sub-agent messages are rendered in a readonly context. No editing, branching, or composing.
 
+<Callout type="info">
+  This renders a sub-agent's **messages**. To visualize a sub-agent's **execution trace** instead (timing, span hierarchy, waterfalls), see [react-o11y](/docs/utilities/react-o11y), which renders observability spans as collapsible trees and timelines.
+</Callout>
+
 ## Quick Start
 
 <Steps>
@@ -226,6 +230,7 @@ function SubConversation({
 ## Related
 
 - [Generative UI](/docs/tools/tool-ui) — Creating tool call UIs
+- [react-o11y](/docs/utilities/react-o11y) — Visualize sub-agent execution as collapsible span trees, waterfalls, and call timelines
 - [MessagePartPrimitive](/docs/api-reference/primitives/message-part) — API reference for message part primitives
 - [Sub-Agent Model Tracking](/docs/cloud/ai-sdk#sub-agent-model-tracking) — Track delegated model usage and costs in the Cloud dashboard
 - [LangGraph Streaming](/docs/runtimes/langgraph/streaming) — Event handlers, subgraph events, and message metadata

--- a/apps/docs/content/docs/utilities/react-o11y.mdx
+++ b/apps/docs/content/docs/utilities/react-o11y.mdx
@@ -1,6 +1,6 @@
 ---
 title: react-o11y
-description: Headless primitives for visualizing observability spans (traces, waterfalls).
+description: Headless primitives for visualizing observability spans as collapsible trace trees, waterfalls, and agent and LLM call timelines.
 platforms: ["react"]
 ---
 

--- a/apps/docs/scripts/api-reference/classify.mts
+++ b/apps/docs/scripts/api-reference/classify.mts
@@ -56,6 +56,7 @@ const STATE_HOOKS = new Set([
 const COMPOSER_TRIGGER_HOOKS = new Set([
   "unstable_useMentionAdapter",
   "unstable_useSlashCommandAdapter",
+  "unstable_useLiveCompletionAdapter",
   "unstable_useTriggerPopoverRootContext",
   "unstable_useTriggerPopoverRootContextOptional",
   "unstable_useTriggerPopoverScopeContext",


### PR DESCRIPTION
small in-repo docs polish, closing discoverability gaps surfaced in the recent audit.

## react-o11y discoverability
- cross-link react-o11y from the multi-agent guide: a disambiguating callout (this renders sub-agent **messages**; to visualize the **execution trace**, timing / span hierarchy / waterfalls, use react-o11y) plus a Related entry, so subagent-tree and timeline builders can find it
- enrich the react-o11y page description with agent and timeline keywords for search

## thread.export()
- document `thread.export()`, the serializable-snapshot counterpart to the already-documented `thread.import()`, in the external-store branching section (capture a thread, persist it, re-import later)

## api-reference
- regenerate the api-reference to include `unstable_useLiveCompletionAdapter` (merged in #4411), and route it via the classifier to the composer-triggers page so it sits with `unstable_useMentionAdapter` / `unstable_useSlashCommandAdapter` rather than the Utilities fallback page

docs-only (`apps/docs` is private, no changeset). MDX generates clean, lint passes. The generated `typeDocs.ts` is gitignored and rebuilt at docs-build time, so only the hand-authored / auto-generated `.mdx` and the classifier config are committed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

