### PR TITLE
test(react-native): add a vitest suite for the primitives

### DIFF
--- a/.changeset/react-native-primitive-tests.md
+++ b/.changeset/react-native-primitive-tests.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-native": patch
+---
+
+test: add a vitest suite covering the react-native primitives (composer input IME and submit behavior, action buttons, conditionals, state readers, error, chain-of-thought, and message content dispatch)

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -54,8 +54,6 @@
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
-    "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "jsdom": "^29.1.1",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -54,9 +54,15 @@
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.1.1",
     "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "react-native": "^0.86.0",
+    "react-native-web": "~0.21.2",
     "vitest": "^4.1.8"
   },
   "publishConfig": {

--- a/packages/react-native/src/primitives/attachment/AttachmentName.test.tsx
+++ b/packages/react-native/src/primitives/attachment/AttachmentName.test.tsx
@@ -1,0 +1,55 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AttachmentName } from "./AttachmentName";
+
+const h = vi.hoisted(() => ({
+  state: { attachment: { name: "" } },
+}));
+
+vi.mock("@assistant-ui/store", () => ({
+  useAuiState: <T,>(selector: (s: { attachment: { name: string } }) => T) =>
+    selector(h.state),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("AttachmentName", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.state.attachment.name = "";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async () => {
+    await act(async () => {
+      root.render(<AttachmentName testID="name" />);
+    });
+    const el = container.querySelector('[data-testid="name"]');
+    expect(el).not.toBeNull();
+    return el as HTMLElement;
+  };
+
+  it("renders the attachment name from store state", async () => {
+    h.state.attachment.name = "report.pdf";
+    const el = await mount();
+    expect(el.textContent).toBe("report.pdf");
+  });
+
+  it("renders a different attachment name", async () => {
+    h.state.attachment.name = "photo.png";
+    const el = await mount();
+    expect(el.textContent).toBe("photo.png");
+  });
+});

--- a/packages/react-native/src/primitives/attachment/AttachmentRemove.test.tsx
+++ b/packages/react-native/src/primitives/attachment/AttachmentRemove.test.tsx
@@ -1,0 +1,81 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AttachmentRemove } from "./AttachmentRemove";
+
+const h = vi.hoisted(() => ({
+  remove: vi.fn<() => void>(),
+}));
+
+vi.mock("@assistant-ui/store", () => {
+  const aui = {
+    attachment: () => ({ remove: h.remove }),
+  };
+  return {
+    useAui: () => aui,
+  };
+});
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("AttachmentRemove", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.remove.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof AttachmentRemove>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <AttachmentRemove testID="remove" {...props}>
+          x
+        </AttachmentRemove>,
+      );
+    });
+    return container.querySelector('[data-testid="remove"]') as HTMLElement;
+  };
+
+  const press = async (el: HTMLElement) => {
+    await act(async () => {
+      el.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+  };
+
+  it("calls attachment().remove when pressed", async () => {
+    const el = await mount();
+    await press(el);
+    expect(h.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call remove before any press", async () => {
+    await mount();
+    expect(h.remove).not.toHaveBeenCalled();
+  });
+
+  it("renders its children", async () => {
+    const el = await mount();
+    expect(el.textContent).toBe("x");
+  });
+
+  it("does not fire remove when the Pressable is disabled", async () => {
+    const el = await mount({ disabled: true });
+    await press(el);
+    expect(h.remove).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native/src/primitives/attachment/AttachmentThumb.test.tsx
+++ b/packages/react-native/src/primitives/attachment/AttachmentThumb.test.tsx
@@ -1,0 +1,75 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AttachmentThumb } from "./AttachmentThumb";
+
+const h = vi.hoisted(() => ({
+  attachment: { name: "" },
+}));
+
+vi.mock("@assistant-ui/store", () => ({
+  useAuiState: <T,>(selector: (s: { attachment: typeof h.attachment }) => T) =>
+    selector({ attachment: h.attachment }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("AttachmentThumb", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.attachment.name = "";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (name: string) => {
+    h.attachment.name = name;
+    await act(async () => {
+      root.render(<AttachmentThumb testID="thumb" />);
+    });
+    return container.querySelector('[data-testid="thumb"]') as HTMLElement;
+  };
+
+  it("renders the dotted extension for a single-extension name", async () => {
+    const el = await mount("photo.png");
+    expect(el.textContent).toBe(".png");
+  });
+
+  it("takes only the last segment for a multi-extension name", async () => {
+    const el = await mount("archive.tar.gz");
+    expect(el.textContent).toBe(".gz");
+  });
+
+  it("renders just a dot when the name has no extension", async () => {
+    const el = await mount("noext");
+    expect(el.textContent).toBe(".");
+  });
+
+  it("renders just a dot for an empty name", async () => {
+    const el = await mount("");
+    expect(el.textContent).toBe(".");
+  });
+
+  it("treats a leading-dot name as an extension", async () => {
+    const el = await mount(".gitignore");
+    expect(el.textContent).toBe(".gitignore");
+  });
+
+  it("forwards props to the underlying Text", async () => {
+    h.attachment.name = "photo.png";
+    await act(async () => {
+      root.render(<AttachmentThumb testID="forwarded" />);
+    });
+    expect(container.querySelector('[data-testid="forwarded"]')).not.toBeNull();
+  });
+});

--- a/packages/react-native/src/primitives/branchPicker/BranchPickerCount.test.tsx
+++ b/packages/react-native/src/primitives/branchPicker/BranchPickerCount.test.tsx
@@ -1,0 +1,55 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BranchPickerCount } from "./BranchPickerCount";
+
+const h = vi.hoisted(() => ({
+  state: { message: { branchCount: 0 } },
+}));
+
+vi.mock("@assistant-ui/store", () => ({
+  useAuiState: <T,>(selector: (s: { message: { branchCount: number } }) => T) =>
+    selector(h.state),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("BranchPickerCount", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.state.message.branchCount = 0;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async () => {
+    await act(async () => {
+      root.render(<BranchPickerCount testID="count" />);
+    });
+    const el = container.querySelector('[data-testid="count"]');
+    expect(el).not.toBeNull();
+    return el as HTMLElement;
+  };
+
+  it("renders the branchCount from store state", async () => {
+    h.state.message.branchCount = 3;
+    const el = await mount();
+    expect(el.textContent).toBe("3");
+  });
+
+  it("renders a different branchCount value", async () => {
+    h.state.message.branchCount = 12;
+    const el = await mount();
+    expect(el.textContent).toBe("12");
+  });
+});

--- a/packages/react-native/src/primitives/branchPicker/BranchPickerNext.test.tsx
+++ b/packages/react-native/src/primitives/branchPicker/BranchPickerNext.test.tsx
@@ -1,0 +1,97 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BranchPickerNext } from "./BranchPickerNext";
+
+const h = vi.hoisted(() => ({
+  next: vi.fn<() => void>(),
+  state: { disabled: false },
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useBranchPickerNext: () => ({ next: h.next, disabled: h.state.disabled }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const click = (el: Element) =>
+  el.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+
+describe("BranchPickerNext", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.next.mockReset();
+    h.state.disabled = false;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof BranchPickerNext>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <BranchPickerNext testID="t" {...props}>
+          next
+        </BranchPickerNext>,
+      );
+    });
+    return container.querySelector('[data-testid="t"]') as HTMLElement;
+  };
+
+  it("fires next when pressed and the hook is enabled", async () => {
+    const el = await mount();
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.next).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire next when the hook reports disabled", async () => {
+    h.state.disabled = true;
+    const el = await mount();
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.next).not.toHaveBeenCalled();
+  });
+
+  it("lets an explicit disabled prop override an enabled hook", async () => {
+    h.state.disabled = false;
+    const el = await mount({ disabled: true });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.next).not.toHaveBeenCalled();
+  });
+
+  it("lets an explicit disabled={false} prop override a disabled hook", async () => {
+    h.state.disabled = true;
+    const el = await mount({ disabled: false });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native/src/primitives/branchPicker/BranchPickerNumber.test.tsx
+++ b/packages/react-native/src/primitives/branchPicker/BranchPickerNumber.test.tsx
@@ -1,0 +1,56 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BranchPickerNumber } from "./BranchPickerNumber";
+
+const h = vi.hoisted(() => ({
+  state: { message: { branchNumber: 0 } },
+}));
+
+vi.mock("@assistant-ui/store", () => ({
+  useAuiState: <T,>(
+    selector: (s: { message: { branchNumber: number } }) => T,
+  ) => selector(h.state),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("BranchPickerNumber", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.state.message.branchNumber = 0;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async () => {
+    await act(async () => {
+      root.render(<BranchPickerNumber testID="number" />);
+    });
+    const el = container.querySelector('[data-testid="number"]');
+    expect(el).not.toBeNull();
+    return el as HTMLElement;
+  };
+
+  it("renders the branchNumber from store state", async () => {
+    h.state.message.branchNumber = 1;
+    const el = await mount();
+    expect(el.textContent).toBe("1");
+  });
+
+  it("renders a different branchNumber value", async () => {
+    h.state.message.branchNumber = 7;
+    const el = await mount();
+    expect(el.textContent).toBe("7");
+  });
+});

--- a/packages/react-native/src/primitives/branchPicker/BranchPickerPrevious.test.tsx
+++ b/packages/react-native/src/primitives/branchPicker/BranchPickerPrevious.test.tsx
@@ -1,0 +1,100 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BranchPickerPrevious } from "./BranchPickerPrevious";
+
+const h = vi.hoisted(() => ({
+  previous: vi.fn<() => void>(),
+  state: { disabled: false },
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useBranchPickerPrevious: () => ({
+    previous: h.previous,
+    disabled: h.state.disabled,
+  }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const click = (el: Element) =>
+  el.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+
+describe("BranchPickerPrevious", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.previous.mockReset();
+    h.state.disabled = false;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof BranchPickerPrevious>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <BranchPickerPrevious testID="t" {...props}>
+          prev
+        </BranchPickerPrevious>,
+      );
+    });
+    return container.querySelector('[data-testid="t"]') as HTMLElement;
+  };
+
+  it("fires previous when pressed and the hook is enabled", async () => {
+    const el = await mount();
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.previous).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire previous when the hook reports disabled", async () => {
+    h.state.disabled = true;
+    const el = await mount();
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.previous).not.toHaveBeenCalled();
+  });
+
+  it("lets an explicit disabled prop override an enabled hook", async () => {
+    h.state.disabled = false;
+    const el = await mount({ disabled: true });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.previous).not.toHaveBeenCalled();
+  });
+
+  it("lets an explicit disabled={false} prop override a disabled hook", async () => {
+    h.state.disabled = true;
+    const el = await mount({ disabled: false });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.previous).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native/src/primitives/chainOfThought/ChainOfThoughtAccordionTrigger.test.tsx
+++ b/packages/react-native/src/primitives/chainOfThought/ChainOfThoughtAccordionTrigger.test.tsx
@@ -1,0 +1,85 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Text } from "react-native";
+import { ChainOfThoughtAccordionTrigger } from "./ChainOfThoughtAccordionTrigger";
+
+const h = vi.hoisted(() => ({
+  setCollapsed: vi.fn<(collapsed: boolean) => void>(),
+  state: { chainOfThought: { collapsed: true } },
+}));
+
+vi.mock("@assistant-ui/store", () => {
+  const aui = {
+    chainOfThought: () => ({ setCollapsed: h.setCollapsed }),
+  };
+  return {
+    useAui: () => aui,
+    useAuiState: <T,>(selector: (s: typeof h.state) => T) => selector(h.state),
+  };
+});
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ChainOfThoughtAccordionTrigger", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.setCollapsed.mockReset();
+    h.state.chainOfThought.collapsed = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async () => {
+    await act(async () => {
+      root.render(
+        <ChainOfThoughtAccordionTrigger testID="trigger">
+          <Text>toggle</Text>
+        </ChainOfThoughtAccordionTrigger>,
+      );
+    });
+    return container.querySelector(
+      '[data-testid="trigger"]',
+    ) as HTMLElement | null;
+  };
+
+  const press = async (el: HTMLElement) => {
+    await act(async () => {
+      el.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+  };
+
+  it("renders the trigger with its children", async () => {
+    const el = await mount();
+    expect(el).not.toBeNull();
+    expect(el?.textContent).toBe("toggle");
+  });
+
+  it("expands (sets collapsed false) when currently collapsed", async () => {
+    h.state.chainOfThought.collapsed = true;
+    const el = await mount();
+    await press(el!);
+    expect(h.setCollapsed).toHaveBeenCalledTimes(1);
+    expect(h.setCollapsed).toHaveBeenCalledWith(false);
+  });
+
+  it("collapses (sets collapsed true) when currently expanded", async () => {
+    h.state.chainOfThought.collapsed = false;
+    const el = await mount();
+    await press(el!);
+    expect(h.setCollapsed).toHaveBeenCalledTimes(1);
+    expect(h.setCollapsed).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/react-native/src/primitives/composer/ComposerAddAttachment.test.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerAddAttachment.test.tsx
@@ -1,0 +1,136 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComposerAddAttachment } from "./ComposerAddAttachment";
+
+const h = vi.hoisted(() => ({
+  disabled: false,
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useComposerAddAttachment: () => ({ disabled: h.disabled }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const click = (el: Element) => {
+  el.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+};
+
+describe("ComposerAddAttachment", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.disabled = false;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof ComposerAddAttachment>[0]> & {
+      onPress?: () => void;
+    } = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <ComposerAddAttachment testID="add" {...props}>
+          add
+        </ComposerAddAttachment>,
+      );
+    });
+    const el = container.querySelector('[data-testid="add"]');
+    expect(el).not.toBeNull();
+    return el as Element;
+  };
+
+  it("renders its children", async () => {
+    const el = await mount();
+    expect(el.textContent).toBe("add");
+  });
+
+  it("wires no onPress so pressing is a no-op", async () => {
+    const el = await mount();
+
+    let threw = false;
+    await act(async () => {
+      try {
+        click(el);
+      } catch {
+        threw = true;
+      }
+    });
+
+    expect(threw).toBe(false);
+  });
+
+  it("forwards an explicit onPress prop", async () => {
+    const onPress = vi.fn();
+    const el = await mount({ onPress });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks a forwarded onPress when the hook reports disabled", async () => {
+    h.disabled = true;
+    const onPress = vi.fn();
+    const el = await mount({ onPress });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("lets a false prop override the hook's disabled:true", async () => {
+    h.disabled = true;
+    const onPress = vi.fn();
+    const el = await mount({ disabled: false, onPress });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a true prop override the hook's disabled:false", async () => {
+    h.disabled = false;
+    const onPress = vi.fn();
+    const el = await mount({ disabled: true, onPress });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("defers to the hook when disabled is undefined", async () => {
+    h.disabled = false;
+    const onPress = vi.fn();
+    const el = await mount({ disabled: undefined, onPress });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native/src/primitives/composer/ComposerCancel.test.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerCancel.test.tsx
@@ -1,0 +1,116 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComposerCancel } from "./ComposerCancel";
+
+const h = vi.hoisted(() => ({
+  cancel: vi.fn<() => void>(),
+  disabled: false,
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useComposerCancel: () => ({ cancel: h.cancel, disabled: h.disabled }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const click = (el: Element) => {
+  el.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+};
+
+describe("ComposerCancel", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.cancel.mockReset();
+    h.disabled = false;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof ComposerCancel>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <ComposerCancel testID="cancel" {...props}>
+          cancel
+        </ComposerCancel>,
+      );
+    });
+    const el = container.querySelector('[data-testid="cancel"]');
+    expect(el).not.toBeNull();
+    return el as Element;
+  };
+
+  it("renders its children", async () => {
+    const el = await mount();
+    expect(el.textContent).toBe("cancel");
+  });
+
+  it("calls cancel on press", async () => {
+    const el = await mount();
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not press when the hook reports disabled", async () => {
+    h.disabled = true;
+    const el = await mount();
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.cancel).not.toHaveBeenCalled();
+  });
+
+  it("lets a false prop override the hook's disabled:true", async () => {
+    h.disabled = true;
+    const el = await mount({ disabled: false });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a true prop override the hook's disabled:false", async () => {
+    h.disabled = false;
+    const el = await mount({ disabled: true });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.cancel).not.toHaveBeenCalled();
+  });
+
+  it("defers to the hook when disabled is undefined", async () => {
+    h.disabled = false;
+    const el = await mount({ disabled: undefined });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.cancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native/src/primitives/composer/ComposerInput.test.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerInput.test.tsx
@@ -1,0 +1,253 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComposerInput } from "./ComposerInput";
+
+const h = vi.hoisted(() => ({
+  setText: vi.fn<(text: string) => void>(),
+  sendSpy: vi.fn<() => void>(),
+  flushTapSyncSpy: vi.fn(<T,>(fn: () => T) => fn()),
+  composerState: { text: "" },
+  platform: { os: "web" as "web" | "ios" | "android" },
+}));
+
+vi.mock("@assistant-ui/store", () => {
+  const aui = {
+    composer: () => ({
+      setText: h.setText,
+      send: h.sendSpy,
+    }),
+  };
+  return {
+    useAui: () => aui,
+    useAuiState: <T,>(
+      selector: (s: { composer: typeof h.composerState }) => T,
+    ) => selector({ composer: h.composerState }),
+  };
+});
+
+vi.mock("@assistant-ui/tap", () => ({
+  flushTapSync: h.flushTapSyncSpy,
+}));
+
+vi.mock("react-native", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown> & {
+    Platform: Record<string, unknown>;
+  };
+  return {
+    ...actual,
+    Platform: {
+      ...actual.Platform,
+      get OS() {
+        return h.platform.os;
+      },
+      select: (obj: Record<string, unknown>) =>
+        h.platform.os in obj ? obj[h.platform.os] : obj.default,
+    },
+  };
+});
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const setNativeValue = (input: HTMLInputElement, value: string) => {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(input, value);
+};
+
+const fireInput = (input: HTMLInputElement, value: string) => {
+  setNativeValue(input, value);
+  input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+};
+
+const fireKeyDown = (
+  input: HTMLInputElement,
+  opts: {
+    key?: string;
+    shiftKey?: boolean;
+    isComposing?: boolean;
+    keyCode?: number;
+  } = {},
+): KeyboardEvent => {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key: opts.key ?? "Enter",
+    shiftKey: opts.shiftKey ?? false,
+    isComposing: opts.isComposing ?? false,
+  });
+  if (opts.keyCode !== undefined) {
+    Object.defineProperty(event, "keyCode", { value: opts.keyCode });
+  }
+  input.dispatchEvent(event);
+  return event;
+};
+
+describe("ComposerInput", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.setText.mockReset();
+    h.sendSpy.mockReset();
+    h.flushTapSyncSpy.mockClear();
+    h.composerState.text = "";
+    h.platform.os = "web";
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof ComposerInput>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(<ComposerInput {...props} />);
+    });
+    const input = container.querySelector("input") as HTMLInputElement;
+    expect(input).not.toBeNull();
+    return input;
+  };
+
+  it("renders an input controlled by the composer text", async () => {
+    h.composerState.text = "hello";
+    const input = await mount();
+    expect(input.value).toBe("hello");
+  });
+
+  describe("web", () => {
+    it("routes typing through setText wrapped in flushTapSync", async () => {
+      const input = await mount();
+
+      await act(async () => {
+        fireInput(input, "ni");
+      });
+
+      expect(h.setText).toHaveBeenCalledWith("ni");
+      expect(h.flushTapSyncSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("submits on plain Enter under the default submitMode", async () => {
+      const input = await mount();
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(input, { key: "Enter" });
+      });
+
+      expect(h.sendSpy).toHaveBeenCalledTimes(1);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("inserts a newline on Shift+Enter without submitting", async () => {
+      const input = await mount();
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(input, { key: "Enter", shiftKey: true });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("ignores Enter while isComposing is set", async () => {
+      const input = await mount();
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(input, { key: "Enter", isComposing: true });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("ignores Enter while keyCode is the IME sentinel 229", async () => {
+      const input = await mount();
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(input, { key: "Enter", keyCode: 229 });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("does not submit on a non-Enter key", async () => {
+      const input = await mount();
+
+      await act(async () => {
+        fireKeyDown(input, { key: "a" });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not submit when submitMode is none", async () => {
+      const input = await mount({ submitMode: "none" });
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(input, { key: "Enter" });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("forwards keydown events to a consumer onKeyPress handler", async () => {
+      const onKeyPress = vi.fn();
+      const input = await mount({ onKeyPress });
+
+      await act(async () => {
+        fireKeyDown(input, { key: "Enter" });
+        fireKeyDown(input, { key: "a" });
+      });
+
+      expect(onKeyPress).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("native", () => {
+    beforeEach(() => {
+      h.platform.os = "ios";
+    });
+
+    it("routes typing through setText without flushTapSync", async () => {
+      const input = await mount();
+
+      await act(async () => {
+        fireInput(input, "ni");
+      });
+
+      expect(h.setText).toHaveBeenCalledWith("ni");
+      expect(h.flushTapSyncSpy).not.toHaveBeenCalled();
+    });
+
+    it("never submits on Enter and leaves the event untouched", async () => {
+      const onKeyPress = vi.fn();
+      const input = await mount({ onKeyPress });
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(input, { key: "Enter" });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+      expect(onKeyPress).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/react-native/src/primitives/composer/ComposerSend.test.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerSend.test.tsx
@@ -1,0 +1,116 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComposerSend } from "./ComposerSend";
+
+const h = vi.hoisted(() => ({
+  send: vi.fn<() => void>(),
+  disabled: false,
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useComposerSend: () => ({ send: h.send, disabled: h.disabled }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const click = (el: Element) => {
+  el.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+};
+
+describe("ComposerSend", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.send.mockReset();
+    h.disabled = false;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof ComposerSend>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <ComposerSend testID="send" {...props}>
+          send
+        </ComposerSend>,
+      );
+    });
+    const el = container.querySelector('[data-testid="send"]');
+    expect(el).not.toBeNull();
+    return el as Element;
+  };
+
+  it("renders its children", async () => {
+    const el = await mount();
+    expect(el.textContent).toBe("send");
+  });
+
+  it("calls send on press", async () => {
+    const el = await mount();
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not press when the hook reports disabled", async () => {
+    h.disabled = true;
+    const el = await mount();
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.send).not.toHaveBeenCalled();
+  });
+
+  it("lets a false prop override the hook's disabled:true", async () => {
+    h.disabled = true;
+    const el = await mount({ disabled: false });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a true prop override the hook's disabled:false", async () => {
+    h.disabled = false;
+    const el = await mount({ disabled: true });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.send).not.toHaveBeenCalled();
+  });
+
+  it("defers to the hook when disabled is undefined", async () => {
+    h.disabled = false;
+    const el = await mount({ disabled: undefined });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native/src/primitives/error/ErrorMessage.test.tsx
+++ b/packages/react-native/src/primitives/error/ErrorMessage.test.tsx
@@ -1,0 +1,64 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Text } from "react-native";
+import { ErrorMessage } from "./ErrorMessage";
+
+const h = vi.hoisted(() => ({
+  error: undefined as unknown,
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useMessageError: () => h.error,
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ErrorMessage", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.error = undefined;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (children?: React.ReactNode) => {
+    await act(async () => {
+      root.render(<ErrorMessage testID="msg">{children}</ErrorMessage>);
+    });
+    return container.querySelector('[data-testid="msg"]');
+  };
+
+  it("renders nothing when there is no error", async () => {
+    expect(await mount()).toBeNull();
+  });
+
+  it("falls back to String(error) when no children are given", async () => {
+    h.error = new Error("boom");
+    const el = await mount();
+    expect(el?.textContent).toBe("Error: boom");
+  });
+
+  it("stringifies a plain string error", async () => {
+    h.error = "kaboom";
+    const el = await mount();
+    expect(el?.textContent).toBe("kaboom");
+  });
+
+  it("renders children verbatim instead of the error when provided", async () => {
+    h.error = new Error("boom");
+    const el = await mount(<Text>custom</Text>);
+    expect(el?.textContent).toBe("custom");
+    expect(el?.textContent).not.toContain("boom");
+  });
+});

--- a/packages/react-native/src/primitives/error/ErrorRoot.test.tsx
+++ b/packages/react-native/src/primitives/error/ErrorRoot.test.tsx
@@ -1,0 +1,65 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Text } from "react-native";
+import { ErrorRoot } from "./ErrorRoot";
+
+const h = vi.hoisted(() => ({
+  error: undefined as unknown,
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useMessageError: () => h.error,
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ErrorRoot", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.error = undefined;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async () => {
+    await act(async () => {
+      root.render(
+        <ErrorRoot testID="root">
+          <Text testID="child">child</Text>
+        </ErrorRoot>,
+      );
+    });
+  };
+
+  it("renders nothing when there is no error", async () => {
+    await mount();
+    expect(container.querySelector('[data-testid="root"]')).toBeNull();
+    expect(container.querySelector('[data-testid="child"]')).toBeNull();
+  });
+
+  it("renders the view with children once an error is present", async () => {
+    h.error = new Error("boom");
+    await mount();
+    expect(container.querySelector('[data-testid="root"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="child"]')?.textContent).toBe(
+      "child",
+    );
+  });
+
+  it("treats a falsy-but-defined error as present", async () => {
+    h.error = "";
+    await mount();
+    expect(container.querySelector('[data-testid="root"]')).not.toBeNull();
+  });
+});

--- a/packages/react-native/src/primitives/message/MessageContent.test.tsx
+++ b/packages/react-native/src/primitives/message/MessageContent.test.tsx
@@ -90,7 +90,7 @@ describe("MessageContent", () => {
     });
     const el = container.querySelector('[data-testid="text-0"]');
     expect(el?.textContent).toBe("custom:raw");
-    expect(container.textContent).not.toContain(">raw<");
+    expect(container.innerHTML).not.toContain(">raw<");
   });
 
   it("renders nothing for an unknown part type", async () => {

--- a/packages/react-native/src/primitives/message/MessageContent.test.tsx
+++ b/packages/react-native/src/primitives/message/MessageContent.test.tsx
@@ -1,0 +1,278 @@
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MessageContent } from "./MessageContent";
+
+type AnyPart = { type: string; [key: string]: unknown };
+
+const h = vi.hoisted(() => ({
+  addToolResult: vi.fn(),
+  resumeToolCall: vi.fn(),
+  respondToToolApproval: vi.fn(),
+  state: {
+    message: { content: [] as AnyPart[] },
+    tools: { tools: {} as Record<string, unknown> },
+    dataRenderers: { renderers: {} as Record<string, unknown> },
+  },
+}));
+
+vi.mock("@assistant-ui/store", () => {
+  const aui = {
+    message: () => ({
+      part: ({ index }: { index: number }) => ({
+        addToolResult: (...args: unknown[]) => h.addToolResult(index, ...args),
+        resumeToolCall: (...args: unknown[]) =>
+          h.resumeToolCall(index, ...args),
+        respondToToolApproval: (...args: unknown[]) =>
+          h.respondToToolApproval(index, ...args),
+      }),
+    }),
+  };
+  return {
+    useAui: () => aui,
+    useAuiState: <T,>(selector: (s: typeof h.state) => T) => selector(h.state),
+  };
+});
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("MessageContent", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.addToolResult.mockReset();
+    h.resumeToolCall.mockReset();
+    h.respondToToolApproval.mockReset();
+    h.state.message.content = [];
+    h.state.tools.tools = {};
+    h.state.dataRenderers.renderers = {};
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof MessageContent>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(<MessageContent {...props} />);
+    });
+  };
+
+  it("renders a text part through the default text renderer", async () => {
+    h.state.message.content = [{ type: "text", text: "hello world" }];
+    await mount();
+    expect(container.textContent).toContain("hello world");
+  });
+
+  it("prefers a provided renderText over the default renderer", async () => {
+    h.state.message.content = [{ type: "text", text: "raw" }];
+    const renderText = vi.fn(
+      ({ part, index }): ReactElement => (
+        <span data-testid={`text-${index}`}>custom:{part.text}</span>
+      ),
+    );
+    await mount({ renderText });
+
+    expect(renderText).toHaveBeenCalledTimes(1);
+    expect(renderText).toHaveBeenCalledWith({
+      part: { type: "text", text: "raw" },
+      index: 0,
+    });
+    const el = container.querySelector('[data-testid="text-0"]');
+    expect(el?.textContent).toBe("custom:raw");
+    expect(container.textContent).not.toContain(">raw<");
+  });
+
+  it("renders nothing for an unknown part type", async () => {
+    h.state.message.content = [{ type: "mystery" }];
+    await mount();
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders null for optional parts when no renderer is provided", async () => {
+    h.state.message.content = [
+      { type: "image", image: "x" },
+      { type: "reasoning", text: "r" },
+      { type: "source", sourceType: "url", id: "1", url: "u" },
+      { type: "file", filename: "f" },
+    ];
+    await mount();
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders optional parts via their provided renderers", async () => {
+    h.state.message.content = [
+      { type: "image", image: "x" },
+      { type: "reasoning", text: "r" },
+      { type: "source", sourceType: "url", id: "1", url: "u" },
+      { type: "file", filename: "f" },
+    ];
+    const renderImage = vi.fn(
+      ({ index }): ReactElement => <span>image-{index}</span>,
+    );
+    const renderReasoning = vi.fn(
+      ({ index }): ReactElement => <span>reasoning-{index}</span>,
+    );
+    const renderSource = vi.fn(
+      ({ index }): ReactElement => <span>source-{index}</span>,
+    );
+    const renderFile = vi.fn(
+      ({ index }): ReactElement => <span>file-{index}</span>,
+    );
+    await mount({ renderImage, renderReasoning, renderSource, renderFile });
+
+    expect(container.textContent).toBe("image-0reasoning-1source-2file-3");
+    expect(renderImage).toHaveBeenCalledWith({
+      part: h.state.message.content[0],
+      index: 0,
+    });
+    expect(renderFile).toHaveBeenCalledWith({
+      part: h.state.message.content[3],
+      index: 3,
+    });
+  });
+
+  describe("tool-call parts", () => {
+    it("renders a registered tool renderer with part methods wired in", async () => {
+      h.state.message.content = [
+        { type: "tool-call", toolName: "search", toolCallId: "c1" },
+      ];
+      const ToolRender = vi.fn((props: Record<string, unknown>) => {
+        (props.addResult as () => void)();
+        (props.resume as () => void)();
+        (props.respondToApproval as () => void)();
+        return <span data-testid="tool">tool:{String(props.toolName)}</span>;
+      });
+      h.state.tools.tools = { search: ToolRender };
+
+      await mount();
+
+      const el = container.querySelector('[data-testid="tool"]');
+      expect(el?.textContent).toBe("tool:search");
+      expect(h.addToolResult).toHaveBeenCalledWith(0);
+      expect(h.resumeToolCall).toHaveBeenCalledWith(0);
+      expect(h.respondToToolApproval).toHaveBeenCalledWith(0);
+    });
+
+    it("picks the first renderer when the registry holds an array", async () => {
+      h.state.message.content = [
+        { type: "tool-call", toolName: "search", toolCallId: "c1" },
+      ];
+      const First = vi.fn(() => <span data-testid="first">first</span>);
+      const Second = vi.fn(() => <span>second</span>);
+      h.state.tools.tools = { search: [First, Second] };
+
+      await mount();
+
+      expect(container.querySelector('[data-testid="first"]')).not.toBeNull();
+      expect(First).toHaveBeenCalledTimes(1);
+      expect(Second).not.toHaveBeenCalled();
+    });
+
+    it("falls back to renderToolCall when no renderer is registered", async () => {
+      h.state.message.content = [
+        { type: "tool-call", toolName: "search", toolCallId: "c1" },
+      ];
+      const renderToolCall = vi.fn(
+        ({ part, index }): ReactElement => (
+          <span data-testid="fallback">
+            fallback:{String(part.toolName)}:{index}
+          </span>
+        ),
+      );
+      await mount({ renderToolCall });
+
+      const el = container.querySelector('[data-testid="fallback"]');
+      expect(el?.textContent).toBe("fallback:search:0");
+      expect(renderToolCall.mock.calls[0]![0]).toEqual({
+        part: h.state.message.content[0],
+        index: 0,
+      });
+    });
+
+    it("renders null when no renderer is registered and no fallback is given", async () => {
+      h.state.message.content = [
+        { type: "tool-call", toolName: "search", toolCallId: "c1" },
+      ];
+      await mount();
+      expect(container.textContent).toBe("");
+    });
+  });
+
+  describe("data parts", () => {
+    it("renders a registered data renderer", async () => {
+      h.state.message.content = [
+        { type: "data", name: "chart", data: { a: 1 } },
+      ];
+      const DataRender = vi.fn((props: Record<string, unknown>) => (
+        <span data-testid="data">data:{String(props.name)}</span>
+      ));
+      h.state.dataRenderers.renderers = { chart: DataRender };
+
+      await mount();
+
+      const el = container.querySelector('[data-testid="data"]');
+      expect(el?.textContent).toBe("data:chart");
+    });
+
+    it("picks the first data renderer when the registry holds an array", async () => {
+      h.state.message.content = [{ type: "data", name: "chart", data: {} }];
+      const First = vi.fn(() => <span data-testid="dfirst">first</span>);
+      const Second = vi.fn(() => <span>second</span>);
+      h.state.dataRenderers.renderers = { chart: [First, Second] };
+
+      await mount();
+
+      expect(container.querySelector('[data-testid="dfirst"]')).not.toBeNull();
+      expect(Second).not.toHaveBeenCalled();
+    });
+
+    it("falls back to renderData when no renderer is registered", async () => {
+      h.state.message.content = [{ type: "data", name: "chart", data: {} }];
+      const renderData = vi.fn(
+        ({ part, index }): ReactElement => (
+          <span data-testid="dfallback">
+            fallback:{String(part.name)}:{index}
+          </span>
+        ),
+      );
+      await mount({ renderData });
+
+      const el = container.querySelector('[data-testid="dfallback"]');
+      expect(el?.textContent).toBe("fallback:chart:0");
+    });
+
+    it("renders null when no data renderer is registered and no fallback is given", async () => {
+      h.state.message.content = [{ type: "data", name: "chart", data: {} }];
+      await mount();
+      expect(container.textContent).toBe("");
+    });
+  });
+
+  it("dispatches a mixed content array in order", async () => {
+    h.state.message.content = [
+      { type: "text", text: "A" },
+      { type: "tool-call", toolName: "t", toolCallId: "c" },
+      { type: "data", name: "d", data: {} },
+    ];
+    h.state.tools.tools = {
+      t: () => <span>[tool]</span>,
+    };
+    h.state.dataRenderers.renderers = {
+      d: () => <span>[data]</span>,
+    };
+    await mount();
+
+    expect(container.textContent).toBe("A[tool][data]");
+  });
+});

--- a/packages/react-native/src/primitives/message/MessageIf.test.tsx
+++ b/packages/react-native/src/primitives/message/MessageIf.test.tsx
@@ -1,0 +1,156 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Text } from "react-native";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MessageIf } from "./MessageIf";
+
+const h = vi.hoisted(() => ({
+  message: {
+    role: "assistant" as "user" | "assistant" | "system",
+    status: { type: "complete" as "running" | "complete" | "incomplete" },
+    isLast: false,
+  },
+}));
+
+vi.mock("@assistant-ui/store", () => ({
+  useAuiState: <T,>(selector: (s: { message: typeof h.message }) => T) =>
+    selector({ message: h.message }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("MessageIf", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.message.role = "assistant";
+    h.message.status = { type: "complete" };
+    h.message.isLast = false;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof MessageIf>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <MessageIf {...props}>
+          <Text testID="child">visible</Text>
+        </MessageIf>,
+      );
+    });
+    return container.querySelector('[data-testid="child"]');
+  };
+
+  it("renders children when no guard is set", async () => {
+    expect(await mount()).not.toBeNull();
+  });
+
+  describe("user guard", () => {
+    it("renders children when user:true matches a user message", async () => {
+      h.message.role = "user";
+      expect(await mount({ user: true })).not.toBeNull();
+    });
+
+    it("hides children when user:true but the message is from the assistant", async () => {
+      h.message.role = "assistant";
+      expect(await mount({ user: true })).toBeNull();
+    });
+
+    it("renders children when user:false matches a non-user message", async () => {
+      h.message.role = "assistant";
+      expect(await mount({ user: false })).not.toBeNull();
+    });
+
+    it("hides children when user:false but the message is from the user", async () => {
+      h.message.role = "user";
+      expect(await mount({ user: false })).toBeNull();
+    });
+  });
+
+  describe("assistant guard", () => {
+    it("renders children when assistant:true matches an assistant message", async () => {
+      h.message.role = "assistant";
+      expect(await mount({ assistant: true })).not.toBeNull();
+    });
+
+    it("hides children when assistant:true but the message is from the user", async () => {
+      h.message.role = "user";
+      expect(await mount({ assistant: true })).toBeNull();
+    });
+
+    it("renders children when assistant:false matches a non-assistant message", async () => {
+      h.message.role = "user";
+      expect(await mount({ assistant: false })).not.toBeNull();
+    });
+  });
+
+  describe("running guard", () => {
+    it("renders children when an assistant message is running", async () => {
+      h.message.role = "assistant";
+      h.message.status = { type: "running" };
+      expect(await mount({ running: true })).not.toBeNull();
+    });
+
+    it("hides children when running:true but the assistant message is complete", async () => {
+      h.message.role = "assistant";
+      h.message.status = { type: "complete" };
+      expect(await mount({ running: true })).toBeNull();
+    });
+
+    it("treats a running user message as not running", async () => {
+      h.message.role = "user";
+      h.message.status = { type: "running" };
+      expect(await mount({ running: true })).toBeNull();
+      expect(await mount({ running: false })).not.toBeNull();
+    });
+  });
+
+  describe("last guard", () => {
+    it("renders children when last:true matches the last message", async () => {
+      h.message.isLast = true;
+      expect(await mount({ last: true })).not.toBeNull();
+    });
+
+    it("hides children when last:true but the message is not last", async () => {
+      h.message.isLast = false;
+      expect(await mount({ last: true })).toBeNull();
+    });
+
+    it("renders children when last:false matches a non-last message", async () => {
+      h.message.isLast = false;
+      expect(await mount({ last: false })).not.toBeNull();
+    });
+  });
+
+  describe("combined guards", () => {
+    it("renders children only when assistant and last both match", async () => {
+      h.message.role = "assistant";
+      h.message.isLast = true;
+      expect(await mount({ assistant: true, last: true })).not.toBeNull();
+    });
+
+    it("hides children when assistant matches but last does not", async () => {
+      h.message.role = "assistant";
+      h.message.isLast = false;
+      expect(await mount({ assistant: true, last: true })).toBeNull();
+    });
+
+    it("hides children when last matches but assistant does not", async () => {
+      h.message.role = "user";
+      h.message.isLast = true;
+      expect(await mount({ assistant: true, last: true })).toBeNull();
+    });
+  });
+});

--- a/packages/react-native/src/primitives/suggestion/SuggestionDescription.test.tsx
+++ b/packages/react-native/src/primitives/suggestion/SuggestionDescription.test.tsx
@@ -1,0 +1,62 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { vi } from "vitest";
+import { SuggestionDescription } from "./SuggestionDescription";
+
+const h = vi.hoisted(() => ({
+  suggestion: { label: "" as string | undefined },
+}));
+
+vi.mock("@assistant-ui/store", () => ({
+  useAuiState: <T,>(selector: (s: { suggestion: typeof h.suggestion }) => T) =>
+    selector({ suggestion: h.suggestion }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("SuggestionDescription", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.suggestion.label = "";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof SuggestionDescription>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(<SuggestionDescription testID="t" {...props} />);
+    });
+    return container.querySelector('[data-testid="t"]') as HTMLElement;
+  };
+
+  it("renders the store suggestion label", async () => {
+    h.suggestion.label = "Generate a quick summary";
+    const el = await mount();
+    expect(el.textContent).toBe("Generate a quick summary");
+  });
+
+  it("renders explicit children over the store label", async () => {
+    h.suggestion.label = "Generate a quick summary";
+    const el = await mount({ children: "Custom label" });
+    expect(el.textContent).toBe("Custom label");
+  });
+
+  it("falls back to the store label when children is undefined", async () => {
+    h.suggestion.label = "Store label";
+    const el = await mount({ children: undefined });
+    expect(el.textContent).toBe("Store label");
+  });
+});

--- a/packages/react-native/src/primitives/suggestion/SuggestionDescription.test.tsx
+++ b/packages/react-native/src/primitives/suggestion/SuggestionDescription.test.tsx
@@ -1,7 +1,6 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SuggestionDescription } from "./SuggestionDescription";
 
 const h = vi.hoisted(() => ({

--- a/packages/react-native/src/primitives/suggestion/SuggestionTitle.test.tsx
+++ b/packages/react-native/src/primitives/suggestion/SuggestionTitle.test.tsx
@@ -1,7 +1,6 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SuggestionTitle } from "./SuggestionTitle";
 
 const h = vi.hoisted(() => ({

--- a/packages/react-native/src/primitives/suggestion/SuggestionTitle.test.tsx
+++ b/packages/react-native/src/primitives/suggestion/SuggestionTitle.test.tsx
@@ -1,0 +1,62 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { vi } from "vitest";
+import { SuggestionTitle } from "./SuggestionTitle";
+
+const h = vi.hoisted(() => ({
+  suggestion: { title: "" as string | undefined },
+}));
+
+vi.mock("@assistant-ui/store", () => ({
+  useAuiState: <T,>(selector: (s: { suggestion: typeof h.suggestion }) => T) =>
+    selector({ suggestion: h.suggestion }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("SuggestionTitle", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.suggestion.title = "";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof SuggestionTitle>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(<SuggestionTitle testID="t" {...props} />);
+    });
+    return container.querySelector('[data-testid="t"]') as HTMLElement;
+  };
+
+  it("renders the store suggestion title", async () => {
+    h.suggestion.title = "Summarize this";
+    const el = await mount();
+    expect(el.textContent).toBe("Summarize this");
+  });
+
+  it("renders explicit children over the store title", async () => {
+    h.suggestion.title = "Summarize this";
+    const el = await mount({ children: "Custom title" });
+    expect(el.textContent).toBe("Custom title");
+  });
+
+  it("falls back to the store title when children is undefined", async () => {
+    h.suggestion.title = "Store title";
+    const el = await mount({ children: undefined });
+    expect(el.textContent).toBe("Store title");
+  });
+});

--- a/packages/react-native/src/primitives/suggestion/SuggestionTrigger.test.tsx
+++ b/packages/react-native/src/primitives/suggestion/SuggestionTrigger.test.tsx
@@ -1,0 +1,144 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SuggestionTrigger } from "./SuggestionTrigger";
+
+const h = vi.hoisted(() => ({
+  trigger: vi.fn<() => void>(),
+  useSuggestionTrigger: vi.fn<
+    (arg: {
+      prompt: string | undefined;
+      send?: boolean;
+      clearComposer?: boolean;
+    }) => {
+      trigger: () => void;
+      disabled: boolean;
+    }
+  >(),
+  suggestion: { prompt: "" as string | undefined },
+}));
+
+vi.mock("@assistant-ui/store", () => ({
+  useAuiState: <T,>(selector: (s: { suggestion: typeof h.suggestion }) => T) =>
+    selector({ suggestion: h.suggestion }),
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useSuggestionTrigger: (arg: Parameters<typeof h.useSuggestionTrigger>[0]) =>
+    h.useSuggestionTrigger(arg),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("SuggestionTrigger", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.trigger.mockReset();
+    h.suggestion.prompt = "Tell me a joke";
+    h.useSuggestionTrigger.mockReset();
+    h.useSuggestionTrigger.mockReturnValue({
+      trigger: h.trigger,
+      disabled: false,
+    });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof SuggestionTrigger>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <SuggestionTrigger testID="t" {...props}>
+          {props.children ?? "Press me"}
+        </SuggestionTrigger>,
+      );
+    });
+    return container.querySelector('[data-testid="t"]') as HTMLElement;
+  };
+
+  const press = async (el: HTMLElement) => {
+    await act(async () => {
+      el.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+  };
+
+  it("passes the store prompt and trigger options to useSuggestionTrigger", async () => {
+    h.suggestion.prompt = "Write a poem";
+    await mount({ send: true, clearComposer: false });
+
+    expect(h.useSuggestionTrigger).toHaveBeenCalledWith({
+      prompt: "Write a poem",
+      send: true,
+      clearComposer: false,
+    });
+  });
+
+  it("defaults clearComposer to true and leaves send undefined", async () => {
+    await mount();
+
+    expect(h.useSuggestionTrigger).toHaveBeenCalledWith({
+      prompt: "Tell me a joke",
+      send: undefined,
+      clearComposer: true,
+    });
+  });
+
+  it("fires the trigger when pressed", async () => {
+    const el = await mount();
+    await press(el);
+
+    expect(h.trigger).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders its children", async () => {
+    const el = await mount({ children: "Suggested action" });
+    expect(el.textContent).toBe("Suggested action");
+  });
+
+  it("does not fire the trigger when the hook reports disabled", async () => {
+    h.useSuggestionTrigger.mockReturnValue({
+      trigger: h.trigger,
+      disabled: true,
+    });
+    const el = await mount();
+    await press(el);
+
+    expect(h.trigger).not.toHaveBeenCalled();
+  });
+
+  it("lets an explicit disabled prop override the hook's enabled state", async () => {
+    h.useSuggestionTrigger.mockReturnValue({
+      trigger: h.trigger,
+      disabled: false,
+    });
+    const el = await mount({ disabled: true });
+    await press(el);
+
+    expect(h.trigger).not.toHaveBeenCalled();
+  });
+
+  it("stays pressable when the prop disabled is false but the hook is disabled", async () => {
+    h.useSuggestionTrigger.mockReturnValue({
+      trigger: h.trigger,
+      disabled: true,
+    });
+    const el = await mount({ disabled: false });
+    await press(el);
+
+    expect(h.trigger).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native/src/primitives/thread/ThreadEmpty.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadEmpty.test.tsx
@@ -1,0 +1,56 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Text } from "react-native";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThreadEmpty } from "./ThreadEmpty";
+
+const h = vi.hoisted(() => ({
+  isEmpty: true,
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useThreadIsEmpty: () => h.isEmpty,
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ThreadEmpty", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.isEmpty = true;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async () => {
+    await act(async () => {
+      root.render(
+        <ThreadEmpty>
+          <Text testID="child">visible</Text>
+        </ThreadEmpty>,
+      );
+    });
+    return container.querySelector('[data-testid="child"]');
+  };
+
+  it("renders children when the thread is empty", async () => {
+    h.isEmpty = true;
+    expect(await mount()).not.toBeNull();
+  });
+
+  it("hides children when the thread is not empty", async () => {
+    h.isEmpty = false;
+    expect(await mount()).toBeNull();
+  });
+});

--- a/packages/react-native/src/primitives/thread/ThreadIf.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadIf.test.tsx
@@ -1,0 +1,121 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Text } from "react-native";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThreadIf } from "./ThreadIf";
+
+const h = vi.hoisted(() => ({
+  thread: { messages: [] as unknown[], isRunning: false },
+}));
+
+vi.mock("@assistant-ui/store", () => ({
+  useAuiState: <T,>(selector: (s: { thread: typeof h.thread }) => T) =>
+    selector({ thread: h.thread }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ThreadIf", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.thread.messages = [];
+    h.thread.isRunning = false;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (props: Partial<Parameters<typeof ThreadIf>[0]> = {}) => {
+    await act(async () => {
+      root.render(
+        <ThreadIf {...props}>
+          <Text testID="child">visible</Text>
+        </ThreadIf>,
+      );
+    });
+    return container.querySelector('[data-testid="child"]');
+  };
+
+  const setMessages = (count: number) => {
+    h.thread.messages = Array.from({ length: count }, (_, i) => i);
+  };
+
+  it("renders children when no guard is set", async () => {
+    setMessages(2);
+    expect(await mount()).not.toBeNull();
+  });
+
+  describe("empty guard", () => {
+    it("renders children when empty:true matches an empty thread", async () => {
+      setMessages(0);
+      expect(await mount({ empty: true })).not.toBeNull();
+    });
+
+    it("hides children when empty:true but the thread has messages", async () => {
+      setMessages(3);
+      expect(await mount({ empty: true })).toBeNull();
+    });
+
+    it("renders children when empty:false matches a non-empty thread", async () => {
+      setMessages(3);
+      expect(await mount({ empty: false })).not.toBeNull();
+    });
+
+    it("hides children when empty:false but the thread is empty", async () => {
+      setMessages(0);
+      expect(await mount({ empty: false })).toBeNull();
+    });
+  });
+
+  describe("running guard", () => {
+    it("renders children when running:true matches a running thread", async () => {
+      h.thread.isRunning = true;
+      expect(await mount({ running: true })).not.toBeNull();
+    });
+
+    it("hides children when running:true but the thread is idle", async () => {
+      h.thread.isRunning = false;
+      expect(await mount({ running: true })).toBeNull();
+    });
+
+    it("renders children when running:false matches an idle thread", async () => {
+      h.thread.isRunning = false;
+      expect(await mount({ running: false })).not.toBeNull();
+    });
+
+    it("hides children when running:false but the thread is running", async () => {
+      h.thread.isRunning = true;
+      expect(await mount({ running: false })).toBeNull();
+    });
+  });
+
+  describe("combined guards", () => {
+    it("renders children only when both empty and running match", async () => {
+      setMessages(0);
+      h.thread.isRunning = true;
+      expect(await mount({ empty: true, running: true })).not.toBeNull();
+    });
+
+    it("hides children when empty matches but running does not", async () => {
+      setMessages(0);
+      h.thread.isRunning = false;
+      expect(await mount({ empty: true, running: true })).toBeNull();
+    });
+
+    it("hides children when running matches but empty does not", async () => {
+      setMessages(2);
+      h.thread.isRunning = true;
+      expect(await mount({ empty: true, running: true })).toBeNull();
+    });
+  });
+});

--- a/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadMessages.test.tsx
@@ -1,0 +1,192 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThreadMessages } from "./ThreadMessages";
+
+type Msg = { id: string; role: string };
+
+const h = vi.hoisted(() => ({
+  state: {
+    thread: { messages: [] as Msg[] },
+    message: { role: "user" as string, composer: { isEditing: false } },
+  },
+  itemState: { role: "user" } as { role: string },
+}));
+
+vi.mock("@assistant-ui/store", () => ({
+  useAuiState: <T,>(selector: (s: typeof h.state) => T) => selector(h.state),
+  RenderChildrenWithAccessor: ({
+    children,
+  }: {
+    children: (getItem: () => unknown) => unknown;
+  }) => children(() => h.itemState),
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  MessageByIndexProvider: ({ children }: { children: unknown }) => children,
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ThreadMessages", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.state.thread.messages = [];
+    h.state.message.role = "user";
+    h.state.message.composer.isEditing = false;
+    h.itemState = { role: "user" };
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (props: Parameters<typeof ThreadMessages>[0]) => {
+    await act(async () => {
+      root.render(<ThreadMessages {...props} />);
+    });
+  };
+
+  describe("components mode dispatch", () => {
+    const makeComponents = () => ({
+      Message: vi.fn(() => <span data-testid="c-message">message</span>),
+      EditComposer: vi.fn(() => <span data-testid="c-edit">edit</span>),
+      UserEditComposer: vi.fn(() => (
+        <span data-testid="c-user-edit">user-edit</span>
+      )),
+      AssistantEditComposer: vi.fn(() => (
+        <span data-testid="c-assistant-edit">assistant-edit</span>
+      )),
+      SystemEditComposer: vi.fn(() => (
+        <span data-testid="c-system-edit">system-edit</span>
+      )),
+      UserMessage: vi.fn(() => <span data-testid="c-user">user</span>),
+      AssistantMessage: vi.fn(() => (
+        <span data-testid="c-assistant">assistant</span>
+      )),
+      SystemMessage: vi.fn(() => <span data-testid="c-system">system</span>),
+    });
+
+    it("renders the user message component for a user role", async () => {
+      h.state.thread.messages = [{ id: "1", role: "user" }];
+      h.state.message.role = "user";
+      await mount({ components: makeComponents() });
+      expect(container.querySelector('[data-testid="c-user"]')).not.toBeNull();
+      expect(container.querySelector('[data-testid="c-message"]')).toBeNull();
+    });
+
+    it("renders the assistant message component for an assistant role", async () => {
+      h.state.thread.messages = [{ id: "1", role: "assistant" }];
+      h.state.message.role = "assistant";
+      await mount({ components: makeComponents() });
+      expect(
+        container.querySelector('[data-testid="c-assistant"]'),
+      ).not.toBeNull();
+    });
+
+    it("renders the system message component for a system role", async () => {
+      h.state.thread.messages = [{ id: "1", role: "system" }];
+      h.state.message.role = "system";
+      await mount({ components: makeComponents() });
+      expect(
+        container.querySelector('[data-testid="c-system"]'),
+      ).not.toBeNull();
+    });
+
+    it("prefers the role-specific edit composer while editing", async () => {
+      h.state.thread.messages = [{ id: "1", role: "user" }];
+      h.state.message.role = "user";
+      h.state.message.composer.isEditing = true;
+      await mount({ components: makeComponents() });
+      expect(
+        container.querySelector('[data-testid="c-user-edit"]'),
+      ).not.toBeNull();
+    });
+
+    it("falls back to the shared EditComposer when no role edit composer exists", async () => {
+      h.state.thread.messages = [{ id: "1", role: "user" }];
+      h.state.message.role = "user";
+      h.state.message.composer.isEditing = true;
+      const components = makeComponents() as Record<string, unknown>;
+      delete components.UserEditComposer;
+      await mount({ components: components as never });
+      expect(container.querySelector('[data-testid="c-edit"]')).not.toBeNull();
+    });
+
+    it("falls back to the role message then Message when no edit composer exists", async () => {
+      h.state.thread.messages = [{ id: "1", role: "assistant" }];
+      h.state.message.role = "assistant";
+      h.state.message.composer.isEditing = true;
+      const components = makeComponents() as Record<string, unknown>;
+      delete components.AssistantEditComposer;
+      delete components.EditComposer;
+      await mount({ components: components as never });
+      expect(
+        container.querySelector('[data-testid="c-assistant"]'),
+      ).not.toBeNull();
+    });
+
+    it("falls back to Message when no role-specific component exists", async () => {
+      h.state.thread.messages = [{ id: "1", role: "user" }];
+      h.state.message.role = "user";
+      const components = makeComponents() as Record<string, unknown>;
+      delete components.UserMessage;
+      await mount({ components: components as never });
+      expect(
+        container.querySelector('[data-testid="c-message"]'),
+      ).not.toBeNull();
+    });
+
+    it("renders nothing for a system role with no system or Message component", async () => {
+      h.state.thread.messages = [{ id: "1", role: "system" }];
+      h.state.message.role = "system";
+      const components = makeComponents() as Record<string, unknown>;
+      delete components.SystemMessage;
+      delete components.Message;
+      await mount({ components: components as never });
+      expect(container.querySelector('[data-testid="c-system"]')).toBeNull();
+      expect(container.querySelector('[data-testid="c-message"]')).toBeNull();
+    });
+
+    it("throws for an unknown role", async () => {
+      h.state.thread.messages = [{ id: "1", role: "ghost" }];
+      h.state.message.role = "ghost";
+      await expect(mount({ components: makeComponents() })).rejects.toThrow(
+        /Unknown message role/,
+      );
+    });
+  });
+
+  describe("children mode", () => {
+    it("renders via the children render prop", async () => {
+      h.state.thread.messages = [{ id: "1", role: "user" }];
+      h.itemState = { role: "user" };
+      const children = vi.fn(({ message }: { message: { role: string } }) => (
+        <span data-testid="child">child:{message.role}</span>
+      ));
+      await mount({ children });
+      const el = container.querySelector('[data-testid="child"]');
+      expect(el?.textContent).toBe("child:user");
+      expect(children).toHaveBeenCalled();
+    });
+  });
+
+  it("renders no items for an empty thread", async () => {
+    h.state.thread.messages = [];
+    await mount({
+      components: {
+        Message: () => <span data-testid="c-message">message</span>,
+      } as never,
+    });
+    expect(container.querySelector('[data-testid="c-message"]')).toBeNull();
+  });
+});

--- a/packages/react-native/src/primitives/threadList/ThreadListNew.test.tsx
+++ b/packages/react-native/src/primitives/threadList/ThreadListNew.test.tsx
@@ -1,0 +1,72 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThreadListNew } from "./ThreadListNew";
+
+const h = vi.hoisted(() => ({
+  switchToNewThread: vi.fn<() => void>(),
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useThreadListNew: () => ({ switchToNewThread: h.switchToNewThread }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const click = (el: Element) =>
+  el.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+
+describe("ThreadListNew", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.switchToNewThread.mockReset();
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof ThreadListNew>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <ThreadListNew testID="t" {...props}>
+          new
+        </ThreadListNew>,
+      );
+    });
+    return container.querySelector('[data-testid="t"]') as HTMLElement;
+  };
+
+  it("fires switchToNewThread when pressed", async () => {
+    const el = await mount();
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.switchToNewThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when a disabled prop is passed through", async () => {
+    const el = await mount({ disabled: true });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.switchToNewThread).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native/src/primitives/threadListItem/ThreadListItemArchive.test.tsx
+++ b/packages/react-native/src/primitives/threadListItem/ThreadListItemArchive.test.tsx
@@ -1,0 +1,72 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThreadListItemArchive } from "./ThreadListItemArchive";
+
+const h = vi.hoisted(() => ({
+  archive: vi.fn<() => void>(),
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useThreadListItemArchive: () => ({ archive: h.archive }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const click = (el: Element) =>
+  el.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+
+describe("ThreadListItemArchive", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.archive.mockReset();
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof ThreadListItemArchive>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <ThreadListItemArchive testID="t" {...props}>
+          archive
+        </ThreadListItemArchive>,
+      );
+    });
+    return container.querySelector('[data-testid="t"]') as HTMLElement;
+  };
+
+  it("fires archive when pressed", async () => {
+    const el = await mount();
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.archive).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when a disabled prop is passed through", async () => {
+    const el = await mount({ disabled: true });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.archive).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native/src/primitives/threadListItem/ThreadListItemDelete.test.tsx
+++ b/packages/react-native/src/primitives/threadListItem/ThreadListItemDelete.test.tsx
@@ -1,0 +1,72 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThreadListItemDelete } from "./ThreadListItemDelete";
+
+const h = vi.hoisted(() => ({
+  deleteThread: vi.fn<() => void>(),
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useThreadListItemDelete: () => ({ delete: h.deleteThread }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const click = (el: Element) =>
+  el.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+
+describe("ThreadListItemDelete", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.deleteThread.mockReset();
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof ThreadListItemDelete>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <ThreadListItemDelete testID="t" {...props}>
+          delete
+        </ThreadListItemDelete>,
+      );
+    });
+    return container.querySelector('[data-testid="t"]') as HTMLElement;
+  };
+
+  it("fires the bound delete when pressed", async () => {
+    const el = await mount();
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.deleteThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when a disabled prop is passed through", async () => {
+    const el = await mount({ disabled: true });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.deleteThread).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native/src/primitives/threadListItem/ThreadListItemTrigger.test.tsx
+++ b/packages/react-native/src/primitives/threadListItem/ThreadListItemTrigger.test.tsx
@@ -1,0 +1,72 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThreadListItemTrigger } from "./ThreadListItemTrigger";
+
+const h = vi.hoisted(() => ({
+  switchTo: vi.fn<() => void>(),
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useThreadListItemTrigger: () => ({ switchTo: h.switchTo }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const click = (el: Element) =>
+  el.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+
+describe("ThreadListItemTrigger", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.switchTo.mockReset();
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof ThreadListItemTrigger>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <ThreadListItemTrigger testID="t" {...props}>
+          open
+        </ThreadListItemTrigger>,
+      );
+    });
+    return container.querySelector('[data-testid="t"]') as HTMLElement;
+  };
+
+  it("fires switchTo when pressed", async () => {
+    const el = await mount();
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.switchTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when a disabled prop is passed through", async () => {
+    const el = await mount({ disabled: true });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.switchTo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native/src/primitives/threadListItem/ThreadListItemUnarchive.test.tsx
+++ b/packages/react-native/src/primitives/threadListItem/ThreadListItemUnarchive.test.tsx
@@ -1,0 +1,72 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThreadListItemUnarchive } from "./ThreadListItemUnarchive";
+
+const h = vi.hoisted(() => ({
+  unarchive: vi.fn<() => void>(),
+}));
+
+vi.mock("@assistant-ui/core/react", () => ({
+  useThreadListItemUnarchive: () => ({ unarchive: h.unarchive }),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const click = (el: Element) =>
+  el.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+
+describe("ThreadListItemUnarchive", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.unarchive.mockReset();
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof ThreadListItemUnarchive>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <ThreadListItemUnarchive testID="t" {...props}>
+          unarchive
+        </ThreadListItemUnarchive>,
+      );
+    });
+    return container.querySelector('[data-testid="t"]') as HTMLElement;
+  };
+
+  it("fires unarchive when pressed", async () => {
+    const el = await mount();
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.unarchive).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when a disabled prop is passed through", async () => {
+    const el = await mount({ disabled: true });
+
+    await act(async () => {
+      click(el);
+    });
+
+    expect(h.unarchive).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native/vitest.config.ts
+++ b/packages/react-native/vitest.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "react-native": "react-native-web",
+    },
+  },
   test: {
-    environment: "node",
+    environment: "jsdom",
     globals: true,
     passWithNoTests: true,
+    include: ["src/**/*.test.{ts,tsx}"],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1798,7 +1798,7 @@ importers:
         version: link:../../packages/ui
       '@google/adk':
         specifier: ^1.2.0
-        version: 1.2.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.3)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
+        version: 1.2.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.3)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3759,7 +3759,7 @@ importers:
         version: link:../store
       '@google/adk':
         specifier: '>=0.5.0'
-        version: 1.2.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14)(pg@8.20.0))(@mikro-orm/mssql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.3)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+        version: 1.2.0(@bufbuild/protobuf@2.12.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.14(@mikro-orm/core@6.6.14))(@mikro-orm/mssql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.14(@mikro-orm/core@6.6.14)(@types/node@25.9.3)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.14(@mikro-orm/core@6.6.14)(mariadb@3.4.5))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
       assistant-cloud:
         specifier: '*'
         version: link:../cloud
@@ -4118,15 +4118,33 @@ importers:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       react:
         specifier: ^19.2.7
         version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
       react-native:
         specifier: ^0.86.0
         version: 0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)
+      react-native-web:
+        specifier: ~0.21.2
+        version: 0.21.2(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -30180,6 +30198,21 @@ snapshots:
       postcss-value-parser: 4.2.0
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+      styleq: 0.1.3
+    transitivePeerDependencies:
+      - encoding
+
+  react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@react-native/normalize-colors': 0.74.89
+      fbjs: 3.0.5(encoding@0.1.13)
+      inline-style-prefixer: 7.0.1
+      memoize-one: 6.0.0
+      nullthrows: 1.1.1
+      postcss-value-parser: 4.2.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       styleq: 0.1.3
     transitivePeerDependencies:
       - encoding

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4118,12 +4118,6 @@ importers:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils
-      '@testing-library/dom':
-        specifier: ^10.4.1
-        version: 10.4.1
-      '@testing-library/react':
-        specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17


### PR DESCRIPTION
## summary

- adds the first test suite for `@assistant-ui/react-native` (the package shipped zero tests), following up on the IME composer fix in #4513.
- stands up a vitest harness: aliases `react-native` to `react-native-web` under jsdom so the primitives render to real DOM, plus the test devDependencies (`@testing-library/react`, `jsdom`, `react-dom`). `Platform.OS` resolves to web through the alias, and a per-file `vi.mock` of the `react-native` Platform drives the native branch.
- 143 tests across 27 files: `ComposerInput` (both platform branches, the `isComposing`/`keyCode === 229` IME guards, `flushTapSync` wrapping, submit modes, `onKeyPress` passthrough), the composer / branch picker / thread list / thread-list-item action buttons (press plus the `disabled ?? hookDisabled` merge), the conditional primitives (`ThreadIf`, `MessageIf`, `ThreadEmpty`), the state-reader primitives, `AttachmentThumb` extension extraction, error and chain-of-thought, and the `MessageContent` part dispatch.

## test plan

### already verified

- [x] `cd packages/react-native && pnpm exec vitest run` -> 27 files / 143 tests green
- [x] `pnpm --filter @assistant-ui/react-native exec tsc --noEmit` -> exit 0
- [x] `pnpm lint` -> oxlint + oxfmt clean
- [x] `pnpm --filter @assistant-ui/react-native build` -> complete, no test files leak into `dist`

## notes

- no production code changes; test and dev-tooling only. the patch changeset is included for the package release flow.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

