### PR TITLE
docs: add the adapter-orchestration convention to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,15 @@ Assume other coding agents are working alongside you. Before editing, check the 
 `@assistant-ui/ui` contains shadcn-style components that get copied into user projects. We use them directly in the monorepo to avoid duplication.
 
 There is an ongoing migration from the legacy runtime architecture to a tap-only architecture.
+
+## Adapter orchestration
+
+A framework adapter (`@assistant-ui/react-*`) maps a provider onto a core runtime through one `use<Name>Runtime` entry hook, accessor hooks in `hooks.ts`, and pure converters. The rule of thumb: the runtime file orchestrates, pure modules convert, the controller (if any) reduces, hooks read.
+
+- **Core runtime.** Build on `useExternalStoreRuntime` (messages derived from an external source) or `useLocalRuntime` plus a `ChatModelAdapter` (no provider-side thread state, like `react-data-stream`), and wrap it in `useRemoteThreadListRuntime` for multi-thread support.
+- **State exposure.** Expose runtime state to accessor hooks with `createRuntimeExtras` from `@assistant-ui/core/internal`, not a hand-rolled `Symbol` brand and guard.
+- **Standard files.** `use<Name>Runtime.ts` (orchestration only), `hooks.ts` (accessor and action hooks), a pure `convertMessages.ts` (both directions), and `types.ts`; add a `<Name>ThreadController.ts` plus a pure `reduce<Name>ThreadState` reducer when the adapter owns thread state, and a `./server` or `./node` subpath entry when the protocol owns the wire.
+- **Tests.** Colocate them beside each module, covering the converter both ways, the reducer or controller, and each accessor hook.
+- **Do not introduce.** A state holder named `*ThreadRuntimeCore`, a `notifyUpdate` plus version-counter re-render hack (bridge non-React state with `useSyncExternalStore`), `Object.create` method grafting, or monkeypatching the caller's objects. The legacy `react-a2a` and `react-ag-ui` predate this and are being migrated.
+
+Keep provider-driven choices flexible: the core-primitive choice, thin wrapper vs accumulator vs controller, bespoke transports, HITL richness, and thread-list depth. `@assistant-ui/react-langchain` is the reference for the external-store plus converter plus `createRuntimeExtras` shape.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ A big welcome and thank you for considering contributing to assistant-ui! It’s
 
 You can contribute by opening an issue, or by making a pull request. For large pull requests, we ask that you open an issue first to discuss the changes before submitting a pull request.
 
+Project conventions (architecture, package layout, changesets, and how to author a runtime adapter) live in [`AGENTS.md`](./AGENTS.md); please read and follow them.
+
 ### Setting up your environment
 
 You need to have Node.js installed on your computer. We develop with the latest LTS version of Node.js.


### PR DESCRIPTION
## what

documents the framework-adapter orchestration convention in `AGENTS.md`, and points `CONTRIBUTING.md` at `AGENTS.md` for project conventions (CONTRIBUTING stays generic).

the convention codifies the shared skeleton proven by #4466 (the `createRuntimeExtras` helper) and #4467 (react-langchain): one `use<Name>Runtime` entry hook that only orchestrates, accessor hooks in `hooks.ts` behind `createRuntimeExtras` from `@assistant-ui/core/internal`, pure converters, and a `useSyncExternalStore` controller where the adapter owns thread state. it also records what stays flexible (core-primitive choice, thin vs accumulator vs controller, transport, HITL richness, thread-list depth) so provider differences are not flattened.

## why

orchestration had diverged across the `react-*` adapters: file layout, where accessor hooks live, and a Symbol-branded `extras` side-channel reinvented in several packages. this is the written reference for bringing the remaining adapters (pi, google-adk, langgraph, ai-sdk, a2a, ag-ui) onto one shape.

## notes

- no changeset: `AGENTS.md` and `CONTRIBUTING.md` are root docs, not a published package.
- the "do not introduce" items are forward-framed; the legacy `react-a2a` / `react-ag-ui` predate the convention and are being migrated.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

