### PR TITLE
feat(react-langchain): attach per-message streaming timing

### DIFF
--- a/.changeset/langchain-streaming-timing.md
+++ b/.changeset/langchain-streaming-timing.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): attach per-message streaming timing

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -766,7 +766,10 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | Subgraph discovery | Via `eventHandlers` | Yes (`useLangChainSubgraphs`) |
 | End-to-end cancellation primitive | Yes (`unstable_createLangGraphStream`) | Not exposed |
 | Message accumulator utility | Yes (`LangGraphMessageAccumulator`) | Not exposed |
+| Streaming timing (per-message) | Yes | Yes |
 | Cloud thread persistence | Yes | Yes |
+
+Per-message streaming timing is attached automatically to `message.metadata.timing` (no setup), matching `react-langgraph`. It captures time-to-first-token, total stream time, chunk count, and tokens/sec, computed from message growth while the run is in flight.
 
 `react-langchain` is the newer, thinner wrapper. It delegates to upstream `useStream` rather than re-implementing the stream plumbing, which is why its footprint is smaller. Features absent today have not been ported, not deprecated.
 

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -1,7 +1,11 @@
 "use client";
 
 import type { useExternalMessageConverter } from "@assistant-ui/core/react";
-import type { AppendMessage, DataMessagePart } from "@assistant-ui/core";
+import type {
+  AppendMessage,
+  DataMessagePart,
+  MessageTiming,
+} from "@assistant-ui/core";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
 import type {
   LangChainBaseMessage,
@@ -12,6 +16,7 @@ import type {
 type LangChainMessageConverterMetadata =
   useExternalMessageConverter.Metadata & {
     uiMessagesByParent?: Map<string, UIMessage[]>;
+    messageTiming?: Record<string, MessageTiming>;
   };
 
 const uiMessageToDataPart = (ui: UIMessage): DataMessagePart => ({
@@ -135,6 +140,8 @@ export const convertLangChainBaseMessage = (
               ?.map(uiMessageToDataPart)
           : undefined) ?? [];
 
+      const timing = metadata.messageTiming?.[message.id ?? ""];
+
       return {
         role: "assistant",
         id: message.id,
@@ -145,6 +152,7 @@ export const convertLangChainBaseMessage = (
         ],
         metadata: {
           custom: getCustomMetadata(message.additional_kwargs),
+          ...(timing && { timing }),
         },
         ...(assistantStatus && { status: assistantStatus }),
       };

--- a/packages/react-langchain/src/streamingTiming.test.ts
+++ b/packages/react-langchain/src/streamingTiming.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { LangChainBaseMessage } from "./types";
+import { useStreamingTiming } from "./streamingTiming";
+
+const ai = (
+  fields: Partial<LangChainBaseMessage> & { id: string; content: unknown },
+): LangChainBaseMessage => ({
+  _getType: () => "ai",
+  ...fields,
+});
+
+describe("useStreamingTiming", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns empty object when not running", () => {
+    const messages: LangChainBaseMessage[] = [];
+    const { result } = renderHook(() => useStreamingTiming(messages, false));
+    expect(result.current).toEqual({});
+  });
+
+  it("tracks timing when streaming starts and ends", () => {
+    const messages = [
+      ai({ id: "msg-1", content: [{ type: "text", text: "Hello" }] }),
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ msgs, running }) => useStreamingTiming(msgs, running),
+      { initialProps: { msgs: messages, running: true } },
+    );
+
+    vi.advanceTimersByTime(100);
+
+    const updatedMessages = [
+      ai({
+        id: "msg-1",
+        content: [{ type: "text", text: "Hello world! More text here." }],
+      }),
+    ];
+
+    act(() => {
+      rerender({ msgs: updatedMessages, running: true });
+    });
+    vi.advanceTimersByTime(200);
+
+    act(() => {
+      rerender({ msgs: updatedMessages, running: false });
+    });
+
+    const timing = result.current["msg-1"];
+    expect(timing).toBeDefined();
+    expect(timing!.totalStreamTime).toBeGreaterThanOrEqual(300);
+    expect(timing!.totalChunks).toBe(2);
+    expect(timing!.toolCallCount).toBe(0);
+  });
+
+  it("tracks first token time on content growth", () => {
+    const initial = [ai({ id: "msg-1", content: "" })];
+
+    const { result, rerender } = renderHook(
+      ({ msgs, running }) => useStreamingTiming(msgs, running),
+      { initialProps: { msgs: initial, running: true } },
+    );
+
+    vi.advanceTimersByTime(50);
+
+    const withContent = [ai({ id: "msg-1", content: "First token!" })];
+
+    act(() => {
+      rerender({ msgs: withContent, running: true });
+    });
+
+    vi.advanceTimersByTime(100);
+
+    act(() => {
+      rerender({ msgs: withContent, running: false });
+    });
+
+    const timing = result.current["msg-1"];
+    expect(timing).toBeDefined();
+    expect(timing!.firstTokenTime).toBe(50);
+  });
+
+  it("sums text and thinking lengths in array content", () => {
+    const initial = [ai({ id: "msg-1", content: [] })];
+
+    const { result, rerender } = renderHook(
+      ({ msgs, running }) => useStreamingTiming(msgs, running),
+      { initialProps: { msgs: initial, running: true } },
+    );
+
+    vi.advanceTimersByTime(10);
+
+    const grown = [
+      ai({
+        id: "msg-1",
+        content: [
+          { type: "thinking", thinking: "hmm" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    act(() => {
+      rerender({ msgs: grown, running: true });
+    });
+    act(() => {
+      rerender({ msgs: grown, running: false });
+    });
+
+    const timing = result.current["msg-1"];
+    expect(timing).toBeDefined();
+    expect(timing!.tokenCount).toBe(Math.ceil("hmmanswer".length / 4));
+  });
+
+  it("tracks tool calls", () => {
+    const messages = [
+      ai({
+        id: "msg-1",
+        content: "",
+        tool_calls: [
+          { id: "tool-1", name: "search", args: {} },
+          { id: "tool-2", name: "fetch", args: {} },
+        ],
+      }),
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ msgs, running }) => useStreamingTiming(msgs, running),
+      { initialProps: { msgs: messages, running: true } },
+    );
+
+    act(() => {
+      rerender({ msgs: messages, running: false });
+    });
+
+    expect(result.current["msg-1"]?.toolCallCount).toBe(2);
+  });
+
+  it("tracks multiple content updates as chunks", () => {
+    const { result, rerender } = renderHook(
+      ({ msgs, running }) => useStreamingTiming(msgs, running),
+      {
+        initialProps: {
+          msgs: [ai({ id: "msg-1", content: "a" })],
+          running: true,
+        },
+      },
+    );
+
+    act(() => {
+      rerender({ msgs: [ai({ id: "msg-1", content: "ab" })], running: true });
+    });
+    act(() => {
+      rerender({ msgs: [ai({ id: "msg-1", content: "abc" })], running: true });
+    });
+    act(() => {
+      rerender({ msgs: [ai({ id: "msg-1", content: "abc" })], running: false });
+    });
+
+    expect(result.current["msg-1"]?.totalChunks).toBe(3);
+  });
+
+  it("does not finalize timing while still running", () => {
+    const messages = [ai({ id: "msg-1", content: "test" })];
+
+    const { result } = renderHook(() => useStreamingTiming(messages, true));
+
+    vi.advanceTimersByTime(500);
+
+    expect(result.current).toEqual({});
+  });
+});

--- a/packages/react-langchain/src/streamingTiming.ts
+++ b/packages/react-langchain/src/streamingTiming.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { MessageTiming } from "@assistant-ui/core";
+import type { LangChainBaseMessage, LangChainContentBlock } from "./types";
+import { getMessageType } from "./convertMessages";
+
+type TrackingState = {
+  messageId: string;
+  startTime: number;
+  firstTokenTime?: number;
+  lastContentLength: number;
+  totalChunks: number;
+};
+
+const findAiMessage = (
+  messages: readonly LangChainBaseMessage[],
+  messageId: string,
+): LangChainBaseMessage | undefined =>
+  messages.find((m) => getMessageType(m) === "ai" && m.id === messageId);
+
+const getMessageTextLength = (
+  messages: readonly LangChainBaseMessage[],
+  messageId: string,
+): number => {
+  const m = findAiMessage(messages, messageId);
+  if (!m) return 0;
+  const content = m.content;
+  if (typeof content === "string") return content.length;
+  if (!Array.isArray(content)) return 0;
+  let len = 0;
+  for (const part of content as readonly LangChainContentBlock[]) {
+    if ("text" in part && typeof part.text === "string")
+      len += part.text.length;
+    if ("thinking" in part && typeof part.thinking === "string")
+      len += part.thinking.length;
+  }
+  return len;
+};
+
+const getMessageToolCallCount = (
+  messages: readonly LangChainBaseMessage[],
+  messageId: string,
+): number => findAiMessage(messages, messageId)?.tool_calls?.length ?? 0;
+
+const getLastAssistantId = (
+  messages: readonly LangChainBaseMessage[],
+): string | undefined => {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m && getMessageType(m) === "ai" && m.id) return m.id;
+  }
+  return undefined;
+};
+
+export const useStreamingTiming = (
+  messages: readonly LangChainBaseMessage[],
+  isRunning: boolean,
+): Record<string, MessageTiming> => {
+  const [timings, setTimings] = useState<Record<string, MessageTiming>>({});
+  const trackRef = useRef<TrackingState | null>(null);
+
+  useEffect(() => {
+    const lastId = getLastAssistantId(messages);
+
+    if (isRunning && lastId) {
+      if (!trackRef.current || trackRef.current.messageId !== lastId) {
+        trackRef.current = {
+          messageId: lastId,
+          startTime: Date.now(),
+          lastContentLength: 0,
+          totalChunks: 0,
+        };
+      }
+
+      const t = trackRef.current;
+      const len = getMessageTextLength(messages, t.messageId);
+      if (len > t.lastContentLength) {
+        if (t.firstTokenTime === undefined) {
+          t.firstTokenTime = Date.now() - t.startTime;
+        }
+        t.totalChunks++;
+        t.lastContentLength = len;
+      }
+    } else if (!isRunning && trackRef.current) {
+      const t = trackRef.current;
+      const totalStreamTime = Date.now() - t.startTime;
+      const tokenCount = Math.ceil(t.lastContentLength / 4);
+      const toolCallCount = getMessageToolCallCount(messages, t.messageId);
+
+      const timing: MessageTiming = {
+        streamStartTime: t.startTime,
+        totalStreamTime,
+        totalChunks: t.totalChunks,
+        toolCallCount,
+        ...(t.firstTokenTime !== undefined && {
+          firstTokenTime: t.firstTokenTime,
+        }),
+        ...(tokenCount > 0 && { tokenCount }),
+        ...(totalStreamTime > 0 &&
+          tokenCount > 0 && {
+            tokensPerSecond: tokenCount / (totalStreamTime / 1000),
+          }),
+      };
+      setTimings((prev) => ({ ...prev, [t.messageId]: timing }));
+      trackRef.current = null;
+    }
+  }, [messages, isRunning]);
+
+  return timings;
+};

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -27,6 +27,7 @@ import {
 import { foldUIUpdates, mergeUIMessages } from "./uiMessages";
 import { langChainExtras } from "./runtimeExtras";
 import { resolveForkCheckpoint } from "./resolveForkCheckpoint";
+import { useStreamingTiming } from "./streamingTiming";
 
 const UI_CUSTOM_CHANNELS: readonly Channel[] = ["custom"];
 
@@ -122,13 +123,22 @@ const useStreamThreadRuntime = (
     [liveUiMessages, uiStateValue],
   );
 
+  const messageTiming = useStreamingTiming(
+    stream.messages as LangChainBaseMessage[],
+    effectiveIsRunning,
+  );
+
   const convertWithUI = useMemo<
     useExternalMessageConverter.Callback<LangChainBaseMessage>
   >(() => {
     const uiMessagesByParent = groupUIMessagesByParent(mergedUiMessages);
     return (message, metadata) =>
-      convertLangChainBaseMessage(message, { ...metadata, uiMessagesByParent });
-  }, [mergedUiMessages]);
+      convertLangChainBaseMessage(message, {
+        ...metadata,
+        uiMessagesByParent,
+        messageTiming,
+      });
+  }, [mergedUiMessages, messageTiming]);
 
   const threadMessages = useExternalMessageConverter({
     callback: convertWithUI,


### PR DESCRIPTION
### Summary

This PR Attaches per-message streaming timing to assistant messages in react-langchain, matching react-langgraph. Timing lands on `message.metadata.timing` (the standard core `MessageTiming` field the UI can render): time-to-first-token, total stream time, chunk count, estimated token count, and tokens/sec.


### How
New internal `streamingTiming.ts` (`useStreamingTiming`) ports react-langgraph's `useLangGraphStreamingTiming`, adapted to the `LangChainBaseMessage` shape (`getMessageType(m) === "ai"`, duck-typed `content`, `tool_calls`, `id`). `convertMessages.ts` gains an optional `messageTiming` on the converter metadata and injects `...(timing && { timing })` into the assistant message metadata. `useStreamRuntime.ts` calls the tracker and threads `messageTiming` through the existing `convertWithUI` closure.
### Tests
Verified: `pnpm --filter @assistant-ui/react-langchain test` (97 passed), `pnpm lint`, `pnpm turbo run build` (86/86).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

