### PR TITLE
feat(react-ag-ui): add useAgUiSteerAway to steer past interrupts

### DIFF
--- a/.changeset/react-ag-ui-steer-away.md
+++ b/.changeset/react-ag-ui-steer-away.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat(react-ag-ui): add `useAgUiSteerAway` to send a new user message while an AG-UI interrupt is pending; it cancels every open interrupt as `{status:"cancelled"}` on the wire (honoring the AG-UI interrupts spec) and resumes the run with the new message, instead of throwing

--- a/.changeset/react-ag-ui-steer-away.md
+++ b/.changeset/react-ag-ui-steer-away.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-ag-ui": patch
 ---
 
-feat(react-ag-ui): add `useAgUiSteerAway` to send a new user message while an AG-UI interrupt is pending; it cancels every open interrupt as `{status:"cancelled"}` on the wire (honoring the AG-UI interrupts spec) and resumes the run with the new message, instead of throwing
+feat(react-ag-ui): add `useAgUiSteerAway` to send a new message while an AG-UI interrupt is pending; it accepts a string or partial message (the parent defaults to the head), cancels every open interrupt as `{status:"cancelled"}` on the wire (honoring the AG-UI interrupts spec), and resumes the run instead of throwing. pass `responses` to resolve specific interrupts while cancelling the rest

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -131,6 +131,25 @@ await runtime.unstable_submitInterruptResponses(
 );
 ```
 
+### Steering away from an interrupt
+
+When the user ignores the interrupt UI and just sends a new message, use the `useAgUiSteerAway` hook. Every open interrupt defaults to `status: "cancelled"`, the new message is appended, and the run resumes with `resume: ResumeEntry[]` on the wire. With no pending interrupts it behaves like a normal append.
+
+```tsx
+const steerAway = useAgUiSteerAway();
+
+// the user typed a new message instead of answering the interrupt
+await steerAway("actually, let's do something else");
+```
+
+The message accepts a plain string or a partial `AppendMessage` (the parent defaults to the current head, which is the interrupted assistant message). Pass `responses` to override the status of specific interrupts; the rest still default to cancelled.
+
+```tsx
+await steerAway("continue without the file", [
+  { interruptId: "tool-1", status: "resolved", payload: { approved: true } },
+]);
+```
+
 ## Supported events
 
 The runtime parses the AG-UI event stream and maps each event type to assistant-ui state.

--- a/packages/react-ag-ui/src/hooks.ts
+++ b/packages/react-ag-ui/src/hooks.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAui } from "@assistant-ui/store";
+import type { AppendMessage } from "@assistant-ui/core";
 import { agUiExtras } from "./agUiExtras";
 import type { AgUiInterrupt, AgUiResumeEntry } from "./runtime/types";
 
@@ -21,4 +22,16 @@ export const useAgUiSubmitInterruptResponses = () => {
   const aui = useAui();
   return (responses: readonly AgUiResumeEntry[]): Promise<void> =>
     agUiExtras.get(aui).submitInterruptResponses(responses);
+};
+
+/**
+ * Returns a function that discards the pending AG-UI interrupts and appends the
+ * given user message, starting a fresh run. Use this when the user sends a new
+ * message instead of resolving the interrupt(s): every open interrupt is
+ * reported to the agent as cancelled.
+ */
+export const useAgUiSteerAway = () => {
+  const aui = useAui();
+  return (message: AppendMessage): Promise<void> =>
+    agUiExtras.get(aui).steerAway(message);
 };

--- a/packages/react-ag-ui/src/hooks.ts
+++ b/packages/react-ag-ui/src/hooks.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useAui } from "@assistant-ui/store";
-import type { AppendMessage } from "@assistant-ui/core";
+import type { CreateAppendMessage } from "@assistant-ui/core";
 import { agUiExtras } from "./agUiExtras";
 import type { AgUiInterrupt, AgUiResumeEntry } from "./runtime/types";
 
@@ -28,10 +28,15 @@ export const useAgUiSubmitInterruptResponses = () => {
  * Returns a function that discards the pending AG-UI interrupts and appends the
  * given user message, starting a fresh run. Use this when the user sends a new
  * message instead of resolving the interrupt(s): every open interrupt is
- * reported to the agent as cancelled.
+ * reported to the agent as cancelled. The message accepts a plain string or a
+ * partial `AppendMessage` (the parent defaults to the current head). Pass
+ * `responses` to override the status of specific interrupts; the rest still
+ * default to cancelled.
  */
 export const useAgUiSteerAway = () => {
   const aui = useAui();
-  return (message: AppendMessage): Promise<void> =>
-    agUiExtras.get(aui).steerAway(message);
+  return (
+    message: CreateAppendMessage,
+    responses?: readonly AgUiResumeEntry[],
+  ): Promise<void> => agUiExtras.get(aui).steerAway(message, responses);
 };

--- a/packages/react-ag-ui/src/index.ts
+++ b/packages/react-ag-ui/src/index.ts
@@ -1,6 +1,10 @@
 export { useAgUiRuntime } from "./useAgUiRuntime";
 export type { AgUiAssistantRuntime } from "./useAgUiRuntime";
-export { useAgUiInterrupts, useAgUiSubmitInterruptResponses } from "./hooks";
+export {
+  useAgUiInterrupts,
+  useAgUiSubmitInterruptResponses,
+  useAgUiSteerAway,
+} from "./hooks";
 export { fromAgUiMessages } from "./runtime/adapter/conversions";
 export type { FromAgUiMessagesOptions } from "./runtime/adapter/conversions";
 export type {

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -348,6 +348,42 @@ export class AgUiThreadRuntimeCore {
     await this.startRun(pending.messageId, this.lastRunConfig, resume);
   }
 
+  async steerAway(message: AppendMessage): Promise<void> {
+    const pending = this.getPendingInterrupts();
+    if (!pending) {
+      await this.append({ ...message, startRun: true });
+      return;
+    }
+
+    if (this.isRunningFlag) {
+      throw new Error("[agui] steerAway: a run is already in progress");
+    }
+
+    const resume: AgUiResumeEntry[] = pending.interrupts.map((interrupt) => ({
+      interruptId: interrupt.id,
+      status: "cancelled" as const,
+    }));
+
+    // Clear before resetHead so the interrupted assistant is still in
+    // this.messages when its status is flipped; a parentId that points at an
+    // ancestor would otherwise truncate it away before it can be cleared.
+    this.clearPendingInterrupts(pending.messageId);
+
+    if (message.sourceId) {
+      this.messages = this.messages.filter(
+        (entry) => entry.id !== message.sourceId,
+      );
+    }
+    this.resetHead(message.parentId);
+
+    const threadMessage = this.toThreadMessage(message);
+    this.messages = [...this.messages, threadMessage];
+    this.notifyUpdate();
+    this.recordHistoryEntry(message.parentId ?? null, threadMessage);
+
+    await this.startRun(threadMessage.id, message.runConfig, resume);
+  }
+
   private clearPendingInterrupts(messageId: string): void {
     let touched = false;
     this.messages = this.messages.map((message) => {

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -4,6 +4,7 @@ import { generateId, fromThreadMessageLike } from "@assistant-ui/core";
 import type {
   AddToolResultOptions,
   AppendMessage,
+  CreateAppendMessage,
   AssistantRuntime,
   ChatModelRunOptions,
   ChatModelRunResult,
@@ -174,6 +175,12 @@ export class AgUiThreadRuntimeCore {
   async append(message: AppendMessage): Promise<void> {
     const startRun = message.startRun ?? message.role === "user";
     if (startRun) this.assertNoPendingInterrupts();
+    const threadMessageId = this.appendEntry(message);
+    if (!startRun) return;
+    await this.startRun(threadMessageId, message.runConfig);
+  }
+
+  private appendEntry(message: AppendMessage): string {
     if (message.sourceId) {
       this.messages = this.messages.filter(
         (entry) => entry.id !== message.sourceId,
@@ -185,9 +192,7 @@ export class AgUiThreadRuntimeCore {
     this.messages = [...this.messages, threadMessage];
     this.notifyUpdate();
     this.recordHistoryEntry(message.parentId ?? null, threadMessage);
-
-    if (!startRun) return;
-    await this.startRun(threadMessage.id, message.runConfig);
+    return threadMessage.id;
   }
 
   async edit(message: AppendMessage): Promise<void> {
@@ -348,40 +353,95 @@ export class AgUiThreadRuntimeCore {
     await this.startRun(pending.messageId, this.lastRunConfig, resume);
   }
 
-  async steerAway(message: AppendMessage): Promise<void> {
+  async steerAway(
+    message: CreateAppendMessage,
+    responses?: readonly AgUiResumeEntry[],
+  ): Promise<void> {
     const pending = this.getPendingInterrupts();
     if (!pending) {
-      await this.append({ ...message, startRun: true });
+      if (responses?.length) {
+        throw new Error(
+          "[agui] steerAway: no pending interrupts on this thread",
+        );
+      }
+      await this.append(this.toAppendMessage(message));
       return;
     }
+
+    const resume = this.resolveSteerAwayResume(pending.interrupts, responses);
 
     if (this.isRunningFlag) {
       throw new Error("[agui] steerAway: a run is already in progress");
     }
 
-    const resume: AgUiResumeEntry[] = pending.interrupts.map((interrupt) => ({
-      interruptId: interrupt.id,
-      status: "cancelled" as const,
-    }));
-
-    // Clear before resetHead so the interrupted assistant is still in
+    const normalized = this.toAppendMessage(message);
+    // Clear before appendEntry so the interrupted assistant is still in
     // this.messages when its status is flipped; a parentId that points at an
     // ancestor would otherwise truncate it away before it can be cleared.
     this.clearPendingInterrupts(pending.messageId);
+    const threadMessageId = this.appendEntry(normalized);
+    await this.startRun(threadMessageId, normalized.runConfig, resume);
+  }
 
-    if (message.sourceId) {
-      this.messages = this.messages.filter(
-        (entry) => entry.id !== message.sourceId,
-      );
+  private resolveSteerAwayResume(
+    interrupts: readonly AgUiInterrupt[],
+    responses: readonly AgUiResumeEntry[] | undefined,
+  ): AgUiResumeEntry[] {
+    const openIds = interrupts.map((interrupt) => interrupt.id);
+    const known = new Set(openIds);
+    const responsesById = new Map<string, AgUiResumeEntry>();
+    for (const entry of responses ?? []) {
+      if (!entry || typeof entry.interruptId !== "string") {
+        throw new Error(
+          "[agui] steerAway: every response must have an interruptId",
+        );
+      }
+      if (entry.status !== "resolved" && entry.status !== "cancelled") {
+        throw new Error(
+          `[agui] steerAway: invalid status "${entry.status}" for interrupt ${entry.interruptId}`,
+        );
+      }
+      if (!known.has(entry.interruptId)) {
+        throw new Error(
+          `[agui] steerAway: unknown interrupt id ${entry.interruptId}`,
+        );
+      }
+      if (responsesById.has(entry.interruptId)) {
+        throw new Error(
+          `[agui] steerAway: duplicate response for interrupt ${entry.interruptId}`,
+        );
+      }
+      responsesById.set(entry.interruptId, entry);
     }
-    this.resetHead(message.parentId);
+    return openIds.map(
+      (id) => responsesById.get(id) ?? { interruptId: id, status: "cancelled" },
+    );
+  }
 
-    const threadMessage = this.toThreadMessage(message);
-    this.messages = [...this.messages, threadMessage];
-    this.notifyUpdate();
-    this.recordHistoryEntry(message.parentId ?? null, threadMessage);
-
-    await this.startRun(threadMessage.id, message.runConfig, resume);
+  private toAppendMessage(message: CreateAppendMessage): AppendMessage {
+    if (typeof message === "string") {
+      return {
+        createdAt: new Date(),
+        parentId: this.messages.at(-1)?.id ?? null,
+        sourceId: null,
+        runConfig: {},
+        role: "user",
+        content: [{ type: "text", text: message }],
+        attachments: [],
+        metadata: { custom: {} },
+      };
+    }
+    return {
+      createdAt: message.createdAt ?? new Date(),
+      parentId: message.parentId ?? this.messages.at(-1)?.id ?? null,
+      sourceId: message.sourceId ?? null,
+      role: message.role ?? "user",
+      content: message.content,
+      attachments: message.attachments ?? [],
+      metadata: message.metadata ?? { custom: {} },
+      runConfig: message.runConfig ?? {},
+      startRun: message.startRun,
+    } as AppendMessage;
   }
 
   private clearPendingInterrupts(messageId: string): void {

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -1,4 +1,5 @@
 import type {
+  AppendMessage,
   AttachmentAdapter,
   DictationAdapter,
   ExternalStoreSharedOptions,
@@ -90,6 +91,7 @@ export type AgUiRuntimeExtras = {
   submitInterruptResponses: (
     responses: readonly AgUiResumeEntry[],
   ) => Promise<void>;
+  steerAway: (message: AppendMessage) => Promise<void>;
 };
 
 export type AgUiRunFinishedOutcome =

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -1,5 +1,5 @@
 import type {
-  AppendMessage,
+  CreateAppendMessage,
   AttachmentAdapter,
   DictationAdapter,
   ExternalStoreSharedOptions,
@@ -91,7 +91,10 @@ export type AgUiRuntimeExtras = {
   submitInterruptResponses: (
     responses: readonly AgUiResumeEntry[],
   ) => Promise<void>;
-  steerAway: (message: AppendMessage) => Promise<void>;
+  steerAway: (
+    message: CreateAppendMessage,
+    responses?: readonly AgUiResumeEntry[],
+  ) => Promise<void>;
 };
 
 export type AgUiRunFinishedOutcome =

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -144,6 +144,7 @@ export function useAgUiRuntime(
             core.getPendingInterrupts()?.interrupts ?? EMPTY_INTERRUPTS,
           submitInterruptResponses: (responses) =>
             core.submitInterruptResponses(responses),
+          steerAway: (message) => core.steerAway(message),
         }),
         unstable_enableToolInvocations: true,
         setToolStatuses,

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -144,7 +144,7 @@ export function useAgUiRuntime(
             core.getPendingInterrupts()?.interrupts ?? EMPTY_INTERRUPTS,
           submitInterruptResponses: (responses) =>
             core.submitInterruptResponses(responses),
-          steerAway: (message) => core.steerAway(message),
+          steerAway: (message, responses) => core.steerAway(message, responses),
         }),
         unstable_enableToolInvocations: true,
         setToolStatuses,

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1484,21 +1484,10 @@ describe("AGUIThreadRuntimeCore", () => {
     const core = createCore({ runAgent } as unknown as HttpAgent);
     await core.append(createAppendMessage());
 
-    const pending = core.getPendingInterrupts();
-    expect(pending).toBeTruthy();
+    expect(core.getPendingInterrupts()).toBeTruthy();
 
-    const steerMessage: AppendMessage = {
-      role: "user",
-      content: [{ type: "text", text: "changed my mind" }],
-      attachments: [],
-      metadata: { custom: {} },
-      createdAt: new Date(),
-      parentId: pending!.messageId,
-      sourceId: null,
-      runConfig: {},
-      startRun: true,
-    };
-    await core.steerAway(steerMessage);
+    // string input: parentId defaults to the head (the interrupted assistant)
+    await core.steerAway("changed my mind");
 
     expect(runCount).toBe(2);
     expect(runInputs[1].resume).toEqual([
@@ -1590,7 +1579,9 @@ describe("AGUIThreadRuntimeCore", () => {
 
     expect(runCount).toBe(2);
     expect(runInputs[1].resume).toBeUndefined();
-    expect(core.getMessages().filter((m) => m.role === "user")).toHaveLength(1);
+    // no-pending steerAway is a normal append onto the head, so the new user
+    // message joins the conversation (the first user turn plus this one).
+    expect(core.getMessages().filter((m) => m.role === "user")).toHaveLength(2);
   });
 
   it("steerAway from a root parentId clears interrupts without leaving a stale pending state", async () => {
@@ -1634,6 +1625,108 @@ describe("AGUIThreadRuntimeCore", () => {
       { interruptId: "int-1", status: "cancelled" },
     ]);
     expect(core.getPendingInterrupts()).toBeNull();
+  });
+
+  it("steerAway honors an explicit resume override and cancels the rest", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: {
+              type: "interrupt",
+              interrupts: [
+                { id: "int-1", reason: "tool_call" },
+                { id: "int-2", reason: "confirmation" },
+              ],
+            },
+          },
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+
+    await core.steerAway("never mind", [
+      { interruptId: "int-2", status: "resolved", payload: { ok: true } },
+    ]);
+
+    expect(runInputs[1].resume).toEqual([
+      { interruptId: "int-1", status: "cancelled" },
+      { interruptId: "int-2", status: "resolved", payload: { ok: true } },
+    ]);
+  });
+
+  it("steerAway rejects responses when no interrupts are pending", async () => {
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runCount++;
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+    expect(core.getPendingInterrupts()).toBeNull();
+
+    await expect(
+      core.steerAway("hi", [{ interruptId: "int-1", status: "cancelled" }]),
+    ).rejects.toThrow("no pending interrupts");
+    expect(runCount).toBe(1);
+  });
+
+  it("steerAway rejects unknown or duplicate interrupt ids", async () => {
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runCount++;
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [{ id: "int-1", reason: "tool_call" }],
+          },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+
+    await expect(
+      core.steerAway("x", [{ interruptId: "int-9", status: "cancelled" }]),
+    ).rejects.toThrow("unknown interrupt id");
+    await expect(
+      core.steerAway("x", [
+        { interruptId: "int-1", status: "cancelled" },
+        { interruptId: "int-1", status: "resolved" },
+      ]),
+    ).rejects.toThrow("duplicate response");
+    expect(runCount).toBe(1);
   });
 
   it("attaches a TOOL_CALL_RESULT for a prior run's tool call to its owning message", async () => {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1446,6 +1446,196 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(assistant.metadata.custom.agui).toBeUndefined();
   });
 
+  it("steerAway cancels the open interrupt and resumes with the new user message", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: {
+              type: "interrupt",
+              interrupts: [
+                { id: "int-1", reason: "tool_call", toolCallId: "call-1" },
+              ],
+            },
+          },
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onTextMessageContentEvent?.({
+        event: { type: "TEXT_MESSAGE_CONTENT", delta: "Done." },
+      });
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+
+    const pending = core.getPendingInterrupts();
+    expect(pending).toBeTruthy();
+
+    const steerMessage: AppendMessage = {
+      role: "user",
+      content: [{ type: "text", text: "changed my mind" }],
+      attachments: [],
+      metadata: { custom: {} },
+      createdAt: new Date(),
+      parentId: pending!.messageId,
+      sourceId: null,
+      runConfig: {},
+      startRun: true,
+    };
+    await core.steerAway(steerMessage);
+
+    expect(runCount).toBe(2);
+    expect(runInputs[1].resume).toEqual([
+      { interruptId: "int-1", status: "cancelled" },
+    ]);
+    const run2Messages = runInputs[1]?.messages ?? [];
+    expect(
+      run2Messages.some(
+        (m: { role: string; content: unknown }) =>
+          m.role === "user" && m.content === "changed my mind",
+      ),
+    ).toBe(true);
+
+    const assistant = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    expect(assistant.status).toMatchObject({ type: "complete" });
+    expect(assistant.metadata.custom.agui).toBeUndefined();
+  });
+
+  it("steerAway cancels every open interrupt", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: {
+              type: "interrupt",
+              interrupts: [
+                { id: "int-1", reason: "tool_call" },
+                { id: "int-2", reason: "confirmation" },
+              ],
+            },
+          },
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+    const pending = core.getPendingInterrupts();
+    expect(pending?.interrupts).toHaveLength(2);
+
+    await core.steerAway(createAppendMessage({ parentId: pending!.messageId }));
+
+    expect(runCount).toBe(2);
+    expect(runInputs[1].resume).toEqual([
+      { interruptId: "int-1", status: "cancelled" },
+      { interruptId: "int-2", status: "cancelled" },
+    ]);
+  });
+
+  it("steerAway behaves like append when no interrupts are pending", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+    expect(core.getPendingInterrupts()).toBeNull();
+
+    await core.steerAway(createAppendMessage());
+
+    expect(runCount).toBe(2);
+    expect(runInputs[1].resume).toBeUndefined();
+    expect(core.getMessages().filter((m) => m.role === "user")).toHaveLength(1);
+  });
+
+  it("steerAway from a root parentId clears interrupts without leaving a stale pending state", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: {
+              type: "interrupt",
+              interrupts: [{ id: "int-1", reason: "tool_call" }],
+            },
+          },
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+    expect(core.getPendingInterrupts()).toBeTruthy();
+
+    await core.steerAway(createAppendMessage({ parentId: null }));
+
+    expect(runCount).toBe(2);
+    expect(runInputs[1].resume).toEqual([
+      { interruptId: "int-1", status: "cancelled" },
+    ]);
+    expect(core.getPendingInterrupts()).toBeNull();
+  });
+
   it("attaches a TOOL_CALL_RESULT for a prior run's tool call to its owning message", async () => {
     let runCount = 0;
     const runAgent = vi.fn(async (input: any, subscriber: any) => {

--- a/packages/react-ag-ui/test/hooks.spec.ts
+++ b/packages/react-ag-ui/test/hooks.spec.ts
@@ -14,14 +14,27 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
   useAui: (() => mockUseAui()) as typeof import("@assistant-ui/store").useAui,
 }));
 
+import type { AppendMessage } from "@assistant-ui/core";
 import { agUiExtras } from "../src/agUiExtras";
 import {
   useAgUiInterrupts,
   useAgUiSubmitInterruptResponses,
+  useAgUiSteerAway,
 } from "../src/hooks";
 import type { AgUiInterrupt, AgUiResumeEntry } from "../src/runtime/types";
 
 const interrupt: AgUiInterrupt = { id: "int-1", reason: "confirmation" };
+
+const userMessage: AppendMessage = {
+  role: "user",
+  content: [{ type: "text", text: "hi" }],
+  attachments: [],
+  metadata: { custom: {} },
+  createdAt: new Date(),
+  parentId: null,
+  sourceId: null,
+  runConfig: {},
+};
 
 const againstState = (extras: unknown) =>
   mockUseAuiState.mockImplementationOnce((selector: (s: unknown) => unknown) =>
@@ -35,6 +48,7 @@ describe("useAgUiInterrupts", () => {
       agUiExtras.provide({
         interrupts: [interrupt],
         submitInterruptResponses,
+        steerAway: vi.fn(),
       }),
     );
     expect(useAgUiInterrupts()).toEqual([interrupt]);
@@ -52,6 +66,7 @@ describe("useAgUiSubmitInterruptResponses", () => {
     const extras = agUiExtras.provide({
       interrupts: [interrupt],
       submitInterruptResponses,
+      steerAway: vi.fn(),
     });
     mockUseAui.mockReturnValue({
       thread: () => ({ getState: () => ({ extras }) }),
@@ -72,5 +87,30 @@ describe("useAgUiSubmitInterruptResponses", () => {
     expect(() => useAgUiSubmitInterruptResponses()([])).toThrow(
       "useAgUiRuntime",
     );
+  });
+});
+
+describe("useAgUiSteerAway", () => {
+  it("delegates to the extras steerAway with the given message", () => {
+    const steerAway = vi.fn().mockResolvedValue(undefined);
+    const extras = agUiExtras.provide({
+      interrupts: [interrupt],
+      submitInterruptResponses: vi.fn(),
+      steerAway,
+    });
+    mockUseAui.mockReturnValue({
+      thread: () => ({ getState: () => ({ extras }) }),
+    });
+
+    useAgUiSteerAway()(userMessage);
+
+    expect(steerAway).toHaveBeenCalledWith(userMessage);
+  });
+
+  it("throws when the thread is not backed by ag-ui", () => {
+    mockUseAui.mockReturnValue({
+      thread: () => ({ getState: () => ({ extras: undefined }) }),
+    });
+    expect(() => useAgUiSteerAway()(userMessage)).toThrow("useAgUiRuntime");
   });
 });

--- a/packages/react-ag-ui/test/hooks.spec.ts
+++ b/packages/react-ag-ui/test/hooks.spec.ts
@@ -91,7 +91,26 @@ describe("useAgUiSubmitInterruptResponses", () => {
 });
 
 describe("useAgUiSteerAway", () => {
-  it("delegates to the extras steerAway with the given message", () => {
+  it("forwards the message and responses to extras.steerAway", () => {
+    const steerAway = vi.fn().mockResolvedValue(undefined);
+    const extras = agUiExtras.provide({
+      interrupts: [interrupt],
+      submitInterruptResponses: vi.fn(),
+      steerAway,
+    });
+    mockUseAui.mockReturnValue({
+      thread: () => ({ getState: () => ({ extras }) }),
+    });
+    const responses: AgUiResumeEntry[] = [
+      { interruptId: "int-1", status: "cancelled" },
+    ];
+
+    useAgUiSteerAway()("changed my mind", responses);
+
+    expect(steerAway).toHaveBeenCalledWith("changed my mind", responses);
+  });
+
+  it("forwards a bare message with no responses", () => {
     const steerAway = vi.fn().mockResolvedValue(undefined);
     const extras = agUiExtras.provide({
       interrupts: [interrupt],
@@ -104,7 +123,7 @@ describe("useAgUiSteerAway", () => {
 
     useAgUiSteerAway()(userMessage);
 
-    expect(steerAway).toHaveBeenCalledWith(userMessage);
+    expect(steerAway).toHaveBeenCalledWith(userMessage, undefined);
   });
 
   it("throws when the thread is not backed by ag-ui", () => {


### PR DESCRIPTION
closes #4477

## summary

- add `useAgUiSteerAway()`: when an AG-UI interrupt is pending and the user sends a new message instead of answering it, this cancels every open interrupt and resumes the run with the new message, rather than throwing.
- on the wire the run carries `input.resume` with `{ interruptId, status: "cancelled" }` for every open interrupt (honoring the AG-UI interrupts spec), so the agent learns the interrupts were abandoned; it is not a silent drop.
- exposed on the canonical `agUiExtras` + `hooks.ts` surface from #4485, backed by a new `steerAway` method on `AgUiThreadRuntimeCore`; the deprecated `unstable_` graft is untouched.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ag-ui test` -> 168/168 green (added 4 controller + 2 hook tests)
- [x] `pnpm --filter @assistant-ui/react-ag-ui exec tsc --noEmit` -> clean
- [x] `pnpm lint` -> no react-ag-ui issues; `oxfmt --check` clean
- [x] `pnpm --filter @assistant-ui/react-ag-ui build` -> aui-build OK

### reviewer should verify

- [ ] wire `useAgUiSteerAway()` into a composer: with an interrupt pending, sending a new message cancels the interrupt (agent receives `resume: [{ ..., status: "cancelled" }]`), appends the message, and continues the run; the interrupted assistant flips to complete.

## notes

- pure cancel-all semantics: no `resume` override on the public hook (issue #4477's ask is to treat pending interrupts as cancelled). an override to resolve some while abandoning the rest can be added later without a breaking change.
- ordering: the interrupted assistant is cleared before `resetHead`, so a `null` or ancestor `parentId` cannot truncate it before its status is flipped.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

