### PR TITLE
fix(examples): activate dark mode in react-hook-form demo

### DIFF
--- a/examples/with-react-hook-form/app/layout.tsx
+++ b/examples/with-react-hook-form/app/layout.tsx
@@ -20,7 +20,14 @@ export default function RootLayout({
 }>) {
   return (
     <MyRuntimeProvider>
-      <html lang="en">
+      <html lang="en" suppressHydrationWarning>
+        <head>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `(function(){try{var t=new URLSearchParams(location.search).get("theme");var dark=t?t==="dark":matchMedia("(prefers-color-scheme: dark)").matches;document.documentElement.classList.toggle("dark",dark);}catch(e){}})();`,
+            }}
+          />
+        </head>
         <body
           className={`${geistSans.variable} ${geistMono.variable} h-dvh font-sans antialiased`}
         >


### PR DESCRIPTION
The form-filling copilot example already shipped dark-mode CSS tokens(`.dark {}` in globals.css), but nothing ever applied the `.dark` class, so the demo was permanently light.

This adds a small pre-paint script in the root layout that sets the`.dark` class from a `?theme=dark|light` query param, falling back to the visitor's system preference (`prefers-color-scheme`). No new dependency, no UI chrome, no flash of the wrong theme.

The query-param support is forward-looking: it lets an embedder (e.g. the docs site iframe) drive the demo's theme. 


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

