### PR TITLE
feat(docs): sync embedded form demo iframe with docs theme

### DIFF
--- a/apps/docs/components/docs/demo-iframe.tsx
+++ b/apps/docs/components/docs/demo-iframe.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect, useState, type ComponentProps } from "react";
+
+export function DemoIframe({ src, ...props }: ComponentProps<"iframe">) {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  const themedSrc =
+    mounted && src
+      ? `${src}${src.includes("?") ? "&" : "?"}theme=${resolvedTheme ?? "light"}`
+      : undefined;
+
+  return <iframe src={themedSrc} {...props} />;
+}

--- a/apps/docs/content/examples/form-demo.mdx
+++ b/apps/docs/content/examples/form-demo.mdx
@@ -5,7 +5,7 @@ description: Open-source AI copilot that fills forms for users — sidebar UI, f
 
 
 <div className="not-prose h-[600px]">
-  <iframe
+  <DemoIframe
     title="Form Filling Co-Pilot demo"
     className="h-full w-full border-none"
     src="https://assistant-ui-form-demo.vercel.app/"

--- a/apps/docs/mdx-components.tsx
+++ b/apps/docs/mdx-components.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/docs/platform/mdx";
 import { PrimitivesTypeTable } from "@/components/docs/primitives-type-table";
 import { SourceLink } from "@/components/docs/source-link";
+import { DemoIframe } from "@/components/docs/demo-iframe";
 import { Flow } from "@/components/assistant-ui/flow";
 import { Code } from "@radix-ui/themes";
 
@@ -60,6 +61,7 @@ export function getMDXComponents(components: MDXComponents): MDXComponents {
     ParametersTable,
     PrimitivesTypeTable,
     SourceLink,
+    DemoIframe,
     Flow,
     Code,
     blockquote: (props) => <Callout>{props.children}</Callout>,


### PR DESCRIPTION
The form-filling copilot example is embedded in the docs via an `<iframe>`. Because the iframe is a separate document, it can't see the docs site's `.dark` class, so toggling the docs to dark left the demo white.

This adds a `DemoIframe` component that reads `resolvedTheme` from next-themes and appends `?theme=dark|light` to the iframe src. Toggling the docs theme updates the src, so the demo reloads in the matching theme.

Depends on the demo honoring `?theme` https://github.com/assistant-ui/assistant-ui/pull/4441; until that demo redeploys, the param is a harmless no-op.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

