### PR TITLE
feat: add createAISDKRoute helper with escape hatches & options

### DIFF
--- a/.changeset/fuzzy-routes-smile.md
+++ b/.changeset/fuzzy-routes-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+feat: add createAISDKRoute helper for AI SDK chat routes

--- a/examples/with-ai-sdk-v6/app/api/chat/route.ts
+++ b/examples/with-ai-sdk-v6/app/api/chat/route.ts
@@ -1,50 +1,15 @@
 import { openai } from "@ai-sdk/openai";
-import { frontendTools } from "@assistant-ui/react-ai-sdk";
-import {
-  type JSONSchema7,
-  streamText,
-  convertToModelMessages,
-  type UIMessage,
-  tool,
-  stepCountIs,
-  zodSchema,
-} from "ai";
-import { z } from "zod";
+import { createAISDKRoute } from "@assistant-ui/react-ai-sdk";
+import { stepCountIs } from "ai";
+import toolkit from "../../toolkit";
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 30;
 
-export async function POST(req: Request) {
-  const {
-    messages,
-    system,
-    tools,
-  }: {
-    messages: UIMessage[];
-    system?: string;
-    tools?: Record<string, { description?: string; parameters: JSONSchema7 }>;
-  } = await req.json();
-
-  const result = streamText({
-    model: openai("gpt-5.4-nano"),
-    messages: await convertToModelMessages(messages),
-    ...(system ? { system } : {}),
+export const { POST } = createAISDKRoute({
+  toolkit,
+  model: openai("gpt-5.4-nano"),
+  streamText: {
     stopWhen: stepCountIs(10),
-    tools: {
-      ...frontendTools(tools ?? {}),
-      get_current_weather: tool({
-        description: "Get the current weather",
-        inputSchema: zodSchema(
-          z.object({
-            city: z.string(),
-          }),
-        ),
-        execute: async ({ city }) => {
-          return `The weather in ${city} is sunny`;
-        },
-      }),
-    },
-  });
-
-  return result.toUIMessageStreamResponse();
-}
+  },
+});

--- a/examples/with-ai-sdk-v6/app/toolkit.tsx
+++ b/examples/with-ai-sdk-v6/app/toolkit.tsx
@@ -1,0 +1,16 @@
+"use generative";
+
+import { defineToolkit } from "@assistant-ui/react";
+import { z } from "zod";
+
+export default defineToolkit({
+  get_current_weather: {
+    description: "Get the current weather",
+    parameters: z.object({
+      city: z.string(),
+    }),
+    execute: async ({ city }) => {
+      return `The weather in ${city} is sunny`;
+    },
+  },
+});

--- a/packages/react-ai-sdk/src/createAISDKRoute.test.ts
+++ b/packages/react-ai-sdk/src/createAISDKRoute.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createAISDKRoute } from "./createAISDKRoute";
+
+const mocks = vi.hoisted(() => ({
+  convertToModelMessages: vi.fn(),
+  jsonSchema: vi.fn((schema) => ({ kind: "jsonSchema", schema })),
+  streamText: vi.fn(),
+  toUIMessageStreamResponse: vi.fn(),
+}));
+
+vi.mock("ai", () => ({
+  convertToModelMessages: mocks.convertToModelMessages,
+  jsonSchema: mocks.jsonSchema,
+  streamText: mocks.streamText,
+}));
+
+const mockResult = () => ({
+  toUIMessageStreamResponse: mocks.toUIMessageStreamResponse,
+});
+
+const request = (body: unknown) =>
+  new Request("http://localhost/api/chat", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("createAISDKRoute", () => {
+  beforeEach(() => {
+    mocks.convertToModelMessages.mockReset();
+    mocks.convertToModelMessages.mockResolvedValue([
+      { role: "user", content: "hello" },
+    ]);
+    mocks.jsonSchema.mockClear();
+    mocks.streamText.mockReset();
+    mocks.streamText.mockReturnValue(mockResult());
+    mocks.toUIMessageStreamResponse.mockReset();
+    mocks.toUIMessageStreamResponse.mockReturnValue(new Response("ok"));
+  });
+
+  it("creates a POST handler with the default assistant-ui AI SDK wiring", async () => {
+    const messages = [
+      {
+        id: "msg-1",
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+      },
+    ];
+    const { POST } = createAISDKRoute({
+      toolkit: {
+        serverTool: {
+          type: "backend",
+          description: "Server tool",
+          parameters: { type: "object", properties: {} },
+          execute: async () => "ok",
+        } as never,
+      },
+      model: "openai/gpt-5.4-nano",
+    });
+
+    const response = await POST(
+      request({
+        messages,
+        system: "Be concise.",
+        callSettings: { maxTokens: 123, temperature: 0.2 },
+        tools: {
+          clientTool: {
+            description: "Client tool",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      }),
+    );
+
+    expect(await response.text()).toBe("ok");
+    const aiSDKTools = expect.objectContaining({
+      clientTool: expect.any(Object),
+      serverTool: expect.any(Object),
+    });
+    expect(mocks.convertToModelMessages).toHaveBeenCalledWith(messages, {
+      tools: aiSDKTools,
+    });
+    expect(mocks.streamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "openai/gpt-5.4-nano",
+        system: "Be concise.",
+        messages: [{ role: "user", content: "hello" }],
+        maxOutputTokens: 123,
+        temperature: 0.2,
+        tools: aiSDKTools,
+      }),
+    );
+
+    const streamOptions = mocks.streamText.mock.calls[0]![0];
+    expect(streamOptions.tools.serverTool.execute).toBeTypeOf("function");
+    expect(mocks.toUIMessageStreamResponse).toHaveBeenCalledWith(undefined);
+  });
+
+  it("allows context, dynamic model, tool filtering, and final streamText overrides", async () => {
+    const prepareStreamText = vi.fn(({ defaults }) => ({
+      ...defaults,
+      headers: { "x-tenant": "tenant-1" },
+      system: "Prepared system",
+    }));
+    const { POST } = createAISDKRoute({
+      toolkit: {},
+      context: async () => ({ tenantId: "tenant-1" }),
+      model: ({ body }) => (body.config as { modelName: string }).modelName,
+      system: ({ ctx }) => `Tenant ${ctx.tenantId}`,
+      tools: async ({ defaultTools }) => ({
+        ...defaultTools,
+        tenant_lookup: { inputSchema: { type: "object" } } as never,
+      }),
+      streamText: ({ ctx }) => ({
+        maxOutputTokens: 7,
+        providerOptions: { openai: { tenantId: ctx.tenantId } },
+      }),
+      prepareStreamText,
+    });
+
+    await POST(
+      request({
+        messages: [],
+        config: { modelName: "openai/gpt-5.4-mini" },
+      }),
+    );
+
+    expect(prepareStreamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: "Tenant tenant-1",
+        defaults: expect.objectContaining({
+          model: "openai/gpt-5.4-mini",
+          maxOutputTokens: 7,
+          providerOptions: { openai: { tenantId: "tenant-1" } },
+          tools: expect.objectContaining({
+            tenant_lookup: expect.any(Object),
+          }),
+        }),
+      }),
+    );
+    expect(mocks.streamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: { "x-tenant": "tenant-1" },
+        system: "Prepared system",
+      }),
+    );
+  });
+
+  it("passes response options to toUIMessageStreamResponse", async () => {
+    const responseOptions = {
+      status: 202,
+      headers: { "x-route": "assistant" },
+    };
+    const { POST } = createAISDKRoute({
+      toolkit: {},
+      model: "openai/gpt-5.4-nano",
+      response: responseOptions,
+    });
+
+    await POST(request({ messages: [] }));
+
+    expect(mocks.toUIMessageStreamResponse).toHaveBeenCalledWith(
+      responseOptions,
+    );
+  });
+
+  it("lets toResponse replace the default response", async () => {
+    const customResponse = new Response("custom", { status: 203 });
+    const toResponse = vi.fn(() => customResponse);
+    const { POST } = createAISDKRoute({
+      toolkit: {},
+      model: "openai/gpt-5.4-nano",
+      response: { headers: { "x-default": "yes" } },
+      toResponse,
+    });
+
+    const response = await POST(request({ messages: [] }));
+
+    expect(response).toBe(customResponse);
+    expect(toResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseOptions: { headers: { "x-default": "yes" } },
+        result: mockResult(),
+      }),
+    );
+    expect(mocks.toUIMessageStreamResponse).not.toHaveBeenCalled();
+  });
+
+  it("returns thrown Responses for auth-style early exits", async () => {
+    const { POST } = createAISDKRoute({
+      toolkit: {},
+      model: "openai/gpt-5.4-nano",
+      context: async () => {
+        throw new Response("Unauthorized", { status: 401 });
+      },
+    });
+
+    const response = await POST(request({ messages: [] }));
+
+    expect(response.status).toBe(401);
+    expect(await response.text()).toBe("Unauthorized");
+    expect(mocks.streamText).not.toHaveBeenCalled();
+  });
+
+  it("delegates non-Response failures to onError", async () => {
+    const errorResponse = new Response("handled", { status: 500 });
+    const onError = vi.fn(() => errorResponse);
+    const { POST } = createAISDKRoute({
+      toolkit: {},
+      model: () => {
+        throw new Error("boom");
+      },
+      onError,
+    });
+
+    const response = await POST(request({ messages: [] }));
+
+    expect(response).toBe(errorResponse);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.any(Error),
+        body: { messages: [] },
+      }),
+    );
+  });
+});

--- a/packages/react-ai-sdk/src/createAISDKRoute.ts
+++ b/packages/react-ai-sdk/src/createAISDKRoute.ts
@@ -1,0 +1,272 @@
+import {
+  convertToModelMessages,
+  streamText,
+  type LanguageModel,
+  type ModelMessage,
+  type ToolSet,
+  type UIMessage,
+  type UIMessageStreamOptions,
+} from "ai";
+import type { ToolJSONSchema } from "assistant-stream";
+import type { Toolkit } from "@assistant-ui/core/react";
+import { AISDKToolkit } from "./generativeTools";
+
+type Awaitable<T> = T | Promise<T>;
+type StreamTextOptions = Parameters<typeof streamText>[0];
+type StreamTextResult = ReturnType<typeof streamText>;
+
+export type AISDKRouteCallSettings = {
+  maxTokens?: number;
+  maxOutputTokens?: number;
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  stopSequences?: string[];
+  seed?: number;
+  maxRetries?: number;
+  timeout?: StreamTextOptions["timeout"];
+  headers?: Record<string, string | undefined>;
+};
+
+export type AISDKRouteBody<
+  UI_MESSAGE extends UIMessage = UIMessage,
+  TConfig = unknown,
+> = {
+  id?: string;
+  messages: UI_MESSAGE[];
+  system?: string;
+  tools?: Record<string, ToolJSONSchema>;
+  callSettings?: AISDKRouteCallSettings;
+  config?: TConfig;
+  trigger?: string;
+  messageId?: string;
+  metadata?: unknown;
+  [key: string]: unknown;
+};
+
+type AISDKRouteResponseInit = ResponseInit & {
+  consumeSseStream?: (options: {
+    stream: ReadableStream<string>;
+  }) => PromiseLike<void> | void;
+};
+
+export type AISDKRouteResponseOptions<UI_MESSAGE extends UIMessage> =
+  AISDKRouteResponseInit & UIMessageStreamOptions<UI_MESSAGE>;
+
+type RouteValue<TValue, TArgs> = TValue | ((args: TArgs) => Awaitable<TValue>);
+
+type BaseRouteArgs<TBody, TContext> = {
+  req: Request;
+  body: TBody;
+  ctx: TContext;
+  aiToolkit: AISDKToolkit;
+};
+
+type PreparedRouteArgs<TBody, TContext> = BaseRouteArgs<TBody, TContext> & {
+  model: LanguageModel;
+  tools: ToolSet;
+  messages: ModelMessage[];
+  system: StreamTextOptions["system"] | undefined;
+};
+
+type ResultRouteArgs<
+  TBody,
+  TContext,
+  UI_MESSAGE extends UIMessage,
+> = PreparedRouteArgs<TBody, TContext> & {
+  result: StreamTextResult;
+  streamTextOptions: StreamTextOptions;
+  responseOptions: AISDKRouteResponseOptions<UI_MESSAGE> | undefined;
+};
+
+type AISDKRouteBodyMessage<TBody> =
+  TBody extends AISDKRouteBody<infer UI_MESSAGE, unknown>
+    ? UI_MESSAGE
+    : UIMessage;
+
+export type CreateAISDKRouteOptions<
+  TBody extends AISDKRouteBody = AISDKRouteBody,
+  TContext = undefined,
+  UI_MESSAGE extends UIMessage = AISDKRouteBodyMessage<TBody>,
+> = {
+  toolkit: Toolkit;
+  model: RouteValue<LanguageModel, BaseRouteArgs<TBody, TContext>>;
+  parseBody?: (req: Request) => Awaitable<TBody>;
+  context?: (args: { req: Request; body: TBody }) => Awaitable<TContext>;
+  system?: RouteValue<
+    StreamTextOptions["system"] | undefined,
+    BaseRouteArgs<TBody, TContext>
+  >;
+  messages?: (
+    args: BaseRouteArgs<TBody, TContext> & {
+      tools: ToolSet;
+    },
+  ) => Awaitable<ModelMessage[]>;
+  tools?: (
+    args: BaseRouteArgs<TBody, TContext> & {
+      defaultTools: ToolSet;
+    },
+  ) => Awaitable<ToolSet>;
+  streamText?: RouteValue<
+    Partial<StreamTextOptions>,
+    PreparedRouteArgs<TBody, TContext>
+  >;
+  prepareStreamText?: (
+    args: PreparedRouteArgs<TBody, TContext> & {
+      defaults: StreamTextOptions;
+    },
+  ) => Awaitable<StreamTextOptions>;
+  response?: RouteValue<
+    AISDKRouteResponseOptions<UI_MESSAGE> | undefined,
+    PreparedRouteArgs<TBody, TContext> & {
+      result: StreamTextResult;
+      streamTextOptions: StreamTextOptions;
+    }
+  >;
+  toResponse?: (
+    args: ResultRouteArgs<TBody, TContext, UI_MESSAGE>,
+  ) => Awaitable<Response>;
+  onError?: (args: {
+    error: unknown;
+    req: Request;
+    body?: TBody;
+    ctx?: TContext;
+  }) => Awaitable<Response | void>;
+};
+
+export type CreateAISDKRouteResult = {
+  POST: (req: Request) => Promise<Response>;
+  aiToolkit: AISDKToolkit;
+};
+
+export function createAISDKRoute<
+  TBody extends AISDKRouteBody = AISDKRouteBody,
+  TContext = undefined,
+  UI_MESSAGE extends UIMessage = AISDKRouteBodyMessage<TBody>,
+>(
+  options: CreateAISDKRouteOptions<TBody, TContext, UI_MESSAGE>,
+): CreateAISDKRouteResult {
+  const aiToolkit = new AISDKToolkit({ toolkit: options.toolkit });
+
+  return {
+    aiToolkit,
+    POST: async (req) => {
+      let body: TBody | undefined;
+      let ctx: TContext | undefined;
+
+      try {
+        body = options.parseBody
+          ? await options.parseBody(req)
+          : ((await req.json()) as TBody);
+        ctx = options.context
+          ? await options.context({ req, body })
+          : (undefined as TContext);
+
+        const baseArgs: BaseRouteArgs<TBody, TContext> = {
+          req,
+          body,
+          ctx,
+          aiToolkit,
+        };
+
+        const defaultTools = await aiToolkit.tools(
+          body.tools ? { frontend: body.tools } : {},
+        );
+        const tools = options.tools
+          ? await options.tools({ ...baseArgs, defaultTools })
+          : defaultTools;
+        const model = await resolveRouteValue(options.model, baseArgs);
+        const system = options.system
+          ? await resolveRouteValue(options.system, baseArgs)
+          : body.system;
+        const messages = options.messages
+          ? await options.messages({ ...baseArgs, tools })
+          : await convertToModelMessages(body.messages, { tools });
+
+        const preparedArgs: PreparedRouteArgs<TBody, TContext> = {
+          ...baseArgs,
+          model,
+          tools,
+          messages,
+          system,
+        };
+        const streamTextOverrides = options.streamText
+          ? await resolveRouteValue(options.streamText, preparedArgs)
+          : undefined;
+        const defaults = {
+          ...normalizeCallSettings(body.callSettings),
+          model,
+          messages,
+          ...(system !== undefined && { system }),
+          tools,
+          ...streamTextOverrides,
+        } as StreamTextOptions;
+        const streamTextOptions = options.prepareStreamText
+          ? await options.prepareStreamText({ ...preparedArgs, defaults })
+          : defaults;
+        const result = streamText(streamTextOptions);
+        const responseOptions = options.response
+          ? await resolveRouteValue(options.response, {
+              ...preparedArgs,
+              result,
+              streamTextOptions,
+            })
+          : undefined;
+
+        if (options.toResponse) {
+          return await options.toResponse({
+            ...preparedArgs,
+            result,
+            streamTextOptions,
+            responseOptions,
+          });
+        }
+
+        return result.toUIMessageStreamResponse(responseOptions);
+      } catch (error) {
+        if (error instanceof Response) return error;
+
+        const handled = await options.onError?.({
+          error,
+          req,
+          ...(body !== undefined && { body }),
+          ...(ctx !== undefined && { ctx }),
+        });
+        if (handled) return handled;
+
+        throw error;
+      }
+    },
+  };
+}
+
+const resolveRouteValue = async <TValue, TArgs>(
+  value: RouteValue<TValue, TArgs>,
+  args: TArgs,
+): Promise<TValue> => {
+  if (typeof value === "function") {
+    return await (value as (args: TArgs) => Awaitable<TValue>)(args);
+  }
+  return value;
+};
+
+const normalizeCallSettings = (
+  callSettings: AISDKRouteCallSettings | undefined,
+): Partial<StreamTextOptions> => {
+  if (!callSettings) return {};
+
+  const { maxTokens, maxOutputTokens, ...rest } = callSettings;
+  const normalizedMaxOutputTokens = maxOutputTokens ?? maxTokens;
+  const settings: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(rest)) {
+    if (value !== undefined) settings[key] = value;
+  }
+  if (normalizedMaxOutputTokens !== undefined) {
+    settings["maxOutputTokens"] = normalizedMaxOutputTokens;
+  }
+
+  return settings as Partial<StreamTextOptions>;
+};

--- a/packages/react-ai-sdk/src/index.ts
+++ b/packages/react-ai-sdk/src/index.ts
@@ -8,3 +8,11 @@ export {
   type AISDKToolkitToolsOptions,
   type GenerativeToolsOptions,
 } from "./generativeTools";
+export {
+  createAISDKRoute,
+  type AISDKRouteBody,
+  type AISDKRouteCallSettings,
+  type AISDKRouteResponseOptions,
+  type CreateAISDKRouteOptions,
+  type CreateAISDKRouteResult,
+} from "./createAISDKRoute";


### PR DESCRIPTION
## Summary

Adds `createAISDKRoute` to `@assistant-ui/react-ai-sdk`, a small route helper for the common assistant-ui + AI SDK server route pattern.

Instead of every app hand-writing the same `req.json()` → `convertToModelMessages()` → `aiToolkit.tools({ frontend: tools })` → `streamText()` → `toUIMessageStreamResponse()` flow, users can define the route as:

```ts
export const { POST } = createAISDKRoute({
  toolkit,
  model: openai("gpt-5.4-nano"),
  streamText: {
    stopWhen: stepCountIs(10),
  },
});
```

## Why

The existing manual route setup is flexible, but it asks users to understand several pieces before they can ship a normal chat endpoint:

- how assistant-ui sends frontend tool schemas in the request body
- how `AISDKToolkit.tools({ frontend })` merges frontend tools with server toolkit tools
- how UI messages should be converted with the final AI SDK tool set
- how to return an AI SDK UI message stream response

`createAISDKRoute` keeps that default path short while preserving the same underlying primitives for advanced cases.

## Helper Use Cases

- **Basic chat route**: create a working AI SDK route from a toolkit and model with minimal boilerplate.
- **Toolkit-backed tools**: automatically expose server toolkit tools and merge request-provided frontend tool schemas.
- **Example/template DX**: make examples and starters easier to read by keeping the route focused on configuration.
- **Multiple assistant profiles**: create separate route files for billing, analytics, support, docs, etc. by passing a different `toolkit`, `model`, or route options.
- **Tenant-aware routes**: use `context` and dynamic `model`, `system`, or `streamText` options for auth, org config, provider options, or per-tenant headers.
- **Advanced route customization**: override `messages`, `tools`, `prepareStreamText`, `response`, `toResponse`, or `onError` without leaving the helper.

## What Changed

- Added `createAISDKRoute` and exported it from `@assistant-ui/react-ai-sdk`.
- Added route option types for request body, call settings, response options, and helper configuration.
- Added tests for the default route wiring and advanced escape hatches.
- Updated the AI SDK v6 example route to use `createAISDKRoute`.
- Moved the example weather tool into `app/toolkit.tsx` so the route demonstrates the intended compact helper usage.
- Added a patch changeset for `@assistant-ui/react-ai-sdk`.

## Escape Hatches

The helper intentionally does not hide the AI SDK. Callers can still customize the route with:

- `parseBody` for non-standard request parsing
- `context` for auth/session/tenant lookup
- dynamic `model` and `system`
- custom `messages` conversion
- custom `tools` filtering or augmentation
- `streamText` defaults like `stopWhen`, `providerOptions`, headers, max output tokens, and temperature
- `prepareStreamText` for final full control before calling `streamText`
- `response` for `toUIMessageStreamResponse` options
- `toResponse` for fully custom response handling
- `onError` for route-level error responses

## Validation

- `pnpm exec oxfmt --check ...`
- `pnpm exec oxlint ...`
- `pnpm --filter with-ai-sdk-v6 exec tsc --noEmit`
- `pnpm --filter @assistant-ui/react-ai-sdk exec vitest run src/createAISDKRoute.test.ts`
- Local browser smoke test against `examples/with-ai-sdk-v6`: `POST /api/chat 200` and weather tool response rendered in the chat UI.

Note: local checks showed the existing Node engine warning because this machine is on Node `v23.11.0` and the repo requests `>=24`.