### PR TITLE
docs(part-grouping): document flat tool row pattern with GroupedParts

### DIFF
--- a/apps/docs/content/docs/ui/part-grouping.mdx
+++ b/apps/docs/content/docs/ui/part-grouping.mdx
@@ -252,6 +252,44 @@ The synthetic `"standalone-tool-call"` key on `groupPartByType` matches all of t
   The `"mcp-app"` key is deprecated in favor of `"standalone-tool-call"`, which is a superset (it also matches MCP-app tool calls). Existing `"mcp-app"` usage keeps working.
 </Callout>
 
+### Render Tool Calls as Flat Rows
+
+The previous section keeps `"tool-call"` folded into the chain-of-thought and only lifts standalone tool UIs out. To keep reasoning collapsed in a group while every tool call renders as its own row in the message flow, map both tool keys to `[]`:
+
+```tsx
+<MessagePrimitive.GroupedParts
+  groupBy={groupPartByType({
+    reasoning: ["group-thought", "group-reasoning"],
+    "tool-call": [],
+    "standalone-tool-call": [],
+  })}
+>
+  {({ part, children }) => {
+    switch (part.type) {
+      case "group-thought":
+      case "group-reasoning":
+        return <ReasoningBlock>{children}</ReasoningBlock>;
+      case "reasoning":
+        return <Reasoning {...part} />;
+      case "tool-call":
+        return part.toolUI ?? <ToolFallback {...part} />;
+      case "text":
+        return <MarkdownText />;
+      case "indicator":
+        return <LoadingDots />;
+      default:
+        return null;
+    }
+  }}
+</MessagePrimitive.GroupedParts>
+```
+
+Adjacent `reasoning` parts still coalesce into one `group-thought`, while each tool call is a leaf at the same level as text — the `"standalone-tool-call"` entry is mapped to `[]` too so human-in-the-loop and generative-UI tools stay flat alongside routine calls instead of falling through to `"tool-call"`. Tool-call leaves keep their stable identity keys across re-renders, so rows don't remount as the message streams.
+
+<Callout type="warn">
+  This renders tool calls flat **in the message flow** — each leaf sits where the part appears, in order. It does not pin, portal, float, or otherwise move tool UIs out of the flow into a sidebar or fixed region. For out-of-flow placement you still own the layout outside `GroupedParts`.
+</Callout>
+
 ### Group by Custom Metadata
 
 Use any custom metadata in your parts for grouping:

--- a/packages/core/src/tests/groupParts.test.ts
+++ b/packages/core/src/tests/groupParts.test.ts
@@ -190,6 +190,38 @@ describe("groupPartByType", () => {
     expect(fn(standalone, inlineCtx)).toEqual(["group-tool"]);
   });
 
+  it("leaves regular and standalone tool calls ungrouped when both map to []", () => {
+    const fn = groupPartByType({
+      reasoning: ["group-chainOfThought", "group-reasoning"],
+      "tool-call": [],
+      "standalone-tool-call": [],
+    });
+    const regularTool = part({
+      type: "tool-call",
+      toolName: "search",
+    } as Partial<PartState>);
+    const standaloneTool = part({
+      type: "tool-call",
+      toolName: "ask_user",
+    } as Partial<PartState>);
+
+    const paths = [
+      fn(part({ type: "reasoning" })),
+      fn(regularTool),
+      fn(standaloneTool, standaloneContext("ask_user")),
+    ];
+
+    // reasoning groups into the chain-of-thought; both tool kinds stay flat.
+    expect(paths).toEqual([
+      ["group-chainOfThought", "group-reasoning"],
+      [],
+      [],
+    ]);
+    expect(dump(buildGroupTree(paths))).toBe(
+      "G:group-chainOfThought#0[0]{G:group-reasoning#0.0[0]{P:#0.0.0(0)}},P:#1(1),P:#2(2)",
+    );
+  });
+
   it("routes MCP-app parts through 'standalone-tool-call' from the part alone", () => {
     const fn = groupPartByType({
       "tool-call": ["group-tool"],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

