### PR TITLE
chore: require maintainer review for CI config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CI and repository policy changes require maintainer review.
+/.github/CODEOWNERS @assistant-ui/maintainers
+/.github/actions/ @assistant-ui/maintainers
+/.github/workflows/ @assistant-ui/maintainers


### PR DESCRIPTION
## Summary
- add CODEOWNERS entries requiring `@assistant-ui/maintainers` review for CI workflow changes
- cover `.github/workflows/`, `.github/actions/`, and `.github/CODEOWNERS` itself

Follow-up to #4453, which merged before this CODEOWNERS commit landed.

## Test
- `pnpm lint`

Note: `pnpm lint` warned that local Node is v22.22.3 while the repo wants >=24, then completed successfully.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

