### PR TITLE
feat(react-langchain): resume interrupts via useLangChainRespond

### DIFF
--- a/.changeset/langchain-respond.md
+++ b/.changeset/langchain-respond.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): resume interrupts via useLangChainRespond

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -353,7 +353,30 @@ Added in v0.0.2 — see issue [#3862](https://github.com/assistant-ui/assistant-
 
 ## Interrupts
 
-LangGraph interrupts pause the graph and wait for client input. `useLangChainInterruptState` exposes the current interrupt; `useLangChainSubmit` resumes the graph with a raw state update.
+LangGraph interrupts pause the graph and wait for client input. `useLangChainInterruptState` exposes the current interrupt; `useLangChainRespond` resumes it with a response payload, while `useLangChainSubmit` resumes the graph with a raw state update.
+
+`useLangChainRespond` is the cleaner resume path — it carries the response payload via `useStream().respond` and handles interrupt namespaces, so you don't have to construct a `Command`.
+
+```tsx
+import {
+  useLangChainInterruptState,
+  useLangChainRespond,
+} from "@assistant-ui/react-langchain";
+
+function InterruptPrompt() {
+  const interrupt = useLangChainInterruptState();
+  const respond = useLangChainRespond();
+  if (!interrupt) return null;
+  return (
+    <div>
+      <pre>{JSON.stringify(interrupt.value, null, 2)}</pre>
+      <button onClick={() => respond({ approved: true })}>Approve</button>
+    </div>
+  );
+}
+```
+
+You can also resume with a raw `Command` via `useLangChainSubmit`:
 
 <PlatformTabs>
 <Tab value="React">
@@ -604,6 +627,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | `useLangGraphRuntime` | `useStreamRuntime` | Options extend upstream `UseStreamOptions`; no `stream` / `create` / `load` to write. |
 | `useLangGraphInterruptState` | `useLangChainInterruptState` | Same return shape. |
 | `useLangGraphSendCommand` | `useLangChainSubmit` | `submit(values, { command })` replaces the dedicated hook. |
+| `useLangGraphSendCommand` | `useLangChainRespond` | Preferred resume — carries a payload via `stream.respond` (vs the older `useLangChainSubmit(null, { command })`). |
 | `useLangGraphSend` | _(use `runtime.thread.append`)_ | No direct equivalent; send turns through the runtime. |
 | `useLangGraphMessageMetadata` | _(not available)_ | Open an issue if you rely on this. |
 | `useLangGraphUIMessages` | _(not available)_ | Open an issue if you rely on this. |

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -355,7 +355,10 @@ Added in v0.0.2 — see issue [#3862](https://github.com/assistant-ui/assistant-
 
 LangGraph interrupts pause the graph and wait for client input. `useLangChainInterruptState` exposes the current interrupt; `useLangChainRespond` resumes it with a response payload, while `useLangChainSubmit` resumes the graph with a raw state update.
 
-`useLangChainRespond` is the cleaner resume path — it carries the response payload via `useStream().respond` and handles interrupt namespaces, so you don't have to construct a `Command`.
+`useLangChainRespond` is the cleaner resume path; it carries the response payload via `useStream().respond` and handles interrupt namespaces, so you don't have to construct a `Command`.
+
+<PlatformTabs>
+<Tab value="React">
 
 ```tsx
 import {
@@ -375,6 +378,63 @@ function InterruptPrompt() {
   );
 }
 ```
+
+</Tab>
+<Tab value="React Native">
+
+```tsx
+import {
+  useLangChainInterruptState,
+  useLangChainRespond,
+} from "@assistant-ui/react-langchain";
+import { Pressable, Text, View } from "react-native";
+
+function InterruptPrompt() {
+  const interrupt = useLangChainInterruptState();
+  const respond = useLangChainRespond();
+  if (!interrupt) return null;
+  return (
+    <View>
+      <Text>{JSON.stringify(interrupt.value, null, 2)}</Text>
+      <Pressable onPress={() => respond({ approved: true })}>
+        <Text>Approve</Text>
+      </Pressable>
+    </View>
+  );
+}
+```
+
+</Tab>
+<Tab value="React Ink">
+
+```tsx
+import {
+  useLangChainInterruptState,
+  useLangChainRespond,
+} from "@assistant-ui/react-langchain";
+import { Box, Text, useInput } from "ink";
+
+function InterruptPrompt() {
+  const interrupt = useLangChainInterruptState();
+  const respond = useLangChainRespond();
+
+  useInput((input) => {
+    if (!interrupt || input !== "a") return;
+    respond({ approved: true });
+  });
+
+  if (!interrupt) return null;
+  return (
+    <Box flexDirection="column">
+      <Text>{JSON.stringify(interrupt.value, null, 2)}</Text>
+      <Text>Press a to approve.</Text>
+    </Box>
+  );
+}
+```
+
+</Tab>
+</PlatformTabs>
 
 You can also resume with a raw `Command` via `useLangChainSubmit`:
 
@@ -606,7 +666,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | Stream messages | Yes (`useLangGraphRuntime`) | Yes (`useStreamRuntime`) |
 | Interrupt state | Yes | Yes |
 | Thread history loading state (`thread.isLoading`) | Yes | Yes |
-| Send raw state update / resume command | Yes | Yes (`useLangChainSubmit`) |
+| Send raw state update / resume command | Yes | Yes (`useLangChainSubmit`; `useLangChainRespond` for payload resume) |
 | Forward per-run `runConfig` | Yes (whole object → `config`) | Yes (`custom` → `config.configurable`) |
 | Read arbitrary custom state key | No | Yes (`useLangChainState<T>(key)`) |
 | Root tool-calls projection | Via message parts | Yes (`useLangChainToolCalls`) |
@@ -626,8 +686,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | --- | --- | --- |
 | `useLangGraphRuntime` | `useStreamRuntime` | Options extend upstream `UseStreamOptions`; no `stream` / `create` / `load` to write. |
 | `useLangGraphInterruptState` | `useLangChainInterruptState` | Same return shape. |
-| `useLangGraphSendCommand` | `useLangChainSubmit` | `submit(values, { command })` replaces the dedicated hook. |
-| `useLangGraphSendCommand` | `useLangChainRespond` | Preferred resume — carries a payload via `stream.respond` (vs the older `useLangChainSubmit(null, { command })`). |
+| `useLangGraphSendCommand` | `useLangChainRespond` | Preferred resume; carries a payload via `stream.respond`. For a raw `Command`, use `useLangChainSubmit(null, { command })`. |
 | `useLangGraphSend` | _(use `runtime.thread.append`)_ | No direct equivalent; send turns through the runtime. |
 | `useLangGraphMessageMetadata` | _(not available)_ | Open an issue if you rely on this. |
 | `useLangGraphUIMessages` | _(not available)_ | Open an issue if you rely on this. |

--- a/packages/react-langchain/src/index.ts
+++ b/packages/react-langchain/src/index.ts
@@ -2,6 +2,7 @@ export {
   useStreamRuntime,
   useLangChainError,
   useLangChainInterruptState,
+  useLangChainRespond,
   useLangChainSend,
   useLangChainSendCommand,
   useLangChainState,

--- a/packages/react-langchain/src/useLangChainRespond.test.tsx
+++ b/packages/react-langchain/src/useLangChainRespond.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { makeExtras } from "./__tests__/langChainTestUtils";
+
+const { mockUseAui } = vi.hoisted(() => ({
+  mockUseAui: vi.fn(),
+}));
+
+vi.mock(import("@assistant-ui/store"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useAui: (() => mockUseAui()) as unknown as typeof actual.useAui,
+  };
+});
+
+import { useLangChainRespond } from "./useStreamRuntime";
+
+describe("useLangChainRespond", () => {
+  it("forwards the response and options to stream.respond", async () => {
+    const respond = vi.fn().mockResolvedValue(undefined);
+    mockUseAui.mockReturnValue({
+      thread: () => ({
+        getState: () => ({ extras: makeExtras({ respond }) }),
+      }),
+    });
+
+    const { result } = renderHook(() => useLangChainRespond());
+    await result.current({ approved: true }, { interruptId: "x" });
+
+    expect(respond).toHaveBeenCalledWith(
+      { approved: true },
+      { interruptId: "x" },
+    );
+  });
+
+  it("throws when extras are absent or unbranded", () => {
+    mockUseAui.mockReturnValue({
+      thread: () => ({ getState: () => ({ extras: { respond: vi.fn() } }) }),
+    });
+
+    const { result } = renderHook(() => useLangChainRespond());
+    expect(() => result.current({ approved: true })).toThrow(
+      "This method can only be called when you are using useStreamRuntime",
+    );
+  });
+});

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -44,6 +44,10 @@ type LangChainRuntimeExtras = {
     values: Record<string, unknown> | null | undefined,
     options?: Record<string, unknown>,
   ) => Promise<void>;
+  respond: (
+    response: unknown,
+    options?: Record<string, unknown>,
+  ) => Promise<void>;
   values: Record<string, unknown>;
   messagesKey: string;
 };
@@ -226,6 +230,7 @@ const useStreamThreadRuntime = (
       toolCalls: stream.toolCalls,
       error: stream.error,
       submit: stream.submit,
+      respond: stream.respond,
       values: stream.values,
       messagesKey,
     }),
@@ -235,6 +240,7 @@ const useStreamThreadRuntime = (
       stream.toolCalls,
       stream.error,
       stream.submit,
+      stream.respond,
       stream.values,
       messagesKey,
     ],
@@ -399,6 +405,21 @@ export const useLangChainSubmit = () => {
     const extras = aui.thread().getState().extras;
     const { submit } = asLangChainRuntimeExtras(extras);
     return submit(values, options);
+  };
+};
+
+/**
+ * Resume a LangGraph interrupt with a response payload via
+ * `useStream().respond`. Preferred over `useLangChainSendCommand` —
+ * carries the response cleanly and handles interrupt namespaces.
+ */
+export const useLangChainRespond = () => {
+  const aui = useAui();
+  return (response: unknown, options?: Record<string, unknown>) => {
+    const { respond } = asLangChainRuntimeExtras(
+      aui.thread().getState().extras,
+    );
+    return respond(response, options);
   };
 };
 

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -410,7 +410,7 @@ export const useLangChainSubmit = () => {
 
 /**
  * Resume a LangGraph interrupt with a response payload via
- * `useStream().respond`. Preferred over `useLangChainSendCommand` —
+ * `useStream().respond`. Preferred over `useLangChainSendCommand`; it
  * carries the response cleanly and handles interrupt namespaces.
  */
 export const useLangChainRespond = () => {


### PR DESCRIPTION
This PR surfaces v1 `useStream`'s preferred interrupt-resume path as `useLangChainRespond`. It carries the response payload cleanly via `stream.respond` and handles interrupt namespaces, unlike the `useLangChainSendCommand` to `submit(null, { command })` workaround.

Additive only. Mirrors the imperative `useLangChainSubmit` (reads `aui.thread().getState().extras`), exports the hook, and documents it in the Interrupts section and hook-mapping table.

Follow-ups (out of scope here): `respondAll` for parallel interrupts, kept separate to keep this scope minimal and easier to review.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

