### PR TITLE
fix(react-opencode): restore the type exports trimmed in #4470

### DIFF
--- a/.changeset/opencode-restore-exports.md
+++ b/.changeset/opencode-restore-exports.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix: restore the type exports that the previous refactor trimmed from the public barrel; removing a shipped export is a breaking change for npm consumers, even when no in-repo consumer imports it

--- a/packages/react-opencode/src/index.ts
+++ b/packages/react-opencode/src/index.ts
@@ -24,14 +24,53 @@ export {
 export { projectOpenCodeThreadMessages } from "./openCodeMessageProjection";
 
 export type {
+  MessageWithParts,
+  OpenCodeLoadState,
+  OpenCodePartPayload,
   OpenCodePermissionRequest,
   OpenCodePermissionResponse,
+  OpenCodeProjectedThreadMessage,
   OpenCodeQuestionRequest,
+  OpenCodeRunState,
   OpenCodeRuntime,
   OpenCodeRuntimeExtras,
   OpenCodeRuntimeOptions,
+  OpenCodeServerEvent,
+  OpenCodeServerMessage,
+  OpenCodeStateEvent,
+  OpenCodeThreadControllerLike,
+  OpenCodeThreadControllerSnapshot,
   OpenCodeThreadState,
+  OpenCodeThreadStateSelector,
+  OpenCodeUnhandledEvent,
+  OpenCodeUserMessageOptions,
+  PendingUserMessage,
+} from "./types";
+
+export type {
+  AssistantMessage,
+  Event,
+  FilePart,
+  GlobalSession,
+  Message,
+  Model,
+  OpencodeClient,
+  OpencodeClientConfig,
+  Part,
+  PermissionRequest,
+  Provider,
   QuestionAnswer,
+  QuestionRequest,
+  ReasoningPart,
+  Session,
+  SessionStatus,
+  SnapshotPart,
+  StepFinishPart,
+  StepStartPart,
+  TextPart,
+  ToolPart,
+  ToolState,
+  UserMessage,
 } from "./types";
 
 export { createOpencodeClient } from "@opencode-ai/sdk/v2/client";


### PR DESCRIPTION
## what

restores the type exports that #4470 removed from `@assistant-ui/react-opencode`'s public barrel.

#4470 trimmed internal type aliases (`OpenCodeServerEvent`, `OpenCodeThreadControllerLike`, etc.) and the `@opencode-ai/sdk` type re-exports (`Part`, `Session`, etc.) based on an in-repo consumer audit that found no importer. but the audit can only see this monorepo: removing a shipped public export is a breaking change for external npm consumers who may import those types. this re-adds the full original type-export surface.

## scope

- only `index.ts` changes; it now re-exports the same symbol set as before #4470 (verified name-by-name against the pre-#4470 barrel).
- the valuable parts of #4470 (the file decomposition into `hooks.ts`, the `createRuntimeExtras` adoption, the typed selectors) are unchanged.

## why this is a fix

going forward, `AGENTS.md`'s new "Public surface" guardrail codifies this: the barrel is append-only for a published package; never remove a shipped export.

## test plan

- tsc clean, builds clean (the restored types are still defined in `types.ts`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

