### PR TITLE
feat(react): add minCommitMs to SmoothOptions

### DIFF
--- a/.changeset/smooth-min-commit-ms.md
+++ b/.changeset/smooth-min-commit-ms.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat(react): add `minCommitMs` to `SmoothOptions` to throttle committed reveal updates
+
+`useSmooth` keeps advancing the typewriter reveal every frame, but with `minCommitMs` the visible text (and the downstream re-render and markdown re-parse it triggers) is committed at most once per interval. The final frame always commits, so no characters are lost. Defaults to `0`, which commits every frame and preserves the previous behavior.

--- a/packages/react/src/utils/smooth/useSmooth.test.tsx
+++ b/packages/react/src/utils/smooth/useSmooth.test.tsx
@@ -155,4 +155,45 @@ describe("useSmooth", () => {
     expect(floored.final).toBe("0123456789");
     expect(floored.commits).toBeLessThan(everyFrame.commits);
   });
+
+  it("commits the first frame after a discontinuity without waiting out minCommitMs", () => {
+    const raf: FrameRequestCallback[] = [];
+    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
+      raf.push(cb);
+      return raf.length;
+    });
+    vi.spyOn(globalThis, "cancelAnimationFrame").mockImplementation(() => {});
+    let now = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+
+    const frame = () => {
+      if (raf.length === 0) return;
+      const cb = raf.shift()!;
+      now += 16;
+      act(() => {
+        cb(now);
+      });
+    };
+
+    const options: SmoothOptions = {
+      minCommitMs: 10000,
+      maxCharsPerFrame: 1,
+      maxCharIntervalMs: 1,
+    };
+    const { result, rerender } = renderHook(
+      (part) => useSmooth(part, options),
+      {
+        initialProps: runningState("aaaaaaaaaa"),
+      },
+    );
+
+    frame();
+    expect(result.current.text).toBe("a");
+    frame();
+    expect(result.current.text).toBe("a");
+
+    rerender(runningState("zzzzzzzzzz"));
+    frame();
+    expect(result.current.text).toBe("z");
+  });
 });

--- a/packages/react/src/utils/smooth/useSmooth.test.tsx
+++ b/packages/react/src/utils/smooth/useSmooth.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
-import { renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   MessagePartState,
   ReasoningMessagePart,
@@ -32,7 +32,61 @@ const reasoningState = (text: string) =>
     status: { type: "complete", reason: "stop" },
   }) as MessagePartState & ReasoningMessagePart;
 
+const runningState = (text: string) =>
+  ({
+    type: "text",
+    text,
+    status: { type: "running" },
+  }) as MessagePartState & TextMessagePart;
+
+const driveAndCount = (minCommitMs: number) => {
+  const raf: FrameRequestCallback[] = [];
+  const rafSpy = vi
+    .spyOn(globalThis, "requestAnimationFrame")
+    .mockImplementation((cb) => {
+      raf.push(cb);
+      return raf.length;
+    });
+  const cafSpy = vi
+    .spyOn(globalThis, "cancelAnimationFrame")
+    .mockImplementation(() => {});
+  let now = 1000;
+  const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+
+  const state = runningState("0123456789");
+  const { result, unmount } = renderHook(() =>
+    useSmooth(state, {
+      minCommitMs,
+      maxCharsPerFrame: 1,
+      maxCharIntervalMs: 1,
+    }),
+  );
+
+  const seen = new Set<string>();
+  let guard = 0;
+  while (raf.length > 0 && guard < 100) {
+    guard++;
+    const cb = raf.shift()!;
+    now += 16;
+    act(() => {
+      cb(now);
+    });
+    seen.add(result.current.text);
+  }
+
+  const final = result.current.text;
+  unmount();
+  rafSpy.mockRestore();
+  cafSpy.mockRestore();
+  nowSpy.mockRestore();
+  return { final, commits: seen.size };
+};
+
 describe("useSmooth", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("returns the input state unchanged when disabled", () => {
     const state = textState("hello");
     const { result } = renderHook(() => useSmooth(state, false));
@@ -91,5 +145,14 @@ describe("useSmooth", () => {
     const { result } = renderHook(() => useSmooth(state, options));
     expect(result.current.text).toBe("hello");
     expect(result.current.status).toBe(state.status);
+  });
+
+  it("commits fewer times under minCommitMs without losing characters", () => {
+    const everyFrame = driveAndCount(0);
+    const floored = driveAndCount(50);
+
+    expect(everyFrame.final).toBe("0123456789");
+    expect(floored.final).toBe("0123456789");
+    expect(floored.commits).toBeLessThan(everyFrame.commits);
   });
 });

--- a/packages/react/src/utils/smooth/useSmooth.ts
+++ b/packages/react/src/utils/smooth/useSmooth.ts
@@ -49,7 +49,7 @@ const DEFAULT_MAX_CHAR_INTERVAL_MS = 5;
 class TextStreamAnimator {
   private animationFrameId: number | null = null;
   private lastUpdateTime: number = Date.now();
-  private lastCommitTime: number = 0;
+  public lastCommitTime: number = 0;
 
   public targetText: string = "";
   public drainMs: number = DEFAULT_DRAIN_MS;
@@ -231,6 +231,7 @@ export const useSmooth = (
       if (state.status.type === "running") {
         animatorRef.currentText = "";
         animatorRef.targetText = text;
+        animatorRef.lastCommitTime = 0;
         animatorRef.start();
       } else {
         animatorRef.currentText = text;

--- a/packages/react/src/utils/smooth/useSmooth.ts
+++ b/packages/react/src/utils/smooth/useSmooth.ts
@@ -33,6 +33,14 @@ export type SmoothOptions = {
    * @default Infinity
    */
   maxCharsPerFrame?: number | undefined;
+  /**
+   * Minimum time in milliseconds between committed updates. The reveal keeps
+   * advancing every frame, but the visible text (and the downstream re-render
+   * and markdown re-parse it triggers) is committed at most once per interval.
+   * The final frame always commits. `0` commits every frame.
+   * @default 0
+   */
+  minCommitMs?: number | undefined;
 };
 
 const DEFAULT_DRAIN_MS = 250;
@@ -41,11 +49,13 @@ const DEFAULT_MAX_CHAR_INTERVAL_MS = 5;
 class TextStreamAnimator {
   private animationFrameId: number | null = null;
   private lastUpdateTime: number = Date.now();
+  private lastCommitTime: number = 0;
 
   public targetText: string = "";
   public drainMs: number = DEFAULT_DRAIN_MS;
   public maxCharIntervalMs: number = DEFAULT_MAX_CHAR_INTERVAL_MS;
   public maxCharsPerFrame: number = Infinity;
+  public minCommitMs: number = 0;
 
   constructor(
     public currentText: string,
@@ -100,7 +110,12 @@ class TextStreamAnimator {
       this.currentText.length + charsToAdd,
     );
     this.lastUpdateTime = currentTime - timeToConsume;
-    this.setText(this.currentText);
+
+    const isComplete = charsToAdd === remainingChars;
+    if (isComplete || currentTime - this.lastCommitTime >= this.minCommitMs) {
+      this.lastCommitTime = currentTime;
+      this.setText(this.currentText);
+    }
   };
 }
 
@@ -141,6 +156,7 @@ export const useSmooth = (
     DEFAULT_MAX_CHAR_INTERVAL_MS,
   );
   const maxCharsPerFrame = positiveOr(options?.maxCharsPerFrame, Infinity);
+  const minCommitMs = positiveOr(options?.minCommitMs, 0);
 
   const [displayedText, setDisplayedText] = useState(
     state.status.type === "running" ? "" : text,
@@ -194,7 +210,8 @@ export const useSmooth = (
     animatorRef.drainMs = drainMs;
     animatorRef.maxCharIntervalMs = maxCharIntervalMs;
     animatorRef.maxCharsPerFrame = maxCharsPerFrame;
-  }, [animatorRef, drainMs, maxCharIntervalMs, maxCharsPerFrame]);
+    animatorRef.minCommitMs = minCommitMs;
+  }, [animatorRef, drainMs, maxCharIntervalMs, maxCharsPerFrame, minCommitMs]);
 
   const animatorPartRef = useRef(part);
   useEffect(() => {


### PR DESCRIPTION
## what

adds an optional `minCommitMs` to `SmoothOptions`, the tuning object passed to `useSmooth` (and through `smooth` on the markdown text primitives).

the typewriter reveal keeps advancing every animation frame as before, but `minCommitMs` throttles how often the revealed text is *committed* to React state. a commit is what triggers the downstream re-render and, for markdown parts, the full streamdown/remend re-parse of the visible text. on a fast stream that re-parse runs on every frame; `minCommitMs` lets a consumer cap it to at most once per interval.

the final frame always commits, so the reveal still lands on the complete text and no characters are lost. it defaults to `0`, which commits every frame and is byte-for-byte the previous behavior.

```ts
useSmooth(part, { minCommitMs: 50 }) // re-parse markdown at most ~20x/s while still revealing every frame
```

## why

came out of profiling the smooth reveal against a markdown-heavy stream: the reveal animation is cheap, but each committed frame re-parses the entire visible markdown block. decoupling "advance the cursor" from "commit + re-parse" lets the reveal stay smooth while the expensive work is rate limited, without the consumer having to coarsen `maxCharsPerFrame` (which would make the animation visibly chunkier).

## how it works

`TextStreamAnimator` tracks `lastCommitTime`. each frame it advances `currentText` as usual, then commits only when the reveal just completed or `now - lastCommitTime >= minCommitMs`. `minCommitMs` falls through the same `positiveOr(..., 0)` guard as the other options, so `0`, negatives, and `NaN` all collapse to the default.

## test

`packages/react/src/utils/smooth/useSmooth.test.tsx` drives real animation frames with mocked `requestAnimationFrame` / `Date.now`, then asserts that `minCommitMs: 50` produces strictly fewer distinct committed values than `minCommitMs: 0` while both still reach the full text. existing `useSmooth` tests confirm the `0` default is unchanged.

- `pnpm exec vitest run src/utils/smooth/useSmooth.test.tsx` (8 passing)
- full `@assistant-ui/react` suite green (394)
- `tsc --noEmit`, `pnpm lint`, `pnpm --filter @assistant-ui/react build` clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

