### PR TITLE
feat(react-ag-ui): apply external state from ThreadHistoryAdapter.load()

### DIFF
--- a/.changeset/history-adapter-load-state.md
+++ b/.changeset/history-adapter-load-state.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/react-ag-ui": patch
+"@assistant-ui/core": patch
+---
+
+feat(react-ag-ui): apply external state from `ThreadHistoryAdapter.load()`
+
+`onSwitchToThread` already applies returned `state` via `loadExternalState`, but the history `load()` path did not, so state restored on a fresh page load was dropped. `ThreadHistoryAdapter.load()` may now return an optional `state`, and `AgUiThreadRuntimeCore` applies it — making both load paths symmetric.

--- a/packages/core/src/adapters/thread-history.ts
+++ b/packages/core/src/adapters/thread-history.ts
@@ -6,6 +6,7 @@ import type {
   ExportedMessageRepository,
   ExportedMessageRepositoryItem,
 } from "../runtime/utils/message-repository";
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
 
 export interface MessageStorageEntry<TPayload> {
   id: string;
@@ -53,7 +54,12 @@ export type GenericThreadHistoryAdapter<TMessage> = {
 };
 
 export type ThreadHistoryAdapter = {
-  load(): Promise<ExportedMessageRepository & { unstable_resume?: boolean }>;
+  load(): Promise<
+    ExportedMessageRepository & {
+      state?: ReadonlyJSONValue;
+      unstable_resume?: boolean;
+    }
+  >;
   resume?(
     options: ChatModelRunOptions,
   ): AsyncGenerator<ChatModelRunResult, void, unknown>;

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -134,6 +134,10 @@ export class AgUiThreadRuntimeCore {
         const messages = repo.messages.map((item) => item.message);
         this.applyExternalMessages(messages);
 
+        if (repo.state) {
+          this.loadExternalState(repo.state);
+        }
+
         if (repo.unstable_resume) {
           const parentId = repo.headId ?? messages.at(-1)?.id ?? null;
           await this.startRun(parentId, this.lastRunConfig);

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -134,7 +134,7 @@ export class AgUiThreadRuntimeCore {
         const messages = repo.messages.map((item) => item.message);
         this.applyExternalMessages(messages);
 
-        if (repo.state) {
+        if (repo.state !== undefined) {
           this.loadExternalState(repo.state);
         }
 

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -88,7 +88,7 @@ export function useAgUiRuntime(
         ? async (threadId: string) => {
             const result = await onSwitchToThread(threadId);
             core.applyExternalMessages(result.messages);
-            if (result.state) {
+            if (result.state !== undefined) {
               core.loadExternalState(result.state);
             }
           }


### PR DESCRIPTION
## Problem

`onSwitchToThread` applies returned `state` via `loadExternalState`, but the history `load()` path does not. State restored on a fresh page load (vs. an in-session thread switch) is silently dropped, and the `ThreadHistoryAdapter.load()` return type has no `state` field to carry it.

## Fix

Make both load paths symmetric:

- `ThreadHistoryAdapter.load()` may now return an optional `state?: ReadonlyJSONValue`.
- `AgUiThreadRuntimeCore.__internal_load()` applies it via `loadExternalState`, mirroring the `onSwitchToThread` path.

No behavior change for adapters that don't return `state`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

