### PR TITLE
feat(core): add onThreadIdChange for managed threadId on remote thread list runtime

### DIFF
--- a/.changeset/managed-thread-id-callback.md
+++ b/.changeset/managed-thread-id-callback.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat: add `onThreadIdChange` to the remote thread list runtime so `threadId` can be used as a managed/controlled value (e.g. synced to a URL). Only the settled remote ID is emitted; the transient optimistic local ID is never surfaced.

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -163,7 +163,10 @@ export class RemoteThreadListThreadListRuntimeCore
     super();
     this.contextProvider = contextProvider;
 
-    this._state.subscribe(() => this._notifySubscribers());
+    this._state.subscribe(() => {
+      this._notifySubscribers();
+      this._notifyThreadIdChange();
+    });
     this._hookManager = new RemoteThreadListHookInstanceManager(
       options.runtimeHook,
       this,
@@ -251,6 +254,22 @@ export class RemoteThreadListThreadListRuntimeCore
 
   public get mainThreadId(): string {
     return this._mainThreadId;
+  }
+
+  // The settled remote ID of the active thread, or undefined while it is still
+  // a new/optimistic thread. This is the value surfaced to `onThreadIdChange`.
+  private get _mainThreadRemoteId(): string | undefined {
+    if (this._mainThreadId === undefined) return undefined;
+    return getThreadData(this._state.value, this._mainThreadId)?.remoteId;
+  }
+
+  private _lastNotifiedThreadId: string | undefined = undefined;
+
+  private _notifyThreadIdChange() {
+    const threadId = this._mainThreadRemoteId;
+    if (this._lastNotifiedThreadId === threadId) return;
+    this._lastNotifiedThreadId = threadId;
+    this._options.onThreadIdChange?.(threadId);
   }
 
   public getMainThreadRuntimeCore() {
@@ -351,6 +370,7 @@ export class RemoteThreadListThreadListRuntimeCore
     this._mainThreadId = data.id;
 
     this._notifySubscribers();
+    this._notifyThreadIdChange();
   }
 
   public async switchToNewThread(): Promise<void> {

--- a/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
+++ b/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
@@ -1,4 +1,11 @@
-import { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  useCallback,
+  useEffectEvent,
+} from "react";
 import { BaseAssistantRuntimeCore } from "../../runtime/base/base-assistant-runtime-core";
 import { AssistantRuntimeImpl } from "../../runtime/api/assistant-runtime";
 import type { RemoteThreadListOptions } from "../../runtimes/remote-thread-list/types";
@@ -51,12 +58,17 @@ export const useRemoteThreadListRuntime = (
     return runtimeHookRef.current();
   }, []);
 
+  const onThreadIdChange = useEffectEvent((threadId: string | undefined) => {
+    options.onThreadIdChange?.(threadId);
+  });
+
   const stableOptions = useMemo<RemoteThreadListOptions>(
     () => ({
       adapter: options.adapter,
       allowNesting: options.allowNesting,
       initialThreadId: startThreadIdRef.current,
       runtimeHook: stableRuntimeHook,
+      onThreadIdChange,
     }),
     [options.adapter, options.allowNesting, stableRuntimeHook],
   );

--- a/packages/core/src/runtimes/remote-thread-list/types.ts
+++ b/packages/core/src/runtimes/remote-thread-list/types.ts
@@ -78,6 +78,19 @@ export type RemoteThreadListOptions = {
   threadId?: string | undefined;
 
   /**
+   * Called whenever the active thread's canonical (remote) ID changes, so the
+   * value can be treated as a managed/controlled variable (e.g. synced to a
+   * URL query param). Together with `threadId` this forms the controlled
+   * pattern: `threadId` in, `onThreadIdChange` out.
+   *
+   * Only the settled remote ID is emitted: while a freshly created thread is
+   * still optimistic (no remote ID yet) the value is `undefined`, and the real
+   * ID is emitted once the thread is initialized. The transient local ID is
+   * never surfaced.
+   */
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
+
+  /**
    * When true, if this runtime is used inside another RemoteThreadListRuntime,
    * it becomes a no-op and simply calls the runtimeHook directly.
    * This allows wrapping runtimes that internally use RemoteThreadListRuntime.

--- a/packages/core/src/tests/remote-thread-list-reactive-threadId.test.ts
+++ b/packages/core/src/tests/remote-thread-list-reactive-threadId.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { RemoteThreadListThreadListRuntimeCore } from "../react/runtimes/RemoteThreadListThreadListRuntimeCore";
 import type { RemoteThreadListAdapter } from "../runtimes/remote-thread-list/types";
-import {
-  contextProvider,
-  makeAdapter,
-} from "./remote-thread-list-test-helpers";
+import { createCore, makeAdapter } from "./remote-thread-list-test-helpers";
 
 /**
  * Tests for the reactive threadId useEffect logic in useRemoteThreadListRuntime.
@@ -109,17 +105,7 @@ function createCoreWithCallback(
   adapterOverrides: Partial<RemoteThreadListAdapter> = {},
 ) {
   const adapter = makeAdapter(adapterOverrides);
-  const core = new RemoteThreadListThreadListRuntimeCore(
-    { adapter, runtimeHook: () => ({}) as never, onThreadIdChange },
-    contextProvider,
-  );
-  // startThreadRuntime blocks until a React component attaches a runtime; stub
-  // it so these non-React unit tests don't hang.
-  (
-    core as unknown as {
-      _hookManager: { startThreadRuntime: (id: string) => Promise<unknown> };
-    }
-  )._hookManager.startThreadRuntime = async () => ({});
+  const core = createCore(adapter, undefined, onThreadIdChange);
   return { core, adapter };
 }
 

--- a/packages/core/src/tests/remote-thread-list-reactive-threadId.test.ts
+++ b/packages/core/src/tests/remote-thread-list-reactive-threadId.test.ts
@@ -91,3 +91,76 @@ describe("threadId reactive effect", () => {
     expect(switchToThread).toHaveBeenCalledTimes(3);
   });
 });
+
+/**
+ * Tests for the onThreadIdChange notification logic in
+ * RemoteThreadListThreadListRuntimeCore._notifyThreadIdChange.
+ *
+ * The core emits the active thread's settled remote ID, deduping against the
+ * last value so the same ID is never emitted twice, and never surfacing the
+ * transient optimistic local ID (remote ID is undefined until initialized).
+ * We mirror the dedup logic here.
+ */
+function makeNotifier(onThreadIdChange: (id: string | undefined) => void) {
+  let last: string | undefined = undefined;
+  return (remoteId: string | undefined) => {
+    if (last === remoteId) return;
+    last = remoteId;
+    onThreadIdChange(remoteId);
+  };
+}
+
+describe("onThreadIdChange notification", () => {
+  it("does not emit when a new thread stays optimistic (no remote ID)", () => {
+    const cb = vi.fn();
+    const notify = makeNotifier(cb);
+
+    // initial new thread: remote ID undefined, matches initial last → no emit
+    notify(undefined);
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("emits the remote ID once the thread is initialized", () => {
+    const cb = vi.fn();
+    const notify = makeNotifier(cb);
+
+    notify(undefined); // optimistic new thread
+    notify("remote-1"); // initialize resolves
+
+    expect(cb).toHaveBeenCalledExactlyOnceWith("remote-1");
+  });
+
+  it("dedupes repeated notifications for the same remote ID", () => {
+    const cb = vi.fn();
+    const notify = makeNotifier(cb);
+
+    notify("remote-1");
+    notify("remote-1");
+    notify("remote-1");
+
+    expect(cb).toHaveBeenCalledExactlyOnceWith("remote-1");
+  });
+
+  it("emits undefined when switching from a thread to a new thread", () => {
+    const cb = vi.fn();
+    const notify = makeNotifier(cb);
+
+    notify("remote-1"); // on an existing thread
+    notify(undefined); // switched to a fresh new thread
+
+    expect(cb).toHaveBeenLastCalledWith(undefined);
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it("emits each distinct remote ID across navigation", () => {
+    const cb = vi.fn();
+    const notify = makeNotifier(cb);
+
+    notify("remote-1");
+    notify("remote-2");
+    notify("remote-1");
+
+    expect(cb.mock.calls).toEqual([["remote-1"], ["remote-2"], ["remote-1"]]);
+  });
+});

--- a/packages/core/src/tests/remote-thread-list-reactive-threadId.test.ts
+++ b/packages/core/src/tests/remote-thread-list-reactive-threadId.test.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
+import { RemoteThreadListThreadListRuntimeCore } from "../react/runtimes/RemoteThreadListThreadListRuntimeCore";
+import type { RemoteThreadListAdapter } from "../runtimes/remote-thread-list/types";
+import {
+  contextProvider,
+  makeAdapter,
+} from "./remote-thread-list-test-helpers";
 
 /**
  * Tests for the reactive threadId useEffect logic in useRemoteThreadListRuntime.
@@ -93,74 +99,99 @@ describe("threadId reactive effect", () => {
 });
 
 /**
- * Tests for the onThreadIdChange notification logic in
- * RemoteThreadListThreadListRuntimeCore._notifyThreadIdChange.
- *
- * The core emits the active thread's settled remote ID, deduping against the
- * last value so the same ID is never emitted twice, and never surfacing the
- * transient optimistic local ID (remote ID is undefined until initialized).
- * We mirror the dedup logic here.
+ * Tests for onThreadIdChange, driving the real
+ * RemoteThreadListThreadListRuntimeCore via a mock adapter (no React). These
+ * exercise the actual _notifyThreadIdChange / _mainThreadRemoteId path and the
+ * subscription + switchToThread wiring that invokes it.
  */
-function makeNotifier(onThreadIdChange: (id: string | undefined) => void) {
-  let last: string | undefined = undefined;
-  return (remoteId: string | undefined) => {
-    if (last === remoteId) return;
-    last = remoteId;
-    onThreadIdChange(remoteId);
-  };
+function createCoreWithCallback(
+  onThreadIdChange: (id: string | undefined) => void,
+  adapterOverrides: Partial<RemoteThreadListAdapter> = {},
+) {
+  const adapter = makeAdapter(adapterOverrides);
+  const core = new RemoteThreadListThreadListRuntimeCore(
+    { adapter, runtimeHook: () => ({}) as never, onThreadIdChange },
+    contextProvider,
+  );
+  // startThreadRuntime blocks until a React component attaches a runtime; stub
+  // it so these non-React unit tests don't hang.
+  (
+    core as unknown as {
+      _hookManager: { startThreadRuntime: (id: string) => Promise<unknown> };
+    }
+  )._hookManager.startThreadRuntime = async () => ({});
+  return { core, adapter };
 }
 
-describe("onThreadIdChange notification", () => {
-  it("does not emit when a new thread stays optimistic (no remote ID)", () => {
-    const cb = vi.fn();
-    const notify = makeNotifier(cb);
+// Let the constructor's in-flight switchToNewThread settle.
+const flush = () => new Promise((resolve) => setTimeout(resolve));
 
-    // initial new thread: remote ID undefined, matches initial last → no emit
-    notify(undefined);
+describe("onThreadIdChange", () => {
+  it("does not emit while the active thread is still optimistic", async () => {
+    const cb = vi.fn();
+    createCoreWithCallback(cb);
+    await flush();
 
     expect(cb).not.toHaveBeenCalled();
   });
 
-  it("emits the remote ID once the thread is initialized", () => {
+  it("emits the remote ID once a new thread is initialized", async () => {
     const cb = vi.fn();
-    const notify = makeNotifier(cb);
+    const { core } = createCoreWithCallback(cb, {
+      initialize: vi.fn(async () => ({
+        remoteId: "remote-1",
+        externalId: "ext-1",
+      })),
+    });
+    await flush();
 
-    notify(undefined); // optimistic new thread
-    notify("remote-1"); // initialize resolves
+    const newThreadId = core.newThreadId!;
+    expect(newThreadId).toBeDefined();
+    expect(cb).not.toHaveBeenCalled(); // still optimistic, no remote ID
 
-    expect(cb).toHaveBeenCalledExactlyOnceWith("remote-1");
+    await core.initialize(newThreadId);
+
+    expect(cb).toHaveBeenLastCalledWith("remote-1");
   });
 
-  it("dedupes repeated notifications for the same remote ID", () => {
+  it("emits the remote ID when switching to an existing thread", async () => {
     const cb = vi.fn();
-    const notify = makeNotifier(cb);
+    const { core } = createCoreWithCallback(cb);
+    await flush();
 
-    notify("remote-1");
-    notify("remote-1");
-    notify("remote-1");
+    await core.switchToThread("existing-1");
 
-    expect(cb).toHaveBeenCalledExactlyOnceWith("remote-1");
+    expect(cb).toHaveBeenLastCalledWith("existing-1");
   });
 
-  it("emits undefined when switching from a thread to a new thread", () => {
+  it("dedupes: switching to the already-active thread does not re-emit", async () => {
     const cb = vi.fn();
-    const notify = makeNotifier(cb);
+    const { core } = createCoreWithCallback(cb);
+    await flush();
 
-    notify("remote-1"); // on an existing thread
-    notify(undefined); // switched to a fresh new thread
+    await core.switchToThread("existing-1");
+    const callsAfterFirstSwitch = cb.mock.calls.length;
 
-    expect(cb).toHaveBeenLastCalledWith(undefined);
-    expect(cb).toHaveBeenCalledTimes(2);
+    await core.switchToThread("existing-1");
+
+    expect(cb).toHaveBeenCalledTimes(callsAfterFirstSwitch);
   });
 
-  it("emits each distinct remote ID across navigation", () => {
+  it("never surfaces the transient local ID", async () => {
     const cb = vi.fn();
-    const notify = makeNotifier(cb);
+    const { core } = createCoreWithCallback(cb, {
+      initialize: vi.fn(async () => ({
+        remoteId: "remote-1",
+        externalId: "ext-1",
+      })),
+    });
+    await flush();
 
-    notify("remote-1");
-    notify("remote-2");
-    notify("remote-1");
+    const localId = core.newThreadId!;
+    await core.initialize(localId);
 
-    expect(cb.mock.calls).toEqual([["remote-1"], ["remote-2"], ["remote-1"]]);
+    for (const [emitted] of cb.mock.calls) {
+      expect(emitted).not.toBe(localId);
+    }
   });
 });

--- a/packages/core/src/tests/remote-thread-list-test-helpers.ts
+++ b/packages/core/src/tests/remote-thread-list-test-helpers.ts
@@ -52,9 +52,10 @@ export function makeAdapter(
 export function createCore(
   adapter: RemoteThreadListAdapter,
   threadId?: string,
+  onThreadIdChange?: (threadId: string | undefined) => void,
 ): RemoteThreadListThreadListRuntimeCore {
   const core = new RemoteThreadListThreadListRuntimeCore(
-    { adapter, runtimeHook: () => ({}) as never, threadId },
+    { adapter, runtimeHook: () => ({}) as never, threadId, onThreadIdChange },
     contextProvider,
   );
   // `startThreadRuntime` blocks until a React component attaches a runtime;


### PR DESCRIPTION
## Summary

Adds an `onThreadIdChange` callback to `RemoteThreadListOptions`, completing the controlled pattern for the active thread ID: `threadId` in, `onThreadIdChange` out. Consumers can now treat `threadId` as a managed/controlled value (e.g. synced to a URL query param) without polling `runtime.threads.getState().mainThreadId`.

The reactive `threadId` prop already let a parent push a thread ID *in*; there was no way to be notified when the runtime switched threads internally (new thread created, user clicked a thread, optimistic→real ID swap). This adds the missing "out" half.

## Behavior

- Emits only the **settled remote ID** of the active thread.
- While a freshly created thread is still optimistic (no remote ID yet), the value is `undefined`; the real ID is emitted once the thread is initialized. The transient `__LOCALID_*` is never surfaced (this also avoids the "two thread IDs everywhere" problem).
- Deduped so the same ID is never emitted twice.

## Implementation

- `types.ts`: new `onThreadIdChange?: (threadId: string | undefined) => void`.
- `useRemoteThreadListRuntime.ts`: forwarded through `stableOptions` via `useEffectEvent` so it stays stable yet always invokes the latest callback.
- `RemoteThreadListThreadListRuntimeCore.tsx`: `_notifyThreadIdChange()` computes the active thread's remote ID and fires the callback (deduped), invoked from both the state subscription (catches optimistic→real settling) and `switchToThread`.

## Tests

Added coverage for the notification/dedup logic alongside the existing reactive-threadId tests. Build, tests, and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

