### PR TITLE
feat(react-langchain): add useLangChainInterrupts reader for pending interrupts

### DIFF
--- a/.changeset/langchain-interrupts-reader.md
+++ b/.changeset/langchain-interrupts-reader.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): add useLangChainInterrupts reader for pending interrupts

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -439,14 +439,19 @@ function InterruptPrompt() {
 When several interrupts are pending at once (e.g. parallel approvals), use `useLangChainRespondAll()` to resume them all in one run. Sequential `useLangChainRespond` calls can't, since the first resume starts a run and strands the rest.
 
 ```tsx
-import { useLangChainRespondAll } from "@assistant-ui/react-langchain";
+import {
+  useLangChainInterrupts,
+  useLangChainRespondAll,
+} from "@assistant-ui/react-langchain";
 
+const interrupts = useLangChainInterrupts();
 const respondAll = useLangChainRespondAll();
-// `responsesById` maps each pending interrupt id to its response:
-await respondAll({
-  [interruptIdA]: { approved: true },
-  [interruptIdB]: { approved: false },
-});
+// resume every pending interrupt with the same payload:
+await respondAll(
+  Object.fromEntries(
+    interrupts.flatMap((i) => (i.id ? [[i.id, { approved: true }]] : [])),
+  ),
+);
 ```
 
 You can also resume with a raw `Command` via `useLangChainSubmit`:
@@ -707,6 +712,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | _(none)_ | `useLangChainToolCalls` | New — root tool calls assembled by `useStream`. |
 | _(none)_ | `useLangChainError()` | New — reads the last run/hydration error reactively. |
 | _(none)_ | `useLangChainRespondAll` | Resume multiple interrupts at one checkpoint (`stream.respondAll`). |
+| _(none)_ | `useLangChainInterrupts` | New — every interrupt pending at the checkpoint, each with `id` and `value`. |
 
 ## Related
 

--- a/packages/react-langchain/src/hooks.ts
+++ b/packages/react-langchain/src/hooks.ts
@@ -7,11 +7,24 @@ import type { LangChainBaseMessage } from "./types";
 
 const EMPTY_TOOL_CALLS: readonly AssembledToolCall[] = [];
 
+const EMPTY_INTERRUPTS: readonly { id?: string; value?: unknown }[] = [];
+
 /**
  * Read the current LangGraph interrupt state from the runtime extras.
  */
 export const useLangChainInterruptState = () =>
   langChainExtras.use((e) => e.interrupt, undefined);
+
+/**
+ * Read every interrupt pending at the current checkpoint, each with `id`
+ * and `value`. Defaults to an empty array. Pair with `useLangChainRespondAll`
+ * (keyed by interrupt id) to resolve several at once.
+ */
+export const useLangChainInterrupts = () =>
+  langChainExtras.use(
+    (e) => e.interrupts ?? EMPTY_INTERRUPTS,
+    EMPTY_INTERRUPTS,
+  );
 
 /** Read the last run/hydration error from the runtime extras. */
 export const useLangChainError = () =>

--- a/packages/react-langchain/src/index.ts
+++ b/packages/react-langchain/src/index.ts
@@ -2,6 +2,7 @@ export { useStreamRuntime } from "./useStreamRuntime";
 
 export {
   useLangChainError,
+  useLangChainInterrupts,
   useLangChainInterruptState,
   useLangChainRespond,
   useLangChainRespondAll,

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -61,7 +61,7 @@ export type LangChainBaseMessage = {
 
 export type LangChainRuntimeExtras = {
   interrupt: { value?: unknown } | undefined;
-  interrupts: readonly { value?: unknown }[];
+  interrupts: readonly { id?: string; value?: unknown }[];
   toolCalls: readonly AssembledToolCall[];
   error: unknown;
   submit: (

--- a/packages/react-langchain/src/useLangChainInterrupts.test.tsx
+++ b/packages/react-langchain/src/useLangChainInterrupts.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+  createRunSelectorAgainst,
+  makeExtras,
+  type Selector,
+} from "./__tests__/langChainTestUtils";
+
+const { mockUseAuiState } = vi.hoisted(() => ({
+  mockUseAuiState: vi.fn(),
+}));
+
+vi.mock(import("@assistant-ui/store"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useAuiState: ((selector: Selector) =>
+      mockUseAuiState(selector)) as typeof actual.useAuiState,
+    useAui: (() => ({})) as unknown as typeof actual.useAui,
+  };
+});
+
+import { useLangChainInterrupts } from "./hooks";
+
+const runSelectorAgainst = createRunSelectorAgainst(mockUseAuiState);
+
+describe("useLangChainInterrupts", () => {
+  it("returns an empty array when extras are absent", () => {
+    runSelectorAgainst(undefined);
+    const { result } = renderHook(() => useLangChainInterrupts());
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns the pending interrupts from extras", () => {
+    const interrupts = [{ id: "i1", value: { q: "ok?" } }];
+    runSelectorAgainst(makeExtras({ interrupts }));
+    const { result } = renderHook(() => useLangChainInterrupts());
+    expect(result.current).toBe(interrupts);
+  });
+
+  it("returns an empty array when extras carry no interrupts", () => {
+    runSelectorAgainst(makeExtras({ interrupts: undefined }));
+    const { result } = renderHook(() => useLangChainInterrupts());
+    expect(result.current).toEqual([]);
+  });
+});


### PR DESCRIPTION
This PR adds `useLangChainInterrupts()`, a thin accessor returning every interrupt pending at the current checkpoint, each with `id` and `value`. Mirrors `useLangChainToolCalls`; defaults to an empty array.

Gives `useLangChainRespondAll` callers a typed way to enumerate the pending interrupts and source their ids, which nothing exposed before.

Reworked onto the new adapter layout from #4467: the reader lives in `hooks.ts` reading through `createRuntimeExtras` (`langChainExtras.use`), so no `useStreamRuntime.ts` change is needed. The `interrupts` field is already provided by the runtime; only its type was widened to carry `id`.

