### PR TITLE
feat(core): add internal createRuntimeExtras helper for external-store adapters

### DIFF
--- a/.changeset/core-create-runtime-extras.md
+++ b/.changeset/core-create-runtime-extras.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+refactor: add an internal createRuntimeExtras helper shared by external-store adapter authors

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -37,5 +37,12 @@ export { resolveToolApprovalResponse } from "./runtime/utils/resolveToolApproval
 // Composite context provider
 export { CompositeContextProvider } from "./utils/composite-context-provider";
 
+// Runtime extras helper for external-store adapters. Internal because the
+// tap-native runtime path replaces the `thread.extras` side-channel it wraps.
+export {
+  createRuntimeExtras,
+  type RuntimeExtras,
+} from "./react/runtimes/createRuntimeExtras";
+
 export * from "./runtime/internal";
 export * from "./runtimes/internal";

--- a/packages/core/src/react/runtimes/createRuntimeExtras.test.ts
+++ b/packages/core/src/react/runtimes/createRuntimeExtras.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import type { AssistantClient } from "@assistant-ui/store";
+import { createRuntimeExtras } from "./createRuntimeExtras";
+
+type Extras = { value: number; greet: () => string };
+
+const clientWith = (extras: unknown) =>
+  ({
+    thread: () => ({ getState: () => ({ extras }) }),
+  }) as unknown as AssistantClient;
+
+describe("createRuntimeExtras", () => {
+  it("brands a value so its own guards recognize it", () => {
+    const channel = createRuntimeExtras<Extras>("useTestRuntime");
+    const branded = channel.provide({ value: 1, greet: () => "hi" });
+
+    expect(channel.is(branded)).toBe(true);
+    expect(channel.tryGet(branded)).toBe(branded);
+  });
+
+  it("returns the same object reference from provide (stable identity)", () => {
+    const channel = createRuntimeExtras<Extras>("useTestRuntime");
+    const value = { value: 1, greet: () => "hi" };
+    expect(channel.provide(value)).toBe(value);
+  });
+
+  it("keeps the brand non-enumerable so it stays out of serialization", () => {
+    const channel = createRuntimeExtras<Extras>("useTestRuntime");
+    const branded = channel.provide({ value: 1, greet: () => "hi" });
+
+    expect(Object.keys(branded)).toEqual(["value", "greet"]);
+    expect(JSON.parse(JSON.stringify(branded))).toEqual({ value: 1 });
+  });
+
+  it("rejects unbranded and foreign values", () => {
+    const channel = createRuntimeExtras<Extras>("useTestRuntime");
+    const other = createRuntimeExtras<Extras>("useOtherRuntime");
+    const foreign = other.provide({ value: 2, greet: () => "yo" });
+
+    expect(channel.is(undefined)).toBe(false);
+    expect(channel.is({ value: 1 })).toBe(false);
+    expect(channel.is(foreign)).toBe(false);
+    expect(channel.tryGet(foreign)).toBeUndefined();
+  });
+
+  it("get reads the current snapshot off an AssistantClient", () => {
+    const channel = createRuntimeExtras<Extras>("useTestRuntime");
+    const branded = channel.provide({ value: 7, greet: () => "hi" });
+
+    expect(channel.get(clientWith(branded)).value).toBe(7);
+  });
+
+  it("get throws with the runtime name when the thread is not backed by it", () => {
+    const channel = createRuntimeExtras<Extras>("useTestRuntime");
+
+    expect(() => channel.get(clientWith(undefined))).toThrow("useTestRuntime");
+  });
+});

--- a/packages/core/src/react/runtimes/createRuntimeExtras.ts
+++ b/packages/core/src/react/runtimes/createRuntimeExtras.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useAuiState } from "@assistant-ui/store";
+import type { AssistantClient } from "@assistant-ui/store";
+
+export type RuntimeExtras<T> = {
+  provide: (value: T) => T;
+  is: (extras: unknown) => extras is T;
+  tryGet: (extras: unknown) => T | undefined;
+  get: (client: AssistantClient) => T;
+  use: {
+    (): T;
+    <S>(select: (extras: T) => S): S;
+    <S>(select: (extras: T) => S, fallback: S): S;
+  };
+};
+
+export const createRuntimeExtras = <T>(
+  runtimeName: string,
+): RuntimeExtras<T> => {
+  const brand = Symbol(`${runtimeName} extras`);
+
+  const is = (extras: unknown): extras is T =>
+    typeof extras === "object" && extras !== null && brand in extras;
+
+  const assert = (extras: unknown): T => {
+    if (!is(extras))
+      throw new Error(
+        `This hook can only be used inside the ${runtimeName} runtime.`,
+      );
+    return extras;
+  };
+
+  const provide = (value: T): T => {
+    Object.defineProperty(value, brand, {
+      value: true,
+      enumerable: false,
+      configurable: true,
+    });
+    return value;
+  };
+
+  const tryGet = (extras: unknown): T | undefined =>
+    is(extras) ? extras : undefined;
+
+  const get = (client: AssistantClient): T =>
+    assert(client.thread().getState().extras);
+
+  function use<S>(
+    select?: (extras: T) => S,
+    ...rest: [fallback: S] | []
+  ): S | T {
+    // Detect a provided fallback by arity, not value: callers pass an explicit
+    // `undefined` fallback, which must return `undefined` rather than throw.
+    const hasFallback = rest.length > 0;
+    const fallback = rest[0] as S;
+    return useAuiState((s) => {
+      const extras = s.thread.extras;
+      if (is(extras)) return select ? select(extras) : extras;
+      if (hasFallback) return fallback;
+      return assert(extras);
+    });
+  }
+
+  return { provide, is, tryGet, get, use: use as RuntimeExtras<T>["use"] };
+};

--- a/packages/core/src/react/runtimes/createRuntimeExtras.ts
+++ b/packages/core/src/react/runtimes/createRuntimeExtras.ts
@@ -3,7 +3,8 @@
 import { useAuiState } from "@assistant-ui/store";
 import type { AssistantClient } from "@assistant-ui/store";
 
-export type RuntimeExtras<T> = {
+/** @deprecated Internal API for external-store adapter authors. Not part of the public API; may change or be removed without notice. */
+export type RuntimeExtras<T extends object> = {
   provide: (value: T) => T;
   is: (extras: unknown) => extras is T;
   tryGet: (extras: unknown) => T | undefined;
@@ -15,7 +16,8 @@ export type RuntimeExtras<T> = {
   };
 };
 
-export const createRuntimeExtras = <T>(
+/** @deprecated Internal API for external-store adapter authors. Not part of the public API; may change or be removed without notice. */
+export const createRuntimeExtras = <T extends object>(
   runtimeName: string,
 ): RuntimeExtras<T> => {
   const brand = Symbol(`${runtimeName} extras`);

--- a/packages/core/src/react/runtimes/createRuntimeExtras.ts
+++ b/packages/core/src/react/runtimes/createRuntimeExtras.ts
@@ -26,7 +26,7 @@ export const createRuntimeExtras = <T>(
   const assert = (extras: unknown): T => {
     if (!is(extras))
       throw new Error(
-        `This hook can only be used inside the ${runtimeName} runtime.`,
+        `The current thread is not backed by the ${runtimeName} runtime.`,
       );
     return extras;
   };

--- a/packages/core/src/react/runtimes/createRuntimeExtras.use.test.ts
+++ b/packages/core/src/react/runtimes/createRuntimeExtras.use.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+
+const { mockUseAuiState } = vi.hoisted(() => ({ mockUseAuiState: vi.fn() }));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAuiState: ((selector: (s: unknown) => unknown) =>
+    mockUseAuiState(
+      selector,
+    )) as typeof import("@assistant-ui/store").useAuiState,
+}));
+
+import { createRuntimeExtras } from "./createRuntimeExtras";
+
+type Extras = { value: number };
+
+const against = (extras: unknown) =>
+  mockUseAuiState.mockImplementationOnce((selector: (s: unknown) => unknown) =>
+    selector({ thread: { extras } }),
+  );
+
+describe("createRuntimeExtras.use", () => {
+  const channel = createRuntimeExtras<Extras>("useTestRuntime");
+
+  it("projects the extras when the thread is backed by the runtime", () => {
+    against(channel.provide({ value: 5 }));
+    expect(channel.use((e) => e.value, 0)).toBe(5);
+  });
+
+  it("returns the whole extras when called without a selector", () => {
+    const extras = channel.provide({ value: 9 });
+    against(extras);
+    expect(channel.use()).toBe(extras);
+  });
+
+  it("returns the fallback when the thread is not backed by the runtime", () => {
+    against(undefined);
+    expect(channel.use((e) => e.value, 0)).toBe(0);
+  });
+
+  it("returns an explicit undefined fallback instead of throwing", () => {
+    against(undefined);
+    expect(channel.use((e) => e.value, undefined)).toBeUndefined();
+  });
+
+  it("throws when no fallback is given and the runtime is absent", () => {
+    against(undefined);
+    expect(() => channel.use((e) => e.value)).toThrow("useTestRuntime");
+  });
+});


### PR DESCRIPTION
## what

adds `createRuntimeExtras`, a small internal helper for external-store adapter authors. it returns a typed channel over the private `extras` bag an adapter exposes through `ExternalStoreAdapter.extras` and reads back from `thread.extras`:

- `provide(value)` brands the extras bag to pass to the store
- `use(select?, fallback?)` reactively reads it (or a projection) inside accessor hooks
- `get(client)` reads the current snapshot imperatively inside action hooks
- `is` / `tryGet` guards

## why

six places (react-langchain, react-langgraph, react-google-adk, react-opencode, react-pi, plus core's assistant-transport) each hand-roll the same `Symbol("...-extras")` brand + `asXxxRuntimeExtras` guard + `useAuiState(s => s.thread.extras)` accessor idiom. this centralizes that one brand+guard pair so adapters stop reinventing it.

## why internal

exported from `@assistant-ui/core/internal` only, not the public `@assistant-ui/core/react` barrel. it formalizes the `thread.extras` side-channel, which the tap-native runtime path (ExternalThread / InMemoryThreadList) replaces, so it carries no public-api stability promise and can be removed together with that migration.

first adopter is react-langchain in a stacked follow-up.

## test plan

- new unit test covers provide / is / tryGet / get and the non-enumerable brand
- `pnpm --filter @assistant-ui/core build` and tsc clean