### PR TITLE
feat(external-store): add unstable_onBranchChange adapter callback

### DIFF
--- a/.changeset/external-store-branch-change.md
+++ b/.changeset/external-store-branch-change.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+external-store: add `unstable_onBranchChange` adapter callback that fires on explicit `switchToBranch`, emitting the canonical (persisted) head and visible message ids, deduped by head

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -314,6 +314,39 @@ runtime.thread.import(repo);
 
 The exported shape round-trips through `thread.import()` directly, so the same value is both your persistence format and what you load back.
 
+### Persisting branch selection
+
+If you store the full branch tree outside assistant-ui, persist the selected branch head too and pass it back as `messageRepository.headId`. `setMessages` still performs the branch switch; `unstable_onBranchChange` is an additional signal that fires after an explicit `switchToBranch` action, such as a BranchPicker click.
+
+```tsx
+const runtime = useExternalStoreRuntime({
+  messageRepository: {
+    messages: storedMessages,
+    headId: selectedHeadId,
+  },
+  setMessages: (messages) => {
+    setVisibleMessages(messages);
+  },
+  unstable_onBranchChange: ({ headId, visibleMessageIds }) => {
+    saveSelectedBranch({
+      headId,
+      visibleMessageIds,
+    });
+  },
+  onNew,
+});
+```
+
+`headId` is the canonical persisted head of the visible branch. Optimistic or transient message ids are not surfaced there. `visibleMessageIds` is the currently visible path in order, which can include an optimistic leaf while `headId` points to its persisted ancestor.
+
+The callback only fires for explicit branch switches, and consecutive switches that resolve to the same canonical head are de-duped. It does not fire on adapter resync, `messageRepository` reset, append, edit/regenerate, content-only updates, or while the thread is running.
+
+<Callout type="warn">
+  `unstable_onBranchChange` is under active development and may change without
+  notice. It complements `setMessages`; it does not enable branch switching by
+  itself.
+</Callout>
+
 ## Tool calling
 
 Handle tool results by updating the matching tool-call entry:
@@ -731,6 +764,12 @@ useExternalStoreRuntime({
       name: "setMessages",
       type: "(messages: readonly T[]) => void",
       description: "Update messages (required for branch switching).",
+    },
+    {
+      name: "unstable_onBranchChange",
+      type: "(event: ExternalStoreBranchChange) => void",
+      description:
+        "Called after an explicit branch switch with the canonical persisted head id and visible message path. Complements setMessages and is unstable.",
     },
     {
       name: "onEdit",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -289,6 +289,7 @@ export type {
   ExternalStoreMessageConverter,
   ExternalStoreThreadListAdapter,
   ExternalStoreThreadData,
+  ExternalStoreBranchChange,
 } from "./runtimes/external-store/external-store-adapter";
 export type { ExternalStoreSharedOptions } from "./runtimes/external-store/external-store-shared-options";
 export { pickExternalStoreSharedOptions } from "./runtimes/external-store/external-store-shared-options";

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -189,6 +189,16 @@ export class MessageRepository {
     return this.head?.current.id ?? null;
   }
 
+  get canonicalHeadId() {
+    // Optimistic messages are ephemeral, so persisted callers need the nearest
+    // non-optimistic ancestor rather than the raw head.
+    let head = this.head;
+    while (head?.current.metadata?.isOptimistic) {
+      head = head.prev;
+    }
+    return head?.current.id ?? null;
+  }
+
   getMessages(headId?: string) {
     if (headId === undefined || headId === this.head?.current.id) {
       return this._messages.value;
@@ -436,14 +446,8 @@ export class MessageRepository {
       });
     }
 
-    // The head may itself be optimistic; walk up to the nearest persisted ancestor.
-    let head = this.head;
-    while (head?.current.metadata?.isOptimistic) {
-      head = head.prev;
-    }
-
     return {
-      headId: head?.current.id ?? null,
+      headId: this.canonicalHeadId,
       messages: exportItems,
     };
   }

--- a/packages/core/src/runtimes/external-store/external-store-adapter.ts
+++ b/packages/core/src/runtimes/external-store/external-store-adapter.ts
@@ -64,6 +64,14 @@ export type ExternalStoreMessageConverter<T> = (
   idx: number,
 ) => ThreadMessageLike;
 
+/**
+ * @deprecated This API is still under active development and might change without notice.
+ */
+export type ExternalStoreBranchChange = {
+  headId: string | null;
+  visibleMessageIds: readonly string[];
+};
+
 type ExternalStoreMessageConverterAdapter<T> = {
   convertMessage: ExternalStoreMessageConverter<T>;
 };
@@ -102,6 +110,26 @@ type ExternalStoreAdapterBase<T> = {
   extras?: unknown;
 
   setMessages?: ((messages: readonly T[]) => void) | undefined;
+  /**
+   * Fires when the user explicitly switches branches via the runtime's
+   * `switchToBranch` action (e.g. a BranchPicker click). It does not fire on
+   * adapter resync, `append`, edit/regenerate, content-only updates, or while
+   * the thread is running. Consecutive switches that resolve to the same
+   * canonical head are de-duped.
+   *
+   * `headId` is the canonical (persisted) head of the now-visible branch —
+   * optimistic/transient ids are never surfaced. `visibleMessageIds` lists the
+   * visible path in order.
+   *
+   * This complements `setMessages` rather than replacing it: switching still
+   * requires `setMessages`, and this callback does not on its own enable branch
+   * switching.
+   *
+   * @deprecated This API is still under active development and might change without notice.
+   */
+  unstable_onBranchChange?:
+    | ((event: ExternalStoreBranchChange) => void)
+    | undefined;
   onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
   onExportExternalState?: (() => any) | undefined;
   onLoadExternalState?: ((state: any) => void) | undefined;

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -410,7 +410,7 @@ export class ExternalStoreThreadRuntimeCore
 
     const onBranchChange = this._store.unstable_onBranchChange;
     const previousHeadId = onBranchChange
-      ? (this.repository.export().headId ?? null)
+      ? this.repository.canonicalHeadId
       : null;
 
     this.repository.switchToBranch(branchId);
@@ -422,7 +422,7 @@ export class ExternalStoreThreadRuntimeCore
 
   /**
    * Emit `unstable_onBranchChange` for an explicit branch switch. Reads the
-   * canonical head from `repository.export()` (which skips optimistic/transient
+   * canonical head from the repository (which skips optimistic/transient
    * messages) and de-dupes switches that leave the canonical head unchanged.
    * Comparing against the head observed just before the switch — rather than the
    * last emitted head — keeps a switch firing after an adapter resync moved the
@@ -432,7 +432,7 @@ export class ExternalStoreThreadRuntimeCore
     previousHeadId: string | null,
     onBranchChange: (event: ExternalStoreBranchChange) => void,
   ): void {
-    const headId = this.repository.export().headId ?? null;
+    const headId = this.repository.canonicalHeadId;
     if (headId === previousHeadId) return;
 
     onBranchChange({

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -405,8 +405,32 @@ export class ExternalStoreThreadRuntimeCore
       return;
     }
 
+    const previousHeadId = this.repository.export().headId ?? null;
+
     this.repository.switchToBranch(branchId);
     this.updateMessages(this.repository.getMessages());
+    this._notifyBranchChange(previousHeadId);
+  }
+
+  /**
+   * Emit `unstable_onBranchChange` for an explicit branch switch. Reads the
+   * canonical head from `repository.export()` (which skips optimistic/transient
+   * messages) and de-dupes switches that leave the canonical head unchanged.
+   * Comparing against the head observed just before the switch — rather than the
+   * last emitted head — keeps a switch firing after an adapter resync moved the
+   * head elsewhere in the meantime.
+   */
+  private _notifyBranchChange(previousHeadId: string | null): void {
+    const onBranchChange = this._store.unstable_onBranchChange;
+    if (!onBranchChange) return;
+
+    const headId = this.repository.export().headId ?? null;
+    if (headId === previousHeadId) return;
+
+    onBranchChange({
+      headId,
+      visibleMessageIds: this.repository.getMessages().map((m) => m.id),
+    });
   }
 
   public async append(message: AppendMessage): Promise<void> {

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -8,7 +8,10 @@ import type {
   ThreadSuggestion,
 } from "../../runtime/interfaces/thread-runtime-core";
 
-import type { ExternalStoreAdapter } from "./external-store-adapter";
+import type {
+  ExternalStoreAdapter,
+  ExternalStoreBranchChange,
+} from "./external-store-adapter";
 import {
   getExternalStoreMessages,
   bindExternalStoreMessage,
@@ -405,11 +408,16 @@ export class ExternalStoreThreadRuntimeCore
       return;
     }
 
-    const previousHeadId = this.repository.export().headId ?? null;
+    const onBranchChange = this._store.unstable_onBranchChange;
+    const previousHeadId = onBranchChange
+      ? (this.repository.export().headId ?? null)
+      : null;
 
     this.repository.switchToBranch(branchId);
     this.updateMessages(this.repository.getMessages());
-    this._notifyBranchChange(previousHeadId);
+    if (onBranchChange) {
+      this._notifyBranchChange(previousHeadId, onBranchChange);
+    }
   }
 
   /**
@@ -420,10 +428,10 @@ export class ExternalStoreThreadRuntimeCore
    * last emitted head — keeps a switch firing after an adapter resync moved the
    * head elsewhere in the meantime.
    */
-  private _notifyBranchChange(previousHeadId: string | null): void {
-    const onBranchChange = this._store.unstable_onBranchChange;
-    if (!onBranchChange) return;
-
+  private _notifyBranchChange(
+    previousHeadId: string | null,
+    onBranchChange: (event: ExternalStoreBranchChange) => void,
+  ): void {
     const headId = this.repository.export().headId ?? null;
     if (headId === previousHeadId) return;
 

--- a/packages/core/src/tests/MessageRepository.test.ts
+++ b/packages/core/src/tests/MessageRepository.test.ts
@@ -302,6 +302,8 @@ describe("MessageRepository", () => {
       const exported = repository.export();
 
       expect(exported.messages.map((m) => m.message.id)).toEqual(["u"]);
+      expect(repository.headId).toBe("placeholder");
+      expect(repository.canonicalHeadId).toBe("u");
       // head was the optimistic placeholder; the exported head must fall back
       // to the nearest persisted ancestor so it always resolves on import.
       expect(exported.headId).toBe("u");

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -355,6 +355,286 @@ describe("ExternalStoreThreadRuntimeCore - optimistic message reconciliation", (
   });
 });
 
+describe("ExternalStoreThreadRuntimeCore - branch change callback", () => {
+  type Raw = {
+    id: string;
+    role: "user" | "assistant";
+    text: string;
+    optimistic?: boolean;
+  };
+
+  const convertMessage = (m: Raw): ThreadMessageLike => ({
+    id: m.id,
+    role: m.role,
+    content: [{ type: "text", text: m.text }],
+    ...(m.optimistic && { metadata: { isOptimistic: true } }),
+  });
+
+  const u: Raw = { id: "u", role: "user", text: "hi" };
+
+  // Build a runtime whose repository holds two sibling assistant branches
+  // (a1, a2) under the user message, with a2 the currently visible head.
+  const makeBranched = (extra?: Record<string, unknown>) => {
+    const base = { convertMessage, setMessages: vi.fn(), ...extra };
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        ...base,
+        messages: [u, { id: "a1", role: "assistant", text: "first" }],
+      }),
+    );
+    runtime.__internal_setAdapter(
+      makeStore({
+        ...base,
+        messages: [u, { id: "a2", role: "assistant", text: "second" }],
+      }),
+    );
+    return runtime;
+  };
+
+  it("fires on explicit switchToBranch with head and visible path", () => {
+    const onBranchChange = vi.fn();
+    const runtime = makeBranched({
+      unstable_onBranchChange: onBranchChange,
+    });
+
+    runtime.switchToBranch("a1");
+
+    expect(onBranchChange).toHaveBeenCalledTimes(1);
+    expect(onBranchChange).toHaveBeenCalledWith({
+      headId: "a1",
+      visibleMessageIds: ["u", "a1"],
+    });
+  });
+
+  it("dedupes consecutive switches that resolve to the same head", () => {
+    const onBranchChange = vi.fn();
+    const runtime = makeBranched({
+      unstable_onBranchChange: onBranchChange,
+    });
+
+    runtime.switchToBranch("a1");
+    runtime.switchToBranch("a1");
+    expect(onBranchChange).toHaveBeenCalledTimes(1);
+
+    runtime.switchToBranch("a2");
+    expect(onBranchChange).toHaveBeenCalledTimes(2);
+    expect(onBranchChange).toHaveBeenLastCalledWith({
+      headId: "a2",
+      visibleMessageIds: ["u", "a2"],
+    });
+  });
+
+  it("does not fire on adapter resync", () => {
+    const onBranchChange = vi.fn();
+    // makeBranched performs construction + one resync via __internal_setAdapter.
+    makeBranched({ unstable_onBranchChange: onBranchChange });
+    expect(onBranchChange).not.toHaveBeenCalled();
+  });
+
+  it("does not fire on messageRepository resync (resetHead)", () => {
+    const onBranchChange = vi.fn();
+    const source = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [u, { id: "a", role: "assistant", text: "x" }],
+        convertMessage,
+      }),
+    );
+    const exported = source.export();
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messageRepository: exported,
+        unstable_onBranchChange: onBranchChange,
+      }),
+    );
+    runtime.__internal_setAdapter(
+      makeStore({
+        messageRepository: { ...exported },
+        unstable_onBranchChange: onBranchChange,
+      }),
+    );
+
+    expect(onBranchChange).not.toHaveBeenCalled();
+  });
+
+  it("does not fire on append, edit, or content-only resync", async () => {
+    const onBranchChange = vi.fn();
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [u, { id: "a1", role: "assistant", text: "first" }],
+        convertMessage,
+        onNew: vi.fn(),
+        onEdit: vi.fn(),
+        setMessages: vi.fn(),
+        unstable_onBranchChange: onBranchChange,
+      }),
+    );
+
+    // append to the tail (onNew)
+    await runtime.append({
+      role: "user",
+      content: [{ type: "text", text: "again" }],
+      attachments: [],
+      createdAt: new Date(0),
+      parentId: "a1",
+      sourceId: null,
+      runConfig: {},
+      metadata: { custom: {} },
+    });
+
+    // edit a non-tail message (onEdit)
+    await runtime.append({
+      role: "user",
+      content: [{ type: "text", text: "edited" }],
+      attachments: [],
+      createdAt: new Date(0),
+      parentId: null,
+      sourceId: null,
+      runConfig: {},
+      metadata: { custom: {} },
+    });
+
+    // content-only resync of the same structure
+    runtime.__internal_setAdapter(
+      makeStore({
+        messages: [u, { id: "a1", role: "assistant", text: "first edited" }],
+        convertMessage,
+        onNew: vi.fn(),
+        onEdit: vi.fn(),
+        setMessages: vi.fn(),
+        unstable_onBranchChange: onBranchChange,
+      }),
+    );
+
+    expect(onBranchChange).not.toHaveBeenCalled();
+  });
+
+  it("fires again when a resync moved the head away before switching back", () => {
+    const onBranchChange = vi.fn();
+    const runtime = makeBranched({
+      unstable_onBranchChange: onBranchChange,
+    });
+
+    runtime.switchToBranch("a1");
+    expect(onBranchChange).toHaveBeenCalledTimes(1);
+
+    // Adapter resync moves the visible head back to a2 (does not fire).
+    runtime.__internal_setAdapter(
+      makeStore({
+        messages: [u, { id: "a2", role: "assistant", text: "second" }],
+        convertMessage,
+        setMessages: vi.fn(),
+        unstable_onBranchChange: onBranchChange,
+      }),
+    );
+    expect(onBranchChange).toHaveBeenCalledTimes(1);
+
+    // Switching back to a1 must fire — the dedupe compares the head observed
+    // just before the switch, not the last emitted head.
+    runtime.switchToBranch("a1");
+    expect(onBranchChange).toHaveBeenCalledTimes(2);
+    expect(onBranchChange).toHaveBeenLastCalledWith({
+      headId: "a1",
+      visibleMessageIds: ["u", "a1"],
+    });
+  });
+
+  it("does not fire while the thread is running", () => {
+    const onBranchChange = vi.fn();
+    const runtime = makeBranched({
+      unstable_onBranchChange: onBranchChange,
+    });
+
+    // Flip into a running state without adding a trailing placeholder.
+    runtime.__internal_setAdapter(
+      makeStore({
+        messages: [u, { id: "a2", role: "assistant", text: "second" }],
+        convertMessage,
+        setMessages: vi.fn(),
+        isRunning: true,
+        unstable_onBranchChange: onBranchChange,
+      }),
+    );
+
+    runtime.switchToBranch("a1");
+
+    expect(onBranchChange).not.toHaveBeenCalled();
+  });
+
+  it("emits the persisted canonical head, not an optimistic id", () => {
+    const onBranchChange = vi.fn();
+
+    // Build a repository whose visible head is the persisted a1, with an
+    // optimistic sibling a2 also present under the user message.
+    const source = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [u, { id: "a1", role: "assistant", text: "first" }],
+        convertMessage,
+      }),
+    );
+    const exported = source.export();
+    const a1Item = exported.messages.find((m) => m.message.id === "a1")!;
+    const optimisticRepo = {
+      headId: "a1",
+      messages: [
+        ...exported.messages,
+        {
+          parentId: "u",
+          message: {
+            ...a1Item.message,
+            id: "a2",
+            metadata: { ...a1Item.message.metadata, isOptimistic: true },
+          },
+        },
+      ],
+    };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messageRepository: optimisticRepo,
+        setMessages: vi.fn(),
+        unstable_onBranchChange: onBranchChange,
+      }),
+    );
+
+    // Switch onto the optimistic leaf: the canonical head changes (a1 -> the
+    // persisted ancestor) so the callback fires.
+    runtime.switchToBranch("a2");
+
+    const event = onBranchChange.mock.calls.at(-1)![0];
+    // export() walks up from the optimistic a2 to its persisted ancestor.
+    expect(event.headId).toBe("u");
+    // The visible path still reflects the optimistic leaf.
+    expect(event.visibleMessageIds).toEqual(["u", "a2"]);
+  });
+
+  it("is a no-op when no callback is provided", () => {
+    const runtime = makeBranched();
+    expect(() => runtime.switchToBranch("a1")).not.toThrow();
+  });
+
+  it("still calls setMessages on branch switch", () => {
+    const setMessages = vi.fn();
+    const runtime = makeBranched({
+      setMessages,
+      unstable_onBranchChange: vi.fn(),
+    });
+
+    runtime.switchToBranch("a1");
+
+    expect(setMessages).toHaveBeenCalledWith([
+      expect.objectContaining({ id: "u" }),
+      expect.objectContaining({ id: "a1" }),
+    ]);
+  });
+});
+
 describe("ExternalStoreThreadRuntimeCore - initialize event replay", () => {
   const message = { id: "m", role: "assistant" as const, content: [] };
   const flushMicrotasks = () => Promise.resolve();

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -619,6 +619,49 @@ describe("ExternalStoreThreadRuntimeCore - branch change callback", () => {
     expect(() => runtime.switchToBranch("a1")).not.toThrow();
   });
 
+  it("does not export canonical heads when no callback is provided", () => {
+    const runtime = makeBranched();
+    const repository = (
+      runtime as unknown as { repository: { export: () => unknown } }
+    ).repository;
+    const exportSpy = vi.spyOn(repository, "export");
+
+    runtime.switchToBranch("a1");
+
+    expect(exportSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses the initiating adapter callback if setMessages swaps adapters synchronously", () => {
+    const initialOnBranchChange = vi.fn();
+    const swappedOnBranchChange = vi.fn();
+    let runtime!: ExternalStoreThreadRuntimeCore;
+    const setMessages = vi.fn(() => {
+      runtime.__internal_setAdapter(
+        makeStore({
+          messages: [u, { id: "a1", role: "assistant", text: "first" }],
+          convertMessage,
+          setMessages: vi.fn(),
+          unstable_onBranchChange: swappedOnBranchChange,
+        }),
+      );
+    });
+
+    runtime = makeBranched({
+      setMessages,
+      unstable_onBranchChange: initialOnBranchChange,
+    });
+
+    runtime.switchToBranch("a1");
+
+    expect(setMessages).toHaveBeenCalledTimes(1);
+    expect(initialOnBranchChange).toHaveBeenCalledTimes(1);
+    expect(initialOnBranchChange).toHaveBeenCalledWith({
+      headId: "a1",
+      visibleMessageIds: ["u", "a1"],
+    });
+    expect(swappedOnBranchChange).not.toHaveBeenCalled();
+  });
+
   it("still calls setMessages on branch switch", () => {
     const setMessages = vi.fn();
     const runtime = makeBranched({

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -619,8 +619,21 @@ describe("ExternalStoreThreadRuntimeCore - branch change callback", () => {
     expect(() => runtime.switchToBranch("a1")).not.toThrow();
   });
 
-  it("does not export canonical heads when no callback is provided", () => {
+  it("does not read canonical heads when no callback is provided", () => {
     const runtime = makeBranched();
+    const repository = (
+      runtime as unknown as { repository: { canonicalHeadId: string | null } }
+    ).repository;
+    const canonicalHeadIdSpy = vi.spyOn(repository, "canonicalHeadId", "get");
+
+    runtime.switchToBranch("a1");
+
+    expect(canonicalHeadIdSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not export snapshots when emitting branch changes", () => {
+    const onBranchChange = vi.fn();
+    const runtime = makeBranched({ unstable_onBranchChange: onBranchChange });
     const repository = (
       runtime as unknown as { repository: { export: () => unknown } }
     ).repository;
@@ -628,6 +641,7 @@ describe("ExternalStoreThreadRuntimeCore - branch change callback", () => {
 
     runtime.switchToBranch("a1");
 
+    expect(onBranchChange).toHaveBeenCalledTimes(1);
     expect(exportSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -136,6 +136,7 @@ export type {
   ExternalStoreSharedOptions,
   ExternalStoreThreadListAdapter,
   ExternalStoreThreadData,
+  ExternalStoreBranchChange,
 } from "@assistant-ui/core";
 export {
   createMessageQueue,


### PR DESCRIPTION
### summary

adds an optional `unstable_onBranchChange` callback to the external-store adapter. it gives external-store apps a hook to observe and persist the user-selected branch after an explicit runtime branch switch, so a reload can restore the same branch the user was looking at.

it fires with a single event:

```ts
export type ExternalStoreBranchChange = {
  headId: string | null;
  visibleMessageIds: readonly string[];
};
```

- `headId`: the canonical persisted head from `repository.export().headId`, never an optimistic/transient id.
- `visibleMessageIds`: the now-visible path from `repository.getMessages()`, in order. this can include an optimistic leaf even when `headId` points to a persisted ancestor.

### basic usage

```tsx
const runtime = useExternalStoreRuntime({
  ...externalStoreAdapter,
  unstable_onBranchChange: ({ headId, visibleMessageIds }) => {
    persistSelectedBranch({ headId, visibleMessageIds });
  },
});
```

this complements `setMessages` rather than replacing it. switching still requires `setMessages`, and the callback does not enable branch switching on its own.

`ExternalStoreBranchChange` is re-exported from `@assistant-ui/core` and `@assistant-ui/react`.

### how it works

the callback only fires from the explicit `switchToBranch` path (e.g. a BranchPicker click). it stays silent on adapter resync, `messageRepository` resetHead/resync, append, edit/regenerate, content-only updates, and while the thread is running, because none of those represent the user choosing a branch.

switches are deduped by comparing the canonical persisted head before vs after the switch, so a switch that lands on the same persisted head emits nothing. if a later resync moves the head away, switching back fires again as expected.

### testing

adds a patch changeset for core/react. tests cover explicit-switch emission, dedupe by persisted head, no emission on resync/resetHead/append/edit/content-only/running, firing again after a resync moved the head away, canonical persisted head vs optimistic id, no-op when no callback is provided, and that `setMessages` is still called alongside the callback.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

