### PR TITLE
fix: add client directives to UI components

### DIFF
--- a/packages/ui/src/components/assistant-ui/thread-list.tsx
+++ b/packages/ui/src/components/assistant-ui/thread-list.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   ComposerAddAttachment,
   ComposerAttachments,


### PR DESCRIPTION
## Summary

Adds explicit `"use client"` directives to the assistant UI `Thread` and `ThreadList` registry components.

## Why

Both components call React/client hooks such as `useAuiState`, `useContext`, and `useMemo`. Without the directive, Next App Router consumers can import the generated registry files from a server boundary and have them treated incorrectly as server components.

## Validation

- `pnpm exec oxlint packages/ui/src/components/assistant-ui/thread.tsx packages/ui/src/components/assistant-ui/thread-list.tsx`
- `pnpm exec oxfmt --check packages/ui/src/components/assistant-ui/thread.tsx packages/ui/src/components/assistant-ui/thread-list.tsx`
- `pnpm sync-templates`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

