### PR TITLE
fix(react-langgraph): surface tool-call messages and interrupts from subgraph updates

### DIFF
--- a/.changeset/langgraph-subgraph-interrupt-updates.md
+++ b/.changeset/langgraph-subgraph-interrupt-updates.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: surface tool-call messages and interrupts raised inside a subgraph
+
+A subgraph `interrupt()` emits both the tool-call `AIMessage` and the `__interrupt__` payload under a namespaced `updates` event, which the runtime dropped early. The toolkit therefore never rendered the tool UI and `useLangGraphInterruptState` stayed `undefined`. Namespaced `updates` now extract messages and set the interrupt (never clearing an active interrupt from a later subgraph update), so subgraph HITL flows behave like top-level ones.

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -3331,6 +3331,98 @@ describe("useLangGraphMessages", {}, () => {
     ]);
   });
 
+  it("surfaces the tool-call message and interrupt from a subgraph interrupt", async () => {
+    const onSubgraphUpdates = vi.fn();
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      // AIMessage with tool_calls emitted by the subgraph LLM node
+      {
+        event: "updates|weatherAgent:model:abc",
+        data: {
+          "weatherAgent:model:abc": {
+            messages: [
+              {
+                id: "ai-1",
+                type: "ai",
+                content: "",
+                tool_calls: [{ name: "ask_location", id: "tc-1", args: {} }],
+              },
+            ],
+          },
+        },
+      },
+      // interrupt raised by the subgraph tool node
+      {
+        event: "updates|weatherAgent:tools:def",
+        data: {
+          __interrupt__: [{ id: "int-1", value: { awaiting: "location" } }],
+        },
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+        eventHandlers: { onSubgraphUpdates },
+      }),
+    );
+
+    act(() => {
+      result.current.sendMessage([{ type: "human", content: "weather?" }], {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.interrupt).toEqual({
+        id: "int-1",
+        value: { awaiting: "location" },
+      });
+    });
+
+    const aiMessage = result.current.messages.find((m) => m.id === "ai-1") as
+      | { tool_calls?: { name: string }[] }
+      | undefined;
+    expect(aiMessage).toBeDefined();
+    expect(aiMessage!.tool_calls?.[0]!.name).toEqual("ask_location");
+    // existing subgraph callback still fires for both events
+    expect(onSubgraphUpdates).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let a later subgraph update clear an active interrupt", async () => {
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      {
+        event: "updates|sub:tools:1",
+        data: {
+          __interrupt__: [{ id: "int-1", value: { awaiting: "location" } }],
+        },
+      },
+      // a subsequent non-interrupt subgraph update must not wipe it
+      {
+        event: "updates|sub:model:2",
+        data: { "sub:model:2": { messages: [] } },
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    act(() => {
+      result.current.sendMessage([{ type: "human", content: "hi" }], {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.interrupt).toEqual({
+        id: "int-1",
+        value: { awaiting: "location" },
+      });
+    });
+  });
+
   it("fires onSubgraphValues when onValues is not registered", async () => {
     const onSubgraphValues = vi.fn();
     const mockStreamCallback = mockStreamCallbackFactory([

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -3165,7 +3165,7 @@ describe("useLangGraphMessages", {}, () => {
     });
   });
 
-  it("ignores subgraph updates events (namespaced)", async () => {
+  it("routes namespaced updates to onSubgraphUpdates, not onUpdates", async () => {
     const onUpdates = vi.fn();
     const mockStreamCallback = mockStreamCallbackFactory([
       metadataEvent,
@@ -3192,7 +3192,6 @@ describe("useLangGraphMessages", {}, () => {
     });
 
     await waitFor(() => {
-      // only the root-level updates event fires the handler
       expect(onUpdates).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -253,16 +253,28 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
             case LangGraphKnownEventTypes.Updates: {
               if (eventNamespace) {
                 onSubgraphUpdates?.(eventNamespace, chunk.data);
-                break;
+              } else {
+                onUpdates?.(chunk.data);
               }
-              onUpdates?.(chunk.data);
+              // A subgraph interrupt() pauses the whole run, so the tool-call
+              // AIMessage and __interrupt__ payload it emits under a namespace
+              // must still reach the store and interrupt state. addMessages
+              // dedupes by id and the final values snapshot reconciles, so
+              // extracting from subgraph updates is safe.
               const extracted = extractMessagesFromUpdates<TMessage>(
                 chunk.data,
               );
               if (extracted.length > 0) {
                 setMessagesImmediate(accumulator.addMessages(extracted));
               }
-              setInterrupt(chunk.data.__interrupt__?.[0]);
+              const updateInterrupt = chunk.data.__interrupt__?.[0];
+              if (!eventNamespace) {
+                setInterrupt(updateInterrupt);
+              } else if (updateInterrupt !== undefined) {
+                // Never clear from a subgraph update: a later non-interrupt
+                // subgraph event must not wipe an interrupt raised earlier.
+                setInterrupt(updateInterrupt);
+              }
               break;
             }
             case LangGraphKnownEventTypes.Values:

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -256,23 +256,15 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
               } else {
                 onUpdates?.(chunk.data);
               }
-              // A subgraph interrupt() pauses the whole run, so the tool-call
-              // AIMessage and __interrupt__ payload it emits under a namespace
-              // must still reach the store and interrupt state. addMessages
-              // dedupes by id and the final values snapshot reconciles, so
-              // extracting from subgraph updates is safe.
               const extracted = extractMessagesFromUpdates<TMessage>(
                 chunk.data,
               );
               if (extracted.length > 0) {
                 setMessagesImmediate(accumulator.addMessages(extracted));
               }
+              // A subgraph update may set an interrupt but never clear one; the parent's top-level update clears it when the subgraph ends.
               const updateInterrupt = chunk.data.__interrupt__?.[0];
-              if (!eventNamespace) {
-                setInterrupt(updateInterrupt);
-              } else if (updateInterrupt !== undefined) {
-                // Never clear from a subgraph update: a later non-interrupt
-                // subgraph event must not wipe an interrupt raised earlier.
+              if (!eventNamespace || updateInterrupt !== undefined) {
                 setInterrupt(updateInterrupt);
               }
               break;


### PR DESCRIPTION
## Problem

When a LangGraph **subgraph** calls a tool whose body calls `interrupt()`, both the `AIMessage` carrying the `tool_calls` and the `__interrupt__` payload arrive over SSE as **namespaced** `updates` events (e.g. `updates|weatherAgent:tools:def`). `useLangGraphMessages` returned early on any namespaced `updates` event — it fired `onSubgraphUpdates` and `break`ed before running `extractMessagesFromUpdates` or `setInterrupt`:

```ts
case LangGraphKnownEventTypes.Updates: {
  if (eventNamespace) {
    onSubgraphUpdates?.(eventNamespace, chunk.data);
    break; // ← no message extraction, no setInterrupt
  }
  ...
```

As a result, for a subgraph-triggered interrupt:
- `useLangGraphInterruptState()` stays `undefined`,
- the toolkit never sees a tool-call message part, so the registered `render` component never mounts,
- the run pauses with no UI feedback.

The same flow works when the tool is bound to the **parent** graph (the events arrive without a namespace). The regression is purely the move to a subgraph. Reported in #4563 with a full root-cause analysis.

The subgraph branch is the only place these payloads appear when the subgraph LLM node is invoked synchronously (`.invoke()`), so there is no `messages` tuple stream and no parent `values` reconcile while the run is paused.

## Solution

Run the same message extraction and interrupt handling on the namespaced `updates` branch as on the top-level one, after firing `onSubgraphUpdates`:

- `extractMessagesFromUpdates` so the tool-call `AIMessage` lands in the store. This is safe: the accumulator dedupes by message `id`, and the final `values` snapshot reconciles, so no duplicate or leaked messages.
- `setInterrupt` so `useLangGraphInterruptState` returns the value. A subgraph update only **sets** an interrupt, never clears one — a later non-interrupt subgraph event must not wipe an interrupt raised earlier in the same run. Top-level behavior (which still clears) is unchanged.

`onSubgraphUpdates` / `onUpdates` callbacks keep firing exactly as before.

## Why this approach

A subgraph `interrupt()` pauses the **whole** run, so its interrupt is a run-level concern, not subgraph-private state — surfacing it matches how top-level interrupts already work. Subgraph `values` events stay callback-only (unchanged), since a completed subgraph reconciles through the parent `values` snapshot; only `updates` need this treatment because that is where the interrupt and its preceding tool-call message live during the pause.

## Testing

`pnpm vitest run` in `packages/react-langgraph` — 152 passing, including two new cases:
- a subgraph interrupt surfaces both the `ask_location` tool-call message and the interrupt state;
- a later non-interrupt subgraph update does not clear an active interrupt.

Both fail on `main` and pass with this change (verified by reverting the fix).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

