### PR TITLE
fix(build-utils): resolve bundled ambient types from hoisted monorepo installs.


### DIFF
--- a/.changeset/x-buildutils-hoisted-types.md
+++ b/.changeset/x-buildutils-hoisted-types.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-buildutils": patch
+---
+
+Resolve bundled ambient types from hoisted monorepo installs.

--- a/packages/x-buildutils/ts/base.json
+++ b/packages/x-buildutils/ts/base.json
@@ -4,8 +4,13 @@
   "compilerOptions": {
     "typeRoots": [
       "${configDir}/node_modules/@types",
+      "${configDir}/../node_modules/@types",
       "${configDir}/../../node_modules/@types",
+      "${configDir}/../../../node_modules/@types",
       "${configDir}/node_modules/@assistant-ui/x-buildutils/types",
+      "${configDir}/../node_modules/@assistant-ui/x-buildutils/types",
+      "${configDir}/../../node_modules/@assistant-ui/x-buildutils/types",
+      "${configDir}/../../../node_modules/@assistant-ui/x-buildutils/types",
       "${configDir}/types"
     ],
     "types": ["browser-process"],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

