### PR TITLE
feat: add toolkit composition with duplicate warnings

### DIFF
--- a/.changeset/merge-toolkits-dx.md
+++ b/.changeset/merge-toolkits-dx.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+---
+
+feat: add mergeToolkits and toolkit shorthand registration

--- a/apps/docs/content/docs/tools/defining-tools.mdx
+++ b/apps/docs/content/docs/tools/defining-tools.mdx
@@ -71,11 +71,11 @@ For a bare React Native app, import `getDefaultConfig` from `@react-native/metro
 </Step>
 <Step>
 
-### Write the toolkit
+### Write a feature toolkit
 
 The file's first line is `"use generative"`, and its default export is `defineToolkit({ ... })`. Each tool is an inline object literal with a `parameters` schema, an `execute`, and a `render` (or `renderText`):
 
-```tsx title="app/toolkit.tsx"
+```tsx title="app/toolkits/files.tsx"
 "use generative";
 
 import { defineToolkit } from "@assistant-ui/react";
@@ -113,20 +113,48 @@ The inner `"use client"` inside `execute` marks this as a **frontend** tool — 
 </Step>
 <Step>
 
+### Compose feature toolkits
+
+For larger apps, keep each product area in its own `"use generative"` file and compose them from a plain index file:
+
+```tsx title="app/toolkits/index.tsx"
+import { mergeToolkits } from "@assistant-ui/react";
+import filesToolkit from "./files";
+import tasksToolkit from "./tasks";
+import calendarToolkit from "./calendar";
+import crmToolkit from "./crm";
+import approvalsToolkit from "./approvals";
+
+export const appToolkit = mergeToolkits(
+  filesToolkit,
+  tasksToolkit,
+  calendarToolkit,
+  crmToolkit,
+  approvalsToolkit,
+);
+
+export default appToolkit;
+```
+
+`mergeToolkits` keeps the first definition when two feature files use the same tool name and logs a warning so duplicate model-facing names do not silently override each other.
+
+</Step>
+<Step>
+
 ### Register the toolkit
 
-Import the toolkit in your runtime provider and pass it to `useAui` via `Tools`:
+Import the composed toolkit in your runtime provider and pass it directly to `useAui`:
 
 ```tsx title="app/MyRuntimeProvider.tsx"
 "use client";
 
-import { AssistantRuntimeProvider, Tools, useAui } from "@assistant-ui/react";
+import { AssistantRuntimeProvider, useAui } from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
-import toolkit from "./toolkit";
+import { appToolkit } from "./toolkits";
 
 export function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
   const runtime = useChatRuntime({ api: "/api/chat" });
-  const aui = useAui({ tools: Tools({ toolkit }) });
+  const aui = useAui({ tools: appToolkit });
 
   return (
     <AssistantRuntimeProvider aui={aui} runtime={runtime}>
@@ -147,9 +175,9 @@ The same import resolves to the **server build** inside a route handler. Wrap it
 import { AISDKToolkit } from "@assistant-ui/react-ai-sdk";
 import { streamText, convertToModelMessages } from "ai";
 import { openai } from "@ai-sdk/openai";
-import toolkit from "../../toolkit";
+import { appToolkit } from "../../toolkits";
 
-const aiToolkit = new AISDKToolkit({ toolkit });
+const aiToolkit = new AISDKToolkit({ toolkit: appToolkit });
 
 export async function POST(req: Request) {
   const { messages, tools } = await req.json();

--- a/apps/docs/content/docs/tools/defining-tools.mdx
+++ b/apps/docs/content/docs/tools/defining-tools.mdx
@@ -148,13 +148,27 @@ Import the composed toolkit in your runtime provider and pass it directly to `us
 ```tsx title="app/MyRuntimeProvider.tsx"
 "use client";
 
-import { AssistantRuntimeProvider, useAui } from "@assistant-ui/react";
+import {
+  AssistantRuntimeProvider,
+  AuiProvider,
+  useAui,
+} from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 import { appToolkit } from "./toolkits";
 
 export function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
-  const runtime = useChatRuntime({ api: "/api/chat" });
   const aui = useAui({ tools: appToolkit });
+
+  return (
+    <AuiProvider value={aui}>
+      <RuntimeProvider>{children}</RuntimeProvider>
+    </AuiProvider>
+  );
+}
+
+function RuntimeProvider({ children }: { children: React.ReactNode }) {
+  const aui = useAui();
+  const runtime = useChatRuntime({ api: "/api/chat" });
 
   return (
     <AssistantRuntimeProvider aui={aui} runtime={runtime}>

--- a/packages/core/src/react/client/Tools.test.ts
+++ b/packages/core/src/react/client/Tools.test.ts
@@ -1,0 +1,85 @@
+import { createTapRoot } from "@assistant-ui/tap";
+import { useAui } from "@assistant-ui/store";
+import { describe, expect, it } from "vitest";
+
+import { ModelContext } from "../../store";
+import { defineToolkit } from "../model-context/define-toolkit";
+import { Tools } from "./Tools";
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+const toolkit = defineToolkit({
+  search_files: {
+    type: "backend",
+    description: "Search files.",
+    parameters: { type: "object", properties: {} },
+    renderText: {
+      running: "Searching files",
+      complete: "Finished searching files",
+    },
+  } as never,
+});
+
+describe("Tools", () => {
+  it("registers toolkit tools into an explicit model context scope", async () => {
+    const root = createTapRoot(function Root() {
+      return useAui(
+        {
+          modelContext: ModelContext(),
+          tools: Tools({ toolkit }),
+        },
+        { parent: null },
+      );
+    });
+
+    try {
+      await tick();
+
+      const contextTool = root.getValue().modelContext().getModelContext()
+        .tools?.search_files;
+
+      expect(contextTool?.description).toBe("Search files.");
+      expect(contextTool).not.toHaveProperty("renderText");
+      expect(root.getValue().modelContext().getState().toolNames).toEqual([
+        "search_files",
+      ]);
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("registers descendant toolkit tools into the parent model context", async () => {
+    const root = createTapRoot(function Root() {
+      const parent = useAui(
+        {
+          modelContext: ModelContext(),
+        },
+        { parent: null },
+      );
+
+      useAui(
+        {
+          tools: Tools({ toolkit }),
+        },
+        { parent },
+      );
+
+      return parent;
+    });
+
+    try {
+      await tick();
+
+      const contextTool = root.getValue().modelContext().getModelContext()
+        .tools?.search_files;
+
+      expect(contextTool?.description).toBe("Search files.");
+      expect(contextTool).not.toHaveProperty("renderText");
+      expect(root.getValue().modelContext().getState().toolNames).toEqual([
+        "search_files",
+      ]);
+    } finally {
+      root.unmount();
+    }
+  });
+});

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -1,11 +1,15 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import {
   useResources,
   resource,
   withKey,
   type ResourceElement,
 } from "@assistant-ui/tap";
-import { type ClientOutput, attachTransformScopes } from "@assistant-ui/store";
+import {
+  useAssistantClientRef,
+  type ClientOutput,
+  attachTransformScopes,
+} from "@assistant-ui/store";
 import type { McpAppResourceOutput, ToolsState } from "../types/scopes/tools";
 import type { Tool } from "assistant-stream";
 import {
@@ -14,16 +18,10 @@ import {
   type Toolkit,
 } from "../model-context/toolbox";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
-import type {
-  ModelContext as ModelContextValue,
-  ModelContextProvider,
-} from "../../model-context/types";
-import { mergeModelContexts } from "../../model-context/types";
-import type { ModelContextState } from "../../store";
+import { ModelContext } from "../../store";
 
 export type { McpAppResourceOutput };
 
-const EMPTY_TOOL_NAMES: readonly string[] = [];
 const toolsWithoutRenderCache = new WeakMap<
   Toolkit,
   Record<string, Tool<any, any>>
@@ -54,136 +52,6 @@ const getToolsWithoutRender = (
   return tools;
 };
 
-const getModelContextForToolkit = (toolkit: Toolkit | undefined) => ({
-  tools: getToolsWithoutRender(toolkit),
-});
-
-const toolNamesEqual = (a: readonly string[], b: readonly string[]): boolean =>
-  a === b || (a.length === b.length && a.every((v, i) => v === b[i]));
-
-const deriveModelContextState = (
-  provider: ModelContextProvider,
-  prev: ModelContextState,
-): ModelContextState => {
-  const ctx = provider.getModelContext();
-  const modelName = ctx.config?.modelName;
-  const keys = ctx.tools ? Object.keys(ctx.tools).sort() : EMPTY_TOOL_NAMES;
-  const toolNames = keys.length ? keys : EMPTY_TOOL_NAMES;
-
-  if (modelName === prev.modelName && toolNamesEqual(toolNames, prev.toolNames))
-    return prev;
-
-  return { modelName, toolNames };
-};
-
-const INITIAL_MODEL_CONTEXT_STATE: ModelContextState = {
-  modelName: undefined,
-  toolNames: EMPTY_TOOL_NAMES,
-};
-
-const useToolkitModelContext = ({
-  toolkit,
-  parent,
-}: {
-  toolkit?: Toolkit | undefined;
-  parent?: ModelContextProvider | undefined;
-}): ClientOutput<"modelContext"> => {
-  const modelContextRef = useRef<ModelContextValue>(
-    getModelContextForToolkit(toolkit),
-  );
-  const subscribersRef = useRef(new Set<() => void>());
-  const providersRef = useRef(new Set<ModelContextProvider>());
-
-  const toolkitProvider = useMemo<ModelContextProvider>(
-    () => ({
-      getModelContext: () => modelContextRef.current,
-      subscribe: (callback: () => void) => {
-        subscribersRef.current.add(callback);
-        return () => {
-          subscribersRef.current.delete(callback);
-        };
-      },
-    }),
-    [],
-  );
-
-  const getModelContext = useCallback(
-    () =>
-      mergeModelContexts(
-        new Set([
-          toolkitProvider,
-          ...(parent ? [parent] : []),
-          ...providersRef.current,
-        ]),
-      ),
-    [parent, toolkitProvider],
-  );
-
-  const modelContextProvider = useMemo<ModelContextProvider>(
-    () => ({
-      getModelContext,
-      subscribe: (callback: () => void) => {
-        subscribersRef.current.add(callback);
-        return () => {
-          subscribersRef.current.delete(callback);
-        };
-      },
-    }),
-    [getModelContext],
-  );
-
-  const [state, setState] = useState<ModelContextState>(() =>
-    deriveModelContextState(modelContextProvider, INITIAL_MODEL_CONTEXT_STATE),
-  );
-
-  const notifySubscribers = useCallback(() => {
-    for (const callback of subscribersRef.current) callback();
-  }, []);
-
-  useEffect(() => {
-    modelContextRef.current = getModelContextForToolkit(toolkit);
-    notifySubscribers();
-  }, [toolkit, notifySubscribers]);
-
-  useEffect(() => {
-    if (!parent) return undefined;
-    return parent.subscribe?.(notifySubscribers);
-  }, [notifySubscribers, parent]);
-
-  useEffect(() => {
-    setState((prev) => deriveModelContextState(modelContextProvider, prev));
-    return modelContextProvider.subscribe?.(() => {
-      setState((prev) => deriveModelContextState(modelContextProvider, prev));
-    });
-  }, [modelContextProvider]);
-
-  const register = useCallback(
-    (provider: ModelContextProvider) => {
-      providersRef.current.add(provider);
-      const unsubscribe = provider.subscribe?.(notifySubscribers);
-      notifySubscribers();
-      return () => {
-        providersRef.current.delete(provider);
-        unsubscribe?.();
-        notifySubscribers();
-      };
-    },
-    [notifySubscribers],
-  );
-
-  return useMemo(
-    (): ClientOutput<"modelContext"> => ({
-      getState: () => deriveModelContextState(modelContextProvider, state),
-      getModelContext,
-      subscribe: (callback) => modelContextProvider.subscribe!(callback),
-      register,
-    }),
-    [getModelContext, modelContextProvider, register, state],
-  );
-};
-
-const ToolkitModelContext = resource(useToolkitModelContext);
-
 /**
  * Registers tools with model context and installs tool-call renderers.
  *
@@ -205,6 +73,7 @@ const useTools = ({
   const mcpAppOutput = mcpAppOutputs[0];
 
   const [toolUIs, setToolUIs] = useState<ToolsState["toolUIs"]>(() => ({}));
+  const clientRef = useAssistantClientRef();
 
   const state = useMemo(
     (): ToolsState => ({
@@ -276,10 +145,19 @@ const useTools = ({
       }
     }
 
+    const toolsWithoutRender = getToolsWithoutRender(toolkit);
+    unsubscribes.push(
+      clientRef.current!.modelContext().register({
+        getModelContext: () => ({
+          tools: toolsWithoutRender,
+        }),
+      }),
+    );
+
     return () => {
       unsubscribes.forEach((fn) => fn());
     };
-  }, [toolkit, setToolUI]);
+  }, [toolkit, setToolUI, clientRef]);
 
   return {
     getState: () => state,
@@ -290,16 +168,7 @@ const useTools = ({
 export const Tools = resource(useTools);
 
 attachTransformScopes(useTools, (scopes, parent) => {
-  if (!scopes.modelContext && scopes.tools?.hook === useTools) {
-    const [{ toolkit }] = scopes.tools.args as [
-      {
-        toolkit?: Toolkit | undefined;
-      },
-    ];
-    scopes.modelContext = ToolkitModelContext({
-      toolkit,
-      parent:
-        parent.modelContext.source === null ? undefined : parent.modelContext(),
-    });
+  if (!scopes.modelContext && parent.modelContext.source === null) {
+    scopes.modelContext = ModelContext();
   }
 });

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -1,15 +1,11 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import {
   useResources,
   resource,
   withKey,
   type ResourceElement,
 } from "@assistant-ui/tap";
-import {
-  useAssistantClientRef,
-  type ClientOutput,
-  attachTransformScopes,
-} from "@assistant-ui/store";
+import { type ClientOutput, attachTransformScopes } from "@assistant-ui/store";
 import type { McpAppResourceOutput, ToolsState } from "../types/scopes/tools";
 import type { Tool } from "assistant-stream";
 import {
@@ -18,9 +14,175 @@ import {
   type Toolkit,
 } from "../model-context/toolbox";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
-import { ModelContext } from "../../store";
+import type {
+  ModelContext as ModelContextValue,
+  ModelContextProvider,
+} from "../../model-context/types";
+import { mergeModelContexts } from "../../model-context/types";
+import type { ModelContextState } from "../../store";
 
 export type { McpAppResourceOutput };
+
+const EMPTY_TOOL_NAMES: readonly string[] = [];
+const toolsWithoutRenderCache = new WeakMap<
+  Toolkit,
+  Record<string, Tool<any, any>>
+>();
+
+const getToolsWithoutRender = (
+  toolkit: Toolkit | undefined,
+): Record<string, Tool<any, any>> | undefined => {
+  if (!toolkit) return undefined;
+  const cached = toolsWithoutRenderCache.get(toolkit);
+  if (cached) return cached;
+
+  const tools = Object.entries(toolkit).reduce(
+    (acc, [name, tool]) => {
+      if (tool.type === "mcp") return acc;
+      const {
+        display: _display,
+        render: _render,
+        renderText: _renderText,
+        ...rest
+      } = tool as typeof tool & { renderText?: unknown };
+      acc[name] = rest as Tool<any, any>;
+      return acc;
+    },
+    {} as Record<string, Tool<any, any>>,
+  );
+  toolsWithoutRenderCache.set(toolkit, tools);
+  return tools;
+};
+
+const getModelContextForToolkit = (toolkit: Toolkit | undefined) => ({
+  tools: getToolsWithoutRender(toolkit),
+});
+
+const toolNamesEqual = (a: readonly string[], b: readonly string[]): boolean =>
+  a === b || (a.length === b.length && a.every((v, i) => v === b[i]));
+
+const deriveModelContextState = (
+  provider: ModelContextProvider,
+  prev: ModelContextState,
+): ModelContextState => {
+  const ctx = provider.getModelContext();
+  const modelName = ctx.config?.modelName;
+  const keys = ctx.tools ? Object.keys(ctx.tools).sort() : EMPTY_TOOL_NAMES;
+  const toolNames = keys.length ? keys : EMPTY_TOOL_NAMES;
+
+  if (modelName === prev.modelName && toolNamesEqual(toolNames, prev.toolNames))
+    return prev;
+
+  return { modelName, toolNames };
+};
+
+const INITIAL_MODEL_CONTEXT_STATE: ModelContextState = {
+  modelName: undefined,
+  toolNames: EMPTY_TOOL_NAMES,
+};
+
+const useToolkitModelContext = ({
+  toolkit,
+  parent,
+}: {
+  toolkit?: Toolkit | undefined;
+  parent?: ModelContextProvider | undefined;
+}): ClientOutput<"modelContext"> => {
+  const modelContextRef = useRef<ModelContextValue>(
+    getModelContextForToolkit(toolkit),
+  );
+  const subscribersRef = useRef(new Set<() => void>());
+  const providersRef = useRef(new Set<ModelContextProvider>());
+
+  const toolkitProvider = useMemo<ModelContextProvider>(
+    () => ({
+      getModelContext: () => modelContextRef.current,
+      subscribe: (callback: () => void) => {
+        subscribersRef.current.add(callback);
+        return () => {
+          subscribersRef.current.delete(callback);
+        };
+      },
+    }),
+    [],
+  );
+
+  const getModelContext = useCallback(
+    () =>
+      mergeModelContexts(
+        new Set([
+          toolkitProvider,
+          ...(parent ? [parent] : []),
+          ...providersRef.current,
+        ]),
+      ),
+    [parent, toolkitProvider],
+  );
+
+  const modelContextProvider = useMemo<ModelContextProvider>(
+    () => ({
+      getModelContext,
+      subscribe: (callback: () => void) => {
+        subscribersRef.current.add(callback);
+        return () => {
+          subscribersRef.current.delete(callback);
+        };
+      },
+    }),
+    [getModelContext],
+  );
+
+  const [state, setState] = useState<ModelContextState>(() =>
+    deriveModelContextState(modelContextProvider, INITIAL_MODEL_CONTEXT_STATE),
+  );
+
+  const notifySubscribers = useCallback(() => {
+    for (const callback of subscribersRef.current) callback();
+  }, []);
+
+  useEffect(() => {
+    modelContextRef.current = getModelContextForToolkit(toolkit);
+    notifySubscribers();
+  }, [toolkit, notifySubscribers]);
+
+  useEffect(() => {
+    if (!parent) return undefined;
+    return parent.subscribe?.(notifySubscribers);
+  }, [notifySubscribers, parent]);
+
+  useEffect(() => {
+    setState((prev) => deriveModelContextState(modelContextProvider, prev));
+    return modelContextProvider.subscribe?.(() => {
+      setState((prev) => deriveModelContextState(modelContextProvider, prev));
+    });
+  }, [modelContextProvider]);
+
+  const register = useCallback(
+    (provider: ModelContextProvider) => {
+      providersRef.current.add(provider);
+      const unsubscribe = provider.subscribe?.(notifySubscribers);
+      notifySubscribers();
+      return () => {
+        providersRef.current.delete(provider);
+        unsubscribe?.();
+        notifySubscribers();
+      };
+    },
+    [notifySubscribers],
+  );
+
+  return useMemo(
+    (): ClientOutput<"modelContext"> => ({
+      getState: () => deriveModelContextState(modelContextProvider, state),
+      getModelContext,
+      subscribe: (callback) => modelContextProvider.subscribe!(callback),
+      register,
+    }),
+    [getModelContext, modelContextProvider, register, state],
+  );
+};
+
+const ToolkitModelContext = resource(useToolkitModelContext);
 
 /**
  * Registers tools with model context and installs tool-call renderers.
@@ -58,8 +220,6 @@ const useTools = ({
     }),
     [toolUIs, mcpAppOutput],
   );
-
-  const clientRef = useAssistantClientRef();
 
   const setToolUI = useCallback(
     (
@@ -116,38 +276,10 @@ const useTools = ({
       }
     }
 
-    // Register tools with model context (exclude symbols). `render`,
-    // `renderText`, and `display` are client-only presentation concerns and
-    // never reach the model.
-    const toolsWithoutRender = Object.entries(toolkit).reduce(
-      (acc, [name, tool]) => {
-        if (tool.type === "mcp") return acc;
-        const {
-          display: _display,
-          render: _render,
-          renderText: _renderText,
-          ...rest
-        } = tool as typeof tool & { renderText?: unknown };
-        acc[name] = rest as Tool<any, any>;
-        return acc;
-      },
-      {} as Record<string, Tool<any, any>>,
-    );
-
-    const modelContextProvider = {
-      getModelContext: () => ({
-        tools: toolsWithoutRender,
-      }),
-    };
-
-    unsubscribes.push(
-      clientRef.current!.modelContext().register(modelContextProvider),
-    );
-
     return () => {
       unsubscribes.forEach((fn) => fn());
     };
-  }, [toolkit, setToolUI, clientRef]);
+  }, [toolkit, setToolUI]);
 
   return {
     getState: () => state,
@@ -158,7 +290,16 @@ const useTools = ({
 export const Tools = resource(useTools);
 
 attachTransformScopes(useTools, (scopes, parent) => {
-  if (!scopes.modelContext && parent.modelContext.source === null) {
-    scopes.modelContext = ModelContext();
+  if (!scopes.modelContext && scopes.tools?.hook === useTools) {
+    const [{ toolkit }] = scopes.tools.args as [
+      {
+        toolkit?: Toolkit | undefined;
+      },
+    ];
+    scopes.modelContext = ToolkitModelContext({
+      toolkit,
+      parent:
+        parent.modelContext.source === null ? undefined : parent.modelContext(),
+    });
   }
 });

--- a/packages/core/src/react/client/useAui.ts
+++ b/packages/core/src/react/client/useAui.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import type { ResourceElement } from "@assistant-ui/tap";
+import { useMemo } from "react";
+import {
+  useAui as useStoreAui,
+  type AssistantClient,
+} from "@assistant-ui/store";
+
+import { Tools } from "./Tools";
+import type { Toolkit } from "../model-context/toolbox";
+
+type StoreUseAuiProps = useStoreAui.Props;
+type StoreUseAui = (
+  clients?: StoreUseAuiProps,
+  config?: { parent: null | AssistantClient },
+) => AssistantClient;
+
+const useStoreAuiOptional = useStoreAui as StoreUseAui;
+
+const isResourceElement = (
+  value: unknown,
+): value is ResourceElement<unknown> => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "hook" in value &&
+    typeof value.hook === "function" &&
+    "args" in value &&
+    Array.isArray(value.args)
+  );
+};
+
+const normalizeUseAuiProps = (
+  clients: useAui.Props | undefined,
+): StoreUseAuiProps | undefined => {
+  const tools = clients?.tools;
+  if (!tools || isResourceElement(tools)) return clients as StoreUseAuiProps;
+
+  return {
+    ...clients,
+    tools: Tools({ toolkit: tools }),
+  } as StoreUseAuiProps;
+};
+
+export namespace useAui {
+  export type Props = Omit<StoreUseAuiProps, "tools"> & {
+    tools?: StoreUseAuiProps["tools"] | Toolkit | undefined;
+  };
+}
+
+export function useAui(): AssistantClient;
+export function useAui(clients: useAui.Props): AssistantClient;
+export function useAui(
+  clients: useAui.Props,
+  config: { parent: null | AssistantClient },
+): AssistantClient;
+export function useAui(
+  clients?: useAui.Props,
+  config?: { parent: null | AssistantClient },
+): AssistantClient {
+  const normalizedClients = useMemo(
+    () => normalizeUseAuiProps(clients),
+    [clients],
+  );
+
+  return useStoreAuiOptional(normalizedClients, config);
+}

--- a/packages/core/src/react/client/useAui.ts
+++ b/packages/core/src/react/client/useAui.ts
@@ -31,6 +31,14 @@ const isResourceElement = (
   );
 };
 
+const useShallowMemoClients = (
+  clients: StoreUseAuiProps | undefined,
+): StoreUseAuiProps | undefined => {
+  const deps = clients ? Object.entries(clients).flat() : [clients];
+  // oxlint-disable-next-line react/exhaustive-deps -- shallow memo over the flattened client entries
+  return useMemo(() => clients, deps);
+};
+
 export namespace useAui {
   export type Props = Omit<StoreUseAuiProps, "tools"> & {
     tools?: StoreUseAuiProps["tools"] | Toolkit | undefined;
@@ -53,15 +61,13 @@ export function useAui(
     return Tools({ toolkit: tools });
   }, [tools]);
 
-  const normalizedClients = useMemo(
-    (): StoreUseAuiProps | undefined =>
-      clients && toolsResource !== tools
-        ? ({
-            ...clients,
-            tools: toolsResource,
-          } as StoreUseAuiProps)
-        : (clients as StoreUseAuiProps | undefined),
-    [clients, tools, toolsResource],
+  const normalizedClients = useShallowMemoClients(
+    clients && toolsResource !== tools
+      ? ({
+          ...clients,
+          tools: toolsResource,
+        } as StoreUseAuiProps)
+      : (clients as StoreUseAuiProps | undefined),
   );
 
   return useStoreAuiOptional(normalizedClients, config);

--- a/packages/core/src/react/client/useAui.ts
+++ b/packages/core/src/react/client/useAui.ts
@@ -31,18 +31,6 @@ const isResourceElement = (
   );
 };
 
-const normalizeUseAuiProps = (
-  clients: useAui.Props | undefined,
-): StoreUseAuiProps | undefined => {
-  const tools = clients?.tools;
-  if (!tools || isResourceElement(tools)) return clients as StoreUseAuiProps;
-
-  return {
-    ...clients,
-    tools: Tools({ toolkit: tools }),
-  } as StoreUseAuiProps;
-};
-
 export namespace useAui {
   export type Props = Omit<StoreUseAuiProps, "tools"> & {
     tools?: StoreUseAuiProps["tools"] | Toolkit | undefined;
@@ -59,9 +47,21 @@ export function useAui(
   clients?: useAui.Props,
   config?: { parent: null | AssistantClient },
 ): AssistantClient {
+  const tools = clients?.tools;
+  const toolsResource = useMemo(() => {
+    if (!tools || isResourceElement(tools)) return tools;
+    return Tools({ toolkit: tools });
+  }, [tools]);
+
   const normalizedClients = useMemo(
-    () => normalizeUseAuiProps(clients),
-    [clients],
+    (): StoreUseAuiProps | undefined =>
+      clients && toolsResource !== tools
+        ? ({
+            ...clients,
+            tools: toolsResource,
+          } as StoreUseAuiProps)
+        : (clients as StoreUseAuiProps | undefined),
+    [clients, tools, toolsResource],
   );
 
   return useStoreAuiOptional(normalizedClients, config);

--- a/packages/core/src/react/index.ts
+++ b/packages/core/src/react/index.ts
@@ -40,6 +40,10 @@ export {
   type ToolCallText,
 } from "./model-context/toolbox";
 export { defineToolkit } from "./model-context/define-toolkit";
+export {
+  mergeToolkits,
+  type MergedToolkit,
+} from "./model-context/merge-toolkits";
 export { stubTool } from "./model-context/stub-tool";
 export { externalTool } from "./model-context/external-tool";
 export { useAuiToolOverrides } from "./model-context/useAuiToolOverrides";
@@ -63,6 +67,7 @@ export {
 } from "./model-context/useToolArgsStatus";
 
 // client
+export { useAui } from "./client/useAui";
 export { Tools, type McpAppResourceOutput } from "./client/Tools";
 export { DataRenderers } from "./client/DataRenderers";
 export { Interactables } from "./client/Interactables";

--- a/packages/core/src/react/model-context/merge-toolkits.test.ts
+++ b/packages/core/src/react/model-context/merge-toolkits.test.ts
@@ -32,7 +32,7 @@ describe("mergeToolkits", () => {
 
     const appToolkit = mergeToolkits(filesToolkit, calendarToolkit);
 
-    expect(appToolkit).toEqual({
+    expect({ ...appToolkit }).toEqual({
       search_files: filesTool,
       create_event: calendarTool,
     });
@@ -87,5 +87,21 @@ describe("mergeToolkits", () => {
     } finally {
       warn.mockRestore();
     }
+  });
+
+  it("keeps prototype-like tool names as own entries", () => {
+    const protoTool = tool("Prototype-safe tool.");
+    const protoToolkit = defineToolkit(
+      Object.defineProperty({}, "__proto__", {
+        value: protoTool,
+        enumerable: true,
+      }) as { __proto__: typeof protoTool },
+    );
+
+    const appToolkit = mergeToolkits(protoToolkit);
+
+    expect(Object.getPrototypeOf(appToolkit)).toBeNull();
+    expect(Object.hasOwn(appToolkit, "__proto__")).toBe(true);
+    expect(appToolkit["__proto__"]).toBe(protoTool);
   });
 });

--- a/packages/core/src/react/model-context/merge-toolkits.test.ts
+++ b/packages/core/src/react/model-context/merge-toolkits.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+
+import { defineToolkit } from "./define-toolkit";
+import { mergeToolkits } from "./merge-toolkits";
+import type { ToolDefinition } from "./toolbox";
+
+const tool = <
+  TArgs extends Record<string, unknown> = Record<string, unknown>,
+  TResult = unknown,
+>(
+  description: string,
+) =>
+  ({
+    type: "backend",
+    description,
+  }) as ToolDefinition<TArgs, TResult>;
+
+describe("mergeToolkits", () => {
+  it("merges feature toolkits into one toolkit", () => {
+    const filesTool = tool<{ query: string }, { ids: string[] }>(
+      "Search files.",
+    );
+    const calendarTool = tool<{ title: string }, { eventId: string }>(
+      "Create a calendar event.",
+    );
+    const filesToolkit = defineToolkit({
+      search_files: filesTool,
+    });
+    const calendarToolkit = defineToolkit({
+      create_event: calendarTool,
+    });
+
+    const appToolkit = mergeToolkits(filesToolkit, calendarToolkit);
+
+    expect(appToolkit).toEqual({
+      search_files: filesTool,
+      create_event: calendarTool,
+    });
+    expect(appToolkit.search_files).toBe(filesTool);
+    expect(appToolkit.create_event).toBe(calendarTool);
+    expectTypeOf(appToolkit.search_files).toEqualTypeOf(filesTool);
+    expectTypeOf(appToolkit.create_event).toEqualTypeOf(calendarTool);
+  });
+
+  it("keeps the first tool definition and warns once for a duplicate name", () => {
+    const filesSearchTool = tool<{ query: string }, { files: string[] }>(
+      "Search files.",
+    );
+    const crmSearchTool = tool<{ query: string }, { contacts: string[] }>(
+      "Search CRM records.",
+    );
+    const calendarSearchTool = tool<{ query: string }, { events: string[] }>(
+      "Search calendar events.",
+    );
+    const filesToolkit = defineToolkit({ search: filesSearchTool });
+    const crmToolkit = defineToolkit({ search: crmSearchTool });
+    const calendarToolkit = defineToolkit({ search: calendarSearchTool });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const appToolkit = mergeToolkits(
+        filesToolkit,
+        crmToolkit,
+        calendarToolkit,
+      );
+
+      expect(appToolkit.search).toBe(filesSearchTool);
+      expectTypeOf(appToolkit.search).toEqualTypeOf(filesSearchTool);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        '[assistant-ui] Duplicate tool name "search" while merging toolkits. Keeping the first definition.',
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("does not warn when tool names are unique", () => {
+    const filesToolkit = defineToolkit({ search_files: tool("Search files.") });
+    const crmToolkit = defineToolkit({ search_crm: tool("Search CRM.") });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      mergeToolkits(filesToolkit, crmToolkit);
+
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/react/model-context/merge-toolkits.ts
+++ b/packages/core/src/react/model-context/merge-toolkits.ts
@@ -1,0 +1,56 @@
+import type { Toolkit } from "./toolbox";
+
+type KnownKeys<T> = {
+  [K in keyof T]: string extends K
+    ? never
+    : number extends K
+      ? never
+      : symbol extends K
+        ? never
+        : K;
+}[keyof T];
+
+type ToolkitEntries<T> = Pick<T, KnownKeys<T>>;
+
+type Simplify<T> = { [K in keyof T]: T[K] } & {};
+
+type MergeToolkitEntries<
+  TToolkits extends readonly Toolkit[],
+  TMerged = object,
+> = TToolkits extends readonly [
+  infer TFirst extends Toolkit,
+  ...infer TRest extends readonly Toolkit[],
+]
+  ? MergeToolkitEntries<
+      TRest,
+      TMerged & Omit<ToolkitEntries<TFirst>, keyof TMerged>
+    >
+  : Simplify<TMerged>;
+
+export type MergedToolkit<TToolkits extends readonly Toolkit[]> = Toolkit &
+  MergeToolkitEntries<TToolkits>;
+
+export function mergeToolkits<const TToolkits extends readonly Toolkit[]>(
+  ...toolkits: TToolkits
+): MergedToolkit<TToolkits> {
+  const merged: Toolkit = {};
+  const warned = new Set<string>();
+
+  for (const toolkit of toolkits) {
+    for (const [name, tool] of Object.entries(toolkit)) {
+      if (Object.hasOwn(merged, name)) {
+        if (!warned.has(name)) {
+          console.warn(
+            `[assistant-ui] Duplicate tool name "${name}" while merging toolkits. Keeping the first definition.`,
+          );
+          warned.add(name);
+        }
+        continue;
+      }
+
+      merged[name] = tool;
+    }
+  }
+
+  return merged as MergedToolkit<TToolkits>;
+}

--- a/packages/core/src/react/model-context/merge-toolkits.ts
+++ b/packages/core/src/react/model-context/merge-toolkits.ts
@@ -33,7 +33,7 @@ export type MergedToolkit<TToolkits extends readonly Toolkit[]> = Toolkit &
 export function mergeToolkits<const TToolkits extends readonly Toolkit[]>(
   ...toolkits: TToolkits
 ): MergedToolkit<TToolkits> {
-  const merged: Toolkit = {};
+  const merged = Object.create(null) as Toolkit;
   const warned = new Set<string>();
 
   for (const toolkit of toolkits) {

--- a/packages/react-ai-sdk/src/generativeTools.test.ts
+++ b/packages/react-ai-sdk/src/generativeTools.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mergeToolkits } from "@assistant-ui/core/react";
 import { AISDKToolkit } from "./generativeTools";
 import { wrapModelContentEnvelope } from "./modelContentEnvelope";
 
@@ -20,6 +21,33 @@ vi.mock("@ai-sdk/mcp/mcp-stdio", () => ({
 }));
 
 describe("AISDKToolkit.tools()", () => {
+  it("accepts a merged app toolkit from feature toolkits", async () => {
+    const filesToolkit = {
+      search_files: {
+        type: "backend",
+        description: "Search files",
+        parameters: { type: "object", properties: {} },
+        execute: async () => "files",
+      } as never,
+    };
+    const calendarToolkit = {
+      create_event: {
+        type: "backend",
+        description: "Create a calendar event",
+        parameters: { type: "object", properties: {} },
+        execute: async () => "event",
+      } as never,
+    };
+    const appToolkit = mergeToolkits(filesToolkit, calendarToolkit);
+
+    const toolSet = await new AISDKToolkit({ toolkit: appToolkit }).tools();
+
+    expect(toolSet.search_files?.description).toBe("Search files");
+    expect(toolSet.search_files?.execute).toBeTypeOf("function");
+    expect(toolSet.create_event?.description).toBe("Create a calendar event");
+    expect(toolSet.create_event?.execute).toBeTypeOf("function");
+  });
+
   it("merges frontend tools with toolkit tools", async () => {
     const toolSet = await new AISDKToolkit({
       toolkit: {

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -85,7 +85,6 @@ export type {
 
 // Store hooks and components
 export {
-  useAui,
   useAuiState,
   useAuiEvent,
   AuiProvider,
@@ -98,6 +97,7 @@ export {
   type AssistantEventPayload,
   type AssistantEventCallback,
 } from "@assistant-ui/store";
+export { useAui } from "@assistant-ui/core/react";
 
 // Context providers
 export { AssistantRuntimeProvider } from "./context/AssistantContext";
@@ -199,6 +199,8 @@ export {
   type ToolkitDefinition,
   type ToolkitDefinitionEntry,
   type ToolCallText,
+  mergeToolkits,
+  type MergedToolkit,
   useAuiToolOverrides,
   type ProviderToolConfig,
   defineMcpToolkit,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -89,7 +89,6 @@ export type {
 
 // Store hooks and components
 export {
-  useAui,
   useAuiState,
   useAuiEvent,
   AuiProvider,
@@ -102,6 +101,7 @@ export {
   type AssistantEventPayload,
   type AssistantEventCallback,
 } from "@assistant-ui/store";
+export { useAui } from "@assistant-ui/core/react";
 
 // Context providers and hooks
 export { AssistantRuntimeProvider } from "./context/AssistantContext";
@@ -169,6 +169,8 @@ export {
   type ToolkitDefinitionEntry,
   type ToolCallText,
   defineToolkit,
+  mergeToolkits,
+  type MergedToolkit,
   stubTool,
   externalTool,
   useAuiToolOverrides,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,7 +2,6 @@
 
 // Re-export from @assistant-ui/store
 export {
-  useAui,
   AuiProvider,
   useAuiState,
   useAuiEvent,
@@ -15,6 +14,7 @@ export {
   type AssistantEventPayload,
   type AssistantEventCallback,
 } from "@assistant-ui/store";
+export { useAui } from "@assistant-ui/core/react";
 
 // Re-export public runtime types from @assistant-ui/core
 export type {
@@ -200,6 +200,8 @@ export {
   type ToolkitDefinition,
   type ToolkitDefinitionEntry,
   defineToolkit,
+  mergeToolkits,
+  type MergedToolkit,
   stubTool,
   externalTool,
   useAuiToolOverrides,

--- a/packages/react/src/tests/useAui-toolkit.test.tsx
+++ b/packages/react/src/tests/useAui-toolkit.test.tsx
@@ -3,7 +3,7 @@
 import { render, act } from "@testing-library/react";
 import type { FC } from "react";
 import { describe, expect, it } from "vitest";
-import { AuiProvider, defineToolkit, useAui } from "../index";
+import { AuiProvider, defineToolkit, useAui, useAuiState } from "../index";
 
 const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
@@ -21,8 +21,18 @@ describe("useAui toolkit shorthand", () => {
       } as never,
     });
     const captured: { aui?: ReturnType<typeof useAui> } = {};
+    const observed: {
+      modelToolNames?: string;
+      rendererToolNames?: string;
+    } = {};
     const Capture: FC = () => {
       captured.aui = useAui();
+      observed.modelToolNames = useAuiState((state) =>
+        state.modelContext.toolNames.join(","),
+      );
+      observed.rendererToolNames = useAuiState((state) =>
+        Object.keys(state.tools.toolUIs).sort().join(","),
+      );
       return null;
     };
     const App: FC = () => {
@@ -46,5 +56,7 @@ describe("useAui toolkit shorthand", () => {
     expect(captured.aui!.tools().getState().toolUIs.search_files).toHaveLength(
       1,
     );
+    expect(observed.modelToolNames).toBe("search_files");
+    expect(observed.rendererToolNames).toBe("search_files");
   });
 });

--- a/packages/react/src/tests/useAui-toolkit.test.tsx
+++ b/packages/react/src/tests/useAui-toolkit.test.tsx
@@ -59,4 +59,37 @@ describe("useAui toolkit shorthand", () => {
     expect(observed.modelToolNames).toBe("search_files");
     expect(observed.rendererToolNames).toBe("search_files");
   });
+
+  it("keeps the client stable when shorthand props are inline", async () => {
+    const toolkit = defineToolkit({
+      search_files: {
+        type: "backend",
+        description: "Search files.",
+        parameters: { type: "object", properties: {} },
+      } as never,
+    });
+    const clients: ReturnType<typeof useAui>[] = [];
+
+    const App: FC<{ label: string }> = ({ label }) => {
+      const aui = useAui({ tools: toolkit });
+      clients.push(aui);
+      return (
+        <AuiProvider value={aui}>
+          <div>{label}</div>
+        </AuiProvider>
+      );
+    };
+
+    const { rerender } = render(<App label="before" />);
+    await act(async () => {
+      await flush();
+    });
+
+    rerender(<App label="after" />);
+    await act(async () => {
+      await flush();
+    });
+
+    expect(clients[1]).toBe(clients[0]);
+  });
 });

--- a/packages/react/src/tests/useAui-toolkit.test.tsx
+++ b/packages/react/src/tests/useAui-toolkit.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { render, act } from "@testing-library/react";
+import type { FC } from "react";
+import { describe, expect, it } from "vitest";
+import { AuiProvider, defineToolkit, useAui } from "../index";
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe("useAui toolkit shorthand", () => {
+  it("registers toolkit tools and renderers through the tools client", async () => {
+    const toolkit = defineToolkit({
+      search_files: {
+        type: "backend",
+        description: "Search files.",
+        parameters: { type: "object", properties: {} },
+        renderText: {
+          running: "Searching files",
+          complete: "Finished searching files",
+        },
+      } as never,
+    });
+    const captured: { aui?: ReturnType<typeof useAui> } = {};
+    const Capture: FC = () => {
+      captured.aui = useAui();
+      return null;
+    };
+    const App: FC = () => {
+      const aui = useAui({ tools: toolkit });
+      return (
+        <AuiProvider value={aui}>
+          <Capture />
+        </AuiProvider>
+      );
+    };
+
+    render(<App />);
+    await act(async () => {
+      await flush();
+    });
+
+    const contextTool = captured.aui!.modelContext().getModelContext()
+      .tools?.search_files;
+    expect(contextTool?.description).toBe("Search files.");
+    expect(contextTool).not.toHaveProperty("renderText");
+    expect(captured.aui!.tools().getState().toolUIs.search_files).toHaveLength(
+      1,
+    );
+  });
+});


### PR DESCRIPTION
## What

Add `mergeToolkits` so apps can split tools by feature and compose them from a single toolkit entrypoint. The helper is left-biased: if two toolkits declare the same model-facing tool name, it keeps the first definition and logs a warning instead of silently overriding it.

This also lets `useAui` accept a plain toolkit for the `tools` scope, so app code can use:

```tsx
const aui = useAui({ tools: appToolkit });
```

instead of wrapping the toolkit manually with `Tools({ toolkit })`.

## Toolkit folder DX

This is the intended shape for larger apps:

```txt
app/toolkits/
  files.tsx
  tasks.tsx
  calendar.tsx
  crm.tsx
  approvals.tsx
  index.tsx
```

Each feature file owns one focused toolkit:

```tsx
// app/toolkits/files.tsx
"use generative";

import { defineToolkit } from "@assistant-ui/react";

export const filesToolkit = defineToolkit({
  search_files: {
    description: "Search files the user has access to.",
    parameters: z.object({ query: z.string() }),
    execute: async ({ query }) => searchFiles(query),
    render: ({ args, result }) => <FileSearchResult query={args.query} result={result} />,
  },
});
```

The folder entrypoint composes those feature toolkits once:

```tsx
// app/toolkits/index.tsx
import { mergeToolkits } from "@assistant-ui/react";
import { approvalsToolkit } from "./approvals";
import { calendarToolkit } from "./calendar";
import { crmToolkit } from "./crm";
import { filesToolkit } from "./files";
import { tasksToolkit } from "./tasks";

export const appToolkit = mergeToolkits(
  filesToolkit,
  tasksToolkit,
  calendarToolkit,
  crmToolkit,
  approvalsToolkit,
);
```

That gives users one import to share across client runtime setup and server route setup, while keeping feature teams from editing one huge `toolkit.tsx` file.

## Client and server usage

Client runtime setup can pass the composed toolkit directly:

```tsx
// app/MyRuntimeProvider.tsx
"use client";

import { AssistantRuntimeProvider, AuiProvider, useAui } from "@assistant-ui/react";
import { appToolkit } from "./toolkits";

export function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
  const aui = useAui({ tools: appToolkit });
  const runtime = useChatRuntime();

  return (
    <AuiProvider value={aui}>
      <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>
    </AuiProvider>
  );
}
```

The server route can import the same composed toolkit and hand it to the AI SDK adapter:

```ts
// app/api/chat/route.ts
import { AISDKToolkit } from "@assistant-ui/react-ai-sdk";
import { appToolkit } from "../../toolkits";

const aiToolkit = new AISDKToolkit({ toolkit: appToolkit });

const result = streamText({
  model,
  messages,
  tools: await aiToolkit.tools({ frontend: tools }),
});
```

On the client, `useAui({ tools: appToolkit })` registers model-visible tool schemas and tool renderers through the existing tools scope. On the server, `AISDKToolkit` receives the same merged toolkit and exposes those tools to the model.

## Non-breaking behavior

This is additive DX, not a breaking change. Existing `useAui()` calls and existing `useAui({ tools: Tools({ toolkit }) })` calls continue to work. The new wrapper only normalizes `tools` when the value is a plain toolkit object; existing resource elements are passed through unchanged.

Duplicate tool names are not an error because that would be disruptive while composing feature folders, but they are visible: `mergeToolkits` warns once per duplicate name and keeps the first definition. That avoids normal object-spread behavior where later tools silently override earlier ones.

## How

- Added `mergeToolkits` and `MergedToolkit` in `@assistant-ui/core/react`.
- Re-exported `mergeToolkits` through web, React Native, and Ink packages.
- Re-exported a core `useAui` wrapper from the public distributions that normalizes a plain toolkit into `Tools({ toolkit })`.
- Registered toolkit model context declaratively so `useAui({ tools: appToolkit })` exposes both model tools and renderer UIs.
- Documented the `app/toolkits/files.tsx`, `tasks.tsx`, `calendar.tsx`, `crm.tsx`, `approvals.tsx`, `index.tsx` pattern.
- Added tests for merging, duplicate warnings, first-definition behavior, type preservation, client `useAui` registration, and server `AISDKToolkit` usage.

## Real-app verification

I verified this in `examples/with-ai-sdk-v6` with temporary `app/toolkits/*` files, a test page, and a route handler, then removed the temporary files before committing. The real app confirmed:

- Server route saw the composed toolkit tools: `create_task`, `lookup_shared`, `request_approval`, `schedule_meeting`, `search_crm`, `search_files`.
- Browser runtime saw the same tools through both `modelContext.toolNames` and `tools.toolUIs`.
- Duplicate `lookup_shared` emitted the expected `[assistant-ui] Duplicate tool name ... Keeping the first definition.` warning.
- No browser error logs were emitted.

## Validation

- `git diff --check`
- `pnpm --filter @assistant-ui/core exec vitest run src/react/model-context/merge-toolkits.test.ts`
- `pnpm --filter @assistant-ui/react exec vitest run src/tests/useAui-toolkit.test.tsx`
- `pnpm --filter @assistant-ui/react-ai-sdk exec vitest run src/generativeTools.test.ts`
- `pnpm --filter @assistant-ui/core build`
- `pnpm --filter @assistant-ui/react build`
- `pnpm --filter @assistant-ui/react-native build`
- `pnpm --filter @assistant-ui/react-ink build`
- `pnpm --filter @assistant-ui/docs exec fumadocs-mdx`
- `pnpm --filter @assistant-ui/docs build`
- `gh pr checks 4570` shows all checks passing or skipped, including changed-package build/test, Oxlint + Oxfmt, Semver Check, Template Sync, Vercel, and code review checks.

Note: local commands emit the existing Node engine warning because this machine is on Node v23.11.0 and the repo requests Node >=24; the commands above still passed.