### PR TITLE
refactor(react-ai-sdk): adopt shared streaming timing primitive

### DIFF
--- a/.changeset/ai-sdk-streaming-timing-primitive.md
+++ b/.changeset/ai-sdk-streaming-timing-primitive.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+refactor: delegate useStreamingTiming to the shared core primitive, with no public API change

--- a/packages/react-ai-sdk/src/ui/use-chat/useStreamingTiming.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useStreamingTiming.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { UIMessage } from "@ai-sdk/react";
+import { aiSdkStreamingTimingAccessors } from "./useStreamingTiming";
+
+const assistant = (id: string, parts: UIMessage["parts"]): UIMessage => ({
+  id,
+  role: "assistant",
+  parts,
+});
+
+const user = (id: string, text: string): UIMessage => ({
+  id,
+  role: "user",
+  parts: [{ type: "text", text }],
+});
+
+const { getAssistantMessageId, getTextLength, getToolCallCount } =
+  aiSdkStreamingTimingAccessors;
+
+describe("aiSdkStreamingTimingAccessors", () => {
+  it("resolves the last assistant message id", () => {
+    expect(getAssistantMessageId([user("u1", "hi"), assistant("a1", [])])).toBe(
+      "a1",
+    );
+    expect(
+      getAssistantMessageId([
+        assistant("a1", [{ type: "text", text: "x" }]),
+        user("u2", "hi"),
+        assistant("a2", [{ type: "text", text: "y" }]),
+      ]),
+    ).toBe("a2");
+  });
+
+  it("returns undefined when there is no assistant message", () => {
+    expect(getAssistantMessageId([user("u1", "hi")])).toBeUndefined();
+  });
+
+  it("sums text part lengths", () => {
+    expect(
+      getTextLength([assistant("a1", [{ type: "text", text: "hello" }])], "a1"),
+    ).toBe(5);
+    expect(
+      getTextLength(
+        [
+          assistant("a1", [
+            { type: "text", text: "ab" },
+            { type: "text", text: "cde" },
+          ]),
+        ],
+        "a1",
+      ),
+    ).toBe(5);
+  });
+
+  it("counts tool UI parts", () => {
+    expect(
+      getToolCallCount(
+        [
+          assistant("a1", [
+            {
+              type: "tool-search",
+              toolCallId: "tc-1",
+              state: "input-available",
+              input: { q: "x" },
+            },
+            {
+              type: "tool-fetch",
+              toolCallId: "tc-2",
+              state: "output-available",
+              input: { url: "y" },
+              output: { ok: true },
+            },
+          ]),
+        ],
+        "a1",
+      ),
+    ).toBe(2);
+  });
+
+  it("returns 0 when the message is missing or has no parts", () => {
+    expect(getTextLength([user("u1", "hi")], "a1")).toBe(0);
+    expect(getToolCallCount([assistant("a1", [])], "a1")).toBe(0);
+  });
+});

--- a/packages/react-ai-sdk/src/ui/use-chat/useStreamingTiming.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useStreamingTiming.ts
@@ -11,7 +11,8 @@ import {
 const findAssistant = (
   messages: readonly UIMessage[],
   messageId: string,
-): UIMessage | undefined => messages.find((m) => m.id === messageId);
+): UIMessage | undefined =>
+  messages.find((m) => m.role === "assistant" && m.id === messageId);
 
 const getTextLength = (
   messages: readonly UIMessage[],

--- a/packages/react-ai-sdk/src/ui/use-chat/useStreamingTiming.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useStreamingTiming.ts
@@ -1,102 +1,67 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
 import type { UIMessage } from "@ai-sdk/react";
 import { isToolUIPart } from "ai";
 import type { MessageTiming } from "@assistant-ui/core";
+import {
+  useStreamingTiming as useStreamingTimingPrimitive,
+  type StreamingTimingAccessors,
+} from "@assistant-ui/core/react";
 
-type TrackingState = {
-  messageId: string;
-  startTime: number;
-  firstTokenTime?: number;
-  lastContentLength: number;
-  totalChunks: number;
-};
+const findAssistant = (
+  messages: readonly UIMessage[],
+  messageId: string,
+): UIMessage | undefined => messages.find((m) => m.id === messageId);
 
-function getTextLength(message: UIMessage | undefined): number {
+const getTextLength = (
+  messages: readonly UIMessage[],
+  messageId: string,
+): number => {
+  const message = findAssistant(messages, messageId);
   if (!message?.parts) return 0;
   let len = 0;
   for (const part of message.parts) {
     if (part.type === "text") len += part.text.length;
   }
   return len;
-}
+};
 
-function getToolCallCount(message: UIMessage | undefined): number {
+const getToolCallCount = (
+  messages: readonly UIMessage[],
+  messageId: string,
+): number => {
+  const message = findAssistant(messages, messageId);
   if (!message?.parts) return 0;
   let count = 0;
   for (const part of message.parts) {
     if (isToolUIPart(part)) count++;
   }
   return count;
-}
+};
+
+const getAssistantMessageId = (
+  messages: readonly UIMessage[],
+): string | undefined => messages.findLast((m) => m.role === "assistant")?.id;
+
+export const aiSdkStreamingTimingAccessors: StreamingTimingAccessors<UIMessage> =
+  {
+    getAssistantMessageId,
+    getTextLength,
+    getToolCallCount,
+  };
 
 /**
- * Tracks streaming timing for AI SDK messages client-side.
- *
- * Observes `isRunning` transitions and content changes to estimate
- * timing metrics (TTFT, duration, tok/s). Timing is finalized when
- * streaming ends and stored per message ID.
+ * Tracks streaming timing for AI SDK messages client-side. Delegates to the
+ * shared `useStreamingTiming` primitive in `@assistant-ui/core/react`,
+ * adapted to the `UIMessage` shape. Timing is finalized when streaming ends
+ * and stored per message id.
  */
 export const useStreamingTiming = (
   messages: UIMessage[],
   isRunning: boolean,
-): Record<string, MessageTiming> => {
-  const [timings, setTimings] = useState<Record<string, MessageTiming>>({});
-  const trackRef = useRef<TrackingState | null>(null);
-
-  useEffect(() => {
-    const lastAssistant = messages.findLast((m) => m.role === "assistant");
-
-    if (isRunning && lastAssistant) {
-      // Start tracking if not already or if message changed
-      if (
-        !trackRef.current ||
-        trackRef.current.messageId !== lastAssistant.id
-      ) {
-        trackRef.current = {
-          messageId: lastAssistant.id,
-          startTime: Date.now(),
-          lastContentLength: 0,
-          totalChunks: 0,
-        };
-      }
-
-      // Track content changes
-      const t = trackRef.current;
-      const len = getTextLength(lastAssistant);
-      if (len > t.lastContentLength) {
-        if (t.firstTokenTime === undefined) {
-          t.firstTokenTime = Date.now() - t.startTime;
-        }
-        t.totalChunks++;
-        t.lastContentLength = len;
-      }
-    } else if (!isRunning && trackRef.current) {
-      // Streaming ended — finalize timing
-      const t = trackRef.current;
-      const totalStreamTime = Date.now() - t.startTime;
-      const tokenCount = Math.ceil(t.lastContentLength / 4);
-      const toolCallCount = getToolCallCount(lastAssistant);
-
-      const timing: MessageTiming = {
-        streamStartTime: t.startTime,
-        totalStreamTime,
-        totalChunks: t.totalChunks,
-        toolCallCount,
-        ...(t.firstTokenTime !== undefined && {
-          firstTokenTime: t.firstTokenTime,
-        }),
-        ...(tokenCount > 0 && { tokenCount }),
-        ...(totalStreamTime > 0 &&
-          tokenCount > 0 && {
-            tokensPerSecond: tokenCount / (totalStreamTime / 1000),
-          }),
-      };
-      setTimings((prev) => ({ ...prev, [t.messageId]: timing }));
-      trackRef.current = null;
-    }
-  }, [messages, isRunning]);
-
-  return timings;
-};
+): Record<string, MessageTiming> =>
+  useStreamingTimingPrimitive(
+    messages,
+    isRunning,
+    aiSdkStreamingTimingAccessors,
+  );


### PR DESCRIPTION
## summary

- `useStreamingTiming` (in `src/ui/use-chat/useStreamingTiming.ts`) now delegates to the shared `useStreamingTiming` primitive in `@assistant-ui/core/react` (#4548) via a `StreamingTimingAccessors` adapter for the AI SDK `UIMessage` shape, removing this package's copy of the client-side timing state machine
- the hook stays internal (not in the package barrel) and its `(messages, isRunning) -> Record<string, MessageTiming>` signature is unchanged, so `useAISDKRuntime` wiring and the `convertMessage.ts` metadata injection need no change
- behavior is preserved for every existing case; the only observable change is the inherited core fix where the final content chunk that lands in the same update as the `isRunning -> false` transition is now counted in the token estimate (previously dropped)

## breaking changes

- none; the hook is internal and its signature is unchanged

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ai-sdk exec vitest run src/ui/use-chat/useStreamingTiming.test.ts` -> 5/5 green (new accessor test: last-assistant-id via `findLast`, text-part length summing, tool-UI-part count via `isToolUIPart`, missing/empty fallbacks)
- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` -> 8 files / 82 tests green
- [x] `pnpm --filter @assistant-ui/react-ai-sdk build` -> succeeds
- [x] `oxlint` + `oxfmt --check` on the changed files -> clean

### reviewer should verify

- [ ] the three accessor functions (`getAssistantMessageId` / `getTextLength` / `getToolCallCount`) are the same logic as the inlined originals, just wired into the `StreamingTimingAccessors` object, and the `findLast` + `isToolUIPart` semantics are preserved

## notes

- this is the third adapter migration off the core primitive, after `react-langgraph` (#4549) and `react-langchain` (#4550); `react-opencode` is the last one

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

