### PR TITLE
feat(docs): use Assistant Cloud for Xulux message history and telemetry

### DIFF
--- a/apps/docs/components/xulux/XuluxApp.tsx
+++ b/apps/docs/components/xulux/XuluxApp.tsx
@@ -71,6 +71,52 @@ function XuluxRuntimeProvider({
   selectedTemplateContext: SelectedTemplateContext | null;
   children: ReactNode;
 }) {
+  const cloudBaseUrl =
+    process.env.NEXT_PUBLIC_XULUX_ASSISTANT_BASE_URL ??
+    process.env.NEXT_PUBLIC_ASSISTANT_BASE_URL;
+
+  if (!cloudBaseUrl) {
+    return <XuluxMissingCloudConfig />;
+  }
+
+  return (
+    <XuluxRuntimeProviderInner
+      sessionId={sessionId}
+      selectedTemplateContext={selectedTemplateContext}
+      cloudBaseUrl={cloudBaseUrl}
+    >
+      {children}
+    </XuluxRuntimeProviderInner>
+  );
+}
+
+function XuluxMissingCloudConfig() {
+  return (
+    <div className="text-muted-foreground flex min-h-[320px] items-center justify-center p-6 text-center text-sm">
+      <p>
+        Xulux playground requires{" "}
+        <code className="text-foreground">NEXT_PUBLIC_ASSISTANT_BASE_URL</code>{" "}
+        (or{" "}
+        <code className="text-foreground">
+          NEXT_PUBLIC_XULUX_ASSISTANT_BASE_URL
+        </code>
+        ) to be set for Assistant Cloud message history.
+      </p>
+    </div>
+  );
+}
+
+function XuluxRuntimeProviderInner({
+  sessionId,
+  selectedTemplateContext,
+  cloudBaseUrl,
+  children,
+}: {
+  sessionId: string;
+  selectedTemplateContext: SelectedTemplateContext | null;
+  cloudBaseUrl: string;
+  children: ReactNode;
+}) {
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
   const selectedTemplateContextRef = useRef(selectedTemplateContext);
@@ -81,29 +127,23 @@ function XuluxRuntimeProvider({
     setLimitBlock(null);
   }, [sessionId]);
 
-  const assistantCloud = useMemo(() => {
-    const baseUrl =
-      process.env.NEXT_PUBLIC_XULUX_ASSISTANT_BASE_URL ??
-      process.env.NEXT_PUBLIC_ASSISTANT_BASE_URL;
-    if (!baseUrl) {
-      throw new Error(
-        "NEXT_PUBLIC_XULUX_ASSISTANT_BASE_URL or NEXT_PUBLIC_ASSISTANT_BASE_URL must be set",
-      );
-    }
-    return new AssistantCloud({
-      baseUrl,
-      anonymous: true,
-      telemetry: {
-        beforeReport: (report) => ({
-          ...report,
-          metadata: {
-            ...(report.metadata ?? {}),
-            app: "xulux_playground",
-          },
-        }),
-      },
-    });
-  }, []);
+  const assistantCloud = useMemo(
+    () =>
+      new AssistantCloud({
+        baseUrl: cloudBaseUrl,
+        anonymous: true,
+        telemetry: {
+          beforeReport: (report) => ({
+            ...report,
+            metadata: {
+              ...(report.metadata ?? {}),
+              app: "xulux_playground",
+            },
+          }),
+        },
+      }),
+    [cloudBaseUrl],
+  );
 
   const adapter = useMemo(
     () =>

--- a/apps/docs/components/xulux/XuluxApp.tsx
+++ b/apps/docs/components/xulux/XuluxApp.tsx
@@ -85,16 +85,33 @@ function XuluxRuntimeProvider({
     const baseUrl =
       process.env.NEXT_PUBLIC_XULUX_ASSISTANT_BASE_URL ??
       process.env.NEXT_PUBLIC_ASSISTANT_BASE_URL;
-    if (!baseUrl) return null;
-    return new AssistantCloud({ baseUrl, anonymous: true });
+    if (!baseUrl) {
+      throw new Error(
+        "NEXT_PUBLIC_XULUX_ASSISTANT_BASE_URL or NEXT_PUBLIC_ASSISTANT_BASE_URL must be set",
+      );
+    }
+    return new AssistantCloud({
+      baseUrl,
+      anonymous: true,
+      telemetry: {
+        beforeReport: (report) => ({
+          ...report,
+          metadata: {
+            ...(report.metadata ?? {}),
+            app: "xulux_playground",
+          },
+        }),
+      },
+    });
   }, []);
 
   const adapter = useMemo(
     () =>
       createXuluxLocalThreadListAdapter({
         getCurrentSessionId: () => sessionIdRef.current,
+        cloud: assistantCloud,
       }),
-    [],
+    [assistantCloud],
   );
 
   const transport = useMemo(
@@ -131,7 +148,6 @@ function XuluxRuntimeProvider({
       return useChatRuntime({
         transport,
         isSendDisabled: limitBlock != null,
-        ...(assistantCloud ? { cloud: assistantCloud } : {}),
       });
     },
   });

--- a/apps/docs/components/xulux/runtime/types.ts
+++ b/apps/docs/components/xulux/runtime/types.ts
@@ -24,20 +24,9 @@ export type XuluxThreadCustom = {
 
 export type XuluxStoredThread = {
   remoteId: string;
+  /** The sessionId used to correlate with /api/xulux/chat. Stored as externalId on cloud thread. */
   externalId?: string;
   status: "regular" | "archived";
   title?: string;
   custom: XuluxThreadCustom;
-};
-
-export type XuluxStoredMessageRow = {
-  id: string;
-  parent_id: string | null;
-  format: string;
-  content: Record<string, unknown>;
-};
-
-export type XuluxStoredMessageRepository = {
-  headId?: string | null;
-  messages: XuluxStoredMessageRow[];
 };

--- a/apps/docs/components/xulux/runtime/xulux-local-storage.ts
+++ b/apps/docs/components/xulux/runtime/xulux-local-storage.ts
@@ -3,7 +3,6 @@
 import { useEffect, useSyncExternalStore } from "react";
 import type {
   XuluxCanvasSnapshot,
-  XuluxStoredMessageRepository,
   XuluxStoredThread,
   XuluxThreadCustom,
   XuluxThreadStatus,
@@ -12,7 +11,6 @@ import type { SelectedTemplateContext } from "../XuluxApp";
 
 const PREFIX = "xulux:";
 const THREADS_KEY = `${PREFIX}threads`;
-const MESSAGES_PREFIX = `${PREFIX}messages:`;
 const STORAGE_EVENT = "xulux-storage";
 const EMPTY_THREADS: XuluxStoredThread[] = [];
 
@@ -28,16 +26,6 @@ function notify() {
   window.dispatchEvent(new Event(STORAGE_EVENT));
 }
 
-function readJson<T>(key: string, fallback: T): T {
-  if (!isBrowser()) return fallback;
-  try {
-    const raw = window.localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
 function writeJson<T>(key: string, value: T) {
   if (!isBrowser()) return;
   try {
@@ -48,20 +36,6 @@ function writeJson<T>(key: string, value: T) {
   } catch {
     // Ignore quota and private-mode write failures.
   }
-}
-
-function removeItem(key: string) {
-  if (!isBrowser()) return;
-  try {
-    window.localStorage.removeItem(key);
-    notify();
-  } catch {
-    // Ignore storage failures.
-  }
-}
-
-function messagesKey(remoteId: string) {
-  return `${MESSAGES_PREFIX}${remoteId}`;
 }
 
 function normalizeThread(thread: XuluxStoredThread): XuluxStoredThread {
@@ -112,26 +86,6 @@ function normalizePersistedThreads() {
 
 export function writeXuluxThreads(threads: XuluxStoredThread[]) {
   writeJson(THREADS_KEY, threads);
-}
-
-export function readXuluxMessages(
-  remoteId: string,
-): XuluxStoredMessageRepository {
-  return readJson<XuluxStoredMessageRepository>(messagesKey(remoteId), {
-    headId: null,
-    messages: [],
-  });
-}
-
-export function writeXuluxMessages(
-  remoteId: string,
-  repository: XuluxStoredMessageRepository,
-) {
-  writeJson(messagesKey(remoteId), repository);
-}
-
-export function deleteXuluxMessages(remoteId: string) {
-  removeItem(messagesKey(remoteId));
 }
 
 export function findXuluxThread(remoteId: string): XuluxStoredThread | null {

--- a/apps/docs/components/xulux/runtime/xulux-local-storage.ts
+++ b/apps/docs/components/xulux/runtime/xulux-local-storage.ts
@@ -88,6 +88,10 @@ export function writeXuluxThreads(threads: XuluxStoredThread[]) {
   writeJson(THREADS_KEY, threads);
 }
 
+export function isAssistantCloudThreadId(remoteId: string): boolean {
+  return remoteId.startsWith("thread_");
+}
+
 export function findXuluxThread(remoteId: string): XuluxStoredThread | null {
   return (
     readXuluxThreads().find((thread) => thread.remoteId === remoteId) ?? null
@@ -100,8 +104,21 @@ export function findXuluxThreadBySessionId(
   return (
     readXuluxThreads().find(
       (thread) =>
-        thread.custom.sessionId === sessionId ||
-        thread.externalId === sessionId,
+        isAssistantCloudThreadId(thread.remoteId) &&
+        (thread.custom.sessionId === sessionId ||
+          thread.externalId === sessionId),
+    ) ?? null
+  );
+}
+
+export function findXuluxSessionStub(
+  sessionId: string,
+): XuluxStoredThread | null {
+  return (
+    readXuluxThreads().find(
+      (thread) =>
+        !isAssistantCloudThreadId(thread.remoteId) &&
+        thread.custom.sessionId === sessionId,
     ) ?? null
   );
 }

--- a/apps/docs/components/xulux/runtime/xulux-local-storage.ts
+++ b/apps/docs/components/xulux/runtime/xulux-local-storage.ts
@@ -94,6 +94,18 @@ export function findXuluxThread(remoteId: string): XuluxStoredThread | null {
   );
 }
 
+export function findXuluxThreadBySessionId(
+  sessionId: string,
+): XuluxStoredThread | null {
+  return (
+    readXuluxThreads().find(
+      (thread) =>
+        thread.custom.sessionId === sessionId ||
+        thread.externalId === sessionId,
+    ) ?? null
+  );
+}
+
 export function updateXuluxThread(
   remoteId: string,
   updater: (thread: XuluxStoredThread) => XuluxStoredThread,

--- a/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
+++ b/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
@@ -11,6 +11,7 @@ import {
 import { useAssistantCloudThreadHistoryAdapter } from "@assistant-ui/core/react";
 import {
   findXuluxThread,
+  findXuluxThreadBySessionId,
   readXuluxThreads,
   updateXuluxThread,
   writeXuluxThreads,
@@ -50,6 +51,11 @@ function createXuluxCloudHistoryProvider(
   };
 }
 
+type InitializeResult = {
+  remoteId: string;
+  externalId: string;
+};
+
 export function createXuluxLocalThreadListAdapter({
   getCurrentSessionId,
   cloud,
@@ -58,6 +64,7 @@ export function createXuluxLocalThreadListAdapter({
   cloud: AssistantCloud;
 }): RemoteThreadListAdapter {
   const Provider = createXuluxCloudHistoryProvider(cloud);
+  const initializeTasks = new Map<string, Promise<InitializeResult>>();
 
   const upsertThread = (
     remoteId: string,
@@ -73,6 +80,52 @@ export function createXuluxLocalThreadListAdapter({
             threadIndex === index ? nextThread : thread,
           );
     writeXuluxThreads(nextThreads);
+  };
+
+  const createCloudThread = async (
+    sessionId: string,
+  ): Promise<InitializeResult> => {
+    const now = Date.now();
+    let cloudThreadId: string;
+
+    try {
+      ({ thread_id: cloudThreadId } = await cloud.threads.create({
+        last_message_at: new Date(),
+        external_id: sessionId,
+        metadata: { source: "xulux_playground" },
+      }));
+    } catch (error) {
+      console.warn("[xulux] cloud thread create failed", error);
+      throw new Error(
+        "Unable to start a chat session. Assistant Cloud is unavailable — please try again.",
+      );
+    }
+
+    upsertThread(cloudThreadId, (existing) => ({
+      remoteId: cloudThreadId,
+      externalId: sessionId,
+      status: existing?.status ?? "regular",
+      ...(existing?.title !== undefined ? { title: existing.title } : {}),
+      custom: {
+        xuluxStatus: existing?.custom.xuluxStatus ?? "idle",
+        sessionId,
+        updatedAt: now,
+        ...(existing?.custom.pendingUserMessage !== undefined
+          ? { pendingUserMessage: existing.custom.pendingUserMessage }
+          : {}),
+        ...(existing?.custom.selectedTemplate !== undefined
+          ? { selectedTemplate: existing.custom.selectedTemplate }
+          : {}),
+        ...(existing?.custom.canvas !== undefined
+          ? { canvas: existing.custom.canvas }
+          : {}),
+      } satisfies XuluxThreadCustom,
+    }));
+
+    return {
+      remoteId: cloudThreadId,
+      externalId: sessionId,
+    };
   };
 
   return {
@@ -91,39 +144,22 @@ export function createXuluxLocalThreadListAdapter({
     },
     async initialize() {
       const sessionId = getCurrentSessionId();
-      const now = Date.now();
+      const existing = findXuluxThreadBySessionId(sessionId);
+      if (existing?.remoteId) {
+        return {
+          remoteId: existing.remoteId,
+          externalId: sessionId,
+        };
+      }
 
-      // Create a cloud thread — its id becomes our remoteId
-      const { thread_id: cloudThreadId } = await cloud.threads.create({
-        last_message_at: new Date(),
-        external_id: sessionId,
-        metadata: { source: "xulux_playground" },
+      const inFlight = initializeTasks.get(sessionId);
+      if (inFlight) return inFlight;
+
+      const task = createCloudThread(sessionId).finally(() => {
+        initializeTasks.delete(sessionId);
       });
-
-      upsertThread(cloudThreadId, (existing) => ({
-        remoteId: cloudThreadId,
-        externalId: sessionId,
-        status: existing?.status ?? "regular",
-        custom: {
-          xuluxStatus: existing?.custom.xuluxStatus ?? "idle",
-          sessionId,
-          updatedAt: now,
-          ...(existing?.custom.pendingUserMessage !== undefined
-            ? { pendingUserMessage: existing.custom.pendingUserMessage }
-            : {}),
-          ...(existing?.custom.selectedTemplate !== undefined
-            ? { selectedTemplate: existing.custom.selectedTemplate }
-            : {}),
-          ...(existing?.custom.canvas !== undefined
-            ? { canvas: existing.custom.canvas }
-            : {}),
-        } satisfies XuluxThreadCustom,
-      }));
-
-      return {
-        remoteId: cloudThreadId,
-        externalId: sessionId,
-      };
+      initializeTasks.set(sessionId, task);
+      return task;
     },
     async rename(remoteId, title) {
       updateXuluxThread(remoteId, (thread) => ({

--- a/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
+++ b/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
@@ -10,8 +10,10 @@ import {
 } from "@assistant-ui/react";
 import { useAssistantCloudThreadHistoryAdapter } from "@assistant-ui/core/react";
 import {
+  findXuluxSessionStub,
   findXuluxThread,
   findXuluxThreadBySessionId,
+  isAssistantCloudThreadId,
   readXuluxThreads,
   updateXuluxThread,
   writeXuluxThreads,
@@ -86,6 +88,7 @@ export function createXuluxLocalThreadListAdapter({
     sessionId: string,
   ): Promise<InitializeResult> => {
     const now = Date.now();
+    const sessionStub = findXuluxSessionStub(sessionId);
     let cloudThreadId: string;
 
     try {
@@ -101,24 +104,48 @@ export function createXuluxLocalThreadListAdapter({
       );
     }
 
+    // Drop pre-init local stubs (remoteId was sessionId) now that we have a cloud id.
+    const threadsWithoutStub = readXuluxThreads().filter(
+      (thread) =>
+        thread.remoteId !== sessionId &&
+        !(
+          !isAssistantCloudThreadId(thread.remoteId) &&
+          thread.custom.sessionId === sessionId
+        ),
+    );
+    writeXuluxThreads(threadsWithoutStub);
+
     upsertThread(cloudThreadId, (existing) => ({
       remoteId: cloudThreadId,
       externalId: sessionId,
-      status: existing?.status ?? "regular",
-      ...(existing?.title !== undefined ? { title: existing.title } : {}),
+      status: existing?.status ?? sessionStub?.status ?? "regular",
+      ...(existing?.title !== undefined
+        ? { title: existing.title }
+        : sessionStub?.title !== undefined
+          ? { title: sessionStub.title }
+          : {}),
       custom: {
-        xuluxStatus: existing?.custom.xuluxStatus ?? "idle",
+        xuluxStatus:
+          existing?.custom.xuluxStatus ??
+          sessionStub?.custom.xuluxStatus ??
+          "idle",
         sessionId,
         updatedAt: now,
         ...(existing?.custom.pendingUserMessage !== undefined
           ? { pendingUserMessage: existing.custom.pendingUserMessage }
-          : {}),
+          : sessionStub?.custom.pendingUserMessage !== undefined
+            ? { pendingUserMessage: sessionStub.custom.pendingUserMessage }
+            : {}),
         ...(existing?.custom.selectedTemplate !== undefined
           ? { selectedTemplate: existing.custom.selectedTemplate }
-          : {}),
+          : sessionStub?.custom.selectedTemplate !== undefined
+            ? { selectedTemplate: sessionStub.custom.selectedTemplate }
+            : {}),
         ...(existing?.custom.canvas !== undefined
           ? { canvas: existing.custom.canvas }
-          : {}),
+          : sessionStub?.custom.canvas !== undefined
+            ? { canvas: sessionStub.custom.canvas }
+            : {}),
       } satisfies XuluxThreadCustom,
     }));
 
@@ -142,7 +169,7 @@ export function createXuluxLocalThreadListAdapter({
         })),
       };
     },
-    async initialize() {
+    async initialize(_threadId: string) {
       const sessionId = getCurrentSessionId();
       const existing = findXuluxThreadBySessionId(sessionId);
       if (existing?.remoteId) {

--- a/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
+++ b/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
@@ -1,29 +1,21 @@
 "use client";
 
 import { createAssistantStream } from "assistant-stream";
-import { type FC, type PropsWithChildren, useMemo } from "react";
+import { type FC, type PropsWithChildren, useMemo, useRef } from "react";
 import {
+  type AssistantCloud,
   RuntimeAdapterProvider,
-  useAui,
-  type MessageFormatAdapter,
   type RemoteThreadListAdapter,
-  type ThreadHistoryAdapter,
   type ThreadMessage,
 } from "@assistant-ui/react";
+import { useAssistantCloudThreadHistoryAdapter } from "@assistant-ui/core/react";
 import {
-  deleteXuluxMessages,
   findXuluxThread,
-  readXuluxMessages,
   readXuluxThreads,
   updateXuluxThread,
-  writeXuluxMessages,
   writeXuluxThreads,
 } from "./xulux-local-storage";
-import type {
-  XuluxStoredMessageRow,
-  XuluxStoredThread,
-  XuluxThreadCustom,
-} from "./types";
+import type { XuluxStoredThread, XuluxThreadCustom } from "./types";
 
 function getTextFromMessages(messages: readonly ThreadMessage[]): string {
   for (const message of messages) {
@@ -42,100 +34,30 @@ function titleFromMessages(messages: readonly ThreadMessage[]): string {
   return text.length > 44 ? `${text.slice(0, 41)}...` : text;
 }
 
-class XuluxLocalHistoryAdapter implements ThreadHistoryAdapter {
-  constructor(private aui: ReturnType<typeof useAui>) {}
-
-  async load() {
-    return { messages: [] };
-  }
-
-  async append() {}
-
-  withFormat<TMessage, TStorageFormat extends Record<string, unknown>>(
-    fmt: MessageFormatAdapter<TMessage, TStorageFormat>,
-  ) {
-    const adapter = this;
-    return {
-      async load() {
-        const remoteId = adapter.aui.threadListItem().getState().remoteId;
-        if (!remoteId) return { headId: null, messages: [] };
-        const repository = readXuluxMessages(remoteId);
-        return {
-          headId: repository.headId ?? null,
-          messages: repository.messages
-            .filter((row) => row.format === fmt.format)
-            .map((row) =>
-              fmt.decode({
-                id: row.id,
-                parent_id: row.parent_id,
-                format: row.format,
-                content: row.content as TStorageFormat,
-              }),
-            ),
-        };
-      },
-      async append(item: { parentId: string | null; message: TMessage }) {
-        const { remoteId } = await adapter.aui.threadListItem().initialize();
-        const repository = readXuluxMessages(remoteId);
-        const id = fmt.getId(item.message);
-        const row: XuluxStoredMessageRow = {
-          id,
-          parent_id: item.parentId,
-          format: fmt.format,
-          content: fmt.encode(item),
-        };
-        const index = repository.messages.findIndex(
-          (message) => message.id === id,
-        );
-        const messages =
-          index === -1
-            ? [...repository.messages, row]
-            : repository.messages.map((message, messageIndex) =>
-                messageIndex === index ? row : message,
-              );
-        writeXuluxMessages(remoteId, { headId: id, messages });
-      },
-      async update(
-        item: { parentId: string | null; message: TMessage },
-        localMessageId: string,
-      ) {
-        const remoteId = adapter.aui.threadListItem().getState().remoteId;
-        if (!remoteId) return;
-        const repository = readXuluxMessages(remoteId);
-        const row: XuluxStoredMessageRow = {
-          id: localMessageId,
-          parent_id: item.parentId,
-          format: fmt.format,
-          content: fmt.encode(item),
-        };
-        writeXuluxMessages(remoteId, {
-          headId: repository.headId ?? null,
-          messages: repository.messages.map((message) =>
-            message.id === localMessageId ? row : message,
-          ),
-        });
-      },
-    };
-  }
-}
-
-function XuluxLocalHistoryProvider({ children }: PropsWithChildren) {
-  const aui = useAui();
-  const history = useMemo(() => new XuluxLocalHistoryAdapter(aui), [aui]);
-  const adapters = useMemo(() => ({ history }), [history]);
-  return (
-    <RuntimeAdapterProvider adapters={adapters}>
-      {children}
-    </RuntimeAdapterProvider>
-  );
+function createXuluxCloudHistoryProvider(
+  cloud: AssistantCloud,
+): FC<PropsWithChildren> {
+  return function XuluxCloudHistoryProvider({ children }) {
+    const cloudRef = useRef(cloud);
+    cloudRef.current = cloud;
+    const history = useAssistantCloudThreadHistoryAdapter(cloudRef);
+    const adapters = useMemo(() => ({ history }), [history]);
+    return (
+      <RuntimeAdapterProvider adapters={adapters}>
+        {children}
+      </RuntimeAdapterProvider>
+    );
+  };
 }
 
 export function createXuluxLocalThreadListAdapter({
   getCurrentSessionId,
+  cloud,
 }: {
   getCurrentSessionId: () => string;
+  cloud: AssistantCloud;
 }): RemoteThreadListAdapter {
-  const Provider: FC<PropsWithChildren> = XuluxLocalHistoryProvider;
+  const Provider = createXuluxCloudHistoryProvider(cloud);
 
   const upsertThread = (
     remoteId: string,
@@ -170,8 +92,17 @@ export function createXuluxLocalThreadListAdapter({
     async initialize() {
       const sessionId = getCurrentSessionId();
       const now = Date.now();
-      upsertThread(sessionId, (existing) => ({
-        remoteId: sessionId,
+
+      // Create a cloud thread — its id becomes our remoteId
+      const { thread_id: cloudThreadId } = await cloud.threads.create({
+        last_message_at: new Date(),
+        external_id: sessionId,
+        metadata: { source: "xulux_playground" },
+      });
+
+      upsertThread(cloudThreadId, (existing) => ({
+        remoteId: cloudThreadId,
+        externalId: sessionId,
         status: existing?.status ?? "regular",
         custom: {
           xuluxStatus: existing?.custom.xuluxStatus ?? "idle",
@@ -187,12 +118,12 @@ export function createXuluxLocalThreadListAdapter({
             ? { canvas: existing.custom.canvas }
             : {}),
         } satisfies XuluxThreadCustom,
-        ...(existing?.externalId !== undefined
-          ? { externalId: existing.externalId }
-          : {}),
-        ...(existing?.title !== undefined ? { title: existing.title } : {}),
       }));
-      return { remoteId: sessionId, externalId: undefined };
+
+      return {
+        remoteId: cloudThreadId,
+        externalId: sessionId,
+      };
     },
     async rename(remoteId, title) {
       updateXuluxThread(remoteId, (thread) => ({
@@ -219,7 +150,6 @@ export function createXuluxLocalThreadListAdapter({
       writeXuluxThreads(
         readXuluxThreads().filter((thread) => thread.remoteId !== remoteId),
       );
-      deleteXuluxMessages(remoteId);
     },
     async fetch(remoteId) {
       const thread = findXuluxThread(remoteId);

--- a/apps/docs/components/xulux/shell/XuluxShell.tsx
+++ b/apps/docs/components/xulux/shell/XuluxShell.tsx
@@ -22,7 +22,7 @@ function useIsSmallScreen(): boolean {
     () => false,
   );
 }
-import { useAui, useAuiState } from "@assistant-ui/react";
+import { useAui, useAuiState, type ThreadMessage } from "@assistant-ui/react";
 import { useAssistantPanel } from "@/components/docs/assistant/context";
 import { Button } from "@/components/ui/button";
 import { XuluxThread } from "../chat/XuluxThread";
@@ -36,7 +36,6 @@ import { XuluxLandingPage } from "../landing/XuluxLandingPage";
 import { TemplatesModal } from "../landing/TemplatesModal";
 import { XuluxHeaderActions } from "./XuluxHeaderActions";
 import {
-  readXuluxMessages,
   updateXuluxPendingUserMessage,
   updateXuluxThreadContext,
   updateXuluxThreadStatus,
@@ -156,12 +155,13 @@ export function XuluxShell({
     storedThreads.find((thread) => thread.remoteId === currentRemoteId) ?? null;
   const isInterrupted =
     activeStoredThread?.custom.xuluxStatus === "interrupted";
+  const runtimeMessages = useAuiState((s) => s.thread.messages);
   const interruptedUserMessage = useMemo(() => {
     if (!isInterrupted || !currentRemoteId) return null;
     const pending = activeStoredThread?.custom.pendingUserMessage?.trim();
     if (pending) return pending;
-    return getLatestSavedUserMessage(currentRemoteId);
-  }, [activeStoredThread, currentRemoteId, isInterrupted]);
+    return getLatestUserTextFromMessages(runtimeMessages);
+  }, [activeStoredThread, currentRemoteId, isInterrupted, runtimeMessages]);
 
   const handleRetryInterrupted = useCallback(() => {
     if (!interruptedUserMessage) return;
@@ -402,33 +402,19 @@ function fromCanvasSnapshot(
   };
 }
 
-function getLatestSavedUserMessage(remoteId: string): string | null {
-  const repository = readXuluxMessages(remoteId);
-  for (let index = repository.messages.length - 1; index >= 0; index -= 1) {
-    const row = repository.messages[index];
-    if (row?.format !== "ai-sdk/v6") continue;
-    if (row.content.role !== "user") continue;
-
-    const text = getTextFromMessageContent(row.content);
+function getLatestUserTextFromMessages(
+  messages: readonly ThreadMessage[],
+): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg?.role !== "user") continue;
+    const text = msg.content
+      .flatMap((part) => (part.type === "text" ? [part.text] : []))
+      .join("\n")
+      .trim();
     if (text) return text;
   }
   return null;
-}
-
-function getTextFromMessageContent(content: Record<string, unknown>): string {
-  const parts = content.parts;
-  if (!Array.isArray(parts)) return "";
-
-  return parts
-    .flatMap((part) => {
-      if (!part || typeof part !== "object") return [];
-      const typedPart = part as Record<string, unknown>;
-      return typedPart.type === "text" && typeof typedPart.text === "string"
-        ? [typedPart.text]
-        : [];
-    })
-    .join("\n")
-    .trim();
 }
 
 function previewText(text: string): string {

--- a/apps/docs/components/xulux/shell/XuluxShell.tsx
+++ b/apps/docs/components/xulux/shell/XuluxShell.tsx
@@ -163,6 +163,16 @@ export function XuluxShell({
     return getLatestUserTextFromMessages(runtimeMessages);
   }, [activeStoredThread, currentRemoteId, isInterrupted, runtimeMessages]);
 
+  useEffect(() => {
+    if (!isInterrupted || !currentRemoteId) return;
+    if (activeStoredThread?.custom.pendingUserMessage?.trim()) return;
+
+    const latestUserText = getLatestUserTextFromMessages(runtimeMessages);
+    if (latestUserText) {
+      updateXuluxPendingUserMessage(currentRemoteId, latestUserText);
+    }
+  }, [activeStoredThread, currentRemoteId, isInterrupted, runtimeMessages]);
+
   const handleRetryInterrupted = useCallback(() => {
     if (!interruptedUserMessage) return;
     updateXuluxPendingUserMessage(


### PR DESCRIPTION
## Summary
- Wire Xulux playground to Assistant Cloud for message persistence and run telemetry via `useAssistantCloudThreadHistoryAdapter`, replacing hand-rolled localStorage message mirroring and custom run reporting.
- Keep localStorage-backed thread metadata (titles, canvas, template context, interrupted status) and the custom `XuluxHistoryMenu` UI.
- Flip thread id mapping: `remoteId` is now the cloud thread id; `sessionId` stays in `custom.sessionId` / `external_id` for `/api/xulux/chat`.

## What changed
| File | Change |
|------|--------|
| `xulux-thread-list-adapter.tsx` | Replace `XuluxLocalHistoryAdapter` (localStorage messages) with `useAssistantCloudThreadHistoryAdapter` in `unstable_Provider`. `initialize()` now creates a cloud thread and uses its id as `remoteId`. |
| `XuluxApp.tsx` | Remove `cloud` param from inner `useChatRuntime` (no longer needed — history adapter handles it). Add telemetry `beforeReport` metadata. Require env var. |
| `XuluxShell.tsx` | Remove `readXuluxMessages` usage. Interrupted-run recovery now reads from runtime messages instead of localStorage. |
| `xulux-local-storage.ts` | Remove `readXuluxMessages`, `writeXuluxMessages`, `deleteXuluxMessages` and supporting utils. |
| `types.ts` | Remove `XuluxStoredMessageRow` / `XuluxStoredMessageRepository`. |

## Deleted files (via diff — content removed from adapter)
- `xulux-cloud-message-mirror.ts` — SDK handles message persistence
- `xulux-cloud-telemetry.ts` — SDK handles run telemetry

## Test plan
- [x] Set `NEXT_PUBLIC_ASSISTANT_BASE_URL` in `.env.local`, open Xulux playground
- [x] Start a new chat, send a message — messages appear in Assistant Cloud dashboard (Conversation + Trace tabs)
- [x] Open History menu — only localStorage threads shown; click a thread, messages load from cloud
- [x] Interrupted run banner still works (uses runtime messages + `pendingUserMessage` custom field)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

