### PR TITLE
refactor(react-pi): adopt createRuntimeExtras and split accessor hooks/types

### DIFF
--- a/.changeset/pi-runtime-extras.md
+++ b/.changeset/pi-runtime-extras.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+refactor: adopt the shared createRuntimeExtras helper and split the accessor hooks and runtime types into hooks.ts and runtimeTypes.ts, with no public API or behavior change

--- a/packages/react-pi/package.json
+++ b/packages/react-pi/package.json
@@ -52,6 +52,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@assistant-ui/core": "^0.2.18",
+    "@assistant-ui/store": "^0.2.18",
     "use-effect-event": "^2.0.3"
   },
   "peerDependencies": {

--- a/packages/react-pi/src/index.ts
+++ b/packages/react-pi/src/index.ts
@@ -39,14 +39,14 @@ export type {
   PiSendOptions,
 } from "./runtime/ThreadController";
 
+export { usePiRuntime } from "./runtime/usePiRuntime";
 export {
-  usePiRuntime,
   usePiRuntimeExtras,
   usePiSession,
   usePiThreadState,
   usePiHostUiRequests,
-} from "./runtime/usePiRuntime";
-export type { PiRuntimeOptions, PiRuntimeExtras } from "./runtime/usePiRuntime";
+} from "./runtime/hooks";
+export type { PiRuntimeOptions, PiRuntimeExtras } from "./runtime/runtimeTypes";
 
 export { createPiHttpClient } from "./client/httpClient";
 export type { PiHttpClientOptions } from "./client/httpClient";

--- a/packages/react-pi/src/runtime/hooks.ts
+++ b/packages/react-pi/src/runtime/hooks.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useMemo } from "react";
+import { piExtras } from "./piExtras";
+import {
+  EMPTY_RUNTIME_EXTRAS,
+  NOOP_CONTROLLER,
+  usePiControllerStateSelector,
+} from "./usePiRuntime";
+import type { PiRuntimeExtras } from "./runtimeTypes";
+import type { PiThreadState } from "./threadState";
+import type { PiThreadMetadata } from "../types";
+
+/** The full Pi runtime extras for the active thread. */
+export const usePiRuntimeExtras = (): PiRuntimeExtras =>
+  piExtras.use((e) => e, EMPTY_RUNTIME_EXTRAS);
+
+/** The active Pi thread's metadata, or `null` when none is attached. */
+export const usePiSession = (): PiThreadMetadata | null =>
+  piExtras.use((e) => e.metadata, null);
+
+/** The live Pi thread state, optionally projected through a selector. */
+export function usePiThreadState(): PiThreadState;
+export function usePiThreadState<T>(selector: (state: PiThreadState) => T): T;
+export function usePiThreadState<T>(selector?: (state: PiThreadState) => T) {
+  const controller = piExtras.use((e) => e.controller, NOOP_CONTROLLER);
+  return usePiControllerStateSelector(
+    controller,
+    selector ?? ((state) => state as T),
+  );
+}
+
+/** Pending free-standing host-UI requests plus a responder. */
+export const usePiHostUiRequests = () => {
+  const extras = piExtras.use((e) => e, undefined);
+
+  return useMemo(
+    () => ({
+      requests: extras?.hostUiRequests ?? [],
+      respond:
+        extras?.respondToHostUiRequest ??
+        (async () => {
+          throw new Error("Pi runtime is not ready yet");
+        }),
+    }),
+    [extras],
+  );
+};

--- a/packages/react-pi/src/runtime/piExtras.ts
+++ b/packages/react-pi/src/runtime/piExtras.ts
@@ -1,0 +1,5 @@
+import { createRuntimeExtras } from "@assistant-ui/core/internal";
+import type { PiRuntimeExtrasInternal } from "./runtimeTypes";
+
+export const piExtras =
+  createRuntimeExtras<PiRuntimeExtrasInternal>("usePiRuntime");

--- a/packages/react-pi/src/runtime/runtimeTypes.ts
+++ b/packages/react-pi/src/runtime/runtimeTypes.ts
@@ -1,0 +1,65 @@
+import type {
+  ExternalStoreAdapter,
+  ExternalStoreSharedOptions,
+  ThreadMessageLike,
+} from "@assistant-ui/react";
+import type { PiThreadControllerLike } from "./ThreadController";
+import type { PiInterruptAnswer } from "./hostUi";
+import type { PiThreadState } from "./threadState";
+import type {
+  PiClient,
+  PiContextUsage,
+  PiHostUiRequest,
+  PiHostUiResponse,
+  PiRuntimeReadiness,
+  PiThinkingLevel,
+  PiThreadMetadata,
+  PiThreadStatus,
+} from "../types";
+
+export type PiRuntimeOptions = ExternalStoreSharedOptions & {
+  /** The transport-agnostic Pi client (HTTP/SSE, RPC, IPC). */
+  client: PiClient;
+  /** Workspace scoping for the thread list. */
+  workspacePath?: string;
+  includeArchived?: boolean;
+  initialThreadId?: string;
+  threadId?: string;
+  onError?: (error: unknown) => void;
+  adapters?: ExternalStoreAdapter<ThreadMessageLike>["adapters"];
+};
+
+export interface PiRuntimeExtras {
+  state: PiThreadState;
+  metadata: PiThreadMetadata;
+  status: PiThreadStatus;
+  readiness: PiRuntimeReadiness | undefined;
+  contextUsage: PiContextUsage | undefined;
+  /** Pending side-channel (free-standing) host-UI requests — those not attached
+   * to a tool call. Tool-associated requests render as native approval/interrupt
+   * on the message instead. */
+  hostUiRequests: readonly PiHostUiRequest[];
+  /** All pending host-UI requests, including tool-associated ones. */
+  allHostUiRequests: readonly PiHostUiRequest[];
+  queue: PiThreadState["queue"];
+  compaction: PiThreadState["compaction"];
+  retry: PiThreadState["retry"];
+  lastError: string | undefined;
+  cancel: () => Promise<void>;
+  refresh: () => Promise<void>;
+  /** Clear Pi's queued (steering + follow-up) messages; resolves with the
+   * cleared text so it can be restored into the composer. */
+  clearQueue: () => Promise<{ steering: string[]; followUp: string[] }>;
+  setModel: (input: { provider: string; modelId: string }) => Promise<void>;
+  setThinkingLevel: (level: PiThinkingLevel) => Promise<void>;
+  respondToHostUiRequest: (response: PiHostUiResponse) => Promise<void>;
+  respondToToolApproval: (id: string, approved: boolean) => Promise<void>;
+  resumeToolCall: (
+    toolCallId: string,
+    payload: PiInterruptAnswer,
+  ) => Promise<void>;
+}
+
+export type PiRuntimeExtrasInternal = PiRuntimeExtras & {
+  controller: PiThreadControllerLike;
+};

--- a/packages/react-pi/src/runtime/usePiRuntime.ts
+++ b/packages/react-pi/src/runtime/usePiRuntime.ts
@@ -10,7 +10,6 @@ import {
 import type {
   AssistantRuntime,
   ExternalStoreAdapter,
-  ExternalStoreSharedOptions,
   ExternalThreadQueueAdapter,
   ThreadMessage,
   ThreadMessageLike,
@@ -35,90 +34,9 @@ import {
 import { piQueueItemId } from "../queueIds";
 import { splitHostUiRequests, type PiInterruptAnswer } from "./hostUi";
 import { createPiThreadState, type PiThreadState } from "./threadState";
-import type {
-  PiClient,
-  PiContextUsage,
-  PiHostUiRequest,
-  PiHostUiResponse,
-  PiRuntimeReadiness,
-  PiSendMessageInput,
-  PiThinkingLevel,
-  PiThreadMetadata,
-  PiThreadStatus,
-} from "../types";
-
-// ---------------------------------------------------------------------------
-// Options & extras.
-// ---------------------------------------------------------------------------
-
-export type PiRuntimeOptions = ExternalStoreSharedOptions & {
-  /** The transport-agnostic Pi client (HTTP/SSE, RPC, IPC). */
-  client: PiClient;
-  /** Workspace scoping for the thread list. */
-  workspacePath?: string;
-  includeArchived?: boolean;
-  initialThreadId?: string;
-  threadId?: string;
-  onError?: (error: unknown) => void;
-  adapters?: ExternalStoreAdapter<ThreadMessageLike>["adapters"];
-};
-
-export interface PiRuntimeExtras {
-  state: PiThreadState;
-  metadata: PiThreadMetadata;
-  status: PiThreadStatus;
-  readiness: PiRuntimeReadiness | undefined;
-  contextUsage: PiContextUsage | undefined;
-  /** Pending side-channel (free-standing) host-UI requests — those not attached
-   * to a tool call. Tool-associated requests render as native approval/interrupt
-   * on the message instead. */
-  hostUiRequests: readonly PiHostUiRequest[];
-  /** All pending host-UI requests, including tool-associated ones. */
-  allHostUiRequests: readonly PiHostUiRequest[];
-  queue: PiThreadState["queue"];
-  compaction: PiThreadState["compaction"];
-  retry: PiThreadState["retry"];
-  lastError: string | undefined;
-  cancel: () => Promise<void>;
-  refresh: () => Promise<void>;
-  /** Clear Pi's queued (steering + follow-up) messages; resolves with the
-   * cleared text so it can be restored into the composer. */
-  clearQueue: () => Promise<{ steering: string[]; followUp: string[] }>;
-  setModel: (input: { provider: string; modelId: string }) => Promise<void>;
-  setThinkingLevel: (level: PiThinkingLevel) => Promise<void>;
-  respondToHostUiRequest: (response: PiHostUiResponse) => Promise<void>;
-  respondToToolApproval: (id: string, approved: boolean) => Promise<void>;
-  resumeToolCall: (
-    toolCallId: string,
-    payload: PiInterruptAnswer,
-  ) => Promise<void>;
-}
-
-export type { PiInterruptAnswer } from "./hostUi";
-
-// ---------------------------------------------------------------------------
-// Symbol-tagged extras (so the selector hooks can validate context).
-// ---------------------------------------------------------------------------
-
-const symbolPiRuntimeExtras = Symbol("pi-runtime-extras");
-
-type PiRuntimeExtrasInternal = PiRuntimeExtras & {
-  [symbolPiRuntimeExtras]: true;
-  controller: PiThreadControllerLike;
-};
-
-const isPiRuntimeExtras = (
-  extras: unknown,
-): extras is PiRuntimeExtrasInternal =>
-  typeof extras === "object" &&
-  extras != null &&
-  symbolPiRuntimeExtras in extras;
-
-const tryGetPiRuntimeExtras = (extras: unknown) =>
-  isPiRuntimeExtras(extras) ? extras : undefined;
-
-const asPiRuntimeExtras = (extras: unknown) =>
-  tryGetPiRuntimeExtras(extras) ?? EMPTY_RUNTIME_EXTRAS;
+import type { PiClient, PiSendMessageInput, PiThreadMetadata } from "../types";
+import { piExtras } from "./piExtras";
+import type { PiRuntimeExtrasInternal, PiRuntimeOptions } from "./runtimeTypes";
 
 const EMPTY_THREAD_STATE = createPiThreadState("__pending__");
 const EMPTY_PROJECTED_MESSAGES: readonly ThreadMessageLike[] = [];
@@ -156,7 +74,7 @@ const getController = (registry: PiControllerRegistry, threadId: string) => {
   return controller;
 };
 
-const NOOP_CONTROLLER: PiThreadControllerLike = {
+export const NOOP_CONTROLLER: PiThreadControllerLike = {
   getState: () => EMPTY_THREAD_STATE,
   getProjectedMessages: () => EMPTY_PROJECTED_MESSAGES,
   getMessageRepository: () => EMPTY_MESSAGE_REPOSITORY,
@@ -186,8 +104,7 @@ const buildExtras = (
   state: PiThreadState,
 ): PiRuntimeExtrasInternal => {
   const { freeStanding } = splitHostUiRequests(state.hostUiRequests);
-  return {
-    [symbolPiRuntimeExtras]: true,
+  return piExtras.provide({
     controller,
     state,
     metadata: state.metadata,
@@ -211,10 +128,13 @@ const buildExtras = (
       controller.respondToToolApproval(id, approved),
     resumeToolCall: (toolCallId, payload) =>
       controller.resumeToolCall(toolCallId, payload),
-  };
+  });
 };
 
-const EMPTY_RUNTIME_EXTRAS = buildExtras(NOOP_CONTROLLER, EMPTY_THREAD_STATE);
+export const EMPTY_RUNTIME_EXTRAS = buildExtras(
+  NOOP_CONTROLLER,
+  EMPTY_THREAD_STATE,
+);
 
 // ---------------------------------------------------------------------------
 // Per-thread runtime.
@@ -254,7 +174,7 @@ const usePiControllerMessageRepository = (
   return controller.getMessageRepository();
 };
 
-const usePiControllerStateSelector = <T>(
+export const usePiControllerStateSelector = <T>(
   controller: PiThreadControllerLike,
   selector: (state: PiThreadState) => T,
 ): T =>
@@ -502,9 +422,9 @@ const useRuntimeHook = (
   options: PiRuntimeOptions,
   pendingInitialMessageRef: { current: PiSendMessageInput | undefined },
 ) => {
-  const threadListItem = useAuiState((state: any) => state.threadListItem);
+  const threadListItem = useAuiState((state) => state.threadListItem);
   const isMainThread = useAuiState(
-    (state: any) => state.threads.mainThreadId === state.threadListItem.id,
+    (state) => state.threads.mainThreadId === state.threadListItem.id,
   );
   const threadId = threadListItem.externalId ?? threadListItem.remoteId;
 
@@ -641,50 +561,4 @@ export const usePiRuntime = (options: PiRuntimeOptions): AssistantRuntime => {
       return useRuntimeHook(registry, options, pendingInitialMessageRef);
     },
   });
-};
-
-// ---------------------------------------------------------------------------
-// Selector hooks.
-// ---------------------------------------------------------------------------
-
-export const usePiRuntimeExtras = (): PiRuntimeExtras =>
-  useAuiState((state: any) => asPiRuntimeExtras(state.thread.extras));
-
-export const usePiSession = (): PiThreadMetadata | null =>
-  useAuiState(
-    (state: any) =>
-      tryGetPiRuntimeExtras(state.thread.extras)?.metadata ?? null,
-  );
-
-export function usePiThreadState(): PiThreadState;
-export function usePiThreadState<T>(selector: (state: PiThreadState) => T): T;
-export function usePiThreadState<T>(selector?: (state: PiThreadState) => T) {
-  const extras = useAuiState((state: any) =>
-    tryGetPiRuntimeExtras(state.thread.extras),
-  );
-  const controller = extras?.controller ?? NOOP_CONTROLLER;
-  const selected = usePiControllerStateSelector(
-    controller,
-    selector ?? ((state) => state as T),
-  );
-
-  return selected;
-}
-
-export const usePiHostUiRequests = () => {
-  const extras = useAuiState((state: any) =>
-    tryGetPiRuntimeExtras(state.thread.extras),
-  );
-
-  return useMemo(
-    () => ({
-      requests: extras?.hostUiRequests ?? [],
-      respond:
-        extras?.respondToHostUiRequest ??
-        (async () => {
-          throw new Error("Pi runtime is not ready yet");
-        }),
-    }),
-    [extras],
-  );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4183,6 +4183,12 @@ importers:
 
   packages/react-pi:
     dependencies:
+      '@assistant-ui/core':
+        specifier: ^0.2.18
+        version: link:../core
+      '@assistant-ui/store':
+        specifier: ^0.2.18
+        version: link:../store
       use-effect-event:
         specifier: ^2.0.3
         version: 2.0.3(react@19.2.7)


### PR DESCRIPTION
## what

brings `react-pi` onto the `createRuntimeExtras` + file-layout convention (the last A-group adapter), with no public API or behavior change.

- adopts `createRuntimeExtras` from `@assistant-ui/core/internal`, replacing the hand-rolled `symbolPiRuntimeExtras` brand + guards.
- moves the four accessor hooks (`usePiRuntimeExtras` / `usePiSession` / `usePiThreadState` / `usePiHostUiRequests`) into `runtime/hooks.ts`.
- extracts `PiRuntimeOptions` / `PiRuntimeExtras` / `PiRuntimeExtrasInternal` into `runtime/runtimeTypes.ts` (cycle-free, keeping the browser-safe boundary: `index.ts` / `types.ts` still pull no `@earendil-works/pi-*`).
- types the previously-`any` aui-state selectors.
- adds `@assistant-ui/core` + `@assistant-ui/store` as dependencies (pi only depended on `use-effect-event`; `@assistant-ui/react` does not re-export `createRuntimeExtras`).

## preserved exactly

- the public barrel re-exports the same 35 symbols (verified name-by-name); nothing removed, accessors and types only re-pointed.
- the pure reducer / projection / host-UI, the `PiThreadController` + `useSyncExternalStore` bridge (reactivity already convention-compliant), and the node transport are unchanged. the browser/node entry split is intact.

## deferred (separate PR)

unifying the two optimistic-message strategies (the controller's `optimisticUserMessages` vs the new-thread store's `useState`) is behavior-changing: they serve different lifecycles (a live thread vs the first message before a controller exists), so it stays out of this structural refactor.

## test plan

- full react-pi suite green (10 files, 139 tests), tsc clean, oxlint clean, both `.` and `./node` entries build clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

