### PR TITLE
fix(devtools): preserve shared references when sanitizing model context

### DIFF
--- a/.changeset/devtools-sanitize-shared-refs.md
+++ b/.changeset/devtools-sanitize-shared-refs.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-devtools": patch
+---
+
+fix(devtools): stop reporting shared (non-cyclic) references as `[Circular]` when serializing model context

--- a/packages/react-devtools/src/utils/serialization.test.ts
+++ b/packages/react-devtools/src/utils/serialization.test.ts
@@ -2,8 +2,39 @@ import { describe, expect, it } from "vitest";
 import {
   REDACTED,
   redactSensitive,
+  sanitizeForMessage,
   serializeModelContext,
 } from "./serialization";
+
+describe("sanitizeForMessage", () => {
+  it("preserves shared (non-cyclic) sibling references instead of marking them circular", () => {
+    const shared = { value: 1 };
+
+    expect(sanitizeForMessage({ a: shared, b: shared })).toEqual({
+      a: { value: 1 },
+      b: { value: 1 },
+    });
+
+    const sharedArray = [1, 2];
+    expect(sanitizeForMessage({ a: sharedArray, b: sharedArray })).toEqual({
+      a: [1, 2],
+      b: [1, 2],
+    });
+  });
+
+  it("still detects genuine circular references", () => {
+    const cyclic: Record<string, unknown> = { name: "root" };
+    cyclic.self = cyclic;
+    expect(sanitizeForMessage(cyclic)).toEqual({
+      name: "root",
+      self: "[Circular]",
+    });
+
+    const cyclicArray: unknown[] = [];
+    cyclicArray.push(cyclicArray);
+    expect(sanitizeForMessage(cyclicArray)).toEqual(["[Circular]"]);
+  });
+});
 
 describe("redactSensitive", () => {
   it("masks credential-named keys but leaves lookalikes alone", () => {

--- a/packages/react-devtools/src/utils/serialization.ts
+++ b/packages/react-devtools/src/utils/serialization.ts
@@ -34,9 +34,13 @@ export const sanitizeForMessage = (
   if (Array.isArray(value)) {
     if (seen.has(value as unknown as object)) return "[Circular]";
     seen.add(value as unknown as object);
-    return value
+    const result = value
       .map((entry) => sanitizeForMessage(entry, seen))
       .filter((item) => item !== undefined);
+    // Track only the current ancestor path so shared (non-cyclic) sibling
+    // references are not misreported as circular.
+    seen.delete(value as unknown as object);
+    return result;
   }
   if (typeof value === "object") {
     if (seen.has(value as object)) return "[Circular]";
@@ -47,6 +51,7 @@ export const sanitizeForMessage = (
     )) {
       result[key] = sanitizeForMessage(entry, seen);
     }
+    seen.delete(value as object);
     return result;
   }
   return value;

--- a/packages/react-devtools/src/utils/serialization.ts
+++ b/packages/react-devtools/src/utils/serialization.ts
@@ -37,8 +37,6 @@ export const sanitizeForMessage = (
     const result = value
       .map((entry) => sanitizeForMessage(entry, seen))
       .filter((item) => item !== undefined);
-    // Track only the current ancestor path so shared (non-cyclic) sibling
-    // references are not misreported as circular.
     seen.delete(value as unknown as object);
     return result;
   }


### PR DESCRIPTION
### Bug

`sanitizeForMessage` (used by the devtools to serialize a thread's model context for the inspector message) detects cycles with a `WeakSet` of visited objects, but it only ever *adds* to the set — it never removes a node after walking its subtree.

That makes the set track *every* object seen anywhere in the traversal rather than the current ancestor path. As a result, a value that is reachable through two **sibling** paths (a diamond, not a cycle) has its second occurrence replaced with `"[Circular]"`:

```ts
const shared = { value: 1 };
sanitizeForMessage({ a: shared, b: shared });
// → { a: { value: 1 }, b: "[Circular]" }   ❌  (b is not circular)
```

Model context tool `parameters`, `callSettings`, and `config` commonly reuse the same nested object across fields, so the devtools panel renders `"[Circular]"` for perfectly valid shared data.

### Fix

Delete each object/array from the visited set once its subtree has been fully processed, so the set reflects only the current ancestor path. Genuine cycles are still caught (the ancestor is still in the set when its descendant references it); shared non-cyclic references now serialize correctly.

```ts
sanitizeForMessage({ a: shared, b: shared });
// → { a: { value: 1 }, b: { value: 1 } }   ✅
```

### Verification

Added focused tests in `serialization.test.ts` covering shared sibling references (objects and arrays) and genuine self-cycles (object and array), then ran the package suite:

```
$ pnpm vitest run    # packages/react-devtools
 Test Files  2 passed (2)
      Tests  14 passed (14)
```

The shared-reference test fails on `main` and passes with this change; the self-cycle test passes both before and after, confirming cycle detection is preserved.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

