### PR TITLE
feat(docs): use Assistant Cloud for Xulux message history and telemetry

### DIFF
--- a/apps/docs/components/xulux/XuluxApp.tsx
+++ b/apps/docs/components/xulux/XuluxApp.tsx
@@ -85,16 +85,33 @@ function XuluxRuntimeProvider({
     const baseUrl =
       process.env.NEXT_PUBLIC_XULUX_ASSISTANT_BASE_URL ??
       process.env.NEXT_PUBLIC_ASSISTANT_BASE_URL;
-    if (!baseUrl) return null;
-    return new AssistantCloud({ baseUrl, anonymous: true });
+    if (!baseUrl) {
+      throw new Error(
+        "NEXT_PUBLIC_XULUX_ASSISTANT_BASE_URL or NEXT_PUBLIC_ASSISTANT_BASE_URL must be set",
+      );
+    }
+    return new AssistantCloud({
+      baseUrl,
+      anonymous: true,
+      telemetry: {
+        beforeReport: (report) => ({
+          ...report,
+          metadata: {
+            ...(report.metadata ?? {}),
+            app: "xulux_playground",
+          },
+        }),
+      },
+    });
   }, []);
 
   const adapter = useMemo(
     () =>
       createXuluxLocalThreadListAdapter({
         getCurrentSessionId: () => sessionIdRef.current,
+        cloud: assistantCloud,
       }),
-    [],
+    [assistantCloud],
   );
 
   const transport = useMemo(
@@ -131,7 +148,6 @@ function XuluxRuntimeProvider({
       return useChatRuntime({
         transport,
         isSendDisabled: limitBlock != null,
-        ...(assistantCloud ? { cloud: assistantCloud } : {}),
       });
     },
   });

--- a/apps/docs/components/xulux/runtime/types.ts
+++ b/apps/docs/components/xulux/runtime/types.ts
@@ -24,20 +24,9 @@ export type XuluxThreadCustom = {
 
 export type XuluxStoredThread = {
   remoteId: string;
+  /** The sessionId used to correlate with /api/xulux/chat. Stored as externalId on cloud thread. */
   externalId?: string;
   status: "regular" | "archived";
   title?: string;
   custom: XuluxThreadCustom;
-};
-
-export type XuluxStoredMessageRow = {
-  id: string;
-  parent_id: string | null;
-  format: string;
-  content: Record<string, unknown>;
-};
-
-export type XuluxStoredMessageRepository = {
-  headId?: string | null;
-  messages: XuluxStoredMessageRow[];
 };

--- a/apps/docs/components/xulux/runtime/xulux-local-storage.ts
+++ b/apps/docs/components/xulux/runtime/xulux-local-storage.ts
@@ -3,7 +3,6 @@
 import { useEffect, useSyncExternalStore } from "react";
 import type {
   XuluxCanvasSnapshot,
-  XuluxStoredMessageRepository,
   XuluxStoredThread,
   XuluxThreadCustom,
   XuluxThreadStatus,
@@ -12,7 +11,6 @@ import type { SelectedTemplateContext } from "../XuluxApp";
 
 const PREFIX = "xulux:";
 const THREADS_KEY = `${PREFIX}threads`;
-const MESSAGES_PREFIX = `${PREFIX}messages:`;
 const STORAGE_EVENT = "xulux-storage";
 const EMPTY_THREADS: XuluxStoredThread[] = [];
 
@@ -28,16 +26,6 @@ function notify() {
   window.dispatchEvent(new Event(STORAGE_EVENT));
 }
 
-function readJson<T>(key: string, fallback: T): T {
-  if (!isBrowser()) return fallback;
-  try {
-    const raw = window.localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
 function writeJson<T>(key: string, value: T) {
   if (!isBrowser()) return;
   try {
@@ -48,20 +36,6 @@ function writeJson<T>(key: string, value: T) {
   } catch {
     // Ignore quota and private-mode write failures.
   }
-}
-
-function removeItem(key: string) {
-  if (!isBrowser()) return;
-  try {
-    window.localStorage.removeItem(key);
-    notify();
-  } catch {
-    // Ignore storage failures.
-  }
-}
-
-function messagesKey(remoteId: string) {
-  return `${MESSAGES_PREFIX}${remoteId}`;
 }
 
 function normalizeThread(thread: XuluxStoredThread): XuluxStoredThread {
@@ -112,26 +86,6 @@ function normalizePersistedThreads() {
 
 export function writeXuluxThreads(threads: XuluxStoredThread[]) {
   writeJson(THREADS_KEY, threads);
-}
-
-export function readXuluxMessages(
-  remoteId: string,
-): XuluxStoredMessageRepository {
-  return readJson<XuluxStoredMessageRepository>(messagesKey(remoteId), {
-    headId: null,
-    messages: [],
-  });
-}
-
-export function writeXuluxMessages(
-  remoteId: string,
-  repository: XuluxStoredMessageRepository,
-) {
-  writeJson(messagesKey(remoteId), repository);
-}
-
-export function deleteXuluxMessages(remoteId: string) {
-  removeItem(messagesKey(remoteId));
 }
 
 export function findXuluxThread(remoteId: string): XuluxStoredThread | null {

--- a/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
+++ b/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
@@ -1,29 +1,21 @@
 "use client";
 
 import { createAssistantStream } from "assistant-stream";
-import { type FC, type PropsWithChildren, useMemo } from "react";
+import { type FC, type PropsWithChildren, useMemo, useRef } from "react";
 import {
+  type AssistantCloud,
   RuntimeAdapterProvider,
-  useAui,
-  type MessageFormatAdapter,
   type RemoteThreadListAdapter,
-  type ThreadHistoryAdapter,
   type ThreadMessage,
 } from "@assistant-ui/react";
+import { useAssistantCloudThreadHistoryAdapter } from "@assistant-ui/core/react";
 import {
-  deleteXuluxMessages,
   findXuluxThread,
-  readXuluxMessages,
   readXuluxThreads,
   updateXuluxThread,
-  writeXuluxMessages,
   writeXuluxThreads,
 } from "./xulux-local-storage";
-import type {
-  XuluxStoredMessageRow,
-  XuluxStoredThread,
-  XuluxThreadCustom,
-} from "./types";
+import type { XuluxStoredThread, XuluxThreadCustom } from "./types";
 
 function getTextFromMessages(messages: readonly ThreadMessage[]): string {
   for (const message of messages) {
@@ -42,100 +34,30 @@ function titleFromMessages(messages: readonly ThreadMessage[]): string {
   return text.length > 44 ? `${text.slice(0, 41)}...` : text;
 }
 
-class XuluxLocalHistoryAdapter implements ThreadHistoryAdapter {
-  constructor(private aui: ReturnType<typeof useAui>) {}
-
-  async load() {
-    return { messages: [] };
-  }
-
-  async append() {}
-
-  withFormat<TMessage, TStorageFormat extends Record<string, unknown>>(
-    fmt: MessageFormatAdapter<TMessage, TStorageFormat>,
-  ) {
-    const adapter = this;
-    return {
-      async load() {
-        const remoteId = adapter.aui.threadListItem().getState().remoteId;
-        if (!remoteId) return { headId: null, messages: [] };
-        const repository = readXuluxMessages(remoteId);
-        return {
-          headId: repository.headId ?? null,
-          messages: repository.messages
-            .filter((row) => row.format === fmt.format)
-            .map((row) =>
-              fmt.decode({
-                id: row.id,
-                parent_id: row.parent_id,
-                format: row.format,
-                content: row.content as TStorageFormat,
-              }),
-            ),
-        };
-      },
-      async append(item: { parentId: string | null; message: TMessage }) {
-        const { remoteId } = await adapter.aui.threadListItem().initialize();
-        const repository = readXuluxMessages(remoteId);
-        const id = fmt.getId(item.message);
-        const row: XuluxStoredMessageRow = {
-          id,
-          parent_id: item.parentId,
-          format: fmt.format,
-          content: fmt.encode(item),
-        };
-        const index = repository.messages.findIndex(
-          (message) => message.id === id,
-        );
-        const messages =
-          index === -1
-            ? [...repository.messages, row]
-            : repository.messages.map((message, messageIndex) =>
-                messageIndex === index ? row : message,
-              );
-        writeXuluxMessages(remoteId, { headId: id, messages });
-      },
-      async update(
-        item: { parentId: string | null; message: TMessage },
-        localMessageId: string,
-      ) {
-        const remoteId = adapter.aui.threadListItem().getState().remoteId;
-        if (!remoteId) return;
-        const repository = readXuluxMessages(remoteId);
-        const row: XuluxStoredMessageRow = {
-          id: localMessageId,
-          parent_id: item.parentId,
-          format: fmt.format,
-          content: fmt.encode(item),
-        };
-        writeXuluxMessages(remoteId, {
-          headId: repository.headId ?? null,
-          messages: repository.messages.map((message) =>
-            message.id === localMessageId ? row : message,
-          ),
-        });
-      },
-    };
-  }
-}
-
-function XuluxLocalHistoryProvider({ children }: PropsWithChildren) {
-  const aui = useAui();
-  const history = useMemo(() => new XuluxLocalHistoryAdapter(aui), [aui]);
-  const adapters = useMemo(() => ({ history }), [history]);
-  return (
-    <RuntimeAdapterProvider adapters={adapters}>
-      {children}
-    </RuntimeAdapterProvider>
-  );
+function createXuluxCloudHistoryProvider(
+  cloud: AssistantCloud,
+): FC<PropsWithChildren> {
+  return function XuluxCloudHistoryProvider({ children }) {
+    const cloudRef = useRef(cloud);
+    cloudRef.current = cloud;
+    const history = useAssistantCloudThreadHistoryAdapter(cloudRef);
+    const adapters = useMemo(() => ({ history }), [history]);
+    return (
+      <RuntimeAdapterProvider adapters={adapters}>
+        {children}
+      </RuntimeAdapterProvider>
+    );
+  };
 }
 
 export function createXuluxLocalThreadListAdapter({
   getCurrentSessionId,
+  cloud,
 }: {
   getCurrentSessionId: () => string;
+  cloud: AssistantCloud;
 }): RemoteThreadListAdapter {
-  const Provider: FC<PropsWithChildren> = XuluxLocalHistoryProvider;
+  const Provider = createXuluxCloudHistoryProvider(cloud);
 
   const upsertThread = (
     remoteId: string,
@@ -170,8 +92,17 @@ export function createXuluxLocalThreadListAdapter({
     async initialize() {
       const sessionId = getCurrentSessionId();
       const now = Date.now();
-      upsertThread(sessionId, (existing) => ({
-        remoteId: sessionId,
+
+      // Create a cloud thread — its id becomes our remoteId
+      const { thread_id: cloudThreadId } = await cloud.threads.create({
+        last_message_at: new Date(),
+        external_id: sessionId,
+        metadata: { source: "xulux_playground" },
+      });
+
+      upsertThread(cloudThreadId, (existing) => ({
+        remoteId: cloudThreadId,
+        externalId: sessionId,
         status: existing?.status ?? "regular",
         custom: {
           xuluxStatus: existing?.custom.xuluxStatus ?? "idle",
@@ -187,12 +118,12 @@ export function createXuluxLocalThreadListAdapter({
             ? { canvas: existing.custom.canvas }
             : {}),
         } satisfies XuluxThreadCustom,
-        ...(existing?.externalId !== undefined
-          ? { externalId: existing.externalId }
-          : {}),
-        ...(existing?.title !== undefined ? { title: existing.title } : {}),
       }));
-      return { remoteId: sessionId, externalId: undefined };
+
+      return {
+        remoteId: cloudThreadId,
+        externalId: sessionId,
+      };
     },
     async rename(remoteId, title) {
       updateXuluxThread(remoteId, (thread) => ({
@@ -219,7 +150,6 @@ export function createXuluxLocalThreadListAdapter({
       writeXuluxThreads(
         readXuluxThreads().filter((thread) => thread.remoteId !== remoteId),
       );
-      deleteXuluxMessages(remoteId);
     },
     async fetch(remoteId) {
       const thread = findXuluxThread(remoteId);

--- a/apps/docs/components/xulux/shell/XuluxShell.tsx
+++ b/apps/docs/components/xulux/shell/XuluxShell.tsx
@@ -22,7 +22,7 @@ function useIsSmallScreen(): boolean {
     () => false,
   );
 }
-import { useAui, useAuiState } from "@assistant-ui/react";
+import { useAui, useAuiState, type ThreadMessage } from "@assistant-ui/react";
 import { useAssistantPanel } from "@/components/docs/assistant/context";
 import { Button } from "@/components/ui/button";
 import { XuluxThread } from "../chat/XuluxThread";
@@ -36,7 +36,6 @@ import { XuluxLandingPage } from "../landing/XuluxLandingPage";
 import { TemplatesModal } from "../landing/TemplatesModal";
 import { XuluxHeaderActions } from "./XuluxHeaderActions";
 import {
-  readXuluxMessages,
   updateXuluxPendingUserMessage,
   updateXuluxThreadContext,
   updateXuluxThreadStatus,
@@ -156,12 +155,13 @@ export function XuluxShell({
     storedThreads.find((thread) => thread.remoteId === currentRemoteId) ?? null;
   const isInterrupted =
     activeStoredThread?.custom.xuluxStatus === "interrupted";
+  const runtimeMessages = useAuiState((s) => s.thread.messages);
   const interruptedUserMessage = useMemo(() => {
     if (!isInterrupted || !currentRemoteId) return null;
     const pending = activeStoredThread?.custom.pendingUserMessage?.trim();
     if (pending) return pending;
-    return getLatestSavedUserMessage(currentRemoteId);
-  }, [activeStoredThread, currentRemoteId, isInterrupted]);
+    return getLatestUserTextFromMessages(runtimeMessages);
+  }, [activeStoredThread, currentRemoteId, isInterrupted, runtimeMessages]);
 
   const handleRetryInterrupted = useCallback(() => {
     if (!interruptedUserMessage) return;
@@ -402,33 +402,19 @@ function fromCanvasSnapshot(
   };
 }
 
-function getLatestSavedUserMessage(remoteId: string): string | null {
-  const repository = readXuluxMessages(remoteId);
-  for (let index = repository.messages.length - 1; index >= 0; index -= 1) {
-    const row = repository.messages[index];
-    if (row?.format !== "ai-sdk/v6") continue;
-    if (row.content.role !== "user") continue;
-
-    const text = getTextFromMessageContent(row.content);
+function getLatestUserTextFromMessages(
+  messages: readonly ThreadMessage[],
+): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg?.role !== "user") continue;
+    const text = msg.content
+      .flatMap((part) => (part.type === "text" ? [part.text] : []))
+      .join("\n")
+      .trim();
     if (text) return text;
   }
   return null;
-}
-
-function getTextFromMessageContent(content: Record<string, unknown>): string {
-  const parts = content.parts;
-  if (!Array.isArray(parts)) return "";
-
-  return parts
-    .flatMap((part) => {
-      if (!part || typeof part !== "object") return [];
-      const typedPart = part as Record<string, unknown>;
-      return typedPart.type === "text" && typeof typedPart.text === "string"
-        ? [typedPart.text]
-        : [];
-    })
-    .join("\n")
-    .trim();
 }
 
 function previewText(text: string): string {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,9 +15,11 @@
   "dependencies": {
     "@ai-sdk/openai": "^3.0.71",
     "@ai-sdk/react": "^3.0.207",
+    "@assistant-ui/core": "workspace:*",
     "@assistant-ui/next": "workspace:*",
     "@assistant-ui/react": "workspace:*",
     "@assistant-ui/react-ai-sdk": "workspace:*",
+    "@assistant-ui/cloud-ai-sdk": "workspace:*",
     "@assistant-ui/react-data-stream": "workspace:*",
     "@assistant-ui/react-devtools": "workspace:*",
     "@assistant-ui/react-generative-ui": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,12 @@ importers:
       '@ai-sdk/react':
         specifier: ^3.0.207
         version: 3.0.207(react@19.2.7)(zod@4.4.3)
+      '@assistant-ui/cloud-ai-sdk':
+        specifier: workspace:*
+        version: link:../../packages/cloud-ai-sdk
+      '@assistant-ui/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@assistant-ui/next':
         specifier: workspace:*
         version: link:../../packages/next
@@ -1719,7 +1725,7 @@ importers:
         version: link:../../packages/ui
       '@google/adk':
         specifier: ^1.2.0
-        version: 1.2.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.3)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+        version: 1.2.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.3)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3655,7 +3661,7 @@ importers:
         version: link:../store
       '@google/adk':
         specifier: '>=0.5.0'
-        version: 1.2.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.3)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
+        version: 1.2.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.3)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
       assistant-cloud:
         specifier: '*'
         version: link:../cloud


### PR DESCRIPTION
## Summary
- Wire Xulux playground to Assistant Cloud for message persistence and run telemetry via `useAssistantCloudThreadHistoryAdapter`, instead of hand-rolled localStorage mirroring.
- Keep localStorage-backed thread metadata (titles, canvas, template context, interrupted status) and the custom history menu UI.
- Flip thread id mapping so `remoteId` is the cloud thread id and `sessionId` stays in `custom` / `external_id` for `/api/xulux/chat`.

## Architecture
- **Local thread list adapter** — lists/creates/renames/archives threads from localStorage only
- **Cloud history adapter** (`unstable_Provider`) — loads/saves messages and reports runs to Assistant Cloud
- Requires `NEXT_PUBLIC_XULUX_ASSISTANT_BASE_URL` or `NEXT_PUBLIC_ASSISTANT_BASE_URL`

## Test plan
- [ ] Set Assistant Cloud base URL in `.env.local` and open the Xulux playground
- [ ] Start a new chat, send a message, confirm it appears in Assistant Cloud dashboard (Conversation + Trace tabs)
- [ ] Open History menu — only local threads shown; click a thread and confirm messages load from cloud
- [ ] Start new chat, verify a new cloud thread is created and local metadata is stored
- [ ] Retry interrupted run banner still works (uses runtime messages + pendingUserMessage)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

