### PR TITLE
feat: forward onThreadIdChange through remote thread list adapters

### DIFF
--- a/.changeset/forward-onthreadidchange-adapters.md
+++ b/.changeset/forward-onthreadidchange-adapters.md
@@ -1,0 +1,10 @@
+---
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-google-adk": patch
+"@assistant-ui/react-opencode": patch
+"@assistant-ui/react-pi": patch
+---
+
+feat: forward `onThreadIdChange` through the adapter entry hooks (`useLangGraphRuntime`, `useStreamRuntime`, `useChatRuntime`, `useAdkRuntime`, `useOpenCodeRuntime`, `usePiRuntime`). the option already existed on `useRemoteThreadListRuntime` but every wrapper dropped it, so routing/persistence built on the settled remote thread id never fired from these hooks. only the settled remote id is emitted; the transient `__LOCALID_*` placeholder is never surfaced.

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -30,6 +30,7 @@ export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
       toCreateMessage?: CustomToCreateMessageFunction;
       onResume?: AISDKRuntimeAdapter["onResume"];
       joinStrategy?: AISDKRuntimeAdapter["joinStrategy"];
+      onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
     };
 
 const useDynamicChatTransport = <UI_MESSAGE extends UIMessage = UIMessage>(
@@ -137,6 +138,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
 
 export const useChatRuntime = <UI_MESSAGE extends UIMessage = UIMessage>({
   cloud,
+  onThreadIdChange,
   ...options
 }: UseChatRuntimeOptions<UI_MESSAGE> = {}): AssistantRuntime => {
   const cloudAdapter = useCloudThreadListAdapter({ cloud });
@@ -146,5 +148,6 @@ export const useChatRuntime = <UI_MESSAGE extends UIMessage = UIMessage>({
     },
     adapter: cloudAdapter,
     allowNesting: true,
+    onThreadIdChange,
   });
 };

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -140,6 +140,15 @@ const truncateAdkMessages = (
 
 export type UseAdkRuntimeOptions = ExternalStoreSharedOptions & {
   stream: AdkStreamCallback;
+  /**
+   * Called whenever the active thread's canonical (remote) ID changes, so the
+   * value can be treated as a managed/controlled variable (e.g. synced to a URL
+   * query param). Only the settled remote ID is emitted: while a freshly created
+   * thread is still optimistic the value is `undefined`, and the real ID is
+   * emitted once the thread is initialized; the transient local ID is never
+   * surfaced.
+   */
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   autoCancelPendingToolCalls?: boolean | undefined;
   unstable_allowCancellation?: boolean | undefined;
   getCheckpointId?: (
@@ -372,6 +381,7 @@ export const useAdkRuntime = ({
   sessionAdapter,
   create,
   delete: deleteFn,
+  onThreadIdChange,
   ...options
 }: UseAdkRuntimeOptions) => {
   const aui = useAui();
@@ -393,5 +403,6 @@ export const useAdkRuntime = ({
     },
     adapter,
     allowNesting: true,
+    onThreadIdChange,
   });
 };

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -108,6 +108,15 @@ export type LangChainRuntimeExtras = {
 };
 
 export type LangChainRuntimeExtraOptions = ExternalStoreSharedOptions & {
+  /**
+   * Called whenever the active thread's canonical (remote) ID changes, so the
+   * value can be treated as a managed/controlled variable (e.g. synced to a URL
+   * query param). Only the settled remote ID is emitted: while a freshly created
+   * thread is still optimistic the value is `undefined`, and the real ID is
+   * emitted once the thread is initialized; the transient local ID is never
+   * surfaced.
+   */
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   cloud?: AssistantCloud | undefined;
   adapters?:
     | {

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -274,6 +274,7 @@ export const useStreamRuntime = (rawOptions: UseStreamRuntimeOptions) => {
     unstable_threadListAdapter,
     create,
     delete: deleteFn,
+    onThreadIdChange,
     ...options
   } = rawOptions;
 
@@ -293,5 +294,6 @@ export const useStreamRuntime = (rawOptions: UseStreamRuntimeOptions) => {
     },
     adapter,
     allowNesting: true,
+    onThreadIdChange,
   });
 };

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -248,6 +248,15 @@ export type LangGraphRuntimeExtras = {
 };
 
 export type UseLangGraphRuntimeOptions = ExternalStoreSharedOptions & {
+  /**
+   * Called whenever the active thread's canonical (remote) ID changes, so the
+   * value can be treated as a managed/controlled variable (e.g. synced to a URL
+   * query param). Only the settled remote ID is emitted: while a freshly created
+   * thread is still optimistic the value is `undefined`, and the real ID is
+   * emitted once the thread is initialized; the transient local ID is never
+   * surfaced.
+   */
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   autoCancelPendingToolCalls?: boolean | undefined;
   /**
    * When true, renders the Cancel button in the composer and aborts the

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -585,6 +585,32 @@ describe("useLangGraphRuntime", () => {
     expect(signal?.aborted).toBe(true);
   });
 
+  it("forwards onThreadIdChange so the settled remote thread id reaches the consumer", async () => {
+    const onThreadIdChange = vi.fn();
+    const streamMock = vi
+      .fn()
+      .mockImplementation(() => mockStreamCallbackFactory([])());
+
+    const { result: runtimeResult } = renderHook(() =>
+      useLangGraphRuntime({
+        stream: streamMock,
+        unstable_threadListAdapter: makeThreadListAdapter(),
+        onThreadIdChange,
+      }),
+    );
+
+    const wrapper = wrapperFactory(runtimeResult.current);
+    renderHook(() => useAuiState((s) => s.threads.mainThreadId), { wrapper });
+
+    await act(async () => {
+      await runtimeResult.current.threads.switchToThread("lg-thread-1");
+    });
+
+    await waitFor(() =>
+      expect(onThreadIdChange).toHaveBeenLastCalledWith("lg-thread-1"),
+    );
+  });
+
   it("invokes user-provided create when stream calls initialize without cloud", async () => {
     const userCreate = vi.fn(async () => ({ externalId: "lg-thread-xyz" }));
 

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -415,6 +415,7 @@ export const useLangGraphRuntime = ({
   unstable_threadListAdapter,
   create,
   delete: deleteFn,
+  onThreadIdChange,
   ...options
 }: UseLangGraphRuntimeOptions) => {
   const aui = useAui();
@@ -442,5 +443,6 @@ export const useLangGraphRuntime = ({
     },
     adapter,
     allowNesting: true,
+    onThreadIdChange,
   });
 };

--- a/packages/react-opencode/src/types.ts
+++ b/packages/react-opencode/src/types.ts
@@ -183,6 +183,15 @@ export type OpenCodeUserMessageOptions = {
 };
 
 export type OpenCodeRuntimeOptions = ExternalStoreSharedOptions & {
+  /**
+   * Called whenever the active thread's canonical (remote) ID changes, so the
+   * value can be treated as a managed/controlled variable (e.g. synced to a URL
+   * query param). Only the settled remote ID is emitted: while a freshly created
+   * thread is still optimistic the value is `undefined`, and the real ID is
+   * emitted once the thread is initialized; the transient local ID is never
+   * surfaced.
+   */
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   client?: OpencodeClient;
   baseUrl?: string | undefined;
   initialSessionId?: string | undefined;

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -241,6 +241,7 @@ export const useOpenCodeRuntime = (
     allowNesting: true,
     adapter,
     initialThreadId: options.initialSessionId,
+    onThreadIdChange: options.onThreadIdChange,
     // oxlint-disable-next-line react-hooks/rules-of-hooks -- runtimeHook callback is invoked by useRemoteThreadListRuntime at the appropriate hook position
     runtimeHook: () => useRuntimeHook(client, registry, options),
   });

--- a/packages/react-pi/src/runtime/runtimeTypes.ts
+++ b/packages/react-pi/src/runtime/runtimeTypes.ts
@@ -25,6 +25,8 @@ export type PiRuntimeOptions = ExternalStoreSharedOptions & {
   includeArchived?: boolean;
   initialThreadId?: string;
   threadId?: string;
+  /** Notified when the active thread's settled remote ID changes; `undefined` while still optimistic. */
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   onError?: (error: unknown) => void;
   adapters?: ExternalStoreAdapter<ThreadMessageLike>["adapters"];
 };

--- a/packages/react-pi/src/runtime/usePiRuntime.ts
+++ b/packages/react-pi/src/runtime/usePiRuntime.ts
@@ -556,6 +556,9 @@ export const usePiRuntime = (options: PiRuntimeOptions): AssistantRuntime => {
       ? { initialThreadId: options.initialThreadId }
       : {}),
     ...(options.threadId !== undefined ? { threadId: options.threadId } : {}),
+    ...(options.onThreadIdChange !== undefined
+      ? { onThreadIdChange: options.onThreadIdChange }
+      : {}),
     runtimeHook: () => {
       // oxlint-disable-next-line react-hooks/rules-of-hooks -- runtimeHook is invoked by useRemoteThreadListRuntime at the correct hook position
       return useRuntimeHook(registry, options, pendingInitialMessageRef);


### PR DESCRIPTION
closes #4507

## summary

- forward `onThreadIdChange` through all six remote thread list adapter entry hooks (`useLangGraphRuntime`, `useStreamRuntime`, `useChatRuntime`, `useAdkRuntime`, `useOpenCodeRuntime`, `usePiRuntime`). the option already existed on `useRemoteThreadListRuntime` (added in #4482) but every wrapper dropped it, so a consumer of these hooks could never receive the settled remote thread id; #4507 hit this on the `useLangGraphRuntime` path.
- each hook adds an optional `onThreadIdChange?: (threadId: string | undefined) => void` to its public options and passes it to the underlying `useRemoteThreadListRuntime`. only the settled remote id is emitted; the transient `__LOCALID_*` placeholder is never surfaced. `mainThreadId` still intentionally stays on the optimistic local id (unchanged).
- additive optional option; no behavior change for existing callers.

## test plan

### already verified

- [x] `pnpm turbo build` for the 6 packages, typecheck green
- [x] `pnpm turbo test` for the 6 packages, green (langgraph 148 incl. a new `forwards onThreadIdChange` regression test, ai-sdk 77, opencode 44, pi 139, langchain and google-adk green)
- [x] `pnpm lint` (oxlint + oxfmt), clean

### reviewer should verify

- [ ] in a `useLangGraphRuntime` app with `unstable_threadListAdapter`, pass `onThreadIdChange`, send the first message in a new thread, and confirm the callback fires once with the server uuid (and `undefined` while still optimistic) instead of never firing.

## notes

- the `threadId` controlled "in" half is still not forwarded by the langgraph, langchain, ai-sdk, and google-adk hooks; this PR only adds the "out" half they were missing. forwarding the "in" half and documenting the controlled routing pattern are separate follow-ups.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

