### PR TITLE
fix: authenticate CLI GitHub downloads

### DIFF
--- a/.changeset/quiet-tokens-share.md
+++ b/.changeset/quiet-tokens-share.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: authenticate CLI GitHub downloads with configured tokens

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -61,10 +61,25 @@ export function resolvePackageManager(opts: {
   return undefined;
 }
 
+function resolveGitHubAuthToken(): string | undefined {
+  const token =
+    process.env.GIGET_AUTH ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const trimmed = token?.trim();
+  return trimmed || undefined;
+}
+
+function toBearerAuthHeader(token: string): string {
+  return token.toLowerCase().startsWith("bearer ") ? token : `Bearer ${token}`;
+}
+
 export async function resolveLatestReleaseRef(): Promise<string | undefined> {
   try {
+    const authToken = resolveGitHubAuthToken();
     const res = await fetch(
       "https://api.github.com/repos/assistant-ui/assistant-ui/releases/latest",
+      authToken
+        ? { headers: { Authorization: toBearerAuthHeader(authToken) } }
+        : undefined,
     );
     if (!res.ok) return undefined;
     const release = (await res.json()) as { tag_name: string };
@@ -92,10 +107,12 @@ export async function downloadProject(
   const origDebug = process.env.DEBUG;
   delete process.env.DEBUG;
   try {
+    const authToken = resolveGitHubAuthToken();
     const downloadPromise = downloadTemplate(source, {
       dir: destDir,
       force: true,
       silent: true,
+      ...(authToken ? { auth: authToken } : {}),
     });
 
     let timer: ReturnType<typeof setTimeout>;

--- a/packages/cli/test/lib/create-project.test.ts
+++ b/packages/cli/test/lib/create-project.test.ts
@@ -54,13 +54,33 @@ const defaultOpts = {
 } as const;
 
 let testDir: string;
+const GITHUB_AUTH_ENV_KEYS = [
+  "GIGET_AUTH",
+  "GITHUB_TOKEN",
+  "GH_TOKEN",
+] as const;
+let originalGitHubAuthEnv: Record<
+  (typeof GITHUB_AUTH_ENV_KEYS)[number],
+  string | undefined
+>;
 
 beforeEach(() => {
   testDir = fs.mkdtempSync(path.join(os.tmpdir(), "cli-create-project-"));
+  originalGitHubAuthEnv = Object.fromEntries(
+    GITHUB_AUTH_ENV_KEYS.map((key) => [key, process.env[key]]),
+  ) as Record<(typeof GITHUB_AUTH_ENV_KEYS)[number], string | undefined>;
+  for (const key of GITHUB_AUTH_ENV_KEYS) {
+    delete process.env[key];
+  }
 });
 
 afterEach(() => {
   fs.rmSync(testDir, { recursive: true, force: true });
+  for (const key of GITHUB_AUTH_ENV_KEYS) {
+    const value = originalGitHubAuthEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
   vi.clearAllMocks();
   vi.unstubAllGlobals();
 });
@@ -97,6 +117,21 @@ describe("resolveLatestReleaseRef", () => {
     expect(await resolveLatestReleaseRef()).toBe("@assistant-ui/react@0.12.15");
   });
 
+  it("authenticates the latest release request when a GitHub token is configured", async () => {
+    process.env.GITHUB_TOKEN = "ghs_test-token";
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ tag_name: "@assistant-ui/react@0.12.15" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await resolveLatestReleaseRef()).toBe("@assistant-ui/react@0.12.15");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/assistant-ui/assistant-ui/releases/latest",
+      { headers: { Authorization: "Bearer ghs_test-token" } },
+    );
+  });
+
   it("returns undefined when fetch fails", async () => {
     vi.stubGlobal(
       "fetch",
@@ -122,6 +157,17 @@ describe("downloadProject", () => {
     expect(downloadTemplate).toHaveBeenCalledWith(
       "gh:assistant-ui/assistant-ui/examples/with-tanstack",
       expect.objectContaining({ dir: "/tmp/dest", force: true, silent: true }),
+    );
+  });
+
+  it("passes auth to giget when a GitHub token is configured", async () => {
+    process.env.GH_TOKEN = "ghs_test-token";
+
+    await downloadProject("templates/default", "/tmp/dest", "v1.0.0");
+
+    expect(downloadTemplate).toHaveBeenCalledWith(
+      "gh:assistant-ui/assistant-ui/templates/default#v1.0.0",
+      expect.objectContaining({ auth: "ghs_test-token" }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- Read GitHub auth from `GIGET_AUTH`, `GITHUB_TOKEN`, or `GH_TOKEN` when scaffolding projects.
- Send the token to the latest-release lookup and pass it through to giget downloads.
- Add regression coverage for both authenticated GitHub calls.

## Validation
- `pnpm --filter assistant-ui test -- test/lib/create-project.test.ts`

Closes #4434.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

