### PR TITLE
style(docs): refine ChatGPT example to match real ChatGPT UI

### DIFF
--- a/apps/docs/components/examples/chatgpt.tsx
+++ b/apps/docs/components/examples/chatgpt.tsx
@@ -61,7 +61,7 @@ export const ChatGPT: FC = () => {
           <ThreadPrimitive.ViewportFooter className="sticky bottom-0 mx-auto mt-auto flex w-full max-w-3xl flex-col gap-2 overflow-visible rounded-t-3xl bg-white pb-2 dark:bg-black">
             <ThreadScrollToBottom />
             <Composer placeholder="Ask anything" />
-            <p className="text-center text-xs text-[#5d5d5d] dark:text-[#a8a8a8]">
+            <p className="text-center text-xs text-[#5d5d5d] dark:text-[#afafaf]">
               ChatGPT can make mistakes. Check important info.
             </p>
           </ThreadPrimitive.ViewportFooter>
@@ -73,9 +73,9 @@ export const ChatGPT: FC = () => {
 
 const EmptyState: FC = () => {
   return (
-    <div className="flex grow flex-col items-center justify-center px-4">
+    <div className="flex grow flex-col items-center justify-center px-4 pb-[16vh]">
       <div className="mx-auto flex w-full max-w-3xl flex-col items-stretch gap-6">
-        <h1 className="text-center text-2xl font-medium text-[#0d0d0d] sm:text-3xl dark:text-[#ececec]">
+        <h1 className="text-center text-2xl leading-7 font-normal text-[#0d0d0d] dark:text-[#ececec]">
           Where should we begin?
         </h1>
         <Composer placeholder="Ask anything" />
@@ -86,7 +86,7 @@ const EmptyState: FC = () => {
 
 const Composer: FC<{ placeholder: string }> = ({ placeholder }) => {
   return (
-    <ComposerPrimitive.Root className="group/composer flex w-full flex-col rounded-[28px] border border-[#e5e5e5] bg-white px-2 py-2 shadow-[0_2px_6px_-2px_rgba(0,0,0,0.05)] focus-within:border-[#d0d0d0] dark:border-transparent dark:bg-[#212121] dark:shadow-none dark:focus-within:border-transparent">
+    <ComposerPrimitive.Root className="group/composer flex w-full flex-col rounded-[28px] border border-[#e5e5e5] bg-white px-2 py-2 shadow-[0_2px_6px_-2px_rgba(0,0,0,0.05)] focus-within:border-[#d0d0d0] dark:border-transparent dark:bg-[#212121] dark:shadow-[inset_0_0_1px_0_rgba(255,255,255,0.2)] dark:focus-within:border-transparent">
       <AuiIf condition={(s) => s.composer.attachments.length > 0}>
         <div className="flex flex-row flex-wrap gap-2 px-1 pt-1 pb-2">
           <ComposerPrimitive.Attachments
@@ -97,19 +97,22 @@ const Composer: FC<{ placeholder: string }> = ({ placeholder }) => {
 
       <div className="flex items-end gap-1">
         <ComposerPrimitive.AddAttachment asChild>
-          <button
+          <TooltipIconButton
             type="button"
-            className="flex size-9 shrink-0 items-center justify-center rounded-full text-[#5d5d5d] transition-colors hover:bg-[#0d0d0d]/5 hover:text-[#0d0d0d] dark:text-[#cdcdcd] dark:hover:bg-white/10 dark:hover:text-white"
+            tooltip="Add photos & files"
+            side="top"
             aria-label="Add attachment"
+            className="flex size-9 shrink-0 items-center justify-center rounded-full text-[#5d5d5d] transition-colors hover:bg-[#0d0d0d]/5 hover:text-[#0d0d0d] dark:text-[#cdcdcd] dark:hover:bg-white/10 dark:hover:text-white"
           >
             <PlusIcon size={20} />
-          </button>
+          </TooltipIconButton>
         </ComposerPrimitive.AddAttachment>
 
         <ComposerPrimitive.Input
+          autoFocus
           placeholder={placeholder}
           rows={1}
-          className="max-h-52 min-h-9 flex-1 resize-none bg-transparent px-2 py-1.5 text-base text-[#0d0d0d] outline-none placeholder:text-[#8e8e8e] dark:text-[#ececec] dark:placeholder:text-[#8e8e8e]"
+          className="max-h-52 min-h-9 flex-1 resize-none bg-transparent py-1.5 pr-2 pl-1 text-base text-[#0d0d0d] outline-none placeholder:text-[#8e8e8e] dark:text-[#ececec] dark:placeholder:text-[#8e8e8e]"
         />
 
         <div className="flex shrink-0 items-center gap-1">
@@ -159,21 +162,27 @@ const ComposerPrimaryAction: FC = () => {
           s.composer.isEmpty
         }
       >
-        <ComposerPrimitive.Dictate
-          className="flex size-9 items-center justify-center rounded-full text-[#5d5d5d] transition-colors hover:bg-[#0d0d0d]/5 hover:text-[#0d0d0d] dark:text-[#cdcdcd] dark:hover:bg-white/10 dark:hover:text-white"
-          aria-label="Dictate"
-        >
-          <Mic className="size-5" />
+        <ComposerPrimitive.Dictate asChild>
+          <TooltipIconButton
+            tooltip="Dictate"
+            side="top"
+            aria-label="Dictate"
+            className="flex size-9 items-center justify-center rounded-full text-[#5d5d5d] transition-colors hover:bg-[#0d0d0d]/5 hover:text-[#0d0d0d] dark:text-[#cdcdcd] dark:hover:bg-white/10 dark:hover:text-white"
+          >
+            <Mic className="size-5" />
+          </TooltipIconButton>
         </ComposerPrimitive.Dictate>
 
-        <button
+        <TooltipIconButton
           type="button"
+          tooltip="Use voice mode"
+          side="top"
           aria-hidden="true"
           tabIndex={-1}
-          className="flex size-9 items-center justify-center rounded-full bg-[#0d0d0d] text-white dark:bg-white dark:text-black"
+          className="flex size-9 items-center justify-center rounded-full bg-[#0d0d0d] text-white hover:bg-[#0d0d0d] dark:bg-white dark:text-black dark:hover:bg-white"
         >
           <AudioLines className="size-5" />
-        </button>
+        </TooltipIconButton>
       </AuiIf>
     </div>
   );
@@ -201,33 +210,44 @@ const UserMessage: FC = () => {
         />
       </div>
 
-      <div className="flex items-start gap-4">
+      <div className="max-w-[70%] rounded-[22px] bg-[#0d0d0d] px-4 py-2.5 leading-6 text-white dark:bg-[#ececec] dark:text-[#0d0d0d]">
+        <MessagePrimitive.Parts />
+      </div>
+
+      <div className="flex items-center gap-0.5">
         <ActionBarPrimitive.Root
           hideWhenRunning
-          autohide="not-last"
+          autohide="always"
           autohideFloat="single-branch"
-          className="mt-2"
+          className="flex items-center gap-0.5"
         >
+          <ActionBarPrimitive.Copy className={assistantActionClassName}>
+            <AuiIf condition={(s) => s.message.isCopied}>
+              <CheckIcon className="size-5" />
+            </AuiIf>
+            <AuiIf condition={(s) => !s.message.isCopied}>
+              <CopyIcon className="size-5" />
+            </AuiIf>
+          </ActionBarPrimitive.Copy>
           <ActionBarPrimitive.Edit asChild>
-            <TooltipIconButton tooltip="Edit" className="text-[#b4b4b4]">
+            <TooltipIconButton
+              tooltip="Edit"
+              className={assistantActionClassName}
+            >
               <Pencil1Icon className="size-5" />
             </TooltipIconButton>
           </ActionBarPrimitive.Edit>
         </ActionBarPrimitive.Root>
 
-        <div className="bg-secondary text-foreground rounded-3xl px-5 py-2 dark:bg-white/5 dark:text-[#eee]">
-          <MessagePrimitive.Parts />
-        </div>
+        <BranchPicker />
       </div>
-
-      <BranchPicker className="mt-2 mr-3" />
     </MessagePrimitive.Root>
   );
 };
 
 const EditComposer: FC = () => {
   return (
-    <ComposerPrimitive.Root className="bg-secondary mx-auto flex w-full max-w-3xl flex-col justify-end gap-1 rounded-3xl dark:bg-white/15">
+    <ComposerPrimitive.Root className="mx-auto flex w-full max-w-3xl flex-col justify-end gap-1 rounded-3xl bg-[#e9e9e9]/50 dark:bg-[#323232]">
       <ComposerPrimitive.Input className="text-foreground flex h-8 w-full resize-none bg-transparent p-5 pb-0 outline-none dark:text-white" />
 
       <div className="m-3 mt-2 flex items-center justify-center gap-2 self-end">

--- a/apps/docs/components/examples/chatgpt.tsx
+++ b/apps/docs/components/examples/chatgpt.tsx
@@ -102,7 +102,7 @@ const Composer: FC<{ placeholder: string }> = ({ placeholder }) => {
             tooltip="Add photos & files"
             side="top"
             aria-label="Add attachment"
-            className="flex size-9 shrink-0 items-center justify-center rounded-full text-[#5d5d5d] transition-colors hover:bg-[#0d0d0d]/5 hover:text-[#0d0d0d] dark:text-[#cdcdcd] dark:hover:bg-white/10 dark:hover:text-white"
+            className="flex size-9 shrink-0 items-center justify-center rounded-full text-[#5d5d5d] transition-colors hover:bg-black/[0.07] hover:text-[#5d5d5d] dark:text-[#cdcdcd] dark:hover:bg-white/15 dark:hover:text-[#cdcdcd]"
           >
             <PlusIcon size={20} />
           </TooltipIconButton>
@@ -167,7 +167,7 @@ const ComposerPrimaryAction: FC = () => {
             tooltip="Dictate"
             side="top"
             aria-label="Dictate"
-            className="flex size-9 items-center justify-center rounded-full text-[#5d5d5d] transition-colors hover:bg-[#0d0d0d]/5 hover:text-[#0d0d0d] dark:text-[#cdcdcd] dark:hover:bg-white/10 dark:hover:text-white"
+            className="flex size-9 items-center justify-center rounded-full text-[#5d5d5d] transition-colors hover:bg-black/[0.07] hover:text-[#5d5d5d] dark:text-[#cdcdcd] dark:hover:bg-white/15 dark:hover:text-[#cdcdcd]"
           >
             <Mic className="size-5" />
           </TooltipIconButton>
@@ -219,19 +219,26 @@ const UserMessage: FC = () => {
           hideWhenRunning
           autohide="always"
           autohideFloat="single-branch"
-          className="flex items-center gap-0.5"
+          className="flex items-center"
         >
-          <ActionBarPrimitive.Copy className={assistantActionClassName}>
-            <AuiIf condition={(s) => s.message.isCopied}>
-              <CheckIcon className="size-5" />
-            </AuiIf>
-            <AuiIf condition={(s) => !s.message.isCopied}>
-              <CopyIcon className="size-5" />
-            </AuiIf>
+          <ActionBarPrimitive.Copy asChild>
+            <TooltipIconButton
+              tooltip="Copy"
+              side="top"
+              className={assistantActionClassName}
+            >
+              <AuiIf condition={(s) => s.message.isCopied}>
+                <CheckIcon className="size-5" />
+              </AuiIf>
+              <AuiIf condition={(s) => !s.message.isCopied}>
+                <CopyIcon className="size-5" />
+              </AuiIf>
+            </TooltipIconButton>
           </ActionBarPrimitive.Copy>
           <ActionBarPrimitive.Edit asChild>
             <TooltipIconButton
               tooltip="Edit"
+              side="top"
               className={assistantActionClassName}
             >
               <Pencil1Icon className="size-5" />
@@ -263,7 +270,7 @@ const EditComposer: FC = () => {
 };
 
 const assistantActionClassName =
-  "flex size-8 items-center justify-center rounded-md text-[#5d5d5d] transition-colors hover:bg-[#0d0d0d]/5 hover:text-[#0d0d0d] dark:text-[#afafaf] dark:hover:bg-white/10 dark:hover:text-white";
+  "flex size-8 items-center justify-center rounded-lg text-[#5d5d5d] transition-colors hover:bg-black/[0.07] hover:text-[#5d5d5d] dark:text-[#cdcdcd] dark:hover:bg-white/15 dark:hover:text-[#cdcdcd]";
 
 const AssistantMessage: FC = () => {
   return (
@@ -280,36 +287,63 @@ const AssistantMessage: FC = () => {
       </div>
 
       <div className="-ml-2 flex items-center pt-1">
-        <ActionBarPrimitive.Root
-          hideWhenRunning
-          className="flex items-center gap-0.5"
-        >
-          <ActionBarPrimitive.Copy className={assistantActionClassName}>
-            <AuiIf condition={(s) => s.message.isCopied}>
-              <CheckIcon className="size-5" />
-            </AuiIf>
-            <AuiIf condition={(s) => !s.message.isCopied}>
-              <CopyIcon className="size-5" />
-            </AuiIf>
+        <ActionBarPrimitive.Root hideWhenRunning className="flex items-center">
+          <ActionBarPrimitive.Copy asChild>
+            <TooltipIconButton
+              tooltip="Copy"
+              side="top"
+              className={assistantActionClassName}
+            >
+              <AuiIf condition={(s) => s.message.isCopied}>
+                <CheckIcon className="size-5" />
+              </AuiIf>
+              <AuiIf condition={(s) => !s.message.isCopied}>
+                <CopyIcon className="size-5" />
+              </AuiIf>
+            </TooltipIconButton>
           </ActionBarPrimitive.Copy>
-          <ActionBarPrimitive.FeedbackPositive
-            className={assistantActionClassName}
-          >
-            <ThumbsUp className="size-5" />
+          <ActionBarPrimitive.FeedbackPositive asChild>
+            <TooltipIconButton
+              tooltip="Good response"
+              side="top"
+              className={assistantActionClassName}
+            >
+              <ThumbsUp className="size-5" />
+            </TooltipIconButton>
           </ActionBarPrimitive.FeedbackPositive>
-          <ActionBarPrimitive.FeedbackNegative
+          <ActionBarPrimitive.FeedbackNegative asChild>
+            <TooltipIconButton
+              tooltip="Bad response"
+              side="top"
+              className={assistantActionClassName}
+            >
+              <ThumbsDown className="size-5" />
+            </TooltipIconButton>
+          </ActionBarPrimitive.FeedbackNegative>
+          <ActionBarPrimitive.Speak asChild>
+            <TooltipIconButton
+              tooltip="Read aloud"
+              side="top"
+              className={assistantActionClassName}
+            >
+              <Volume2 className="size-5" />
+            </TooltipIconButton>
+          </ActionBarPrimitive.Speak>
+          <TooltipIconButton
+            tooltip="Share"
+            side="top"
             className={assistantActionClassName}
           >
-            <ThumbsDown className="size-5" />
-          </ActionBarPrimitive.FeedbackNegative>
-          <ActionBarPrimitive.Speak className={assistantActionClassName}>
-            <Volume2 className="size-5" />
-          </ActionBarPrimitive.Speak>
-          <button type="button" className={assistantActionClassName}>
             <Share className="size-5" />
-          </button>
-          <ActionBarPrimitive.Reload className={assistantActionClassName}>
-            <ReloadIcon className="size-5" />
+          </TooltipIconButton>
+          <ActionBarPrimitive.Reload asChild>
+            <TooltipIconButton
+              tooltip="Regenerate"
+              side="top"
+              className={assistantActionClassName}
+            >
+              <ReloadIcon className="size-5" />
+            </TooltipIconButton>
           </ActionBarPrimitive.Reload>
           <ActionBarMorePrimitive.Root>
             <ActionBarMorePrimitive.Trigger asChild>
@@ -318,7 +352,7 @@ const AssistantMessage: FC = () => {
                 aria-label="More"
                 className={cn(
                   assistantActionClassName,
-                  "data-[state=open]:bg-[#0d0d0d]/5 dark:data-[state=open]:bg-white/10",
+                  "data-[state=open]:bg-black/[0.07] dark:data-[state=open]:bg-white/15",
                 )}
               >
                 <MoreHorizontal className="size-5" />

--- a/apps/docs/content/examples/chatgpt.mdx
+++ b/apps/docs/content/examples/chatgpt.mdx
@@ -1,6 +1,6 @@
 ---
 title: ChatGPT Clone Example
-description: Open-source ChatGPT clone built in React with assistant-ui — centered welcome composer, Tools dropdown, four-state primary action, and full assistant action bar.
+description: Open-source ChatGPT clone built in React with assistant-ui — centered welcome composer, high-contrast user bubbles, tooltipped controls, and full assistant action bar.
 ---
 
 import { ChatGPT } from "@/components/examples/chatgpt";
@@ -11,16 +11,16 @@ import { ChatGPT } from "@/components/examples/chatgpt";
 
 ## Overview
 
-The ChatGPT Clone demonstrates how to customize assistant-ui to match OpenAI's ChatGPT interface. This version mirrors the current chatgpt.com layout: a centered welcome composer in the empty state, a Tools dropdown, and an always-visible assistant action bar with thumbs, share, speak, reload, and more.
+The ChatGPT Clone demonstrates how to customize assistant-ui to match OpenAI's ChatGPT interface. This version mirrors the current chatgpt.com layout: a centered welcome composer, tooltipped attachment/dictation/voice controls, high-contrast user bubbles with Copy + Edit actions, and an always-visible assistant action bar with thumbs, share, speak, reload, and more.
 
 ## Features
 
-- **Theme-Aware**: White light mode (`#ffffff`) and dark mode (`#212121`) with no forced theme
-- **Centered Empty State**: "Where should we begin?" heading + composer rendered together in the middle of the viewport
-- **Functional Tools Dropdown**: `Search the web` / `Create an image` / `Run deep research` / `Think longer` / `Study and learn`
-- **Four-State Primary Action**: Cancel (running), Send (typing), Dictate mic + orange Voice circle (idle), StopDictation (recording)
-- **Assistant Action Bar**: Always visible — Copy, FeedbackPositive, FeedbackNegative, Speak, Share, Reload, More
-- **User Bubble**: Right-aligned `bg-secondary` pill with hover-only Edit action
+- **Theme-Aware**: White light mode (`#ffffff`) and black dark mode (`#000000`) with ChatGPT-style `#212121` composer surfaces
+- **Centered Empty State**: "Where should we begin?" heading + composer rendered together above the viewport center
+- **Tooltipped Composer Controls**: Add attachment, Dictate, and voice-mode buttons use ChatGPT's circular controls and hover tooltips
+- **Four-State Primary Action**: Cancel (running), StopDictation (recording), Send (typing), Dictate + voice mode (idle)
+- **Assistant Action Bar**: Always visible — Copy, Good response, Bad response, Read aloud, Share, Regenerate, More
+- **User Bubble**: Right-aligned high-contrast bubble with Copy + Edit actions below on hover
 - **Sticky Footer**: Composer + "ChatGPT can make mistakes" disclaimer at the bottom of the chat
 
 ## Quick Start
@@ -31,7 +31,7 @@ npx assistant-ui add thread
 
 ## Code
 
-The ChatGPT clone splits into an `EmptyState` and a sticky chat layout. The composer is shared by both:
+The ChatGPT clone splits into an `EmptyState` and a sticky chat layout. The same composer shell is shared by both:
 
 ```tsx
 import {
@@ -40,9 +40,11 @@ import {
   ComposerPrimitive,
   ActionBarPrimitive,
 } from "@assistant-ui/react";
+import { PlusIcon } from "lucide-react";
+import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 
 export const ChatGPT = () => (
-  <ThreadPrimitive.Root className="bg-white dark:bg-[#212121]">
+  <ThreadPrimitive.Root className="bg-white text-[#0d0d0d] dark:bg-black dark:text-[#ececec]">
     <AuiIf condition={(s) => s.thread.isEmpty}>
       <EmptyState />
     </AuiIf>
@@ -50,7 +52,7 @@ export const ChatGPT = () => (
       <ThreadPrimitive.Viewport>
         <ThreadPrimitive.Messages />
         <ThreadPrimitive.ViewportFooter className="sticky bottom-0">
-          <Composer />
+          <Composer placeholder="Ask anything" />
           <p>ChatGPT can make mistakes. Check important info.</p>
         </ThreadPrimitive.ViewportFooter>
       </ThreadPrimitive.Viewport>
@@ -58,15 +60,16 @@ export const ChatGPT = () => (
   </ThreadPrimitive.Root>
 );
 
-const Composer = () => (
-  <ComposerPrimitive.Root className="rounded-[28px] border bg-white dark:bg-[#303030]">
-    <ComposerPrimitive.Input rows={1} placeholder="Ask anything" />
-    <div className="flex items-center justify-between">
-      <ComposerPrimitive.AddAttachment />
-      <div className="flex items-center gap-1">
-        <ToolsMenu />
-        <PrimaryAction />
-      </div>
+const Composer = ({ placeholder }: { placeholder: string }) => (
+  <ComposerPrimitive.Root className="rounded-[28px] border border-[#e5e5e5] bg-white dark:border-transparent dark:bg-[#212121]">
+    <div className="flex items-end gap-1">
+      <ComposerPrimitive.AddAttachment asChild>
+        <TooltipIconButton tooltip="Add photos & files" aria-label="Add attachment">
+          <PlusIcon />
+        </TooltipIconButton>
+      </ComposerPrimitive.AddAttachment>
+      <ComposerPrimitive.Input autoFocus rows={1} placeholder={placeholder} />
+      <PrimaryAction />
     </div>
   </ComposerPrimitive.Root>
 );
@@ -78,56 +81,79 @@ const Composer = () => (
 <AuiIf condition={(s) => s.thread.isRunning}>
   <ComposerPrimitive.Cancel />
 </AuiIf>
-<AuiIf condition={(s) => s.composer.dictation != null}>
+<AuiIf condition={(s) => !s.thread.isRunning && s.composer.dictation != null}>
   <ComposerPrimitive.StopDictation />
 </AuiIf>
-<AuiIf condition={(s) => s.composer.dictation == null && !s.composer.isEmpty}>
+<AuiIf
+  condition={(s) =>
+    !s.thread.isRunning && s.composer.dictation == null && !s.composer.isEmpty
+  }
+>
   <ComposerPrimitive.Send />
 </AuiIf>
-<AuiIf condition={(s) => s.composer.dictation == null && s.composer.isEmpty}>
-  <ComposerPrimitive.Dictate />
-  <button aria-hidden="true" className="bg-[#ff5d1f]"> {/* Voice */}</button>
+<AuiIf
+  condition={(s) =>
+    !s.thread.isRunning && s.composer.dictation == null && s.composer.isEmpty
+  }
+>
+  <ComposerPrimitive.Dictate asChild>
+    <TooltipIconButton tooltip="Dictate" aria-label="Dictate">
+      <Mic />
+    </TooltipIconButton>
+  </ComposerPrimitive.Dictate>
+  <TooltipIconButton
+    tooltip="Use voice mode"
+    aria-hidden="true"
+    tabIndex={-1}
+    className="bg-[#0d0d0d] text-white dark:bg-white dark:text-black"
+  >
+    <AudioLines />
+  </TooltipIconButton>
 </AuiIf>
 ```
 
-The conditions are mutually exclusive in priority order (`Cancel > StopDictation > Send > Dictate`) so dictation can be paused even when transcribed text is in the composer.
+The conditions are mutually exclusive in priority order (`Cancel > StopDictation > Send > Dictate/voice mode`) so dictation can be paused even when transcribed text is in the composer.
 
-### Tools Dropdown
+### User Bubble and Actions
 
 ```tsx
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/shared/dropdown-menu";
+<MessagePrimitive.Root className="flex flex-col items-end gap-1">
+  <div className="max-w-[70%] rounded-[22px] bg-[#0d0d0d] px-4 py-2.5 text-white dark:bg-[#ececec] dark:text-[#0d0d0d]">
+    <MessagePrimitive.Parts />
+  </div>
 
-<DropdownMenu>
-  <DropdownMenuTrigger>Tools <ChevronDown /></DropdownMenuTrigger>
-  <DropdownMenuContent>
-    <DropdownMenuItem icon={<Globe />}>Search the web</DropdownMenuItem>
-    <DropdownMenuItem icon={<ImageIcon />}>Create an image</DropdownMenuItem>
-    <DropdownMenuItem icon={<Telescope />}>Run deep research</DropdownMenuItem>
-    <DropdownMenuItem icon={<Lightbulb />}>Think longer</DropdownMenuItem>
-    <DropdownMenuItem icon={<Sparkles />}>Study and learn</DropdownMenuItem>
-  </DropdownMenuContent>
-</DropdownMenu>
+  <ActionBarPrimitive.Root autohide="always">
+    <ActionBarPrimitive.Copy asChild>
+      <TooltipIconButton tooltip="Copy" />
+    </ActionBarPrimitive.Copy>
+    <ActionBarPrimitive.Edit asChild>
+      <TooltipIconButton tooltip="Edit" />
+    </ActionBarPrimitive.Edit>
+  </ActionBarPrimitive.Root>
+</MessagePrimitive.Root>
 ```
 
 ### Color Palette
 
 | Element | Light | Dark |
 |---------|-------|------|
-| Background | `#ffffff` | `#212121` |
-| Composer surface | `#ffffff` | `#303030` |
-| Composer border | `#e5e5e5` | `transparent` |
+| Background | `#ffffff` | `#000000` |
+| Composer surface | `#ffffff` | `#212121` |
+| Composer border / edge | `#e5e5e5` | `transparent` + inset white edge |
 | Primary text | `#0d0d0d` | `#ececec` |
-| Muted text | `#5d5d5d` | `#a8a8a8` |
-| Send button | `#0d0d0d` (white icon) | `#ffffff` (black icon) |
-| Voice button | `#ff5d1f` (orange) | `#ff5d1f` |
+| Muted text | `#5d5d5d` | `#afafaf` |
+| User bubble | `#0d0d0d` (white text) | `#ececec` (`#0d0d0d` text) |
+| Action icon | `#5d5d5d` | `#cdcdcd` |
+| Icon hover background | black at 7% | white at 15% |
+| Send / voice button | `#0d0d0d` (white icon) | `#ffffff` (black icon) |
 
 ### Styling Details
 
-- **Composer**: `rounded-[28px]` with thin border in light mode, no border in dark mode
-- **Empty Layout**: heading + composer centered together; no avatar
-- **Tools Pill**: `hidden sm:flex` so it collapses on narrow screens; mobile only shows + and primary action
-- **Assistant Action Bar**: always visible, no hover-only behavior
-- **User Bubble**: `rounded-3xl bg-secondary` with hover-only Edit primitive
+- **Composer**: `rounded-[28px]` with a thin light-mode border, dark `#212121` surface, and an inset dark-mode edge
+- **Empty Layout**: 24px/400 heading + composer raised above center; no avatar
+- **Composer Buttons**: 36px circular controls with hover tooltips and background-only hover states
+- **Assistant Action Bar**: 32px controls, 8px radius, zero gap, background-only hover, and tooltips on every action
+- **User Bubble**: `rounded-[22px]`, 70% max width, high-contrast theme colors, Copy + Edit actions below on hover
 
 ## Source
 


### PR DESCRIPTION
## What

Refines the ChatGPT demo (`apps/docs/components/examples/chatgpt.tsx`) so it reads as an almost-exact copy of chatgpt.com, in both light and dark mode.

## Why

The demo was already close, but a number of small details drifted from the real product. Each change here was derived from the **live computed styles / design tokens** on chatgpt.com, not guessed.

## How

- **User bubble:** match ChatGPT's high-contrast design — light (`#ececec`/dark text) in dark mode, dark (`#0d0d0d`/white text) in light mode; correct radius (22px), padding, line-height, and 70% max-width. Actions (Copy + Edit) now sit below the bubble on hover.
- **Composer:** auto-focus the input, tighten the `+`-to-input gap, add the dark inset edge, and add hover tooltips to the add/dictate/voice buttons.
- **Empty state:** greeting at 24px/400 and raised higher to reduce the space above it.
- **Action bar:** 8px radius, `#cdcdcd` resting color, background-only hover (white-15% / black-7%, no icon brighten), zero gap, and a hover tooltip on every button (also fixes previously-unlabeled icon buttons).

No changeset — `@assistant-ui/docs` is private.

## Verification

Ran locally against chatgpt.com side by side (light + dark): bubble colors, composer focus/spacing/tooltips, empty-state position, and action-bar sizing/hover/tooltips all match. `pnpm lint` (oxlint + oxfmt) clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

