### PR TITLE
fix: warn about duplicate generative toolkit spread names

### DIFF
--- a/.changeset/generative-toolkit-duplicate-spreads.md
+++ b/.changeset/generative-toolkit-duplicate-spreads.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-generative-compiler": patch
+---
+
+fix: warn about duplicate tool names across generative toolkit spreads

--- a/apps/docs/content/docs/tools/defining-tools.mdx
+++ b/apps/docs/content/docs/tools/defining-tools.mdx
@@ -423,6 +423,10 @@ The compiler splits each file across the client/server boundary on its own, then
 - **Spread a default import** (`import weatherTools from "./tools/weather"`). Relative paths and `tsconfig` path aliases like `@/tools/weather` both resolve. Only the default export crosses the generative-module boundary, so a named import (or any opaque, non-generative import) is rejected.
 - You can also spread a local `defineToolkit(...)` or `defineMcpToolkit(...)` binding declared in the same file.
 
+The compiler checks static tool names across inline entries and compiler-visible
+spreads. If two fragments define the same tool name, the build warns that
+JavaScript object spread will keep the later tool definition.
+
 ### Add MCP server tools
 
 `defineMcpToolkit` exposes tools from an MCP server. For an MCP-only toolkit, export it directly:

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import * as nodePath from "node:path";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   compileGenerative,
   isGenerativeModule,
@@ -84,6 +84,19 @@ function createMergeFixture(childSource: string): string {
   mkdirSync(toolsRoot, { recursive: true });
   writeFileSync(nodePath.join(toolsRoot, "weather.tsx"), childSource);
   return nodePath.join(appRoot, "src", "toolkit.tsx");
+}
+
+function createMultiMergeFixture(files: Record<string, string>): string {
+  const appRoot = mkdtempSync(
+    nodePath.join(tmpdir(), "aui-generative-merge-many-"),
+  );
+  const srcRoot = nodePath.join(appRoot, "src");
+  for (const [relativePath, source] of Object.entries(files)) {
+    const file = nodePath.join(srcRoot, relativePath);
+    mkdirSync(nodePath.dirname(file), { recursive: true });
+    writeFileSync(file, source);
+  }
+  return nodePath.join(srcRoot, "toolkit.tsx");
 }
 
 /**
@@ -557,6 +570,291 @@ export default defineToolkit({
     const client = compileGenerative(src, { target: "client", filename }).code;
     expect(client).toContain("...weatherTools");
     expect(client).toContain('from "./tools/weather"');
+  });
+
+  it("allows unique tool names across more than two imported generative spreads", () => {
+    const filename = createMultiMergeFixture({
+      "tools/weather.tsx": `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  get_weather: { execute: async () => 1, render: () => null },
+});`,
+      "tools/database.tsx": `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  query_db: { execute: async () => 1, render: () => null },
+});`,
+      "tools/calendar.tsx": `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  create_event: { execute: async () => 1, render: () => null },
+});`,
+      "tools/email.tsx": `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  send_email: { execute: async () => 1, render: () => null },
+});`,
+    });
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import weatherTools from "./tools/weather";
+import databaseTools from "./tools/database";
+import calendarTools from "./tools/calendar";
+import emailTools from "./tools/email";
+export default defineToolkit({
+  ...weatherTools,
+  ...databaseTools,
+  ...calendarTools,
+  ...emailTools,
+});`;
+
+    const client = compileGenerative(src, { target: "client", filename }).code;
+    expect(client).toContain("...weatherTools");
+    expect(client).toContain("...databaseTools");
+    expect(client).toContain("...calendarTools");
+    expect(client).toContain("...emailTools");
+  });
+
+  it("warns about duplicate tool names across more than two imported generative spreads", () => {
+    const filename = createMultiMergeFixture({
+      "tools/weather.tsx": `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  get_weather: { execute: async () => 1, render: () => null },
+  search: { execute: async () => 1, render: () => null },
+});`,
+      "tools/database.tsx": `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  query_db: { execute: async () => 1, render: () => null },
+});`,
+      "tools/calendar.tsx": `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  search: { execute: async () => 1, render: () => null },
+});`,
+      "tools/email.tsx": `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  send_email: { execute: async () => 1, render: () => null },
+});`,
+    });
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import weatherTools from "./tools/weather";
+import databaseTools from "./tools/database";
+import calendarTools from "./tools/calendar";
+import emailTools from "./tools/email";
+export default defineToolkit({
+  ...weatherTools,
+  ...databaseTools,
+  ...calendarTools,
+  ...emailTools,
+});`;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const client = compileGenerative(src, {
+        target: "client",
+        filename,
+      }).code;
+
+      expect(client).toContain("...weatherTools");
+      expect(client).toContain("...databaseTools");
+      expect(client).toContain("...calendarTools");
+      expect(client).toContain("...emailTools");
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("[assistant-ui/use-generative]"),
+      );
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Duplicate tool name "search" while composing toolkits. ' +
+            "JavaScript object spread keeps the last definition.",
+        ),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("does not reuse imported toolkit names across compile calls", () => {
+    const filename = createMultiMergeFixture({
+      "tools/weather.tsx": `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  get_weather: { execute: async () => 1, render: () => null },
+});`,
+      "tools/calendar.tsx": `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  search: { execute: async () => 1, render: () => null },
+});`,
+    });
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import weatherTools from "./tools/weather";
+import calendarTools from "./tools/calendar";
+export default defineToolkit({
+  ...weatherTools,
+  ...calendarTools,
+});`;
+
+    compileGenerative(src, { target: "client", filename });
+    writeFileSync(
+      nodePath.join(nodePath.dirname(filename), "tools", "weather.tsx"),
+      `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+export default defineToolkit({
+  search: { execute: async () => 1, render: () => null },
+});`,
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      compileGenerative(src, { target: "client", filename });
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Duplicate tool name "search" while composing toolkits. ' +
+            "JavaScript object spread keeps the last definition.",
+        ),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("warns about duplicate tool names between local toolkit spreads", () => {
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+const weatherTools = defineToolkit({
+  get_weather: { execute: async () => 1, render: () => null },
+  search: { execute: async () => 1, render: () => null },
+});
+const databaseTools = defineToolkit({
+  query_db: { execute: async () => 1, render: () => null },
+});
+const calendarTools = defineToolkit({
+  search: { execute: async () => 1, render: () => null },
+});
+const emailTools = defineToolkit({
+  send_email: { execute: async () => 1, render: () => null },
+});
+export default defineToolkit({
+  ...weatherTools,
+  ...databaseTools,
+  ...calendarTools,
+  ...emailTools,
+});`;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const client = compileGenerative(src, { target: "client" }).code;
+
+      expect(client).toContain("...weatherTools");
+      expect(client).toContain("...databaseTools");
+      expect(client).toContain("...calendarTools");
+      expect(client).toContain("...emailTools");
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '[assistant-ui/use-generative] Duplicate tool name "search" while composing toolkits. ' +
+            "JavaScript object spread keeps the last definition.",
+        ),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("warns once across server and client compiles", () => {
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+const weatherTools = defineToolkit({
+  search: { execute: async () => 1, render: () => null },
+});
+const calendarTools = defineToolkit({
+  search: { execute: async () => 1, render: () => null },
+});
+export default defineToolkit({
+  ...weatherTools,
+  ...calendarTools,
+});`;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      compileGenerative(src, { target: "server" });
+      compileGenerative(src, { target: "client" });
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Duplicate tool name "search" while composing toolkits. ' +
+            "JavaScript object spread keeps the last definition.",
+        ),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("warns about duplicate names through nested local toolkit spreads", () => {
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+const baseTools = defineToolkit({
+  search: { execute: async () => 1, render: () => null },
+});
+const weatherTools = defineToolkit({
+  ...baseTools,
+  get_weather: { execute: async () => 1, render: () => null },
+});
+const calendarTools = defineToolkit({
+  search: { execute: async () => 1, render: () => null },
+});
+export default defineToolkit({
+  ...weatherTools,
+  ...calendarTools,
+});`;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      compileGenerative(src, { target: "client" });
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Duplicate tool name "search" while composing toolkits. ' +
+            "JavaScript object spread keeps the last definition.",
+        ),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("does not warn again when spreading a fragment with an internal duplicate", () => {
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+const baseTools = defineToolkit({
+  search: { execute: async () => 1, render: () => null },
+  search: { execute: async () => 2, render: () => null },
+});
+export default defineToolkit({
+  ...baseTools,
+});`;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      compileGenerative(src, { target: "client" });
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Duplicate tool name "search" while composing toolkits. ' +
+            "JavaScript object spread keeps the last definition.",
+        ),
+      );
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("rejects spreading the default import of a non-generative module", () => {

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -78,7 +78,9 @@ export interface CompileResult {
 /** Thrown when a `"use generative"` file violates an authoring constraint. */
 export class GenerativeCompileError extends Error {
   constructor(message: string, filename?: string) {
-    super(`[assistant-ui/next]${filename ? ` ${filename}:` : ""} ${message}`);
+    super(
+      `[assistant-ui/use-generative]${filename ? ` ${filename}:` : ""} ${message}`,
+    );
     this.name = "GenerativeCompileError";
   }
 }
@@ -140,7 +142,11 @@ export function compileGenerative(
   // such entries pass through.
   ensureDefaultExport(ast, filename);
   const generativeInstances = collectGenerativeInstances(ast);
-  const safeToolkitSpreads = collectSafeToolkitSpreads(ast, filename);
+  const toolkitSpreadNames = collectToolkitSpreadNames(
+    ast,
+    filename,
+    createToolkitNameContext(),
+  );
 
   const flags: TargetFlags = { keptRender: false, keptBackendExecute: false };
 
@@ -177,7 +183,7 @@ export function compileGenerative(
           object,
           target,
           generativeInstances,
-          safeToolkitSpreads,
+          toolkitSpreadNames,
           flags,
           filename,
         );
@@ -486,8 +492,25 @@ function collectGenerativeInstances(ast: t.File): Set<string> {
   return names;
 }
 
+type ToolkitStaticNames = readonly string[] | null;
+type ToolkitSpreadNames = Map<string, ToolkitStaticNames>;
+
+interface ToolkitNameContext {
+  importedToolkitNamesByFile: Map<string, ToolkitStaticNames | undefined>;
+  resolvingImportedToolkitNames: Set<string>;
+}
+
+function createToolkitNameContext(): ToolkitNameContext {
+  return {
+    importedToolkitNamesByFile: new Map(),
+    resolvingImportedToolkitNames: new Set(),
+  };
+}
+
 /**
- * Toolkit identifiers that are safe to spread into a `defineToolkit({ ... })`.
+ * Toolkit identifiers that are safe to spread into a `defineToolkit({ ... })`,
+ * paired with the static tool names they contain. A `null` name list means the
+ * spread is safe, but its names are not statically known for duplicate checks.
  *
  * Two kinds qualify:
  *
@@ -500,19 +523,21 @@ function collectGenerativeInstances(ast: t.File): Set<string> {
  *   export crosses the generative-module boundary, so named imports don't
  *   qualify — they would be `undefined` once that module is build-split.
  */
-function collectSafeToolkitSpreads(
+function collectToolkitSpreadNames(
   ast: t.File,
   filename: string | undefined,
-): Set<string> {
-  const names = new Set<string>();
-  const generativeBySource = new Map<string, boolean>();
+  context: ToolkitNameContext,
+): ToolkitSpreadNames {
+  const spreadNames: ToolkitSpreadNames = new Map();
+  const localToolkitCalls = new Map<string, t.CallExpression>();
 
   for (const statement of ast.program.body) {
     if (t.isVariableDeclaration(statement)) {
       for (const declaration of statement.declarations) {
         const { id, init } = declaration;
-        if (t.isIdentifier(id) && init && unwrapToToolkitCall(init)) {
-          names.add(id.name);
+        if (t.isIdentifier(id) && init) {
+          const toolkitCall = unwrapToToolkitCall(init);
+          if (toolkitCall) localToolkitCalls.set(id.name, toolkitCall);
         }
       }
       continue;
@@ -525,17 +550,40 @@ function collectSafeToolkitSpreads(
       );
       if (!defaultSpecifier) continue;
 
-      const source = statement.source.value;
-      let isGenerative = generativeBySource.get(source);
-      if (isGenerative === undefined) {
-        isGenerative = isGenerativeImport(source, filename);
-        generativeBySource.set(source, isGenerative);
+      const names = getGenerativeImportToolkitNames(
+        statement.source.value,
+        filename,
+        context,
+      );
+      if (names !== undefined) {
+        spreadNames.set(defaultSpecifier.local.name, names);
       }
-      if (isGenerative) names.add(defaultSpecifier.local.name);
     }
   }
 
-  return names;
+  const resolveLocal = (name: string): ToolkitStaticNames | undefined => {
+    if (spreadNames.has(name)) return spreadNames.get(name);
+
+    const call = localToolkitCalls.get(name);
+    if (!call) return undefined;
+
+    const object = t.isObjectExpression(call.arguments[0])
+      ? call.arguments[0]
+      : null;
+    const names = object
+      ? collectToolkitObjectNames(object, spreadNames)
+      : null;
+    const publicNames = uniqueToolkitNames(names);
+
+    spreadNames.set(name, publicNames);
+    return publicNames;
+  };
+
+  for (const name of localToolkitCalls.keys()) {
+    resolveLocal(name);
+  }
+
+  return spreadNames;
 }
 
 const MODULE_EXTENSIONS = [
@@ -553,26 +601,78 @@ const MODULE_EXTENSIONS = [
 const REWRITABLE_JS_EXTENSIONS = new Set([".js", ".jsx", ".mjs", ".cjs"]);
 
 /**
- * Whether an import specifier resolves on disk to a `"use generative"` module.
- * Relative specifiers and `tsconfig` path aliases (e.g. `@/tools`) are resolved;
- * anything else (a bare package, an unresolvable alias) is treated as
- * non-generative, and thus an unsafe spread.
+ * Reads the static tool names from the default export of an imported
+ * `"use generative"` module. Relative specifiers and `tsconfig` path aliases
+ * (e.g. `@/tools`) are resolved; anything else (a bare package, an unresolvable
+ * alias) is treated as non-generative, and thus an unsafe spread.
  */
-function isGenerativeImport(
+function getGenerativeImportToolkitNames(
   source: string,
   filename: string | undefined,
-): boolean {
+  context: ToolkitNameContext,
+): ToolkitStaticNames | undefined {
   const cleanFilename = cleanAbsoluteFilename(filename);
-  if (!cleanFilename) return false;
+  if (!cleanFilename) return undefined;
 
   const resolved = resolveImportedModuleFile(source, cleanFilename);
-  if (!resolved) return false;
+  if (!resolved) return undefined;
 
-  try {
-    return isGenerativeModule(readFileSync(resolved, "utf8"));
-  } catch {
-    return false;
+  if (context.importedToolkitNamesByFile.has(resolved)) {
+    return context.importedToolkitNamesByFile.get(resolved);
   }
+  if (context.resolvingImportedToolkitNames.has(resolved)) return null;
+
+  let code: string;
+  try {
+    code = readFileSync(resolved, "utf8");
+  } catch {
+    context.importedToolkitNamesByFile.set(resolved, undefined);
+    return undefined;
+  }
+
+  if (!isGenerativeModule(code)) {
+    context.importedToolkitNamesByFile.set(resolved, undefined);
+    return undefined;
+  }
+
+  context.resolvingImportedToolkitNames.add(resolved);
+  try {
+    const importedAst = parse(code, {
+      sourceType: "module",
+      plugins: ["typescript", "jsx", "explicitResourceManagement"],
+    });
+    const names = getDefaultExportToolkitNames(importedAst, resolved, context);
+    context.importedToolkitNamesByFile.set(resolved, names);
+    return names;
+  } catch (error) {
+    if (error instanceof GenerativeCompileError) throw error;
+    context.importedToolkitNamesByFile.set(resolved, null);
+    return null;
+  } finally {
+    context.resolvingImportedToolkitNames.delete(resolved);
+  }
+}
+
+function getDefaultExportToolkitNames(
+  ast: t.File,
+  filename: string | undefined,
+  context: ToolkitNameContext,
+): ToolkitStaticNames {
+  const def = ast.program.body.find(
+    (stmt): stmt is t.ExportDefaultDeclaration =>
+      t.isExportDefaultDeclaration(stmt),
+  );
+  if (!def) return null;
+
+  const toolkitCall = unwrapToToolkitCall(def.declaration);
+  if (!toolkitCall || !t.isObjectExpression(toolkitCall.arguments[0])) {
+    return null;
+  }
+
+  const spreadNames = collectToolkitSpreadNames(ast, filename, context);
+  return uniqueToolkitNames(
+    collectToolkitObjectNames(toolkitCall.arguments[0], spreadNames),
+  );
 }
 
 /** Resolves an import specifier (relative or `tsconfig`-aliased) to a file on disk. */
@@ -797,12 +897,90 @@ function unwrapToToolkitCall(node: t.Node): t.CallExpression | null {
   );
 }
 
+function collectToolkitObjectNames(
+  object: t.ObjectExpression,
+  toolkitSpreadNames: ToolkitSpreadNames,
+): ToolkitStaticNames {
+  const names: string[] = [];
+
+  for (const entry of object.properties) {
+    const entryNames = toolkitEntryNames(entry, toolkitSpreadNames);
+    if (!entryNames) return null;
+    names.push(...entryNames);
+  }
+
+  return names;
+}
+
+function uniqueToolkitNames(names: ToolkitStaticNames): ToolkitStaticNames {
+  return names ? [...new Set(names)] : names;
+}
+
+function toolkitEntryNames(
+  entry: t.ObjectExpression["properties"][number],
+  toolkitSpreadNames: ToolkitSpreadNames,
+): ToolkitStaticNames {
+  if (t.isSpreadElement(entry)) {
+    if (t.isIdentifier(entry.argument)) {
+      return toolkitSpreadNames.get(entry.argument.name) ?? null;
+    }
+
+    const directMcpToolkit = unwrapToCall(entry.argument, MCP_TOOLKIT_WRAPPER);
+    if (
+      directMcpToolkit &&
+      t.isObjectExpression(directMcpToolkit.arguments[0])
+    ) {
+      return collectToolkitObjectNames(
+        directMcpToolkit.arguments[0],
+        toolkitSpreadNames,
+      );
+    }
+
+    return null;
+  }
+
+  if (t.isObjectProperty(entry) || t.isObjectMethod(entry)) {
+    const name = memberName(entry.key, entry.computed);
+    return name ? [name] : [];
+  }
+
+  return [];
+}
+
+function warnDuplicateToolkitNames(
+  object: t.ObjectExpression,
+  toolkitSpreadNames: ToolkitSpreadNames,
+  filename: string | undefined,
+): void {
+  const names = collectToolkitObjectNames(object, toolkitSpreadNames);
+  if (!names) return;
+
+  const seen = new Set<string>();
+  const warned = new Set<string>();
+  for (const name of names) {
+    if (seen.has(name)) {
+      if (!warned.has(name)) {
+        console.warn(
+          new GenerativeCompileError(
+            `Duplicate tool name "${name}" while composing toolkits. ` +
+              "JavaScript object spread keeps the last definition.",
+            filename,
+          ).message,
+        );
+        warned.add(name);
+      }
+      continue;
+    }
+    seen.add(name);
+  }
+}
+
 function isSafeToolkitSpread(
   entry: t.SpreadElement,
-  safeToolkitSpreads: Set<string>,
+  toolkitSpreadNames: ToolkitSpreadNames,
 ): boolean {
   if (t.isIdentifier(entry.argument)) {
-    return safeToolkitSpreads.has(entry.argument.name);
+    return toolkitSpreadNames.has(entry.argument.name);
   }
 
   const directMcpToolkit = unwrapToCall(entry.argument, MCP_TOOLKIT_WRAPPER);
@@ -871,10 +1049,16 @@ function compileToolkit(
   object: t.ObjectExpression,
   target: Target,
   instances: Set<string>,
-  safeToolkitSpreads: Set<string>,
+  toolkitSpreadNames: ToolkitSpreadNames,
   flags: TargetFlags,
   filename: string | undefined,
 ): void {
+  // Split builds compile both targets; emit target-independent warnings from
+  // the client pass so each duplicate is logged once.
+  if (target === "client") {
+    warnDuplicateToolkitNames(object, toolkitSpreadNames, filename);
+  }
+
   const nextProperties: t.ObjectExpression["properties"] = [];
 
   for (const entry of object.properties) {
@@ -882,7 +1066,7 @@ function compileToolkit(
     if (!value) {
       if (
         t.isSpreadElement(entry) &&
-        isSafeToolkitSpread(entry, safeToolkitSpreads)
+        isSafeToolkitSpread(entry, toolkitSpreadNames)
       ) {
         nextProperties.push(entry);
         continue;


### PR DESCRIPTION
## Summary

Adds a compile-time warning for duplicate tool names when a `"use generative"` toolkit composes multiple toolkit fragments with object spread.

Today this pattern is supported:

```tsx
export default defineToolkit({
  ...weatherTools,
  ...databaseTools,
  ...calendarTools,
});
```

But if two fragments define the same tool key, normal JavaScript object spread silently overwrites the earlier tool before `defineToolkit` ever sees the object. That makes the resulting model/tool UI behavior depend on spread order, with no assistant-ui-specific signal.

## What Changed

- Tracks static tool names for compiler-visible toolkit spreads.
- Reads default-exported tool names from imported `"use generative"` toolkit modules without executing user code.
- Checks inline entries, local `defineToolkit(...)` fragments, `defineMcpToolkit(...)` fragments, and imported generative default toolkit spreads for duplicate static names before routing the toolkit.
- Emits a warning rather than failing the build, preserving existing JavaScript object-spread behavior while making the overwrite visible.
- Emits duplicate-name warnings from the client compile pass so split client/server builds log the warning once.
- Treats a toolkit fragment's spread-visible names as its unique public keys, so an internal duplicate is not reported again by every parent spread.
- Scopes imported toolkit-name caching to a single compile pass so rebuilds pick up changed toolkit fragments.
- Renames the shared generative compiler diagnostic prefix from `[assistant-ui/next]` to `[assistant-ui/use-generative]`, since the compiler is used beyond the Next adapter.
- Documents that duplicate names across compiler-visible spreads now warn.

## Warning Behavior

If composition includes a duplicate, the generative compiler now logs a warning and continues compiling:

```txt
[assistant-ui/use-generative] /path/to/src/toolkit.tsx: Duplicate tool name "search" while composing toolkits. JavaScript object spread keeps the last definition.
```

For example, this warns when both `weatherTools` and `calendarTools` expose `search`:

```tsx
export default defineToolkit({
  ...weatherTools,
  ...databaseTools,
  ...calendarTools,
  ...emailTools,
});
```

The output keeps normal JavaScript semantics: the later `search` definition wins.

## Validation

- `pnpm --filter @assistant-ui/x-generative-compiler test`
- `pnpm --filter @assistant-ui/x-generative-compiler build`
- `pnpm lint`

Note: local `pnpm` emitted the existing Node engine warning because this machine is on Node v23.11.0 while the repo requests `>=24`, but all commands exited successfully.