### PR TITLE
refactor(docs): split Xulux markdown from shared docs assistant component

### DIFF
--- a/apps/docs/components/xulux/chat/XuluxMarkdownText.tsx
+++ b/apps/docs/components/xulux/chat/XuluxMarkdownText.tsx
@@ -4,31 +4,41 @@ import "@assistant-ui/react-markdown/styles/dot.css";
 import "react-shiki/css";
 
 import {
-  type CodeHeaderProps,
-  MarkdownTextPrimitive,
+  StreamdownTextPrimitive,
+  useIsStreamdownCodeBlock,
+  type StreamdownTextComponents,
   type SyntaxHighlighterProps,
-  unstable_memoizeMarkdownComponents as memoizeMarkdownComponents,
-  useIsMarkdownCodeBlock,
-} from "@assistant-ui/react-markdown";
-import remarkGfm from "remark-gfm";
-import { type CSSProperties, type FC, memo } from "react";
+} from "@assistant-ui/react-streamdown";
+import { type CodeHeaderProps } from "@assistant-ui/react-markdown";
+import { OpenInSyntaxHighlighter } from "@/components/xulux/chat/OpenInCard";
+import {
+  type ComponentPropsWithoutRef,
+  type CSSProperties,
+  type FC,
+  memo,
+} from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import ShikiHighlighter from "react-shiki";
 import Link from "next/link";
 import { useCopyToClipboard } from "@assistant-ui/ui/hooks/use-copy-to-clipboard";
 
-const MarkdownTextImpl = () => {
+const XuluxMarkdownTextImpl = () => {
   return (
-    <MarkdownTextPrimitive
-      remarkPlugins={[remarkGfm]}
-      className="aui-md-assistant"
-      components={markdownComponents}
+    <StreamdownTextPrimitive
+      containerClassName="aui-md-assistant"
+      components={markdownComponents as StreamdownTextComponents}
+      componentsByLanguage={{
+        "open-in": {
+          SyntaxHighlighter: OpenInSyntaxHighlighter,
+          CodeHeader: () => null,
+        },
+      }}
     />
   );
 };
 
-export const MarkdownText = memo(MarkdownTextImpl);
+export const XuluxMarkdownText = memo(XuluxMarkdownTextImpl);
 
 const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
   const { isCopied, copyToClipboard } = useCopyToClipboard();
@@ -81,9 +91,9 @@ const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({ code, language }) => {
   );
 };
 
-const markdownComponents = memoizeMarkdownComponents({
+const markdownComponents = {
   SyntaxHighlighter: SyntaxHighlighter,
-  h1: ({ className, ...props }) => (
+  h1: ({ className, ...props }: ComponentPropsWithoutRef<"h1">) => (
     <h1
       className={cn(
         "mb-2 text-base font-semibold first:mt-0 last:mb-0",
@@ -92,7 +102,7 @@ const markdownComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h2: ({ className, ...props }) => (
+  h2: ({ className, ...props }: ComponentPropsWithoutRef<"h2">) => (
     <h2
       className={cn(
         "mt-3 mb-1.5 text-sm font-semibold first:mt-0 last:mb-0",
@@ -101,7 +111,7 @@ const markdownComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h3: ({ className, ...props }) => (
+  h3: ({ className, ...props }: ComponentPropsWithoutRef<"h3">) => (
     <h3
       className={cn(
         "mt-2.5 mb-1 text-sm font-semibold first:mt-0 last:mb-0",
@@ -110,7 +120,7 @@ const markdownComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h4: ({ className, ...props }) => (
+  h4: ({ className, ...props }: ComponentPropsWithoutRef<"h4">) => (
     <h4
       className={cn(
         "mt-2 mb-1 text-sm font-medium first:mt-0 last:mb-0",
@@ -119,7 +129,7 @@ const markdownComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h5: ({ className, ...props }) => (
+  h5: ({ className, ...props }: ComponentPropsWithoutRef<"h5">) => (
     <h5
       className={cn(
         "mt-2 mb-1 text-sm font-medium first:mt-0 last:mb-0",
@@ -128,7 +138,7 @@ const markdownComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  h6: ({ className, ...props }) => (
+  h6: ({ className, ...props }: ComponentPropsWithoutRef<"h6">) => (
     <h6
       className={cn(
         "mt-2 mb-1 text-sm font-medium first:mt-0 last:mb-0",
@@ -137,13 +147,20 @@ const markdownComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  p: ({ className, ...props }) => (
+  p: ({ className, ...props }: ComponentPropsWithoutRef<"p">) => (
     <p
       className={cn("my-2.5 leading-normal first:mt-0 last:mb-0", className)}
       {...props}
     />
   ),
-  a: ({ className, href, children, title, target, rel }) => {
+  a: ({
+    className,
+    href,
+    children,
+    title,
+    target,
+    rel,
+  }: ComponentPropsWithoutRef<"a">) => {
     const linkClass = cn(
       "text-primary hover:text-primary/80 underline underline-offset-2",
       className,
@@ -168,7 +185,10 @@ const markdownComponents = memoizeMarkdownComponents({
       </a>
     );
   },
-  blockquote: ({ className, ...props }) => (
+  blockquote: ({
+    className,
+    ...props
+  }: ComponentPropsWithoutRef<"blockquote">) => (
     <blockquote
       className={cn(
         "border-muted-foreground/30 text-muted-foreground my-2.5 border-l-2 pl-3 italic",
@@ -177,7 +197,7 @@ const markdownComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  ul: ({ className, ...props }) => (
+  ul: ({ className, ...props }: ComponentPropsWithoutRef<"ul">) => (
     <ul
       className={cn(
         "marker:text-muted-foreground my-2 ml-4 list-disc [&>li]:mt-1",
@@ -186,7 +206,7 @@ const markdownComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  ol: ({ className, ...props }) => (
+  ol: ({ className, ...props }: ComponentPropsWithoutRef<"ol">) => (
     <ol
       className={cn(
         "marker:text-muted-foreground my-2 ml-4 list-decimal [&>li]:mt-1",
@@ -195,16 +215,16 @@ const markdownComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  li: ({ className, ...props }) => (
+  li: ({ className, ...props }: ComponentPropsWithoutRef<"li">) => (
     <li className={cn("leading-normal", className)} {...props} />
   ),
-  hr: ({ className, ...props }) => (
+  hr: ({ className, ...props }: ComponentPropsWithoutRef<"hr">) => (
     <hr
       className={cn("border-muted-foreground/20 my-2", className)}
       {...props}
     />
   ),
-  table: ({ className, ...props }) => (
+  table: ({ className, ...props }: ComponentPropsWithoutRef<"table">) => (
     <div className="my-2 overflow-x-auto">
       <table
         className={cn("w-full border-collapse text-xs", className)}
@@ -212,7 +232,7 @@ const markdownComponents = memoizeMarkdownComponents({
       />
     </div>
   ),
-  th: ({ className, ...props }) => (
+  th: ({ className, ...props }: ComponentPropsWithoutRef<"th">) => (
     <th
       className={cn(
         "border-muted-foreground/20 bg-muted border px-2 py-1 text-left font-medium",
@@ -221,7 +241,7 @@ const markdownComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  td: ({ className, ...props }) => (
+  td: ({ className, ...props }: ComponentPropsWithoutRef<"td">) => (
     <td
       className={cn(
         "border-muted-foreground/20 border px-2 py-1 text-left",
@@ -230,8 +250,8 @@ const markdownComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  tr: (props) => <tr {...props} />,
-  pre: ({ className, ...props }) => (
+  tr: (props: ComponentPropsWithoutRef<"tr">) => <tr {...props} />,
+  pre: ({ className, ...props }: ComponentPropsWithoutRef<"pre">) => (
     <pre
       className={cn(
         "border-border/50 bg-muted/30 overflow-x-auto rounded-t-none rounded-b-lg border border-t-0 p-3 text-xs leading-relaxed",
@@ -240,8 +260,11 @@ const markdownComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  code: function Code({ className, ...props }) {
-    const isCodeBlock = useIsMarkdownCodeBlock();
+  code: function Code({
+    className,
+    ...props
+  }: ComponentPropsWithoutRef<"code">) {
+    const isCodeBlock = useIsStreamdownCodeBlock();
     return (
       <code
         className={cn(
@@ -254,4 +277,4 @@ const markdownComponents = memoizeMarkdownComponents({
     );
   },
   CodeHeader,
-});
+};

--- a/apps/docs/components/xulux/chat/XuluxThread.tsx
+++ b/apps/docs/components/xulux/chat/XuluxThread.tsx
@@ -3,7 +3,7 @@
 import { ModelSelector } from "@/components/assistant-ui/model-selector";
 import { AssistantComposer } from "@/components/docs/assistant/composer";
 import { AssistantActionBar } from "@/components/docs/assistant/assistant-action-bar";
-import { MarkdownText } from "@/components/docs/assistant/markdown";
+import { XuluxMarkdownText } from "./XuluxMarkdownText";
 import { AssistantFooter } from "@/components/docs/assistant/footer";
 import { AssistantThread } from "@/components/docs/assistant/thread";
 import { Reasoning } from "@/components/assistant-ui/reasoning";
@@ -142,7 +142,7 @@ function XuluxAssistantMessage(): ReactNode {
             if (part.type === "text") {
               return (
                 <div data-part-type="text">
-                  <MarkdownText />
+                  <XuluxMarkdownText />
                 </div>
               );
             }


### PR DESCRIPTION
## Summary
- Restores `components/docs/assistant/markdown.tsx` to the original docs-assistant `MarkdownTextPrimitive` implementation (matches pre-#4417 shared behavior).
- Adds `components/xulux/chat/XuluxMarkdownText.tsx` for Xulux-only Streamdown rendering, including the `open-in` code block → `OpenInCard` integration.
- Updates `XuluxThread` to use `XuluxMarkdownText` instead of the shared docs assistant markdown component.

Follow-up to merged #4417 — keeps Xulux playground behavior while decoupling the docs chat markdown renderer.

## Test plan
- [ ] Docs assistant chat still renders markdown normally (GFM, code blocks, links)
- [ ] Xulux playground still renders assistant messages with Streamdown
- [ ] Xulux agent `open-in` blocks still render `OpenInCard` with download + external agent deeplinks
- [ ] `git diff main -- apps/docs/components/docs/assistant/markdown.tsx` shows only the restore to `MarkdownTextPrimitive` (no Xulux imports)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

