### PR TITLE
ci: Require maintainer approval for public API changes

### DIFF
--- a/.github/scripts/check-api-surface-review.mjs
+++ b/.github/scripts/check-api-surface-review.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -79,10 +79,6 @@ export function derivePublicApiMatchers(
         dirPrefixes.add(candidate.replace(/\*.*$/, ""));
         continue;
       }
-      if (candidate.endsWith("/")) {
-        dirPrefixes.add(candidate);
-        continue;
-      }
       if (
         candidate.includes("/src/") &&
         !candidate.endsWith(".ts") &&
@@ -127,6 +123,21 @@ export function collectPublicApiMatchers(
   };
 }
 
+export function mergePublicApiMatchers(...matcherSets) {
+  const files = new Set();
+  const directories = new Set();
+
+  for (const matchers of matcherSets) {
+    for (const file of matchers.files) files.add(file);
+    for (const directory of matchers.directories) directories.add(directory);
+  }
+
+  return {
+    files: [...files].sort(),
+    directories: [...directories].sort(),
+  };
+}
+
 export function findApiSurfaceChanges(changedFiles, matchers) {
   return changedFiles.filter((file) => {
     if (matchers.files.includes(file)) return true;
@@ -134,48 +145,79 @@ export function findApiSurfaceChanges(changedFiles, matchers) {
   });
 }
 
-export async function latestReviewStateByUser({ repo, prNumber, token }) {
-  const response = await fetch(
-    `https://api.github.com/repos/${repo}/pulls/${prNumber}/reviews?per_page=100`,
-    {
+function parseNextPageUrl(linkHeader) {
+  if (!linkHeader) return null;
+
+  for (const part of linkHeader.split(",")) {
+    const [rawUrl, rawRel] = part.split(";").map((value) => value.trim());
+    if (rawRel !== 'rel="next"') continue;
+    return rawUrl?.startsWith("<") && rawUrl.endsWith(">")
+      ? rawUrl.slice(1, -1)
+      : null;
+  }
+
+  return null;
+}
+
+export async function latestReviewStateByUser({
+  repo,
+  prNumber,
+  token,
+  fetchImpl = fetch,
+}) {
+  let nextUrl = `https://api.github.com/repos/${repo}/pulls/${prNumber}/reviews?per_page=100&page=1`;
+  const latestByUser = new Map();
+
+  while (nextUrl) {
+    const response = await fetchImpl(nextUrl, {
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
         "User-Agent": "assistant-ui-api-surface-check",
       },
-    },
-  );
-  if (!response.ok) {
-    throw new Error(
-      `Failed to load PR reviews: ${response.status} ${response.statusText}`,
-    );
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to load PR reviews: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const reviews = await response.json();
+    for (const review of reviews) {
+      if (!review?.user?.login || review.state === "COMMENTED") continue;
+      latestByUser.set(String(review.user.login).toLowerCase(), review.state);
+    }
+
+    nextUrl = parseNextPageUrl(response.headers.get("link"));
   }
-  const reviews = await response.json();
-  const latestByUser = new Map();
-  for (const review of reviews) {
-    if (!review?.user?.login || review.state === "COMMENTED") continue;
-    latestByUser.set(String(review.user.login).toLowerCase(), review.state);
-  }
+
   return latestByUser;
 }
 
-async function runGit(args) {
-  const { spawnSync } = await import("node:child_process");
+function runGitSync(args, { allowFailure = false } = {}) {
   const result = spawnSync("git", args, { cwd: REPO_ROOT, encoding: "utf8" });
-  if (result.status !== 0) {
+  if (!allowFailure && result.status !== 0) {
     throw new Error(
       `git ${args.join(" ")} failed\n${result.stdout}\n${result.stderr}`,
     );
   }
-  return result.stdout;
+  return result;
 }
 
-function repoRelativeExists(relativePath) {
-  return existsSync(path.join(REPO_ROOT, relativePath));
+async function runGit(args) {
+  return runGitSync(args).stdout;
 }
 
-function loadPackageJson(relativePath) {
-  return JSON.parse(readFileSync(path.join(REPO_ROOT, relativePath), "utf8"));
+function repoRelativeExistsAtRevision(revision, relativePath) {
+  return (
+    runGitSync(["cat-file", "-e", `${revision}:${relativePath}`], {
+      allowFailure: true,
+    }).status === 0
+  );
+}
+
+function loadPackageJsonAtRevision(revision, relativePath) {
+  return JSON.parse(runGitSync(["show", `${revision}:${relativePath}`]).stdout);
 }
 
 async function main() {
@@ -197,14 +239,26 @@ async function main() {
     throw new Error("Missing required environment for API surface check");
   }
 
-  const packageJsonEntries = listPackageJsonsFromTree(
+  const basePackageJsonEntries = listPackageJsonsFromTree(
+    await runGit(["ls-tree", "-r", "--name-only", BASE_SHA, "packages"]),
+  );
+  const headPackageJsonEntries = listPackageJsonsFromTree(
     await runGit(["ls-tree", "-r", "--name-only", HEAD_SHA, "packages"]),
   );
-  const matchers = collectPublicApiMatchers(
-    packageJsonEntries,
-    loadPackageJson,
-    repoRelativeExists,
+
+  const matchers = mergePublicApiMatchers(
+    collectPublicApiMatchers(
+      basePackageJsonEntries,
+      (relativePath) => loadPackageJsonAtRevision(BASE_SHA, relativePath),
+      (relativePath) => repoRelativeExistsAtRevision(BASE_SHA, relativePath),
+    ),
+    collectPublicApiMatchers(
+      headPackageJsonEntries,
+      (relativePath) => loadPackageJsonAtRevision(HEAD_SHA, relativePath),
+      (relativePath) => repoRelativeExistsAtRevision(HEAD_SHA, relativePath),
+    ),
   );
+
   const changedFiles = (
     await runGit(["diff", "--name-only", `${BASE_SHA}...${HEAD_SHA}`])
   )

--- a/.github/scripts/check-api-surface-review.mjs
+++ b/.github/scripts/check-api-surface-review.mjs
@@ -1,0 +1,245 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+export function listPackageJsonsFromTree(treeOutput) {
+  return treeOutput
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter(
+      (file) => file.startsWith("packages/") && file.endsWith("/package.json"),
+    )
+    .sort();
+}
+
+export function flattenExportTargets(exportsField) {
+  const targets = [];
+  function visit(value) {
+    if (typeof value === "string") {
+      targets.push(value);
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+    for (const nested of Object.values(value)) visit(nested);
+  }
+  visit(exportsField);
+  return [...new Set(targets)];
+}
+
+export function distTargetToSourceCandidates(pkgDir, target) {
+  if (!target.startsWith("./")) return [];
+  if (target.includes("*")) {
+    const srcPrefix = target
+      .replace(/^\.\/dist\//, "src/")
+      .replace(/^\.\/src\//, "src/");
+    return [path.posix.join(pkgDir, srcPrefix.replace(/\*.*$/, ""))];
+  }
+
+  const normalized = target
+    .replace(/^\.\/dist\//, "src/")
+    .replace(/^\.\/src\//, "src/")
+    .replace(/\.d\.(ts|cts|mts)$/, "")
+    .replace(/\.(js|cjs|mjs)$/, "");
+
+  const candidates = [
+    `${normalized}.ts`,
+    `${normalized}.tsx`,
+    path.posix.join(normalized, "index.ts"),
+    path.posix.join(normalized, "index.tsx"),
+  ];
+
+  return [
+    ...new Set(
+      candidates.map((candidate) => path.posix.join(pkgDir, candidate)),
+    ),
+  ];
+}
+
+export function derivePublicApiMatchers(
+  packageJsonPath,
+  packageJson,
+  { exists = () => true } = {},
+) {
+  const pkgDir = path.posix.dirname(packageJsonPath);
+  const fileSet = new Set([packageJsonPath]);
+  const dirPrefixes = new Set();
+
+  for (const target of flattenExportTargets(packageJson.exports)) {
+    for (const candidate of distTargetToSourceCandidates(pkgDir, target)) {
+      if (candidate.endsWith("/")) {
+        dirPrefixes.add(candidate);
+        continue;
+      }
+      if (candidate.includes("*")) {
+        dirPrefixes.add(candidate.replace(/\*.*$/, ""));
+        continue;
+      }
+      if (candidate.endsWith("/")) {
+        dirPrefixes.add(candidate);
+        continue;
+      }
+      if (
+        candidate.includes("/src/") &&
+        !candidate.endsWith(".ts") &&
+        !candidate.endsWith(".tsx")
+      ) {
+        dirPrefixes.add(candidate.endsWith("/") ? candidate : `${candidate}/`);
+        continue;
+      }
+      if (exists(candidate)) {
+        fileSet.add(candidate);
+      }
+    }
+  }
+
+  return {
+    files: [...fileSet].sort(),
+    directories: [...dirPrefixes].sort(),
+  };
+}
+
+export function collectPublicApiMatchers(
+  packageJsonEntries,
+  packageJsonLoader,
+  fileExists,
+) {
+  const files = new Set();
+  const directories = new Set();
+
+  for (const packageJsonPath of packageJsonEntries) {
+    const packageJson = packageJsonLoader(packageJsonPath);
+    if (!packageJson?.name || !packageJson?.exports) continue;
+    const matchers = derivePublicApiMatchers(packageJsonPath, packageJson, {
+      exists: fileExists,
+    });
+    for (const file of matchers.files) files.add(file);
+    for (const directory of matchers.directories) directories.add(directory);
+  }
+
+  return {
+    files: [...files].sort(),
+    directories: [...directories].sort(),
+  };
+}
+
+export function findApiSurfaceChanges(changedFiles, matchers) {
+  return changedFiles.filter((file) => {
+    if (matchers.files.includes(file)) return true;
+    return matchers.directories.some((prefix) => file.startsWith(prefix));
+  });
+}
+
+export async function latestReviewStateByUser({ repo, prNumber, token }) {
+  const response = await fetch(
+    `https://api.github.com/repos/${repo}/pulls/${prNumber}/reviews?per_page=100`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "assistant-ui-api-surface-check",
+      },
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to load PR reviews: ${response.status} ${response.statusText}`,
+    );
+  }
+  const reviews = await response.json();
+  const latestByUser = new Map();
+  for (const review of reviews) {
+    if (!review?.user?.login || review.state === "COMMENTED") continue;
+    latestByUser.set(String(review.user.login).toLowerCase(), review.state);
+  }
+  return latestByUser;
+}
+
+async function runGit(args) {
+  const { spawnSync } = await import("node:child_process");
+  const result = spawnSync("git", args, { cwd: REPO_ROOT, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed\n${result.stdout}\n${result.stderr}`,
+    );
+  }
+  return result.stdout;
+}
+
+function repoRelativeExists(relativePath) {
+  return existsSync(path.join(REPO_ROOT, relativePath));
+}
+
+function loadPackageJson(relativePath) {
+  return JSON.parse(readFileSync(path.join(REPO_ROOT, relativePath), "utf8"));
+}
+
+async function main() {
+  const {
+    BASE_SHA,
+    HEAD_SHA,
+    PR_NUMBER,
+    GITHUB_REPOSITORY,
+    GITHUB_TOKEN,
+    REQUIRED_REVIEWER = "Yonom",
+  } = process.env;
+  if (
+    !BASE_SHA ||
+    !HEAD_SHA ||
+    !PR_NUMBER ||
+    !GITHUB_REPOSITORY ||
+    !GITHUB_TOKEN
+  ) {
+    throw new Error("Missing required environment for API surface check");
+  }
+
+  const packageJsonEntries = listPackageJsonsFromTree(
+    await runGit(["ls-tree", "-r", "--name-only", HEAD_SHA, "packages"]),
+  );
+  const matchers = collectPublicApiMatchers(
+    packageJsonEntries,
+    loadPackageJson,
+    repoRelativeExists,
+  );
+  const changedFiles = (
+    await runGit(["diff", "--name-only", `${BASE_SHA}...${HEAD_SHA}`])
+  )
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const apiSurfaceChanges = findApiSurfaceChanges(changedFiles, matchers);
+  if (apiSurfaceChanges.length === 0) {
+    console.log("No public API surface entry changes detected.");
+    return;
+  }
+
+  console.log("Detected public API surface entry changes:");
+  for (const file of apiSurfaceChanges) console.log(`- ${file}`);
+
+  const latestByUser = await latestReviewStateByUser({
+    repo: GITHUB_REPOSITORY,
+    prNumber: PR_NUMBER,
+    token: GITHUB_TOKEN,
+  });
+
+  if (latestByUser.get(REQUIRED_REVIEWER.toLowerCase()) === "APPROVED") {
+    console.log(`${REQUIRED_REVIEWER} has approved the API surface change.`);
+    return;
+  }
+
+  throw new Error(
+    `Public API surface entry changed, but @${REQUIRED_REVIEWER} has not approved the PR yet.`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/.github/scripts/check-api-surface-review.test.mjs
+++ b/.github/scripts/check-api-surface-review.test.mjs
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  collectPublicApiMatchers,
+  derivePublicApiMatchers,
+  findApiSurfaceChanges,
+  flattenExportTargets,
+  listPackageJsonsFromTree,
+} from "./check-api-surface-review.mjs";
+
+test("listPackageJsonsFromTree keeps package manifests only", () => {
+  const result = listPackageJsonsFromTree(
+    [
+      "packages/react/package.json",
+      "packages/react/src/index.ts",
+      "apps/docs/package.json",
+      "packages/core/package.json",
+      "",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(result, [
+    "packages/core/package.json",
+    "packages/react/package.json",
+  ]);
+});
+
+test("flattenExportTargets collects nested condition targets", () => {
+  const targets = flattenExportTargets({
+    ".": {
+      types: "./dist/index.d.ts",
+      default: "./dist/index.js",
+    },
+    "./loader": {
+      default: "./dist/loader.js",
+    },
+  });
+
+  assert.deepEqual(targets, [
+    "./dist/index.d.ts",
+    "./dist/index.js",
+    "./dist/loader.js",
+  ]);
+});
+
+test("derivePublicApiMatchers resolves files and wildcard directories", () => {
+  const exists = (candidate) =>
+    [
+      "packages/react/src/index.ts",
+      "packages/next/src/index.ts",
+      "packages/next/src/loader.ts",
+    ].includes(candidate);
+
+  const reactMatchers = derivePublicApiMatchers(
+    "packages/react/package.json",
+    {
+      name: "@assistant-ui/react",
+      exports: {
+        ".": {
+          types: "./dist/index.d.ts",
+          default: "./dist/index.js",
+        },
+      },
+    },
+    { exists },
+  );
+  assert.deepEqual(reactMatchers.files, [
+    "packages/react/package.json",
+    "packages/react/src/index.ts",
+  ]);
+
+  const uiMatchers = derivePublicApiMatchers(
+    "packages/ui/package.json",
+    {
+      name: "@assistant-ui/ui",
+      exports: {
+        "./components/ui/*": "./src/components/ui/*",
+      },
+    },
+    { exists: () => false },
+  );
+  assert.deepEqual(uiMatchers.directories, ["packages/ui/src/components/ui/"]);
+});
+
+test("findApiSurfaceChanges matches files and wildcard directories", () => {
+  const changes = findApiSurfaceChanges(
+    [
+      "packages/react/src/index.ts",
+      "packages/ui/src/components/ui/button.tsx",
+      "packages/core/src/runtime/internal.ts",
+    ],
+    {
+      files: ["packages/react/src/index.ts"],
+      directories: ["packages/ui/src/components/ui/"],
+    },
+  );
+
+  assert.deepEqual(changes, [
+    "packages/react/src/index.ts",
+    "packages/ui/src/components/ui/button.tsx",
+  ]);
+});
+
+test("collectPublicApiMatchers merges package-level matchers", () => {
+  const packageJsonLoader = (relativePath) => {
+    if (relativePath === "packages/react/package.json") {
+      return {
+        name: "@assistant-ui/react",
+        exports: { ".": { default: "./dist/index.js" } },
+      };
+    }
+    if (relativePath === "packages/ui/package.json") {
+      return {
+        name: "@assistant-ui/ui",
+        exports: { "./components/ui/*": "./src/components/ui/*" },
+      };
+    }
+    return null;
+  };
+  const fileExists = (candidate) => candidate === "packages/react/src/index.ts";
+  const matchers = collectPublicApiMatchers(
+    ["packages/react/package.json", "packages/ui/package.json"],
+    packageJsonLoader,
+    fileExists,
+  );
+
+  assert.deepEqual(matchers.files, [
+    "packages/react/package.json",
+    "packages/react/src/index.ts",
+    "packages/ui/package.json",
+  ]);
+  assert.deepEqual(matchers.directories, ["packages/ui/src/components/ui/"]);
+});

--- a/.github/scripts/check-api-surface-review.test.mjs
+++ b/.github/scripts/check-api-surface-review.test.mjs
@@ -1,11 +1,13 @@
-import test from "node:test";
 import assert from "node:assert/strict";
+import test from "node:test";
 import {
   collectPublicApiMatchers,
   derivePublicApiMatchers,
   findApiSurfaceChanges,
   flattenExportTargets,
   listPackageJsonsFromTree,
+  latestReviewStateByUser,
+  mergePublicApiMatchers,
 } from "./check-api-surface-review.mjs";
 
 test("listPackageJsonsFromTree keeps package manifests only", () => {
@@ -130,4 +132,68 @@ test("collectPublicApiMatchers merges package-level matchers", () => {
     "packages/ui/package.json",
   ]);
   assert.deepEqual(matchers.directories, ["packages/ui/src/components/ui/"]);
+});
+
+test("mergePublicApiMatchers keeps base-only API entries for deletions", () => {
+  const baseMatchers = {
+    files: ["packages/react/package.json", "packages/react/src/index.ts"],
+    directories: [],
+  };
+  const headMatchers = {
+    files: ["packages/ui/package.json"],
+    directories: ["packages/ui/src/components/ui/"],
+  };
+
+  const mergedMatchers = mergePublicApiMatchers(baseMatchers, headMatchers);
+  const changes = findApiSurfaceChanges(
+    ["packages/react/src/index.ts", "packages/ui/src/components/ui/button.tsx"],
+    mergedMatchers,
+  );
+
+  assert.deepEqual(changes, [
+    "packages/react/src/index.ts",
+    "packages/ui/src/components/ui/button.tsx",
+  ]);
+});
+
+test("latestReviewStateByUser paginates and keeps the latest non-comment state", async () => {
+  const responses = [
+    {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({
+        link: '<https://api.github.com/repositories/1/pulls/2/reviews?per_page=100&page=2>; rel="next"',
+      }),
+      json: async () => [
+        { user: { login: "Yonom" }, state: "CHANGES_REQUESTED" },
+        { user: { login: "Other" }, state: "COMMENTED" },
+      ],
+    },
+    {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers(),
+      json: async () => [{ user: { login: "Yonom" }, state: "APPROVED" }],
+    },
+  ];
+  const seenUrls = [];
+
+  const latest = await latestReviewStateByUser({
+    repo: "assistant-ui/assistant-ui",
+    prNumber: "4539",
+    token: "token",
+    fetchImpl: async (url) => {
+      seenUrls.push(url);
+      return responses.shift();
+    },
+  });
+
+  assert.deepEqual(seenUrls, [
+    "https://api.github.com/repos/assistant-ui/assistant-ui/pulls/4539/reviews?per_page=100&page=1",
+    "https://api.github.com/repositories/1/pulls/2/reviews?per_page=100&page=2",
+  ]);
+  assert.equal(latest.get("yonom"), "APPROVED");
+  assert.equal(latest.has("other"), false);
 });

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -13,6 +13,7 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - ".github/workflows/code-quality.yaml"
+      - ".github/scripts/**"
   pull_request:
     branches: [main]
     paths:
@@ -25,6 +26,7 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - ".github/workflows/code-quality.yaml"
+      - ".github/scripts/**"
 
 permissions:
   contents: read
@@ -74,6 +76,32 @@ jobs:
 
       - name: Verify templates match packages/ui source
         run: bash scripts/sync-templates.sh
+
+  api-surface-review:
+    name: API Surface Review
+    if: github.event_name == 'pull_request'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Require maintainer approval for public API changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUIRED_REVIEWER: Yonom
+        run: node .github/scripts/check-api-surface-review.mjs
 
   build:
     name: Build Changed Packages


### PR DESCRIPTION
## Summary

- add an API surface review check to `code-quality`
- detect public API entry changes from package exports and public source entrypoints
- require `Yonom` approval before those API-surface changes can merge

## Validation

- `node --test .github/scripts/check-api-surface-review.test.mjs`
- `pnpm exec oxfmt --check .github/scripts/check-api-surface-review.mjs .github/scripts/check-api-surface-review.test.mjs .github/workflows/code-quality.yaml`

fixes #4451


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

