### PR TITLE
chore(core): mark generateId and fromThreadMessageLike as experimental

### DIFF
--- a/.changeset/deprecate-internal-message-conversion-utils.md
+++ b/.changeset/deprecate-internal-message-conversion-utils.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+---
+
+chore: mark `generateId` and `fromThreadMessageLike` as experimental
+
+these two utilities became public in #4414. they now carry an `@deprecated` JSDoc noting the API is experimental and may change without notice, matching how the other unstable public utilities (e.g. `bindExternalStoreMessage`) are flagged. the framework packages (`@assistant-ui/react`, `@assistant-ui/react-native`, `@assistant-ui/react-ink`) re-export them, so the same hint shows up there too.

--- a/.changeset/deprecate-internal-message-conversion-utils.md
+++ b/.changeset/deprecate-internal-message-conversion-utils.md
@@ -1,7 +1,10 @@
 ---
 "@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
 ---
 
 chore: mark `generateId` and `fromThreadMessageLike` as experimental
 
-these two utilities became public in #4414. they now carry an `@deprecated` JSDoc noting the API is experimental and may change without notice, matching how the other unstable public utilities (e.g. `bindExternalStoreMessage`) are flagged. the framework packages (`@assistant-ui/react`, `@assistant-ui/react-native`, `@assistant-ui/react-ink`) re-export them, so the same hint shows up there too.
+these two utilities became public in #4414. they now carry an `@deprecated` JSDoc noting the API is experimental and may change without notice, matching how the other unstable public utilities (e.g. `bindExternalStoreMessage`) are flagged. the distribution packages (`@assistant-ui/react`, `@assistant-ui/react-native`, `@assistant-ui/react-ink`) re-export them, so the annotation lands in their published types too.

--- a/packages/core/src/runtime/utils/thread-message-like.ts
+++ b/packages/core/src/runtime/utils/thread-message-like.ts
@@ -104,6 +104,9 @@ const convertDataPrefixedPart = (
   return { type: "data", name: type.substring(5), data };
 };
 
+/**
+ * @deprecated This API is experimental and may change without notice.
+ */
 export const fromThreadMessageLike = (
   like: ThreadMessageLike,
   fallbackId: string,

--- a/packages/core/src/utils/id.ts
+++ b/packages/core/src/utils/id.ts
@@ -1,5 +1,8 @@
 import { customAlphabet } from "nanoid/non-secure";
 
+/**
+ * @deprecated This API is experimental and may change without notice.
+ */
 export const generateId = customAlphabet(
   "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
   7,


### PR DESCRIPTION
## summary

- mark the now-public `generateId` and `fromThreadMessageLike` utilities as experimental via an `@deprecated` jsdoc ("This API is experimental and may change without notice."), so editors surface a strikethrough hint on both the public entries (`@assistant-ui/core`, `@assistant-ui/react`, `@assistant-ui/react-native`, `@assistant-ui/react-ink`) and `@assistant-ui/core/internal`.
- matches how the other unstable public utilities (e.g. `bindExternalStoreMessage`) are already flagged.

no test plan, jsdoc/types only

## notes

- these two became public in #4414; this only annotates them, with no runtime or signature change.
- the annotation lives on the function declarations (not the re-export specifiers) because the tsdown dts bundler collapses re-exports and drops specifier-level jsdoc; declaration-level jsdoc survives into the published `.d.ts`.
- verified: rebuilt `@assistant-ui/core` and confirmed via the TypeScript language service that importing either symbol from `@assistant-ui/core` or `@assistant-ui/core/internal` reports `is deprecated`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

