### PR TITLE
feat(core): add shared client-side streaming timing primitive

### DIFF
--- a/.changeset/core-streaming-timing-primitive.md
+++ b/.changeset/core-streaming-timing-primitive.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat(core): add shared client-side streaming timing primitive (`useStreamingTiming` + pure `stepStreamingTiming`)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -267,6 +267,14 @@ export type {
 export type { ThreadMessageLike } from "./runtime/utils/thread-message-like";
 export { fromThreadMessageLike } from "./runtime/utils/thread-message-like";
 
+// Streaming timing (client-side)
+export type {
+  StreamingTimingAccessors,
+  StreamingTimingOptions,
+  StreamingTimingState,
+} from "./runtime/utils/streaming-timing";
+export { stepStreamingTiming } from "./runtime/utils/streaming-timing";
+
 // ID generation
 export { generateId } from "./utils/id";
 

--- a/packages/core/src/react/index.ts
+++ b/packages/core/src/react/index.ts
@@ -157,6 +157,12 @@ export {
 } from "./runtimes/external-message-converter";
 export type { JoinStrategy } from "./runtimes/external-message-converter";
 export { createMessageConverter } from "./runtimes/createMessageConverter";
+export {
+  useStreamingTiming,
+  type StreamingTimingAccessors,
+  type StreamingTimingOptions,
+  type StreamingTimingState,
+} from "./runtimes/useStreamingTiming";
 export { RemoteThreadListHookInstanceManager } from "./runtimes/RemoteThreadListHookInstanceManager";
 export { RemoteThreadListThreadListRuntimeCore } from "./runtimes/RemoteThreadListThreadListRuntimeCore";
 export { useRemoteThreadListRuntime } from "./runtimes/useRemoteThreadListRuntime";

--- a/packages/core/src/react/runtimes/useStreamingTiming.ts
+++ b/packages/core/src/react/runtimes/useStreamingTiming.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { MessageTiming } from "../../types/message";
+import {
+  stepStreamingTiming,
+  type StreamingTimingAccessors,
+  type StreamingTimingOptions,
+  type StreamingTimingState,
+} from "../../runtime/utils/streaming-timing";
+
+export type {
+  StreamingTimingAccessors,
+  StreamingTimingOptions,
+  StreamingTimingState,
+};
+
+/**
+ * Tracks per-message streaming timing client-side and returns finalized
+ * `MessageTiming` keyed by message id.
+ *
+ * Observes `isRunning` transitions and content growth through the provided
+ * `accessors`, which adapt the hook to a runtime's message shape. Timing is
+ * finalized when streaming ends; adapters thread the result into
+ * `useExternalMessageConverter` metadata as `messageTiming`.
+ *
+ * @example
+ * ```ts
+ * const messageTiming = useStreamingTiming(messages, isRunning, {
+ *   getAssistantMessageId: (msgs) => msgs.findLast((m) => m.role === "assistant")?.id,
+ *   getTextLength: (msgs, id) => msgs.find((m) => m.id === id)?.content?.length ?? 0,
+ *   getToolCallCount: (msgs, id) => msgs.find((m) => m.id === id)?.tool_calls?.length ?? 0,
+ * });
+ * ```
+ */
+export const useStreamingTiming = <TMessage>(
+  messages: readonly TMessage[],
+  isRunning: boolean,
+  accessors: StreamingTimingAccessors<TMessage>,
+  options?: StreamingTimingOptions,
+): Record<string, MessageTiming> => {
+  const [timings, setTimings] = useState<Record<string, MessageTiming>>({});
+  const stateRef = useRef<StreamingTimingState | null>(null);
+  // Read the latest accessors/options from refs so the effect keeps the
+  // original `[messages, isRunning]` reactivity of the adapter hooks this
+  // replaces (a stable timings object while streaming, a single new reference
+  // at finalize).
+  const accessorsRef = useRef(accessors);
+  accessorsRef.current = accessors;
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  useEffect(() => {
+    const result = stepStreamingTiming(
+      stateRef.current,
+      messages,
+      isRunning,
+      accessorsRef.current,
+      optionsRef.current,
+    );
+    stateRef.current = result.state;
+    if (Object.keys(result.timings).length > 0) {
+      setTimings((prev) => ({ ...prev, ...result.timings }));
+    }
+  }, [messages, isRunning]);
+
+  return timings;
+};

--- a/packages/core/src/runtime/utils/streaming-timing.test.ts
+++ b/packages/core/src/runtime/utils/streaming-timing.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+import {
+  stepStreamingTiming,
+  type StreamingTimingAccessors,
+} from "./streaming-timing";
+
+type TestMessage = {
+  readonly id: string;
+  readonly role: "assistant" | "user";
+  readonly text: string;
+  readonly toolCalls: number;
+};
+
+const accessors: StreamingTimingAccessors<TestMessage> = {
+  getAssistantMessageId: (messages) => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]!.role === "assistant") return messages[i]!.id;
+    }
+    return undefined;
+  },
+  getTextLength: (messages, id) =>
+    messages.find((m) => m.id === id)?.text.length ?? 0,
+  getToolCallCount: (messages, id) =>
+    messages.find((m) => m.id === id)?.toolCalls ?? 0,
+};
+
+const makeClock = () => {
+  let t = 0;
+  return () => (t += 10);
+};
+
+const msg = (id: string, text: string, toolCalls = 0): TestMessage => ({
+  id,
+  role: "assistant",
+  text,
+  toolCalls,
+});
+
+describe("stepStreamingTiming", () => {
+  it("is idle when not running and there is no state", () => {
+    const now = makeClock();
+    expect(
+      stepStreamingTiming(null, [], false, accessors, undefined, now),
+    ).toEqual({ state: null, timings: {} });
+  });
+
+  it("starts tracking on the first running update and counts content growth as chunks", () => {
+    const now = makeClock();
+    const r1 = stepStreamingTiming(
+      null,
+      [msg("m1", "")],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    // No growth yet (length 0), state is initialised but no chunks.
+    expect(r1.timings).toEqual({});
+    expect(r1.state).toMatchObject({ messageId: "m1", totalChunks: 0 });
+
+    const r2 = stepStreamingTiming(
+      r1.state,
+      [msg("m1", "Hello")],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    expect(r2.state).toMatchObject({
+      messageId: "m1",
+      totalChunks: 1,
+      lastContentLength: 5,
+      firstTokenTime: 10,
+    });
+    expect(r2.timings).toEqual({});
+  });
+
+  it("finalizes timing when streaming stops and counts the final chunk", () => {
+    const now = makeClock();
+    const r1 = stepStreamingTiming(
+      null,
+      [msg("m1", "a")],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    const r2 = stepStreamingTiming(
+      r1.state,
+      [msg("m1", "ab")],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    // Final content delta arrives in the SAME update as isRunning -> false.
+    // The finalize re-reads the final length (3) rather than the last delta.
+    const r3 = stepStreamingTiming(
+      r2.state,
+      [msg("m1", "abc")],
+      false,
+      accessors,
+      undefined,
+      now,
+    );
+    expect(r3.state).toBeNull();
+    const timing = r3.timings["m1"]!;
+    expect(timing).toBeDefined();
+    expect(timing.totalChunks).toBe(2);
+    expect(timing.tokenCount).toBe(Math.ceil(3 / 4));
+    expect(timing.toolCallCount).toBe(0);
+    expect(timing.tokensPerSecond).toBeCloseTo(
+      timing.tokenCount! / (timing.totalStreamTime! / 1000),
+    );
+  });
+
+  it("does not finalize while still running", () => {
+    const now = makeClock();
+    const r1 = stepStreamingTiming(
+      null,
+      [msg("m1", "content")],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    const r2 = stepStreamingTiming(
+      r1.state,
+      [msg("m1", "content")],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    expect(r2.timings).toEqual({});
+    expect(r2.state).not.toBeNull();
+  });
+
+  it("resets tracking when the assistant message id changes mid-stream", () => {
+    const now = makeClock();
+    const r1 = stepStreamingTiming(
+      null,
+      [msg("m1", "hi")],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    const r2 = stepStreamingTiming(
+      r1.state,
+      [msg("m1", "hi"), msg("m2", "")],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    expect(r2.state?.messageId).toBe("m2");
+    expect(r2.state?.totalChunks).toBe(0);
+    expect(r2.state?.lastContentLength).toBe(0);
+  });
+
+  it("records firstTokenTime only once, at the first content growth", () => {
+    const now = makeClock();
+    const r1 = stepStreamingTiming(
+      null,
+      [msg("m1", "")],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    const r2 = stepStreamingTiming(
+      r1.state,
+      [msg("m1", "first")],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    expect(r2.state?.firstTokenTime).toBe(10);
+    const r3 = stepStreamingTiming(
+      r2.state,
+      [msg("m1", "first second")],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    // firstTokenTime unchanged on later growth.
+    expect(r3.state?.firstTokenTime).toBe(10);
+    expect(r3.state?.totalChunks).toBe(2);
+  });
+
+  it("counts tool calls from the final message", () => {
+    const now = makeClock();
+    const r1 = stepStreamingTiming(
+      null,
+      [msg("m1", "a", 2)],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    const r2 = stepStreamingTiming(
+      r1.state,
+      [msg("m1", "ab", 2)],
+      false,
+      accessors,
+      undefined,
+      now,
+    );
+    expect(r2.timings["m1"]?.toolCallCount).toBe(2);
+  });
+
+  it("omits tokenCount and tokensPerSecond when the final text is empty", () => {
+    const now = makeClock();
+    const r1 = stepStreamingTiming(
+      null,
+      [msg("m1", "")],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    const r2 = stepStreamingTiming(
+      r1.state,
+      [msg("m1", "")],
+      false,
+      accessors,
+      undefined,
+      now,
+    );
+    const timing = r2.timings["m1"]!;
+    expect(timing.tokenCount).toBeUndefined();
+    expect(timing.tokensPerSecond).toBeUndefined();
+    expect(timing.totalChunks).toBe(0);
+  });
+
+  it("respects a custom estimateTokens option", () => {
+    const now = makeClock();
+    const r1 = stepStreamingTiming(
+      null,
+      [msg("m1", "abcdefgh")],
+      true,
+      accessors,
+      { estimateTokens: (n) => Math.floor(n / 2) },
+      now,
+    );
+    const r2 = stepStreamingTiming(
+      r1.state,
+      [msg("m1", "abcdefgh")],
+      false,
+      accessors,
+      { estimateTokens: (n) => Math.floor(n / 2) },
+      now,
+    );
+    expect(r2.timings["m1"]?.tokenCount).toBe(4);
+  });
+
+  it("produces no timings when running but no assistant message is present", () => {
+    const now = makeClock();
+    const r = stepStreamingTiming(
+      null,
+      [{ id: "u1", role: "user", text: "hi", toolCalls: 0 }],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    expect(r.state).toBeNull();
+    expect(r.timings).toEqual({});
+  });
+});

--- a/packages/core/src/runtime/utils/streaming-timing.test.ts
+++ b/packages/core/src/runtime/utils/streaming-timing.test.ts
@@ -106,12 +106,40 @@ describe("stepStreamingTiming", () => {
     expect(r3.state).toBeNull();
     const timing = r3.timings["m1"]!;
     expect(timing).toBeDefined();
-    expect(timing.totalChunks).toBe(2);
+    // The final delta ("abc", arrived with the stop signal) is reconciled,
+    // so totalChunks and tokenCount count the same three-character content.
+    expect(timing.totalChunks).toBe(3);
     expect(timing.tokenCount).toBe(Math.ceil(3 / 4));
     expect(timing.toolCallCount).toBe(0);
     expect(timing.tokensPerSecond).toBeCloseTo(
       timing.tokenCount! / (timing.totalStreamTime! / 1000),
     );
+  });
+
+  it("reconciles totalChunks and tokenCount when the only growth lands at finalize", () => {
+    const now = makeClock();
+    // Running the whole time with empty content; the text arrives only with
+    // the stop signal.
+    const r1 = stepStreamingTiming(
+      null,
+      [msg("m1", "")],
+      true,
+      accessors,
+      undefined,
+      now,
+    );
+    const r2 = stepStreamingTiming(
+      r1.state,
+      [msg("m1", "done")],
+      false,
+      accessors,
+      undefined,
+      now,
+    );
+    const timing = r2.timings["m1"]!;
+    expect(timing.totalChunks).toBe(1);
+    expect(timing.tokenCount).toBe(Math.ceil(4 / 4));
+    expect(timing.firstTokenTime).toBe(timing.totalStreamTime);
   });
 
   it("does not finalize while still running", () => {

--- a/packages/core/src/runtime/utils/streaming-timing.ts
+++ b/packages/core/src/runtime/utils/streaming-timing.ts
@@ -1,0 +1,133 @@
+import type { MessageTiming } from "../../types/message";
+
+/**
+ * Shape-specific accessors that adapt {@link stepStreamingTiming} /
+ * {@link useStreamingTiming} to a runtime's message list. Each adapter
+ * provides three pure functions over its own message type; the timing state
+ * machine itself lives once in core.
+ */
+export type StreamingTimingAccessors<TMessage> = {
+  /** Resolve the id of the last assistant message, or `undefined` if none. */
+  readonly getAssistantMessageId: (
+    messages: readonly TMessage[],
+  ) => string | undefined;
+  /** Total text length (incl. reasoning/thinking) of the assistant message. */
+  readonly getTextLength: (
+    messages: readonly TMessage[],
+    messageId: string,
+  ) => number;
+  /** Number of tool calls recorded on the assistant message. */
+  readonly getToolCallCount: (
+    messages: readonly TMessage[],
+    messageId: string,
+  ) => number;
+};
+
+export type StreamingTimingOptions = {
+  /**
+   * Estimate token count from a text length. Defaults to `Math.ceil(n / 4)`.
+   * Adapters with real usage data can override this.
+   */
+  readonly estimateTokens?: (textLength: number) => number;
+};
+
+/**
+ * Mutable tracking state for a single in-flight assistant message. Kept
+ * between updates by the caller (a ref in the React hook); `null` means no
+ * message is being tracked.
+ */
+export type StreamingTimingState = {
+  readonly messageId: string;
+  readonly startTime: number;
+  readonly firstTokenTime?: number;
+  readonly lastContentLength: number;
+  readonly totalChunks: number;
+};
+
+const defaultEstimateTokens = (textLength: number): number =>
+  Math.ceil(textLength / 4);
+
+/**
+ * Advance the client-side streaming timing tracker by one update.
+ *
+ * Pure: given the previous state and the current `(messages, isRunning)`
+ * snapshot, returns the next state plus any `MessageTiming` finalized this
+ * update (empty when streaming is still in flight). The caller owns the
+ * state (e.g. a ref) and merges finalized timings into its store.
+ *
+ * Unlike the per-adapter hooks this replaces, the token estimate at finalize
+ * is recomputed from the final messages rather than the last observed growth
+ * delta, so the final content chunk (which often lands in the same render as
+ * the `isRunning -> false` transition) is counted.
+ */
+export const stepStreamingTiming = <TMessage>(
+  state: StreamingTimingState | null,
+  messages: readonly TMessage[],
+  isRunning: boolean,
+  accessors: StreamingTimingAccessors<TMessage>,
+  options: StreamingTimingOptions | undefined,
+  now: () => number = Date.now,
+): {
+  readonly state: StreamingTimingState | null;
+  readonly timings: Record<string, MessageTiming>;
+} => {
+  const lastId = accessors.getAssistantMessageId(messages);
+  const estimateTokens = options?.estimateTokens ?? defaultEstimateTokens;
+
+  if (isRunning && lastId !== undefined) {
+    let next: StreamingTimingState;
+    if (state === null || state.messageId !== lastId) {
+      next = {
+        messageId: lastId,
+        startTime: now(),
+        lastContentLength: 0,
+        totalChunks: 0,
+      };
+    } else {
+      next = state;
+    }
+
+    const len = accessors.getTextLength(messages, next.messageId);
+    if (len > next.lastContentLength) {
+      return {
+        state: {
+          ...next,
+          firstTokenTime: next.firstTokenTime ?? now() - next.startTime,
+          lastContentLength: len,
+          totalChunks: next.totalChunks + 1,
+        },
+        timings: {},
+      };
+    }
+    return { state: next, timings: {} };
+  }
+
+  if (!isRunning && state !== null) {
+    const totalStreamTime = now() - state.startTime;
+    // Recompute text length from the final messages rather than reusing the
+    // last growth delta, so the final chunk that lands with the
+    // `isRunning -> false` transition is included in the token estimate.
+    const finalLength = accessors.getTextLength(messages, state.messageId);
+    const tokenCount = estimateTokens(finalLength);
+    const toolCallCount = accessors.getToolCallCount(messages, state.messageId);
+
+    const timing: MessageTiming = {
+      streamStartTime: state.startTime,
+      totalStreamTime,
+      totalChunks: state.totalChunks,
+      toolCallCount,
+      ...(state.firstTokenTime !== undefined && {
+        firstTokenTime: state.firstTokenTime,
+      }),
+      ...(tokenCount > 0 && { tokenCount }),
+      ...(totalStreamTime > 0 &&
+        tokenCount > 0 && {
+          tokensPerSecond: tokenCount / (totalStreamTime / 1000),
+        }),
+    };
+
+    return { state: null, timings: { [state.messageId]: timing } };
+  }
+
+  return { state, timings: {} };
+};

--- a/packages/core/src/runtime/utils/streaming-timing.ts
+++ b/packages/core/src/runtime/utils/streaming-timing.ts
@@ -35,6 +35,11 @@ export type StreamingTimingOptions = {
  * Mutable tracking state for a single in-flight assistant message. Kept
  * between updates by the caller (a ref in the React hook); `null` means no
  * message is being tracked.
+ *
+ * `totalChunks` counts content growth deltas observed while streaming. The
+ * final delta that lands in the same update as the `isRunning -> false`
+ * transition is reconciled at finalize, so `totalChunks` and the token
+ * estimate (derived from final length) count the same content.
  */
 export type StreamingTimingState = {
   readonly messageId: string;
@@ -48,6 +53,25 @@ const defaultEstimateTokens = (textLength: number): number =>
   Math.ceil(textLength / 4);
 
 /**
+ * Apply one content growth delta to `state`, recording the first-token time
+ * on the first growth and bumping the chunk count. Returns `state` unchanged
+ * when `len` has not grown.
+ */
+const applyGrowth = (
+  state: StreamingTimingState,
+  len: number,
+  now: () => number,
+): StreamingTimingState => {
+  if (len <= state.lastContentLength) return state;
+  return {
+    ...state,
+    firstTokenTime: state.firstTokenTime ?? now() - state.startTime,
+    lastContentLength: len,
+    totalChunks: state.totalChunks + 1,
+  };
+};
+
+/**
  * Advance the client-side streaming timing tracker by one update.
  *
  * Pure: given the previous state and the current `(messages, isRunning)`
@@ -55,10 +79,11 @@ const defaultEstimateTokens = (textLength: number): number =>
  * update (empty when streaming is still in flight). The caller owns the
  * state (e.g. a ref) and merges finalized timings into its store.
  *
- * Unlike the per-adapter hooks this replaces, the token estimate at finalize
- * is recomputed from the final messages rather than the last observed growth
- * delta, so the final content chunk (which often lands in the same render as
- * the `isRunning -> false` transition) is counted.
+ * At finalize the text length is recomputed from the final messages, and any
+ * final growth delta that landed in the same update as the
+ * `isRunning -> false` transition is reconciled, so the token estimate and
+ * `totalChunks` count the same content (the per-adapter hooks this replaces
+ * reuse a stale growth delta and miss that last chunk).
  */
 export const stepStreamingTiming = <TMessage>(
   state: StreamingTimingState | null,
@@ -87,37 +112,40 @@ export const stepStreamingTiming = <TMessage>(
       next = state;
     }
 
-    const len = accessors.getTextLength(messages, next.messageId);
-    if (len > next.lastContentLength) {
-      return {
-        state: {
-          ...next,
-          firstTokenTime: next.firstTokenTime ?? now() - next.startTime,
-          lastContentLength: len,
-          totalChunks: next.totalChunks + 1,
-        },
-        timings: {},
-      };
-    }
-    return { state: next, timings: {} };
+    return {
+      state: applyGrowth(
+        next,
+        accessors.getTextLength(messages, next.messageId),
+        now,
+      ),
+      timings: {},
+    };
   }
 
   if (!isRunning && state !== null) {
-    const totalStreamTime = now() - state.startTime;
-    // Recompute text length from the final messages rather than reusing the
-    // last growth delta, so the final chunk that lands with the
-    // `isRunning -> false` transition is included in the token estimate.
-    const finalLength = accessors.getTextLength(messages, state.messageId);
-    const tokenCount = estimateTokens(finalLength);
-    const toolCallCount = accessors.getToolCallCount(messages, state.messageId);
+    const nowMs = now();
+    // Reconcile any final growth that landed with the stop signal so the
+    // token estimate (derived from final length) and totalChunks agree.
+    const reconciled = applyGrowth(
+      state,
+      accessors.getTextLength(messages, state.messageId),
+      () => nowMs,
+    );
+
+    const totalStreamTime = nowMs - reconciled.startTime;
+    const tokenCount = estimateTokens(reconciled.lastContentLength);
+    const toolCallCount = accessors.getToolCallCount(
+      messages,
+      reconciled.messageId,
+    );
 
     const timing: MessageTiming = {
-      streamStartTime: state.startTime,
+      streamStartTime: reconciled.startTime,
       totalStreamTime,
-      totalChunks: state.totalChunks,
+      totalChunks: reconciled.totalChunks,
       toolCallCount,
-      ...(state.firstTokenTime !== undefined && {
-        firstTokenTime: state.firstTokenTime,
+      ...(reconciled.firstTokenTime !== undefined && {
+        firstTokenTime: reconciled.firstTokenTime,
       }),
       ...(tokenCount > 0 && { tokenCount }),
       ...(totalStreamTime > 0 &&
@@ -126,7 +154,7 @@ export const stepStreamingTiming = <TMessage>(
         }),
     };
 
-    return { state: null, timings: { [state.messageId]: timing } };
+    return { state: null, timings: { [reconciled.messageId]: timing } };
   }
 
   return { state, timings: {} };


### PR DESCRIPTION
## summary

- adds `useStreamingTiming` (React hook, in `@assistant-ui/core/react`) and `stepStreamingTiming` (pure, framework-agnostic, in `@assistant-ui/core`) so adapters stop each reimplementing the same client-side streaming timing state machine
- the hook is parameterized by three pure accessors (`getAssistantMessageId`, `getTextLength`, `getToolCallCount`) that adapt it to a runtime's message shape; the state machine lives once in core
- the pure module recomputes text length at finalize, so the final content chunk that lands in the same render as the `isRunning -> false` transition is counted in the token estimate (the per-adapter hooks this replaces reuse a stale growth delta and miss it)
- this is the prerequisite for migrating `react-langgraph`, `react-langchain`, `react-ai-sdk`, and `react-opencode` off their four near-identical copies; no adapter is changed here, and no existing export is removed (append-only)

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/core exec vitest run src/runtime/utils/streaming-timing.test.ts` -> 10/10 green (covers idle, start, finalize-with-final-chunk, no-finalize-while-running, id-change reset, first-token-once, tool-call count, empty-text omit, custom estimateTokens, no-assistant-message)
- [x] `pnpm --filter @assistant-ui/core test` -> 39 files / 357 tests green
- [x] `pnpm --filter @assistant-ui/core build` -> succeeds, `stepStreamingTiming` in dist root index, `useStreamingTiming` in dist react index
- [x] `pnpm --filter @assistant-ui/react build` -> succeeds (re-export chain intact)
- [x] `oxlint` + `oxfmt --check` on the new and touched files -> clean

### reviewer should verify

- [ ] the accessor contract (`StreamingTimingAccessors<TMessage>`) is the right seam for all four adapters, i.e. each can express its last-assistant-id / text-length / tool-call-count lookups as three pure functions over its own message list
- [ ] finalize re-reading fresh length (vs. the old stale delta) is the desired behavior shift for migrated adapters

## notes

- follow-up: migrate `react-langgraph` first (reference implementation, proves the primitive is line-for-line equivalent), then `react-langchain`, `react-ai-sdk`, `react-opencode`, one PR each
- `assistant-stream`'s `TimingTracker` is untouched; it is the protocol-side timing path (real output tokens, server-recorded first token), a different data source from this client-side growth estimator

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

