### PR TITLE
fix(ui): only truncate sidebar thread titles on hover

### DIFF
--- a/packages/ui/src/components/assistant-ui/thread-list.tsx
+++ b/packages/ui/src/components/assistant-ui/thread-list.tsx
@@ -133,8 +133,8 @@ const ThreadListSkeleton: FC = () => {
 
 const ThreadListItem: FC = () => {
   return (
-    <ThreadListItemPrimitive.Root className="aui-thread-list-item group hover:bg-muted focus-visible:bg-muted data-active:bg-muted flex h-8 items-center gap-1 rounded-md transition-colors focus-visible:outline-none">
-      <ThreadListItemPrimitive.Trigger className="aui-thread-list-item-trigger flex h-full min-w-0 flex-1 items-center px-2.5 text-start text-sm">
+    <ThreadListItemPrimitive.Root className="aui-thread-list-item group hover:bg-muted focus-visible:bg-muted data-active:bg-muted relative flex h-8 items-center rounded-md transition-colors focus-visible:outline-none">
+      <ThreadListItemPrimitive.Trigger className="aui-thread-list-item-trigger flex h-full min-w-0 flex-1 items-center ps-2.5 pe-2.5 text-start text-sm group-hover:pe-9 group-has-data-[state=open]:pe-9 group-data-active:pe-9">
         <span className="aui-thread-list-item-title min-w-0 flex-1 truncate">
           <ThreadListItemPrimitive.Title fallback="New Chat" />
         </span>
@@ -151,7 +151,7 @@ const ThreadListItemMore: FC = () => {
         <Button
           variant="ghost"
           size="icon"
-          className="aui-thread-list-item-more data-[state=open]:bg-accent me-1.5 size-6 p-0 opacity-0 transition-opacity group-hover:opacity-100 group-data-active:opacity-100 data-[state=open]:opacity-100"
+          className="aui-thread-list-item-more data-[state=open]:bg-accent absolute end-1.5 top-1/2 size-6 -translate-y-1/2 p-0 opacity-0 transition-opacity group-hover:opacity-100 group-data-active:opacity-100 data-[state=open]:opacity-100"
         >
           <MoreHorizontalIcon className="size-3.5" />
           <span className="sr-only">More options</span>


### PR DESCRIPTION
## Problem

In the thread-list sidebar, every title was clipped with an ellipsis to reserve room for the more-options (`⋯`) button, but that button only appears on hover. The result: titles were permanently truncated with an empty gap on the right where nothing was shown, which looked odd.

## Fix

`packages/ui/src/components/assistant-ui/thread-list.tsx`:

- The more-options button is now **absolutely positioned** (`absolute end-1.5`, vertically centered) instead of taking a flex slot, so it no longer reserves layout width when hidden.
- The trigger reserves end-padding (`pe-9`) **only** when the row is hovered, active, or its menu is open — via `group-hover`, `group-data-active`, and `group-has-data-[state=open]` — so titles use the full width otherwise and truncate shorter only while the button is actually shown.

This mirrors the existing `SidebarMenuButton`/`SidebarMenuAction` pattern in `components/ui/sidebar.tsx`, with the reservation gated on interaction rather than always-on.

## Notes

- `@assistant-ui/ui` is a private package, so no changeset is required.
- Lint + format pass (`pnpm lint`). CSS-only className change; no logic or type changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)