### PR TITLE
feat: re-export unstable interactable helpers from platform barrels

### DIFF
--- a/.changeset/unstable-interactable-barrels.md
+++ b/.changeset/unstable-interactable-barrels.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+---
+
+feat: re-export unstable interactable snapshot helpers from native and ink barrels

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -251,6 +251,13 @@ export type {
   LanguageModelV1CallSettings,
 } from "@assistant-ui/core";
 export { mergeModelContexts } from "@assistant-ui/core";
+export {
+  unstable_getInteractableSnapshots,
+  unstable_formatInteractableSnapshot,
+  unstable_getInteractableVersions,
+  type Unstable_InteractableSnapshotEntry,
+  type Unstable_InteractableVersion,
+} from "@assistant-ui/core";
 export type { Tool } from "assistant-stream";
 export { tool } from "@assistant-ui/core";
 export { Suggestions, type SuggestionConfig } from "@assistant-ui/core/store";

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -218,6 +218,14 @@ export type {
 
 export { mergeModelContexts } from "@assistant-ui/core";
 
+export {
+  unstable_getInteractableSnapshots,
+  unstable_formatInteractableSnapshot,
+  unstable_getInteractableVersions,
+  type Unstable_InteractableSnapshotEntry,
+  type Unstable_InteractableVersion,
+} from "@assistant-ui/core";
+
 export type { ExportedMessageRepositoryItem } from "@assistant-ui/core";
 export { ExportedMessageRepository } from "@assistant-ui/core";
 


### PR DESCRIPTION
## Summary

Re-export the interactable snapshot/version helpers from the React Native and Ink public barrels:

- `unstable_getInteractableSnapshots`
- `unstable_formatInteractableSnapshot`
- `unstable_getInteractableVersions`
- related `Unstable_InteractableSnapshotEntry` and `Unstable_InteractableVersion` types

## Context

This follows the recent interactables redesign in #4310, which introduced the unstable interactables API and exposed these helper names through `@assistant-ui/core` and the web `@assistant-ui/react` barrel. This PR finishes the same public-barrel surface for `@assistant-ui/react-native` and `@assistant-ui/react-ink`.

## Why

The helpers already live in `@assistant-ui/core` and are available through `@assistant-ui/react`, but the platform distribution barrels did not expose them. That creates an import parity gap for users who follow the package boundary and import from their chosen distribution package instead of reaching into core directly.

Before this change, TypeScript export resolution failed with errors like:

```text
"./packages/react-native/dist/index" has no exported member named 'unstable_getInteractableSnapshots'. Did you mean 'unstable_Interactables'?
"./packages/react-ink/dist/index" has no exported member named 'unstable_getInteractableSnapshots'. Did you mean 'unstable_Interactables'?
```

The helpers are pure message/history utilities, not DOM-specific UI APIs, so the same core implementations are usable from React Native and Ink.

## Validation

- `pnpm exec turbo build --filter=@assistant-ui/react-native --filter=@assistant-ui/react-ink`
- TypeScript export-resolution check against `packages/react-native/dist/index` and `packages/react-ink/dist/index` now reports `ok` for the three unstable helper imports.