### PR TITLE
fix(mcp-docs-server): stop bundling unused blog posts

### DIFF
--- a/.changeset/mcp-docs-server-drop-blog-bake.md
+++ b/.changeset/mcp-docs-server-drop-blog-bake.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/mcp-docs-server": patch
+---
+
+fix: do not bundle unused blog posts in the docs server

--- a/packages/mcp-docs-server/src/prepare-docs/copy-raw.ts
+++ b/packages/mcp-docs-server/src/prepare-docs/copy-raw.ts
@@ -4,7 +4,6 @@ import { logger } from "../utils/logger.js";
 import { ROOT_DIR } from "../constants.js";
 
 const DOCS_SOURCE = join(ROOT_DIR, "apps/docs/content/docs");
-const BLOG_SOURCE = join(ROOT_DIR, "apps/docs/content/blog");
 const DOCS_DEST = join(ROOT_DIR, "packages/mcp-docs-server/.docs/raw");
 
 async function copyDir(src: string, dest: string): Promise<void> {
@@ -42,10 +41,6 @@ export async function copyRaw(): Promise<void> {
     const docsPath = join(DOCS_DEST, "docs");
     await copyDir(DOCS_SOURCE, docsPath);
     logger.info(`Copied documentation to ${docsPath}`);
-
-    const blogPath = join(DOCS_DEST, "blog");
-    await copyDir(BLOG_SOURCE, blogPath);
-    logger.info(`Copied blog posts to ${blogPath}`);
 
     logger.info("Raw documentation copy complete");
   } catch (error) {


### PR DESCRIPTION
## What

Remove the blog copy from the docs server's build-time content preparation. `src/prepare-docs/copy-raw.ts` was copying `apps/docs/content/blog` into the shipped `.docs/raw/blog` directory, but nothing reads it.

## Why

The two tools only serve `.docs/raw/docs` (`assistantUIDocs`) and `.docs/organized/code-examples` (`assistantUIExamples`). No constant, tool, or test references `.docs/raw/blog`, so the baked blog posts were dead content shipped in the npm tarball (`files: [".docs"]`). Blog content is already served to agents by the docs site itself (`/blog/llms.md/[slug]`), so this removes redundant, unreachable bytes from the package.

## How

Delete the `BLOG_SOURCE` constant and the blog copy block (plus its log line) in `copyRaw()`. Docs and examples preparation are unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

