### PR TITLE
feat(react-o11y): add span timeline primitives for trace waterfalls

### DIFF
--- a/.changeset/tiny-timers-sip.md
+++ b/.changeset/tiny-timers-sip.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-o11y": patch
+---
+
+feat: add headless span timeline primitives for rendering waterfall bars

--- a/apps/docs/components/docs/samples/o11y/waterfall-bar.tsx
+++ b/apps/docs/components/docs/samples/o11y/waterfall-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CSSProperties } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 import { useAuiState } from "@assistant-ui/store";
 import { SpanPrimitive, type SpanItemState } from "@assistant-ui/react-o11y";
 import {
@@ -16,15 +16,39 @@ const STATUS_OPACITY: Record<SpanItemState["status"], number> = {
   skipped: 0.5,
 };
 
+function useRunningNow(enabled: boolean) {
+  const [now, setNow] = useState<number>();
+
+  useEffect(() => {
+    if (!enabled) {
+      setNow(undefined);
+      return;
+    }
+
+    let frameId: number;
+    const tick = () => {
+      setNow(Date.now());
+      frameId = requestAnimationFrame(tick);
+    };
+
+    frameId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frameId);
+  }, [enabled]);
+
+  return now;
+}
+
 export function WaterfallBar() {
   const { barHeight } = useWaterfallLayout();
   const status = useAuiState((s) => s.span.status) as SpanItemState["status"];
   const type = useAuiState((s) => s.span.type);
   const fill = TYPE_COLORS[type] ?? FALLBACK_COLOR;
   const opacity = STATUS_OPACITY[status];
+  const now = useRunningNow(status === "running");
 
   return (
     <SpanPrimitive.TimelineBar
+      now={now}
       className={status === "running" ? "animate-pulse" : ""}
       style={
         {

--- a/apps/docs/components/docs/samples/o11y/waterfall-bar.tsx
+++ b/apps/docs/components/docs/samples/o11y/waterfall-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type CSSProperties } from "react";
+import { type CSSProperties } from "react";
 import { useAuiState } from "@assistant-ui/store";
 import { SpanPrimitive, type SpanItemState } from "@assistant-ui/react-o11y";
 import {
@@ -16,39 +16,15 @@ const STATUS_OPACITY: Record<SpanItemState["status"], number> = {
   skipped: 0.5,
 };
 
-function useRunningNow(enabled: boolean) {
-  const [now, setNow] = useState<number>();
-
-  useEffect(() => {
-    if (!enabled) {
-      setNow(undefined);
-      return;
-    }
-
-    let frameId: number;
-    const tick = () => {
-      setNow(Date.now());
-      frameId = requestAnimationFrame(tick);
-    };
-
-    frameId = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(frameId);
-  }, [enabled]);
-
-  return now;
-}
-
 export function WaterfallBar() {
   const { barHeight } = useWaterfallLayout();
   const status = useAuiState((s) => s.span.status) as SpanItemState["status"];
   const type = useAuiState((s) => s.span.type);
   const fill = TYPE_COLORS[type] ?? FALLBACK_COLOR;
   const opacity = STATUS_OPACITY[status];
-  const now = useRunningNow(status === "running");
 
   return (
     <SpanPrimitive.TimelineBar
-      now={now}
       className={status === "running" ? "animate-pulse" : ""}
       style={
         {

--- a/apps/docs/components/docs/samples/o11y/waterfall-bar.tsx
+++ b/apps/docs/components/docs/samples/o11y/waterfall-bar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import type { CSSProperties } from "react";
 import { useAuiState } from "@assistant-ui/store";
-import type { SpanItemState } from "@assistant-ui/react-o11y";
+import { SpanPrimitive, type SpanItemState } from "@assistant-ui/react-o11y";
 import {
   FALLBACK_COLOR,
   TYPE_COLORS,
@@ -17,67 +17,27 @@ const STATUS_OPACITY: Record<SpanItemState["status"], number> = {
 };
 
 export function WaterfallBar() {
-  const { barWidth, timeRange, barHeight } = useWaterfallLayout();
-  const startedAt = useAuiState((s) => s.span.startedAt);
-  const endedAt = useAuiState((s) => s.span.endedAt) as number | null;
+  const { barHeight } = useWaterfallLayout();
   const status = useAuiState((s) => s.span.status) as SpanItemState["status"];
   const type = useAuiState((s) => s.span.type);
-
-  const barRef = useRef<SVGRectElement>(null);
-
-  const scale = useCallback(
-    (t: number) => {
-      const range = timeRange.max - timeRange.min || 1;
-      return ((t - timeRange.min) / range) * barWidth;
-    },
-    [timeRange, barWidth],
-  );
-
-  const x = scale(startedAt);
-
-  useEffect(() => {
-    if (status !== "running") return;
-
-    let frameId: number;
-    const tick = () => {
-      const width = scale(Date.now()) - x;
-      barRef.current?.setAttribute("width", String(Math.max(0, width)));
-      frameId = requestAnimationFrame(tick);
-    };
-    frameId = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(frameId);
-  }, [status, x, scale]);
-
-  const rawWidth = endedAt !== null ? scale(endedAt) - x : 0;
-  const width = Math.max(rawWidth, 4);
   const fill = TYPE_COLORS[type] ?? FALLBACK_COLOR;
   const opacity = STATUS_OPACITY[status];
 
   return (
-    <g>
-      <rect
-        ref={barRef}
-        x={x}
-        y={4}
-        width={width}
-        height={barHeight - 8}
-        rx={3}
-        fill={fill}
-        opacity={opacity}
-        className={status === "running" ? "animate-pulse" : ""}
-      />
-      {status === "failed" && (
-        <rect
-          x={x}
-          y={4}
-          width={width}
-          height={barHeight - 8}
-          rx={3}
-          fill="none"
-          stroke="hsl(0 84% 60%)"
-          strokeWidth={2}
-        />
-      )}
-    </g>
+    <SpanPrimitive.TimelineBar
+      className={status === "running" ? "animate-pulse" : ""}
+      style={
+        {
+          "--span-timeline-min-width": "4px",
+          top: 4,
+          height: barHeight - 8,
+          borderRadius: 3,
+          background: fill,
+          opacity,
+          boxShadow:
+            status === "failed" ? "inset 0 0 0 2px hsl(0 84% 60%)" : undefined,
+        } as CSSProperties & { "--span-timeline-min-width": string }
+      }
+    />
   );
 }

--- a/apps/docs/components/docs/samples/o11y/waterfall-row.tsx
+++ b/apps/docs/components/docs/samples/o11y/waterfall-row.tsx
@@ -40,12 +40,10 @@ export function WaterfallRow() {
       </SpanPrimitive.Indent>
 
       <div
-        className="group-hover:bg-accent/30"
+        className="group-hover:bg-accent/30 relative"
         style={{ width: barWidth, height: barHeight }}
       >
-        <svg aria-hidden="true" width={barWidth} height={barHeight}>
-          <WaterfallBar />
-        </svg>
+        <WaterfallBar />
       </div>
     </SpanPrimitive.Root>
   );

--- a/apps/docs/components/docs/samples/o11y/waterfall-timeline.tsx
+++ b/apps/docs/components/docs/samples/o11y/waterfall-timeline.tsx
@@ -230,11 +230,14 @@ export function WaterfallTimeline() {
         </div>
 
         <WaterfallLayoutContext.Provider value={layoutValue}>
-          <div style={{ width: contentWidth }}>
+          <SpanPrimitive.Timeline
+            paddingEnd={RIGHT_PADDING_RATIO}
+            style={{ width: contentWidth }}
+          >
             <SpanPrimitive.Children>
               {() => <WaterfallRow />}
             </SpanPrimitive.Children>
-          </div>
+          </SpanPrimitive.Timeline>
         </WaterfallLayoutContext.Provider>
       </div>
 

--- a/apps/docs/components/docs/samples/o11y/waterfall-timeline.tsx
+++ b/apps/docs/components/docs/samples/o11y/waterfall-timeline.tsx
@@ -231,7 +231,7 @@ export function WaterfallTimeline() {
 
         <WaterfallLayoutContext.Provider value={layoutValue}>
           <SpanPrimitive.Timeline
-            paddingEnd={RIGHT_PADDING_RATIO}
+            timeRange={renderTimeRange}
             style={{ width: contentWidth }}
           >
             <SpanPrimitive.Children>

--- a/apps/docs/content/docs/utilities/react-o11y.mdx
+++ b/apps/docs/content/docs/utilities/react-o11y.mdx
@@ -310,7 +310,7 @@ A `<div>` that positions the current span within the nearest `SpanPrimitive.Time
 </SpanPrimitive.Timeline>
 ```
 
-Running spans use the timeline range max when `now` is omitted, keeping SSR and hydration deterministic. Pass `now` when you want live ticking.
+Running spans use the timeline range max when `now` is omitted, keeping SSR and hydration deterministic. For live ticking, update a timestamp from an effect or animation loop and pass it as `now`.
 
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/apps/docs/content/docs/utilities/react-o11y.mdx
+++ b/apps/docs/content/docs/utilities/react-o11y.mdx
@@ -279,6 +279,47 @@ Convenience component that pairs `SpanByIndexProvider` with a render component:
 
 Useful when you want explicit control over which child indices to render (e.g. for virtualization).
 
+### SpanPrimitive.Timeline
+
+A `<div>` that provides a timeline range to descendant `TimelineBar` primitives and exposes range CSS variables.
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `timeRange` | `{ min: number; max: number }` | `span.timeRange` | Override the range used for positioning bars. |
+| `paddingEnd` | `number` | `0` | Extends the max by this ratio of the range duration, useful for right-side breathing room. |
+
+Exposes `data-span-timeline` and CSS variables:
+
+| Variable | Description |
+| --- | --- |
+| `--span-timeline-min-ms` | Timeline start timestamp. |
+| `--span-timeline-max-ms` | Timeline end timestamp after padding. |
+| `--span-timeline-range-ms` | Timeline duration after padding. |
+
+### SpanPrimitive.TimelineBar
+
+A `<div>` that positions the current span within the nearest `SpanPrimitive.Timeline` range. It reads `startedAt`, `endedAt`, `status`, `type`, and `timeRange` from the current span scope.
+
+```tsx
+<SpanPrimitive.Timeline className="relative h-8">
+  <SpanPrimitive.Children>
+    {() => (
+      <SpanPrimitive.TimelineBar className="top-1 h-6 rounded bg-blue-500" />
+    )}
+  </SpanPrimitive.Children>
+</SpanPrimitive.Timeline>
+```
+
+Exposes `data-span-status`, `data-span-type`, `data-span-running`, and these CSS variables:
+
+| Variable | Description |
+| --- | --- |
+| `--span-timeline-left` | Bar start position as a percentage. |
+| `--span-timeline-end` | Bar end position as a percentage. |
+| `--span-timeline-width` | Bar width as a percentage. |
+| `--span-timeline-duration-ms` | Bar duration in milliseconds. |
+| `--span-timeline-min-width` | Optional consumer-set minimum width used by the default inline size. |
+
 ## Styling
 
 All primitives forward refs and accept standard DOM props (`className`, `style`, etc.). Use the data attributes for state-based styling:

--- a/apps/docs/content/docs/utilities/react-o11y.mdx
+++ b/apps/docs/content/docs/utilities/react-o11y.mdx
@@ -301,10 +301,12 @@ Exposes `data-span-timeline` and CSS variables:
 A `<div>` that positions the current span within the nearest `SpanPrimitive.Timeline` range. It reads `startedAt`, `endedAt`, `status`, `type`, and `timeRange` from the current span scope.
 
 ```tsx
-<SpanPrimitive.Timeline className="relative h-8">
+<SpanPrimitive.Timeline>
   <SpanPrimitive.Children>
     {() => (
-      <SpanPrimitive.TimelineBar className="top-1 h-6 rounded bg-blue-500" />
+      <div className="relative h-8">
+        <SpanPrimitive.TimelineBar className="top-1 h-6 rounded bg-blue-500" />
+      </div>
     )}
   </SpanPrimitive.Children>
 </SpanPrimitive.Timeline>

--- a/apps/docs/content/docs/utilities/react-o11y.mdx
+++ b/apps/docs/content/docs/utilities/react-o11y.mdx
@@ -310,6 +310,13 @@ A `<div>` that positions the current span within the nearest `SpanPrimitive.Time
 </SpanPrimitive.Timeline>
 ```
 
+Running spans use the timeline range max when `now` is omitted, keeping SSR and hydration deterministic. Pass `now` when you want live ticking.
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `now` | `number` | `undefined` | Explicit timestamp used as the end of running spans. |
+| `timeRange` | `{ min: number; max: number }` | nearest `Timeline` range | Override the range used for this bar. |
+
 Exposes `data-span-status`, `data-span-type`, `data-span-running`, and these CSS variables:
 
 | Variable | Description |

--- a/packages/react-o11y/README.md
+++ b/packages/react-o11y/README.md
@@ -14,7 +14,7 @@ npm install @assistant-ui/react-o11y
 "use client";
 
 import { AuiProvider, useAui } from "@assistant-ui/store";
-import { SpanResource } from "@assistant-ui/react-o11y";
+import { SpanPrimitive, SpanResource } from "@assistant-ui/react-o11y";
 
 const spans = [
   { id: "a", parentSpanId: null, name: "request", type: "http", status: "completed", startedAt: 0, endedAt: 120, latencyMs: 120 },
@@ -25,12 +25,18 @@ export function Waterfall() {
   const aui = useAui({ span: SpanResource({ spans }) });
   return (
     <AuiProvider value={aui}>
-      {/* compose SpanPrimitive.* components here — see examples/waterfall for a full layout */}
+      <SpanPrimitive.Timeline className="relative h-8">
+        <SpanPrimitive.Children>
+          {() => (
+            <SpanPrimitive.TimelineBar className="top-1 h-6 rounded bg-blue-500" />
+          )}
+        </SpanPrimitive.Children>
+      </SpanPrimitive.Timeline>
     </AuiProvider>
   );
 }
 ```
 
-`SpanPrimitive.*` components rendered inside `<AuiProvider>` cover rows, indentation, names, status, and the collapse toggle.
+`SpanPrimitive.*` components rendered inside `<AuiProvider>` cover rows, indentation, names, status, collapse controls, and timeline bars. `SpanPrimitive.Timeline` provides the time range for its children; `SpanPrimitive.TimelineBar` positions each current span with CSS variables such as `--span-timeline-left` and `--span-timeline-width`.
 
 See [`examples/waterfall`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/waterfall) for a complete waterfall implementation.

--- a/packages/react-o11y/README.md
+++ b/packages/react-o11y/README.md
@@ -25,10 +25,12 @@ export function Waterfall() {
   const aui = useAui({ span: SpanResource({ spans }) });
   return (
     <AuiProvider value={aui}>
-      <SpanPrimitive.Timeline className="relative h-8">
+      <SpanPrimitive.Timeline>
         <SpanPrimitive.Children>
           {() => (
-            <SpanPrimitive.TimelineBar className="top-1 h-6 rounded bg-blue-500" />
+            <div className="relative h-8">
+              <SpanPrimitive.TimelineBar className="top-1 h-6 rounded bg-blue-500" />
+            </div>
           )}
         </SpanPrimitive.Children>
       </SpanPrimitive.Timeline>

--- a/packages/react-o11y/README.md
+++ b/packages/react-o11y/README.md
@@ -37,6 +37,6 @@ export function Waterfall() {
 }
 ```
 
-`SpanPrimitive.*` components rendered inside `<AuiProvider>` cover rows, indentation, names, status, collapse controls, and timeline bars. `SpanPrimitive.Timeline` provides the time range for its children; `SpanPrimitive.TimelineBar` positions each current span with CSS variables such as `--span-timeline-left` and `--span-timeline-width`.
+`SpanPrimitive.*` components rendered inside `<AuiProvider>` cover rows, indentation, names, status, collapse controls, and timeline bars. `SpanPrimitive.Timeline` provides the time range for its children; `SpanPrimitive.TimelineBar` positions each current span with CSS variables such as `--span-timeline-left` and `--span-timeline-width`. Running bars use the timeline range max unless you pass an explicit `now` timestamp for live ticking.
 
 See [`examples/waterfall`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/waterfall) for a complete waterfall implementation.

--- a/packages/react-o11y/README.md
+++ b/packages/react-o11y/README.md
@@ -37,6 +37,6 @@ export function Waterfall() {
 }
 ```
 
-`SpanPrimitive.*` components rendered inside `<AuiProvider>` cover rows, indentation, names, status, collapse controls, and timeline bars. `SpanPrimitive.Timeline` provides the time range for its children; `SpanPrimitive.TimelineBar` positions each current span with CSS variables such as `--span-timeline-left` and `--span-timeline-width`. Running bars use the timeline range max unless you pass an explicit `now` timestamp for live ticking.
+`SpanPrimitive.*` components rendered inside `<AuiProvider>` cover rows, indentation, names, status, collapse controls, and timeline bars. `SpanPrimitive.Timeline` provides the time range for its children; `SpanPrimitive.TimelineBar` positions each current span with CSS variables such as `--span-timeline-left` and `--span-timeline-width`. Running bars use the timeline range max unless you pass an explicit `now` timestamp from your own effect or animation loop.
 
 See [`examples/waterfall`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/waterfall) for a complete waterfall implementation.

--- a/packages/react-o11y/package.json
+++ b/packages/react-o11y/package.json
@@ -28,7 +28,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "aui-build"
+    "build": "aui-build",
+    "test": "vitest run"
   },
   "dependencies": {
     "@assistant-ui/store": "workspace:*",
@@ -47,7 +48,10 @@
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
     "@types/react": "^19.2.17",
-    "react": "^19.2.7"
+    "@types/react-dom": "^19.2.3",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "vitest": "^4.1.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/react-o11y/src/primitives/span.ts
+++ b/packages/react-o11y/src/primitives/span.ts
@@ -5,3 +5,8 @@ export { SpanPrimitiveStatusIndicator as StatusIndicator } from "./span/SpanStat
 export { SpanPrimitiveCollapseToggle as CollapseToggle } from "./span/SpanCollapseToggle";
 export { SpanPrimitiveIndent as Indent } from "./span/SpanIndent";
 export { SpanPrimitiveChildren as Children } from "./span/SpanChildren";
+export {
+  SpanPrimitiveTimeline as Timeline,
+  SpanPrimitiveTimelineBar as TimelineBar,
+  type SpanTimelineRange,
+} from "./span/SpanTimeline";

--- a/packages/react-o11y/src/primitives/span/SpanTimeline.test.tsx
+++ b/packages/react-o11y/src/primitives/span/SpanTimeline.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AuiProvider, useAui } from "@assistant-ui/store";
 import * as SpanPrimitive from "../span";
 import { SpanResource, type SpanData } from "../../resources/SpanResource";
@@ -70,6 +70,27 @@ describe("SpanPrimitive.Timeline", () => {
       durationMs: 0,
       effectiveEnd: 80,
     });
+  });
+
+  it("uses the range boundary for running spans when now is omitted", () => {
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_000);
+
+    expect(
+      getSpanTimelineBarVars({
+        startedAt: 25,
+        endedAt: null,
+        timeRange: { min: 0, max: 100 },
+      }),
+    ).toMatchObject({
+      leftPercent: 25,
+      endPercent: 100,
+      widthPercent: 75,
+      durationMs: 75,
+      effectiveEnd: 100,
+    });
+    expect(dateNow).not.toHaveBeenCalled();
+
+    dateNow.mockRestore();
   });
 
   it("provides the padded timeline range to child bars", () => {

--- a/packages/react-o11y/src/primitives/span/SpanTimeline.test.tsx
+++ b/packages/react-o11y/src/primitives/span/SpanTimeline.test.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import { AuiProvider, useAui } from "@assistant-ui/store";
@@ -21,9 +22,11 @@ const spans: SpanData[] = [
 const TimelineFixture = ({
   paddingEnd,
   now,
+  barStyle,
 }: {
   paddingEnd?: number | undefined;
   now?: number | undefined;
+  barStyle?: CSSProperties | undefined;
 }) => {
   const aui = useAui({ span: SpanResource({ spans }) });
 
@@ -31,7 +34,34 @@ const TimelineFixture = ({
     <AuiProvider value={aui}>
       <SpanPrimitive.Timeline paddingEnd={paddingEnd}>
         <SpanPrimitive.Children>
-          {() => <SpanPrimitive.TimelineBar now={now} />}
+          {() => <SpanPrimitive.TimelineBar now={now} style={barStyle} />}
+        </SpanPrimitive.Children>
+      </SpanPrimitive.Timeline>
+    </AuiProvider>
+  );
+};
+
+const runningSpans: SpanData[] = [
+  {
+    id: "root",
+    parentSpanId: null,
+    name: "request",
+    type: "http",
+    status: "running",
+    startedAt: 0,
+    endedAt: null,
+    latencyMs: null,
+  },
+];
+
+const RunningFixture = () => {
+  const aui = useAui({ span: SpanResource({ spans: runningSpans }) });
+
+  return (
+    <AuiProvider value={aui}>
+      <SpanPrimitive.Timeline timeRange={{ min: 0, max: 100 }}>
+        <SpanPrimitive.Children>
+          {() => <SpanPrimitive.TimelineBar />}
         </SpanPrimitive.Children>
       </SpanPrimitive.Timeline>
     </AuiProvider>
@@ -93,6 +123,34 @@ describe("SpanPrimitive.Timeline", () => {
     dateNow.mockRestore();
   });
 
+  it("clamps bar geometry to the timeline when now or startedAt fall outside the range", () => {
+    expect(
+      getSpanTimelineBarVars({
+        startedAt: 25,
+        endedAt: null,
+        timeRange: { min: 0, max: 100 },
+        now: 10_000,
+      }),
+    ).toMatchObject({
+      leftPercent: 25,
+      endPercent: 100,
+      widthPercent: 75,
+      effectiveEnd: 10_000,
+    });
+
+    expect(
+      getSpanTimelineBarVars({
+        startedAt: -50,
+        endedAt: 50,
+        timeRange: { min: 0, max: 100 },
+      }),
+    ).toMatchObject({
+      leftPercent: 0,
+      endPercent: 50,
+      widthPercent: 50,
+    });
+  });
+
   it("provides the padded timeline range to child bars", () => {
     const html = renderToStaticMarkup(<TimelineFixture paddingEnd={1} />);
 
@@ -101,5 +159,34 @@ describe("SpanPrimitive.Timeline", () => {
     expect(html).toContain("--span-timeline-width:50%");
     expect(html).toContain('data-span-status="completed"');
     expect(html).toContain('data-span-type="http"');
+  });
+
+  it("marks running bars with data-span-running and omits it for completed spans", () => {
+    expect(renderToStaticMarkup(<RunningFixture />)).toContain(
+      "data-span-running",
+    );
+    expect(renderToStaticMarkup(<TimelineFixture />)).not.toContain(
+      "data-span-running",
+    );
+  });
+
+  it("passes a consumer --span-timeline-min-width through to the bar style", () => {
+    const html = renderToStaticMarkup(
+      <TimelineFixture
+        barStyle={{ "--span-timeline-min-width": "4px" } as CSSProperties}
+      />,
+    );
+
+    expect(html).toContain("--span-timeline-min-width:4px");
+    expect(html).toContain("position:absolute");
+  });
+
+  it("clamps a negative paddingEnd and leaves the default range unpadded", () => {
+    expect(renderToStaticMarkup(<TimelineFixture paddingEnd={-1} />)).toContain(
+      "--span-timeline-range-ms:100",
+    );
+    expect(renderToStaticMarkup(<TimelineFixture />)).toContain(
+      "--span-timeline-range-ms:100",
+    );
   });
 });

--- a/packages/react-o11y/src/primitives/span/SpanTimeline.test.tsx
+++ b/packages/react-o11y/src/primitives/span/SpanTimeline.test.tsx
@@ -1,0 +1,84 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AuiProvider, useAui } from "@assistant-ui/store";
+import * as SpanPrimitive from "../span";
+import { SpanResource, type SpanData } from "../../resources/SpanResource";
+import { getSpanTimelineBarVars } from "./SpanTimeline";
+
+const spans: SpanData[] = [
+  {
+    id: "root",
+    parentSpanId: null,
+    name: "request",
+    type: "http",
+    status: "completed",
+    startedAt: 0,
+    endedAt: 100,
+    latencyMs: 100,
+  },
+];
+
+const TimelineFixture = ({
+  paddingEnd,
+  now,
+}: {
+  paddingEnd?: number | undefined;
+  now?: number | undefined;
+}) => {
+  const aui = useAui({ span: SpanResource({ spans }) });
+
+  return (
+    <AuiProvider value={aui}>
+      <SpanPrimitive.Timeline paddingEnd={paddingEnd}>
+        <SpanPrimitive.Children>
+          {() => <SpanPrimitive.TimelineBar now={now} />}
+        </SpanPrimitive.Children>
+      </SpanPrimitive.Timeline>
+    </AuiProvider>
+  );
+};
+
+describe("SpanPrimitive.Timeline", () => {
+  it("computes stable timeline percentages for completed spans", () => {
+    expect(
+      getSpanTimelineBarVars({
+        startedAt: 25,
+        endedAt: 75,
+        timeRange: { min: 0, max: 100 },
+      }),
+    ).toMatchObject({
+      leftPercent: 25,
+      endPercent: 75,
+      widthPercent: 50,
+      durationMs: 50,
+      effectiveEnd: 75,
+    });
+  });
+
+  it("uses now for running spans without producing negative widths", () => {
+    expect(
+      getSpanTimelineBarVars({
+        startedAt: 100,
+        endedAt: null,
+        timeRange: { min: 0, max: 200 },
+        now: 80,
+      }),
+    ).toMatchObject({
+      leftPercent: 50,
+      endPercent: 50,
+      widthPercent: 0,
+      durationMs: 0,
+      effectiveEnd: 80,
+    });
+  });
+
+  it("provides the padded timeline range to child bars", () => {
+    const html = renderToStaticMarkup(<TimelineFixture paddingEnd={1} />);
+
+    expect(html).toContain("data-span-timeline");
+    expect(html).toContain("--span-timeline-range-ms:200");
+    expect(html).toContain("--span-timeline-width:50%");
+    expect(html).toContain('data-span-status="completed"');
+    expect(html).toContain('data-span-type="http"');
+  });
+});

--- a/packages/react-o11y/src/primitives/span/SpanTimeline.tsx
+++ b/packages/react-o11y/src/primitives/span/SpanTimeline.tsx
@@ -23,6 +23,8 @@ type TimelineCssProperties = CSSProperties & {
   "--span-timeline-min-width"?: string | number;
 };
 
+const clampPercent = (value: number) => Math.min(100, Math.max(0, value));
+
 const normalizeRange = (
   range: SpanTimelineRange,
   paddingEnd = 0,
@@ -100,9 +102,11 @@ export const getSpanTimelineBarVars = ({
 }) => {
   const rangeMs = Math.max(1, timeRange.max - timeRange.min);
   const effectiveEnd = endedAt ?? now ?? timeRange.max;
-  const leftPercent = ((startedAt - timeRange.min) / rangeMs) * 100;
+  const leftPercent = clampPercent(
+    ((startedAt - timeRange.min) / rangeMs) * 100,
+  );
   const rawEndPercent = ((effectiveEnd - timeRange.min) / rangeMs) * 100;
-  const endPercent = Math.max(leftPercent, rawEndPercent);
+  const endPercent = clampPercent(Math.max(leftPercent, rawEndPercent));
   const widthPercent = endPercent - leftPercent;
   const durationMs = Math.max(0, effectiveEnd - startedAt);
 

--- a/packages/react-o11y/src/primitives/span/SpanTimeline.tsx
+++ b/packages/react-o11y/src/primitives/span/SpanTimeline.tsx
@@ -91,7 +91,7 @@ export const getSpanTimelineBarVars = ({
   startedAt,
   endedAt,
   timeRange,
-  now = Date.now(),
+  now,
 }: {
   startedAt: number;
   endedAt: number | null;
@@ -99,7 +99,7 @@ export const getSpanTimelineBarVars = ({
   now?: number | undefined;
 }) => {
   const rangeMs = Math.max(1, timeRange.max - timeRange.min);
-  const effectiveEnd = endedAt ?? now;
+  const effectiveEnd = endedAt ?? now ?? timeRange.max;
   const leftPercent = ((startedAt - timeRange.min) / rangeMs) * 100;
   const endPercent = ((effectiveEnd - timeRange.min) / rangeMs) * 100;
   const widthPercent = Math.max(0, endPercent - leftPercent);

--- a/packages/react-o11y/src/primitives/span/SpanTimeline.tsx
+++ b/packages/react-o11y/src/primitives/span/SpanTimeline.tsx
@@ -101,13 +101,14 @@ export const getSpanTimelineBarVars = ({
   const rangeMs = Math.max(1, timeRange.max - timeRange.min);
   const effectiveEnd = endedAt ?? now ?? timeRange.max;
   const leftPercent = ((startedAt - timeRange.min) / rangeMs) * 100;
-  const endPercent = ((effectiveEnd - timeRange.min) / rangeMs) * 100;
-  const widthPercent = Math.max(0, endPercent - leftPercent);
+  const rawEndPercent = ((effectiveEnd - timeRange.min) / rangeMs) * 100;
+  const endPercent = Math.max(leftPercent, rawEndPercent);
+  const widthPercent = endPercent - leftPercent;
   const durationMs = Math.max(0, effectiveEnd - startedAt);
 
   return {
     leftPercent,
-    endPercent: Math.max(leftPercent, endPercent),
+    endPercent,
     widthPercent,
     durationMs,
     effectiveEnd,

--- a/packages/react-o11y/src/primitives/span/SpanTimeline.tsx
+++ b/packages/react-o11y/src/primitives/span/SpanTimeline.tsx
@@ -1,0 +1,159 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  type CSSProperties,
+  createContext,
+  forwardRef,
+  useContext,
+  useMemo,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAuiState } from "@assistant-ui/store";
+
+export type SpanTimelineRange = { min: number; max: number };
+
+type TimelineCssProperties = CSSProperties & {
+  "--span-timeline-min-ms"?: number;
+  "--span-timeline-max-ms"?: number;
+  "--span-timeline-range-ms"?: number;
+  "--span-timeline-left"?: string;
+  "--span-timeline-end"?: string;
+  "--span-timeline-width"?: string;
+  "--span-timeline-duration-ms"?: number;
+  "--span-timeline-min-width"?: string | number;
+};
+
+const normalizeRange = (
+  range: SpanTimelineRange,
+  paddingEnd = 0,
+): SpanTimelineRange => {
+  const duration = Math.max(1, range.max - range.min);
+  const safePaddingEnd = Math.max(0, paddingEnd);
+  return {
+    min: range.min,
+    max: range.max + duration * safePaddingEnd,
+  };
+};
+
+const SpanTimelineRangeContext = createContext<SpanTimelineRange | null>(null);
+
+export namespace SpanPrimitiveTimeline {
+  export type Element = ComponentRef<typeof Primitive.div>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.div> & {
+    timeRange?: SpanTimelineRange | undefined;
+    paddingEnd?: number | undefined;
+  };
+}
+
+export const SpanPrimitiveTimeline = forwardRef<
+  SpanPrimitiveTimeline.Element,
+  SpanPrimitiveTimeline.Props
+>(({ timeRange, paddingEnd = 0, style, children, ...props }, ref) => {
+  const spanTimeRange = useAuiState((s) => s.span.timeRange);
+  const resolvedRange = useMemo(
+    () => normalizeRange(timeRange ?? spanTimeRange, paddingEnd),
+    [timeRange, spanTimeRange, paddingEnd],
+  );
+  const rangeMs = Math.max(1, resolvedRange.max - resolvedRange.min);
+
+  const mergedStyle: TimelineCssProperties = {
+    ...style,
+    "--span-timeline-min-ms": resolvedRange.min,
+    "--span-timeline-max-ms": resolvedRange.max,
+    "--span-timeline-range-ms": rangeMs,
+  };
+
+  return (
+    <SpanTimelineRangeContext.Provider value={resolvedRange}>
+      <Primitive.div
+        {...props}
+        ref={ref}
+        style={mergedStyle}
+        data-span-timeline=""
+      >
+        {children}
+      </Primitive.div>
+    </SpanTimelineRangeContext.Provider>
+  );
+});
+
+SpanPrimitiveTimeline.displayName = "SpanPrimitive.Timeline";
+
+export namespace SpanPrimitiveTimelineBar {
+  export type Element = ComponentRef<typeof Primitive.div>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.div> & {
+    now?: number | undefined;
+    timeRange?: SpanTimelineRange | undefined;
+  };
+}
+
+export const getSpanTimelineBarVars = ({
+  startedAt,
+  endedAt,
+  timeRange,
+  now = Date.now(),
+}: {
+  startedAt: number;
+  endedAt: number | null;
+  timeRange: SpanTimelineRange;
+  now?: number | undefined;
+}) => {
+  const rangeMs = Math.max(1, timeRange.max - timeRange.min);
+  const effectiveEnd = endedAt ?? now;
+  const leftPercent = ((startedAt - timeRange.min) / rangeMs) * 100;
+  const endPercent = ((effectiveEnd - timeRange.min) / rangeMs) * 100;
+  const widthPercent = Math.max(0, endPercent - leftPercent);
+  const durationMs = Math.max(0, effectiveEnd - startedAt);
+
+  return {
+    leftPercent,
+    endPercent: Math.max(leftPercent, endPercent),
+    widthPercent,
+    durationMs,
+    effectiveEnd,
+  };
+};
+
+export const SpanPrimitiveTimelineBar = forwardRef<
+  SpanPrimitiveTimelineBar.Element,
+  SpanPrimitiveTimelineBar.Props
+>(({ now, timeRange, style, ...props }, ref) => {
+  const contextRange = useContext(SpanTimelineRangeContext);
+  const spanTimeRange = useAuiState((s) => s.span.timeRange);
+  const startedAt = useAuiState((s) => s.span.startedAt);
+  const endedAt = useAuiState((s) => s.span.endedAt);
+  const status = useAuiState((s) => s.span.status);
+  const type = useAuiState((s) => s.span.type);
+
+  const vars = getSpanTimelineBarVars({
+    startedAt,
+    endedAt,
+    timeRange: timeRange ?? contextRange ?? spanTimeRange,
+    now,
+  });
+
+  const mergedStyle: TimelineCssProperties = {
+    ...style,
+    position: "absolute",
+    insetInlineStart: "var(--span-timeline-left)",
+    inlineSize:
+      "max(var(--span-timeline-width), var(--span-timeline-min-width, 0px))",
+    "--span-timeline-left": `${vars.leftPercent}%`,
+    "--span-timeline-end": `${vars.endPercent}%`,
+    "--span-timeline-width": `${vars.widthPercent}%`,
+    "--span-timeline-duration-ms": vars.durationMs,
+  };
+
+  return (
+    <Primitive.div
+      {...props}
+      ref={ref}
+      style={mergedStyle}
+      data-span-status={status}
+      data-span-type={type}
+      data-span-running={endedAt === null ? "" : undefined}
+    />
+  );
+});
+
+SpanPrimitiveTimelineBar.displayName = "SpanPrimitive.TimelineBar";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4161,9 +4161,18 @@ importers:
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       react:
         specifier: ^19.2.7
         version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/react-opencode:
     dependencies:


### PR DESCRIPTION
## summary

adds headless span timeline primitives to `@assistant-ui/react-o11y` so consumers can render waterfall/gantt bars from package-level span state instead of reimplementing timing math in app code.

- adds `SpanPrimitive.Timeline` (provides the time range to descendants via context and exposes range CSS variables) and `SpanPrimitive.TimelineBar` (positions the current span with `--span-timeline-left` / `--span-timeline-width`, plus `data-span-status` / `data-span-type` / `data-span-running`)
- refactors the docs waterfall sample to consume the new primitives
- documents the API in the README and docs

## behavior and hardening

- `TimelineBar` clamps its geometry to `[0, 100]%` of the timeline. a span whose `now` or `startedAt` falls outside the range can no longer emit a width above 100%, which previously let the absolutely positioned bar overflow with no clipping ancestor and inflate the scroll container into thousands of px of empty space (most visible as a running bar growing every frame; the old svg clipped bar hid this, so it regressed when the bar became a div). running bars now cap at the visible edge.
- the docs demo uses the deterministic range max fallback for running bars (plus `animate-pulse`) instead of a per frame `requestAnimationFrame` tick, so the running bar stays put and there is no perpetual re-render.
- fixes the minimal usage examples in the README and docs: each `TimelineBar` is absolutely positioned, so the examples now wrap each bar in its own `relative` row instead of stacking every bar onto one shared Timeline box.

## tests

`SpanTimeline.test.tsx` covers `getSpanTimelineBarVars` both ways, the clamp (out of range `now` / `startedAt`), the padded range passthrough, `data-span-running` presence and absence, the `--span-timeline-min-width` passthrough, and the negative `paddingEnd` clamp.

## validation

- `pnpm --filter @assistant-ui/react-o11y test` (8 passing)
- `pnpm --filter @assistant-ui/react-o11y exec tsc --noEmit`
- `pnpm --filter @assistant-ui/docs exec tsc --noEmit`
- `oxlint` + `oxfmt --check` on touched files
- manual chrome check of `/react-o11y`: horizontal scroll stays bounded (no runaway width), the sticky span column stays pinned, and the time axis scrolls correctly when zoomed
