### PR TITLE
fix(docs): add assistant-cloud tsconfig path mapping for api-reference

### DIFF
--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -18,7 +18,9 @@
       "@assistant-ui/react/*": ["../../packages/react/src/*"],
       "@assistant-ui/tap/*": ["../../packages/tap/src/*"],
       "assistant-stream": ["../../packages/assistant-stream/src"],
-      "assistant-stream/*": ["../../packages/assistant-stream/src/*"]
+      "assistant-stream/*": ["../../packages/assistant-stream/src/*"],
+      "assistant-cloud": ["../../packages/cloud/src"],
+      "assistant-cloud/*": ["../../packages/cloud/src/*"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
Closes #4525.

The api-reference generator builds its ts-morph project from `apps/docs/tsconfig.json` (apps/docs/scripts/generated-docs/extract.mts:89), but that tsconfig had a path mapping for `assistant-stream` and not `assistant-cloud`. So the public re-export `export { AssistantCloud } from "assistant-cloud"` (packages/react/src/index.ts) resolved through node to `packages/cloud/dist`, and silently dropped from the reference whenever that package wasn't built .

This adds an `assistant-cloud` mapping pointing at `packages/cloud/src`, mirroring the existing `assistant-stream` entry, so resolution is build-independent.

Verified on current main: with `packages/cloud/dist` removed, regenerating api-reference drops `AssistantCloud` (3 refs to 0); with this mapping it stays. No other reference output changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

