### PR TITLE
feat(react-langchain): expose useStream handle via useLangChainStream

### DIFF
--- a/.changeset/langchain-stream-handle.md
+++ b/.changeset/langchain-stream-handle.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): expose useStream handle via useLangChainStream

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -646,6 +646,43 @@ function Discovered() {
 }
 ```
 
+## Subagent and subgraph views
+
+The discovery maps above pair with v1's scoped selector hooks to render a subagent's or subgraph's own messages and tool calls. `useLangChainStream` exposes the underlying `useStream` handle; feed it to `useMessages(stream, target)` / `useToolCalls(stream, target)` from `@langchain/react`, with a `SubagentDiscoverySnapshot` / `SubgraphDiscoverySnapshot` from `useLangChainSubagents` / `useLangChainSubgraphs` as the target. `useLangChainStream` returns `undefined` outside the runtime provider.
+
+```tsx
+import {
+  useLangChainStream,
+  useLangChainSubagents,
+} from "@assistant-ui/react-langchain";
+import { useMessages, useToolCalls } from "@langchain/react";
+
+function SubagentCard({ stream, subagent }) {
+  const messages = useMessages(stream, subagent);
+  const toolCalls = useToolCalls(stream, subagent);
+  return (
+    <div>
+      <strong>{subagent.namespace.join("/")}</strong>
+      <pre>{messages.map((m) => m.content).join("\n")}</pre>
+      <ul>
+        {toolCalls.map((tc) => (
+          <li key={tc.id}>{tc.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function Subagents() {
+  const stream = useLangChainStream();
+  const subagents = useLangChainSubagents();
+  if (!stream) return null;
+  return [...subagents.values()].map((s) => (
+    <SubagentCard key={s.namespace.join("/")} stream={stream} subagent={s} />
+  ));
+}
+```
+
 ## Generative UI
 
 Graphs can accumulate UI components in their state and attach each one to the assistant message that produced it. The runtime reads these from `stream.values[uiStateKey]` (default `"ui"`) and, for every `UIMessage` whose parent id matches an assistant message, emits a `data` part on that message. The parent id is read from `metadata.message_id` (Python SDK) or `metadata.id` (JS SDK). Pass `uiStateKey` if your graph stores them elsewhere.
@@ -762,6 +799,7 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | Subgraph / namespaced stream events | Yes (via `eventHandlers`) | Not exposed |
 | Subagent discovery | Via `eventHandlers` | Yes (`useLangChainSubagents`) |
 | Subgraph discovery | Via `eventHandlers` | Yes (`useLangChainSubgraphs`) |
+| Subagent/subgraph message views | Via `eventHandlers` | Yes (via `useLangChainStream` + v1 selector hooks) |
 | End-to-end cancellation primitive | Yes (`unstable_createLangGraphStream`) | Not exposed |
 | Message accumulator utility | Yes (`LangGraphMessageAccumulator`) | Not exposed |
 | Cloud thread persistence | Yes | Yes |
@@ -787,6 +825,7 @@ Regenerate works without configuration. Clicking regenerate resolves the server 
 | _(none)_ | `useLangChainInterrupts` | New — every interrupt pending at the checkpoint, each with `id` and `value`. |
 | _(via `eventHandlers`)_ | `useLangChainSubagents` | New — subagents discovered on the current run; replaces subgraph event handlers. |
 | _(via `eventHandlers`)_ | `useLangChainSubgraphs` | New — subgraphs discovered on the current run; replaces subgraph event handlers. |
+| _(none)_ | `useLangChainStream` | New — the raw `useStream` handle for v1's scoped `useMessages` / `useToolCalls` selector hooks. |
 
 ## Related
 

--- a/packages/react-langchain/src/hooks.ts
+++ b/packages/react-langchain/src/hooks.ts
@@ -58,6 +58,15 @@ export const useLangChainSubgraphs = () =>
   langChainExtras.use((e) => e.subgraphs ?? EMPTY_SUBGRAPHS, EMPTY_SUBGRAPHS);
 
 /**
+ * The underlying `useStream` handle, for advanced views — pass it to v1's
+ * `useMessages(stream, target)` / `useToolCalls(stream, target)` with a
+ * subagent/subgraph from `useLangChainSubagents` / `useLangChainSubgraphs`.
+ * `undefined` outside the runtime provider.
+ */
+export const useLangChainStream = () =>
+  langChainExtras.use((e) => e.stream, undefined);
+
+/**
  * Returns a function to submit raw state updates to the LangGraph agent,
  * bypassing the normal message flow. Useful for sending interrupt resume
  * commands.

--- a/packages/react-langchain/src/index.ts
+++ b/packages/react-langchain/src/index.ts
@@ -9,6 +9,7 @@ export {
   useLangChainSend,
   useLangChainSendCommand,
   useLangChainState,
+  useLangChainStream,
   useLangChainSubagents,
   useLangChainSubgraphs,
   useLangChainSubmit,

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -12,6 +12,7 @@ import type { AssistantCloud } from "assistant-cloud";
 import type {
   UseStreamOptions,
   AssembledToolCall,
+  AnyStream,
   SubagentDiscoverySnapshot,
   SubgraphDiscoverySnapshot,
 } from "@langchain/react";
@@ -97,6 +98,7 @@ export type LangChainRuntimeExtras = {
   toolCalls: readonly AssembledToolCall[];
   subagents: ReadonlyMap<string, SubagentDiscoverySnapshot>;
   subgraphs: ReadonlyMap<string, SubgraphDiscoverySnapshot>;
+  stream: AnyStream;
   error: unknown;
   submit: (
     values: Record<string, unknown> | null | undefined,

--- a/packages/react-langchain/src/useLangChainStream.test.tsx
+++ b/packages/react-langchain/src/useLangChainStream.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+  createRunSelectorAgainst,
+  makeExtras,
+  type Selector,
+} from "./__tests__/langChainTestUtils";
+
+const { mockUseAuiState } = vi.hoisted(() => ({
+  mockUseAuiState: vi.fn(),
+}));
+
+vi.mock(import("@assistant-ui/store"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useAuiState: ((selector: Selector) =>
+      mockUseAuiState(selector)) as typeof actual.useAuiState,
+    useAui: (() => ({})) as unknown as typeof actual.useAui,
+  };
+});
+
+import { useLangChainStream } from "./hooks";
+
+const runSelectorAgainst = createRunSelectorAgainst(mockUseAuiState);
+
+describe("useLangChainStream", () => {
+  it("returns undefined when extras are absent", () => {
+    runSelectorAgainst(undefined);
+    const { result } = renderHook(() => useLangChainStream());
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns the stream handle from extras", () => {
+    const stream = { submit: () => {} };
+    runSelectorAgainst(makeExtras({ stream }));
+    const { result } = renderHook(() => useLangChainStream());
+    expect(result.current).toBe(stream);
+  });
+});

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -131,6 +131,7 @@ const useStreamThreadRuntime = (
         toolCalls: stream.toolCalls,
         subagents: stream.subagents,
         subgraphs: stream.subgraphs,
+        stream,
         error: stream.error,
         submit: stream.submit,
         respond: stream.respond,
@@ -138,19 +139,7 @@ const useStreamThreadRuntime = (
         values: stream.values,
         messagesKey,
       }),
-    [
-      stream.interrupt,
-      stream.interrupts,
-      stream.toolCalls,
-      stream.subagents,
-      stream.subgraphs,
-      stream.error,
-      stream.submit,
-      stream.respond,
-      stream.respondAll,
-      stream.values,
-      messagesKey,
-    ],
+    [stream, messagesKey],
   );
 
   const runtime = useExternalStoreRuntime({


### PR DESCRIPTION
## Summary

Adds `useLangChainStream()`, a reader that exposes the underlying `useStream` handle so consumers can feed it to v1's scoped selector hooks (`useMessages(stream, target)` / `useToolCalls(stream, target)`) with a subagent/subgraph from `useLangChainSubagents` / `useLangChainSubgraphs`.

## Why

This is the last missing piece for subagent/subgraph message views. The discovery maps (#4516) already return the right `target`; the package just hid the `stream`.

## How

Design call: Expose the raw stream handle (typed as `AnyStream`, the erased type all v1 selector hooks accept) rather than wrapping each selector hook. Minimal, and unblocks the whole selector-hook tail in one hook. The alternative was per-selector `useLangChainSubagent*` wrappers; open to redirect if you'd prefer the package own that surface.

## Changes

- `types.ts`: add `stream: AnyStream` to `LangChainRuntimeExtras` (type-only import).
- `useStreamRuntime.ts`: provide `stream` in the extras memo.
- `hooks.ts`: `useLangChainStream()` selector-based reader (`undefined` outside the provider).
- `index.ts`: append-only export.
- Test, docs (views section + table rows), changeset.

## Note

The extras memo's dependency array is collapsed to `[stream, messagesKey]`. Upstream `useStream` returns a memoized object keyed on `[root, subagents, subgraphs, ...]`, and every field the extras memo reads derives from those same deps, so `stream` subsumes the previous field-level deps. Behavior is identical and it avoids spurious `exhaustive-deps` warnings.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

