### PR TITLE
docs: update nav and pricing layout

### DIFF
--- a/apps/docs/app/(home)/pricing/page.tsx
+++ b/apps/docs/app/(home)/pricing/page.tsx
@@ -27,34 +27,7 @@ export default function PricingPage() {
         </p>
       </header>
 
-      {/* assistant-cloud section */}
       <section className="mb-20">
-        <div className="mb-8">
-          <h2 className="text-xl font-medium tracking-tight">
-            assistant-cloud
-          </h2>
-          <p className="text-muted-foreground mt-1">
-            Fully managed backend for AI chat applications
-          </p>
-        </div>
-
-        <div className="grid gap-6 md:grid-cols-3">
-          {pricingPlans.map((plan) => (
-            <PricingPlanCard key={plan.name} plan={plan} />
-          ))}
-        </div>
-
-        <p className="text-muted-foreground mt-4 text-xs">
-          * MAU = Monthly Active Users who send at least one message.{" "}
-          <a href="mailto:b2c-pricing@assistant.dev" className="underline">
-            Contact us
-          </a>{" "}
-          for B2C pricing.
-        </p>
-      </section>
-
-      {/* assistant-ui section */}
-      <section>
         <div className="mb-8">
           <h2 className="text-xl font-medium tracking-tight">assistant-ui</h2>
           <p className="text-muted-foreground mt-1">
@@ -89,6 +62,31 @@ export default function PricingPage() {
             ))}
           </ul>
         </div>
+      </section>
+
+      <section>
+        <div className="mb-8">
+          <h2 className="text-xl font-medium tracking-tight">
+            assistant-cloud
+          </h2>
+          <p className="text-muted-foreground mt-1">
+            Fully managed backend for AI chat applications
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-3">
+          {pricingPlans.map((plan) => (
+            <PricingPlanCard key={plan.name} plan={plan} />
+          ))}
+        </div>
+
+        <p className="text-muted-foreground mt-4 text-xs">
+          * MAU = Monthly Active Users who send at least one message.{" "}
+          <a href="mailto:b2c-pricing@assistant.dev" className="underline">
+            Contact us
+          </a>{" "}
+          for B2C pricing.
+        </p>
       </section>
     </main>
   );

--- a/apps/docs/components/docs/layout/docs-header.tsx
+++ b/apps/docs/components/docs/layout/docs-header.tsx
@@ -77,7 +77,7 @@ function HeaderSearch() {
   );
 }
 
-const CONDENSED_HIDDEN = new Set(["Showcase", "Playground", "Pricing"]);
+const CONDENSED_HIDDEN = new Set(["Showcase", "Pricing"]);
 
 function MobileSectionBreadcrumb({
   tree,
@@ -252,6 +252,14 @@ export function DocsHeader({
             <NavItems items={condensedItems} megaAlign="end" />
             {moreItems.length > 0 && <MoreDropdown items={moreItems} />}
           </nav>
+          <a
+            href="https://cloud.assistant-ui.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="border-border/50 bg-muted/50 hover:bg-muted flex h-8 items-center rounded-lg border px-3 text-sm font-medium transition-colors"
+          >
+            Cloud
+          </a>
           <ThemeToggle />
         </div>
 
@@ -262,6 +270,14 @@ export function DocsHeader({
           <nav className="flex shrink-0 items-center">
             <NavItems items={filteredItems} megaAlign="end" />
           </nav>
+          <a
+            href="https://cloud.assistant-ui.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="border-border/50 bg-muted/50 hover:bg-muted flex h-8 items-center rounded-lg border px-3 text-sm font-medium transition-colors"
+          >
+            Cloud
+          </a>
           <ThemeToggle />
         </div>
       </div>
@@ -337,6 +353,17 @@ export function DocsHeader({
               </div>
             );
           })}
+          <div className="mt-auto border-t py-6">
+            <a
+              href="https://cloud.assistant-ui.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setNavMenuOpen(false)}
+              className="border-border hover:bg-muted inline-flex rounded-md border px-3 py-1.5 text-sm font-medium transition-colors"
+            >
+              Cloud
+            </a>
+          </div>
         </nav>
       </div>
     </header>

--- a/apps/docs/components/docs/layout/docs-header.tsx
+++ b/apps/docs/components/docs/layout/docs-header.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { useSearchContext } from "fumadocs-ui/contexts/search";
 import { NAV_ITEMS, type NavItem } from "@/lib/constants";
+import { CloudButton } from "@/components/shared/cloud-button";
 import { MoreDropdown } from "@/components/shared/more-dropdown";
 import { NavItems } from "@/components/shared/nav-items";
 import { useDocsSidebar } from "@/components/docs/contexts/sidebar";
@@ -252,14 +253,7 @@ export function DocsHeader({
             <NavItems items={condensedItems} megaAlign="end" />
             {moreItems.length > 0 && <MoreDropdown items={moreItems} />}
           </nav>
-          <a
-            href="https://cloud.assistant-ui.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="border-border/50 bg-muted/50 hover:bg-muted flex h-8 items-center rounded-lg border px-3 text-sm font-medium transition-colors"
-          >
-            Cloud
-          </a>
+          <CloudButton variant="docs" />
           <ThemeToggle />
         </div>
 
@@ -270,14 +264,7 @@ export function DocsHeader({
           <nav className="flex shrink-0 items-center">
             <NavItems items={filteredItems} megaAlign="end" />
           </nav>
-          <a
-            href="https://cloud.assistant-ui.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="border-border/50 bg-muted/50 hover:bg-muted flex h-8 items-center rounded-lg border px-3 text-sm font-medium transition-colors"
-          >
-            Cloud
-          </a>
+          <CloudButton variant="docs" />
           <ThemeToggle />
         </div>
       </div>
@@ -354,15 +341,11 @@ export function DocsHeader({
             );
           })}
           <div className="mt-auto border-t py-6">
-            <a
-              href="https://cloud.assistant-ui.com"
-              target="_blank"
-              rel="noopener noreferrer"
+            <CloudButton
+              variant="mobile"
+              className="w-auto"
               onClick={() => setNavMenuOpen(false)}
-              className="border-border hover:bg-muted inline-flex rounded-md border px-3 py-1.5 text-sm font-medium transition-colors"
-            >
-              Cloud
-            </a>
+            />
           </div>
         </nav>
       </div>

--- a/apps/docs/components/shared/cloud-button.tsx
+++ b/apps/docs/components/shared/cloud-button.tsx
@@ -1,0 +1,32 @@
+import { CLOUD_URL } from "@/lib/constants";
+import { cn } from "@/lib/utils";
+
+const cloudButtonVariants = {
+  marketing:
+    "border-border hover:bg-muted hidden rounded-md border px-3 py-1.5 text-sm font-medium transition-colors md:inline-flex",
+  docs: "border-border/50 bg-muted/50 hover:bg-muted flex h-8 items-center rounded-lg border px-3 text-sm font-medium transition-colors",
+  mobile:
+    "border-border hover:bg-muted inline-flex w-fit rounded-md border px-3 py-1.5 text-sm font-medium transition-colors",
+};
+
+export function CloudButton({
+  variant,
+  className,
+  onClick,
+}: {
+  variant: keyof typeof cloudButtonVariants;
+  className?: string;
+  onClick?: () => void;
+}) {
+  return (
+    <a
+      href={CLOUD_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={onClick}
+      className={cn(cloudButtonVariants[variant], className)}
+    >
+      Cloud
+    </a>
+  );
+}

--- a/apps/docs/components/shared/footer.tsx
+++ b/apps/docs/components/shared/footer.tsx
@@ -5,7 +5,7 @@ import { ArrowUpRight } from "lucide-react";
 import { GitHubIcon } from "@/components/icons/github";
 import { DiscordIcon } from "@/components/icons/discord";
 import { ThemeToggle } from "@/components/shared/theme-toggle";
-import { PRODUCTS } from "@/lib/constants";
+import { CLOUD_URL, PRODUCTS } from "@/lib/constants";
 
 type FooterLinkItem = {
   label: string;
@@ -17,7 +17,7 @@ const FOOTER_LINKS: Record<string, FooterLinkItem[]> = {
   Products: [
     {
       label: "Cloud",
-      href: "https://cloud.assistant-ui.com/",
+      href: CLOUD_URL,
       external: true,
     },
     { label: "Playground", href: "/playground" },

--- a/apps/docs/components/shared/header.tsx
+++ b/apps/docs/components/shared/header.tsx
@@ -12,6 +12,7 @@ import { SearchDialog } from "./search-dialog";
 import { GitHubIcon } from "@/components/icons/github";
 import { DiscordIcon } from "@/components/icons/discord";
 import { NAV_ITEMS } from "@/lib/constants";
+import { CloudButton } from "@/components/shared/cloud-button";
 import { NavItems } from "@/components/shared/nav-items";
 
 function SearchButton({ onToggle }: { onToggle: () => void }) {
@@ -132,14 +133,7 @@ export function Header() {
             </>
           )}
 
-          <a
-            href="https://cloud.assistant-ui.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="border-border hover:bg-muted hidden rounded-md border px-3 py-1.5 text-sm font-medium transition-colors md:inline-flex"
-          >
-            Cloud
-          </a>
+          <CloudButton variant="marketing" />
 
           <a
             href="https://github.com/assistant-ui/assistant-ui"
@@ -255,15 +249,10 @@ export function Header() {
           })}
 
           <div className="mt-auto flex flex-col gap-4 border-t py-6">
-            <a
-              href="https://cloud.assistant-ui.com"
-              target="_blank"
-              rel="noopener noreferrer"
+            <CloudButton
+              variant="mobile"
               onClick={() => setMobileMenuOpen(false)}
-              className="border-border hover:bg-muted inline-flex w-fit rounded-md border px-3 py-1.5 text-sm font-medium transition-colors"
-            >
-              Cloud
-            </a>
+            />
             <div className="flex gap-4">
               <a
                 href="https://github.com/assistant-ui/assistant-ui"

--- a/apps/docs/components/shared/header.tsx
+++ b/apps/docs/components/shared/header.tsx
@@ -133,6 +133,15 @@ export function Header() {
           )}
 
           <a
+            href="https://cloud.assistant-ui.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="border-border hover:bg-muted hidden rounded-md border px-3 py-1.5 text-sm font-medium transition-colors md:inline-flex"
+          >
+            Cloud
+          </a>
+
+          <a
             href="https://github.com/assistant-ui/assistant-ui"
             target="_blank"
             rel="noopener noreferrer"
@@ -245,23 +254,34 @@ export function Header() {
             );
           })}
 
-          <div className="mt-auto flex gap-4 border-t py-6">
+          <div className="mt-auto flex flex-col gap-4 border-t py-6">
             <a
-              href="https://github.com/assistant-ui/assistant-ui"
+              href="https://cloud.assistant-ui.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
+              onClick={() => setMobileMenuOpen(false)}
+              className="border-border hover:bg-muted inline-flex w-fit rounded-md border px-3 py-1.5 text-sm font-medium transition-colors"
             >
-              <GitHubIcon className="size-5" />
+              Cloud
             </a>
-            <a
-              href="https://discord.gg/S9dwgCNEFs"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
-            >
-              <DiscordIcon className="size-5" />
-            </a>
+            <div className="flex gap-4">
+              <a
+                href="https://github.com/assistant-ui/assistant-ui"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
+              >
+                <GitHubIcon className="size-5" />
+              </a>
+              <a
+                href="https://discord.gg/S9dwgCNEFs"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
+              >
+                <DiscordIcon className="size-5" />
+              </a>
+            </div>
           </div>
         </nav>
       </div>

--- a/apps/docs/lib/constants.ts
+++ b/apps/docs/lib/constants.ts
@@ -102,6 +102,7 @@ export type NavItem =
 
 export const NAV_ITEMS: NavItem[] = [
   { type: "link", label: "Docs", href: "/docs" },
+  { type: "link", label: "Playground", href: "/playground" },
   {
     type: "mega",
     label: "Resources",
@@ -119,12 +120,6 @@ export const NAV_ITEMS: NavItem[] = [
             label: "Showcase",
             href: "/showcase",
             description: "Apps built with assistant-ui",
-            external: false,
-          },
-          {
-            label: "Playground",
-            href: "/playground",
-            description: "Experiment in the browser",
             external: false,
           },
           {
@@ -195,6 +190,5 @@ export const NAV_ITEMS: NavItem[] = [
       },
     ],
   },
-  { type: "link", label: "Cloud", href: "https://cloud.assistant-ui.com" },
   { type: "link", label: "Pricing", href: "/pricing" },
 ];

--- a/apps/docs/lib/constants.ts
+++ b/apps/docs/lib/constants.ts
@@ -1,4 +1,5 @@
 export const BASE_URL = "https://www.assistant-ui.com";
+export const CLOUD_URL = "https://cloud.assistant-ui.com";
 
 export const PLATFORMS = ["react", "rn", "ink"] as const;
 export type Platform = (typeof PLATFORMS)[number];


### PR DESCRIPTION
## Summary
- move Playground next to Docs in the top-level docs nav
- move Cloud to separate right-side header buttons
- show the free open-source assistant-ui pricing section before assistant-cloud plans

## Test plan
- pnpm lint
- pnpm build

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

