### PR TITLE
fix(react-native): preserve IME composition in the web composer input

### DIFF
--- a/.changeset/react-native-composer-ime.md
+++ b/.changeset/react-native-composer-ime.md
@@ -1,0 +1,12 @@
+---
+"@assistant-ui/react-native": patch
+---
+
+fix(react-native): stop IME composition from breaking the web composer input
+
+two related IME regressions on the rn-web `ComposerInput` (#4506, #4510):
+
+- #4506: typing a CJK/IME composition was interrupted mid character. `onChangeText` called `aui.composer().setText(value)`, which the tap scheduler defers to a macrotask, so the controlled `value={text}` stayed stale while react-dom reconciled the textarea and reset it back, killing the in flight composition buffer. now wraps `setText` in `flushTapSync` on web so the controlled value is synced synchronously before react can write the stale value back, mirroring the web `ComposerPrimitive.Input`.
+- #4510: pressing Enter to commit an IME candidate submitted the message instead of only confirming it. rn-web forwards the raw dom keydown to `onKeyPress` before its own composition guard, so the Enter branch fired while `isComposing`/`keyCode === 229` was set. now bails out of the submit branch when the forwarded `nativeEvent` reports an active composition, matching rn-web's own `isEventComposing`.
+
+both only affect the web path; native iOS/Android keep the existing behavior.

--- a/packages/react-native/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerInput.tsx
@@ -7,6 +7,7 @@ import {
   type TextInputProps,
 } from "react-native";
 import { useAui, useAuiState } from "@assistant-ui/store";
+import { flushTapSync } from "@assistant-ui/tap";
 
 export type ComposerInputProps = Omit<
   TextInputProps,
@@ -46,6 +47,13 @@ export const ComposerInput = ({
 
   const onChangeText = useCallback(
     (value: string) => {
+      if (Platform.OS === "web") {
+        // Keep the controlled value in sync mid-IME so react-dom does not reset the textarea to a stale value
+        flushTapSync(() => {
+          aui.composer().setText(value);
+        });
+        return;
+      }
       aui.composer().setText(value);
     },
     [aui],
@@ -66,7 +74,11 @@ export const ComposerInput = ({
 
       const nativeEvent = e.nativeEvent as TextInputKeyPressEventData & {
         shiftKey?: boolean;
+        isComposing?: boolean;
+        keyCode?: number;
       };
+      // react-native-web forwards the raw DOM keydown before its own composition guard, so re-check it here (mirrors isEventComposing)
+      if (nativeEvent.isComposing || nativeEvent.keyCode === 229) return;
       if (nativeEvent.key === "Enter" && !nativeEvent.shiftKey) {
         (e as unknown as Event).preventDefault?.();
         aui.composer().send();


### PR DESCRIPTION
closes #4506
closes #4510

## summary

- on web, the react-native `ComposerPrimitive.Input` no longer breaks CJK/IME composition: typing a composition keeps the candidate window open instead of swallowing characters mid-composition (#4506), and pressing Enter to commit a candidate only confirms it instead of sending the message (#4510).
- #4506: `onChangeText` now wraps `aui.composer().setText(value)` in `flushTapSync` on web. the tap scheduler defers `setText` to a `MessageChannel` macrotask, so the controlled `value={text}` stayed stale through react-dom's post-event controlled-input restore, which then wrote the stale value back onto the textarea and aborted the in flight composition. flushing synchronously syncs the controlled value before react reconciles, so the restore is a no-op. this mirrors the web `ComposerPrimitive.Input`.
- #4510: `onKeyPress` now bails out of the Enter-to-submit branch when the forwarded `nativeEvent` reports `isComposing` or `keyCode === 229`. react-native-web forwards the raw DOM keydown to `onKeyPress` before applying its own composition guard, so the commit Enter (key `Enter`, keyCode 229) reached the submit path. the guard mirrors react-native-web's own `isEventComposing`.
- both paths are gated to `Platform.OS === "web"`; native iOS/Android keep the existing `setText` and Enter handling.

## test plan

### already verified

- [x] `pnpm lint` -> exit 0 (oxlint + oxfmt clean)
- [x] `pnpm --filter @assistant-ui/react-native exec tsc --noEmit` -> exit 0
- [x] `pnpm --filter @assistant-ui/react-native build` -> build complete
- [x] reproduced the #4506 mechanism in a jsdom harness driving the real tap scheduler: deferred `setText` resets the controlled textarea to the stale value mid-composition, `flushTapSync` prevents the reset

### reviewer should verify

- [ ] on the Expo web demo, switch to a CJK IME (pinyin / japanese / korean), type a composition into the composer: the candidate popup stays open and characters are not swallowed mid-composition (#4506)
- [ ] with the candidate window open, press Enter to commit: it only confirms the composition and does not send the message (#4510)

## notes

- no composer tests exist in `packages/react-native` yet (the package ships zero test infra: node env, no jsdom / react-dom / testing-library). adding a jsdom + testing-library setup is left as a follow-up so this PR stays one concern.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

