### PR TITLE
fix: add shimmer registry dependencies

### DIFF
--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -316,8 +316,11 @@ export const registry: RegistryItem[] = [
           "../../packages/ui/src/components/assistant-ui/tool-fallback.tsx",
       },
     ],
-    dependencies: ["@assistant-ui/react", "lucide-react"],
+    dependencies: ["@assistant-ui/react", "lucide-react", "tw-shimmer"],
     registryDependencies: ["button", "collapsible"],
+    css: {
+      '@import "tw-shimmer"': {},
+    },
   },
   {
     name: "tool-group",
@@ -334,6 +337,7 @@ export const registry: RegistryItem[] = [
       "@assistant-ui/react",
       "lucide-react",
       "class-variance-authority",
+      "tw-shimmer",
     ],
     registryDependencies: ["collapsible"],
     css: {


### PR DESCRIPTION
## Summary

Makes the `tool-fallback` and `tool-group` registry items self-contained for the `shimmer` utility.

## Why

Both copied components render the `shimmer` class. Before this change:

- `tool-fallback` used `shimmer` but did not install `tw-shimmer` or add the CSS import.
- `tool-group` added `@import "tw-shimmer"` but did not install the `tw-shimmer` package.

That means standalone registry installs could either miss the running-state shimmer styling or emit an unresolved CSS package import in a consumer app.

## Validation

- `pnpm --filter @assistant-ui/shadcn-registry build`
- `pnpm exec oxlint apps/registry/src/registry.ts`
- `pnpm exec oxfmt --check apps/registry/src/registry.ts`
- Generated-registry assertion confirmed `tool-fallback`, `tool-group`, and `reasoning` all use shimmer with both `@import "tw-shimmer"` and `tw-shimmer` in dependencies.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

