### PR TITLE
docs: show file parts in user message

### DIFF
--- a/apps/docs/content/docs/ui/file.mdx
+++ b/apps/docs/content/docs/ui/file.mdx
@@ -27,7 +27,7 @@ Pass `File` to `MessagePrimitive.Parts`:
 ```tsx title="/components/assistant-ui/thread.tsx" {1,8}
 import { File } from "@/components/assistant-ui/file";
 
-const AssistantMessage: FC = () => {
+const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root className="...">
       <MessagePrimitive.Parts>


### PR DESCRIPTION
## Summary
- Update the File UI docs snippet to render file parts from `UserMessage` instead of `AssistantMessage`.

## Testing
- `pnpm lint`
- `pnpm build`

No changeset: docs app is private.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

