### PR TITLE
fix(core): make PartPrimitive.Messages props a discriminated union

### DIFF
--- a/.changeset/part-messages-discriminated-union.md
+++ b/.changeset/part-messages-discriminated-union.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: make PartPrimitive.Messages props a discriminated union so rendering with neither components nor children is a compile error

--- a/packages/core/src/react/primitives/part/PartMessages.test.tsx
+++ b/packages/core/src/react/primitives/part/PartMessages.test.tsx
@@ -1,0 +1,17 @@
+import { expectTypeOf } from "vitest";
+import { PartPrimitiveMessages } from "./PartMessages";
+
+const checkPartMessagesProps = () => {
+  <PartPrimitiveMessages>{() => null}</PartPrimitiveMessages>;
+  <PartPrimitiveMessages components={{ Message: () => null }} />;
+
+  // @ts-expect-error neither components nor children is allowed
+  <PartPrimitiveMessages />;
+  // @ts-expect-error components must be defined, not undefined
+  <PartPrimitiveMessages components={undefined} />;
+  // @ts-expect-error components and children are mutually exclusive
+  <PartPrimitiveMessages components={{ Message: () => null }}>
+    {() => null}
+  </PartPrimitiveMessages>;
+};
+expectTypeOf(checkPartMessagesProps).toEqualTypeOf<() => void>();

--- a/packages/core/src/react/primitives/part/PartMessages.tsx
+++ b/packages/core/src/react/primitives/part/PartMessages.tsx
@@ -8,11 +8,16 @@ import {
 } from "../thread/ThreadMessages";
 
 export namespace PartPrimitiveMessages {
-  export type Props = {
-    components?: ThreadPrimitiveMessages.Props["components"];
-    /** Render function called for each message. Receives the message. */
-    children?: (value: { message: ThreadMessage }) => ReactNode;
-  };
+  export type Props =
+    | {
+        components: NonNullable<ThreadPrimitiveMessages.Props["components"]>;
+        children?: never;
+      }
+    | {
+        /** Render function called for each message. Receives the message. */
+        children: (value: { message: ThreadMessage }) => ReactNode;
+        components?: never;
+      };
 }
 
 const usePartMessages = (): readonly ThreadMessage[] | undefined => {
@@ -57,17 +62,17 @@ export const PartPrimitiveMessagesImpl: FC<PartPrimitiveMessages.Props> = ({
 
   if (!messages?.length) return null;
 
-  if (children) {
+  if (components) {
     return (
       <ReadonlyThreadProvider messages={messages}>
-        <ThreadPrimitiveMessagesImpl>{children}</ThreadPrimitiveMessagesImpl>
+        <ThreadPrimitiveMessagesImpl components={components} />
       </ReadonlyThreadProvider>
     );
   }
 
   return (
     <ReadonlyThreadProvider messages={messages}>
-      <ThreadPrimitiveMessagesImpl components={components!} />
+      <ThreadPrimitiveMessagesImpl>{children}</ThreadPrimitiveMessagesImpl>
     </ReadonlyThreadProvider>
   );
 };


### PR DESCRIPTION
## What

`PartPrimitiveMessages.Props` declared `components?` and `children?` as **independently** optional, unlike its sibling `ThreadPrimitiveMessages.Props`, which is a proper `components`-xor-`children` union. This change makes `Props` the same discriminated union so invalid prop combinations are rejected at compile time.

## Why

Because the two props were independently optional, `<MessagePartPrimitive.Messages />` (or `components={undefined}`) **type-checked but crashed at runtime**:

1. `usePartMessages()` returns the tool-call part's nested messages; the early `return null` only fires when there are *no* messages, so with nested messages present it continues.
2. With no `children`, it fell through to `<ThreadPrimitiveMessagesImpl components={components!} />` with `components === undefined` — the `!` masked the hole.
3. `ThreadPrimitiveMessagesImpl` then rendered `<ThreadPrimitiveMessagesInner>{children}</…>` with `children === undefined`, which calls `children({ … })` unguarded → `TypeError: children is not a function`.

This only reproduces when the tool-call part actually has nested messages (e.g. a sub-agent conversation).

## How

- `PartPrimitiveMessages.Props` is now a discriminated xor union mirroring `ThreadPrimitiveMessages.Props` (one of `components` / `children`, each with the other as `?: never`). The `components` member uses `NonNullable<…>` because the indexed access `ThreadPrimitiveMessages.Props["components"]` otherwise inherits `undefined` from the sibling's optional member — without it, `components={undefined}` would still compile.
- `PartPrimitiveMessagesImpl` now branches on `if (components)` (matching the sibling's destructure-and-branch shape), so TypeScript's destructured-union narrowing removes the need for the `components!` non-null assertion. No runtime guard is added — the type now makes the illegal state unrepresentable, consistent with the sibling, which has no such guard.
- Added a colocated type-level regression test (`@ts-expect-error` + `expectTypeOf`, the existing repo convention) asserting the three invalid shapes are rejected and the two valid shapes compile.

No behavior change for valid callers; only the impossible no-prop path is removed at the type level.

## Verification

- `tsc --noEmit` on `@assistant-ui/core` — clean; the impl compiles without the assertion and all three `@ts-expect-error` directives are genuinely "used".
- `vitest run` on the new test file — passes.
- `oxlint` + `oxfmt --check` on the changed files — clean.

Changeset: patch for `@assistant-ui/core` (re-exported as `MessagePartPrimitive.Messages` in `@assistant-ui/react` and `react-ink`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

