### PR TITLE
fix(core): tolerate reasoning parts with undefined text

### DIFF
--- a/.changeset/core-reasoning-undefined-text.md
+++ b/.changeset/core-reasoning-undefined-text.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): tolerate reasoning parts with undefined text

--- a/packages/core/src/runtime/utils/thread-message-like.ts
+++ b/packages/core/src/runtime/utils/thread-message-like.ts
@@ -160,7 +160,7 @@ export const fromThreadMessageLike = (
             switch (type) {
               case "text":
               case "reasoning":
-                if (part.text.trim().length === 0) return null;
+                if (!part.text?.trim()) return null;
                 return part;
 
               case "file":

--- a/packages/core/src/tests/thread-message-like.test.ts
+++ b/packages/core/src/tests/thread-message-like.test.ts
@@ -110,4 +110,45 @@ describe("fromThreadMessageLike", () => {
       ).toThrow("Unsupported user message part type: tool-call");
     });
   });
+
+  describe("reasoning parts", () => {
+    it("drops a reasoning part with undefined text without throwing", () => {
+      const result = fromThreadMessageLike(
+        {
+          role: "assistant",
+          content: [{ type: "reasoning" } as any],
+        },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result.content).toEqual([]);
+    });
+
+    it("drops a reasoning part with empty text", () => {
+      const result = fromThreadMessageLike(
+        {
+          role: "assistant",
+          content: [{ type: "reasoning", text: "   " }],
+        },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result.content).toEqual([]);
+    });
+
+    it("keeps a reasoning part with text", () => {
+      const result = fromThreadMessageLike(
+        {
+          role: "assistant",
+          content: [{ type: "reasoning", text: "thinking" }],
+        },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result.content).toEqual([{ type: "reasoning", text: "thinking" }]);
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes part of #4486.

## What

`fromThreadMessageLike` called `part.text.trim()` for `text` and `reasoning` parts, which throws when a provider streams a reasoning block before `text` is populated (Claude extended thinking, OpenAI o-series, etc.).

## Change

Guard with `if (!part.text?.trim()) return null;`. An undefined or whitespace-only reasoning part is dropped instead of crashing the runtime. Behavior is unchanged for populated parts.

## Tests

Added three cases to `thread-message-like.test.ts`: an undefined-text reasoning part is dropped without throwing, a whitespace-only one is dropped, and a part with real text is kept.

Internal robustness only. No public-API change, no new deps.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

