### PR TITLE
fix(eve): support eve 0.12

### DIFF
--- a/.changeset/eve-0-12-support.md
+++ b/.changeset/eve-0-12-support.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/eve": patch
+---
+
+fix: support eve 0.12 (the `InputResponse` and `SendTurnPayload` types now come from `eve/client`, and `output-denied` tool parts carry a required `approval`)

--- a/examples/with-eve/package.json
+++ b/examples/with-eve/package.json
@@ -15,7 +15,7 @@
     "@assistant-ui/ui": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "eve": "^0.11.4",
+    "eve": "^0.12.0",
     "lucide-react": "^1.21.0",
     "next": "^16.2.9",
     "react": "^19.2.7",

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@types/react": "*",
-    "eve": "^0.11.4",
+    "eve": "^0.12.0",
     "react": "^18 || ^19"
   },
   "peerDependenciesMeta": {
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
     "@types/react": "^19.2.17",
-    "eve": "^0.11.4",
+    "eve": "^0.12.0",
     "react": "^19.2.7",
     "vitest": "^4.1.9"
   },

--- a/packages/eve/src/convertEveMessages.test.ts
+++ b/packages/eve/src/convertEveMessages.test.ts
@@ -106,7 +106,7 @@ describe("convertEveMessages", () => {
     });
   });
 
-  it("handles denied tool parts without approval metadata", () => {
+  it("handles denied tool parts without an approval reason", () => {
     const data = {
       messages: [
         {
@@ -119,6 +119,7 @@ describe("convertEveMessages", () => {
               toolCallId: "call_1",
               toolName: "send_email",
               input: { to: "dev@example.com" },
+              approval: { id: "req_1", approved: false },
             },
           ],
         },
@@ -164,6 +165,7 @@ describe("getEveMessageContent", () => {
   it("returns plain text for text-only messages", () => {
     const message = {
       role: "user",
+      createdAt: new Date(),
       parentId: null,
       sourceId: null,
       runConfig: undefined,

--- a/packages/eve/src/convertEveMessages.ts
+++ b/packages/eve/src/convertEveMessages.ts
@@ -15,9 +15,8 @@ import type {
   EveMessageData,
   EveMessageInputRequest,
   EveMessagePart,
-  InputResponse,
-  SendTurnPayload,
 } from "eve/react";
+import type { InputResponse, SendTurnPayload } from "eve/client";
 
 const ASSISTANT_COMPLETE_STATUS = {
   type: "complete",
@@ -45,10 +44,10 @@ export type ConvertEveMessagesOptions = {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const toJsonObject = (value: unknown): Record<string, unknown> => {
-  if (isRecord(value)) return value;
+const toJsonObject = (value: unknown): ToolCallMessagePart["args"] => {
+  if (isRecord(value)) return value as ToolCallMessagePart["args"];
   if (value === undefined) return {};
-  return { value };
+  return { value } as ToolCallMessagePart["args"];
 };
 
 const stringifyArgs = (value: unknown): string => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1399,8 +1399,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       eve:
-        specifier: ^0.11.4
-        version: 0.11.4(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.0-beta.178(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.0.1)(lru-cache@11.5.1)(mysql2@3.20.0(@types/node@26.0.0))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(sqlite3@5.1.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^0.12.0
+        version: 0.12.0(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.0-beta.178(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.0.1)(lru-cache@11.5.1)(mysql2@3.20.0(@types/node@26.0.0))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(sqlite3@5.1.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       lucide-react:
         specifier: ^1.21.0
         version: 1.21.0(react@19.2.7)
@@ -3333,8 +3333,8 @@ importers:
         specifier: ^19.2.17
         version: 19.2.17
       eve:
-        specifier: ^0.11.4
-        version: 0.11.4(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.0-beta.178(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.0.1)(lru-cache@11.5.1)(mysql2@3.20.0(@types/node@26.0.0))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(sqlite3@5.1.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^0.12.0
+        version: 0.12.0(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.0-beta.178(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.0.1)(lru-cache@11.5.1)(mysql2@3.20.0(@types/node@26.0.0))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(sqlite3@5.1.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -4950,8 +4950,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       eve:
-        specifier: ^0.11.4
-        version: 0.11.4(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.0-beta.178(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.0.1)(lru-cache@11.5.1)(mysql2@3.20.0(@types/node@26.0.0))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(sqlite3@5.1.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^0.12.0
+        version: 0.12.0(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.0-beta.178(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.0.1)(lru-cache@11.5.1)(mysql2@3.20.0(@types/node@26.0.0))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(sqlite3@5.1.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       lucide-react:
         specifier: ^1.21.0
         version: 1.21.0(react@19.2.7)
@@ -11990,8 +11990,8 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eve@0.11.4:
-    resolution: {integrity: sha512-gwJO+mIFj/LQL+D4WJTshPMUkK6cYXIA6ff1RML8I3rFOeIm1x/Mw6U8C+1Mx4o5HhWda38DnnlK84Bewqo/+Q==}
+  eve@0.12.0:
+    resolution: {integrity: sha512-SKlO6mqY4Eo24QGBAnxNkKORFALQhBQefU58k9kqHnmKkD5QXvaHiaxaJFet1Pu646mMtW3VxbcxU9fQt/dkPg==}
     engines: {node: '>=24'}
     hasBin: true
     peerDependencies:
@@ -25429,7 +25429,7 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eve@0.11.4(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.0-beta.178(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.0.1)(lru-cache@11.5.1)(mysql2@3.20.0(@types/node@26.0.0))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(sqlite3@5.1.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  eve@0.12.0(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.0-beta.178(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.0.1)(lru-cache@11.5.1)(mysql2@3.20.0(@types/node@26.0.0))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(sqlite3@5.1.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       ai: 7.0.0-beta.178(zod@4.4.3)
       nitro: 3.0.260610-beta(@azure/identity@4.13.1)(@upstash/redis@1.38.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(lru-cache@11.5.1)(mysql2@3.20.0(@types/node@26.0.0))(sqlite3@5.1.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))

--- a/templates/eve/package.json
+++ b/templates/eve/package.json
@@ -22,7 +22,7 @@
     "@assistant-ui/ui": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "eve": "^0.11.4",
+    "eve": "^0.12.0",
     "lucide-react": "^1.21.0",
     "next": "^16.2.9",
     "react": "^19.2.7",


### PR DESCRIPTION
## summary

- upgrades the `eve` dependency from `^0.11.4` to `^0.12.0` (peer + dev in `@assistant-ui/eve`, plus the `with-eve` example and `eve` template) and migrates the adapter to compile against it.
- root cause of the prior breakage: `convertEveMessages.ts` imported `InputResponse` and `SendTurnPayload` from `eve/react`, but eve exports those from `eve/client`, so `@assistant-ui/eve`'s `tsc --noEmit` failed even on the pinned 0.11.4.
- fix: move those two `import type`s to `eve/client` (type-only, fully erased, so no runtime or bundle impact, RN included); type `toJsonObject` as `ToolCallMessagePart["args"]` to clear a pre-existing `ReadonlyJSONObject` mismatch; update the test fixtures for eve 0.12 (the `output-denied` dynamic-tool part now carries a required `approval`, and the `AppendMessage` fixture needed `createdAt`). the runtime conversion logic is unchanged.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/eve exec tsc --noEmit` -> 0 errors
- [x] `pnpm --filter @assistant-ui/eve test` -> 6/6 green
- [x] `pnpm build` -> 86/86 and `pnpm turbo test` -> 71/71
- [x] `pnpm lint`, `pnpm check:resource-memo`, Template Sync -> all green

### reviewer should verify

- [ ] the `with-eve` example still runs against eve 0.12 (the HITL approval flow renders and resolves)

## notes

- this PR does not touch `@assistant-ui/react-langchain`. that package has a separate, pre-existing `test:types` breakage on main (the `@langchain` sdk bump in #4517 against #4516's new code), being fixed in a follow-up PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

