### PR TITLE
feat(react): add id-keyed message rendering

### DIFF
--- a/.changeset/unstable-message-by-id.md
+++ b/.changeset/unstable-message-by-id.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+---
+
+add unstable id-keyed thread message rendering APIs for virtualized and custom message lists. `unstable_useThreadMessageIds()` returns the thread's message ids (stable array identity across content-only updates), and `ThreadPrimitive.Unstable_MessageById` renders a single message by id with the same component surface as `MessageByIndex`. A missing or removed id renders `null` instead of throwing.

--- a/apps/docs/content/docs/guides/virtualization.mdx
+++ b/apps/docs/content/docs/guides/virtualization.mdx
@@ -1,6 +1,6 @@
 ---
 title: Thread Virtualization
-description: Render very long threads with @tanstack/react-virtual, preferably with id-keyed message rows.
+description: Render very long threads with @tanstack/react-virtual, with ThreadPrimitive.Unstable_MessageById and ThreadPrimitive.MessageByIndex.
 platforms: ["react"]
 ---
 
@@ -52,17 +52,40 @@ briefly outlives the item it was created for.
 
 ## Grouping into turns
 
-The example virtualizes per user turn (a user message plus the responses that follow it), which gives the virtualizer stable, meaningfully sized items. Use `unstable_useThreadMessageIds` as the source of message identity, and subscribe only to the role sequence needed to decide where turns begin:
+The example virtualizes per user turn (a user message plus the responses that follow it), which gives the virtualizer stable, meaningfully sized items. Keep the id and role together in a stable row shape so the turn array only rebuilds when message membership or roles change:
 
 ```tsx
-const messageIds = unstable_useThreadMessageIds();
-const roleSignature = useAuiState((s) =>
-  s.thread.messages.map((m) => m.role).join("\n"),
-);
+type MessageRow = {
+  id: string;
+  role: "user" | "assistant" | "system";
+};
 
+const useThreadMessageRows = (): readonly MessageRow[] => {
+  const prevRowsRef = useRef<readonly MessageRow[]>([]);
+
+  return useAuiState((s) => {
+    const messages = s.thread.messages;
+    const prev = prevRowsRef.current;
+    if (
+      prev.length === messages.length &&
+      prev.every((row, index) => {
+        const message = messages[index]!;
+        return row.id === message.id && row.role === message.role;
+      })
+    ) {
+      return prev;
+    }
+
+    const next = messages.map(({ id, role }) => ({ id, role }));
+    prevRowsRef.current = next;
+    return next;
+  });
+};
+
+const messageRows = useThreadMessageRows();
 const turns = useMemo(
-  () => buildTurns(messageIds, roleSignature),
-  [messageIds, roleSignature],
+  () => buildTurns(messageRows),
+  [messageRows],
 );
 ```
 

--- a/apps/docs/content/docs/guides/virtualization.mdx
+++ b/apps/docs/content/docs/guides/virtualization.mdx
@@ -1,6 +1,6 @@
 ---
 title: Thread Virtualization
-description: Render very long threads with @tanstack/react-virtual and ThreadPrimitive.MessageByIndex.
+description: Render very long threads with @tanstack/react-virtual, preferably with id-keyed message rows.
 platforms: ["react"]
 ---
 
@@ -10,9 +10,35 @@ Virtualization mounts only the messages near the viewport and represents the res
 
 Probably not. The default kit already renders message bodies with `content-visibility: auto` and `contain-intrinsic-size`, which skips paint work for off-screen messages, and `ThreadPrimitive.Viewport` handles auto-scroll. That covers typical threads. Reach for virtualization when React mount and update cost itself becomes the bottleneck: threads with hundreds to thousands of messages, or very heavy per-message content, where typing latency degrades because every message stays mounted.
 
-## Rendering messages by index
+## Rendering Messages By Id
 
-`ThreadPrimitive.MessageByIndex` renders a single message at a given index and memoizes on the index plus per-field `components` identity. Pass a module-level components object so the memo holds and a streaming delta only re-renders the message it belongs to:
+For virtualized rows, use message ids as the row identity. `unstable_useThreadMessageIds` returns the thread's ids with stable array identity across content-only updates, and `ThreadPrimitive.Unstable_MessageById` renders one message with the same `components` surface as `MessageByIndex`. Unknown ids render `null`, which is useful when a virtual row unmounts after a message was removed.
+
+```tsx
+const MESSAGE_COMPONENTS = { UserMessage, AssistantMessage };
+
+const messageIds = unstable_useThreadMessageIds();
+
+return messageIds.map((messageId) => (
+  <ThreadPrimitive.Unstable_MessageById
+    key={messageId}
+    messageId={messageId}
+    components={MESSAGE_COMPONENTS}
+  />
+));
+```
+
+<Callout type="warn">
+  `unstable_useThreadMessageIds` and `ThreadPrimitive.Unstable_MessageById` are
+  experimental and may change in any release.
+</Callout>
+
+## Rendering Messages By Index
+
+`ThreadPrimitive.MessageByIndex` is still supported and is the smaller API when
+you already have a stable index from a fixed-order list. It renders a single
+message at that index and memoizes on the index plus the per-field `components`
+identity:
 
 ```tsx
 const MESSAGE_COMPONENTS = { UserMessage, AssistantMessage };
@@ -20,15 +46,36 @@ const MESSAGE_COMPONENTS = { UserMessage, AssistantMessage };
 <ThreadPrimitive.MessageByIndex index={index} components={MESSAGE_COMPONENTS} />;
 ```
 
+For virtualizers, prefer the id-based API above when you can. Index rows are more
+fragile when messages are inserted, removed, reordered, or when a virtual row
+briefly outlives the item it was created for.
+
 ## Grouping into turns
 
-Virtualizing per user turn (a user message plus the responses that follow it) gives the virtualizer stable, meaningfully sized items. Subscribe to a single signature string so the selector returns a primitive and the turn array only rebuilds when membership actually changes:
+The example virtualizes per user turn (a user message plus the responses that follow it), which gives the virtualizer stable, meaningfully sized items. Use `unstable_useThreadMessageIds` as the source of message identity, and subscribe only to the role sequence needed to decide where turns begin:
 
 ```tsx
-const signature = useAuiState((s) =>
-  s.thread.messages.map((m, i) => `${i}:${m.role}:${m.id}`).join("\n"),
+const messageIds = unstable_useThreadMessageIds();
+const roleSignature = useAuiState((s) =>
+  s.thread.messages.map((m) => m.role).join("\n"),
 );
-const turns = useMemo(() => buildTurns(signature), [signature]);
+
+const turns = useMemo(
+  () => buildTurns(messageIds, roleSignature),
+  [messageIds, roleSignature],
+);
+```
+
+Then each virtual turn renders the ids it owns:
+
+```tsx
+{turn.messageIds.map((messageId) => (
+  <ThreadPrimitive.Unstable_MessageById
+    key={messageId}
+    messageId={messageId}
+    components={MESSAGE_COMPONENTS}
+  />
+))}
 ```
 
 ## Padding spacers, not absolute positioning

--- a/apps/docs/content/docs/primitives/thread.mdx
+++ b/apps/docs/content/docs/primitives/thread.mdx
@@ -319,6 +319,30 @@ Renders a single message at a specific index in the thread.
 
 <PrimitivesTypeTable type="ThreadPrimitiveMessageByIndexProps" parameters={ThreadPrimitiveDocs.MessageByIndex.props} />
 
+### Unstable_MessageById
+
+Renders a single message by id with the same `components` surface as
+`MessageByIndex`. Pair it with `unstable_useThreadMessageIds` for virtualized or
+custom message lists that should stay attached to messages across reordering and
+windowing. Unknown ids render `null`.
+
+```tsx
+const messageIds = unstable_useThreadMessageIds();
+
+messageIds.map((messageId) => (
+  <ThreadPrimitive.Unstable_MessageById
+    key={messageId}
+    messageId={messageId}
+    components={{ Message: MyMessage }}
+  />
+));
+```
+
+<Callout type="warn">
+  `unstable_useThreadMessageIds` and `ThreadPrimitive.Unstable_MessageById` are
+  experimental and may change in any release.
+</Callout>
+
 ### ScrollToBottom
 
 Scrolls the viewport to the bottom. Automatically disabled when already at the bottom. Renders a `<button>` element unless `asChild` is set.

--- a/examples/with-virtualized-thread/README.md
+++ b/examples/with-virtualized-thread/README.md
@@ -14,7 +14,7 @@ pnpm --filter with-virtualized-thread dev
 | Concern | File |
 | --- | --- |
 | Virtualizer over user turns, padding spacers, `measureElement` | `app/VirtualizedThread.tsx` |
-| Per-message rendering through `ThreadPrimitive.MessageByIndex` | `app/VirtualizedThread.tsx` |
+| Id-keyed per-message rendering through `ThreadPrimitive.Unstable_MessageById` | `app/VirtualizedThread.tsx` |
 | Sticky-bottom auto-follow with a user-scroll disarm guard | `app/VirtualizedThread.tsx` |
 | External store runtime with seeded messages and a streaming tail | `app/MyRuntimeProvider.tsx` |
 | Deterministic synthetic thread content | `app/seed-messages.ts` |

--- a/examples/with-virtualized-thread/app/VirtualizedThread.tsx
+++ b/examples/with-virtualized-thread/app/VirtualizedThread.tsx
@@ -5,7 +5,6 @@ import {
   ComposerPrimitive,
   MessagePrimitive,
   ThreadPrimitive,
-  unstable_useThreadMessageIds,
   useAuiState,
 } from "@assistant-ui/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -28,18 +27,41 @@ type MessageComponents = ComponentProps<
   typeof ThreadPrimitive.Unstable_MessageById
 >["components"];
 
+type MessageRow = {
+  id: string;
+  role: "user" | "assistant" | "system";
+};
+
 type Turn = { id: string; messageIds: string[] };
 
-const buildTurns = (
-  messageIds: readonly string[],
-  roleSignature: string,
-): Turn[] => {
-  if (messageIds.length === 0) return [];
-  const roles = roleSignature ? roleSignature.split("\n") : [];
+const useThreadMessageRows = (): readonly MessageRow[] => {
+  const prevRowsRef = useRef<readonly MessageRow[]>([]);
+
+  return useAuiState((s) => {
+    const messages = s.thread.messages;
+    const prev = prevRowsRef.current;
+    if (
+      prev.length === messages.length &&
+      prev.every((row, index) => {
+        const message = messages[index]!;
+        return row.id === message.id && row.role === message.role;
+      })
+    ) {
+      return prev;
+    }
+
+    const next = messages.map(({ id, role }) => ({ id, role }));
+    prevRowsRef.current = next;
+    return next;
+  });
+};
+
+const buildTurns = (messages: readonly MessageRow[]): Turn[] => {
+  if (messages.length === 0) return [];
   const turns: Turn[] = [];
-  for (const [index, id] of messageIds.entries()) {
+  for (const { id, role } of messages) {
     const last = turns.at(-1);
-    if (roles[index] === "user" || !last) turns.push({ id, messageIds: [id] });
+    if (role === "user" || !last) turns.push({ id, messageIds: [id] });
     else last.messageIds.push(id);
   }
   return turns;
@@ -83,15 +105,9 @@ const Composer: FC = () => (
 );
 
 export const VirtualizedThread: FC = () => {
-  const messageIds = unstable_useThreadMessageIds();
-  const roleSignature = useAuiState((s) =>
-    s.thread.messages.map((m) => m.role).join("\n"),
-  );
+  const messages = useThreadMessageRows();
   const isRunning = useAuiState((s) => s.thread.isRunning);
-  const turns = useMemo(
-    () => buildTurns(messageIds, roleSignature),
-    [messageIds, roleSignature],
-  );
+  const turns = useMemo(() => buildTurns(messages), [messages]);
 
   const scrollerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);

--- a/examples/with-virtualized-thread/app/VirtualizedThread.tsx
+++ b/examples/with-virtualized-thread/app/VirtualizedThread.tsx
@@ -5,6 +5,7 @@ import {
   ComposerPrimitive,
   MessagePrimitive,
   ThreadPrimitive,
+  unstable_useThreadMessageIds,
   useAuiState,
 } from "@assistant-ui/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -24,23 +25,22 @@ const ESTIMATED_TURN_HEIGHT = 200;
 const AT_BOTTOM_THRESHOLD = 4;
 
 type MessageComponents = ComponentProps<
-  typeof ThreadPrimitive.MessageByIndex
+  typeof ThreadPrimitive.Unstable_MessageById
 >["components"];
 
-type Turn = { id: string; indices: number[] };
+type Turn = { id: string; messageIds: string[] };
 
-const buildTurns = (signature: string): Turn[] => {
-  if (!signature) return [];
+const buildTurns = (
+  messageIds: readonly string[],
+  roleSignature: string,
+): Turn[] => {
+  if (messageIds.length === 0) return [];
+  const roles = roleSignature ? roleSignature.split("\n") : [];
   const turns: Turn[] = [];
-  for (const row of signature.split("\n")) {
-    const firstColon = row.indexOf(":");
-    const secondColon = row.indexOf(":", firstColon + 1);
-    const index = Number(row.slice(0, firstColon));
-    const role = row.slice(firstColon + 1, secondColon);
-    const id = row.slice(secondColon + 1);
+  for (const [index, id] of messageIds.entries()) {
     const last = turns.at(-1);
-    if (role === "user" || !last) turns.push({ id, indices: [index] });
-    else last.indices.push(index);
+    if (roles[index] === "user" || !last) turns.push({ id, messageIds: [id] });
+    else last.messageIds.push(id);
   }
   return turns;
 };
@@ -83,11 +83,15 @@ const Composer: FC = () => (
 );
 
 export const VirtualizedThread: FC = () => {
-  const signature = useAuiState((s) =>
-    s.thread.messages.map((m, i) => `${i}:${m.role}:${m.id}`).join("\n"),
+  const messageIds = unstable_useThreadMessageIds();
+  const roleSignature = useAuiState((s) =>
+    s.thread.messages.map((m) => m.role).join("\n"),
   );
   const isRunning = useAuiState((s) => s.thread.isRunning);
-  const turns = useMemo(() => buildTurns(signature), [signature]);
+  const turns = useMemo(
+    () => buildTurns(messageIds, roleSignature),
+    [messageIds, roleSignature],
+  );
 
   const scrollerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -211,10 +215,10 @@ export const VirtualizedThread: FC = () => {
                 ref={virtualizer.measureElement}
                 className="flex flex-col gap-4 py-3"
               >
-                {turns[item.index]!.indices.map((index) => (
-                  <ThreadPrimitive.MessageByIndex
-                    key={index}
-                    index={index}
+                {turns[item.index]!.messageIds.map((messageId) => (
+                  <ThreadPrimitive.Unstable_MessageById
+                    key={messageId}
+                    messageId={messageId}
                     components={MESSAGE_COMPONENTS}
                   />
                 ))}

--- a/packages/core/src/react/index.ts
+++ b/packages/core/src/react/index.ts
@@ -184,6 +184,7 @@ export {
   ThreadPrimitiveMessages,
   ThreadPrimitiveMessagesImpl,
   ThreadPrimitiveMessageByIndex,
+  ThreadPrimitiveUnstable_MessageById,
 } from "./primitives/thread/ThreadMessages";
 export {
   MessagePrimitiveParts,
@@ -234,6 +235,7 @@ export { getMessageQuote } from "./utils/getMessageQuote";
 
 // Primitive hooks (shared behavior logic)
 export { useThreadMessages } from "./primitive-hooks/useThreadMessages";
+export { unstable_useThreadMessageIds } from "./primitive-hooks/useThreadMessageIds";
 export { useThreadIsRunning } from "./primitive-hooks/useThreadIsRunning";
 export { useThreadIsEmpty } from "./primitive-hooks/useThreadIsEmpty";
 export { useComposerSend } from "./primitive-hooks/useComposerSend";

--- a/packages/core/src/react/primitive-hooks/useThreadMessageIds.ts
+++ b/packages/core/src/react/primitive-hooks/useThreadMessageIds.ts
@@ -1,19 +1,17 @@
-import { useMemo, useRef } from "react";
+import { useRef } from "react";
 import { useAuiState } from "@assistant-ui/store";
 
 const useThreadMessageIds = (): readonly string[] => {
   const messages = useAuiState((s) => s.thread.messages);
   const prevIdsRef = useRef<readonly string[]>([]);
 
-  return useMemo(() => {
-    const ids = messages.map((m) => m.id);
-    const prev = prevIdsRef.current;
-    if (prev.length === ids.length && prev.every((id, i) => id === ids[i])) {
-      return prev;
-    }
+  const ids = messages.map((m) => m.id);
+  const prev = prevIdsRef.current;
+  if (prev.length !== ids.length || prev.some((id, i) => id !== ids[i])) {
     prevIdsRef.current = ids;
-    return ids;
-  }, [messages]);
+  }
+
+  return prevIdsRef.current;
 };
 
 /**

--- a/packages/core/src/react/primitive-hooks/useThreadMessageIds.ts
+++ b/packages/core/src/react/primitive-hooks/useThreadMessageIds.ts
@@ -1,0 +1,29 @@
+import { useMemo, useRef } from "react";
+import { useAuiState } from "@assistant-ui/store";
+
+const useThreadMessageIds = (): readonly string[] => {
+  const messages = useAuiState((s) => s.thread.messages);
+  const prevIdsRef = useRef<readonly string[]>([]);
+
+  return useMemo(() => {
+    const ids = messages.map((m) => m.id);
+    const prev = prevIdsRef.current;
+    if (prev.length === ids.length && prev.every((id, i) => id === ids[i])) {
+      return prev;
+    }
+    prevIdsRef.current = ids;
+    return ids;
+  }, [messages]);
+};
+
+/**
+ * Returns the ids of the messages in the current thread, in order.
+ *
+ * The returned array keeps a stable identity across content-only updates (e.g.
+ * streaming), changing reference only when the id sequence itself changes. Pair
+ * with `ThreadPrimitive.Unstable_MessageById` to drive a virtualized or custom
+ * message list.
+ *
+ * @deprecated Unstable / Experimental - may change in any release.
+ */
+export const unstable_useThreadMessageIds = useThreadMessageIds;

--- a/packages/core/src/react/primitives/thread/ThreadMessages.tsx
+++ b/packages/core/src/react/primitives/thread/ThreadMessages.tsx
@@ -80,6 +80,20 @@ const isComponentsSame = (
 
 const DEFAULT_SYSTEM_MESSAGE = () => null;
 
+const messageIdSetCache = new WeakMap<
+  readonly MessageState[],
+  ReadonlySet<string>
+>();
+
+const hasMessageId = (messages: readonly MessageState[], messageId: string) => {
+  let ids = messageIdSetCache.get(messages);
+  if (!ids) {
+    ids = new Set(messages.map((m) => m.id));
+    messageIdSetCache.set(messages, ids);
+  }
+  return ids.has(messageId);
+};
+
 const getComponent = (
   components: MessagesComponentConfig,
   role: MessageState["role"],
@@ -205,7 +219,7 @@ export const ThreadPrimitiveUnstable_MessageById: FC<ThreadPrimitiveUnstable_Mes
   memo(
     ({ messageId, components }) => {
       const exists = useAuiState((s) =>
-        s.thread.messages.some((m) => m.id === messageId),
+        hasMessageId(s.thread.messages, messageId),
       );
       if (!exists) return null;
 

--- a/packages/core/src/react/primitives/thread/ThreadMessages.tsx
+++ b/packages/core/src/react/primitives/thread/ThreadMessages.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
 import { MessageByIndexProvider } from "../../providers/MessageByIndexProvider";
+import { MessageByIdProvider } from "../../providers/MessageByIdProvider";
 import type { MessageState } from "../../../store";
 
 type MessagesComponentConfig =
@@ -169,6 +170,58 @@ export const ThreadPrimitiveMessageByIndex: FC<ThreadPrimitiveMessageByIndex.Pro
   );
 
 ThreadPrimitiveMessageByIndex.displayName = "ThreadPrimitive.MessageByIndex";
+
+export namespace ThreadPrimitiveUnstable_MessageById {
+  export type Props = {
+    messageId: string;
+    components: MessagesComponentConfig;
+  };
+}
+
+/**
+ * Renders the message with the given id in the current thread.
+ *
+ * Unlike {@link ThreadPrimitiveMessageByIndex}, this keys off the message id,
+ * so it stays attached to the same message across reordering and windowing -
+ * the shape needed to drive a virtualized or custom message list together with
+ * `unstable_useThreadMessageIds`. A missing or removed id renders `null` rather
+ * than throwing.
+ *
+ * @deprecated Unstable / Experimental - may change in any release.
+ *
+ * @example
+ * ```tsx
+ * const messageIds = unstable_useThreadMessageIds();
+ * return messageIds.map((messageId) => (
+ *   <ThreadPrimitive.Unstable_MessageById
+ *     key={messageId}
+ *     messageId={messageId}
+ *     components={MESSAGE_COMPONENTS}
+ *   />
+ * ));
+ * ```
+ */
+export const ThreadPrimitiveUnstable_MessageById: FC<ThreadPrimitiveUnstable_MessageById.Props> =
+  memo(
+    ({ messageId, components }) => {
+      const exists = useAuiState((s) =>
+        s.thread.messages.some((m) => m.id === messageId),
+      );
+      if (!exists) return null;
+
+      return (
+        <MessageByIdProvider id={messageId}>
+          <ThreadMessageComponent components={components} />
+        </MessageByIdProvider>
+      );
+    },
+    (prev, next) =>
+      prev.messageId === next.messageId &&
+      isComponentsSame(prev.components, next.components),
+  );
+
+ThreadPrimitiveUnstable_MessageById.displayName =
+  "ThreadPrimitive.Unstable_MessageById";
 
 const ThreadPrimitiveMessagesInner: FC<{
   children: (value: { message: MessageState }) => ReactNode;

--- a/packages/core/src/react/providers/MessageByIdProvider.tsx
+++ b/packages/core/src/react/providers/MessageByIdProvider.tsx
@@ -1,0 +1,23 @@
+import type { FC, PropsWithChildren } from "react";
+import { useAui, AuiProvider, Derived } from "@assistant-ui/store";
+
+export const MessageByIdProvider: FC<
+  PropsWithChildren<{
+    id: string;
+  }>
+> = ({ id, children }) => {
+  const aui = useAui({
+    message: Derived({
+      source: "thread",
+      query: { type: "id", id },
+      get: (aui) => aui.thread().message({ id }),
+    }),
+    composer: Derived({
+      source: "message",
+      query: {},
+      get: (aui) => aui.thread().message({ id }).composer(),
+    }),
+  });
+
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+};

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -174,6 +174,8 @@ export {
   SuggestionByIndexProvider,
 } from "@assistant-ui/core/react";
 
+export { unstable_useThreadMessageIds } from "@assistant-ui/core/react";
+
 // Model context, tools & clients
 export {
   makeAssistantTool,

--- a/packages/react-ink/src/primitives/thread.ts
+++ b/packages/react-ink/src/primitives/thread.ts
@@ -7,6 +7,7 @@ export {
   type ThreadMessagesProps as MessagesProps,
 } from "./thread/ThreadMessages";
 export { ThreadPrimitiveMessageByIndex as MessageByIndex } from "@assistant-ui/core/react";
+export { ThreadPrimitiveUnstable_MessageById as Unstable_MessageById } from "@assistant-ui/core/react";
 export {
   ThreadEmpty as Empty,
   type ThreadEmptyProps as EmptyProps,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -132,6 +132,7 @@ export * as SuggestionPrimitive from "./primitives/suggestion";
 export * as ErrorPrimitive from "./primitives/error";
 
 export { groupPartByType, type GroupByContext } from "@assistant-ui/core/react";
+export { unstable_useThreadMessageIds } from "@assistant-ui/core/react";
 
 // Re-export shared providers from core/react
 export {

--- a/packages/react-native/src/primitives/thread.ts
+++ b/packages/react-native/src/primitives/thread.ts
@@ -7,6 +7,7 @@ export {
   type ThreadMessagesProps as MessagesProps,
 } from "./thread/ThreadMessages";
 export { ThreadPrimitiveMessageByIndex as MessageByIndex } from "@assistant-ui/core/react";
+export { ThreadPrimitiveUnstable_MessageById as Unstable_MessageById } from "@assistant-ui/core/react";
 export {
   ThreadEmpty as Empty,
   type ThreadEmptyProps as EmptyProps,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -280,6 +280,7 @@ export * as ThreadListItemMorePrimitive from "./primitives/threadListItemMore";
 export * as SelectionToolbarPrimitive from "./primitives/selectionToolbar";
 
 export { groupPartByType, type GroupByContext } from "@assistant-ui/core/react";
+export { unstable_useThreadMessageIds } from "@assistant-ui/core/react";
 export { useMessagePartText } from "./primitives/messagePart/useMessagePartText";
 export { useMessagePartReasoning } from "./primitives/messagePart/useMessagePartReasoning";
 export { useMessagePartSource } from "./primitives/messagePart/useMessagePartSource";

--- a/packages/react/src/primitives/thread.ts
+++ b/packages/react/src/primitives/thread.ts
@@ -6,6 +6,7 @@ export { ThreadPrimitiveViewportProvider as ViewportProvider } from "../context/
 export { ThreadPrimitiveViewportFooter as ViewportFooter } from "./thread/ThreadViewportFooter";
 export { ThreadPrimitiveMessages as Messages } from "./thread/ThreadMessages";
 export { ThreadPrimitiveMessageByIndex as MessageByIndex } from "./thread/ThreadMessages";
+export { ThreadPrimitiveUnstable_MessageById as Unstable_MessageById } from "./thread/ThreadMessages";
 export { ThreadPrimitiveScrollToBottom as ScrollToBottom } from "./thread/ThreadScrollToBottom";
 export { ThreadPrimitiveSuggestion as Suggestion } from "./thread/ThreadSuggestion";
 export {

--- a/packages/react/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react/src/primitives/thread/ThreadMessages.tsx
@@ -4,4 +4,5 @@ export {
   ThreadPrimitiveMessages,
   ThreadPrimitiveMessagesImpl,
   ThreadPrimitiveMessageByIndex,
+  ThreadPrimitiveUnstable_MessageById,
 } from "@assistant-ui/core/react";

--- a/packages/react/src/tests/threadMessageById.test.tsx
+++ b/packages/react/src/tests/threadMessageById.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+
+import { act, render, screen } from "@testing-library/react";
+import { useState, type FC, type PropsWithChildren } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  AssistantRuntimeProvider,
+  useExternalStoreRuntime,
+  unstable_useThreadMessageIds,
+  type ThreadMessageLike,
+} from "../index";
+import * as ThreadPrimitive from "../primitives/thread";
+import * as MessagePrimitive from "../primitives/message";
+import * as MessagePartPrimitive from "../primitives/messagePart";
+
+type Msg = { id: string; role: "user" | "assistant"; text: string };
+
+const convertMessage = (m: Msg): ThreadMessageLike => ({
+  id: m.id,
+  role: m.role,
+  content: [{ type: "text", text: m.text }],
+});
+
+const TextPart: FC = () => <MessagePartPrimitive.Text />;
+const Message: FC = () => (
+  <MessagePrimitive.Parts components={{ Text: TextPart }} />
+);
+const COMPONENTS = { Message };
+
+let setMessages: (updater: (prev: Msg[]) => Msg[]) => void;
+
+const Provider: FC<PropsWithChildren<{ initial: Msg[] }>> = ({
+  initial,
+  children,
+}) => {
+  const [messages, setState] = useState(initial);
+  setMessages = setState;
+  const runtime = useExternalStoreRuntime({
+    messages,
+    convertMessage,
+    onNew: async () => {},
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+};
+
+let lastIds: readonly string[] | undefined;
+const idIdentities: (readonly string[])[] = [];
+
+const List: FC = () => {
+  const ids = unstable_useThreadMessageIds();
+  lastIds = ids;
+  if (idIdentities[idIdentities.length - 1] !== ids) idIdentities.push(ids);
+  return (
+    <>
+      {ids.map((id) => (
+        <div data-testid={`by-id-${id}`} key={id}>
+          <ThreadPrimitive.Unstable_MessageById
+            messageId={id}
+            components={COMPONENTS}
+          />
+        </div>
+      ))}
+    </>
+  );
+};
+
+const initial: Msg[] = [
+  { id: "m1", role: "user", text: "first" },
+  { id: "m2", role: "assistant", text: "second" },
+  { id: "m3", role: "user", text: "third" },
+];
+
+const reset = () => {
+  lastIds = undefined;
+  idIdentities.length = 0;
+};
+
+describe("unstable_useThreadMessageIds", () => {
+  it("returns the message ids in thread order", () => {
+    reset();
+    render(
+      <Provider initial={initial}>
+        <List />
+      </Provider>,
+    );
+    expect(lastIds).toEqual(["m1", "m2", "m3"]);
+  });
+
+  it("keeps a stable array identity across content-only updates", async () => {
+    reset();
+    render(
+      <Provider initial={initial}>
+        <List />
+      </Provider>,
+    );
+    const before = lastIds;
+
+    await act(async () => {
+      setMessages((prev) =>
+        prev.map((m) => (m.id === "m2" ? { ...m, text: "second-edited" } : m)),
+      );
+    });
+
+    expect(lastIds).toBe(before);
+    expect(idIdentities).toHaveLength(1);
+  });
+
+  it("changes array identity when the id sequence changes", async () => {
+    reset();
+    render(
+      <Provider initial={initial}>
+        <List />
+      </Provider>,
+    );
+    const before = lastIds;
+
+    await act(async () => {
+      setMessages((prev) => [
+        ...prev,
+        { id: "m4", role: "user", text: "fourth" },
+      ]);
+    });
+
+    expect(lastIds).not.toBe(before);
+    expect(lastIds).toEqual(["m1", "m2", "m3", "m4"]);
+  });
+});
+
+describe("ThreadPrimitive.Unstable_MessageById", () => {
+  it("renders the same content as MessageByIndex for a known id", () => {
+    reset();
+    render(
+      <Provider initial={initial}>
+        <ThreadPrimitive.MessageByIndex index={1} components={COMPONENTS} />
+        <div data-testid="by-id">
+          <ThreadPrimitive.Unstable_MessageById
+            messageId="m2"
+            components={COMPONENTS}
+          />
+        </div>
+      </Provider>,
+    );
+    expect(screen.getByTestId("by-id").textContent).toBe("second");
+  });
+
+  it("renders null for an unknown id without throwing", () => {
+    reset();
+    expect(() =>
+      render(
+        <Provider initial={initial}>
+          <div data-testid="by-id">
+            <ThreadPrimitive.Unstable_MessageById
+              messageId="does-not-exist"
+              components={COMPONENTS}
+            />
+          </div>
+        </Provider>,
+      ),
+    ).not.toThrow();
+    expect(screen.getByTestId("by-id").textContent).toBe("");
+  });
+
+  it("renders null when messageId changes from known to unknown", () => {
+    reset();
+    const { rerender } = render(
+      <Provider initial={initial}>
+        <div data-testid="by-id">
+          <ThreadPrimitive.Unstable_MessageById
+            messageId="m3"
+            components={COMPONENTS}
+          />
+        </div>
+      </Provider>,
+    );
+    expect(screen.getByTestId("by-id").textContent).toBe("third");
+
+    expect(() =>
+      rerender(
+        <Provider initial={initial}>
+          <div data-testid="by-id">
+            <ThreadPrimitive.Unstable_MessageById
+              messageId="does-not-exist"
+              components={COMPONENTS}
+            />
+          </div>
+        </Provider>,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByTestId("by-id").textContent).toBe("");
+  });
+
+  it("stays attached to the same message across reordering", async () => {
+    reset();
+    render(
+      <Provider initial={initial}>
+        <div data-testid="by-id">
+          <ThreadPrimitive.Unstable_MessageById
+            messageId="m1"
+            components={COMPONENTS}
+          />
+        </div>
+      </Provider>,
+    );
+    expect(screen.getByTestId("by-id").textContent).toBe("first");
+
+    await act(async () => {
+      setMessages((prev) => [...prev].reverse());
+    });
+
+    expect(screen.getByTestId("by-id").textContent).toBe("first");
+  });
+});
+
+describe("exports", () => {
+  it("exposes the unstable id-keyed surface", () => {
+    expect(typeof unstable_useThreadMessageIds).toBe("function");
+    expect(ThreadPrimitive.Unstable_MessageById).toBeDefined();
+  });
+});


### PR DESCRIPTION
### summary

adds unstable id-keyed message rendering for virtualized and custom thread lists.

```tsx
const messageIds = unstable_useThreadMessageIds();

return messageIds.map((messageId) => (
  <ThreadPrimitive.Unstable_MessageById
    key={messageId}
    messageId={messageId}
    components={MESSAGE_COMPONENTS}
  />
));
```

`unstable_useThreadMessageIds()` returns the current thread message ids in order, and keeps a stable array identity across content-only updates. the reference only changes when the id sequence itself changes, so streaming deltas don't churn the row list.

paired with it, `ThreadPrimitive.Unstable_MessageById` renders one message by id using the same `components` surface as `MessageByIndex`. unknown or removed ids render `null` instead of throwing, so rows stay safe across reordering/removal.

### docs + testing

the virtualization guide now recommends id-keyed rows for virtualized/custom lists, while keeping `MessageByIndex` documented as supported. the thread primitive docs add `Unstable_MessageById`, and the virtualized-thread example + README move from index-based rendering to id-keyed rendering.

the existence guard is backed by a `WeakMap` cache from message-array snapshot to id set, so long threads don't run a full scan for every mounted row on every streaming update.

tests cover id order, stable identity across content-only updates, identity changes when ids change, parity with `MessageByIndex`, `null` for unknown ids, staying attached across reordering, and exports from core/react, react, react-native, and react-ink.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

