### PR TITLE
feat(react-langchain): resume parallel interrupts via useLangChainRespondAll

### DIFF
--- a/.changeset/respond-all-interrupts.md
+++ b/.changeset/respond-all-interrupts.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): resume parallel interrupts via useLangChainRespondAll

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -436,6 +436,19 @@ function InterruptPrompt() {
 </Tab>
 </PlatformTabs>
 
+When several interrupts are pending at once (e.g. parallel approvals), use `useLangChainRespondAll()` to resume them all in one run. Sequential `useLangChainRespond` calls can't, since the first resume starts a run and strands the rest.
+
+```tsx
+import { useLangChainRespondAll } from "@assistant-ui/react-langchain";
+
+const respondAll = useLangChainRespondAll();
+// `interrupts` is the list of interrupts pending at the checkpoint;
+// resume every one with the same payload:
+await respondAll(
+  Object.fromEntries(interrupts.map((i) => [i.id!, { approved: true }])),
+);
+```
+
 You can also resume with a raw `Command` via `useLangChainSubmit`:
 
 <PlatformTabs>
@@ -693,6 +706,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | _(none)_ | `useLangChainState<T>(key)` | New — reads any custom state key reactively. |
 | _(none)_ | `useLangChainToolCalls` | New — root tool calls assembled by `useStream`. |
 | _(none)_ | `useLangChainError()` | New — reads the last run/hydration error reactively. |
+| _(none)_ | `useLangChainRespondAll` | Resume multiple interrupts at one checkpoint (`stream.respondAll`). |
 
 ## Related
 

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -442,11 +442,11 @@ When several interrupts are pending at once (e.g. parallel approvals), use `useL
 import { useLangChainRespondAll } from "@assistant-ui/react-langchain";
 
 const respondAll = useLangChainRespondAll();
-// `interrupts` is the list of interrupts pending at the checkpoint;
-// resume every one with the same payload:
-await respondAll(
-  Object.fromEntries(interrupts.map((i) => [i.id!, { approved: true }])),
-);
+// `responsesById` maps each pending interrupt id to its response:
+await respondAll({
+  [interruptIdA]: { approved: true },
+  [interruptIdB]: { approved: false },
+});
 ```
 
 You can also resume with a raw `Command` via `useLangChainSubmit`:

--- a/packages/react-langchain/src/index.ts
+++ b/packages/react-langchain/src/index.ts
@@ -3,6 +3,7 @@ export {
   useLangChainError,
   useLangChainInterruptState,
   useLangChainRespond,
+  useLangChainRespondAll,
   useLangChainSend,
   useLangChainSendCommand,
   useLangChainState,

--- a/packages/react-langchain/src/useLangChainRespondAll.test.tsx
+++ b/packages/react-langchain/src/useLangChainRespondAll.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { makeExtras } from "./__tests__/langChainTestUtils";
+
+const { mockUseAui } = vi.hoisted(() => ({
+  mockUseAui: vi.fn(),
+}));
+
+vi.mock(import("@assistant-ui/store"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useAui: (() => mockUseAui()) as unknown as typeof actual.useAui,
+  };
+});
+
+import { useLangChainRespondAll } from "./useStreamRuntime";
+
+describe("useLangChainRespondAll", () => {
+  it("forwards the responses and options to stream.respondAll", async () => {
+    const respondAll = vi.fn().mockResolvedValue(undefined);
+    mockUseAui.mockReturnValue({
+      thread: () => ({
+        getState: () => ({ extras: makeExtras({ respondAll }) }),
+      }),
+    });
+
+    const { result } = renderHook(() => useLangChainRespondAll());
+    await result.current(
+      { a: { approved: true }, b: { approved: false } },
+      { metadata: { src: "ui" } },
+    );
+
+    expect(respondAll).toHaveBeenCalledWith(
+      { a: { approved: true }, b: { approved: false } },
+      { metadata: { src: "ui" } },
+    );
+  });
+
+  it("throws when extras are absent or unbranded", () => {
+    mockUseAui.mockReturnValue({
+      thread: () => ({ getState: () => ({ extras: { respondAll: vi.fn() } }) }),
+    });
+
+    const { result } = renderHook(() => useLangChainRespondAll());
+    expect(() => result.current({ a: { approved: true } })).toThrow(
+      "This method can only be called when you are using useStreamRuntime",
+    );
+  });
+});

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -48,6 +48,10 @@ type LangChainRuntimeExtras = {
     response: unknown,
     options?: Record<string, unknown>,
   ) => Promise<void>;
+  respondAll: (
+    responsesById: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ) => Promise<void>;
   values: Record<string, unknown>;
   messagesKey: string;
 };
@@ -231,6 +235,7 @@ const useStreamThreadRuntime = (
       error: stream.error,
       submit: stream.submit,
       respond: stream.respond,
+      respondAll: stream.respondAll,
       values: stream.values,
       messagesKey,
     }),
@@ -241,6 +246,7 @@ const useStreamThreadRuntime = (
       stream.error,
       stream.submit,
       stream.respond,
+      stream.respondAll,
       stream.values,
       messagesKey,
     ],
@@ -420,6 +426,25 @@ export const useLangChainRespond = () => {
       aui.thread().getState().extras,
     );
     return respond(response, options);
+  };
+};
+
+/**
+ * Resume several LangGraph interrupts pending at the same checkpoint in
+ * one run via `useStream().respondAll`. Use when a run pauses on multiple
+ * interrupts at once; sequential `useLangChainRespond` calls can't service
+ * them (the first resume starts a run, stranding the rest).
+ */
+export const useLangChainRespondAll = () => {
+  const aui = useAui();
+  return (
+    responsesById: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ) => {
+    const { respondAll } = asLangChainRuntimeExtras(
+      aui.thread().getState().extras,
+    );
+    return respondAll(responsesById, options);
   };
 };
 


### PR DESCRIPTION
This PR  adds `useLangChainRespondAll`, the sibling of `useLangChainRespond` https://github.com/assistant-ui/assistant-ui/pull/4447. It wraps `useStream().respondAll(responsesById, options?)` to resume several LangGraph interrupts pending at the same checkpoint in a single run.

This is needed when a run pauses on multiple interrupts at once (e.g. parallel approvals). Sequential `useLangChainRespond` calls can't service that case: the first resume starts a run, stranding the rest.

## Changes

- `useStreamRuntime.ts`: add `respondAll` to the `LangChainRuntimeExtras` type (mirroring `respond`'s loose typing), populate it from `stream.respondAll` in the extras `useMemo` (and its dep array), and add the `useLangChainRespondAll` hook cloned from `useLangChainRespond` (imperative: `useAui()` then extras guard then delegate).
- `index.ts`: export `useLangChainRespondAll`.
- Docs (`runtimes/langchain.mdx`): note plus snippet under the `useLangChainRespond` example, and a hook-name-mapping row.
- Test: `useLangChainRespondAll.test.tsx` asserts the returned function delegates to `extras.respondAll` with the right args, and throws via the guard when extras are absent or unbranded.

Additive only. No new dependencies. `stream.respondAll` is part of the upstream `@langchain/react` `useStream` API.

## Verification

- `pnpm --filter @assistant-ui/react-langchain test`: 22 passed (2 new).
- `pnpm lint`: clean (oxlint plus oxfmt).
- `pnpm turbo run build`: 86/86 successful.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

