### PR TITLE
feat(react-langchain): convert file content parts in messages

### DIFF
--- a/.changeset/langchain-file-content-parts.md
+++ b/.changeset/langchain-file-content-parts.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): convert file content parts in messages

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -495,6 +495,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | Interrupt state | Yes | Yes |
 | Send raw state update / resume command | Yes | Yes (`useLangChainSubmit`) |
 | Read arbitrary custom state key | No | Yes (`useLangChainState<T>(key)`) |
+| File content parts in messages | Yes | Yes |
 | Per-message metadata (`messages-tuple`) | Yes | Not exposed |
 | Generative UI messages (LangSmith) | Yes | Not exposed |
 | Subgraph / namespaced stream events | Yes (via `eventHandlers`) | Not exposed |

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -9,13 +9,14 @@ const humanMessage = (content: unknown): LangChainBaseMessage => ({
 });
 
 describe("convertLangChainBaseMessage file content parts", () => {
-  it("converts a flat data file block", () => {
+  it("converts a base64 file block", () => {
     const result = convertLangChainBaseMessage(
       humanMessage([
         {
           type: "file",
           data: "ZmFrZQ==",
           mime_type: "application/pdf",
+          source_type: "base64",
           metadata: { filename: "a.pdf" },
         },
       ]),
@@ -32,17 +33,10 @@ describe("convertLangChainBaseMessage file content parts", () => {
     ]);
   });
 
-  it("converts a legacy nested file block", () => {
+  it("falls back to a default filename when metadata is absent", () => {
     const result = convertLangChainBaseMessage(
       humanMessage([
-        {
-          type: "file",
-          file: {
-            filename: "b.pdf",
-            file_data: "YmFzZTY0",
-            mime_type: "application/pdf",
-          },
-        },
+        { type: "file", data: "ZmFrZQ==", mime_type: "application/pdf" },
       ]),
       {},
     );
@@ -50,42 +44,10 @@ describe("convertLangChainBaseMessage file content parts", () => {
     expect(result.content).toEqual([
       {
         type: "file",
-        filename: "b.pdf",
-        data: "YmFzZTY0",
+        filename: "file",
+        data: "ZmFrZQ==",
         mimeType: "application/pdf",
       },
     ]);
-  });
-
-  it("converts a top-level base64 file block", () => {
-    const result = convertLangChainBaseMessage(
-      humanMessage([
-        {
-          type: "file",
-          base64: "dG9w",
-          mime_type: "application/pdf",
-          filename: "c.pdf",
-        },
-      ]),
-      {},
-    );
-
-    expect(result.content).toEqual([
-      {
-        type: "file",
-        filename: "c.pdf",
-        data: "dG9w",
-        mimeType: "application/pdf",
-      },
-    ]);
-  });
-
-  it("drops an unrecognized file block shape", () => {
-    const result = convertLangChainBaseMessage(
-      humanMessage([{ type: "file", unknown: true } as never]),
-      {},
-    );
-
-    expect(result.content).toEqual([]);
   });
 });

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { convertLangChainBaseMessage } from "./convertMessages";
+import type { LangChainBaseMessage } from "./types";
+
+const humanMessage = (content: unknown): LangChainBaseMessage => ({
+  _getType: () => "human",
+  id: "msg-1",
+  content,
+});
+
+describe("convertLangChainBaseMessage file content parts", () => {
+  it("converts a flat data file block", () => {
+    const result = convertLangChainBaseMessage(
+      humanMessage([
+        {
+          type: "file",
+          data: "ZmFrZQ==",
+          mime_type: "application/pdf",
+          metadata: { filename: "a.pdf" },
+        },
+      ]),
+      {},
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "file",
+        filename: "a.pdf",
+        data: "ZmFrZQ==",
+        mimeType: "application/pdf",
+      },
+    ]);
+  });
+
+  it("converts a legacy nested file block", () => {
+    const result = convertLangChainBaseMessage(
+      humanMessage([
+        {
+          type: "file",
+          file: {
+            filename: "b.pdf",
+            file_data: "YmFzZTY0",
+            mime_type: "application/pdf",
+          },
+        },
+      ]),
+      {},
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "file",
+        filename: "b.pdf",
+        data: "YmFzZTY0",
+        mimeType: "application/pdf",
+      },
+    ]);
+  });
+
+  it("converts a top-level base64 file block", () => {
+    const result = convertLangChainBaseMessage(
+      humanMessage([
+        {
+          type: "file",
+          base64: "dG9w",
+          mime_type: "application/pdf",
+          filename: "c.pdf",
+        },
+      ]),
+      {},
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "file",
+        filename: "c.pdf",
+        data: "dG9w",
+        mimeType: "application/pdf",
+      },
+    ]);
+  });
+
+  it("drops an unrecognized file block shape", () => {
+    const result = convertLangChainBaseMessage(
+      humanMessage([{ type: "file", unknown: true } as never]),
+      {},
+    );
+
+    expect(result.content).toEqual([]);
+  });
+});

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -11,43 +11,6 @@ export const getMessageType = (message: LangChainBaseMessage): string => {
   throw new Error("Cannot determine message type");
 };
 
-type LangChainFileBlock = Extract<LangChainContentBlock, { type: "file" }>;
-
-const contentFilePartToThreadPart = (
-  part: LangChainFileBlock,
-): {
-  type: "file";
-  filename: string;
-  data: string;
-  mimeType: string;
-} | null => {
-  if ("file" in part) {
-    return {
-      type: "file" as const,
-      filename: part.file.filename,
-      data: part.file.file_data,
-      mimeType: part.file.mime_type,
-    };
-  }
-  if ("data" in part && typeof part.data === "string") {
-    return {
-      type: "file" as const,
-      filename: part.metadata?.filename ?? "file",
-      data: part.data,
-      mimeType: part.mime_type,
-    };
-  }
-  if ("base64" in part && typeof part.base64 === "string") {
-    return {
-      type: "file" as const,
-      filename: part.filename ?? "file",
-      data: part.base64,
-      mimeType: part.mime_type,
-    };
-  }
-  return null;
-};
-
 const contentToParts = (content: unknown) => {
   if (typeof content === "string")
     return [{ type: "text" as const, text: content }];
@@ -66,7 +29,12 @@ const contentToParts = (content: unknown) => {
           }
           return { type: "image" as const, image: part.image_url.url };
         case "file":
-          return contentFilePartToThreadPart(part);
+          return {
+            type: "file" as const,
+            filename: part.metadata?.filename ?? "file",
+            data: part.data,
+            mimeType: part.mime_type,
+          };
         case "thinking":
           return { type: "reasoning" as const, text: part.thinking };
         case "reasoning":

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -11,6 +11,43 @@ export const getMessageType = (message: LangChainBaseMessage): string => {
   throw new Error("Cannot determine message type");
 };
 
+type LangChainFileBlock = Extract<LangChainContentBlock, { type: "file" }>;
+
+const contentFilePartToThreadPart = (
+  part: LangChainFileBlock,
+): {
+  type: "file";
+  filename: string;
+  data: string;
+  mimeType: string;
+} | null => {
+  if ("file" in part) {
+    return {
+      type: "file" as const,
+      filename: part.file.filename,
+      data: part.file.file_data,
+      mimeType: part.file.mime_type,
+    };
+  }
+  if ("data" in part && typeof part.data === "string") {
+    return {
+      type: "file" as const,
+      filename: part.metadata?.filename ?? "file",
+      data: part.data,
+      mimeType: part.mime_type,
+    };
+  }
+  if ("base64" in part && typeof part.base64 === "string") {
+    return {
+      type: "file" as const,
+      filename: part.filename ?? "file",
+      data: part.base64,
+      mimeType: part.mime_type,
+    };
+  }
+  return null;
+};
+
 const contentToParts = (content: unknown) => {
   if (typeof content === "string")
     return [{ type: "text" as const, text: content }];
@@ -28,6 +65,8 @@ const contentToParts = (content: unknown) => {
             return { type: "image" as const, image: part.image_url };
           }
           return { type: "image" as const, image: part.image_url.url };
+        case "file":
+          return contentFilePartToThreadPart(part);
         case "thinking":
           return { type: "reasoning" as const, text: part.thinking };
         case "reasoning":

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -12,15 +12,11 @@ export type LangChainContentBlock =
     }
   | {
       type: "file";
-      file: { filename: string; file_data: string; mime_type: string };
-    }
-  | {
-      type: "file";
       data: string;
       mime_type: string;
+      source_type?: "base64";
       metadata?: { filename?: string };
     }
-  | { type: "file"; base64: string; mime_type: string; filename?: string }
   | { type: "tool_use" | "input_json_delta" };
 
 export type LangChainToolCall = {

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -10,6 +10,17 @@ export type LangChainContentBlock =
       type: "reasoning";
       summary: Array<{ type: "summary_text"; text: string }>;
     }
+  | {
+      type: "file";
+      file: { filename: string; file_data: string; mime_type: string };
+    }
+  | {
+      type: "file";
+      data: string;
+      mime_type: string;
+      metadata?: { filename?: string };
+    }
+  | { type: "file"; base64: string; mime_type: string; filename?: string }
   | { type: "tool_use" | "input_json_delta" };
 
 export type LangChainToolCall = {


### PR DESCRIPTION

## Summary

`convertLangChainBaseMessage` mapped LangChain content blocks (text, image, thinking, reasoning, tool_use) to assistant-ui message parts but silently dropped `file` blocks, so file attachments in messages never rendered. The sibling `@assistant-ui/react-langgraph` already supports them.

This ports `react-langgraph`'s file handling into `react-langchain`, keeping the package's minimal style. File-only: `computer_call` and the partial-JSON tool-arg streaming stabilization are intentionally out of scope.

## Notes

`computer_call` was deliberately left out: react-langchain's converter has none of the tool-args stabilization machinery (`stableStringifyToolArgs`, key-order cache, `messageId` plumbing) that react-langgraph's `computer_call` case depends on, so porting it would add real type/complexity weight rather than being a trivial addition.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

