### PR TITLE
feat(docs): Xulux playground — starter helper agent, usage limits, and template flow

### DIFF
--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -34,3 +34,16 @@ BL_API_KEY=
 # Optional sandbox overrides:
 BL_SANDBOX_TEMPLATE=
 BL_REGION=
+
+# Xulux agent usage budget (/api/xulux/chat only).
+# Enabled by default: $1/chat, $2/day, 8 turns/chat, 10 chats/day.
+# Uses Upstash Redis when UPSTASH_REDIS_REST_URL is set; otherwise in-memory (single instance).
+# Set to "0" to disable gating entirely.
+# XULUX_USAGE_BUDGET_ENABLED=0
+# Optional. Force in-memory store even when Upstash is configured (local/tests).
+# XULUX_USAGE_BUDGET_STORE=memory
+# Defaults: $1/chat, $2/day, 8 turns/chat, 10 chats/day
+# XULUX_CHAT_BUDGET_USD=1
+# XULUX_DAILY_BUDGET_USD=2
+# XULUX_MAX_TURNS_PER_CHAT=8
+# XULUX_MAX_CHATS_PER_DAY=10

--- a/apps/docs/app/(demos)/playground/layout.tsx
+++ b/apps/docs/app/(demos)/playground/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { type ReactNode, Suspense } from "react";
 import { SubProjectLayout } from "@/components/shared/sub-project-layout";
-import { PlaygroundRuntimeProvider } from "@/contexts/PlaygroundRuntimeProvider";
 import { createOgMetadata } from "@/lib/og";
 
 const title = "Playground";
@@ -26,9 +25,7 @@ export default function PlaygroundLayout({
       fullHeight
       hideFooter
     >
-      <Suspense>
-        <PlaygroundRuntimeProvider>{children}</PlaygroundRuntimeProvider>
-      </Suspense>
+      <Suspense>{children}</Suspense>
     </SubProjectLayout>
   );
 }

--- a/apps/docs/app/(demos)/playground/page.tsx
+++ b/apps/docs/app/(demos)/playground/page.tsx
@@ -383,6 +383,18 @@ export default function PlaygroundPage() {
   const [mode, setMode] = useState<"agent" | "builder">(
     isAiPlaygroundEnabled ? "agent" : "builder",
   );
+  const [visitedModes, setVisitedModes] = useState({
+    agent: isAiPlaygroundEnabled,
+    builder: !isAiPlaygroundEnabled,
+  });
+
+  const handleModeChange = useCallback((nextMode: "agent" | "builder") => {
+    setMode(nextMode);
+    setVisitedModes((current) => ({
+      ...current,
+      [nextMode]: true,
+    }));
+  }, []);
 
   return (
     <>
@@ -391,7 +403,7 @@ export default function PlaygroundPage() {
           <div className="bg-muted/40 grid grid-cols-2 rounded-md border p-0.5 text-xs">
             <button
               type="button"
-              onClick={() => setMode("agent")}
+              onClick={() => handleModeChange("agent")}
               className={cn(
                 "rounded px-2.5 py-1 font-medium transition-colors",
                 mode === "agent"
@@ -403,7 +415,7 @@ export default function PlaygroundPage() {
             </button>
             <button
               type="button"
-              onClick={() => setMode("builder")}
+              onClick={() => handleModeChange("builder")}
               className={cn(
                 "rounded px-2.5 py-1 font-medium transition-colors",
                 mode === "builder"
@@ -418,7 +430,28 @@ export default function PlaygroundPage() {
       )}
 
       <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
-        {XuluxApp && mode === "agent" ? <XuluxApp /> : <BuilderPlayground />}
+        {XuluxApp && visitedModes.agent && (
+          <div
+            className={cn(
+              "h-full min-h-0 w-full flex-col overflow-hidden",
+              mode === "agent" ? "flex" : "hidden",
+            )}
+            aria-hidden={mode !== "agent"}
+          >
+            <XuluxApp />
+          </div>
+        )}
+        {visitedModes.builder && (
+          <div
+            className={cn(
+              "h-full min-h-0 w-full flex-col overflow-hidden",
+              mode === "builder" ? "flex" : "hidden",
+            )}
+            aria-hidden={mode !== "builder"}
+          >
+            <BuilderPlayground />
+          </div>
+        )}
       </div>
     </>
   );

--- a/apps/docs/app/(demos)/playground/page.tsx
+++ b/apps/docs/app/(demos)/playground/page.tsx
@@ -44,6 +44,7 @@ import {
   type ViewportPreset,
 } from "@/lib/playground-url-state";
 import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
+import { PlaygroundRuntimeProvider } from "@/contexts/PlaygroundRuntimeProvider";
 
 const XuluxApp = isAiPlaygroundEnabled
   ? dynamic(() =>
@@ -360,9 +361,11 @@ function BuilderPlayground() {
   );
 
   return (
-    <PlaygroundChatProvider config={config} setConfig={setConfig}>
-      {content}
-    </PlaygroundChatProvider>
+    <PlaygroundRuntimeProvider>
+      <PlaygroundChatProvider config={config} setConfig={setConfig}>
+        {content}
+      </PlaygroundChatProvider>
+    </PlaygroundRuntimeProvider>
   );
 }
 

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -15,6 +15,7 @@ import {
   streamText,
 } from "ai";
 import type { UIMessage } from "ai";
+import { beginTurn, finishTurn } from "@/lib/xulux/usage-budget";
 import { createXuluxChatTools } from "./tools";
 
 type XuluxReasoningEffort =
@@ -56,10 +57,8 @@ function resolveXuluxModel(config: XuluxRequestConfig | undefined) {
   }
 
   return {
-    model: modelName ? getModel(modelName) : openai.responses("gpt-5.4"),
-    providerOptions: modelName
-      ? undefined
-      : { openai: { reasoningEffort: "low" } },
+    model: modelName ? getModel(modelName) : getModel("gpt-5.4-mini"),
+    providerOptions: undefined,
   };
 }
 
@@ -125,7 +124,7 @@ function formatSelectedTemplateContext(
   return lines.join("\n");
 }
 
-const SYSTEM_PROMPT = `You are a coding assistant that helps users build starter MVP projects with assistant-ui.
+const SYSTEM_PROMPT = `You are a coding assistant that helps users get started with assistant-ui using our starter templates.
 
 <about_assistant_ui>
 assistant-ui is a React library for building AI chat interfaces. It provides:
@@ -158,7 +157,7 @@ Do NOT dump all documentation categories. Keep it conversational.
 </greetings>
 
 <tools>
-You have tools to explore docs, read the monorepo source, and operate a live sandbox.
+You have tools to explore docs, read the monorepo source, and open hosted app previews.
 
 1. **listDocs** - Browse docs structure
    - Call with no path FIRST to discover available top-level sections
@@ -167,69 +166,79 @@ You have tools to explore docs, read the monorepo source, and operate a live san
 2. **readDoc** - Read a specific documentation page
    - Input: slug (e.g., "ui/thread") or URL (e.g., "/docs/ui/thread")
    - Returns: full page content
-3. **inspectSourceMap** / **readSourceMapFile** - Explore the source code of the assistant-ui monorepo
-   - Use for: grep, find, cat, awk, head, tail, wc, ls, tree, etc.
+3. **inspectSourceMap** / **readSourceMapFile** - Explore the assistant-ui monorepo source code
+   - Use for: grep, find, cat, ls, tree on repo files
    - Example: \`grep -r "useThread" packages/ --include="*.ts" -l\`
-   - This is not real sandbox, we just provision the mono repo code through a sourcemap
-4. **provisionSandbox** - Call this once before using the sandbox. Pass the sessionId from the request.
-   - Creates (or resumes) a cloud sandbox tied to this session
-5. **exec** - Run any shell command in the live sandbox
-   - Write files: \`printf '%s' "$CONTENT" > /workspace/file.ts\` or use \`tee\`
-   - Read files: \`cat /workspace/file.ts\`
-   - Install deps: \`cd /workspace && npm install\`
-   - Start the server: see <running_the_server> below — this is the step that breaks most often, follow it exactly
-   - All standard shell tools available: grep, find, ls, tree, curl, lsof, etc.
-6. **refreshCanvas** - Send the preview URL to the client
-   - Only after the server is ready and responding on port 3000
-   - Returns: preview URL
+4. **getTemplateList** - Get all available hosted app templates and their versions
+   - Call this first for any app-building request
+   - Returns: lightweight list of template ids, titles, and version ids
+5. **getTemplateDetails** - Get full details for a specific template
+   - Input: templateId from getTemplateList
+   - Returns: intent metadata, versions, contract roots, source files, example config
+6. **openTemplatePreview** - Open a hosted template preview in the canvas
+   - Input: templateId, optional versionId, optional config object
+   - If config is provided, creates a preview session on the template sandbox
+   - Returns: previewUrl, downloadUrl, title
 </tools>
 
 <recommended_pattern>
-- User asks a question →
-- **Discovery**: agent starts with listDocs to find relevant section → readDoc to get content -> bash to explore the source code
-- **Planning**: agent plans how to implement the user's request based on **Discovery** results
-- **Execution**: agent provisions the sandbox -> executes the plan -> checks server readiness <running_the_server> -> uses refreshCanvas to send the preview URL to the client
+Case 1: User wants to build an app:
+1. Call **getTemplateList** to see what hosted templates are available.
+2. Call **getTemplateDetails** on any templates that look like a match.
+3. Based on users request you can take following three paths:
+   - If the template matches the user's request, call **openTemplatePreview** with the selected templateId and versionId.
+   - If you feel the users request needs some customization which the template supports, review the <template_customization_guide> and then call the **openTemplatePreview** with the config object.
+   - If you dont find the right template and even configs dont support the user's request, follow **Case 1B** below. Do NOT call openTemplatePreview. Do NOT pretend you set up a hosted starter.
 
-Points to remember:
-- Use \`npx tsc -b --noEmit\` for TypeScript fix loops; avoid repeated \`npm run build\` until typecheck passes because full builds create unnecessary delays.
+4. **Case 1A — openTemplatePreview succeeded:** include a fenced code block with language \`open-in\` at the end of your response (this renders a card with download + coding agent buttons — do NOT separately write a download markdown link):
+\`\`\`
+\`\`\`open-in
+{"title":"<template title>","downloadUrl":"<exact downloadUrl from openTemplatePreview result>","customizationNote":"<2-4 sentences: which files to edit and what to change>"}
+\`\`\`
+\`\`\`
+  - \`downloadUrl\` MUST be copied exactly from the openTemplatePreview tool result. Never use placeholders like \`<downloadUrl-from-tool-result>\`.
+  - This renders an interactive card with buttons to open the template in Claude Code, Codex, Cursor, Conductor, or ChatGPT. Don't share preview or download url seperately.
+
+5. **Case 1B — no suitable hosted template:**
+- You MUST call **listDocs** and **readDoc** (and **inspectSourceMap** / **readSourceMapFile** when helpful) before answering. Do not skip documentation.
+- Tell the user honestly that no hosted template fits their request and you are not opening a preview.
+- Do NOT call **openTemplatePreview**. Do NOT claim you "set up a starter" or adapted a template unless the tool actually succeeded.
+- Do NOT include \`downloadUrl\` in an open-in block unless openTemplatePreview returned a real https URL.
+- Write a concrete build guide grounded in docs you read (CLI, architecture, components, runtime).
+- Optionally end with a prompt-only \`open-in\` block (no downloadUrl) so the user can open the guide in their coding agent:
+\`\`\`
+\`\`\`open-in
+{"title":"<short app name>","customizationNote":"<full step-by-step build prompt from docs — no fake download link>"}
+\`\`\`
+\`\`\`
+- Also include the same prompt as a blockquote in your response.
+
+Case 2: User ask questions about assistant-ui:
+- Use listDocs → readDoc to find relevant information.
+- Use inspectSourceMap / readSourceMapFile to explore source code.
 </recommended_pattern>
 
+<template_customization_guide>
+- A hosted template is a packaged starter made of multiple parts: the visible app UI, the assistant experience, the tool setup, and the mock/demo flows. Understand the whole template before deciding it matches the user’s request.
+- Customization is meant for supported adaptation within that template’s shape, not for turning one kind of app into a completely different kind of product. You can change the UI to show case the app like a dashboard and CRM can be handled by one tempalte, but an app to make movies won't work.
+- When customizing, review both the visible UI and the assistant behavior together. A good match requires the screen, assistant identity, prompts, tool descriptions, and mock/demo responses to all reflect the same user request.
+- Use 'getTemplateDetails' and especially 'exampleConfig' to understand what the template actually represents in practice: what the UI looks like, how the assistant behaves, what the tools do, and what the demo/mock flows are modeling.
+- After reading that full template shape, decide whether the user’s request can be represented within it with supported customization. If not, do not force the template.
+</template_customization_guide>
+
 <common_pitfalls_to_avoid>
+- You some times try to force a user's requirement on to a template, you can create mock pages to kinda look like users requirement , but that is just slop. Instead read docs, source map and share a starter prompt for them to build that app.
+- You creating a prompt to guide the user to build that app, you do not read the docs or the sourcemap to be accurate. Instead read the docs and the sourcemap to be accurate and create a prompt for them to build that app.
 - You skip the architecture, installation, and CLI docs and manually scaffold with Next/React create commands, writing low-level code. Instead, read the docs and use the assistant-ui CLI and other available utilities to scaffold with prebuilt components.
 - You assume wrong CLI flags; use the help command to understand how to use the CLI.
 - You confuse assistant-ui components at \`@/components/assistant-ui/*\` to be exported from \`@assistant-ui/react\`. They are shadcn-based components—read the Components doc/subdocs for details on available components and installation (use assistant-ui CLI or shadcn). If customization is needed, customize the generated components.
-- You replace real API/LLM code with mock-only code. Instead, keep the real code path and add a mock fallback for when keys are absent.
 </common_pitfalls_to_avoid>
-
-<running_the_server>
-The Blaxel preview only proxies **port 3000** on **0.0.0.0**. The sandbox image may set a \`PORT\` env var (often 80), so a server started with default settings can end up on the wrong port or bound to localhost only — either way the preview is blank. Whatever you're running — a Node dev server (Next.js, Vite, etc.), a Python server (\`uvicorn\`, \`flask run\`, \`python -m http.server\`), or anything else — these rules are the same:
-
-1. **The server MUST listen on host \`0.0.0.0\` and port \`3000\`.** Figure out the right flags/env for the stack you scaffolded (check \`package.json\` scripts, the framework docs, or the template README) and pass them explicitly. Examples — adapt, don't copy blindly:
-   - Next.js: \`PORT=3000 npm run dev -- --hostname 0.0.0.0 --port 3000\`
-     a. IF its a next.js app - Before starting the dev server, add \`allowedDevOrigins: ["*.preview.bl.run"]\` to \`next.config.js\` / \`next.config.ts\`, preserving existing config fields. This is so we dont get HMR issues when accessing the preview.
-   - Vite: \`npm run dev -- --host 0.0.0.0 --port 3000\` — first add \`server: { allowedHosts: true }\` to \`vite.config.ts\`/\`.js\` (preserve existing fields). This is so we dont get route issues accessing.
-   - uvicorn: \`uvicorn main:app --host 0.0.0.0 --port 3000\`
-   - Flask: \`flask run --host 0.0.0.0 --port 3000\`
-
-2. **If restarting, kill anything already on the port 3000**
-
-3. **Start it backgrounded with logs to a file** so the exec call returns immediately and you can inspect output:
-   \`cd /workspace/<project> && nohup <your start command bound to 0.0.0.0:3000> > /tmp/server.log 2>&1 &\`
-
-4. **Wait for readiness — do not skip this.** Poll until the server actually responds:
-   \`for i in $(seq 1 30); do curl -sf -o /dev/null http://localhost:3000 && echo READY && break; sleep 1; done; echo "--- server.log ---"; cat /tmp/server.log\`
-   - If you see \`READY\`, proceed.
-   - If you see \`EADDRINUSE\` / "address already in use", go back to step 2 (kill harder), then retry.
-   - If you see a build/compile/import error in the log, fix the code and restart. Read the error — don't guess.
-   - If it never becomes ready, tell the user it failed and show the relevant log lines. Do NOT call \`refreshCanvas\` or claim success.
-
-5. Only once the readiness check passes: call \`refreshCanvas\` and tell the user the app is running. Never send a preview link or say "Done" for a server you haven't confirmed is responding on \`0.0.0.0:3000\`.
-</running_the_server>
 
 <answering>
 - Use the documentation tools to find relevant information
 - **CRITICAL: ONLY use URLs that are explicitly returned by your tools**
 - **NEVER guess or fabricate URLs** - if a tool didn't return a URL, don't link to it
+- **NEVER put placeholder URLs in open-in JSON** (e.g. \`<downloadUrl-from-tool-result>\`). Omit \`downloadUrl\` when there is no real download.
 - When linking, copy the exact URL from tool results: [Page Title](/docs/exact-path-from-tool)
 - Prefer not linking over linking to a potentially non-existent page
 - Admit uncertainty rather than guessing
@@ -269,6 +278,17 @@ export async function POST(req: Request): Promise<Response> {
     const inputError = validateDocChatInput(prunedMessages);
     if (inputError) return inputError;
 
+    if (typeof sessionId !== "string" || sessionId.trim().length === 0) {
+      return NextResponse.json(
+        { error: "sessionId required" },
+        { status: 400 },
+      );
+    }
+
+    const distinctId = getDistinctId(req);
+    const budgetDenied = await beginTurn(sessionId.trim(), distinctId);
+    if (budgetDenied) return budgetDenied;
+
     const isFirstUserTurn =
       prunedMessages.filter((m) => m.role === "user").length === 1 &&
       !prunedMessages.some((m) => m.role === "assistant");
@@ -291,11 +311,9 @@ export async function POST(req: Request): Promise<Response> {
     const localTraceUrl = req.headers.get("x-agent-eval-trace-url");
     const modelConfig = resolveXuluxModel(config);
     const baseModel = modelConfig.model;
-    const distinctId = getDistinctId(req);
     const prismTracer = createPrismTracer({ evalRunId, localTraceUrl });
     const xuluxTools = createXuluxChatTools({
       clientTools,
-      sessionId,
       routeUrl: req.url,
     });
     const toolManifest =
@@ -349,7 +367,8 @@ export async function POST(req: Request): Promise<Response> {
       maxOutputTokens: 8192,
       stopWhen: stepCountIs(50),
       tools: xuluxTools,
-      onFinish: async () => {
+      onFinish: async ({ usage, response }) => {
+        await finishTurn(sessionId.trim(), distinctId, usage, response.modelId);
         await prism?.end();
       },
       onError: async ({ error }) => {

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -113,9 +113,6 @@ function formatSelectedTemplateContext(
   if (typeof selectedTemplate.sourcePath === "string") {
     lines.push(`sourcePath: ${selectedTemplate.sourcePath}`);
   }
-  if (typeof selectedTemplate.docsUrl === "string") {
-    lines.push(`docsUrl: ${selectedTemplate.docsUrl}`);
-  }
   if (typeof selectedTemplate.downloadUrl === "string") {
     lines.push(`downloadUrl: ${selectedTemplate.downloadUrl}`);
   }

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -286,8 +286,9 @@ export async function POST(req: Request): Promise<Response> {
     }
 
     const distinctId = getDistinctId(req);
-    const budgetDenied = await beginTurn(sessionId.trim(), distinctId);
-    if (budgetDenied) return budgetDenied;
+    const budget = await beginTurn(sessionId.trim(), distinctId);
+    if (budget.denied) return budget.denied;
+    const budgetDate = budget.budgetDate;
 
     const isFirstUserTurn =
       prunedMessages.filter((m) => m.role === "user").length === 1 &&
@@ -368,7 +369,13 @@ export async function POST(req: Request): Promise<Response> {
       stopWhen: stepCountIs(50),
       tools: xuluxTools,
       onFinish: async ({ usage, response }) => {
-        await finishTurn(sessionId.trim(), distinctId, usage, response.modelId);
+        await finishTurn(
+          sessionId.trim(),
+          distinctId,
+          usage,
+          response.modelId,
+          budgetDate,
+        );
         await prism?.end();
       },
       onError: async ({ error }) => {

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -77,7 +77,7 @@ type SelectedTemplateRequestContext = {
   kind?: unknown;
   prompt?: unknown;
   sourcePath?: unknown;
-  docsUrl?: unknown;
+  downloadUrl?: unknown;
 };
 
 async function prepareMessages(messages: readonly UIMessage[]) {
@@ -115,6 +115,9 @@ function formatSelectedTemplateContext(
   }
   if (typeof selectedTemplate.docsUrl === "string") {
     lines.push(`docsUrl: ${selectedTemplate.docsUrl}`);
+  }
+  if (typeof selectedTemplate.downloadUrl === "string") {
+    lines.push(`downloadUrl: ${selectedTemplate.downloadUrl}`);
   }
 
   lines.push(
@@ -193,11 +196,11 @@ Case 1: User wants to build an app:
 4. **Case 1A — openTemplatePreview succeeded:** include a fenced code block with language \`open-in\` at the end of your response (this renders a card with download + coding agent buttons — do NOT separately write a download markdown link):
 \`\`\`
 \`\`\`open-in
-{"title":"<template title>","downloadUrl":"<exact downloadUrl from openTemplatePreview result>","customizationNote":"<2-4 sentences: which files to edit and what to change>"}
+{"title":"<template title>","downloadUrl":"<exact downloadUrl from openTemplatePreview result>","prompt":"<your build/customization instructions for the external coding agent — be specific about which files to edit and what to change>"}
 \`\`\`
 \`\`\`
-  - \`downloadUrl\` MUST be copied exactly from the openTemplatePreview tool result. Never use placeholders like \`<downloadUrl-from-tool-result>\`.
-  - This renders an interactive card with buttons to open the template in Claude Code, Codex, Cursor, Conductor, or ChatGPT. Don't share preview or download url seperately.
+  - \`downloadUrl\` MUST be copied exactly from the openTemplatePreview tool result. Never use placeholders.
+  - This renders an interactive card with buttons to open the template in Claude Code, Codex, Cursor, Conductor, or ChatGPT. Don't share preview or download url separately.
 
 5. **Case 1B — no suitable hosted template:**
 - You MUST call **listDocs** and **readDoc** (and **inspectSourceMap** / **readSourceMapFile** when helpful) before answering. Do not skip documentation.
@@ -208,7 +211,7 @@ Case 1: User wants to build an app:
 - Optionally end with a prompt-only \`open-in\` block (no downloadUrl) so the user can open the guide in their coding agent:
 \`\`\`
 \`\`\`open-in
-{"title":"<short app name>","customizationNote":"<full step-by-step build prompt from docs — no fake download link>"}
+{"title":"<short app name>","prompt":"<full step-by-step build guide from the docs you read — no fake download link>"}
 \`\`\`
 \`\`\`
 - Also include the same prompt as a blockquote in your response.
@@ -216,6 +219,7 @@ Case 1: User wants to build an app:
 Case 2: User ask questions about assistant-ui:
 - Use listDocs → readDoc to find relevant information.
 - Use inspectSourceMap / readSourceMapFile to explore source code.
+- You can also use open-in code block to share a prompt to help user get started with assistant-ui, try sharing the code block if you think it is relevant.
 </recommended_pattern>
 
 <template_customization_guide>
@@ -232,6 +236,7 @@ Case 2: User ask questions about assistant-ui:
 - You skip the architecture, installation, and CLI docs and manually scaffold with Next/React create commands, writing low-level code. Instead, read the docs and use the assistant-ui CLI and other available utilities to scaffold with prebuilt components.
 - You assume wrong CLI flags; use the help command to understand how to use the CLI.
 - You confuse assistant-ui components at \`@/components/assistant-ui/*\` to be exported from \`@assistant-ui/react\`. They are shadcn-based components—read the Components doc/subdocs for details on available components and installation (use assistant-ui CLI or shadcn). If customization is needed, customize the generated components.
+- You some time guess for fabricate urls, always use the urls from the tool results.
 </common_pitfalls_to_avoid>
 
 <answering>

--- a/apps/docs/app/api/xulux/chat/tools.ts
+++ b/apps/docs/app/api/xulux/chat/tools.ts
@@ -1,21 +1,19 @@
 import { frontendTools } from "@assistant-ui/react-ai-sdk";
 import { createDocsTools } from "./tools/docs-tools";
-import { createSandboxTools } from "./tools/sandbox-tools";
 import { createSourceMapTools } from "./tools/source-map-tools";
+import { createTemplateTools } from "./tools/template-tools";
 
 export function createXuluxChatTools({
   clientTools,
-  sessionId,
   routeUrl,
 }: {
   clientTools: Parameters<typeof frontendTools>[0];
-  sessionId: string | undefined;
   routeUrl: string;
 }) {
   return {
     ...frontendTools(clientTools),
     ...createSourceMapTools(),
-    ...createSandboxTools({ sessionId }),
     ...createDocsTools({ routeUrl }),
+    ...createTemplateTools(),
   };
 }

--- a/apps/docs/app/api/xulux/chat/tools/template-tools.ts
+++ b/apps/docs/app/api/xulux/chat/tools/template-tools.ts
@@ -2,10 +2,7 @@ import { getXuluxHostedTemplatesCatalog } from "@/lib/xulux/templates-catalog";
 import type { XuluxTemplate } from "@/components/xulux/templates/types";
 import { getDemoDownloadManifest } from "@/lib/xulux/demo-downloads/manifest";
 import { tool, zodSchema } from "ai";
-import { setDefaultResultOrder } from "node:dns";
 import z from "zod";
-
-setDefaultResultOrder("ipv4first");
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/apps/docs/app/api/xulux/chat/tools/template-tools.ts
+++ b/apps/docs/app/api/xulux/chat/tools/template-tools.ts
@@ -1,0 +1,1196 @@
+import { getXuluxHostedTemplatesCatalog } from "@/lib/xulux/templates-catalog";
+import type { XuluxTemplate } from "@/components/xulux/templates/types";
+import { getDemoDownloadManifest } from "@/lib/xulux/demo-downloads/manifest";
+import { tool, zodSchema } from "ai";
+import { setDefaultResultOrder } from "node:dns";
+import z from "zod";
+
+setDefaultResultOrder("ipv4first");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function templateId(t: XuluxTemplate): string {
+  return t.templateId ?? t.id;
+}
+
+function findFirstByTemplateId(
+  templates: XuluxTemplate[],
+  tid: string,
+): XuluxTemplate | undefined {
+  return templates.find((t) => templateId(t) === tid);
+}
+
+function toAbsolute(baseUrl: string, url: string): string {
+  if (/^https?:\/\//.test(url)) return url;
+  return `${baseUrl}${url.startsWith("/") ? "" : "/"}${url}`;
+}
+
+function withVersion(url: string, versionId: string | undefined): string {
+  if (!versionId) return url;
+  const [path, query = ""] = url.split("?");
+  const params = new URLSearchParams(query);
+  if (!params.has("v")) params.set("v", versionId);
+  return `${path}?${params.toString()}`;
+}
+
+function hasConfig(config: Record<string, unknown> | undefined): boolean {
+  return !!config && Object.keys(config).length > 0;
+}
+
+function isFixedDemo(entry: XuluxTemplate): boolean {
+  return entry.kind === "example" && !!getDemoDownloadManifest(entry.id);
+}
+
+async function fetchTemplateContract(entry: XuluxTemplate, versionId?: string) {
+  if (!entry.sandboxBaseUrl) return null;
+  try {
+    const url = new URL("/api/template/contract", entry.sandboxBaseUrl);
+    if (versionId) url.searchParams.set("v", versionId);
+    const res = await fetch(url, { cache: "no-store" });
+    if (!res.ok) return null;
+    return (await res.json()) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Agent-facing static metadata (selection + authoring hints per template id)
+// These are agent-facing descriptions, not catalog/runtime metadata.
+// ---------------------------------------------------------------------------
+
+type TemplateListMeta = {
+  name: string;
+  summary: string;
+  assistantPlacement: string;
+  features: string[];
+  customizable: string[];
+};
+
+const TEMPLATE_LIST_META: Record<string, TemplateListMeta> = {
+  "webpage-assistant": {
+    name: "Webpage with Assistant",
+    summary:
+      "A full-page docs or website layout with a sidebar or modal assistant. Pages are defined in config and the assistant can search, preview, and generate code snippets grounded in those pages.",
+    assistantPlacement: "sidebar (desktop) / modal (mobile)",
+    features: [
+      "ContentShell layout: header, left nav, article area, right assistant sidebar",
+      "assistant-ui Thread in sidebar on desktop, AssistantModal on mobile",
+      "Three built-in tools: searchDocs (sourceResults card), openPage (pagePreview card), generateCodeSnippet (codeSnippet card)",
+      "Deterministic demo flows: scripted tool sequences run without an API key",
+      "Suggested prompt chips wired to demo flows",
+    ],
+    customizable: [
+      "hostUi: productName, docsName, defaultPageId, assistantPlacement, navGroups, pages (id/title/section/description/url/markdown/keywords/relatedPageIds)",
+      "assistant: productName, docsName, assistantName, welcome (headline/body), labels (10 UI strings), demoModeNotice, suggestedPrompts, tools (id/displayName/aiDescription/realImplementationHint/rendererType), demoFlows (auth401/webhooks/codeExample steps)",
+      "brandTheme: accent, surface, border, mutedText, focusRing",
+    ],
+  },
+  "product-page-assistant": {
+    name: "Product Page with Floating Assistant",
+    summary:
+      "A mock product dashboard with a floating modal support assistant. The dashboard is a configurable JSON component tree. The assistant runs a two-step analyze-then-handoff flow.",
+    assistantPlacement: "floating modal (bottom-right)",
+    features: [
+      "DashboardShell layout: nav, alert banner, configurable panel tree",
+      "Panel components: Overview, MetricGrid + MetricCard, TwoColumnRow, StatusList, ActivityFeed",
+      "assistant-ui AssistantModal as a floating trigger button",
+      "Two built-in tools: analyzeIssue (analysis card), createSupportSummary (summary card)",
+      "Deterministic demo flows keyed by scenarioId (sync_failure, auth_error)",
+      "File attachment support (mock) in demo flows",
+    ],
+    customizable: [
+      "hostUi: full DashboardShell component tree (NOT deep-merged — provide complete tree)",
+      "assistant: companyName, productName, assistantName, welcome (badge/title/subtitle), labels, demoModeNotice, agentPrompt (persona/instructions/responseStyle), toolCardLabels, toolCardDesign, suggestedPrompts, tools, demoFlows",
+      "assistant.toolData: serviceOptions, mockAccountStatus, escalationLabels, priorityLabels, scenarioPacks",
+      "brandTheme: accent, surface, border, mutedText, success, warning, destructive, focusRing",
+    ],
+  },
+};
+
+function fixedDemoListMeta(entry: XuluxTemplate): TemplateListMeta | undefined {
+  const demo = getDemoDownloadManifest(entry.id);
+  if (!demo) return undefined;
+
+  return {
+    name: demo.name,
+    summary: demo.description,
+    assistantPlacement: "full-page demo route",
+    features: demo.features,
+    customizable: [],
+  };
+}
+
+const CONFIG_ROOTS_SCHEMAS: Record<string, Record<string, unknown>> = {
+  "webpage-assistant": {
+    hostUi: {
+      description:
+        "Controls the visible page — product name, docs name, navigation, and all page content. All pages the assistant can open or reference must be defined here. Deep-merged with template defaults.",
+      schema: {
+        version: { type: "number", value: 1, description: "Always 1." },
+        root: {
+          type: {
+            type: "string",
+            value: "ContentShell",
+            description: "Fixed — do not change.",
+          },
+          props: {
+            productName: {
+              type: "string",
+              default: "OrbitKit API",
+              description: "Product name shown in the top nav.",
+            },
+            docsName: {
+              type: "string",
+              default: "OrbitKit Docs",
+              description: "Docs workspace label shown below product name.",
+            },
+            defaultPageId: {
+              type: "string",
+              default: "quickstart",
+              description:
+                "Id of the page shown on first load. Must be one of the ids in pages.",
+            },
+            assistantPlacement: {
+              type: "string",
+              enum: ["sidebar", "modal"],
+              default: "sidebar",
+              optional: true,
+              description: "Where the assistant appears on desktop.",
+            },
+            navGroups: {
+              type: "array",
+              optional: true,
+              description:
+                "Groups pages under section labels in the left nav. If omitted, pages are listed flat.",
+              item: {
+                label: {
+                  type: "string",
+                  description: "Section label shown in the nav.",
+                },
+                pageIds: {
+                  type: "array",
+                  items: "string",
+                  description: "Page ids in this group. Must exist in pages.",
+                },
+              },
+            },
+            pages: {
+              type: "array",
+              description:
+                "All content pages. Must include the page with defaultPageId.",
+              item: {
+                id: {
+                  type: "string",
+                  description:
+                    "Unique page id. Referenced by defaultPageId, navGroups, and demo flow steps.",
+                },
+                title: {
+                  type: "string",
+                  description: "Page title shown in nav and article header.",
+                },
+                section: {
+                  type: "string",
+                  description: "Nav section label this page belongs to.",
+                },
+                description: {
+                  type: "string",
+                  description: "Short description shown in search results.",
+                },
+                url: {
+                  type: "string",
+                  description: "Canonical URL path for the page.",
+                },
+                markdown: {
+                  type: "string",
+                  description: "Full page content in markdown.",
+                },
+                keywords: {
+                  type: "array",
+                  items: "string",
+                  description: "Search keywords for this page.",
+                },
+                relatedPageIds: {
+                  type: "array",
+                  items: "string",
+                  description: "Ids of related pages. Must exist in pages.",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    assistant: {
+      description:
+        "Controls the thread experience — identity, welcome, labels, suggested prompts, tools, demo flows, and demo mode notice. Deep-merged with template defaults — only include fields you want to override.",
+      schema: {
+        productName: { type: "string", default: "OrbitKit API" },
+        docsName: { type: "string", default: "OrbitKit Docs" },
+        assistantName: { type: "string", default: "Docs Copilot" },
+        welcome: {
+          headline: { type: "string", default: "Ask about these docs" },
+          body: {
+            type: "string",
+            default:
+              "I can search the docs, preview pages, and generate implementation snippets from the current article.",
+          },
+        },
+        labels: {
+          type: "object",
+          optional: true,
+          description:
+            "UI label overrides. All fields optional — omit any to keep the default.",
+          fields: {
+            currentPage: { type: "string", default: "Current page" },
+            source: { type: "string", default: "Source" },
+            relatedPages: { type: "string", default: "Related pages" },
+            openPage: { type: "string", default: "Open in preview" },
+            headerSearch: {
+              type: "string",
+              default: "Search docs with the assistant",
+            },
+            articleCtaTitle: {
+              type: "string",
+              default: "Need a targeted answer?",
+            },
+            articleCtaBody: {
+              type: "string",
+              default:
+                "Use the assistant to search these docs with this page as context.",
+            },
+            articleCtaAction: { type: "string", default: "Ask in sidebar" },
+            composerPlaceholder: {
+              type: "string",
+              default:
+                "Ask about auth, webhooks, errors, or the current page...",
+            },
+            previewWarning: {
+              type: "string",
+              default:
+                "Preview config could not be loaded. Showing default template.",
+            },
+          },
+        },
+        demoModeNotice: {
+          type: "string",
+          optional: true,
+          default:
+            "Demo mode is deterministic because no OPENAI_API_KEY is set. Add a key to enable live model responses.",
+        },
+        suggestedPrompts: {
+          type: "array",
+          description: "Prompt chips shown on thread open. 1–4 items.",
+          item: {
+            title: { type: "string" },
+            description: { type: "string", optional: true },
+            prompt: { type: "string" },
+            flowId: {
+              type: "string",
+              optional: true,
+              enum: ["auth401", "webhooks", "codeExample"],
+            },
+          },
+        },
+        tools: {
+          type: "array",
+          description:
+            "Tools registered in the assistant. Built-in ids (searchDocs, openPage, generateCodeSnippet) have specialized renderers. Custom ids use generic.",
+          item: {
+            id: { type: "string" },
+            displayName: { type: "string" },
+            aiDescription: { type: "string" },
+            realImplementationHint: { type: "string" },
+            rendererType: {
+              type: "string",
+              enum: ["sourceResults", "pagePreview", "codeSnippet", "generic"],
+            },
+          },
+        },
+        demoFlows: {
+          type: "object",
+          description:
+            "Keyed by flow id. Each flow runs in demo mode or when a matching prompt chip is clicked.",
+          keys: ["auth401", "webhooks", "codeExample"],
+          valueSchema: {
+            title: { type: "string" },
+            triggerPhrases: { type: "array", items: "string" },
+            steps: {
+              type: "array",
+              item: {
+                id: { type: "string" },
+                assistantText: { type: "string" },
+                toolId: {
+                  type: "string",
+                  description: "Must match an id in assistant.tools.",
+                },
+                input: {
+                  type: "object",
+                  description: "Must match the tool's input shape.",
+                },
+                output: {
+                  type: "object",
+                  description:
+                    "Must match the tool's outputShape for the renderer to display correctly.",
+                },
+              },
+            },
+            finalResponse: { type: "string" },
+          },
+        },
+      },
+    },
+    brandTheme: {
+      description: "Color tokens shared across the page and thread.",
+      schema: {
+        accent: { type: "string", default: "#0369a1" },
+        surface: { type: "string", default: "#ffffff" },
+        border: { type: "string", default: "#dbe3ea" },
+        mutedText: { type: "string", default: "#64748b" },
+        focusRing: { type: "string", default: "#38bdf8" },
+      },
+    },
+  },
+  "product-page-assistant": {
+    hostUi: {
+      description:
+        "Controls the visible dashboard page — shell layout, nav, and all panel content. hostUi is NOT deep-merged. Provide the complete tree whenever you include this root.",
+      schema: {
+        version: { type: "number", value: 1, description: "Always 1." },
+        root: {
+          type: {
+            type: "string",
+            value: "DashboardShell",
+            description: "Fixed — do not change.",
+          },
+          props: {
+            productName: { type: "string", default: "Northstar Sync" },
+            companyName: { type: "string", default: "Northstar Cloud" },
+            workspaceLabel: { type: "string", default: "Workspace" },
+            accountName: { type: "string", default: "Acme Operations" },
+            accountMeta: { type: "string", default: "Scale plan, us-west" },
+            alertText: {
+              type: "string",
+              optional: true,
+              default: "Workflow attention needed in us-west",
+              description: "Omit to hide the alert banner.",
+            },
+            navItems: {
+              type: "array",
+              items: "string",
+              default: ["Overview", "Workflows", "Records", "Assistant"],
+            },
+          },
+          children: {
+            type: "array",
+            description:
+              "Panel components inside the shell. Supported: Overview, MetricGrid+MetricCard, TwoColumnRow, StatusList, ActivityFeed.",
+            supportedNodes: {
+              Overview: {
+                props: {
+                  title: "string",
+                  subtitle: "string",
+                  status: "string",
+                },
+              },
+              MetricGrid: { description: "Wrapper for MetricCard children." },
+              MetricCard: {
+                props: { label: "string", value: "string", trend: "string" },
+              },
+              TwoColumnRow: {
+                description:
+                  "Fixed two-column dashboard row. Place StatusList or ActivityFeed as children.",
+              },
+              StatusList: {
+                props: {
+                  title: "string",
+                  items: [
+                    { name: "string", state: "string", detail: "string" },
+                  ],
+                },
+              },
+              ActivityFeed: { props: { title: "string", items: ["string"] } },
+            },
+          },
+        },
+      },
+    },
+    assistant: {
+      description:
+        "Controls the floating modal thread — identity, welcome, labels, tools, demo flows, and support routing data. Deep-merged with template defaults — only include fields you want to override.",
+      schema: {
+        companyName: { type: "string", default: "Northstar Cloud" },
+        productName: { type: "string", default: "Northstar Sync" },
+        assistantName: { type: "string", default: "Northstar Support" },
+        welcome: {
+          badge: { type: "string", default: "Screenshots and logs supported" },
+          title: { type: "string", default: "Get support for your workspace" },
+          subtitle: {
+            type: "string",
+            default:
+              "Describe the issue, attach a screenshot or log, and I will prepare a support handoff.",
+          },
+        },
+        labels: {
+          type: "object",
+          optional: true,
+          description:
+            "Free-form string record. Any key overrides the matching default label.",
+          commonKeys: {
+            modalTrigger: { default: "Open support" },
+            composerPlaceholder: {
+              default: "Describe the issue or attach a screenshot/log...",
+            },
+            escalationCta: { default: "Ready for support handoff" },
+            loading: { default: "Preparing support handoff..." },
+            success: { default: "Handoff ready" },
+          },
+        },
+        demoModeNotice: {
+          type: "string",
+          optional: true,
+          default:
+            "Demo note: This is a mock support demo. Add OPENAI_API_KEY to .env.local to use real AI and connect your own tools.",
+        },
+        agentPrompt: {
+          persona: {
+            type: "string",
+            default: "a support troubleshooting assistant",
+          },
+          instructions: {
+            type: "string",
+            default:
+              "When enough context exists, use the available tools to analyze the issue and prepare a support handoff. Ask a concise follow-up only when the issue is too vague.",
+          },
+          responseStyle: {
+            type: "string",
+            default:
+              "Keep responses customer-facing, concise, and handoff-ready.",
+          },
+        },
+        toolCardLabels: {
+          type: "object",
+          optional: true,
+          description:
+            "Display name overrides for built-in tool result cards. Keyed by tool id.",
+          default: {
+            analyzeIssue: "Issue analysis",
+            createSupportSummary: "Support summary",
+          },
+        },
+        toolCardDesign: {
+          type: "object",
+          optional: true,
+          description: "Visual style options for tool result cards.",
+          fields: {
+            density: {
+              type: "string",
+              enum: ["compact", "default"],
+              default: "compact",
+            },
+            iconSet: { type: "string", enum: ["lucide"], default: "lucide" },
+            statusBadgeStyle: {
+              type: "string",
+              enum: ["solid", "outline"],
+              default: "solid",
+            },
+            ticketSummaryLayout: {
+              type: "string",
+              enum: ["handoff", "default"],
+              default: "handoff",
+            },
+          },
+        },
+        suggestedPrompts: {
+          type: "array",
+          description: "Prompt chips shown on modal open. 1–4 items.",
+          item: {
+            title: { type: "string" },
+            label: { type: "string" },
+            prompt: { type: "string" },
+            scenarioId: {
+              type: "string",
+              enum: ["sync_failure", "auth_error"],
+            },
+          },
+        },
+        tools: {
+          type: "array",
+          description:
+            "Built-in ids (analyzeIssue, createSupportSummary) have specialized renderers. Custom ids use generic.",
+          item: {
+            id: { type: "string" },
+            displayName: { type: "string" },
+            aiDescription: { type: "string" },
+            realImplementationHint: { type: "string" },
+            rendererType: {
+              type: "string",
+              enum: ["analysis", "summary", "generic"],
+            },
+          },
+        },
+        demoFlows: {
+          type: "object",
+          description:
+            "Keyed by scenarioId. Runs in demo mode or when a matching prompt chip is clicked.",
+          keys: ["sync_failure", "auth_error"],
+          valueSchema: {
+            finalResponse: { type: "string" },
+            steps: {
+              type: "array",
+              item: {
+                id: { type: "string" },
+                toolId: {
+                  type: "string",
+                  description: "Must match an id in assistant.tools.",
+                },
+                assistantText: { type: "string" },
+                input: {
+                  type: "object",
+                  description: "Must match the tool's input shape.",
+                },
+                output: {
+                  type: "object",
+                  description:
+                    "Must match the tool's outputShape for the renderer to display correctly.",
+                },
+              },
+            },
+          },
+        },
+        toolData: {
+          description:
+            "Support routing data used by demo flows and tool handlers.",
+          schema: {
+            serviceOptions: {
+              type: "array",
+              items: "string",
+              default: [
+                "Primary workflow",
+                "User access",
+                "Data source",
+                "Notifications",
+                "API",
+              ],
+            },
+            mockAccountStatus: {
+              accountName: { type: "string", default: "Acme Operations" },
+              plan: { type: "string", default: "Scale" },
+              region: { type: "string", default: "us-west" },
+              accountHealth: { type: "string", default: "Active" },
+            },
+            escalationLabels: {
+              defaultOwner: { type: "string", default: "Tier 2 Sync Support" },
+              defaultSla: {
+                type: "string",
+                default: "First response within 2 business hours",
+              },
+            },
+            priorityLabels: {
+              P1: { type: "string", default: "Critical" },
+              P2: { type: "string", default: "High" },
+              P3: { type: "string", default: "Normal" },
+            },
+            scenarioPacks: {
+              type: "array",
+              description:
+                "One pack per demo scenario. Seeds mock analysis and summary outputs.",
+              item: {
+                id: { type: "string", enum: ["sync_failure", "auth_error"] },
+                title: { type: "string" },
+                triggerPhrases: { type: "array", items: "string" },
+                defaultAffectedService: { type: "string" },
+                mockAttachments: { type: "array", items: "string" },
+                firstResponse: { type: "string" },
+                analysis: {
+                  category: "string",
+                  likelyCause: "string",
+                  severity: "low|medium|high",
+                  explanation: "string",
+                  nextStep: "string",
+                },
+                summary: {
+                  ticketId: "string",
+                  priority: "P1|P2|P3",
+                  customerImpact: "string",
+                  recommendedOwner: "string",
+                  nextResponseSla: "string",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    brandTheme: {
+      description: "Color tokens shared across the dashboard and thread.",
+      schema: {
+        accent: { type: "string", default: "#2563eb" },
+        surface: { type: "string", default: "#ffffff" },
+        border: { type: "string", default: "#d8dee8" },
+        mutedText: { type: "string", default: "#64748b" },
+        success: { type: "string", default: "#15803d" },
+        warning: { type: "string", default: "#b45309" },
+        destructive: { type: "string", default: "#b91c1c" },
+        focusRing: { type: "string", default: "#3b82f6" },
+      },
+    },
+  },
+};
+
+const TOOLS_META: Record<
+  string,
+  {
+    builtIn: Array<{
+      id: string;
+      description: string;
+      renderer: string;
+      input: Record<string, unknown>;
+      outputShape: Record<string, unknown>;
+    }>;
+    customToolSupported: boolean;
+    renderers: Array<{
+      type: string;
+      description: string;
+      requiredOutputShape: unknown;
+    }>;
+  }
+> = {
+  "webpage-assistant": {
+    builtIn: [
+      {
+        id: "searchDocs",
+        description: "Searches configured pages and returns matching results.",
+        renderer: "sourceResults",
+        input: {
+          query: {
+            type: "string",
+            required: true,
+            description: "Search query string.",
+          },
+          limit: { type: "number", required: false, default: 3 },
+        },
+        outputShape: {
+          query: "string",
+          results: [
+            {
+              pageId: "string",
+              title: "string",
+              section: "string",
+              url: "string",
+              snippet: "string",
+              score: "number",
+            },
+          ],
+        },
+      },
+      {
+        id: "openPage",
+        description: "Opens a specific page by id and returns its metadata.",
+        renderer: "pagePreview",
+        input: {
+          pageId: {
+            type: "string",
+            required: true,
+            description: "Must match an id in hostUi.root.props.pages.",
+          },
+        },
+        outputShape: {
+          pageId: "string",
+          title: "string",
+          section: "string",
+          url: "string",
+          description: "string",
+          relatedPageIds: ["string"],
+        },
+      },
+      {
+        id: "generateCodeSnippet",
+        description: "Generates a code snippet grounded in docs context.",
+        renderer: "codeSnippet",
+        input: {
+          topic: { type: "string", required: true },
+          language: {
+            type: "string",
+            required: false,
+            enum: ["curl", "typescript", "python"],
+            default: "typescript",
+          },
+        },
+        outputShape: {
+          topic: "string",
+          language: "string",
+          code: "string",
+          notes: ["string"],
+          docsUrl: "string",
+        },
+      },
+    ],
+    customToolSupported: true,
+    renderers: [
+      {
+        type: "sourceResults",
+        description:
+          "List of page result cards showing title, section, snippet, and open link.",
+        requiredOutputShape: {
+          query: "string",
+          results: [
+            {
+              pageId: "string",
+              title: "string",
+              section: "string",
+              url: "string",
+              snippet: "string",
+              score: "number",
+            },
+          ],
+        },
+      },
+      {
+        type: "pagePreview",
+        description:
+          "Single page card with title, section, description, and related page links.",
+        requiredOutputShape: {
+          pageId: "string",
+          title: "string",
+          section: "string",
+          url: "string",
+          description: "string",
+          relatedPageIds: ["string"],
+        },
+      },
+      {
+        type: "codeSnippet",
+        description:
+          "Syntax-highlighted code block with topic, language badge, notes, and docs link.",
+        requiredOutputShape: {
+          topic: "string",
+          language: "string",
+          code: "string",
+          notes: ["string"],
+          docsUrl: "string",
+        },
+      },
+      {
+        type: "generic",
+        description:
+          "Fallback collapsible card rendering any tool output as JSON.",
+        requiredOutputShape: "any",
+      },
+    ],
+  },
+  "product-page-assistant": {
+    builtIn: [
+      {
+        id: "analyzeIssue",
+        description:
+          "Analyzes the issue and returns severity, likely cause, affected service, and next step.",
+        renderer: "analysis",
+        input: {
+          description: { type: "string", required: true },
+          service: { type: "string", required: true },
+          attachments: {
+            type: "array",
+            required: false,
+            items: { name: "string", type: "string" },
+          },
+          scenarioId: {
+            type: "string",
+            required: true,
+            enum: ["sync_failure", "auth_error"],
+          },
+        },
+        outputShape: {
+          category: "string",
+          confidence: "number",
+          likelyCause: "string",
+          affectedService: "string",
+          severity: "low|medium|high",
+          explanation: "string",
+          nextStep: "string",
+          followUpQuestions: ["string"],
+          attachments: [{ name: "string", type: "string" }],
+        },
+      },
+      {
+        id: "createSupportSummary",
+        description:
+          "Creates a structured handoff summary card from the issue analysis.",
+        renderer: "summary",
+        input: {
+          issue: {
+            type: "object",
+            required: true,
+            description: "The full output of analyzeIssue.",
+          },
+          attachments: {
+            type: "array",
+            required: false,
+            items: { name: "string", type: "string" },
+          },
+          scenarioId: {
+            type: "string",
+            required: true,
+            enum: ["sync_failure", "auth_error"],
+          },
+        },
+        outputShape: {
+          ticketId: "string",
+          priority: "P1|P2|P3",
+          customerImpact: "string",
+          summary: "string",
+          recommendedOwner: "string",
+          nextResponseSla: "string",
+          attachments: ["string"],
+        },
+      },
+    ],
+    customToolSupported: true,
+    renderers: [
+      {
+        type: "analysis",
+        description:
+          "Issue analysis card showing severity badge, likely cause, affected service, explanation, next step, and follow-up questions.",
+        requiredOutputShape: {
+          category: "string",
+          confidence: "number",
+          likelyCause: "string",
+          affectedService: "string",
+          severity: "string",
+          explanation: "string",
+          nextStep: "string",
+          followUpQuestions: ["string"],
+        },
+      },
+      {
+        type: "summary",
+        description:
+          "Handoff summary card showing ticket id, priority, customer impact, recommended owner, and SLA.",
+        requiredOutputShape: {
+          ticketId: "string",
+          priority: "string",
+          customerImpact: "string",
+          summary: "string",
+          recommendedOwner: "string",
+          nextResponseSla: "string",
+        },
+      },
+      {
+        type: "generic",
+        description:
+          "Fallback collapsible card rendering any tool output as JSON.",
+        requiredOutputShape: "any",
+      },
+    ],
+  },
+};
+
+const RULES: Record<string, string[]> = {
+  "webpage-assistant": [
+    "hostUi.root.props.defaultPageId must be one of the ids in root.props.pages.",
+    "hostUi.root.props.navGroups[].pageIds must reference ids that exist in pages.",
+    "assistant.suggestedPrompts[].flowId must match a key in assistant.demoFlows.",
+    "assistant.demoFlows.*.steps[].toolId must match an id in assistant.tools.",
+    "Each demo flow step must include assistantText, toolId, input, and output.",
+  ],
+  "product-page-assistant": [
+    "If hostUi is provided, provide the complete tree — hostUi is not deep-merged with defaults.",
+    "assistant.suggestedPrompts[].scenarioId must match a key in assistant.demoFlows and a pack id in assistant.toolData.scenarioPacks.",
+    "assistant.demoFlows.*.steps[].toolId must match an id in assistant.tools.",
+    "Each demo flow step must include assistantText, toolId, input, and output.",
+    "demoFlows step input and output must match the tool's input shape and outputShape respectively.",
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+
+export function createTemplateTools() {
+  return {
+    getTemplateList: tool({
+      description:
+        "Get all available hosted app templates and fixed demos with their features, customizable surfaces, and versions. " +
+        "Call this first for any app-building request. Use the features and customizable fields to decide which template fits. " +
+        "If customizable is empty, the entry is a fixed demo that should be shown as-is rather than configured. " +
+        "Call getTemplateDetails on the chosen template before opening a preview.",
+      inputSchema: zodSchema(z.object({})),
+      execute: async () => {
+        const { templates } = getXuluxHostedTemplatesCatalog();
+        const seen = new Set<string>();
+        const list: Array<{
+          id: string;
+          name: string;
+          summary: string;
+          assistantPlacement: string;
+          features: string[];
+          customizable: string[];
+          versions: Array<{ id: string; name: string; description: string }>;
+        }> = [];
+
+        for (const t of templates) {
+          const tid = templateId(t);
+          if (seen.has(tid)) continue;
+          seen.add(tid);
+          const meta = TEMPLATE_LIST_META[tid] ?? fixedDemoListMeta(t);
+          if (!meta) continue;
+          list.push({
+            id: tid,
+            name: meta.name,
+            summary: meta.summary,
+            assistantPlacement: meta.assistantPlacement,
+            features: meta.features,
+            customizable: meta.customizable,
+            versions: (t.versions ?? []).map((v) => ({
+              id: v.id,
+              name: v.title,
+              description: v.description,
+            })),
+          });
+        }
+
+        return { templates: list };
+      },
+    }),
+
+    getTemplateDetails: tool({
+      description:
+        "Get the full authoring surface for a specific template. " +
+        "Returns configRoots schemas (with types, defaults, and enums), rules, built-in tool input/outputShape, renderer contracts, and an exampleConfig. " +
+        "Fixed demos return no configRoots; open those as-is without config. " +
+        "Use this before calling openTemplatePreview to understand exactly what config to write. " +
+        "If openTemplatePreview returns validationWarnings, call this again and cross-reference configRoots to correct the config.",
+      inputSchema: zodSchema(
+        z.object({
+          templateId: z
+            .string()
+            .describe("The template id from getTemplateList"),
+          versionId: z
+            .string()
+            .optional()
+            .describe(
+              "Optional version id. When provided, exampleConfig reflects that version's resolved defaults.",
+            ),
+        }),
+      ),
+      execute: async ({ templateId: tid, versionId }) => {
+        const { templates } = getXuluxHostedTemplatesCatalog();
+        const entry =
+          (versionId
+            ? templates.find(
+                (t) => templateId(t) === tid && t.versionId === versionId,
+              )
+            : undefined) ?? findFirstByTemplateId(templates, tid);
+
+        if (!entry) {
+          return { error: `Template "${tid}" not found.` };
+        }
+
+        if (isFixedDemo(entry)) {
+          const demo = getDemoDownloadManifest(entry.id);
+          return {
+            id: tid,
+            name: demo?.name ?? entry.title,
+            selectedVersionId: null,
+            summary: demo?.description ?? entry.description,
+            assistantPlacement: "full-page demo route",
+            features: demo?.features ?? [],
+            customizable: [],
+            previewUrl: entry.previewUrl,
+            downloadUrl: entry.downloadUrl,
+            sourcePath: demo?.entry ?? entry.sourcePath,
+            tools: {
+              builtIn: [],
+              customToolSupported: false,
+              renderers: [],
+            },
+            rules: {
+              required: [
+                "No configRoots are returned for this entry, so it is not schema-customizable.",
+                "Use openTemplatePreview without config to show this demo as-is.",
+                "If the user needs domain-specific content or behavior changes, choose a configurable hosted template or produce a custom implementation brief instead.",
+              ],
+            },
+            fixedDemoNote:
+              "This is a fixed assistant-ui demo. It supports preview and download, but not template config.",
+          };
+        }
+
+        const effectiveVersionId = versionId ?? entry.versionId;
+        const configRootsSchema = CONFIG_ROOTS_SCHEMAS[tid];
+        const toolsMeta = TOOLS_META[tid];
+        const rules = RULES[tid] ?? [];
+
+        if (!configRootsSchema || !toolsMeta) {
+          return { error: `No authoring schema found for template "${tid}".` };
+        }
+
+        // Fetch exampleConfig from the live sandbox contract endpoint.
+        // Falls back to null if the sandbox is unreachable — the static schema
+        // above is still returned so the agent can author config.
+        const contract = await fetchTemplateContract(entry, effectiveVersionId);
+        const exampleConfig =
+          (contract?.exampleCompleteConfig as Record<string, unknown> | null) ??
+          null;
+
+        return {
+          id: tid,
+          name: TEMPLATE_LIST_META[tid]?.name ?? tid,
+          selectedVersionId: effectiveVersionId,
+          configRoots: configRootsSchema,
+          rules: { required: rules },
+          tools: toolsMeta,
+          exampleConfig,
+          exampleConfigNote: exampleConfig
+            ? `Resolved defaults for version "${effectiveVersionId}". Use as a complete working starting point.`
+            : `Could not reach sandbox to resolve exampleConfig. Use configRoots schemas and defaults to author config manually.`,
+        };
+      },
+    }),
+
+    openTemplatePreview: tool({
+      description:
+        "Open a hosted template preview in the canvas. " +
+        "If you are using an existing version, you can pass versionId to select a specific variant. " +
+        "If you are customizing the template, you can pass config to apply customizations and generate a preview. " +
+        "Do not pass config for fixed demos that have no configRoots in getTemplateDetails. " +
+        "Returns previewUrl and downloadUrl on success. " +
+        "Only after a successful call, include an open-in block with the exact downloadUrl from this result. " +
+        "If no template fits, do not call this tool — read docs instead and use a prompt-only open-in block without downloadUrl.",
+      inputSchema: zodSchema(
+        z.object({
+          templateId: z
+            .string()
+            .describe("The template id from getTemplateList"),
+          versionId: z
+            .string()
+            .optional()
+            .describe(
+              "Version id to open. Uses the template default if omitted.",
+            ),
+          config: z
+            .record(z.string(), z.unknown())
+            .optional()
+            .describe(
+              "Customization config for the preview. Must contain only the top-level keys: hostUi, assistant, and brandTheme. " +
+                "Use the schemas from getTemplateDetails.configRoots as the source of truth for each root. " +
+                "Do not pass any other root keys.",
+            ),
+        }),
+      ),
+      execute: async ({ templateId: tid, versionId, config }) => {
+        const { templates } = getXuluxHostedTemplatesCatalog();
+
+        let entry: XuluxTemplate | undefined;
+        if (versionId) {
+          entry = templates.find(
+            (t) => templateId(t) === tid && t.versionId === versionId,
+          );
+        }
+        if (!entry) entry = findFirstByTemplateId(templates, tid);
+
+        if (!entry) {
+          return { success: false, error: `Template "${tid}" not found.` };
+        }
+
+        if (isFixedDemo(entry)) {
+          if (hasConfig(config)) {
+            return {
+              success: false,
+              error: `Template "${tid}" is a fixed demo and does not support config.`,
+              retryHint:
+                "Call getTemplateDetails for this template. If no configRoots are returned, call openTemplatePreview again without config or choose a configurable hosted template.",
+            };
+          }
+
+          return {
+            success: true,
+            templateId: tid,
+            versionId: null,
+            previewUrl: entry.previewUrl ?? `/demos/${entry.id}`,
+            downloadUrl:
+              entry.downloadUrl ?? `/api/xulux/demo-download?slug=${entry.id}`,
+            title: entry.title,
+            summary: `Opened ${entry.title} as a fixed demo.`,
+          };
+        }
+
+        const baseUrl = entry.sandboxBaseUrl;
+        if (!baseUrl) {
+          return {
+            success: false,
+            error: `Template "${tid}" has no sandbox URL configured.`,
+          };
+        }
+
+        if (hasConfig(config)) {
+          try {
+            const sessionUrl = new URL("/api/preview/session", baseUrl);
+            if (versionId) sessionUrl.searchParams.set("v", versionId);
+            const res = await fetch(sessionUrl, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(config),
+            });
+            if (!res.ok) {
+              const details = await res.text();
+              return {
+                success: false,
+                error: `Preview session failed: HTTP ${res.status}`,
+                details,
+                retryHint:
+                  "Check validationWarnings for the specific fields that failed. " +
+                  "Call getTemplateDetails for this template and use configRoots schemas to correct the config. " +
+                  "Pass only hostUi, assistant, and brandTheme at the top level.",
+              };
+            }
+            const data = (await res.json()) as {
+              previewUrl?: string;
+              downloadUrl?: string;
+              validationWarnings?: unknown[];
+            };
+            if (!data.previewUrl) {
+              return {
+                success: false,
+                error: "Session endpoint did not return a previewUrl.",
+              };
+            }
+            return {
+              success: true,
+              templateId: tid,
+              versionId: versionId ?? entry.versionId,
+              previewUrl: toAbsolute(
+                baseUrl,
+                withVersion(data.previewUrl, versionId),
+              ),
+              downloadUrl: toAbsolute(
+                baseUrl,
+                withVersion(data.downloadUrl ?? "/api/download", versionId),
+              ),
+              title: entry.title,
+              summary: `Opened ${entry.title} with custom configuration.`,
+              validationWarnings: data.validationWarnings ?? [],
+            };
+          } catch (err) {
+            return {
+              success: false,
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        }
+
+        return {
+          success: true,
+          templateId: tid,
+          versionId: versionId ?? entry.versionId,
+          previewUrl: entry.previewUrl ?? baseUrl,
+          downloadUrl: entry.downloadUrl ?? `${baseUrl}/api/download`,
+          title: entry.title,
+          summary: `Opened ${entry.title}.`,
+        };
+      },
+    }),
+  };
+}

--- a/apps/docs/app/api/xulux/demo-download/route.ts
+++ b/apps/docs/app/api/xulux/demo-download/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
+import {
+  createDemoZip,
+  getDemoArchiveFilename,
+} from "@/lib/xulux/demo-downloads/create-demo-zip";
+import { getDemoDownloadManifest } from "@/lib/xulux/demo-downloads/manifest";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  if (!isAiPlaygroundEnabled) {
+    return NextResponse.json({ error: "Not found." }, { status: 404 });
+  }
+
+  const url = new URL(req.url);
+  const slug = url.searchParams.get("slug") ?? "";
+  const manifest = getDemoDownloadManifest(slug);
+
+  if (!manifest) {
+    return NextResponse.json(
+      { error: `Unsupported demo slug: ${slug}` },
+      { status: 404 },
+    );
+  }
+
+  try {
+    const zip = await createDemoZip(manifest.slug);
+    return new NextResponse(zip, {
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": `attachment; filename="${getDemoArchiveFilename(manifest.slug)}"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: "Failed to generate demo download.",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/docs/app/api/xulux/templates/route.ts
+++ b/apps/docs/app/api/xulux/templates/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
 import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
-import { getXuluxExamplesCatalog } from "@/lib/xulux/examples-catalog";
+import { getXuluxHostedTemplatesCatalog } from "@/lib/xulux/templates-catalog";
 
 export function GET() {
   if (!isAiPlaygroundEnabled) {
     return NextResponse.json({ error: "Not found." }, { status: 404 });
   }
 
-  return NextResponse.json(getXuluxExamplesCatalog());
+  return NextResponse.json(getXuluxHostedTemplatesCatalog());
 }

--- a/apps/docs/components/docs/assistant/markdown.tsx
+++ b/apps/docs/components/docs/assistant/markdown.tsx
@@ -11,7 +11,12 @@ import {
 } from "@assistant-ui/react-streamdown";
 import { type CodeHeaderProps } from "@assistant-ui/react-markdown";
 import { OpenInSyntaxHighlighter } from "@/components/xulux/chat/OpenInCard";
-import { type CSSProperties, type FC, memo } from "react";
+import {
+  type ComponentPropsWithoutRef,
+  type CSSProperties,
+  type FC,
+  memo,
+} from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import ShikiHighlighter from "react-shiki";
@@ -22,7 +27,7 @@ const MarkdownTextImpl = () => {
   return (
     <StreamdownTextPrimitive
       containerClassName="aui-md-assistant"
-      components={markdownComponents as unknown as StreamdownTextComponents}
+      components={markdownComponents}
       componentsByLanguage={{
         "open-in": {
           SyntaxHighlighter: OpenInSyntaxHighlighter,
@@ -86,9 +91,9 @@ const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({ code, language }) => {
   );
 };
 
-const markdownComponents = {
+const markdownComponents: StreamdownTextComponents = {
   SyntaxHighlighter: SyntaxHighlighter,
-  h1: ({ className, ...props }) => (
+  h1: ({ className, ...props }: ComponentPropsWithoutRef<"h1">) => (
     <h1
       className={cn(
         "mb-2 text-base font-semibold first:mt-0 last:mb-0",
@@ -97,7 +102,7 @@ const markdownComponents = {
       {...props}
     />
   ),
-  h2: ({ className, ...props }) => (
+  h2: ({ className, ...props }: ComponentPropsWithoutRef<"h2">) => (
     <h2
       className={cn(
         "mt-3 mb-1.5 text-sm font-semibold first:mt-0 last:mb-0",
@@ -106,7 +111,7 @@ const markdownComponents = {
       {...props}
     />
   ),
-  h3: ({ className, ...props }) => (
+  h3: ({ className, ...props }: ComponentPropsWithoutRef<"h3">) => (
     <h3
       className={cn(
         "mt-2.5 mb-1 text-sm font-semibold first:mt-0 last:mb-0",
@@ -115,7 +120,7 @@ const markdownComponents = {
       {...props}
     />
   ),
-  h4: ({ className, ...props }) => (
+  h4: ({ className, ...props }: ComponentPropsWithoutRef<"h4">) => (
     <h4
       className={cn(
         "mt-2 mb-1 text-sm font-medium first:mt-0 last:mb-0",
@@ -124,7 +129,7 @@ const markdownComponents = {
       {...props}
     />
   ),
-  h5: ({ className, ...props }) => (
+  h5: ({ className, ...props }: ComponentPropsWithoutRef<"h5">) => (
     <h5
       className={cn(
         "mt-2 mb-1 text-sm font-medium first:mt-0 last:mb-0",
@@ -133,7 +138,7 @@ const markdownComponents = {
       {...props}
     />
   ),
-  h6: ({ className, ...props }) => (
+  h6: ({ className, ...props }: ComponentPropsWithoutRef<"h6">) => (
     <h6
       className={cn(
         "mt-2 mb-1 text-sm font-medium first:mt-0 last:mb-0",
@@ -142,13 +147,20 @@ const markdownComponents = {
       {...props}
     />
   ),
-  p: ({ className, ...props }) => (
+  p: ({ className, ...props }: ComponentPropsWithoutRef<"p">) => (
     <p
       className={cn("my-2.5 leading-normal first:mt-0 last:mb-0", className)}
       {...props}
     />
   ),
-  a: ({ className, href, children, title, target, rel }) => {
+  a: ({
+    className,
+    href,
+    children,
+    title,
+    target,
+    rel,
+  }: ComponentPropsWithoutRef<"a">) => {
     const linkClass = cn(
       "text-primary hover:text-primary/80 underline underline-offset-2",
       className,
@@ -173,7 +185,10 @@ const markdownComponents = {
       </a>
     );
   },
-  blockquote: ({ className, ...props }) => (
+  blockquote: ({
+    className,
+    ...props
+  }: ComponentPropsWithoutRef<"blockquote">) => (
     <blockquote
       className={cn(
         "border-muted-foreground/30 text-muted-foreground my-2.5 border-l-2 pl-3 italic",
@@ -182,7 +197,7 @@ const markdownComponents = {
       {...props}
     />
   ),
-  ul: ({ className, ...props }) => (
+  ul: ({ className, ...props }: ComponentPropsWithoutRef<"ul">) => (
     <ul
       className={cn(
         "marker:text-muted-foreground my-2 ml-4 list-disc [&>li]:mt-1",
@@ -191,7 +206,7 @@ const markdownComponents = {
       {...props}
     />
   ),
-  ol: ({ className, ...props }) => (
+  ol: ({ className, ...props }: ComponentPropsWithoutRef<"ol">) => (
     <ol
       className={cn(
         "marker:text-muted-foreground my-2 ml-4 list-decimal [&>li]:mt-1",
@@ -200,16 +215,16 @@ const markdownComponents = {
       {...props}
     />
   ),
-  li: ({ className, ...props }) => (
+  li: ({ className, ...props }: ComponentPropsWithoutRef<"li">) => (
     <li className={cn("leading-normal", className)} {...props} />
   ),
-  hr: ({ className, ...props }) => (
+  hr: ({ className, ...props }: ComponentPropsWithoutRef<"hr">) => (
     <hr
       className={cn("border-muted-foreground/20 my-2", className)}
       {...props}
     />
   ),
-  table: ({ className, ...props }) => (
+  table: ({ className, ...props }: ComponentPropsWithoutRef<"table">) => (
     <div className="my-2 overflow-x-auto">
       <table
         className={cn("w-full border-collapse text-xs", className)}
@@ -217,7 +232,7 @@ const markdownComponents = {
       />
     </div>
   ),
-  th: ({ className, ...props }) => (
+  th: ({ className, ...props }: ComponentPropsWithoutRef<"th">) => (
     <th
       className={cn(
         "border-muted-foreground/20 bg-muted border px-2 py-1 text-left font-medium",
@@ -226,7 +241,7 @@ const markdownComponents = {
       {...props}
     />
   ),
-  td: ({ className, ...props }) => (
+  td: ({ className, ...props }: ComponentPropsWithoutRef<"td">) => (
     <td
       className={cn(
         "border-muted-foreground/20 border px-2 py-1 text-left",
@@ -235,8 +250,8 @@ const markdownComponents = {
       {...props}
     />
   ),
-  tr: (props) => <tr {...props} />,
-  pre: ({ className, ...props }) => (
+  tr: (props: ComponentPropsWithoutRef<"tr">) => <tr {...props} />,
+  pre: ({ className, ...props }: ComponentPropsWithoutRef<"pre">) => (
     <pre
       className={cn(
         "border-border/50 bg-muted/30 overflow-x-auto rounded-t-none rounded-b-lg border border-t-0 p-3 text-xs leading-relaxed",
@@ -245,7 +260,10 @@ const markdownComponents = {
       {...props}
     />
   ),
-  code: function Code({ className, ...props }) {
+  code: function Code({
+    className,
+    ...props
+  }: ComponentPropsWithoutRef<"code">) {
     const isCodeBlock = useIsStreamdownCodeBlock();
     return (
       <code

--- a/apps/docs/components/docs/assistant/markdown.tsx
+++ b/apps/docs/components/docs/assistant/markdown.tsx
@@ -27,7 +27,7 @@ const MarkdownTextImpl = () => {
   return (
     <StreamdownTextPrimitive
       containerClassName="aui-md-assistant"
-      components={markdownComponents}
+      components={markdownComponents as StreamdownTextComponents}
       componentsByLanguage={{
         "open-in": {
           SyntaxHighlighter: OpenInSyntaxHighlighter,
@@ -91,7 +91,7 @@ const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({ code, language }) => {
   );
 };
 
-const markdownComponents: StreamdownTextComponents = {
+const markdownComponents = {
   SyntaxHighlighter: SyntaxHighlighter,
   h1: ({ className, ...props }: ComponentPropsWithoutRef<"h1">) => (
     <h1

--- a/apps/docs/components/docs/assistant/markdown.tsx
+++ b/apps/docs/components/docs/assistant/markdown.tsx
@@ -4,13 +4,13 @@ import "@assistant-ui/react-markdown/styles/dot.css";
 import "react-shiki/css";
 
 import {
-  type CodeHeaderProps,
-  MarkdownTextPrimitive,
+  StreamdownTextPrimitive,
+  useIsStreamdownCodeBlock,
+  type StreamdownTextComponents,
   type SyntaxHighlighterProps,
-  unstable_memoizeMarkdownComponents as memoizeMarkdownComponents,
-  useIsMarkdownCodeBlock,
-} from "@assistant-ui/react-markdown";
-import remarkGfm from "remark-gfm";
+} from "@assistant-ui/react-streamdown";
+import { type CodeHeaderProps } from "@assistant-ui/react-markdown";
+import { OpenInSyntaxHighlighter } from "@/components/xulux/chat/OpenInCard";
 import { type CSSProperties, type FC, memo } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -20,10 +20,15 @@ import { useCopyToClipboard } from "@assistant-ui/ui/hooks/use-copy-to-clipboard
 
 const MarkdownTextImpl = () => {
   return (
-    <MarkdownTextPrimitive
-      remarkPlugins={[remarkGfm]}
-      className="aui-md-assistant"
-      components={markdownComponents}
+    <StreamdownTextPrimitive
+      containerClassName="aui-md-assistant"
+      components={markdownComponents as unknown as StreamdownTextComponents}
+      componentsByLanguage={{
+        "open-in": {
+          SyntaxHighlighter: OpenInSyntaxHighlighter,
+          CodeHeader: () => null,
+        },
+      }}
     />
   );
 };
@@ -81,7 +86,7 @@ const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({ code, language }) => {
   );
 };
 
-const markdownComponents = memoizeMarkdownComponents({
+const markdownComponents = {
   SyntaxHighlighter: SyntaxHighlighter,
   h1: ({ className, ...props }) => (
     <h1
@@ -241,7 +246,7 @@ const markdownComponents = memoizeMarkdownComponents({
     />
   ),
   code: function Code({ className, ...props }) {
-    const isCodeBlock = useIsMarkdownCodeBlock();
+    const isCodeBlock = useIsStreamdownCodeBlock();
     return (
       <code
         className={cn(
@@ -254,4 +259,4 @@ const markdownComponents = memoizeMarkdownComponents({
     );
   },
   CodeHeader,
-});
+};

--- a/apps/docs/components/xulux/XuluxApp.tsx
+++ b/apps/docs/components/xulux/XuluxApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   AssistantRuntimeProvider,
   useRemoteThreadListRuntime,
@@ -14,10 +14,25 @@ import type { XuluxTemplate } from "./templates/types";
 import { XuluxShell } from "./shell/XuluxShell";
 import { createXuluxLocalThreadListAdapter } from "./runtime/xulux-thread-list-adapter";
 import { XuluxThreadStatusObserver } from "./runtime/XuluxThreadStatusObserver";
+import {
+  parseXuluxLimitBlock,
+  XuluxUsageBudgetProvider,
+  type XuluxLimitBlock,
+} from "./chat/XuluxUsageLimitBanner";
 
 export type SelectedTemplateContext = Pick<
   XuluxTemplate,
-  "id" | "title" | "description" | "kind" | "prompt" | "sourcePath" | "docsUrl"
+  | "id"
+  | "templateId"
+  | "versionId"
+  | "title"
+  | "description"
+  | "kind"
+  | "prompt"
+  | "previewUrl"
+  | "downloadUrl"
+  | "sourcePath"
+  | "docsUrl"
 >;
 
 export function XuluxApp() {
@@ -57,6 +72,11 @@ function XuluxRuntimeProvider({
 }) {
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
+  const [limitBlock, setLimitBlock] = useState<XuluxLimitBlock | null>(null);
+
+  useEffect(() => {
+    setLimitBlock(null);
+  }, [sessionId]);
 
   const adapter = useMemo(
     () =>
@@ -66,25 +86,49 @@ function XuluxRuntimeProvider({
     [],
   );
 
+  const transport = useMemo(
+    () =>
+      new AssistantChatTransport({
+        api: "/api/xulux/chat",
+        body: {
+          sessionId,
+          selectedTemplate: selectedTemplateContext,
+        },
+        fetch: async (input, init) => {
+          const res = await fetch(input, init);
+          if (res.status === 429) {
+            const payload = await res
+              .clone()
+              .json()
+              .catch(() => null);
+            const block = parseXuluxLimitBlock(payload);
+            if (block) setLimitBlock(block);
+          }
+          return res;
+        },
+      }),
+    [sessionId, selectedTemplateContext],
+  );
+
   const runtime = useRemoteThreadListRuntime({
     adapter,
     runtimeHook: function XuluxChatRuntimeHook() {
       return useChatRuntime({
-        transport: new AssistantChatTransport({
-          api: "/api/xulux/chat",
-          body: {
-            sessionId,
-            selectedTemplate: selectedTemplateContext,
-          },
-        }),
+        transport,
+        isSendDisabled: limitBlock != null,
       });
     },
   });
 
   return (
-    <AssistantRuntimeProvider runtime={runtime}>
-      <XuluxThreadStatusObserver />
-      {children}
-    </AssistantRuntimeProvider>
+    <XuluxUsageBudgetProvider
+      limitBlock={limitBlock}
+      clearLimitBlock={() => setLimitBlock(null)}
+    >
+      <AssistantRuntimeProvider runtime={runtime}>
+        <XuluxThreadStatusObserver />
+        {children}
+      </AssistantRuntimeProvider>
+    </XuluxUsageBudgetProvider>
   );
 }

--- a/apps/docs/components/xulux/XuluxApp.tsx
+++ b/apps/docs/components/xulux/XuluxApp.tsx
@@ -72,6 +72,8 @@ function XuluxRuntimeProvider({
 }) {
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
+  const selectedTemplateContextRef = useRef(selectedTemplateContext);
+  selectedTemplateContextRef.current = selectedTemplateContext;
   const [limitBlock, setLimitBlock] = useState<XuluxLimitBlock | null>(null);
 
   useEffect(() => {
@@ -91,8 +93,12 @@ function XuluxRuntimeProvider({
       new AssistantChatTransport({
         api: "/api/xulux/chat",
         body: {
-          sessionId,
-          selectedTemplate: selectedTemplateContext,
+          get sessionId() {
+            return sessionIdRef.current;
+          },
+          get selectedTemplate() {
+            return selectedTemplateContextRef.current;
+          },
         },
         fetch: async (input, init) => {
           const res = await fetch(input, init);
@@ -107,7 +113,7 @@ function XuluxRuntimeProvider({
           return res;
         },
       }),
-    [sessionId, selectedTemplateContext],
+    [],
   );
 
   const runtime = useRemoteThreadListRuntime({

--- a/apps/docs/components/xulux/XuluxApp.tsx
+++ b/apps/docs/components/xulux/XuluxApp.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
+  AssistantCloud,
   AssistantRuntimeProvider,
   useRemoteThreadListRuntime,
 } from "@assistant-ui/react";
@@ -80,6 +81,14 @@ function XuluxRuntimeProvider({
     setLimitBlock(null);
   }, [sessionId]);
 
+  const assistantCloud = useMemo(() => {
+    const baseUrl =
+      process.env.NEXT_PUBLIC_XULUX_ASSISTANT_BASE_URL ??
+      process.env.NEXT_PUBLIC_ASSISTANT_BASE_URL;
+    if (!baseUrl) return null;
+    return new AssistantCloud({ baseUrl, anonymous: true });
+  }, []);
+
   const adapter = useMemo(
     () =>
       createXuluxLocalThreadListAdapter({
@@ -122,6 +131,7 @@ function XuluxRuntimeProvider({
       return useChatRuntime({
         transport,
         isSendDisabled: limitBlock != null,
+        ...(assistantCloud ? { cloud: assistantCloud } : {}),
       });
     },
   });

--- a/apps/docs/components/xulux/XuluxApp.tsx
+++ b/apps/docs/components/xulux/XuluxApp.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
-import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  AssistantRuntimeProvider,
+  useRemoteThreadListRuntime,
+} from "@assistant-ui/react";
 import {
   AssistantChatTransport,
   useChatRuntime,
@@ -9,6 +12,8 @@ import {
 import { AssistantPanelProvider } from "@/components/docs/assistant/context";
 import type { XuluxTemplate } from "./templates/types";
 import { XuluxShell } from "./shell/XuluxShell";
+import { createXuluxLocalThreadListAdapter } from "./runtime/xulux-thread-list-adapter";
+import { XuluxThreadStatusObserver } from "./runtime/XuluxThreadStatusObserver";
 
 export type SelectedTemplateContext = Pick<
   XuluxTemplate,
@@ -22,18 +27,17 @@ export function XuluxApp() {
 
   const resetSession = () => {
     setSelectedTemplateContext(null);
-    setSessionId(crypto.randomUUID());
   };
 
   return (
     <XuluxRuntimeProvider
-      key={sessionId}
       sessionId={sessionId}
       selectedTemplateContext={selectedTemplateContext}
     >
       <AssistantPanelProvider>
         <XuluxShell
           sessionId={sessionId}
+          onSetSessionId={setSessionId}
           onSetSelectedTemplateContext={setSelectedTemplateContext}
           onResetSession={resetSession}
         />
@@ -51,18 +55,35 @@ function XuluxRuntimeProvider({
   selectedTemplateContext: SelectedTemplateContext | null;
   children: ReactNode;
 }) {
-  const runtime = useChatRuntime({
-    transport: new AssistantChatTransport({
-      api: "/api/xulux/chat",
-      body: {
-        sessionId,
-        selectedTemplate: selectedTemplateContext,
-      },
-    }),
+  const sessionIdRef = useRef(sessionId);
+  sessionIdRef.current = sessionId;
+
+  const adapter = useMemo(
+    () =>
+      createXuluxLocalThreadListAdapter({
+        getCurrentSessionId: () => sessionIdRef.current,
+      }),
+    [],
+  );
+
+  const runtime = useRemoteThreadListRuntime({
+    adapter,
+    runtimeHook: function XuluxChatRuntimeHook() {
+      return useChatRuntime({
+        transport: new AssistantChatTransport({
+          api: "/api/xulux/chat",
+          body: {
+            sessionId,
+            selectedTemplate: selectedTemplateContext,
+          },
+        }),
+      });
+    },
   });
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
+      <XuluxThreadStatusObserver />
       {children}
     </AssistantRuntimeProvider>
   );

--- a/apps/docs/components/xulux/canvas/XuluxCanvas.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxCanvas.tsx
@@ -24,6 +24,7 @@ export function XuluxCanvas({
   previewUrl,
   source,
   error,
+  downloadUrl,
   sourceUrl,
   title,
 }: {
@@ -32,6 +33,7 @@ export function XuluxCanvas({
   previewUrl: string | null;
   source: "template" | "refresh" | null;
   error: string | null;
+  downloadUrl?: string;
   sourceUrl?: string;
   title?: string;
 }) {
@@ -39,7 +41,8 @@ export function XuluxCanvas({
   const [downloadError, setDownloadError] = useState<string | null>(null);
   const [iframeVersion, setIframeVersion] = useState(0);
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
-  const canDownload = source === "refresh" && status === "ready";
+  const canDownloadTemplate = Boolean(downloadUrl) && status === "ready";
+  const canDownloadSandbox = source === "refresh" && status === "ready";
   const canOpenSource =
     source === "template" && status === "ready" && sourceUrl;
   const resolvedPreviewUrl = toAbsoluteUrl(previewUrl);
@@ -128,7 +131,21 @@ export function XuluxCanvas({
               <span className="sr-only">Refresh preview</span>
             </Button>
           )}
-          {canDownload && (
+          {canDownloadTemplate && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 px-2.5 text-xs"
+              asChild
+            >
+              <a href={downloadUrl} target="_blank" rel="noreferrer">
+                <Download className="size-3.5" />
+                <span className="hidden sm:inline">Download</span>
+              </a>
+            </Button>
+          )}
+          {canDownloadSandbox && (
             <Button
               type="button"
               variant="ghost"

--- a/apps/docs/components/xulux/canvas/XuluxCanvas.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxCanvas.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Download, ExternalLink, Loader2, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { GitHubIcon } from "@/components/icons/github";
+import { XuluxPreviewTabBar } from "./XuluxPreviewTabBar";
 
 function toAbsoluteUrl(url: string | null): string | null {
   if (!url) return null;
@@ -16,6 +17,14 @@ function filenameFromDisposition(header: string | null): string | null {
   if (!header) return null;
   const match = /filename="?([^";]+)"?/i.exec(header);
   return match?.[1] ?? null;
+}
+
+function hostnameFromUrl(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
 }
 
 export function XuluxCanvas({
@@ -98,126 +107,143 @@ export function XuluxCanvas({
     }
   }, [sessionId]);
 
-  return (
-    <div className="bg-muted/20 relative h-full overflow-hidden">
-      {resolvedPreviewUrl && (
-        <div className="bg-background/90 absolute top-3 right-3 z-10 flex items-center gap-1.5 rounded-md border p-1 shadow-sm backdrop-blur">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="size-7"
-            asChild
-          >
-            <a href={resolvedPreviewUrl} target="_blank" rel="noreferrer">
-              <ExternalLink className="size-3.5" />
-              <span className="sr-only">Open preview</span>
-            </a>
-          </Button>
-          {canRefresh && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="size-7"
-              disabled={isPreviewLoading}
-              onClick={handleRefreshPreview}
-            >
-              <RefreshCw
-                className={
-                  isPreviewLoading ? "size-3.5 animate-spin" : "size-3.5"
-                }
-              />
-              <span className="sr-only">Refresh preview</span>
-            </Button>
-          )}
-          {canDownloadTemplate && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-7 gap-1.5 px-2.5 text-xs"
-              asChild
-            >
-              <a href={downloadUrl} target="_blank" rel="noreferrer">
-                <Download className="size-3.5" />
-                <span className="hidden sm:inline">Download</span>
-              </a>
-            </Button>
-          )}
-          {canDownloadSandbox && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-7 gap-1.5 px-2.5 text-xs"
-              disabled={isDownloading}
-              onClick={handleDownload}
-            >
-              {isDownloading ? (
-                <Loader2 className="size-3.5 animate-spin" />
-              ) : (
-                <Download className="size-3.5" />
-              )}
-              <span className="hidden sm:inline">Download</span>
-            </Button>
-          )}
-          {canOpenSource && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-7 gap-1.5 px-2.5 text-xs"
-              asChild
-            >
-              <a href={sourceUrl} target="_blank" rel="noreferrer">
-                <GitHubIcon className="size-3.5" />
-                <span className="hidden sm:inline">Source</span>
-              </a>
-            </Button>
-          )}
-        </div>
+  const hasPreview = !!resolvedPreviewUrl;
+  const tabTitle = hasPreview
+    ? (title ?? hostnameFromUrl(resolvedPreviewUrl))
+    : status === "error"
+      ? "Preview unavailable"
+      : "Preview";
+
+  const tabActions = (
+    <>
+      {hasPreview && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="text-muted-foreground hover:text-foreground size-7"
+          asChild
+        >
+          <a href={resolvedPreviewUrl} target="_blank" rel="noreferrer">
+            <ExternalLink className="size-3.5" />
+            <span className="sr-only">Open preview</span>
+          </a>
+        </Button>
       )}
+      {canRefresh && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="text-muted-foreground hover:text-foreground size-7"
+          disabled={isPreviewLoading}
+          onClick={handleRefreshPreview}
+        >
+          <RefreshCw
+            className={isPreviewLoading ? "size-3.5 animate-spin" : "size-3.5"}
+          />
+          <span className="sr-only">Refresh preview</span>
+        </Button>
+      )}
+      {canDownloadTemplate && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="text-muted-foreground hover:text-foreground size-7"
+          asChild
+        >
+          <a href={downloadUrl} target="_blank" rel="noreferrer">
+            <Download className="size-3.5" />
+            <span className="sr-only">Download</span>
+          </a>
+        </Button>
+      )}
+      {canDownloadSandbox && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="text-muted-foreground hover:text-foreground size-7"
+          disabled={isDownloading}
+          onClick={handleDownload}
+        >
+          {isDownloading ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <Download className="size-3.5" />
+          )}
+          <span className="sr-only">Download</span>
+        </Button>
+      )}
+      {canOpenSource && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="text-muted-foreground hover:text-foreground size-7"
+          asChild
+        >
+          <a href={sourceUrl} target="_blank" rel="noreferrer">
+            <GitHubIcon className="size-3.5" />
+            <span className="sr-only">Source</span>
+          </a>
+        </Button>
+      )}
+    </>
+  );
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-[#e8eaed] dark:bg-[#202124]">
+      <XuluxPreviewTabBar
+        title={tabTitle}
+        isLoading={isPreviewLoading}
+        isActive={hasPreview}
+        actions={tabActions}
+      />
 
       {downloadError && (
-        <div className="border-destructive/30 bg-background text-destructive absolute top-14 right-3 left-3 z-10 rounded-md border px-3 py-2 text-xs shadow-sm">
+        <div className="border-destructive/30 bg-background text-destructive z-10 border-b px-3 py-1.5 text-xs">
           {downloadError}
         </div>
       )}
 
-      {resolvedPreviewUrl ? (
-        <>
-          {isPreviewLoading && (
-            <div className="bg-background/80 absolute inset-0 z-5 flex items-center justify-center backdrop-blur-sm">
-              <div className="bg-background text-muted-foreground flex items-center gap-2 rounded-md border px-3 py-2 text-sm shadow-sm">
-                <Loader2 className="size-4 animate-spin" />
-                <span>Loading preview...</span>
+      {/* Content pane — same bg as active tab */}
+      <div className="bg-background relative min-h-0 flex-1">
+        {resolvedPreviewUrl ? (
+          <>
+            {isPreviewLoading && (
+              <div className="bg-background/80 absolute inset-0 z-5 flex items-center justify-center backdrop-blur-sm">
+                <div className="bg-background text-muted-foreground flex items-center gap-2 rounded-md border px-3 py-2 text-sm shadow-sm">
+                  <Loader2 className="size-4 animate-spin" />
+                  <span>Loading preview...</span>
+                </div>
               </div>
+            )}
+            <iframe
+              key={iframeKey}
+              title={title ?? "Xulux preview"}
+              src={resolvedPreviewUrl}
+              onLoad={() => setIsPreviewLoading(false)}
+              className="h-full w-full border-0 bg-white"
+            />
+          </>
+        ) : (
+          <div className="flex h-full items-center justify-center p-6 text-center">
+            <div className="max-w-md">
+              <p className="text-sm font-medium">
+                {status === "error"
+                  ? "Preview unavailable"
+                  : "Waiting for preview"}
+              </p>
+              <p className="text-muted-foreground mt-2 text-sm">
+                {error ??
+                  "The preview will appear after the agent finishes preparing the app."}
+              </p>
             </div>
-          )}
-          <iframe
-            key={iframeKey}
-            title={title ?? "Xulux preview"}
-            src={resolvedPreviewUrl}
-            onLoad={() => setIsPreviewLoading(false)}
-            className="h-full w-full border-0 bg-white"
-          />
-        </>
-      ) : (
-        <div className="flex h-full items-center justify-center p-6 text-center">
-          <div className="max-w-md">
-            <p className="text-sm font-medium">
-              {status === "error"
-                ? "Preview unavailable"
-                : "Waiting for preview"}
-            </p>
-            <p className="text-muted-foreground mt-2 text-sm">
-              {error ??
-                "The preview will appear after the agent finishes preparing the app."}
-            </p>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/docs/components/xulux/canvas/XuluxPreviewTabBar.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxPreviewTabBar.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { GlobeIcon, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  title: string;
+  isLoading?: boolean;
+  isActive?: boolean;
+  actions?: ReactNode;
+};
+
+/**
+ * Chrome-style active tab: rounded top + concave bottom curves via box-shadow.
+ * Sits on a darker tab strip; background matches the preview content below.
+ */
+export function XuluxPreviewTabBar({
+  title,
+  isLoading = false,
+  isActive = true,
+  actions,
+}: Props) {
+  return (
+    <div
+      className="flex h-9 shrink-0 items-end gap-1 bg-[#e8eaed] pt-1 pr-1 pl-2 dark:bg-[#202124]"
+      role="tablist"
+    >
+      {/* overflow-visible so the left/right tab swoosh curves aren't clipped */}
+      <div className="flex min-w-0 flex-1 items-end overflow-visible">
+        <div
+          role="tab"
+          aria-selected={isActive}
+          className={cn(
+            "relative flex h-8 max-w-[min(260px,52vw)] min-w-[120px] shrink-0 items-center gap-1.5 px-3 text-xs",
+            "bg-background text-foreground rounded-t-[10px]",
+            "before:absolute before:bottom-0 before:-left-[10px] before:z-0 before:h-[10px] before:w-[10px] before:rounded-br-[10px] before:shadow-[5px_5px_0_5px_var(--background)]",
+            "after:absolute after:-right-[10px] after:bottom-0 after:z-0 after:h-[10px] after:w-[10px] after:rounded-bl-[10px] after:shadow-[-5px_5px_0_5px_var(--background)]",
+            !isActive && "bg-muted/80 text-muted-foreground opacity-80",
+          )}
+        >
+          <GlobeIcon className="text-muted-foreground relative z-[1] size-3.5 shrink-0" />
+          <span className="relative z-[1] min-w-0 flex-1 truncate font-medium">
+            {title}
+          </span>
+          {isLoading && (
+            <Loader2 className="text-muted-foreground relative z-[1] size-3 shrink-0 animate-spin" />
+          )}
+        </div>
+      </div>
+
+      {actions ? (
+        <div className="mb-0.5 flex shrink-0 items-center gap-0.5 pr-0.5">
+          {actions}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { useAuiState, type ToolCallMessagePart } from "@assistant-ui/react";
+
+type OpenTemplatePreviewResult =
+  | {
+      success: true;
+      templateId: string;
+      versionId?: string;
+      previewUrl: string;
+      downloadUrl: string;
+      title: string;
+      summary?: string;
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
+type TemplatePreviewReady = {
+  previewUrl: string;
+  downloadUrl: string;
+  templateId: string;
+  versionId?: string;
+  title: string;
+};
+
+function isOpenTemplatePreviewCall(part: unknown): part is ToolCallMessagePart {
+  return (
+    !!part &&
+    typeof part === "object" &&
+    (part as ToolCallMessagePart).type === "tool-call" &&
+    (part as ToolCallMessagePart).toolName === "openTemplatePreview"
+  );
+}
+
+function getResult(
+  part: ToolCallMessagePart,
+): OpenTemplatePreviewResult | null {
+  const result = (part as ToolCallMessagePart & { result?: unknown }).result;
+  if (!result || typeof result !== "object") return null;
+  return result as OpenTemplatePreviewResult;
+}
+
+export function XuluxTemplatePreviewObserver({
+  onTemplatePreviewReady,
+  onCanvasError,
+}: {
+  onTemplatePreviewReady: (preview: TemplatePreviewReady) => void;
+  onCanvasError: (error: string) => void;
+}) {
+  const handledKeyRef = useRef<string | null>(null);
+
+  const latestCall = useAuiState((state) => {
+    const messages = state.thread.messages ?? [];
+    return messages
+      .flatMap((message) => message.content.filter(isOpenTemplatePreviewCall))
+      .at(-1);
+  });
+
+  const result = useMemo(() => {
+    if (!latestCall) return null;
+    const toolCallId =
+      (latestCall as ToolCallMessagePart & { toolCallId?: string })
+        .toolCallId ?? "";
+    const payload = getResult(latestCall);
+    if (!payload) return null;
+    return { toolCallId, payload };
+  }, [latestCall]);
+
+  useEffect(() => {
+    if (!result) return;
+    const { toolCallId, payload } = result;
+    const key = `${toolCallId}:${payload.success ? "ok" : "err"}`;
+    if (handledKeyRef.current === key) return;
+    handledKeyRef.current = key;
+
+    if (payload.success) {
+      onTemplatePreviewReady({
+        previewUrl: payload.previewUrl,
+        downloadUrl: payload.downloadUrl,
+        templateId: payload.templateId,
+        ...(payload.versionId !== undefined
+          ? { versionId: payload.versionId }
+          : {}),
+        title: payload.title,
+      });
+    } else {
+      onCanvasError(payload.error);
+    }
+  }, [onCanvasError, onTemplatePreviewReady, result]);
+
+  return null;
+}

--- a/apps/docs/components/xulux/chat/OpenInCard.tsx
+++ b/apps/docs/components/xulux/chat/OpenInCard.tsx
@@ -7,13 +7,14 @@ import { useCopyToClipboard } from "@assistant-ui/ui/hooks/use-copy-to-clipboard
 export type OpenInData = {
   title: string;
   downloadUrl?: string;
-  customizationNote?: string;
+  prompt?: string;
 };
 
-function isValidDownloadUrl(url: unknown): url is string {
+function isValidOpenInUrl(url: unknown): url is string {
   if (typeof url !== "string" || url.trim().length === 0) return false;
   if (url.includes("<") || url.includes(">")) return false;
   if (/from-tool-result|placeholder|<downloadurl/i.test(url)) return false;
+  if (url.startsWith("/")) return true;
   try {
     const parsed = new URL(url);
     return parsed.protocol === "http:" || parsed.protocol === "https:";
@@ -23,18 +24,16 @@ function isValidDownloadUrl(url: unknown): url is string {
 }
 
 function buildPrompt(data: OpenInData): string {
-  const note =
-    data.customizationNote ?? "Help me build this with assistant-ui.";
-  if (data.downloadUrl) {
-    return [
-      `I downloaded the "${data.title}" app template.`,
-      `Download: ${data.downloadUrl}`,
-      note,
-    ].join("\n\n");
-  }
-  return [`I want to build a "${data.title}" with assistant-ui.`, note].join(
-    "\n\n",
-  );
+  const sections: string[] = [];
+
+  if (data.prompt?.trim()) sections.push(data.prompt.trim());
+
+  const downloadUrl = isValidOpenInUrl(data.downloadUrl)
+    ? data.downloadUrl
+    : undefined;
+  if (downloadUrl) sections.push(`Download: ${downloadUrl}`);
+
+  return sections.join("\n\n");
 }
 
 const TOOLS = [
@@ -136,12 +135,12 @@ const TOOLS = [
 export function OpenInCard({
   title,
   downloadUrl,
-  customizationNote,
+  prompt: agentPrompt,
 }: OpenInData) {
   const prompt = buildPrompt({
     title,
     ...(downloadUrl ? { downloadUrl } : {}),
-    ...(customizationNote ? { customizationNote } : {}),
+    ...(agentPrompt ? { prompt: agentPrompt } : {}),
   });
   const encoded = encodeURIComponent(prompt);
   const { isCopied, copyToClipboard } = useCopyToClipboard();
@@ -207,16 +206,14 @@ export function OpenInSyntaxHighlighter({ code }: SyntaxHighlighterProps) {
     return null;
   }
   if (!data.title) return null;
-  const downloadUrl = isValidDownloadUrl(data.downloadUrl)
+  const downloadUrl = isValidOpenInUrl(data.downloadUrl)
     ? data.downloadUrl
     : undefined;
   return (
     <OpenInCard
       title={data.title}
       {...(downloadUrl ? { downloadUrl } : {})}
-      {...(data.customizationNote
-        ? { customizationNote: data.customizationNote }
-        : {})}
+      {...(data.prompt ? { prompt: data.prompt } : {})}
     />
   );
 }

--- a/apps/docs/components/xulux/chat/OpenInCard.tsx
+++ b/apps/docs/components/xulux/chat/OpenInCard.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import type { SyntaxHighlighterProps } from "@assistant-ui/react-streamdown";
+import { useState } from "react";
+import { CheckIcon, CopyIcon, DownloadIcon } from "lucide-react";
+import { useCopyToClipboard } from "@assistant-ui/ui/hooks/use-copy-to-clipboard";
+
+export type OpenInData = {
+  title: string;
+  downloadUrl?: string;
+  customizationNote?: string;
+};
+
+function isValidDownloadUrl(url: unknown): url is string {
+  if (typeof url !== "string" || url.trim().length === 0) return false;
+  if (url.includes("<") || url.includes(">")) return false;
+  if (/from-tool-result|placeholder|<downloadurl/i.test(url)) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function buildPrompt(data: OpenInData): string {
+  const note =
+    data.customizationNote ?? "Help me build this with assistant-ui.";
+  if (data.downloadUrl) {
+    return [
+      `I downloaded the "${data.title}" app template.`,
+      `Download: ${data.downloadUrl}`,
+      note,
+    ].join("\n\n");
+  }
+  return [`I want to build a "${data.title}" with assistant-ui.`, note].join(
+    "\n\n",
+  );
+}
+
+const TOOLS = [
+  {
+    id: "claude",
+    label: "Open in Claude Code",
+    buildUrl: (enc: string) => `claude-cli://open?q=${enc}`,
+    icon: (
+      <svg
+        viewBox="0 0 24 24"
+        width="15"
+        height="15"
+        fill="currentColor"
+        aria-hidden
+      >
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M20.998 10.949H24v3.102h-3v3.028h-1.487V20H18v-2.921h-1.487V20H15v-2.921H9V20H7.488v-2.921H6V20H4.487v-2.921H3V14.05H0V10.95h3V5h17.998v5.949zM6 10.949h1.488V8.102H6v2.847zm10.51 0H18V8.102h-1.49v2.847z"
+        />
+      </svg>
+    ),
+  },
+  {
+    id: "codex",
+    label: "Open in Codex",
+    buildUrl: (enc: string) => `codex://threads/new?prompt=${enc}`,
+    icon: (
+      <svg
+        viewBox="0 0 24 24"
+        width="15"
+        height="15"
+        fill="currentColor"
+        aria-hidden
+      >
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M8.086.457a6.105 6.105 0 013.046-.415c1.333.153 2.521.72 3.564 1.7a.117.117 0 00.107.029c1.408-.346 2.762-.224 4.061.366l.063.03.154.076c1.357.703 2.33 1.77 2.918 3.198.278.679.418 1.388.421 2.126a5.655 5.655 0 01-.18 1.631.167.167 0 00.04.155 5.982 5.982 0 011.578 2.891c.385 1.901-.01 3.615-1.183 5.14l-.182.22a6.063 6.063 0 01-2.934 1.851.162.162 0 00-.108.102c-.255.736-.511 1.364-.987 1.992-1.199 1.582-2.962 2.462-4.948 2.451-1.583-.008-2.986-.587-4.21-1.736a.145.145 0 00-.14-.032c-.518.167-1.04.191-1.604.185a5.924 5.924 0 01-2.595-.622 6.058 6.058 0 01-2.146-1.781c-.203-.269-.404-.522-.551-.821a7.74 7.74 0 01-.495-1.283 6.11 6.11 0 01-.017-3.064.166.166 0 00.008-.074.115.115 0 00-.037-.064 5.958 5.958 0 01-1.38-2.202 5.196 5.196 0 01-.333-1.589 6.915 6.915 0 01.188-2.132c.45-1.484 1.309-2.648 2.577-3.493.282-.188.55-.334.802-.438.286-.12.573-.22.861-.304a.129.129 0 00.087-.087A6.016 6.016 0 015.635 2.31C6.315 1.464 7.132.846 8.086.457zm-.804 7.85a.848.848 0 00-1.473.842l1.694 2.965-1.688 2.848a.849.849 0 001.46.864l1.94-3.272a.849.849 0 00.007-.854l-1.94-3.393zm5.446 6.24a.849.849 0 000 1.695h4.848a.849.849 0 000-1.696h-4.848z"
+        />
+      </svg>
+    ),
+  },
+  {
+    id: "cursor",
+    label: "Open in Cursor",
+    buildUrl: (enc: string) => `https://cursor.com/link/prompt?text=${enc}`,
+    icon: (
+      <svg
+        viewBox="0 0 24 24"
+        width="15"
+        height="15"
+        fill="currentColor"
+        aria-hidden
+      >
+        <path d="M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23" />
+      </svg>
+    ),
+  },
+  {
+    id: "conductor",
+    label: "Open in Conductor",
+    buildUrl: (enc: string) => `conductor://prompt=${enc}`,
+    icon: (
+      <svg
+        viewBox="0 0 115 174"
+        width="15"
+        height="15"
+        fill="currentColor"
+        aria-hidden
+      >
+        <path d="M4.57422 63.6992H22.373V37.251H4.57422C3.58785 37.2511 2.78711 38.0517 2.78711 39.0381V61.9121C2.78725 62.8984 3.58794 63.6991 4.57422 63.6992Z" />
+        <path d="M36.5977 63.6992H18.7988V37.251H36.5977C37.584 37.2511 38.3848 38.0517 38.3848 39.0381V61.9121C38.3846 62.8984 37.5839 63.6991 36.5977 63.6992Z" />
+        <path d="M4.57422 100.297H22.373V73.8486H4.57422C3.58785 73.8488 2.78711 74.6493 2.78711 75.6357V98.5098C2.78725 99.496 3.58794 100.297 4.57422 100.297Z" />
+        <path d="M36.5977 100.297H18.7988V73.8486H36.5977C37.584 73.8488 38.3848 74.6493 38.3848 75.6357V98.5098C38.3846 99.496 37.5839 100.297 36.5977 100.297Z" />
+        <path d="M77.7695 63.6992H95.5684V37.251H77.7695C76.7832 37.2511 75.9824 38.0517 75.9824 39.0381V61.9121C75.9826 62.8984 76.7833 63.6991 77.7695 63.6992Z" />
+        <path d="M109.793 63.6992H91.9941V37.251H109.793C110.779 37.2511 111.58 38.0517 111.58 39.0381V61.9121C111.58 62.8984 110.779 63.6991 109.793 63.6992Z" />
+      </svg>
+    ),
+  },
+  {
+    id: "chatgpt",
+    label: "Open in ChatGPT",
+    buildUrl: (enc: string) => `https://chatgpt.com/?prompt=${enc}`,
+    icon: (
+      <svg
+        viewBox="0 0 24 24"
+        width="15"
+        height="15"
+        fill="currentColor"
+        aria-hidden
+      >
+        <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+      </svg>
+    ),
+  },
+] as const;
+
+export function OpenInCard({
+  title,
+  downloadUrl,
+  customizationNote,
+}: OpenInData) {
+  const prompt = buildPrompt({ title, downloadUrl, customizationNote });
+  const encoded = encodeURIComponent(prompt);
+  const { isCopied, copyToClipboard } = useCopyToClipboard();
+  const hasDownload = Boolean(downloadUrl);
+
+  return (
+    <div className="border-border/60 bg-muted/20 my-3 rounded-lg border p-3 text-sm">
+      <div className="mb-2.5 flex items-center justify-between gap-2">
+        <span className="text-muted-foreground text-xs font-medium">
+          {hasDownload
+            ? "Open in your coding agent"
+            : "Continue building in your coding agent"}
+        </span>
+        {hasDownload ? (
+          <a
+            href={downloadUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:text-primary/80 flex items-center gap-1 text-xs underline underline-offset-2"
+          >
+            <DownloadIcon className="size-3" />
+            Download starter app
+          </a>
+        ) : null}
+      </div>
+
+      <div className="grid grid-cols-2 gap-1 sm:grid-cols-3">
+        {TOOLS.map((tool) => (
+          <a
+            key={tool.id}
+            href={tool.buildUrl(encoded)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-foreground hover:bg-muted flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors"
+          >
+            {tool.icon}
+            <span className="truncate text-xs">{tool.label}</span>
+          </a>
+        ))}
+
+        <button
+          type="button"
+          onClick={() => copyToClipboard(prompt)}
+          className="text-muted-foreground hover:text-foreground hover:bg-muted flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors"
+        >
+          {isCopied ? (
+            <CheckIcon className="size-[15px] shrink-0" />
+          ) : (
+            <CopyIcon className="size-[15px] shrink-0" />
+          )}
+          <span className="truncate text-xs">Copy context</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function OpenInSyntaxHighlighter({ code }: SyntaxHighlighterProps) {
+  let data: OpenInData;
+  try {
+    data = JSON.parse(code) as OpenInData;
+  } catch {
+    return null;
+  }
+  if (!data.title) return null;
+  const downloadUrl = isValidDownloadUrl(data.downloadUrl)
+    ? data.downloadUrl
+    : undefined;
+  return (
+    <OpenInCard
+      title={data.title}
+      {...(downloadUrl ? { downloadUrl } : {})}
+      {...(data.customizationNote
+        ? { customizationNote: data.customizationNote }
+        : {})}
+    />
+  );
+}

--- a/apps/docs/components/xulux/chat/OpenInCard.tsx
+++ b/apps/docs/components/xulux/chat/OpenInCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { SyntaxHighlighterProps } from "@assistant-ui/react-streamdown";
-import { useState } from "react";
 import { CheckIcon, CopyIcon, DownloadIcon } from "lucide-react";
 import { useCopyToClipboard } from "@assistant-ui/ui/hooks/use-copy-to-clipboard";
 
@@ -139,7 +138,11 @@ export function OpenInCard({
   downloadUrl,
   customizationNote,
 }: OpenInData) {
-  const prompt = buildPrompt({ title, downloadUrl, customizationNote });
+  const prompt = buildPrompt({
+    title,
+    ...(downloadUrl ? { downloadUrl } : {}),
+    ...(customizationNote ? { customizationNote } : {}),
+  });
   const encoded = encodeURIComponent(prompt);
   const { isCopied, copyToClipboard } = useCopyToClipboard();
   const hasDownload = Boolean(downloadUrl);

--- a/apps/docs/components/xulux/chat/OpenInCard.tsx
+++ b/apps/docs/components/xulux/chat/OpenInCard.tsx
@@ -23,6 +23,25 @@ function isValidOpenInUrl(url: unknown): url is string {
   }
 }
 
+function toAbsoluteDownloadUrl(url: string): string {
+  if (/^https?:\/\//i.test(url)) return url;
+  if (typeof window === "undefined") return url;
+  return new URL(url, window.location.origin).href;
+}
+
+function getDocsAppendix(): string {
+  const docsIndexUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/llms.txt`
+      : "https://www.assistant-ui.com/llms.txt";
+
+  return (
+    `Before implementing, read ${docsIndexUrl} to discover relevant documentation pages. ` +
+    "Traverse the index and read the specific pages you need (installation, architecture, runtimes, components) so your setup matches current assistant-ui APIs. " +
+    "Use the assistant-ui CLI for scaffolding — do not manually create projects with create-next-app."
+  );
+}
+
 function buildPrompt(data: OpenInData): string {
   const sections: string[] = [];
 
@@ -31,7 +50,11 @@ function buildPrompt(data: OpenInData): string {
   const downloadUrl = isValidOpenInUrl(data.downloadUrl)
     ? data.downloadUrl
     : undefined;
-  if (downloadUrl) sections.push(`Download: ${downloadUrl}`);
+  if (downloadUrl) {
+    sections.push(`Download: ${toAbsoluteDownloadUrl(downloadUrl)}`);
+  }
+
+  sections.push(getDocsAppendix());
 
   return sections.join("\n\n");
 }

--- a/apps/docs/components/xulux/chat/XuluxTemplateContext.tsx
+++ b/apps/docs/components/xulux/chat/XuluxTemplateContext.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import type { SelectedTemplateContext } from "../XuluxApp";
+import { createContext, useContext, type ReactNode } from "react";
+
+const XuluxTemplateContext = createContext<SelectedTemplateContext | null>(
+  null,
+);
+
+export function XuluxTemplateProvider({
+  template,
+  children,
+}: {
+  template: SelectedTemplateContext | null;
+  children: ReactNode;
+}) {
+  return (
+    <XuluxTemplateContext.Provider value={template}>
+      {children}
+    </XuluxTemplateContext.Provider>
+  );
+}
+
+export function useXuluxTemplateContext(): SelectedTemplateContext | null {
+  return useContext(XuluxTemplateContext);
+}

--- a/apps/docs/components/xulux/chat/XuluxThread.tsx
+++ b/apps/docs/components/xulux/chat/XuluxThread.tsx
@@ -10,22 +10,16 @@ import Image from "next/image";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { XuluxPoweredBy } from "../XuluxPoweredBy";
 import { XuluxToolCall } from "./XuluxToolCall";
+import { XuluxUsageLimitBanner } from "./XuluxUsageLimitBanner";
 
 const XULUX_CONTEXT_WINDOW = 400_000;
-const XULUX_DEFAULT_MODEL_ID = "gpt-5.4-low";
+const XULUX_DEFAULT_MODEL_ID = "gpt-5.4-mini";
 
 const XULUX_MODELS = [
   {
     id: "gpt-5.4-mini",
     name: "GPT-5.4 Mini",
     modelName: "gpt-5.4-mini",
-  },
-  {
-    id: "gpt-5.4-low",
-    name: "GPT-5.4 Low",
-    description: "Low reasoning",
-    modelName: "gpt-5.4",
-    reasoningEffort: "low",
   },
 ] as const;
 
@@ -39,7 +33,7 @@ export function XuluxThread({
   return (
     <AssistantThread
       welcome={<XuluxWelcome />}
-      composer={<XuluxComposer />}
+      composer={<XuluxComposer onNewThread={onNewThread} />}
       footer={
         <AssistantFooter
           onNewThread={onNewThread}
@@ -52,12 +46,19 @@ export function XuluxThread({
   );
 }
 
-function XuluxComposer(): ReactNode {
+function XuluxComposer({
+  onNewThread,
+}: {
+  onNewThread: () => void;
+}): ReactNode {
   return (
-    <AssistantComposer
-      placeholder="Ask Xulux to build or refine the UI..."
-      modelSelector={<XuluxModelSelector />}
-    />
+    <div>
+      <XuluxUsageLimitBanner onNewThread={onNewThread} />
+      <AssistantComposer
+        placeholder="Ask Xulux to build or refine the UI..."
+        modelSelector={<XuluxModelSelector />}
+      />
+    </div>
   );
 }
 

--- a/apps/docs/components/xulux/chat/XuluxThread.tsx
+++ b/apps/docs/components/xulux/chat/XuluxThread.tsx
@@ -2,13 +2,23 @@
 
 import { ModelSelector } from "@/components/assistant-ui/model-selector";
 import { AssistantComposer } from "@/components/docs/assistant/composer";
+import { AssistantActionBar } from "@/components/docs/assistant/assistant-action-bar";
+import { MarkdownText } from "@/components/docs/assistant/markdown";
 import { AssistantFooter } from "@/components/docs/assistant/footer";
-import { AssistantMessage } from "@/components/docs/assistant/messages";
 import { AssistantThread } from "@/components/docs/assistant/thread";
-import { useAui } from "@assistant-ui/react";
+import { Reasoning } from "@/components/assistant-ui/reasoning";
+import { DotMatrix } from "@/components/assistant-ui/dot-matrix";
+import { getXuluxThreadWelcome } from "@/lib/xulux/thread-welcome";
+import {
+  AuiIf,
+  ErrorPrimitive,
+  MessagePrimitive,
+  useAui,
+} from "@assistant-ui/react";
 import Image from "next/image";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { XuluxPoweredBy } from "../XuluxPoweredBy";
+import { useXuluxTemplateContext } from "./XuluxTemplateContext";
 import { XuluxToolCall } from "./XuluxToolCall";
 import { XuluxUsageLimitBanner } from "./XuluxUsageLimitBanner";
 
@@ -30,10 +40,20 @@ export function XuluxThread({
 }: {
   onNewThread: () => void;
 }): ReactNode {
+  const template = useXuluxTemplateContext();
+  const welcome = useMemo(() => getXuluxThreadWelcome(template), [template]);
+
   return (
     <AssistantThread
-      welcome={<XuluxWelcome />}
-      composer={<XuluxComposer onNewThread={onNewThread} />}
+      welcome={
+        <XuluxWelcome welcome={welcome} templateTitle={template?.title} />
+      }
+      composer={
+        <XuluxComposer
+          onNewThread={onNewThread}
+          placeholder={welcome.composerPlaceholder}
+        />
+      }
       footer={
         <AssistantFooter
           onNewThread={onNewThread}
@@ -48,14 +68,16 @@ export function XuluxThread({
 
 function XuluxComposer({
   onNewThread,
+  placeholder,
 }: {
   onNewThread: () => void;
+  placeholder: string;
 }): ReactNode {
   return (
     <div>
       <XuluxUsageLimitBanner onNewThread={onNewThread} />
       <AssistantComposer
-        placeholder="Ask Xulux to build or refine the UI..."
+        placeholder={placeholder}
         modelSelector={<XuluxModelSelector />}
       />
     </div>
@@ -112,14 +134,76 @@ function XuluxModelSelector(): ReactNode {
 }
 
 function XuluxAssistantMessage(): ReactNode {
-  return <AssistantMessage ToolCallComponent={XuluxToolCall} />;
+  return (
+    <MessagePrimitive.Root className="py-2" data-role="assistant">
+      <div className="text-sm [&_[data-part-type=tool-call]+[data-part-type=text]]:mt-2.5">
+        <MessagePrimitive.Parts>
+          {({ part }) => {
+            if (part.type === "text") {
+              return (
+                <div data-part-type="text">
+                  <MarkdownText />
+                </div>
+              );
+            }
+            if (part.type === "reasoning") {
+              return (
+                <div data-part-type="reasoning">
+                  <Reasoning {...part} />
+                </div>
+              );
+            }
+            if (part.type === "tool-call") {
+              return (
+                <div data-part-type="tool-call">
+                  {part.toolUI ?? <XuluxToolCall {...part} />}
+                </div>
+              );
+            }
+            return null;
+          }}
+        </MessagePrimitive.Parts>
+
+        <AuiIf
+          condition={(s) =>
+            s.thread.isRunning && s.message.content.length === 0
+          }
+        >
+          <div className="text-muted-foreground flex items-center gap-2 py-1">
+            <DotMatrix state="connecting" aria-hidden />
+            <span className="text-sm">Connecting</span>
+          </div>
+        </AuiIf>
+        <MessagePrimitive.Error>
+          <ErrorPrimitive.Root className="border-destructive bg-destructive/10 text-destructive dark:bg-destructive/5 mt-2 rounded-md border p-2 text-xs dark:text-red-200">
+            <ErrorPrimitive.Message className="line-clamp-2" />
+          </ErrorPrimitive.Root>
+        </MessagePrimitive.Error>
+      </div>
+      <AssistantActionBar />
+    </MessagePrimitive.Root>
+  );
 }
 
-function XuluxWelcome(): ReactNode {
+function XuluxWelcome({
+  welcome,
+  templateTitle,
+}: {
+  welcome: ReturnType<typeof getXuluxThreadWelcome>;
+  templateTitle?: string | undefined;
+}): ReactNode {
   return (
     <div className="flex flex-1 flex-col items-center justify-center p-6 text-center">
-      <p className="text-muted-foreground text-sm">
-        Pick a template preview or describe what to build.
+      {templateTitle ? (
+        <span className="text-muted-foreground mb-3 inline-block rounded-full border px-2.5 py-0.5 text-xs">
+          {templateTitle}
+        </span>
+      ) : null}
+      <h2 className="text-base font-semibold tracking-tight">
+        {welcome.headline}
+      </h2>
+      <p className="text-muted-foreground mt-1 max-w-sm text-sm">
+        {welcome.body}
       </p>
     </div>
   );

--- a/apps/docs/components/xulux/chat/XuluxThread.tsx
+++ b/apps/docs/components/xulux/chat/XuluxThread.tsx
@@ -74,9 +74,6 @@ function XuluxModelSelector(): ReactNode {
       XULUX_MODELS.map((model) => ({
         id: model.id,
         name: model.name,
-        ...("description" in model
-          ? { description: model.description }
-          : undefined),
         icon: (
           <Image
             src="/icons/openai.svg"
@@ -91,17 +88,12 @@ function XuluxModelSelector(): ReactNode {
   );
 
   useEffect(() => {
-    const config = {
-      config: {
-        modelName: selectedModel.modelName,
-        ...("reasoningEffort" in selectedModel
-          ? { reasoningEffort: selectedModel.reasoningEffort }
-          : undefined),
-      },
-    };
-
     return aui.modelContext().register({
-      getModelContext: () => config,
+      getModelContext: () => ({
+        config: {
+          modelName: selectedModel.modelName,
+        },
+      }),
     });
   }, [aui, selectedModel]);
 

--- a/apps/docs/components/xulux/chat/XuluxToolCall.tsx
+++ b/apps/docs/components/xulux/chat/XuluxToolCall.tsx
@@ -7,9 +7,12 @@ import {
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
+  ExternalLinkIcon,
   FileCodeIcon,
   FileTextIcon,
   FolderTreeIcon,
+  InfoIcon,
+  LayoutTemplateIcon,
   LoaderIcon,
   TerminalIcon,
   type LucideIcon,
@@ -56,6 +59,48 @@ function getToolDisplay(
         icon: FileCodeIcon,
         label: isRunning ? "Reading" : "Read",
         detail: shortPath,
+      };
+    }
+    case "inspectSourceMap": {
+      const command = (args as { command?: string })?.command ?? "";
+      const preview =
+        command.length > 60 ? `${command.slice(0, 57)}...` : command;
+      return {
+        icon: TerminalIcon,
+        label: isRunning ? "Running" : "Ran",
+        detail: preview,
+      };
+    }
+    case "readSourceMapFile": {
+      const filePath = (args as { path?: string })?.path ?? "";
+      const shortPath = filePath.split("/").slice(-2).join("/");
+      return {
+        icon: FileCodeIcon,
+        label: isRunning ? "Reading" : "Read",
+        detail: shortPath,
+      };
+    }
+    case "getTemplateList":
+      return {
+        icon: LayoutTemplateIcon,
+        label: isRunning ? "Searching" : "Searched",
+        detail: "templates",
+      };
+    case "getTemplateDetails": {
+      const tid = (args as { templateId?: string })?.templateId ?? "";
+      return {
+        icon: InfoIcon,
+        label: isRunning ? "Reading" : "Read",
+        detail: tid,
+      };
+    }
+    case "openTemplatePreview": {
+      const tid = (args as { templateId?: string })?.templateId ?? "";
+      const vid = (args as { versionId?: string })?.versionId;
+      return {
+        icon: ExternalLinkIcon,
+        label: isRunning ? "Opening" : "Opened",
+        detail: vid ? `${tid}/${vid}` : tid,
       };
     }
     default:

--- a/apps/docs/components/xulux/chat/XuluxToolCall.tsx
+++ b/apps/docs/components/xulux/chat/XuluxToolCall.tsx
@@ -1,179 +1,148 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import {
+  formatToolCall,
+  ToolErrorCard,
+  ToolStatusCard,
+  ToolTraceCard,
+} from "@/lib/tool-trace";
 import type { ToolCallMessagePartProps } from "@assistant-ui/react";
 import {
   BookOpenIcon,
-  CheckIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
   ExternalLinkIcon,
   FileCodeIcon,
   FileTextIcon,
   FolderTreeIcon,
   InfoIcon,
   LayoutTemplateIcon,
-  LoaderIcon,
   TerminalIcon,
   type LucideIcon,
 } from "lucide-react";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { type ReactNode } from "react";
 
-function getToolDisplay(
-  toolName: string,
-  args: Record<string, unknown>,
-  isRunning: boolean,
-): { icon: LucideIcon; label: string; detail: string } {
+function getToolIcon(toolName: string): ReactNode {
+  const Icon = getToolIconComponent(toolName);
+  return <Icon className="size-3.5" />;
+}
+
+function getToolIconComponent(toolName: string): LucideIcon {
+  switch (toolName) {
+    case "listDocs":
+      return FolderTreeIcon;
+    case "readDoc":
+      return FileTextIcon;
+    case "bash":
+    case "inspectSourceMap":
+      return TerminalIcon;
+    case "readFile":
+    case "readSourceMapFile":
+      return FileCodeIcon;
+    case "getTemplateList":
+      return LayoutTemplateIcon;
+    case "getTemplateDetails":
+      return InfoIcon;
+    case "openTemplatePreview":
+      return ExternalLinkIcon;
+    default:
+      return BookOpenIcon;
+  }
+}
+
+function getRunningMessage(toolName: string): string {
+  switch (toolName) {
+    case "listDocs":
+      return "Listing docs...";
+    case "readDoc":
+      return "Reading page...";
+    case "bash":
+    case "inspectSourceMap":
+      return "Running command...";
+    case "readFile":
+    case "readSourceMapFile":
+      return "Reading file...";
+    case "getTemplateList":
+      return "Loading templates...";
+    case "getTemplateDetails":
+      return "Reading template...";
+    case "openTemplatePreview":
+      return "Opening preview...";
+    default:
+      return "Running...";
+  }
+}
+
+function extractToolError(result: unknown): string | null {
+  if (!result || typeof result !== "object") return null;
+  const record = result as Record<string, unknown>;
+  if (record.success === false) {
+    if (typeof record.error === "string") return record.error;
+    return "Tool failed";
+  }
+  if (typeof record.error === "string") return record.error;
+  return null;
+}
+
+function summarizeXuluxResult(toolName: string, result: unknown): string {
+  if (result === undefined || result === null) return "Done";
+
+  const error = extractToolError(result);
+  if (error) return error;
+
+  if (typeof result !== "object") return String(result);
+
+  const record = result as Record<string, unknown>;
+
   switch (toolName) {
     case "listDocs": {
-      const path = (args as { path?: string })?.path;
-      return {
-        icon: FolderTreeIcon,
-        label: isRunning ? "Listing" : "Listed",
-        detail: path ? `/${path}` : "documentation structure",
-      };
+      const children = record.children;
+      if (Array.isArray(children)) {
+        return `${children.length} item${children.length === 1 ? "" : "s"}`;
+      }
+      return "Listed";
     }
-    case "readDoc": {
-      const slug = (args as { slugOrUrl?: string })?.slugOrUrl ?? "";
-      const normalizedSlug = slug.replace(/^\/docs\/?/, "");
-      return {
-        icon: FileTextIcon,
-        label: isRunning ? "Reading" : "Read",
-        detail: `/docs/${normalizedSlug}`,
-      };
-    }
-    case "bash": {
-      const command = (args as { command?: string })?.command ?? "";
-      const preview =
-        command.length > 60 ? `${command.slice(0, 57)}...` : command;
-      return {
-        icon: TerminalIcon,
-        label: isRunning ? "Running" : "Ran",
-        detail: preview,
-      };
-    }
-    case "readFile": {
-      const filePath = (args as { path?: string })?.path ?? "";
-      const shortPath = filePath.split("/").slice(-2).join("/");
-      return {
-        icon: FileCodeIcon,
-        label: isRunning ? "Reading" : "Read",
-        detail: shortPath,
-      };
-    }
+    case "readDoc":
+      return typeof record.title === "string" ? record.title : "Read page";
+    case "bash":
     case "inspectSourceMap": {
-      const command = (args as { command?: string })?.command ?? "";
-      const preview =
-        command.length > 60 ? `${command.slice(0, 57)}...` : command;
-      return {
-        icon: TerminalIcon,
-        label: isRunning ? "Running" : "Ran",
-        detail: preview,
-      };
+      const stdout = record.stdout;
+      if (typeof stdout === "string" && stdout.trim()) {
+        const line = stdout.trim().split("\n")[0] ?? "";
+        return line.length > 48 ? `${line.slice(0, 45)}...` : line;
+      }
+      return "Completed";
     }
+    case "readFile":
     case "readSourceMapFile": {
-      const filePath = (args as { path?: string })?.path ?? "";
-      const shortPath = filePath.split("/").slice(-2).join("/");
-      return {
-        icon: FileCodeIcon,
-        label: isRunning ? "Reading" : "Read",
-        detail: shortPath,
-      };
+      const path = typeof record.path === "string" ? record.path : "";
+      return path ? path.split("/").slice(-2).join("/") : "Read file";
     }
-    case "getTemplateList":
-      return {
-        icon: LayoutTemplateIcon,
-        label: isRunning ? "Searching" : "Searched",
-        detail: "templates",
-      };
+    case "getTemplateList": {
+      const templates = record.templates;
+      if (Array.isArray(templates)) {
+        return `${templates.length} template${templates.length === 1 ? "" : "s"}`;
+      }
+      return "Templates loaded";
+    }
     case "getTemplateDetails": {
-      const tid = (args as { templateId?: string })?.templateId ?? "";
-      return {
-        icon: InfoIcon,
-        label: isRunning ? "Reading" : "Read",
-        detail: tid,
-      };
+      const name =
+        typeof record.name === "string"
+          ? record.name
+          : typeof record.id === "string"
+            ? record.id
+            : "Template details";
+      return name;
     }
     case "openTemplatePreview": {
-      const tid = (args as { templateId?: string })?.templateId ?? "";
-      const vid = (args as { versionId?: string })?.versionId;
-      return {
-        icon: ExternalLinkIcon,
-        label: isRunning ? "Opening" : "Opened",
-        detail: vid ? `${tid}/${vid}` : tid,
-      };
+      if (typeof record.title === "string") return record.title;
+      const templateId =
+        typeof record.templateId === "string" ? record.templateId : "";
+      const versionId =
+        typeof record.versionId === "string" ? record.versionId : "";
+      if (templateId && versionId) return `${templateId} · ${versionId}`;
+      return templateId || "Preview opened";
     }
     default:
-      return {
-        icon: BookOpenIcon,
-        label: isRunning ? "Running" : "Completed",
-        detail: toolName,
-      };
-  }
-}
-
-function ToolStatusIcon({
-  status,
-  FallbackIcon,
-}: {
-  status: { type: string } | undefined;
-  FallbackIcon: LucideIcon;
-}): ReactNode {
-  switch (status?.type) {
-    case "running":
-      return <LoaderIcon className="size-3 animate-spin" />;
-    case "complete":
-      return <CheckIcon className="size-3 text-emerald-500" />;
-    default:
-      return <FallbackIcon className="size-3" />;
-  }
-}
-
-function useToolDuration(isRunning: boolean): number | null {
-  const startTimeRef = useRef<number | null>(null);
-  const [duration, setDuration] = useState<number | null>(null);
-
-  useEffect(() => {
-    if (isRunning && startTimeRef.current === null) {
-      startTimeRef.current = Date.now();
-    } else if (!isRunning && startTimeRef.current !== null) {
-      setDuration(Date.now() - startTimeRef.current);
-    }
-  }, [isRunning]);
-
-  return duration;
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  return `${(ms / 1000).toFixed(1)}s`;
-}
-
-function ToolPayload({
-  label,
-  value,
-}: {
-  label: string;
-  value: unknown;
-}): ReactNode {
-  return (
-    <div>
-      <p className="text-muted-foreground/60 mb-1 text-[10px] font-medium tracking-wide uppercase">
-        {label}
-      </p>
-      <pre className="text-muted-foreground overflow-x-auto break-all whitespace-pre-wrap">
-        {formatPayload(value)}
-      </pre>
-    </div>
-  );
-}
-
-function formatPayload(value: unknown): string {
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
+      return "Completed";
   }
 }
 
@@ -183,45 +152,32 @@ export function XuluxToolCall({
   result,
   status,
 }: ToolCallMessagePartProps): ReactNode {
+  const signature = formatToolCall(toolName, args);
+  const icon = getToolIcon(toolName);
   const isRunning = status?.type === "running";
-  const { icon, label, detail } = getToolDisplay(toolName, args, isRunning);
-  const duration = useToolDuration(isRunning);
-  const [expanded, setExpanded] = useState(false);
+  const error = !isRunning ? extractToolError(result) : null;
+
+  if (isRunning) {
+    return (
+      <ToolStatusCard
+        icon={icon}
+        signature={signature}
+        message={getRunningMessage(toolName)}
+        loading
+      />
+    );
+  }
+
+  if (error) {
+    return <ToolErrorCard signature={signature} error={error} />;
+  }
 
   return (
-    <div className="border-border/60 bg-muted/30 my-1.5 rounded-lg border text-xs">
-      <button
-        type="button"
-        onClick={() => setExpanded((value) => !value)}
-        className={cn(
-          "text-muted-foreground flex w-full items-center gap-2 px-2.5 py-1.5",
-          isRunning && "animate-pulse",
-        )}
-      >
-        <ToolStatusIcon status={status} FallbackIcon={icon} />
-        <span className="flex-1 truncate text-left">
-          {label} {detail}
-        </span>
-        {duration !== null && (
-          <span className="text-muted-foreground/60">
-            {formatDuration(duration)}
-          </span>
-        )}
-        {expanded ? (
-          <ChevronUpIcon className="text-muted-foreground/50 size-3" />
-        ) : (
-          <ChevronDownIcon className="text-muted-foreground/50 size-3" />
-        )}
-      </button>
-
-      {expanded && (
-        <div className="border-border/60 space-y-2 border-t px-2.5 py-2">
-          <ToolPayload label="Input" value={args} />
-          {result !== undefined && (
-            <ToolPayload label="Output" value={result} />
-          )}
-        </div>
-      )}
-    </div>
+    <ToolTraceCard
+      icon={icon}
+      signature={signature}
+      description={summarizeXuluxResult(toolName, result)}
+      result={result}
+    />
   );
 }

--- a/apps/docs/components/xulux/chat/XuluxUsageLimitBanner.tsx
+++ b/apps/docs/components/xulux/chat/XuluxUsageLimitBanner.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+import type { BudgetDenyCode } from "@/lib/xulux/usage-budget-codes";
+import { isDailyLimitCode } from "@/lib/xulux/usage-budget-codes";
+import { Button } from "@/components/ui/button";
+
+export type XuluxLimitBlock = {
+  code: BudgetDenyCode;
+  message: string;
+};
+
+type XuluxUsageBudgetContextValue = {
+  limitBlock: XuluxLimitBlock | null;
+  clearLimitBlock: () => void;
+};
+
+const XuluxUsageBudgetContext =
+  createContext<XuluxUsageBudgetContextValue | null>(null);
+
+export function XuluxUsageBudgetProvider({
+  limitBlock,
+  clearLimitBlock,
+  children,
+}: {
+  limitBlock: XuluxLimitBlock | null;
+  clearLimitBlock: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <XuluxUsageBudgetContext.Provider value={{ limitBlock, clearLimitBlock }}>
+      {children}
+    </XuluxUsageBudgetContext.Provider>
+  );
+}
+
+export function useXuluxUsageBudget(): XuluxUsageBudgetContextValue {
+  const ctx = useContext(XuluxUsageBudgetContext);
+  if (!ctx) {
+    return { limitBlock: null, clearLimitBlock: () => {} };
+  }
+  return ctx;
+}
+
+export function parseXuluxLimitBlock(payload: unknown): XuluxLimitBlock | null {
+  if (!payload || typeof payload !== "object") return null;
+  const { code, error } = payload as { code?: unknown; error?: unknown };
+  if (typeof code !== "string" || typeof error !== "string") return null;
+  return { code: code as BudgetDenyCode, message: error };
+}
+
+export function XuluxUsageLimitBanner({
+  onNewThread,
+}: {
+  onNewThread: () => void;
+}): ReactNode {
+  const { limitBlock } = useXuluxUsageBudget();
+  if (!limitBlock) return null;
+
+  const showNewChat = !isDailyLimitCode(limitBlock.code);
+
+  return (
+    <div
+      className="border-destructive/30 bg-destructive/10 text-destructive mb-2 rounded-lg border px-3 py-2 text-xs dark:text-red-200"
+      role="alert"
+    >
+      <p>{limitBlock.message}</p>
+      {showNewChat ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="mt-2 h-7"
+          onClick={onNewThread}
+        >
+          New chat
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/docs/components/xulux/landing/CategoryGrid.tsx
+++ b/apps/docs/components/xulux/landing/CategoryGrid.tsx
@@ -117,11 +117,7 @@ export function CategoryGrid({ onBrowseAll, onSelectTemplate }: Props) {
                 <Thumbnail
                   gradient={template.gradient}
                   src={template.screenshotUrl}
-                  previewUrl={
-                    template.kind === "template"
-                      ? template.previewUrl
-                      : undefined
-                  }
+                  previewUrl={template.previewUrl}
                   label={template.title}
                   className="aspect-video w-full"
                 />

--- a/apps/docs/components/xulux/landing/CategoryGrid.tsx
+++ b/apps/docs/components/xulux/landing/CategoryGrid.tsx
@@ -117,6 +117,11 @@ export function CategoryGrid({ onBrowseAll, onSelectTemplate }: Props) {
                 <Thumbnail
                   gradient={template.gradient}
                   src={template.screenshotUrl}
+                  previewUrl={
+                    template.kind === "template"
+                      ? template.previewUrl
+                      : undefined
+                  }
                   label={template.title}
                   className="aspect-video w-full"
                 />

--- a/apps/docs/components/xulux/landing/CategoryGrid.tsx
+++ b/apps/docs/components/xulux/landing/CategoryGrid.tsx
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export function CategoryGrid({ onBrowseAll, onSelectTemplate }: Props) {
-  const { templates, error } = useXuluxTemplateCatalog();
+  const { templates, isLoading, error } = useXuluxTemplateCatalog();
   const [selected, setSelected] = useState<XuluxTemplate | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -40,6 +40,10 @@ export function CategoryGrid({ onBrowseAll, onSelectTemplate }: Props) {
       resizeObserver.disconnect();
     };
   }, [updateScrollState, templates]);
+
+  if (isLoading) {
+    return <TemplateGridSkeleton />;
+  }
 
   const scrollLeft = () => {
     const el = scrollRef.current;
@@ -155,5 +159,34 @@ export function CategoryGrid({ onBrowseAll, onSelectTemplate }: Props) {
         }}
       />
     </>
+  );
+}
+
+function TemplateGridSkeleton() {
+  return (
+    <section className="w-full">
+      <div className="mb-4 flex items-baseline justify-between">
+        <h2 className="text-lg font-semibold tracking-tight">Templates</h2>
+        <div className="bg-muted h-4 w-20 animate-pulse rounded" />
+      </div>
+
+      <div className="flex gap-4 overflow-hidden">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={index}
+            className="border-border bg-card/40 flex min-w-[190px] flex-1 flex-col gap-2 rounded-xl border p-2"
+          >
+            <div className="bg-muted aspect-video w-full animate-pulse rounded-md" />
+            <div className="space-y-2 px-1 pb-1">
+              <div className="bg-muted h-4 w-3/4 animate-pulse rounded" />
+              <div className="space-y-1">
+                <div className="bg-muted h-3 w-full animate-pulse rounded" />
+                <div className="bg-muted h-3 w-2/3 animate-pulse rounded" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }

--- a/apps/docs/components/xulux/landing/LandingSuggestions.tsx
+++ b/apps/docs/components/xulux/landing/LandingSuggestions.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import {
+  BookOpenIcon,
+  CloudIcon,
+  LayoutTemplateIcon,
+  SparklesIcon,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type SuggestionGroup = {
+  label: string;
+  icon: ReactNode;
+  options: { label: string; prompt: string }[];
+};
+
+const SUGGESTION_GROUPS: SuggestionGroup[] = [
+  {
+    label: "New app",
+    icon: <SparklesIcon />,
+    options: [
+      {
+        label: "ChatGPT style",
+        prompt:
+          "Build me a ChatGPT-style chat app with assistant-ui — empty state, composer, and message layout.",
+      },
+      {
+        label: "docs assistant",
+        prompt:
+          "Build a SaaS product docs site with a sidebar assistant for onboarding guides and release notes.",
+      },
+      {
+        label: "website copilot",
+        prompt:
+          "Build a marketing website with an on-page copilot that explains each page and suggests next steps.",
+      },
+    ],
+  },
+  {
+    label: "Templates",
+    icon: <LayoutTemplateIcon />,
+    options: [
+      {
+        label: "ChatGPT",
+        prompt:
+          "Open the ChatGPT Style Assistant demo and show me the live preview with download.",
+      },
+      {
+        label: "Claude",
+        prompt:
+          "Open the Claude Style Assistant demo and show me the live preview with download.",
+      },
+      {
+        label: "Grok",
+        prompt:
+          "Open the Grok Style Assistant demo and show me the live preview with download.",
+      },
+    ],
+  },
+  {
+    label: "Learn",
+    icon: <BookOpenIcon />,
+    options: [
+      {
+        label: "Thread component",
+        prompt: "How do I set up the assistant-ui Thread component?",
+      },
+      {
+        label: "AI SDK runtime",
+        prompt: "How do I connect assistant-ui to the Vercel AI SDK?",
+      },
+      {
+        label: "tool UI",
+        prompt: "How do I render custom tool UIs in assistant-ui?",
+      },
+    ],
+  },
+  {
+    label: "Cloud",
+    icon: <CloudIcon />,
+    options: [
+      {
+        label: "thread persistence",
+        prompt:
+          "How do I add thread persistence and chat history with Assistant Cloud?",
+      },
+      {
+        label: "AI SDK + UI",
+        prompt:
+          "How do I set up Assistant Cloud with useChatRuntime, Thread, and ThreadList?",
+      },
+      {
+        label: "authorization",
+        prompt:
+          "How do I set up user authorization and workspaces for Assistant Cloud?",
+      },
+    ],
+  },
+];
+
+const suggestionChipClass =
+  "aui-thread-welcome-suggestion text-foreground hover:bg-muted border-border/60 h-auto gap-1.5 rounded-full border px-3.5 py-1.5 text-sm font-normal whitespace-nowrap transition-colors [&_svg]:size-4";
+
+type Props = {
+  onSelectPrompt: (prompt: string) => void;
+  disabled?: boolean;
+};
+
+export function LandingSuggestions({ onSelectPrompt, disabled }: Props) {
+  const [expandedLabel, setExpandedLabel] = useState<string | null>(null);
+  const expandedGroup = SUGGESTION_GROUPS.find(
+    (group) => group.label === expandedLabel,
+  );
+
+  return (
+    <div className="aui-thread-welcome-suggestions mt-4 flex w-full flex-col gap-2">
+      <div className="w-full scrollbar-none overflow-x-auto">
+        <div className="mx-auto flex w-max max-w-full items-center gap-2 px-1">
+          {SUGGESTION_GROUPS.map((group) => (
+            <Button
+              key={group.label}
+              type="button"
+              variant="ghost"
+              disabled={disabled}
+              className={cn(
+                suggestionChipClass,
+                group.label === expandedLabel && "bg-muted",
+              )}
+              onClick={() =>
+                setExpandedLabel(
+                  group.label === expandedLabel ? null : group.label,
+                )
+              }
+            >
+              {group.icon}
+              {group.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+      {expandedGroup && (
+        <div
+          key={expandedGroup.label}
+          className="fade-in slide-in-from-top-1 animate-in w-full scrollbar-none overflow-x-auto duration-200"
+        >
+          <div className="mx-auto flex w-max max-w-full items-center gap-2 px-1">
+            {expandedGroup.options.map((option) => (
+              <Button
+                key={option.label}
+                type="button"
+                variant="ghost"
+                disabled={disabled}
+                className={suggestionChipClass}
+                onClick={() => onSelectPrompt(option.prompt)}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/docs/components/xulux/landing/PromptInput.tsx
+++ b/apps/docs/components/xulux/landing/PromptInput.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { ArrowRight, Plus } from "lucide-react";
+import { ArrowUpIcon, PlusIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 type Props = {
   value?: string | undefined;
@@ -31,7 +32,7 @@ export function PromptInput({
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+    el.style.height = `${Math.min(el.scrollHeight, 128)}px`;
   }, [value]);
 
   const handleSubmit = () => {
@@ -41,42 +42,56 @@ export function PromptInput({
   };
 
   return (
-    <div className="border-border bg-card/40 focus-within:border-border/80 w-full rounded-2xl border p-3 backdrop-blur transition-colors">
-      <textarea
-        ref={textareaRef}
-        value={value}
-        onChange={(event) => setValue(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.nativeEvent.isComposing) return;
-          if (event.key === "Enter" && !event.shiftKey) {
-            event.preventDefault();
-            handleSubmit();
-          }
-        }}
-        placeholder={placeholder}
-        rows={1}
-        className="text-foreground placeholder:text-muted-foreground w-full resize-none bg-transparent px-2 py-2 text-base focus:outline-none"
-      />
-      <div className="flex items-center justify-between pt-2">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          className="text-muted-foreground hover:text-foreground rounded-lg"
-          aria-label="Attach file"
-        >
-          <Plus className="size-4" />
-        </Button>
-        <Button
-          type="button"
-          size="icon-sm"
-          className="rounded-lg"
-          onClick={handleSubmit}
-          disabled={!value.trim()}
-          aria-label="Send prompt"
-        >
-          <ArrowRight className="size-4" />
-        </Button>
+    <div className="aui-composer-root relative flex w-full flex-col">
+      <div
+        data-slot="aui_composer-shell"
+        className={cn(
+          "bg-background border-border/60 dark:border-muted-foreground/15 dark:bg-muted/30",
+          "flex w-full flex-col gap-2 rounded-3xl border p-2",
+          "shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)]",
+          "transition-[border-color,box-shadow]",
+          "focus-within:border-border dark:focus-within:border-muted-foreground/30",
+          "focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]",
+          "dark:shadow-none",
+        )}
+      >
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.nativeEvent.isComposing) return;
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              handleSubmit();
+            }
+          }}
+          placeholder={placeholder}
+          rows={1}
+          className="aui-composer-input text-foreground placeholder:text-muted-foreground/80 relative max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
+        />
+        <div className="aui-composer-action-wrapper relative flex items-center justify-between px-0.5 pb-0.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="text-muted-foreground size-7 rounded-full"
+            aria-label="Attach file"
+            disabled
+          >
+            <PlusIcon className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            className="aui-composer-send size-7 rounded-full"
+            onClick={handleSubmit}
+            disabled={!value.trim()}
+            aria-label="Send prompt"
+          >
+            <ArrowUpIcon className="size-4.5" />
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/apps/docs/components/xulux/landing/TemplateDetailModal.tsx
+++ b/apps/docs/components/xulux/landing/TemplateDetailModal.tsx
@@ -81,11 +81,7 @@ export function TemplateDetailModal({
                     <Thumbnail
                       gradient={current.gradient}
                       src={current.screenshotUrl}
-                      previewUrl={
-                        current.kind === "template"
-                          ? current.previewUrl
-                          : undefined
-                      }
+                      previewUrl={current.previewUrl}
                       className="absolute inset-0 h-full w-full rounded-none"
                     />
                     <div className="relative flex flex-col items-center gap-2 rounded-md bg-black/40 px-4 py-2 text-white/90 backdrop-blur-sm">
@@ -122,9 +118,7 @@ export function TemplateDetailModal({
               <Thumbnail
                 gradient={current.gradient}
                 src={current.screenshotUrl}
-                previewUrl={
-                  current.kind === "template" ? current.previewUrl : undefined
-                }
+                previewUrl={current.previewUrl}
                 label={current.title}
                 className="absolute inset-0 h-full w-full rounded-none"
               />
@@ -263,9 +257,7 @@ export function TemplateDetailModal({
                   <Thumbnail
                     gradient={other.gradient}
                     src={other.screenshotUrl}
-                    previewUrl={
-                      other.kind === "template" ? other.previewUrl : undefined
-                    }
+                    previewUrl={other.previewUrl}
                     label={other.title}
                     className="aspect-video w-full"
                   />

--- a/apps/docs/components/xulux/landing/TemplateDetailModal.tsx
+++ b/apps/docs/components/xulux/landing/TemplateDetailModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   AlertTriangle,
   Code2,
+  Download,
   ExternalLink,
   KeyRound,
   Loader2,
@@ -52,9 +53,10 @@ export function TemplateDetailModal({
   if (!current) return null;
 
   const hasPreview = Boolean(current.previewUrl);
+  const hasDownload = Boolean(current.downloadUrl);
   const requiredEnv = current.env.filter((item) => item.required);
   const startLabel =
-    current.kind === "template" ? "Start building" : "Use this example";
+    current.kind === "template" ? "Spin up app" : "Use this example";
   const previewLabel =
     current.previewStatus === "live"
       ? "Hosted preview"
@@ -79,6 +81,11 @@ export function TemplateDetailModal({
                     <Thumbnail
                       gradient={current.gradient}
                       src={current.screenshotUrl}
+                      previewUrl={
+                        current.kind === "template"
+                          ? current.previewUrl
+                          : undefined
+                      }
                       className="absolute inset-0 h-full w-full rounded-none"
                     />
                     <div className="relative flex flex-col items-center gap-2 rounded-md bg-black/40 px-4 py-2 text-white/90 backdrop-blur-sm">
@@ -115,6 +122,9 @@ export function TemplateDetailModal({
               <Thumbnail
                 gradient={current.gradient}
                 src={current.screenshotUrl}
+                previewUrl={
+                  current.kind === "template" ? current.previewUrl : undefined
+                }
                 label={current.title}
                 className="absolute inset-0 h-full w-full rounded-none"
               />
@@ -147,10 +157,11 @@ export function TemplateDetailModal({
                 <div className="flex flex-wrap gap-1.5">
                   <InfoPill>
                     {current.kind === "template"
-                      ? "Editable template"
+                      ? "Hosted template"
                       : "Reference example"}
                   </InfoPill>
                   <InfoPill>{previewLabel}</InfoPill>
+                  {hasDownload && <InfoPill>Download ready</InfoPill>}
                   <InfoPill>{current.tech.framework}</InfoPill>
                 </div>
                 <div className="text-muted-foreground flex items-start gap-2 text-xs">
@@ -189,17 +200,47 @@ export function TemplateDetailModal({
                     </span>
                   </div>
                 ) : null}
+                {current.versions && current.versions.length > 0 ? (
+                  <div className="space-y-1.5">
+                    <div className="text-foreground text-xs font-medium">
+                      Available versions
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {current.versions.map((version) => (
+                        <span
+                          key={version.id}
+                          className="border-border bg-background text-muted-foreground rounded-md border px-2 py-1 text-[11px]"
+                        >
+                          {version.title}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
               </div>
             </div>
 
-            <button
-              type="button"
-              onClick={() => current.canStart && onSelect(current)}
-              disabled={!current.canStart}
-              className="bg-foreground text-background mt-6 w-full rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-45"
-            >
-              {startLabel}
-            </button>
+            <div className="mt-6 space-y-2">
+              <button
+                type="button"
+                onClick={() => current.canStart && onSelect(current)}
+                disabled={!current.canStart}
+                className="bg-foreground text-background w-full rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-45"
+              >
+                {startLabel}
+              </button>
+              {current.downloadUrl ? (
+                <a
+                  href={current.downloadUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="border-border text-muted-foreground hover:text-foreground flex w-full items-center justify-center gap-2 rounded-lg border px-5 py-2.5 text-sm font-medium transition-colors"
+                >
+                  <Download className="size-4" />
+                  Download app
+                </a>
+              ) : null}
+            </div>
           </div>
         </div>
 
@@ -222,6 +263,9 @@ export function TemplateDetailModal({
                   <Thumbnail
                     gradient={other.gradient}
                     src={other.screenshotUrl}
+                    previewUrl={
+                      other.kind === "template" ? other.previewUrl : undefined
+                    }
                     label={other.title}
                     className="aspect-video w-full"
                   />

--- a/apps/docs/components/xulux/landing/TemplatesModal.tsx
+++ b/apps/docs/components/xulux/landing/TemplatesModal.tsx
@@ -125,6 +125,11 @@ export function TemplatesModal({
                     <Thumbnail
                       gradient={template.gradient}
                       src={template.screenshotUrl}
+                      previewUrl={
+                        template.kind === "template"
+                          ? template.previewUrl
+                          : undefined
+                      }
                       label={template.title}
                       className="aspect-video w-full"
                     />

--- a/apps/docs/components/xulux/landing/TemplatesModal.tsx
+++ b/apps/docs/components/xulux/landing/TemplatesModal.tsx
@@ -125,11 +125,7 @@ export function TemplatesModal({
                     <Thumbnail
                       gradient={template.gradient}
                       src={template.screenshotUrl}
-                      previewUrl={
-                        template.kind === "template"
-                          ? template.previewUrl
-                          : undefined
-                      }
+                      previewUrl={template.previewUrl}
                       label={template.title}
                       className="aspect-video w-full"
                     />

--- a/apps/docs/components/xulux/landing/Thumbnail.tsx
+++ b/apps/docs/components/xulux/landing/Thumbnail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 
 type Props = {
@@ -8,14 +8,47 @@ type Props = {
   label?: string | undefined;
   className?: string | undefined;
   src?: string | undefined;
+  previewUrl?: string | undefined;
 };
 
-export function Thumbnail({ gradient, label, className, src }: Props) {
+export function Thumbnail({
+  gradient,
+  label,
+  className,
+  src,
+  previewUrl,
+}: Props) {
   const [imgFailed, setImgFailed] = useState(false);
+  const [isNearViewport, setIsNearViewport] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
   const showImage = src && !imgFailed;
+  const showPreviewFrame = !showImage && previewUrl && isNearViewport;
+
+  useEffect(() => {
+    if (!previewUrl || showImage) return;
+    const el = rootRef.current;
+    if (!el) return;
+
+    if (!("IntersectionObserver" in window)) {
+      setIsNearViewport(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return;
+        setIsNearViewport(true);
+        observer.disconnect();
+      },
+      { rootMargin: "500px 0px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [previewUrl, showImage]);
 
   return (
     <div
+      ref={rootRef}
       className={cn(
         "relative overflow-hidden rounded-md bg-gradient-to-br",
         gradient,
@@ -31,6 +64,24 @@ export function Thumbnail({ gradient, label, className, src }: Props) {
           onError={() => setImgFailed(true)}
           className="absolute inset-0 h-full w-full object-cover"
         />
+      ) : showPreviewFrame ? (
+        <>
+          <iframe
+            src={previewUrl}
+            loading="lazy"
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+            title={label ? `${label} thumbnail preview` : "Template preview"}
+            className="pointer-events-none absolute top-0 left-0 h-[400%] w-[400%] origin-top-left scale-25 border-0 bg-white"
+          />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-black/65 to-transparent" />
+          {label ? (
+            <div className="pointer-events-none absolute inset-0 flex items-end p-2">
+              <span className="text-[10px] font-medium tracking-wider text-white/80 uppercase drop-shadow-sm">
+                {label}
+              </span>
+            </div>
+          ) : null}
+        </>
       ) : (
         <>
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(255,255,255,0.15),transparent_55%)]" />

--- a/apps/docs/components/xulux/landing/XuluxLandingPage.tsx
+++ b/apps/docs/components/xulux/landing/XuluxLandingPage.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { XuluxTemplate } from "../templates/types";
 import { XuluxPoweredBy } from "../XuluxPoweredBy";
 import { CategoryGrid } from "./CategoryGrid";
+import { LandingSuggestions } from "./LandingSuggestions";
 import { PromptInput } from "./PromptInput";
 import { TemplatesModal } from "./TemplatesModal";
 
@@ -39,6 +40,12 @@ export function XuluxLandingPage({
           onValueChange={setPrompt}
           onSubmit={onStartChat}
           placeholder={placeholder}
+        />
+        <LandingSuggestions
+          onSelectPrompt={(nextPrompt) => {
+            setPrompt(nextPrompt);
+            onStartChat(nextPrompt);
+          }}
         />
       </div>
 

--- a/apps/docs/components/xulux/runtime/XuluxThreadStatusObserver.tsx
+++ b/apps/docs/components/xulux/runtime/XuluxThreadStatusObserver.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useRef } from "react";
 import { useAuiState } from "@assistant-ui/react";
 import {
-  getXuluxTextFromParts,
   updateXuluxPendingUserMessage,
   updateXuluxThreadStatus,
 } from "./xulux-local-storage";
@@ -57,7 +56,17 @@ function getLatestUserText(
     const message = messages[index];
     if (message?.role !== "user") continue;
 
-    const text = getXuluxTextFromParts(message.content);
+    const text = message.content
+      .flatMap((part) => {
+        if (!part || typeof part !== "object") return [];
+        const typedPart = part as Record<string, unknown>;
+        return typedPart.type === "text" && typeof typedPart.text === "string"
+          ? [typedPart.text]
+          : [];
+      })
+      .join("\n")
+      .trim();
+
     if (text) return text;
   }
 

--- a/apps/docs/components/xulux/runtime/XuluxThreadStatusObserver.tsx
+++ b/apps/docs/components/xulux/runtime/XuluxThreadStatusObserver.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useAuiState } from "@assistant-ui/react";
+import {
+  getXuluxTextFromParts,
+  updateXuluxPendingUserMessage,
+  updateXuluxThreadStatus,
+} from "./xulux-local-storage";
+
+export function XuluxThreadStatusObserver() {
+  const remoteId = useAuiState((state) => state.threadListItem.remoteId);
+  const isRunning = useAuiState((state) => state.thread.isRunning);
+  const messages = useAuiState((state) => state.thread.messages);
+  const previous = useRef<{
+    remoteId: string | undefined;
+    isRunning: boolean;
+  }>({ remoteId: undefined, isRunning: false });
+
+  useEffect(() => {
+    if (!remoteId || !isRunning) return;
+
+    const latestUserText = getLatestUserText(messages);
+    if (latestUserText) {
+      updateXuluxPendingUserMessage(remoteId, latestUserText);
+    }
+  }, [isRunning, messages, remoteId]);
+
+  useEffect(() => {
+    const prior = previous.current;
+    previous.current = { remoteId, isRunning };
+
+    if (!remoteId) return;
+    if (prior.remoteId !== remoteId) return;
+
+    if (isRunning && !prior.isRunning) {
+      updateXuluxThreadStatus(remoteId, "running");
+      return;
+    }
+
+    if (!isRunning && prior.isRunning) {
+      updateXuluxThreadStatus(remoteId, "idle");
+      updateXuluxPendingUserMessage(remoteId, null);
+    }
+  }, [remoteId, isRunning]);
+
+  return null;
+}
+
+function getLatestUserText(
+  messages: readonly {
+    role: string;
+    content: readonly unknown[];
+  }[],
+): string | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "user") continue;
+
+    const text = getXuluxTextFromParts(message.content);
+    if (text) return text;
+  }
+
+  return null;
+}

--- a/apps/docs/components/xulux/runtime/types.ts
+++ b/apps/docs/components/xulux/runtime/types.ts
@@ -1,0 +1,43 @@
+import type { SelectedTemplateContext } from "../XuluxApp";
+
+export type XuluxThreadStatus = "idle" | "running" | "interrupted";
+
+export type XuluxCanvasSnapshot = {
+  status: "empty" | "ready" | "error";
+  url: string | null;
+  source: "template" | "refresh" | null;
+  error: string | null;
+  downloadUrl?: string;
+  templateId?: string;
+  versionId?: string;
+  title?: string;
+};
+
+export type XuluxThreadCustom = {
+  xuluxStatus: XuluxThreadStatus;
+  sessionId: string;
+  updatedAt: number;
+  pendingUserMessage?: string | null;
+  selectedTemplate?: SelectedTemplateContext | null;
+  canvas?: XuluxCanvasSnapshot;
+};
+
+export type XuluxStoredThread = {
+  remoteId: string;
+  externalId?: string;
+  status: "regular" | "archived";
+  title?: string;
+  custom: XuluxThreadCustom;
+};
+
+export type XuluxStoredMessageRow = {
+  id: string;
+  parent_id: string | null;
+  format: string;
+  content: Record<string, unknown>;
+};
+
+export type XuluxStoredMessageRepository = {
+  headId?: string | null;
+  messages: XuluxStoredMessageRow[];
+};

--- a/apps/docs/components/xulux/runtime/xulux-local-storage.ts
+++ b/apps/docs/components/xulux/runtime/xulux-local-storage.ts
@@ -1,0 +1,277 @@
+"use client";
+
+import { useEffect, useSyncExternalStore } from "react";
+import type { SelectedTemplateContext } from "../XuluxApp";
+
+export type XuluxThreadStatus = "idle" | "running" | "interrupted";
+
+export type XuluxCanvasSnapshot = {
+  status: "empty" | "ready" | "error";
+  url: string | null;
+  source: "template" | "refresh" | null;
+  error: string | null;
+  title?: string;
+};
+
+export type XuluxStoredThread = {
+  remoteId: string;
+  externalId?: string;
+  status: "regular" | "archived";
+  title?: string;
+  custom: {
+    xuluxStatus: XuluxThreadStatus;
+    sessionId: string;
+    updatedAt: number;
+    pendingUserMessage?: string | null;
+    selectedTemplate?: SelectedTemplateContext | null;
+    canvas?: XuluxCanvasSnapshot;
+  };
+};
+
+export type XuluxStoredMessageRow = {
+  id: string;
+  parent_id: string | null;
+  format: string;
+  content: Record<string, unknown>;
+};
+
+export type XuluxStoredMessageRepository = {
+  headId?: string | null;
+  messages: XuluxStoredMessageRow[];
+};
+
+export function getXuluxTextFromParts(parts: unknown): string {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .flatMap((part) => {
+      if (!part || typeof part !== "object") return [];
+      const typedPart = part as Record<string, unknown>;
+      return typedPart.type === "text" && typeof typedPart.text === "string"
+        ? [typedPart.text]
+        : [];
+    })
+    .join("\n")
+    .trim();
+}
+
+const PREFIX = "xulux:";
+const THREADS_KEY = `${PREFIX}threads`;
+const MESSAGES_PREFIX = `${PREFIX}messages:`;
+const STORAGE_EVENT = "xulux-storage";
+const EMPTY_THREADS: XuluxStoredThread[] = [];
+
+let cachedThreadsRaw: string | null = null;
+let cachedThreadsSnapshot: XuluxStoredThread[] = EMPTY_THREADS;
+
+function isBrowser() {
+  return typeof window !== "undefined";
+}
+
+function notify() {
+  if (!isBrowser()) return;
+  window.dispatchEvent(new Event(STORAGE_EVENT));
+}
+
+function readJson<T>(key: string, fallback: T): T {
+  if (!isBrowser()) return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson<T>(key: string, value: T) {
+  if (!isBrowser()) return;
+  const nextRaw = JSON.stringify(value);
+  if (window.localStorage.getItem(key) === nextRaw) return;
+  window.localStorage.setItem(key, nextRaw);
+  notify();
+}
+
+function removeItem(key: string) {
+  if (!isBrowser()) return;
+  window.localStorage.removeItem(key);
+  notify();
+}
+
+function messagesKey(remoteId: string) {
+  return `${MESSAGES_PREFIX}${remoteId}`;
+}
+
+function normalizeThread(thread: XuluxStoredThread): XuluxStoredThread {
+  if (thread.custom.xuluxStatus !== "running") return thread;
+  return {
+    ...thread,
+    custom: {
+      ...thread.custom,
+      xuluxStatus: "interrupted",
+      updatedAt: Date.now(),
+    },
+  };
+}
+
+export function readXuluxThreads(): XuluxStoredThread[] {
+  if (!isBrowser()) return EMPTY_THREADS;
+
+  const raw = window.localStorage.getItem(THREADS_KEY);
+  if (raw === cachedThreadsRaw) {
+    return cachedThreadsSnapshot;
+  }
+
+  cachedThreadsRaw = raw;
+  if (!raw) {
+    cachedThreadsSnapshot = EMPTY_THREADS;
+    return cachedThreadsSnapshot;
+  }
+
+  try {
+    cachedThreadsSnapshot = JSON.parse(raw) as XuluxStoredThread[];
+  } catch {
+    cachedThreadsSnapshot = EMPTY_THREADS;
+  }
+  return cachedThreadsSnapshot;
+}
+
+function normalizePersistedThreads() {
+  const threads = readXuluxThreads();
+  const normalized = threads.map(normalizeThread);
+  if (JSON.stringify(threads) !== JSON.stringify(normalized)) {
+    writeXuluxThreads(normalized);
+  }
+}
+
+export function writeXuluxThreads(threads: XuluxStoredThread[]) {
+  writeJson(THREADS_KEY, threads);
+}
+
+export function readXuluxMessages(
+  remoteId: string,
+): XuluxStoredMessageRepository {
+  return readJson<XuluxStoredMessageRepository>(messagesKey(remoteId), {
+    headId: null,
+    messages: [],
+  });
+}
+
+export function writeXuluxMessages(
+  remoteId: string,
+  repository: XuluxStoredMessageRepository,
+) {
+  writeJson(messagesKey(remoteId), repository);
+}
+
+export function deleteXuluxMessages(remoteId: string) {
+  removeItem(messagesKey(remoteId));
+}
+
+export function findXuluxThread(remoteId: string): XuluxStoredThread | null {
+  return (
+    readXuluxThreads().find((thread) => thread.remoteId === remoteId) ?? null
+  );
+}
+
+export function upsertXuluxThread(
+  remoteId: string,
+  updater: (thread: XuluxStoredThread | null) => XuluxStoredThread,
+) {
+  const threads = readXuluxThreads();
+  const index = threads.findIndex((thread) => thread.remoteId === remoteId);
+  const nextThread = updater(index === -1 ? null : threads[index]!);
+  writeXuluxThreads(
+    index === -1
+      ? [nextThread, ...threads]
+      : threads.map((thread, threadIndex) =>
+          threadIndex === index ? nextThread : thread,
+        ),
+  );
+}
+
+export function updateXuluxThread(
+  remoteId: string,
+  updater: (thread: XuluxStoredThread) => XuluxStoredThread,
+) {
+  const thread = findXuluxThread(remoteId);
+  if (thread) upsertXuluxThread(remoteId, () => updater(thread));
+}
+
+function patchXuluxThread(
+  remoteId: string,
+  patch: Partial<XuluxStoredThread["custom"]>,
+) {
+  updateXuluxThread(remoteId, (thread) => ({
+    ...thread,
+    custom: {
+      ...thread.custom,
+      ...patch,
+      updatedAt: Date.now(),
+    },
+  }));
+}
+
+export function updateXuluxThreadStatus(
+  remoteId: string,
+  status: XuluxThreadStatus,
+) {
+  patchXuluxThread(remoteId, { xuluxStatus: status });
+}
+
+export function updateXuluxPendingUserMessage(
+  remoteId: string,
+  pendingUserMessage: string | null,
+) {
+  upsertXuluxThread(remoteId, (thread) =>
+    thread
+      ? {
+          ...thread,
+          custom: {
+            ...thread.custom,
+            pendingUserMessage,
+            updatedAt: Date.now(),
+          },
+        }
+      : {
+          remoteId,
+          status: "regular",
+          custom: {
+            xuluxStatus: pendingUserMessage ? "running" : "idle",
+            sessionId: remoteId,
+            updatedAt: Date.now(),
+            pendingUserMessage,
+          },
+        },
+  );
+}
+
+export function updateXuluxThreadContext(
+  remoteId: string,
+  context: {
+    selectedTemplate?: SelectedTemplateContext | null;
+    canvas?: XuluxCanvasSnapshot;
+  },
+) {
+  patchXuluxThread(remoteId, context);
+}
+
+export function useXuluxStoredThreads() {
+  return useSyncExternalStore(
+    (listener) => {
+      if (!isBrowser()) return () => {};
+      window.addEventListener(STORAGE_EVENT, listener);
+      window.addEventListener("storage", listener);
+      return () => {
+        window.removeEventListener(STORAGE_EVENT, listener);
+        window.removeEventListener("storage", listener);
+      };
+    },
+    readXuluxThreads,
+    () => EMPTY_THREADS,
+  );
+}
+
+export function useNormalizeInterruptedXuluxThreads() {
+  useEffect(() => {
+    normalizePersistedThreads();
+  }, []);
+}

--- a/apps/docs/components/xulux/runtime/xulux-local-storage.ts
+++ b/apps/docs/components/xulux/runtime/xulux-local-storage.ts
@@ -40,16 +40,24 @@ function readJson<T>(key: string, fallback: T): T {
 
 function writeJson<T>(key: string, value: T) {
   if (!isBrowser()) return;
-  const nextRaw = JSON.stringify(value);
-  if (window.localStorage.getItem(key) === nextRaw) return;
-  window.localStorage.setItem(key, nextRaw);
-  notify();
+  try {
+    const nextRaw = JSON.stringify(value);
+    if (window.localStorage.getItem(key) === nextRaw) return;
+    window.localStorage.setItem(key, nextRaw);
+    notify();
+  } catch {
+    // Ignore quota and private-mode write failures.
+  }
 }
 
 function removeItem(key: string) {
   if (!isBrowser()) return;
-  window.localStorage.removeItem(key);
-  notify();
+  try {
+    window.localStorage.removeItem(key);
+    notify();
+  } catch {
+    // Ignore storage failures.
+  }
 }
 
 function messagesKey(remoteId: string) {
@@ -57,11 +65,15 @@ function messagesKey(remoteId: string) {
 }
 
 function normalizeThread(thread: XuluxStoredThread): XuluxStoredThread {
-  if (thread.custom.xuluxStatus !== "running") return thread;
+  const status = thread.custom?.xuluxStatus;
+  if (status !== "running") return thread;
   return {
     ...thread,
     custom: {
-      ...thread.custom,
+      ...(thread.custom ?? {
+        sessionId: thread.remoteId,
+        updatedAt: Date.now(),
+      }),
       xuluxStatus: "interrupted",
       updatedAt: Date.now(),
     },
@@ -147,7 +159,11 @@ export function updateXuluxThreadCustom(
   updateXuluxThread(remoteId, (thread) => ({
     ...thread,
     custom: {
-      ...thread.custom,
+      ...(thread.custom ?? {
+        sessionId: remoteId,
+        xuluxStatus: "idle",
+        updatedAt: Date.now(),
+      }),
       ...patch,
       updatedAt: Date.now(),
     },

--- a/apps/docs/components/xulux/runtime/xulux-local-storage.ts
+++ b/apps/docs/components/xulux/runtime/xulux-local-storage.ts
@@ -1,58 +1,14 @@
 "use client";
 
 import { useEffect, useSyncExternalStore } from "react";
+import type {
+  XuluxCanvasSnapshot,
+  XuluxStoredMessageRepository,
+  XuluxStoredThread,
+  XuluxThreadCustom,
+  XuluxThreadStatus,
+} from "./types";
 import type { SelectedTemplateContext } from "../XuluxApp";
-
-export type XuluxThreadStatus = "idle" | "running" | "interrupted";
-
-export type XuluxCanvasSnapshot = {
-  status: "empty" | "ready" | "error";
-  url: string | null;
-  source: "template" | "refresh" | null;
-  error: string | null;
-  title?: string;
-};
-
-export type XuluxStoredThread = {
-  remoteId: string;
-  externalId?: string;
-  status: "regular" | "archived";
-  title?: string;
-  custom: {
-    xuluxStatus: XuluxThreadStatus;
-    sessionId: string;
-    updatedAt: number;
-    pendingUserMessage?: string | null;
-    selectedTemplate?: SelectedTemplateContext | null;
-    canvas?: XuluxCanvasSnapshot;
-  };
-};
-
-export type XuluxStoredMessageRow = {
-  id: string;
-  parent_id: string | null;
-  format: string;
-  content: Record<string, unknown>;
-};
-
-export type XuluxStoredMessageRepository = {
-  headId?: string | null;
-  messages: XuluxStoredMessageRow[];
-};
-
-export function getXuluxTextFromParts(parts: unknown): string {
-  if (!Array.isArray(parts)) return "";
-  return parts
-    .flatMap((part) => {
-      if (!part || typeof part !== "object") return [];
-      const typedPart = part as Record<string, unknown>;
-      return typedPart.type === "text" && typeof typedPart.text === "string"
-        ? [typedPart.text]
-        : [];
-    })
-    .join("\n")
-    .trim();
-}
 
 const PREFIX = "xulux:";
 const THREADS_KEY = `${PREFIX}threads`;
@@ -172,33 +128,21 @@ export function findXuluxThread(remoteId: string): XuluxStoredThread | null {
   );
 }
 
-export function upsertXuluxThread(
-  remoteId: string,
-  updater: (thread: XuluxStoredThread | null) => XuluxStoredThread,
-) {
-  const threads = readXuluxThreads();
-  const index = threads.findIndex((thread) => thread.remoteId === remoteId);
-  const nextThread = updater(index === -1 ? null : threads[index]!);
-  writeXuluxThreads(
-    index === -1
-      ? [nextThread, ...threads]
-      : threads.map((thread, threadIndex) =>
-          threadIndex === index ? nextThread : thread,
-        ),
-  );
-}
-
 export function updateXuluxThread(
   remoteId: string,
   updater: (thread: XuluxStoredThread) => XuluxStoredThread,
 ) {
-  const thread = findXuluxThread(remoteId);
-  if (thread) upsertXuluxThread(remoteId, () => updater(thread));
+  const threads = readXuluxThreads();
+  const index = threads.findIndex((thread) => thread.remoteId === remoteId);
+  if (index === -1) return;
+  const nextThreads = [...threads];
+  nextThreads[index] = updater(threads[index]!);
+  writeXuluxThreads(nextThreads);
 }
 
-function patchXuluxThread(
+export function updateXuluxThreadCustom(
   remoteId: string,
-  patch: Partial<XuluxStoredThread["custom"]>,
+  patch: Partial<Omit<XuluxThreadCustom, "sessionId">>,
 ) {
   updateXuluxThread(remoteId, (thread) => ({
     ...thread,
@@ -214,34 +158,33 @@ export function updateXuluxThreadStatus(
   remoteId: string,
   status: XuluxThreadStatus,
 ) {
-  patchXuluxThread(remoteId, { xuluxStatus: status });
+  updateXuluxThreadCustom(remoteId, { xuluxStatus: status });
 }
 
 export function updateXuluxPendingUserMessage(
   remoteId: string,
   pendingUserMessage: string | null,
 ) {
-  upsertXuluxThread(remoteId, (thread) =>
-    thread
-      ? {
-          ...thread,
-          custom: {
-            ...thread.custom,
-            pendingUserMessage,
-            updatedAt: Date.now(),
-          },
-        }
-      : {
-          remoteId,
-          status: "regular",
-          custom: {
-            xuluxStatus: pendingUserMessage ? "running" : "idle",
-            sessionId: remoteId,
-            updatedAt: Date.now(),
-            pendingUserMessage,
-          },
+  const threads = readXuluxThreads();
+  const index = threads.findIndex((thread) => thread.remoteId === remoteId);
+  if (index === -1) {
+    writeXuluxThreads([
+      {
+        remoteId,
+        status: "regular",
+        custom: {
+          xuluxStatus: pendingUserMessage ? "running" : "idle",
+          sessionId: remoteId,
+          updatedAt: Date.now(),
+          pendingUserMessage,
         },
-  );
+      },
+      ...threads,
+    ]);
+    return;
+  }
+
+  updateXuluxThreadCustom(remoteId, { pendingUserMessage });
 }
 
 export function updateXuluxThreadContext(
@@ -251,7 +194,7 @@ export function updateXuluxThreadContext(
     canvas?: XuluxCanvasSnapshot;
   },
 ) {
-  patchXuluxThread(remoteId, context);
+  updateXuluxThreadCustom(remoteId, context);
 }
 
 export function useXuluxStoredThreads() {

--- a/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
+++ b/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
@@ -16,12 +16,14 @@ import {
   readXuluxMessages,
   readXuluxThreads,
   updateXuluxThread,
-  upsertXuluxThread,
   writeXuluxMessages,
   writeXuluxThreads,
-  type XuluxStoredMessageRow,
-  type XuluxStoredThread,
 } from "./xulux-local-storage";
+import type {
+  XuluxStoredMessageRow,
+  XuluxStoredThread,
+  XuluxThreadCustom,
+} from "./types";
 
 function getTextFromMessages(messages: readonly ThreadMessage[]): string {
   for (const message of messages) {
@@ -38,28 +40,6 @@ function getTextFromMessages(messages: readonly ThreadMessage[]): string {
 function titleFromMessages(messages: readonly ThreadMessage[]): string {
   const text = getTextFromMessages(messages);
   return text.length > 44 ? `${text.slice(0, 41)}...` : text;
-}
-
-function toRemoteThread(thread: XuluxStoredThread) {
-  return {
-    remoteId: thread.remoteId,
-    externalId: thread.externalId,
-    status: thread.status,
-    title: thread.title,
-    custom: thread.custom,
-  };
-}
-
-function upsertMessage(
-  messages: XuluxStoredMessageRow[],
-  row: XuluxStoredMessageRow,
-) {
-  const index = messages.findIndex((message) => message.id === row.id);
-  return index === -1
-    ? [...messages, row]
-    : messages.map((message, messageIndex) =>
-        messageIndex === index ? row : message,
-      );
 }
 
 class XuluxLocalHistoryAdapter implements ThreadHistoryAdapter {
@@ -97,16 +77,23 @@ class XuluxLocalHistoryAdapter implements ThreadHistoryAdapter {
       async append(item: { parentId: string | null; message: TMessage }) {
         const { remoteId } = await adapter.aui.threadListItem().initialize();
         const repository = readXuluxMessages(remoteId);
+        const id = fmt.getId(item.message);
         const row: XuluxStoredMessageRow = {
-          id: fmt.getId(item.message),
+          id,
           parent_id: item.parentId,
           format: fmt.format,
           content: fmt.encode(item),
         };
-        writeXuluxMessages(remoteId, {
-          headId: row.id,
-          messages: upsertMessage(repository.messages, row),
-        });
+        const index = repository.messages.findIndex(
+          (message) => message.id === id,
+        );
+        const messages =
+          index === -1
+            ? [...repository.messages, row]
+            : repository.messages.map((message, messageIndex) =>
+                messageIndex === index ? row : message,
+              );
+        writeXuluxMessages(remoteId, { headId: id, messages });
       },
       async update(
         item: { parentId: string | null; message: TMessage },
@@ -150,23 +137,60 @@ export function createXuluxLocalThreadListAdapter({
 }): RemoteThreadListAdapter {
   const Provider: FC<PropsWithChildren> = XuluxLocalHistoryProvider;
 
+  const upsertThread = (
+    remoteId: string,
+    updater: (thread: XuluxStoredThread | null) => XuluxStoredThread,
+  ) => {
+    const threads = readXuluxThreads();
+    const index = threads.findIndex((thread) => thread.remoteId === remoteId);
+    const nextThread = updater(index === -1 ? null : threads[index]!);
+    const nextThreads =
+      index === -1
+        ? [nextThread, ...threads]
+        : threads.map((thread, threadIndex) =>
+            threadIndex === index ? nextThread : thread,
+          );
+    writeXuluxThreads(nextThreads);
+  };
+
   return {
     unstable_Provider: Provider,
     async list() {
-      return { threads: readXuluxThreads().map(toRemoteThread) };
+      const threads = readXuluxThreads();
+      return {
+        threads: threads.map((thread) => ({
+          remoteId: thread.remoteId,
+          externalId: thread.externalId,
+          status: thread.status,
+          title: thread.title,
+          custom: thread.custom,
+        })),
+      };
     },
     async initialize() {
       const sessionId = getCurrentSessionId();
-      upsertXuluxThread(sessionId, (existing) => ({
-        ...existing,
+      const now = Date.now();
+      upsertThread(sessionId, (existing) => ({
         remoteId: sessionId,
         status: existing?.status ?? "regular",
         custom: {
+          xuluxStatus: existing?.custom.xuluxStatus ?? "idle",
           sessionId,
-          xuluxStatus: "idle",
-          ...existing?.custom,
-          updatedAt: Date.now(),
-        },
+          updatedAt: now,
+          ...(existing?.custom.pendingUserMessage !== undefined
+            ? { pendingUserMessage: existing.custom.pendingUserMessage }
+            : {}),
+          ...(existing?.custom.selectedTemplate !== undefined
+            ? { selectedTemplate: existing.custom.selectedTemplate }
+            : {}),
+          ...(existing?.custom.canvas !== undefined
+            ? { canvas: existing.custom.canvas }
+            : {}),
+        } satisfies XuluxThreadCustom,
+        ...(existing?.externalId !== undefined
+          ? { externalId: existing.externalId }
+          : {}),
+        ...(existing?.title !== undefined ? { title: existing.title } : {}),
       }));
       return { remoteId: sessionId, externalId: undefined };
     },
@@ -200,7 +224,13 @@ export function createXuluxLocalThreadListAdapter({
     async fetch(remoteId) {
       const thread = findXuluxThread(remoteId);
       if (!thread) throw new Error("Thread not found");
-      return toRemoteThread(thread);
+      return {
+        remoteId: thread.remoteId,
+        externalId: thread.externalId,
+        status: thread.status,
+        title: thread.title,
+        custom: thread.custom,
+      };
     },
     async generateTitle(remoteId, messages) {
       const title = titleFromMessages(messages);

--- a/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
+++ b/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { createAssistantStream } from "assistant-stream";
+import { type FC, type PropsWithChildren, useMemo } from "react";
+import {
+  RuntimeAdapterProvider,
+  useAui,
+  type MessageFormatAdapter,
+  type RemoteThreadListAdapter,
+  type ThreadHistoryAdapter,
+  type ThreadMessage,
+} from "@assistant-ui/react";
+import {
+  deleteXuluxMessages,
+  findXuluxThread,
+  readXuluxMessages,
+  readXuluxThreads,
+  updateXuluxThread,
+  upsertXuluxThread,
+  writeXuluxMessages,
+  writeXuluxThreads,
+  type XuluxStoredMessageRow,
+  type XuluxStoredThread,
+} from "./xulux-local-storage";
+
+function getTextFromMessages(messages: readonly ThreadMessage[]): string {
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    const text = message.content
+      .flatMap((part) => (part.type === "text" ? [part.text] : []))
+      .join(" ")
+      .trim();
+    if (text) return text;
+  }
+  return "New chat";
+}
+
+function titleFromMessages(messages: readonly ThreadMessage[]): string {
+  const text = getTextFromMessages(messages);
+  return text.length > 44 ? `${text.slice(0, 41)}...` : text;
+}
+
+function toRemoteThread(thread: XuluxStoredThread) {
+  return {
+    remoteId: thread.remoteId,
+    externalId: thread.externalId,
+    status: thread.status,
+    title: thread.title,
+    custom: thread.custom,
+  };
+}
+
+function upsertMessage(
+  messages: XuluxStoredMessageRow[],
+  row: XuluxStoredMessageRow,
+) {
+  const index = messages.findIndex((message) => message.id === row.id);
+  return index === -1
+    ? [...messages, row]
+    : messages.map((message, messageIndex) =>
+        messageIndex === index ? row : message,
+      );
+}
+
+class XuluxLocalHistoryAdapter implements ThreadHistoryAdapter {
+  constructor(private aui: ReturnType<typeof useAui>) {}
+
+  async load() {
+    return { messages: [] };
+  }
+
+  async append() {}
+
+  withFormat<TMessage, TStorageFormat extends Record<string, unknown>>(
+    fmt: MessageFormatAdapter<TMessage, TStorageFormat>,
+  ) {
+    const adapter = this;
+    return {
+      async load() {
+        const remoteId = adapter.aui.threadListItem().getState().remoteId;
+        if (!remoteId) return { headId: null, messages: [] };
+        const repository = readXuluxMessages(remoteId);
+        return {
+          headId: repository.headId ?? null,
+          messages: repository.messages
+            .filter((row) => row.format === fmt.format)
+            .map((row) =>
+              fmt.decode({
+                id: row.id,
+                parent_id: row.parent_id,
+                format: row.format,
+                content: row.content as TStorageFormat,
+              }),
+            ),
+        };
+      },
+      async append(item: { parentId: string | null; message: TMessage }) {
+        const { remoteId } = await adapter.aui.threadListItem().initialize();
+        const repository = readXuluxMessages(remoteId);
+        const row: XuluxStoredMessageRow = {
+          id: fmt.getId(item.message),
+          parent_id: item.parentId,
+          format: fmt.format,
+          content: fmt.encode(item),
+        };
+        writeXuluxMessages(remoteId, {
+          headId: row.id,
+          messages: upsertMessage(repository.messages, row),
+        });
+      },
+      async update(
+        item: { parentId: string | null; message: TMessage },
+        localMessageId: string,
+      ) {
+        const remoteId = adapter.aui.threadListItem().getState().remoteId;
+        if (!remoteId) return;
+        const repository = readXuluxMessages(remoteId);
+        const row: XuluxStoredMessageRow = {
+          id: localMessageId,
+          parent_id: item.parentId,
+          format: fmt.format,
+          content: fmt.encode(item),
+        };
+        writeXuluxMessages(remoteId, {
+          headId: repository.headId ?? null,
+          messages: repository.messages.map((message) =>
+            message.id === localMessageId ? row : message,
+          ),
+        });
+      },
+    };
+  }
+}
+
+function XuluxLocalHistoryProvider({ children }: PropsWithChildren) {
+  const aui = useAui();
+  const history = useMemo(() => new XuluxLocalHistoryAdapter(aui), [aui]);
+  const adapters = useMemo(() => ({ history }), [history]);
+  return (
+    <RuntimeAdapterProvider adapters={adapters}>
+      {children}
+    </RuntimeAdapterProvider>
+  );
+}
+
+export function createXuluxLocalThreadListAdapter({
+  getCurrentSessionId,
+}: {
+  getCurrentSessionId: () => string;
+}): RemoteThreadListAdapter {
+  const Provider: FC<PropsWithChildren> = XuluxLocalHistoryProvider;
+
+  return {
+    unstable_Provider: Provider,
+    async list() {
+      return { threads: readXuluxThreads().map(toRemoteThread) };
+    },
+    async initialize() {
+      const sessionId = getCurrentSessionId();
+      upsertXuluxThread(sessionId, (existing) => ({
+        ...existing,
+        remoteId: sessionId,
+        status: existing?.status ?? "regular",
+        custom: {
+          sessionId,
+          xuluxStatus: "idle",
+          ...existing?.custom,
+          updatedAt: Date.now(),
+        },
+      }));
+      return { remoteId: sessionId, externalId: undefined };
+    },
+    async rename(remoteId, title) {
+      updateXuluxThread(remoteId, (thread) => ({
+        ...thread,
+        title,
+        custom: { ...thread.custom, updatedAt: Date.now() },
+      }));
+    },
+    async archive(remoteId) {
+      updateXuluxThread(remoteId, (thread) => ({
+        ...thread,
+        status: "archived",
+        custom: { ...thread.custom, updatedAt: Date.now() },
+      }));
+    },
+    async unarchive(remoteId) {
+      updateXuluxThread(remoteId, (thread) => ({
+        ...thread,
+        status: "regular",
+        custom: { ...thread.custom, updatedAt: Date.now() },
+      }));
+    },
+    async delete(remoteId) {
+      writeXuluxThreads(
+        readXuluxThreads().filter((thread) => thread.remoteId !== remoteId),
+      );
+      deleteXuluxMessages(remoteId);
+    },
+    async fetch(remoteId) {
+      const thread = findXuluxThread(remoteId);
+      if (!thread) throw new Error("Thread not found");
+      return toRemoteThread(thread);
+    },
+    async generateTitle(remoteId, messages) {
+      const title = titleFromMessages(messages);
+      updateXuluxThread(remoteId, (thread) => ({
+        ...thread,
+        title,
+        custom: { ...thread.custom, updatedAt: Date.now() },
+      }));
+      return createAssistantStream((controller) => {
+        controller.appendText(title);
+      });
+    },
+  };
+}

--- a/apps/docs/components/xulux/shell/XuluxHeaderActions.tsx
+++ b/apps/docs/components/xulux/shell/XuluxHeaderActions.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { LayoutGrid, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import type { XuluxStoredThread } from "../runtime/xulux-local-storage";
+import type { XuluxStoredThread } from "../runtime/types";
 import { XuluxHistoryMenu } from "./XuluxHistoryMenu";
 
 function HeaderPortal({ children }: { children: ReactNode }) {
@@ -21,16 +21,20 @@ function HeaderPortal({ children }: { children: ReactNode }) {
 }
 
 export function XuluxHeaderActions({
+  visible,
   showChatActions,
   onNewChat,
   onShowTemplates,
   onRestoreThread,
 }: {
+  visible: boolean;
   showChatActions: boolean;
   onNewChat: () => void;
   onShowTemplates: () => void;
   onRestoreThread: (thread: XuluxStoredThread) => void;
 }) {
+  if (!visible) return null;
+
   return (
     <HeaderPortal>
       <XuluxHistoryMenu

--- a/apps/docs/components/xulux/shell/XuluxHeaderActions.tsx
+++ b/apps/docs/components/xulux/shell/XuluxHeaderActions.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { LayoutGrid, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import type { XuluxStoredThread } from "../runtime/xulux-local-storage";
+import { XuluxHistoryMenu } from "./XuluxHistoryMenu";
 
 function HeaderPortal({ children }: { children: ReactNode }) {
   const [container, setContainer] = useState<HTMLElement | null>(null);
@@ -19,38 +21,46 @@ function HeaderPortal({ children }: { children: ReactNode }) {
 }
 
 export function XuluxHeaderActions({
-  visible,
+  showChatActions,
   onNewChat,
   onShowTemplates,
+  onRestoreThread,
 }: {
-  visible: boolean;
+  showChatActions: boolean;
   onNewChat: () => void;
   onShowTemplates: () => void;
+  onRestoreThread: (thread: XuluxStoredThread) => void;
 }) {
-  if (!visible) return null;
-
   return (
     <HeaderPortal>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="h-7 gap-1.5 px-2.5 text-xs"
-        onClick={onShowTemplates}
-      >
-        <LayoutGrid className="size-3.5" />
-        <span className="hidden md:inline">Templates</span>
-      </Button>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="h-7 gap-1.5 px-2.5 text-xs"
-        onClick={onNewChat}
-      >
-        <Plus className="size-3.5" />
-        <span className="hidden md:inline">New</span>
-      </Button>
+      <XuluxHistoryMenu
+        onNewChat={onNewChat}
+        onRestoreThread={onRestoreThread}
+      />
+      {showChatActions && (
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1.5 px-2.5 text-xs"
+            onClick={onShowTemplates}
+          >
+            <LayoutGrid className="size-3.5" />
+            <span className="hidden md:inline">Templates</span>
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1.5 px-2.5 text-xs"
+            onClick={onNewChat}
+          >
+            <Plus className="size-3.5" />
+            <span className="hidden md:inline">New</span>
+          </Button>
+        </>
+      )}
     </HeaderPortal>
   );
 }

--- a/apps/docs/components/xulux/shell/XuluxHistoryMenu.tsx
+++ b/apps/docs/components/xulux/shell/XuluxHistoryMenu.tsx
@@ -54,8 +54,11 @@ export function XuluxHistoryMenu({
   );
 
   const handleSelect = (thread: XuluxStoredThread) => {
-    onRestoreThread(thread);
-    void aui.threads().switchToThread(thread.remoteId);
+    void Promise.resolve(aui.threads().switchToThread(thread.remoteId)).then(
+      () => {
+        onRestoreThread(thread);
+      },
+    );
   };
 
   return (

--- a/apps/docs/components/xulux/shell/XuluxHistoryMenu.tsx
+++ b/apps/docs/components/xulux/shell/XuluxHistoryMenu.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { ChevronDown, History } from "lucide-react";
+import { useAui, useAuiState } from "@assistant-ui/react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/shared/dropdown-menu";
+import { cn } from "@/lib/utils";
+import {
+  useNormalizeInterruptedXuluxThreads,
+  useXuluxStoredThreads,
+} from "../runtime/xulux-local-storage";
+import type { XuluxStoredThread } from "../runtime/xulux-local-storage";
+
+function formatUpdatedAt(updatedAt: number): string {
+  const delta = Date.now() - updatedAt;
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (delta < minute) return "Just now";
+  if (delta < hour) return `${Math.max(1, Math.floor(delta / minute))}m ago`;
+  if (delta < day) return `${Math.floor(delta / hour)}h ago`;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(updatedAt));
+}
+
+function fallbackTitle(thread: XuluxStoredThread): string {
+  return thread.title?.trim() || "New chat";
+}
+
+export function XuluxHistoryMenu({
+  onRestoreThread,
+  onNewChat,
+}: {
+  onRestoreThread: (thread: XuluxStoredThread) => void;
+  onNewChat: () => void;
+}) {
+  useNormalizeInterruptedXuluxThreads();
+  const threads = useXuluxStoredThreads().filter(
+    (thread) => thread.status === "regular",
+  );
+  const aui = useAui();
+  const currentRemoteId = useAuiState((state) => state.threadListItem.remoteId);
+  const hasInterrupted = threads.some(
+    (thread) => thread.custom.xuluxStatus === "interrupted",
+  );
+
+  const handleSelect = (thread: XuluxStoredThread) => {
+    onRestoreThread(thread);
+    void aui.threads().switchToThread(thread.remoteId);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="relative h-7 gap-1.5 px-2.5 text-xs"
+        >
+          <History className="size-3.5" />
+          <span className="hidden md:inline">History</span>
+          <ChevronDown className="size-3" />
+          {hasInterrupted && (
+            <span className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-amber-500" />
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="max-h-80 w-64 overflow-y-auto"
+      >
+        <div className="text-muted-foreground px-2.5 py-1 text-xs font-medium">
+          History
+        </div>
+        {threads.length === 0 ? (
+          <div className="text-muted-foreground px-2.5 py-2 text-sm">
+            No saved chats yet.
+          </div>
+        ) : (
+          threads.map((thread) => {
+            const status = thread.custom.xuluxStatus;
+            const isCurrent = currentRemoteId === thread.remoteId;
+            return (
+              <DropdownMenuItem
+                key={thread.remoteId}
+                className="items-start px-2 py-1.5"
+                onSelect={() => handleSelect(thread)}
+              >
+                <span className="min-w-0 flex-1">
+                  <span className="text-foreground block truncate text-xs font-medium">
+                    {fallbackTitle(thread)}
+                  </span>
+                  <span className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-[11px] leading-none">
+                    {formatUpdatedAt(thread.custom.updatedAt)}
+                    {isCurrent && (
+                      <span className="bg-muted text-muted-foreground rounded px-1 py-0.5 text-[10px] font-medium">
+                        Current
+                      </span>
+                    )}
+                    {status !== "idle" && (
+                      <span
+                        className={cn(
+                          "rounded px-1 py-0.5 text-[10px] font-medium",
+                          status === "interrupted"
+                            ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                            : "bg-muted text-muted-foreground",
+                        )}
+                      >
+                        {status === "interrupted" ? "Interrupted" : "Running"}
+                      </span>
+                    )}
+                  </span>
+                </span>
+              </DropdownMenuItem>
+            );
+          })
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="px-2 py-1.5 text-xs" onSelect={onNewChat}>
+          New chat
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/docs/components/xulux/shell/XuluxHistoryMenu.tsx
+++ b/apps/docs/components/xulux/shell/XuluxHistoryMenu.tsx
@@ -15,7 +15,7 @@ import {
   useNormalizeInterruptedXuluxThreads,
   useXuluxStoredThreads,
 } from "../runtime/xulux-local-storage";
-import type { XuluxStoredThread } from "../runtime/xulux-local-storage";
+import type { XuluxStoredThread } from "../runtime/types";
 
 function formatUpdatedAt(updatedAt: number): string {
   const delta = Date.now() - updatedAt;

--- a/apps/docs/components/xulux/shell/XuluxShell.tsx
+++ b/apps/docs/components/xulux/shell/XuluxShell.tsx
@@ -1,11 +1,32 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { Group, Panel, Separator } from "react-resizable-panels";
+
+const SM_BREAKPOINT = 640;
+
+function useIsSmallScreen(): boolean {
+  return useSyncExternalStore(
+    (cb) => {
+      const mql = window.matchMedia(`(max-width: ${SM_BREAKPOINT - 1}px)`);
+      mql.addEventListener("change", cb);
+      return () => mql.removeEventListener("change", cb);
+    },
+    () => window.innerWidth < SM_BREAKPOINT,
+    () => false,
+  );
+}
 import { useAui, useAuiState } from "@assistant-ui/react";
 import { useAssistantPanel } from "@/components/docs/assistant/context";
 import { Button } from "@/components/ui/button";
 import { XuluxThread } from "../chat/XuluxThread";
+import { XuluxTemplateProvider } from "../chat/XuluxTemplateContext";
 import type { XuluxTemplate } from "../templates/types";
 import type { SelectedTemplateContext } from "../XuluxApp";
 import { XuluxCanvas } from "../canvas/XuluxCanvas";
@@ -52,6 +73,7 @@ export function XuluxShell({
 }) {
   const { askAI } = useAssistantPanel();
   const aui = useAui();
+  const isSmallScreen = useIsSmallScreen();
   const currentRemoteId = useAuiState((state) => state.threadListItem.remoteId);
   const storedThreads = useXuluxStoredThreads();
   const [viewMode, setViewMode] = useState<XuluxViewMode>("landing");
@@ -84,6 +106,7 @@ export function XuluxShell({
   const handleSelectTemplate = useCallback(
     (template: XuluxTemplate) => {
       const context = toSelectedTemplateContext(template);
+      void aui.threads().switchToNewThread();
       setSelectedTemplate(template);
       setSelectedTemplateContext(context);
       onSetSelectedTemplateContext(context);
@@ -100,7 +123,7 @@ export function XuluxShell({
       setTemplatesOpen(false);
       setViewMode(template.previewUrl ? "preview" : "chat");
     },
-    [onSetSelectedTemplateContext],
+    [aui, onSetSelectedTemplateContext],
   );
 
   const handleNewChat = useCallback(() => {
@@ -180,112 +203,142 @@ export function XuluxShell({
   const canvasTitle = canvas.title ?? selectedTemplate?.title;
 
   return (
-    <div className="bg-background text-foreground flex h-full min-h-0 flex-col overflow-hidden">
-      <XuluxCanvasObserver
-        onCanvasReady={(url) => {
-          setCanvas({
-            status: "ready",
-            url,
-            source: "refresh",
-            error: null,
-          });
-          setViewMode("preview");
-        }}
-        onCanvasError={(error) => {
-          setCanvas({ status: "error", url: null, source: null, error });
-          setViewMode("preview");
-        }}
-      />
-      <XuluxTemplatePreviewObserver
-        onTemplatePreviewReady={(preview) => {
-          setCanvas({
-            status: "ready",
-            url: preview.previewUrl,
-            source: "template",
-            error: null,
-            downloadUrl: preview.downloadUrl,
-            templateId: preview.templateId,
-            ...(preview.versionId !== undefined
-              ? { versionId: preview.versionId }
-              : {}),
-            title: preview.title,
-          });
-          setViewMode("preview");
-        }}
-        onCanvasError={(error) => {
-          setCanvas({ status: "error", url: null, source: null, error });
-          setViewMode("preview");
-        }}
-      />
-
-      <XuluxHeaderActions
-        visible
-        showChatActions={viewMode !== "landing"}
-        onNewChat={handleNewChat}
-        onShowTemplates={() => setTemplatesOpen(true)}
-        onRestoreThread={handleRestoreThread}
-      />
-
-      {viewMode === "landing" ? (
-        <XuluxLandingPage
-          onStartChat={handleStartChat}
-          onSelectTemplate={handleSelectTemplate}
+    <XuluxTemplateProvider template={selectedTemplateContext}>
+      <div className="bg-background text-foreground flex h-full min-h-0 flex-col overflow-hidden">
+        <XuluxCanvasObserver
+          onCanvasReady={(url) => {
+            setCanvas({
+              status: "ready",
+              url,
+              source: "refresh",
+              error: null,
+            });
+            setViewMode("preview");
+          }}
+          onCanvasError={(error) => {
+            setCanvas({ status: "error", url: null, source: null, error });
+            setViewMode("preview");
+          }}
         />
-      ) : viewMode === "preview" ? (
-        <Group
-          orientation="horizontal"
-          className="min-h-0 flex-1 overflow-hidden"
-        >
-          <Panel
-            defaultSize="30%"
-            minSize="20%"
-            maxSize="55%"
-            className="flex h-full flex-col overflow-hidden border-r"
-          >
-            {isInterrupted && (
-              <InterruptedRunBanner
-                lastUserMessage={interruptedUserMessage}
-                onRetry={handleRetryInterrupted}
-              />
-            )}
-            <XuluxThread onNewThread={handleNewChat} />
-          </Panel>
-          <Separator className="bg-border hover:bg-primary/30 w-1 cursor-col-resize transition-colors" />
-          <Panel className="h-full overflow-hidden">
-            <XuluxCanvas
-              sessionId={sessionId}
-              status={canvas.status}
-              previewUrl={canvas.url}
-              source={canvas.source}
-              error={canvas.error}
-              {...(canvas.downloadUrl
-                ? { downloadUrl: canvas.downloadUrl }
-                : {})}
-              {...(sourceUrl ? { sourceUrl } : {})}
-              {...(canvasTitle ? { title: canvasTitle } : {})}
-            />
-          </Panel>
-        </Group>
-      ) : (
-        <div className="flex min-h-0 flex-1 justify-center overflow-hidden">
-          <section className="flex w-full max-w-3xl flex-col">
-            {isInterrupted && (
-              <InterruptedRunBanner
-                lastUserMessage={interruptedUserMessage}
-                onRetry={handleRetryInterrupted}
-              />
-            )}
-            <XuluxThread onNewThread={handleNewChat} />
-          </section>
-        </div>
-      )}
+        <XuluxTemplatePreviewObserver
+          onTemplatePreviewReady={(preview) => {
+            setCanvas({
+              status: "ready",
+              url: preview.previewUrl,
+              source: "template",
+              error: null,
+              downloadUrl: preview.downloadUrl,
+              templateId: preview.templateId,
+              ...(preview.versionId !== undefined
+                ? { versionId: preview.versionId }
+                : {}),
+              title: preview.title,
+            });
+            setViewMode("preview");
+          }}
+          onCanvasError={(error) => {
+            setCanvas({ status: "error", url: null, source: null, error });
+            setViewMode("preview");
+          }}
+        />
 
-      <TemplatesModal
-        open={templatesOpen}
-        onOpenChange={setTemplatesOpen}
-        onSelect={handleSelectTemplate}
-      />
-    </div>
+        <XuluxHeaderActions
+          visible
+          showChatActions={viewMode !== "landing"}
+          onNewChat={handleNewChat}
+          onShowTemplates={() => setTemplatesOpen(true)}
+          onRestoreThread={handleRestoreThread}
+        />
+
+        {viewMode === "landing" ? (
+          <XuluxLandingPage
+            onStartChat={handleStartChat}
+            onSelectTemplate={handleSelectTemplate}
+          />
+        ) : viewMode === "preview" ? (
+          isSmallScreen ? (
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+              <div className="min-h-0 flex-1 overflow-hidden">
+                <XuluxCanvas
+                  sessionId={sessionId}
+                  status={canvas.status}
+                  previewUrl={canvas.url}
+                  source={canvas.source}
+                  error={canvas.error}
+                  {...(canvas.downloadUrl
+                    ? { downloadUrl: canvas.downloadUrl }
+                    : {})}
+                  {...(sourceUrl ? { sourceUrl } : {})}
+                  {...(canvasTitle ? { title: canvasTitle } : {})}
+                />
+              </div>
+              <div className="flex h-[45%] min-h-[180px] flex-col overflow-hidden border-t">
+                {isInterrupted && (
+                  <InterruptedRunBanner
+                    lastUserMessage={interruptedUserMessage}
+                    onRetry={handleRetryInterrupted}
+                  />
+                )}
+                <XuluxThread onNewThread={handleNewChat} />
+              </div>
+            </div>
+          ) : (
+            <Group
+              orientation="horizontal"
+              className="min-h-0 flex-1 overflow-hidden"
+            >
+              <Panel
+                defaultSize="30%"
+                minSize="20%"
+                maxSize="55%"
+                className="flex h-full flex-col overflow-hidden border-r"
+              >
+                {isInterrupted && (
+                  <InterruptedRunBanner
+                    lastUserMessage={interruptedUserMessage}
+                    onRetry={handleRetryInterrupted}
+                  />
+                )}
+                <XuluxThread onNewThread={handleNewChat} />
+              </Panel>
+              <Separator className="bg-border hover:bg-primary/30 w-1 cursor-col-resize transition-colors" />
+              <Panel className="h-full overflow-hidden">
+                <XuluxCanvas
+                  sessionId={sessionId}
+                  status={canvas.status}
+                  previewUrl={canvas.url}
+                  source={canvas.source}
+                  error={canvas.error}
+                  {...(canvas.downloadUrl
+                    ? { downloadUrl: canvas.downloadUrl }
+                    : {})}
+                  {...(sourceUrl ? { sourceUrl } : {})}
+                  {...(canvasTitle ? { title: canvasTitle } : {})}
+                />
+              </Panel>
+            </Group>
+          )
+        ) : (
+          <div className="flex min-h-0 flex-1 justify-center overflow-hidden">
+            <section className="flex w-full max-w-3xl flex-col">
+              {isInterrupted && (
+                <InterruptedRunBanner
+                  lastUserMessage={interruptedUserMessage}
+                  onRetry={handleRetryInterrupted}
+                />
+              )}
+              <XuluxThread onNewThread={handleNewChat} />
+            </section>
+          </div>
+        )}
+
+        <TemplatesModal
+          open={templatesOpen}
+          onOpenChange={setTemplatesOpen}
+          onSelect={handleSelectTemplate}
+        />
+      </div>
+    </XuluxTemplateProvider>
   );
 }
 

--- a/apps/docs/components/xulux/shell/XuluxShell.tsx
+++ b/apps/docs/components/xulux/shell/XuluxShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { Group, Panel, Separator } from "react-resizable-panels";
 import { useAui, useAuiState } from "@assistant-ui/react";
 import { useAssistantPanel } from "@/components/docs/assistant/context";
 import { Button } from "@/components/ui/button";
@@ -9,18 +10,17 @@ import type { XuluxTemplate } from "../templates/types";
 import type { SelectedTemplateContext } from "../XuluxApp";
 import { XuluxCanvas } from "../canvas/XuluxCanvas";
 import { XuluxCanvasObserver } from "../canvas/XuluxCanvasObserver";
+import { XuluxTemplatePreviewObserver } from "../canvas/XuluxTemplatePreviewObserver";
 import { XuluxLandingPage } from "../landing/XuluxLandingPage";
 import { TemplatesModal } from "../landing/TemplatesModal";
 import { XuluxHeaderActions } from "./XuluxHeaderActions";
 import {
-  getXuluxTextFromParts,
   readXuluxMessages,
   updateXuluxPendingUserMessage,
   updateXuluxThreadContext,
   useXuluxStoredThreads,
-  type XuluxCanvasSnapshot,
-  type XuluxStoredThread,
 } from "../runtime/xulux-local-storage";
+import type { XuluxCanvasSnapshot, XuluxStoredThread } from "../runtime/types";
 
 const ASSISTANT_UI_REPO_URL = "https://github.com/assistant-ui/assistant-ui";
 
@@ -30,6 +30,10 @@ type CanvasState = {
   url: string | null;
   source: "template" | "refresh" | null;
   error: string | null;
+  downloadUrl?: string;
+  templateId?: string;
+  versionId?: string;
+  title?: string;
 };
 
 export function XuluxShell({
@@ -87,6 +91,10 @@ export function XuluxShell({
         url: template.previewUrl ?? null,
         source: template.previewUrl ? "template" : null,
         error: null,
+        ...(template.downloadUrl ? { downloadUrl: template.downloadUrl } : {}),
+        ...(template.templateId ? { templateId: template.templateId } : {}),
+        ...(template.versionId ? { versionId: template.versionId } : {}),
+        title: template.title,
       });
       setTemplatesOpen(false);
       setViewMode(template.previewUrl ? "preview" : "chat");
@@ -157,6 +165,7 @@ export function XuluxShell({
     (selectedTemplate || selectedTemplateContext)
       ? getTemplateSourceUrl(selectedTemplate ?? selectedTemplateContext!)
       : undefined;
+  const canvasTitle = canvas.title ?? selectedTemplate?.title;
 
   return (
     <div className="bg-background text-foreground flex h-full min-h-0 flex-col overflow-hidden">
@@ -175,8 +184,30 @@ export function XuluxShell({
           setViewMode("preview");
         }}
       />
+      <XuluxTemplatePreviewObserver
+        onTemplatePreviewReady={(preview) => {
+          setCanvas({
+            status: "ready",
+            url: preview.previewUrl,
+            source: "template",
+            error: null,
+            downloadUrl: preview.downloadUrl,
+            templateId: preview.templateId,
+            ...(preview.versionId !== undefined
+              ? { versionId: preview.versionId }
+              : {}),
+            title: preview.title,
+          });
+          setViewMode("preview");
+        }}
+        onCanvasError={(error) => {
+          setCanvas({ status: "error", url: null, source: null, error });
+          setViewMode("preview");
+        }}
+      />
 
       <XuluxHeaderActions
+        visible
         showChatActions={viewMode !== "landing"}
         onNewChat={handleNewChat}
         onShowTemplates={() => setTemplatesOpen(true)}
@@ -188,14 +219,16 @@ export function XuluxShell({
           onStartChat={handleStartChat}
           onSelectTemplate={handleSelectTemplate}
         />
-      ) : (
-        <div className="flex min-h-0 flex-1 overflow-hidden">
-          <section
-            className={
-              viewMode === "preview"
-                ? "flex w-[40%] min-w-[320px] flex-col border-r"
-                : "flex flex-1 flex-col"
-            }
+      ) : viewMode === "preview" ? (
+        <Group
+          orientation="horizontal"
+          className="min-h-0 flex-1 overflow-hidden"
+        >
+          <Panel
+            defaultSize="30%"
+            minSize="20%"
+            maxSize="55%"
+            className="flex h-full flex-col overflow-hidden border-r"
           >
             {isInterrupted && (
               <InterruptedRunBanner
@@ -204,23 +237,34 @@ export function XuluxShell({
               />
             )}
             <XuluxThread onNewThread={handleNewChat} />
-          </section>
-
-          {viewMode === "preview" && (
-            <main className="min-w-0 flex-1">
-              <XuluxCanvas
-                sessionId={sessionId}
-                status={canvas.status}
-                previewUrl={canvas.url}
-                source={canvas.source}
-                error={canvas.error}
-                {...(sourceUrl ? { sourceUrl } : {})}
-                {...(selectedTemplate?.title
-                  ? { title: selectedTemplate.title }
-                  : {})}
+          </Panel>
+          <Separator className="bg-border hover:bg-primary/30 w-1 cursor-col-resize transition-colors" />
+          <Panel className="h-full overflow-hidden">
+            <XuluxCanvas
+              sessionId={sessionId}
+              status={canvas.status}
+              previewUrl={canvas.url}
+              source={canvas.source}
+              error={canvas.error}
+              {...(canvas.downloadUrl
+                ? { downloadUrl: canvas.downloadUrl }
+                : {})}
+              {...(sourceUrl ? { sourceUrl } : {})}
+              {...(canvasTitle ? { title: canvasTitle } : {})}
+            />
+          </Panel>
+        </Group>
+      ) : (
+        <div className="flex min-h-0 flex-1 justify-center overflow-hidden">
+          <section className="flex w-full max-w-3xl flex-col">
+            {isInterrupted && (
+              <InterruptedRunBanner
+                lastUserMessage={interruptedUserMessage}
+                onRetry={handleRetryInterrupted}
               />
-            </main>
-          )}
+            )}
+            <XuluxThread onNewThread={handleNewChat} />
+          </section>
         </div>
       )}
 
@@ -244,6 +288,10 @@ function toSelectedTemplateContext(
     prompt: template.prompt,
     ...(template.sourcePath ? { sourcePath: template.sourcePath } : {}),
     ...(template.docsUrl ? { docsUrl: template.docsUrl } : {}),
+    ...(template.templateId ? { templateId: template.templateId } : {}),
+    ...(template.versionId ? { versionId: template.versionId } : {}),
+    ...(template.previewUrl ? { previewUrl: template.previewUrl } : {}),
+    ...(template.downloadUrl ? { downloadUrl: template.downloadUrl } : {}),
   };
 }
 
@@ -264,6 +312,9 @@ function toCanvasSnapshot(
     url: canvas.url,
     source: canvas.source,
     error: canvas.error,
+    ...(canvas.downloadUrl ? { downloadUrl: canvas.downloadUrl } : {}),
+    ...(canvas.templateId ? { templateId: canvas.templateId } : {}),
+    ...(canvas.versionId ? { versionId: canvas.versionId } : {}),
     ...(title ? { title } : {}),
   };
 }
@@ -279,6 +330,10 @@ function fromCanvasSnapshot(
     url: snapshot.url,
     source: snapshot.source,
     error: snapshot.error,
+    ...(snapshot.downloadUrl ? { downloadUrl: snapshot.downloadUrl } : {}),
+    ...(snapshot.templateId ? { templateId: snapshot.templateId } : {}),
+    ...(snapshot.versionId ? { versionId: snapshot.versionId } : {}),
+    ...(snapshot.title ? { title: snapshot.title } : {}),
   };
 }
 
@@ -289,10 +344,26 @@ function getLatestSavedUserMessage(remoteId: string): string | null {
     if (row?.format !== "ai-sdk/v6") continue;
     if (row.content.role !== "user") continue;
 
-    const text = getXuluxTextFromParts(row.content.parts);
+    const text = getTextFromMessageContent(row.content);
     if (text) return text;
   }
   return null;
+}
+
+function getTextFromMessageContent(content: Record<string, unknown>): string {
+  const parts = content.parts;
+  if (!Array.isArray(parts)) return "";
+
+  return parts
+    .flatMap((part) => {
+      if (!part || typeof part !== "object") return [];
+      const typedPart = part as Record<string, unknown>;
+      return typedPart.type === "text" && typeof typedPart.text === "string"
+        ? [typedPart.text]
+        : [];
+    })
+    .join("\n")
+    .trim();
 }
 
 function previewText(text: string): string {

--- a/apps/docs/components/xulux/shell/XuluxShell.tsx
+++ b/apps/docs/components/xulux/shell/XuluxShell.tsx
@@ -18,6 +18,7 @@ import {
   readXuluxMessages,
   updateXuluxPendingUserMessage,
   updateXuluxThreadContext,
+  updateXuluxThreadStatus,
   useXuluxStoredThreads,
 } from "../runtime/xulux-local-storage";
 import type { XuluxCanvasSnapshot, XuluxStoredThread } from "../runtime/types";
@@ -145,9 +146,20 @@ export function XuluxShell({
       currentRemoteId ?? sessionId,
       interruptedUserMessage,
     );
+    updateXuluxThreadStatus(currentRemoteId ?? sessionId, "running");
     setViewMode("chat");
+
+    const messages = aui.thread().getState().messages;
+    const lastUserMessage = [...messages]
+      .reverse()
+      .find((message) => message.role === "user");
+    if (lastUserMessage) {
+      void aui.thread().startRun({ parentId: lastUserMessage.id });
+      return;
+    }
+
     askAI(interruptedUserMessage);
-  }, [askAI, currentRemoteId, interruptedUserMessage, sessionId]);
+  }, [askAI, aui, currentRemoteId, interruptedUserMessage, sessionId]);
 
   useEffect(() => {
     if (!currentRemoteId) return;

--- a/apps/docs/components/xulux/shell/XuluxShell.tsx
+++ b/apps/docs/components/xulux/shell/XuluxShell.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAui, useAuiState } from "@assistant-ui/react";
 import { useAssistantPanel } from "@/components/docs/assistant/context";
+import { Button } from "@/components/ui/button";
 import { XuluxThread } from "../chat/XuluxThread";
 import type { XuluxTemplate } from "../templates/types";
 import type { SelectedTemplateContext } from "../XuluxApp";
@@ -10,6 +12,15 @@ import { XuluxCanvasObserver } from "../canvas/XuluxCanvasObserver";
 import { XuluxLandingPage } from "../landing/XuluxLandingPage";
 import { TemplatesModal } from "../landing/TemplatesModal";
 import { XuluxHeaderActions } from "./XuluxHeaderActions";
+import {
+  getXuluxTextFromParts,
+  readXuluxMessages,
+  updateXuluxPendingUserMessage,
+  updateXuluxThreadContext,
+  useXuluxStoredThreads,
+  type XuluxCanvasSnapshot,
+  type XuluxStoredThread,
+} from "../runtime/xulux-local-storage";
 
 const ASSISTANT_UI_REPO_URL = "https://github.com/assistant-ui/assistant-ui";
 
@@ -23,19 +34,26 @@ type CanvasState = {
 
 export function XuluxShell({
   sessionId,
+  onSetSessionId,
   onSetSelectedTemplateContext,
   onResetSession,
 }: {
   sessionId: string;
+  onSetSessionId: (sessionId: string) => void;
   onSetSelectedTemplateContext: (
     template: SelectedTemplateContext | null,
   ) => void;
   onResetSession: () => void;
 }) {
   const { askAI } = useAssistantPanel();
+  const aui = useAui();
+  const currentRemoteId = useAuiState((state) => state.threadListItem.remoteId);
+  const storedThreads = useXuluxStoredThreads();
   const [viewMode, setViewMode] = useState<XuluxViewMode>("landing");
   const [selectedTemplate, setSelectedTemplate] =
     useState<XuluxTemplate | null>(null);
+  const [selectedTemplateContext, setSelectedTemplateContext] =
+    useState<SelectedTemplateContext | null>(null);
   const [templatesOpen, setTemplatesOpen] = useState(false);
   const [canvas, setCanvas] = useState<CanvasState>({
     status: "empty",
@@ -46,19 +64,24 @@ export function XuluxShell({
 
   const handleStartChat = useCallback(
     (prompt: string) => {
+      updateXuluxPendingUserMessage(currentRemoteId ?? sessionId, prompt);
+      setSelectedTemplate(null);
+      setSelectedTemplateContext(null);
       onSetSelectedTemplateContext(null);
       setCanvas({ status: "empty", url: null, source: null, error: null });
       setViewMode("chat");
       setTemplatesOpen(false);
       askAI(prompt);
     },
-    [askAI, onSetSelectedTemplateContext],
+    [askAI, currentRemoteId, onSetSelectedTemplateContext, sessionId],
   );
 
   const handleSelectTemplate = useCallback(
     (template: XuluxTemplate) => {
+      const context = toSelectedTemplateContext(template);
       setSelectedTemplate(template);
-      onSetSelectedTemplateContext(toSelectedTemplateContext(template));
+      setSelectedTemplateContext(context);
+      onSetSelectedTemplateContext(context);
       setCanvas({
         status: template.previewUrl ? "ready" : "empty",
         url: template.previewUrl ?? null,
@@ -72,15 +95,67 @@ export function XuluxShell({
   );
 
   const handleNewChat = useCallback(() => {
+    const nextSessionId = crypto.randomUUID();
+    onSetSessionId(nextSessionId);
     setSelectedTemplate(null);
+    setSelectedTemplateContext(null);
     setCanvas({ status: "empty", url: null, source: null, error: null });
     setTemplatesOpen(false);
     setViewMode("landing");
     onResetSession();
-  }, [onResetSession]);
+    void aui.threads().switchToNewThread();
+  }, [aui, onResetSession, onSetSessionId]);
+
+  const handleRestoreThread = useCallback(
+    (thread: XuluxStoredThread) => {
+      const restoredTemplate = thread.custom.selectedTemplate ?? null;
+      onSetSessionId(thread.custom.sessionId);
+      setSelectedTemplate(null);
+      setSelectedTemplateContext(restoredTemplate);
+      onSetSelectedTemplateContext(restoredTemplate);
+      setCanvas(fromCanvasSnapshot(thread.custom.canvas));
+      setTemplatesOpen(false);
+      setViewMode(thread.custom.canvas?.url ? "preview" : "chat");
+    },
+    [onSetSelectedTemplateContext, onSetSessionId],
+  );
+
+  const activeStoredThread =
+    storedThreads.find((thread) => thread.remoteId === currentRemoteId) ?? null;
+  const isInterrupted =
+    activeStoredThread?.custom.xuluxStatus === "interrupted";
+  const interruptedUserMessage = useMemo(() => {
+    if (!isInterrupted || !currentRemoteId) return null;
+    const pending = activeStoredThread?.custom.pendingUserMessage?.trim();
+    if (pending) return pending;
+    return getLatestSavedUserMessage(currentRemoteId);
+  }, [activeStoredThread, currentRemoteId, isInterrupted]);
+
+  const handleRetryInterrupted = useCallback(() => {
+    if (!interruptedUserMessage) return;
+    updateXuluxPendingUserMessage(
+      currentRemoteId ?? sessionId,
+      interruptedUserMessage,
+    );
+    setViewMode("chat");
+    askAI(interruptedUserMessage);
+  }, [askAI, currentRemoteId, interruptedUserMessage, sessionId]);
+
+  useEffect(() => {
+    if (!currentRemoteId) return;
+    updateXuluxThreadContext(currentRemoteId, {
+      selectedTemplate: selectedTemplateContext,
+      canvas: toCanvasSnapshot(
+        canvas,
+        selectedTemplate?.title ?? selectedTemplateContext?.title,
+      ),
+    });
+  }, [canvas, currentRemoteId, selectedTemplate, selectedTemplateContext]);
+
   const sourceUrl =
-    canvas.source === "template" && selectedTemplate
-      ? getTemplateSourceUrl(selectedTemplate)
+    canvas.source === "template" &&
+    (selectedTemplate || selectedTemplateContext)
+      ? getTemplateSourceUrl(selectedTemplate ?? selectedTemplateContext!)
       : undefined;
 
   return (
@@ -102,9 +177,10 @@ export function XuluxShell({
       />
 
       <XuluxHeaderActions
-        visible={viewMode !== "landing"}
+        showChatActions={viewMode !== "landing"}
         onNewChat={handleNewChat}
         onShowTemplates={() => setTemplatesOpen(true)}
+        onRestoreThread={handleRestoreThread}
       />
 
       {viewMode === "landing" ? (
@@ -121,6 +197,12 @@ export function XuluxShell({
                 : "flex flex-1 flex-col"
             }
           >
+            {isInterrupted && (
+              <InterruptedRunBanner
+                lastUserMessage={interruptedUserMessage}
+                onRetry={handleRetryInterrupted}
+              />
+            )}
             <XuluxThread onNewThread={handleNewChat} />
           </section>
 
@@ -165,8 +247,89 @@ function toSelectedTemplateContext(
   };
 }
 
-function getTemplateSourceUrl(template: XuluxTemplate): string | undefined {
+function getTemplateSourceUrl(
+  template: XuluxTemplate | SelectedTemplateContext,
+): string | undefined {
   if (!template.sourcePath) return template.docsUrl;
   if (/^https?:\/\//i.test(template.sourcePath)) return template.sourcePath;
   return `${ASSISTANT_UI_REPO_URL}/tree/main/${template.sourcePath}`;
+}
+
+function toCanvasSnapshot(
+  canvas: CanvasState,
+  title: string | undefined,
+): XuluxCanvasSnapshot {
+  return {
+    status: canvas.status === "loading" ? "empty" : canvas.status,
+    url: canvas.url,
+    source: canvas.source,
+    error: canvas.error,
+    ...(title ? { title } : {}),
+  };
+}
+
+function fromCanvasSnapshot(
+  snapshot: XuluxCanvasSnapshot | undefined,
+): CanvasState {
+  if (!snapshot) {
+    return { status: "empty", url: null, source: null, error: null };
+  }
+  return {
+    status: snapshot.status,
+    url: snapshot.url,
+    source: snapshot.source,
+    error: snapshot.error,
+  };
+}
+
+function getLatestSavedUserMessage(remoteId: string): string | null {
+  const repository = readXuluxMessages(remoteId);
+  for (let index = repository.messages.length - 1; index >= 0; index -= 1) {
+    const row = repository.messages[index];
+    if (row?.format !== "ai-sdk/v6") continue;
+    if (row.content.role !== "user") continue;
+
+    const text = getXuluxTextFromParts(row.content.parts);
+    if (text) return text;
+  }
+  return null;
+}
+
+function previewText(text: string): string {
+  return text.length > 96 ? `${text.slice(0, 93)}...` : text;
+}
+
+function InterruptedRunBanner({
+  lastUserMessage,
+  onRetry,
+}: {
+  lastUserMessage: string | null;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="mx-3 mt-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="font-medium text-amber-700 dark:text-amber-300">
+            This run was interrupted.
+          </p>
+          <p className="text-muted-foreground mt-0.5 text-xs">
+            {lastUserMessage
+              ? `Retry the last saved request: "${previewText(lastUserMessage)}"`
+              : "The original request was not saved, so this run cannot be retried safely."}
+          </p>
+        </div>
+        {lastUserMessage && (
+          <Button
+            type="button"
+            size="sm"
+            className="h-7 shrink-0 px-2.5 text-xs"
+            onClick={onRetry}
+          >
+            Retry
+          </Button>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/apps/docs/components/xulux/templates/types.ts
+++ b/apps/docs/components/xulux/templates/types.ts
@@ -6,6 +6,8 @@ export type XuluxTemplateCategory = {
 
 export type XuluxTemplate = {
   id: string;
+  templateId?: string | undefined;
+  versionId?: string | undefined;
   title: string;
   description: string;
   categoryId: string;
@@ -16,10 +18,35 @@ export type XuluxTemplate = {
   kind: "template" | "example";
   previewStatus: "live" | "stale" | "missing";
   previewUrl?: string | undefined;
+  downloadUrl?: string | undefined;
+  sandboxBaseUrl?: string | undefined;
   screenshotUrl?: string | undefined;
   sourcePath?: string | undefined;
   docsUrl?: string | undefined;
   featured?: boolean | undefined;
+  versions?:
+    | Array<{
+        id: string;
+        title: string;
+        description: string;
+        previewUrl: string;
+        downloadUrl: string;
+      }>
+    | undefined;
+  intent?:
+    | {
+        goodFor: string[];
+        notFor?: string[] | undefined;
+        exampleUserRequests?: string[] | undefined;
+      }
+    | undefined;
+  customization?:
+    | {
+        safeFieldsSummary: string[];
+        supportedRenderers: string[];
+        sourceEditFiles: string[];
+      }
+    | undefined;
   tech: {
     framework: string;
     runtime: string;

--- a/apps/docs/components/xulux/templates/useXuluxTemplateCatalog.ts
+++ b/apps/docs/components/xulux/templates/useXuluxTemplateCatalog.ts
@@ -21,12 +21,19 @@ export function useXuluxTemplateCatalog(): XuluxTemplateCatalog & {
       setIsLoading(true);
       setError(null);
       try {
-        const response = await fetch("/api/xulux/examples");
-        if (!response.ok) {
-          throw new Error(`Examples API failed with ${response.status}`);
+        const templatesResponse = await fetch("/api/xulux/templates");
+        if (!templatesResponse.ok) {
+          throw new Error(
+            `Templates API failed with ${templatesResponse.status}`,
+          );
         }
-        const nextCatalog = (await response.json()) as XuluxTemplateCatalog;
-        if (!cancelled) setCatalog(nextCatalog);
+
+        const templatesCatalog =
+          (await templatesResponse.json()) as XuluxTemplateCatalog;
+
+        if (!cancelled) {
+          setCatalog(templatesCatalog);
+        }
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : String(err));

--- a/apps/docs/lib/docs-toolkit.tsx
+++ b/apps/docs/lib/docs-toolkit.tsx
@@ -10,25 +10,24 @@ import {
   fetchWeatherWidgetFromOpenMeteo,
   geocodeLocationWithOpenMeteo,
 } from "@/lib/open-meteo-weather-adapter";
-import { MapPin, CloudSun, AlertCircle, ChevronRight } from "lucide-react";
-import { useRef, useState } from "react";
+import { MapPin, CloudSun, AlertCircle } from "lucide-react";
 import { z } from "zod";
 import {
   defineToolkit,
   useAuiState,
-  useScrollLock,
   type ToolCallMessagePartComponent,
 } from "@assistant-ui/react";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
 import {
   JSONGenerativeUI,
   defineGenerativeComponents,
   generativeUIToJSX,
 } from "@assistant-ui/react-generative-ui";
+import {
+  formatToolCall,
+  ToolErrorCard,
+  ToolStatusCard,
+  ToolTraceCard,
+} from "@/lib/tool-trace";
 
 const weatherFormatSchema = z.enum(["fahrenheit", "celsius"]);
 
@@ -316,109 +315,8 @@ const ToolCard = ({
   </div>
 );
 
-/**
- * A backend tool's trace: the call signature and a one-line summary, with the
- * full JSON result tucked inside a collapsible.
- */
-const TRACE_ANIMATION_DURATION = 200;
-
-const ToolTraceCard = ({
-  icon,
-  signature,
-  description,
-  result,
-}: {
-  icon: React.ReactNode;
-  signature: string;
-  description: React.ReactNode;
-  result: unknown;
-}) => {
-  const rootRef = useRef<HTMLDivElement>(null);
-  const [open, setOpen] = useState(false);
-  const lockScroll = useScrollLock(rootRef, TRACE_ANIMATION_DURATION);
-
-  return (
-    <Collapsible
-      ref={rootRef}
-      open={open}
-      onOpenChange={(next) => {
-        lockScroll();
-        setOpen(next);
-      }}
-      className="group/tool-trace max-w-full"
-      style={
-        {
-          "--animation-duration": `${TRACE_ANIMATION_DURATION}ms`,
-        } as React.CSSProperties
-      }
-    >
-      <CollapsibleTrigger className="text-muted-foreground hover:text-foreground flex w-fit max-w-full cursor-pointer items-center gap-2 py-0.5 transition-colors select-none">
-        <span className="flex size-4 shrink-0 items-center justify-center [&_svg]:size-3.5">
-          {icon}
-        </span>
-        <span className="truncate font-mono text-[13px]">{signature}</span>
-        <span className="text-muted-foreground/60 truncate text-xs">
-          {description}
-        </span>
-        <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]/tool-trace:rotate-90" />
-      </CollapsibleTrigger>
-      <CollapsibleContent
-        className={cn(
-          "relative overflow-hidden outline-none",
-          "data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down ease-out",
-          "data-[state=closed]:fill-mode-forwards data-[state=closed]:pointer-events-none",
-          "data-[state=closed]:duration-(--animation-duration) data-[state=open]:duration-(--animation-duration)",
-        )}
-      >
-        <pre className="text-muted-foreground bg-muted/50 my-1 ml-6 max-h-60 overflow-auto rounded-md p-2.5 text-[11px] leading-relaxed">
-          {JSON.stringify(result, null, 2)}
-        </pre>
-      </CollapsibleContent>
-    </Collapsible>
-  );
-};
-
-/** A backend tool's pending/loading trace: the call signature with a spinner icon. */
-const ToolStatusCard = ({
-  icon,
-  signature,
-  message,
-  loading = false,
-}: {
-  icon: React.ReactNode;
-  signature: string;
-  message: string;
-  loading?: boolean;
-}) => (
-  <div className="text-muted-foreground flex max-w-full items-center gap-2 py-0.5">
-    <span
-      className={cn(
-        "flex size-4 shrink-0 items-center justify-center [&_svg]:size-3.5",
-        loading && "animate-pulse",
-      )}
-    >
-      {icon}
-    </span>
-    <span className="truncate font-mono text-[13px]">{signature}</span>
-    <span className="text-muted-foreground/60 truncate text-xs">{message}</span>
-  </div>
-);
-
-/** A backend tool's error trace: the call signature with the error message. */
-const ToolErrorCard = ({
-  signature,
-  error,
-}: {
-  signature: string;
-  error?: string;
-}) => (
-  <div className="text-destructive flex max-w-full items-center gap-2 py-0.5">
-    <AlertCircle className="size-3.5 shrink-0" />
-    <span className="truncate font-mono text-[13px]">{signature}</span>
-    <span className="truncate text-xs opacity-80">
-      {error || "Unknown error"}
-    </span>
-  </div>
+const ToolCardDescription = ({ children }: { children: React.ReactNode }) => (
+  <span className="text-muted-foreground truncate text-xs">{children}</span>
 );
 
 const ToolCardIcon = ({
@@ -458,20 +356,3 @@ const ToolCardTitle = ({
     {children}
   </span>
 );
-
-const ToolCardDescription = ({ children }: { children: React.ReactNode }) => (
-  <span className="text-muted-foreground truncate text-xs">{children}</span>
-);
-
-/** Renders a tool call as a readable signature, e.g. `get_weather({ location: "SF" })`. */
-const formatToolCall = (
-  toolName: string,
-  args: Record<string, unknown> | undefined,
-): string => {
-  const entries = Object.entries(args ?? {});
-  if (entries.length === 0) return `${toolName}()`;
-  const body = entries
-    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
-    .join(", ");
-  return `${toolName}({ ${body} })`;
-};

--- a/apps/docs/lib/tool-trace.tsx
+++ b/apps/docs/lib/tool-trace.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useScrollLock } from "@assistant-ui/react";
+import { AlertCircle, ChevronRight } from "lucide-react";
+import { useRef, useState, type ReactNode } from "react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+
+const TRACE_ANIMATION_DURATION = 200;
+
+/** Renders a tool call as a readable signature, e.g. `get_weather({ location: "SF" })`. */
+export function formatToolCall(
+  toolName: string,
+  args: Record<string, unknown> | undefined,
+): string {
+  const entries = Object.entries(args ?? {});
+  if (entries.length === 0) return `${toolName}()`;
+  const body = entries
+    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+    .join(", ");
+  return `${toolName}({ ${body} })`;
+}
+
+export function ToolTraceCard({
+  icon,
+  signature,
+  description,
+  result,
+}: {
+  icon: ReactNode;
+  signature: string;
+  description: ReactNode;
+  result: unknown;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const lockScroll = useScrollLock(rootRef, TRACE_ANIMATION_DURATION);
+
+  return (
+    <Collapsible
+      ref={rootRef}
+      open={open}
+      onOpenChange={(next) => {
+        lockScroll();
+        setOpen(next);
+      }}
+      className="group/tool-trace max-w-full"
+      style={
+        {
+          "--animation-duration": `${TRACE_ANIMATION_DURATION}ms`,
+        } as React.CSSProperties
+      }
+    >
+      <CollapsibleTrigger className="text-muted-foreground hover:text-foreground flex w-fit max-w-full cursor-pointer items-center gap-2 py-0.5 transition-colors select-none">
+        <span className="flex size-4 shrink-0 items-center justify-center [&_svg]:size-3.5">
+          {icon}
+        </span>
+        <span className="truncate font-mono text-[13px]">{signature}</span>
+        <span className="text-muted-foreground/60 truncate text-xs">
+          {description}
+        </span>
+        <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]/tool-trace:rotate-90" />
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        className={cn(
+          "relative overflow-hidden outline-none",
+          "data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down ease-out",
+          "data-[state=closed]:fill-mode-forwards data-[state=closed]:pointer-events-none",
+          "data-[state=closed]:duration-(--animation-duration) data-[state=open]:duration-(--animation-duration)",
+        )}
+      >
+        <pre className="text-muted-foreground bg-muted/50 my-1 ml-6 max-h-60 overflow-auto rounded-md p-2.5 text-[11px] leading-relaxed">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export function ToolStatusCard({
+  icon,
+  signature,
+  message,
+  loading = false,
+}: {
+  icon: ReactNode;
+  signature: string;
+  message: string;
+  loading?: boolean;
+}) {
+  return (
+    <div className="text-muted-foreground flex max-w-full items-center gap-2 py-0.5">
+      <span
+        className={cn(
+          "flex size-4 shrink-0 items-center justify-center [&_svg]:size-3.5",
+          loading && "animate-pulse",
+        )}
+      >
+        {icon}
+      </span>
+      <span className="truncate font-mono text-[13px]">{signature}</span>
+      <span className="text-muted-foreground/60 truncate text-xs">
+        {message}
+      </span>
+    </div>
+  );
+}
+
+export function ToolErrorCard({
+  signature,
+  error,
+}: {
+  signature: string;
+  error?: string;
+}) {
+  return (
+    <div className="text-destructive flex max-w-full items-center gap-2 py-0.5">
+      <AlertCircle className="size-3.5 shrink-0" />
+      <span className="truncate font-mono text-[13px]">{signature}</span>
+      <span className="truncate text-xs opacity-80">
+        {error || "Unknown error"}
+      </span>
+    </div>
+  );
+}

--- a/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
+++ b/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
@@ -1,0 +1,207 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  DEMO_DOWNLOAD_MANIFESTS,
+  getDemoDownloadManifest,
+  type DemoDownloadManifest,
+  type DemoDownloadSlug,
+} from "./manifest";
+import {
+  DEMO_DEPENDENCIES,
+  DEMO_DEV_DEPENDENCIES,
+  dependencyVersions,
+} from "./package-versions";
+import { createZip, type ZipFileMap } from "./zip";
+
+type SourceSnapshot = Record<string, string>;
+
+export async function loadSourceSnapshot(snapshotPath = defaultSnapshotPath()) {
+  const raw = await readFile(snapshotPath, "utf8");
+  return JSON.parse(raw) as SourceSnapshot;
+}
+
+export async function createDemoZip(slug: string) {
+  const snapshot = await loadSourceSnapshot();
+  return createZip(createDemoFileMap(slug, snapshot));
+}
+
+export function createDemoFileMap(slug: string, snapshot: SourceSnapshot) {
+  const manifest = getDemoDownloadManifest(slug);
+  if (!manifest) {
+    throw new Error(`Unsupported demo slug: ${slug}`);
+  }
+
+  const demoSource = assertSnapshotFile(snapshot, manifest.entry);
+  const files: ZipFileMap = {
+    "package.json": packageJson(manifest, snapshot),
+    "next.config.ts": nextConfigTs(),
+    "tsconfig.json": tsconfigJson(),
+    "postcss.config.mjs": postcssConfigMjs(),
+    "README.md": readme(manifest),
+    ".env.example": "OPENAI_API_KEY=\n",
+    "app/globals.css": globalsCss(),
+    "app/layout.tsx": layoutTsx(manifest),
+    "app/page.tsx": pageTsx(manifest),
+    "app/api/chat/route.ts": chatRouteTs(),
+    "components/runtime/demo-runtime-provider.tsx": runtimeProviderTsx(),
+    "components/assistant-ui/markdown-text.tsx": markdownTextShim(),
+    "components/assistant-ui/shiki-highlighter.tsx": shikiHighlighterShim(),
+    "components/assistant-ui/tool-fallback.tsx": toolFallbackShim(),
+    "components/assistant-ui/tooltip-icon-button.tsx": tooltipIconButtonShim(),
+    "components/docs/assistant/docs-model-options.ts": docsModelOptionsShim(),
+    "constants/model.ts": 'export const DEFAULT_MODEL_ID = "gpt-4.1-mini";\n',
+    "public/favicon/icon.svg": faviconSvg(),
+    [`components/examples/${manifest.slug}.tsx`]: demoSource,
+  };
+
+  for (const sourceFile of manifest.extraSourceFiles ?? []) {
+    files[targetPathForSourceFile(sourceFile)] = assertSnapshotFile(
+      snapshot,
+      sourceFile,
+    );
+  }
+
+  return files;
+}
+
+export function getDemoArchiveFilename(slug: DemoDownloadSlug) {
+  return `xulux-${slug}-demo.zip`;
+}
+
+export function supportedDemoSlugs() {
+  return Object.keys(DEMO_DOWNLOAD_MANIFESTS) as DemoDownloadSlug[];
+}
+
+function defaultSnapshotPath() {
+  return path.join(process.cwd(), "generated", "source-snapshot.json");
+}
+
+function assertSnapshotFile(snapshot: SourceSnapshot, snapshotKey: string) {
+  const contents = snapshot[snapshotKey];
+  if (typeof contents !== "string") {
+    throw new Error(`Missing source snapshot entry: ${snapshotKey}`);
+  }
+  return contents;
+}
+
+function targetPathForSourceFile(sourceFile: string) {
+  if (sourceFile.startsWith("packages/ui/src/")) {
+    return sourceFile
+      .replace(/^packages\/ui\/src\//, "")
+      .replace(/^components\/ui\//, "components/ui/")
+      .replace(/^components\/assistant-ui\//, "components/assistant-ui/")
+      .replace(/^lib\//, "lib/");
+  }
+
+  if (sourceFile.startsWith("apps/docs/")) {
+    return sourceFile.replace(/^apps\/docs\//, "");
+  }
+
+  throw new Error(`Unsupported demo source path: ${sourceFile}`);
+}
+
+function packageJson(manifest: DemoDownloadManifest, snapshot: SourceSnapshot) {
+  return `${JSON.stringify(
+    {
+      name: `xulux-${manifest.slug}-demo`,
+      version: "0.1.0",
+      private: true,
+      type: "module",
+      scripts: {
+        dev: "next dev",
+        build: "next build",
+        start: "next start",
+      },
+      dependencies: dependencyVersions(snapshot, DEMO_DEPENDENCIES),
+      devDependencies: dependencyVersions(snapshot, DEMO_DEV_DEPENDENCIES),
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function nextConfigTs() {
+  return 'import type { NextConfig } from "next";\n\nconst nextConfig: NextConfig = {};\n\nexport default nextConfig;\n';
+}
+
+function tsconfigJson() {
+  return `${JSON.stringify(
+    {
+      compilerOptions: {
+        target: "ES2020",
+        lib: ["dom", "dom.iterable", "esnext"],
+        allowJs: false,
+        skipLibCheck: true,
+        strict: true,
+        noEmit: true,
+        esModuleInterop: true,
+        module: "esnext",
+        moduleResolution: "bundler",
+        resolveJsonModule: true,
+        isolatedModules: true,
+        jsx: "preserve",
+        incremental: true,
+        plugins: [{ name: "next" }],
+        paths: {
+          "@/*": ["./*"],
+        },
+      },
+      include: ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+      exclude: ["node_modules"],
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function postcssConfigMjs() {
+  return 'const config = { plugins: { "@tailwindcss/postcss": {} } };\n\nexport default config;\n';
+}
+
+function readme(manifest: DemoDownloadManifest) {
+  return `# Xulux ${manifest.name}\n\n${manifest.description}\n\n## Run\n\n\`\`\`bash\nnpm install\nnpm run dev\n\`\`\`\n\nAdd \`OPENAI_API_KEY\` to \`.env.local\` for live AI responses. Without a key, \`app/api/chat/route.ts\` returns a deterministic fallback response so the demo still runs locally.\n\nSource demo: \`${manifest.entry}\`\n`;
+}
+
+function globalsCss() {
+  return `@import "tailwindcss";\n\n@theme inline {\n  --color-background: var(--background);\n  --color-foreground: var(--foreground);\n  --color-muted: var(--muted);\n  --color-muted-foreground: var(--muted-foreground);\n  --color-border: var(--border);\n  --color-input: var(--input);\n  --color-ring: var(--ring);\n  --color-primary: var(--primary);\n  --color-primary-foreground: var(--primary-foreground);\n  --color-accent: var(--accent);\n  --color-accent-foreground: var(--accent-foreground);\n  --color-popover: var(--popover);\n  --color-popover-foreground: var(--popover-foreground);\n}\n\n:root {\n  --background: #ffffff;\n  --foreground: #171717;\n  --muted: #f4f4f5;\n  --muted-foreground: #71717a;\n  --border: #e4e4e7;\n  --input: #e4e4e7;\n  --ring: #18181b;\n  --primary: #18181b;\n  --primary-foreground: #fafafa;\n  --accent: #f4f4f5;\n  --accent-foreground: #18181b;\n  --popover: #ffffff;\n  --popover-foreground: #18181b;\n}\n\n.dark {\n  --background: #09090b;\n  --foreground: #fafafa;\n  --muted: #27272a;\n  --muted-foreground: #a1a1aa;\n  --border: #27272a;\n  --input: #27272a;\n  --ring: #fafafa;\n  --primary: #fafafa;\n  --primary-foreground: #18181b;\n  --accent: #27272a;\n  --accent-foreground: #fafafa;\n  --popover: #18181b;\n  --popover-foreground: #fafafa;\n}\n\nhtml, body {\n  height: 100%;\n}\n\nbody {\n  margin: 0;\n  background: var(--background);\n  color: var(--foreground);\n}\n\nbutton, input, textarea, select {\n  font: inherit;\n}\n`;
+}
+
+function layoutTsx(manifest: DemoDownloadManifest) {
+  return `import type { Metadata } from "next";\nimport "./globals.css";\n\nexport const metadata: Metadata = {\n  title: "${manifest.name}",\n  description: "Downloadable assistant-ui demo starter generated by Xulux.",\n};\n\nexport default function RootLayout({ children }: { children: React.ReactNode }) {\n  return (\n    <html lang="en" suppressHydrationWarning>\n      <body>{children}</body>\n    </html>\n  );\n}\n`;
+}
+
+function pageTsx(manifest: DemoDownloadManifest) {
+  return `import { DemoRuntimeProvider } from "@/components/runtime/demo-runtime-provider";\nimport { ${manifest.componentName} } from "@/components/examples/${manifest.slug}";\n\nexport default function Page() {\n  return (\n    <main className="h-dvh overflow-hidden">\n      <DemoRuntimeProvider>\n        <${manifest.componentName} />\n      </DemoRuntimeProvider>\n    </main>\n  );\n}\n`;
+}
+
+function runtimeProviderTsx() {
+  return `"use client";\n\nimport { AssistantRuntimeProvider } from "@assistant-ui/react";\nimport { AssistantChatTransport, useChatRuntime } from "@assistant-ui/react-ai-sdk";\n\nexport function DemoRuntimeProvider({ children }: { children: React.ReactNode }) {\n  const runtime = useChatRuntime({\n    transport: new AssistantChatTransport({ api: "/api/chat" }),\n  });\n\n  return (\n    <AssistantRuntimeProvider runtime={runtime}>\n      {children}\n    </AssistantRuntimeProvider>\n  );\n}\n`;
+}
+
+function chatRouteTs() {
+  return `import { openai } from "@ai-sdk/openai";\nimport {\n  convertToModelMessages,\n  createUIMessageStream,\n  createUIMessageStreamResponse,\n  streamText,\n} from "ai";\n\nexport const maxDuration = 30;\n\nexport async function POST(req: Request) {\n  const { messages } = await req.json();\n\n  if (!process.env.OPENAI_API_KEY) {\n    const stream = createUIMessageStream({\n      originalMessages: messages,\n      execute: async ({ writer }) => {\n        await writer.write({\n          type: "text-delta",\n          id: "fallback-text",\n          delta:\n            "This starter is running without OPENAI_API_KEY. Add one to .env.local to enable live AI responses.",\n        });\n      },\n    });\n\n    return createUIMessageStreamResponse({ stream });\n  }\n\n  const result = streamText({\n    model: openai("gpt-4.1-mini"),\n    messages: await convertToModelMessages(messages),\n  });\n\n  return result.toUIMessageStreamResponse();\n}\n`;
+}
+
+function markdownTextShim() {
+  return `"use client";\n\nimport { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";\nimport remarkGfm from "remark-gfm";\n\nexport function MarkdownText() {\n  return <MarkdownTextPrimitive remarkPlugins={[remarkGfm]} className="aui-md" />;\n}\n`;
+}
+
+function shikiHighlighterShim() {
+  return `"use client";\n\nexport function SyntaxHighlighter({ code }: { code?: string }) {\n  return <pre className="overflow-auto rounded-md bg-muted p-3 text-sm"><code>{code}</code></pre>;\n}\n`;
+}
+
+function toolFallbackShim() {
+  return `"use client";\n\nimport type { ToolCallMessagePartComponent } from "@assistant-ui/react";\n\nexport const ToolFallback: ToolCallMessagePartComponent = ({ toolName, argsText, result }) => {\n  return (\n    <div className="rounded-md border border-border bg-muted/40 p-3 text-sm">\n      <div className="font-medium">{toolName}</div>\n      {argsText ? <pre className="mt-2 overflow-auto text-xs">{argsText}</pre> : null}\n      {result ? <pre className="mt-2 overflow-auto text-xs">{JSON.stringify(result, null, 2)}</pre> : null}\n    </div>\n  );\n};\n`;
+}
+
+function tooltipIconButtonShim() {
+  return `"use client";\n\nimport type { ButtonHTMLAttributes, ReactNode } from "react";\nimport { cn } from "@/lib/utils";\n\ntype TooltipIconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {\n  tooltip?: string;\n  side?: "top" | "right" | "bottom" | "left";\n  variant?: string;\n  size?: string;\n  children?: ReactNode;\n};\n\nexport function TooltipIconButton({ tooltip, className, children, ...props }: TooltipIconButtonProps) {\n  return (\n    <button\n      type="button"\n      aria-label={tooltip}\n      title={tooltip}\n      className={cn("inline-flex size-8 items-center justify-center rounded-md transition-colors hover:bg-muted disabled:opacity-50", className)}\n      {...props}\n    >\n      {children}\n    </button>\n  );\n}\n`;
+}
+
+function docsModelOptionsShim() {
+  return `export function docsModelOptions() {\n  return [\n    { id: "gpt-4.1-mini", name: "GPT-4.1 mini" },\n    { id: "gpt-4.1", name: "GPT-4.1" },\n  ];\n}\n`;
+}
+
+function faviconSvg() {
+  return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="8" fill="#111827"/><path d="M9 10h14v12H9z" fill="#fff" opacity=".9"/><path d="M12 14h8M12 18h5" stroke="#111827" stroke-width="2" stroke-linecap="round"/></svg>\n';
+}

--- a/apps/docs/lib/xulux/demo-downloads/manifest.ts
+++ b/apps/docs/lib/xulux/demo-downloads/manifest.ts
@@ -1,0 +1,182 @@
+export const DEMO_DOWNLOAD_CATEGORY = {
+  id: "assistant-ui-demos",
+  name: "Assistant UI Demos",
+  description:
+    "Fixed assistant-ui demo surfaces shown as-is with downloadable starter apps.",
+};
+
+export type DemoDownloadSlug =
+  | "base"
+  | "chatgpt"
+  | "claude"
+  | "grok"
+  | "gemini"
+  | "perplexity";
+
+export type DemoDownloadManifest = {
+  slug: DemoDownloadSlug;
+  name: string;
+  tagline: string;
+  description: string;
+  features: string[];
+  entry: string;
+  componentName: string;
+  tags: string[];
+  gradient: string;
+  featured?: boolean;
+  extraSourceFiles?: string[];
+};
+
+const COMMON_EXTRA_SOURCE_FILES = [
+  "packages/ui/src/lib/utils.ts",
+  "apps/docs/components/shared/dropdown-menu.tsx",
+] as const;
+
+const BASE_EXTRA_SOURCE_FILES = [
+  "packages/ui/src/components/assistant-ui/attachment.tsx",
+  "packages/ui/src/components/assistant-ui/badge.tsx",
+  "packages/ui/src/components/assistant-ui/composer-trigger-popover.tsx",
+  "packages/ui/src/components/assistant-ui/directive-text.tsx",
+  "packages/ui/src/components/assistant-ui/dot-matrix.tsx",
+  "packages/ui/src/components/assistant-ui/message-timing.tsx",
+  "packages/ui/src/components/assistant-ui/model-selector.tsx",
+  "packages/ui/src/components/assistant-ui/quote.tsx",
+  "packages/ui/src/components/assistant-ui/reasoning.tsx",
+  "packages/ui/src/components/assistant-ui/select.tsx",
+  "packages/ui/src/components/assistant-ui/thread-list.tsx",
+  "packages/ui/src/components/assistant-ui/tool-group.tsx",
+  "packages/ui/src/components/ui/avatar.tsx",
+  "packages/ui/src/components/ui/button.tsx",
+  "packages/ui/src/components/ui/collapsible.tsx",
+  "packages/ui/src/components/ui/command.tsx",
+  "packages/ui/src/components/ui/dialog.tsx",
+  "packages/ui/src/components/ui/popover.tsx",
+  "packages/ui/src/components/ui/sheet.tsx",
+  "packages/ui/src/components/ui/skeleton.tsx",
+  "packages/ui/src/components/ui/tooltip.tsx",
+] as const;
+
+export const DEMO_DOWNLOAD_MANIFESTS: Record<
+  DemoDownloadSlug,
+  DemoDownloadManifest
+> = {
+  base: {
+    slug: "base",
+    name: "Base Assistant UI",
+    tagline: "The full assistant-ui experience, unthemed.",
+    description:
+      "A complete chat application built from assistant-ui primitives: thread management, attachments, mentions, slash commands, model picker, and voice input.",
+    features: [
+      "Full assistant-ui thread layout with sidebar thread list",
+      "Composer attachments, mentions, slash commands, voice, and model picker controls",
+      "Message actions, branching controls, reasoning, quote selection, and tool fallback UI",
+    ],
+    entry: "apps/docs/components/examples/base.tsx",
+    componentName: "Base",
+    tags: ["assistant-ui", "base", "thread", "composer"],
+    gradient: "from-zinc-500/35 via-neutral-400/25 to-slate-300/20",
+    featured: true,
+    extraSourceFiles: [
+      ...COMMON_EXTRA_SOURCE_FILES,
+      ...BASE_EXTRA_SOURCE_FILES,
+    ],
+  },
+  chatgpt: {
+    slug: "chatgpt",
+    name: "ChatGPT Style Assistant",
+    tagline: "A ChatGPT look and feel, rebuilt on assistant-ui.",
+    description:
+      "Customized colors, typography, tools menu, composer, and message layout that recreate the ChatGPT interface on top of assistant-ui primitives.",
+    features: [
+      "ChatGPT-style empty state, composer, tool menu, and dark mode treatment",
+      "Assistant and user message layouts with actions, attachments, and branch controls",
+      "Voice, dictation, and tool fallback UI wired through assistant-ui primitives",
+    ],
+    entry: "apps/docs/components/examples/chatgpt.tsx",
+    componentName: "ChatGPT",
+    tags: ["assistant-ui", "ChatGPT", "clone", "chat"],
+    gradient: "from-emerald-500/35 via-zinc-400/25 to-neutral-300/20",
+    featured: true,
+    extraSourceFiles: [...COMMON_EXTRA_SOURCE_FILES],
+  },
+  claude: {
+    slug: "claude",
+    name: "Claude Style Assistant",
+    tagline: "A Claude look and feel, rebuilt on assistant-ui.",
+    description:
+      "A Claude-inspired assistant surface with serif typography, warm visual styling, file controls, message actions, and compact composer interactions.",
+    features: [
+      "Claude-style empty state, composer, and warm document-like message surface",
+      "Attachment, action, branch, and regeneration controls",
+      "Dropdown controls and markdown rendering wired to assistant-ui primitives",
+    ],
+    entry: "apps/docs/components/examples/claude.tsx",
+    componentName: "Claude",
+    tags: ["assistant-ui", "Claude", "clone", "chat"],
+    gradient: "from-orange-400/35 via-stone-300/25 to-zinc-200/20",
+    extraSourceFiles: [...COMMON_EXTRA_SOURCE_FILES],
+  },
+  grok: {
+    slug: "grok",
+    name: "Grok Style Assistant",
+    tagline: "A Grok look and feel, rebuilt on assistant-ui.",
+    description:
+      "A Grok-inspired assistant surface with minimal dark styling, center composer, icon branding, message actions, and concise controls.",
+    features: [
+      "Grok-style centered empty state and branded icon",
+      "Minimal message viewport with action and branch controls",
+      "Dropdown controls and markdown rendering wired to assistant-ui primitives",
+    ],
+    entry: "apps/docs/components/examples/grok.tsx",
+    componentName: "Grok",
+    tags: ["assistant-ui", "Grok", "clone", "chat"],
+    gradient: "from-neutral-700/35 via-zinc-500/25 to-cyan-300/20",
+    extraSourceFiles: [
+      ...COMMON_EXTRA_SOURCE_FILES,
+      "apps/docs/components/icons/grok.tsx",
+    ],
+  },
+  gemini: {
+    slug: "gemini",
+    name: "Gemini Style Assistant",
+    tagline: "A Gemini look and feel, rebuilt on assistant-ui.",
+    description:
+      "A Gemini-inspired assistant surface with suggested starter prompts, rounded composer controls, message actions, and lightweight visual styling.",
+    features: [
+      "Gemini-style empty state and composer",
+      "Suggested prompt cards and message action controls",
+      "Dropdown controls and markdown rendering wired to assistant-ui primitives",
+    ],
+    entry: "apps/docs/components/examples/gemini.tsx",
+    componentName: "Gemini",
+    tags: ["assistant-ui", "Gemini", "clone", "chat"],
+    gradient: "from-blue-500/35 via-sky-300/25 to-rose-300/20",
+    extraSourceFiles: [...COMMON_EXTRA_SOURCE_FILES],
+  },
+  perplexity: {
+    slug: "perplexity",
+    name: "Perplexity Style Assistant",
+    tagline: "A Perplexity look and feel, rebuilt on assistant-ui.",
+    description:
+      "A Perplexity-inspired search assistant surface with focused input, source-like styling, message actions, and compact follow-up composer.",
+    features: [
+      "Perplexity-style search prompt and follow-up composer",
+      "Source/search flavored controls and message actions",
+      "Dropdown controls and markdown rendering wired to assistant-ui primitives",
+    ],
+    entry: "apps/docs/components/examples/perplexity.tsx",
+    componentName: "Perplexity",
+    tags: ["assistant-ui", "Perplexity", "clone", "search"],
+    gradient: "from-teal-500/35 via-cyan-300/25 to-zinc-200/20",
+    featured: true,
+    extraSourceFiles: [...COMMON_EXTRA_SOURCE_FILES],
+  },
+};
+
+export const DEMO_DOWNLOAD_SLUGS = Object.keys(
+  DEMO_DOWNLOAD_MANIFESTS,
+) as DemoDownloadSlug[];
+
+export function getDemoDownloadManifest(slug: string) {
+  return DEMO_DOWNLOAD_MANIFESTS[slug as DemoDownloadSlug];
+}

--- a/apps/docs/lib/xulux/demo-downloads/package-versions.ts
+++ b/apps/docs/lib/xulux/demo-downloads/package-versions.ts
@@ -1,0 +1,86 @@
+type Snapshot = Record<string, string>;
+
+const WORKSPACE_PACKAGE_JSON: Record<string, string> = {
+  "@assistant-ui/react": "packages/react/package.json",
+  "@assistant-ui/react-ai-sdk": "packages/react-ai-sdk/package.json",
+  "@assistant-ui/react-lexical": "packages/react-lexical/package.json",
+  "@assistant-ui/react-markdown": "packages/react-markdown/package.json",
+};
+
+export const DEMO_DEPENDENCIES = [
+  "@ai-sdk/openai",
+  "@assistant-ui/react",
+  "@assistant-ui/react-ai-sdk",
+  "@assistant-ui/react-lexical",
+  "@assistant-ui/react-markdown",
+  "@radix-ui/react-icons",
+  "ai",
+  "class-variance-authority",
+  "clsx",
+  "cmdk",
+  "lucide-react",
+  "next",
+  "radix-ui",
+  "react",
+  "react-dom",
+  "remark-gfm",
+  "tailwind-merge",
+  "vaul",
+  "zod",
+  "zustand",
+] as const;
+
+export const DEMO_DEV_DEPENDENCIES = [
+  "@tailwindcss/postcss",
+  "@types/node",
+  "@types/react",
+  "@types/react-dom",
+  "tailwindcss",
+  "typescript",
+] as const;
+
+export function dependencyVersions(
+  snapshot: Snapshot,
+  names: readonly string[],
+) {
+  return Object.fromEntries(
+    names.map((name) => [name, dependencyVersion(snapshot, name)]),
+  );
+}
+
+function dependencyVersion(snapshot: Snapshot, name: string) {
+  const workspacePackagePath = WORKSPACE_PACKAGE_JSON[name];
+  if (workspacePackagePath) {
+    const pkg = packageJsonFromSnapshot(snapshot, workspacePackagePath);
+    if (typeof pkg.version === "string" && pkg.version) {
+      return `^${pkg.version}`;
+    }
+  }
+
+  const docsPkg = packageJsonFromSnapshot(snapshot, "apps/docs/package.json");
+  const version =
+    docsPkg.dependencies?.[name] ??
+    docsPkg.devDependencies?.[name] ??
+    docsPkg.peerDependencies?.[name];
+
+  if (typeof version === "string" && version && version !== "workspace:*") {
+    return version;
+  }
+
+  throw new Error(`No installable version found for ${name}.`);
+}
+
+function packageJsonFromSnapshot(snapshot: Snapshot, snapshotKey: string) {
+  const raw = snapshot[snapshotKey];
+  if (typeof raw !== "string") {
+    throw new Error(
+      `Missing package metadata in source snapshot: ${snapshotKey}`,
+    );
+  }
+  return JSON.parse(raw) as {
+    version?: string;
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+  };
+}

--- a/apps/docs/lib/xulux/demo-downloads/zip.ts
+++ b/apps/docs/lib/xulux/demo-downloads/zip.ts
@@ -6,8 +6,10 @@ export function createZip(files: ZipFileMap) {
   const localParts: Buffer[] = [];
   const centralParts: Buffer[] = [];
   let offset = 0;
+  let entryCount = 0;
 
   for (const [rawName, rawContents] of Object.entries(files).sort()) {
+    entryCount += 1;
     const name = normalizeZipPath(rawName);
     const nameBytes = Buffer.from(encoder.encode(name));
     const contents =
@@ -59,8 +61,8 @@ export function createZip(files: ZipFileMap) {
   end.writeUInt32LE(0x06054b50, 0);
   end.writeUInt16LE(0, 4);
   end.writeUInt16LE(0, 6);
-  end.writeUInt16LE(Object.keys(files).length, 8);
-  end.writeUInt16LE(Object.keys(files).length, 10);
+  end.writeUInt16LE(entryCount, 8);
+  end.writeUInt16LE(entryCount, 10);
   end.writeUInt32LE(centralDirectory.length, 12);
   end.writeUInt32LE(offset, 16);
   end.writeUInt16LE(0, 20);

--- a/apps/docs/lib/xulux/demo-downloads/zip.ts
+++ b/apps/docs/lib/xulux/demo-downloads/zip.ts
@@ -1,0 +1,130 @@
+const encoder = new TextEncoder();
+
+export type ZipFileMap = Record<string, string | Uint8Array>;
+
+export function createZip(files: ZipFileMap) {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const [rawName, rawContents] of Object.entries(files).sort()) {
+    const name = normalizeZipPath(rawName);
+    const nameBytes = Buffer.from(encoder.encode(name));
+    const contents =
+      typeof rawContents === "string"
+        ? Buffer.from(rawContents, "utf8")
+        : Buffer.from(rawContents);
+    const crc = crc32(contents);
+    const localHeader = Buffer.alloc(30);
+
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(0x0800, 6);
+    localHeader.writeUInt16LE(0, 8);
+    localHeader.writeUInt16LE(0, 10);
+    localHeader.writeUInt16LE(0, 12);
+    localHeader.writeUInt32LE(crc, 14);
+    localHeader.writeUInt32LE(contents.length, 18);
+    localHeader.writeUInt32LE(contents.length, 22);
+    localHeader.writeUInt16LE(nameBytes.length, 26);
+    localHeader.writeUInt16LE(0, 28);
+
+    localParts.push(localHeader, nameBytes, contents);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(20, 4);
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt16LE(0x0800, 8);
+    centralHeader.writeUInt16LE(0, 10);
+    centralHeader.writeUInt16LE(0, 12);
+    centralHeader.writeUInt16LE(0, 14);
+    centralHeader.writeUInt32LE(crc, 16);
+    centralHeader.writeUInt32LE(contents.length, 20);
+    centralHeader.writeUInt32LE(contents.length, 24);
+    centralHeader.writeUInt16LE(nameBytes.length, 28);
+    centralHeader.writeUInt16LE(0, 30);
+    centralHeader.writeUInt16LE(0, 32);
+    centralHeader.writeUInt16LE(0, 34);
+    centralHeader.writeUInt16LE(0, 36);
+    centralHeader.writeUInt32LE(0, 38);
+    centralHeader.writeUInt32LE(offset, 42);
+
+    centralParts.push(centralHeader, nameBytes);
+    offset += localHeader.length + nameBytes.length + contents.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(0, 4);
+  end.writeUInt16LE(0, 6);
+  end.writeUInt16LE(Object.keys(files).length, 8);
+  end.writeUInt16LE(Object.keys(files).length, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(offset, 16);
+  end.writeUInt16LE(0, 20);
+
+  return Buffer.concat([...localParts, centralDirectory, end]);
+}
+
+export function listZipEntries(zip: Uint8Array) {
+  const entries: string[] = [];
+  const buffer = Buffer.from(zip);
+  let index = buffer.length - 22;
+
+  while (index >= 0 && buffer.readUInt32LE(index) !== 0x06054b50) {
+    index -= 1;
+  }
+  if (index < 0)
+    throw new Error("Invalid zip: missing end of central directory.");
+
+  const totalEntries = buffer.readUInt16LE(index + 10);
+  let cursor = buffer.readUInt32LE(index + 16);
+
+  for (let i = 0; i < totalEntries; i += 1) {
+    if (buffer.readUInt32LE(cursor) !== 0x02014b50) {
+      throw new Error("Invalid zip: missing central directory header.");
+    }
+    const nameLength = buffer.readUInt16LE(cursor + 28);
+    const extraLength = buffer.readUInt16LE(cursor + 30);
+    const commentLength = buffer.readUInt16LE(cursor + 32);
+    entries.push(
+      buffer.subarray(cursor + 46, cursor + 46 + nameLength).toString("utf8"),
+    );
+    cursor += 46 + nameLength + extraLength + commentLength;
+  }
+
+  return entries;
+}
+
+function normalizeZipPath(path: string) {
+  const normalized = path.replace(/\\/g, "/").replace(/^\/+/, "");
+  if (!normalized || normalized.includes("../")) {
+    throw new Error(`Unsafe zip path: ${path}`);
+  }
+  return normalized;
+}
+
+let crcTable: Uint32Array | undefined;
+
+function crc32(input: Uint8Array) {
+  const table = crcTable ?? (crcTable = createCrcTable());
+  let crc = 0xffffffff;
+  for (const byte of input) {
+    crc = table[(crc ^ byte) & 0xff]! ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function createCrcTable() {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i += 1) {
+    let c = i;
+    for (let j = 0; j < 8; j += 1) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[i] = c >>> 0;
+  }
+  return table;
+}

--- a/apps/docs/lib/xulux/templates-catalog.ts
+++ b/apps/docs/lib/xulux/templates-catalog.ts
@@ -13,6 +13,7 @@ const SUPPORT_BASE_URL =
   "https://8fd186ab9f30417b876d717f734067a9.preview.bl.run";
 
 const CATEGORIES: XuluxTemplateCategory[] = [
+  DEMO_DOWNLOAD_CATEGORY,
   {
     id: "docs",
     name: "Docs and Knowledge",
@@ -25,7 +26,6 @@ const CATEGORIES: XuluxTemplateCategory[] = [
     description:
       "Support triage, troubleshooting, handoffs, and tool-call demos.",
   },
-  DEMO_DOWNLOAD_CATEGORY,
 ];
 
 type HostedTemplateVersion = {
@@ -148,65 +148,74 @@ function docsVersionCards(): XuluxTemplate[] {
     downloadUrl: joinUrl(DOCS_BASE_URL, version.downloadPath),
   }));
 
-  return docsVersions.map((version, index) => ({
-    id: `webpage-assistant-${version.id}`,
-    templateId: "webpage-assistant",
-    versionId: version.id,
-    title: version.title,
-    description: version.description,
-    categoryId: "docs",
-    categoryName: "Docs and Knowledge",
-    tags: version.tags,
-    prompt: version.prompt,
-    gradient: "from-sky-500/40 via-cyan-500/30 to-emerald-400/20",
-    kind: "template",
-    previewStatus: "live",
-    previewUrl: joinUrl(DOCS_BASE_URL, version.previewPath),
-    downloadUrl: joinUrl(DOCS_BASE_URL, version.downloadPath),
-    sandboxBaseUrl: DOCS_BASE_URL,
-    featured: index < 4,
-    versions,
-    intent: {
-      goodFor: version.goodFor,
-      notFor: ["Support ticket triage", "CRM workflows"],
-      exampleUserRequests: [
-        "Build me an API docs assistant for a billing API.",
-        "Create a website copilot that explains the current page.",
-        "Make a docs search assistant that can generate code snippets.",
-      ],
-    },
-    customization: {
-      safeFieldsSummary: [
-        "hostUi docs shell names, default page, nav groups, and rendered pages",
-        "assistant product/docs/assistant names, welcome copy, labels, and suggested prompts",
-        "assistant tools with fixed ids, display metadata, implementation hints, and renderer types",
-        "assistant.demoFlows steps with assistant text, tool order, tool input, mock output, and final response",
-        "brandTheme shared visual tokens",
-        "template-owned contract at /api/template/contract",
-      ],
-      supportedRenderers: [
-        "sourceResults",
-        "pagePreview",
-        "codeSnippet",
-        "generic",
-      ],
-      sourceEditFiles: [
-        "lib/docs/host-ui.ts",
-        "lib/docs/assistant-config.ts",
-        "lib/docs/tool-data.ts",
-        "lib/docs/version-presets.ts",
-        "lib/docs/preview-schema.ts",
-        "lib/docs/download-materializer.ts",
-      ],
-    },
-    tech: {
-      framework: "Next.js",
-      runtime: "assistant-ui + AI SDK",
-      frontendPattern: "Docs assistant",
-    },
-    env: [],
-    canStart: true,
-  }));
+  return docsVersions.map((version, index) => {
+    const gradients = [
+      "from-sky-500/40 via-cyan-500/30 to-emerald-400/20",
+      "from-blue-500/40 via-indigo-500/30 to-violet-400/20",
+      "from-teal-500/40 via-cyan-500/30 to-sky-400/20",
+      "from-indigo-500/40 via-purple-500/30 to-pink-400/20",
+      "from-cyan-500/40 via-sky-500/30 to-blue-400/20",
+    ];
+    return {
+      id: `webpage-assistant-${version.id}`,
+      templateId: "webpage-assistant",
+      versionId: version.id,
+      title: version.title,
+      description: version.description,
+      categoryId: "docs",
+      categoryName: "Docs and Knowledge",
+      tags: version.tags,
+      prompt: version.prompt,
+      gradient: gradients[index % gradients.length],
+      kind: "template",
+      previewStatus: "live",
+      previewUrl: joinUrl(DOCS_BASE_URL, version.previewPath),
+      downloadUrl: joinUrl(DOCS_BASE_URL, version.downloadPath),
+      sandboxBaseUrl: DOCS_BASE_URL,
+      featured: index < 4,
+      versions,
+      intent: {
+        goodFor: version.goodFor,
+        notFor: ["Support ticket triage", "CRM workflows"],
+        exampleUserRequests: [
+          "Build me an API docs assistant for a billing API.",
+          "Create a website copilot that explains the current page.",
+          "Make a docs search assistant that can generate code snippets.",
+        ],
+      },
+      customization: {
+        safeFieldsSummary: [
+          "hostUi docs shell names, default page, nav groups, and rendered pages",
+          "assistant product/docs/assistant names, welcome copy, labels, and suggested prompts",
+          "assistant tools with fixed ids, display metadata, implementation hints, and renderer types",
+          "assistant.demoFlows steps with assistant text, tool order, tool input, mock output, and final response",
+          "brandTheme shared visual tokens",
+          "template-owned contract at /api/template/contract",
+        ],
+        supportedRenderers: [
+          "sourceResults",
+          "pagePreview",
+          "codeSnippet",
+          "generic",
+        ],
+        sourceEditFiles: [
+          "lib/docs/host-ui.ts",
+          "lib/docs/assistant-config.ts",
+          "lib/docs/tool-data.ts",
+          "lib/docs/version-presets.ts",
+          "lib/docs/preview-schema.ts",
+          "lib/docs/download-materializer.ts",
+        ],
+      },
+      tech: {
+        framework: "Next.js",
+        runtime: "assistant-ui + AI SDK",
+        frontendPattern: "Docs assistant",
+      },
+      env: [],
+      canStart: true,
+    };
+  });
 }
 
 function supportVersionCards(): XuluxTemplate[] {
@@ -218,66 +227,68 @@ function supportVersionCards(): XuluxTemplate[] {
     downloadUrl: joinUrl(SUPPORT_BASE_URL, version.downloadPath),
   }));
 
-  return supportVersions.map((version, index) => ({
-    id: `product-page-assistant-${version.id}`,
-    templateId: "product-page-assistant",
-    versionId: version.id,
-    title: version.title,
-    description: version.description,
-    categoryId: "support",
-    categoryName: "Support and Operations",
-    tags: version.tags,
-    prompt: version.prompt,
-    gradient:
-      index === 1
-        ? "from-violet-500/40 via-fuchsia-500/25 to-sky-400/20"
-        : index === 2
-          ? "from-teal-500/40 via-emerald-500/25 to-cyan-400/20"
-          : "from-blue-500/40 via-cyan-500/30 to-teal-400/20",
-    kind: "template",
-    previewStatus: "live",
-    previewUrl: joinUrl(SUPPORT_BASE_URL, version.previewPath),
-    downloadUrl: joinUrl(SUPPORT_BASE_URL, version.downloadPath),
-    sandboxBaseUrl: SUPPORT_BASE_URL,
-    featured: true,
-    versions,
-    intent: {
-      goodFor: version.goodFor,
-      notFor: ["Docs search", "API reference helpers"],
-      exampleUserRequests: [
-        "Build me a support assistant that triages customer issues.",
-        "Create a troubleshooting copilot with two tool calls and a handoff summary.",
-        "Make an integration health assistant for support teams.",
-      ],
-    },
-    customization: {
-      safeFieldsSummary: [
-        "hostUi dashboard shell names, labels, metrics, status lists, and activity content",
-        "assistant company/product/assistant names, welcome copy, labels, prompts, and scenario ids",
-        "assistant tools with fixed ids, display metadata, implementation hints, and card types",
-        "assistant.demoFlows steps with assistant text, tool order, tool input, mock output, and final response",
-        "support-specific assistant.toolData for routing, account status, labels, and scenario metadata",
-        "brandTheme shared visual tokens",
-        "template-owned contract at /api/template/contract",
-      ],
-      supportedRenderers: ["analysis", "summary", "generic"],
-      sourceEditFiles: [
-        "lib/support/host-ui.ts",
-        "lib/support/assistant-config.ts",
-        "lib/support/tool-data.ts",
-        "lib/support/version-presets.ts",
-        "lib/support/preview-schema.ts",
-        "lib/support/download-materializer.ts",
-      ],
-    },
-    tech: {
-      framework: "Next.js",
-      runtime: "assistant-ui + AI SDK",
-      frontendPattern: "Support modal + dashboard",
-    },
-    env: [],
-    canStart: true,
-  }));
+  return supportVersions.map((version, index) => {
+    const gradients = [
+      "from-rose-500/40 via-orange-500/30 to-amber-400/20",
+      "from-violet-500/40 via-fuchsia-500/25 to-sky-400/20",
+      "from-teal-500/40 via-emerald-500/25 to-cyan-400/20",
+    ];
+    return {
+      id: `product-page-assistant-${version.id}`,
+      templateId: "product-page-assistant",
+      versionId: version.id,
+      title: version.title,
+      description: version.description,
+      categoryId: "support",
+      categoryName: "Support and Operations",
+      tags: version.tags,
+      prompt: version.prompt,
+      gradient: gradients[index % gradients.length],
+      kind: "template",
+      previewStatus: "live",
+      previewUrl: joinUrl(SUPPORT_BASE_URL, version.previewPath),
+      downloadUrl: joinUrl(SUPPORT_BASE_URL, version.downloadPath),
+      sandboxBaseUrl: SUPPORT_BASE_URL,
+      featured: true,
+      versions,
+      intent: {
+        goodFor: version.goodFor,
+        notFor: ["Docs search", "API reference helpers"],
+        exampleUserRequests: [
+          "Build me a support assistant that triages customer issues.",
+          "Create a troubleshooting copilot with two tool calls and a handoff summary.",
+          "Make an integration health assistant for support teams.",
+        ],
+      },
+      customization: {
+        safeFieldsSummary: [
+          "hostUi dashboard shell names, labels, metrics, status lists, and activity content",
+          "assistant company/product/assistant names, welcome copy, labels, prompts, and scenario ids",
+          "assistant tools with fixed ids, display metadata, implementation hints, and card types",
+          "assistant.demoFlows steps with assistant text, tool order, tool input, mock output, and final response",
+          "support-specific assistant.toolData for routing, account status, labels, and scenario metadata",
+          "brandTheme shared visual tokens",
+          "template-owned contract at /api/template/contract",
+        ],
+        supportedRenderers: ["analysis", "summary", "generic"],
+        sourceEditFiles: [
+          "lib/support/host-ui.ts",
+          "lib/support/assistant-config.ts",
+          "lib/support/tool-data.ts",
+          "lib/support/version-presets.ts",
+          "lib/support/preview-schema.ts",
+          "lib/support/download-materializer.ts",
+        ],
+      },
+      tech: {
+        framework: "Next.js",
+        runtime: "assistant-ui + AI SDK",
+        frontendPattern: "Support modal + dashboard",
+      },
+      env: [],
+      canStart: true,
+    };
+  });
 }
 
 function demoCards(): XuluxTemplate[] {
@@ -319,9 +330,9 @@ export function getXuluxHostedTemplatesCatalog(): XuluxTemplateCatalog {
   return {
     categories: CATEGORIES,
     templates: [
+      ...demoCards(),
       ...docsVersionCards(),
       ...supportVersionCards(),
-      ...demoCards(),
     ],
   };
 }

--- a/apps/docs/lib/xulux/templates-catalog.ts
+++ b/apps/docs/lib/xulux/templates-catalog.ts
@@ -139,6 +139,10 @@ function joinUrl(baseUrl: string, path: string) {
   return `${baseUrl}${path}`;
 }
 
+function pickGradient(gradients: readonly string[], index: number): string {
+  return gradients[index % gradients.length] ?? gradients[0]!;
+}
+
 function docsVersionCards(): XuluxTemplate[] {
   const versions = docsVersions.map((version) => ({
     id: version.id,
@@ -166,7 +170,7 @@ function docsVersionCards(): XuluxTemplate[] {
       categoryName: "Docs and Knowledge",
       tags: version.tags,
       prompt: version.prompt,
-      gradient: gradients[index % gradients.length],
+      gradient: pickGradient(gradients, index),
       kind: "template",
       previewStatus: "live",
       previewUrl: joinUrl(DOCS_BASE_URL, version.previewPath),
@@ -243,7 +247,7 @@ function supportVersionCards(): XuluxTemplate[] {
       categoryName: "Support and Operations",
       tags: version.tags,
       prompt: version.prompt,
-      gradient: gradients[index % gradients.length],
+      gradient: pickGradient(gradients, index),
       kind: "template",
       previewStatus: "live",
       previewUrl: joinUrl(SUPPORT_BASE_URL, version.previewPath),

--- a/apps/docs/lib/xulux/templates-catalog.ts
+++ b/apps/docs/lib/xulux/templates-catalog.ts
@@ -1,0 +1,327 @@
+import type {
+  XuluxTemplate,
+  XuluxTemplateCatalog,
+  XuluxTemplateCategory,
+} from "@/components/xulux/templates/types";
+import {
+  DEMO_DOWNLOAD_CATEGORY,
+  DEMO_DOWNLOAD_MANIFESTS,
+} from "@/lib/xulux/demo-downloads/manifest";
+
+const DOCS_BASE_URL = "https://0d9e27d14127c0eeadfc34b424cc7ed0.preview.bl.run";
+const SUPPORT_BASE_URL =
+  "https://8fd186ab9f30417b876d717f734067a9.preview.bl.run";
+
+const CATEGORIES: XuluxTemplateCategory[] = [
+  {
+    id: "docs",
+    name: "Docs and Knowledge",
+    description:
+      "Docs, API references, website guidance, search, and examples.",
+  },
+  {
+    id: "support",
+    name: "Support and Operations",
+    description:
+      "Support triage, troubleshooting, handoffs, and tool-call demos.",
+  },
+  DEMO_DOWNLOAD_CATEGORY,
+];
+
+type HostedTemplateVersion = {
+  id: string;
+  title: string;
+  description: string;
+  goodFor: string[];
+  previewPath: string;
+  downloadPath: string;
+  tags: string[];
+  prompt: string;
+};
+
+const docsVersions: HostedTemplateVersion[] = [
+  {
+    id: "product-docs",
+    title: "Product Docs Assistant",
+    description:
+      "Answers product documentation questions beside a SaaS docs article.",
+    goodFor: ["Product guides", "Onboarding docs", "Release notes"],
+    previewPath: "/preview?v=product-docs",
+    downloadPath: "/api/download?v=product-docs",
+    tags: ["Docs", "Product", "Guides"],
+    prompt:
+      "Spin up a product docs assistant for onboarding and release notes.",
+  },
+  {
+    id: "developer-api",
+    title: "Developer API Integration Assistant",
+    description:
+      "Helps developers debug API setup, auth, SDKs, webhooks, and errors.",
+    goodFor: ["API authentication", "Webhook handlers", "SDK setup"],
+    previewPath: "/preview?v=developer-api",
+    downloadPath: "/api/download?v=developer-api",
+    tags: ["API", "Developers", "Webhooks"],
+    prompt: "Spin up an API docs assistant for debugging auth and webhooks.",
+  },
+  {
+    id: "website-copilot",
+    title: "Website Page Copilot",
+    description:
+      "Explains the current site page and suggests the visitor's next action.",
+    goodFor: ["Marketing pages", "Pricing guidance", "Visitor help"],
+    previewPath: "/preview?v=website-copilot",
+    downloadPath: "/api/download?v=website-copilot",
+    tags: ["Website", "Copilot", "Guidance"],
+    prompt: "Spin up a website copilot that explains pages and next steps.",
+  },
+  {
+    id: "docs-search",
+    title: "Search-and-Navigate Docs Helper",
+    description:
+      "Prioritizes source search and page preview navigation across a docs corpus.",
+    goodFor: ["Docs search", "Source previews", "Knowledge base navigation"],
+    previewPath: "/preview?v=docs-search",
+    downloadPath: "/api/download?v=docs-search",
+    tags: ["Search", "Knowledge Base", "Navigation"],
+    prompt: "Spin up a docs search assistant with source previews.",
+  },
+  {
+    id: "code-examples",
+    title: "Code Example Generator",
+    description:
+      "Focuses on generating implementation snippets grounded in docs context.",
+    goodFor: ["curl snippets", "TypeScript examples", "Webhook examples"],
+    previewPath: "/preview?v=code-examples",
+    downloadPath: "/api/download?v=code-examples",
+    tags: ["Code", "Snippets", "Examples"],
+    prompt: "Spin up a docs-backed code example generator.",
+  },
+];
+
+const supportVersions: HostedTemplateVersion[] = [
+  {
+    id: "integration-health",
+    title: "Integration Health Assistant",
+    description:
+      "Triage sync delays, connector health, and access issues for integration teams.",
+    goodFor: ["Connector health", "Sync delays", "Integration access"],
+    previewPath: "/preview?v=integration-health",
+    downloadPath: "/api/download?v=integration-health",
+    tags: ["Support", "Integrations", "Sync"],
+    prompt:
+      "Spin up an integration health assistant for connector support teams.",
+  },
+  {
+    id: "incident-command",
+    title: "Incident Command Assistant",
+    description:
+      "Prepare incident triage notes for reliability and on-call teams.",
+    goodFor: ["Incident triage", "On-call handoffs", "Reliability workflows"],
+    previewPath: "/preview?v=incident-command",
+    downloadPath: "/api/download?v=incident-command",
+    tags: ["Incident", "On-call", "Reliability"],
+    prompt: "Spin up an incident command assistant for on-call teams.",
+  },
+  {
+    id: "billing-operations",
+    title: "Billing Operations Assistant",
+    description:
+      "Triage payment, invoice, and account-access issues for revenue teams.",
+    goodFor: ["Payment issues", "Invoice access", "Finance handoffs"],
+    previewPath: "/preview?v=billing-operations",
+    downloadPath: "/api/download?v=billing-operations",
+    tags: ["Billing", "Finance", "Operations"],
+    prompt: "Spin up a billing operations assistant for finance support.",
+  },
+];
+
+function joinUrl(baseUrl: string, path: string) {
+  return `${baseUrl}${path}`;
+}
+
+function docsVersionCards(): XuluxTemplate[] {
+  const versions = docsVersions.map((version) => ({
+    id: version.id,
+    title: version.title,
+    description: version.description,
+    previewUrl: joinUrl(DOCS_BASE_URL, version.previewPath),
+    downloadUrl: joinUrl(DOCS_BASE_URL, version.downloadPath),
+  }));
+
+  return docsVersions.map((version, index) => ({
+    id: `webpage-assistant-${version.id}`,
+    templateId: "webpage-assistant",
+    versionId: version.id,
+    title: version.title,
+    description: version.description,
+    categoryId: "docs",
+    categoryName: "Docs and Knowledge",
+    tags: version.tags,
+    prompt: version.prompt,
+    gradient: "from-sky-500/40 via-cyan-500/30 to-emerald-400/20",
+    kind: "template",
+    previewStatus: "live",
+    previewUrl: joinUrl(DOCS_BASE_URL, version.previewPath),
+    downloadUrl: joinUrl(DOCS_BASE_URL, version.downloadPath),
+    sandboxBaseUrl: DOCS_BASE_URL,
+    featured: index < 4,
+    versions,
+    intent: {
+      goodFor: version.goodFor,
+      notFor: ["Support ticket triage", "CRM workflows"],
+      exampleUserRequests: [
+        "Build me an API docs assistant for a billing API.",
+        "Create a website copilot that explains the current page.",
+        "Make a docs search assistant that can generate code snippets.",
+      ],
+    },
+    customization: {
+      safeFieldsSummary: [
+        "hostUi docs shell names, default page, nav groups, and rendered pages",
+        "assistant product/docs/assistant names, welcome copy, labels, and suggested prompts",
+        "assistant tools with fixed ids, display metadata, implementation hints, and renderer types",
+        "assistant.demoFlows steps with assistant text, tool order, tool input, mock output, and final response",
+        "brandTheme shared visual tokens",
+        "template-owned contract at /api/template/contract",
+      ],
+      supportedRenderers: [
+        "sourceResults",
+        "pagePreview",
+        "codeSnippet",
+        "generic",
+      ],
+      sourceEditFiles: [
+        "lib/docs/host-ui.ts",
+        "lib/docs/assistant-config.ts",
+        "lib/docs/tool-data.ts",
+        "lib/docs/version-presets.ts",
+        "lib/docs/preview-schema.ts",
+        "lib/docs/download-materializer.ts",
+      ],
+    },
+    tech: {
+      framework: "Next.js",
+      runtime: "assistant-ui + AI SDK",
+      frontendPattern: "Docs assistant",
+    },
+    env: [],
+    canStart: true,
+  }));
+}
+
+function supportVersionCards(): XuluxTemplate[] {
+  const versions = supportVersions.map((version) => ({
+    id: version.id,
+    title: version.title,
+    description: version.description,
+    previewUrl: joinUrl(SUPPORT_BASE_URL, version.previewPath),
+    downloadUrl: joinUrl(SUPPORT_BASE_URL, version.downloadPath),
+  }));
+
+  return supportVersions.map((version, index) => ({
+    id: `product-page-assistant-${version.id}`,
+    templateId: "product-page-assistant",
+    versionId: version.id,
+    title: version.title,
+    description: version.description,
+    categoryId: "support",
+    categoryName: "Support and Operations",
+    tags: version.tags,
+    prompt: version.prompt,
+    gradient:
+      index === 1
+        ? "from-violet-500/40 via-fuchsia-500/25 to-sky-400/20"
+        : index === 2
+          ? "from-teal-500/40 via-emerald-500/25 to-cyan-400/20"
+          : "from-blue-500/40 via-cyan-500/30 to-teal-400/20",
+    kind: "template",
+    previewStatus: "live",
+    previewUrl: joinUrl(SUPPORT_BASE_URL, version.previewPath),
+    downloadUrl: joinUrl(SUPPORT_BASE_URL, version.downloadPath),
+    sandboxBaseUrl: SUPPORT_BASE_URL,
+    featured: true,
+    versions,
+    intent: {
+      goodFor: version.goodFor,
+      notFor: ["Docs search", "API reference helpers"],
+      exampleUserRequests: [
+        "Build me a support assistant that triages customer issues.",
+        "Create a troubleshooting copilot with two tool calls and a handoff summary.",
+        "Make an integration health assistant for support teams.",
+      ],
+    },
+    customization: {
+      safeFieldsSummary: [
+        "hostUi dashboard shell names, labels, metrics, status lists, and activity content",
+        "assistant company/product/assistant names, welcome copy, labels, prompts, and scenario ids",
+        "assistant tools with fixed ids, display metadata, implementation hints, and card types",
+        "assistant.demoFlows steps with assistant text, tool order, tool input, mock output, and final response",
+        "support-specific assistant.toolData for routing, account status, labels, and scenario metadata",
+        "brandTheme shared visual tokens",
+        "template-owned contract at /api/template/contract",
+      ],
+      supportedRenderers: ["analysis", "summary", "generic"],
+      sourceEditFiles: [
+        "lib/support/host-ui.ts",
+        "lib/support/assistant-config.ts",
+        "lib/support/tool-data.ts",
+        "lib/support/version-presets.ts",
+        "lib/support/preview-schema.ts",
+        "lib/support/download-materializer.ts",
+      ],
+    },
+    tech: {
+      framework: "Next.js",
+      runtime: "assistant-ui + AI SDK",
+      frontendPattern: "Support modal + dashboard",
+    },
+    env: [],
+    canStart: true,
+  }));
+}
+
+function demoCards(): XuluxTemplate[] {
+  return Object.values(DEMO_DOWNLOAD_MANIFESTS).map((demo) => ({
+    id: demo.slug,
+    title: demo.name,
+    description: demo.description,
+    categoryId: DEMO_DOWNLOAD_CATEGORY.id,
+    categoryName: DEMO_DOWNLOAD_CATEGORY.name,
+    tags: demo.tags,
+    prompt: `Open the ${demo.name} demo.`,
+    gradient: demo.gradient,
+    kind: "example",
+    previewStatus: "live",
+    previewUrl: `/demos/${demo.slug}`,
+    downloadUrl: `/api/xulux/demo-download?slug=${demo.slug}`,
+    sourcePath: demo.entry,
+    docsUrl: `/demos/${demo.slug}`,
+    featured: demo.featured,
+    tech: {
+      framework: "Next.js",
+      runtime: "assistant-ui + AI SDK",
+      frontendPattern: "Fixed demo",
+    },
+    env: [
+      {
+        name: "OPENAI_API_KEY",
+        required: false,
+        secret: true,
+        description:
+          "Optional. Enables live AI responses in the downloaded starter app.",
+      },
+    ],
+    canStart: true,
+  }));
+}
+
+export function getXuluxHostedTemplatesCatalog(): XuluxTemplateCatalog {
+  return {
+    categories: CATEGORIES,
+    templates: [
+      ...docsVersionCards(),
+      ...supportVersionCards(),
+      ...demoCards(),
+    ],
+  };
+}

--- a/apps/docs/lib/xulux/thread-welcome.ts
+++ b/apps/docs/lib/xulux/thread-welcome.ts
@@ -1,0 +1,382 @@
+import type { SelectedTemplateContext } from "@/components/xulux/XuluxApp";
+import { getDemoDownloadManifest } from "@/lib/xulux/demo-downloads/manifest";
+import { getXuluxHostedTemplatesCatalog } from "@/lib/xulux/templates-catalog";
+
+export type XuluxThreadWelcomeSuggestion = {
+  label: string;
+  prompt: string;
+};
+
+export type XuluxThreadWelcome = {
+  headline: string;
+  body: string;
+  composerPlaceholder: string;
+  suggestions: XuluxThreadWelcomeSuggestion[];
+};
+
+const DEFAULT_WELCOME: XuluxThreadWelcome = {
+  headline: "What should we build?",
+  body: "Describe an app idea or open a template preview to customize it with Xulux.",
+  composerPlaceholder: "Ask Xulux to build or refine the UI...",
+  suggestions: [
+    {
+      label: "ChatGPT style app",
+      prompt:
+        "Build me a ChatGPT-style chat app with assistant-ui — empty state, composer, and message layout.",
+    },
+    {
+      label: "docs assistant",
+      prompt:
+        "Build a SaaS product docs site with a sidebar assistant for onboarding guides.",
+    },
+    {
+      label: "website copilot",
+      prompt:
+        "Build a marketing website with an on-page copilot that explains each page.",
+    },
+  ],
+};
+
+const DEMO_WELCOME_OVERRIDES: Record<
+  string,
+  Pick<XuluxThreadWelcome, "suggestions" | "composerPlaceholder">
+> = {
+  chatgpt: {
+    composerPlaceholder:
+      "Ask to customize the ChatGPT-style layout, tools, or theme...",
+    suggestions: [
+      {
+        label: "dark mode polish",
+        prompt:
+          "Customize this ChatGPT-style demo for dark mode — composer, message surface, and empty state.",
+      },
+      {
+        label: "tool menu",
+        prompt:
+          "Update the tools menu and suggested prompts for a developer productivity assistant.",
+      },
+      {
+        label: "download starter",
+        prompt:
+          "Open this ChatGPT-style demo and give me the download link with setup notes.",
+      },
+    ],
+  },
+  claude: {
+    composerPlaceholder:
+      "Ask to customize the Claude-style layout, typography, or actions...",
+    suggestions: [
+      {
+        label: "warm typography",
+        prompt:
+          "Customize this Claude-style demo with warmer serif typography and document-like messages.",
+      },
+      {
+        label: "file attachments",
+        prompt:
+          "Tune the attachment controls and welcome copy for a research assistant.",
+      },
+      {
+        label: "download starter",
+        prompt:
+          "Open this Claude-style demo and give me the download link with setup notes.",
+      },
+    ],
+  },
+  grok: {
+    composerPlaceholder:
+      "Ask to customize the Grok-style layout, branding, or controls...",
+    suggestions: [
+      {
+        label: "centered composer",
+        prompt:
+          "Customize this Grok-style demo with a centered composer and minimal dark branding.",
+      },
+      {
+        label: "message actions",
+        prompt:
+          "Update message actions and suggested prompts for a concise Q&A assistant.",
+      },
+      {
+        label: "download starter",
+        prompt:
+          "Open this Grok-style demo and give me the download link with setup notes.",
+      },
+    ],
+  },
+};
+
+const DOCS_VERSION_WELCOME: Record<
+  string,
+  Pick<XuluxThreadWelcome, "suggestions" | "composerPlaceholder">
+> = {
+  "product-docs": {
+    composerPlaceholder:
+      "Ask to customize product name, docs pages, or welcome copy...",
+    suggestions: [
+      {
+        label: "rebrand product",
+        prompt:
+          "Rebrand this product docs template for a SaaS called Acme Cloud with onboarding-focused welcome copy.",
+      },
+      {
+        label: "add docs page",
+        prompt:
+          "Add a Quickstart docs page with setup steps and update the left nav.",
+      },
+      {
+        label: "tune prompt chips",
+        prompt:
+          "Update the in-app suggested prompts for onboarding and release notes.",
+      },
+    ],
+  },
+  "developer-api": {
+    composerPlaceholder:
+      "Ask to customize API branding, docs pages, or assistant prompts...",
+    suggestions: [
+      {
+        label: "rebrand API",
+        prompt:
+          'Rebrand this developer API docs template for "Nimbus API" with auth and webhook-focused welcome copy.',
+      },
+      {
+        label: "add auth page",
+        prompt:
+          "Add an Authentication docs page covering API keys, OAuth, and error handling.",
+      },
+      {
+        label: "tune prompt chips",
+        prompt:
+          "Update the in-app suggested prompts for 401 debugging and webhook setup.",
+      },
+    ],
+  },
+  "website-copilot": {
+    composerPlaceholder:
+      "Ask to customize site pages, copilot copy, or visitor guidance...",
+    suggestions: [
+      {
+        label: "rebrand site",
+        prompt:
+          "Rebrand this website copilot template for a B2B analytics product with pricing and product pages.",
+      },
+      {
+        label: "pricing guidance",
+        prompt:
+          "Customize the pricing page and copilot welcome copy to explain plans and next steps.",
+      },
+      {
+        label: "tune prompt chips",
+        prompt:
+          "Update the in-app suggested prompts for page explanations and visitor help.",
+      },
+    ],
+  },
+  "docs-search": {
+    composerPlaceholder:
+      "Ask to customize search flows, docs pages, or preview navigation...",
+    suggestions: [
+      {
+        label: "rebrand docs",
+        prompt:
+          "Rebrand this docs search template for an internal knowledge base called Atlas Docs.",
+      },
+      {
+        label: "search prompts",
+        prompt:
+          "Update welcome copy and suggested prompts for docs search and page previews.",
+      },
+      {
+        label: "add corpus page",
+        prompt:
+          "Add a docs page about webhooks and link it in the nav for search demos.",
+      },
+    ],
+  },
+  "code-examples": {
+    composerPlaceholder:
+      "Ask to customize snippet flows, docs pages, or example prompts...",
+    suggestions: [
+      {
+        label: "rebrand generator",
+        prompt:
+          "Rebrand this code example generator for a payments API with SDK-focused welcome copy.",
+      },
+      {
+        label: "snippet prompts",
+        prompt:
+          "Update suggested prompts for curl, TypeScript, and webhook handler examples.",
+      },
+      {
+        label: "add examples page",
+        prompt:
+          "Add a Webhooks docs page with keywords for grounded snippet generation.",
+      },
+    ],
+  },
+};
+
+const SUPPORT_VERSION_WELCOME: Record<
+  string,
+  Pick<XuluxThreadWelcome, "suggestions" | "composerPlaceholder">
+> = {
+  "integration-health": {
+    composerPlaceholder:
+      "Ask to customize the dashboard, support persona, or handoff flows...",
+    suggestions: [
+      {
+        label: "rebrand dashboard",
+        prompt:
+          "Customize the integration health template for a data pipeline product called Pipestream.",
+      },
+      {
+        label: "sync failure flow",
+        prompt:
+          "Tune the support welcome message and suggested prompts for connector sync failures.",
+      },
+      {
+        label: "dashboard panels",
+        prompt:
+          "Update the dashboard panels to highlight connector status and recent sync delays.",
+      },
+    ],
+  },
+  "incident-command": {
+    composerPlaceholder:
+      "Ask to customize incident triage copy, dashboard panels, or handoffs...",
+    suggestions: [
+      {
+        label: "on-call persona",
+        prompt:
+          "Customize the incident command template for a reliability team at CloudScale.",
+      },
+      {
+        label: "triage prompts",
+        prompt:
+          "Update suggested prompts for incident triage and on-call handoff notes.",
+      },
+      {
+        label: "dashboard panels",
+        prompt:
+          "Update dashboard panels for active incidents, severity, and recent alerts.",
+      },
+    ],
+  },
+  "billing-operations": {
+    composerPlaceholder:
+      "Ask to customize billing support copy, dashboard panels, or handoffs...",
+    suggestions: [
+      {
+        label: "finance persona",
+        prompt:
+          "Customize the billing operations template for a subscription billing team at Ledgerly.",
+      },
+      {
+        label: "payment prompts",
+        prompt:
+          "Update suggested prompts for invoice access, failed payments, and finance handoffs.",
+      },
+      {
+        label: "dashboard panels",
+        prompt:
+          "Update dashboard panels for payment issues, open invoices, and account access.",
+      },
+    ],
+  },
+};
+
+function findCatalogEntry(template: SelectedTemplateContext) {
+  const { templates } = getXuluxHostedTemplatesCatalog();
+  return (
+    templates.find((entry) => entry.id === template.id) ??
+    templates.find(
+      (entry) =>
+        entry.templateId === template.templateId &&
+        entry.versionId === template.versionId,
+    )
+  );
+}
+
+function hostedWelcomeOverrides(
+  template: SelectedTemplateContext,
+): Pick<XuluxThreadWelcome, "suggestions" | "composerPlaceholder"> | undefined {
+  const versionId = template.versionId;
+  if (!versionId) return undefined;
+
+  if (template.templateId === "webpage-assistant") {
+    return DOCS_VERSION_WELCOME[versionId];
+  }
+  if (template.templateId === "product-page-assistant") {
+    return SUPPORT_VERSION_WELCOME[versionId];
+  }
+  return undefined;
+}
+
+function demoWelcomeOverrides(
+  template: SelectedTemplateContext,
+): Pick<XuluxThreadWelcome, "suggestions" | "composerPlaceholder"> | undefined {
+  const slug = template.id;
+  return DEMO_WELCOME_OVERRIDES[slug];
+}
+
+function exampleRequestsSuggestions(
+  template: SelectedTemplateContext,
+): XuluxThreadWelcomeSuggestion[] {
+  const entry = findCatalogEntry(template);
+  const examples = entry?.intent?.exampleUserRequests ?? [];
+  return examples.slice(0, 3).map((prompt, index) => ({
+    label: `idea ${index + 1}`,
+    prompt,
+  }));
+}
+
+export function getXuluxThreadWelcome(
+  template: SelectedTemplateContext | null | undefined,
+): XuluxThreadWelcome {
+  if (!template) {
+    return DEFAULT_WELCOME;
+  }
+
+  const catalogEntry = findCatalogEntry(template);
+  const headline = template.title;
+  const body =
+    template.kind === "example"
+      ? (getDemoDownloadManifest(template.id)?.tagline ?? template.description)
+      : `${template.description} Ask Xulux to customize branding, copy, pages, or demo flows.`;
+
+  const overrides =
+    template.kind === "example"
+      ? demoWelcomeOverrides(template)
+      : hostedWelcomeOverrides(template);
+
+  const suggestions =
+    overrides?.suggestions ??
+    (catalogEntry?.prompt
+      ? [
+          {
+            label: "open preview",
+            prompt: `Open the ${template.title} template and show me the live preview.`,
+          },
+          {
+            label: "customize branding",
+            prompt: `Customize branding and welcome copy on the ${template.title} template.`,
+          },
+          ...exampleRequestsSuggestions(template),
+        ].slice(0, 3)
+      : exampleRequestsSuggestions(template));
+
+  const composerPlaceholder =
+    overrides?.composerPlaceholder ??
+    (template.kind === "template"
+      ? "Ask to customize this template — branding, pages, copy, or flows..."
+      : "Ask to customize this example or get the download link...");
+
+  return {
+    headline,
+    body,
+    composerPlaceholder,
+    suggestions:
+      suggestions.length > 0 ? suggestions : DEFAULT_WELCOME.suggestions,
+  };
+}

--- a/apps/docs/lib/xulux/usage-budget-codes.ts
+++ b/apps/docs/lib/xulux/usage-budget-codes.ts
@@ -1,0 +1,130 @@
+export type BudgetDenyCode =
+  | "CHAT_TURN_LIMIT"
+  | "CHAT_BUDGET_EXCEEDED"
+  | "DAILY_BUDGET_EXCEEDED"
+  | "DAILY_CHAT_LIMIT";
+
+export type BudgetLimits = {
+  chatBudgetMicroUsd: number;
+  dailyBudgetMicroUsd: number;
+  maxTurnsPerChat: number;
+  maxChatsPerDay: number;
+};
+
+export type BudgetSnapshot = {
+  sessionTurns: number;
+  sessionSpentMicroUsd: number;
+  dailySpentMicroUsd: number;
+  dailyChatCount: number;
+  isNewSession: boolean;
+};
+
+export type TokenUsage = {
+  inputTokens?: number | undefined;
+  outputTokens?: number | undefined;
+};
+
+const DEFAULT_INPUT_MICRO_USD_PER_M = 250_000;
+const DEFAULT_OUTPUT_MICRO_USD_PER_M = 2_000_000;
+
+export function usdToMicroUsd(usd: number): number {
+  return Math.round(usd * 1_000_000);
+}
+
+/** Product defaults — used when env vars are unset. */
+export const DEFAULT_BUDGET_LIMITS: BudgetLimits = {
+  chatBudgetMicroUsd: usdToMicroUsd(1),
+  dailyBudgetMicroUsd: usdToMicroUsd(2),
+  maxTurnsPerChat: 8,
+  maxChatsPerDay: 10,
+};
+
+export function parseUsdEnv(name: string, fallbackUsd: number): number {
+  const raw = process.env[name];
+  if (!raw) return usdToMicroUsd(fallbackUsd);
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0)
+    return usdToMicroUsd(fallbackUsd);
+  return usdToMicroUsd(parsed);
+}
+
+export function parseIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+export function getBudgetLimits(): BudgetLimits {
+  return {
+    chatBudgetMicroUsd: parseUsdEnv(
+      "XULUX_CHAT_BUDGET_USD",
+      DEFAULT_BUDGET_LIMITS.chatBudgetMicroUsd / 1_000_000,
+    ),
+    dailyBudgetMicroUsd: parseUsdEnv(
+      "XULUX_DAILY_BUDGET_USD",
+      DEFAULT_BUDGET_LIMITS.dailyBudgetMicroUsd / 1_000_000,
+    ),
+    maxTurnsPerChat: parseIntEnv(
+      "XULUX_MAX_TURNS_PER_CHAT",
+      DEFAULT_BUDGET_LIMITS.maxTurnsPerChat,
+    ),
+    maxChatsPerDay: parseIntEnv(
+      "XULUX_MAX_CHATS_PER_DAY",
+      DEFAULT_BUDGET_LIMITS.maxChatsPerDay,
+    ),
+  };
+}
+
+export function estimateMicroUsd(usage: TokenUsage, _modelId?: string): number {
+  const inputTokens = usage.inputTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? 0;
+  const inputMicro = (inputTokens * DEFAULT_INPUT_MICRO_USD_PER_M) / 1_000_000;
+  const outputMicro =
+    (outputTokens * DEFAULT_OUTPUT_MICRO_USD_PER_M) / 1_000_000;
+  return Math.max(1, Math.ceil(inputMicro + outputMicro));
+}
+
+export function evaluateBudget(
+  snap: BudgetSnapshot,
+  limits: BudgetLimits,
+): BudgetDenyCode | null {
+  if (snap.dailySpentMicroUsd >= limits.dailyBudgetMicroUsd) {
+    return "DAILY_BUDGET_EXCEEDED";
+  }
+  if (snap.sessionTurns >= limits.maxTurnsPerChat) {
+    return "CHAT_TURN_LIMIT";
+  }
+  if (snap.sessionSpentMicroUsd >= limits.chatBudgetMicroUsd) {
+    return "CHAT_BUDGET_EXCEEDED";
+  }
+  if (snap.isNewSession && snap.dailyChatCount >= limits.maxChatsPerDay) {
+    return "DAILY_CHAT_LIMIT";
+  }
+  return null;
+}
+
+export function budgetDenyMessage(
+  code: BudgetDenyCode,
+  limits: BudgetLimits,
+): string {
+  switch (code) {
+    case "CHAT_TURN_LIMIT":
+      return `This chat reached the ${limits.maxTurnsPerChat}-message limit. Start a new chat to continue.`;
+    case "CHAT_BUDGET_EXCEEDED":
+      return `This chat reached the ~$${limits.chatBudgetMicroUsd / 1_000_000} usage limit. Start a new chat to continue.`;
+    case "DAILY_BUDGET_EXCEEDED":
+      return `Daily usage limit reached (~$${limits.dailyBudgetMicroUsd / 1_000_000}). Try again tomorrow.`;
+    case "DAILY_CHAT_LIMIT":
+      return `You reached the ${limits.maxChatsPerDay}-chat limit for today. Try again tomorrow.`;
+  }
+}
+
+export function isDailyLimitCode(code: BudgetDenyCode): boolean {
+  return code === "DAILY_BUDGET_EXCEEDED" || code === "DAILY_CHAT_LIMIT";
+}
+
+export function utcDateKey(date = new Date()): string {
+  return date.toISOString().slice(0, 10);
+}

--- a/apps/docs/lib/xulux/usage-budget.ts
+++ b/apps/docs/lib/xulux/usage-budget.ts
@@ -1,0 +1,282 @@
+import type { Redis } from "@upstash/redis";
+import {
+  budgetDenyMessage,
+  evaluateBudget,
+  estimateMicroUsd,
+  getBudgetLimits,
+  utcDateKey,
+  type BudgetDenyCode,
+  type TokenUsage,
+} from "./usage-budget-codes";
+
+export type {
+  BudgetDenyCode,
+  BudgetLimits,
+  BudgetSnapshot,
+} from "./usage-budget-codes";
+export {
+  evaluateBudget,
+  estimateMicroUsd,
+  getBudgetLimits,
+  budgetDenyMessage,
+  isDailyLimitCode,
+} from "./usage-budget-codes";
+
+const SESSION_TTL_SEC = 7 * 24 * 60 * 60;
+const DAY_TTL_SEC = 48 * 60 * 60;
+
+function sessionTurnsKey(sessionId: string): string {
+  return `xulux:sess:${sessionId}:turns`;
+}
+
+function sessionSpentKey(sessionId: string): string {
+  return `xulux:sess:${sessionId}:spent`;
+}
+
+function dailySpentKey(distinctId: string, date: string): string {
+  return `xulux:day:${distinctId}:${date}:spent`;
+}
+
+function dailySessionsKey(distinctId: string, date: string): string {
+  return `xulux:day:${distinctId}:${date}:sessions`;
+}
+
+function sessionRegisteredKey(sessionId: string, date: string): string {
+  return `xulux:sess:${sessionId}:reg:${date}`;
+}
+
+export function isUsageBudgetEnabled(): boolean {
+  if (process.env.XULUX_USAGE_BUDGET_ENABLED === "0") return false;
+  return true;
+}
+
+type UsageBudgetStore = {
+  loadSnapshot: (
+    sessionId: string,
+    distinctId: string,
+    date: string,
+  ) => Promise<import("./usage-budget-codes").BudgetSnapshot>;
+  registerChat: (
+    sessionId: string,
+    distinctId: string,
+    date: string,
+  ) => Promise<number>;
+  incrementTurn: (sessionId: string) => Promise<number>;
+  addSpend: (
+    sessionId: string,
+    distinctId: string,
+    date: string,
+    microUsd: number,
+  ) => Promise<void>;
+};
+
+function createMemoryStore(): UsageBudgetStore {
+  const turns = new Map<string, number>();
+  const sessionSpent = new Map<string, number>();
+  const dailySpent = new Map<string, number>();
+  const dailySessions = new Map<string, Set<string>>();
+  const registered = new Set<string>();
+
+  return {
+    async loadSnapshot(sessionId, distinctId, date) {
+      const sessionTurns = turns.get(sessionId) ?? 0;
+      return {
+        sessionTurns,
+        sessionSpentMicroUsd: sessionSpent.get(sessionId) ?? 0,
+        dailySpentMicroUsd: dailySpent.get(`${distinctId}:${date}`) ?? 0,
+        dailyChatCount: dailySessions.get(`${distinctId}:${date}`)?.size ?? 0,
+        isNewSession:
+          sessionTurns === 0 && !registered.has(`${sessionId}:${date}`),
+      };
+    },
+    async registerChat(sessionId, distinctId, date) {
+      const regKey = `${sessionId}:${date}`;
+      if (registered.has(regKey)) {
+        return dailySessions.get(`${distinctId}:${date}`)?.size ?? 0;
+      }
+      registered.add(regKey);
+      const dayKey = `${distinctId}:${date}`;
+      const set = dailySessions.get(dayKey) ?? new Set<string>();
+      set.add(sessionId);
+      dailySessions.set(dayKey, set);
+      return set.size;
+    },
+    async incrementTurn(sessionId) {
+      const next = (turns.get(sessionId) ?? 0) + 1;
+      turns.set(sessionId, next);
+      return next;
+    },
+    async addSpend(sessionId, distinctId, date, microUsd) {
+      sessionSpent.set(
+        sessionId,
+        (sessionSpent.get(sessionId) ?? 0) + microUsd,
+      );
+      const dayKey = `${distinctId}:${date}`;
+      dailySpent.set(dayKey, (dailySpent.get(dayKey) ?? 0) + microUsd);
+    },
+  };
+}
+
+function createRedisStore(redis: Redis): UsageBudgetStore {
+  return {
+    async loadSnapshot(sessionId, distinctId, date) {
+      const [
+        sessionTurnsRaw,
+        sessionSpentRaw,
+        dailySpentRaw,
+        chatCount,
+        registered,
+      ] = await Promise.all([
+        redis.get<number>(sessionTurnsKey(sessionId)),
+        redis.get<number>(sessionSpentKey(sessionId)),
+        redis.get<number>(dailySpentKey(distinctId, date)),
+        redis.scard(dailySessionsKey(distinctId, date)),
+        redis.get(sessionRegisteredKey(sessionId, date)),
+      ]);
+
+      const sessionTurns = sessionTurnsRaw ?? 0;
+      return {
+        sessionTurns,
+        sessionSpentMicroUsd: sessionSpentRaw ?? 0,
+        dailySpentMicroUsd: dailySpentRaw ?? 0,
+        dailyChatCount: chatCount ?? 0,
+        isNewSession: sessionTurns === 0 && !registered,
+      };
+    },
+    async registerChat(sessionId, distinctId, date) {
+      const regKey = sessionRegisteredKey(sessionId, date);
+      const wasSet = await redis.set(regKey, "1", {
+        nx: true,
+        ex: DAY_TTL_SEC,
+      });
+      if (!wasSet) {
+        return redis.scard(dailySessionsKey(distinctId, date));
+      }
+      await redis.sadd(dailySessionsKey(distinctId, date), sessionId);
+      await redis.expire(dailySessionsKey(distinctId, date), DAY_TTL_SEC);
+      return redis.scard(dailySessionsKey(distinctId, date));
+    },
+    async incrementTurn(sessionId) {
+      const turns = await redis.incr(sessionTurnsKey(sessionId));
+      await redis.expire(sessionTurnsKey(sessionId), SESSION_TTL_SEC);
+      return turns;
+    },
+    async addSpend(sessionId, distinctId, date, microUsd) {
+      await Promise.all([
+        redis.incrby(sessionSpentKey(sessionId), microUsd),
+        redis.incrby(dailySpentKey(distinctId, date), microUsd),
+      ]);
+      await Promise.all([
+        redis.expire(sessionSpentKey(sessionId), SESSION_TTL_SEC),
+        redis.expire(dailySpentKey(distinctId, date), DAY_TTL_SEC),
+      ]);
+    },
+  };
+}
+
+let storePromise: Promise<UsageBudgetStore | null> | null = null;
+let memoryStore: UsageBudgetStore | null = null;
+
+async function getStore(): Promise<UsageBudgetStore | null> {
+  if (!isUsageBudgetEnabled()) return null;
+
+  const forceMemory =
+    process.env.XULUX_USAGE_BUDGET_STORE === "memory" ||
+    !process.env.UPSTASH_REDIS_REST_URL;
+
+  if (forceMemory) {
+    memoryStore ??= createMemoryStore();
+    return memoryStore;
+  }
+
+  storePromise ??= (async () => {
+    const { Redis } = await import("@upstash/redis");
+    return createRedisStore(Redis.fromEnv());
+  })();
+  return storePromise;
+}
+
+function denyResponse(code: BudgetDenyCode): Response {
+  const limits = getBudgetLimits();
+  return Response.json(
+    { error: budgetDenyMessage(code, limits), code },
+    { status: 429 },
+  );
+}
+
+export async function beginTurn(
+  sessionId: string,
+  distinctId: string,
+): Promise<Response | null> {
+  const store = await getStore();
+  if (!store) return null;
+
+  const limits = getBudgetLimits();
+  const date = utcDateKey();
+  const snap = await store.loadSnapshot(sessionId, distinctId, date);
+  const deny = evaluateBudget(snap, limits);
+  if (deny) return denyResponse(deny);
+
+  if (snap.isNewSession) {
+    const chatCount = await store.registerChat(sessionId, distinctId, date);
+    if (chatCount > limits.maxChatsPerDay) {
+      return denyResponse("DAILY_CHAT_LIMIT");
+    }
+  }
+
+  await store.incrementTurn(sessionId);
+  return null;
+}
+
+export async function finishTurn(
+  sessionId: string,
+  distinctId: string,
+  usage: TokenUsage,
+  modelId?: string,
+): Promise<void> {
+  const store = await getStore();
+  if (!store) return;
+
+  const microUsd = estimateMicroUsd(usage, modelId);
+  await store.addSpend(sessionId, distinctId, utcDateKey(), microUsd);
+}
+
+/** @internal Test-only memory store for integration checks. */
+export function createTestUsageBudgetStore(): UsageBudgetStore {
+  return createMemoryStore();
+}
+
+/** @internal Runs beginTurn/finishTurn against an injected store (tests). */
+export async function beginTurnWithStore(
+  store: UsageBudgetStore,
+  sessionId: string,
+  distinctId: string,
+  date = utcDateKey(),
+): Promise<Response | null> {
+  const limits = getBudgetLimits();
+  const snap = await store.loadSnapshot(sessionId, distinctId, date);
+  const deny = evaluateBudget(snap, limits);
+  if (deny) return denyResponse(deny);
+
+  if (snap.isNewSession) {
+    const chatCount = await store.registerChat(sessionId, distinctId, date);
+    if (chatCount > limits.maxChatsPerDay) {
+      return denyResponse("DAILY_CHAT_LIMIT");
+    }
+  }
+
+  await store.incrementTurn(sessionId);
+  return null;
+}
+
+export async function finishTurnWithStore(
+  store: UsageBudgetStore,
+  sessionId: string,
+  distinctId: string,
+  usage: TokenUsage,
+  modelId?: string,
+  date = utcDateKey(),
+): Promise<void> {
+  const microUsd = estimateMicroUsd(usage, modelId);
+  await store.addSpend(sessionId, distinctId, date, microUsd);
+}

--- a/apps/docs/lib/xulux/usage-budget.ts
+++ b/apps/docs/lib/xulux/usage-budget.ts
@@ -70,6 +70,19 @@ type UsageBudgetStore = {
   ) => Promise<void>;
 };
 
+function pruneStaleMemoryDailyKeys(
+  dailySpent: Map<string, number>,
+  dailySessions: Map<string, Set<string>>,
+  currentDate: string,
+) {
+  for (const key of dailySpent.keys()) {
+    if (!key.endsWith(`:${currentDate}`)) dailySpent.delete(key);
+  }
+  for (const key of dailySessions.keys()) {
+    if (!key.endsWith(`:${currentDate}`)) dailySessions.delete(key);
+  }
+}
+
 function createMemoryStore(): UsageBudgetStore {
   const turns = new Map<string, number>();
   const sessionSpent = new Map<string, number>();
@@ -79,6 +92,7 @@ function createMemoryStore(): UsageBudgetStore {
 
   return {
     async loadSnapshot(sessionId, distinctId, date) {
+      pruneStaleMemoryDailyKeys(dailySpent, dailySessions, date);
       const sessionTurns = turns.get(sessionId) ?? 0;
       return {
         sessionTurns,
@@ -190,11 +204,25 @@ async function getStore(): Promise<UsageBudgetStore | null> {
   }
 
   storePromise ??= (async () => {
-    const { Redis } = await import("@upstash/redis");
-    return createRedisStore(Redis.fromEnv());
+    try {
+      const { Redis } = await import("@upstash/redis");
+      return createRedisStore(Redis.fromEnv());
+    } catch (error) {
+      console.error(
+        "[usage-budget] Redis init failed; using memory store",
+        error,
+      );
+      memoryStore ??= createMemoryStore();
+      return memoryStore;
+    }
   })();
   return storePromise;
 }
+
+export type BeginTurnResult = {
+  denied: Response | null;
+  budgetDate: string;
+};
 
 function denyResponse(code: BudgetDenyCode): Response {
   const limits = getBudgetLimits();
@@ -207,25 +235,29 @@ function denyResponse(code: BudgetDenyCode): Response {
 export async function beginTurn(
   sessionId: string,
   distinctId: string,
-): Promise<Response | null> {
+): Promise<BeginTurnResult> {
+  const budgetDate = utcDateKey();
   const store = await getStore();
-  if (!store) return null;
+  if (!store) return { denied: null, budgetDate };
 
   const limits = getBudgetLimits();
-  const date = utcDateKey();
-  const snap = await store.loadSnapshot(sessionId, distinctId, date);
+  const snap = await store.loadSnapshot(sessionId, distinctId, budgetDate);
   const deny = evaluateBudget(snap, limits);
-  if (deny) return denyResponse(deny);
+  if (deny) return { denied: denyResponse(deny), budgetDate };
 
   if (snap.isNewSession) {
-    const chatCount = await store.registerChat(sessionId, distinctId, date);
+    const chatCount = await store.registerChat(
+      sessionId,
+      distinctId,
+      budgetDate,
+    );
     if (chatCount > limits.maxChatsPerDay) {
-      return denyResponse("DAILY_CHAT_LIMIT");
+      return { denied: denyResponse("DAILY_CHAT_LIMIT"), budgetDate };
     }
   }
 
   await store.incrementTurn(sessionId);
-  return null;
+  return { denied: null, budgetDate };
 }
 
 export async function finishTurn(
@@ -233,12 +265,13 @@ export async function finishTurn(
   distinctId: string,
   usage: TokenUsage,
   modelId?: string,
+  budgetDate = utcDateKey(),
 ): Promise<void> {
   const store = await getStore();
   if (!store) return;
 
   const microUsd = estimateMicroUsd(usage, modelId);
-  await store.addSpend(sessionId, distinctId, utcDateKey(), microUsd);
+  await store.addSpend(sessionId, distinctId, budgetDate, microUsd);
 }
 
 /** @internal Test-only memory store for integration checks. */


### PR DESCRIPTION
Closes #4416

## Summary

- Reframe the Xulux playground agent as a **starter helper**: use hosted templates when they fit, otherwise read docs and guide custom setup instead of inventing fake starters
- Add usage budget gating ($1/chat, 8 turns, $2/day, 10 chats) with limit banner and 429 handling
- Add `open-in` card for template download + coding-agent deep links; fix Cursor to use prompt deeplinks
- Guard no-template responses: no placeholder download URLs; prompt-only open-in when there is no real download
- Persist playground thread history and URL/state across refresh
- Add template catalog, demo zip downloads, and canvas preview wiring

## Agent behavior change

| Before | After |
|--------|-------|
| Full coding agent tone; force unrelated templates | Template-first when a hosted starter matches |
| Fake `open-in` URLs when no preview succeeded | Docs-based guidance; download only after `openTemplatePreview` |
| Cursor rule deeplinks | Cursor chat prompt deeplinks |

## Commits

1. `fix(docs): preserve Xulux playground state`
2. `fix(docs): persist Xulux chat history locally`
3. `feat(docs): add Xulux usage budget gating with limit banner`
4. `fix(docs): improve Xulux open-in card and no-template agent guidance`
5. `feat(docs): add Xulux template catalog, demo downloads, and preview wiring`

## Test plan

- [ ] Template match: preview + `open-in` card with real download URL
- [ ] No-template request: honest docs answer, no fake download
- [ ] Turn limit: banner + disabled send; New chat clears block
- [ ] Refresh: history/state preserved
- [ ] Open in Cursor: chat prompt prefilled, not a rule file

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

