### PR TITLE
docs(api-ref): regenerate, update classification logic

### DIFF
--- a/apps/docs/content/docs/(reference)/api-reference/external-store/message-conversion.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/external-store/message-conversion.mdx
@@ -14,29 +14,11 @@ import { useExternalMessageConverter } from "@/generated/typeDocs";
 
 ## API Reference
 
-### bindExternalStoreMessage
-
-<Callout type="warn">
-<strong>Deprecated.</strong> This API is experimental and may change without notice.
-</Callout>
-
-Attach the original external store message(s) to a ThreadMessage or message part.
-This is a no-op if the target already has a bound message.
-Use `getExternalStoreMessages` to retrieve the bound messages later.
-
-```ts
-const bindExternalStoreMessage: <T>(target: object, message: T | T[]) => void;
-```
-
 ### getExternalStoreMessages
 
 ```ts
 const getExternalStoreMessages: <T>(input: { messages: readonly ThreadMessage[]; } | ThreadMessage | ThreadMessage["content"][number]) => T[];
 ```
-
-### useExternalMessageConverter
-
-<ParametersTable {...useExternalMessageConverter} />
 
 ### unstable_convertExternalMessages
 
@@ -48,5 +30,23 @@ const unstable_convertExternalMessages: <T extends WeakKey>(messages: T[], callb
 
 ```ts
 const unstable_createMessageConverter: <T extends object>(callback: useExternalMessageConverter.Callback<T>) => { useThreadMessages: ({ messages, isRunning, joinStrategy, metadata, }: { messages: T[]; isRunning: boolean; joinStrategy?: JoinStrategy | undefined; metadata?: useExternalMessageConverter.Metadata; }) => ThreadMessage[]; toThreadMessages: (messages: T[], isRunning?: boolean, metadata?: useExternalMessageConverter.Metadata) => ThreadMessage[]; toOriginalMessages: (input: ThreadState | ThreadMessage | ThreadMessage["content"][number]) => unknown[]; toOriginalMessage: (input: ThreadState | ThreadMessage | ThreadMessage["content"][number]) => {}; useOriginalMessage: () => {}; useOriginalMessages: () => unknown[]; };
+```
+
+### useExternalMessageConverter
+
+<ParametersTable {...useExternalMessageConverter} />
+
+### bindExternalStoreMessage
+
+<Callout type="tip">
+<strong>Experimental.</strong> This API is experimental and may change without notice.
+</Callout>
+
+Attach the original external store message(s) to a ThreadMessage or message part.
+This is a no-op if the target already has a bound message.
+Use `getExternalStoreMessages` to retrieve the bound messages later.
+
+```ts
+const bindExternalStoreMessage: <T>(target: object, message: T | T[]) => void;
 ```
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/composer-triggers.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/composer-triggers.mdx
@@ -14,78 +14,6 @@ import { unstable_useLiveCompletionAdapter, unstable_useMentionAdapter, unstable
 
 ## API Reference
 
-### unstable_useLiveCompletionAdapter
-
-<Callout type="warn">
-<strong>Deprecated.</strong> Under active development and may change without notice.
-</Callout>
-
-Bridges an async completion source (a server search, a gateway RPC) into the
-synchronous `Unstable_TriggerAdapter` that `ComposerTriggerPopover` consumes.
-`search(query)` returns the last fetched items synchronously and schedules a
-debounced fetch when the query changes; when results arrive the returned
-`adapter` identity changes, which re-runs the popover's lookup so the fresh
-items render. This is a search-only adapter (`categories` are empty).
-
-`isLoading` is `true` while a fetch is in flight. Pass it to the popover's
-`isLoading` prop to render a loading state.
-
-```tsx
-const mentions = unstable_useLiveCompletionAdapter({
-  fetcher: (query) => searchUsers(query),
-});
-
-<ComposerTriggerPopover
-  char="@"
-  adapter={mentions.adapter}
-  isLoading={mentions.isLoading}
-  directive={{ onInserted }}
-/>
-```
-
-<ParametersTable {...unstable_useLiveCompletionAdapter} />
-
-### unstable_useMentionAdapter
-
-<Callout type="warn">
-<strong>Deprecated.</strong> Under active development and might change without notice.
-</Callout>
-
-Creates a spreadable `{ adapter, directive }` bundle for `@` mentions.
-Supports tools registered in model context, explicit items, or both —
-flat or categorized.
-
-```tsx
-const mention = unstable_useMentionAdapter();
-<ComposerTriggerPopover char="@" {...mention} />
-```
-
-<ParametersTable {...unstable_useMentionAdapter} />
-
-### unstable_useSlashCommandAdapter
-
-<Callout type="warn">
-<strong>Deprecated.</strong> Under active development and may change without notice.
-</Callout>
-
-Bundles slash command definitions (with inline `execute` callbacks) into
-`{adapter, action}` that plug directly into `ComposerTriggerPopover`.
-`execute` stays in the hook closure and is never attached to the returned
-`TriggerItem`, keeping items serializable.
-
-```tsx
-const slash = unstable_useSlashCommandAdapter({
-  commands: [
-    { id: "summarize", execute: () => runSummarize(), icon: "FileText" },
-    { id: "translate", execute: () => runTranslate(), icon: "Languages" },
-  ],
-});
-
-<ComposerTriggerPopover char="/" {...slash} />
-```
-
-<ParametersTable {...unstable_useSlashCommandAdapter} />
-
 ### unstable_useTriggerPopoverRootContext
 
 ```ts
@@ -126,4 +54,76 @@ Like `useTriggerPopoverTriggers` but returns an empty map outside a root.
 ```ts
 const unstable_useTriggerPopoverTriggersOptional: () => ReadonlyMap<string, RegisteredTrigger>;
 ```
+
+### unstable_useLiveCompletionAdapter
+
+<Callout type="tip">
+<strong>Experimental.</strong> Under active development and may change without notice.
+</Callout>
+
+Bridges an async completion source (a server search, a gateway RPC) into the
+synchronous `Unstable_TriggerAdapter` that `ComposerTriggerPopover` consumes.
+`search(query)` returns the last fetched items synchronously and schedules a
+debounced fetch when the query changes; when results arrive the returned
+`adapter` identity changes, which re-runs the popover's lookup so the fresh
+items render. This is a search-only adapter (`categories` are empty).
+
+`isLoading` is `true` while a fetch is in flight. Pass it to the popover's
+`isLoading` prop to render a loading state.
+
+```tsx
+const mentions = unstable_useLiveCompletionAdapter({
+  fetcher: (query) => searchUsers(query),
+});
+
+<ComposerTriggerPopover
+  char="@"
+  adapter={mentions.adapter}
+  isLoading={mentions.isLoading}
+  directive={{ onInserted }}
+/>
+```
+
+<ParametersTable {...unstable_useLiveCompletionAdapter} />
+
+### unstable_useMentionAdapter
+
+<Callout type="tip">
+<strong>Experimental.</strong> Under active development and might change without notice.
+</Callout>
+
+Creates a spreadable `{ adapter, directive }` bundle for `@` mentions.
+Supports tools registered in model context, explicit items, or both —
+flat or categorized.
+
+```tsx
+const mention = unstable_useMentionAdapter();
+<ComposerTriggerPopover char="@" {...mention} />
+```
+
+<ParametersTable {...unstable_useMentionAdapter} />
+
+### unstable_useSlashCommandAdapter
+
+<Callout type="tip">
+<strong>Experimental.</strong> Under active development and may change without notice.
+</Callout>
+
+Bundles slash command definitions (with inline `execute` callbacks) into
+`{adapter, action}` that plug directly into `ComposerTriggerPopover`.
+`execute` stays in the hook closure and is never attached to the returned
+`TriggerItem`, keeping items serializable.
+
+```tsx
+const slash = unstable_useSlashCommandAdapter({
+  commands: [
+    { id: "summarize", execute: () => runSummarize(), icon: "FileText" },
+    { id: "translate", execute: () => runTranslate(), icon: "Languages" },
+  ],
+});
+
+<ComposerTriggerPopover char="/" {...slash} />
+```
+
+<ParametersTable {...unstable_useSlashCommandAdapter} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/model-context.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/model-context.mdx
@@ -25,8 +25,8 @@ state, use [useInteractableState](/docs/api-reference/hooks/model-context#useint
 
 ### useAuiToolOverrides
 
-<Callout type="warn">
-<strong>Deprecated.</strong> Experimental, API may change.
+<Callout type="tip">
+<strong>Experimental.</strong> Experimental, API may change.
 </Callout>
 
 Overrides toolkit entries for the current assistant scope.

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/primitives.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/primitives.mdx
@@ -3,7 +3,7 @@ title: Primitive Hooks
 description: Primitive hooks for reading scoped assistant-ui runtime state, viewport behavior, timing, and message part data inside React components.
 ---
 
-import { unstable_useMessageStallDetection, useAssistantRuntime, useAttachmentRuntime, useCloudThreadListAdapter, useComposerRuntime, useEditComposerAttachmentRuntime, useMessageAttachmentRuntime, useMessagePartData, useMessagePartRuntime, useMessageRuntime, useScrollLock, useThreadComposerAttachmentRuntime, useThreadListItemRuntime, useThreadRuntime, useThreadViewportAutoScroll } from "@/generated/typeDocs";
+import { unstable_useComposerInput, unstable_useMessageStallDetection, useAssistantRuntime, useAttachmentRuntime, useCloudThreadListAdapter, useComposerRuntime, useEditComposerAttachmentRuntime, useMessageAttachmentRuntime, useMessagePartData, useMessagePartRuntime, useMessageRuntime, useScrollLock, useThreadComposerAttachmentRuntime, useThreadListItemRuntime, useThreadRuntime, useThreadViewportAutoScroll } from "@/generated/typeDocs";
 
 {/* AUTO-GENERATED PAGE by scripts/generate-api-reference.mts */}
 {/* Do not edit manually. */}
@@ -13,6 +13,239 @@ import { unstable_useMessageStallDetection, useAssistantRuntime, useAttachmentRu
 {/* Do not edit this block manually. */}
 
 ## API Reference
+
+### useCloudThreadListAdapter
+
+<ParametersTable {...useCloudThreadListAdapter} />
+
+### useEditComposerAttachment
+
+```ts
+const useEditComposerAttachment: { (): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }); <TSelected>(selector: (state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; })) => TSelected): TSelected; <TSelected>(selector: ((state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; })) => TSelected) | undefined): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | TSelected; (options: { optional?: false | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }); (options: { optional?: boolean | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | null; <TSelected>(options: { optional?: false | undefined; selector: (state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; })) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; })) => TSelected) | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; })) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; })) => TSelected) | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | TSelected | null; };
+```
+
+### useEditComposerAttachmentRuntime
+
+<ParametersTable {...useEditComposerAttachmentRuntime} />
+
+### useMessageAttachment
+
+```ts
+const useMessageAttachment: { (): { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }; <TSelected>(selector: (state: { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) => TSelected): TSelected; <TSelected>(selector: ((state: { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) => TSelected) | undefined): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) | TSelected; (options: { optional?: false | undefined; }): { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }; (options: { optional?: boolean | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) | null; <TSelected>(options: { optional?: false | undefined; selector: (state: { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) => TSelected) | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) => TSelected) | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) | TSelected | null; };
+```
+
+### useMessageAttachmentRuntime
+
+<ParametersTable {...useMessageAttachmentRuntime} />
+
+### useMessageQuote
+
+Hook that returns the quote info for the current message, if any.
+
+Reads from `message.metadata.custom.quote`.
+
+```tsx
+function QuoteBlock() {
+  const quote = useMessageQuote();
+  if (!quote) return null;
+  return <blockquote>{quote.text}</blockquote>;
+}
+```
+
+```ts
+const useMessageQuote: () => QuoteInfo;
+```
+
+### useMessageTiming
+
+Hook that returns timing information for the current assistant message.
+
+Reads from `message.metadata.timing`.
+
+```tsx
+function MessageStats() {
+  const timing = useMessageTiming();
+  if (!timing) return null;
+  return <span>{timing.tokensPerSecond?.toFixed(1)} tok/s</span>;
+}
+```
+
+```ts
+const useMessageTiming: () => MessageTiming;
+```
+
+### useRuntimeAdapters
+
+```ts
+type RuntimeAdapters = {
+  modelContext?: ModelContextProvider | undefined;
+  history?: ThreadHistoryAdapter | undefined;
+  attachments?: AttachmentAdapter | undefined;
+};
+
+const useRuntimeAdapters: () => RuntimeAdapters | null;
+```
+
+### useScrollLock
+
+Locks scroll position during collapsible/height animations and hides scrollbar.
+
+This utility prevents page jumps when content height changes during animations,
+providing a smooth user experience. It finds the nearest scrollable ancestor and
+temporarily locks its scroll position while the animation completes.
+
+- Prevents forced reflows: no layout reads, mutations scoped to scrollable parent only
+- Reactive: only intercepts scroll events when browser actually adjusts
+- Cleans up automatically after animation duration
+
+```tsx
+const collapsibleRef = useRef<HTMLDivElement>(null);
+const lockScroll = useScrollLock(collapsibleRef, 200);
+
+const handleCollapse = () => {
+  lockScroll(); // Lock scroll before collapsing
+  setIsOpen(false);
+};
+```
+
+<ParametersTable {...useScrollLock} />
+
+### useThreadComposerAttachment
+
+```ts
+const useThreadComposerAttachment: { (): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }); <TSelected>(selector: (state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; })) => TSelected): TSelected; <TSelected>(selector: ((state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; })) => TSelected) | undefined): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | TSelected; (options: { optional?: false | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }); (options: { optional?: boolean | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | null; <TSelected>(options: { optional?: false | undefined; selector: (state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; })) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; })) => TSelected) | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; })) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; })) => TSelected) | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | TSelected | null; };
+```
+
+### useThreadComposerAttachmentRuntime
+
+<ParametersTable {...useThreadComposerAttachmentRuntime} />
+
+### useThreadViewport
+
+```ts
+const useThreadViewport: { (): ThreadViewportState; <TSelected>(selector: (state: ThreadViewportState) => TSelected): TSelected; (options: { optional: true; }): ThreadViewportState | null; <TSelected>(options: { optional: true; selector?: (state: ThreadViewportState) => TSelected; }): TSelected | null; };
+```
+
+### useThreadViewportAutoScroll
+
+<ParametersTable {...useThreadViewportAutoScroll} />
+
+### useThreadViewportStore
+
+```ts
+const useThreadViewportStore: { (): ReadonlyStore<ThreadViewportState>; (options: { optional: true; }): ReadonlyStore<ThreadViewportState> | null; };
+```
+
+### unstable_useComposerInput
+
+<Callout type="tip">
+<strong>Experimental.</strong> Under active development and might change without notice.
+</Callout>
+
+Headless bridge to the composer's text value and send action, for building a
+custom composer input without `ComposerPrimitive.Input`. It is a thin bridge,
+not a second input: it does not own keyboard behavior, autosize, IME or
+contentEditable sync, paste/drop attachments, focus management, or rich-text
+state. Spread `unstable_useTriggerPopoverAriaProps()` onto your element for
+trigger-popover combobox semantics.
+
+```tsx
+const { value, setText, send, isDisabled, canSend } = unstable_useComposerInput();
+<textarea
+  value={value}
+  disabled={isDisabled}
+  onChange={(e) => setText(e.target.value)}
+  onKeyDown={(e) => {
+    if (e.key === "Enter" && !e.shiftKey && canSend) {
+      e.preventDefault();
+      send();
+    }
+  }}
+/>
+```
+
+<ParametersTable {...unstable_useComposerInput} />
+
+### unstable_useComposerInputHistory
+
+<Callout type="tip">
+<strong>Experimental.</strong> Under active development and might change without notice.
+</Callout>
+
+Terminal-style input history for the thread composer: ArrowUp on an
+empty draft recalls previously sent user messages (newest first),
+ArrowDown steps back toward the newest and finally restores the draft
+that was being typed when browsing started.
+
+Recall only triggers when the caret is on the first/last line with no
+selection, so multi-line editing keeps native arrow behavior. The
+handler yields to an open mention/slash popover, to IME composition,
+to modifier keys, and to consumer handlers that already called
+`preventDefault`. It is inert on edit composers.
+
+```tsx
+const history = unstable_useComposerInputHistory();
+<ComposerPrimitive.Input {...history} />
+```
+
+```ts
+function unstable_useComposerInputHistory(): Unstable_ComposerInputHistory;
+```
+
+### unstable_useMessageStallDetection
+
+<Callout type="tip">
+<strong>Experimental.</strong> Under active development and might change without notice.
+</Callout>
+
+Detects mid-run output stalls on the current message: while the message is
+running, watches a fingerprint of its content (part count plus text,
+argument, and result sizes) and reports a stall once the fingerprint stops
+changing for `thresholdMs`. Useful for re-surfacing a "still working"
+indicator during tool think-time or provider stalls, after the first
+tokens have already streamed.
+
+Must be used inside a message scope.
+
+<ParametersTable {...unstable_useMessageStallDetection} />
+
+### unstable_useThreadMessageIds
+
+<Callout type="tip">
+<strong>Experimental.</strong> Unstable / Experimental - may change in any release.
+</Callout>
+
+Returns the ids of the messages in the current thread, in order.
+
+The returned array keeps a stable identity across content-only updates (e.g.
+streaming), changing reference only when the id sequence itself changes. Pair
+with `ThreadPrimitive.Unstable_MessageById` to drive a virtualized or custom
+message list.
+
+```ts
+const unstable_useThreadMessageIds: () => readonly string[];
+```
+
+### unstable_useTriggerPopoverAriaProps
+
+<Callout type="tip">
+<strong>Experimental.</strong> Under active development and might change without notice.
+</Callout>
+
+ARIA combobox attributes for the focused element (typically the composer
+input) describing the open trigger popover, per the WAI-ARIA editable
+combobox pattern. Returns an empty object outside a `TriggerPopoverRoot` or
+when no popover is open. Spread these last so they take precedence over any
+matching ARIA props you set yourself, mirroring `ComposerPrimitive.Input`.
+
+```tsx
+const aria = unstable_useTriggerPopoverAriaProps();
+<textarea {...aria} />
+```
+
+```ts
+function unstable_useTriggerPopoverAriaProps(): Unstable_TriggerPopoverAriaProps;
+```
 
 ### useAssistantRuntime
 
@@ -64,10 +297,6 @@ const useAttachment: { (): AttachmentState & { source: "message" | "thread-compo
 </Callout>
 
 <ParametersTable {...useAttachmentRuntime} />
-
-### useCloudThreadListAdapter
-
-<ParametersTable {...useCloudThreadListAdapter} />
 
 ### useComposer
 
@@ -185,16 +414,6 @@ function ComposerActions() {
 const useEditComposer: { (): EditComposerState; <TSelected>(selector: (state: EditComposerState) => TSelected): TSelected; <TSelected>(selector: ((state: EditComposerState) => TSelected) | undefined): EditComposerState | TSelected; (options: { optional?: false | undefined; }): EditComposerState; (options: { optional?: boolean | undefined; }): EditComposerState | null; <TSelected>(options: { optional?: false | undefined; selector: (state: EditComposerState) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: EditComposerState) => TSelected) | undefined; }): EditComposerState | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: EditComposerState) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: EditComposerState) => TSelected) | undefined; }): EditComposerState | TSelected | null; };
 ```
 
-### useEditComposerAttachment
-
-```ts
-const useEditComposerAttachment: { (): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }); <TSelected>(selector: (state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; })) => TSelected): TSelected; <TSelected>(selector: ((state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; })) => TSelected) | undefined): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | TSelected; (options: { optional?: false | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }); (options: { optional?: boolean | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | null; <TSelected>(options: { optional?: false | undefined; selector: (state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; })) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; })) => TSelected) | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; })) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; })) => TSelected) | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "edit-composer"; } & { source: "edit-composer"; }) | TSelected | null; };
-```
-
-### useEditComposerAttachmentRuntime
-
-<ParametersTable {...useEditComposerAttachmentRuntime} />
-
 ### useMessage
 
 <Callout type="warn">
@@ -235,16 +454,6 @@ function MessageContent() {
 ```ts
 const useMessage: { (): MessageState; <TSelected>(selector: (state: MessageState) => TSelected): TSelected; <TSelected>(selector: ((state: MessageState) => TSelected) | undefined): MessageState | TSelected; (options: { optional?: false | undefined; }): MessageState; (options: { optional?: boolean | undefined; }): MessageState | null; <TSelected>(options: { optional?: false | undefined; selector: (state: MessageState) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: MessageState) => TSelected) | undefined; }): MessageState | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: MessageState) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: MessageState) => TSelected) | undefined; }): MessageState | TSelected | null; };
 ```
-
-### useMessageAttachment
-
-```ts
-const useMessageAttachment: { (): { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }; <TSelected>(selector: (state: { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) => TSelected): TSelected; <TSelected>(selector: ((state: { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) => TSelected) | undefined): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) | TSelected; (options: { optional?: false | undefined; }): { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }; (options: { optional?: boolean | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) | null; <TSelected>(options: { optional?: false | undefined; selector: (state: { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) => TSelected) | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: { id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) => TSelected) | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "message"; } & { source: "message"; }) | TSelected | null; };
-```
-
-### useMessageAttachmentRuntime
-
-<ParametersTable {...useMessageAttachmentRuntime} />
 
 ### useMessagePart
 
@@ -389,24 +598,6 @@ See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
 const useMessagePartText: () => (TextMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; }) | (ReasoningMessagePart & { readonly status: MessagePartStatus | ToolCallMessagePartStatus; });
 ```
 
-### useMessageQuote
-
-Hook that returns the quote info for the current message, if any.
-
-Reads from `message.metadata.custom.quote`.
-
-```tsx
-function QuoteBlock() {
-  const quote = useMessageQuote();
-  if (!quote) return null;
-  return <blockquote>{quote.text}</blockquote>;
-}
-```
-
-```ts
-const useMessageQuote: () => QuoteInfo;
-```
-
 ### useMessageRuntime
 
 <Callout type="warn">
@@ -456,60 +647,6 @@ function MessageActions() {
 
 <ParametersTable {...useMessageRuntime} />
 
-### useMessageTiming
-
-Hook that returns timing information for the current assistant message.
-
-Reads from `message.metadata.timing`.
-
-```tsx
-function MessageStats() {
-  const timing = useMessageTiming();
-  if (!timing) return null;
-  return <span>{timing.tokensPerSecond?.toFixed(1)} tok/s</span>;
-}
-```
-
-```ts
-const useMessageTiming: () => MessageTiming;
-```
-
-### useRuntimeAdapters
-
-```ts
-type RuntimeAdapters = {
-  modelContext?: ModelContextProvider | undefined;
-  history?: ThreadHistoryAdapter | undefined;
-  attachments?: AttachmentAdapter | undefined;
-};
-
-const useRuntimeAdapters: () => RuntimeAdapters | null;
-```
-
-### useScrollLock
-
-Locks scroll position during collapsible/height animations and hides scrollbar.
-
-This utility prevents page jumps when content height changes during animations,
-providing a smooth user experience. It finds the nearest scrollable ancestor and
-temporarily locks its scroll position while the animation completes.
-
-- Prevents forced reflows: no layout reads, mutations scoped to scrollable parent only
-- Reactive: only intercepts scroll events when browser actually adjusts
-- Cleans up automatically after animation duration
-
-```tsx
-const collapsibleRef = useRef<HTMLDivElement>(null);
-const lockScroll = useScrollLock(collapsibleRef, 200);
-
-const handleCollapse = () => {
-  lockScroll(); // Lock scroll before collapsing
-  setIsOpen(false);
-};
-```
-
-<ParametersTable {...useScrollLock} />
-
 ### useThread
 
 <Callout type="warn">
@@ -550,16 +687,6 @@ const useThread: { (): ThreadState; <TSelected>(selector: (state: ThreadState) =
 ```ts
 const useThreadComposer: { (): ThreadComposerState; <TSelected>(selector: (state: ThreadComposerState) => TSelected): TSelected; <TSelected>(selector: ((state: ThreadComposerState) => TSelected) | undefined): ThreadComposerState | TSelected; (options: { optional?: false | undefined; }): ThreadComposerState; (options: { optional?: boolean | undefined; }): ThreadComposerState | null; <TSelected>(options: { optional?: false | undefined; selector: (state: ThreadComposerState) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: ThreadComposerState) => TSelected) | undefined; }): ThreadComposerState | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: ThreadComposerState) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: ThreadComposerState) => TSelected) | undefined; }): ThreadComposerState | TSelected | null; };
 ```
-
-### useThreadComposerAttachment
-
-```ts
-const useThreadComposerAttachment: { (): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }); <TSelected>(selector: (state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; })) => TSelected): TSelected; <TSelected>(selector: ((state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; })) => TSelected) | undefined): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | TSelected; (options: { optional?: false | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }); (options: { optional?: boolean | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | null; <TSelected>(options: { optional?: false | undefined; selector: (state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; })) => TSelected; }): TSelected; <TSelected>(options: { optional?: false | undefined; selector: ((state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; })) => TSelected) | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | TSelected; <TSelected>(options: { optional?: boolean | undefined; selector: (state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; })) => TSelected; }): TSelected | null; <TSelected>(options: { optional?: boolean | undefined; selector: ((state: ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; })) => TSelected) | undefined; }): ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: PendingAttachmentStatus; file: File; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | ({ id: string; type: "image" | "document" | "file" | (string & {}); name: string; contentType?: string | undefined; file?: File; content?: ThreadUserMessagePart[]; } & { status: CompleteAttachmentStatus; content: ThreadUserMessagePart[]; } & { readonly source: "thread-composer"; } & { source: "thread-composer"; }) | TSelected | null; };
-```
-
-### useThreadComposerAttachmentRuntime
-
-<ParametersTable {...useThreadComposerAttachmentRuntime} />
 
 ### useThreadList
 
@@ -621,63 +748,4 @@ function MyComponent() {
 ```
 
 <ParametersTable {...useThreadRuntime} />
-
-### useThreadViewport
-
-```ts
-const useThreadViewport: { (): ThreadViewportState; <TSelected>(selector: (state: ThreadViewportState) => TSelected): TSelected; (options: { optional: true; }): ThreadViewportState | null; <TSelected>(options: { optional: true; selector?: (state: ThreadViewportState) => TSelected; }): TSelected | null; };
-```
-
-### useThreadViewportAutoScroll
-
-<ParametersTable {...useThreadViewportAutoScroll} />
-
-### useThreadViewportStore
-
-```ts
-const useThreadViewportStore: { (): ReadonlyStore<ThreadViewportState>; (options: { optional: true; }): ReadonlyStore<ThreadViewportState> | null; };
-```
-
-### unstable_useComposerInputHistory
-
-<Callout type="warn">
-<strong>Deprecated.</strong> Under active development and might change without notice.
-</Callout>
-
-Terminal-style input history for the thread composer: ArrowUp on an
-empty draft recalls previously sent user messages (newest first),
-ArrowDown steps back toward the newest and finally restores the draft
-that was being typed when browsing started.
-
-Recall only triggers when the caret is on the first/last line with no
-selection, so multi-line editing keeps native arrow behavior. The
-handler yields to an open mention/slash popover, to IME composition,
-to modifier keys, and to consumer handlers that already called
-`preventDefault`. It is inert on edit composers.
-
-```tsx
-const history = unstable_useComposerInputHistory();
-<ComposerPrimitive.Input {...history} />
-```
-
-```ts
-function unstable_useComposerInputHistory(): Unstable_ComposerInputHistory;
-```
-
-### unstable_useMessageStallDetection
-
-<Callout type="warn">
-<strong>Deprecated.</strong> Under active development and might change without notice.
-</Callout>
-
-Detects mid-run output stalls on the current message: while the message is
-running, watches a fingerprint of its content (part count plus text,
-argument, and result sizes) and reports a stall once the fingerprint stops
-changing for `thresholdMs`. Useful for re-surfacing a "still working"
-indicator during tool think-time or provider stalls, after the first
-tokens have already streamed.
-
-Must be used inside a message scope.
-
-<ParametersTable {...unstable_useMessageStallDetection} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/action-bar.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/action-bar.mdx
@@ -53,6 +53,18 @@ const AssistantMessageBar = () => (
   <p>This primitive renders a <code>{`<${ActionBarPrimitiveDocs.Root?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<ActionBarPrimitive.Root
+  hideWhenRunning={true}
+  autohide="not-last"
+  autohideFloat="single-branch"
+>
+  <ActionBarPrimitive.Copy />
+  <ActionBarPrimitive.Edit />
+  <ActionBarPrimitive.Reload />
+</ActionBarPrimitive.Root>
+```
+
 <ParametersTable {...ActionBarPrimitiveRootProps} />
 
 {/* api-manual:ActionBarPrimitive.Root:start */}
@@ -74,6 +86,12 @@ const AssistantMessageBar = () => (
 {ActionBarPrimitiveDocs.Copy?.element && (
   <p>This primitive renders a <code>{`<${ActionBarPrimitiveDocs.Copy?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<ActionBarPrimitive.Copy copiedDuration={2000}>
+  Copy Message
+</ActionBarPrimitive.Copy>
+```
 
 <ParametersTable {...ActionBarPrimitiveCopyProps} />
 
@@ -97,6 +115,12 @@ const AssistantMessageBar = () => (
   <p>This primitive renders a <code>{`<${ActionBarPrimitiveDocs.Reload?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<ActionBarPrimitive.Reload>
+  Reload Message
+</ActionBarPrimitive.Reload>
+```
+
 <ParametersTable {...ActionBarPrimitiveReloadProps} />
 
 ### Edit
@@ -112,6 +136,12 @@ const AssistantMessageBar = () => (
 {ActionBarPrimitiveDocs.Edit?.element && (
   <p>This primitive renders a <code>{`<${ActionBarPrimitiveDocs.Edit?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<ActionBarPrimitive.Edit>
+  Edit Message
+</ActionBarPrimitive.Edit>
+```
 
 <ParametersTable {...ActionBarPrimitiveEditProps} />
 

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/attachment.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/attachment.mdx
@@ -54,6 +54,13 @@ const MyComposerAttachment = () => (
   <p>This primitive renders a <code>{`<${AttachmentPrimitiveDocs.Root?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<AttachmentPrimitive.Root>
+  <AttachmentPrimitive.Name />
+  <AttachmentPrimitive.Remove />
+</AttachmentPrimitive.Root>
+```
+
 <ParametersTable {...AttachmentPrimitiveRootProps} />
 
 ### Name

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/branch-picker.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/branch-picker.mdx
@@ -47,6 +47,14 @@ const BranchPicker = () => (
   <p>This primitive renders a <code>{`<${BranchPickerPrimitiveDocs.Root?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<BranchPickerPrimitive.Root hideWhenSingleBranch={true}>
+  <BranchPickerPrimitive.Previous />
+  <BranchPickerPrimitive.Count />
+  <BranchPickerPrimitive.Next />
+</BranchPickerPrimitive.Root>
+```
+
 <ParametersTable {...BranchPickerPrimitiveRootProps} />
 
 ### Next
@@ -62,6 +70,12 @@ const BranchPicker = () => (
 {BranchPickerPrimitiveDocs.Next?.element && (
   <p>This primitive renders a <code>{`<${BranchPickerPrimitiveDocs.Next?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<BranchPickerPrimitive.Next>
+  Next →
+</BranchPickerPrimitive.Next>
+```
 
 <ParametersTable {...BranchPickerPrimitiveNextProps} />
 
@@ -79,6 +93,12 @@ const BranchPicker = () => (
   <p>This primitive renders a <code>{`<${BranchPickerPrimitiveDocs.Previous?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<BranchPickerPrimitive.Previous>
+  ← Previous
+</BranchPickerPrimitive.Previous>
+```
+
 <ParametersTable {...BranchPickerPrimitivePreviousProps} />
 
 ### Count
@@ -94,6 +114,12 @@ const BranchPicker = () => (
 {BranchPickerPrimitiveDocs.Count?.element && (
   <p>This primitive renders a <code>{`<${BranchPickerPrimitiveDocs.Count?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<div>
+  Branch <BranchPickerPrimitive.Count /> of {totalBranches}
+</div>
+```
 
 {BranchPickerPrimitiveDocs.Count?.props && (
   <ParametersTable type={BranchPickerPrimitiveDocs.Count?.element} parameters={BranchPickerPrimitiveDocs.Count.props} />

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/chain-of-thought.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/chain-of-thought.mdx
@@ -31,6 +31,15 @@ For examples and usage patterns, see [ChainOfThought](/docs/primitives/chain-of-
   <p>This primitive renders a <code>{`<${ChainOfThoughtPrimitiveDocs.Root?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<ChainOfThoughtPrimitive.Root>
+  <ChainOfThoughtPrimitive.AccordionTrigger>
+    Toggle reasoning
+  </ChainOfThoughtPrimitive.AccordionTrigger>
+  <ChainOfThoughtPrimitive.Parts />
+</ChainOfThoughtPrimitive.Root>
+```
+
 <ParametersTable {...ChainOfThoughtPrimitiveRootProps} />
 
 ### AccordionTrigger
@@ -46,6 +55,12 @@ For examples and usage patterns, see [ChainOfThought](/docs/primitives/chain-of-
 {ChainOfThoughtPrimitiveDocs.AccordionTrigger?.element && (
   <p>This primitive renders a <code>{`<${ChainOfThoughtPrimitiveDocs.AccordionTrigger?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<ChainOfThoughtPrimitive.AccordionTrigger>
+  Toggle Reasoning
+</ChainOfThoughtPrimitive.AccordionTrigger>
+```
 
 <ParametersTable {...ChainOfThoughtPrimitiveAccordionTriggerProps} />
 

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/composer.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/composer.mdx
@@ -78,6 +78,13 @@ const ComposerWithDictation = () => (
   <p>This primitive renders a <code>{`<${ComposerPrimitiveDocs.Root?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<ComposerPrimitive.Root>
+  <ComposerPrimitive.Input placeholder="Type your message..." />
+  <ComposerPrimitive.Send>Send</ComposerPrimitive.Send>
+</ComposerPrimitive.Root>
+```
+
 <ParametersTable {...ComposerPrimitiveRootProps} />
 
 ### Input
@@ -93,6 +100,26 @@ const ComposerWithDictation = () => (
 {ComposerPrimitiveDocs.Input?.element && (
   <p>This primitive renders a <code>{`<${ComposerPrimitiveDocs.Input?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+// Ctrl/Cmd+Enter to submit (plain Enter inserts newline)
+<ComposerPrimitive.Input
+  placeholder="Type your message..."
+  submitMode="ctrlEnter"
+/>
+
+// Insert a newline on Enter on touch-primary devices.
+<ComposerPrimitive.Input
+  placeholder="Type your message..."
+  unstable_insertNewlineOnTouchEnter
+/>
+
+// Old API (deprecated, still supported)
+<ComposerPrimitive.Input
+  placeholder="Type your message..."
+  submitOnEnter={true}
+/>
+```
 
 <ParametersTable {...ComposerPrimitiveInputProps} />
 
@@ -150,6 +177,12 @@ Only takes effect when `submitMode` resolves to `"enter"` (the default); `"ctrlE
   <p>This primitive renders a <code>{`<${ComposerPrimitiveDocs.Send?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<ComposerPrimitive.Send>
+  Send Message
+</ComposerPrimitive.Send>
+```
+
 <ParametersTable {...ComposerPrimitiveSendProps} />
 
 ### Cancel
@@ -165,6 +198,12 @@ Only takes effect when `submitMode` resolves to `"enter"` (the default); `"ctrlE
 {ComposerPrimitiveDocs.Cancel?.element && (
   <p>This primitive renders a <code>{`<${ComposerPrimitiveDocs.Cancel?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<ComposerPrimitive.Cancel>
+  Cancel
+</ComposerPrimitive.Cancel>
+```
 
 <ParametersTable {...ComposerPrimitiveCancelProps} />
 
@@ -252,6 +291,12 @@ Only takes effect when `submitMode` resolves to `"enter"` (the default); `"ctrlE
   <p>This primitive renders a <code>{`<${ComposerPrimitiveDocs.Dictate?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<ComposerPrimitive.Dictate>
+  <MicIcon />
+</ComposerPrimitive.Dictate>
+```
+
 <ParametersTable {...ComposerPrimitiveDictateProps} />
 
 ### StopDictation
@@ -268,6 +313,12 @@ Only takes effect when `submitMode` resolves to `"enter"` (the default); `"ctrlE
   <p>This primitive renders a <code>{`<${ComposerPrimitiveDocs.StopDictation?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<ComposerPrimitive.StopDictation>
+  <StopIcon />
+</ComposerPrimitive.StopDictation>
+```
+
 <ParametersTable {...ComposerPrimitiveStopDictationProps} />
 
 ### DictationTranscript
@@ -283,6 +334,14 @@ Only takes effect when `submitMode` resolves to `"enter"` (the default); `"ctrlE
 {ComposerPrimitiveDocs.DictationTranscript?.element && (
   <p>This primitive renders a <code>{`<${ComposerPrimitiveDocs.DictationTranscript?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<ComposerPrimitive.If dictation>
+  <div className="dictation-preview">
+    <ComposerPrimitive.DictationTranscript />
+  </div>
+</ComposerPrimitive.If>
+```
 
 <ParametersTable {...ComposerPrimitiveDictationTranscriptProps} />
 
@@ -316,6 +375,13 @@ Only takes effect when `submitMode` resolves to `"enter"` (the default); `"ctrlE
   <p>This primitive renders a <code>{`<${ComposerPrimitiveDocs.Quote?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<ComposerPrimitive.Quote>
+  <ComposerPrimitive.QuoteText />
+  <ComposerPrimitive.QuoteDismiss>×</ComposerPrimitive.QuoteDismiss>
+</ComposerPrimitive.Quote>
+```
+
 <ParametersTable {...ComposerPrimitiveQuoteProps} />
 
 ### QuoteText
@@ -331,6 +397,10 @@ Only takes effect when `submitMode` resolves to `"enter"` (the default); `"ctrlE
 {ComposerPrimitiveDocs.QuoteText?.element && (
   <p>This primitive renders a <code>{`<${ComposerPrimitiveDocs.QuoteText?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<ComposerPrimitive.QuoteText />
+```
 
 <ParametersTable {...ComposerPrimitiveQuoteTextProps} />
 
@@ -348,6 +418,10 @@ Only takes effect when `submitMode` resolves to `"enter"` (the default); `"ctrlE
   <p>This primitive renders a <code>{`<${ComposerPrimitiveDocs.QuoteDismiss?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<ComposerPrimitive.QuoteDismiss>×</ComposerPrimitive.QuoteDismiss>
+```
+
 <ParametersTable {...ComposerPrimitiveQuoteDismissProps} />
 
 ### Queue
@@ -363,6 +437,17 @@ Only takes effect when `submitMode` resolves to `"enter"` (the default); `"ctrlE
 {ComposerPrimitiveDocs.Queue?.element && (
   <p>This primitive renders a <code>{`<${ComposerPrimitiveDocs.Queue?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<ComposerPrimitive.Queue>
+  {({ queueItem }) => (
+    <div>
+      <QueueItemPrimitive.Text />
+      <QueueItemPrimitive.Steer>Run Now</QueueItemPrimitive.Steer>
+    </div>
+  )}
+</ComposerPrimitive.Queue>
+```
 
 <ParametersTable {...ComposerPrimitiveQueueProps} />
 
@@ -401,6 +486,24 @@ Only takes effect when `submitMode` resolves to `"enter"` (the default); `"ctrlE
 {ComposerPrimitiveDocs.Unstable_TriggerPopoverRoot?.element && (
   <p>This primitive renders a <code>{`<${ComposerPrimitiveDocs.Unstable_TriggerPopoverRoot?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<ComposerPrimitive.Unstable_TriggerPopoverRoot>
+  <ComposerPrimitive.Unstable_TriggerPopover char="@" adapter={mentionAdapter}>
+    <ComposerPrimitive.Unstable_TriggerPopover.Directive formatter={formatter} />
+    ...
+  </ComposerPrimitive.Unstable_TriggerPopover>
+
+  <ComposerPrimitive.Unstable_TriggerPopover char="/" adapter={slashAdapter}>
+    <ComposerPrimitive.Unstable_TriggerPopover.Action onExecute={handler} />
+    ...
+  </ComposerPrimitive.Unstable_TriggerPopover>
+
+  <ComposerPrimitive.Root>
+    <ComposerPrimitive.Input />
+  </ComposerPrimitive.Root>
+</ComposerPrimitive.Unstable_TriggerPopoverRoot>
+```
 
 <ParametersTable {...ComposerPrimitiveUnstable_TriggerPopoverRootProps} />
 

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/message-part.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/message-part.mdx
@@ -41,6 +41,14 @@ const TextMessagePart = () => {
   <p>This primitive renders a <code>{`<${MessagePartPrimitiveDocs.Text?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<MessagePartPrimitive.Text
+  smooth={true}
+  component="p"
+  className="message-text"
+/>
+```
+
 <ParametersTable {...MessagePartPrimitiveTextProps} />
 
 {/* api-manual:MessagePartPrimitive.Text:start */}
@@ -62,6 +70,14 @@ const TextMessagePart = () => {
 {MessagePartPrimitiveDocs.Image?.element && (
   <p>This primitive renders a <code>{`<${MessagePartPrimitiveDocs.Image?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<MessagePartPrimitive.Image
+  alt="Generated image"
+  className="message-image"
+  style={{ maxWidth: '100%' }}
+/>
+```
 
 <ParametersTable {...MessagePartPrimitiveImageProps} />
 

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/message.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/message.mdx
@@ -55,6 +55,16 @@ const AssistantMessage = () => (
   <p>This primitive renders a <code>{`<${MessagePrimitiveDocs.Root?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<MessagePrimitive.Root>
+  <MessagePrimitive.Content />
+  <ActionBarPrimitive.Root>
+    <ActionBarPrimitive.Copy />
+    <ActionBarPrimitive.Edit />
+  </ActionBarPrimitive.Root>
+</MessagePrimitive.Root>
+```
+
 <ParametersTable {...MessagePrimitiveRootProps} />
 
 ### Parts
@@ -201,6 +211,27 @@ const AssistantMessage = () => (
   <p>This primitive renders a <code>{`<${MessagePrimitiveDocs.GroupedParts?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<MessagePrimitive.GroupedParts
+  groupBy={groupPartByType({
+    reasoning: ["group-thought", "group-reasoning"],
+    "tool-call": ["group-thought", "group-tool"],
+  })}
+>
+  {({ part, children }) => {
+    switch (part.type) {
+      case "group-thought":   return <Thought>{children}</Thought>;
+      case "group-reasoning": return <Reasoning>{children}</Reasoning>;
+      case "group-tool":      return <ToolStack>{children}</ToolStack>;
+      case "text":            return <MarkdownText />;
+      case "tool-call":       return part.toolUI ?? <ToolFallback {...part} />;
+      case "indicator":       return <LoadingDots />;
+      default:                return null;
+    }
+  }}
+</MessagePrimitive.GroupedParts>
+```
+
 <ParametersTable {...MessagePrimitiveGroupedPartsProps} />
 
 ### GenerativeUI
@@ -217,6 +248,12 @@ const AssistantMessage = () => (
   <p>This primitive renders a <code>{`<${MessagePrimitiveDocs.GenerativeUI?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<MessagePrimitive.GenerativeUI
+  components={{ Card: MyCard, Button: MyButton }}
+/>
+```
+
 <ParametersTable {...MessagePrimitiveGenerativeUIProps} />
 
 ### Unstable_PartsGrouped
@@ -232,6 +269,25 @@ const AssistantMessage = () => (
 {MessagePrimitiveDocs.Unstable_PartsGrouped?.element && (
   <p>This primitive renders a <code>{`<${MessagePrimitiveDocs.Unstable_PartsGrouped?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+// Group by parent ID (default behavior)
+<MessagePrimitive.Unstable_PartsGrouped
+  components={{
+    Text: ({ text }) => <p className="message-text">{text}</p>,
+    Image: ({ image }) => <img src={image} alt="Message image" />,
+    Group: ({ groupKey, indices, children }) => {
+      if (!groupKey) return <>{children}</>;
+      return (
+        <div className="parent-group border rounded p-4">
+          <h4>Parent ID: {groupKey}</h4>
+          {children}
+        </div>
+      );
+    }
+  }}
+/>
+```
 
 <ParametersTable {...MessagePrimitiveUnstable_PartsGroupedProps} />
 

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/queue-item.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/queue-item.mdx
@@ -29,6 +29,10 @@ import { QueueItemPrimitive as QueueItemPrimitiveDocs } from "@/generated/primit
   <p>This primitive renders a <code>{`<${QueueItemPrimitiveDocs.Text?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<QueueItemPrimitive.Text />
+```
+
 <ParametersTable {...QueueItemPrimitiveTextProps} />
 
 ### Steer
@@ -45,6 +49,10 @@ import { QueueItemPrimitive as QueueItemPrimitiveDocs } from "@/generated/primit
   <p>This primitive renders a <code>{`<${QueueItemPrimitiveDocs.Steer?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<QueueItemPrimitive.Steer>Run Now</QueueItemPrimitive.Steer>
+```
+
 <ParametersTable {...QueueItemPrimitiveSteerProps} />
 
 ### Remove
@@ -60,6 +68,10 @@ import { QueueItemPrimitive as QueueItemPrimitiveDocs } from "@/generated/primit
 {QueueItemPrimitiveDocs.Remove?.element && (
   <p>This primitive renders a <code>{`<${QueueItemPrimitiveDocs.Remove?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<QueueItemPrimitive.Remove>×</QueueItemPrimitive.Remove>
+```
 
 <ParametersTable {...QueueItemPrimitiveRemoveProps} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/selection-toolbar.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/selection-toolbar.mdx
@@ -54,6 +54,12 @@ Place this component inside `ThreadPrimitive.Root`:
   <p>This primitive renders a <code>{`<${SelectionToolbarPrimitiveDocs.Root?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<SelectionToolbarPrimitive.Root>
+  <SelectionToolbarPrimitive.Quote>Quote</SelectionToolbarPrimitive.Quote>
+</SelectionToolbarPrimitive.Root>
+```
+
 <ParametersTable {...SelectionToolbarPrimitiveRootProps} />
 
 ### Quote
@@ -69,6 +75,12 @@ Place this component inside `ThreadPrimitive.Root`:
 {SelectionToolbarPrimitiveDocs.Quote?.element && (
   <p>This primitive renders a <code>{`<${SelectionToolbarPrimitiveDocs.Quote?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<SelectionToolbarPrimitive.Quote>
+  <QuoteIcon /> Quote
+</SelectionToolbarPrimitive.Quote>
+```
 
 <ParametersTable {...SelectionToolbarPrimitiveQuoteProps} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/suggestion.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/suggestion.mdx
@@ -31,6 +31,10 @@ For examples and usage patterns, see [Suggestion](/docs/primitives/suggestion).
   <p>This primitive renders a <code>{`<${SuggestionPrimitiveDocs.Title?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<SuggestionPrimitive.Title />
+```
+
 <ParametersTable {...SuggestionPrimitiveTitleProps} />
 
 ### Description
@@ -47,6 +51,10 @@ For examples and usage patterns, see [Suggestion](/docs/primitives/suggestion).
   <p>This primitive renders a <code>{`<${SuggestionPrimitiveDocs.Description?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<SuggestionPrimitive.Description />
+```
+
 <ParametersTable {...SuggestionPrimitiveDescriptionProps} />
 
 ### Trigger
@@ -62,6 +70,12 @@ For examples and usage patterns, see [Suggestion](/docs/primitives/suggestion).
 {SuggestionPrimitiveDocs.Trigger?.element && (
   <p>This primitive renders a <code>{`<${SuggestionPrimitiveDocs.Trigger?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<SuggestionPrimitive.Trigger send>
+  Click me
+</SuggestionPrimitive.Trigger>
+```
 
 <ParametersTable {...SuggestionPrimitiveTriggerProps} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/thread.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/thread.mdx
@@ -3,7 +3,7 @@ title: ThreadPrimitive
 description: Thread primitives for rendering chat transcripts, message lists, viewport state, suggestions, and composers in assistant-ui.
 ---
 
-import { ThreadPrimitiveIfProps, ThreadPrimitiveMessageByIndexProps, ThreadPrimitiveMessagesProps, ThreadPrimitiveRootProps, ThreadPrimitiveScrollToBottomProps, ThreadPrimitiveSuggestionByIndexProps, ThreadPrimitiveSuggestionProps, ThreadPrimitiveSuggestionsProps, ThreadPrimitiveViewportFooterProps, ThreadPrimitiveViewportProps, ThreadPrimitiveViewportProviderProps } from "@/generated/typeDocs";
+import { ThreadPrimitiveIfProps, ThreadPrimitiveMessageByIndexProps, ThreadPrimitiveMessagesProps, ThreadPrimitiveRootProps, ThreadPrimitiveScrollToBottomProps, ThreadPrimitiveSuggestionByIndexProps, ThreadPrimitiveSuggestionProps, ThreadPrimitiveSuggestionsProps, ThreadPrimitiveUnstable_MessageByIdProps, ThreadPrimitiveViewportFooterProps, ThreadPrimitiveViewportProps, ThreadPrimitiveViewportProviderProps } from "@/generated/typeDocs";
 import { ThreadPrimitive as ThreadPrimitiveDocs } from "@/generated/primitiveDocs";
 
 {/* AUTO-GENERATED PAGE by scripts/generate-api-reference.mts */}
@@ -50,6 +50,16 @@ const Thread = () => (
 {ThreadPrimitiveDocs.Root?.element && (
   <p>This primitive renders a <code>{`<${ThreadPrimitiveDocs.Root?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<ThreadPrimitive.Root>
+  <ThreadPrimitive.Viewport>
+    <ThreadPrimitive.Messages>
+      {() => <MyMessage />}
+    </ThreadPrimitive.Messages>
+  </ThreadPrimitive.Viewport>
+</ThreadPrimitive.Root>
+```
 
 <ParametersTable {...ThreadPrimitiveRootProps} />
 
@@ -101,6 +111,14 @@ const Thread = () => (
   <p>This primitive renders a <code>{`<${ThreadPrimitiveDocs.Viewport?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
 
+```tsx
+<ThreadPrimitive.Viewport turnAnchor="top">
+  <ThreadPrimitive.Messages>
+    {() => <MyMessage />}
+  </ThreadPrimitive.Messages>
+</ThreadPrimitive.Viewport>
+```
+
 <ParametersTable {...ThreadPrimitiveViewportProps} />
 
 ### ViewportProvider
@@ -132,6 +150,17 @@ const Thread = () => (
 {ThreadPrimitiveDocs.ViewportFooter?.element && (
   <p>This primitive renders a <code>{`<${ThreadPrimitiveDocs.ViewportFooter?.element}>`}</code> element unless <code>asChild</code> is set.</p>
 )}
+
+```tsx
+<ThreadPrimitive.Viewport>
+  <ThreadPrimitive.Messages>
+    {() => <MyMessage />}
+  </ThreadPrimitive.Messages>
+  <ThreadPrimitive.ViewportFooter className="sticky bottom-0">
+    <Composer />
+  </ThreadPrimitive.ViewportFooter>
+</ThreadPrimitive.Viewport>
+```
 
 <ParametersTable {...ThreadPrimitiveViewportFooterProps} />
 
@@ -166,6 +195,33 @@ const Thread = () => (
 )}
 
 <ParametersTable {...ThreadPrimitiveMessageByIndexProps} />
+
+### Unstable_MessageById
+
+{ThreadPrimitiveDocs.Unstable_MessageById?.deprecated && (
+  <Callout type="tip">
+    <strong>Experimental.</strong> {ThreadPrimitiveDocs.Unstable_MessageById.deprecated}
+  </Callout>
+)}
+
+{ThreadPrimitiveDocs.Unstable_MessageById?.description}
+
+{ThreadPrimitiveDocs.Unstable_MessageById?.element && (
+  <p>This primitive renders a <code>{`<${ThreadPrimitiveDocs.Unstable_MessageById?.element}>`}</code> element unless <code>asChild</code> is set.</p>
+)}
+
+```tsx
+const messageIds = unstable_useThreadMessageIds();
+return messageIds.map((messageId) => (
+  <ThreadPrimitive.Unstable_MessageById
+    key={messageId}
+    messageId={messageId}
+    components={MESSAGE_COMPONENTS}
+  />
+));
+```
+
+<ParametersTable {...ThreadPrimitiveUnstable_MessageByIdProps} />
 
 ### ScrollToBottom
 

--- a/apps/docs/content/docs/(reference)/api-reference/tools/rendering.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/rendering.mdx
@@ -44,6 +44,21 @@ type AssistantDataUIProps = {
 const makeAssistantDataUI: <T = any>(dataUI: AssistantDataUIProps<T>) => AssistantDataUI;
 ```
 
+### McpAppRenderer
+
+<ParametersTable {...McpAppRenderer} />
+
+### McpAppsRemoteHost
+
+<ParametersTable {...McpAppsRemoteHost} />
+
+### useAssistantDataUI
+
+Registers a renderer for named `data` message parts while the component is
+mounted.
+
+<ParametersTable {...useAssistantDataUI} />
+
 ### makeAssistantToolUI
 
 <Callout type="warn">
@@ -73,21 +88,6 @@ type AssistantToolUIProps = {
 
 const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<TArgs, TResult>) => AssistantToolUI;
 ```
-
-### McpAppRenderer
-
-<ParametersTable {...McpAppRenderer} />
-
-### McpAppsRemoteHost
-
-<ParametersTable {...McpAppsRemoteHost} />
-
-### useAssistantDataUI
-
-Registers a renderer for named `data` message parts while the component is
-mounted.
-
-<ParametersTable {...useAssistantDataUI} />
 
 ### useAssistantToolUI
 

--- a/apps/docs/content/docs/(reference)/api-reference/tools/toolkits.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/toolkits.mdx
@@ -115,26 +115,6 @@ client build.
 function externalTool(): never;
 ```
 
-### hitl
-
-<Callout type="warn">
-<strong>Deprecated.</strong> Use [humanTool](/docs/api-reference/tools/toolkits#humantool).
-</Callout>
-
-```ts
-const hitl: typeof humanTool;
-```
-
-### hitlTool
-
-<Callout type="warn">
-<strong>Deprecated.</strong> Use [humanTool](/docs/api-reference/tools/toolkits#humantool).
-</Callout>
-
-```ts
-const hitlTool: typeof humanTool;
-```
-
 ### humanTool
 
 Marks a tool as **human-in-the-loop**: the agent pauses and the UI (`render`)
@@ -171,5 +151,25 @@ supplied by `useAuiToolOverrides(...)`.
 
 ```ts
 function stubTool(): never;
+```
+
+### hitl
+
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [humanTool](/docs/api-reference/tools/toolkits#humantool).
+</Callout>
+
+```ts
+const hitl: typeof humanTool;
+```
+
+### hitlTool
+
+<Callout type="warn">
+<strong>Deprecated.</strong> Use [humanTool](/docs/api-reference/tools/toolkits#humantool).
+</Callout>
+
+```ts
+const hitlTool: typeof humanTool;
 ```
 {/* api-reference:end */}

--- a/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/utilities/miscellaneous.mdx
@@ -32,26 +32,6 @@ const createMessageQueue: (driver: MessageQueueDriver) => MessageQueueController
 
 <ParametersTable {...DevToolsHooks} />
 
-### fromThreadMessageLike
-
-<Callout type="warn">
-<strong>Deprecated.</strong> This API is experimental and may change without notice.
-</Callout>
-
-```ts
-const fromThreadMessageLike: (like: ThreadMessageLike, fallbackId: string, fallbackStatus: MessageStatus) => ThreadMessage;
-```
-
-### generateId
-
-<Callout type="warn">
-<strong>Deprecated.</strong> This API is experimental and may change without notice.
-</Callout>
-
-```ts
-const generateId: (size?: number) => string;
-```
-
 ### InMemoryThreadList
 
 <ParametersTable {...InMemoryThreadList} />
@@ -67,6 +47,16 @@ const generateId: (size?: number) => string;
 ### Suggestions
 
 <ParametersTable {...Suggestions} />
+
+### unstable_defaultDirectiveFormatter
+
+Default directive formatter using the `:type[label]{name=id}` syntax.
+
+When `id` equals `label`, the `{name=…}` attribute is omitted for brevity.
+
+```ts
+const unstable_defaultDirectiveFormatter: Unstable_DirectiveFormatter;
+```
 
 ### useSmooth
 
@@ -86,13 +76,23 @@ const { text, status } = useSmooth(useMessagePartText(), {
 
 <ParametersTable {...useSmooth} />
 
-### unstable_defaultDirectiveFormatter
+### fromThreadMessageLike
 
-Default directive formatter using the `:type[label]{name=id}` syntax.
-
-When `id` equals `label`, the `{name=…}` attribute is omitted for brevity.
+<Callout type="tip">
+<strong>Experimental.</strong> This API is experimental and may change without notice.
+</Callout>
 
 ```ts
-const unstable_defaultDirectiveFormatter: Unstable_DirectiveFormatter;
+const fromThreadMessageLike: (like: ThreadMessageLike, fallbackId: string, fallbackStatus: MessageStatus) => ThreadMessage;
+```
+
+### generateId
+
+<Callout type="tip">
+<strong>Experimental.</strong> This API is experimental and may change without notice.
+</Callout>
+
+```ts
+const generateId: (size?: number) => string;
 ```
 {/* api-reference:end */}

--- a/apps/docs/scripts/generated-docs/extract.mts
+++ b/apps/docs/scripts/generated-docs/extract.mts
@@ -418,7 +418,7 @@ export function jsDocTag(
     : undefined;
 }
 
-function jsDocTags(
+export function jsDocTags(
   doc: JSDoc | undefined,
   name: string,
   source = "unknown source",

--- a/apps/docs/scripts/generated-docs/primitive-extract.mts
+++ b/apps/docs/scripts/generated-docs/primitive-extract.mts
@@ -13,6 +13,7 @@ import {
   getProject,
   getJsDocCommentText,
   jsDocTag,
+  jsDocTags,
   processComponentDeclaration,
   processTypeOrInterface,
   type JsDocRenderOptions,
@@ -32,6 +33,7 @@ export type PrimitivePartModel = {
   element?: string;
   description?: string;
   deprecated?: string;
+  examples?: string[];
   supportsAsChild: boolean;
   isActionButton: boolean;
   isRequireAtLeastOne: boolean;
@@ -143,7 +145,11 @@ function getPrimitiveComponentMeta(
   sourceFile: SourceFile,
   localName: string,
   options?: JsDocRenderOptions,
-): { description?: string | undefined; deprecated?: string | undefined } {
+): {
+  description?: string | undefined;
+  deprecated?: string | undefined;
+  examples?: string[] | undefined;
+} {
   for (const varDecl of sourceFile.getVariableDeclarations()) {
     if (varDecl.getName() !== localName) continue;
     const statement = varDecl.getVariableStatement();
@@ -162,7 +168,13 @@ function getPrimitiveComponentMeta(
       `${localName} primitive`,
       options,
     );
-    return { description, deprecated };
+    const examples = jsDocTags(
+      doc,
+      "example",
+      `${localName} primitive`,
+      options,
+    );
+    return { description, deprecated, examples };
   }
   return {};
 }
@@ -345,7 +357,7 @@ function extractPrimitivePart(
   const ns = findNamespace(sourceFile, localName);
   const propsAlias = ns?.getTypeAliases().find((t) => t.getName() === "Props");
   const element = ns ? extractElementType(ns) : undefined;
-  const { description, deprecated } = getPrimitiveComponentMeta(
+  const { description, deprecated, examples } = getPrimitiveComponentMeta(
     sourceFile,
     localName,
     options,
@@ -423,6 +435,7 @@ function extractPrimitivePart(
   if (element) model.element = element;
   if (description) model.description = description;
   if (deprecated) model.deprecated = deprecated;
+  if (examples) model.examples = examples;
   return model;
 }
 

--- a/apps/docs/scripts/generated-docs/render.mts
+++ b/apps/docs/scripts/generated-docs/render.mts
@@ -12,6 +12,7 @@ import {
   type ExportInfo,
 } from "./discover.mts";
 import {
+  extractPrimitivePartsFor,
   primitivePartTypeDocName,
   readPrimitiveParts,
 } from "./primitive-extract.mts";
@@ -141,6 +142,37 @@ function renderJsDocExample(value: string): string {
     ? trimmed
     : ["```tsx", trimmed, "```"].join("\n");
   return mdxEscape(example);
+}
+
+type ApiStatus = "stable" | "experimental" | "deprecated";
+
+function isExperimentalDeprecation(deprecated?: string): boolean {
+  return /^(unstable \/ experimental|experimental\b|this (api|feature) is experimental\b|this api is (still )?under active development\b|under active development\b)|\bapi may change\b|\bmay change (without notice|in any release)\b/i.test(
+    deprecated ?? "",
+  );
+}
+
+function apiStatusForDeprecatedTag(deprecated?: string): ApiStatus {
+  if (!deprecated) return "stable";
+  return isExperimentalDeprecation(deprecated) ? "experimental" : "deprecated";
+}
+
+function apiStatusCallout(deprecated?: string): string[] {
+  if (!deprecated) return [];
+  if (apiStatusForDeprecatedTag(deprecated) === "experimental") {
+    return [
+      `<Callout type="tip">`,
+      `<strong>Experimental.</strong> ${mdxEscape(deprecated)}`,
+      `</Callout>`,
+      "",
+    ];
+  }
+  return [
+    `<Callout type="warn">`,
+    `<strong>Deprecated.</strong> ${mdxEscape(deprecated)}`,
+    `</Callout>`,
+    "",
+  ];
 }
 
 function mdxCommentMarker(name: string, boundary: "start" | "end"): string {
@@ -340,10 +372,6 @@ function assertPreservedSlots(
   );
 }
 
-function isUnstableName(name: string): boolean {
-  return name.startsWith("unstable_") || name.startsWith("Unstable_");
-}
-
 const EXPORT_ORDER_BY_PAGE: Record<string, readonly string[]> = {
   "tools/interactables": [
     "unstable_Interactables",
@@ -362,25 +390,40 @@ const EXPORT_ORDER_BY_PAGE: Record<string, readonly string[]> = {
   ],
 };
 
-function exportSortKey(item: ExportInfo): [number, string] {
+const API_STATUS_ORDER = {
+  stable: 0,
+  experimental: 1,
+  deprecated: 2,
+} satisfies Record<ApiStatus, number>;
+
+function exportSortKey(
+  item: ExportInfo,
+): [number, number, number, number, string] {
   const pageOrder = EXPORT_ORDER_BY_PAGE[`${item.section}/${item.page}`];
   const pageIndex = pageOrder?.indexOf(item.name) ?? -1;
-  if (pageIndex !== -1) return [pageIndex, item.name];
-
-  const fallbackGroup = pageOrder ? pageOrder.length : 0;
-  if (isUnstableName(item.name)) return [fallbackGroup + 1, item.name];
-  return [fallbackGroup, item.name];
+  const orderIndex = pageIndex === -1 ? (pageOrder?.length ?? 0) : pageIndex;
+  const roleOrder = { primary: 0, related: 1, "supporting-type": 2 };
+  return [
+    item.pageRole === "supporting-type" ? 1 : 0,
+    API_STATUS_ORDER[apiStatusForDeprecatedTag(item.deprecated)],
+    roleOrder[item.pageRole],
+    orderIndex,
+    item.name,
+  ];
 }
 
 function sortExportsForPage(items: ExportInfo[]): ExportInfo[] {
   return [...items].sort((a, b) => {
-    if (a.pageRole !== b.pageRole) {
-      const roleOrder = { primary: 0, related: 1, "supporting-type": 2 };
-      return roleOrder[a.pageRole] - roleOrder[b.pageRole];
+    const [aSupportingGroup, aStatusGroup, aRoleGroup, aOrderIndex, aName] =
+      exportSortKey(a);
+    const [bSupportingGroup, bStatusGroup, bRoleGroup, bOrderIndex, bName] =
+      exportSortKey(b);
+    if (aSupportingGroup !== bSupportingGroup) {
+      return aSupportingGroup - bSupportingGroup;
     }
-    const [aGroup, aName] = exportSortKey(a);
-    const [bGroup, bName] = exportSortKey(b);
-    if (aGroup !== bGroup) return aGroup - bGroup;
+    if (aStatusGroup !== bStatusGroup) return aStatusGroup - bStatusGroup;
+    if (aRoleGroup !== bRoleGroup) return aRoleGroup - bRoleGroup;
+    if (aOrderIndex !== bOrderIndex) return aOrderIndex - bOrderIndex;
     return aName.localeCompare(bName);
   });
 }
@@ -395,14 +438,7 @@ function exportSection(
   if (!hasGeneratedEntryContent(item, typeDocNames, slots)) return [];
   const heading = "#".repeat(headingLevel);
   const lines = [`${heading} ${item.name}`, ""];
-  if (item.deprecated) {
-    lines.push(
-      `<Callout type="warn">`,
-      `<strong>Deprecated.</strong> ${mdxEscape(item.deprecated)}`,
-      `</Callout>`,
-      "",
-    );
-  }
+  lines.push(...apiStatusCallout(item.deprecated));
   if (item.jsDoc) {
     lines.push(mdxEscape(item.jsDoc), "");
   }
@@ -498,8 +534,21 @@ function generatePrimitiveReferenceRegion(
       lines.push(`### ${part}`, "");
       const partName = `${item.name}.${part}`;
       const example = slots.examples.get(partName);
-      if (example) lines.push(example, "");
-      lines.push(primitiveParametersTable(item.name, part, typeDocNames), "");
+      const examples = example
+        ? [example]
+        : primitiveJsDocExamples(item.name, part, item.jsDocRenderOptions).map(
+            renderJsDocExample,
+          );
+      lines.push(
+        primitiveParametersTable(
+          item.name,
+          part,
+          typeDocNames,
+          item.jsDocRenderOptions,
+          examples,
+        ),
+        "",
+      );
       const manual = slots.namedManual.get(partName);
       if (manual) lines.push(manual, "");
     }
@@ -527,13 +576,51 @@ function generatePrimitiveReferenceRegion(
   return lines.join("\n").trimEnd();
 }
 
+function primitiveJsDocExamples(
+  primitiveName: string,
+  part: string,
+  options: ExportInfo["jsDocRenderOptions"],
+): string[] {
+  return primitivePartFor(primitiveName, part, options)?.examples ?? [];
+}
+
+function primitivePartFor(
+  primitiveName: string,
+  part: string,
+  options: ExportInfo["jsDocRenderOptions"],
+) {
+  return extractPrimitivePartsFor(primitiveName, options).find(
+    (primitivePart) => primitivePart.partName === part,
+  );
+}
+
 function primitiveParametersTable(
   primitiveName: string,
   part: string,
   typeDocNames: Set<string>,
+  options: ExportInfo["jsDocRenderOptions"],
+  examples: string[],
 ): string {
   const binding = `${primitiveName}Docs.${part}`;
   const typeDocName = primitivePartTypeDocName(primitiveName, part);
+  const statusCallout =
+    apiStatusForDeprecatedTag(
+      primitivePartFor(primitiveName, part, options)?.deprecated,
+    ) === "experimental"
+      ? [
+          `{${binding}?.deprecated && (`,
+          `  <Callout type="tip">`,
+          `    <strong>Experimental.</strong> {${binding}.deprecated}`,
+          `  </Callout>`,
+          `)}`,
+        ]
+      : [
+          `{${binding}?.deprecated && (`,
+          `  <Callout type="warn">`,
+          `    <strong>Deprecated.</strong> {${binding}.deprecated}`,
+          `  </Callout>`,
+          `)}`,
+        ];
   const table = typeDocNames.has(typeDocName)
     ? `<ParametersTable {...${typeDocName}} />`
     : [
@@ -542,11 +629,7 @@ function primitiveParametersTable(
         `)}`,
       ].join("\n");
   return [
-    `{${binding}?.deprecated && (`,
-    `  <Callout type="warn">`,
-    `    <strong>Deprecated.</strong> {${binding}.deprecated}`,
-    `  </Callout>`,
-    `)}`,
+    ...statusCallout,
     "",
     `{${binding}?.description}`,
     "",
@@ -554,6 +637,7 @@ function primitiveParametersTable(
     `  <p>This primitive renders a <code>{\`<\${${binding}?.element}>\`}</code> element unless <code>asChild</code> is set.</p>`,
     `)}`,
     "",
+    ...examples.flatMap((example) => [example, ""]),
     table,
   ].join("\n");
 }

--- a/apps/docs/scripts/generated-docs/render.mts
+++ b/apps/docs/scripts/generated-docs/render.mts
@@ -15,6 +15,7 @@ import {
   extractPrimitivePartsFor,
   primitivePartTypeDocName,
   readPrimitiveParts,
+  type PrimitivePartModel,
 } from "./primitive-extract.mts";
 import type { TypeDoc, TypeDocBindings } from "./type-docs.mts";
 
@@ -147,7 +148,7 @@ function renderJsDocExample(value: string): string {
 type ApiStatus = "stable" | "experimental" | "deprecated";
 
 function isExperimentalDeprecation(deprecated?: string): boolean {
-  return /^(unstable \/ experimental|experimental\b|this (api|feature) is experimental\b|this api is (still )?under active development\b|under active development\b)|\bapi may change\b|\bmay change (without notice|in any release)\b/i.test(
+  return /^(unstable \/ experimental|experimental\b|this (api|feature) is experimental\b|this api is (still )?under active development\b|under active development\b)/i.test(
     deprecated ?? "",
   );
 }
@@ -396,17 +397,22 @@ const API_STATUS_ORDER = {
   deprecated: 2,
 } satisfies Record<ApiStatus, number>;
 
+const PAGE_ROLE_ORDER = {
+  primary: 0,
+  related: 1,
+  "supporting-type": 2,
+} satisfies Record<ExportInfo["pageRole"], number>;
+
 function exportSortKey(
   item: ExportInfo,
 ): [number, number, number, number, string] {
   const pageOrder = EXPORT_ORDER_BY_PAGE[`${item.section}/${item.page}`];
   const pageIndex = pageOrder?.indexOf(item.name) ?? -1;
   const orderIndex = pageIndex === -1 ? (pageOrder?.length ?? 0) : pageIndex;
-  const roleOrder = { primary: 0, related: 1, "supporting-type": 2 };
   return [
     item.pageRole === "supporting-type" ? 1 : 0,
     API_STATUS_ORDER[apiStatusForDeprecatedTag(item.deprecated)],
-    roleOrder[item.pageRole],
+    PAGE_ROLE_ORDER[item.pageRole],
     orderIndex,
     item.name,
   ];
@@ -533,18 +539,21 @@ function generatePrimitiveReferenceRegion(
     for (const part of parts) {
       lines.push(`### ${part}`, "");
       const partName = `${item.name}.${part}`;
+      const primitivePart = primitivePartFor(
+        item.name,
+        part,
+        item.jsDocRenderOptions,
+      );
       const example = slots.examples.get(partName);
       const examples = example
         ? [example]
-        : primitiveJsDocExamples(item.name, part, item.jsDocRenderOptions).map(
-            renderJsDocExample,
-          );
+        : (primitivePart?.examples ?? []).map(renderJsDocExample);
       lines.push(
         primitiveParametersTable(
           item.name,
           part,
           typeDocNames,
-          item.jsDocRenderOptions,
+          primitivePart,
           examples,
         ),
         "",
@@ -576,14 +585,6 @@ function generatePrimitiveReferenceRegion(
   return lines.join("\n").trimEnd();
 }
 
-function primitiveJsDocExamples(
-  primitiveName: string,
-  part: string,
-  options: ExportInfo["jsDocRenderOptions"],
-): string[] {
-  return primitivePartFor(primitiveName, part, options)?.examples ?? [];
-}
-
 function primitivePartFor(
   primitiveName: string,
   part: string,
@@ -598,15 +599,13 @@ function primitiveParametersTable(
   primitiveName: string,
   part: string,
   typeDocNames: Set<string>,
-  options: ExportInfo["jsDocRenderOptions"],
+  primitivePart: PrimitivePartModel | undefined,
   examples: string[],
 ): string {
   const binding = `${primitiveName}Docs.${part}`;
   const typeDocName = primitivePartTypeDocName(primitiveName, part);
   const statusCallout =
-    apiStatusForDeprecatedTag(
-      primitivePartFor(primitiveName, part, options)?.deprecated,
-    ) === "experimental"
+    apiStatusForDeprecatedTag(primitivePart?.deprecated) === "experimental"
       ? [
           `{${binding}?.deprecated && (`,
           `  <Callout type="tip">`,


### PR DESCRIPTION
- Primitive api-ref now extracts JSDoc examples and renders them on the page like other api-reference sections
- Don’t mark experimental items as deprecated, mark as experimental
- Sort pages by normal, experimental, deprecated
- Regenerate reference to fill items from recent PRs

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

