### PR TITLE
fix: add missing registry package dependencies

### DIFF
--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -334,6 +334,7 @@ export const registry: RegistryItem[] = [
       "@assistant-ui/react",
       "lucide-react",
       "class-variance-authority",
+      "tw-shimmer",
     ],
     registryDependencies: ["collapsible"],
     css: {
@@ -438,7 +439,7 @@ export const registry: RegistryItem[] = [
         sourcePath: "../../packages/ui/src/components/assistant-ui/sources.tsx",
       },
     ],
-    dependencies: ["@assistant-ui/react"],
+    dependencies: ["@assistant-ui/react", "lucide-react"],
     registryDependencies: ["https://r.assistant-ui.com/badge.json"],
   },
   {


### PR DESCRIPTION
## Summary

Adds the missing package dependencies for two standalone registry entries found while scanning for the same install-gap class as #4556:

- `sources` now declares `lucide-react`, because `components/assistant-ui/sources.tsx` imports `ExternalLinkIcon` from `lucide-react`.
- `tool-group` now declares `tw-shimmer`, because its registry CSS imports `tw-shimmer`.

## Reproduced errors before the fix

Installing `sources` into a fresh project succeeded, but TypeScript failed because the package dependency was not installed:

```text
components/assistant-ui/sources.tsx(4,30): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
```

Installing `tool-group` into a fresh project updated `app/globals.css` with `@import "tw-shimmer"`, but the package dependency was not installed:

```text
Error: Cannot find module 'tw-shimmer'
code: 'MODULE_NOT_FOUND'
```

The earlier `tool-fallback` standalone install error was fixed separately in #4556:

```text
components/assistant-ui/tool-fallback.tsx(26,24): error TS2307: Cannot find module '@/components/ui/button' or its corresponding type declarations.
```

I also checked `ai-sdk-backend` after the metadata scan flagged it, but a real standalone install did not copy `app/api/chat/route.ts` and did not reproduce a broken-import error, so this PR leaves it unchanged.

## Validation

- `pnpm --filter @assistant-ui/shadcn-registry build`
- Registry import/dependency scan after the fix: `No local import/package install gaps found.`
- Fresh `shadcn add /Users/mac/oss/assistant-ui/apps/registry/dist/sources.json --yes` fixture, then `pnpm exec tsc -p tsconfig.json --noEmit`
- Fresh `shadcn add /Users/mac/oss/assistant-ui/apps/registry/dist/tool-group.json --yes` fixture, then `node -e "console.log(require.resolve('tw-shimmer'))"`

Note: local validation still prints the repo's Node engine warning because this machine is on Node v23.11.0 and the repo requests Node >=24.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

