### PR TITLE
fix: tolerate content blocks that omit their declared fields

### DIFF
--- a/.changeset/content-block-missing-fields.md
+++ b/.changeset/content-block-missing-fields.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/core": patch
+---
+
+fix: tolerate reasoning and image content blocks that omit their declared fields

--- a/packages/core/src/runtime/utils/thread-message-like.ts
+++ b/packages/core/src/runtime/utils/thread-message-like.ts
@@ -127,6 +127,7 @@ export const fromThreadMessageLike = (
     image,
     ...rest
   }: ImageMessagePart): ImageMessagePart | null => {
+    if (typeof image !== "string") return null;
     const dataUri = image.match(
       /^data:image\/(png|jpeg|jpg|gif|webp|svg\+xml);base64,(.*)$/,
     );
@@ -160,7 +161,7 @@ export const fromThreadMessageLike = (
             switch (type) {
               case "text":
               case "reasoning":
-                if (part.text.trim().length === 0) return null;
+                if (!part.text?.trim()) return null;
                 return part;
 
               case "file":

--- a/packages/core/src/tests/thread-message-like.test.ts
+++ b/packages/core/src/tests/thread-message-like.test.ts
@@ -110,4 +110,54 @@ describe("fromThreadMessageLike", () => {
       ).toThrow("Unsupported user message part type: tool-call");
     });
   });
+
+  describe("reasoning and image robustness", () => {
+    it("drops a reasoning part whose text is undefined", () => {
+      const result = fromThreadMessageLike(
+        {
+          role: "assistant",
+          content: [
+            { type: "reasoning", text: undefined as unknown as string },
+          ],
+        },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result.content).toEqual([]);
+    });
+
+    it("drops a whitespace-only text part", () => {
+      const result = fromThreadMessageLike(
+        { role: "assistant", content: [{ type: "text", text: "   " }] },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result.content).toEqual([]);
+    });
+
+    it("keeps a reasoning part with real text", () => {
+      const result = fromThreadMessageLike(
+        { role: "assistant", content: [{ type: "reasoning", text: "hi" }] },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result.content).toEqual([{ type: "reasoning", text: "hi" }]);
+    });
+
+    it("drops an assistant image part whose image is undefined", () => {
+      const result = fromThreadMessageLike(
+        {
+          role: "assistant",
+          content: [{ type: "image", image: undefined as unknown as string }],
+        },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result.content).toEqual([]);
+    });
+  });
 });

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -127,9 +127,12 @@ describe("convertLangChainBaseMessage image content parts", () => {
     ]);
   });
 
-  it("does not throw when image_url is undefined", () => {
-    expect(() =>
-      convertLangChainBaseMessage(humanMessage([{ type: "image_url" }]), {}),
-    ).not.toThrow();
+  it("drops the image part when image_url is undefined", () => {
+    const result = convertLangChainBaseMessage(
+      humanMessage([{ type: "image_url" }]),
+      {},
+    );
+
+    expect(result.content).toEqual([]);
   });
 });

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -8,6 +8,12 @@ const humanMessage = (content: unknown): LangChainBaseMessage => ({
   content,
 });
 
+const aiMessage = (content: unknown): LangChainBaseMessage => ({
+  _getType: () => "ai",
+  id: "msg-2",
+  content,
+});
+
 describe("convertLangChainBaseMessage file content parts", () => {
   it("converts a base64 file block", () => {
     const result = convertLangChainBaseMessage(
@@ -49,5 +55,81 @@ describe("convertLangChainBaseMessage file content parts", () => {
         mimeType: "application/pdf",
       },
     ]);
+  });
+});
+
+describe("convertLangChainBaseMessage reasoning content parts", () => {
+  it("joins summary parts into a single reasoning part", () => {
+    const result = convertLangChainBaseMessage(
+      aiMessage([
+        {
+          type: "reasoning",
+          summary: [
+            { type: "summary_text", text: "first" },
+            { type: "summary_text", text: "second" },
+          ],
+        },
+      ]),
+      {},
+    );
+
+    expect(result.content).toEqual([
+      { type: "reasoning", text: "first\n\n\nsecond" },
+    ]);
+  });
+
+  it("falls back to the reasoning string when summary is absent", () => {
+    const result = convertLangChainBaseMessage(
+      aiMessage([{ type: "reasoning", reasoning: "thinking out loud" }]),
+      {},
+    );
+
+    expect(result.content).toEqual([
+      { type: "reasoning", text: "thinking out loud" },
+    ]);
+  });
+
+  it("does not throw when a reasoning block omits both summary and reasoning", () => {
+    const result = convertLangChainBaseMessage(
+      aiMessage([{ type: "reasoning" }]),
+      {},
+    );
+
+    expect(result.content).toEqual([{ type: "reasoning", text: "" }]);
+  });
+
+  it("tolerates null entries inside the summary array", () => {
+    const result = convertLangChainBaseMessage(
+      aiMessage([
+        {
+          type: "reasoning",
+          summary: [null, { type: "summary_text", text: "kept" }],
+        },
+      ]),
+      {},
+    );
+
+    expect(result.content).toEqual([{ type: "reasoning", text: "\n\n\nkept" }]);
+  });
+});
+
+describe("convertLangChainBaseMessage image content parts", () => {
+  it("reads the url from an image_url object", () => {
+    const result = convertLangChainBaseMessage(
+      humanMessage([
+        { type: "image_url", image_url: { url: "https://example.com/a.png" } },
+      ]),
+      {},
+    );
+
+    expect(result.content).toEqual([
+      { type: "image", image: "https://example.com/a.png" },
+    ]);
+  });
+
+  it("does not throw when image_url is undefined", () => {
+    expect(() =>
+      convertLangChainBaseMessage(humanMessage([{ type: "image_url" }]), {}),
+    ).not.toThrow();
   });
 });

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -24,11 +24,14 @@ const contentToParts = (content: unknown) => {
         case "text":
         case "text_delta":
           return { type: "text" as const, text: part.text };
-        case "image_url":
-          if (typeof part.image_url === "string") {
-            return { type: "image" as const, image: part.image_url };
-          }
-          return { type: "image" as const, image: part.image_url?.url };
+        case "image_url": {
+          const image =
+            typeof part.image_url === "string"
+              ? part.image_url
+              : part.image_url?.url;
+          if (!image) return null;
+          return { type: "image" as const, image };
+        }
         case "file":
           return {
             type: "file" as const,

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -28,7 +28,7 @@ const contentToParts = (content: unknown) => {
           if (typeof part.image_url === "string") {
             return { type: "image" as const, image: part.image_url };
           }
-          return { type: "image" as const, image: part.image_url.url };
+          return { type: "image" as const, image: part.image_url?.url };
         case "file":
           return {
             type: "file" as const,
@@ -41,7 +41,10 @@ const contentToParts = (content: unknown) => {
         case "reasoning":
           return {
             type: "reasoning" as const,
-            text: part.summary.map((s) => s.text).join("\n\n\n"),
+            text:
+              part.summary?.map((s) => s?.text ?? "").join("\n\n\n") ??
+              part.reasoning ??
+              "",
           };
         case "tool_use":
         case "input_json_delta":

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -15,11 +15,12 @@ import type { UseStreamOptions, AssembledToolCall } from "@langchain/react";
 export type LangChainContentBlock =
   | { type: "text"; text: string }
   | { type: "text_delta"; text: string }
-  | { type: "image_url"; image_url: string | { url: string } }
+  | { type: "image_url"; image_url: string | { url?: string } }
   | { type: "thinking"; thinking: string }
   | {
       type: "reasoning";
-      summary: Array<{ type: "summary_text"; text: string }>;
+      summary?: Array<{ type: "summary_text"; text?: string }>;
+      reasoning?: string;
     }
   | {
       type: "file";

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -403,6 +403,61 @@ describe("convertLangChainMessages reasoning content", () => {
       ],
     });
   });
+
+  it("tolerates null entries inside the summary array", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-reasoning-null-summary",
+      content: [
+        {
+          type: "reasoning",
+          summary: [null, { type: "summary_text", text: "kept" }],
+        } as any,
+      ],
+    });
+
+    expect(result).toMatchObject({
+      role: "assistant",
+      content: [{ type: "reasoning", text: "\n\n\nkept" }],
+    });
+  });
+
+  it("does not throw when a reasoning block omits summary and reasoning", () => {
+    expect(() =>
+      convertLangChainMessages({
+        type: "ai",
+        id: "ai-reasoning-empty",
+        content: [{ type: "reasoning" } as any],
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("convertLangChainMessages image content", () => {
+  it("reads the url from an image_url object", () => {
+    const result = convertLangChainMessages({
+      type: "human",
+      id: "human-image",
+      content: [
+        { type: "image_url", image_url: { url: "https://example.com/a.png" } },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      role: "user",
+      content: [{ type: "image", image: "https://example.com/a.png" }],
+    });
+  });
+
+  it("does not throw when image_url is undefined", () => {
+    expect(() =>
+      convertLangChainMessages({
+        type: "human",
+        id: "human-image-undefined",
+        content: [{ type: "image_url" } as any],
+      }),
+    ).not.toThrow();
+  });
 });
 
 describe("convertLangChainMessages UI messages", () => {

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -449,14 +449,14 @@ describe("convertLangChainMessages image content", () => {
     });
   });
 
-  it("does not throw when image_url is undefined", () => {
-    expect(() =>
-      convertLangChainMessages({
-        type: "human",
-        id: "human-image-undefined",
-        content: [{ type: "image_url" } as any],
-      }),
-    ).not.toThrow();
+  it("drops the image part when image_url is undefined", () => {
+    const result = convertLangChainMessages({
+      type: "human",
+      id: "human-image-undefined",
+      content: [{ type: "image_url" } as any],
+    });
+
+    expect(result.content).toEqual([]);
   });
 });
 

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -188,7 +188,7 @@ const contentToParts = (
             } else {
               return {
                 type: "image",
-                image: part.image_url.url,
+                image: part.image_url?.url,
               };
             }
           case "file":
@@ -206,7 +206,7 @@ const contentToParts = (
             return {
               type: "reasoning",
               text:
-                part.summary?.map((s) => s.text).join("\n\n\n") ??
+                part.summary?.map((s) => s?.text ?? "").join("\n\n\n") ??
                 part.reasoning ??
                 "",
             };

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -182,15 +182,14 @@ const contentToParts = (
             return { type: "text", text: part.text };
           case "text_delta":
             return { type: "text", text: part.text };
-          case "image_url":
-            if (typeof part.image_url === "string") {
-              return { type: "image", image: part.image_url };
-            } else {
-              return {
-                type: "image",
-                image: part.image_url?.url,
-              };
-            }
+          case "image_url": {
+            const image =
+              typeof part.image_url === "string"
+                ? part.image_url
+                : part.image_url?.url;
+            if (!image) return null;
+            return { type: "image", image };
+          }
           case "file":
             return {
               type: "file",

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -40,7 +40,7 @@ export type MessageContentText = {
 
 export type MessageContentImageUrl = {
   type: "image_url";
-  image_url: string | { url: string };
+  image_url: string | { url?: string };
 };
 
 export type MessageContentThinking = {
@@ -50,7 +50,7 @@ export type MessageContentThinking = {
 
 export type MessageContentReasoningSummaryText = {
   type: "summary_text";
-  text: string;
+  text?: string;
 };
 
 export type MessageContentReasoning = {


### PR DESCRIPTION
closes #4486

## summary

- some providers stream partial or off spec content blocks whose typed payload field is absent (a reasoning block without `summary`, an `image_url` block without `url`, a `summary` array with null entries); the langchain and langgraph converters and core's `fromThreadMessageLike` assumed those fields were always present and threw a `TypeError` on `.map` / `.trim` / `.match`.
- react-langchain and react-langgraph converters now guard `summary` at the container and element level with a `reasoning ?? ""` fallback and read `image_url?.url`.
- core `fromThreadMessageLike` drops text/reasoning parts that carry no text (`!part.text?.trim()`) and image parts whose `image` is not a string, which backstops every external-store adapter (eve, react-ai-sdk, others) without a converter change of their own.
- widened the langchain and langgraph content-block types so they stop declaring the optional wire fields as required.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-langchain test` -> 28/28 green
- [x] `pnpm --filter @assistant-ui/react-langgraph test` -> 147/147 green
- [x] `pnpm --filter @assistant-ui/core test` -> 346/346 green
- [x] build of core, react-langchain, react-langgraph -> typecheck + build pass
- [x] `pnpm lint` -> oxlint + oxfmt clean

### reviewer should verify

- [ ] in a langchain or langgraph app with Claude extended thinking enabled, stream an assistant message whose reasoning block omits `summary`, and confirm the thread renders instead of crashing the runtime.

## notes

- supersedes #4487 and #4488 (both by the same author, credited via `Co-authored-by`); they can be closed in favor of this PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

