### PR TITLE
refactor(react-a2a): adopt createRuntimeExtras and split accessor hooks/types

### DIFF
--- a/.changeset/a2a-runtime-extras.md
+++ b/.changeset/a2a-runtime-extras.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+refactor: adopt the shared createRuntimeExtras helper and move the accessor hooks and option/extras types into hooks.ts and types.ts, with no public API or behavior change

--- a/packages/react-a2a/src/a2aExtras.ts
+++ b/packages/react-a2a/src/a2aExtras.ts
@@ -1,0 +1,4 @@
+import { createRuntimeExtras } from "@assistant-ui/core/internal";
+import type { A2AExtras } from "./types";
+
+export const a2aExtras = createRuntimeExtras<A2AExtras>("useA2ARuntime");

--- a/packages/react-a2a/src/hooks.ts
+++ b/packages/react-a2a/src/hooks.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { a2aExtras } from "./a2aExtras";
+
+/** The current A2A task, if a run is in progress. */
+export const useA2ATask = () => a2aExtras.use((e) => e.task);
+
+/** The artifacts accumulated for the current A2A run. */
+export const useA2AArtifacts = () => a2aExtras.use((e) => e.artifacts);
+
+/** The discovered A2A agent card. */
+export const useA2AAgentCard = () => a2aExtras.use((e) => e.agentCard);

--- a/packages/react-a2a/src/index.ts
+++ b/packages/react-a2a/src/index.ts
@@ -1,14 +1,7 @@
 // Main hook
-export {
-  useA2ARuntime,
-  useA2ATask,
-  useA2AArtifacts,
-  useA2AAgentCard,
-} from "./useA2ARuntime";
-export type {
-  UseA2ARuntimeOptions,
-  UseA2AThreadListAdapter,
-} from "./useA2ARuntime";
+export { useA2ARuntime } from "./useA2ARuntime";
+export { useA2ATask, useA2AArtifacts, useA2AAgentCard } from "./hooks";
+export type { UseA2ARuntimeOptions, UseA2AThreadListAdapter } from "./types";
 
 // Client
 export { A2AClient, A2AError } from "./A2AClient";

--- a/packages/react-a2a/src/types.ts
+++ b/packages/react-a2a/src/types.ts
@@ -2,6 +2,18 @@
 // Enum values use lowercase internally; normalized from ProtoJSON SCREAMING_SNAKE_CASE on read.
 // Wire format uses ROLE_USER/ROLE_AGENT and TASK_STATE_* per ADR-001.
 
+import type {
+  AttachmentAdapter,
+  DictationAdapter,
+  ExternalStoreSharedOptions,
+  FeedbackAdapter,
+  RealtimeVoiceAdapter,
+  SpeechSynthesisAdapter,
+  ThreadHistoryAdapter,
+  ThreadMessage,
+} from "@assistant-ui/core";
+import type { A2AClient, A2AClientOptions } from "./A2AClient";
+
 export const A2A_PROTOCOL_VERSION = "1.0";
 
 export type A2ARole = "unspecified" | "user" | "agent";
@@ -280,4 +292,58 @@ export type A2AAgentCard = {
   skills: A2AAgentSkill[];
   signatures?: A2AAgentCardSignature[] | undefined;
   iconUrl?: string | undefined;
+};
+
+/** Private state `useA2ARuntime` exposes through `thread.extras`. */
+export type A2AExtras = {
+  task: A2ATask | undefined;
+  artifacts: readonly A2AArtifact[];
+  agentCard: A2AAgentCard | undefined;
+};
+
+export type UseA2AThreadListAdapter = {
+  threadId?: string;
+  onSwitchToNewThread?: () => Promise<void> | void;
+  onSwitchToThread?: (threadId: string) => Promise<{
+    messages: readonly ThreadMessage[];
+  }>;
+};
+
+export type UseA2ARuntimeOptions = ExternalStoreSharedOptions & {
+  /** Pre-built A2A client instance. Provide this OR baseUrl. */
+  client?: A2AClient;
+  /** Base URL of the A2A server. Used to create a client if `client` is not provided. */
+  baseUrl?: string;
+  /** Optional path prefix for all API endpoints (e.g. "/v1"). Does not affect agent card discovery. Only used with baseUrl. */
+  basePath?: string;
+  /** Optional tenant ID for multi-tenant servers. Only used with baseUrl. */
+  tenant?: string;
+  /** Headers for the A2A client (only used with baseUrl). */
+  headers?: A2AClientOptions["headers"];
+  /** A2A extension URIs to negotiate. Only used with baseUrl. */
+  extensions?: string[];
+  /** Extra fetch options (e.g. `{ credentials: 'include' }`). Only used with `baseUrl`. */
+  fetchOptions?: A2AClientOptions["fetchOptions"];
+
+  /** Initial context ID for the conversation. */
+  contextId?: string;
+  /** Default send message configuration. */
+  configuration?: A2ASendMessageConfiguration;
+
+  /** Called when an error occurs. */
+  onError?: (error: Error) => void;
+  /** Called when a run is cancelled. */
+  onCancel?: () => void;
+  /** Called when an artifact is fully received (lastChunk). */
+  onArtifactComplete?: (artifact: A2AArtifact) => void;
+
+  adapters?: {
+    attachments?: AttachmentAdapter;
+    speech?: SpeechSynthesisAdapter;
+    dictation?: DictationAdapter;
+    voice?: RealtimeVoiceAdapter;
+    feedback?: FeedbackAdapter;
+    history?: ThreadHistoryAdapter;
+    threadList?: UseA2AThreadListAdapter;
+  };
 };

--- a/packages/react-a2a/src/useA2ARuntime.ts
+++ b/packages/react-a2a/src/useA2ARuntime.ts
@@ -9,116 +9,13 @@ import {
 import type {
   AssistantRuntime,
   AppendMessage,
-  AttachmentAdapter,
-  DictationAdapter,
   ExternalStoreAdapter,
-  ExternalStoreSharedOptions,
-  FeedbackAdapter,
-  RealtimeVoiceAdapter,
-  SpeechSynthesisAdapter,
-  ThreadHistoryAdapter,
   ThreadMessage,
 } from "@assistant-ui/core";
-import { useAuiState } from "@assistant-ui/store";
 import { A2AClient } from "./A2AClient";
-import type { A2AClientOptions } from "./A2AClient";
 import { A2AThreadRuntimeCore } from "./A2AThreadRuntimeCore";
-import type {
-  A2AArtifact,
-  A2AAgentCard,
-  A2ASendMessageConfiguration,
-  A2ATask,
-} from "./types";
-
-// --- Extras symbol for A2A-specific state ---
-
-const symbolA2AExtras = Symbol("a2a-extras");
-
-type A2AExtras = {
-  [symbolA2AExtras]: true;
-  task: A2ATask | undefined;
-  artifacts: readonly A2AArtifact[];
-  agentCard: A2AAgentCard | undefined;
-};
-
-const asA2AExtras = (extras: unknown): A2AExtras => {
-  if (
-    typeof extras !== "object" ||
-    extras == null ||
-    !(symbolA2AExtras in extras)
-  )
-    throw new Error(
-      "This hook can only be used inside a useA2ARuntime provider",
-    );
-  return extras as A2AExtras;
-};
-
-// --- Public hooks for A2A state ---
-
-export const useA2ATask = () => {
-  return useAuiState((s) => asA2AExtras(s.thread.extras).task);
-};
-
-export const useA2AArtifacts = () => {
-  return useAuiState((s) => asA2AExtras(s.thread.extras).artifacts);
-};
-
-export const useA2AAgentCard = () => {
-  return useAuiState((s) => asA2AExtras(s.thread.extras).agentCard);
-};
-
-// --- Thread list adapter type ---
-
-export type UseA2AThreadListAdapter = {
-  threadId?: string;
-  onSwitchToNewThread?: () => Promise<void> | void;
-  onSwitchToThread?: (threadId: string) => Promise<{
-    messages: readonly ThreadMessage[];
-  }>;
-};
-
-// --- Options ---
-
-export type UseA2ARuntimeOptions = ExternalStoreSharedOptions & {
-  /** Pre-built A2A client instance. Provide this OR baseUrl. */
-  client?: A2AClient;
-  /** Base URL of the A2A server. Used to create a client if `client` is not provided. */
-  baseUrl?: string;
-  /** Optional path prefix for all API endpoints (e.g. "/v1"). Does not affect agent card discovery. Only used with baseUrl. */
-  basePath?: string;
-  /** Optional tenant ID for multi-tenant servers. Only used with baseUrl. */
-  tenant?: string;
-  /** Headers for the A2A client (only used with baseUrl). */
-  headers?: A2AClientOptions["headers"];
-  /** A2A extension URIs to negotiate. Only used with baseUrl. */
-  extensions?: string[];
-  /** Extra fetch options (e.g. `{ credentials: 'include' }`). Only used with `baseUrl`. */
-  fetchOptions?: A2AClientOptions["fetchOptions"];
-
-  /** Initial context ID for the conversation. */
-  contextId?: string;
-  /** Default send message configuration. */
-  configuration?: A2ASendMessageConfiguration;
-
-  /** Called when an error occurs. */
-  onError?: (error: Error) => void;
-  /** Called when a run is cancelled. */
-  onCancel?: () => void;
-  /** Called when an artifact is fully received (lastChunk). */
-  onArtifactComplete?: (artifact: import("./types").A2AArtifact) => void;
-
-  adapters?: {
-    attachments?: AttachmentAdapter;
-    speech?: SpeechSynthesisAdapter;
-    dictation?: DictationAdapter;
-    voice?: RealtimeVoiceAdapter;
-    feedback?: FeedbackAdapter;
-    history?: ThreadHistoryAdapter;
-    threadList?: UseA2AThreadListAdapter;
-  };
-};
-
-// --- Main hook ---
+import { a2aExtras } from "./a2aExtras";
+import type { UseA2ARuntimeOptions } from "./types";
 
 export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
   const [_version, setVersion] = useState(0);
@@ -224,12 +121,11 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
       isLoading: core.isLoading,
       messages: core.getMessages(),
       isRunning: core.isRunning(),
-      extras: {
-        [symbolA2AExtras]: true,
+      extras: a2aExtras.provide({
         task: core.getTask(),
         artifacts: core.getArtifacts(),
         agentCard: core.getAgentCard(),
-      } satisfies A2AExtras,
+      }),
       onNew: (message: AppendMessage) => core.append(message),
       onEdit: (message: AppendMessage) => core.edit(message),
       onReload: (parentId: string | null) => core.reload(parentId),


### PR DESCRIPTION
## what

brings `react-a2a` onto the `createRuntimeExtras` + file-layout parts of the adapter convention, with no public API or behavior change.

- adopts `createRuntimeExtras` from `@assistant-ui/core/internal`, replacing the hand-rolled `symbolA2AExtras` brand + `asA2AExtras` guard.
- moves the three accessor hooks (`useA2ATask` / `useA2AArtifacts` / `useA2AAgentCard`) into `hooks.ts`.
- moves `UseA2ARuntimeOptions` / `UseA2AThreadListAdapter` / `A2AExtras` into `types.ts`.

## deliberately deferred (separate PR)

the `A2AThreadRuntimeCore` controller is **untouched** here. its rename to `A2AThreadController` and the `notifyUpdate` + `void _version` to `useSyncExternalStore` reactivity rewrite are a behavior-changing follow-up: the controller has no `subscribe()` / `getState()` surface today (unlike react-opencode / react-pi, this is not a free conversion), the deliberate no-notify-on-content-update ordering invariant must be preserved exactly, and the current suite does not assert re-render timing (`notifyUpdate` is an un-asserted mock; there is no `renderHook` test). that follow-up will add the missing render/snapshot-stability tests first, and the converter dedup (`threadMessageToA2AMessage` delegating to the exported `contentPartsToA2AParts`) rides along with it since it also touches the controller.

## preserved exactly

- the public barrel re-exports the same 51 symbols as before (verified name-by-name); nothing removed, the accessors and option types are only re-pointed to their new files.
- the controller, `A2AClient`, the conversions, the single-run thread-list fork, and `__internal_load` are unchanged.

## test plan

- full react-a2a suite green (3 files, 119 tests), tsc clean, oxlint clean, builds clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

