### PR TITLE
feat(python/langgraph): send granular delta chunks over the network

### DIFF
--- a/examples/with-assistant-transport/app/MyRuntimeProvider.tsx
+++ b/examples/with-assistant-transport/app/MyRuntimeProvider.tsx
@@ -2,7 +2,6 @@
 
 import {
   AssistantRuntimeProvider,
-  defineToolkit,
   Tools,
   type AssistantTransportConnectionMetadata,
   unstable_createMessageConverter as createMessageConverter,
@@ -14,57 +13,7 @@ import {
   type LangChainMessage,
 } from "@assistant-ui/react-langgraph";
 import type { ReactNode } from "react";
-import { z } from "zod";
-
-const toolkit = defineToolkit({
-  get_weather: {
-    type: "frontend",
-    description: "Get the current weather for a city",
-    parameters: z.object({
-      location: z.string().describe("The city to get weather for"),
-      unit: z
-        .enum(["celsius", "fahrenheit"])
-        .optional()
-        .describe("Temperature unit"),
-    }),
-    execute: async ({ location, unit = "celsius" }) => {
-      console.log(`Getting weather for ${location} in ${unit}`);
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      const temp = Math.floor(Math.random() * 30) + 10;
-      const conditions = ["sunny", "cloudy", "rainy", "partly cloudy"];
-      const condition =
-        conditions[Math.floor(Math.random() * conditions.length)];
-
-      return {
-        location,
-        temperature: temp,
-        unit,
-        condition,
-        humidity: Math.floor(Math.random() * 40) + 40,
-        windSpeed: Math.floor(Math.random() * 20) + 5,
-      };
-    },
-    streamCall: async (reader) => {
-      console.log("streamCall", reader);
-      const city = await reader.args.get("location");
-      console.log("location", city);
-
-      const args = await reader.args.get();
-      console.log("args", args);
-
-      const result = await reader.response.get();
-      console.log("result", result);
-    },
-    renderText: {
-      running: ({ args }) => `Getting weather for ${args.location ?? "..."}`,
-      complete: ({ args, result }) =>
-        result
-          ? `${args.location}: ${result.temperature}° ${result.unit}, ${result.condition}`
-          : "Weather lookup complete",
-    },
-  },
-});
+import toolkit from "./toolkit";
 
 type MyRuntimeProviderProps = {
   children: ReactNode;
@@ -122,6 +71,10 @@ export function MyRuntimeProvider({ children }: MyRuntimeProviderProps) {
     }),
     body: {
       "Test-Body": "test-value",
+    },
+    prepareSendCommandsRequest: (body) => {
+      console.log("Assistant transport request tools:", body.tools);
+      return body;
     },
     onResponse: () => {
       console.log("Response received from server");

--- a/examples/with-assistant-transport/app/toolkit.tsx
+++ b/examples/with-assistant-transport/app/toolkit.tsx
@@ -1,0 +1,57 @@
+"use generative";
+
+import { defineToolkit } from "@assistant-ui/react";
+import { z } from "zod";
+
+export default defineToolkit({
+  get_weather: {
+    description: "Get the current weather for a city",
+    parameters: z.object({
+      location: z.string().describe("The city to get weather for"),
+      unit: z
+        .enum(["celsius", "fahrenheit"])
+        .optional()
+        .describe("Temperature unit"),
+    }),
+    execute: async ({ location, unit = "celsius" }) => {
+      "use client";
+
+      console.log(`Getting weather for ${location} in ${unit}`);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      const temp = Math.floor(Math.random() * 30) + 10;
+      const conditions = ["sunny", "cloudy", "rainy", "partly cloudy"];
+      const condition =
+        conditions[Math.floor(Math.random() * conditions.length)];
+
+      return {
+        location,
+        temperature: temp,
+        unit,
+        condition,
+        humidity: Math.floor(Math.random() * 40) + 40,
+        windSpeed: Math.floor(Math.random() * 20) + 5,
+      };
+    },
+    streamCall: async (reader) => {
+      "use client";
+
+      console.log("streamCall", reader);
+      const city = await reader.args.get("location");
+      console.log("location", city);
+
+      const args = await reader.args.get();
+      console.log("args", args);
+
+      const result = await reader.response.get();
+      console.log("result", result);
+    },
+    renderText: {
+      running: ({ args }) => `Getting weather for ${args.location ?? "..."}`,
+      complete: ({ args, result }) =>
+        result
+          ? `${args.location}: ${result.temperature}° ${result.unit}, ${result.condition}`
+          : "Weather lookup complete",
+    },
+  },
+});

--- a/python/assistant-stream/README_LANGGRAPH.md
+++ b/python/assistant-stream/README_LANGGRAPH.md
@@ -44,7 +44,7 @@ The function will:
 
 - Create a `messages` list in the state if it does not exist.
 - Convert the message to a plain dict with `model_dump()`.
-- Merge into an existing message when the `id` (or `tool_call_id`) matches: for an `AIMessageChunk` the content is concatenated with `add_ai_message_chunks`, otherwise the stored message is replaced.
+- Merge into an existing message when the `id` (or `tool_call_id`) matches: for an `AIMessageChunk` the message is merged with `add_ai_message_chunks`, then patched into state with granular `set` / `append-text` operations where possible. This lets streaming text and tool-call argument chunks update only the field that changed instead of sending the whole message again. If the shape cannot be represented safely as object-stream operations, the helper falls back to replacing the message.
 - Append the message when no existing id matches.
 
 ```python

--- a/python/assistant-stream/pyproject.toml
+++ b/python/assistant-stream/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "assistant-stream"
-version = "0.0.33"
+version = "0.0.34"
 description = ""
 authors = [
   { name="Simon Farshid", email="simon@assistant-ui.com" },

--- a/python/assistant-stream/src/assistant_stream/modules/langgraph.py
+++ b/python/assistant-stream/src/assistant_stream/modules/langgraph.py
@@ -136,9 +136,7 @@ def append_langgraph_event(
 
         if existing_message_index is not None:
             if is_ai_message_chunk:
-                existing_message = state["messages"][
-                    existing_message_index
-                ]._get_value()
+                existing_message = _plain(state["messages"][existing_message_index])
                 new_message_dict = add_ai_message_chunks(
                     AIMessageChunk(**{**existing_message, "type": "AIMessageChunk"}),
                     AIMessageChunk(**{**message_dict, "type": "AIMessageChunk"}),

--- a/python/assistant-stream/src/assistant_stream/modules/langgraph.py
+++ b/python/assistant-stream/src/assistant_stream/modules/langgraph.py
@@ -1,8 +1,95 @@
-from typing import Any, Dict, List, Union, Tuple, Callable, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from assistant_stream.create_run import RunController
 from langchain_core.messages.ai import AIMessageChunk, add_ai_message_chunks
 from langchain_core.messages.tool import ToolMessage
+
+
+def _plain(value: Any) -> Any:
+    if hasattr(value, "_get_value"):
+        return value._get_value()
+    return value
+
+
+def _message_matches(existing_message: Any, message_dict: Dict[str, Any]) -> bool:
+    existing_message = _plain(existing_message)
+    if not isinstance(existing_message, dict):
+        return False
+
+    message_id = message_dict.get("id")
+    if message_id is not None and existing_message.get("id") == message_id:
+        return True
+
+    tool_call_id = message_dict.get("tool_call_id")
+    return (
+        tool_call_id is not None
+        and existing_message.get("tool_call_id") == tool_call_id
+    )
+
+
+def _find_existing_message_index(
+    messages: Any, message_dict: Dict[str, Any]
+) -> int | None:
+    for i, existing_message in enumerate(messages):
+        if _message_matches(existing_message, message_dict):
+            return i
+    return None
+
+
+def _patch_child(parent: Any, key: str | int, next_value: Any) -> None:
+    current_value = _plain(parent[key])
+
+    if current_value == next_value:
+        return
+
+    if isinstance(current_value, dict) and isinstance(next_value, dict):
+        current_keys = set(current_value.keys())
+        next_keys = set(next_value.keys())
+        if not current_keys.issubset(next_keys):
+            raise ValueError("Cannot represent deleted dictionary keys as object ops")
+
+        target = parent[key]
+        for key in next_keys:
+            if key not in current_value:
+                target[key] = next_value[key]
+            else:
+                _patch_child(target, key, next_value[key])
+        return
+
+    if isinstance(current_value, list) and isinstance(next_value, list):
+        if len(next_value) < len(current_value):
+            raise ValueError("Cannot represent list truncation as object ops")
+
+        target = parent[key]
+        for index, item in enumerate(next_value):
+            if index >= len(current_value):
+                target.append(item)
+            else:
+                _patch_child(target, index, item)
+        return
+
+    parent[key] = next_value
+
+
+def _patch_message(messages: Any, index: int, next_message: Dict[str, Any]) -> None:
+    try:
+        current_message = _plain(messages[index])
+        if not isinstance(current_message, dict):
+            raise ValueError("Expected existing message to be a dictionary")
+
+        current_keys = set(current_message.keys())
+        next_keys = set(next_message.keys())
+        if not current_keys.issubset(next_keys):
+            raise ValueError("Cannot represent deleted message keys as object ops")
+
+        message = messages[index]
+        for key in next_keys:
+            if key not in current_message:
+                message[key] = next_message[key]
+            else:
+                _patch_child(message, key, next_message[key])
+    except ValueError:
+        messages[index] = next_message
 
 
 def append_langgraph_event(
@@ -26,18 +113,12 @@ def append_langgraph_event(
         message_dict = message.model_dump()
 
         # Check if this is an AIMessageChunk
-        is_ai_message_chunk = message_dict.get("type") == "AIMessageChunk" 
+        is_ai_message_chunk = message_dict.get("type") == "AIMessageChunk"
         if is_ai_message_chunk:
             message_dict["type"] = "ai"
-        existing_message_index = None
-        if "id" in message_dict:
-            for i, existing_message in enumerate(state["messages"]):
-                if existing_message.get("id") == message_dict["id"] or \
-                  "tool_call_id" in existing_message and \
-                  "tool_call_id" in message_dict and \
-                  existing_message["tool_call_id"] == message_dict["tool_call_id"]:
-                    existing_message_index = i
-                    break
+        existing_message_index = _find_existing_message_index(
+            state["messages"], message_dict
+        )
 
         if existing_message_index is not None:
             if is_ai_message_chunk:
@@ -49,7 +130,11 @@ def append_langgraph_event(
                     AIMessageChunk(**{**message_dict, "type": "AIMessageChunk"}),
                 ).model_dump()
                 new_message_dict["type"] = "ai"
-                state["messages"][existing_message_index] = new_message_dict
+                _patch_message(
+                    state["messages"],
+                    existing_message_index,
+                    new_message_dict,
+                )
 
             else:
                 state["messages"][existing_message_index] = message_dict
@@ -63,9 +148,6 @@ def append_langgraph_event(
             for channel_name, channel_value in channels.items():
                 if channel_name == "messages":
                     continue
-                    # if "messages" in state:
-                    #     continue
-                    # state["messages"] = [c.model_dump() for c in channel_value]
 
                 state[channel_name] = channel_value
 

--- a/python/assistant-stream/src/assistant_stream/modules/langgraph.py
+++ b/python/assistant-stream/src/assistant_stream/modules/langgraph.py
@@ -36,7 +36,31 @@ def _find_existing_message_index(
     return None
 
 
+def _can_patch_value(current_value: Any, next_value: Any) -> bool:
+    current_value = _plain(current_value)
+
+    if current_value == next_value:
+        return True
+
+    if isinstance(current_value, dict) and isinstance(next_value, dict):
+        current_keys = set(current_value.keys())
+        next_keys = set(next_value.keys())
+        return current_keys.issubset(next_keys) and all(
+            _can_patch_value(current_value[key], next_value[key])
+            for key in current_keys
+        )
+
+    if isinstance(current_value, list) and isinstance(next_value, list):
+        return len(current_value) <= len(next_value) and all(
+            _can_patch_value(item, next_value[index])
+            for index, item in enumerate(current_value)
+        )
+
+    return True
+
+
 def _patch_child(parent: Any, key: str | int, next_value: Any) -> None:
+    """Patch through StateProxy containers so writes emit granular object ops."""
     current_value = _plain(parent[key])
 
     if current_value == next_value:
@@ -49,11 +73,11 @@ def _patch_child(parent: Any, key: str | int, next_value: Any) -> None:
             raise ValueError("Cannot represent deleted dictionary keys as object ops")
 
         target = parent[key]
-        for key in next_keys:
-            if key not in current_value:
-                target[key] = next_value[key]
+        for child_key in next_keys:
+            if child_key not in current_value:
+                target[child_key] = next_value[child_key]
             else:
-                _patch_child(target, key, next_value[key])
+                _patch_child(target, child_key, next_value[child_key])
         return
 
     if isinstance(current_value, list) and isinstance(next_value, list):
@@ -72,24 +96,14 @@ def _patch_child(parent: Any, key: str | int, next_value: Any) -> None:
 
 
 def _patch_message(messages: Any, index: int, next_message: Dict[str, Any]) -> None:
-    try:
-        current_message = _plain(messages[index])
-        if not isinstance(current_message, dict):
-            raise ValueError("Expected existing message to be a dictionary")
-
-        current_keys = set(current_message.keys())
-        next_keys = set(next_message.keys())
-        if not current_keys.issubset(next_keys):
-            raise ValueError("Cannot represent deleted message keys as object ops")
-
-        message = messages[index]
-        for key in next_keys:
-            if key not in current_message:
-                message[key] = next_message[key]
-            else:
-                _patch_child(message, key, next_message[key])
-    except ValueError:
+    current_message = _plain(messages[index])
+    if not isinstance(current_message, dict) or not _can_patch_value(
+        current_message, next_message
+    ):
         messages[index] = next_message
+        return
+
+    _patch_child(messages, index, next_message)
 
 
 def append_langgraph_event(

--- a/python/assistant-stream/src/assistant_stream/modules/langgraph.py
+++ b/python/assistant-stream/src/assistant_stream/modules/langgraph.py
@@ -37,6 +37,8 @@ def _find_existing_message_index(
 
 
 def _can_patch_value(current_value: Any, next_value: Any) -> bool:
+    # Keep these guards in sync with _patch_child so the later mutation cannot
+    # partially apply before discovering an unsupported deletion/truncation.
     current_value = _plain(current_value)
 
     if current_value == next_value:

--- a/python/assistant-stream/tests/test_langgraph.py
+++ b/python/assistant-stream/tests/test_langgraph.py
@@ -21,6 +21,11 @@ def _manager(initial: Any) -> StateManager:
     return StateManager(lambda _chunk: None, initial)
 
 
+def _manager_with_ops(initial: Any) -> tuple[StateManager, list[dict[str, Any]]]:
+    ops: list[dict[str, Any]] = []
+    return StateManager(lambda chunk: ops.extend(chunk.operations), initial), ops
+
+
 @pytest.mark.anyio
 async def test_appends_single_message_to_empty_state() -> None:
     manager = _manager({})
@@ -66,6 +71,95 @@ async def test_merges_ai_message_chunks_by_id() -> None:
     assert messages[0]["content"] == "Hello world"
     assert messages[0]["id"] == "m1"
     assert messages[0]["type"] == "ai"
+
+
+@pytest.mark.anyio
+async def test_merging_ai_message_chunk_emits_content_append_text_delta() -> None:
+    manager, ops = _manager_with_ops({"messages": []})
+
+    append_langgraph_event(
+        manager.state, (), "messages", (AIMessageChunk(content="Hello", id="m1"), {})
+    )
+    manager.flush()
+    ops.clear()
+
+    append_langgraph_event(
+        manager.state, (), "messages", (AIMessageChunk(content=" world", id="m1"), {})
+    )
+    manager.flush()
+
+    assert manager.state_data["messages"][0]["content"] == "Hello world"
+    assert {
+        "type": "append-text",
+        "path": ["messages", "0", "content"],
+        "value": " world",
+    } in ops
+    assert not any(
+        op["type"] == "set" and op["path"] == ["messages", "0"] for op in ops
+    )
+
+
+@pytest.mark.anyio
+async def test_merging_ai_message_chunk_patches_nested_tool_call_args() -> None:
+    manager, ops = _manager_with_ops({"messages": []})
+
+    append_langgraph_event(
+        manager.state,
+        (),
+        "messages",
+        (
+            AIMessageChunk(
+                content="",
+                id="m1",
+                tool_call_chunks=[
+                    {
+                        "name": "search",
+                        "args": '{"query"',
+                        "id": "call_1",
+                        "index": 0,
+                    }
+                ],
+            ),
+            {},
+        ),
+    )
+    manager.flush()
+    ops.clear()
+
+    append_langgraph_event(
+        manager.state,
+        (),
+        "messages",
+        (
+            AIMessageChunk(
+                content="",
+                id="m1",
+                tool_call_chunks=[
+                    {
+                        "name": None,
+                        "args": ':"docs"}',
+                        "id": None,
+                        "index": 0,
+                    }
+                ],
+            ),
+            {},
+        ),
+    )
+    manager.flush()
+
+    assert (
+        manager.state_data["messages"][0]["tool_call_chunks"][0]["args"]
+        == '{"query":"docs"}'
+    )
+    assert {
+        "type": "append-text",
+        "path": ["messages", "0", "tool_call_chunks", "0", "args"],
+        "value": ':"docs"}',
+    } in ops
+    assert not any(
+        op["type"] == "set" and op["path"] == ["messages", "0"] for op in ops
+    )
 
 
 @pytest.mark.anyio

--- a/python/assistant-stream/tests/test_langgraph.py
+++ b/python/assistant-stream/tests/test_langgraph.py
@@ -100,6 +100,20 @@ async def test_merging_ai_message_chunk_emits_content_append_text_delta() -> Non
 
 
 @pytest.mark.anyio
+async def test_merging_ai_message_chunk_handles_plain_dict_messages() -> None:
+    state: dict[str, Any] = {"messages": []}
+
+    append_langgraph_event(
+        state, (), "messages", (AIMessageChunk(content="Hello", id="m1"), {})
+    )
+    append_langgraph_event(
+        state, (), "messages", (AIMessageChunk(content=" world", id="m1"), {})
+    )
+
+    assert state["messages"][0]["content"] == "Hello world"
+
+
+@pytest.mark.anyio
 async def test_merging_ai_message_chunk_patches_nested_tool_call_args() -> None:
     manager, ops = _manager_with_ops({"messages": []})
 

--- a/python/assistant-stream/uv.lock
+++ b/python/assistant-stream/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "assistant-stream"
-version = "0.0.33"
+version = "0.0.34"
 source = { editable = "." }
 dependencies = [
     { name = "starlette" },

--- a/python/assistant-transport-backend-langgraph/README.md
+++ b/python/assistant-transport-backend-langgraph/README.md
@@ -118,6 +118,8 @@ Health check endpoint.
 5. Both streams are synchronized to the frontend using `append_langgraph_event`
 6. The response is streamed back using assistant-stream's DataStreamResponse
 
+Frontend tools declared by `useAssistantTransportRuntime` are bound to the LangGraph model from the request `tools` payload, but they are not executed by this backend. For example, the `with-assistant-transport` demo keeps `get_weather` frontend-only: the backend streams the tool call, the browser runs the tool and sends an `add-tool-result` command, and LangGraph continues from that result. Server-owned smoke tools such as `calculate_sum`, `save_note`, and `task_tool` still execute inside the backend graph.
+
 ## DeltaChannel Prototype Notes
 
 The graph's `messages` state uses LangGraph's `DeltaChannel` with a bulk reducer:

--- a/python/assistant-transport-backend-langgraph/README.md
+++ b/python/assistant-transport-backend-langgraph/README.md
@@ -7,6 +7,8 @@ This is a LangGraph-based implementation of the assistant transport backend, pro
 - Streaming responses using LangGraph's astream and astream_events
 - Synchronization of LangGraph state to the frontend
 - Support for both message streaming and state updates
+- DeltaChannel-backed LangGraph message checkpoints (`langgraph>=1.2`)
+- Optional Postgres checkpoint storage via `langgraph-checkpoint-postgres`
 - Compatible with the assistant-ui frontend
 
 ## Installation
@@ -16,7 +18,7 @@ This is a LangGraph-based implementation of the assistant transport backend, pro
 1. Initialize and install dependencies:
 ```bash
 uv init --name assistant-transport-backend-langgraph --package
-uv add fastapi uvicorn[standard] assistant-stream pydantic python-dotenv langgraph langchain langchain-core langchain-openai httpx
+uv add fastapi uvicorn[standard] assistant-stream pydantic python-dotenv "langgraph>=1.2.0" langgraph-checkpoint-postgres langchain langchain-core langchain-openai httpx
 # Or simply:
 uv sync
 ```
@@ -50,6 +52,8 @@ The server can be configured via environment variables:
 - `LOG_LEVEL`: Log level (default: info)
 - `CORS_ORIGINS`: CORS origins (default: http://localhost:3000)
 - `OPENAI_API_KEY`: Your OpenAI API key (required)
+- `LANGGRAPH_POSTGRES_URL`: Optional Postgres connection URL for LangGraph checkpoints
+- `DATABASE_URL`: Fallback Postgres connection URL when `LANGGRAPH_POSTGRES_URL` is not set
 
 ## Running the Server
 
@@ -107,12 +111,43 @@ Health check endpoint.
 
 1. The server receives chat requests at `/api/chat`
 2. Commands are converted to LangGraph messages (HumanMessage, AIMessage, etc.)
-3. The LangGraph processes the messages through its nodes
+3. The LangGraph processes the messages through its nodes using a per-thread checkpoint keyed by the AssistantTransport `threadId`
 4. Two streaming tasks run concurrently:
    - `astream` provides state updates
    - `astream_events` provides message streaming
 5. Both streams are synchronized to the frontend using `append_langgraph_event`
 6. The response is streamed back using assistant-stream's DataStreamResponse
+
+## DeltaChannel Prototype Notes
+
+The graph's `messages` state uses LangGraph's `DeltaChannel` with a bulk reducer:
+
+```python
+def add_messages_delta(state, writes):
+    result = list(state)
+    for write in writes:
+        if isinstance(write, BaseMessage):
+            result = add_messages(result, [write])
+        else:
+            result = add_messages(result, list(write))
+    return result
+```
+
+This keeps the assistant-ui API unchanged. The frontend still uses `useAssistantTransportRuntime`; the backend still accepts normal AssistantTransport `add-message` and `add-tool-result` commands; and the response remains the default data-stream encoding. The only required API adjustment is inside the LangGraph state definition: a delta-backed channel reducer receives `(state, writes)` where `writes` is a batch, not the old pairwise `(state, update)` reducer shape.
+
+Postgres works through LangGraph's async checkpointer path:
+
+```bash
+docker run --rm -p 127.0.0.1:55432:5432 \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=assistant_ui \
+  postgres:16-alpine
+
+LANGGRAPH_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:55432/assistant_ui \
+  uv run python main.py
+```
+
+Because the FastAPI route streams with `graph.astream`, the backend uses `AsyncPostgresSaver`; the synchronous `PostgresSaver` does not implement the async checkpointer methods used by this route.
 
 ## Integration with Frontend
 

--- a/python/assistant-transport-backend-langgraph/main.py
+++ b/python/assistant-transport-backend-langgraph/main.py
@@ -57,7 +57,13 @@ class AddToolResultCommand(BaseModel):
 
     type: str = Field(default="add-tool-result", description="Command type")
     tool_call_id: str = Field(..., alias="toolCallId", description="ID of the tool call")
-    result: dict[str, Any] = Field(..., description="Tool execution result")
+    tool_name: str | None = Field(None, alias="toolName", description="Name of the tool")
+    result: Any = Field(..., description="Tool execution result")
+    is_error: bool | None = Field(None, alias="isError", description="Whether the tool failed")
+    artifact: Any | None = Field(None, description="UI-only tool result artifact")
+    model_content: Any | None = Field(
+        None, alias="modelContent", description="Tool result content for the model"
+    )
 
 
 class ChatRequest(BaseModel):
@@ -94,13 +100,49 @@ def add_messages_delta(
     return result
 
 
+def request_tool_schemas(tools: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not tools:
+        return []
+
+    schemas = []
+    for name, tool_definition in tools.items():
+        if name in TOOL_BY_NAME or not isinstance(tool_definition, dict):
+            continue
+
+        parameters = tool_definition.get("parameters") or {
+            "type": "object",
+            "properties": {},
+        }
+        schemas.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": tool_definition.get("description", ""),
+                    "parameters": parameters,
+                },
+            }
+        )
+    return schemas
+
+
+def bindable_tools(tools: dict[str, Any] | None) -> list[Any]:
+    return [*TOOLS, *request_tool_schemas(tools)]
+
+
+def tool_result_content(command: AddToolResultCommand) -> str:
+    content = command.model_content if command.model_content is not None else command.result
+    return content if isinstance(content, str) else json.dumps(content)
+
+
 # Define LangGraph state
-class GraphState(TypedDict):
+class GraphState(TypedDict, total=False):
     """State for the conversation graph."""
     messages: Annotated[
         Sequence[BaseMessage],
         DeltaChannel(reducer=add_messages_delta, snapshot_frequency=50),
     ]
+    tools: dict[str, Any] | None
 
 
 # Define subagent state
@@ -128,26 +170,6 @@ def task_tool(task_description: str) -> str:
     """
     # This is a placeholder - the actual execution will be handled by the subgraph
     return f"Task '{task_description}' will be executed by the subagent."
-
-
-@tool
-def get_weather(location: str, unit: str = "celsius") -> dict[str, Any]:
-    """
-    Get deterministic sample weather for a location.
-
-    Args:
-        location: City or place to look up.
-        unit: Temperature unit, either celsius or fahrenheit.
-    """
-    normalized_unit = unit.lower()
-    celsius = 22 + (len(location) % 7)
-    temperature = celsius if normalized_unit != "fahrenheit" else round(celsius * 9 / 5 + 32)
-    return {
-        "location": location,
-        "temperature": temperature,
-        "unit": "fahrenheit" if normalized_unit == "fahrenheit" else "celsius",
-        "condition": ["sunny", "partly cloudy", "windy"][len(location) % 3],
-    }
 
 
 @tool
@@ -184,7 +206,7 @@ def save_note(title: str, body: str) -> dict[str, Any]:
     }
 
 
-TOOLS = [task_tool, get_weather, calculate_sum, save_note]
+TOOLS = [task_tool, calculate_sum, save_note]
 TOOL_BY_NAME = {tool.name: tool for tool in TOOLS}
 
 
@@ -235,6 +257,7 @@ def create_subagent_graph() -> CompiledStateGraph:
 async def agent_node(state: GraphState) -> dict[str, Any]:
     """Main agent node that can call tools."""
     messages = state.get("messages", [])
+    tools = state.get("tools")
 
     # Check if OpenAI API key is set
     if os.getenv("OPENAI_API_KEY"):
@@ -245,8 +268,8 @@ async def agent_node(state: GraphState) -> dict[str, Any]:
             streaming=True,
         )
 
-        # Bind smoke-test tools to the LLM
-        llm_with_tools = llm.bind_tools(TOOLS)
+        # Bind server tools plus request-provided frontend tool declarations.
+        llm_with_tools = llm.bind_tools(bindable_tools(tools))
         response = await llm_with_tools.ainvoke(messages)
     elif messages and isinstance(messages[-1], ToolMessage):
         response = AIMessage(
@@ -256,11 +279,11 @@ async def agent_node(state: GraphState) -> dict[str, Any]:
         # Mock response with a tool call for testing
         print("⚠️ No OpenAI API key found - using mock response with tool call")
         last_content = messages[-1].content if messages else ""
-        if "weather" in str(last_content).lower():
+        if "weather" in str(last_content).lower() and tools and "get_weather" in tools:
             tool_call = {
                 "id": "weather_001",
                 "name": "get_weather",
-                "args": {"location": "San Francisco", "unit": "celsius"},
+                "args": {"location": "San Francisco", "unit": "fahrenheit"},
             }
         elif "sum" in str(last_content).lower() or "add" in str(last_content).lower():
             tool_call = {
@@ -287,14 +310,17 @@ async def agent_node(state: GraphState) -> dict[str, Any]:
 
 
 def should_call_tools(state: GraphState) -> str:
-    """Determine if tools should be called."""
+    """Run only backend-owned tools. Frontend tools are returned to the client."""
     messages = state.get("messages", [])
     if not messages:
         return "end"
 
     last_message = messages[-1]
-    # Check if the last message has tool calls
-    if hasattr(last_message, 'tool_calls') and last_message.tool_calls:
+    if (
+        hasattr(last_message, 'tool_calls')
+        and last_message.tool_calls
+        and any(tool_call["name"] in TOOL_BY_NAME for tool_call in last_message.tool_calls)
+    ):
         return "tools"
 
     return "end"
@@ -466,8 +492,11 @@ async def chat_endpoint(request: ChatRequest):
             elif command.type == "add-tool-result":
                 # Handle tool results
                 input_messages.append(ToolMessage(
-                    content=str(command.result),
-                    tool_call_id=command.tool_call_id
+                    content=tool_result_content(command),
+                    tool_call_id=command.tool_call_id,
+                    name=command.tool_name,
+                    artifact=command.artifact if command.artifact is not None else command.result,
+                    status="error" if command.is_error else "success",
                 ))
 
         # Add messages to controller state
@@ -475,7 +504,7 @@ async def chat_endpoint(request: ChatRequest):
             controller.state["messages"].append(message.model_dump())
 
         # Create initial state for LangGraph
-        input_state = {"messages": input_messages}
+        input_state = {"messages": input_messages, "tools": request.tools}
 
         # Stream with subgraph support
         config = {

--- a/python/assistant-transport-backend-langgraph/main.py
+++ b/python/assistant-transport-backend-langgraph/main.py
@@ -8,6 +8,7 @@ import os
 from collections.abc import Sequence
 from contextlib import asynccontextmanager
 from typing import Annotated, Any, TypedDict
+from uuid import uuid4
 
 import uvicorn
 from assistant_stream import RunController, create_run
@@ -73,6 +74,11 @@ class ChatRequest(BaseModel):
     )
     thread_id: str | None = Field(None, alias="threadId", description="Assistant UI thread ID")
     state: dict[str, Any] | None = Field(None, description="State")
+
+
+def get_thread_id(request: ChatRequest) -> str:
+    """Use persistent checkpoints only when the AssistantTransport request identifies a thread."""
+    return request.thread_id or f"anonymous-{uuid4()}"
 
 
 def add_messages_delta(
@@ -474,7 +480,7 @@ async def chat_endpoint(request: ChatRequest):
         # Stream with subgraph support
         config = {
             "configurable": {
-                "thread_id": request.thread_id or "assistant-transport-default",
+                "thread_id": get_thread_id(request),
             }
         }
 

--- a/python/assistant-transport-backend-langgraph/main.py
+++ b/python/assistant-transport-backend-langgraph/main.py
@@ -106,7 +106,11 @@ def request_tool_schemas(tools: dict[str, Any] | None) -> list[dict[str, Any]]:
 
     schemas = []
     for name, tool_definition in tools.items():
-        if name in TOOL_BY_NAME or not isinstance(tool_definition, dict):
+        if (
+            name in TOOL_BY_NAME
+            or not isinstance(tool_definition, dict)
+            or tool_definition.get("disabled") is True
+        ):
             continue
 
         parameters = tool_definition.get("parameters") or {

--- a/python/assistant-transport-backend-langgraph/main.py
+++ b/python/assistant-transport-backend-langgraph/main.py
@@ -3,47 +3,45 @@
 Assistant Transport Backend with LangGraph - FastAPI + assistant-stream + LangGraph server
 """
 
-import os
-import asyncio
-from typing import Dict, Any, List, Optional, Union, Sequence, Annotated
-from contextlib import asynccontextmanager
-import uvicorn
 import json
+import os
+from collections.abc import Sequence
+from contextlib import asynccontextmanager
+from typing import Annotated, Any, TypedDict
 
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
-from dotenv import load_dotenv
-
-from assistant_stream.serialization import DataStreamResponse
+import uvicorn
 from assistant_stream import RunController, create_run
 from assistant_stream.modules.langgraph import append_langgraph_event, get_tool_call_subgraph_state
-
-from langgraph.graph import StateGraph, END
-from langgraph.graph.state import CompiledStateGraph
-from langgraph.graph import add_messages
-from langgraph.prebuilt import ToolNode
-
-from langchain_core.messages import HumanMessage, AIMessage, SystemMessage, ToolMessage, BaseMessage
+from assistant_stream.serialization import DataStreamResponse
+from dotenv import load_dotenv
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
-from typing import TypedDict
+from langgraph.channels import DeltaChannel
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, StateGraph, add_messages
+from langgraph.graph.state import CompiledStateGraph
+from pydantic import BaseModel, ConfigDict, Field
 
 # Load environment variables
 load_dotenv()
+
+_postgres_checkpointer_context = None
 
 
 class MessagePart(BaseModel):
     """A part of a user message."""
     type: str = Field(..., description="The type of message part")
-    text: Optional[str] = Field(None, description="Text content")
-    image: Optional[str] = Field(None, description="Image URL or data")
+    text: str | None = Field(None, description="Text content")
+    image: str | None = Field(None, description="Image URL or data")
 
 
 class UserMessage(BaseModel):
     """A user message."""
     role: str = Field(default="user", description="Message role")
-    parts: List[MessagePart] = Field(..., description="Message parts")
+    parts: list[MessagePart] = Field(..., description="Message parts")
 
 
 class AddMessageCommand(BaseModel):
@@ -54,32 +52,58 @@ class AddMessageCommand(BaseModel):
 
 class AddToolResultCommand(BaseModel):
     """Command to add a tool result to the conversation."""
+    model_config = ConfigDict(populate_by_name=True)
+
     type: str = Field(default="add-tool-result", description="Command type")
-    toolCallId: str = Field(..., description="ID of the tool call")
-    result: Dict[str, Any] = Field(..., description="Tool execution result")
+    tool_call_id: str = Field(..., alias="toolCallId", description="ID of the tool call")
+    result: dict[str, Any] = Field(..., description="Tool execution result")
 
 
 class ChatRequest(BaseModel):
     """Request payload for the chat endpoint."""
-    commands: List[Union[AddMessageCommand, AddToolResultCommand]] = Field(
+    model_config = ConfigDict(populate_by_name=True)
+
+    commands: list[AddMessageCommand | AddToolResultCommand] = Field(
         ..., description="List of commands to execute"
     )
-    system: Optional[str] = Field(None, description="System prompt")
-    tools: Optional[Dict[str, Any]] = Field(None, description="Available tools")
-    runConfig: Optional[Dict[str, Any]] = Field(None, description="Run configuration")
-    state: Optional[Dict[str, Any]] = Field(None, description="State")
+    system: str | None = Field(None, description="System prompt")
+    tools: dict[str, Any] | None = Field(None, description="Available tools")
+    run_config: dict[str, Any] | None = Field(
+        None, alias="runConfig", description="Run configuration"
+    )
+    thread_id: str | None = Field(None, alias="threadId", description="Assistant UI thread ID")
+    state: dict[str, Any] | None = Field(None, description="State")
+
+
+def add_messages_delta(
+    state: Sequence[BaseMessage],
+    writes: Sequence[BaseMessage | Sequence[BaseMessage]],
+) -> list[BaseMessage]:
+    result = list(state)
+    for write in writes:
+        if isinstance(write, BaseMessage):
+            result = add_messages(result, [write])
+        else:
+            result = add_messages(result, list(write))
+    return result
 
 
 # Define LangGraph state
 class GraphState(TypedDict):
     """State for the conversation graph."""
-    messages: Annotated[Sequence[BaseMessage], add_messages]
+    messages: Annotated[
+        Sequence[BaseMessage],
+        DeltaChannel(reducer=add_messages_delta, snapshot_frequency=50),
+    ]
 
 
 # Define subagent state
 class SubagentState(TypedDict):
     """State for the subagent."""
-    messages: Annotated[Sequence[BaseMessage], add_messages]
+    messages: Annotated[
+        Sequence[BaseMessage],
+        DeltaChannel(reducer=add_messages_delta, snapshot_frequency=50),
+    ]
     task: str
     result: str
 
@@ -100,18 +124,68 @@ def task_tool(task_description: str) -> str:
     return f"Task '{task_description}' will be executed by the subagent."
 
 
-# Subagent node for executing tasks
-async def subagent_node(state: SubagentState) -> Dict[str, Any]:
-    """Subagent that executes the task."""
-    messages = state.get("messages", [])
-    task = state.get("task", "")
+@tool
+def get_weather(location: str, unit: str = "celsius") -> dict[str, Any]:
+    """
+    Get deterministic sample weather for a location.
 
-    # Initialize a simpler LLM for the subagent
-    llm = ChatOpenAI(
-        model="gpt-5.4-nano",
-        temperature=0.7,
-        streaming=True
-    )
+    Args:
+        location: City or place to look up.
+        unit: Temperature unit, either celsius or fahrenheit.
+    """
+    normalized_unit = unit.lower()
+    celsius = 22 + (len(location) % 7)
+    temperature = celsius if normalized_unit != "fahrenheit" else round(celsius * 9 / 5 + 32)
+    return {
+        "location": location,
+        "temperature": temperature,
+        "unit": "fahrenheit" if normalized_unit == "fahrenheit" else "celsius",
+        "condition": ["sunny", "partly cloudy", "windy"][len(location) % 3],
+    }
+
+
+@tool
+def calculate_sum(numbers: list[float]) -> dict[str, Any]:
+    """
+    Add a list of numbers.
+
+    Args:
+        numbers: Numbers to add together.
+    """
+    return {
+        "numbers": numbers,
+        "sum": sum(numbers),
+        "count": len(numbers),
+    }
+
+
+@tool
+def save_note(title: str, body: str) -> dict[str, Any]:
+    """
+    Save a sample note and return a note ID.
+
+    Args:
+        title: Short note title.
+        body: Note body.
+    """
+    note_seed = f"{title}\n{body}"
+    note_id = sum((index + 1) * ord(char) for index, char in enumerate(note_seed))
+    return {
+        "id": f"note-{note_id % 100000}",
+        "title": title,
+        "body": body,
+        "saved": True,
+    }
+
+
+TOOLS = [task_tool, get_weather, calculate_sum, save_note]
+TOOL_BY_NAME = {tool.name: tool for tool in TOOLS}
+
+
+# Subagent node for executing tasks
+async def subagent_node(state: SubagentState) -> dict[str, Any]:
+    """Subagent that executes the task."""
+    task = state.get("task", "")
 
     # Create a prompt for the subagent
     subagent_messages = [
@@ -121,6 +195,12 @@ async def subagent_node(state: SubagentState) -> Dict[str, Any]:
 
     # Generate response
     if os.getenv("OPENAI_API_KEY"):
+        # Initialize a simpler LLM for the subagent
+        llm = ChatOpenAI(
+            model="gpt-5.4-nano",
+            temperature=0.7,
+            streaming=True
+        )
         response = await llm.ainvoke(subagent_messages)
         result = response.content
     else:
@@ -146,34 +226,56 @@ def create_subagent_graph() -> CompiledStateGraph:
     return workflow.compile()
 
 
-async def agent_node(state: GraphState) -> Dict[str, Any]:
+async def agent_node(state: GraphState) -> dict[str, Any]:
     """Main agent node that can call tools."""
     messages = state.get("messages", [])
 
-    # Initialize the LLM with tool binding
-    llm = ChatOpenAI(
-        model="gpt-5.4-nano",
-        temperature=0.7,
-        streaming=True,
-    )
-
-    # Bind the Task tool to the LLM
-    llm_with_tools = llm.bind_tools([task_tool])
-
     # Check if OpenAI API key is set
     if os.getenv("OPENAI_API_KEY"):
+        # Initialize the LLM with tool binding
+        llm = ChatOpenAI(
+            model="gpt-5.4-nano",
+            temperature=0.7,
+            streaming=True,
+        )
+
+        # Bind smoke-test tools to the LLM
+        llm_with_tools = llm.bind_tools(TOOLS)
         response = await llm_with_tools.ainvoke(messages)
+    elif messages and isinstance(messages[-1], ToolMessage):
+        response = AIMessage(
+            content=f"Task complete: {messages[-1].content}",
+        )
     else:
         # Mock response with a tool call for testing
         print("⚠️ No OpenAI API key found - using mock response with tool call")
-        response = AIMessage(
-            content="I'll help you with that task.",
-            tool_calls=[{
+        last_content = messages[-1].content if messages else ""
+        if "weather" in str(last_content).lower():
+            tool_call = {
+                "id": "weather_001",
+                "name": "get_weather",
+                "args": {"location": "San Francisco", "unit": "celsius"},
+            }
+        elif "sum" in str(last_content).lower() or "add" in str(last_content).lower():
+            tool_call = {
+                "id": "sum_001",
+                "name": "calculate_sum",
+                "args": {"numbers": [2, 3, 5]},
+            }
+        elif "note" in str(last_content).lower():
+            tool_call = {
+                "id": "note_001",
+                "name": "save_note",
+                "args": {"title": "Smoke test", "body": "Saved from mock mode"},
+            }
+        else:
+            tool_call = {
                 "id": "task_001",
                 "name": "task_tool",
-                "args": {"task_description": "Complete the requested task"}
-            }]
-        )
+                "args": {"task_description": "Complete the requested task"},
+            }
+
+        response = AIMessage(content="I'll call a tool for that.", tool_calls=[tool_call])
 
     return {"messages": [response]}
 
@@ -192,7 +294,7 @@ def should_call_tools(state: GraphState) -> str:
     return "end"
 
 
-async def tool_executor_node(state: GraphState) -> Dict[str, Any]:
+async def tool_executor_node(state: GraphState) -> dict[str, Any]:
     """Execute tool calls, including Task tool which spawns subagents."""
     messages = state.get("messages", [])
     if not messages:
@@ -205,7 +307,8 @@ async def tool_executor_node(state: GraphState) -> Dict[str, Any]:
     # Process each tool call
     tool_messages = []
     for tool_call in last_message.tool_calls:
-        if tool_call["name"] == "task_tool":
+        tool_name = tool_call["name"]
+        if tool_name == "task_tool":
             # Extract task description
             task_description = tool_call["args"].get("task_description", "")
 
@@ -229,10 +332,17 @@ async def tool_executor_node(state: GraphState) -> Dict[str, Any]:
             )
             tool_messages.append(tool_message)
         else:
-            # Handle other tools if any
+            tool = TOOL_BY_NAME.get(tool_name)
+            if tool is None:
+                result = {"error": f"Unknown tool: {tool_name}"}
+            else:
+                result = tool.invoke(tool_call.get("args", {}))
+
             tool_message = ToolMessage(
-                content=f"Executed tool {tool_call['name']}",
-                tool_call_id=tool_call["id"]
+                content=json.dumps(result),
+                tool_call_id=tool_call["id"],
+                name=tool_name,
+                artifact=result,
             )
             tool_messages.append(tool_message)
 
@@ -241,7 +351,25 @@ async def tool_executor_node(state: GraphState) -> Dict[str, Any]:
 
 subagent_graph = create_subagent_graph()
 
-def create_graph() -> CompiledStateGraph:
+async def configure_checkpointer_from_env() -> None:
+    """Switch the graph to the configured persistent checkpointer, when present."""
+    postgres_url = os.getenv("LANGGRAPH_POSTGRES_URL") or os.getenv("DATABASE_URL")
+    if not postgres_url:
+        return
+
+    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+
+    global _postgres_checkpointer_context, graph
+    if _postgres_checkpointer_context is not None:
+        return
+
+    _postgres_checkpointer_context = AsyncPostgresSaver.from_conn_string(postgres_url)
+    checkpointer = await _postgres_checkpointer_context.__aenter__()
+    await checkpointer.setup()
+    graph = create_graph(checkpointer)
+
+
+def create_graph(checkpointer=None) -> CompiledStateGraph:
     """Create and compile the LangGraph with subgraph support."""
     # Create the main workflow
     workflow = StateGraph(GraphState)
@@ -266,8 +394,8 @@ def create_graph() -> CompiledStateGraph:
     # After tools, go back to agent for potential follow-up
     workflow.add_edge("tools", "agent")
 
-    # Compile the graph
-    return workflow.compile()
+    # Compile with a checkpointer so DeltaChannel is exercised across thread turns.
+    return workflow.compile(checkpointer=checkpointer or InMemorySaver())
 
 graph = create_graph()
 
@@ -275,14 +403,21 @@ graph = create_graph()
 async def lifespan(app: FastAPI):
     """Application lifespan manager."""
     print("🚀 Assistant Transport Backend with LangGraph starting up...")
-    yield
-    print("🛑 Assistant Transport Backend with LangGraph shutting down...")
+    await configure_checkpointer_from_env()
+    try:
+        yield
+    finally:
+        if _postgres_checkpointer_context is not None:
+            await _postgres_checkpointer_context.__aexit__(None, None, None)
+        print("🛑 Assistant Transport Backend with LangGraph shutting down...")
 
 
 # Create FastAPI app
 app = FastAPI(
     title="Assistant Transport Backend with LangGraph",
-    description="A server implementing the assistant-transport protocol with LangGraph and subgraphs",
+    description=(
+        "A server implementing the assistant-transport protocol with LangGraph and subgraphs"
+    ),
     version="0.2.0",
     lifespan=lifespan,
 )
@@ -326,7 +461,7 @@ async def chat_endpoint(request: ChatRequest):
                 # Handle tool results
                 input_messages.append(ToolMessage(
                     content=str(command.result),
-                    tool_call_id=command.toolCallId
+                    tool_call_id=command.tool_call_id
                 ))
 
         # Add messages to controller state
@@ -337,8 +472,15 @@ async def chat_endpoint(request: ChatRequest):
         input_state = {"messages": input_messages}
 
         # Stream with subgraph support
+        config = {
+            "configurable": {
+                "thread_id": request.thread_id or "assistant-transport-default",
+            }
+        }
+
         async for namespace, event_type, chunk in graph.astream(
             input_state,
+            config=config,
             stream_mode=["messages", "updates"],
             subgraphs=True
         ):

--- a/python/assistant-transport-backend-langgraph/pyproject.toml
+++ b/python/assistant-transport-backend-langgraph/pyproject.toml
@@ -10,11 +10,12 @@ dependencies = [
     "assistant-stream>=0.0.28",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
-    "langgraph>=0.2.0",
+    "langgraph>=1.2.0",
     "langchain>=0.2.0",
     "langchain-core>=0.2.0",
     "langchain-openai>=0.1.0",
     "httpx>=0.24.0",
+    "langgraph-checkpoint-postgres>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/python/assistant-transport-backend-langgraph/requirements.txt
+++ b/python/assistant-transport-backend-langgraph/requirements.txt
@@ -6,7 +6,8 @@ pydantic>=2.0.0
 python-dotenv>=1.0.0
 
 # LangGraph dependencies
-langgraph>=0.2.0
+langgraph>=1.2.0
+langgraph-checkpoint-postgres>=3.0.0
 langchain>=0.2.0
 langchain-core>=0.2.0
 langchain-openai>=0.1.0

--- a/python/assistant-transport-backend-langgraph/uv.lock
+++ b/python/assistant-transport-backend-langgraph/uv.lock
@@ -62,6 +62,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "langgraph-checkpoint-postgres" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "uvicorn", extra = ["standard"] },
@@ -87,7 +88,8 @@ requires-dist = [
     { name = "langchain", specifier = ">=0.2.0" },
     { name = "langchain-core", specifier = ">=0.2.0" },
     { name = "langchain-openai", specifier = ">=0.1.0" },
-    { name = "langgraph", specifier = ">=0.2.0" },
+    { name = "langgraph", specifier = ">=1.2.0" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=3.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -692,6 +694,21 @@ wheels = [
 ]
 
 [[package]]
+name = "langgraph-checkpoint-postgres"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langgraph-checkpoint" },
+    { name = "orjson" },
+    { name = "psycopg" },
+    { name = "psycopg-pool" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/51/5a2dc42e8b5d5942b933b5b7237eae5a4dbc92508a04727c263dd383ad8a/langgraph_checkpoint_postgres-3.1.0.tar.gz", hash = "sha256:02bff4ab63d9dae8eab3a9640fce1d479da8965c9fba7b0dc04cb1f7c56f0a55", size = 148473, upload-time = "2026-05-12T03:40:10.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/cd/eff9b82bc3b5f62d481b437099f44f3ef7b1d907f166fb4ee25e8f84a1e7/langgraph_checkpoint_postgres-3.1.0-py3-none-any.whl", hash = "sha256:814cce2ef35d792bf07b090a95eed004f1acac0724fe6605536b13f6d1e7032c", size = 48988, upload-time = "2026-05-12T03:40:08.925Z" },
+]
+
+[[package]]
 name = "langgraph-prebuilt"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1084,6 +1101,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
 ]
 
 [[package]]
@@ -1720,6 +1762,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add a DeltaChannel-backed messages state to the LangGraph assistant-transport backend, keyed by AssistantTransport threadId and backed by InMemorySaver by default
- add optional AsyncPostgresSaver wiring via LANGGRAPH_POSTGRES_URL or DATABASE_URL and document the local Docker Postgres path
- add smoke-test tools for weather, sum, note saving, and the existing task/subagent flow
- teach the Python assistant-stream LangGraph adapter to patch merged AIMessageChunk updates with granular set / append-text ops when possible

## API notes
- The assistant-ui frontend API does not change: useAssistantTransportRuntime can still point at the backend URL and send the same AssistantTransport command stream.
- The main backend request shape is still compatible with AssistantTransport; this prototype also consumes threadId so LangGraph checkpoints are scoped per assistant-ui thread.
- The LangGraph-side state API does change for the prototype: DeltaChannel reducers receive the previous state plus a batch of writes, so the messages reducer now uses the bulk reducer shape.

## Postgres verification
- Verified locally against Docker Postgres with LANGGRAPH_POSTGRES_URL using LangGraph AsyncPostgresSaver.
- Confirmed checkpoint_writes stores small per-step message writes, and after crossing snapshot_frequency a checkpoint_blobs messages row appears as a _DeltaSnapshot rather than continuously replaying the entire accumulated message list.
- Sync PostgresSaver was not compatible with the async graph stream path because graph.astream requires async checkpointer methods, so this uses AsyncPostgresSaver.

## PyPI CI
- Existing .github/workflows/python-tests.yaml runs Python package tests on python/** changes.
- Existing .github/workflows/pypi-publish.yaml publishes python/assistant-stream via repository_dispatch trusted publishing.
- No npm changeset is included because this PR only changes python/** and the Python demo backend; PyPI versioning/publish is handled by the Python workflow path.

## Tests
- uv run --extra dev --extra langgraph pytest (python/assistant-stream)
- uv run --extra dev ruff check main.py (python/assistant-transport-backend-langgraph)
- pnpm turbo build --filter=with-assistant-transport... (root, with existing local Node v22 vs repo >=24 warning)
- curl smoke test against the running backend weather tool path


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

