### PR TITLE
feat(react-ag-ui): restore pending tool-call status on reload

### DIFF
--- a/.changeset/ag-ui-reload-pending-tool-status.md
+++ b/.changeset/ag-ui-reload-pending-tool-status.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat(react-ag-ui): restore requires-action status for pending tool calls in fromAgUiMessages so reloaded human-in-the-loop calls are actionable

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -68,6 +68,8 @@ time, the same way a live run never stores them.
 
 `fromAgUiMessages` reconstructs the text, reasoning, and tool calls of each message. Multimodal user input (`image`, `audio`, `video`, and `document` parts, as well as legacy `binary` parts) is restored as attachments on the user message, so a backend that persists multimodal messages shows them again on reload and re-sends them on the next run. Legacy `binary` parts that only reference a file id are not restored.
 
+An assistant message whose tool call has no matching tool result is reconstructed with `requires-action` status, the same status the runtime derives for a pending tool call, so a reloaded human-in-the-loop call (for example an `ask_user` tool) is actionable rather than stuck. This matches how every other external-store runtime surfaces a pending tool call on reload. The AG-UI wire snapshot carries no run outcome, so a tool call that a successful run intentionally left without a result is also surfaced as actionable.
+
 ## Thread list (experimental)
 
 <Callout type="warn">

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -2,6 +2,7 @@
 
 import type { InputContent } from "@ag-ui/client";
 import type { ThreadMessageLike as CoreThreadMessageLike } from "@assistant-ui/core";
+import { getAutoStatus } from "@assistant-ui/core/internal";
 import { type Tool, toToolsJSONSchema } from "assistant-stream";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
 
@@ -602,6 +603,25 @@ export function fromAgUiMessages(
 
     if (role === "user" || role === "system") {
       converted.push(toUserOrSystemSnapshotMessage(role, rawMessage));
+    }
+  }
+
+  for (let i = 0; i < converted.length; i++) {
+    const message = converted[i]!;
+    if (message.role !== "assistant" || !Array.isArray(message.content)) {
+      continue;
+    }
+    const hasPendingToolCall = message.content.some(
+      (part) =>
+        isObject(part) &&
+        part.type === "tool-call" &&
+        part.result === undefined,
+    );
+    if (hasPendingToolCall) {
+      converted[i] = {
+        ...message,
+        status: getAutoStatus(false, false, false, true, undefined),
+      };
     }
   }
 

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -150,6 +150,64 @@ describe("adapter conversions", () => {
     });
   });
 
+  it("restores requires-action status for an assistant message with an unresolved tool call", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "msg-1",
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call-1",
+            type: "function",
+            function: { name: "ask_user", arguments: "{}" },
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result).toHaveLength(1);
+    expect((result[0] as any).status).toMatchObject({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+  });
+
+  it("leaves a resolved tool call without a requires-action status", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "msg-1",
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call-1",
+            type: "function",
+            function: { name: "get_weather", arguments: "{}" },
+          },
+        ],
+      },
+      {
+        id: "msg-2",
+        role: "tool",
+        tool_call_id: "call-1",
+        content: '{"temperature":"22C"}',
+      },
+    ] as any);
+
+    expect(result).toHaveLength(1);
+    expect((result[0] as any).status).toBeUndefined();
+  });
+
+  it("does not add status to an assistant message without tool calls", () => {
+    const result = fromAgUiMessages([
+      { id: "msg-1", role: "assistant", content: "done" },
+    ] as any);
+
+    expect(result).toHaveLength(1);
+    expect((result[0] as any).status).toBeUndefined();
+  });
+
   it("creates a synthetic assistant tool-call when snapshot has an orphan tool message", () => {
     const result = fromAgUiMessages([
       {


### PR DESCRIPTION
closes #4522

## summary

- on reload, `fromAgUiMessages` now reconstructs an assistant message whose tool call has no matching tool result with `requires-action` status, so a reloaded human-in-the-loop call (for example an `ask_user` tool) is actionable instead of reading as complete and stuck.
- the status comes from core's `getAutoStatus`, the same primitive every other external-store runtime uses on reload, so AG-UI now behaves consistently with react-langchain, react-ai-sdk, etc. it previously bypassed that path by handing the external store pre-formed messages with a fixed complete fallback.
- it runs as a post-pass after the tool-result merge loop, since a still-pending call is only knowable once every message is converted; `status ?? fallback` in `fromThreadMessageLike` carries it through both the internal MESSAGES_SNAPSHOT import and the public `fromAgUiMessages` consumer path.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ag-ui test` -> 175/175 green (3 new cases: unresolved infers requires-action, resolved stays unset, plain text stays unset)
- [x] `pnpm --filter @assistant-ui/react-ag-ui build` -> green (types ok, `conversions.d.ts` emitted)

### reviewer should verify

- [ ] load a persisted AG-UI thread that ended on a pending `ask_user` tool call (via `thread.reset` or a history adapter) and confirm the call renders as actionable HITL, and that submitting a result resumes the run.

## notes

- the AG-UI wire snapshot carries no run outcome, so a tool call that a successful run intentionally left without a result is also surfaced as actionable. this is the same limitation every external-store runtime has on reload (the wire cannot distinguish the two cases), so there is no AG-UI specific opt-out, matching how the rest of the framework behaves.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

