### PR TITLE
docs: fix speech guide snippet to use AuiIf instead of nonexistent useMessageTTS

### DIFF
--- a/apps/docs/content/docs/guides/speech.mdx
+++ b/apps/docs/content/docs/guides/speech.mdx
@@ -57,24 +57,22 @@ const runtime = useChatRuntime({
 The default action bar does not include a speech button. Add `ActionBarPrimitive.Speak` and `ActionBarPrimitive.StopSpeaking` to your assistant message action bar:
 
 ```tsx
-import { ActionBarPrimitive, useMessageTTS } from "@assistant-ui/react";
+import { ActionBarPrimitive, AuiIf } from "@assistant-ui/react";
 import { AudioLinesIcon, StopCircleIcon } from "lucide-react";
 
 const AssistantActionBar = () => {
-  const isSpeaking = useMessageTTS();
-
   return (
     <ActionBarPrimitive.Root>
-      {!isSpeaking && (
+      <AuiIf condition={(s) => s.message.speech == null}>
         <ActionBarPrimitive.Speak>
           <AudioLinesIcon />
         </ActionBarPrimitive.Speak>
-      )}
-      {isSpeaking && (
+      </AuiIf>
+      <AuiIf condition={(s) => s.message.speech != null}>
         <ActionBarPrimitive.StopSpeaking>
           <StopCircleIcon />
         </ActionBarPrimitive.StopSpeaking>
-      )}
+      </AuiIf>
       <ActionBarPrimitive.Copy />
     </ActionBarPrimitive.Root>
   );


### PR DESCRIPTION
Closes #4527


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

