### PR TITLE
docs(agents): add a general do's and don'ts section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,21 @@ A framework adapter (`@assistant-ui/react-*`) maps a provider onto a core runtim
 - **Standard files.** `use<Name>Runtime.ts` (orchestration only), `hooks.ts` (accessor and action hooks), a pure `convertMessages.ts` (both directions), and `types.ts`; add a `<Name>ThreadController.ts` plus a pure `reduce<Name>ThreadState` reducer when the adapter owns thread state, and a `./server` or `./node` subpath entry when the protocol owns the wire.
 - **Public surface.** A new adapter's `index.ts` should re-export only the entry hook, accessor hooks, converters, and public types. For an already-published package, treat the barrel as append-only: re-point moved exports to their new files, but never remove an export that has shipped (a breaking change for npm consumers the in-repo audit cannot see), even an unused-looking type.
 - **Tests.** Colocate them beside each module, covering the converter both ways, the reducer or controller, and each accessor hook.
-- **Do not introduce.** A state holder named `*ThreadRuntimeCore`, a `notifyUpdate` plus version-counter re-render hack (bridge non-React state with `useSyncExternalStore`), `Object.create` method grafting, or monkeypatching the caller's objects. The legacy `react-a2a` and `react-ag-ui` predate this and are being migrated.
+- **Don't introduce.** A `*ThreadRuntimeCore` state holder, a `notifyUpdate` plus version-counter re-render hack (bridge non-React state with `useSyncExternalStore`), `Object.create` method grafting, or monkeypatching the caller's objects. Keep server-only or provider-SDK code in the `./server` or `./node` subpath, out of the default and React Native entries.
 
 Keep provider-driven choices flexible: the core-primitive choice, thin wrapper vs accumulator vs controller, bespoke transports, HITL richness, and thread-list depth. `@assistant-ui/react-langchain` is the reference for the external-store plus converter plus `createRuntimeExtras` shape.
+
+## Do's and don'ts
+
+Do:
+
+- **One concern per PR.** A PR should do one thing. Break a large or multi-purpose change into separate PRs so each is small enough to review carefully, can be approved on its own merits, and reverts cleanly when it regresses.
+- **Write a clear PR title and description.** Say what the change is, why it is needed, and how you did it, so a reviewer has the context to judge it without reverse-engineering the diff. The title names the change in one line; trade-offs and divergences belong in the body.
+- **Justify any divergence from how the repo already does it.** If the codebase already solves a problem one way, follow it; someone chose that approach deliberately, so a different one needs a real reason written down, not personal preference. When you catch yourself doing something novel but unrelated to your task, pause and reconsider.
+- **Keep unrelated changes out of the diff.** Drive-by deletions, refactors, formatting, and "while I'm here" additions bury the real change and slow review. Open a separate PR, or an issue when you only want to flag something.
+
+Don't:
+
+- **Break the published contract.** A shipped export is a promise to npm consumers we cannot see, so the public surface is append-only and refactors stay behavior-preserving; ship a real behavior change as its own deliberate PR.
+- **Reinvent what the framework already provides.** Build on the shared primitives instead of re-implementing runtime state, reactivity, or other plumbing; a parallel mechanism drifts from the rest of the codebase and costs everyone to maintain.
+- **Add heavy or non-OSS dependencies casually.** assistant-ui is built on open source, so commercial-licensed libraries are off-limits; heavy dependencies and new build steps affect every contributor and need justification and maintainer sign-off.


### PR DESCRIPTION
## what

adds a top-level `## do's and don'ts` section to `AGENTS.md` capturing general engineering principles, each a one-line rule plus a short rationale: one concern per pr, a clear pr title/description, justify divergence from the established approach, keep unrelated changes out of the diff; and don't break the published contract, reinvent what the framework provides, or add heavy/non-oss dependencies casually.

also restores the adapter-specific `don't introduce` anti-patterns (`*ThreadRuntimeCore`, the `notifyUpdate` re-render hack, `Object.create` grafting, monkeypatching, server-only code leaking into the client/RN bundle) into the `## adapter orchestration` section.

## why

the earlier list had drifted into adapter-specific mechanics. the durable, reusable guidance is general and belongs in its own section; the adapter-only rules stay with the adapter section where they apply.

## how

promote the `### do's and don'ts` subsection to a top-level `## do's and don'ts`, rewrite each bullet as a principle plus a why in the same voice as the rest of the doc, and move the adapter anti-patterns back into a `don't introduce` bullet under adapter orchestration so nothing is lost.

docs only, no published package touched, so no changeset.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

