### PR TITLE
docs: add standalone-tool-call grouping key to chain-of-thought sample

### DIFF
--- a/apps/docs/components/docs/samples/chain-of-thought-primitive.tsx
+++ b/apps/docs/components/docs/samples/chain-of-thought-primitive.tsx
@@ -161,6 +161,7 @@ function AssistantMessage() {
             groupBy={groupPartByType({
               reasoning: ["group-chainOfThought", "group-reasoning"],
               "tool-call": ["group-chainOfThought", "group-tool"],
+              "standalone-tool-call": [],
             })}
           >
             {({ part, children }) => {


### PR DESCRIPTION
## What

Add the `"standalone-tool-call": []` grouping key to the `groupPartByType(...)` config in `apps/docs/components/docs/samples/chain-of-thought-primitive.tsx`, aligning the sample's grouping with the current convention used by `base.tsx` and the shipped `thread.tsx`.

The bespoke preview UI is intentionally left exactly as-is — this is a one-line additive change, no visual change.

## Why no visual change

`"standalone-tool-call"` only matches tool calls flagged standalone (MCP-app calls or registry opt-ins). The static `get_weather` sample message has no such tool, so it still falls through to the chain-of-thought tool grouping and the rendered preview is identical. This only keeps the sample's grouping config current.

## Verification
- `"standalone-tool-call"` is an explicitly typed key of `GroupPartType` (`packages/core/src/react/utils/groupParts.ts`), and `"standalone-tool-call": []` is the exact form used in that helper's JSDoc example and in `base.tsx` / `thread.tsx` — type-safe by construction.
- `oxlint` + `oxfmt --check` clean on the changed file.

No changeset: `@assistant-ui/docs` is private and changeset-exempt.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

