### PR TITLE
ci: fail when generated reference docs are out of date

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -98,19 +98,14 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Regenerate reference docs
-        run: pnpm --filter @assistant-ui/docs generate:all
+        run: pnpm --filter @assistant-ui/docs generate:reference-docs
 
       - name: Verify generated docs are committed
         run: |
-          if ! git diff --quiet -- \
-            apps/docs/generated \
-            "apps/docs/content/docs/(reference)" \
-            apps/docs/content/docs/primitives; then
-            echo "::error::Generated reference docs are out of date. Run 'pnpm --filter @assistant-ui/docs generate:all' and commit the result."
-            git --no-pager diff -- \
-              apps/docs/generated \
-              "apps/docs/content/docs/(reference)" \
-              apps/docs/content/docs/primitives
+          git add --intent-to-add "apps/docs/content/docs/(reference)"
+          if ! git diff --quiet -- "apps/docs/content/docs/(reference)"; then
+            echo "::error::Generated reference docs are out of date. Run 'pnpm --filter @assistant-ui/docs generate:reference-docs' and commit the result."
+            git --no-pager diff -- "apps/docs/content/docs/(reference)"
             exit 1
           fi
 

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -75,6 +75,45 @@ jobs:
       - name: Verify templates match packages/ui source
         run: bash scripts/sync-templates.sh
 
+  docs-generated:
+    name: Docs Reference Up-to-date
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Regenerate reference docs
+        run: pnpm --filter @assistant-ui/docs generate:all
+
+      - name: Verify generated docs are committed
+        run: |
+          if ! git diff --quiet -- \
+            apps/docs/generated \
+            "apps/docs/content/docs/(reference)" \
+            apps/docs/content/docs/primitives; then
+            echo "::error::Generated reference docs are out of date. Run 'pnpm --filter @assistant-ui/docs generate:all' and commit the result."
+            git --no-pager diff -- \
+              apps/docs/generated \
+              "apps/docs/content/docs/(reference)" \
+              apps/docs/content/docs/primitives
+            exit 1
+          fi
+
   build:
     name: Build Changed Packages
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -18,7 +18,9 @@
       "@assistant-ui/react/*": ["../../packages/react/src/*"],
       "@assistant-ui/tap/*": ["../../packages/tap/src/*"],
       "assistant-stream": ["../../packages/assistant-stream/src"],
-      "assistant-stream/*": ["../../packages/assistant-stream/src/*"]
+      "assistant-stream/*": ["../../packages/assistant-stream/src/*"],
+      "assistant-cloud": ["../../packages/cloud/src"],
+      "assistant-cloud/*": ["../../packages/cloud/src/*"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
Closes #4450.

Issue 2 (root cause): the api-reference generator resolves re-exports via ts-morph, but `apps/docs/tsconfig.json` was missing an `assistant-cloud` path mapping. So `AssistantCloud` fell back to `packages/cloud/dist` and silently dropped from the docs whenever that package wasn't built (e.g. #4437). Added an `assistant-cloud` mapping to `packages/cloud/src`, mirroring the existing `assistant-stream` entry, so resolution is build-independent.

Issue 1: adds a `Docs Reference Up-to-date` job that regenerates the reference docs in a clean install and fails the PR if the committed output drifts. Scoped to `apps/docs/content/docs/(reference)` (the only path written to tracked files), with `git add --intent-to-add` so new untracked pages are caught too.

Verified: the gate now passes in CI's clean environment, where the same job previously failed on the AssistantCloud drop.
