### PR TITLE
feat(react-langchain): regenerate via checkpoint fork

### DIFF
--- a/.changeset/langchain-regenerate-checkpoint-fork.md
+++ b/.changeset/langchain-regenerate-checkpoint-fork.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): regenerate via checkpoint fork

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -694,7 +694,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 
 `react-langchain` is the newer, thinner wrapper. It delegates to upstream `useStream` rather than re-implementing the stream plumbing, which is why its footprint is smaller. Features absent today have not been ported, not deprecated.
 
-Regenerate works without configuration: clicking regenerate auto-resolves the server checkpoint whose persisted messages match the messages up to that point via `stream.client.threads.getHistory(threadId)`, then re-runs with `submit(null, { forkFrom })`. This works on checkpoint-enabled backends (e.g. LangGraph Cloud) and degrades gracefully — no resolvable checkpoint means the regenerate is a no-op — where `react-langgraph` instead requires a user-supplied `getCheckpointId` callback.
+Regenerate works without configuration. Clicking regenerate resolves the server checkpoint to fork from (the checkpoint each message records as it streams in, falling back to a `stream.client.threads.getHistory(threadId)` id match for older turns), then re-runs with `submit(null, { forkFrom })`. It works on checkpoint-enabled backends (for example LangGraph Cloud) and degrades gracefully; when no checkpoint resolves the regenerate is a no-op. `react-langgraph` instead requires a user-supplied `getCheckpointId` callback.
 
 ### Hook name mapping
 

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -684,6 +684,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | Read arbitrary custom state key | No | Yes (`useLangChainState<T>(key)`) |
 | Root tool-calls projection | Via message parts | Yes (`useLangChainToolCalls`) |
 | File content parts in messages | Yes | Yes |
+| Regenerate (checkpoint fork) | Yes (`getCheckpointId`) | Yes (auto-resolved) |
 | Per-message metadata (`messages-tuple`) | Yes | Not exposed |
 | Generative UI messages (LangSmith) | Yes | Not exposed |
 | Subgraph / namespaced stream events | Yes (via `eventHandlers`) | Not exposed |
@@ -692,6 +693,8 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | Cloud thread persistence | Yes | Yes |
 
 `react-langchain` is the newer, thinner wrapper. It delegates to upstream `useStream` rather than re-implementing the stream plumbing, which is why its footprint is smaller. Features absent today have not been ported, not deprecated.
+
+Regenerate works without configuration: clicking regenerate auto-resolves the server checkpoint whose persisted messages match the messages up to that point via `stream.client.threads.getHistory(threadId)`, then re-runs with `submit(null, { forkFrom })`. This works on checkpoint-enabled backends (e.g. LangGraph Cloud) and degrades gracefully — no resolvable checkpoint means the regenerate is a no-op — where `react-langgraph` instead requires a user-supplied `getCheckpointId` callback.
 
 ### Hook name mapping
 

--- a/packages/react-langchain/src/resolveForkCheckpointId.test.ts
+++ b/packages/react-langchain/src/resolveForkCheckpointId.test.ts
@@ -14,6 +14,32 @@ const makeClient = (history: unknown[]) => ({
   },
 });
 
+type HistoryState = {
+  values: Record<string, unknown>;
+  checkpoint: { checkpoint_id?: string };
+};
+
+const makePaginatedClient = (states: HistoryState[]) => ({
+  threads: {
+    getHistory: vi.fn(
+      async (
+        _threadId: string,
+        options?: {
+          limit?: number;
+          before?: { configurable: { checkpoint_id: string } };
+        },
+      ) => {
+        const limit = options?.limit ?? 10;
+        const beforeId = options?.before?.configurable.checkpoint_id;
+        const start = beforeId
+          ? states.findIndex((s) => s.checkpoint.checkpoint_id === beforeId) + 1
+          : 0;
+        return states.slice(start, start + limit) as never;
+      },
+    ),
+  },
+});
+
 describe("resolveForkCheckpointId", () => {
   it("returns the checkpoint_id of the state whose messages match by id", async () => {
     const client = makeClient([
@@ -39,7 +65,9 @@ describe("resolveForkCheckpointId", () => {
     );
 
     expect(result).toBe("cp-match");
-    expect(client.threads.getHistory).toHaveBeenCalledWith("thread-1");
+    expect(client.threads.getHistory).toHaveBeenCalledWith("thread-1", {
+      limit: 100,
+    });
   });
 
   it("returns null when no state has the same message ids", async () => {
@@ -112,5 +140,124 @@ describe("resolveForkCheckpointId", () => {
     );
 
     expect(result).toBeNull();
+  });
+
+  it("keeps scanning when a matching state has no checkpoint_id", async () => {
+    const client = makeClient([
+      {
+        values: { messages: [msg("a")] },
+        checkpoint: {},
+      },
+      {
+        values: { messages: [msg("a")] },
+        checkpoint: { checkpoint_id: "cp-second" },
+      },
+    ]);
+
+    const result = await resolveForkCheckpointId(
+      client,
+      "thread-1",
+      [msg("a")],
+      "messages",
+    );
+
+    expect(result).toBe("cp-second");
+  });
+
+  it("does not throw when a state's messages payload is not an array", async () => {
+    const client = makeClient([
+      {
+        values: { messages: "ab" },
+        checkpoint: { checkpoint_id: "cp-1" },
+      },
+    ]);
+
+    const result = await resolveForkCheckpointId(
+      client,
+      "thread-1",
+      [msg("a"), msg("b")],
+      "messages",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("forwards a custom history limit to getHistory", async () => {
+    const client = makeClient([]);
+
+    await resolveForkCheckpointId(
+      client,
+      "thread-1",
+      [msg("a")],
+      "messages",
+      25,
+    );
+
+    expect(client.threads.getHistory).toHaveBeenCalledWith("thread-1", {
+      limit: 25,
+    });
+  });
+
+  it("pages through history to find a match beyond the first page", async () => {
+    const client = makePaginatedClient([
+      {
+        values: { messages: [msg("a"), msg("b"), msg("c"), msg("d")] },
+        checkpoint: { checkpoint_id: "cp-4" },
+      },
+      {
+        values: { messages: [msg("a"), msg("b"), msg("c")] },
+        checkpoint: { checkpoint_id: "cp-3" },
+      },
+      {
+        values: { messages: [msg("a"), msg("b")] },
+        checkpoint: { checkpoint_id: "cp-2" },
+      },
+      {
+        values: { messages: [msg("a")] },
+        checkpoint: { checkpoint_id: "cp-1" },
+      },
+    ]);
+
+    const result = await resolveForkCheckpointId(
+      client,
+      "thread-1",
+      [msg("a")],
+      "messages",
+      2,
+    );
+
+    expect(result).toBe("cp-1");
+    expect(client.threads.getHistory).toHaveBeenCalledTimes(2);
+    expect(client.threads.getHistory).toHaveBeenLastCalledWith("thread-1", {
+      limit: 2,
+      before: { configurable: { checkpoint_id: "cp-3" } },
+    });
+  });
+
+  it("stops instead of looping when the cursor does not advance", async () => {
+    const page = [
+      {
+        values: { messages: [msg("x"), msg("y")] },
+        checkpoint: { checkpoint_id: "cp-1" },
+      },
+      {
+        values: { messages: [msg("x")] },
+        checkpoint: { checkpoint_id: "cp-2" },
+      },
+    ];
+    const client = {
+      threads: { getHistory: vi.fn(async () => page as never) },
+    };
+
+    const result = await resolveForkCheckpointId(
+      client,
+      "thread-1",
+      [msg("a")],
+      "messages",
+      2,
+    );
+
+    expect(result).toBeNull();
+    expect(client.threads.getHistory).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/react-langchain/src/resolveForkCheckpointId.test.ts
+++ b/packages/react-langchain/src/resolveForkCheckpointId.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LangChainBaseMessage } from "./types";
+import { resolveForkCheckpointId } from "./resolveForkCheckpointId";
+
+const msg = (id: string | undefined): LangChainBaseMessage => ({
+  _getType: () => "human",
+  content: "",
+  id,
+});
+
+const makeClient = (history: unknown[]) => ({
+  threads: {
+    getHistory: vi.fn(async () => history as never),
+  },
+});
+
+describe("resolveForkCheckpointId", () => {
+  it("returns the checkpoint_id of the state whose messages match by id", async () => {
+    const client = makeClient([
+      {
+        values: { messages: [msg("a"), msg("b"), msg("c")] },
+        checkpoint: { checkpoint_id: "cp-too-long" },
+      },
+      {
+        values: { messages: [msg("a"), msg("b")] },
+        checkpoint: { checkpoint_id: "cp-match" },
+      },
+      {
+        values: { messages: [msg("a")] },
+        checkpoint: { checkpoint_id: "cp-too-short" },
+      },
+    ]);
+
+    const result = await resolveForkCheckpointId(
+      client,
+      "thread-1",
+      [msg("a"), msg("b")],
+      "messages",
+    );
+
+    expect(result).toBe("cp-match");
+    expect(client.threads.getHistory).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("returns null when no state has the same message ids", async () => {
+    const client = makeClient([
+      {
+        values: { messages: [msg("a"), msg("x")] },
+        checkpoint: { checkpoint_id: "cp-1" },
+      },
+    ]);
+
+    const result = await resolveForkCheckpointId(
+      client,
+      "thread-1",
+      [msg("a"), msg("b")],
+      "messages",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when message ids are unstable (missing)", async () => {
+    const client = makeClient([
+      {
+        values: { messages: [msg("a"), msg(undefined)] },
+        checkpoint: { checkpoint_id: "cp-1" },
+      },
+    ]);
+
+    const result = await resolveForkCheckpointId(
+      client,
+      "thread-1",
+      [msg("a"), msg(undefined)],
+      "messages",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("reads messages from a custom messagesKey", async () => {
+    const client = makeClient([
+      {
+        values: { history: [msg("a")] },
+        checkpoint: { checkpoint_id: "cp-custom" },
+      },
+    ]);
+
+    const result = await resolveForkCheckpointId(
+      client,
+      "thread-1",
+      [msg("a")],
+      "history",
+    );
+
+    expect(result).toBe("cp-custom");
+  });
+
+  it("returns null when the matching checkpoint has no checkpoint_id", async () => {
+    const client = makeClient([
+      {
+        values: { messages: [msg("a")] },
+        checkpoint: {},
+      },
+    ]);
+
+    const result = await resolveForkCheckpointId(
+      client,
+      "thread-1",
+      [msg("a")],
+      "messages",
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/react-langchain/src/resolveForkCheckpointId.ts
+++ b/packages/react-langchain/src/resolveForkCheckpointId.ts
@@ -1,0 +1,45 @@
+import type { LangChainBaseMessage } from "./types";
+
+type ForkCheckpointHistoryState = {
+  values?: Record<string, unknown> | undefined;
+  checkpoint?: { checkpoint_id?: string | null | undefined } | undefined;
+};
+
+export type ForkCheckpointClient = {
+  threads: {
+    getHistory: (
+      threadId: string,
+    ) => Promise<readonly ForkCheckpointHistoryState[]>;
+  };
+};
+
+/**
+ * Resolve the server checkpoint to fork from when regenerating. Walks the
+ * thread's checkpoint history and returns the `checkpoint_id` whose persisted
+ * messages match `messagesUpToParent` by id. Returns `null` when no checkpoint
+ * lines up or message ids are unstable, in which case regeneration is skipped.
+ */
+export const resolveForkCheckpointId = async (
+  client: ForkCheckpointClient,
+  threadId: string,
+  messagesUpToParent: readonly LangChainBaseMessage[],
+  messagesKey: string,
+): Promise<string | null> => {
+  const history = await client.threads.getHistory(threadId);
+  for (const state of history) {
+    const stateMessages = state.values?.[messagesKey] as
+      | readonly LangChainBaseMessage[]
+      | undefined;
+    if (!stateMessages || stateMessages.length !== messagesUpToParent.length)
+      continue;
+    const hasStableIds =
+      messagesUpToParent.every((m) => typeof m.id === "string") &&
+      stateMessages.every((m) => typeof m.id === "string");
+    if (!hasStableIds) continue;
+    const isMatch = messagesUpToParent.every(
+      (m, i) => m.id === stateMessages[i]?.id,
+    );
+    if (isMatch) return state.checkpoint?.checkpoint_id ?? null;
+  }
+  return null;
+};

--- a/packages/react-langchain/src/resolveForkCheckpointId.ts
+++ b/packages/react-langchain/src/resolveForkCheckpointId.ts
@@ -5,41 +5,64 @@ type ForkCheckpointHistoryState = {
   checkpoint?: { checkpoint_id?: string | null | undefined } | undefined;
 };
 
+type ForkHistoryCursor = { configurable: { checkpoint_id: string } };
+
 export type ForkCheckpointClient = {
   threads: {
     getHistory: (
       threadId: string,
+      options?: { limit?: number; before?: ForkHistoryCursor },
     ) => Promise<readonly ForkCheckpointHistoryState[]>;
   };
 };
 
-/**
- * Resolve the server checkpoint to fork from when regenerating. Walks the
- * thread's checkpoint history and returns the `checkpoint_id` whose persisted
- * messages match `messagesUpToParent` by id. Returns `null` when no checkpoint
- * lines up or message ids are unstable, in which case regeneration is skipped.
- */
 export const resolveForkCheckpointId = async (
   client: ForkCheckpointClient,
   threadId: string,
   messagesUpToParent: readonly LangChainBaseMessage[],
   messagesKey: string,
+  pageSize = 100,
 ): Promise<string | null> => {
-  const history = await client.threads.getHistory(threadId);
-  for (const state of history) {
-    const stateMessages = state.values?.[messagesKey] as
-      | readonly LangChainBaseMessage[]
-      | undefined;
-    if (!stateMessages || stateMessages.length !== messagesUpToParent.length)
-      continue;
-    const hasStableIds =
-      messagesUpToParent.every((m) => typeof m.id === "string") &&
-      stateMessages.every((m) => typeof m.id === "string");
-    if (!hasStableIds) continue;
-    const isMatch = messagesUpToParent.every(
-      (m, i) => m.id === stateMessages[i]?.id,
+  if (!messagesUpToParent.every((m) => typeof m.id === "string")) return null;
+
+  const scanned = new Set<string>();
+  let before: ForkHistoryCursor | undefined;
+
+  for (;;) {
+    const page = await client.threads.getHistory(
+      threadId,
+      before ? { limit: pageSize, before } : { limit: pageSize },
     );
-    if (isMatch) return state.checkpoint?.checkpoint_id ?? null;
+
+    let oldestCheckpointId: string | undefined;
+    let advanced = false;
+    for (const state of page) {
+      const checkpointId = state.checkpoint?.checkpoint_id;
+      if (typeof checkpointId === "string") {
+        oldestCheckpointId = checkpointId;
+        if (!scanned.has(checkpointId)) {
+          scanned.add(checkpointId);
+          advanced = true;
+        }
+      }
+      const stateMessages = state.values?.[messagesKey] as
+        | readonly LangChainBaseMessage[]
+        | undefined;
+      if (
+        !Array.isArray(stateMessages) ||
+        stateMessages.length !== messagesUpToParent.length
+      )
+        continue;
+      if (!stateMessages.every((m) => typeof m.id === "string")) continue;
+      const isMatch = messagesUpToParent.every(
+        (m, i) => m.id === stateMessages[i]?.id,
+      );
+      if (isMatch && checkpointId) return checkpointId;
+    }
+
+    // `advanced` halts paging if the backend ignores `before` and repeats a page
+    if (page.length < pageSize || oldestCheckpointId === undefined || !advanced)
+      return null;
+    before = { configurable: { checkpoint_id: oldestCheckpointId } };
   }
-  return null;
 };

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -11,7 +11,7 @@ import {
   useRemoteThreadListRuntime,
 } from "@assistant-ui/core/react";
 import { useAuiState } from "@assistant-ui/store";
-import { useStream } from "@langchain/react";
+import { STREAM_CONTROLLER, useStream } from "@langchain/react";
 import type {
   LangChainBaseMessage,
   LangChainToolCall,
@@ -167,19 +167,33 @@ const useStreamThreadRuntime = (
       if (!threadId || parentId == null) return;
       const s = streamRef.current;
       const messages = s.messages as readonly LangChainBaseMessage[];
-      const parentIndex = messages.findIndex((m) => m.id === parentId);
-      if (parentIndex === -1) return;
-      let checkpointId: string | null;
-      try {
-        checkpointId = await resolveForkCheckpointId(
-          s.client,
-          threadId,
-          messages.slice(0, parentIndex + 1),
-          messagesKey,
-        );
-      } catch {
-        return;
+
+      // Hydration seeds every message with the head's parent checkpoint, so only
+      // the head's recorded fork checkpoint is reliable; older turns reverse-map.
+      const sourceId = config.sourceId;
+      const lastMessage = messages[messages.length - 1];
+      let checkpointId: string | null =
+        sourceId != null && lastMessage?.id === sourceId
+          ? (s[STREAM_CONTROLLER]?.messageMetadataStore
+              ?.getSnapshot?.()
+              ?.get(sourceId)?.parentCheckpointId ?? null)
+          : null;
+
+      if (!checkpointId) {
+        const parentIndex = messages.findIndex((m) => m.id === parentId);
+        if (parentIndex === -1) return;
+        try {
+          checkpointId = await resolveForkCheckpointId(
+            s.client,
+            threadId,
+            messages.slice(0, parentIndex + 1),
+            messagesKey,
+          );
+        } catch {
+          return;
+        }
       }
+
       if (!checkpointId) return;
       await s.submit(null, {
         forkFrom: checkpointId,

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -23,6 +23,7 @@ import {
   getMessageType,
 } from "./convertMessages";
 import { langChainExtras } from "./runtimeExtras";
+import { resolveForkCheckpointId } from "./resolveForkCheckpointId";
 
 export const runConfigToSubmitOptions = (
   runConfig: AppendMessage["runConfig"],
@@ -159,6 +160,30 @@ const useStreamThreadRuntime = (
             status: isError ? "error" : "success",
           },
         ],
+      });
+    },
+    onReload: async (parentId, config) => {
+      const threadId = externalId;
+      if (!threadId || parentId == null) return;
+      const s = streamRef.current;
+      const messages = s.messages as readonly LangChainBaseMessage[];
+      const parentIndex = messages.findIndex((m) => m.id === parentId);
+      if (parentIndex === -1) return;
+      let checkpointId: string | null;
+      try {
+        checkpointId = await resolveForkCheckpointId(
+          s.client,
+          threadId,
+          messages.slice(0, parentIndex + 1),
+          messagesKey,
+        );
+      } catch {
+        return;
+      }
+      if (!checkpointId) return;
+      await s.submit(null, {
+        forkFrom: checkpointId,
+        ...runConfigToSubmitOptions(config.runConfig),
       });
     },
     onCancel:


### PR DESCRIPTION
## what

wires up the regenerate button for `useStreamRuntime`. clicking regenerate on an assistant message forks from the matching server checkpoint and re-runs, with no configuration.

## why

`useStreamRuntime` passed no `onReload` to `useExternalStoreRuntime`, so `capabilities.reload` was `false`. but the default `Thread` UI renders the regenerate button unconditionally (neither the markup nor `useActionBarReload` checks `capabilities.reload`), so on the official `-t langchain` starter every assistant message showed an enabled regenerate button that threw `"Runtime does not support reloading messages."` when clicked. this closes that gap on the primary react-langchain surface and brings it to parity with react-langgraph, which exposes regenerate through a user-supplied `getCheckpointId`.

## how

`onReload` resolves the checkpoint to fork from, then re-runs with `submit(null, { forkFrom })`. the SDK folds `forkFrom` into `config.configurable.checkpoint_id`, so the server forks the run and `useStream` re-derives the messages. no manual message mutation.

resolution is two layers:

- **head fast path.** when the message being regenerated is the thread head, the fork checkpoint comes straight from the `parentCheckpointId` that `useStream` records as messages stream in (read from the metadata store), so the common case needs no extra request. it is gated to the head because hydration seeds every message with the head's parent checkpoint, so older messages are not reliable through this path.
- **history fallback.** older turns reverse-map through a pure `resolveForkCheckpointId` module that pages `client.threads.getHistory` newest-first and matches persisted message ids against the messages up to the parent. paging stops when history is exhausted or the cursor stops advancing, so there is no silent truncation on long threads and a backend that ignores the `before` cursor degrades to one page instead of looping.

`onReload` is always on. when nothing resolves (no id match, unstable ids, or a non-checkpoint backend) it is a graceful no-op, not an error.

scope is regenerate only; `resolveForkCheckpointId` is factored so `onEdit` can reuse it.

## tests

`resolveForkCheckpointId` is unit-tested: match / no-match, unstable ids, custom `messagesKey`, missing `checkpoint_id` (keeps scanning), non-array payloads, custom limit, a cross-page match, and cursor-stall termination.
