### PR TITLE
feat(react-langchain): render generative UI from graph state

### DIFF
--- a/.changeset/langchain-generative-ui-state.md
+++ b/.changeset/langchain-generative-ui-state.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): render generative UI from graph state

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -615,7 +615,7 @@ function PendingToolCalls() {
 
 ## Generative UI
 
-Graphs can accumulate UI components in their state and attach each one to the assistant message that produced it. The runtime reads these from `stream.values[uiStateKey]` (default `"ui"`) and, for every `UIMessage` whose `metadata.message_id` matches an assistant message, emits a `data` part on that message. Pass `uiStateKey` if your graph stores them elsewhere.
+Graphs can accumulate UI components in their state and attach each one to the assistant message that produced it. The runtime reads these from `stream.values[uiStateKey]` (default `"ui"`) and, for every `UIMessage` whose parent id matches an assistant message, emits a `data` part on that message. The parent id is read from `metadata.message_id` (Python SDK) or `metadata.id` (JS SDK). Pass `uiStateKey` if your graph stores them elsewhere.
 
 Register the components with `makeAssistantDataUI`, keyed by the `UIMessage`'s `name`, and mount the returned element once inside the runtime provider:
 

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -251,13 +251,14 @@ Follow the [Ink setup](/docs/ink).
 
 ## `useStreamRuntime` options
 
-`useStreamRuntime` accepts every option upstream `useStream` does, plus three assistant-ui-specific fields:
+`useStreamRuntime` accepts every option upstream `useStream` does, plus these assistant-ui-specific fields:
 
 | Option | Type | Description |
 | --- | --- | --- |
 | `cloud` | `AssistantCloud` | Optional. Persists threads via assistant-cloud. |
 | `adapters` | `{ attachments?, speech?, feedback? }` | Optional. Attachment, speech, and feedback adapters. |
 | `messagesKey` | `string` | The state key that holds messages. Defaults to `"messages"`. |
+| `uiStateKey` | `string` | The state key that holds generative `UIMessage`s. Defaults to `"ui"`. |
 
 ### Forwarding per-run config
 
@@ -612,6 +613,42 @@ function PendingToolCalls() {
 </Tab>
 </PlatformTabs>
 
+## Generative UI
+
+Graphs can accumulate UI components in their state and attach each one to the assistant message that produced it. The runtime reads these from `stream.values[uiStateKey]` (default `"ui"`) and, for every `UIMessage` whose `metadata.message_id` matches an assistant message, emits a `data` part on that message. Pass `uiStateKey` if your graph stores them elsewhere.
+
+Register the components with `makeAssistantDataUI`, keyed by the `UIMessage`'s `name`, and mount the returned element once inside the runtime provider:
+
+```tsx
+import {
+  AssistantRuntimeProvider,
+  makeAssistantDataUI,
+  Thread,
+} from "@assistant-ui/react";
+import { useStreamRuntime } from "@assistant-ui/react-langchain";
+
+const ChartUI = makeAssistantDataUI({
+  name: "chart",
+  render: ({ data }) => <Chart points={data.points} />,
+});
+
+function App() {
+  const runtime = useStreamRuntime({
+    assistantId: "agent",
+    apiUrl: "http://localhost:2024",
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ChartUI />
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+This is the state-snapshot path: it renders whatever UI the graph has committed to its state. Streaming a component live over the `push_ui_message` custom channel before it lands in state is a separate path that will arrive in a follow-up.
+
 ## Errors
 
 `useLangChainError` exposes the last run or hydration error from upstream `useStream().error`. It is untyped (`unknown`), so narrow it at the use site before rendering.
@@ -685,7 +722,8 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | Root tool-calls projection | Via message parts | Yes (`useLangChainToolCalls`) |
 | File content parts in messages | Yes | Yes |
 | Per-message metadata (`messages-tuple`) | Yes | Not exposed |
-| Generative UI messages (LangSmith) | Yes | Not exposed |
+| Generative UI (state snapshot) | Yes | Yes (`uiStateKey`) |
+| Generative UI (live `push_ui_message`) | Yes | Not yet |
 | Subgraph / namespaced stream events | Yes (via `eventHandlers`) | Not exposed |
 | End-to-end cancellation primitive | Yes (`unstable_createLangGraphStream`) | Not exposed |
 | Message accumulator utility | Yes (`LangGraphMessageAccumulator`) | Not exposed |

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -160,6 +160,21 @@ describe("convertLangChainBaseMessage generative UI from graph state", () => {
       { type: "data", name: "table", data: { b: 2 } },
     ]);
   });
+
+  it("does not attach UI to an assistant message without an id", () => {
+    const result = convertLangChainBaseMessage(
+      { ...aiMessage("hello"), id: undefined },
+      { uiMessagesByParent: new Map([["", [uiMessage("")]]]) },
+    );
+
+    expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("leaves the message unchanged when no converter metadata is passed", () => {
+    const result = convertLangChainBaseMessage(aiMessage("hello"));
+
+    expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+  });
 });
 
 describe("convertLangChainBaseMessage image content parts", () => {

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { convertLangChainBaseMessage } from "./convertMessages";
-import type { LangChainBaseMessage } from "./types";
+import type { LangChainBaseMessage, UIMessage } from "./types";
 
 const humanMessage = (content: unknown): LangChainBaseMessage => ({
   _getType: () => "human",
@@ -110,6 +110,55 @@ describe("convertLangChainBaseMessage reasoning content parts", () => {
     );
 
     expect(result.content).toEqual([{ type: "reasoning", text: "\n\n\nkept" }]);
+  });
+});
+
+describe("convertLangChainBaseMessage generative UI from graph state", () => {
+  const uiMessage = (messageId: string): UIMessage => ({
+    type: "ui",
+    id: "ui-1",
+    name: "chart",
+    props: { points: [1, 2, 3] },
+    metadata: { message_id: messageId },
+  });
+
+  it("appends a data part for UI attached to the assistant message", () => {
+    const result = convertLangChainBaseMessage(aiMessage("hello"), {
+      uiMessagesByParent: new Map([["msg-2", [uiMessage("msg-2")]]]),
+    });
+
+    expect(result.content).toEqual([
+      { type: "text", text: "hello" },
+      { type: "data", name: "chart", data: { points: [1, 2, 3] } },
+    ]);
+  });
+
+  it("leaves the message unchanged when no UI targets it", () => {
+    const result = convertLangChainBaseMessage(aiMessage("hello"), {
+      uiMessagesByParent: new Map([["other-id", [uiMessage("other-id")]]]),
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("appends a data part per UI when several target the same message", () => {
+    const result = convertLangChainBaseMessage(aiMessage("hello"), {
+      uiMessagesByParent: new Map([
+        [
+          "msg-2",
+          [
+            { ...uiMessage("msg-2"), name: "chart", props: { a: 1 } },
+            { ...uiMessage("msg-2"), name: "table", props: { b: 2 } },
+          ],
+        ],
+      ]),
+    });
+
+    expect(result.content).toEqual([
+      { type: "text", text: "hello" },
+      { type: "data", name: "chart", data: { a: 1 } },
+      { type: "data", name: "table", data: { b: 2 } },
+    ]);
   });
 });
 

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import type { useExternalMessageConverter } from "@assistant-ui/core/react";
-import type { AppendMessage } from "@assistant-ui/core";
+import type { AppendMessage, DataMessagePart } from "@assistant-ui/core";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
 import type {
   LangChainBaseMessage,
@@ -13,6 +13,12 @@ type LangChainMessageConverterMetadata =
   useExternalMessageConverter.Metadata & {
     uiMessagesByParent?: Map<string, UIMessage[]>;
   };
+
+const uiMessageToDataPart = (ui: UIMessage): DataMessagePart => ({
+  type: "data",
+  name: ui.name,
+  data: ui.props,
+});
 
 export const getMessageType = (message: LangChainBaseMessage): string => {
   if (typeof message._getType === "function") return message._getType();
@@ -122,11 +128,11 @@ export const convertLangChainBaseMessage: useExternalMessageConverter.Callback<
         typeof message.status === "object" ? message.status : undefined;
 
       const uiDataParts =
-        metadata.uiMessagesByParent?.get(message.id ?? "")?.map((ui) => ({
-          type: "data" as const,
-          name: ui.name,
-          data: ui.props,
-        })) ?? [];
+        (message.id
+          ? metadata.uiMessagesByParent
+              ?.get(message.id)
+              ?.map(uiMessageToDataPart)
+          : undefined) ?? [];
 
       return {
         role: "assistant",

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -3,7 +3,16 @@
 import type { useExternalMessageConverter } from "@assistant-ui/core/react";
 import type { AppendMessage } from "@assistant-ui/core";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
-import type { LangChainBaseMessage, LangChainContentBlock } from "./types";
+import type {
+  LangChainBaseMessage,
+  LangChainContentBlock,
+  UIMessage,
+} from "./types";
+
+type LangChainMessageConverterMetadata =
+  useExternalMessageConverter.Metadata & {
+    uiMessagesByParent?: Map<string, UIMessage[]>;
+  };
 
 export const getMessageType = (message: LangChainBaseMessage): string => {
   if (typeof message._getType === "function") return message._getType();
@@ -75,7 +84,7 @@ const getStringContent = (content: unknown): string => {
 
 export const convertLangChainBaseMessage: useExternalMessageConverter.Callback<
   LangChainBaseMessage
-> = (message) => {
+> = (message, metadata: LangChainMessageConverterMetadata = {}) => {
   const type = getMessageType(message);
 
   switch (type) {
@@ -112,10 +121,21 @@ export const convertLangChainBaseMessage: useExternalMessageConverter.Callback<
       const assistantStatus =
         typeof message.status === "object" ? message.status : undefined;
 
+      const uiDataParts =
+        metadata.uiMessagesByParent?.get(message.id ?? "")?.map((ui) => ({
+          type: "data" as const,
+          name: ui.name,
+          data: ui.props,
+        })) ?? [];
+
       return {
         role: "assistant",
         id: message.id,
-        content: [...contentToParts(message.content), ...toolCallParts],
+        content: [
+          ...contentToParts(message.content),
+          ...toolCallParts,
+          ...uiDataParts,
+        ],
         metadata: {
           custom: getCustomMetadata(message.additional_kwargs),
         },

--- a/packages/react-langchain/src/groupUIMessagesByParent.test.ts
+++ b/packages/react-langchain/src/groupUIMessagesByParent.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { groupUIMessagesByParent } from "./useStreamRuntime";
+import type { UIMessage } from "./types";
+
+const uiMessage = (
+  metadata: UIMessage["metadata"],
+  name = "chart",
+): UIMessage => ({
+  type: "ui",
+  id: "ui-1",
+  name,
+  props: { points: [1, 2, 3] },
+  metadata,
+});
+
+describe("groupUIMessagesByParent", () => {
+  it("returns an empty map for non-array state", () => {
+    expect(groupUIMessagesByParent(undefined).size).toBe(0);
+    expect(groupUIMessagesByParent(null).size).toBe(0);
+    expect(groupUIMessagesByParent({ ui: [] }).size).toBe(0);
+  });
+
+  it("groups by metadata.message_id (Python SDK)", () => {
+    const ui = uiMessage({ message_id: "msg-2" });
+    const map = groupUIMessagesByParent([ui]);
+
+    expect(map.get("msg-2")).toEqual([ui]);
+  });
+
+  it("falls back to metadata.id when message_id is absent (JS SDK)", () => {
+    const ui = uiMessage({ id: "msg-2" });
+    const map = groupUIMessagesByParent([ui]);
+
+    expect(map.get("msg-2")).toEqual([ui]);
+  });
+
+  it("prefers message_id over id when both are present", () => {
+    const ui = uiMessage({ message_id: "msg-2", id: "msg-9" });
+    const map = groupUIMessagesByParent([ui]);
+
+    expect(map.get("msg-2")).toEqual([ui]);
+    expect(map.has("msg-9")).toBe(false);
+  });
+
+  it("skips entries with no parent link", () => {
+    const map = groupUIMessagesByParent([
+      uiMessage(undefined),
+      uiMessage({ message_id: "" }),
+    ]);
+
+    expect(map.size).toBe(0);
+  });
+
+  it("collects several UIs under the same parent in order", () => {
+    const a = uiMessage({ message_id: "msg-2" }, "chart");
+    const b = uiMessage({ message_id: "msg-2" }, "table");
+    const map = groupUIMessagesByParent([a, b]);
+
+    expect(map.get("msg-2")).toEqual([a, b]);
+  });
+});

--- a/packages/react-langchain/src/index.ts
+++ b/packages/react-langchain/src/index.ts
@@ -18,5 +18,6 @@ export type {
   LangChainBaseMessage,
   LangChainContentBlock,
   LangChainToolCall,
+  UIMessage,
   UseStreamRuntimeOptions,
 } from "./types";

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -41,7 +41,8 @@ export type LangChainToolCall = {
  * A generative UI component the graph accumulates in its state. Read from
  * `stream.values[uiStateKey]` and rendered via `makeAssistantDataUI`.
  *
- * `metadata.message_id` ties the UI to the assistant message it belongs to.
+ * The parent assistant message is carried in `metadata.message_id` by the
+ * Python SDK and in `metadata.id` by the JS SDK; the runtime reads either.
  */
 export type UIMessage<
   TName extends string = string,
@@ -57,6 +58,7 @@ export type UIMessage<
     name?: string;
     tags?: string[];
     message_id?: string;
+    id?: string;
     [key: string]: unknown;
   };
 };
@@ -139,8 +141,9 @@ export type LangChainRuntimeExtraOptions = ExternalStoreSharedOptions & {
   delete?: ((threadId: string) => Promise<void>) | undefined;
   /**
    * State key the graph accumulates generative `UIMessage`s under. Each UI
-   * is attached to the assistant message named by its `metadata.message_id`
-   * and emitted as a `data` part. Defaults to `"ui"`.
+   * is attached to the assistant message identified by its `metadata.message_id`
+   * (Python SDK) or `metadata.id` (JS SDK) and emitted as a `data` part.
+   * Defaults to `"ui"`.
    */
   uiStateKey?: string | undefined;
 };

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -38,6 +38,30 @@ export type LangChainToolCall = {
 };
 
 /**
+ * A generative UI component the graph accumulates in its state. Read from
+ * `stream.values[uiStateKey]` and rendered via `makeAssistantDataUI`.
+ *
+ * `metadata.message_id` ties the UI to the assistant message it belongs to.
+ */
+export type UIMessage<
+  TName extends string = string,
+  TProps extends Record<string, unknown> = Record<string, unknown>,
+> = {
+  type: "ui";
+  id: string;
+  name: TName;
+  props: TProps;
+  metadata?: {
+    merge?: boolean;
+    run_id?: string;
+    name?: string;
+    tags?: string[];
+    message_id?: string;
+    [key: string]: unknown;
+  };
+};
+
+/**
  * Minimal duck-typed interface for BaseMessage class instances returned by
  * `useStream`. Used internally by the message converter.
  *
@@ -113,6 +137,12 @@ export type LangChainRuntimeExtraOptions = ExternalStoreSharedOptions & {
   create?: (() => Promise<{ externalId: string | undefined }>) | undefined;
   /** Custom thread-deletion hook, forwarded to the cloud adapter. */
   delete?: ((threadId: string) => Promise<void>) | undefined;
+  /**
+   * State key the graph accumulates generative `UIMessage`s under. Each UI
+   * is attached to the assistant message named by its `metadata.message_id`
+   * and emitted as a `data` part. Defaults to `"ui"`.
+   */
+  uiStateKey?: string | undefined;
 };
 
 // Distribute the intersection through the union arms of `UseStreamOptions`

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -15,6 +15,7 @@ import { useStream } from "@langchain/react";
 import type {
   LangChainBaseMessage,
   LangChainToolCall,
+  UIMessage,
   UseStreamRuntimeOptions,
 } from "./types";
 import {
@@ -59,6 +60,7 @@ const useStreamThreadRuntime = (
   const { adapters, autoCancelPendingToolCalls, unstable_allowCancellation } =
     options;
   const messagesKey = options.messagesKey ?? "messages";
+  const uiStateKey = options.uiStateKey ?? "ui";
 
   const externalId = useAuiState((s) => s.threadListItem.externalId) as
     | string
@@ -78,10 +80,35 @@ const useStreamThreadRuntime = (
   );
   const effectiveIsRunning = stream.isLoading || hasExecutingTools;
 
+  const uiMessages = Array.isArray(stream.values[uiStateKey])
+    ? (stream.values[uiStateKey] as UIMessage[])
+    : undefined;
+
+  const uiMessagesByParent = useMemo(() => {
+    const map = new Map<string, UIMessage[]>();
+    for (const ui of uiMessages ?? []) {
+      const parentId = ui.metadata?.message_id;
+      if (!parentId) continue;
+      const existing = map.get(parentId);
+      if (existing) {
+        existing.push(ui);
+      } else {
+        map.set(parentId, [ui]);
+      }
+    }
+    return map;
+  }, [uiMessages]);
+
+  const converterMetadata = useMemo(
+    () => ({ uiMessagesByParent }),
+    [uiMessagesByParent],
+  );
+
   const threadMessages = useExternalMessageConverter({
     callback: convertLangChainBaseMessage,
     messages: stream.messages as LangChainBaseMessage[],
     isRunning: effectiveIsRunning,
+    metadata: converterMetadata,
   });
 
   const streamRef = useRef(stream);

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -105,14 +105,9 @@ const useStreamThreadRuntime = (
   const effectiveIsRunning = stream.isLoading || hasExecutingTools;
 
   const uiStateValue = stream.values[uiStateKey];
-  const uiMessagesByParent = useMemo(
-    () => groupUIMessagesByParent(uiStateValue),
-    [uiStateValue],
-  );
-
   const converterMetadata = useMemo(
-    () => ({ uiMessagesByParent }),
-    [uiMessagesByParent],
+    () => ({ uiMessagesByParent: groupUIMessagesByParent(uiStateValue) }),
+    [uiStateValue],
   );
 
   const threadMessages = useExternalMessageConverter({

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -32,6 +32,30 @@ export const runConfigToSubmitOptions = (
     ? { config: { configurable: runConfig.custom } }
     : undefined;
 
+/**
+ * Group the graph's accumulated `UIMessage`s by the assistant message they
+ * belong to. Non-array state and entries without a parent link are dropped.
+ * The parent id comes from `metadata.message_id` (Python SDK) or
+ * `metadata.id` (JS SDK).
+ */
+export const groupUIMessagesByParent = (
+  value: unknown,
+): Map<string, UIMessage[]> => {
+  const map = new Map<string, UIMessage[]>();
+  if (!Array.isArray(value)) return map;
+  for (const ui of value as UIMessage[]) {
+    const parentId = ui.metadata?.message_id ?? ui.metadata?.id;
+    if (!parentId) continue;
+    const existing = map.get(parentId);
+    if (existing) {
+      existing.push(ui);
+    } else {
+      map.set(parentId, [ui]);
+    }
+  }
+  return map;
+};
+
 const getPendingToolCalls = (
   messages: readonly LangChainBaseMessage[],
 ): LangChainToolCall[] => {
@@ -80,24 +104,11 @@ const useStreamThreadRuntime = (
   );
   const effectiveIsRunning = stream.isLoading || hasExecutingTools;
 
-  const uiMessages = Array.isArray(stream.values[uiStateKey])
-    ? (stream.values[uiStateKey] as UIMessage[])
-    : undefined;
-
-  const uiMessagesByParent = useMemo(() => {
-    const map = new Map<string, UIMessage[]>();
-    for (const ui of uiMessages ?? []) {
-      const parentId = ui.metadata?.message_id;
-      if (!parentId) continue;
-      const existing = map.get(parentId);
-      if (existing) {
-        existing.push(ui);
-      } else {
-        map.set(parentId, [ui]);
-      }
-    }
-    return map;
-  }, [uiMessages]);
+  const uiStateValue = stream.values[uiStateKey];
+  const uiMessagesByParent = useMemo(
+    () => groupUIMessagesByParent(uiStateValue),
+    [uiStateValue],
+  );
 
   const converterMetadata = useMemo(
     () => ({ uiMessagesByParent }),


### PR DESCRIPTION
## what

renders generative UI that a LangGraph backend accumulates in its graph state. the runtime reads it from `stream.values[uiStateKey]` (default `"ui"`) and, for every `UIMessage` whose parent id matches an assistant message, emits a `data` part on that message named by the UI's `name`. consumers render it with the existing `makeAssistantDataUI`.

snapshot path only. streaming a component live over `push_ui_message` before it lands in state is a separate path, left for a follow-up.

## how

- `types.ts`: add the `UIMessage` type and a `uiStateKey?: string` option (default `"ui"`).
- `convertMessages.ts`: `convertLangChainBaseMessage` takes a second `metadata` arg; the `ai` case appends `{ type: "data", name, data }` parts via a `uiMessageToDataPart` helper for UI attached to that message id, guarded on `message.id`.
- `useStreamRuntime.ts`: read `stream.values[uiStateKey]`, group it by parent id with the pure `groupUIMessagesByParent` helper, and pass it as `metadata` to the existing `useExternalMessageConverter` call.
- `index.ts`: export `UIMessage`.
- docs: `uiStateKey` option, a generative UI section, and a feature-coverage row.

## parent linkage

the parent assistant message is read from `metadata.message_id` (Python SDK) or `metadata.id` (JS SDK), so gen-UI authored from either SDK renders. the snapshot path, the by-parent grouping, the shared `DataMessagePart` shape, and the `message.id` guard mirror the `react-langgraph` reference adapter.
