### PR TITLE
refactor(react-opencode): adopt shared streaming timing primitive

### DIFF
--- a/.changeset/opencode-streaming-timing-primitive.md
+++ b/.changeset/opencode-streaming-timing-primitive.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+refactor: delegate useOpenCodeStreamingTiming to the shared core primitive, with no public API change

--- a/packages/react-opencode/src/useOpenCodeStreamingTiming.ts
+++ b/packages/react-opencode/src/useOpenCodeStreamingTiming.ts
@@ -1,16 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useMemo } from "react";
 import type { MessageTiming } from "@assistant-ui/react";
+import {
+  useStreamingTiming,
+  type StreamingTimingAccessors,
+} from "@assistant-ui/core/react";
 import type { OpenCodeThreadState } from "./types";
-
-type TrackingState = {
-  messageId: string;
-  startTime: number;
-  firstTokenTime?: number;
-  lastContentLength: number;
-  totalChunks: number;
-};
 
 export function getMessageTextLength(
   state: OpenCodeThreadState,
@@ -53,59 +49,44 @@ export function getLastAssistantId(
   return undefined;
 }
 
+// OpenCode tracks timing off a single thread-state snapshot rather than a
+// message list, so the snapshot is wrapped in a one-element array to satisfy
+// the shared primitive's `readonly TMessage[]` contract. The wrapper is
+// memoized on `state` so the primitive's effect keeps the original
+// `[state, isRunning]` reactivity (runs on state change, not every render).
+const stateOf = (messages: readonly OpenCodeThreadState[]) => messages[0];
+
+const openCodeStreamingTimingAccessors: StreamingTimingAccessors<OpenCodeThreadState> =
+  {
+    getAssistantMessageId: (messages) => {
+      const state = stateOf(messages);
+      return state ? getLastAssistantId(state) : undefined;
+    },
+    getTextLength: (messages, messageId) => {
+      const state = stateOf(messages);
+      return state ? getMessageTextLength(state, messageId) : 0;
+    },
+    getToolCallCount: (messages, messageId) => {
+      const state = stateOf(messages);
+      return state ? getMessageToolCallCount(state, messageId) : 0;
+    },
+  };
+
+/**
+ * Tracks per-message streaming timing for OpenCode messages. Delegates to
+ * the shared `useStreamingTiming` primitive in `@assistant-ui/core/react`,
+ * adapted to the `OpenCodeThreadState` snapshot shape (`messagesById` +
+ * `messageOrder`). Timing is finalized when streaming ends and stored per
+ * message id.
+ */
 export const useOpenCodeStreamingTiming = (
   state: OpenCodeThreadState,
   isRunning: boolean,
 ): Record<string, MessageTiming> => {
-  const [timings, setTimings] = useState<Record<string, MessageTiming>>({});
-  const trackRef = useRef<TrackingState | null>(null);
-
-  useEffect(() => {
-    const lastId = getLastAssistantId(state);
-
-    if (isRunning && lastId) {
-      if (!trackRef.current || trackRef.current.messageId !== lastId) {
-        trackRef.current = {
-          messageId: lastId,
-          startTime: Date.now(),
-          lastContentLength: 0,
-          totalChunks: 0,
-        };
-      }
-
-      const t = trackRef.current;
-      const len = getMessageTextLength(state, t.messageId);
-      if (len > t.lastContentLength) {
-        if (t.firstTokenTime === undefined) {
-          t.firstTokenTime = Date.now() - t.startTime;
-        }
-        t.totalChunks++;
-        t.lastContentLength = len;
-      }
-    } else if (!isRunning && trackRef.current) {
-      const t = trackRef.current;
-      const totalStreamTime = Date.now() - t.startTime;
-      const tokenCount = Math.ceil(t.lastContentLength / 4);
-      const toolCallCount = getMessageToolCallCount(state, t.messageId);
-
-      const timing: MessageTiming = {
-        streamStartTime: t.startTime,
-        totalStreamTime,
-        totalChunks: t.totalChunks,
-        toolCallCount,
-        ...(t.firstTokenTime !== undefined && {
-          firstTokenTime: t.firstTokenTime,
-        }),
-        ...(tokenCount > 0 && { tokenCount }),
-        ...(totalStreamTime > 0 &&
-          tokenCount > 0 && {
-            tokensPerSecond: tokenCount / (totalStreamTime / 1000),
-          }),
-      };
-      setTimings((prev) => ({ ...prev, [t.messageId]: timing }));
-      trackRef.current = null;
-    }
-  }, [state, isRunning]);
-
-  return timings;
+  const messages = useMemo(() => [state], [state]);
+  return useStreamingTiming(
+    messages,
+    isRunning,
+    openCodeStreamingTimingAccessors,
+  );
 };


### PR DESCRIPTION
## summary

- `useOpenCodeStreamingTiming` now delegates to the shared `useStreamingTiming` primitive in `@assistant-ui/core/react` (#4548) via a `StreamingTimingAccessors` adapter for the `OpenCodeThreadState` snapshot shape (`messagesById` + `messageOrder`), removing this package's copy of the client-side timing state machine
- OpenCode tracks timing off a single thread-state snapshot rather than a message list, so the snapshot is wrapped in a memoized one-element array to satisfy the primitive's `readonly TMessage[]` contract; the wrapper is memoized on `state` so the primitive's effect keeps the original `[state, isRunning]` reactivity (runs on state change, not every render)
- the public `useOpenCodeStreamingTiming` export and the exported accessor helpers (`getMessageTextLength`, `getMessageToolCallCount`, `getLastAssistantId`) are unchanged, so `useOpenCodeRuntime` wiring and the existing accessor tests need no change
- behavior is preserved for every existing case; the only observable change is the inherited core fix where the final content chunk that lands in the same update as the `isRunning -> false` transition is now counted in the token estimate (previously dropped)

## breaking changes

- none; the public export and the exported accessor helpers are unchanged

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-opencode test` -> 7 files / 44 tests green (the existing accessor suite is the regression baseline and passes unchanged: getLastAssistantId, getMessageTextLength incl. text+reasoning, getMessageToolCallCount)
- [x] `pnpm --filter @assistant-ui/react-opencode build` -> succeeds, `useOpenCodeStreamingTiming` still exported from the barrel
- [x] `oxlint` + `oxfmt --check` on the changed file -> clean

### reviewer should verify

- [ ] the one-element-array wrapper (`useMemo(() => [state], [state])`) preserves the original `[state, isRunning]` effect reactivity, i.e. the primitive's effect runs on state change or isRunning change, not every render
- [ ] the three accessor functions are the same logic as the inlined originals, just unwrapping `messages[0]` and delegating to the existing `getMessageTextLength` / `getMessageToolCallCount` / `getLastAssistantId` helpers

## notes

- this is the fourth and final adapter migration off the core primitive, after `react-langgraph` (#4549), `react-langchain` (#4550), and `react-ai-sdk` (#4551); all four client-side timing state machines now collapse onto the single core `useStreamingTiming` + `stepStreamingTiming`
- remaining follow-up (separate PR): `react-langgraph`'s `getMessageTextLength` still has the `reasoning`-block gap that #4550 fixed in `react-langchain`; a small follow-up can align it

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

