### PR TITLE
fix(docs): steps component prose styling

### DIFF
--- a/apps/docs/components/docs/fumadocs/steps.tsx
+++ b/apps/docs/components/docs/fumadocs/steps.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 export function Steps({ children }: { children: ReactNode }) {
   return (
-    <div className="steps-container not-prose flex min-w-0 flex-col">
+    <div className="steps-container prose-no-margin flex min-w-0 flex-col">
       {children}
     </div>
   );
@@ -17,7 +17,7 @@ export function Step({ children }: { children: ReactNode }) {
         </div>
         <div className="bg-fd-border w-px flex-1 group-last:hidden" />
       </div>
-      <div className="min-w-0 flex-1 pt-0.5 pb-6 group-last:pb-0 [&>h3]:mt-0 [&>h3]:mb-3 [&>h3]:text-base [&>h3]:font-medium">
+      <div className="min-w-0 flex-1 pt-0.5 pb-6 group-last:pb-0 [&>h3]:!mt-0 [&>h3]:!mb-3 [&>h3]:!text-base [&>h3]:!font-medium">
         {children}
       </div>
     </div>

--- a/apps/docs/styles/fumadocs.css
+++ b/apps/docs/styles/fumadocs.css
@@ -475,17 +475,17 @@ figure.shiki {
   padding: 0 !important;
 }
 
+/* A Callout (or any not-prose block) inside a tab owns its own link styling.
+   The tab's [&_a] color/weight would otherwise bleed in, turning callout links
+   foreground-white and medium-weight. Let them inherit, like .prose does. */
+[role="tabpanel"] :where([class~="not-prose"], [class~="not-prose"] *) a {
+  color: inherit;
+  font-weight: inherit;
+}
+
 /* Steps component */
 .steps-container {
   counter-reset: step;
-}
-
-/* Steps is not-prose, which drops the .prose link styling — restore it so
-   links inside steps aren't invisible. Mirrors the .prose a rule above. */
-.steps-container :where(a):not([data-card]) {
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  text-decoration-color: var(--fd-muted-foreground);
 }
 
 .step-number {


### PR DESCRIPTION
fixes link styling and markdown rendering in callouts inside tabs and steps components

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

