### PR TITLE
feat(react): add unstable headless composer input bridge

### DIFF
--- a/.changeset/headless-composer-input.md
+++ b/.changeset/headless-composer-input.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+add unstable_useComposerInput headless bridge (value/setText/send/isDisabled/canSend) and unstable_useTriggerPopoverAriaProps for building a custom composer input without ComposerPrimitive.Input

--- a/apps/docs/content/docs/guides/headless-composer-input.mdx
+++ b/apps/docs/content/docs/guides/headless-composer-input.mdx
@@ -1,0 +1,113 @@
+---
+title: Headless Composer Input
+description: Build a custom composer input while keeping assistant-ui composer state and send gating.
+platforms: ["react"]
+---
+
+`ComposerPrimitive.Input` is still the recommended composer input for most apps. It owns autosize, keyboard shortcuts, IME handling, paste-to-attachment, focus behavior, and trigger-popover keyboard integration.
+
+Use `unstable_useComposerInput` when you already own the input surface, such as a custom editor, a `contentEditable` surface, or a textarea wrapper whose behavior cannot be expressed through `ComposerPrimitive.Input`'s props, `asChild`, or `render` APIs.
+
+<Callout type="warn">
+  This API is marked unstable and may change without notice. It is a thin bridge
+  to composer text and send state, not a replacement implementation of
+  `ComposerPrimitive.Input`.
+</Callout>
+
+## Usage
+
+Render the custom input inside a composer and mirror text changes into the assistant-ui composer state:
+
+```tsx
+"use client";
+
+import {
+  ComposerPrimitive,
+  unstable_useComposerInput,
+  unstable_useTriggerPopoverAriaProps,
+} from "@assistant-ui/react";
+
+function HeadlessComposer() {
+  const composer = unstable_useComposerInput();
+  const popoverAria = unstable_useTriggerPopoverAriaProps();
+
+  return (
+    <ComposerPrimitive.Root>
+      <textarea
+        aria-label="Message"
+        value={composer.value}
+        disabled={composer.isDisabled}
+        onChange={(event) => {
+          composer.setText(event.currentTarget.value);
+        }}
+        onKeyDown={(event) => {
+          if (event.nativeEvent.isComposing) return;
+
+          if (event.key === "Enter" && !event.shiftKey) {
+            event.preventDefault();
+
+            if (composer.canSend) {
+              composer.send();
+            }
+          }
+        }}
+        {...popoverAria}
+      />
+      <ComposerPrimitive.Send />
+    </ComposerPrimitive.Root>
+  );
+}
+```
+
+`composer.send()` exposes the same send action used by `ComposerPrimitive.Send`, including send options such as `composer.send({ steer: true })`. Check `composer.canSend` before calling it from custom keyboard handlers.
+
+## Hook Result
+
+| Field | Description |
+| --- | --- |
+| `value` | Current composer text. Returns `""` when the composer is not editing. |
+| `setText(text)` | Writes text into the composer while it is editing. |
+| `send(options?)` | Sends the current composer message. Consumers should check `canSend` first. |
+| `isDisabled` | Combines the hook's `disabled` option with assistant-ui disabled sources, such as thread disabled state and active dictation input lock. |
+| `canSend` | Matches `ComposerPrimitive.Send` gating, then also respects `isDisabled`. |
+
+Pass `disabled` when your editor has an additional read-only state:
+
+```tsx
+const composer = unstable_useComposerInput({
+  disabled: editorReadOnly,
+});
+```
+
+## What You Still Own
+
+The hook does not recreate the behavior of `ComposerPrimitive.Input`. Your input or editor remains responsible for:
+
+- Enter/newline shortcuts, steer shortcuts, escape/cancel behavior, and any other keyboard behavior.
+- IME and composition handling.
+- Cursor and selection tracking.
+- Autosize and focus management.
+- Paste/drop attachment behavior.
+- Rich text state, serialization, and DOM synchronization for `contentEditable` or editor-library integrations.
+
+For styled textareas, prefer `ComposerPrimitive.Input`. Reach for the headless hook when the editor has its own model or DOM lifecycle and assistant-ui should only supply composer state and send gating.
+
+## Trigger Popovers
+
+`unstable_useTriggerPopoverAriaProps` returns the combobox ARIA attributes for the currently open trigger popover:
+
+```tsx
+const popoverAria = unstable_useTriggerPopoverAriaProps();
+
+<textarea {...popoverAria} />;
+```
+
+Spread these props last so they can mirror `ComposerPrimitive.Input` when a popover is open.
+
+This helper only describes the open popover to assistive technology. It does not wire a custom editor into mention or slash-command keyboard handling, cursor tracking, or item insertion. For the full built-in trigger-popover experience, use `ComposerPrimitive.Input`; for richer editors, integrate the trigger UI with the editor's own selection and keyboard model.
+
+## Related
+
+- [Composer primitives](/docs/primitives/composer)
+- [Composer Trigger Popover](/docs/ui/composer-trigger-popover)
+- [Input History](/docs/guides/input-history)

--- a/apps/docs/content/docs/guides/headless-composer-input.mdx
+++ b/apps/docs/content/docs/guides/headless-composer-input.mdx
@@ -59,7 +59,7 @@ function HeadlessComposer() {
 }
 ```
 
-`composer.send()` exposes the same send action used by `ComposerPrimitive.Send`, including send options such as `composer.send({ steer: true })`. Check `composer.canSend` before calling it from custom keyboard handlers.
+`composer.send()` exposes the same send action used by `ComposerPrimitive.Send`, including send options such as `composer.send({ steer: true })`. It is a no-op unless `composer.canSend` is `true`; check `canSend` in custom keyboard handlers to keep your event handling explicit.
 
 ## Hook Result
 
@@ -67,7 +67,7 @@ function HeadlessComposer() {
 | --- | --- |
 | `value` | Current composer text. Returns `""` when the composer is not editing. |
 | `setText(text)` | Writes text into the composer while it is editing. |
-| `send(options?)` | Sends the current composer message. Consumers should check `canSend` first. |
+| `send(options?)` | Sends the current composer message when `canSend` is `true`; otherwise a no-op. |
 | `isDisabled` | Combines the hook's `disabled` option with assistant-ui disabled sources, such as thread disabled state and active dictation input lock. |
 | `canSend` | Matches `ComposerPrimitive.Send` gating, then also respects `isDisabled`. |
 

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -11,6 +11,7 @@
     "mentions",
     "slash-commands",
     "input-history",
+    "headless-composer-input",
     "quoting",
     "dictation",
     "---Messages---",

--- a/apps/docs/content/docs/primitives/composer.mdx
+++ b/apps/docs/content/docs/primitives/composer.mdx
@@ -103,6 +103,14 @@ import { ComposerPrimitive } from "@assistant-ui/react";
 
 The primitive's behavior (keyboard handling, disabled state, form submission) is merged onto your element. Your styles, your component, primitive wiring.
 
+<Callout type="info">
+Own the input DOM entirely, such as a `contentEditable` surface or editor
+library that cannot be expressed through `asChild` or `render`? See
+[Headless Composer Input](/docs/guides/headless-composer-input) for the
+unstable hook that supplies composer text and send gating without
+`ComposerPrimitive.Input`.
+</Callout>
+
 ### Unstable Trigger Popovers
 
 Composer includes an unstable **trigger popover** system for character-triggered popovers (e.g. `@` for mentions, `/` for slash commands). Multiple triggers coexist under a single `TriggerPopoverRoot`.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -447,6 +447,15 @@ export {
   type Unstable_ComposerInputHistory,
 } from "./unstable/useComposerInputHistory";
 
+// Unstable - headless composer input bridge (value/send without ComposerPrimitive.Input)
+export {
+  unstable_useComposerInput,
+  unstable_useTriggerPopoverAriaProps,
+  type Unstable_UseComposerInputOptions,
+  type Unstable_ComposerInput,
+  type Unstable_TriggerPopoverAriaProps,
+} from "./unstable/useComposerInput";
+
 export type { Assistant } from "./augmentations";
 
 // --- mcp-apps ---

--- a/packages/react/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react/src/primitives/composer/ComposerInput.tsx
@@ -21,10 +21,14 @@ import TextareaAutosize, {
 import { useEscapeKeydown } from "@radix-ui/react-use-escape-keydown";
 import { useOnScrollToBottom } from "../../utils/hooks/useOnScrollToBottom";
 import { useMediaQuery } from "../../utils/hooks/useMediaQuery";
-import { useAuiState, useAui } from "@assistant-ui/store";
+import { useAui } from "@assistant-ui/store";
 import { flushTapSync } from "@assistant-ui/tap";
 import { useComposerInputPluginRegistryOptional } from "./ComposerInputPluginContext";
-import { useTriggerPopoverActiveAriaOptional } from "./trigger/TriggerPopoverRootContext";
+import {
+  useComposerInputDisabled,
+  useComposerInputValue,
+  useTriggerPopoverAriaProps,
+} from "./useComposerInputState";
 
 const TOUCH_PRIMARY_QUERY = "(pointer: coarse) and (not (any-pointer: fine))";
 
@@ -167,7 +171,6 @@ export const ComposerPrimitiveInput = forwardRef<
   ) => {
     const aui = useAui();
     const pluginRegistry = useComposerInputPluginRegistryOptional();
-    const activeAria = useTriggerPopoverActiveAriaOptional();
 
     const declaredSubmitMode =
       submitMode ?? (submitOnEnter === false ? "none" : "enter");
@@ -181,15 +184,8 @@ export const ComposerPrimitiveInput = forwardRef<
         ? "none"
         : declaredSubmitMode;
 
-    const value = useAuiState((s) => {
-      if (!s.composer.isEditing) return "";
-      return s.composer.text;
-    });
-
-    const isDisabled =
-      useAuiState(
-        (s) => s.thread.isDisabled || s.composer.dictation?.inputDisabled,
-      ) || disabledProp;
+    const value = useComposerInputValue();
+    const isDisabled = useComposerInputDisabled(disabledProp);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const ref = useComposedRefs(forwardedRef, textareaRef);
     // suppress text/cursor broadcasts during IME composition
@@ -322,14 +318,7 @@ export const ComposerPrimitiveInput = forwardRef<
       return aui.on("threadListItem.switchedTo", focus);
     }, [unstable_focusOnThreadSwitched, focus, aui]);
 
-    const ariaComboboxProps = activeAria
-      ? {
-          "aria-controls": activeAria.popoverId,
-          "aria-expanded": true as const,
-          "aria-haspopup": "listbox" as const,
-          "aria-activedescendant": activeAria.highlightedItemId,
-        }
-      : {};
+    const ariaComboboxProps = useTriggerPopoverAriaProps();
 
     const inputProps = {
       name: "input" as const,

--- a/packages/react/src/primitives/composer/useComposerInputState.ts
+++ b/packages/react/src/primitives/composer/useComposerInputState.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useAuiState } from "@assistant-ui/store";
+import { useTriggerPopoverActiveAriaOptional } from "./trigger/TriggerPopoverRootContext";
+
+export type TriggerPopoverAriaProps = {
+  "aria-controls"?: string;
+  "aria-expanded"?: true;
+  "aria-haspopup"?: "listbox";
+  "aria-activedescendant"?: string | undefined;
+};
+
+export function useComposerInputValue() {
+  return useAuiState((s) => (s.composer.isEditing ? s.composer.text : ""));
+}
+
+export function useComposerInputDisabled(disabled?: boolean | undefined) {
+  const composerDisabled = useAuiState(
+    (s) => s.thread.isDisabled || s.composer.dictation?.inputDisabled,
+  );
+  return Boolean(composerDisabled) || Boolean(disabled);
+}
+
+export function useTriggerPopoverAriaProps(): TriggerPopoverAriaProps {
+  const activeAria = useTriggerPopoverActiveAriaOptional();
+  if (!activeAria) return {};
+
+  return {
+    "aria-controls": activeAria.popoverId,
+    "aria-expanded": true,
+    "aria-haspopup": "listbox",
+    "aria-activedescendant": activeAria.highlightedItemId,
+  };
+}

--- a/packages/react/src/unstable/useComposerInput.test.tsx
+++ b/packages/react/src/unstable/useComposerInput.test.tsx
@@ -1,0 +1,168 @@
+/** @vitest-environment jsdom */
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type ComposerState = { isEditing: boolean; text: string };
+
+const fixture = {
+  composer: { isEditing: true, text: "hello" } as ComposerState,
+  threadDisabled: false,
+  dictationInputDisabled: undefined as boolean | undefined,
+  sendDisabled: false,
+  activeAria: null as { popoverId: string; highlightedItemId?: string } | null,
+};
+
+const composerSetText = vi.fn();
+const composerSend = vi.fn();
+const flushTapSync = vi.fn((fn: () => void) => fn());
+
+vi.mock("@assistant-ui/store", () => ({
+  useAui: () => ({
+    composer: () => ({
+      getState: () => ({ isEditing: fixture.composer.isEditing }),
+      setText: composerSetText,
+      send: composerSend,
+    }),
+  }),
+  useAuiState: (selector: (s: unknown) => unknown) =>
+    selector({
+      composer: {
+        isEditing: fixture.composer.isEditing,
+        text: fixture.composer.text,
+        dictation: fixture.dictationInputDisabled
+          ? { inputDisabled: fixture.dictationInputDisabled }
+          : undefined,
+      },
+      thread: { isDisabled: fixture.threadDisabled },
+    }),
+}));
+vi.mock("@assistant-ui/tap", () => ({
+  flushTapSync: (fn: () => void) => flushTapSync(fn),
+}));
+vi.mock("@assistant-ui/core/react", () => ({
+  useComposerSend: () => ({
+    send: composerSend,
+    disabled: fixture.sendDisabled,
+  }),
+}));
+vi.mock("../primitives/composer/trigger/TriggerPopoverRootContext", () => ({
+  useTriggerPopoverActiveAriaOptional: () => fixture.activeAria,
+}));
+
+import {
+  unstable_useComposerInput,
+  unstable_useTriggerPopoverAriaProps,
+  type Unstable_ComposerInput,
+  type Unstable_TriggerPopoverAriaProps,
+} from "./useComposerInput";
+
+const renderInput = (options?: { disabled?: boolean }) => {
+  let result!: Unstable_ComposerInput;
+  function Harness() {
+    result = unstable_useComposerInput(options);
+    return null;
+  }
+  render(<Harness />);
+  return () => result;
+};
+
+const renderAria = () => {
+  let result!: Unstable_TriggerPopoverAriaProps;
+  function Harness() {
+    result = unstable_useTriggerPopoverAriaProps();
+    return null;
+  }
+  render(<Harness />);
+  return () => result;
+};
+
+beforeEach(() => {
+  fixture.composer = { isEditing: true, text: "hello" };
+  fixture.threadDisabled = false;
+  fixture.dictationInputDisabled = undefined;
+  fixture.sendDisabled = false;
+  fixture.activeAria = null;
+  composerSetText.mockClear();
+  composerSend.mockClear();
+  flushTapSync.mockClear();
+});
+
+describe("unstable_useComposerInput", () => {
+  it("exposes the composer text while editing", () => {
+    expect(renderInput()().value).toBe("hello");
+  });
+
+  it("reports an empty value when the composer is not editing", () => {
+    fixture.composer = { isEditing: false, text: "stale" };
+    expect(renderInput()().value).toBe("");
+  });
+
+  it("writes text via flushTapSync when editing", () => {
+    renderInput()().setText("world");
+    expect(flushTapSync).toHaveBeenCalledTimes(1);
+    expect(composerSetText).toHaveBeenCalledWith("world");
+  });
+
+  it("ignores setText when the composer is not editing (editing guard)", () => {
+    fixture.composer = { isEditing: false, text: "" };
+    renderInput()().setText("world");
+    expect(composerSetText).not.toHaveBeenCalled();
+  });
+
+  it("combines the disabled option with composer disabled sources", () => {
+    expect(renderInput()().isDisabled).toBe(false);
+    expect(renderInput({ disabled: true })().isDisabled).toBe(true);
+
+    fixture.threadDisabled = true;
+    expect(renderInput()().isDisabled).toBe(true);
+
+    fixture.threadDisabled = false;
+    fixture.dictationInputDisabled = true;
+    expect(renderInput()().isDisabled).toBe(true);
+  });
+
+  it("derives canSend from send gating and disabled state", () => {
+    expect(renderInput()().canSend).toBe(true);
+
+    fixture.sendDisabled = true;
+    expect(renderInput()().canSend).toBe(false);
+
+    fixture.sendDisabled = false;
+    expect(renderInput({ disabled: true })().canSend).toBe(false);
+
+    fixture.threadDisabled = true;
+    expect(renderInput()().canSend).toBe(false);
+
+    fixture.threadDisabled = false;
+    fixture.dictationInputDisabled = true;
+    expect(renderInput()().canSend).toBe(false);
+  });
+
+  it("forwards send options to the composer action", () => {
+    renderInput()().send({ steer: true });
+    expect(composerSend).toHaveBeenCalledWith({ steer: true });
+  });
+});
+
+describe("unstable_useTriggerPopoverAriaProps", () => {
+  it("is empty when no popover is active", () => {
+    expect(renderAria()()).toEqual({});
+  });
+
+  it("describes the active popover combobox relationship", () => {
+    fixture.activeAria = { popoverId: "pop-1", highlightedItemId: "item-2" };
+    expect(renderAria()()).toEqual({
+      "aria-controls": "pop-1",
+      "aria-expanded": true,
+      "aria-haspopup": "listbox",
+      "aria-activedescendant": "item-2",
+    });
+  });
+
+  it("emits an undefined aria-activedescendant when nothing is highlighted", () => {
+    fixture.activeAria = { popoverId: "pop-1" };
+    const props = renderAria()();
+    expect(props).toHaveProperty("aria-activedescendant", undefined);
+    expect(props["aria-controls"]).toBe("pop-1");
+  });
+});

--- a/packages/react/src/unstable/useComposerInput.test.tsx
+++ b/packages/react/src/unstable/useComposerInput.test.tsx
@@ -142,6 +142,25 @@ describe("unstable_useComposerInput", () => {
     renderInput()().send({ steer: true });
     expect(composerSend).toHaveBeenCalledWith({ steer: true });
   });
+
+  it("does not send while send is unavailable or the input is disabled", () => {
+    fixture.sendDisabled = true;
+    renderInput()().send();
+    expect(composerSend).not.toHaveBeenCalled();
+
+    fixture.sendDisabled = false;
+    renderInput({ disabled: true })().send();
+    expect(composerSend).not.toHaveBeenCalled();
+
+    fixture.threadDisabled = true;
+    renderInput()().send();
+    expect(composerSend).not.toHaveBeenCalled();
+
+    fixture.threadDisabled = false;
+    fixture.dictationInputDisabled = true;
+    renderInput()().send();
+    expect(composerSend).not.toHaveBeenCalled();
+  });
 });
 
 describe("unstable_useTriggerPopoverAriaProps", () => {

--- a/packages/react/src/unstable/useComposerInput.ts
+++ b/packages/react/src/unstable/useComposerInput.ts
@@ -26,8 +26,8 @@ export type Unstable_ComposerInput = {
    */
   setText(text: string): void;
   /**
-   * Sends the current message. Exposes the raw composer action; gating is
-   * reported via `canSend` (consumers should check it before calling).
+   * Sends the current message when `canSend` is `true`; otherwise a no-op.
+   * Accepts the same options as the composer send action.
    */
   send(options?: ComposerSendOptions): void;
   /**
@@ -94,8 +94,15 @@ export function unstable_useComposerInput(
     [aui],
   );
 
-  const { send, disabled: sendDisabled } = useComposerSend();
+  const { send: rawSend, disabled: sendDisabled } = useComposerSend();
   const canSend = !sendDisabled && !isDisabled;
+  const send = useCallback(
+    (options?: ComposerSendOptions) => {
+      if (!canSend) return;
+      rawSend(options);
+    },
+    [canSend, rawSend],
+  );
 
   return { value, setText, send, isDisabled, canSend };
 }

--- a/packages/react/src/unstable/useComposerInput.ts
+++ b/packages/react/src/unstable/useComposerInput.ts
@@ -97,9 +97,9 @@ export function unstable_useComposerInput(
   const { send: rawSend, disabled: sendDisabled } = useComposerSend();
   const canSend = !sendDisabled && !isDisabled;
   const send = useCallback(
-    (options?: ComposerSendOptions) => {
+    (sendOptions?: ComposerSendOptions) => {
       if (!canSend) return;
-      rawSend(options);
+      rawSend(sendOptions);
     },
     [canSend, rawSend],
   );

--- a/packages/react/src/unstable/useComposerInput.ts
+++ b/packages/react/src/unstable/useComposerInput.ts
@@ -1,11 +1,16 @@
 "use client";
 
 import { useCallback } from "react";
-import { useAui, useAuiState } from "@assistant-ui/store";
+import { useAui } from "@assistant-ui/store";
 import { flushTapSync } from "@assistant-ui/tap";
 import { useComposerSend } from "@assistant-ui/core/react";
 import type { ComposerSendOptions } from "@assistant-ui/core/store";
-import { useTriggerPopoverActiveAriaOptional } from "../primitives/composer/trigger/TriggerPopoverRootContext";
+import {
+  type TriggerPopoverAriaProps,
+  useComposerInputDisabled,
+  useComposerInputValue,
+  useTriggerPopoverAriaProps,
+} from "../primitives/composer/useComposerInputState";
 
 export type Unstable_UseComposerInputOptions = {
   /**
@@ -73,16 +78,8 @@ export function unstable_useComposerInput(
   options?: Unstable_UseComposerInputOptions,
 ): Unstable_ComposerInput {
   const aui = useAui();
-  const optionDisabled = options?.disabled ?? false;
-
-  const value = useAuiState((s) =>
-    s.composer.isEditing ? s.composer.text : "",
-  );
-
-  const composerDisabled = useAuiState(
-    (s) => s.thread.isDisabled || s.composer.dictation?.inputDisabled,
-  );
-  const isDisabled = Boolean(composerDisabled) || optionDisabled;
+  const value = useComposerInputValue();
+  const isDisabled = useComposerInputDisabled(options?.disabled);
 
   const setText = useCallback(
     (text: string) => {
@@ -107,12 +104,7 @@ export function unstable_useComposerInput(
   return { value, setText, send, isDisabled, canSend };
 }
 
-export type Unstable_TriggerPopoverAriaProps = {
-  "aria-controls"?: string;
-  "aria-expanded"?: true;
-  "aria-haspopup"?: "listbox";
-  "aria-activedescendant"?: string | undefined;
-};
+export type Unstable_TriggerPopoverAriaProps = TriggerPopoverAriaProps;
 
 /**
  * @deprecated Under active development and might change without notice.
@@ -130,14 +122,5 @@ export type Unstable_TriggerPopoverAriaProps = {
  * ```
  */
 export function unstable_useTriggerPopoverAriaProps(): Unstable_TriggerPopoverAriaProps {
-  const activeAria = useTriggerPopoverActiveAriaOptional();
-  if (!activeAria) return {};
-  // Mirror ComposerPrimitive.Input: emit `aria-activedescendant` even when
-  // there is no highlighted item so spreading these last clears a stale value.
-  return {
-    "aria-controls": activeAria.popoverId,
-    "aria-expanded": true,
-    "aria-haspopup": "listbox",
-    "aria-activedescendant": activeAria.highlightedItemId,
-  };
+  return useTriggerPopoverAriaProps();
 }

--- a/packages/react/src/unstable/useComposerInput.ts
+++ b/packages/react/src/unstable/useComposerInput.ts
@@ -1,0 +1,136 @@
+"use client";
+
+import { useCallback } from "react";
+import { useAui, useAuiState } from "@assistant-ui/store";
+import { flushTapSync } from "@assistant-ui/tap";
+import { useComposerSend } from "@assistant-ui/core/react";
+import type { ComposerSendOptions } from "@assistant-ui/core/store";
+import { useTriggerPopoverActiveAriaOptional } from "../primitives/composer/trigger/TriggerPopoverRootContext";
+
+export type Unstable_UseComposerInputOptions = {
+  /**
+   * Disables the input in addition to the composer's own disabled sources
+   * (thread disabled, active dictation). When disabled, `isDisabled` is `true`
+   * and `canSend` is `false`.
+   */
+  disabled?: boolean | undefined;
+};
+
+export type Unstable_ComposerInput = {
+  /** Current composer text, or `""` when the composer is not editing. */
+  value: string;
+  /**
+   * Writes `text` into the composer, mirroring `ComposerPrimitive.Input`:
+   * a no-op unless the composer is editing, committed via `flushTapSync` so the
+   * controlled value stays in sync within the same tick.
+   */
+  setText(text: string): void;
+  /**
+   * Sends the current message. Exposes the raw composer action; gating is
+   * reported via `canSend` (consumers should check it before calling).
+   */
+  send(options?: ComposerSendOptions): void;
+  /**
+   * Whether the input is disabled, combining the `disabled` option with the
+   * composer's own disabled sources (thread disabled, active dictation).
+   */
+  isDisabled: boolean;
+  /**
+   * Whether a send is currently available. Matches `ComposerPrimitive.Send`
+   * gating (non-empty editing composer, not running without queue support) and
+   * is additionally `false` while `isDisabled`.
+   */
+  canSend: boolean;
+};
+
+/**
+ * @deprecated Under active development and might change without notice.
+ *
+ * Headless bridge to the composer's text value and send action, for building a
+ * custom composer input without `ComposerPrimitive.Input`. It is a thin bridge,
+ * not a second input: it does not own keyboard behavior, autosize, IME or
+ * contentEditable sync, paste/drop attachments, focus management, or rich-text
+ * state. Spread `unstable_useTriggerPopoverAriaProps()` onto your element for
+ * trigger-popover combobox semantics.
+ *
+ * @example
+ * ```tsx
+ * const { value, setText, send, isDisabled, canSend } = unstable_useComposerInput();
+ * <textarea
+ *   value={value}
+ *   disabled={isDisabled}
+ *   onChange={(e) => setText(e.target.value)}
+ *   onKeyDown={(e) => {
+ *     if (e.key === "Enter" && !e.shiftKey && canSend) {
+ *       e.preventDefault();
+ *       send();
+ *     }
+ *   }}
+ * />
+ * ```
+ */
+export function unstable_useComposerInput(
+  options?: Unstable_UseComposerInputOptions,
+): Unstable_ComposerInput {
+  const aui = useAui();
+  const optionDisabled = options?.disabled ?? false;
+
+  const value = useAuiState((s) =>
+    s.composer.isEditing ? s.composer.text : "",
+  );
+
+  const composerDisabled = useAuiState(
+    (s) => s.thread.isDisabled || s.composer.dictation?.inputDisabled,
+  );
+  const isDisabled = Boolean(composerDisabled) || optionDisabled;
+
+  const setText = useCallback(
+    (text: string) => {
+      if (!aui.composer().getState().isEditing) return;
+      flushTapSync(() => {
+        aui.composer().setText(text);
+      });
+    },
+    [aui],
+  );
+
+  const { send, disabled: sendDisabled } = useComposerSend();
+  const canSend = !sendDisabled && !isDisabled;
+
+  return { value, setText, send, isDisabled, canSend };
+}
+
+export type Unstable_TriggerPopoverAriaProps = {
+  "aria-controls"?: string;
+  "aria-expanded"?: true;
+  "aria-haspopup"?: "listbox";
+  "aria-activedescendant"?: string | undefined;
+};
+
+/**
+ * @deprecated Under active development and might change without notice.
+ *
+ * ARIA combobox attributes for the focused element (typically the composer
+ * input) describing the open trigger popover, per the WAI-ARIA editable
+ * combobox pattern. Returns an empty object outside a `TriggerPopoverRoot` or
+ * when no popover is open. Spread these last so they take precedence over any
+ * matching ARIA props you set yourself, mirroring `ComposerPrimitive.Input`.
+ *
+ * @example
+ * ```tsx
+ * const aria = unstable_useTriggerPopoverAriaProps();
+ * <textarea {...aria} />
+ * ```
+ */
+export function unstable_useTriggerPopoverAriaProps(): Unstable_TriggerPopoverAriaProps {
+  const activeAria = useTriggerPopoverActiveAriaOptional();
+  if (!activeAria) return {};
+  // Mirror ComposerPrimitive.Input: emit `aria-activedescendant` even when
+  // there is no highlighted item so spreading these last clears a stale value.
+  return {
+    "aria-controls": activeAria.popoverId,
+    "aria-expanded": true,
+    "aria-haspopup": "listbox",
+    "aria-activedescendant": activeAria.highlightedItemId,
+  };
+}


### PR DESCRIPTION
### summary

adds `unstable_useComposerInput`, a headless bridge for custom composer inputs when `ComposerPrimitive.Input` owns too much of the DOM/behavior.

```tsx
const composer = unstable_useComposerInput();
```

this gives custom editors access to composer text, disabled/send state, and the same send action used by `ComposerPrimitive.Send`.

### basic usage

```tsx
import {
  unstable_useComposerInput,
  unstable_useTriggerPopoverAriaProps,
} from "@assistant-ui/react";

function MyComposerInput() {
  const composer = unstable_useComposerInput();
  const popoverAria = unstable_useTriggerPopoverAriaProps();

  return (
    <textarea
      value={composer.value}
      disabled={composer.isDisabled}
      onChange={(e) => composer.setText(e.currentTarget.value)}
      onKeyDown={(e) => {
        if (e.nativeEvent.isComposing) return;

        if (e.key === "Enter" && !e.shiftKey) {
          e.preventDefault();
          if (composer.canSend) composer.send();
        }
      }}
      {...popoverAria}
    />
  );
}
```

`setText` mirrors `ComposerPrimitive.Input`'s editing guard and sync behavior. `send` accepts the same options as the primitive send action:

```tsx
composer.send({ steer: true });
```

### docs + testing

adds the Headless Composer Input guide, links it from composer primitives, and documents that this is only a thin bridge. keyboard handling, IME, autosize, paste/drop attachments, focus, rich text sync, and full trigger-popover integration still belong to the custom input/editor.

tests cover editing/value behavior, `setText`, disabled + `canSend` gating, send options, and trigger-popover ARIA props.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

