### PR TITLE
feat(react-langchain): edit messages via checkpoint fork

### DIFF
--- a/.changeset/langchain-edit-checkpoint-fork.md
+++ b/.changeset/langchain-edit-checkpoint-fork.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): edit messages via checkpoint fork

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -755,6 +755,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | Root tool-calls projection | Via message parts | Yes (`useLangChainToolCalls`) |
 | File content parts in messages | Yes | Yes |
 | Regenerate (checkpoint fork) | Yes (`getCheckpointId`) | Yes (auto-resolved) |
+| Edit message (checkpoint fork) | Yes | Yes (auto-resolved) |
 | Per-message metadata (`messages-tuple`) | Yes | Not exposed |
 | Generative UI (state snapshot) | Yes | Yes (`uiStateKey`) |
 | Generative UI (live `push_ui_message`) | Yes | Not yet |
@@ -767,7 +768,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 
 `react-langchain` is the newer, thinner wrapper. It delegates to upstream `useStream` rather than re-implementing the stream plumbing, which is why its footprint is smaller. Features absent today have not been ported, not deprecated.
 
-Regenerate works without configuration. Clicking regenerate resolves the server checkpoint to fork from (the checkpoint each message records as it streams in, falling back to a `stream.client.threads.getHistory(threadId)` id match for older turns), then re-runs with `submit(null, { forkFrom })`. It works on checkpoint-enabled backends (for example LangGraph Cloud) and degrades gracefully; when no checkpoint resolves the regenerate is a no-op. `react-langgraph` instead requires a user-supplied `getCheckpointId` callback.
+Regenerate works without configuration. Clicking regenerate resolves the server checkpoint to fork from (the checkpoint each message records as it streams in, falling back to a `stream.client.threads.getHistory(threadId)` id match for older turns), then re-runs with `submit(null, { forkFrom })`. It works on checkpoint-enabled backends (for example LangGraph Cloud) and degrades gracefully; when no checkpoint resolves the regenerate is a no-op. `react-langgraph` instead requires a user-supplied `getCheckpointId` callback. Editing a message forks from the same checkpoint and submits the edited human content instead of re-running the prior turn; editing the first message forks from the thread's initial checkpoint to restart it.
 
 ### Hook name mapping
 

--- a/packages/react-langchain/src/findForkCheckpointInHistory.test.ts
+++ b/packages/react-langchain/src/findForkCheckpointInHistory.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { LangChainBaseMessage } from "./types";
-import { resolveForkCheckpointId } from "./resolveForkCheckpointId";
+import { findForkCheckpointInHistory } from "./findForkCheckpointInHistory";
 
 const msg = (id: string | undefined): LangChainBaseMessage => ({
   _getType: () => "human",
@@ -40,7 +40,7 @@ const makePaginatedClient = (states: HistoryState[]) => ({
   },
 });
 
-describe("resolveForkCheckpointId", () => {
+describe("findForkCheckpointInHistory", () => {
   it("returns the checkpoint_id of the state whose messages match by id", async () => {
     const client = makeClient([
       {
@@ -57,7 +57,7 @@ describe("resolveForkCheckpointId", () => {
       },
     ]);
 
-    const result = await resolveForkCheckpointId(
+    const result = await findForkCheckpointInHistory(
       client,
       "thread-1",
       [msg("a"), msg("b")],
@@ -78,7 +78,7 @@ describe("resolveForkCheckpointId", () => {
       },
     ]);
 
-    const result = await resolveForkCheckpointId(
+    const result = await findForkCheckpointInHistory(
       client,
       "thread-1",
       [msg("a"), msg("b")],
@@ -96,7 +96,7 @@ describe("resolveForkCheckpointId", () => {
       },
     ]);
 
-    const result = await resolveForkCheckpointId(
+    const result = await findForkCheckpointInHistory(
       client,
       "thread-1",
       [msg("a"), msg(undefined)],
@@ -114,7 +114,7 @@ describe("resolveForkCheckpointId", () => {
       },
     ]);
 
-    const result = await resolveForkCheckpointId(
+    const result = await findForkCheckpointInHistory(
       client,
       "thread-1",
       [msg("a")],
@@ -132,7 +132,7 @@ describe("resolveForkCheckpointId", () => {
       },
     ]);
 
-    const result = await resolveForkCheckpointId(
+    const result = await findForkCheckpointInHistory(
       client,
       "thread-1",
       [msg("a")],
@@ -154,7 +154,7 @@ describe("resolveForkCheckpointId", () => {
       },
     ]);
 
-    const result = await resolveForkCheckpointId(
+    const result = await findForkCheckpointInHistory(
       client,
       "thread-1",
       [msg("a")],
@@ -172,7 +172,7 @@ describe("resolveForkCheckpointId", () => {
       },
     ]);
 
-    const result = await resolveForkCheckpointId(
+    const result = await findForkCheckpointInHistory(
       client,
       "thread-1",
       [msg("a"), msg("b")],
@@ -185,7 +185,7 @@ describe("resolveForkCheckpointId", () => {
   it("forwards a custom history limit to getHistory", async () => {
     const client = makeClient([]);
 
-    await resolveForkCheckpointId(
+    await findForkCheckpointInHistory(
       client,
       "thread-1",
       [msg("a")],
@@ -218,7 +218,7 @@ describe("resolveForkCheckpointId", () => {
       },
     ]);
 
-    const result = await resolveForkCheckpointId(
+    const result = await findForkCheckpointInHistory(
       client,
       "thread-1",
       [msg("a")],
@@ -249,7 +249,7 @@ describe("resolveForkCheckpointId", () => {
       threads: { getHistory: vi.fn(async () => page as never) },
     };
 
-    const result = await resolveForkCheckpointId(
+    const result = await findForkCheckpointInHistory(
       client,
       "thread-1",
       [msg("a")],

--- a/packages/react-langchain/src/findForkCheckpointInHistory.ts
+++ b/packages/react-langchain/src/findForkCheckpointInHistory.ts
@@ -16,7 +16,7 @@ export type ForkCheckpointClient = {
   };
 };
 
-export const resolveForkCheckpointId = async (
+export const findForkCheckpointInHistory = async (
   client: ForkCheckpointClient,
   threadId: string,
   messagesUpToParent: readonly LangChainBaseMessage[],

--- a/packages/react-langchain/src/resolveForkCheckpoint.test.ts
+++ b/packages/react-langchain/src/resolveForkCheckpoint.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LangChainBaseMessage } from "./types";
+import type { ForkCheckpointClient } from "./findForkCheckpointInHistory";
+import { resolveForkCheckpoint } from "./resolveForkCheckpoint";
+
+const msg = (id: string): LangChainBaseMessage => ({
+  _getType: () => "human",
+  content: "",
+  id,
+});
+
+type HistoryState = {
+  values: Record<string, unknown>;
+  checkpoint: { checkpoint_id?: string };
+};
+
+const makeClient = (history: HistoryState[]): ForkCheckpointClient => ({
+  threads: {
+    getHistory: vi.fn(async () => history as never),
+  },
+});
+
+const metadata = (entries: Record<string, string | undefined>) =>
+  new Map(
+    Object.entries(entries).map(([id, parentCheckpointId]) => [
+      id,
+      { parentCheckpointId },
+    ]),
+  );
+
+describe("resolveForkCheckpoint", () => {
+  it("uses the head metadata fast-path without hitting getHistory", async () => {
+    const client = makeClient([]);
+
+    const result = await resolveForkCheckpoint(
+      client,
+      "thread-1",
+      [msg("h1"), msg("a1")],
+      "h1",
+      "a1",
+      metadata({ a1: "cp-head" }),
+      "messages",
+    );
+
+    expect(result).toBe("cp-head");
+    expect(client.threads.getHistory).not.toHaveBeenCalled();
+  });
+
+  it("falls back to history search when sourceId is not the head message", async () => {
+    const client = makeClient([
+      {
+        values: { messages: [msg("h1")] },
+        checkpoint: { checkpoint_id: "cp-h1" },
+      },
+    ]);
+
+    const result = await resolveForkCheckpoint(
+      client,
+      "thread-1",
+      [msg("h1"), msg("a1"), msg("h2")],
+      "h1",
+      "h1",
+      metadata({ h2: "cp-head" }),
+      "messages",
+    );
+
+    expect(result).toBe("cp-h1");
+    expect(client.threads.getHistory).toHaveBeenCalled();
+  });
+
+  it("falls back to history search when the head metadata has no checkpoint", async () => {
+    const client = makeClient([
+      {
+        values: { messages: [msg("h1")] },
+        checkpoint: { checkpoint_id: "cp-h1" },
+      },
+    ]);
+
+    const result = await resolveForkCheckpoint(
+      client,
+      "thread-1",
+      [msg("h1"), msg("a1")],
+      "h1",
+      "a1",
+      metadata({}),
+      "messages",
+    );
+
+    expect(result).toBe("cp-h1");
+    expect(client.threads.getHistory).toHaveBeenCalled();
+  });
+
+  it("matches the parent prefix through history search", async () => {
+    const client = makeClient([
+      {
+        values: { messages: [msg("h1"), msg("a1")] },
+        checkpoint: { checkpoint_id: "cp-full" },
+      },
+      {
+        values: { messages: [msg("h1")] },
+        checkpoint: { checkpoint_id: "cp-parent" },
+      },
+    ]);
+
+    const result = await resolveForkCheckpoint(
+      client,
+      "thread-1",
+      [msg("h1"), msg("a1")],
+      "h1",
+      undefined,
+      undefined,
+      "messages",
+    );
+
+    expect(result).toBe("cp-parent");
+  });
+
+  it("returns null when a non-null parentId is not in the messages", async () => {
+    const client = makeClient([]);
+
+    const result = await resolveForkCheckpoint(
+      client,
+      "thread-1",
+      [msg("h1"), msg("a1")],
+      "missing",
+      undefined,
+      undefined,
+      "messages",
+    );
+
+    expect(result).toBeNull();
+    expect(client.threads.getHistory).not.toHaveBeenCalled();
+  });
+
+  it("forks the first message from the initial empty-message checkpoint", async () => {
+    const client = makeClient([
+      {
+        values: { messages: [msg("h1"), msg("a1")] },
+        checkpoint: { checkpoint_id: "cp-full" },
+      },
+      {
+        values: { messages: [] },
+        checkpoint: { checkpoint_id: "cp-initial" },
+      },
+    ]);
+
+    const result = await resolveForkCheckpoint(
+      client,
+      "thread-1",
+      [msg("h1"), msg("a1")],
+      null,
+      "h1",
+      metadata({}),
+      "messages",
+    );
+
+    expect(result).toBe("cp-initial");
+  });
+
+  it("returns null when no checkpoint resolves", async () => {
+    const client = makeClient([
+      {
+        values: { messages: [msg("other")] },
+        checkpoint: { checkpoint_id: "cp-other" },
+      },
+    ]);
+
+    const result = await resolveForkCheckpoint(
+      client,
+      "thread-1",
+      [msg("h1")],
+      "h1",
+      undefined,
+      undefined,
+      "messages",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("swallows history search errors and returns null", async () => {
+    const client: ForkCheckpointClient = {
+      threads: {
+        getHistory: vi.fn(async () => {
+          throw new Error("network");
+        }),
+      },
+    };
+
+    const result = await resolveForkCheckpoint(
+      client,
+      "thread-1",
+      [msg("h1"), msg("a1")],
+      "h1",
+      undefined,
+      undefined,
+      "messages",
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/react-langchain/src/resolveForkCheckpoint.ts
+++ b/packages/react-langchain/src/resolveForkCheckpoint.ts
@@ -1,0 +1,49 @@
+import type { LangChainBaseMessage } from "./types";
+import {
+  findForkCheckpointInHistory,
+  type ForkCheckpointClient,
+} from "./findForkCheckpointInHistory";
+
+type MessageMetadataSnapshot =
+  | ReadonlyMap<string, { readonly parentCheckpointId: string | undefined }>
+  | undefined;
+
+/**
+ * Hydration seeds every message with the head's parent checkpoint, so only the
+ * head's recorded fork checkpoint is reliable; older turns are matched against
+ * server history by message id. A `null` `parentId` edits the first human
+ * message and forks from the thread's initial (empty-message) checkpoint.
+ */
+export const resolveForkCheckpoint = async (
+  client: ForkCheckpointClient,
+  threadId: string,
+  messages: readonly LangChainBaseMessage[],
+  parentId: string | null,
+  sourceId: string | null | undefined,
+  metadata: MessageMetadataSnapshot,
+  messagesKey: string,
+): Promise<string | null> => {
+  const lastMessage = messages[messages.length - 1];
+  let checkpointId: string | null =
+    sourceId != null && lastMessage?.id === sourceId
+      ? (metadata?.get(sourceId)?.parentCheckpointId ?? null)
+      : null;
+
+  if (!checkpointId) {
+    const parentIndex =
+      parentId == null ? -1 : messages.findIndex((m) => m.id === parentId);
+    if (parentId != null && parentIndex === -1) return null;
+    try {
+      checkpointId = await findForkCheckpointInHistory(
+        client,
+        threadId,
+        messages.slice(0, parentIndex + 1),
+        messagesKey,
+      );
+    } catch {
+      return null;
+    }
+  }
+
+  return checkpointId;
+};

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -24,7 +24,7 @@ import {
   getMessageType,
 } from "./convertMessages";
 import { langChainExtras } from "./runtimeExtras";
-import { resolveForkCheckpointId } from "./resolveForkCheckpointId";
+import { resolveForkCheckpoint } from "./resolveForkCheckpoint";
 
 export const runConfigToSubmitOptions = (
   runConfig: AppendMessage["runConfig"],
@@ -205,39 +205,43 @@ const useStreamThreadRuntime = (
       const threadId = externalId;
       if (!threadId || parentId == null) return;
       const s = streamRef.current;
-      const messages = s.messages as readonly LangChainBaseMessage[];
-
-      // Hydration seeds every message with the head's parent checkpoint, so only
-      // the head's recorded fork checkpoint is reliable; older turns reverse-map.
-      const sourceId = config.sourceId;
-      const lastMessage = messages[messages.length - 1];
-      let checkpointId: string | null =
-        sourceId != null && lastMessage?.id === sourceId
-          ? (s[STREAM_CONTROLLER]?.messageMetadataStore
-              ?.getSnapshot?.()
-              ?.get(sourceId)?.parentCheckpointId ?? null)
-          : null;
-
-      if (!checkpointId) {
-        const parentIndex = messages.findIndex((m) => m.id === parentId);
-        if (parentIndex === -1) return;
-        try {
-          checkpointId = await resolveForkCheckpointId(
-            s.client,
-            threadId,
-            messages.slice(0, parentIndex + 1),
-            messagesKey,
-          );
-        } catch {
-          return;
-        }
-      }
-
+      const checkpointId = await resolveForkCheckpoint(
+        s.client,
+        threadId,
+        s.messages as readonly LangChainBaseMessage[],
+        parentId,
+        config.sourceId,
+        s[STREAM_CONTROLLER]?.messageMetadataStore?.getSnapshot?.(),
+        messagesKey,
+      );
       if (!checkpointId) return;
       await s.submit(null, {
         forkFrom: checkpointId,
         ...runConfigToSubmitOptions(config.runConfig),
       });
+    },
+    onEdit: async (message) => {
+      const threadId = externalId;
+      if (!threadId) return;
+      const s = streamRef.current;
+      const checkpointId = await resolveForkCheckpoint(
+        s.client,
+        threadId,
+        s.messages as readonly LangChainBaseMessage[],
+        message.parentId,
+        message.sourceId,
+        s[STREAM_CONTROLLER]?.messageMetadataStore?.getSnapshot?.(),
+        messagesKey,
+      );
+      if (!checkpointId) return;
+      const content = getMessageContent(message);
+      await s.submit(
+        { [messagesKey]: [{ type: "human", content }] },
+        {
+          forkFrom: checkpointId,
+          ...runConfigToSubmitOptions(message.runConfig),
+        },
+      );
     },
     onCancel:
       unstable_allowCancellation !== false


### PR DESCRIPTION
## summary

- adds message editing to the react-langchain useStream runtime: editing a human message forks the thread from the right server checkpoint and submits the edited content, so the turn is replaced rather than appended. providing onEdit also flips capabilities.edit, surfacing the edit affordance.
- consolidates fork checkpoint resolution into a single resolveForkCheckpoint that onReload and onEdit share: the fast path reads the head message's parentCheckpointId from the useStream metadata snapshot, the slow path matches against server history (findForkCheckpointInHistory, renamed from the internal resolveForkCheckpointId).
- editing the first human message (null parentId) forks from the thread's initial checkpoint to restart it. it degrades gracefully: when no checkpoint resolves, the edit is a no-op (same contract as regenerate).

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-langchain test` -> 66/66 green (13 files)
- [x] `pnpm lint` -> clean (oxlint + oxfmt)
- [x] `pnpm --filter @assistant-ui/react-langchain exec tsc --noEmit` -> 0 errors

### reviewer should verify

- [ ] on a checkpoint enabled LangGraph backend (for example LangGraph Cloud), edit a human message mid thread and confirm the edited turn replaces the original (no duplicate human message) and the assistant re-runs from it
- [ ] edit the first human message and confirm the thread restarts from its initial checkpoint

## notes

- supersedes #4512; co-authored with the original author @ShobhitPatra.
- findForkCheckpointInHistory is the internal slow path helper renamed from resolveForkCheckpointId (not exported from the package barrel, so no public surface change).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

