### PR TITLE
feat(react-ag-ui): expose pending interrupts via createRuntimeExtras hooks

### DIFF
--- a/.changeset/react-ag-ui-interrupt-hooks.md
+++ b/.changeset/react-ag-ui-interrupt-hooks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat(react-ag-ui): expose pending interrupts through the shared createRuntimeExtras + hooks.ts surface (`useAgUiInterrupts`, `useAgUiSubmitInterruptResponses`); the equivalent `unstable_getPendingInterrupts` / `unstable_submitInterruptResponses` runtime methods are now deprecated but keep working

--- a/packages/react-ag-ui/package.json
+++ b/packages/react-ag-ui/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@ag-ui/client": "^0.0.57",
     "@assistant-ui/core": "^0.2.18",
+    "@assistant-ui/store": "^0.2.18",
     "assistant-stream": "^0.3.23",
     "fast-json-patch": "^3.1.1"
   },

--- a/packages/react-ag-ui/src/agUiExtras.ts
+++ b/packages/react-ag-ui/src/agUiExtras.ts
@@ -1,0 +1,5 @@
+import { createRuntimeExtras } from "@assistant-ui/core/internal";
+import type { AgUiRuntimeExtras } from "./runtime/types";
+
+export const agUiExtras =
+  createRuntimeExtras<AgUiRuntimeExtras>("useAgUiRuntime");

--- a/packages/react-ag-ui/src/hooks.ts
+++ b/packages/react-ag-ui/src/hooks.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useAui } from "@assistant-ui/store";
+import { agUiExtras } from "./agUiExtras";
+import type { AgUiInterrupt, AgUiResumeEntry } from "./runtime/types";
+
+const EMPTY_INTERRUPTS: readonly AgUiInterrupt[] = [];
+
+/**
+ * Read the pending AG-UI interrupts on the current thread. Returns an empty
+ * array when no interrupts are pending, so consumers can `.map` without a guard.
+ */
+export const useAgUiInterrupts = (): readonly AgUiInterrupt[] =>
+  agUiExtras.use((e) => e.interrupts, EMPTY_INTERRUPTS);
+
+/**
+ * Returns a function that submits responses (each `resolved` or `cancelled`)
+ * for the pending AG-UI interrupts and resumes the run.
+ */
+export const useAgUiSubmitInterruptResponses = () => {
+  const aui = useAui();
+  return (responses: readonly AgUiResumeEntry[]): Promise<void> =>
+    agUiExtras.get(aui).submitInterruptResponses(responses);
+};

--- a/packages/react-ag-ui/src/index.ts
+++ b/packages/react-ag-ui/src/index.ts
@@ -1,5 +1,6 @@
 export { useAgUiRuntime } from "./useAgUiRuntime";
 export type { AgUiAssistantRuntime } from "./useAgUiRuntime";
+export { useAgUiInterrupts, useAgUiSubmitInterruptResponses } from "./hooks";
 export { fromAgUiMessages } from "./runtime/adapter/conversions";
 export type { FromAgUiMessagesOptions } from "./runtime/adapter/conversions";
 export type {

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -85,6 +85,13 @@ export type AgUiResumeEntry = {
   payload?: unknown;
 };
 
+export type AgUiRuntimeExtras = {
+  interrupts: readonly AgUiInterrupt[];
+  submitInterruptResponses: (
+    responses: readonly AgUiResumeEntry[],
+  ) => Promise<void>;
+};
+
 export type AgUiRunFinishedOutcome =
   | { type: "success" }
   | { type: "interrupt"; interrupts: AgUiInterrupt[] };

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -21,9 +21,21 @@ import type {
   UseAgUiRuntimeOptions,
 } from "./runtime/types";
 import { AgUiThreadRuntimeCore } from "./runtime/AgUiThreadRuntimeCore";
+import { agUiExtras } from "./agUiExtras";
+
+const EMPTY_INTERRUPTS: readonly AgUiInterrupt[] = [];
 
 export type AgUiAssistantRuntime = AssistantRuntime & {
+  /**
+   * @deprecated Use the `useAgUiInterrupts()` hook instead. This method is kept
+   * for backward compatibility and will be removed in a future major release.
+   */
   unstable_getPendingInterrupts: () => readonly AgUiInterrupt[];
+  /**
+   * @deprecated Use the `useAgUiSubmitInterruptResponses()` hook instead. This
+   * method is kept for backward compatibility and will be removed in a future
+   * major release.
+   */
   unstable_submitInterruptResponses: (
     responses: readonly AgUiResumeEntry[],
   ) => Promise<void>;
@@ -127,6 +139,12 @@ export function useAgUiRuntime(
         messages: core.getMessages(),
         state: core.getState(),
         isRunning: core.isRunning() || hasExecutingTools,
+        extras: agUiExtras.provide({
+          interrupts:
+            core.getPendingInterrupts()?.interrupts ?? EMPTY_INTERRUPTS,
+          submitInterruptResponses: (responses) =>
+            core.submitInterruptResponses(responses),
+        }),
         unstable_enableToolInvocations: true,
         setToolStatuses,
         onNew: (message: AppendMessage) => core.append(message),

--- a/packages/react-ag-ui/test/hooks.spec.ts
+++ b/packages/react-ag-ui/test/hooks.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+
+const { mockUseAuiState, mockUseAui } = vi.hoisted(() => ({
+  mockUseAuiState: vi.fn(),
+  mockUseAui: vi.fn(),
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAuiState: ((selector: (s: unknown) => unknown) =>
+    mockUseAuiState(
+      selector,
+    )) as typeof import("@assistant-ui/store").useAuiState,
+  useAui: (() => mockUseAui()) as typeof import("@assistant-ui/store").useAui,
+}));
+
+import { agUiExtras } from "../src/agUiExtras";
+import {
+  useAgUiInterrupts,
+  useAgUiSubmitInterruptResponses,
+} from "../src/hooks";
+import type { AgUiInterrupt, AgUiResumeEntry } from "../src/runtime/types";
+
+const interrupt: AgUiInterrupt = { id: "int-1", reason: "confirmation" };
+
+const againstState = (extras: unknown) =>
+  mockUseAuiState.mockImplementationOnce((selector: (s: unknown) => unknown) =>
+    selector({ thread: { extras } }),
+  );
+
+describe("useAgUiInterrupts", () => {
+  it("returns the pending interrupts when the thread is backed by ag-ui", () => {
+    const submitInterruptResponses = vi.fn();
+    againstState(
+      agUiExtras.provide({
+        interrupts: [interrupt],
+        submitInterruptResponses,
+      }),
+    );
+    expect(useAgUiInterrupts()).toEqual([interrupt]);
+  });
+
+  it("returns an empty array when the thread is not backed by ag-ui", () => {
+    againstState(undefined);
+    expect(useAgUiInterrupts()).toEqual([]);
+  });
+});
+
+describe("useAgUiSubmitInterruptResponses", () => {
+  it("delegates to the extras submitInterruptResponses with the given responses", () => {
+    const submitInterruptResponses = vi.fn().mockResolvedValue(undefined);
+    const extras = agUiExtras.provide({
+      interrupts: [interrupt],
+      submitInterruptResponses,
+    });
+    mockUseAui.mockReturnValue({
+      thread: () => ({ getState: () => ({ extras }) }),
+    });
+    const responses: AgUiResumeEntry[] = [
+      { interruptId: "int-1", status: "cancelled" },
+    ];
+
+    useAgUiSubmitInterruptResponses()(responses);
+
+    expect(submitInterruptResponses).toHaveBeenCalledWith(responses);
+  });
+
+  it("throws when the thread is not backed by ag-ui", () => {
+    mockUseAui.mockReturnValue({
+      thread: () => ({ getState: () => ({ extras: undefined }) }),
+    });
+    expect(() => useAgUiSubmitInterruptResponses()([])).toThrow(
+      "useAgUiRuntime",
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1789,7 +1789,7 @@ importers:
         version: link:../../packages/ui
       '@google/adk':
         specifier: ^1.2.0
-        version: 1.2.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.3)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+        version: 1.2.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.3)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3563,6 +3563,9 @@ importers:
       '@assistant-ui/core':
         specifier: ^0.2.18
         version: link:../core
+      '@assistant-ui/store':
+        specifier: ^0.2.18
+        version: link:../store
       assistant-stream:
         specifier: ^0.3.23
         version: link:../assistant-stream
@@ -3747,7 +3750,7 @@ importers:
         version: link:../store
       '@google/adk':
         specifier: '>=0.5.0'
-        version: 1.2.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.3)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
+        version: 1.2.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.3)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
       assistant-cloud:
         specifier: '*'
         version: link:../cloud
@@ -22671,9 +22674,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 


### PR DESCRIPTION
## summary

- expose the pending AG-UI interrupts and the submit action through the canonical createRuntimeExtras + hooks.ts surface: new `useAgUiInterrupts()` (read) and `useAgUiSubmitInterruptResponses()` (action) hooks, mirroring react-a2a and react-langchain.
- deprecate the equivalent `unstable_getPendingInterrupts` / `unstable_submitInterruptResponses` methods on `AgUiAssistantRuntime`; they keep working unchanged.
- additive and behavior-preserving: the `Object.create` graft stays byte-identical and `AgUiThreadRuntimeCore` has zero changes; the new `extras` ride the existing `_version` re-render path, and existing consumers (whose selectors never read `extras`) re-render no more often than before.
- this is phase 0 of moving react-ag-ui onto the shared adapter-orchestration convention (createRuntimeExtras + hooks.ts), and it unblocks building the interrupt steer-away hook on the canonical surface.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ag-ui test` -> 162/162 green (6 files, incl. the new `test/hooks.spec.ts`)
- [x] `pnpm --filter @assistant-ui/react-ag-ui exec tsc --noEmit` -> clean
- [x] `pnpm lint` -> no react-ag-ui issues; `oxfmt --check` clean
- [x] `pnpm --filter @assistant-ui/react-ag-ui build` -> aui-build OK (emits `dist/hooks.js` and `dist/agUiExtras.js`)

### reviewer should verify

- [ ] in an app using `useAgUiRuntime`, `useAgUiInterrupts()` surfaces the pending interrupts when a run finishes with an interrupt outcome, and `useAgUiSubmitInterruptResponses()` resolves/cancels them and resumes the run, matching the deprecated `unstable_` methods.

## notes

- the deprecation warnings are intentional (the replacement hooks now exist); the docs that still show the `unstable_` pattern will be updated in a follow-up.
- adds `@assistant-ui/store` as a direct dependency (already a transitive dep via `@assistant-ui/core`), needed for `useAui` in the action hook, matching react-langchain.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

