### PR TITLE
fix: add tool-fallback button registry dependency

### DIFF
--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -317,7 +317,7 @@ export const registry: RegistryItem[] = [
       },
     ],
     dependencies: ["@assistant-ui/react", "lucide-react"],
-    registryDependencies: ["collapsible"],
+    registryDependencies: ["button", "collapsible"],
   },
   {
     name: "tool-group",


### PR DESCRIPTION
## Summary

- Add `button` to the `tool-fallback` registry dependencies.
- Ensures `shadcn add` installs `components/ui/button.tsx` alongside `components/ui/collapsible.tsx` and `components/assistant-ui/tool-fallback.tsx`.

## Root Cause

`components/assistant-ui/tool-fallback.tsx` imports `Button` from `@/components/ui/button`, but the registry item only declared `collapsible` in `registryDependencies`. Installing `tool-fallback` by itself copied a component with a dangling import.

## Reproduced Error

After installing `tool-fallback` alone into a temp shadcn fixture and filling in normal project utilities/types, TypeScript failed with:

```text
components/assistant-ui/tool-fallback.tsx(26,24): error TS2307: Cannot find module '@/components/ui/button' or its corresponding type declarations.
```

## Validation

- `pnpm --filter @assistant-ui/shadcn-registry build`
- `pnpm dlx shadcn@latest add /Users/mac/oss/assistant-ui/apps/registry/dist/tool-fallback.json --dry-run --yes --cwd <temp-fixture>`

The dry run now resolves:

```text
components/ui/button.tsx
components/ui/collapsible.tsx
components/assistant-ui/tool-fallback.tsx
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

