### PR TITLE
docs: fix runnable mem0 example snippets

### DIFF
--- a/apps/docs/content/examples/mem0.mdx
+++ b/apps/docs/content/examples/mem0.mdx
@@ -38,32 +38,31 @@ A personalized AI chat experience powered by Mem0 that remembers user preference
 The example integrates Mem0's memory SDK with assistant-ui:
 
 ```tsx
-import { Mem0Client } from "mem0ai";
+import MemoryClient from "mem0ai";
 
-const mem0 = new Mem0Client({
+const mem0 = new MemoryClient({
   apiKey: process.env.MEM0_API_KEY,
 });
 
 // Store memories from a conversation
 async function storeMemory(userId: string, messages: Message[]) {
-  await mem0.add({
-    messages: messages.map((m) => ({
+  await mem0.add(
+    messages.map((m) => ({
       role: m.role,
       content: m.content,
     })),
-    user_id: userId,
-  });
+    { user_id: userId },
+  );
 }
 
 // Retrieve relevant memories for context
 async function getRelevantMemories(userId: string, query: string) {
-  const memories = await mem0.search({
-    query,
+  const { results } = await mem0.search(query, {
     user_id: userId,
     limit: 10,
   });
 
-  return memories.map((m) => m.memory).join("\n");
+  return results.map((m) => m.memory).join("\n");
 }
 ```
 


### PR DESCRIPTION
The Mem0 Memory Chat example had non-runnable code snippets. This PR fixes the two real bugs: 

- `Mem0Client` doesn't exist: the hosted SDK is a default export, so `import MemoryClient from "mem0ai"` / `new MemoryClient({ apiKey })`
- `mem0.search()` returns `{ results }`, not an array: destructure and map over `results` so `.map((m) => m.memory)` doesn't throw


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

