### PR TITLE
ci: template size metrics gate

### DIFF
--- a/.github/workflows/template-metrics.yaml
+++ b/.github/workflows/template-metrics.yaml
@@ -93,13 +93,14 @@ jobs:
 
       - name: Build report
         run: |
-          base=install-footprint/branch/main/data.json
-          [ -f "$base" ] || base=""
-          node scripts/template-metrics.mjs report "$base" metrics-head.json metrics-report.md metrics-gate.txt
+          node scripts/template-metrics.mjs report install-footprint/branch/main/data.json metrics-head.json metrics-report.md metrics-gate.txt
           cat metrics-report.md
 
+      # continue-on-error: a fork PR's read-only token makes commenting 403; that
+      # must not fail the check or skip the gate below.
       - name: Post / update PR comment
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -128,10 +129,10 @@ jobs:
               });
             }
 
-      # Runs after the comment is posted so reviewers see the table even when the
-      # gate fails. Only blocks PRs; pushes to main always refresh the baseline.
+      # always(): run even if the comment step failed (e.g. fork 403), so the
+      # gate verdict is never lost. Only blocks PRs; pushes refresh the baseline.
       - name: Enforce regression gate
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         run: |
           if [ "$(cat metrics-gate.txt 2>/dev/null)" = "fail" ]; then
             echo "::error::Template metrics regressed past the configured limits. See the PR comment."

--- a/.github/workflows/template-metrics.yaml
+++ b/.github/workflows/template-metrics.yaml
@@ -6,15 +6,11 @@ on:
     paths:
       - "templates/**"
       - "packages/ui/**"
-      - "scripts/template-metrics.mjs"
-      - ".github/workflows/template-metrics.yaml"
   pull_request:
     branches: [main]
     paths:
       - "templates/**"
       - "packages/ui/**"
-      - "scripts/template-metrics.mjs"
-      - ".github/workflows/template-metrics.yaml"
 
 permissions:
   contents: read
@@ -93,7 +89,7 @@ jobs:
 
       - name: Build report
         run: |
-          node scripts/template-metrics.mjs report install-footprint/branch/main/data.json metrics-head.json metrics-report.md metrics-gate.txt
+          node scripts/template-metrics.mjs report install-footprint/branch/main/data.json metrics-head.json metrics-report.md metrics-gate.txt metrics-comment.txt
           cat metrics-report.md
 
       # continue-on-error: a fork PR's read-only token makes commenting 403; that
@@ -115,6 +111,11 @@ jobs:
               issue_number: context.issue.number,
             });
             const existing = comments.find((c) => c.body.includes(marker));
+            const shouldCreate = fs.readFileSync('metrics-comment.txt', 'utf8').trim() === 'post';
+            if (!existing && !shouldCreate) {
+              console.log('No LOC changes; skipping template metrics comment.');
+              return;
+            }
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,

--- a/.github/workflows/template-metrics.yaml
+++ b/.github/workflows/template-metrics.yaml
@@ -110,7 +110,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            const existing = comments.find((c) => c.body.includes(marker));
+            const existing = comments.find((c) => c.body?.includes(marker));
             const shouldCreate = fs.readFileSync('metrics-comment.txt', 'utf8').trim() === 'post';
             if (!existing && !shouldCreate) {
               console.log('No LOC changes; skipping template metrics comment.');

--- a/.github/workflows/template-metrics.yaml
+++ b/.github/workflows/template-metrics.yaml
@@ -62,14 +62,14 @@ jobs:
             ${{ runner.os }}-turbo-${{ github.ref }}-
             ${{ runner.os }}-turbo-
 
-      # Baseline is the metrics snapshot saved by the last run on main. PRs read
-      # the newest one via the restore-keys prefix to compute deltas.
-      - name: Restore baseline metrics
+      # Baseline is main's metrics, cached by the last run on main. PRs restore
+      # the newest one via the restore-keys prefix to compute deltas against main.
+      - name: Restore main baseline
         uses: actions/cache/restore@v4
         with:
-          path: metrics-baseline.json
-          key: template-metrics-${{ github.sha }}
-          restore-keys: template-metrics-
+          path: install-footprint/branch/main/data.json
+          key: install-footprint-main-${{ github.sha }}
+          restore-keys: install-footprint-main-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build report
         run: |
-          base=metrics-baseline.json
+          base=install-footprint/branch/main/data.json
           [ -f "$base" ] || base=""
           node scripts/template-metrics.mjs report "$base" metrics-head.json metrics-report.md metrics-gate.txt
           cat metrics-report.md
@@ -141,11 +141,13 @@ jobs:
 
       - name: Persist baseline (main only)
         if: github.event_name == 'push'
-        run: cp metrics-head.json metrics-baseline.json
+        run: |
+          mkdir -p install-footprint/branch/main
+          cp metrics-head.json install-footprint/branch/main/data.json
 
       - name: Save baseline cache (main only)
         if: github.event_name == 'push'
         uses: actions/cache/save@v4
         with:
-          path: metrics-baseline.json
-          key: template-metrics-${{ github.sha }}
+          path: install-footprint/branch/main/data.json
+          key: install-footprint-main-${{ github.sha }}

--- a/.github/workflows/template-metrics.yaml
+++ b/.github/workflows/template-metrics.yaml
@@ -1,0 +1,151 @@
+name: Template Metrics
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "templates/**"
+      - "packages/ui/**"
+      - "scripts/template-metrics.mjs"
+      - ".github/workflows/template-metrics.yaml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "templates/**"
+      - "packages/ui/**"
+      - "scripts/template-metrics.mjs"
+      - ".github/workflows/template-metrics.yaml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Templates to build for bundle-size measurement. LOC is measured for all
+  # templates regardless; only these are built (next build is the expensive part).
+  BUNDLE_TEMPLATES: "default minimal"
+  # Per-template regression limits. A template that already exists on the main
+  # baseline fails the gate if it grows past either limit.
+  MAX_LOC_INCREASE: "50"
+  MAX_BUNDLE_INCREASE_KB: "10"
+
+jobs:
+  metrics:
+    name: LOC + Bundle Size
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.ref }}-
+            ${{ runner.os }}-turbo-
+
+      # Baseline is the metrics snapshot saved by the last run on main. PRs read
+      # the newest one via the restore-keys prefix to compute deltas.
+      - name: Restore baseline metrics
+        uses: actions/cache/restore@v4
+        with:
+          path: metrics-baseline.json
+          key: template-metrics-${{ github.sha }}
+          restore-keys: template-metrics-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build templates (bundle subset)
+        env:
+          # next build needs these public vars defined; values are placeholders.
+          NEXT_PUBLIC_ASSISTANT_BASE_URL: "https://example.com"
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_test_placeholder"
+          NEXT_TELEMETRY_DISABLED: "1"
+        run: |
+          filters=""
+          for t in $BUNDLE_TEMPLATES; do
+            filters="$filters --filter=./templates/$t"
+          done
+          # turbo pulls in the @assistant-ui/* workspace deps each template needs.
+          pnpm turbo build $filters
+
+      - name: Measure metrics
+        run: node scripts/template-metrics.mjs measure . metrics-head.json
+
+      - name: Build report
+        run: |
+          base=metrics-baseline.json
+          [ -f "$base" ] || base=""
+          node scripts/template-metrics.mjs report "$base" metrics-head.json metrics-report.md metrics-gate.txt
+          cat metrics-report.md
+
+      - name: Post / update PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('metrics-report.md', 'utf8');
+            const marker = '<!-- template-metrics -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      # Runs after the comment is posted so reviewers see the table even when the
+      # gate fails. Only blocks PRs; pushes to main always refresh the baseline.
+      - name: Enforce regression gate
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ "$(cat metrics-gate.txt 2>/dev/null)" = "fail" ]; then
+            echo "::error::Template metrics regressed past the configured limits. See the PR comment."
+            exit 1
+          fi
+          echo "Template metrics within limits."
+
+      - name: Persist baseline (main only)
+        if: github.event_name == 'push'
+        run: cp metrics-head.json metrics-baseline.json
+
+      - name: Save baseline cache (main only)
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: metrics-baseline.json
+          key: template-metrics-${{ github.sha }}

--- a/.github/workflows/template-metrics.yaml
+++ b/.github/workflows/template-metrics.yaml
@@ -107,7 +107,9 @@ jobs:
             const fs = require('fs');
             const body = fs.readFileSync('metrics-report.md', 'utf8');
             const marker = '<!-- template-metrics -->';
-            const { data: comments } = await github.rest.issues.listComments({
+            // paginate: a long PR thread can push the sticky comment past the
+            // first 30, and missing it would post a duplicate on every re-run.
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,

--- a/scripts/template-metrics.mjs
+++ b/scripts/template-metrics.mjs
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
-// Measures the "install footprint" of each starter template:
-//   - LOC: tracked source lines copied into a user's codebase (git ls-files, so
-//     build output and node_modules are excluded automatically)
+// Measures the "install footprint" of each starter template, i.e. what a user
+// actually gets when they scaffold it:
+//   - own LOC: the template's own tracked source (app glue, config)
+//   - /ui LOC: the packages/ui components it pulls in. Aliased templates import
+//     @/components/* -> packages/ui/src/* via tsconfig paths, so those files are
+//     copied into a user's project on scaffold but live outside templates/ in
+//     this repo. We resolve them by walking the import graph from each template.
 //   - bundle: gzipped client JS emitted by `next build` (.next/static/**/*.js)
 //
 // Usage:
@@ -9,12 +13,18 @@
 //   node scripts/template-metrics.mjs report <baseJson|""> <headJson> <outMd> [gateFile]
 //
 // report writes "pass"/"fail" to gateFile based on the regression thresholds
-// (env: MAX_LOC_INCREASE, MAX_BUNDLE_INCREASE_KB).
+// (env: MAX_LOC_INCREASE applied to total LOC, MAX_BUNDLE_INCREASE_KB).
 
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import {
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  existsSync,
+  statSync,
+} from "node:fs";
 import { gzipSync } from "node:zlib";
-import { join, extname } from "node:path";
+import { join, extname, dirname, resolve } from "node:path";
 
 const CODE_EXT = new Set([
   ".ts",
@@ -25,28 +35,116 @@ const CODE_EXT = new Set([
   ".cjs",
   ".css",
 ]);
+const RESOLVE_EXT = ["", ".tsx", ".ts", ".jsx", ".js"];
 
 function listTemplates(root) {
   return readdirSync(join(root, "templates"), { withFileTypes: true })
-    .filter((d) => d.isDirectory())
+    .filter(
+      (d) =>
+        d.isDirectory() &&
+        existsSync(join(root, "templates", d.name, "package.json")),
+    )
     .map((d) => d.name)
     .sort();
 }
 
-function locFor(root, name) {
-  const tracked = execFileSync("git", ["ls-files", "--", `templates/${name}`], {
+function trackedFiles(root, dir) {
+  return execFileSync("git", ["ls-files", "--", dir], {
     cwd: root,
     encoding: "utf8",
   })
     .split("\n")
     .filter(Boolean);
+}
 
-  let loc = 0;
-  for (const file of tracked) {
-    if (!CODE_EXT.has(extname(file))) continue;
-    loc += readFileSync(join(root, file), "utf8").split("\n").length;
+function lineCount(file) {
+  return readFileSync(file, "utf8").split("\n").length;
+}
+
+// tsconfig `paths` -> longest-prefix alias matchers, resolved against the
+// template dir so "@/components/ui/*" can point into ../../packages/ui/src.
+function loadAliases(tplDir) {
+  // tsconfig values contain "/*" (e.g. "./*"), so strip only full-line "//"
+  // comments and trailing commas; never block comments. Parse raw first.
+  const raw = readFileSync(join(tplDir, "tsconfig.json"), "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    parsed = JSON.parse(
+      raw.replace(/^\s*\/\/.*$/gm, "").replace(/,(\s*[}\]])/g, "$1"),
+    );
   }
-  return loc;
+  const paths = parsed.compilerOptions?.paths ?? {};
+  return Object.entries(paths)
+    .map(([key, [target]]) => ({
+      prefix: key.replace(/\*$/, ""),
+      target: target.replace(/\*$/, ""),
+    }))
+    .sort((a, b) => b.prefix.length - a.prefix.length);
+}
+
+function resolveModule(fromFile, spec, tplDir, aliases) {
+  let target;
+  if (spec.startsWith("@/")) {
+    const alias = aliases.find((a) => spec.startsWith(a.prefix));
+    if (!alias) return null;
+    target = resolve(tplDir, alias.target + spec.slice(alias.prefix.length));
+  } else if (spec.startsWith(".")) {
+    target = resolve(dirname(fromFile), spec);
+  } else {
+    return null; // bare npm import: a dependency, not copied source
+  }
+  for (const ext of RESOLVE_EXT) {
+    const direct = target + ext;
+    if (ext && existsSync(direct) && statSync(direct).isFile()) return direct;
+    const index = join(target, `index${ext}`);
+    if (ext && existsSync(index) && statSync(index).isFile()) return index;
+  }
+  return existsSync(target) && statSync(target).isFile() ? target : null;
+}
+
+function importsOf(file) {
+  const src = readFileSync(file, "utf8");
+  const specs = [];
+  const re = /(?:from|import)\s+["']([^"']+)["']/g;
+  let m;
+  while ((m = re.exec(src))) specs.push(m[1]);
+  return specs;
+}
+
+// Owned template files all ship; packages/ui files count only when reachable
+// from the template's imports (a user only gets the components they use).
+function footprintFor(root, name) {
+  // Absolute paths throughout so seeds match the resolver's output and the
+  // visited Set dedups correctly (relative + absolute spellings would double).
+  const tplDir = resolve(root, "templates", name);
+  const aliases = loadAliases(tplDir);
+  const seeds = trackedFiles(root, `templates/${name}`)
+    .filter((f) => CODE_EXT.has(extname(f)))
+    .map((f) => resolve(root, f));
+
+  const visited = new Set();
+  const stack = [...seeds];
+  while (stack.length) {
+    const file = stack.pop();
+    if (visited.has(file)) continue;
+    visited.add(file);
+    if (!/\.(tsx?|jsx?)$/.test(file)) continue;
+    for (const spec of importsOf(file)) {
+      const resolved = resolveModule(file, spec, tplDir, aliases);
+      if (resolved && !visited.has(resolved)) stack.push(resolved);
+    }
+  }
+
+  let ownLoc = 0;
+  let uiLoc = 0;
+  for (const file of visited) {
+    const loc = lineCount(file);
+    if (file.includes("/packages/ui/")) uiLoc += loc;
+    else ownLoc += loc;
+  }
+  return { ownLoc, uiLoc };
 }
 
 function walkJs(dir, acc) {
@@ -70,10 +168,14 @@ function bundleGzipFor(root, name) {
 function measure(root, outJson) {
   const result = listTemplates(root).map((name) => ({
     name,
-    loc: locFor(root, name),
+    ...footprintFor(root, name),
     bundleGzip: bundleGzipFor(root, name),
   }));
   writeFileSync(outJson, JSON.stringify(result, null, 2));
+}
+
+function totalLoc(t) {
+  return t.ownLoc + t.uiLoc;
 }
 
 function kb(bytes) {
@@ -84,30 +186,29 @@ function signedKb(bytes) {
   return `${bytes > 0 ? "+" : "-"}${kb(Math.abs(bytes))}`;
 }
 
-function deltaLoc(head, base) {
-  if (base == null) return "new";
-  const d = head - base;
-  if (d === 0) return "0";
-  return `${d > 0 ? "+" : ""}${d}`;
+function locCell(cur, base) {
+  if (base == null) return `${cur} (new)`;
+  const d = cur - base;
+  return `${cur} (${d === 0 ? "0" : `${d > 0 ? "+" : ""}${d}`})`;
 }
 
-function deltaBundle(head, base) {
-  if (head == null) return "n/a";
-  if (base == null) return "new";
-  const d = head - base;
-  if (d === 0) return "0";
-  return signedKb(d);
+function bundleCell(cur, base) {
+  if (cur == null) return "n/a";
+  if (base == null) return `${kb(cur)} (new)`;
+  const d = cur - base;
+  return `${kb(cur)} (${d === 0 ? "0" : signedKb(d)})`;
 }
 
 // Per-template thresholds (env-overridable). A template "regresses" when it
-// already existed on the baseline and grows past either limit.
+// already existed on the baseline and grows past either limit. The LOC limit
+// applies to total footprint (own + /ui).
 const MAX_LOC_INCREASE = Number(process.env.MAX_LOC_INCREASE ?? 50);
 const MAX_BUNDLE_INCREASE_KB = Number(process.env.MAX_BUNDLE_INCREASE_KB ?? 10);
 
 function regression(t, base) {
   if (!base) return null;
   const reasons = [];
-  const locDelta = t.loc - base.loc;
+  const locDelta = totalLoc(t) - totalLoc(base);
   if (locDelta > MAX_LOC_INCREASE) {
     reasons.push(`LOC +${locDelta} > ${MAX_LOC_INCREASE}`);
   }
@@ -137,10 +238,10 @@ function report(baseJson, headJson, outMd, gateFile) {
     if (reasons) regressions.push({ name: t.name, reasons });
     return [
       t.name,
-      String(t.loc),
-      deltaLoc(t.loc, b?.loc),
-      t.bundleGzip == null ? "n/a" : kb(t.bundleGzip),
-      deltaBundle(t.bundleGzip, b?.bundleGzip ?? null),
+      locCell(t.ownLoc, b?.ownLoc),
+      locCell(t.uiLoc, b?.uiLoc),
+      locCell(totalLoc(t), b ? totalLoc(b) : null),
+      bundleCell(t.bundleGzip, b?.bundleGzip ?? null),
       reasons ? "regression" : "ok",
     ];
   });
@@ -149,9 +250,9 @@ function report(baseJson, headJson, outMd, gateFile) {
     "<!-- template-metrics -->",
     "## Template install footprint",
     "",
-    "LOC = tracked source lines copied into your project. Bundle = gzipped client JS from `next build`.",
+    "Lines copied into your project on scaffold: **Own** (template glue) + **/ui** (shared `packages/ui` components it imports). Bundle = gzipped client JS from `next build`. Each cell shows `current (delta vs main)`.",
     "",
-    "| Template | LOC | d LOC | Bundle (gz) | d Bundle | Status |",
+    "| Template | Own LOC | /ui LOC | Total LOC | Bundle (gz) | Status |",
     "| --- | ---: | ---: | ---: | ---: | --- |",
     ...rows.map((r) => `| ${r.join(" | ")} |`),
     "",

--- a/scripts/template-metrics.mjs
+++ b/scripts/template-metrics.mjs
@@ -242,15 +242,15 @@ function report(baseJson, headJson, outMd, gateFile) {
       locCell(t.uiLoc, b?.uiLoc),
       locCell(totalLoc(t), b ? totalLoc(b) : null),
       bundleCell(t.bundleGzip, b?.bundleGzip ?? null),
-      reasons ? "regression" : "ok",
+      reasons ? "⚠️" : "✅",
     ];
   });
 
   const lines = [
     "<!-- template-metrics -->",
-    "## Template install footprint",
+    "## 📦 Template install footprint",
     "",
-    "Lines copied into your project on scaffold: **Own** (template glue) + **/ui** (shared `packages/ui` components it imports). Bundle = gzipped client JS from `next build`. Each cell shows `current (delta vs main)`.",
+    "Lines copied into your project on scaffold: **Own** (template glue) + **/ui** (shared `packages/ui` components it imports). Bundle = gzipped client JS from `next build`. Each cell shows `current (Δ vs main)`.",
     "",
     "| Template | Own LOC | /ui LOC | Total LOC | Bundle (gz) | Status |",
     "| --- | ---: | ---: | ---: | ---: | --- |",

--- a/scripts/template-metrics.mjs
+++ b/scripts/template-metrics.mjs
@@ -35,7 +35,7 @@ const CODE_EXT = new Set([
   ".cjs",
   ".css",
 ]);
-const RESOLVE_EXT = ["", ".tsx", ".ts", ".jsx", ".js"];
+const RESOLVE_EXT = [".tsx", ".ts", ".jsx", ".js"];
 
 function listTemplates(root) {
   return readdirSync(join(root, "templates"), { withFileTypes: true })
@@ -89,6 +89,10 @@ function loadAliases(tplDir) {
     .sort((a, b) => b.prefix.length - a.prefix.length);
 }
 
+function isFile(p) {
+  return existsSync(p) && statSync(p).isFile();
+}
+
 function resolveModule(fromFile, spec, tplDir, aliases) {
   let target;
   if (spec.startsWith("@/")) {
@@ -102,11 +106,11 @@ function resolveModule(fromFile, spec, tplDir, aliases) {
   }
   for (const ext of RESOLVE_EXT) {
     const direct = target + ext;
-    if (ext && existsSync(direct) && statSync(direct).isFile()) return direct;
+    if (isFile(direct)) return direct;
     const index = join(target, `index${ext}`);
-    if (ext && existsSync(index) && statSync(index).isFile()) return index;
+    if (isFile(index)) return index;
   }
-  return existsSync(target) && statSync(target).isFile() ? target : null;
+  return isFile(target) ? target : null;
 }
 
 function importsOf(file) {
@@ -188,7 +192,7 @@ function kb(bytes) {
 }
 
 function signedKb(bytes) {
-  return `${bytes > 0 ? "+" : "-"}${kb(Math.abs(bytes))}`;
+  return `${bytes >= 0 ? "+" : "-"}${kb(Math.abs(bytes))}`;
 }
 
 function locCell(cur, base) {

--- a/scripts/template-metrics.mjs
+++ b/scripts/template-metrics.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+// Measures the "install footprint" of each starter template:
+//   - LOC: tracked source lines copied into a user's codebase (git ls-files, so
+//     build output and node_modules are excluded automatically)
+//   - bundle: gzipped client JS emitted by `next build` (.next/static/**/*.js)
+//
+// Usage:
+//   node scripts/template-metrics.mjs measure <rootDir> <outJson>
+//   node scripts/template-metrics.mjs report <baseJson|""> <headJson> <outMd> [gateFile]
+//
+// report writes "pass"/"fail" to gateFile based on the regression thresholds
+// (env: MAX_LOC_INCREASE, MAX_BUNDLE_INCREASE_KB).
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { gzipSync } from "node:zlib";
+import { join, extname } from "node:path";
+
+const CODE_EXT = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".css",
+]);
+
+function listTemplates(root) {
+  return readdirSync(join(root, "templates"), { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+}
+
+function locFor(root, name) {
+  const tracked = execFileSync("git", ["ls-files", "--", `templates/${name}`], {
+    cwd: root,
+    encoding: "utf8",
+  })
+    .split("\n")
+    .filter(Boolean);
+
+  let loc = 0;
+  for (const file of tracked) {
+    if (!CODE_EXT.has(extname(file))) continue;
+    loc += readFileSync(join(root, file), "utf8").split("\n").length;
+  }
+  return loc;
+}
+
+function walkJs(dir, acc) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) walkJs(p, acc);
+    else if (entry.name.endsWith(".js")) acc.push(p);
+  }
+}
+
+function bundleGzipFor(root, name) {
+  const staticDir = join(root, "templates", name, ".next", "static");
+  if (!existsSync(staticDir)) return null;
+  const files = [];
+  walkJs(staticDir, files);
+  let bytes = 0;
+  for (const f of files) bytes += gzipSync(readFileSync(f)).length;
+  return bytes;
+}
+
+function measure(root, outJson) {
+  const result = listTemplates(root).map((name) => ({
+    name,
+    loc: locFor(root, name),
+    bundleGzip: bundleGzipFor(root, name),
+  }));
+  writeFileSync(outJson, JSON.stringify(result, null, 2));
+}
+
+function kb(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+function signedKb(bytes) {
+  return `${bytes > 0 ? "+" : "-"}${kb(Math.abs(bytes))}`;
+}
+
+function deltaLoc(head, base) {
+  if (base == null) return "new";
+  const d = head - base;
+  if (d === 0) return "0";
+  return `${d > 0 ? "+" : ""}${d}`;
+}
+
+function deltaBundle(head, base) {
+  if (head == null) return "n/a";
+  if (base == null) return "new";
+  const d = head - base;
+  if (d === 0) return "0";
+  return signedKb(d);
+}
+
+// Per-template thresholds (env-overridable). A template "regresses" when it
+// already existed on the baseline and grows past either limit.
+const MAX_LOC_INCREASE = Number(process.env.MAX_LOC_INCREASE ?? 50);
+const MAX_BUNDLE_INCREASE_KB = Number(process.env.MAX_BUNDLE_INCREASE_KB ?? 10);
+
+function regression(t, base) {
+  if (!base) return null;
+  const reasons = [];
+  const locDelta = t.loc - base.loc;
+  if (locDelta > MAX_LOC_INCREASE) {
+    reasons.push(`LOC +${locDelta} > ${MAX_LOC_INCREASE}`);
+  }
+  if (t.bundleGzip != null && base.bundleGzip != null) {
+    const bundleDelta = t.bundleGzip - base.bundleGzip;
+    if (bundleDelta > MAX_BUNDLE_INCREASE_KB * 1024) {
+      reasons.push(
+        `bundle ${signedKb(bundleDelta)} > +${MAX_BUNDLE_INCREASE_KB} KB`,
+      );
+    }
+  }
+  return reasons.length ? reasons : null;
+}
+
+function report(baseJson, headJson, outMd, gateFile) {
+  const head = JSON.parse(readFileSync(headJson, "utf8"));
+  const base =
+    baseJson && existsSync(baseJson)
+      ? JSON.parse(readFileSync(baseJson, "utf8"))
+      : [];
+  const baseByName = new Map(base.map((t) => [t.name, t]));
+
+  const regressions = [];
+  const rows = head.map((t) => {
+    const b = baseByName.get(t.name);
+    const reasons = regression(t, b);
+    if (reasons) regressions.push({ name: t.name, reasons });
+    return [
+      t.name,
+      String(t.loc),
+      deltaLoc(t.loc, b?.loc),
+      t.bundleGzip == null ? "n/a" : kb(t.bundleGzip),
+      deltaBundle(t.bundleGzip, b?.bundleGzip ?? null),
+      reasons ? "regression" : "ok",
+    ];
+  });
+
+  const lines = [
+    "<!-- template-metrics -->",
+    "## Template install footprint",
+    "",
+    "LOC = tracked source lines copied into your project. Bundle = gzipped client JS from `next build`.",
+    "",
+    "| Template | LOC | d LOC | Bundle (gz) | d Bundle | Status |",
+    "| --- | ---: | ---: | ---: | ---: | --- |",
+    ...rows.map((r) => `| ${r.join(" | ")} |`),
+    "",
+  ];
+
+  if (base.length === 0) {
+    lines.push(
+      "_No baseline found - deltas will appear once `main` has been measured._",
+    );
+  } else if (regressions.length) {
+    lines.push(
+      `**Gate failed** - ${regressions.length} template(s) regressed past the configured limits (LOC +${MAX_LOC_INCREASE}, bundle +${MAX_BUNDLE_INCREASE_KB} KB):`,
+      ...regressions.map((r) => `- \`${r.name}\`: ${r.reasons.join("; ")}`),
+    );
+  } else {
+    lines.push(
+      "_Within limits. Bundle measured for a representative subset; templates without a build show `n/a`._",
+    );
+  }
+
+  writeFileSync(outMd, lines.join("\n"));
+  if (gateFile) writeFileSync(gateFile, regressions.length ? "fail" : "pass");
+}
+
+const [cmd, ...args] = process.argv.slice(2);
+if (cmd === "measure") measure(args[0], args[1]);
+else if (cmd === "report") report(args[0] || "", args[1], args[2], args[3]);
+else {
+  console.error("usage: template-metrics.mjs measure|report ...");
+  process.exit(1);
+}

--- a/scripts/template-metrics.mjs
+++ b/scripts/template-metrics.mjs
@@ -299,7 +299,10 @@ function report(baseJson, headJson, outMd, gateFile, commentFile) {
   writeFileSync(outMd, lines.join("\n"));
   if (gateFile) writeFileSync(gateFile, regressions.length ? "fail" : "pass");
   if (commentFile)
-    writeFileSync(commentFile, hasAnyLocChange ? "post" : "skip");
+    writeFileSync(
+      commentFile,
+      hasAnyLocChange || regressions.length ? "post" : "skip",
+    );
 }
 
 const [cmd, ...args] = process.argv.slice(2);

--- a/scripts/template-metrics.mjs
+++ b/scripts/template-metrics.mjs
@@ -58,15 +58,20 @@ function trackedFiles(root, dir) {
 }
 
 function lineCount(file) {
-  return readFileSync(file, "utf8").split("\n").length;
+  const text = readFileSync(file, "utf8");
+  // A trailing newline yields a phantom empty element; strip one so a new
+  // N-line file counts as N, not N+1 (which would skew new-file deltas).
+  return text === "" ? 0 : text.replace(/\n$/, "").split("\n").length;
 }
 
 // tsconfig `paths` -> longest-prefix alias matchers, resolved against the
 // template dir so "@/components/ui/*" can point into ../../packages/ui/src.
 function loadAliases(tplDir) {
+  const tsconfig = join(tplDir, "tsconfig.json");
+  if (!existsSync(tsconfig)) return [];
   // tsconfig values contain "/*" (e.g. "./*"), so strip only full-line "//"
   // comments and trailing commas; never block comments. Parse raw first.
-  const raw = readFileSync(join(tplDir, "tsconfig.json"), "utf8");
+  const raw = readFileSync(tsconfig, "utf8");
   let parsed;
   try {
     parsed = JSON.parse(raw);

--- a/scripts/template-metrics.mjs
+++ b/scripts/template-metrics.mjs
@@ -211,7 +211,9 @@ const MAX_LOC_INCREASE = Number(process.env.MAX_LOC_INCREASE ?? 50);
 const MAX_BUNDLE_INCREASE_KB = Number(process.env.MAX_BUNDLE_INCREASE_KB ?? 10);
 
 function regression(t, base) {
-  if (!base) return null;
+  // base.ownLoc missing => incompatible/legacy baseline schema; treat as no
+  // baseline so the LOC gate can't silently fail open on a NaN comparison.
+  if (!base || base.ownLoc == null) return null;
   const reasons = [];
   const locDelta = totalLoc(t) - totalLoc(base);
   if (locDelta > MAX_LOC_INCREASE) {
@@ -245,7 +247,7 @@ function report(baseJson, headJson, outMd, gateFile) {
       t.name,
       locCell(t.ownLoc, b?.ownLoc),
       locCell(t.uiLoc, b?.uiLoc),
-      locCell(totalLoc(t), b ? totalLoc(b) : null),
+      locCell(totalLoc(t), b && b.ownLoc != null ? totalLoc(b) : null),
       bundleCell(t.bundleGzip, b?.bundleGzip ?? null),
       reasons ? "⚠️" : "✅",
     ];

--- a/scripts/template-metrics.mjs
+++ b/scripts/template-metrics.mjs
@@ -10,7 +10,7 @@
 //
 // Usage:
 //   node scripts/template-metrics.mjs measure <rootDir> <outJson>
-//   node scripts/template-metrics.mjs report <baseJson|""> <headJson> <outMd> [gateFile]
+//   node scripts/template-metrics.mjs report <baseJson|""> <headJson> <outMd> [gateFile] [commentFile]
 //
 // report writes "pass"/"fail" to gateFile based on the regression thresholds
 // (env: MAX_LOC_INCREASE applied to total LOC, MAX_BUNDLE_INCREASE_KB).
@@ -208,6 +208,12 @@ function bundleCell(cur, base) {
   return `${kb(cur)} (${d === 0 ? "0" : signedKb(d)})`;
 }
 
+function hasLocChange(t, base, hasBaseline) {
+  if (!hasBaseline) return false;
+  if (!base || base.ownLoc == null) return true;
+  return t.ownLoc !== base.ownLoc || t.uiLoc !== base.uiLoc;
+}
+
 // Per-template thresholds (env-overridable). A template "regresses" when it
 // already existed on the baseline and grows past either limit. The LOC limit
 // applies to total footprint (own + /ui).
@@ -234,19 +240,25 @@ function regression(t, base) {
   return reasons.length ? reasons : null;
 }
 
-function report(baseJson, headJson, outMd, gateFile) {
+function report(baseJson, headJson, outMd, gateFile, commentFile) {
   const head = JSON.parse(readFileSync(headJson, "utf8"));
   const base =
     baseJson && existsSync(baseJson)
       ? JSON.parse(readFileSync(baseJson, "utf8"))
       : [];
   const baseByName = new Map(base.map((t) => [t.name, t]));
+  const headByName = new Map(head.map((t) => [t.name, t]));
+  const hasBaseline = base.length > 0;
 
   const regressions = [];
+  let hasAnyLocChange = base.some(
+    (t) => t.ownLoc != null && !headByName.has(t.name),
+  );
   const rows = head.map((t) => {
     const b = baseByName.get(t.name);
     const reasons = regression(t, b);
     if (reasons) regressions.push({ name: t.name, reasons });
+    if (hasLocChange(t, b, hasBaseline)) hasAnyLocChange = true;
     return [
       t.name,
       locCell(t.ownLoc, b?.ownLoc),
@@ -286,11 +298,14 @@ function report(baseJson, headJson, outMd, gateFile) {
 
   writeFileSync(outMd, lines.join("\n"));
   if (gateFile) writeFileSync(gateFile, regressions.length ? "fail" : "pass");
+  if (commentFile)
+    writeFileSync(commentFile, hasAnyLocChange ? "post" : "skip");
 }
 
 const [cmd, ...args] = process.argv.slice(2);
 if (cmd === "measure") measure(args[0], args[1]);
-else if (cmd === "report") report(args[0] || "", args[1], args[2], args[3]);
+else if (cmd === "report")
+  report(args[0] || "", args[1], args[2], args[3], args[4]);
 else {
   console.error("usage: template-metrics.mjs measure|report ...");
   process.exit(1);


### PR DESCRIPTION
Closes #4452.

Adds a CI job that measures each starter template's install footprint and posts it as a sticky PR comment, with a fail-on-regression gate.

- LOC per template via `git ls-files` (build output / node_modules excluded automatically)
- gzipped client JS from `next build` for a subset (`default`, `minimal`)
- baseline cached from the last `main` run; PRs diff against it
- gate fails a PR when a template grows past `MAX_LOC_INCREASE` (50) or `MAX_BUNDLE_INCREASE_KB` (10), both env-overridable

Files: `.github/workflows/template-metrics.yaml`, `scripts/template-metrics.mjs`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

