### PR TITLE
fix(registry): declare tw-shimmer dependency for tool-group

### DIFF
--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -334,6 +334,7 @@ export const registry: RegistryItem[] = [
       "@assistant-ui/react",
       "lucide-react",
       "class-variance-authority",
+      "tw-shimmer",
     ],
     registryDependencies: ["collapsible"],
     css: {


### PR DESCRIPTION
## What

Add `tw-shimmer` to the `tool-group` registry item's `dependencies` array in `apps/registry/src/registry.ts`.

## Why

The `tool-group` item injects `@import "tw-shimmer"` into the consumer's CSS (via its `css` field) but did not list `tw-shimmer` among its npm `dependencies`. Installing it standalone with `shadcn add .../tool-group.json` therefore wrote an `@import "tw-shimmer";` that resolves to a package the user never installed, breaking the Tailwind/CSS build until they manually added it.

The comparable `reasoning` item already does the same `@import` **and** correctly declares `tw-shimmer` in its dependencies — this change makes `tool-group` consistent with it.

## How

One-line addition, mirroring `reasoning`. Verified by rebuilding the registry (`pnpm build`): the generated `tool-group.json` now lists `tw-shimmer` under `dependencies` alongside the existing `css` `@import`, matching `reasoning.json`.

No changeset — `apps/registry` (`@assistant-ui/shadcn-registry`) is private and changeset-exempt.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

