### PR TITLE
fix(react-langchain): type-check against the current @langchain SDK

### DIFF
--- a/.changeset/react-langchain-sdk-types.md
+++ b/.changeset/react-langchain-sdk-types.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+fix: type-check the langchain message converter against the current `@langchain/langgraph-sdk` (return a single converter `Message`, accept the generative-UI metadata extension, and bind `uiMessagesByParent` through a memoized callback rather than the converter's `metadata` channel). no runtime behavior change.

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -14,6 +14,12 @@ const aiMessage = (content: unknown): LangChainBaseMessage => ({
   content,
 });
 
+const contentOf = (result: ReturnType<typeof convertLangChainBaseMessage>) => {
+  if (result.role === "tool")
+    throw new Error("expected a content-bearing message");
+  return result.content;
+};
+
 describe("convertLangChainBaseMessage file content parts", () => {
   it("converts a base64 file block", () => {
     const result = convertLangChainBaseMessage(
@@ -29,7 +35,7 @@ describe("convertLangChainBaseMessage file content parts", () => {
       {},
     );
 
-    expect(result.content).toEqual([
+    expect(contentOf(result)).toEqual([
       {
         type: "file",
         filename: "a.pdf",
@@ -47,7 +53,7 @@ describe("convertLangChainBaseMessage file content parts", () => {
       {},
     );
 
-    expect(result.content).toEqual([
+    expect(contentOf(result)).toEqual([
       {
         type: "file",
         filename: "file",
@@ -73,7 +79,7 @@ describe("convertLangChainBaseMessage reasoning content parts", () => {
       {},
     );
 
-    expect(result.content).toEqual([
+    expect(contentOf(result)).toEqual([
       { type: "reasoning", text: "first\n\n\nsecond" },
     ]);
   });
@@ -84,7 +90,7 @@ describe("convertLangChainBaseMessage reasoning content parts", () => {
       {},
     );
 
-    expect(result.content).toEqual([
+    expect(contentOf(result)).toEqual([
       { type: "reasoning", text: "thinking out loud" },
     ]);
   });
@@ -95,7 +101,7 @@ describe("convertLangChainBaseMessage reasoning content parts", () => {
       {},
     );
 
-    expect(result.content).toEqual([{ type: "reasoning", text: "" }]);
+    expect(contentOf(result)).toEqual([{ type: "reasoning", text: "" }]);
   });
 
   it("tolerates null entries inside the summary array", () => {
@@ -109,7 +115,9 @@ describe("convertLangChainBaseMessage reasoning content parts", () => {
       {},
     );
 
-    expect(result.content).toEqual([{ type: "reasoning", text: "\n\n\nkept" }]);
+    expect(contentOf(result)).toEqual([
+      { type: "reasoning", text: "\n\n\nkept" },
+    ]);
   });
 });
 
@@ -127,7 +135,7 @@ describe("convertLangChainBaseMessage generative UI from graph state", () => {
       uiMessagesByParent: new Map([["msg-2", [uiMessage("msg-2")]]]),
     });
 
-    expect(result.content).toEqual([
+    expect(contentOf(result)).toEqual([
       { type: "text", text: "hello" },
       { type: "data", name: "chart", data: { points: [1, 2, 3] } },
     ]);
@@ -138,7 +146,7 @@ describe("convertLangChainBaseMessage generative UI from graph state", () => {
       uiMessagesByParent: new Map([["other-id", [uiMessage("other-id")]]]),
     });
 
-    expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+    expect(contentOf(result)).toEqual([{ type: "text", text: "hello" }]);
   });
 
   it("appends a data part per UI when several target the same message", () => {
@@ -154,7 +162,7 @@ describe("convertLangChainBaseMessage generative UI from graph state", () => {
       ]),
     });
 
-    expect(result.content).toEqual([
+    expect(contentOf(result)).toEqual([
       { type: "text", text: "hello" },
       { type: "data", name: "chart", data: { a: 1 } },
       { type: "data", name: "table", data: { b: 2 } },
@@ -167,13 +175,13 @@ describe("convertLangChainBaseMessage generative UI from graph state", () => {
       { uiMessagesByParent: new Map([["", [uiMessage("")]]]) },
     );
 
-    expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+    expect(contentOf(result)).toEqual([{ type: "text", text: "hello" }]);
   });
 
   it("leaves the message unchanged when no converter metadata is passed", () => {
     const result = convertLangChainBaseMessage(aiMessage("hello"));
 
-    expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+    expect(contentOf(result)).toEqual([{ type: "text", text: "hello" }]);
   });
 });
 
@@ -186,7 +194,7 @@ describe("convertLangChainBaseMessage image content parts", () => {
       {},
     );
 
-    expect(result.content).toEqual([
+    expect(contentOf(result)).toEqual([
       { type: "image", image: "https://example.com/a.png" },
     ]);
   });
@@ -197,6 +205,6 @@ describe("convertLangChainBaseMessage image content parts", () => {
       {},
     );
 
-    expect(result.content).toEqual([]);
+    expect(contentOf(result)).toEqual([]);
   });
 });

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -88,9 +88,10 @@ const getStringContent = (content: unknown): string => {
     .join("");
 };
 
-export const convertLangChainBaseMessage: useExternalMessageConverter.Callback<
-  LangChainBaseMessage
-> = (message, metadata: LangChainMessageConverterMetadata = {}) => {
+export const convertLangChainBaseMessage = (
+  message: LangChainBaseMessage,
+  metadata: LangChainMessageConverterMetadata = {},
+): useExternalMessageConverter.Message => {
   const type = getMessageType(message);
 
   switch (type) {

--- a/packages/react-langchain/src/groupUIMessagesByParent.test.ts
+++ b/packages/react-langchain/src/groupUIMessagesByParent.test.ts
@@ -10,7 +10,7 @@ const uiMessage = (
   id: "ui-1",
   name,
   props: { points: [1, 2, 3] },
-  metadata,
+  ...(metadata !== undefined && { metadata }),
 });
 
 describe("groupUIMessagesByParent", () => {

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -106,16 +106,18 @@ const useStreamThreadRuntime = (
   const effectiveIsRunning = stream.isLoading || hasExecutingTools;
 
   const uiStateValue = stream.values[uiStateKey];
-  const converterMetadata = useMemo(
-    () => ({ uiMessagesByParent: groupUIMessagesByParent(uiStateValue) }),
-    [uiStateValue],
-  );
+  const convertWithUI = useMemo<
+    useExternalMessageConverter.Callback<LangChainBaseMessage>
+  >(() => {
+    const uiMessagesByParent = groupUIMessagesByParent(uiStateValue);
+    return (message, metadata) =>
+      convertLangChainBaseMessage(message, { ...metadata, uiMessagesByParent });
+  }, [uiStateValue]);
 
   const threadMessages = useExternalMessageConverter({
-    callback: convertLangChainBaseMessage,
+    callback: convertWithUI,
     messages: stream.messages as LangChainBaseMessage[],
     isRunning: effectiveIsRunning,
-    metadata: converterMetadata,
   });
 
   const streamRef = useRef(stream);


### PR DESCRIPTION
## summary

- `@assistant-ui/react-langchain` did not pass `tsc --noEmit` (about 20 errors) once `@langchain/langgraph-sdk` 1.9.x and core's `useExternalMessageConverter` types met #4516's generative-ui code. this makes the package compile again, with no runtime behavior change.
- `convertLangChainBaseMessage` now declares an explicit signature returning a single `useExternalMessageConverter.Message` with optional extended metadata, instead of the bare `Callback` whose return is `Message | Message[]` with required metadata. that fixes the test's `.content` access and the one-arg call.
- `useStreamRuntime` binds `uiMessagesByParent` through a memoized callback closure rather than the converter's `metadata` channel (core's `Metadata` is a closed type and rejects extra keys); the closure keeps the same per-uiState re-conversion memoization, so behavior is unchanged.
- test fixtures updated: a `contentOf` narrowing helper (the `Message` union includes a content-less tool arm) and a conditional metadata spread for `exactOptionalPropertyTypes`.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-langchain exec tsc --noEmit` -> 0 errors (was about 20)
- [x] `pnpm --filter @assistant-ui/react-langchain test` -> 58/58 green
- [x] `pnpm build` -> 86/86 and `pnpm turbo test` -> 71/71
- [x] `pnpm lint` and `pnpm check:resource-memo` -> green

### reviewer should verify

- [ ] generative ui still renders in a real langgraph stream (ui parts attach to their parent assistant message)

## notes

- scope is react-langchain only. `pnpm test:types` still has separate pre-existing failures on main in other packages, not gated by ci and not caused by this change: `x-generative-compiler` (babel 8 parser/generator types), `react-devtools` (a test fixture), `with-react-router` (react-router generated `./+types/*`), and `with-browser-extension` (a css side-effect import).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

