### PR TITLE
fix(examples): expo composer shows Send on initial render

### DIFF
--- a/examples/with-expo/components/assistant-ui/composer.tsx
+++ b/examples/with-expo/components/assistant-ui/composer.tsx
@@ -39,7 +39,7 @@ export function Composer() {
 
   const aui = useAui();
   const attachmentsCount = useAuiState((s) => s.composer.attachments.length);
-  const canCancel = useAuiState((s) => s.composer.canCancel);
+  const isRunning = useAuiState((s) => s.thread.isRunning);
   const canSend = useAuiState(
     (s) => !s.thread.isRunning && s.composer.isEditing && !s.composer.isEmpty,
   );
@@ -97,7 +97,7 @@ export function Composer() {
         <Pressable
           style={styles.attachButton}
           onPress={pickImage}
-          disabled={canCancel}
+          disabled={isRunning}
         >
           <Ionicons
             name="add-circle-outline"
@@ -111,9 +111,9 @@ export function Composer() {
           placeholderTextColor="#8e8e93"
           multiline
           maxLength={4000}
-          editable={!canCancel}
+          editable={!isRunning}
         />
-        {canCancel ? (
+        {isRunning ? (
           <ComposerPrimitive.Cancel style={[styles.button, styles.stopButton]}>
             <View style={styles.stopIcon} />
           </ComposerPrimitive.Cancel>


### PR DESCRIPTION
closes https://github.com/assistant-ui/assistant-ui/issues/4505

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

