### PR TITLE
[codex] Install ToolFallback approval button dependency

### DIFF
--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -18,6 +18,37 @@ function transformImports(content: string): string {
     .replace(/@assistant-ui\/react-ui\/hooks\//g, "@/hooks/");
 }
 
+const getShadcnUiImports = (content: string) => {
+  return [
+    ...content.matchAll(/from\s+["']@\/components\/ui\/([^"']+)["']/g),
+  ].map((match) => match[1]!.replace(/\.(?:tsx?|jsx?)$/, "").split("/")[0]!);
+};
+
+function validateRegistryDependencies(
+  item: RegistryItem,
+  files: NonNullable<RegistryItem["files"]>,
+) {
+  const registryDependencies = new Set(item.registryDependencies ?? []);
+  const missing = new Set<string>();
+
+  for (const file of files) {
+    const content = "content" in file ? file.content : undefined;
+    if (!content) continue;
+
+    for (const dependency of getShadcnUiImports(content)) {
+      if (!registryDependencies.has(dependency)) missing.add(dependency);
+    }
+  }
+
+  if (missing.size > 0) {
+    throw new Error(
+      `Registry item "${item.name}" imports shadcn UI component(s) without registryDependencies: ${[
+        ...missing,
+      ].join(", ")}`,
+    );
+  }
+}
+
 async function buildRegistry(registry: RegistryItem[]) {
   await fs.mkdir(REGISTRY_PATH, { recursive: true });
 
@@ -37,6 +68,10 @@ async function buildRegistry(registry: RegistryItem[]) {
         ...fileOutput,
       };
     });
+
+    if (files) {
+      validateRegistryDependencies(item, files);
+    }
 
     const payload = {
       $schema: "https://ui.shadcn.com/schema/registry-item.json",

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -317,7 +317,7 @@ export const registry: RegistryItem[] = [
       },
     ],
     dependencies: ["@assistant-ui/react", "lucide-react"],
-    registryDependencies: ["collapsible"],
+    registryDependencies: ["button", "collapsible"],
   },
   {
     name: "tool-group",


### PR DESCRIPTION
## Summary

- add the missing `button` registry dependency for `tool-fallback`
- add a registry build validation that fails when generated files import `@/components/ui/*` without matching `registryDependencies`
- keep `shadcn add tool-fallback` aligned with the approval-aware ToolFallback source component

## Root cause

The ToolFallback source and generated registry payload now render approval controls with `@/components/ui/button`, but the tracked registry metadata still only installed `collapsible`. Fresh out-of-the-box installs could therefore receive an approval-aware ToolFallback with a missing Button primitive.

## Similar cases checked

- Audited source-backed registry entries for direct `@/components/ui/*` imports versus `registryDependencies`; no other missing entries were found.
- Verified the new build guard catches this exact class by temporarily removing `button` from `tool-fallback`, which failed the registry build with the expected missing-dependency error.

## Validation

- `pnpm --filter @assistant-ui/shadcn-registry build`
- `pnpm --filter @assistant-ui/shadcn-registry exec tsc --noEmit`
- `pnpm exec oxlint apps/registry/src/registry.ts apps/registry/scripts/build-registry.ts`
- `pnpm exec oxfmt --check apps/registry/src/registry.ts apps/registry/scripts/build-registry.ts`
- `git diff --check`
- `shadcn add` dry-run against local `tool-fallback.json` resolved `components/ui/button.tsx`, `components/ui/collapsible.tsx`, and `components/assistant-ui/tool-fallback.tsx`

## Notes

- Full `pnpm lint` still fails locally because untracked `.omc` / `.claude` files are included in formatting checks, plus unrelated existing hook warnings.
- This shell is on Node `v22.17.1`; the repo now declares Node `>=24`, so pnpm prints engine warnings.
