### PR TITLE
refactor(react-langgraph): collapse file content block to single shape

### DIFF
--- a/.changeset/langgraph-trim-file-shapes.md
+++ b/.changeset/langgraph-trim-file-shapes.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+refactor(react-langgraph): collapse file content conversion to the single flat block langgraph emits, dropping the nested and top-level base64 shapes that no upstream produces

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -302,35 +302,6 @@ describe("convertLangChainMessages metadata", () => {
 });
 
 describe("convertLangChainMessages file content", () => {
-  it("converts legacy nested file content blocks", () => {
-    const result = convertLangChainMessages({
-      type: "human",
-      id: "human-legacy-file",
-      content: [
-        {
-          type: "file",
-          file: {
-            filename: "legacy.pdf",
-            file_data: "bGVnYWN5",
-            mime_type: "application/pdf",
-          },
-        },
-      ],
-    });
-
-    expect(result).toMatchObject({
-      role: "user",
-      content: [
-        {
-          type: "file",
-          filename: "legacy.pdf",
-          data: "bGVnYWN5",
-          mimeType: "application/pdf",
-        },
-      ],
-    });
-  });
-
   it("converts flat base64-style file content blocks", () => {
     const result = convertLangChainMessages({
       type: "human",
@@ -361,15 +332,14 @@ describe("convertLangChainMessages file content", () => {
     });
   });
 
-  it("converts file blocks with top-level base64 field", () => {
+  it("falls back to a default filename when metadata is absent", () => {
     const result = convertLangChainMessages({
       type: "human",
-      id: "human-top-level-base64-file",
+      id: "human-file-no-filename",
       content: [
         {
           type: "file",
-          filename: "top-level.pdf",
-          base64: "dG9wLWxldmVs",
+          data: "ZmxhdA==",
           mime_type: "application/pdf",
         },
       ],
@@ -380,8 +350,8 @@ describe("convertLangChainMessages file content", () => {
       content: [
         {
           type: "file",
-          filename: "top-level.pdf",
-          data: "dG9wLWxldmVs",
+          filename: "file",
+          data: "ZmxhdA==",
           mimeType: "application/pdf",
         },
       ],

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -161,58 +161,6 @@ const warnForUnknownMessagePartType = (type: string) => {
   console.warn(`Unknown message part type: ${type}`);
 };
 
-const warnedFilePartShapes = new Set<string>();
-const warnForUnsupportedFilePartShape = (part: FileContentPart) => {
-  if (
-    typeof process === "undefined" ||
-    process?.env?.NODE_ENV !== "development"
-  )
-    return;
-  const shape = Object.keys(part).sort().join(",");
-  if (warnedFilePartShapes.has(shape)) return;
-  warnedFilePartShapes.add(shape);
-  console.warn(`Unsupported file content block shape: ${shape}`);
-};
-
-type FileContentPart = Extract<
-  Exclude<LangChainMessage["content"], string>[number],
-  { type: "file" }
->;
-
-const contentFilePartToThreadPart = (
-  part: FileContentPart,
-): Extract<ThreadUserMessage["content"][number], { type: "file" }> | null => {
-  if ("file" in part) {
-    return {
-      type: "file",
-      filename: part.file.filename,
-      data: part.file.file_data,
-      mimeType: part.file.mime_type,
-    };
-  }
-
-  if ("data" in part && typeof part.data === "string") {
-    return {
-      type: "file",
-      filename: part.metadata?.filename ?? "file",
-      data: part.data,
-      mimeType: part.mime_type,
-    };
-  }
-
-  if ("base64" in part && typeof part.base64 === "string") {
-    return {
-      type: "file",
-      filename: part.filename ?? "file",
-      data: part.base64,
-      mimeType: part.mime_type,
-    };
-  }
-
-  warnForUnsupportedFilePartShape(part);
-  return null;
-};
-
 const contentToParts = (
   content: LangChainMessage["content"],
   metadata: LangGraphMessageConverterMetadata,
@@ -243,7 +191,12 @@ const contentToParts = (
               };
             }
           case "file":
-            return contentFilePartToThreadPart(part);
+            return {
+              type: "file",
+              filename: part.metadata?.filename ?? "file",
+              data: part.data,
+              mimeType: part.mime_type,
+            };
 
           case "thinking":
             return { type: "reasoning", text: part.thinking };

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -71,16 +71,7 @@ type CustomEventType = string;
 
 export type EventType = LangGraphKnownEventTypes | CustomEventType;
 
-export type LegacyMessageContentFile = {
-  type: "file";
-  file: {
-    filename: string;
-    file_data: string;
-    mime_type: string;
-  };
-};
-
-export type FlatMessageContentFile = {
+export type MessageContentFile = {
   type: "file";
   data: string;
   mime_type: string;
@@ -89,18 +80,6 @@ export type FlatMessageContentFile = {
     filename?: string;
   };
 };
-
-export type Base64MessageContentFile = {
-  type: "file";
-  base64: string;
-  mime_type: string;
-  filename?: string;
-};
-
-export type MessageContentFile =
-  | LegacyMessageContentFile
-  | FlatMessageContentFile
-  | Base64MessageContentFile;
 
 type UserMessageContentComplex =
   | MessageContentText


### PR DESCRIPTION
## summary

- react-langgraph's file content block conversion now handles only the flat `{ data, mime_type, metadata }` block that langgraph actually emits. behavior is unchanged for real data, since the two dropped shapes had no producer.
- drops the nested `{ file: { file_data } }` shape (langgraph's old write format that LangGraph Cloud rejected outright, see #3475, so nothing ever persisted it) and the top-level `{ base64 }` shape (no producer anywhere in langchainjs or langgraphjs; langgraph-sdk's media assembler only ever delivers `data` / `mime_type`).
- inlines the one remaining branch into the `case "file"` arm like the other content block arms, and removes the now dead file shape dev warning plus the `Extract` helper.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-langgraph test` -> 143/143 green
- [x] `pnpm --filter @assistant-ui/react-langgraph build` -> typecheck and d.ts emit clean
- [x] `pnpm lint` -> oxlint and oxfmt clean

### reviewer should verify

- [ ] send a file attachment through a langgraph runtime and confirm it still renders via the flat block path

## notes

- mirrors the same trim applied to the sibling react-langchain converter in #4438.
- separate follow-ups: a shared file block normalizer in core, and the snake_case `mime_type` versus langchain v1 camelCase `mimeType` forward compatibility gap that affects both converters.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

