### PR TITLE
feat(react-langchain): surface thread-loading state via isLoading

### DIFF
--- a/.changeset/langchain-thread-loading.md
+++ b/.changeset/langchain-thread-loading.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): surface thread-loading state via isLoading

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -28,6 +28,8 @@ Both adapters are first-class. `react-langchain` is newer and thinner; some feat
 
 Shared adapters (attachments, speech, feedback) work the same way described in [adapters](/docs/runtimes/concepts/adapters). Cloud thread persistence is built in.
 
+`thread.isLoading` reflects `useStream`'s `isThreadLoading` (initial history hydration), separate from `isRunning` (a run being in-flight).
+
 ## Requirements
 
 - A LangGraph Cloud API server (locally via [LangGraph Studio](https://github.com/langchain-ai/langgraph-studio) or hosted via [LangSmith](https://www.langchain.com/langsmith)).
@@ -493,6 +495,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | --- | --- | --- |
 | Stream messages | Yes (`useLangGraphRuntime`) | Yes (`useStreamRuntime`) |
 | Interrupt state | Yes | Yes |
+| Thread history loading state (`thread.isLoading`) | Yes | Yes |
 | Send raw state update / resume command | Yes | Yes (`useLangChainSubmit`) |
 | Read arbitrary custom state key | No | Yes (`useLangChainState<T>(key)`) |
 | Per-message metadata (`messages-tuple`) | Yes | Not exposed |

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -224,6 +224,7 @@ const useStreamThreadRuntime = (
   const runtime = useExternalStoreRuntime({
     ...pickExternalStoreSharedOptions(options),
     isRunning: effectiveIsRunning,
+    isLoading: stream.isThreadLoading,
     messages: threadMessages,
     adapters,
     extras,


### PR DESCRIPTION
This PR maps  `useStream'`s `isThreadLoading` (initial history hydration) to the `external-store runtime`'s `isLoading`, so `thread.isLoading` becomes true during hydration matching `react-langgraph` and letting consumers render a thread-history loading state distinct from `isRunning`.
 Wiring-only; covered by typecheck/build. No clean unit assertion possible with the existing reader-only mocked-store harness, so no test added.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

