### PR TITLE
feat(react-langchain): live generative UI via push_ui_message

### DIFF
--- a/.changeset/langchain-generative-ui-live.md
+++ b/.changeset/langchain-generative-ui-live.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): live generative UI via push_ui_message

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -680,7 +680,9 @@ function App() {
 }
 ```
 
-This is the state-snapshot path: it renders whatever UI the graph has committed to its state. Streaming a component live over the `push_ui_message` custom channel before it lands in state is a separate path that will arrive in a follow-up.
+This covers two paths transparently. The **state-snapshot** path renders whatever UI the graph has committed to its state. The **live** path renders UI streamed over the `custom` channel by `push_ui_message` / `remove_ui_message` before (or instead of) it lands in state, so components appear as the graph emits them. The runtime accumulates the live events and merges them with the state snapshot, with the snapshot authoritative once a UI lands in state. Both feed the same `makeAssistantDataUI` renderers.
+
+The live path requires the graph's `streamMode` to include `"custom"` so the UI events reach the client.
 
 ## Errors
 
@@ -758,7 +760,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | Edit message (checkpoint fork) | Yes | Yes (auto-resolved) |
 | Per-message metadata (`messages-tuple`) | Yes | Not exposed |
 | Generative UI (state snapshot) | Yes | Yes (`uiStateKey`) |
-| Generative UI (live `push_ui_message`) | Yes | Not yet |
+| Generative UI (live `push_ui_message`) | Yes | Yes (`streamMode: ["custom"]`) |
 | Subgraph / namespaced stream events | Yes (via `eventHandlers`) | Not exposed |
 | Subagent discovery | Via `eventHandlers` | Yes (`useLangChainSubagents`) |
 | Subgraph discovery | Via `eventHandlers` | Yes (`useLangChainSubgraphs`) |

--- a/packages/react-langchain/src/index.ts
+++ b/packages/react-langchain/src/index.ts
@@ -26,6 +26,7 @@ export type {
   LangChainBaseMessage,
   LangChainContentBlock,
   LangChainToolCall,
+  RemoveUIMessage,
   UIMessage,
   UseStreamRuntimeOptions,
 } from "./types";

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -69,8 +69,8 @@ export type UIMessage<
 };
 
 /**
- * Removes a previously emitted `UIMessage` by id. Emitted on the live
- * `custom` channel by the graph's `remove_ui_message` helper.
+ * Emitted on the live `custom` channel by the graph's `remove_ui_message`
+ * helper to drop a pushed `UIMessage` by id.
  */
 export type RemoveUIMessage = {
   type: "remove-ui";

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -69,6 +69,15 @@ export type UIMessage<
 };
 
 /**
+ * Removes a previously emitted `UIMessage` by id. Emitted on the live
+ * `custom` channel by the graph's `remove_ui_message` helper.
+ */
+export type RemoveUIMessage = {
+  type: "remove-ui";
+  id: string;
+};
+
+/**
  * Minimal duck-typed interface for BaseMessage class instances returned by
  * `useStream`. Used internally by the message converter.
  *

--- a/packages/react-langchain/src/uiMessages.test.ts
+++ b/packages/react-langchain/src/uiMessages.test.ts
@@ -40,6 +40,19 @@ describe("isUIUpdate", () => {
       false,
     );
   });
+
+  it("rejects a ui update missing name or props", () => {
+    expect(isUIUpdate({ type: "ui", id: "a" })).toBe(false);
+    expect(isUIUpdate({ type: "ui", id: "a", name: "x" })).toBe(false);
+    expect(isUIUpdate({ type: "ui", id: "a", props: {} })).toBe(false);
+    expect(isUIUpdate({ type: "ui", id: "a", name: "x", props: null })).toBe(
+      false,
+    );
+  });
+
+  it("rejects an empty array", () => {
+    expect(isUIUpdate([])).toBe(false);
+  });
 });
 
 describe("applyUIUpdate", () => {

--- a/packages/react-langchain/src/uiMessages.test.ts
+++ b/packages/react-langchain/src/uiMessages.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyUIUpdate,
+  extractUIUpdate,
+  isUIUpdate,
+  mergeUIMessages,
+} from "./uiMessages";
+import type { UIMessage } from "./types";
+
+const ui = (id: string, props: Record<string, unknown> = {}): UIMessage => ({
+  type: "ui",
+  id,
+  name: "chart",
+  props,
+});
+
+describe("isUIUpdate", () => {
+  it("accepts ui and remove-ui objects with a string id", () => {
+    expect(isUIUpdate({ type: "ui", id: "a", name: "x", props: {} })).toBe(
+      true,
+    );
+    expect(isUIUpdate({ type: "remove-ui", id: "a" })).toBe(true);
+  });
+
+  it("accepts an array of updates", () => {
+    expect(
+      isUIUpdate([
+        { type: "ui", id: "a", name: "x", props: {} },
+        { type: "remove-ui", id: "b" },
+      ]),
+    ).toBe(true);
+  });
+
+  it("rejects non-UI values", () => {
+    expect(isUIUpdate(null)).toBe(false);
+    expect(isUIUpdate("ui")).toBe(false);
+    expect(isUIUpdate({ type: "ui", name: "x" })).toBe(false);
+    expect(isUIUpdate({ type: "other", id: "a" })).toBe(false);
+    expect(isUIUpdate([{ type: "ui", id: "a", name: "x", props: {} }, 5])).toBe(
+      false,
+    );
+  });
+});
+
+describe("applyUIUpdate", () => {
+  it("pushes a new UI message", () => {
+    expect(applyUIUpdate([], ui("a"))).toEqual([ui("a")]);
+  });
+
+  it("replaces an existing UI message by id", () => {
+    const result = applyUIUpdate([ui("a", { v: 1 })], ui("a", { v: 2 }));
+    expect(result).toEqual([ui("a", { v: 2 })]);
+  });
+
+  it("merges props when metadata.merge is true", () => {
+    const result = applyUIUpdate([ui("a", { keep: 1, v: 1 })], {
+      ...ui("a", { v: 2 }),
+      metadata: { merge: true },
+    });
+    expect(result).toEqual([
+      { ...ui("a", { keep: 1, v: 2 }), metadata: { merge: true } },
+    ]);
+  });
+
+  it("removes a UI message by id", () => {
+    const result = applyUIUpdate([ui("a"), ui("b")], {
+      type: "remove-ui",
+      id: "a",
+    });
+    expect(result).toEqual([ui("b")]);
+  });
+
+  it("applies an array of updates in order", () => {
+    const result = applyUIUpdate(
+      [ui("a")],
+      [ui("b"), { type: "remove-ui", id: "a" }, ui("c")],
+    );
+    expect(result).toEqual([ui("b"), ui("c")]);
+  });
+
+  it("does not mutate the input list", () => {
+    const input = [ui("a")];
+    applyUIUpdate(input, ui("b"));
+    expect(input).toEqual([ui("a")]);
+  });
+});
+
+describe("extractUIUpdate", () => {
+  it("reads a UI update straight from params.data", () => {
+    const event = {
+      params: { data: { type: "ui", id: "a", name: "x", props: {} } },
+    };
+    expect(extractUIUpdate(event)).toEqual({
+      type: "ui",
+      id: "a",
+      name: "x",
+      props: {},
+    });
+  });
+
+  it("falls back to params.data.payload when data wraps the update", () => {
+    const event = {
+      params: { data: { payload: { type: "remove-ui", id: "a" } } },
+    };
+    expect(extractUIUpdate(event)).toEqual({ type: "remove-ui", id: "a" });
+  });
+
+  it("reads an array of updates", () => {
+    const event = {
+      params: { data: [ui("a"), { type: "remove-ui", id: "b" }] },
+    };
+    expect(extractUIUpdate(event)).toEqual([
+      ui("a"),
+      { type: "remove-ui", id: "b" },
+    ]);
+  });
+
+  it("returns undefined for non-UI custom events and malformed shapes", () => {
+    expect(extractUIUpdate({ params: { data: { foo: 1 } } })).toBeUndefined();
+    expect(extractUIUpdate({ params: {} })).toBeUndefined();
+    expect(extractUIUpdate({})).toBeUndefined();
+    expect(extractUIUpdate(null)).toBeUndefined();
+  });
+});
+
+describe("mergeUIMessages", () => {
+  it("returns the snapshot when there are no live messages", () => {
+    expect(mergeUIMessages([], [ui("a")])).toEqual([ui("a")]);
+  });
+
+  it("returns live messages when the snapshot is not an array", () => {
+    expect(mergeUIMessages([ui("a")], undefined)).toEqual([ui("a")]);
+  });
+
+  it("lets the snapshot win by id", () => {
+    const result = mergeUIMessages([ui("a", { v: 1 })], [ui("a", { v: 2 })]);
+    expect(result).toEqual([ui("a", { v: 2 })]);
+  });
+
+  it("keeps live and snapshot entries with distinct ids", () => {
+    expect(mergeUIMessages([ui("a")], [ui("b")])).toEqual([ui("a"), ui("b")]);
+  });
+});

--- a/packages/react-langchain/src/uiMessages.test.ts
+++ b/packages/react-langchain/src/uiMessages.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyUIUpdate,
   extractUIUpdate,
+  foldUIUpdates,
   isUIUpdate,
   mergeUIMessages,
 } from "./uiMessages";
@@ -152,5 +153,38 @@ describe("mergeUIMessages", () => {
 
   it("keeps live and snapshot entries with distinct ids", () => {
     expect(mergeUIMessages([ui("a")], [ui("b")])).toEqual([ui("a"), ui("b")]);
+  });
+});
+
+describe("foldUIUpdates", () => {
+  const evt = (data: unknown) => ({ params: { data } });
+
+  it("folds a sequence of custom events into a UI list", () => {
+    expect(foldUIUpdates([evt(ui("a")), evt(ui("b"))])).toEqual([
+      ui("a"),
+      ui("b"),
+    ]);
+  });
+
+  it("reads updates nested under params.data.payload", () => {
+    expect(foldUIUpdates([evt({ payload: ui("a") })])).toEqual([ui("a")]);
+  });
+
+  it("applies a remove across events", () => {
+    const result = foldUIUpdates([
+      evt(ui("a")),
+      evt(ui("b")),
+      evt({ type: "remove-ui", id: "a" }),
+    ]);
+    expect(result).toEqual([ui("b")]);
+  });
+
+  it("ignores non-UI custom events", () => {
+    const result = foldUIUpdates([evt(ui("a")), evt({ foo: 1 }), evt(ui("b"))]);
+    expect(result).toEqual([ui("a"), ui("b")]);
+  });
+
+  it("returns an empty list for no events", () => {
+    expect(foldUIUpdates([])).toEqual([]);
   });
 });

--- a/packages/react-langchain/src/uiMessages.ts
+++ b/packages/react-langchain/src/uiMessages.ts
@@ -1,0 +1,70 @@
+import type { RemoveUIMessage, UIMessage } from "./types";
+
+export type UIUpdate = UIMessage | RemoveUIMessage;
+
+export const isUIUpdate = (
+  value: unknown,
+): value is UIUpdate | readonly UIUpdate[] => {
+  if (Array.isArray(value)) return value.every(isUIUpdate);
+  if (value == null || typeof value !== "object") return false;
+  const v = value as { type?: unknown; id?: unknown };
+  if (typeof v.id !== "string") return false;
+  return v.type === "ui" || v.type === "remove-ui";
+};
+
+export const applyUIUpdate = (
+  list: readonly UIMessage[],
+  update: UIUpdate | readonly UIUpdate[],
+): UIMessage[] => {
+  const events = Array.isArray(update) ? update : [update as UIUpdate];
+  let next = list.slice();
+  for (const event of events) {
+    if (event.type === "remove-ui") {
+      next = next.filter((ui) => ui.id !== event.id);
+      continue;
+    }
+    const index = next.findIndex((ui) => ui.id === event.id);
+    if (index === -1) {
+      next.push(event);
+      continue;
+    }
+    next[index] =
+      event.metadata?.merge === true
+        ? { ...event, props: { ...next[index]!.props, ...event.props } }
+        : event;
+  }
+  return next;
+};
+
+/**
+ * Pulls a UI update out of a raw `custom`-channel event. The graph writes the
+ * `UIMessage` straight to the channel, so it lands at `params.data`; some
+ * transports wrap it one level deeper at `params.data.payload`. Non-UI custom
+ * events are ignored.
+ */
+export const extractUIUpdate = (
+  event: unknown,
+): UIUpdate | readonly UIUpdate[] | undefined => {
+  const data = (event as { params?: { data?: unknown } } | null)?.params?.data;
+  if (isUIUpdate(data)) return data;
+  const payload = (data as { payload?: unknown } | undefined)?.payload;
+  if (isUIUpdate(payload)) return payload;
+  return undefined;
+};
+
+/**
+ * Merges live-streamed UI with the state snapshot. The snapshot is
+ * authoritative by id: once a UI lands in graph state it supersedes its live
+ * copy. Non-array snapshots are ignored.
+ */
+export const mergeUIMessages = (
+  live: readonly UIMessage[],
+  snapshot: unknown,
+): UIMessage[] => {
+  const byId = new Map<string, UIMessage>();
+  for (const ui of live) byId.set(ui.id, ui);
+  if (Array.isArray(snapshot)) {
+    for (const ui of snapshot as UIMessage[]) byId.set(ui.id, ui);
+  }
+  return [...byId.values()];
+};

--- a/packages/react-langchain/src/uiMessages.ts
+++ b/packages/react-langchain/src/uiMessages.ts
@@ -50,8 +50,7 @@ export const applyUIUpdate = (
 /**
  * Pulls a UI update out of a raw `custom`-channel event. The graph writes the
  * `UIMessage` straight to the channel, so it lands at `params.data`; some
- * transports wrap it one level deeper at `params.data.payload`. Non-UI custom
- * events are ignored.
+ * transports wrap it one level deeper at `params.data.payload`.
  */
 export const extractUIUpdate = (
   event: unknown,
@@ -63,12 +62,21 @@ export const extractUIUpdate = (
   return undefined;
 };
 
+export const foldUIUpdates = (events: readonly unknown[]): UIMessage[] => {
+  let acc: UIMessage[] = [];
+  for (const event of events) {
+    const update = extractUIUpdate(event);
+    if (update) acc = applyUIUpdate(acc, update);
+  }
+  return acc;
+};
+
 /**
  * Merges live-streamed UI with the state snapshot. The snapshot is
  * authoritative by id: once a UI lands in graph state it supersedes its live
  * copy. A consequence is that a live `remove-ui` is overridden while the
- * snapshot still contains that id — the removal only takes visible effect once
- * the snapshot catches up. Non-array snapshots are ignored.
+ * snapshot still contains that id; the removal only takes visible effect once
+ * the snapshot catches up.
  */
 export const mergeUIMessages = (
   live: readonly UIMessage[],

--- a/packages/react-langchain/src/uiMessages.ts
+++ b/packages/react-langchain/src/uiMessages.ts
@@ -5,11 +5,22 @@ export type UIUpdate = UIMessage | RemoveUIMessage;
 export const isUIUpdate = (
   value: unknown,
 ): value is UIUpdate | readonly UIUpdate[] => {
-  if (Array.isArray(value)) return value.every(isUIUpdate);
+  if (Array.isArray(value)) return value.length > 0 && value.every(isUIUpdate);
   if (value == null || typeof value !== "object") return false;
-  const v = value as { type?: unknown; id?: unknown };
+  const v = value as {
+    type?: unknown;
+    id?: unknown;
+    name?: unknown;
+    props?: unknown;
+  };
   if (typeof v.id !== "string") return false;
-  return v.type === "ui" || v.type === "remove-ui";
+  if (v.type === "remove-ui") return true;
+  return (
+    v.type === "ui" &&
+    typeof v.name === "string" &&
+    typeof v.props === "object" &&
+    v.props !== null
+  );
 };
 
 export const applyUIUpdate = (
@@ -55,7 +66,9 @@ export const extractUIUpdate = (
 /**
  * Merges live-streamed UI with the state snapshot. The snapshot is
  * authoritative by id: once a UI lands in graph state it supersedes its live
- * copy. Non-array snapshots are ignored.
+ * copy. A consequence is that a live `remove-ui` is overridden while the
+ * snapshot still contains that id — the removal only takes visible effect once
+ * the snapshot catches up. Non-array snapshots are ignored.
  */
 export const mergeUIMessages = (
   live: readonly UIMessage[],

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -11,7 +11,8 @@ import {
   useRemoteThreadListRuntime,
 } from "@assistant-ui/core/react";
 import { useAuiState } from "@assistant-ui/store";
-import { STREAM_CONTROLLER, useStream } from "@langchain/react";
+import { STREAM_CONTROLLER, useChannel, useStream } from "@langchain/react";
+import type { Channel } from "@langchain/react";
 import type {
   LangChainBaseMessage,
   LangChainToolCall,
@@ -23,8 +24,11 @@ import {
   getMessageContent,
   getMessageType,
 } from "./convertMessages";
+import { applyUIUpdate, extractUIUpdate, mergeUIMessages } from "./uiMessages";
 import { langChainExtras } from "./runtimeExtras";
 import { resolveForkCheckpoint } from "./resolveForkCheckpoint";
+
+const UI_CUSTOM_CHANNELS: readonly Channel[] = ["custom"];
 
 export const runConfigToSubmitOptions = (
   runConfig: AppendMessage["runConfig"],
@@ -106,13 +110,29 @@ const useStreamThreadRuntime = (
   const effectiveIsRunning = stream.isLoading || hasExecutingTools;
 
   const uiStateValue = stream.values[uiStateKey];
+
+  const customEvents = useChannel(stream, UI_CUSTOM_CHANNELS);
+  const liveUiMessages = useMemo(() => {
+    let acc: UIMessage[] = [];
+    for (const event of customEvents) {
+      const update = extractUIUpdate(event);
+      if (update) acc = applyUIUpdate(acc, update);
+    }
+    return acc;
+  }, [customEvents]);
+
+  const mergedUiMessages = useMemo(
+    () => mergeUIMessages(liveUiMessages, uiStateValue),
+    [liveUiMessages, uiStateValue],
+  );
+
   const convertWithUI = useMemo<
     useExternalMessageConverter.Callback<LangChainBaseMessage>
   >(() => {
-    const uiMessagesByParent = groupUIMessagesByParent(uiStateValue);
+    const uiMessagesByParent = groupUIMessagesByParent(mergedUiMessages);
     return (message, metadata) =>
       convertLangChainBaseMessage(message, { ...metadata, uiMessagesByParent });
-  }, [uiStateValue]);
+  }, [mergedUiMessages]);
 
   const threadMessages = useExternalMessageConverter({
     callback: convertWithUI,

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -24,7 +24,7 @@ import {
   getMessageContent,
   getMessageType,
 } from "./convertMessages";
-import { applyUIUpdate, extractUIUpdate, mergeUIMessages } from "./uiMessages";
+import { foldUIUpdates, mergeUIMessages } from "./uiMessages";
 import { langChainExtras } from "./runtimeExtras";
 import { resolveForkCheckpoint } from "./resolveForkCheckpoint";
 
@@ -112,14 +112,10 @@ const useStreamThreadRuntime = (
   const uiStateValue = stream.values[uiStateKey];
 
   const customEvents = useChannel(stream, UI_CUSTOM_CHANNELS);
-  const liveUiMessages = useMemo(() => {
-    let acc: UIMessage[] = [];
-    for (const event of customEvents) {
-      const update = extractUIUpdate(event);
-      if (update) acc = applyUIUpdate(acc, update);
-    }
-    return acc;
-  }, [customEvents]);
+  const liveUiMessages = useMemo(
+    () => foldUIUpdates(customEvents),
+    [customEvents],
+  );
 
   const mergedUiMessages = useMemo(
     () => mergeUIMessages(liveUiMessages, uiStateValue),


### PR DESCRIPTION
Builds on the state-snapshot path (#4503)

## What

Renders generative UI streamed live on the `custom` channel via `push_ui_message` / `remove_ui_message`, before (or instead of) it lands in graph state. Merged with the state snapshot, snapshot authoritative by id. Both paths feed the same `makeAssistantDataUI` renderers.

## How

- `uiMessages.ts` (new, pure): `isUIUpdate` guard + `applyUIUpdate(list, update)` reducer (remove-ui filters by id; ui upserts by id, props-merge when `metadata.merge === true`). Functional port of react-langgraph's accumulator.
- `useStreamRuntime.ts`: `useChannel(stream, ["custom"])`, fold the event buffer through the reducer, merge with `stream.values[uiStateKey]` (snapshot wins by id), feed into the existing `groupUIMessagesByParent` helper — so the live path inherits its `message_id ?? id` parent resolution.
- `types.ts` / `index.ts`: add and export `RemoveUIMessage`.
- Docs: live `push_ui_message` row → Yes; note `streamMode` must include `"custom"`.

`useChannel` (not `useChannelEffect`) because its buffer accumulates across the thread lifetime incl. replayed history, so the UI list is derived purely each render with no manual state.

## Scope

Additive. Public surface: `useChannel` only (no internals) plus the `RemoveUIMessage` type. No new dependencies.

