### PR TITLE
fix(docs): drop no-op identity replacements in demo zip path mapping

### DIFF
--- a/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
+++ b/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
@@ -86,11 +86,7 @@ function assertSnapshotFile(snapshot: SourceSnapshot, snapshotKey: string) {
 
 function targetPathForSourceFile(sourceFile: string) {
   if (sourceFile.startsWith("packages/ui/src/")) {
-    return sourceFile
-      .replace(/^packages\/ui\/src\//, "")
-      .replace(/^components\/ui\//, "components/ui/")
-      .replace(/^components\/assistant-ui\//, "components/assistant-ui/")
-      .replace(/^lib\//, "lib/");
+    return sourceFile.replace(/^packages\/ui\/src\//, "");
   }
 
   if (sourceFile.startsWith("apps/docs/")) {


### PR DESCRIPTION
## summary

- clears the three CodeQL `js/identity-replacement` alerts (#59, #60, #61) in `apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts`
- in `targetPathForSourceFile`, after `.replace(/^packages\/ui\/src\//, "")` strips the prefix, the three chained `.replace()` calls each matched the already-stripped path and substituted it with the identical string, so they never changed the result
- removed them, leaving the single prefix-stripping replace; behavior is unchanged

## test plan

### already verified

- [x] ran both the old and new `targetPathForSourceFile` against every real `extraSourceFiles` value from `manifest.ts` plus adversarial edge cases (empty tail, prefix-like segment mid-path, non-matching remainders) -> 0 differences across all inputs
- [x] `pnpm exec oxlint apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts` -> clean

### reviewer should verify

- [ ] `extraSourceFiles` entries under `packages/ui/src/` still map to the expected `lib/`, `components/ui/`, and `components/assistant-ui/` targets in a generated demo zip

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

