### PR TITLE
fix(docs): center collapsed sidebar rail in the base demo

### DIFF
--- a/apps/docs/components/examples/base.tsx
+++ b/apps/docs/components/examples/base.tsx
@@ -927,12 +927,7 @@ export const Base: FC = () => {
       <div className="hidden md:block">
         <Sidebar collapsed={sidebarCollapsed} />
       </div>
-      <div
-        className={cn(
-          "flex flex-1 flex-col overflow-hidden p-2 transition-[padding] duration-200",
-          !sidebarCollapsed && "md:pl-0",
-        )}
-      >
+      <div className="flex flex-1 flex-col overflow-hidden p-2 md:pl-0">
         <div className="bg-background flex flex-1 flex-col overflow-hidden rounded-lg">
           <Header
             sidebarCollapsed={sidebarCollapsed}


### PR DESCRIPTION
## What

In the homepage Base demo, the collapsed sidebar's logo and new-thread button looked slightly off-center.

## Why

The icons are centered within the 48px rail, but the chat content wrapper kept its `p-2` when collapsed (its `md:pl-0` only applied while the sidebar was expanded). That left an 8px gap between the rail and the panel, widening the left gutter so the rail-centered icons landed ~4px left of the visual center.

## Fix

Make the content wrapper always flush-left against the sidebar/rail (`md:pl-0` unconditionally), matching shadcn's inset pattern. The panel now sits flush against the rail in both states, so the collapsed icons read as centered. The now-static padding transition was dropped.

Verified in the running docs app: collapsed rail icons centered in the 0→48 gutter, expanded layout unchanged.

`@assistant-ui/docs` is a private package, so no changeset is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)