### PR TITLE
fix(ui): add accessible names to icon-only combobox controls

### DIFF
--- a/packages/ui/src/components/ui/combobox.tsx
+++ b/packages/ui/src/components/ui/combobox.tsx
@@ -35,6 +35,7 @@ function ComboboxTrigger({
         data-slot="combobox-trigger-icon"
         className="text-muted-foreground pointer-events-none size-4"
       />
+      {!children && <span className="sr-only">Open</span>}
     </ComboboxPrimitive.Trigger>
   );
 }
@@ -48,6 +49,7 @@ function ComboboxClear({ className, ...props }: ComboboxPrimitive.Clear.Props) {
       {...props}
     >
       <XIcon className="pointer-events-none" />
+      <span className="sr-only">Clear</span>
     </ComboboxPrimitive.Clear>
   );
 }
@@ -266,6 +268,7 @@ function ComboboxChip({
           data-slot="combobox-chip-remove"
         >
           <XIcon className="pointer-events-none" />
+          <span className="sr-only">Remove</span>
         </ComboboxPrimitive.ChipRemove>
       )}
     </ComboboxPrimitive.Chip>


### PR DESCRIPTION
## What

Adds visually-hidden (`sr-only`) accessible names to the three icon-only controls in the Combobox component (`packages/ui/src/components/ui/combobox.tsx`):

- `ComboboxClear` → `Clear`
- `ComboboxTrigger` → `Open` (only when no children are provided)
- `ComboboxChipRemove` → `Remove`

## Why

These parts render only an icon (`XIcon` / `ChevronDownIcon`). Base UI does not auto-provide accessible names for them, so screen readers announce them merely as "button" — clearing the value, opening the listbox, and removing a chip are all unlabeled. It is also inconsistent with every other icon-only control in this package (dialog/sheet close, sidebar trigger, carousel prev/next, breadcrumb/pagination ellipsis), which all add an explicit `<span className="sr-only">`.

## How

Follows the package's existing convention exactly — icon followed by an `sr-only` span. The `ComboboxTrigger` label is guarded by `!children` so a consumer-supplied visible trigger label is not double-announced. All three components still spread `{...props}`, so a consumer-provided `aria-label` continues to override the default name.

Verified: oxlint clean and `tsc --noEmit` passes on `@assistant-ui/ui`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

