### PR TITLE
feat(react-ag-ui): add unstable_cancelPendingInterruptsAndAppend for steering away from interrupts

### DIFF
--- a/.changeset/ag-ui-cancel-interrupts-append.md
+++ b/.changeset/ag-ui-cancel-interrupts-append.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: add unstable_cancelPendingInterruptsAndAppend to steer away from pending AG-UI interrupts by sending a new message

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -109,14 +109,15 @@ The interrupt API is experimental and may change without notice.
 
 When the agent emits `RUN_FINISHED` with `outcome = { type: "interrupt", interrupts: [...] }`, the active assistant message is marked `requires-action` with `reason: "interrupt"` and the `Interrupt[]` payload is written to `metadata.custom.agui.interrupts`. Render an approval / input UI from there.
 
-`useAgUiRuntime` returns an `AgUiAssistantRuntime` with two extra methods:
+`useAgUiRuntime` returns an `AgUiAssistantRuntime` with these extra methods:
 
 | Method | Description |
 | --- | --- |
 | `unstable_getPendingInterrupts(): readonly AgUiInterrupt[]` | Snapshot of the open interrupts on the most recent assistant message. |
 | `unstable_submitInterruptResponses(responses: ResumeEntry[]): Promise<void>` | Submits one `ResumeEntry` per open interrupt and resumes the run. |
+| `unstable_cancelPendingInterruptsAndAppend(message: CreateAppendMessage, responses?: ResumeEntry[]): Promise<void>` | Cancels the open interrupts and appends a new message, resuming the run. Lets the user steer away from the interrupt UI by just typing. |
 
-`responses` must address every open interrupt; missing entries, unknown ids, or expired interrupts (`expiresAt`) reject before any network call. Each entry is `{ interruptId, status: "resolved" | "cancelled", payload? }`. The next `RunAgentInput` carries `resume: ResumeEntry[]`.
+For `unstable_submitInterruptResponses`, `responses` must address every open interrupt; missing entries, unknown ids, or expired interrupts (`expiresAt`) reject before any network call. Each entry is `{ interruptId, status: "resolved" | "cancelled", payload? }`. The next `RunAgentInput` carries `resume: ResumeEntry[]`. (`unstable_cancelPendingInterruptsAndAppend` is looser: missing entries default to `cancelled` and expiry is ignored.)
 
 ```tsx
 const runtime = useAgUiRuntime({ agent });
@@ -129,6 +130,17 @@ await runtime.unstable_submitInterruptResponses(
     payload: { approved: true },
   })),
 );
+```
+
+### Steering away from an interrupt
+
+When the user ignores the interrupt UI and just sends a new message, use `unstable_cancelPendingInterruptsAndAppend`. Every open interrupt defaults to `status: "cancelled"`, the new message is appended, and the run resumes with `resume: ResumeEntry[]`. Pass `responses` to override the status for specific interrupts; the rest still default to cancelled. With no pending interrupts it behaves like a normal append.
+
+```tsx
+await runtime.unstable_cancelPendingInterruptsAndAppend({
+  role: "user",
+  content: [{ type: "text", text: "actually, let's do something else" }],
+});
 ```
 
 ## Supported events

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -7,6 +7,7 @@ import type {
   AssistantRuntime,
   ChatModelRunOptions,
   ChatModelRunResult,
+  CreateAppendMessage,
   MessageStatus,
   ThreadAssistantMessage,
   ThreadHistoryAdapter,
@@ -174,6 +175,12 @@ export class AgUiThreadRuntimeCore {
   async append(message: AppendMessage): Promise<void> {
     const startRun = message.startRun ?? message.role === "user";
     if (startRun) this.assertNoPendingInterrupts();
+    const threadMessageId = this.appendEntry(message);
+    if (!startRun) return;
+    await this.startRun(threadMessageId, message.runConfig);
+  }
+
+  private appendEntry(message: AppendMessage): string {
     if (message.sourceId) {
       this.messages = this.messages.filter(
         (entry) => entry.id !== message.sourceId,
@@ -185,9 +192,7 @@ export class AgUiThreadRuntimeCore {
     this.messages = [...this.messages, threadMessage];
     this.notifyUpdate();
     this.recordHistoryEntry(message.parentId ?? null, threadMessage);
-
-    if (!startRun) return;
-    await this.startRun(threadMessage.id, message.runConfig);
+    return threadMessage.id;
   }
 
   async edit(message: AppendMessage): Promise<void> {
@@ -346,6 +351,96 @@ export class AgUiThreadRuntimeCore {
 
     this.clearPendingInterrupts(pending.messageId);
     await this.startRun(pending.messageId, this.lastRunConfig, resume);
+  }
+
+  async cancelPendingInterruptsAndAppend(
+    message: CreateAppendMessage,
+    responses?: readonly AgUiResumeEntry[],
+  ): Promise<void> {
+    const pending = this.getPendingInterrupts();
+    if (!pending) {
+      if (responses?.length) {
+        throw new Error(
+          "[agui] cancelPendingInterruptsAndAppend: no pending interrupts on this thread",
+        );
+      }
+      await this.append(this.normalizeAppendMessage(message));
+      return;
+    }
+
+    const resume = this.resolveCancelledResume(pending.interrupts, responses);
+    if (this.isRunningFlag) {
+      throw new Error(
+        "[agui] cancelPendingInterruptsAndAppend: a run is already in progress",
+      );
+    }
+
+    const normalized = this.normalizeAppendMessage(message);
+    this.clearPendingInterrupts(pending.messageId);
+    const threadMessageId = this.appendEntry(normalized);
+    await this.startRun(threadMessageId, normalized.runConfig, resume);
+  }
+
+  private normalizeAppendMessage(message: CreateAppendMessage): AppendMessage {
+    if (typeof message === "string") {
+      return {
+        createdAt: new Date(),
+        parentId: this.messages.at(-1)?.id ?? null,
+        sourceId: null,
+        runConfig: {},
+        role: "user",
+        content: [{ type: "text", text: message }],
+        attachments: [],
+        metadata: { custom: {} },
+      };
+    }
+    return {
+      createdAt: message.createdAt ?? new Date(),
+      parentId: message.parentId ?? this.messages.at(-1)?.id ?? null,
+      sourceId: message.sourceId ?? null,
+      role: message.role ?? "user",
+      content: message.content,
+      attachments: message.attachments ?? [],
+      metadata: message.metadata ?? { custom: {} },
+      runConfig: message.runConfig ?? {},
+      startRun: message.startRun,
+    } as AppendMessage;
+  }
+
+  private resolveCancelledResume(
+    interrupts: readonly AgUiInterrupt[],
+    responses: readonly AgUiResumeEntry[] | undefined,
+  ): AgUiResumeEntry[] {
+    const openIds = interrupts.map((interrupt) => interrupt.id);
+    const known = new Set(openIds);
+    const responsesById = new Map<string, AgUiResumeEntry>();
+    for (const entry of responses ?? []) {
+      if (!entry || typeof entry.interruptId !== "string") {
+        throw new Error(
+          "[agui] cancelPendingInterruptsAndAppend: every response must have an interruptId",
+        );
+      }
+      if (entry.status !== "resolved" && entry.status !== "cancelled") {
+        throw new Error(
+          `[agui] cancelPendingInterruptsAndAppend: invalid status "${entry.status}" for interrupt ${entry.interruptId}`,
+        );
+      }
+      if (!known.has(entry.interruptId)) {
+        throw new Error(
+          `[agui] cancelPendingInterruptsAndAppend: unknown interrupt id ${entry.interruptId}`,
+        );
+      }
+      if (responsesById.has(entry.interruptId)) {
+        throw new Error(
+          `[agui] cancelPendingInterruptsAndAppend: duplicate response for interrupt ${entry.interruptId}`,
+        );
+      }
+      responsesById.set(entry.interruptId, entry);
+    }
+
+    return openIds.map(
+      (id) => responsesById.get(id) ?? { interruptId: id, status: "cancelled" },
+    );
   }
 
   private clearPendingInterrupts(messageId: string): void {

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -10,6 +10,7 @@ import type { ToolExecutionStatus } from "@assistant-ui/core";
 import type {
   AssistantRuntime,
   AppendMessage,
+  CreateAppendMessage,
   ExternalStoreAdapter,
   ThreadMessage,
 } from "@assistant-ui/core";
@@ -26,6 +27,10 @@ export type AgUiAssistantRuntime = AssistantRuntime & {
   unstable_getPendingInterrupts: () => readonly AgUiInterrupt[];
   unstable_submitInterruptResponses: (
     responses: readonly AgUiResumeEntry[],
+  ) => Promise<void>;
+  unstable_cancelPendingInterruptsAndAppend: (
+    message: CreateAppendMessage,
+    responses?: readonly AgUiResumeEntry[],
   ) => Promise<void>;
 };
 
@@ -160,6 +165,8 @@ export function useAgUiRuntime(
       core.getPendingInterrupts()?.interrupts ?? [];
     wrapper.unstable_submitInterruptResponses = (responses) =>
       core.submitInterruptResponses(responses);
+    wrapper.unstable_cancelPendingInterruptsAndAppend = (message, responses) =>
+      core.cancelPendingInterruptsAndAppend(message, responses);
     return wrapper;
   }, [baseRuntime, core]);
 

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1921,6 +1921,252 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(runCount).toBe(2);
   });
 
+  it("cancels pending interrupts and appends a user message, resuming with cancelled statuses", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: {
+              type: "interrupt",
+              interrupts: [{ id: "int-1", reason: "tool_call" }],
+            },
+          },
+        });
+      } else {
+        subscriber.onTextMessageContentEvent?.({
+          event: { type: "TEXT_MESSAGE_CONTENT", delta: "Sure." },
+        });
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: { type: "success" },
+          },
+        });
+      }
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const interruptMessageId = core.getPendingInterrupts()!.messageId;
+    await core.cancelPendingInterruptsAndAppend(
+      createAppendMessage({ parentId: interruptMessageId }),
+    );
+
+    expect(runCount).toBe(2);
+    expect(runInputs[1].resume).toEqual([
+      { interruptId: "int-1", status: "cancelled" },
+    ]);
+    expect(core.getPendingInterrupts()).toBeNull();
+
+    const roles = core.getMessages().map((m) => m.role);
+    expect(roles).toEqual(["user", "assistant", "user", "assistant"]);
+    const firstAssistant = core.getMessages()[1] as ThreadAssistantMessage;
+    expect(firstAssistant.status).toMatchObject({ type: "complete" });
+    expect(firstAssistant.metadata.custom.agui).toBeUndefined();
+  });
+
+  it("honors explicit resume responses when cancelling and appending", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: {
+              type: "interrupt",
+              interrupts: [
+                { id: "int-1", reason: "tool_call" },
+                { id: "int-2", reason: "input_required" },
+              ],
+            },
+          },
+        });
+      } else {
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: { type: "success" },
+          },
+        });
+      }
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const interruptMessageId = core.getPendingInterrupts()!.messageId;
+    await core.cancelPendingInterruptsAndAppend(
+      createAppendMessage({ parentId: interruptMessageId }),
+      [{ interruptId: "int-1", status: "resolved", payload: { ok: true } }],
+    );
+
+    expect(runInputs[1].resume).toEqual([
+      { interruptId: "int-1", status: "resolved", payload: { ok: true } },
+      { interruptId: "int-2", status: "cancelled" },
+    ]);
+  });
+
+  it("appends without a resume payload when no interrupts are pending", async () => {
+    const runInputs: any[] = [];
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.cancelPendingInterruptsAndAppend(createAppendMessage());
+
+    expect(runAgent).toHaveBeenCalledTimes(1);
+    expect(runInputs[0].resume).toBeUndefined();
+  });
+
+  it("rejects cancel-and-append with unknown interrupt ids", async () => {
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [{ id: "int-1", reason: "tool_call" }],
+          },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    await expect(
+      core.cancelPendingInterruptsAndAppend(createAppendMessage(), [
+        { interruptId: "int-unknown", status: "cancelled" },
+      ]),
+    ).rejects.toThrow(/unknown interrupt id/);
+    expect(runAgent).toHaveBeenCalledTimes(1);
+    expect(core.getPendingInterrupts()).not.toBeNull();
+  });
+
+  it("rejects cancel-and-append responses when no interrupts are pending", async () => {
+    const runAgent = vi.fn(async (_input: any, subscriber: any) => {
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+    const core = createCore(agent);
+
+    await expect(
+      core.cancelPendingInterruptsAndAppend(createAppendMessage(), [
+        { interruptId: "int-1", status: "cancelled" },
+      ]),
+    ).rejects.toThrow(/no pending interrupts/);
+    expect(runAgent).not.toHaveBeenCalled();
+  });
+
+  it("rejects cancel-and-append while the interrupting run is still draining", async () => {
+    let releaseRun!: () => void;
+    const released = new Promise<void>((resolve) => {
+      releaseRun = resolve;
+    });
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [{ id: "int-1", reason: "tool_call" }],
+          },
+        },
+      });
+      await released;
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    const appendPromise = core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(core.getPendingInterrupts()?.interrupts).toHaveLength(1);
+    expect(core.isRunning()).toBe(true);
+
+    await expect(
+      core.cancelPendingInterruptsAndAppend(createAppendMessage()),
+    ).rejects.toThrow(/a run is already in progress/);
+
+    releaseRun();
+    await appendPromise;
+    expect(runAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults parentId to the thread head so a minimal call preserves the thread", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: {
+              type: "interrupt",
+              interrupts: [{ id: "int-1", reason: "tool_call" }],
+            },
+          },
+        });
+      } else {
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: { type: "success" },
+          },
+        });
+      }
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    await core.cancelPendingInterruptsAndAppend({
+      role: "user",
+      content: [{ type: "text", text: "do something else" }],
+    });
+
+    expect(core.getMessages().map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+    expect(runInputs[1].resume).toEqual([
+      { interruptId: "int-1", status: "cancelled" },
+    ]);
+  });
+
   it("syncs runtime state snapshot onto the agent before runAgent", async () => {
     let stateAtRun: unknown;
     const agent = {


### PR DESCRIPTION
Closes #4477

## What

Adds `runtime.unstable_cancelPendingInterruptsAndAppend(message, responses?)` for the common HITL UX where the user ignores the interrupt UI and just types a new message. Today that path throws via `assertNoPendingInterrupts` and consumers work around it with a pnpm patch.

- No pending interrupts: behaves like a normal `append`.
- Pending interrupts: every open interrupt defaults to `{ interruptId, status: "cancelled" }`, the message is appended, and the run resumes with `resume: ResumeEntry[]`.
- Optional `responses` override the status per interrupt; validation mirrors `submitInterruptResponses`.

## How

Extracted `appendEntry` from `append` so the cancel path reuses the same insertion logic, minus the pending guard, plus a `resume` payload. Exposed as `unstable_*` to match the existing interrupt surface. Docs updated in `runtimes/ag-ui/runtime-options.mdx`.

Skipped the `expiresAt` check that `submitInterruptResponses` does, since cancelling an expired interrupt is the expected outcome here, not an error.

## Tests

6 new cases in `ag-ui-thread-runtime-core.spec.ts` (cancelled default, explicit override, no-pending fallback, and the rejection paths). Package suite 163/163 green, lint and build clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

