### PR TITLE
feat(mcp-docs-server): adopt registerTool API with read-only annotations

### DIFF
--- a/.changeset/mcp-docs-server-register-tool.md
+++ b/.changeset/mcp-docs-server-register-tool.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/mcp-docs-server": patch
+---
+
+feat: adopt registerTool API and advertise read-only tool annotations

--- a/packages/mcp-docs-server/src/index.ts
+++ b/packages/mcp-docs-server/src/index.ts
@@ -17,16 +17,24 @@ export const server = new McpServer({
   version: packageJson.version,
 });
 
-server.tool(
+server.registerTool(
   docsTools.name,
-  docsTools.description,
-  docsTools.parameters,
+  {
+    title: "assistant-ui Documentation",
+    description: docsTools.description,
+    inputSchema: docsTools.parameters,
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  },
   docsTools.execute,
 );
-server.tool(
+server.registerTool(
   examplesTools.name,
-  examplesTools.description,
-  examplesTools.parameters,
+  {
+    title: "assistant-ui Examples",
+    description: examplesTools.description,
+    inputSchema: examplesTools.parameters,
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  },
   examplesTools.execute,
 );
 

--- a/packages/mcp-docs-server/src/tools/tests/mcp-protocol.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/mcp-protocol.test.ts
@@ -73,6 +73,16 @@ describe("MCP Protocol Integration", () => {
     expect(examplesTool.inputSchema).toBeDefined();
     expect(examplesTool.inputSchema.type).toBe("object");
     expect(examplesTool.inputSchema.properties).toBeDefined();
+
+    // registerTool metadata is surfaced on tools/list
+    expect(docsTool.annotations?.readOnlyHint).toBe(true);
+    expect(docsTool.annotations?.title ?? docsTool.title).toBe(
+      "assistant-ui Documentation",
+    );
+    expect(examplesTool.annotations?.readOnlyHint).toBe(true);
+    expect(examplesTool.annotations?.title ?? examplesTool.title).toBe(
+      "assistant-ui Examples",
+    );
   });
 
   it("should handle CallTool request for assistantUIDocs", async () => {

--- a/packages/mcp-docs-server/src/tools/tests/mcp-protocol.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/mcp-protocol.test.ts
@@ -74,15 +74,14 @@ describe("MCP Protocol Integration", () => {
     expect(examplesTool.inputSchema.type).toBe("object");
     expect(examplesTool.inputSchema.properties).toBeDefined();
 
-    // registerTool metadata is surfaced on tools/list
+    // registerTool metadata is surfaced on tools/list: `title` is a
+    // top-level field, `annotations` carries only the hint flags.
+    expect(docsTool.title).toBe("assistant-ui Documentation");
     expect(docsTool.annotations?.readOnlyHint).toBe(true);
-    expect(docsTool.annotations?.title ?? docsTool.title).toBe(
-      "assistant-ui Documentation",
-    );
+    expect(docsTool.annotations?.openWorldHint).toBe(false);
+    expect(examplesTool.title).toBe("assistant-ui Examples");
     expect(examplesTool.annotations?.readOnlyHint).toBe(true);
-    expect(examplesTool.annotations?.title ?? examplesTool.title).toBe(
-      "assistant-ui Examples",
-    );
+    expect(examplesTool.annotations?.openWorldHint).toBe(false);
   });
 
   it("should handle CallTool request for assistantUIDocs", async () => {


### PR DESCRIPTION
## What

Migrate `mcp-docs-server` from the deprecated `server.tool()` registration API to `server.registerTool()`, and advertise both tools as read-only.

## Why

`@modelcontextprotocol/sdk` marks `server.tool()` `@deprecated` in favor of `registerTool()`. The newer API lets the server attach a human-readable `title` and tool `annotations`. Both `assistantUIDocs` and `assistantUIExamples` are pure reads of a baked, local documentation set, so they now advertise `readOnlyHint: true` and `openWorldHint: false`, which are accurate hints MCP clients can surface.

## How

- `src/index.ts`: replace the two `server.tool(...)` calls with `server.registerTool(name, { title, description, inputSchema, annotations }, execute)`. The same input schema and execute callback are reused, so the tool names, input schemas, and response shapes are unchanged. This is additive metadata only, not a contract change.
- Add assertions to the existing `tools/list` protocol test confirming the new `title`/`readOnlyHint` are surfaced.
- No changes to the tool modules or their `zod/v3` schemas (left for a separate PR).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

