### PR TITLE
feat(react-ag-ui): infer pending tool-call status in fromAgUiMessages

### DIFF
--- a/.changeset/ag-ui-infer-pending-tool-status.md
+++ b/.changeset/ag-ui-infer-pending-tool-status.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat(react-ag-ui): infer requires-action status for unresolved tool calls in fromAgUiMessages

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -66,6 +66,11 @@ messages are gone on the next page load.
 `showThinking: false`, so imported reasoning messages are dropped at conversion
 time, the same way a live run never stores them.
 
+By default `fromAgUiMessages` also restores `requires-action` status on assistant
+messages that still have unresolved tool calls, so a reloaded thread surfaces
+pending human-in-the-loop calls as actionable instead of stuck running, matching
+the live run. Pass `{ inferPendingToolCallStatus: false }` to opt out.
+
 `fromAgUiMessages` reconstructs the text, reasoning, and tool calls of each message. Multimodal user input (`image`, `audio`, `video`, and `document` parts, as well as legacy `binary` parts) is restored as attachments on the user message, so a backend that persists multimodal messages shows them again on reload and re-sends them on the next run. Legacy `binary` parts that only reference a file id are not restored.
 
 ## Thread list (experimental)

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -479,6 +479,12 @@ export type FromAgUiMessagesOptions = {
    * Matches the `showThinking` option of `useAgUiRuntime`. Defaults to `true`.
    */
   showThinking?: boolean;
+  /**
+   * Whether to restore `requires-action` status on assistant messages that
+   * still have unresolved tool calls, matching what `RunAggregator` produces
+   * during a live run so a cold reload looks identical. Defaults to `true`.
+   */
+  inferPendingToolCallStatus?: boolean;
 };
 
 export function fromAgUiMessages(
@@ -486,6 +492,8 @@ export function fromAgUiMessages(
   options?: FromAgUiMessagesOptions,
 ): CoreThreadMessageLike[] {
   const showThinking = options?.showThinking ?? true;
+  const inferPendingToolCallStatus =
+    options?.inferPendingToolCallStatus ?? true;
   const converted: CoreThreadMessageLike[] = [];
 
   for (const rawMessage of messages) {
@@ -602,6 +610,33 @@ export function fromAgUiMessages(
 
     if (role === "user" || role === "system") {
       converted.push(toUserOrSystemSnapshotMessage(role, rawMessage));
+    }
+  }
+
+  // Tool results merge into their call parts above, so a still-pending tool
+  // call is only knowable once every message is converted. Mirror the live
+  // RunAggregator, which ends an unresolved run as requires-action/tool-calls.
+  if (inferPendingToolCallStatus) {
+    for (let i = 0; i < converted.length; i++) {
+      const message = converted[i]!;
+      if (
+        message.role !== "assistant" ||
+        message.status !== undefined ||
+        !Array.isArray(message.content)
+      )
+        continue;
+      const hasPendingToolCall = message.content.some(
+        (part) =>
+          isObject(part) &&
+          part.type === "tool-call" &&
+          part.result === undefined,
+      );
+      if (hasPendingToolCall) {
+        converted[i] = {
+          ...message,
+          status: { type: "requires-action", reason: "tool-calls" },
+        };
+      }
     }
   }
 

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -150,6 +150,78 @@ describe("adapter conversions", () => {
     });
   });
 
+  it("infers requires-action status for assistant messages with an unresolved tool call", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "msg-1",
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call-1",
+            type: "function",
+            function: { name: "ask_user", arguments: "{}" },
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result).toHaveLength(1);
+    expect((result[0] as any).status).toEqual({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+  });
+
+  it("leaves a resolved tool call without a requires-action status", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "msg-1",
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call-1",
+            type: "function",
+            function: { name: "get_weather", arguments: "{}" },
+          },
+        ],
+      },
+      {
+        id: "msg-2",
+        role: "tool",
+        tool_call_id: "call-1",
+        content: '{"temperature":"22C"}',
+      },
+    ] as any);
+
+    expect(result).toHaveLength(1);
+    expect((result[0] as any).status).toBeUndefined();
+  });
+
+  it("does not infer status when inferPendingToolCallStatus is false", () => {
+    const result = fromAgUiMessages(
+      [
+        {
+          id: "msg-1",
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: "call-1",
+              type: "function",
+              function: { name: "ask_user", arguments: "{}" },
+            },
+          ],
+        },
+      ] as any,
+      { inferPendingToolCallStatus: false },
+    );
+
+    expect(result).toHaveLength(1);
+    expect((result[0] as any).status).toBeUndefined();
+  });
+
   it("creates a synthetic assistant tool-call when snapshot has an orphan tool message", () => {
     const result = fromAgUiMessages([
       {


### PR DESCRIPTION
## What

`fromAgUiMessages` now restores `status: { type: "requires-action", reason: "tool-calls" }` on reconstructed assistant messages that still have an unresolved tool call. A new `inferPendingToolCallStatus` option (default `true`) gates the behavior, with `false` to opt out.

## Why

During a live run, `RunAggregator` ends an unresolved run as `requires-action` / `tool-calls`, which is what powers HITL UIs (status drives "submit tool result" and "resume run").

`fromAgUiMessages` only reconstructed content (text, reasoning, tool-call parts, merged tool results) and never restored status. So loading an old thread via `thread.reset(...)` made pending calls (e.g. `ask_user`) look like they were still running instead of actionable.

This closes that round-trip gap so a cold reload matches the live run, the same principle the existing `showThinking` option already follows.

## How

Status can only be set once every message is converted, because tool results merge into their call parts from later `tool` messages. So this runs as a post-pass at the end of `fromAgUiMessages`, after the merge loop: for each assistant message with array content and no existing status, if any tool-call part has `result === undefined`, it is marked `requires-action` / `tool-calls`.

`inferPendingToolCallStatus` defaults to `true`, mirroring `showThinking`. The opt-out covers the one case the heuristic cannot see: the wire carries no run status, so a run the aggregator force-completed on a success outcome despite unresolved calls would still be inferred as `requires-action`. Setting `false` disables inference for backends where that matters.

## Testing

Added three converter tests: unresolved tool call infers the status, a resolved call does not, and `{ inferPendingToolCallStatus: false }` skips inference. Updated the AG-UI runtime-options docs. Full package test suite (175) passes, lint and format clean, build green.

Closes #4522


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

