### PR TITLE
feat(react-langchain): attach per-message streaming timing

### DIFF
--- a/.changeset/langchain-streaming-timing.md
+++ b/.changeset/langchain-streaming-timing.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+feat(react-langchain): attach per-message streaming timing via the shared core primitive

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -804,7 +804,10 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | Subagent/subgraph message views | Via `eventHandlers` | Yes (via `useLangChainStream` + v1 selector hooks) |
 | End-to-end cancellation primitive | Yes (`unstable_createLangGraphStream`) | Not exposed |
 | Message accumulator utility | Yes (`LangGraphMessageAccumulator`) | Not exposed |
+| Streaming timing (per-message) | Yes | Yes |
 | Cloud thread persistence | Yes | Yes |
+
+Per-message streaming timing is attached automatically to `message.metadata.timing` (no setup), matching `react-langgraph`. It captures time-to-first-token, total stream time, chunk count, and tokens/sec, computed from message growth while the run is in flight.
 
 `react-langchain` is the newer, thinner wrapper. It delegates to upstream `useStream` rather than re-implementing the stream plumbing, which is why its footprint is smaller. Features absent today have not been ported, not deprecated.
 

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -1,7 +1,11 @@
 "use client";
 
 import type { useExternalMessageConverter } from "@assistant-ui/core/react";
-import type { AppendMessage, DataMessagePart } from "@assistant-ui/core";
+import type {
+  AppendMessage,
+  DataMessagePart,
+  MessageTiming,
+} from "@assistant-ui/core";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
 import type {
   LangChainBaseMessage,
@@ -12,6 +16,7 @@ import type {
 type LangChainMessageConverterMetadata =
   useExternalMessageConverter.Metadata & {
     uiMessagesByParent?: Map<string, UIMessage[]>;
+    messageTiming?: Record<string, MessageTiming>;
   };
 
 const uiMessageToDataPart = (ui: UIMessage): DataMessagePart => ({
@@ -135,6 +140,8 @@ export const convertLangChainBaseMessage = (
               ?.map(uiMessageToDataPart)
           : undefined) ?? [];
 
+      const timing = metadata.messageTiming?.[message.id ?? ""];
+
       return {
         role: "assistant",
         id: message.id,
@@ -145,6 +152,7 @@ export const convertLangChainBaseMessage = (
         ],
         metadata: {
           custom: getCustomMetadata(message.additional_kwargs),
+          ...(timing && { timing }),
         },
         ...(assistantStatus && { status: assistantStatus }),
       };

--- a/packages/react-langchain/src/index.ts
+++ b/packages/react-langchain/src/index.ts
@@ -17,6 +17,7 @@ export {
 } from "./hooks";
 
 export { convertLangChainBaseMessage } from "./convertMessages";
+export { useLangChainStreamingTiming } from "./streamingTiming";
 
 export type {
   SubagentDiscoverySnapshot,

--- a/packages/react-langchain/src/streamingTiming.test.ts
+++ b/packages/react-langchain/src/streamingTiming.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { LangChainBaseMessage } from "./types";
+import { langChainStreamingTimingAccessors } from "./streamingTiming";
+
+const ai = (
+  fields: Partial<LangChainBaseMessage> & { id: string; content: unknown },
+): LangChainBaseMessage => ({
+  _getType: () => "ai",
+  ...fields,
+});
+
+const human = (id: string, content: unknown): LangChainBaseMessage => ({
+  _getType: () => "human",
+  id,
+  content,
+});
+
+const { getAssistantMessageId, getTextLength, getToolCallCount } =
+  langChainStreamingTimingAccessors;
+
+describe("langChainStreamingTimingAccessors", () => {
+  it("resolves the last assistant message id via _getType()", () => {
+    expect(
+      getAssistantMessageId([human("u1", "hi"), ai({ id: "a1", content: "" })]),
+    ).toBe("a1");
+    expect(
+      getAssistantMessageId([
+        ai({ id: "a1", content: "" }),
+        human("u2", "hi"),
+        ai({ id: "a2", content: "" }),
+      ]),
+    ).toBe("a2");
+  });
+
+  it("returns undefined when there is no assistant message", () => {
+    expect(getAssistantMessageId([human("u1", "hi")])).toBeUndefined();
+  });
+
+  it("measures string content length", () => {
+    expect(getTextLength([ai({ id: "a1", content: "hello" })], "a1")).toBe(5);
+  });
+
+  it("sums text and thinking lengths across content blocks", () => {
+    expect(
+      getTextLength(
+        [
+          ai({
+            id: "a1",
+            content: [
+              { type: "thinking", thinking: "hmm" },
+              { type: "text", text: "answer" },
+            ],
+          }),
+        ],
+        "a1",
+      ),
+    ).toBe("hmm".length + "answer".length);
+  });
+
+  it("counts tool_calls on the assistant message", () => {
+    expect(
+      getToolCallCount(
+        [
+          ai({
+            id: "a1",
+            content: "",
+            tool_calls: [
+              { id: "t1", name: "search", args: {} },
+              { id: "t2", name: "fetch", args: {} },
+            ],
+          }),
+        ],
+        "a1",
+      ),
+    ).toBe(2);
+  });
+
+  it("returns 0 when the message is missing or not assistant", () => {
+    expect(getTextLength([human("u1", "hi")], "a1")).toBe(0);
+    expect(getToolCallCount([human("u1", "hi")], "a1")).toBe(0);
+  });
+});

--- a/packages/react-langchain/src/streamingTiming.test.ts
+++ b/packages/react-langchain/src/streamingTiming.test.ts
@@ -57,6 +57,42 @@ describe("langChainStreamingTimingAccessors", () => {
     ).toBe("hmm".length + "answer".length);
   });
 
+  it("measures reasoning blocks (summary and reasoning fields)", () => {
+    // reasoning via summary_text entries, joined like contentToParts does.
+    expect(
+      getTextLength(
+        [
+          ai({
+            id: "a1",
+            content: [
+              {
+                type: "reasoning",
+                summary: [
+                  { type: "summary_text", text: "step one" },
+                  { type: "summary_text", text: "step two" },
+                ],
+              },
+            ],
+          }),
+        ],
+        "a1",
+      ),
+    ).toBe("step one\n\n\nstep two".length);
+
+    // reasoning via the bare `reasoning` field when no summary is present.
+    expect(
+      getTextLength(
+        [
+          ai({
+            id: "a2",
+            content: [{ type: "reasoning", reasoning: "deduced" }],
+          }),
+        ],
+        "a2",
+      ),
+    ).toBe("deduced".length);
+  });
+
   it("counts tool_calls on the assistant message", () => {
     expect(
       getToolCallCount(

--- a/packages/react-langchain/src/streamingTiming.ts
+++ b/packages/react-langchain/src/streamingTiming.ts
@@ -1,4 +1,10 @@
-import type { StreamingTimingAccessors } from "@assistant-ui/core/react";
+"use client";
+
+import type { MessageTiming } from "@assistant-ui/core";
+import {
+  useStreamingTiming,
+  type StreamingTimingAccessors,
+} from "@assistant-ui/core/react";
 import type { LangChainBaseMessage, LangChainContentBlock } from "./types";
 import { getMessageType } from "./convertMessages";
 
@@ -7,6 +13,15 @@ const findAiMessage = (
   messageId: string,
 ): LangChainBaseMessage | undefined =>
   messages.find((m) => getMessageType(m) === "ai" && m.id === messageId);
+
+const reasoningTextLength = (part: {
+  readonly summary?: ReadonlyArray<{ readonly text?: string }>;
+  readonly reasoning?: string;
+}): number => {
+  if (part.summary && part.summary.length > 0)
+    return part.summary.map((s) => s?.text ?? "").join("\n\n\n").length;
+  return part.reasoning?.length ?? 0;
+};
 
 const getTextLength = (
   messages: readonly LangChainBaseMessage[],
@@ -19,10 +34,18 @@ const getTextLength = (
   if (!Array.isArray(content)) return 0;
   let len = 0;
   for (const part of content as readonly LangChainContentBlock[]) {
-    if ("text" in part && typeof part.text === "string")
-      len += part.text.length;
-    if ("thinking" in part && typeof part.thinking === "string")
-      len += part.thinking.length;
+    switch (part.type) {
+      case "text":
+      case "text_delta":
+        if (typeof part.text === "string") len += part.text.length;
+        break;
+      case "thinking":
+        if (typeof part.thinking === "string") len += part.thinking.length;
+        break;
+      case "reasoning":
+        len += reasoningTextLength(part);
+        break;
+    }
   }
   return len;
 };
@@ -42,14 +65,21 @@ const getAssistantMessageId = (
   return undefined;
 };
 
-/**
- * Adapts the shared `useStreamingTiming` primitive to the LangChain
- * `LangChainBaseMessage` shape (`_getType()` -> "ai", duck-typed content
- * blocks, `tool_calls`). The timing state machine itself lives in core.
- */
 export const langChainStreamingTimingAccessors: StreamingTimingAccessors<LangChainBaseMessage> =
   {
     getAssistantMessageId,
     getTextLength,
     getToolCallCount,
   };
+
+/**
+ * Tracks per-message streaming timing for LangChain messages. Delegates to
+ * the shared `useStreamingTiming` primitive in `@assistant-ui/core/react`,
+ * adapted to the `LangChainBaseMessage` shape (`_getType() -> "ai"`, content
+ * blocks including text/thinking/reasoning, `tool_calls`).
+ */
+export const useLangChainStreamingTiming = (
+  messages: readonly LangChainBaseMessage[],
+  isRunning: boolean,
+): Record<string, MessageTiming> =>
+  useStreamingTiming(messages, isRunning, langChainStreamingTimingAccessors);

--- a/packages/react-langchain/src/streamingTiming.ts
+++ b/packages/react-langchain/src/streamingTiming.ts
@@ -1,0 +1,55 @@
+import type { StreamingTimingAccessors } from "@assistant-ui/core/react";
+import type { LangChainBaseMessage, LangChainContentBlock } from "./types";
+import { getMessageType } from "./convertMessages";
+
+const findAiMessage = (
+  messages: readonly LangChainBaseMessage[],
+  messageId: string,
+): LangChainBaseMessage | undefined =>
+  messages.find((m) => getMessageType(m) === "ai" && m.id === messageId);
+
+const getTextLength = (
+  messages: readonly LangChainBaseMessage[],
+  messageId: string,
+): number => {
+  const m = findAiMessage(messages, messageId);
+  if (!m) return 0;
+  const content = m.content;
+  if (typeof content === "string") return content.length;
+  if (!Array.isArray(content)) return 0;
+  let len = 0;
+  for (const part of content as readonly LangChainContentBlock[]) {
+    if ("text" in part && typeof part.text === "string")
+      len += part.text.length;
+    if ("thinking" in part && typeof part.thinking === "string")
+      len += part.thinking.length;
+  }
+  return len;
+};
+
+const getToolCallCount = (
+  messages: readonly LangChainBaseMessage[],
+  messageId: string,
+): number => findAiMessage(messages, messageId)?.tool_calls?.length ?? 0;
+
+const getAssistantMessageId = (
+  messages: readonly LangChainBaseMessage[],
+): string | undefined => {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m && getMessageType(m) === "ai" && m.id) return m.id;
+  }
+  return undefined;
+};
+
+/**
+ * Adapts the shared `useStreamingTiming` primitive to the LangChain
+ * `LangChainBaseMessage` shape (`_getType()` -> "ai", duck-typed content
+ * blocks, `tool_calls`). The timing state machine itself lives in core.
+ */
+export const langChainStreamingTimingAccessors: StreamingTimingAccessors<LangChainBaseMessage> =
+  {
+    getAssistantMessageId,
+    getTextLength,
+    getToolCallCount,
+  };

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -9,6 +9,7 @@ import {
   useExternalStoreRuntime,
   useExternalMessageConverter,
   useRemoteThreadListRuntime,
+  useStreamingTiming,
 } from "@assistant-ui/core/react";
 import { useAuiState } from "@assistant-ui/store";
 import { STREAM_CONTROLLER, useChannel, useStream } from "@langchain/react";
@@ -27,6 +28,7 @@ import {
 import { foldUIUpdates, mergeUIMessages } from "./uiMessages";
 import { langChainExtras } from "./runtimeExtras";
 import { resolveForkCheckpoint } from "./resolveForkCheckpoint";
+import { langChainStreamingTimingAccessors } from "./streamingTiming";
 
 const UI_CUSTOM_CHANNELS: readonly Channel[] = ["custom"];
 
@@ -122,13 +124,23 @@ const useStreamThreadRuntime = (
     [liveUiMessages, uiStateValue],
   );
 
+  const messageTiming = useStreamingTiming(
+    stream.messages as LangChainBaseMessage[],
+    effectiveIsRunning,
+    langChainStreamingTimingAccessors,
+  );
+
   const convertWithUI = useMemo<
     useExternalMessageConverter.Callback<LangChainBaseMessage>
   >(() => {
     const uiMessagesByParent = groupUIMessagesByParent(mergedUiMessages);
     return (message, metadata) =>
-      convertLangChainBaseMessage(message, { ...metadata, uiMessagesByParent });
-  }, [mergedUiMessages]);
+      convertLangChainBaseMessage(message, {
+        ...metadata,
+        uiMessagesByParent,
+        messageTiming,
+      });
+  }, [mergedUiMessages, messageTiming]);
 
   const threadMessages = useExternalMessageConverter({
     callback: convertWithUI,

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -9,7 +9,6 @@ import {
   useExternalStoreRuntime,
   useExternalMessageConverter,
   useRemoteThreadListRuntime,
-  useStreamingTiming,
 } from "@assistant-ui/core/react";
 import { useAuiState } from "@assistant-ui/store";
 import { STREAM_CONTROLLER, useChannel, useStream } from "@langchain/react";
@@ -28,7 +27,7 @@ import {
 import { foldUIUpdates, mergeUIMessages } from "./uiMessages";
 import { langChainExtras } from "./runtimeExtras";
 import { resolveForkCheckpoint } from "./resolveForkCheckpoint";
-import { langChainStreamingTimingAccessors } from "./streamingTiming";
+import { useLangChainStreamingTiming } from "./streamingTiming";
 
 const UI_CUSTOM_CHANNELS: readonly Channel[] = ["custom"];
 
@@ -124,10 +123,9 @@ const useStreamThreadRuntime = (
     [liveUiMessages, uiStateValue],
   );
 
-  const messageTiming = useStreamingTiming(
+  const messageTiming = useLangChainStreamingTiming(
     stream.messages as LangChainBaseMessage[],
     effectiveIsRunning,
-    langChainStreamingTimingAccessors,
   );
 
   const convertWithUI = useMemo<


### PR DESCRIPTION
## summary

- adds per-message streaming timing to `react-langchain`, attaching it to `message.metadata.timing` (the standard core `MessageTiming` field): time-to-first-token, total stream time, chunk count, and tokens/sec
- built on the shared `useStreamingTiming` primitive (#4548) via a `StreamingTimingAccessors` adapter for the `LangChainBaseMessage` shape (`_getType() -> "ai"`, content blocks including `thinking`, `tool_calls`), instead of a per-package copy of the timing state machine
- wired into `useStreamRuntime` alongside the existing `convertWithUI` metadata, matching how `react-langgraph` already does it; no setup needed, it attaches automatically

## breaking changes

- none; this is additive (new metadata field on assistant messages), no existing export or signature changes

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-langchain test` -> 16 files / 98 tests green (incl. a new `streamingTiming.test.ts` covering the accessors: last-assistant-id via `_getType()`, text+thinking length summing, tool-call count, missing/non-assistant fallbacks)
- [x] `pnpm --filter @assistant-ui/react-langchain build` -> succeeds
- [x] `oxlint` + `oxfmt --check` on changed files -> clean

### reviewer should verify

- [ ] the `langChainStreamingTimingAccessors` (`getAssistantMessageId` / `getTextLength` / `getToolCallCount`) correctly adapt the `LangChainBaseMessage` shape, in particular the `_getType()` accessor path and the `content` block union (string vs array of text/thinking/other)
- [ ] timing is attached with no setup, i.e. `useStreamRuntime` callers see `message.metadata.timing` populated after a run the same way `react-langgraph` users do

## notes

- this is the feature the closed #4544 attempted with a throwaway per-package copy of the state machine; it lands cleanly on the core primitive instead, so there is no new duplication
- `react-langgraph` already migrated to the same primitive (#4549); `react-ai-sdk` and `react-opencode` follow as separate PRs
- docs comparison table in `langchain.mdx` updated to show streaming timing as supported, matching `react-langgraph`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

