### PR TITLE
feat(react-langchain): forward runConfig to the graph as config.configurable

### DIFF
--- a/.changeset/forward-runconfig-langchain.md
+++ b/.changeset/forward-runconfig-langchain.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): forward runConfig to the graph as config.configurable

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -498,7 +498,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | Stream messages | Yes (`useLangGraphRuntime`) | Yes (`useStreamRuntime`) |
 | Interrupt state | Yes | Yes |
 | Send raw state update / resume command | Yes | Yes (`useLangChainSubmit`) |
-| Forward per-run `runConfig` | Yes | Yes |
+| Forward per-run `runConfig` | Yes (whole object → `config`) | Yes (`custom` → `config.configurable`) |
 | Read arbitrary custom state key | No | Yes (`useLangChainState<T>(key)`) |
 | Per-message metadata (`messages-tuple`) | Yes | Not exposed |
 | Generative UI messages (LangSmith) | Yes | Not exposed |

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -259,7 +259,7 @@ Follow the [Ink setup](/docs/ink).
 
 ### Forwarding per-run config
 
-When a message is sent, its `runConfig.custom` (for example a selected mode or model) is forwarded to the graph as `config.configurable` on the underlying `useStream().submit` call. This lets per-run app config reach the graph without extra wiring.
+When a message is sent, its `runConfig.custom` (for example a selected mode or model) is forwarded on the underlying `useStream().submit` call as `config.configurable`. Read it in the graph from `config["configurable"]`; on LangGraph v1 the same values are also reachable through the Runtime `context`, which `config.configurable` is aliased to. This lets per-run app config reach the graph without extra wiring.
 
 ## Reading custom state keys
 

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -257,6 +257,10 @@ Follow the [Ink setup](/docs/ink).
 | `adapters` | `{ attachments?, speech?, feedback? }` | Optional. Attachment, speech, and feedback adapters. |
 | `messagesKey` | `string` | The state key that holds messages. Defaults to `"messages"`. |
 
+### Forwarding per-run config
+
+When a message is sent, its `runConfig.custom` (for example a selected mode or model) is forwarded to the graph as `config.configurable` on the underlying `useStream().submit` call. This lets per-run app config reach the graph without extra wiring.
+
 ## Reading custom state keys
 
 LangGraph agents often expose structured state beyond messages (plans, todos, scratch files, generative-UI artifacts). Read them directly with `useLangChainState`. It mirrors `useStream().values[key]` upstream and updates when the stream emits new state.
@@ -494,6 +498,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | Stream messages | Yes (`useLangGraphRuntime`) | Yes (`useStreamRuntime`) |
 | Interrupt state | Yes | Yes |
 | Send raw state update / resume command | Yes | Yes (`useLangChainSubmit`) |
+| Forward per-run `runConfig` | Yes | Yes |
 | Read arbitrary custom state key | No | Yes (`useLangChainState<T>(key)`) |
 | Per-message metadata (`messages-tuple`) | Yes | Not exposed |
 | Generative UI messages (LangSmith) | Yes | Not exposed |

--- a/packages/react-langchain/src/runConfigToSubmitOptions.test.ts
+++ b/packages/react-langchain/src/runConfigToSubmitOptions.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import type { AppendMessage } from "@assistant-ui/core";
+import { runConfigToSubmitOptions } from "./useStreamRuntime";
+
+type RunConfig = AppendMessage["runConfig"];
+
+describe("runConfigToSubmitOptions", () => {
+  it("returns undefined when runConfig is undefined", () => {
+    expect(runConfigToSubmitOptions(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when custom is undefined", () => {
+    expect(
+      runConfigToSubmitOptions({ custom: undefined } as unknown as RunConfig),
+    ).toBeUndefined();
+  });
+
+  it("maps custom to config.configurable", () => {
+    const runConfig = { custom: { mode: "plan" } } as RunConfig;
+    expect(runConfigToSubmitOptions(runConfig)).toEqual({
+      config: { configurable: { mode: "plan" } },
+    });
+  });
+});

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -86,6 +86,13 @@ type LangChainRuntimeExtraOptions = ExternalStoreSharedOptions & {
   delete?: ((threadId: string) => Promise<void>) | undefined;
 };
 
+export const runConfigToSubmitOptions = (
+  runConfig: AppendMessage["runConfig"],
+) =>
+  runConfig?.custom
+    ? { config: { configurable: runConfig.custom } }
+    : undefined;
+
 const getPendingToolCalls = (
   messages: readonly LangChainBaseMessage[],
 ): LangChainToolCall[] => {
@@ -243,9 +250,10 @@ const useStreamThreadRuntime = (
               status: "error" as const,
             }))
           : [];
-      await stream.submit({
-        [messagesKey]: [...cancellations, { type: "human", content }],
-      });
+      await stream.submit(
+        { [messagesKey]: [...cancellations, { type: "human", content }] },
+        runConfigToSubmitOptions(msg.runConfig),
+      );
     },
     onAddToolResult: async ({
       toolCallId,


### PR DESCRIPTION
## Summary

Forwards an `AppendMessage`'s `runConfig.custom` into `useStream().submit` as `config.configurable`, so per-run app config (e.g. a selected mode/model) reaches the graph. Previously this was dropped in `onNew`.

A small pure helper does the mapping:

```ts
const runConfigToSubmitOptions = (runConfig: AppendMessage["runConfig"]) =>
  runConfig?.custom ? { config: { configurable: runConfig.custom } } : undefined;
```

## Tests

Direct unit coverage of all three branches of `runConfigToSubmitOptions`:
- `undefined` → `undefined`
- `{ custom: undefined }` → `undefined`
- `{ custom: { mode: "plan" } }` → `{ config: { configurable: { mode: "plan" } } }`

## Docs

- New "Forwarding per-run config" section under `useStreamRuntime` options.
- Feature-coverage table row for "Forward per-run `runConfig`".

## Mapping choice

We unwrap `runConfig.custom` into `config.configurable`: the canonical LangGraph location for per-run user values (where `thread_id` etc. also live), accessible in the graph as `config["configurable"]`.

This differs from `react-langgraph`, which forwards the whole `runConfig` as `config` (`createLangGraphStream.ts:50`), so values land at `config.custom.*`: a non-standard `RunnableConfig` slot. We went with `configurable` here because it's the idiomatic target; the two adapters can be aligned later if we want parity.
