### PR TITLE
docs(react-langchain): reframe react-langgraph comparison as at-parity

### DIFF
--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -18,9 +18,9 @@ Pick `react-langchain` over `react-langgraph` when:
 
 Pick `react-langgraph` instead when:
 
-- You need subgraph events, generative UI messages, message metadata, or end-to-end cancellation today.
+- You need a fully custom/bespoke backend stream (your own async generator) rather than `useStream`'s transport, or you're maintaining an existing `react-langgraph` app.
 
-Both adapters are first-class. `react-langchain` is newer and thinner; some features have not been ported yet (the [comparison](#comparison-with-react-langgraph) below has the full table).
+Both adapters are first-class and now at feature parity (the [comparison](#comparison-with-react-langgraph) below has the full table); `react-langchain` is the newer, thinner wrapper pinned to upstream `useStream`.
 
 ## Architecture
 
@@ -821,7 +821,7 @@ const runtime = useStreamRuntime({
 
 ## Comparison with `react-langgraph`
 
-Both packages connect assistant-ui to LangGraph backends. They are independent adapters for different upstream libraries; one is not a successor to the other. The official `create-assistant-ui` template (`-t langchain`) ships `react-langchain`; `react-langgraph` remains available for subgraph events, generative UI, per-message metadata, and end-to-end cancellation.
+Both packages connect assistant-ui to LangGraph backends. They are independent adapters for different upstream libraries; one is not a successor to the other. The official `create-assistant-ui` template (`-t langchain`) ships `react-langchain`. The two are now at feature parity; `react-langgraph` remains the choice for a fully custom backend stream or an existing `react-langgraph` app.
 
 | Aspect | `react-langgraph` | `react-langchain` |
 | --- | --- | --- |
@@ -850,18 +850,18 @@ Both packages connect assistant-ui to LangGraph backends. They are independent a
 | Multimodal media (audio/image/video/file) | Via parts | Yes (v1 media hooks via `useLangChainStream`) |
 | Generative UI (state snapshot) | Yes | Yes (`uiStateKey`) |
 | Generative UI (live `push_ui_message`) | Yes | Yes (`streamMode: ["custom"]`) |
-| Subgraph / namespaced stream events | Yes (via `eventHandlers`) | Not exposed |
+| Subgraph / namespaced stream events | Yes (via `eventHandlers`) | Replaced by `useLangChainSubagents` / `useLangChainSubgraphs` + views |
 | Subagent discovery | Via `eventHandlers` | Yes (`useLangChainSubagents`) |
 | Subgraph discovery | Via `eventHandlers` | Yes (`useLangChainSubgraphs`) |
 | Subagent/subgraph message views | Via `eventHandlers` | Yes (via `useLangChainStream` + v1 selector hooks) |
-| End-to-end cancellation primitive | Yes (`unstable_createLangGraphStream`) | Not exposed |
-| Message accumulator utility | Yes (`LangGraphMessageAccumulator`) | Not exposed |
+| End-to-end cancellation primitive | Yes (`unstable_createLangGraphStream`) | n/a — cancellation via `useStream().stop()` (Cancel button on by default) |
+| Message accumulator utility | Yes (`LangGraphMessageAccumulator`) | n/a — `useStream` owns accumulation |
 | Streaming timing (per-message) | Yes | Yes |
 | Cloud thread persistence | Yes | Yes |
 
 Per-message streaming timing is attached automatically to `message.metadata.timing` (no setup), matching `react-langgraph`. It captures time-to-first-token, total stream time, chunk count, and tokens/sec, computed from message growth while the run is in flight.
 
-`react-langchain` is the newer, thinner wrapper. It delegates to upstream `useStream` rather than re-implementing the stream plumbing, which is why its footprint is smaller. Features absent today have not been ported, not deprecated.
+`react-langchain` is the newer, thinner wrapper. It delegates to upstream `useStream` rather than re-implementing the stream plumbing, which is why its footprint is smaller.
 
 Regenerate works without configuration. Clicking regenerate resolves the server checkpoint to fork from (the checkpoint each message records as it streams in, falling back to a `stream.client.threads.getHistory(threadId)` id match for older turns), then re-runs with `submit(null, { forkFrom })`. It works on checkpoint-enabled backends (for example LangGraph Cloud) and degrades gracefully; when no checkpoint resolves the regenerate is a no-op. `react-langgraph` instead requires a user-supplied `getCheckpointId` callback. Editing a message forks from the same checkpoint and submits the edited human content instead of re-running the prior turn; editing the first message forks from the thread's initial checkpoint to restart it.
 
@@ -890,7 +890,7 @@ Regenerate works without configuration. Clicking regenerate resolves the server 
   <Card
     icon={<LangGraphIcon width={20} height={20} className="text-[#1C3C3C] dark:text-[#5b9595]" />}
     title="LangGraph"
-    description="The full-featured adapter with subgraph events, UI messages, metadata."
+    description="The original LangGraph adapter, built on the raw SDK."
     href="/docs/runtimes/langgraph"
   />
   <Card


### PR DESCRIPTION
## Summary

Docs-only. react-langchain now matches react-langgraph on features, so this PR retires the stale "not ported yet" framing in the comparison.

## Why

The `## When to use it` text and the comparison section still pointed readers to react-langgraph for subgraph events, generative UI, metadata, and cancellation. All of those now exist in react-langchain. Three table cells also read "Not exposed", which looks unfinished but is really a non-gap: the feature exists under a different API.

## What changed

`apps/docs/content/docs/runtimes/langchain.mdx`:
- `## When to use it`: dropped the list of closed gaps; the remaining reason to pick react-langgraph is a custom backend stream or an existing react-langgraph app.
- Comparison intro prose: same stale list, reframed to at-parity.
- Three feature-coverage cells now point at the equivalent API instead of "Not exposed":
  - Subgraph / namespaced stream events: `Replaced by useLangChainSubagents / useLangChainSubgraphs + views`
  - End-to-end cancellation: `n/a, via useStream().stop()`
  - Message accumulator: `n/a, useStream owns accumulation`

No changeset, `@assistant-ui/docs` is exempt per AGENTS.md.

## Validation

`pnpm turbo run build` green (86/86); the build compiles the MDX. Docs-only, no tests needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

