### PR TITLE
fix(react-langchain): handle reasoning content without a summary

### DIFF
--- a/.changeset/react-langchain-reasoning-no-summary.md
+++ b/.changeset/react-langchain-reasoning-no-summary.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+fix(react-langchain): handle reasoning content without a summary

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -8,6 +8,12 @@ const humanMessage = (content: unknown): LangChainBaseMessage => ({
   content,
 });
 
+const aiMessage = (content: unknown): LangChainBaseMessage => ({
+  _getType: () => "ai",
+  id: "msg-1",
+  content,
+});
+
 describe("convertLangChainBaseMessage file content parts", () => {
   it("converts a base64 file block", () => {
     const result = convertLangChainBaseMessage(
@@ -49,5 +55,44 @@ describe("convertLangChainBaseMessage file content parts", () => {
         mimeType: "application/pdf",
       },
     ]);
+  });
+});
+
+describe("convertLangChainBaseMessage reasoning content parts", () => {
+  it("joins summary text blocks", () => {
+    const result = convertLangChainBaseMessage(
+      aiMessage([
+        {
+          type: "reasoning",
+          summary: [
+            { type: "summary_text", text: "a" },
+            { type: "summary_text", text: "b" },
+          ],
+        },
+      ]),
+      {},
+    );
+
+    expect(result.content).toEqual([{ type: "reasoning", text: "a\n\n\nb" }]);
+  });
+
+  it("falls back to the reasoning string when summary is absent", () => {
+    const result = convertLangChainBaseMessage(
+      aiMessage([{ type: "reasoning", reasoning: "thinking..." }]),
+      {},
+    );
+
+    expect(result.content).toEqual([
+      { type: "reasoning", text: "thinking..." },
+    ]);
+  });
+
+  it("falls back to empty text when neither summary nor reasoning is present", () => {
+    const result = convertLangChainBaseMessage(
+      aiMessage([{ type: "reasoning" }]),
+      {},
+    );
+
+    expect(result.content).toEqual([{ type: "reasoning", text: "" }]);
   });
 });

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -41,7 +41,10 @@ const contentToParts = (content: unknown) => {
         case "reasoning":
           return {
             type: "reasoning" as const,
-            text: part.summary.map((s) => s.text).join("\n\n\n"),
+            text:
+              part.summary?.map((s) => s.text).join("\n\n\n") ??
+              part.reasoning ??
+              "",
           };
         case "tool_use":
         case "input_json_delta":

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -19,7 +19,8 @@ export type LangChainContentBlock =
   | { type: "thinking"; thinking: string }
   | {
       type: "reasoning";
-      summary: Array<{ type: "summary_text"; text: string }>;
+      summary?: Array<{ type: "summary_text"; text: string }>;
+      reasoning?: string;
     }
   | {
       type: "file";


### PR DESCRIPTION
## What

The `reasoning` content-block converter assumed `summary` is always present and called `part.summary.map(...)`, which throws when a provider sends a plain `reasoning` string instead.

## Change

Make the `reasoning` variant tolerant and fall back: `summary ?? reasoning ?? ""`. Mirrors the handling already in `react-langgraph`, so the two converters reach parity.

## Tests

Added three cases to `convertMessages.test.ts`: summary blocks join to `"a\n\n\nb"`, a bare `reasoning` string passes through, and an empty block yields `""` without throwing.

Internal converter robustness only. No public-API change, no new deps.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

