### PR TITLE
feat: refine tool call display UI

### DIFF
--- a/apps/docs/components/xulux/chat/XuluxToolCall.tsx
+++ b/apps/docs/components/xulux/chat/XuluxToolCall.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  formatToolCall,
-  ToolErrorCard,
-  ToolStatusCard,
-  ToolTraceCard,
-} from "@/lib/tool-trace";
+import { ToolErrorCard, ToolStatusCard, ToolTraceCard } from "@/lib/tool-trace";
 import type { ToolCallMessagePartProps } from "@assistant-ui/react";
 import {
   BookOpenIcon,
@@ -152,7 +147,7 @@ export function XuluxToolCall({
   result,
   status,
 }: ToolCallMessagePartProps): ReactNode {
-  const signature = formatToolCall(toolName, args);
+  const signature = toolName;
   const icon = getToolIcon(toolName);
   const isRunning = status?.type === "running";
   const error = !isRunning ? extractToolError(result) : null;

--- a/apps/docs/components/xulux/chat/XuluxToolCall.tsx
+++ b/apps/docs/components/xulux/chat/XuluxToolCall.tsx
@@ -169,7 +169,7 @@ export function XuluxToolCall({
   }
 
   if (error) {
-    return <ToolErrorCard signature={signature} error={error} />;
+    return <ToolErrorCard signature={signature} error={error} args={args} />;
   }
 
   return (
@@ -177,6 +177,7 @@ export function XuluxToolCall({
       icon={icon}
       signature={signature}
       description={summarizeXuluxResult(toolName, result)}
+      args={args}
       result={result}
     />
   );

--- a/apps/docs/lib/docs-toolkit.tsx
+++ b/apps/docs/lib/docs-toolkit.tsx
@@ -22,12 +22,7 @@ import {
   defineGenerativeComponents,
   generativeUIToJSX,
 } from "@assistant-ui/react-generative-ui";
-import {
-  formatToolCall,
-  ToolErrorCard,
-  ToolStatusCard,
-  ToolTraceCard,
-} from "@/lib/tool-trace";
+import { ToolErrorCard, ToolStatusCard, ToolTraceCard } from "@/lib/tool-trace";
 
 const weatherFormatSchema = z.enum(["fahrenheit", "celsius"]);
 
@@ -61,16 +56,18 @@ const GeocodeLocationToolUI: ToolCallMessagePartComponent<
   GeocodeLocationArgs,
   GeocodeLocationResult
 > = ({ toolName, args, result }) => {
-  const signature = formatToolCall(toolName, args);
   const icon = <MapPin className="size-4" />;
 
   if (result?.success === false) {
-    return <ToolErrorCard signature={signature} error={result.error} />;
+    return (
+      <ToolErrorCard signature={toolName} error={result.error} args={args} />
+    );
   }
+
   if (!result) {
     return (
       <ToolStatusCard
-        signature={signature}
+        signature={toolName}
         icon={icon}
         message="Finding location..."
         loading
@@ -79,11 +76,13 @@ const GeocodeLocationToolUI: ToolCallMessagePartComponent<
   }
 
   const { name, latitude, longitude } = result.result;
+
   return (
     <ToolTraceCard
       icon={icon}
-      signature={signature}
+      signature={toolName}
       description={`${name} · ${latitude.toFixed(2)}, ${longitude.toFixed(2)}`}
+      args={args}
       result={result}
     />
   );
@@ -93,16 +92,18 @@ const GetWeatherToolUI: ToolCallMessagePartComponent<
   GetWeatherArgs,
   GetWeatherResult
 > = ({ toolName, args, result }) => {
-  const signature = formatToolCall(toolName, args);
   const icon = <CloudSun className="size-4" />;
 
   if (result?.success === false) {
-    return <ToolErrorCard signature={signature} error={result.error} />;
+    return (
+      <ToolErrorCard signature={toolName} error={result.error} args={args} />
+    );
   }
+
   if (!result) {
     return (
       <ToolStatusCard
-        signature={signature}
+        signature={toolName}
         icon={icon}
         message="Fetching weather..."
         loading
@@ -112,15 +113,17 @@ const GetWeatherToolUI: ToolCallMessagePartComponent<
 
   const current = result.widget?.current;
   const unitSymbol = result.widget?.units.temperature === "celsius" ? "C" : "F";
+
   return (
     <ToolTraceCard
       icon={icon}
-      signature={signature}
+      signature={toolName}
       description={
         current
           ? `${Math.round(current.temperature)}°${unitSymbol} · ${current.conditionCode} in ${result.location}`
           : "Weather ready"
       }
+      args={args}
       result={result}
     />
   );

--- a/apps/docs/lib/tool-trace.tsx
+++ b/apps/docs/lib/tool-trace.tsx
@@ -29,16 +29,19 @@ export function ToolTraceCard({
   icon,
   signature,
   description,
+  args,
   result,
 }: {
   icon: ReactNode;
   signature: string;
   description: ReactNode;
+  args?: Record<string, unknown>;
   result: unknown;
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
   const lockScroll = useScrollLock(rootRef, TRACE_ANIMATION_DURATION);
+  const hasArgs = !!args && Object.keys(args).length > 0;
 
   return (
     <Collapsible
@@ -59,7 +62,9 @@ export function ToolTraceCard({
         <span className="flex size-4 shrink-0 items-center justify-center [&_svg]:size-3.5">
           {icon}
         </span>
-        <span className="truncate font-mono text-[13px]">{signature}</span>
+        <span className="min-w-0 truncate font-mono text-[13px]">
+          {signature}
+        </span>
         <span className="text-muted-foreground/60 truncate text-xs">
           {description}
         </span>
@@ -73,9 +78,24 @@ export function ToolTraceCard({
           "data-[state=closed]:duration-(--animation-duration) data-[state=open]:duration-(--animation-duration)",
         )}
       >
-        <pre className="text-muted-foreground bg-muted/50 my-1 ml-6 max-h-60 overflow-auto rounded-md p-2.5 text-[11px] leading-relaxed">
-          {JSON.stringify(result, null, 2)}
-        </pre>
+        <div className="my-1 ml-6 space-y-2">
+          <div className="space-y-1">
+            <p className="text-muted-foreground/60 text-[10px] font-medium tracking-wide uppercase">
+              Parameters
+            </p>
+            <pre className="text-muted-foreground bg-muted/50 max-h-60 overflow-auto rounded-md p-2.5 text-[11px] leading-relaxed">
+              {hasArgs ? JSON.stringify(args, null, 2) : "{}"}
+            </pre>
+          </div>
+          <div className="space-y-1">
+            <p className="text-muted-foreground/60 text-[10px] font-medium tracking-wide uppercase">
+              Result
+            </p>
+            <pre className="text-muted-foreground bg-muted/50 max-h-60 overflow-auto rounded-md p-2.5 text-[11px] leading-relaxed">
+              {JSON.stringify(result, null, 2)}
+            </pre>
+          </div>
+        </div>
       </CollapsibleContent>
     </Collapsible>
   );
@@ -102,7 +122,9 @@ export function ToolStatusCard({
       >
         {icon}
       </span>
-      <span className="truncate font-mono text-[13px]">{signature}</span>
+      <span className="min-w-0 truncate font-mono text-[13px]">
+        {signature}
+      </span>
       <span className="text-muted-foreground/60 truncate text-xs">
         {message}
       </span>
@@ -113,17 +135,66 @@ export function ToolStatusCard({
 export function ToolErrorCard({
   signature,
   error,
+  args,
 }: {
   signature: string;
   error?: string;
+  args?: Record<string, unknown>;
 }) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const lockScroll = useScrollLock(rootRef, TRACE_ANIMATION_DURATION);
+  const message = error || "Unknown error";
+  const hasArgs = !!args && Object.keys(args).length > 0;
+
   return (
-    <div className="text-destructive flex max-w-full items-center gap-2 py-0.5">
-      <AlertCircle className="size-3.5 shrink-0" />
-      <span className="truncate font-mono text-[13px]">{signature}</span>
-      <span className="truncate text-xs opacity-80">
-        {error || "Unknown error"}
-      </span>
-    </div>
+    <Collapsible
+      ref={rootRef}
+      open={open}
+      onOpenChange={(next) => {
+        lockScroll();
+        setOpen(next);
+      }}
+      className="group/tool-error max-w-full"
+      style={
+        {
+          "--animation-duration": `${TRACE_ANIMATION_DURATION}ms`,
+        } as React.CSSProperties
+      }
+    >
+      <CollapsibleTrigger className="text-destructive hover:text-destructive/80 flex w-fit max-w-full cursor-pointer items-center gap-2 py-0.5 text-left transition-colors select-none">
+        <span className="flex size-4 shrink-0 items-center justify-center [&_svg]:size-3.5">
+          <AlertCircle />
+        </span>
+        <span className="min-w-0 truncate font-mono text-[13px]">
+          {signature}
+        </span>
+        <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]/tool-error:rotate-90" />
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        className={cn(
+          "relative overflow-hidden outline-none",
+          "data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down ease-out",
+          "data-[state=closed]:fill-mode-forwards data-[state=closed]:pointer-events-none",
+          "data-[state=closed]:duration-(--animation-duration) data-[state=open]:duration-(--animation-duration)",
+        )}
+      >
+        <div className="my-1 ml-6 space-y-2">
+          <div className="space-y-1">
+            <p className="text-muted-foreground/60 text-[10px] font-medium tracking-wide uppercase">
+              Parameters
+            </p>
+            <pre className="text-muted-foreground bg-muted/50 max-h-60 overflow-auto rounded-md p-2.5 text-[11px] leading-relaxed">
+              {hasArgs ? JSON.stringify(args, null, 2) : "{}"}
+            </pre>
+          </div>
+          <div className="bg-destructive/20 rounded-md p-2.5">
+            <p className="text-destructive text-xs leading-relaxed break-words">
+              {message}
+            </p>
+          </div>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }

--- a/apps/docs/lib/tool-trace.tsx
+++ b/apps/docs/lib/tool-trace.tsx
@@ -12,17 +12,17 @@ import {
 
 const TRACE_ANIMATION_DURATION = 200;
 
-/** Renders a tool call as a readable signature, e.g. `get_weather({ location: "SF" })`. */
-export function formatToolCall(
-  toolName: string,
-  args: Record<string, unknown> | undefined,
-): string {
-  const entries = Object.entries(args ?? {});
-  if (entries.length === 0) return `${toolName}()`;
-  const body = entries
-    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
-    .join(", ");
-  return `${toolName}({ ${body} })`;
+function ToolJsonBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-muted-foreground/60 text-[10px] font-medium tracking-wide uppercase">
+        {label}
+      </p>
+      <pre className="text-muted-foreground bg-muted/50 max-h-60 overflow-auto rounded-md p-2.5 text-[11px] leading-relaxed">
+        {value}
+      </pre>
+    </div>
+  );
 }
 
 export function ToolTraceCard({
@@ -79,22 +79,14 @@ export function ToolTraceCard({
         )}
       >
         <div className="my-1 ml-6 space-y-2">
-          <div className="space-y-1">
-            <p className="text-muted-foreground/60 text-[10px] font-medium tracking-wide uppercase">
-              Parameters
-            </p>
-            <pre className="text-muted-foreground bg-muted/50 max-h-60 overflow-auto rounded-md p-2.5 text-[11px] leading-relaxed">
-              {hasArgs ? JSON.stringify(args, null, 2) : "{}"}
-            </pre>
-          </div>
-          <div className="space-y-1">
-            <p className="text-muted-foreground/60 text-[10px] font-medium tracking-wide uppercase">
-              Result
-            </p>
-            <pre className="text-muted-foreground bg-muted/50 max-h-60 overflow-auto rounded-md p-2.5 text-[11px] leading-relaxed">
-              {JSON.stringify(result, null, 2)}
-            </pre>
-          </div>
+          <ToolJsonBlock
+            label="Parameters"
+            value={hasArgs ? JSON.stringify(args, null, 2) : "{}"}
+          />
+          <ToolJsonBlock
+            label="Result"
+            value={JSON.stringify(result, null, 2)}
+          />
         </div>
       </CollapsibleContent>
     </Collapsible>
@@ -169,6 +161,7 @@ export function ToolErrorCard({
         <span className="min-w-0 truncate font-mono text-[13px]">
           {signature}
         </span>
+        <span className="text-destructive/70 truncate text-xs">{message}</span>
         <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]/tool-error:rotate-90" />
       </CollapsibleTrigger>
       <CollapsibleContent
@@ -180,14 +173,10 @@ export function ToolErrorCard({
         )}
       >
         <div className="my-1 ml-6 space-y-2">
-          <div className="space-y-1">
-            <p className="text-muted-foreground/60 text-[10px] font-medium tracking-wide uppercase">
-              Parameters
-            </p>
-            <pre className="text-muted-foreground bg-muted/50 max-h-60 overflow-auto rounded-md p-2.5 text-[11px] leading-relaxed">
-              {hasArgs ? JSON.stringify(args, null, 2) : "{}"}
-            </pre>
-          </div>
+          <ToolJsonBlock
+            label="Parameters"
+            value={hasArgs ? JSON.stringify(args, null, 2) : "{}"}
+          />
           <div className="bg-destructive/20 rounded-md p-2.5">
             <p className="text-destructive text-xs leading-relaxed break-words">
               {message}

--- a/packages/ui/src/components/assistant-ui/tool-group.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-group.tsx
@@ -118,7 +118,7 @@ function ToolGroupTrigger({
       {active && (
         <LoaderIcon
           data-slot="tool-group-trigger-loader"
-          className="aui-tool-group-trigger-loader size-4 shrink-0 animate-spin"
+          className="aui-tool-group-trigger-loader size-3 shrink-0 animate-spin"
         />
       )}
       <span
@@ -130,12 +130,12 @@ function ToolGroupTrigger({
           "group-data-[variant=muted]/tool-group-root:grow",
         )}
       >
-        <span>{label}</span>
+        <span className="text-xs">{label}</span>
         {active && (
           <span
             aria-hidden
             data-slot="tool-group-trigger-shimmer"
-            className="aui-tool-group-trigger-shimmer shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+            className="aui-tool-group-trigger-shimmer shimmer pointer-events-none absolute inset-0 text-xs motion-reduce:animate-none"
           >
             {label}
           </span>
@@ -144,7 +144,7 @@ function ToolGroupTrigger({
       <ChevronDownIcon
         data-slot="tool-group-trigger-chevron"
         className={cn(
-          "aui-tool-group-trigger-chevron size-4 shrink-0",
+          "aui-tool-group-trigger-chevron size-3 shrink-0",
           "transition-transform duration-(--animation-duration) ease-out",
           "group-data-[state=closed]/trigger:-rotate-90",
           "group-data-[state=open]/trigger:rotate-0",


### PR DESCRIPTION
Show the passed parameters alongside the result in the tool trace card, and unify the parameters/result code-block styling between `ToolTraceCard` and `ToolErrorCard` so they match. Also tighten the tool-group trigger icon and label sizing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

