### PR TITLE
fix(react-langgraph): count reasoning content blocks in streaming timing

### DIFF
--- a/.changeset/langgraph-reasoning-timing.md
+++ b/.changeset/langgraph-reasoning-timing.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix(react-langgraph): count reasoning content blocks in the streaming timing text length

--- a/packages/react-langgraph/src/useLangGraphStreamingTiming.test.ts
+++ b/packages/react-langgraph/src/useLangGraphStreamingTiming.test.ts
@@ -119,6 +119,75 @@ describe("useLangGraphStreamingTiming", () => {
     expect(result.current["msg-1"]?.toolCallCount).toBe(2);
   });
 
+  it("counts reasoning block content toward the token estimate", () => {
+    const start: LangChainMessage[] = [
+      {
+        id: "msg-1",
+        type: "ai",
+        content: [
+          {
+            type: "reasoning",
+            summary: [{ type: "summary_text", text: "step one" }],
+          },
+        ],
+      } as never,
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ msgs, running }) => useLangGraphStreamingTiming(msgs, running),
+      { initialProps: { msgs: start, running: true } },
+    );
+
+    // Grow the reasoning summary, then finalize in the same update as stop.
+    const grown: LangChainMessage[] = [
+      {
+        id: "msg-1",
+        type: "ai",
+        content: [
+          {
+            type: "reasoning",
+            summary: [
+              { type: "summary_text", text: "step one" },
+              { type: "summary_text", text: "step two" },
+            ],
+          },
+        ],
+      } as never,
+    ];
+
+    act(() => {
+      rerender({ msgs: grown, running: false });
+    });
+
+    const timing = result.current["msg-1"];
+    // Reasoning text is joined like convertLangChainMessages renders it.
+    const reasoningText = "step one\n\n\nstep two";
+    expect(timing?.tokenCount).toBe(Math.ceil(reasoningText.length / 4));
+  });
+
+  it("counts a bare reasoning field when no summary is present", () => {
+    const messages: LangChainMessage[] = [
+      {
+        id: "msg-1",
+        type: "ai",
+        content: [{ type: "reasoning", reasoning: "deduced" }],
+      } as never,
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ msgs, running }) => useLangGraphStreamingTiming(msgs, running),
+      { initialProps: { msgs: messages, running: true } },
+    );
+
+    act(() => {
+      rerender({ msgs: messages, running: false });
+    });
+
+    expect(result.current["msg-1"]?.tokenCount).toBe(
+      Math.ceil("deduced".length / 4),
+    );
+  });
+
   it("tracks multiple content updates as chunks", () => {
     const messages: LangChainMessage[] = [
       { id: "msg-1", type: "ai", content: "a" } as never,

--- a/packages/react-langgraph/src/useLangGraphStreamingTiming.ts
+++ b/packages/react-langgraph/src/useLangGraphStreamingTiming.ts
@@ -7,6 +7,15 @@ import {
   type StreamingTimingAccessors,
 } from "@assistant-ui/core/react";
 
+const reasoningTextLength = (part: {
+  readonly summary?: ReadonlyArray<{ readonly text?: string }>;
+  readonly reasoning?: string;
+}): number => {
+  if (part.summary && part.summary.length > 0)
+    return part.summary.map((s) => s?.text ?? "").join("\n\n\n").length;
+  return part.reasoning?.length ?? 0;
+};
+
 const getMessageTextLength = (
   messages: readonly LangChainMessage[],
   messageId: string,
@@ -18,10 +27,18 @@ const getMessageTextLength = (
   if (!Array.isArray(content)) return 0;
   let len = 0;
   for (const part of content) {
-    if ("text" in part && typeof part.text === "string")
-      len += part.text.length;
-    if ("thinking" in part && typeof part.thinking === "string")
-      len += part.thinking.length;
+    switch (part.type) {
+      case "text":
+      case "text_delta":
+        if (typeof part.text === "string") len += part.text.length;
+        break;
+      case "thinking":
+        if (typeof part.thinking === "string") len += part.thinking.length;
+        break;
+      case "reasoning":
+        len += reasoningTextLength(part);
+        break;
+    }
   }
   return len;
 };


### PR DESCRIPTION
## summary

- `getMessageTextLength` in `useLangGraphStreamingTiming` now measures `reasoning` content blocks (summary_text entries joined the same way `convertLangChainMessages` renders them, or the bare `reasoning` field), in addition to `text` and `thinking`
- previously, reasoning-only growth (e.g. OpenAI o-series `{ type: "reasoning", summary | reasoning }` blocks) was not reflected in the token estimate, so `tokensPerSecond` was under-reported for that model family
- this aligns `react-langgraph` with the same fix already shipped in `react-langchain` (#4550), closing the last timing gap left after the primitive migration

## breaking changes

- none; this only changes (improves) the accuracy of an estimated field

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-langgraph test` -> 8 files / 150 tests green (incl. two new cases: reasoning via `summary` joined like the converter, and reasoning via the bare `reasoning` field)
- [x] `pnpm --filter @assistant-ui/react-langgraph build` -> succeeds
- [x] `oxlint` + `oxfmt --check` on the changed files -> clean

### reviewer should verify

- [ ] the `reasoningTextLength` helper matches `convertLangChainMessages`' rendering: `summary.map(s => s.text ?? "").join("\n\n\n")` when a summary is present, else `reasoning ?? ""`
- [ ] the `text` / `text_delta` / `thinking` cases still behave exactly as before (the duck-typed checks were replaced by a `switch (part.type)` with the same outcomes)

## notes

- this is the last follow-up from the streaming-timing primitive migration (#4548, #4549, #4550, #4551, #4553); all four adapters now count reasoning consistently where their message shape exposes it

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

