### PR TITLE
feat(react-langchain): surface useStream error via useLangChainError

### DIFF
--- a/.changeset/red-langchain-error.md
+++ b/.changeset/red-langchain-error.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): surface useStream error via useLangChainError

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -441,6 +441,20 @@ function InterruptPrompt() {
 </Tab>
 </PlatformTabs>
 
+## Errors
+
+`useLangChainError` exposes the last run or hydration error from upstream `useStream().error`. It is untyped (`unknown`), so narrow it at the use site before rendering.
+
+```tsx
+import { useLangChainError } from "@assistant-ui/react-langchain";
+
+function ErrorBanner() {
+  const error = useLangChainError();
+  if (!error) return null;
+  return <div role="alert">{error instanceof Error ? error.message : String(error)}</div>;
+}
+```
+
 ## Message conversion
 
 `convertLangChainBaseMessage` transforms a LangChain `BaseMessage` into an assistant-ui message. Use it when building a custom `ExternalStoreAdapter` that consumes LangChain messages outside `useStreamRuntime`.
@@ -515,6 +529,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | `useLangGraphMessageMetadata` | _(not available)_ | Open an issue if you rely on this. |
 | `useLangGraphUIMessages` | _(not available)_ | Open an issue if you rely on this. |
 | _(none)_ | `useLangChainState<T>(key)` | New — reads any custom state key reactively. |
+| _(none)_ | `useLangChainError()` | New — reads the last run/hydration error reactively. |
 
 ## Related
 

--- a/packages/react-langchain/README.md
+++ b/packages/react-langchain/README.md
@@ -35,4 +35,4 @@ export function App() {
 
 `useStreamRuntime` accepts every option `@langchain/react`'s `useStream` does, plus `cloud` for thread persistence, an `adapters` bag, and a `messagesKey` override.
 
-Full reference for `useLangChainState`, `useLangChainInterruptState`, `useLangChainSubmit`, and `convertLangChainBaseMessage` at [assistant-ui.com/docs/runtimes/langchain](https://www.assistant-ui.com/docs/runtimes/langchain).
+Full reference for `useLangChainState`, `useLangChainInterruptState`, `useLangChainError`, `useLangChainSubmit`, and `convertLangChainBaseMessage` at [assistant-ui.com/docs/runtimes/langchain](https://www.assistant-ui.com/docs/runtimes/langchain).

--- a/packages/react-langchain/src/__tests__/langChainTestUtils.ts
+++ b/packages/react-langchain/src/__tests__/langChainTestUtils.ts
@@ -1,0 +1,22 @@
+import type { Mock } from "vitest";
+
+export type Selector = (state: unknown) => unknown;
+
+// The real guard symbol in useStreamRuntime is module-private. To stand in for
+// runtime-produced extras, wrap a plain object in a Proxy whose `has` trap
+// claims any symbol described "langchain-runtime-extras" is present.
+export const makeExtras = (extras: Record<string, unknown>) =>
+  new Proxy(extras, {
+    has: (target, key) =>
+      (typeof key === "symbol" &&
+        key.description === "langchain-runtime-extras") ||
+      Reflect.has(target, key),
+  });
+
+export const createRunSelectorAgainst =
+  (mock: Mock) =>
+  (extras: unknown): void => {
+    mock.mockImplementationOnce((selector: Selector) =>
+      selector({ thread: { extras } }),
+    );
+  };

--- a/packages/react-langchain/src/index.ts
+++ b/packages/react-langchain/src/index.ts
@@ -1,5 +1,6 @@
 export {
   useStreamRuntime,
+  useLangChainError,
   useLangChainInterruptState,
   useLangChainSend,
   useLangChainSendCommand,

--- a/packages/react-langchain/src/useLangChainError.test.tsx
+++ b/packages/react-langchain/src/useLangChainError.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+type Selector = (state: unknown) => unknown;
+const { mockUseAuiState } = vi.hoisted(() => ({
+  mockUseAuiState: vi.fn(),
+}));
+
+vi.mock(import("@assistant-ui/store"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useAuiState: ((selector: Selector) =>
+      mockUseAuiState(selector)) as typeof actual.useAuiState,
+    useAui: (() => ({})) as unknown as typeof actual.useAui,
+  };
+});
+
+import { useLangChainError } from "./useStreamRuntime";
+
+// The real guard symbol in useStreamRuntime is module-private. To stand in for
+// runtime-produced extras, we use a Proxy whose `has` trap claims any symbol
+// with the description "langchain-runtime-extras" is present.
+const makeExtrasWith = (obj: Record<string, unknown>) =>
+  new Proxy(obj, {
+    has: (target, key) =>
+      (typeof key === "symbol" &&
+        key.description === "langchain-runtime-extras") ||
+      Reflect.has(target, key),
+  });
+
+const runSelectorAgainst = (extras: unknown) => {
+  mockUseAuiState.mockImplementationOnce((selector: Selector) =>
+    selector({ thread: { extras } }),
+  );
+};
+
+describe("useLangChainError", () => {
+  it("returns undefined when extras are absent", () => {
+    runSelectorAgainst(undefined);
+    const { result } = renderHook(() => useLangChainError());
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns the error value when extras carry error", () => {
+    const error = new Error("boom");
+    runSelectorAgainst(makeExtrasWith({ error }));
+    const { result } = renderHook(() => useLangChainError());
+    expect(result.current).toBe(error);
+  });
+
+  it("returns undefined when extras carry no error", () => {
+    runSelectorAgainst(makeExtrasWith({ error: undefined }));
+    const { result } = renderHook(() => useLangChainError());
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/react-langchain/src/useLangChainError.test.tsx
+++ b/packages/react-langchain/src/useLangChainError.test.tsx
@@ -2,8 +2,12 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
+import {
+  createRunSelectorAgainst,
+  makeExtras,
+  type Selector,
+} from "./__tests__/langChainTestUtils";
 
-type Selector = (state: unknown) => unknown;
 const { mockUseAuiState } = vi.hoisted(() => ({
   mockUseAuiState: vi.fn(),
 }));
@@ -20,22 +24,7 @@ vi.mock(import("@assistant-ui/store"), async (importOriginal) => {
 
 import { useLangChainError } from "./useStreamRuntime";
 
-// The real guard symbol in useStreamRuntime is module-private. To stand in for
-// runtime-produced extras, we use a Proxy whose `has` trap claims any symbol
-// with the description "langchain-runtime-extras" is present.
-const makeExtrasWith = (obj: Record<string, unknown>) =>
-  new Proxy(obj, {
-    has: (target, key) =>
-      (typeof key === "symbol" &&
-        key.description === "langchain-runtime-extras") ||
-      Reflect.has(target, key),
-  });
-
-const runSelectorAgainst = (extras: unknown) => {
-  mockUseAuiState.mockImplementationOnce((selector: Selector) =>
-    selector({ thread: { extras } }),
-  );
-};
+const runSelectorAgainst = createRunSelectorAgainst(mockUseAuiState);
 
 describe("useLangChainError", () => {
   it("returns undefined when extras are absent", () => {
@@ -46,13 +35,13 @@ describe("useLangChainError", () => {
 
   it("returns the error value when extras carry error", () => {
     const error = new Error("boom");
-    runSelectorAgainst(makeExtrasWith({ error }));
+    runSelectorAgainst(makeExtras({ error }));
     const { result } = renderHook(() => useLangChainError());
     expect(result.current).toBe(error);
   });
 
   it("returns undefined when extras carry no error", () => {
-    runSelectorAgainst(makeExtrasWith({ error: undefined }));
+    runSelectorAgainst(makeExtras({ error: undefined }));
     const { result } = renderHook(() => useLangChainError());
     expect(result.current).toBeUndefined();
   });

--- a/packages/react-langchain/src/useLangChainState.test.tsx
+++ b/packages/react-langchain/src/useLangChainState.test.tsx
@@ -2,8 +2,12 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
+import {
+  createRunSelectorAgainst,
+  makeExtras,
+  type Selector,
+} from "./__tests__/langChainTestUtils";
 
-type Selector = (state: unknown) => unknown;
 const { mockUseAuiState } = vi.hoisted(() => ({
   mockUseAuiState: vi.fn(),
 }));
@@ -20,25 +24,7 @@ vi.mock(import("@assistant-ui/store"), async (importOriginal) => {
 
 import { useLangChainState } from "./useStreamRuntime";
 
-// The real guard symbol in useStreamRuntime is module-private. To stand in for
-// runtime-produced extras, we use a Proxy whose `has` trap claims any symbol
-// with the description "langchain-runtime-extras" is present.
-const makeExtras = (values: Record<string, unknown>) =>
-  new Proxy(
-    { values },
-    {
-      has: (target, key) =>
-        (typeof key === "symbol" &&
-          key.description === "langchain-runtime-extras") ||
-        Reflect.has(target, key),
-    },
-  );
-
-const runSelectorAgainst = (extras: unknown) => {
-  mockUseAuiState.mockImplementationOnce((selector: Selector) =>
-    selector({ thread: { extras } }),
-  );
-};
+const runSelectorAgainst = createRunSelectorAgainst(mockUseAuiState);
 
 describe("useLangChainState", () => {
   it("returns undefined when extras are absent", () => {
@@ -54,7 +40,9 @@ describe("useLangChainState", () => {
   });
 
   it("reads the value for the given key from extras.values", () => {
-    runSelectorAgainst(makeExtras({ todos: [{ id: "a" }], count: 7 }));
+    runSelectorAgainst(
+      makeExtras({ values: { todos: [{ id: "a" }], count: 7 } }),
+    );
     const { result } = renderHook(() =>
       useLangChainState<Array<{ id: string }>>("todos"),
     );
@@ -62,26 +50,26 @@ describe("useLangChainState", () => {
   });
 
   it("falls back to defaultValue when the key is missing from values", () => {
-    runSelectorAgainst(makeExtras({ unrelated: "x" }));
+    runSelectorAgainst(makeExtras({ values: { unrelated: "x" } }));
     const { result } = renderHook(() => useLangChainState<number>("count", 99));
     expect(result.current).toBe(99);
   });
 
   it("returns undefined when the key is missing and no default is given", () => {
-    runSelectorAgainst(makeExtras({ unrelated: "x" }));
+    runSelectorAgainst(makeExtras({ values: { unrelated: "x" } }));
     const { result } = renderHook(() => useLangChainState<number>("count"));
     expect(result.current).toBeUndefined();
   });
 
   it("returns the stored value (not default) when both are present", () => {
-    runSelectorAgainst(makeExtras({ count: 0 }));
+    runSelectorAgainst(makeExtras({ values: { count: 0 } }));
     const { result } = renderHook(() => useLangChainState<number>("count", 99));
     // 0 is a valid value; must be preserved over the default.
     expect(result.current).toBe(0);
   });
 
   it("preserves explicit null over defaultValue", () => {
-    runSelectorAgainst(makeExtras({ flag: null }));
+    runSelectorAgainst(makeExtras({ values: { flag: null } }));
     const { result } = renderHook(() =>
       useLangChainState<string | null>("flag", "default"),
     );

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -32,6 +32,7 @@ type LangChainRuntimeExtras = {
   [symbolLangChainRuntimeExtras]: true;
   interrupt: { value?: unknown } | undefined;
   interrupts: readonly { value?: unknown }[];
+  error: unknown;
   submit: (
     values: Record<string, unknown> | null | undefined,
     options?: Record<string, unknown>,
@@ -208,6 +209,7 @@ const useStreamThreadRuntime = (
       [symbolLangChainRuntimeExtras]: true,
       interrupt: stream.interrupt,
       interrupts: stream.interrupts,
+      error: stream.error,
       submit: stream.submit,
       values: stream.values,
       messagesKey,
@@ -215,6 +217,7 @@ const useStreamThreadRuntime = (
     [
       stream.interrupt,
       stream.interrupts,
+      stream.error,
       stream.submit,
       stream.values,
       messagesKey,
@@ -338,6 +341,15 @@ export const useLangChainInterruptState = () => {
     const extras = s.thread.extras;
     if (!extras) return undefined;
     return asLangChainRuntimeExtras(extras).interrupt;
+  });
+};
+
+/** Read the last run/hydration error from the runtime extras. */
+export const useLangChainError = () => {
+  return useAuiState((s) => {
+    const extras = s.thread.extras;
+    if (!extras) return undefined;
+    return asLangChainRuntimeExtras(extras).error;
   });
 };
 


### PR DESCRIPTION
This PR forwards stream.error from `useStream` through the runtime extras and adds a `useLangChainError()` reader hook, mirroring `useLangChainInterruptState`. Parity step toward deprecating `react-langgraph` . Additive; patch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

