### PR TITLE
feat: improve docs agent readiness

### DIFF
--- a/apps/docs/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/(docs)/docs/[[...slug]]/page.tsx
@@ -41,7 +41,7 @@ export default async function Page(props: {
   });
 
   const path = `apps/docs/content/docs/${page.path}`;
-  const markdownUrl = `${page.url}.mdx`;
+  const markdownUrl = `${page.url}.md`;
   const githubEditUrl = `https://github.com/assistant-ui/assistant-ui/edit/main/${path}`;
 
   const neighbours = getDocsNeighbours(source.pageTree, page.url);

--- a/apps/docs/app/(docs)/examples/[[...slug]]/page.tsx
+++ b/apps/docs/app/(docs)/examples/[[...slug]]/page.tsx
@@ -38,7 +38,7 @@ export default async function Page(props: {
     ? getDemo(EXAMPLE_TO_DEMO_SLUG[exampleSlug] ?? exampleSlug)
     : undefined;
 
-  const markdownUrl = `${page.url}.mdx`;
+  const markdownUrl = `${page.url}.md`;
 
   const neighbours = findNeighbour(examples.pageTree, page.url);
   const footerPrevious = neighbours.previous

--- a/apps/docs/app/(home)/blog/llms.md/[slug]/route.ts
+++ b/apps/docs/app/(home)/blog/llms.md/[slug]/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { AGENT_DOCS_DIRECTIVE_MARKDOWN } from "@/lib/agent-docs-directive";
 import { blog, type BlogPage } from "@/lib/source";
 import { notFound } from "next/navigation";
 import { remark } from "remark";
@@ -9,9 +10,6 @@ import { remarkInclude } from "fumadocs-mdx/config";
 const processor = remark().use(remarkMdx).use(remarkInclude).use(remarkGfm);
 
 export const revalidate = false;
-
-const AGENT_MARKDOWN_DIRECTIVE =
-  "> For AI agents: a documentation index is available at [llms.txt](/llms.txt). Use `.md` for canonical markdown pages; `.mdx` is kept as a backwards-compatible alias on supported URL paths.";
 
 export async function GET(
   _req: NextRequest,
@@ -29,7 +27,7 @@ export async function GET(
   const text = `# ${page.data.title}
 URL: ${page.url}
 ${page.data.description ? `\n${page.data.description}\n` : ""}
-${AGENT_MARKDOWN_DIRECTIVE}
+${AGENT_DOCS_DIRECTIVE_MARKDOWN}
 
 ${processed.value}`;
 

--- a/apps/docs/app/(home)/blog/llms.md/[slug]/route.ts
+++ b/apps/docs/app/(home)/blog/llms.md/[slug]/route.ts
@@ -10,6 +10,9 @@ const processor = remark().use(remarkMdx).use(remarkInclude).use(remarkGfm);
 
 export const revalidate = false;
 
+const AGENT_MARKDOWN_DIRECTIVE =
+  "> For AI agents: a documentation index is available at [llms.txt](/llms.txt). Use `.md` for canonical markdown pages; `.mdx` is kept as a backwards-compatible alias on supported URL paths.";
+
 export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ slug: string }> },
@@ -26,11 +29,14 @@ export async function GET(
   const text = `# ${page.data.title}
 URL: ${page.url}
 ${page.data.description ? `\n${page.data.description}\n` : ""}
+${AGENT_MARKDOWN_DIRECTIVE}
+
 ${processed.value}`;
 
   return new NextResponse(text, {
     headers: {
       "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "no-cache, must-revalidate",
       "X-Robots-Tag": "noindex, follow",
     },
   });

--- a/apps/docs/app/(home)/llms-full.txt/route.ts
+++ b/apps/docs/app/(home)/llms-full.txt/route.ts
@@ -1,7 +1,6 @@
 import { examples, source } from "@/lib/source";
 import { getLLMText } from "@/lib/get-llm-text";
 
-// cached forever
 export const revalidate = false;
 
 export async function GET() {
@@ -10,6 +9,7 @@ export async function GET() {
 
   return new Response(scanned.join("\n\n"), {
     headers: {
+      "Cache-Control": "no-cache, must-revalidate",
       "Content-Type": "text/plain; charset=utf-8",
       "X-Robots-Tag": "noindex, follow",
     },

--- a/apps/docs/app/(home)/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/(home)/llms.mdx/[[...slug]]/route.ts
@@ -15,6 +15,7 @@ export async function GET(
 
   return new NextResponse(await getLLMText(page), {
     headers: {
+      "Cache-Control": "no-cache, must-revalidate",
       "Content-Type": "text/markdown; charset=utf-8",
       "X-Robots-Tag": "noindex, follow",
     },

--- a/apps/docs/app/(home)/llms.txt/route.ts
+++ b/apps/docs/app/(home)/llms.txt/route.ts
@@ -6,6 +6,7 @@ export const revalidate = false;
 export async function GET() {
   return new Response(buildLLMSIndex(source.getPages(), examples.getPages()), {
     headers: {
+      "Cache-Control": "no-cache, must-revalidate",
       "Content-Type": "text/plain; charset=utf-8",
     },
   });

--- a/apps/docs/app/(home)/pricing.md/route.ts
+++ b/apps/docs/app/(home)/pricing.md/route.ts
@@ -2,6 +2,9 @@ import { pricingPlans } from "../pricing/pricing-data";
 
 export const revalidate = false;
 
+const AGENT_MARKDOWN_DIRECTIVE =
+  "> For AI agents: a documentation index is available at [llms.txt](/llms.txt). Use `.md` for canonical markdown pages; `.mdx` is kept as a backwards-compatible alias on supported URL paths.";
+
 const formatPlan = (plan: (typeof pricingPlans)[number]) => {
   const price = plan.period ? `${plan.price}${plan.period}` : plan.price;
 
@@ -23,6 +26,8 @@ export function GET() {
   const markdown = [
     "# assistant-ui pricing",
     "",
+    AGENT_MARKDOWN_DIRECTIVE,
+    "",
     "assistant-ui is a free, MIT-licensed TypeScript/React library for AI chat. The commercial pricing below is for assistant-cloud, the fully managed backend for AI chat applications.",
     "",
     "MAU means Monthly Active Users who send at least one message.",
@@ -33,6 +38,7 @@ export function GET() {
 
   return new Response(`${markdown}\n`, {
     headers: {
+      "Cache-Control": "no-cache, must-revalidate",
       "Content-Type": "text/markdown; charset=utf-8",
       "X-Robots-Tag": "noindex, follow",
     },

--- a/apps/docs/app/(home)/pricing.md/route.ts
+++ b/apps/docs/app/(home)/pricing.md/route.ts
@@ -1,9 +1,7 @@
+import { AGENT_DOCS_DIRECTIVE_MARKDOWN } from "@/lib/agent-docs-directive";
 import { pricingPlans } from "../pricing/pricing-data";
 
 export const revalidate = false;
-
-const AGENT_MARKDOWN_DIRECTIVE =
-  "> For AI agents: a documentation index is available at [llms.txt](/llms.txt). Use `.md` for canonical markdown pages; `.mdx` is kept as a backwards-compatible alias on supported URL paths.";
 
 const formatPlan = (plan: (typeof pricingPlans)[number]) => {
   const price = plan.period ? `${plan.price}${plan.period}` : plan.price;
@@ -26,7 +24,7 @@ export function GET() {
   const markdown = [
     "# assistant-ui pricing",
     "",
-    AGENT_MARKDOWN_DIRECTIVE,
+    AGENT_DOCS_DIRECTIVE_MARKDOWN,
     "",
     "assistant-ui is a free, MIT-licensed TypeScript/React library for AI chat. The commercial pricing below is for assistant-cloud, the fully managed backend for AI chat applications.",
     "",

--- a/apps/docs/app/(home)/tap-llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/(home)/tap-llms.mdx/[[...slug]]/route.ts
@@ -10,6 +10,7 @@ export async function GET(
   { params }: { params: Promise<{ slug?: string[] }> },
 ) {
   const { slug } = await params;
+  // The Tap index MDX redirects; markdown should return content directly.
   const effectiveSlug =
     slug && slug.length > 0 ? slug : ["overview", "introduction"];
   const page = tapDocs.getPage(effectiveSlug);

--- a/apps/docs/app/(home)/tap-llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/(home)/tap-llms.mdx/[[...slug]]/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getLLMText } from "@/lib/get-llm-text";
-import { tapDocs } from "@/lib/source";
+import { getTapDocsPage, tapDocs } from "@/lib/source";
 import { notFound } from "next/navigation";
 
 export const revalidate = false;
@@ -11,9 +11,7 @@ export async function GET(
 ) {
   const { slug } = await params;
   // The Tap index MDX redirects; markdown should return content directly.
-  const effectiveSlug =
-    slug && slug.length > 0 ? slug : ["overview", "introduction"];
-  const page = tapDocs.getPage(effectiveSlug);
+  const page = getTapDocsPage(slug);
   if (!page) notFound();
 
   return new NextResponse(await getLLMText(page), {

--- a/apps/docs/app/(home)/tap-llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/(home)/tap-llms.mdx/[[...slug]]/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getLLMText } from "@/lib/get-llm-text";
-import { examples } from "@/lib/source";
+import { tapDocs } from "@/lib/source";
 import { notFound } from "next/navigation";
 
 export const revalidate = false;
@@ -10,7 +10,9 @@ export async function GET(
   { params }: { params: Promise<{ slug?: string[] }> },
 ) {
   const { slug } = await params;
-  const page = examples.getPage(slug);
+  const effectiveSlug =
+    slug && slug.length > 0 ? slug : ["overview", "introduction"];
+  const page = tapDocs.getPage(effectiveSlug);
   if (!page) notFound();
 
   return new NextResponse(await getLLMText(page), {
@@ -23,7 +25,7 @@ export async function GET(
 }
 
 export function generateStaticParams() {
-  return examples.getPages().map((page) => ({
+  return tapDocs.getPages().map((page) => ({
     slug: page.slugs,
   }));
 }

--- a/apps/docs/app/(products)/tap/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/(products)/tap/docs/[[...slug]]/page.tsx
@@ -38,7 +38,7 @@ export default async function Page(props: {
   });
 
   const path = `apps/docs/content/tap-docs/${page.path}`;
-  const markdownUrl = `${page.url}.mdx`;
+  const markdownUrl = `${page.url}.md`;
   const githubEditUrl = `https://github.com/assistant-ui/assistant-ui/edit/main/${path}`;
 
   const neighbours = findNeighbour(tapDocs.pageTree, page.url);

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -107,24 +107,52 @@ function allPages() {
   ];
 }
 
-function normalizePath(rawPath: string, requestUrl: string) {
-  let value = rawPath.trim();
-  if (!value) return { kind: "docs" as const, slugs: [] };
+function hasHttpScheme(value: string) {
+  const prefix = value.slice(0, "https://".length).toLowerCase();
+  return prefix.startsWith("http://") || prefix.startsWith("https://");
+}
 
-  if (/^https?:\/\//i.test(value)) {
-    const request = new URL(requestUrl);
+function stripLeadingSlashes(value: string) {
+  let start = 0;
+  while (start < value.length && value.charCodeAt(start) === 47) start += 1;
+  return value.slice(start);
+}
+
+function stripTrailingSlashes(value: string) {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1;
+  return value.slice(0, end);
+}
+
+function stripMarkdownSuffix(value: string) {
+  const lower = value.toLowerCase();
+  if (lower.endsWith("/index.mdx")) return value.slice(0, -"/index.mdx".length);
+  if (lower.endsWith("/index.md")) return value.slice(0, -"/index.md".length);
+  if (lower.endsWith(".mdx")) return value.slice(0, -".mdx".length);
+  if (lower.endsWith(".md")) return value.slice(0, -".md".length);
+  return value;
+}
+
+function normalizePathname(rawPath: string, requestUrl?: string) {
+  let value = rawPath.trim();
+
+  if (hasHttpScheme(value)) {
     const parsed = new URL(value);
-    if (parsed.origin !== request.origin) {
-      throw new Error("Only same-origin docs URLs are supported");
+    if (requestUrl) {
+      const request = new URL(requestUrl);
+      if (parsed.origin !== request.origin) {
+        throw new Error("Only same-origin docs URLs are supported");
+      }
     }
     value = parsed.pathname;
   }
 
-  value = value
-    .replace(/^\/+/, "")
-    .replace(/\/index\.mdx?$/i, "")
-    .replace(/\.mdx?$/i, "")
-    .replace(/\/+$/, "");
+  return stripMarkdownSuffix(stripTrailingSlashes(stripLeadingSlashes(value)));
+}
+
+function normalizePath(rawPath: string, requestUrl: string) {
+  const value = normalizePathname(rawPath, requestUrl);
+  if (!value) return { kind: "docs" as const, slugs: [] };
 
   if (value.includes("..")) {
     throw new Error("Parent directory segments are not supported");
@@ -148,11 +176,7 @@ function normalizePath(rawPath: string, requestUrl: string) {
 }
 
 function listPages(path: string | undefined) {
-  const normalizedPrefix = path
-    ?.trim()
-    .replace(/^https?:\/\/[^/]+/i, "")
-    .replace(/\.mdx?$/i, "")
-    .replace(/\/+$/, "");
+  const normalizedPrefix = path ? normalizePathname(path) : undefined;
 
   return allPages()
     .map(({ page }) => pageSummary(page))
@@ -319,7 +343,7 @@ async function handleJsonRpcMessage(
               mimeType: "application/json",
             },
             ...allPages().map(({ page }) => ({
-              uri: `assistant-ui://${page.url.replace(/^\//, "")}`,
+              uri: `assistant-ui://${stripLeadingSlashes(page.url)}`,
               name: page.data.title,
               mimeType: "text/markdown",
             })),

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -1,7 +1,7 @@
 import type * as PageTree from "fumadocs-core/page-tree";
 import { NextResponse, type NextRequest } from "next/server";
 import { getLLMText } from "@/lib/get-llm-text";
-import { examples, source } from "@/lib/source";
+import { examples, source, tapDocs } from "@/lib/source";
 
 export const revalidate = false;
 
@@ -18,7 +18,7 @@ const toolDefinitions = [
   {
     name: "list_pages",
     description:
-      "List assistant-ui documentation pages. Optionally filter by a URL path prefix such as /docs/tools or /examples.",
+      "List assistant-ui documentation pages. Optionally filter by a URL path prefix such as /docs/tools, /examples, or /tap/docs.",
     inputSchema: {
       type: "object",
       properties: {
@@ -42,7 +42,7 @@ const toolDefinitions = [
   {
     name: "search_docs",
     description:
-      "Search assistant-ui docs and examples by title, description, or URL.",
+      "Search assistant-ui docs, examples, and Tap docs by title, description, or URL.",
     inputSchema: {
       type: "object",
       properties: {
@@ -58,14 +58,14 @@ const toolDefinitions = [
   {
     name: "read_page",
     description:
-      "Read one assistant-ui docs or examples page as markdown. Accepts a slug, path, .md URL, or same-origin URL.",
+      "Read one assistant-ui docs, examples, or Tap docs page as markdown. Accepts a slug, path, .md URL, or same-origin URL.",
     inputSchema: {
       type: "object",
       properties: {
         path: {
           type: "string",
           description:
-            "Page path such as /docs/installation, /docs/installation.md, examples/ai-sdk, or a same-origin URL.",
+            "Page path such as /docs/installation, /docs/installation.md, examples/ai-sdk, tap/docs/store/state, or a same-origin URL.",
         },
       },
       required: ["path"],
@@ -102,6 +102,10 @@ function allPages() {
     ...source.getPages().map((page) => ({ kind: "docs" as const, page })),
     ...examples.getPages().map((page) => ({
       kind: "examples" as const,
+      page,
+    })),
+    ...tapDocs.getPages().map((page) => ({
+      kind: "tap" as const,
       page,
     })),
   ];
@@ -150,6 +154,11 @@ function normalizePathname(rawPath: string, requestUrl?: string) {
   return stripMarkdownSuffix(stripTrailingSlashes(stripLeadingSlashes(value)));
 }
 
+function normalizePageUrlPrefix(rawPath: string) {
+  const pathname = normalizePathname(rawPath);
+  return pathname ? `/${pathname}` : "";
+}
+
 function normalizePath(rawPath: string, requestUrl: string) {
   const value = normalizePathname(rawPath, requestUrl);
   if (!value) return { kind: "docs" as const, slugs: [] };
@@ -160,6 +169,7 @@ function normalizePath(rawPath: string, requestUrl: string) {
 
   if (value === "docs") return { kind: "docs" as const, slugs: [] };
   if (value === "examples") return { kind: "examples" as const, slugs: [] };
+  if (value === "tap/docs") return { kind: "tap" as const, slugs: [] };
   if (value.startsWith("docs/")) {
     return {
       kind: "docs" as const,
@@ -172,11 +182,17 @@ function normalizePath(rawPath: string, requestUrl: string) {
       slugs: value.slice("examples/".length).split("/").filter(Boolean),
     };
   }
+  if (value.startsWith("tap/docs/")) {
+    return {
+      kind: "tap" as const,
+      slugs: value.slice("tap/docs/".length).split("/").filter(Boolean),
+    };
+  }
   return { kind: "docs" as const, slugs: value.split("/").filter(Boolean) };
 }
 
 function listPages(path: string | undefined) {
-  const normalizedPrefix = path ? normalizePathname(path) : undefined;
+  const normalizedPrefix = path ? normalizePageUrlPrefix(path) : undefined;
 
   return allPages()
     .map(({ page }) => pageSummary(page))
@@ -225,6 +241,7 @@ function getNavigation() {
   return {
     docs: source.pageTree.children.map(serializeNode),
     examples: examples.pageTree.children.map(serializeNode),
+    tapDocs: tapDocs.pageTree.children.map(serializeNode),
   };
 }
 
@@ -242,6 +259,12 @@ function searchDocs(query: string) {
     .slice(0, 20);
 }
 
+function getTapDocsPage(slugs: string[]) {
+  return tapDocs.getPage(
+    slugs.length > 0 ? slugs : ["overview", "introduction"],
+  );
+}
+
 async function readPage(path: string | undefined, requestUrl: string) {
   if (!path) throw new Error("path is required");
 
@@ -249,7 +272,9 @@ async function readPage(path: string | undefined, requestUrl: string) {
   const page =
     normalized.kind === "examples"
       ? examples.getPage(normalized.slugs)
-      : source.getPage(normalized.slugs);
+      : normalized.kind === "tap"
+        ? getTapDocsPage(normalized.slugs)
+        : source.getPage(normalized.slugs);
 
   if (!page) throw new Error(`Page not found: ${path}`);
 
@@ -301,12 +326,8 @@ async function handleJsonRpcMessage(
   try {
     switch (message.method) {
       case "initialize": {
-        const requestedVersion = getStringParam(
-          message.params,
-          "protocolVersion",
-        );
         return jsonRpcResult(message.id, {
-          protocolVersion: requestedVersion ?? PROTOCOL_VERSION,
+          protocolVersion: PROTOCOL_VERSION,
           capabilities: {
             tools: { listChanged: false },
             resources: { subscribe: false, listChanged: false },
@@ -426,6 +447,12 @@ export async function POST(request: NextRequest) {
   }
 
   if (Array.isArray(payload)) {
+    if (payload.length === 0) {
+      return jsonResponse(jsonRpcError(null, -32600, "Invalid Request"), {
+        status: 400,
+      });
+    }
+
     const results = (
       await Promise.all(
         payload.map((message) =>

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -332,7 +332,20 @@ async function handleJsonRpcMessage(
         return jsonRpcResult(message.id, { tools: toolDefinitions });
       case "tools/call": {
         const name = getStringParam(message.params, "name");
-        const result = await callTool(name, message.params, requestUrl);
+        let result: unknown;
+        try {
+          result = await callTool(name, message.params, requestUrl);
+        } catch (error) {
+          return jsonRpcResult(message.id, {
+            content: [
+              {
+                type: "text",
+                text: error instanceof Error ? error.message : String(error),
+              },
+            ],
+            isError: true,
+          });
+        }
         return jsonRpcResult(message.id, {
           content: [
             {

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -1,0 +1,436 @@
+import type * as PageTree from "fumadocs-core/page-tree";
+import { NextResponse, type NextRequest } from "next/server";
+import { getLLMText } from "@/lib/get-llm-text";
+import { examples, source } from "@/lib/source";
+
+export const revalidate = false;
+
+type JsonRpcRequest = {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: unknown;
+};
+
+const PROTOCOL_VERSION = "2025-06-18";
+
+const toolDefinitions = [
+  {
+    name: "list_pages",
+    description:
+      "List assistant-ui documentation pages. Optionally filter by a URL path prefix such as /docs/tools or /examples.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Optional docs path or prefix to filter by.",
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_navigation",
+    description: "Return the assistant-ui docs navigation tree.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "search_docs",
+    description:
+      "Search assistant-ui docs and examples by title, description, or URL.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search query.",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "read_page",
+    description:
+      "Read one assistant-ui docs or examples page as markdown. Accepts a slug, path, .md URL, or same-origin URL.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description:
+            "Page path such as /docs/installation, /docs/installation.md, examples/ai-sdk, or a same-origin URL.",
+        },
+      },
+      required: ["path"],
+      additionalProperties: false,
+    },
+  },
+];
+
+function getStringParam(params: unknown, key: string) {
+  if (params && typeof params === "object" && key in params) {
+    const value = (params as Record<string, unknown>)[key];
+    if (typeof value === "string") return value;
+  }
+  return undefined;
+}
+
+function pageTitle(page: { data: { title: string } }) {
+  return page.data.title;
+}
+
+function pageSummary(page: {
+  url: string;
+  data: { title: string; description?: string | undefined };
+}) {
+  return {
+    title: pageTitle(page),
+    url: page.url,
+    ...(page.data.description ? { description: page.data.description } : {}),
+  };
+}
+
+function allPages() {
+  return [
+    ...source.getPages().map((page) => ({ kind: "docs" as const, page })),
+    ...examples.getPages().map((page) => ({
+      kind: "examples" as const,
+      page,
+    })),
+  ];
+}
+
+function normalizePath(rawPath: string, requestUrl: string) {
+  let value = rawPath.trim();
+  if (!value) return { kind: "docs" as const, slugs: [] };
+
+  if (/^https?:\/\//i.test(value)) {
+    const request = new URL(requestUrl);
+    const parsed = new URL(value);
+    if (parsed.origin !== request.origin) {
+      throw new Error("Only same-origin docs URLs are supported");
+    }
+    value = parsed.pathname;
+  }
+
+  value = value
+    .replace(/^\/+/, "")
+    .replace(/\/index\.mdx?$/i, "")
+    .replace(/\.mdx?$/i, "")
+    .replace(/\/+$/, "");
+
+  if (value.includes("..")) {
+    throw new Error("Parent directory segments are not supported");
+  }
+
+  if (value === "docs") return { kind: "docs" as const, slugs: [] };
+  if (value === "examples") return { kind: "examples" as const, slugs: [] };
+  if (value.startsWith("docs/")) {
+    return {
+      kind: "docs" as const,
+      slugs: value.slice("docs/".length).split("/").filter(Boolean),
+    };
+  }
+  if (value.startsWith("examples/")) {
+    return {
+      kind: "examples" as const,
+      slugs: value.slice("examples/".length).split("/").filter(Boolean),
+    };
+  }
+  return { kind: "docs" as const, slugs: value.split("/").filter(Boolean) };
+}
+
+function listPages(path: string | undefined) {
+  const normalizedPrefix = path
+    ?.trim()
+    .replace(/^https?:\/\/[^/]+/i, "")
+    .replace(/\.mdx?$/i, "")
+    .replace(/\/+$/, "");
+
+  return allPages()
+    .map(({ page }) => pageSummary(page))
+    .filter(
+      (page) =>
+        !normalizedPrefix ||
+        page.url === normalizedPrefix ||
+        page.url.startsWith(`${normalizedPrefix}/`),
+    );
+}
+
+function serializeNode(node: PageTree.Node): unknown {
+  if (node.type === "page") {
+    return {
+      type: "page",
+      title: typeof node.name === "string" ? node.name : node.url,
+      url: node.url,
+      ...("description" in node &&
+      typeof node.description === "string" &&
+      node.description
+        ? { description: node.description }
+        : {}),
+    };
+  }
+
+  if (node.type === "folder") {
+    return {
+      type: "folder",
+      title: typeof node.name === "string" ? node.name : undefined,
+      ...(node.index ? { url: node.index.url } : {}),
+      ...("description" in node &&
+      typeof node.description === "string" &&
+      node.description
+        ? { description: node.description }
+        : {}),
+      children: node.children.map(serializeNode),
+    };
+  }
+
+  return {
+    type: node.type,
+  };
+}
+
+function getNavigation() {
+  return {
+    docs: source.pageTree.children.map(serializeNode),
+    examples: examples.pageTree.children.map(serializeNode),
+  };
+}
+
+function searchDocs(query: string) {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return [];
+
+  return allPages()
+    .map(({ page }) => pageSummary(page))
+    .filter((page) =>
+      [page.title, page.url, page.description ?? ""].some((value) =>
+        value.toLowerCase().includes(normalized),
+      ),
+    )
+    .slice(0, 20);
+}
+
+async function readPage(path: string | undefined, requestUrl: string) {
+  if (!path) throw new Error("path is required");
+
+  const normalized = normalizePath(path, requestUrl);
+  const page =
+    normalized.kind === "examples"
+      ? examples.getPage(normalized.slugs)
+      : source.getPage(normalized.slugs);
+
+  if (!page) throw new Error(`Page not found: ${path}`);
+
+  return {
+    title: page.data.title,
+    url: page.url,
+    content: await getLLMText(page),
+  };
+}
+
+async function callTool(
+  name: string | undefined,
+  params: unknown,
+  requestUrl: string,
+) {
+  const args =
+    params && typeof params === "object" && "arguments" in params
+      ? (params as { arguments?: unknown }).arguments
+      : undefined;
+
+  switch (name) {
+    case "list_pages":
+      return listPages(getStringParam(args, "path"));
+    case "get_navigation":
+      return getNavigation();
+    case "search_docs":
+      return searchDocs(getStringParam(args, "query") ?? "");
+    case "read_page":
+      return readPage(getStringParam(args, "path"), requestUrl);
+    default:
+      throw new Error(`Unknown tool: ${name ?? "missing"}`);
+  }
+}
+
+function jsonRpcResult(id: JsonRpcRequest["id"], result: unknown) {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function jsonRpcError(id: JsonRpcRequest["id"], code: number, message: string) {
+  return { jsonrpc: "2.0", id: id ?? null, error: { code, message } };
+}
+
+async function handleJsonRpcMessage(
+  message: JsonRpcRequest,
+  requestUrl: string,
+) {
+  if (message.id === undefined) return null;
+
+  try {
+    switch (message.method) {
+      case "initialize": {
+        const requestedVersion = getStringParam(
+          message.params,
+          "protocolVersion",
+        );
+        return jsonRpcResult(message.id, {
+          protocolVersion: requestedVersion ?? PROTOCOL_VERSION,
+          capabilities: {
+            tools: { listChanged: false },
+            resources: { subscribe: false, listChanged: false },
+          },
+          serverInfo: {
+            name: "assistant-ui-docs",
+            version: "1.0.0",
+          },
+        });
+      }
+      case "tools/list":
+        return jsonRpcResult(message.id, { tools: toolDefinitions });
+      case "tools/call": {
+        const name = getStringParam(message.params, "name");
+        const result = await callTool(name, message.params, requestUrl);
+        return jsonRpcResult(message.id, {
+          content: [
+            {
+              type: "text",
+              text:
+                typeof result === "string"
+                  ? result
+                  : JSON.stringify(result, null, 2),
+            },
+          ],
+        });
+      }
+      case "resources/list":
+        return jsonRpcResult(message.id, {
+          resources: [
+            {
+              uri: "assistant-ui://navigation",
+              name: "assistant-ui docs navigation",
+              mimeType: "application/json",
+            },
+            ...allPages().map(({ page }) => ({
+              uri: `assistant-ui://${page.url.replace(/^\//, "")}`,
+              name: page.data.title,
+              mimeType: "text/markdown",
+            })),
+          ],
+        });
+      case "resources/read": {
+        const uri = getStringParam(message.params, "uri");
+        if (uri === "assistant-ui://navigation") {
+          return jsonRpcResult(message.id, {
+            contents: [
+              {
+                uri,
+                mimeType: "application/json",
+                text: JSON.stringify(getNavigation(), null, 2),
+              },
+            ],
+          });
+        }
+        if (!uri?.startsWith("assistant-ui://")) {
+          return jsonRpcError(message.id, -32602, "Unsupported resource URI");
+        }
+        const path = uri.slice("assistant-ui://".length);
+        const page = await readPage(path, requestUrl);
+        return jsonRpcResult(message.id, {
+          contents: [
+            {
+              uri,
+              mimeType: "text/markdown",
+              text: page.content,
+            },
+          ],
+        });
+      }
+      default:
+        return jsonRpcError(
+          message.id,
+          -32601,
+          `Method not found: ${message.method ?? "missing"}`,
+        );
+    }
+  } catch (error) {
+    return jsonRpcError(
+      message.id,
+      -32000,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return NextResponse.json(body, {
+    ...init,
+    headers: {
+      "Cache-Control": "no-store",
+      ...init?.headers,
+    },
+  });
+}
+
+export async function GET() {
+  return jsonResponse({
+    name: "assistant-ui-docs",
+    protocol: "mcp",
+    endpoints: ["/mcp", "/.well-known/mcp", "/docs/mcp"],
+    tools: toolDefinitions.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+    })),
+  });
+}
+
+export async function POST(request: NextRequest) {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return jsonResponse(jsonRpcError(null, -32700, "Parse error"), {
+      status: 400,
+    });
+  }
+
+  if (Array.isArray(payload)) {
+    const results = (
+      await Promise.all(
+        payload.map((message) =>
+          handleJsonRpcMessage(message as JsonRpcRequest, request.url),
+        ),
+      )
+    ).filter((result) => result !== null);
+
+    return results.length > 0
+      ? jsonResponse(results)
+      : new NextResponse(null, { status: 202 });
+  }
+
+  const result = await handleJsonRpcMessage(
+    payload as JsonRpcRequest,
+    request.url,
+  );
+
+  return result
+    ? jsonResponse(result)
+    : new NextResponse(null, { status: 202 });
+}
+
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      Allow: "GET, POST, OPTIONS",
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -1,7 +1,7 @@
 import type * as PageTree from "fumadocs-core/page-tree";
 import { NextResponse, type NextRequest } from "next/server";
 import { getLLMText } from "@/lib/get-llm-text";
-import { examples, source, tapDocs } from "@/lib/source";
+import { examples, getTapDocsPage, source, tapDocs } from "@/lib/source";
 
 export const revalidate = false;
 
@@ -82,16 +82,12 @@ function getStringParam(params: unknown, key: string) {
   return undefined;
 }
 
-function pageTitle(page: { data: { title: string } }) {
-  return page.data.title;
-}
-
 function pageSummary(page: {
   url: string;
   data: { title: string; description?: string | undefined };
 }) {
   return {
-    title: pageTitle(page),
+    title: page.data.title,
     url: page.url,
     ...(page.data.description ? { description: page.data.description } : {}),
   };
@@ -257,12 +253,6 @@ function searchDocs(query: string) {
       ),
     )
     .slice(0, 20);
-}
-
-function getTapDocsPage(slugs: string[]) {
-  return tapDocs.getPage(
-    slugs.length > 0 ? slugs : ["overview", "introduction"],
-  );
 }
 
 async function readPage(path: string | undefined, requestUrl: string) {

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -89,6 +89,12 @@ export default function Layout({ children }: { children: ReactNode }) {
           GeistMono.variable,
         )}
       >
+        <div className="sr-only">
+          For AI agents: a documentation index is available at{" "}
+          <a href="/llms.txt">llms.txt</a>. Use .md for canonical markdown
+          pages; .mdx is kept as a backwards-compatible alias on supported URL
+          paths.
+        </div>
         <Provider>{children}</Provider>
         <Analytics />
       </body>

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -91,9 +91,11 @@ export default function Layout({ children }: { children: ReactNode }) {
       >
         <div aria-hidden="true" className="sr-only">
           For AI agents: a documentation index is available at{" "}
-          <a href="/llms.txt">llms.txt</a>. Use .md for canonical markdown
-          pages; .mdx is kept as a backwards-compatible alias on supported URL
-          paths.
+          <a href="/llms.txt" tabIndex={-1}>
+            llms.txt
+          </a>
+          . Use .md for canonical markdown pages; .mdx is kept as a
+          backwards-compatible alias on supported URL paths.
         </div>
         <Provider>{children}</Provider>
         <Analytics />

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -89,7 +89,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           GeistMono.variable,
         )}
       >
-        <div className="sr-only">
+        <div aria-hidden="true" className="sr-only">
           For AI agents: a documentation index is available at{" "}
           <a href="/llms.txt">llms.txt</a>. Use .md for canonical markdown
           pages; .mdx is kept as a backwards-compatible alias on supported URL

--- a/apps/docs/components/home/setup-prompt.ts
+++ b/apps/docs/components/home/setup-prompt.ts
@@ -5,8 +5,8 @@
 export const SETUP_PROMPT = `Step 1: Read the docs
 
 Read https://assistant-ui.com/llms-full.txt — the full reference in one
-file. Append ".mdx" to any docs URL for raw markdown
-(e.g. /docs/installation.mdx).
+file. Append ".md" to any docs URL for raw markdown
+(e.g. /docs/installation.md).
 
 Step 2: Ask the user
 
@@ -37,7 +37,7 @@ scaffolds app/assistant.tsx + app/api/chat/route.ts).
   \`with-tanstack\` / \`with-expo\` and migrating code in. In-place only
   if you must: \`npx shadcn@latest add https://r.assistant-ui.com/thread.json\`,
   install the provider SDK, and wire your own server for the chat endpoint
-  (Vite/Expo do not bundle one). See /docs/installation.mdx Manual Setup.
+  (Vite/Expo do not bundle one). See /docs/installation.md Manual Setup.
 - Next.js App Router → confirm package manager, Tailwind (v3 or v4), and
   env var location, then run:
 

--- a/apps/docs/lib/agent-docs-directive.ts
+++ b/apps/docs/lib/agent-docs-directive.ts
@@ -1,0 +1,2 @@
+export const AGENT_DOCS_DIRECTIVE_MARKDOWN =
+  "> For AI agents: a documentation index is available at [llms.txt](/llms.txt). Use `.md` for canonical markdown pages; `.mdx` is kept as a backwards-compatible alias on supported URL paths.";

--- a/apps/docs/lib/get-llm-text.tsx
+++ b/apps/docs/lib/get-llm-text.tsx
@@ -11,7 +11,7 @@ import remarkGfm from "remark-gfm";
 import remarkStringify from "remark-stringify";
 import { unified } from "unified";
 import { LLM_COMPONENTS } from "@/lib/llm-components";
-import type { examples, source } from "@/lib/source";
+import type { examples, source, tapDocs } from "@/lib/source";
 import type { InferPageType } from "fumadocs-core/source";
 
 const processor = unified()
@@ -306,7 +306,13 @@ async function resolveStaticReactNode(node: ReactNode): Promise<ReactNode> {
   return renderClientFallback(props, resolvedChildren);
 }
 
-type LLMPage = InferPageType<typeof source> | InferPageType<typeof examples>;
+type LLMPage =
+  | InferPageType<typeof source>
+  | InferPageType<typeof examples>
+  | InferPageType<typeof tapDocs>;
+
+const AGENT_DOCS_DIRECTIVE =
+  "> For AI agents: a documentation index is available at [llms.txt](/llms.txt). Use `.md` for canonical markdown pages; `.mdx` is kept as a backwards-compatible alias on supported URL paths.";
 
 export async function getLLMText(page: LLMPage) {
   const Body = page.data.body;
@@ -328,5 +334,7 @@ export async function getLLMText(page: LLMPage) {
   return `# ${page.data.title}
 URL: ${page.url}
 ${page.data.description ? `\n${page.data.description}\n` : ""}
+${AGENT_DOCS_DIRECTIVE}
+
 ${markdown}`;
 }

--- a/apps/docs/lib/get-llm-text.tsx
+++ b/apps/docs/lib/get-llm-text.tsx
@@ -10,6 +10,7 @@ import rehypeRemark from "rehype-remark";
 import remarkGfm from "remark-gfm";
 import remarkStringify from "remark-stringify";
 import { unified } from "unified";
+import { AGENT_DOCS_DIRECTIVE_MARKDOWN } from "@/lib/agent-docs-directive";
 import { LLM_COMPONENTS } from "@/lib/llm-components";
 import type { examples, source, tapDocs } from "@/lib/source";
 import type { InferPageType } from "fumadocs-core/source";
@@ -311,9 +312,6 @@ type LLMPage =
   | InferPageType<typeof examples>
   | InferPageType<typeof tapDocs>;
 
-const AGENT_DOCS_DIRECTIVE =
-  "> For AI agents: a documentation index is available at [llms.txt](/llms.txt). Use `.md` for canonical markdown pages; `.mdx` is kept as a backwards-compatible alias on supported URL paths.";
-
 export async function getLLMText(page: LLMPage) {
   const Body = page.data.body;
 
@@ -334,7 +332,7 @@ export async function getLLMText(page: LLMPage) {
   return `# ${page.data.title}
 URL: ${page.url}
 ${page.data.description ? `\n${page.data.description}\n` : ""}
-${AGENT_DOCS_DIRECTIVE}
+${AGENT_DOCS_DIRECTIVE_MARKDOWN}
 
 ${markdown}`;
 }

--- a/apps/docs/lib/llms-index.ts
+++ b/apps/docs/lib/llms-index.ts
@@ -15,10 +15,11 @@ function addPageToSection(
   page: LLMIndexPage,
 ) {
   const list = map.get(section) ?? [];
-  const markdownUrl = `${BASE_URL}${page.url}.mdx`;
-  list.push(
-    `- [${page.data.title}](${markdownUrl}): ${page.data.description || ""}`,
-  );
+  const markdownUrl = `${BASE_URL}${page.url}.md`;
+  const description = page.data.description
+    ? `: ${page.data.description.slice(0, 120)}`
+    : "";
+  list.push(`- [${page.data.title}](${markdownUrl})${description}`);
   map.set(section, list);
 }
 
@@ -37,13 +38,13 @@ export function buildLLMSIndex(
     `- [Full documentation](${BASE_URL}/llms-full.txt): all docs and examples pages rendered into one large text file.`,
   );
   lines.push(
-    "- Per-page markdown: append `.mdx` to any docs page URL. For example, `/docs/getting-started.mdx` returns the markdown for `/docs/getting-started`, and `/examples/ai-sdk.mdx` returns the markdown for `/examples/ai-sdk`.",
+    "- Per-page markdown: append `.md` to any docs page URL. `.mdx` is kept as a backwards-compatible alias for agents that request source-style URLs. For example, `/docs/installation.md` and `/docs/installation.mdx` both return markdown for `/docs/installation`.",
   );
   lines.push(
     "- Markdown by Accept header: requesting a docs or examples page with `Accept: text/markdown` also returns that page's markdown.",
   );
   lines.push(
-    "- Use the index below to choose a specific page. Remove the `.mdx` suffix to open the human-readable docs page.",
+    "- Use the index below to choose a specific page. Remove the `.md` or `.mdx` suffix to open the human-readable docs page.",
   );
   lines.push("");
   lines.push("## Table of Contents");

--- a/apps/docs/lib/source.tsx
+++ b/apps/docs/lib/source.tsx
@@ -51,6 +51,14 @@ export const tapDocs = loader({
   source: tapDocsCollection.toFumadocsSource(),
 });
 
+const TAP_DOCS_INDEX_SLUG = ["overview", "introduction"];
+
+export function getTapDocsPage(slugs: string[] | undefined) {
+  return tapDocs.getPage(
+    slugs && slugs.length > 0 ? slugs : TAP_DOCS_INDEX_SLUG,
+  );
+}
+
 export const examples = loader({
   baseUrl: "/examples",
   source: toFumadocsSource(examplePages, []),

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -36,25 +36,72 @@ const config: NextConfig = {
       ],
     },
   ],
-  redirects: async () => [
-    {
-      source: "/docs/:path*.md",
-      destination: "/docs/:path*.mdx",
-      permanent: true,
-    },
-    {
-      source: "/examples.md",
-      destination: "/examples.mdx",
-      permanent: true,
-    },
-    {
-      source: "/examples/:path*.md",
-      destination: "/examples/:path*.mdx",
-      permanent: true,
-    },
-  ],
   rewrites: async () => ({
     beforeFiles: [
+      {
+        source: "/mcp",
+        destination: "/api/mcp",
+      },
+      {
+        source: "/.well-known/mcp",
+        destination: "/api/mcp",
+      },
+      {
+        source: "/docs/mcp",
+        destination: "/api/mcp",
+      },
+      {
+        source: "/docs/.well-known/mcp",
+        destination: "/api/mcp",
+      },
+      {
+        source: "/docs.md",
+        destination: "/llms.mdx",
+      },
+      {
+        source: "/docs.mdx",
+        destination: "/llms.mdx",
+      },
+      {
+        source: "/docs/:path*.md",
+        destination: "/llms.mdx/:path*",
+      },
+      {
+        source: "/docs/:path*.mdx",
+        destination: "/llms.mdx/:path*",
+      },
+      {
+        source: "/examples.md",
+        destination: "/llms.mdx/examples",
+      },
+      {
+        source: "/examples.mdx",
+        destination: "/llms.mdx/examples",
+      },
+      {
+        source: "/examples/:path*.md",
+        destination: "/llms.mdx/examples/:path*",
+      },
+      {
+        source: "/examples/:path*.mdx",
+        destination: "/llms.mdx/examples/:path*",
+      },
+      {
+        source: "/tap/docs.md",
+        destination: "/tap-llms.mdx",
+      },
+      {
+        source: "/tap/docs.mdx",
+        destination: "/tap-llms.mdx",
+      },
+      {
+        source: "/tap/docs/:path*.md",
+        destination: "/tap-llms.mdx/:path*",
+      },
+      {
+        source: "/tap/docs/:path*.mdx",
+        destination: "/tap-llms.mdx/:path*",
+      },
       {
         source: "/",
         has: [
@@ -67,6 +114,10 @@ const config: NextConfig = {
         has: [
           { type: "header", key: "accept", value: "(?:.*text/markdown.*)" },
         ],
+        destination: "/pricing.md",
+      },
+      {
+        source: "/pricing.mdx",
         destination: "/pricing.md",
       },
       {
@@ -88,19 +139,11 @@ const config: NextConfig = {
         destination: "https://assistant-ui-umami.vercel.app/:path*",
       },
       {
-        source: "/docs/:path*.mdx",
-        destination: "/llms.mdx/:path*",
-      },
-      {
-        source: "/examples.mdx",
-        destination: "/llms.mdx/examples",
-      },
-      {
-        source: "/examples/:path*.mdx",
-        destination: "/llms.mdx/examples/:path*",
-      },
-      {
         source: "/blog/:path.md",
+        destination: "/blog/llms.md/:path",
+      },
+      {
+        source: "/blog/:path.mdx",
         destination: "/blog/llms.md/:path",
       },
       {


### PR DESCRIPTION
## Summary

This improves the docs site's agent-readiness without migrating to a new docs framework. The implementation follows the AFDocs / Agent-Friendly Docs guidance directly:

- make `.md` the canonical markdown route for docs pages
- keep `.mdx` as a backwards-compatible alias only
- expose `llms.txt` near the top of HTML and markdown responses so agents can discover the docs index
- add no-cache headers for generated markdown endpoints
- add MCP discovery endpoints that support `initialize`, `tools/list`, resources, and page reads
- keep `llms.txt` under the 50k truncation-risk threshold

## Reviewer References

- AFDocs standard and checker: https://afdocs.dev/
- Agent-Friendly Docs spec: https://agentdocsspec.com/spec/
- Farming-Labs Docs spec: https://docs.farming-labs.dev
- The key spec choice for this PR is `.md` URLs or `Accept: text/markdown`; `.mdx` is included only as a compatibility alias.

## Markdown Route Decision

Per the Agent-Friendly Docs spec, the recommended markdown surface is `.md` URLs or `Accept: text/markdown` content negotiation. This PR treats `.md` as canonical across the site:

- `llms.txt` links point to `.md`
- docs/examples/Tap copy buttons point to `.md`
- setup prompt guidance points agents to `.md`

`.mdx` routes are still supported for backwards compatibility with older/source-style agent requests, but they are aliases that return the same resolved `text/markdown` response. They are not the primary route format.

## Score Movement

Before:

- Prompt baseline: `79/100`
- Live production check before this branch is deployed: `86/100 (B)`
- Remaining live-site failures before this PR: missing HTML/markdown `llms.txt` directives, missing `.md` routes, and missing MCP handshake support

After local validation on this branch:

- `97/100 (A)` from:

```bash
npx -y afdocs check http://localhost:3001/docs --urls http://localhost:3001/docs --format scorecard --score
```

Remaining local warnings are non-blocking:

- `llms-txt-links-resolve`: local preview uses production canonical links, so AFDocs reports cross-origin links during localhost testing
- `content-start-position`: docs content starts after shared layout/sidebar markup
- `markdown-content-parity`: minor intentional differences from agent-oriented markdown serialization

## Verification

- `pnpm exec oxlint ...`
- `pnpm exec oxfmt --check ...`
- `git diff --check`
- Route probes confirmed `.md` and `.mdx` return `text/markdown` with no redirects or HTML shell
- Local AFDocs score: `97/100 (A)`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

