### PR TITLE
refactor(react-langgraph): adopt shared streaming timing primitive

### DIFF
--- a/.changeset/langgraph-streaming-timing-primitive.md
+++ b/.changeset/langgraph-streaming-timing-primitive.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+refactor: delegate useLangGraphStreamingTiming to the shared useStreamingTiming primitive in core, with no public API change

--- a/packages/react-langgraph/src/useLangGraphStreamingTiming.ts
+++ b/packages/react-langgraph/src/useLangGraphStreamingTiming.ts
@@ -1,21 +1,16 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
 import type { LangChainMessage } from "./types";
 import type { MessageTiming } from "@assistant-ui/core";
+import {
+  useStreamingTiming,
+  type StreamingTimingAccessors,
+} from "@assistant-ui/core/react";
 
-type TrackingState = {
-  messageId: string;
-  startTime: number;
-  firstTokenTime?: number;
-  lastContentLength: number;
-  totalChunks: number;
-};
-
-function getMessageTextLength(
+const getMessageTextLength = (
   messages: readonly LangChainMessage[],
   messageId: string,
-): number {
+): number => {
   const m = messages.find((msg) => msg.type === "ai" && msg.id === messageId);
   if (!m) return 0;
   const content = m.content;
@@ -29,81 +24,42 @@ function getMessageTextLength(
       len += part.thinking.length;
   }
   return len;
-}
+};
 
-function getMessageToolCallCount(
+const getMessageToolCallCount = (
   messages: readonly LangChainMessage[],
   messageId: string,
-): number {
+): number => {
   const m = messages.find((msg) => msg.type === "ai" && msg.id === messageId);
   if (!m || m.type !== "ai") return 0;
   return m.tool_calls?.length ?? 0;
-}
+};
 
-function getLastAssistantId(
+const getLastAssistantId = (
   messages: readonly LangChainMessage[],
-): string | undefined {
+): string | undefined => {
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i]?.type === "ai" && messages[i]?.id) {
       return messages[i]!.id;
     }
   }
   return undefined;
-}
+};
 
+const langGraphStreamingTimingAccessors: StreamingTimingAccessors<LangChainMessage> =
+  {
+    getAssistantMessageId: getLastAssistantId,
+    getTextLength: getMessageTextLength,
+    getToolCallCount: getMessageToolCallCount,
+  };
+
+/**
+ * Tracks per-message streaming timing for LangGraph messages. Delegates to
+ * the shared `useStreamingTiming` primitive in `@assistant-ui/core/react`,
+ * adapted to the LangGraph message shape via the accessors above.
+ */
 export const useLangGraphStreamingTiming = (
   messages: readonly LangChainMessage[],
   isRunning: boolean,
-): Record<string, MessageTiming> => {
-  const [timings, setTimings] = useState<Record<string, MessageTiming>>({});
-  const trackRef = useRef<TrackingState | null>(null);
-
-  useEffect(() => {
-    const lastId = getLastAssistantId(messages);
-
-    if (isRunning && lastId) {
-      if (!trackRef.current || trackRef.current.messageId !== lastId) {
-        trackRef.current = {
-          messageId: lastId,
-          startTime: Date.now(),
-          lastContentLength: 0,
-          totalChunks: 0,
-        };
-      }
-
-      const t = trackRef.current;
-      const len = getMessageTextLength(messages, t.messageId);
-      if (len > t.lastContentLength) {
-        if (t.firstTokenTime === undefined) {
-          t.firstTokenTime = Date.now() - t.startTime;
-        }
-        t.totalChunks++;
-        t.lastContentLength = len;
-      }
-    } else if (!isRunning && trackRef.current) {
-      const t = trackRef.current;
-      const totalStreamTime = Date.now() - t.startTime;
-      const tokenCount = Math.ceil(t.lastContentLength / 4);
-      const toolCallCount = getMessageToolCallCount(messages, t.messageId);
-
-      const timing: MessageTiming = {
-        streamStartTime: t.startTime,
-        totalStreamTime,
-        totalChunks: t.totalChunks,
-        toolCallCount,
-        ...(t.firstTokenTime !== undefined && {
-          firstTokenTime: t.firstTokenTime,
-        }),
-        ...(tokenCount > 0 && { tokenCount }),
-        ...(totalStreamTime > 0 &&
-          tokenCount > 0 && {
-            tokensPerSecond: tokenCount / (totalStreamTime / 1000),
-          }),
-      };
-      setTimings((prev) => ({ ...prev, [t.messageId]: timing }));
-      trackRef.current = null;
-    }
-  }, [messages, isRunning]);
-
-  return timings;
-};
+): Record<string, MessageTiming> =>
+  useStreamingTiming(messages, isRunning, langGraphStreamingTimingAccessors);


### PR DESCRIPTION
## summary

- `useLangGraphStreamingTiming` now delegates to the shared `useStreamingTiming` primitive (#4548) via a `StreamingTimingAccessors` adapter for the LangGraph message shape, removing this package's copy of the client-side timing state machine
- the public `useLangGraphStreamingTiming` export and its `(messages, isRunning) -> Record<string, MessageTiming>` signature are unchanged, so `useLangGraphRuntime` wiring needs no change
- behavior is preserved for every existing case; the only observable change is the inherited core fix where the final content chunk that lands in the same update as the `isRunning -> false` transition is now counted in the token estimate (previously dropped)

## breaking changes

- none; the export is kept, the signature is unchanged

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-langgraph exec vitest run src/useLangGraphStreamingTiming.test.ts` -> 6/6 green (the existing suite is the regression baseline; none of its cases hit the reconcile path, so they pass unchanged)
- [x] `pnpm --filter @assistant-ui/react-langgraph test` -> 8 files / 148 tests green
- [x] `pnpm --filter @assistant-ui/react-langgraph build` -> succeeds
- [x] `oxlint` + `oxfmt` on the changed file -> clean

### reviewer should verify

- [ ] the three accessor functions (`getMessageTextLength`, `getMessageToolCallCount`, `getLastAssistantId`) are byte-for-byte the same logic as before, just wired into the `StreamingTimingAccessors` object instead of called inline

## notes

- this is the first adapter migration off the core primitive; `react-langchain`, `react-ai-sdk`, and `react-opencode` follow as separate PRs

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

