### PR TITLE
refactor(react-opencode): adopt createRuntimeExtras and split the runtime file

### DIFF
--- a/.changeset/opencode-runtime-extras.md
+++ b/.changeset/opencode-runtime-extras.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+refactor: adopt the shared createRuntimeExtras helper, move the accessor hooks into hooks.ts, extract the thread-list adapter, and trim unused internal type and SDK re-exports from the public barrel

--- a/packages/react-opencode/package.json
+++ b/packages/react-opencode/package.json
@@ -46,6 +46,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@assistant-ui/core": "^0.2.18",
+    "@assistant-ui/store": "^0.2.18",
     "@opencode-ai/sdk": "^1.17.6"
   },
   "peerDependencies": {

--- a/packages/react-opencode/src/hooks.test.tsx
+++ b/packages/react-opencode/src/hooks.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+const { extrasRef } = vi.hoisted(() => ({
+  extrasRef: { current: undefined as unknown },
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAuiState: ((selector: (s: unknown) => unknown) =>
+    selector({
+      thread: { extras: extrasRef.current },
+    })) as typeof import("@assistant-ui/store").useAuiState,
+}));
+
+import { openCodeExtras } from "./openCodeExtras";
+import { EMPTY_OPENCODE_THREAD_STATE } from "./openCodeThreadState";
+import {
+  useOpenCodePermissions,
+  useOpenCodeQuestions,
+  useOpenCodeSession,
+  useOpenCodeThreadState,
+} from "./hooks";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | undefined;
+
+const renderHookValue = <T,>(useHook: () => T): T => {
+  let captured!: T;
+  const Probe = () => {
+    captured = useHook();
+    return null;
+  };
+  const container = document.createElement("div");
+  root = createRoot(container);
+  act(() => {
+    root!.render(createElement(Probe));
+  });
+  return captured;
+};
+
+const provideExtras = (over: Record<string, unknown>) =>
+  openCodeExtras.provide({
+    session: null,
+    state: EMPTY_OPENCODE_THREAD_STATE,
+    permissions: {},
+    questions: {},
+    fork: async () => "",
+    revert: async () => {},
+    unrevert: async () => {},
+    cancel: async () => {},
+    refresh: async () => {},
+    replyToPermission: async () => {},
+    replyToQuestion: async () => {},
+    rejectQuestion: async () => {},
+    ...over,
+  } as Parameters<typeof openCodeExtras.provide>[0]);
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  extrasRef.current = undefined;
+});
+
+describe("react-opencode hooks", () => {
+  it("reads session and thread state from the runtime extras", () => {
+    const session = { id: "s1" };
+    const state = { ...EMPTY_OPENCODE_THREAD_STATE, sessionId: "s1" };
+    extrasRef.current = provideExtras({ session, state });
+
+    expect(renderHookValue(() => useOpenCodeSession())).toBe(session);
+    expect(renderHookValue(() => useOpenCodeThreadState())).toBe(state);
+    expect(
+      renderHookValue(() => useOpenCodeThreadState((s) => s.sessionId)),
+    ).toBe("s1");
+  });
+
+  it("falls back when no OpenCode runtime is active", () => {
+    extrasRef.current = undefined;
+
+    expect(renderHookValue(() => useOpenCodeSession())).toBeNull();
+    expect(renderHookValue(() => useOpenCodeThreadState())).toBe(
+      EMPTY_OPENCODE_THREAD_STATE,
+    );
+    expect(renderHookValue(() => useOpenCodePermissions()).pending).toEqual([]);
+    expect(renderHookValue(() => useOpenCodeQuestions())).toEqual([]);
+  });
+
+  it("projects pending permissions and questions to arrays", () => {
+    const permission = { id: "p1" };
+    const question = { id: "q1" };
+    extrasRef.current = provideExtras({
+      permissions: { p1: permission },
+      questions: { q1: question },
+    });
+
+    expect(renderHookValue(() => useOpenCodePermissions()).pending).toEqual([
+      permission,
+    ]);
+    expect(renderHookValue(() => useOpenCodeQuestions())).toEqual([question]);
+  });
+});

--- a/packages/react-opencode/src/hooks.ts
+++ b/packages/react-opencode/src/hooks.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useMemo } from "react";
+import { openCodeExtras } from "./openCodeExtras";
+import { EMPTY_OPENCODE_THREAD_STATE } from "./openCodeThreadState";
+import type { OpenCodeRuntimeExtras, OpenCodeThreadState } from "./types";
+
+/** Read the full OpenCode runtime extras. Throws outside an OpenCode runtime. */
+export const useOpenCodeRuntimeExtras = (): OpenCodeRuntimeExtras =>
+  openCodeExtras.use();
+
+/** Read the active OpenCode session, or `null` when none is attached. */
+export const useOpenCodeSession = () =>
+  openCodeExtras.use((e) => e.session, null);
+
+/** Read the OpenCode thread state, optionally projected through a selector. */
+export function useOpenCodeThreadState(): OpenCodeThreadState;
+export function useOpenCodeThreadState<T>(
+  selector: (state: OpenCodeThreadState) => T,
+): T;
+export function useOpenCodeThreadState<T>(
+  selector?: (state: OpenCodeThreadState) => T,
+) {
+  return openCodeExtras.use(
+    (e) => (selector ? selector(e.state) : e.state),
+    selector
+      ? selector(EMPTY_OPENCODE_THREAD_STATE)
+      : EMPTY_OPENCODE_THREAD_STATE,
+  );
+}
+
+/** Pending permission requests plus a reply action. */
+export const useOpenCodePermissions = () => {
+  const extras = openCodeExtras.use((e) => e, undefined);
+
+  return useMemo(
+    () => ({
+      pending: extras
+        ? (Object.values(extras.permissions) as Array<
+            OpenCodeRuntimeExtras["permissions"][string]
+          >)
+        : [],
+      reply:
+        extras?.replyToPermission ??
+        (async () => {
+          throw new Error("OpenCode runtime is not ready yet");
+        }),
+    }),
+    [extras],
+  );
+};
+
+/** Pending question requests. */
+export const useOpenCodeQuestions = () => {
+  const extras = openCodeExtras.use((e) => e, undefined);
+
+  return useMemo(
+    () =>
+      extras
+        ? (Object.values(extras.questions) as Array<
+            OpenCodeRuntimeExtras["questions"][string]
+          >)
+        : [],
+    [extras],
+  );
+};

--- a/packages/react-opencode/src/index.ts
+++ b/packages/react-opencode/src/index.ts
@@ -12,7 +12,10 @@ export { useOpenCodeStreamingTiming } from "./useOpenCodeStreamingTiming";
 
 // Lower-level building blocks, deliberately public as advanced API and
 // documented in the docs site's OpenCode "lower-level building blocks" table.
-export { OpenCodeEventSource } from "./OpenCodeEventSource";
+export {
+  OpenCodeEventSource,
+  STREAM_RECONNECTED_EVENT_TYPE,
+} from "./OpenCodeEventSource";
 export { OpenCodeThreadController } from "./OpenCodeThreadController";
 export {
   createOpenCodeThreadState,

--- a/packages/react-opencode/src/index.ts
+++ b/packages/react-opencode/src/index.ts
@@ -1,18 +1,18 @@
+export { useOpenCodeRuntime } from "./useOpenCodeRuntime";
+
 export {
   useOpenCodePermissions,
   useOpenCodeQuestions,
-  useOpenCodeRuntime,
   useOpenCodeRuntimeExtras,
   useOpenCodeSession,
   useOpenCodeThreadState,
-} from "./useOpenCodeRuntime";
+} from "./hooks";
 
 export { useOpenCodeStreamingTiming } from "./useOpenCodeStreamingTiming";
 
-export {
-  OpenCodeEventSource,
-  STREAM_RECONNECTED_EVENT_TYPE,
-} from "./OpenCodeEventSource";
+// Lower-level building blocks, deliberately public as advanced API and
+// documented in the docs site's OpenCode "lower-level building blocks" table.
+export { OpenCodeEventSource } from "./OpenCodeEventSource";
 export { OpenCodeThreadController } from "./OpenCodeThreadController";
 export {
   createOpenCodeThreadState,
@@ -21,53 +21,14 @@ export {
 export { projectOpenCodeThreadMessages } from "./openCodeMessageProjection";
 
 export type {
-  MessageWithParts,
-  OpenCodeLoadState,
-  OpenCodePartPayload,
   OpenCodePermissionRequest,
   OpenCodePermissionResponse,
-  OpenCodeProjectedThreadMessage,
   OpenCodeQuestionRequest,
-  OpenCodeRunState,
   OpenCodeRuntime,
   OpenCodeRuntimeExtras,
   OpenCodeRuntimeOptions,
-  OpenCodeServerEvent,
-  OpenCodeServerMessage,
-  OpenCodeStateEvent,
-  OpenCodeThreadControllerLike,
-  OpenCodeThreadControllerSnapshot,
   OpenCodeThreadState,
-  OpenCodeThreadStateSelector,
-  OpenCodeUnhandledEvent,
-  OpenCodeUserMessageOptions,
-  PendingUserMessage,
-} from "./types";
-
-export type {
-  AssistantMessage,
-  Event,
-  FilePart,
-  GlobalSession,
-  Message,
-  Model,
-  OpencodeClient,
-  OpencodeClientConfig,
-  Part,
-  PermissionRequest,
-  Provider,
   QuestionAnswer,
-  QuestionRequest,
-  ReasoningPart,
-  Session,
-  SessionStatus,
-  SnapshotPart,
-  StepFinishPart,
-  StepStartPart,
-  TextPart,
-  ToolPart,
-  ToolState,
-  UserMessage,
 } from "./types";
 
 export { createOpencodeClient } from "@opencode-ai/sdk/v2/client";

--- a/packages/react-opencode/src/openCodeExtras.ts
+++ b/packages/react-opencode/src/openCodeExtras.ts
@@ -1,0 +1,5 @@
+import { createRuntimeExtras } from "@assistant-ui/core/internal";
+import type { OpenCodeRuntimeExtras } from "./types";
+
+export const openCodeExtras =
+  createRuntimeExtras<OpenCodeRuntimeExtras>("useOpenCodeRuntime");

--- a/packages/react-opencode/src/openCodeThreadListAdapter.ts
+++ b/packages/react-opencode/src/openCodeThreadListAdapter.ts
@@ -1,0 +1,98 @@
+import {
+  createOpencodeClient,
+  type GlobalSession,
+} from "@opencode-ai/sdk/v2/client";
+
+const isArchivedSession = (session: Pick<GlobalSession, "time">) => {
+  return typeof session.time.archived === "number";
+};
+
+const mapThreadMetadata = (session: {
+  id: string;
+  title: string;
+  time: { archived?: number };
+}) => ({
+  status: isArchivedSession(session as GlobalSession)
+    ? ("archived" as const)
+    : ("regular" as const),
+  remoteId: session.id,
+  externalId: session.id,
+  title: session.title,
+});
+
+export const createOpenCodeThreadListAdapter = (
+  client: ReturnType<typeof createOpencodeClient>,
+) => ({
+  list: async () => {
+    const response = await client.experimental.session.list({
+      roots: true,
+      archived: true,
+    });
+    const sessions = new Map<string, GlobalSession>();
+
+    for (const session of response.data ?? []) {
+      if (session.parentID) continue;
+      sessions.set(session.id, session);
+    }
+
+    return {
+      threads: [...sessions.values()].map(mapThreadMetadata),
+    };
+  },
+  rename: async (remoteId: string, newTitle: string) => {
+    await client.session.update({
+      sessionID: remoteId,
+      title: newTitle,
+    });
+  },
+  archive: async (remoteId: string) => {
+    await client.session.update({
+      sessionID: remoteId,
+      time: { archived: Date.now() },
+    });
+  },
+  unarchive: async (remoteId: string) => {
+    await client.session.update({
+      sessionID: remoteId,
+      // The SDK models archived timestamps as numbers, but OpenCode uses
+      // `null` here to clear the archived flag when unarchiving.
+      time: { archived: null as never } as never,
+    });
+  },
+  delete: async (remoteId: string) => {
+    await client.session.delete({
+      sessionID: remoteId,
+    });
+  },
+  initialize: async () => {
+    const response = await client.session.create({});
+    if (!response.data?.id) {
+      throw new Error("Failed to create OpenCode session");
+    }
+    return {
+      remoteId: response.data.id,
+      externalId: response.data.id,
+    };
+  },
+  generateTitle: async (remoteId: string) => {
+    await client.session.summarize({
+      sessionID: remoteId,
+    });
+    // Title updates arrive through the OpenCode event stream, so this
+    // placeholder stream only satisfies the remote thread list contract.
+    return new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }) as never;
+  },
+  fetch: async (threadId: string) => {
+    const response = await client.session.get({
+      sessionID: threadId,
+    });
+    if (!response.data?.id) {
+      throw new Error("OpenCode session not found");
+    }
+    return mapThreadMetadata(response.data as GlobalSession);
+  },
+});

--- a/packages/react-opencode/src/openCodeThreadState.ts
+++ b/packages/react-opencode/src/openCodeThreadState.ts
@@ -687,3 +687,7 @@ export const reduceOpenCodeThreadState = (
     }
   }
 };
+
+/** Stable placeholder state used before a session controller is attached. */
+export const EMPTY_OPENCODE_THREAD_STATE =
+  createOpenCodeThreadState("__pending__");

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -7,14 +7,14 @@ import {
   useExternalStoreRuntime,
   useRemoteThreadListRuntime,
 } from "@assistant-ui/react";
-import type { AssistantRuntime, ThreadMessage } from "@assistant-ui/react";
-import {
-  createOpencodeClient,
-  type GlobalSession,
-} from "@opencode-ai/sdk/v2/client";
+import type {
+  AppendMessage,
+  AssistantRuntime,
+  ThreadMessage,
+} from "@assistant-ui/react";
+import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 import { useEffect, useEffectEvent, useMemo } from "react";
 import type {
-  OpenCodeRuntimeExtras,
   OpenCodeRuntimeOptions,
   OpenCodeThreadControllerLike,
   OpenCodeThreadState,
@@ -22,7 +22,9 @@ import type {
 import { OpenCodeEventSource } from "./OpenCodeEventSource";
 import { OpenCodeThreadController } from "./OpenCodeThreadController";
 import { projectOpenCodeThreadRepository } from "./openCodeMessageProjection";
-import { createOpenCodeThreadState } from "./openCodeThreadState";
+import { EMPTY_OPENCODE_THREAD_STATE } from "./openCodeThreadState";
+import { openCodeExtras } from "./openCodeExtras";
+import { createOpenCodeThreadListAdapter } from "./openCodeThreadListAdapter";
 import { useOpenCodeControllerState } from "./useOpenCodeControllerState";
 import { useOpenCodeStreamingTiming } from "./useOpenCodeStreamingTiming";
 
@@ -31,38 +33,6 @@ type OpenCodeControllerRegistry = {
   controllers: Map<string, OpenCodeThreadController>;
   dispose(): void;
 };
-
-const symbolOpenCodeRuntimeExtras = Symbol("opencode-runtime-extras");
-
-type OpenCodeRuntimeExtrasInternal = OpenCodeRuntimeExtras & {
-  [symbolOpenCodeRuntimeExtras]: true;
-};
-
-const isOpenCodeRuntimeExtras = (
-  extras: unknown,
-): extras is OpenCodeRuntimeExtrasInternal => {
-  return (
-    typeof extras === "object" &&
-    extras != null &&
-    symbolOpenCodeRuntimeExtras in extras
-  );
-};
-
-const asOpenCodeRuntimeExtras = (extras: unknown) => {
-  if (!isOpenCodeRuntimeExtras(extras)) {
-    throw new Error(
-      "This hook can only be used inside an OpenCode runtime context",
-    );
-  }
-
-  return extras;
-};
-
-const tryGetOpenCodeRuntimeExtras = (extras: unknown) => {
-  return isOpenCodeRuntimeExtras(extras) ? extras : undefined;
-};
-
-const EMPTY_THREAD_STATE = createOpenCodeThreadState("__pending__");
 
 const createRegistry = (
   client: ReturnType<typeof createOpencodeClient>,
@@ -108,7 +78,7 @@ const getController = (
 };
 
 const NOOP_CONTROLLER: OpenCodeThreadControllerLike = {
-  getState: () => EMPTY_THREAD_STATE,
+  getState: () => EMPTY_OPENCODE_THREAD_STATE,
   subscribe: () => () => {},
   load: async () => {},
   refresh: async () => {},
@@ -157,8 +127,7 @@ const useOpenCodeThreadRuntime = (
 
   const extras = useMemo(
     () =>
-      ({
-        [symbolOpenCodeRuntimeExtras]: true,
+      openCodeExtras.provide({
         session: state.session,
         state,
         permissions: state.interactions.permissions.pending,
@@ -178,7 +147,7 @@ const useOpenCodeThreadRuntime = (
         ) => controller.replyToQuestion(questionId, answers),
         rejectQuestion: (questionId: string) =>
           controller.rejectQuestion(questionId),
-      }) satisfies OpenCodeRuntimeExtrasInternal,
+      }),
     [controller, state],
   );
 
@@ -189,7 +158,7 @@ const useOpenCodeThreadRuntime = (
     messageRepository,
     extras,
     ...(options.adapters && { adapters: options.adapters }),
-    onNew: async (message: any) => {
+    onNew: async (message: AppendMessage) => {
       try {
         const sendOptions = {
           model: options.defaultModel,
@@ -227,8 +196,7 @@ const useRuntimeHook = (
   options: OpenCodeRuntimeOptions,
 ) => {
   const sessionId = useAuiState(
-    (state: any) =>
-      state.threadListItem.externalId ?? state.threadListItem.remoteId,
+    (state) => state.threadListItem.externalId ?? state.threadListItem.remoteId,
   );
 
   const controller = sessionId
@@ -248,23 +216,6 @@ const useRuntimeHook = (
   return threadRuntime;
 };
 
-const isArchivedSession = (session: Pick<GlobalSession, "time">) => {
-  return typeof session.time.archived === "number";
-};
-
-const mapThreadMetadata = (session: {
-  id: string;
-  title: string;
-  time: { archived?: number };
-}) => ({
-  status: isArchivedSession(session as GlobalSession)
-    ? ("archived" as const)
-    : ("regular" as const),
-  remoteId: session.id,
-  externalId: session.id,
-  title: session.title,
-});
-
 export const useOpenCodeRuntime = (
   options: OpenCodeRuntimeOptions = {},
 ): AssistantRuntime => {
@@ -282,80 +233,7 @@ export const useOpenCodeRuntime = (
   }, [registry]);
 
   const adapter = useMemo(
-    () => ({
-      list: async () => {
-        const response = await client.experimental.session.list({
-          roots: true,
-          archived: true,
-        });
-        const sessions = new Map<string, GlobalSession>();
-
-        for (const session of response.data ?? []) {
-          if (session.parentID) continue;
-          sessions.set(session.id, session);
-        }
-
-        return {
-          threads: [...sessions.values()].map(mapThreadMetadata),
-        };
-      },
-      rename: async (remoteId: string, newTitle: string) => {
-        await client.session.update({
-          sessionID: remoteId,
-          title: newTitle,
-        });
-      },
-      archive: async (remoteId: string) => {
-        await client.session.update({
-          sessionID: remoteId,
-          time: { archived: Date.now() },
-        });
-      },
-      unarchive: async (remoteId: string) => {
-        await client.session.update({
-          sessionID: remoteId,
-          // The SDK models archived timestamps as numbers, but OpenCode uses
-          // `null` here to clear the archived flag when unarchiving.
-          time: { archived: null as never } as never,
-        });
-      },
-      delete: async (remoteId: string) => {
-        await client.session.delete({
-          sessionID: remoteId,
-        });
-      },
-      initialize: async () => {
-        const response = await client.session.create({});
-        if (!response.data?.id) {
-          throw new Error("Failed to create OpenCode session");
-        }
-        return {
-          remoteId: response.data.id,
-          externalId: response.data.id,
-        };
-      },
-      generateTitle: async (remoteId: string) => {
-        await client.session.summarize({
-          sessionID: remoteId,
-        });
-        // Title updates arrive through the OpenCode event stream, so this
-        // placeholder stream only satisfies the remote thread list contract.
-        return new ReadableStream({
-          start(controller) {
-            controller.close();
-          },
-        }) as never;
-      },
-      fetch: async (threadId: string) => {
-        const response = await client.session.get({
-          sessionID: threadId,
-        });
-        if (!response.data?.id) {
-          throw new Error("OpenCode session not found");
-        }
-        return mapThreadMetadata(response.data as GlobalSession);
-      },
-    }),
+    () => createOpenCodeThreadListAdapter(client),
     [client],
   );
 
@@ -366,68 +244,4 @@ export const useOpenCodeRuntime = (
     // oxlint-disable-next-line react-hooks/rules-of-hooks -- runtimeHook callback is invoked by useRemoteThreadListRuntime at the appropriate hook position
     runtimeHook: () => useRuntimeHook(client, registry, options),
   });
-};
-
-export const useOpenCodeRuntimeExtras = (): OpenCodeRuntimeExtras => {
-  return useAuiState((state: any) =>
-    asOpenCodeRuntimeExtras(state.thread.extras),
-  );
-};
-
-export const useOpenCodeSession = () => {
-  return useAuiState((state: any) => {
-    return tryGetOpenCodeRuntimeExtras(state.thread.extras)?.session ?? null;
-  });
-};
-
-export function useOpenCodeThreadState(): OpenCodeThreadState;
-export function useOpenCodeThreadState<T>(
-  selector: (state: OpenCodeThreadState) => T,
-): T;
-export function useOpenCodeThreadState<T>(
-  selector?: (state: OpenCodeThreadState) => T,
-) {
-  return useAuiState((state: any) => {
-    const extras = tryGetOpenCodeRuntimeExtras(state.thread.extras);
-    const threadState = extras?.state ?? EMPTY_THREAD_STATE;
-    return selector ? selector(threadState) : threadState;
-  });
-}
-
-export const useOpenCodePermissions = () => {
-  const extras = useAuiState((state: any) =>
-    tryGetOpenCodeRuntimeExtras(state.thread.extras),
-  );
-
-  return useMemo(
-    () => ({
-      pending: extras
-        ? (Object.values(extras.permissions) as Array<
-            OpenCodeRuntimeExtras["permissions"][string]
-          >)
-        : [],
-      reply:
-        extras?.replyToPermission ??
-        (async () => {
-          throw new Error("OpenCode runtime is not ready yet");
-        }),
-    }),
-    [extras],
-  );
-};
-
-export const useOpenCodeQuestions = () => {
-  const extras = useAuiState((state: any) =>
-    tryGetOpenCodeRuntimeExtras(state.thread.extras),
-  );
-
-  return useMemo(
-    () =>
-      extras
-        ? (Object.values(extras.questions) as Array<
-            OpenCodeRuntimeExtras["questions"][string]
-          >)
-        : [],
-    [extras],
-  );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4143,6 +4143,12 @@ importers:
 
   packages/react-opencode:
     dependencies:
+      '@assistant-ui/core':
+        specifier: ^0.2.18
+        version: link:../core
+      '@assistant-ui/store':
+        specifier: ^0.2.18
+        version: link:../store
       '@opencode-ai/sdk':
         specifier: ^1.17.6
         version: 1.17.6


### PR DESCRIPTION
## what

brings `react-opencode` onto the adapter-orchestration convention (the third package after react-langchain), with no behavior change.

- adopts the shared `createRuntimeExtras` helper from `@assistant-ui/core/internal`, replacing the hand-rolled `Symbol` brand + `asOpenCodeRuntimeExtras` guard.
- moves the five accessor hooks (`useOpenCodeRuntimeExtras` / `Session` / `ThreadState` / `Permissions` / `Questions`) into `hooks.ts`.
- extracts the remote-thread-list adapter into `openCodeThreadListAdapter.ts`, leaving `useOpenCodeRuntime.ts` to orchestrate only.
- types the previously-`any` core-state selectors and the `onNew` callback.
- trims the public barrel of internal type aliases and `@opencode-ai/sdk` re-exports that have no consumer.

## what's deliberately unchanged

the pure reducer (`openCodeThreadState.ts`), the projection (`openCodeMessageProjection.ts`), the `OpenCodeThreadController`, and the `useSyncExternalStore` bridge already matched the convention. the documented "lower-level building blocks" (`OpenCodeThreadController`, the reducer/factory, `projectOpenCodeThreadMessages`, `OpenCodeEventSource`) stay exported, since the docs site documents them as advanced public API.

## notes

- adds `@assistant-ui/core` + `@assistant-ui/store` as dependencies (needed for `@assistant-ui/core/internal`; `@assistant-ui/react` does not re-export it).
- the barrel trim only removes internal type aliases and SDK type pass-throughs with zero in-repo consumer (verified across `examples/` + `apps/docs`); all public hooks and types are kept.

## test plan

- full react-opencode suite green (44 tests, including a new `hooks.test.tsx`), tsc clean, oxlint clean, builds clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

