### PR TITLE
fix: validate registry install metadata

### DIFF
--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -1,10 +1,30 @@
 import { promises as fs, readFileSync } from "node:fs";
 import * as path from "node:path";
+import * as ts from "typescript";
 import { registry } from "../src/registry";
-import type { RegistryItem } from "@/src/schema";
+import { registrySchema, type RegistryItem } from "../src/schema";
 
 const REGISTRY_PATH = path.join(process.cwd(), "dist");
 const REGISTRY_INDEX_PATH = path.join(REGISTRY_PATH, "registry.json");
+const REGISTRY_ITEM_SCHEMA_URL =
+  "https://ui.shadcn.com/schema/registry-item.json";
+const ASSISTANT_REGISTRY_DEPENDENCY_RE =
+  /^https:\/\/r\.assistant-ui\.com\/(.+)\.json$/;
+const PROJECT_PACKAGE_IMPORTS = new Set([
+  "next",
+  "next-themes",
+  "react",
+  "react-dom",
+]);
+
+type RegistryFile = NonNullable<RegistryItem["files"]>[number];
+type RegistryOutputFile = Omit<RegistryFile, "sourcePath"> & {
+  content: string;
+};
+type RegistryOutputItem = Omit<RegistryItem, "files"> & {
+  $schema: string;
+  files?: RegistryOutputFile[];
+};
 
 /**
  * Transform @assistant-ui/react-ui/* imports to @/* imports for standalone projects
@@ -18,33 +38,266 @@ function transformImports(content: string): string {
     .replace(/@assistant-ui\/react-ui\/hooks\//g, "@/hooks/");
 }
 
+function validateRegistrySchema(registry: RegistryItem[]) {
+  const result = registrySchema.safeParse(registry);
+
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => {
+        const location = issue.path.length
+          ? issue.path.map(String).join(".")
+          : "registry";
+        return `- ${location}: ${issue.message}`;
+      })
+      .join("\n");
+
+    throw new Error(`Invalid registry metadata:\n${issues}`);
+  }
+}
+
+function createRegistryPayload(item: RegistryItem): RegistryOutputItem {
+  const files = item.files?.map((file) => {
+    // Read from sourcePath if provided, otherwise use path
+    const readPath = file.sourcePath ?? file.path;
+    let content = readFileSync(path.join(process.cwd(), readPath), "utf8");
+
+    // Transform @assistant-ui/react-ui/* imports to @/* imports
+    content = transformImports(content);
+
+    // Exclude sourcePath from output (it's only for build)
+    const { sourcePath: _, ...fileOutput } = file;
+    return {
+      ...fileOutput,
+      content,
+    };
+  });
+  const { files: _, ...itemOutput } = item;
+
+  const payload = {
+    $schema: REGISTRY_ITEM_SCHEMA_URL,
+    ...itemOutput,
+  };
+
+  return files ? { ...payload, files } : payload;
+}
+
+function getAssistantRegistryDependencyName(dependency: string) {
+  return ASSISTANT_REGISTRY_DEPENDENCY_RE.exec(dependency)?.[1] ?? null;
+}
+
+function getPackageName(specifier: string) {
+  if (specifier.startsWith("@")) {
+    return specifier.split("/").slice(0, 2).join("/");
+  }
+
+  return specifier.split("/")[0]!;
+}
+
+function isStringLiteralLike(
+  node: ts.Node,
+): node is ts.StringLiteral | ts.NoSubstitutionTemplateLiteral {
+  return ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node);
+}
+
+function getScriptKind(filePath: string) {
+  if (filePath.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (filePath.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  if (filePath.endsWith(".ts")) return ts.ScriptKind.TS;
+  if (filePath.endsWith(".js")) return ts.ScriptKind.JS;
+  return ts.ScriptKind.Unknown;
+}
+
+function collectModuleSpecifiers(file: RegistryOutputFile) {
+  const sourceFile = ts.createSourceFile(
+    file.path,
+    file.content,
+    ts.ScriptTarget.Latest,
+    true,
+    getScriptKind(file.path),
+  );
+  const specifiers = new Set<string>();
+
+  const visit = (node: ts.Node) => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      specifiers.add(node.moduleSpecifier.text);
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1
+    ) {
+      const importArgument = node.arguments[0];
+      if (importArgument && isStringLiteralLike(importArgument)) {
+        specifiers.add(importArgument.text);
+      }
+    }
+
+    if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      isStringLiteralLike(node.argument.literal)
+    ) {
+      specifiers.add(node.argument.literal.text);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return specifiers;
+}
+
+function getLocalComponentPath(specifier: string) {
+  if (!specifier.startsWith("@/components/")) return null;
+
+  const componentPath = specifier.slice(2);
+  if (path.extname(componentPath)) return componentPath;
+
+  return `${componentPath}.tsx`;
+}
+
+function collectCssPackageImports(value: unknown, imports = new Set<string>()) {
+  if (typeof value === "string") {
+    for (const match of value.matchAll(
+      /@import\s+(?:url\()?["']([^"')]+)["']/g,
+    )) {
+      const specifier = match[1]!;
+      if (!specifier.startsWith(".") && !specifier.startsWith("@/")) {
+        imports.add(getPackageName(specifier));
+      }
+    }
+  } else if (value && typeof value === "object") {
+    for (const [key, childValue] of Object.entries(value)) {
+      collectCssPackageImports(key, imports);
+      collectCssPackageImports(childValue, imports);
+    }
+  }
+
+  return imports;
+}
+
+function collectInstallContext(
+  item: RegistryOutputItem,
+  itemByName: Map<string, RegistryOutputItem>,
+  seen = new Set<string>(),
+) {
+  if (seen.has(item.name)) {
+    return { files: new Set<string>(), packages: new Set<string>() };
+  }
+
+  seen.add(item.name);
+
+  const files = new Set(item.files?.map((file) => file.path) ?? []);
+  const packages = new Set([
+    ...(item.dependencies ?? []),
+    ...(item.devDependencies ?? []),
+  ]);
+
+  for (const dependency of item.registryDependencies ?? []) {
+    const assistantDependencyName =
+      getAssistantRegistryDependencyName(dependency);
+
+    if (assistantDependencyName) {
+      const dependencyItem = itemByName.get(assistantDependencyName);
+      if (!dependencyItem) continue;
+
+      const dependencyContext = collectInstallContext(
+        dependencyItem,
+        itemByName,
+        seen,
+      );
+
+      for (const file of dependencyContext.files) files.add(file);
+      for (const pkg of dependencyContext.packages) packages.add(pkg);
+    } else if (!dependency.startsWith("http")) {
+      files.add(`components/ui/${dependency}.tsx`);
+    }
+  }
+
+  return { files, packages };
+}
+
+function validateRegistryInstallMetadata(payloads: RegistryOutputItem[]) {
+  const itemByName = new Map(payloads.map((item) => [item.name, item]));
+  const findings = new Set<string>();
+
+  for (const item of payloads) {
+    for (const dependency of item.registryDependencies ?? []) {
+      const assistantDependencyName =
+        getAssistantRegistryDependencyName(dependency);
+
+      if (assistantDependencyName && !itemByName.has(assistantDependencyName)) {
+        findings.add(
+          `${item.name}: registry dependency "${dependency}" does not match a local registry item`,
+        );
+      }
+    }
+
+    const installContext = collectInstallContext(item, itemByName);
+
+    for (const file of item.files ?? []) {
+      for (const specifier of collectModuleSpecifiers(file)) {
+        const localComponentPath = getLocalComponentPath(specifier);
+
+        if (localComponentPath) {
+          if (!installContext.files.has(localComponentPath)) {
+            findings.add(
+              `${item.name}: ${file.path} imports "${specifier}", but no file or registryDependency provides ${localComponentPath}`,
+            );
+          }
+
+          continue;
+        }
+
+        if (specifier.startsWith(".") || specifier.startsWith("@/")) {
+          continue;
+        }
+
+        const packageName = getPackageName(specifier);
+        if (
+          !PROJECT_PACKAGE_IMPORTS.has(packageName) &&
+          !installContext.packages.has(packageName)
+        ) {
+          findings.add(
+            `${item.name}: ${file.path} imports package "${packageName}", but it is not declared in dependencies/devDependencies or a transitive assistant-ui registry dependency`,
+          );
+        }
+      }
+    }
+
+    for (const packageName of collectCssPackageImports(item.css)) {
+      if (!installContext.packages.has(packageName)) {
+        findings.add(
+          `${item.name}: registry css imports package "${packageName}", but it is not declared in dependencies/devDependencies or a transitive assistant-ui registry dependency`,
+        );
+      }
+    }
+  }
+
+  if (findings.size > 0) {
+    throw new Error(
+      `Invalid registry install metadata:\n${[...findings]
+        .map((finding) => `- ${finding}`)
+        .join("\n")}`,
+    );
+  }
+}
+
 async function buildRegistry(registry: RegistryItem[]) {
+  validateRegistrySchema(registry);
+
+  const payloads = registry.map(createRegistryPayload);
+  validateRegistryInstallMetadata(payloads);
+
   await fs.mkdir(REGISTRY_PATH, { recursive: true });
 
-  for (const item of registry) {
-    const files = item.files?.map((file) => {
-      // Read from sourcePath if provided, otherwise use path
-      const readPath = file.sourcePath ?? file.path;
-      let content = readFileSync(path.join(process.cwd(), readPath), "utf8");
-
-      // Transform @assistant-ui/react-ui/* imports to @/* imports
-      content = transformImports(content);
-
-      // Exclude sourcePath from output (it's only for build)
-      const { sourcePath: _, ...fileOutput } = file;
-      return {
-        content,
-        ...fileOutput,
-      };
-    });
-
-    const payload = {
-      $schema: "https://ui.shadcn.com/schema/registry-item.json",
-      ...item,
-      files,
-    };
-
-    const p = path.join(REGISTRY_PATH, `${item.name}.json`);
+  for (const payload of payloads) {
+    const p = path.join(REGISTRY_PATH, `${payload.name}.json`);
     await fs.mkdir(path.dirname(p), { recursive: true });
 
     await fs.writeFile(p, JSON.stringify(payload, null, 2), "utf8");

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -52,7 +52,7 @@ export const registry: RegistryItem[] = [
         target: "app/api/chat/route.ts",
       },
     ],
-    dependencies: ["ai", "@ai-sdk/openai"],
+    dependencies: ["ai", "@ai-sdk/openai", "@assistant-ui/react-ai-sdk"],
   },
   {
     name: "thread",

--- a/apps/registry/src/schema.ts
+++ b/apps/registry/src/schema.ts
@@ -51,4 +51,6 @@ export const registryItemSchema = z.object({
   docs: z.string().optional(),
 });
 
+export const registrySchema = z.array(registryItemSchema);
+
 export type RegistryItem = z.infer<typeof registryItemSchema>;


### PR DESCRIPTION
## Summary

Adds registry build validation so install metadata gaps fail before publishing generated registry JSON:

- validates the registry array with the existing zod schema
- scans emitted TypeScript/TSX files with the TypeScript AST for package imports and local component imports
- scans registry CSS metadata for package `@import` entries
- checks imports against direct and transitive assistant-ui registry dependencies, plus shadcn UI registry dependencies for local `components/ui/*` files
- fixes the current missing `@assistant-ui/react-ai-sdk` dependency on `ai-sdk-backend`

## Reproduced validation failure

After adding the validator, the build failed before the metadata fix with:

```text
Error: Invalid registry install metadata:
- ai-sdk-backend: app/api/chat/route.ts imports package "@assistant-ui/react-ai-sdk", but it is not declared in dependencies/devDependencies or a transitive assistant-ui registry dependency
```

That confirmed the build validation gap is real: `registryItemSchema` existed, but `build-registry` was not using it and was not checking copied imports against install metadata.

## Actual install verification

I also tested the old and fixed `ai-sdk-backend` entries through `shadcn add` in fresh temp projects.

Current `shadcn add ai-sdk-backend` behavior for this standalone `registry:page` item installs dependencies but does not write `app/api/chat/route.ts`. So I did not reproduce this as a standalone file-copy install failure in the CLI.

However, when typechecking the route file emitted by the registry JSON in the old dependency environment, TypeScript fails with the same missing package:

```text
app/api/chat/route.ts(2,31): error TS2307: Cannot find module '@assistant-ui/react-ai-sdk' or its corresponding type declarations.
```

With the fixed dependency list, the same emitted route file typechecks successfully. So this PR is fixing a real emitted-registry metadata inconsistency and adding a guard to prevent the same class of issue from slipping through again.

## Validation

- `pnpm --filter @assistant-ui/shadcn-registry build`
- `pnpm --filter @assistant-ui/shadcn-registry exec tsc -p tsconfig.json --noEmit`
- `pnpm exec oxlint apps/registry/scripts/build-registry.ts apps/registry/src/schema.ts apps/registry/src/registry.ts`
- `pnpm exec oxfmt --check apps/registry/scripts/build-registry.ts apps/registry/src/schema.ts apps/registry/src/registry.ts`
- `git diff --check`
- old emitted `ai-sdk-backend` route file + old deps: reproduced `TS2307` for `@assistant-ui/react-ai-sdk`
- fixed emitted `ai-sdk-backend` route file + fixed deps: `pnpm exec tsc -p tsconfig.json --noEmit` passes

Note: local commands still print the repo's Node engine warning because this machine is on Node v23.11.0 and the repo requests Node >=24. The final build/typecheck also printed pnpm node_modules bin-link warnings, but exited successfully.
