### PR TITLE
fix: keep registry markdown highlighting opt-in

### DIFF
--- a/apps/docs/components/assistant-ui/markdown-text.tsx
+++ b/apps/docs/components/assistant-ui/markdown-text.tsx
@@ -12,6 +12,7 @@ import remarkGfm from "remark-gfm";
 import { type FC, memo, useState } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 
+import { SyntaxHighlighter } from "@/components/assistant-ui/shiki-highlighter";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { cn } from "@/lib/utils";
 
@@ -77,6 +78,7 @@ const useCopyToClipboard = ({
 };
 
 const defaultComponents = memoizeMarkdownComponents({
+  SyntaxHighlighter,
   h1: ({ className, ...props }) => (
     <h1
       className={cn(

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -4,6 +4,9 @@
     "paths": {
       "@/components/ui/*": ["../../packages/ui/src/components/ui/*"],
       "@/lib/utils": ["../../packages/ui/src/lib/utils"],
+      "@/components/assistant-ui/markdown-text": [
+        "./components/assistant-ui/markdown-text"
+      ],
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],


### PR DESCRIPTION
due to bundle size constraint for default thread component and templates.
adds local `markdown-text.tsx` to docs to enable highlighting in docs.