### PR TITLE
fix(docs): render search highlights instead of literal <mark> tags

### DIFF
--- a/apps/docs/components/shared/search-dialog.tsx
+++ b/apps/docs/components/shared/search-dialog.tsx
@@ -99,7 +99,43 @@ function getResultTitle(item: SearchResult): string {
       .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
       .join(" ");
   }
-  return item.content;
+  return item.content.replace(/<\/?mark>/g, "");
+}
+
+function parseHighlightedContent(content: string): HighlightSegment[] {
+  const segments: HighlightSegment[] = [];
+  const regex = /<mark>([\s\S]*?)<\/mark>/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(content)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({
+        type: "text",
+        content: content.slice(lastIndex, match.index),
+      });
+    }
+    segments.push({
+      type: "text",
+      content: match[1] ?? "",
+      styles: { highlight: true },
+    });
+    lastIndex = regex.lastIndex;
+  }
+
+  if (lastIndex < content.length) {
+    segments.push({ type: "text", content: content.slice(lastIndex) });
+  }
+
+  return segments;
+}
+
+function getResultSegments(item: SearchResult): HighlightSegment[] | undefined {
+  if (item.contentWithHighlights && item.contentWithHighlights.length > 0) {
+    return item.contentWithHighlights;
+  }
+  if (item.type === "page") return undefined;
+  return parseHighlightedContent(item.content);
 }
 
 function ResultIcon({ type }: { type: string }) {
@@ -378,7 +414,7 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
                             <div className="flex min-w-0 flex-1 flex-col">
                               <span className="text-foreground truncate text-sm font-medium">
                                 <HighlightedText
-                                  segments={item.contentWithHighlights}
+                                  segments={getResultSegments(item)}
                                   fallback={title}
                                 />
                               </span>


### PR DESCRIPTION
## What

The docs search dialog rendered raw `<mark>…</mark>` HTML tags as literal text in result titles and snippets instead of highlighting the matched substrings.

## Why

`fumadocs-core` (16.10.5) deprecated `SortedResult.contentWithHighlights` and now embeds match highlights inside `content` as Markdown using `<mark />`. Our `HighlightedText` still read the now-undefined `contentWithHighlights`, fell through to the `fallback` (`item.content`), and React rendered the literal `<mark>` characters. Closes #4546.

## How

Parse `<mark>…</mark>` out of `content` on the client into the existing `HighlightSegment[]` shape (`parseHighlightedContent`), and feed it to `HighlightedText` via `getResultSegments`, which still prefers `contentWithHighlights` if a future fumadocs version repopulates it. `getResultTitle` now also strips `<mark>` tags so the truncate fallback cannot leak markup either. Segments render as text content (not `innerHTML`), so there is no XSS surface.

## Test plan

- Run `pnpm dev` in `apps/docs`, open the search dialog (⌘K), and search `suggestion` / `thread` / `runtime`.
- Matched substrings now show with a tinted highlight background; no literal `<mark>` text appears, including in truncated titles and results with multiple matches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

