### PR TITLE
refactor(react-langchain): split runtime file and adopt createRuntimeExtras

### DIFF
--- a/.changeset/react-langchain-runtime-extras.md
+++ b/.changeset/react-langchain-runtime-extras.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+refactor: split the useStreamRuntime file into hooks/types/converter modules and adopt the shared createRuntimeExtras helper

--- a/packages/react-langchain/src/__tests__/langChainTestUtils.ts
+++ b/packages/react-langchain/src/__tests__/langChainTestUtils.ts
@@ -2,14 +2,14 @@ import type { Mock } from "vitest";
 
 export type Selector = (state: unknown) => unknown;
 
-// The real guard symbol in useStreamRuntime is module-private. To stand in for
+// The createRuntimeExtras brand symbol is module-private. To stand in for
 // runtime-produced extras, wrap a plain object in a Proxy whose `has` trap
-// claims any symbol described "langchain-runtime-extras" is present.
+// claims any symbol described "useStreamRuntime extras" is present.
 export const makeExtras = (extras: Record<string, unknown>) =>
   new Proxy(extras, {
     has: (target, key) =>
       (typeof key === "symbol" &&
-        key.description === "langchain-runtime-extras") ||
+        key.description === "useStreamRuntime extras") ||
       Reflect.has(target, key),
   });
 

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { useExternalMessageConverter } from "@assistant-ui/core/react";
+import type { AppendMessage } from "@assistant-ui/core";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
 import type { LangChainBaseMessage, LangChainContentBlock } from "./types";
 
@@ -141,4 +142,55 @@ export const convertLangChainBaseMessage: useExternalMessageConverter.Callback<
         ],
       };
   }
+};
+
+export const getMessageContent = (msg: AppendMessage) => {
+  const allContent = [
+    ...msg.content,
+    ...(msg.attachments?.flatMap((a) => a.content) ?? []),
+  ];
+
+  const hasNonText = allContent.some(
+    (part) => part.type === "file" || part.type === "image",
+  );
+  const hasText = allContent.some((part) => part.type === "text");
+  if (hasNonText && !hasText) {
+    allContent.unshift({ type: "text", text: " " });
+  }
+
+  const content = allContent.map((part) => {
+    const type = part.type;
+    switch (type) {
+      case "text":
+        return { type: "text" as const, text: part.text };
+      case "image":
+        return { type: "image_url" as const, image_url: { url: part.image } };
+      case "file":
+        return {
+          type: "file" as const,
+          data: part.data,
+          mime_type: part.mimeType,
+          metadata: { filename: part.filename ?? "file" },
+          source_type: "base64" as const,
+        };
+      case "tool-call":
+        throw new Error("Tool call appends are not supported.");
+      default: {
+        const _exhaustiveCheck:
+          | "reasoning"
+          | "source"
+          | "audio"
+          | "data"
+          | "generative-ui" = type;
+        throw new Error(
+          `Unsupported append message part type: ${_exhaustiveCheck}`,
+        );
+      }
+    }
+  });
+
+  if (content.length === 1 && content[0]?.type === "text") {
+    return content[0].text ?? "";
+  }
+  return content;
 };

--- a/packages/react-langchain/src/hooks.ts
+++ b/packages/react-langchain/src/hooks.ts
@@ -1,0 +1,116 @@
+"use client";
+
+import { useAui } from "@assistant-ui/store";
+import type { AssembledToolCall } from "@langchain/react";
+import { langChainExtras } from "./runtimeExtras";
+import type { LangChainBaseMessage } from "./types";
+
+const EMPTY_TOOL_CALLS: readonly AssembledToolCall[] = [];
+
+/**
+ * Read the current LangGraph interrupt state from the runtime extras.
+ */
+export const useLangChainInterruptState = () =>
+  langChainExtras.use((e) => e.interrupt, undefined);
+
+/** Read the last run/hydration error from the runtime extras. */
+export const useLangChainError = () =>
+  langChainExtras.use((e) => e.error, undefined);
+
+/**
+ * Read the root tool calls assembled by `useStream` from the `tools`
+ * channel. Defaults to an empty array, so consumers can `.map` without
+ * a guard. Useful for rendering pending/streamed tool calls and
+ * approval UIs.
+ */
+export const useLangChainToolCalls = () =>
+  langChainExtras.use((e) => e.toolCalls ?? EMPTY_TOOL_CALLS, EMPTY_TOOL_CALLS);
+
+/**
+ * Returns a function to submit raw state updates to the LangGraph agent,
+ * bypassing the normal message flow. Useful for sending interrupt resume
+ * commands.
+ */
+export const useLangChainSubmit = () => {
+  const aui = useAui();
+  return (
+    values: Record<string, unknown> | null | undefined,
+    options?: Record<string, unknown>,
+  ) => langChainExtras.get(aui).submit(values, options);
+};
+
+/**
+ * Resume a LangGraph interrupt with a response payload via
+ * `useStream().respond`. Preferred over `useLangChainSendCommand`; it
+ * carries the response cleanly and handles interrupt namespaces.
+ */
+export const useLangChainRespond = () => {
+  const aui = useAui();
+  return (response: unknown, options?: Record<string, unknown>) =>
+    langChainExtras.get(aui).respond(response, options);
+};
+
+/**
+ * Resume several LangGraph interrupts pending at the same checkpoint in
+ * one run via `useStream().respondAll`. Use when a run pauses on multiple
+ * interrupts at once; sequential `useLangChainRespond` calls can't service
+ * them (the first resume starts a run, stranding the rest).
+ */
+export const useLangChainRespondAll = () => {
+  const aui = useAui();
+  return (
+    responsesById: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ) => langChainExtras.get(aui).respondAll(responsesById, options);
+};
+
+/**
+ * Submit a list of LangChain-shaped messages on the current thread.
+ * Parity helper for migrating from `useLangGraphSend`. Routes to
+ * `useStream().submit({ [messagesKey]: messages }, options)`.
+ */
+export const useLangChainSend = () => {
+  const aui = useAui();
+  return (
+    messages: readonly LangChainBaseMessage[],
+    options?: Record<string, unknown>,
+  ) => {
+    const extras = langChainExtras.get(aui);
+    return extras.submit({ [extras.messagesKey]: messages }, options);
+  };
+};
+
+/**
+ * Submit a `useStream` command (e.g. interrupt resume). Parity helper
+ * for migrating from `useLangGraphSendCommand`. Note that v1's command
+ * shape (`{ resume?, goto?, update? }`) differs from the legacy
+ * `{ resume: string }` form; to carry a payload, use the input or
+ * `stream.respond` instead.
+ */
+export const useLangChainSendCommand = () => {
+  const submit = useLangChainSubmit();
+  return (command: Record<string, unknown>) => submit(null, { command });
+};
+
+/**
+ * Read a custom LangGraph state key from the current thread. Mirrors
+ * `useStream().values[key]` from `@langchain/react` and updates when the
+ * stream emits new state.
+ *
+ * @example
+ * ```tsx
+ * const todos = useLangChainState<Todo[]>("todos");
+ * const files = useLangChainState<Record<string, string>>("files", {});
+ * ```
+ */
+export function useLangChainState<T>(key: string): T | undefined;
+export function useLangChainState<T>(key: string, defaultValue: T): T;
+export function useLangChainState<T>(
+  key: string,
+  defaultValue?: T,
+): T | undefined {
+  return langChainExtras.use((e) => {
+    const value = e.values[key] as T | undefined;
+    return value !== undefined ? value : defaultValue;
+  }, defaultValue);
+}

--- a/packages/react-langchain/src/index.ts
+++ b/packages/react-langchain/src/index.ts
@@ -1,5 +1,6 @@
+export { useStreamRuntime } from "./useStreamRuntime";
+
 export {
-  useStreamRuntime,
   useLangChainError,
   useLangChainInterruptState,
   useLangChainRespond,
@@ -9,8 +10,7 @@ export {
   useLangChainState,
   useLangChainSubmit,
   useLangChainToolCalls,
-} from "./useStreamRuntime";
-export type { UseStreamRuntimeOptions } from "./useStreamRuntime";
+} from "./hooks";
 
 export { convertLangChainBaseMessage } from "./convertMessages";
 
@@ -18,4 +18,5 @@ export type {
   LangChainBaseMessage,
   LangChainContentBlock,
   LangChainToolCall,
+  UseStreamRuntimeOptions,
 } from "./types";

--- a/packages/react-langchain/src/runtimeExtras.ts
+++ b/packages/react-langchain/src/runtimeExtras.ts
@@ -1,0 +1,5 @@
+import { createRuntimeExtras } from "@assistant-ui/core/internal";
+import type { LangChainRuntimeExtras } from "./types";
+
+export const langChainExtras =
+  createRuntimeExtras<LangChainRuntimeExtras>("useStreamRuntime");

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -1,4 +1,15 @@
-import type { MessageStatus } from "@assistant-ui/core";
+import type {
+  AttachmentAdapter,
+  DictationAdapter,
+  ExternalStoreSharedOptions,
+  FeedbackAdapter,
+  MessageStatus,
+  RealtimeVoiceAdapter,
+  RemoteThreadListAdapter,
+  SpeechSynthesisAdapter,
+} from "@assistant-ui/core";
+import type { AssistantCloud } from "assistant-cloud";
+import type { UseStreamOptions, AssembledToolCall } from "@langchain/react";
 
 /** Known content block types from @langchain/core messages. */
 export type LangChainContentBlock =
@@ -47,3 +58,68 @@ export type LangChainBaseMessage = {
   /** Present on ToolMessage */
   artifact?: unknown;
 };
+
+export type LangChainRuntimeExtras = {
+  interrupt: { value?: unknown } | undefined;
+  interrupts: readonly { value?: unknown }[];
+  toolCalls: readonly AssembledToolCall[];
+  error: unknown;
+  submit: (
+    values: Record<string, unknown> | null | undefined,
+    options?: Record<string, unknown>,
+  ) => Promise<void>;
+  respond: (
+    response: unknown,
+    options?: Record<string, unknown>,
+  ) => Promise<void>;
+  respondAll: (
+    responsesById: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ) => Promise<void>;
+  values: Record<string, unknown>;
+  messagesKey: string;
+};
+
+export type LangChainRuntimeExtraOptions = ExternalStoreSharedOptions & {
+  cloud?: AssistantCloud | undefined;
+  adapters?:
+    | {
+        attachments?: AttachmentAdapter | undefined;
+        speech?: SpeechSynthesisAdapter | undefined;
+        dictation?: DictationAdapter | undefined;
+        voice?: RealtimeVoiceAdapter | undefined;
+        feedback?: FeedbackAdapter | undefined;
+      }
+    | undefined;
+  /**
+   * When the user sends a new message while previous tool calls are
+   * still pending, automatically submit `tool` messages that cancel
+   * them so the agent's tool-call accounting stays consistent.
+   * Defaults to `true`.
+   */
+  autoCancelPendingToolCalls?: boolean | undefined;
+  /**
+   * Routes the Cancel button's click to `useStream().stop()`. On by
+   * default. Pass `false` to disable the Cancel button.
+   */
+  unstable_allowCancellation?: boolean | undefined;
+  /**
+   * Custom `RemoteThreadListAdapter`. When provided, replaces the
+   * cloud-backed thread list adapter.
+   */
+  unstable_threadListAdapter?: RemoteThreadListAdapter | undefined;
+  /** Custom thread-creation hook, forwarded to the cloud adapter. */
+  create?: (() => Promise<{ externalId: string | undefined }>) | undefined;
+  /** Custom thread-deletion hook, forwarded to the cloud adapter. */
+  delete?: ((threadId: string) => Promise<void>) | undefined;
+};
+
+// Distribute the intersection through the union arms of `UseStreamOptions`
+// (`AgentServerOptions | CustomAdapterOptions`). Writing `UseStreamOptions & X`
+// directly collapses arm tracking, so `Omit<…, "cloud">` and the like would
+// produce a flattened structural type that no longer matches either arm.
+export type UseStreamRuntimeOptions = UseStreamOptions extends infer O
+  ? O extends UseStreamOptions
+    ? O & LangChainRuntimeExtraOptions
+    : never
+  : never;

--- a/packages/react-langchain/src/useLangChainError.test.tsx
+++ b/packages/react-langchain/src/useLangChainError.test.tsx
@@ -22,7 +22,7 @@ vi.mock(import("@assistant-ui/store"), async (importOriginal) => {
   };
 });
 
-import { useLangChainError } from "./useStreamRuntime";
+import { useLangChainError } from "./hooks";
 
 const runSelectorAgainst = createRunSelectorAgainst(mockUseAuiState);
 

--- a/packages/react-langchain/src/useLangChainRespond.test.tsx
+++ b/packages/react-langchain/src/useLangChainRespond.test.tsx
@@ -16,7 +16,7 @@ vi.mock(import("@assistant-ui/store"), async (importOriginal) => {
   };
 });
 
-import { useLangChainRespond } from "./useStreamRuntime";
+import { useLangChainRespond } from "./hooks";
 
 describe("useLangChainRespond", () => {
   it("forwards the response and options to stream.respond", async () => {
@@ -43,7 +43,7 @@ describe("useLangChainRespond", () => {
 
     const { result } = renderHook(() => useLangChainRespond());
     expect(() => result.current({ approved: true })).toThrow(
-      "This method can only be called when you are using useStreamRuntime",
+      "useStreamRuntime",
     );
   });
 });

--- a/packages/react-langchain/src/useLangChainRespondAll.test.tsx
+++ b/packages/react-langchain/src/useLangChainRespondAll.test.tsx
@@ -16,7 +16,7 @@ vi.mock(import("@assistant-ui/store"), async (importOriginal) => {
   };
 });
 
-import { useLangChainRespondAll } from "./useStreamRuntime";
+import { useLangChainRespondAll } from "./hooks";
 
 describe("useLangChainRespondAll", () => {
   it("forwards the responses and options to stream.respondAll", async () => {
@@ -46,7 +46,7 @@ describe("useLangChainRespondAll", () => {
 
     const { result } = renderHook(() => useLangChainRespondAll());
     expect(() => result.current({ a: { approved: true } })).toThrow(
-      "This method can only be called when you are using useStreamRuntime",
+      "useStreamRuntime",
     );
   });
 });

--- a/packages/react-langchain/src/useLangChainState.test.tsx
+++ b/packages/react-langchain/src/useLangChainState.test.tsx
@@ -22,7 +22,7 @@ vi.mock(import("@assistant-ui/store"), async (importOriginal) => {
   };
 });
 
-import { useLangChainState } from "./useStreamRuntime";
+import { useLangChainState } from "./hooks";
 
 const runSelectorAgainst = createRunSelectorAgainst(mockUseAuiState);
 

--- a/packages/react-langchain/src/useLangChainToolCalls.test.tsx
+++ b/packages/react-langchain/src/useLangChainToolCalls.test.tsx
@@ -22,7 +22,7 @@ vi.mock(import("@assistant-ui/store"), async (importOriginal) => {
   };
 });
 
-import { useLangChainToolCalls } from "./useStreamRuntime";
+import { useLangChainToolCalls } from "./hooks";
 
 const runSelectorAgainst = createRunSelectorAgainst(mockUseAuiState);
 

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -2,17 +2,7 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
-import type {
-  AppendMessage,
-  AttachmentAdapter,
-  DictationAdapter,
-  ExternalStoreSharedOptions,
-  FeedbackAdapter,
-  RealtimeVoiceAdapter,
-  RemoteThreadListAdapter,
-  SpeechSynthesisAdapter,
-  ToolExecutionStatus,
-} from "@assistant-ui/core";
+import type { AppendMessage, ToolExecutionStatus } from "@assistant-ui/core";
 import { pickExternalStoreSharedOptions } from "@assistant-ui/core";
 import {
   useCloudThreadListAdapter,
@@ -20,87 +10,19 @@ import {
   useExternalMessageConverter,
   useRemoteThreadListRuntime,
 } from "@assistant-ui/core/react";
-import { useAui, useAuiState } from "@assistant-ui/store";
-import type { AssistantCloud } from "assistant-cloud";
+import { useAuiState } from "@assistant-ui/store";
+import { useStream } from "@langchain/react";
+import type {
+  LangChainBaseMessage,
+  LangChainToolCall,
+  UseStreamRuntimeOptions,
+} from "./types";
 import {
-  useStream,
-  type UseStreamOptions,
-  type AssembledToolCall,
-} from "@langchain/react";
-import type { LangChainBaseMessage, LangChainToolCall } from "./types";
-import { convertLangChainBaseMessage, getMessageType } from "./convertMessages";
-
-const symbolLangChainRuntimeExtras = Symbol("langchain-runtime-extras");
-
-const EMPTY_TOOL_CALLS: readonly AssembledToolCall[] = [];
-
-type LangChainRuntimeExtras = {
-  [symbolLangChainRuntimeExtras]: true;
-  interrupt: { value?: unknown } | undefined;
-  interrupts: readonly { value?: unknown }[];
-  toolCalls: readonly AssembledToolCall[];
-  error: unknown;
-  submit: (
-    values: Record<string, unknown> | null | undefined,
-    options?: Record<string, unknown>,
-  ) => Promise<void>;
-  respond: (
-    response: unknown,
-    options?: Record<string, unknown>,
-  ) => Promise<void>;
-  respondAll: (
-    responsesById: Record<string, unknown>,
-    options?: Record<string, unknown>,
-  ) => Promise<void>;
-  values: Record<string, unknown>;
-  messagesKey: string;
-};
-
-const asLangChainRuntimeExtras = (extras: unknown): LangChainRuntimeExtras => {
-  if (
-    typeof extras !== "object" ||
-    extras == null ||
-    !(symbolLangChainRuntimeExtras in extras)
-  )
-    throw new Error(
-      "This method can only be called when you are using useStreamRuntime",
-    );
-  return extras as LangChainRuntimeExtras;
-};
-
-type LangChainRuntimeExtraOptions = ExternalStoreSharedOptions & {
-  cloud?: AssistantCloud | undefined;
-  adapters?:
-    | {
-        attachments?: AttachmentAdapter | undefined;
-        speech?: SpeechSynthesisAdapter | undefined;
-        dictation?: DictationAdapter | undefined;
-        voice?: RealtimeVoiceAdapter | undefined;
-        feedback?: FeedbackAdapter | undefined;
-      }
-    | undefined;
-  /**
-   * When the user sends a new message while previous tool calls are
-   * still pending, automatically submit `tool` messages that cancel
-   * them so the agent's tool-call accounting stays consistent.
-   * Defaults to `true`.
-   */
-  autoCancelPendingToolCalls?: boolean | undefined;
-  /**
-   * Routes the Cancel button's click to `useStream().stop()`. On by
-   * default. Pass `false` to disable the Cancel button.
-   */
-  unstable_allowCancellation?: boolean | undefined;
-  /**
-   * Custom `RemoteThreadListAdapter`. When provided, replaces the
-   * cloud-backed thread list adapter.
-   */
-  unstable_threadListAdapter?: RemoteThreadListAdapter | undefined;
-  /** Custom thread-creation hook, forwarded to the cloud adapter. */
-  create?: (() => Promise<{ externalId: string | undefined }>) | undefined;
-  /** Custom thread-deletion hook, forwarded to the cloud adapter. */
-  delete?: ((threadId: string) => Promise<void>) | undefined;
-};
+  convertLangChainBaseMessage,
+  getMessageContent,
+  getMessageType,
+} from "./convertMessages";
+import { langChainExtras } from "./runtimeExtras";
 
 export const runConfigToSubmitOptions = (
   runConfig: AppendMessage["runConfig"],
@@ -122,67 +44,6 @@ const getPendingToolCalls = (
     }
   }
   return [...pending.values()];
-};
-
-// Distribute the intersection through the union arms of `UseStreamOptions`
-// (`AgentServerOptions | CustomAdapterOptions`). Writing `UseStreamOptions & X`
-// directly collapses arm tracking, so `Omit<…, "cloud">` and the like would
-// produce a flattened structural type that no longer matches either arm.
-export type UseStreamRuntimeOptions = UseStreamOptions extends infer O
-  ? O extends UseStreamOptions
-    ? O & LangChainRuntimeExtraOptions
-    : never
-  : never;
-
-const getMessageContent = (msg: AppendMessage) => {
-  const allContent = [
-    ...msg.content,
-    ...(msg.attachments?.flatMap((a) => a.content) ?? []),
-  ];
-
-  const hasNonText = allContent.some(
-    (part) => part.type === "file" || part.type === "image",
-  );
-  const hasText = allContent.some((part) => part.type === "text");
-  if (hasNonText && !hasText) {
-    allContent.unshift({ type: "text", text: " " });
-  }
-
-  const content = allContent.map((part) => {
-    const type = part.type;
-    switch (type) {
-      case "text":
-        return { type: "text" as const, text: part.text };
-      case "image":
-        return { type: "image_url" as const, image_url: { url: part.image } };
-      case "file":
-        return {
-          type: "file" as const,
-          data: part.data,
-          mime_type: part.mimeType,
-          metadata: { filename: part.filename ?? "file" },
-          source_type: "base64" as const,
-        };
-      case "tool-call":
-        throw new Error("Tool call appends are not supported.");
-      default: {
-        const _exhaustiveCheck:
-          | "reasoning"
-          | "source"
-          | "audio"
-          | "data"
-          | "generative-ui" = type;
-        throw new Error(
-          `Unsupported append message part type: ${_exhaustiveCheck}`,
-        );
-      }
-    }
-  });
-
-  if (content.length === 1 && content[0]?.type === "text") {
-    return content[0].text ?? "";
-  }
-  return content;
 };
 
 type DistributiveOmit<T, K extends keyof any> = T extends unknown
@@ -227,18 +88,18 @@ const useStreamThreadRuntime = (
   streamRef.current = stream;
 
   const extras = useMemo(
-    (): LangChainRuntimeExtras => ({
-      [symbolLangChainRuntimeExtras]: true,
-      interrupt: stream.interrupt,
-      interrupts: stream.interrupts,
-      toolCalls: stream.toolCalls,
-      error: stream.error,
-      submit: stream.submit,
-      respond: stream.respond,
-      respondAll: stream.respondAll,
-      values: stream.values,
-      messagesKey,
-    }),
+    () =>
+      langChainExtras.provide({
+        interrupt: stream.interrupt,
+        interrupts: stream.interrupts,
+        toolCalls: stream.toolCalls,
+        error: stream.error,
+        submit: stream.submit,
+        respond: stream.respond,
+        respondAll: stream.respondAll,
+        values: stream.values,
+        messagesKey,
+      }),
     [
       stream.interrupt,
       stream.interrupts,
@@ -362,143 +223,3 @@ export const useStreamRuntime = (rawOptions: UseStreamRuntimeOptions) => {
     allowNesting: true,
   });
 };
-
-/**
- * Read the current LangGraph interrupt state from the runtime extras.
- */
-export const useLangChainInterruptState = () => {
-  return useAuiState((s) => {
-    const extras = s.thread.extras;
-    if (!extras) return undefined;
-    return asLangChainRuntimeExtras(extras).interrupt;
-  });
-};
-
-/** Read the last run/hydration error from the runtime extras. */
-export const useLangChainError = () => {
-  return useAuiState((s) => {
-    const extras = s.thread.extras;
-    if (!extras) return undefined;
-    return asLangChainRuntimeExtras(extras).error;
-  });
-};
-
-/**
- * Read the root tool calls assembled by `useStream` from the `tools`
- * channel. Defaults to an empty array, so consumers can `.map` without
- * a guard. Useful for rendering pending/streamed tool calls and
- * approval UIs.
- */
-export const useLangChainToolCalls = () => {
-  return useAuiState((s) => {
-    const extras = s.thread.extras;
-    if (!extras) return EMPTY_TOOL_CALLS;
-    return asLangChainRuntimeExtras(extras).toolCalls ?? EMPTY_TOOL_CALLS;
-  });
-};
-
-/**
- * Returns a function to submit raw state updates to the LangGraph agent,
- * bypassing the normal message flow. Useful for sending interrupt resume
- * commands.
- */
-export const useLangChainSubmit = () => {
-  const aui = useAui();
-  return (
-    values: Record<string, unknown> | null | undefined,
-    options?: Record<string, unknown>,
-  ) => {
-    const extras = aui.thread().getState().extras;
-    const { submit } = asLangChainRuntimeExtras(extras);
-    return submit(values, options);
-  };
-};
-
-/**
- * Resume a LangGraph interrupt with a response payload via
- * `useStream().respond`. Preferred over `useLangChainSendCommand`; it
- * carries the response cleanly and handles interrupt namespaces.
- */
-export const useLangChainRespond = () => {
-  const aui = useAui();
-  return (response: unknown, options?: Record<string, unknown>) => {
-    const { respond } = asLangChainRuntimeExtras(
-      aui.thread().getState().extras,
-    );
-    return respond(response, options);
-  };
-};
-
-/**
- * Resume several LangGraph interrupts pending at the same checkpoint in
- * one run via `useStream().respondAll`. Use when a run pauses on multiple
- * interrupts at once; sequential `useLangChainRespond` calls can't service
- * them (the first resume starts a run, stranding the rest).
- */
-export const useLangChainRespondAll = () => {
-  const aui = useAui();
-  return (
-    responsesById: Record<string, unknown>,
-    options?: Record<string, unknown>,
-  ) => {
-    const { respondAll } = asLangChainRuntimeExtras(
-      aui.thread().getState().extras,
-    );
-    return respondAll(responsesById, options);
-  };
-};
-
-/**
- * Submit a list of LangChain-shaped messages on the current thread.
- * Parity helper for migrating from `useLangGraphSend`. Routes to
- * `useStream().submit({ [messagesKey]: messages }, options)`.
- */
-export const useLangChainSend = () => {
-  const aui = useAui();
-  return (
-    messages: readonly LangChainBaseMessage[],
-    options?: Record<string, unknown>,
-  ) => {
-    const { submit, messagesKey } = asLangChainRuntimeExtras(
-      aui.thread().getState().extras,
-    );
-    return submit({ [messagesKey]: messages }, options);
-  };
-};
-
-/**
- * Submit a `useStream` command (e.g. interrupt resume). Parity helper
- * for migrating from `useLangGraphSendCommand`. Note that v1's command
- * shape (`{ resume?, goto?, update? }`) differs from the legacy
- * `{ resume: string }` form — to carry a payload, use the input or
- * `stream.respond` instead.
- */
-export const useLangChainSendCommand = () => {
-  const submit = useLangChainSubmit();
-  return (command: Record<string, unknown>) => submit(null, { command });
-};
-
-/**
- * Read a custom LangGraph state key from the current thread. Mirrors
- * `useStream().values[key]` from `@langchain/react` and updates when the
- * stream emits new state.
- *
- * @example
- * ```tsx
- * const todos = useLangChainState<Todo[]>("todos");
- * const files = useLangChainState<Record<string, string>>("files", {});
- * ```
- */
-export function useLangChainState<T>(key: string): T | undefined;
-export function useLangChainState<T>(key: string, defaultValue: T): T;
-export function useLangChainState<T>(
-  key: string,
-  defaultValue?: T,
-): T | undefined {
-  return useAuiState((s) => {
-    const extras = s.thread.extras;
-    if (!extras) return defaultValue;
-    const value = asLangChainRuntimeExtras(extras).values[key] as T | undefined;
-    return value !== undefined ? value : defaultValue;
-  });
-}


### PR DESCRIPTION
stacked on #4466. review and merge that one first; this PR's base is the #4466 branch, so its diff is langchain-only. once #4466 squash-merges i will rebase this onto main.

## what

decomposes react-langchain's 505-line `useStreamRuntime.ts` into the standard adapter layout, with no behavior change:

- `hooks.ts` holds the nine `useLangChain*` accessor/action hooks
- `types.ts` holds the option and extras types (moved out of the runtime file)
- `convertMessages.ts` gains the outbound `getMessageContent` mapper
- `useStreamRuntime.ts` is left to orchestrate only (entry hook + inner thread runtime)

and replaces the package's private `Symbol` + `asLangChainRuntimeExtras` guard with the shared `createRuntimeExtras` helper from `@assistant-ui/core/internal` (added in #4466).

## why

this is the first package brought onto the adapter-orchestration convention: the runtime file orchestrates, pure modules convert, hooks read. it adopts the `hooks.ts` split that react-google-adk already uses, and it is the highest-value lowest-risk decomposition since the spine (remote-thread-list over external-store over langchain's `useStream`) was already correct.

## test plan

- full react-langchain suite green (7 files, 22 tests), oxlint clean, tsc clean (the two pre-existing `convertMessages.test.ts` errors are on main and unrelated)