### PR TITLE
fix(mcp-docs-server): cap aggregate directory content size

### DIFF
--- a/.changeset/mcp-docs-dir-size-cap.md
+++ b/.changeset/mcp-docs-dir-size-cap.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/mcp-docs-server": patch
+---
+
+fix: cap aggregate directory content size in assistantUIDocs

--- a/packages/mcp-docs-server/src/constants.ts
+++ b/packages/mcp-docs-server/src/constants.ts
@@ -17,6 +17,8 @@ export const MD_EXTENSION = ".md";
 
 export const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
+export const MAX_DIRECTORY_CONTENT_SIZE = 1024 * 1024;
+
 export const IS_PREPARE_MODE = process.argv[1]?.includes(
   "prepare-docs/prepare",
 );

--- a/packages/mcp-docs-server/src/tools/docs.ts
+++ b/packages/mcp-docs-server/src/tools/docs.ts
@@ -88,8 +88,17 @@ async function readDocumentation(docPath: string): Promise<DocResult> {
         let aggregateSize = 0;
         let truncated = false;
         for (const file of files) {
-          const fileStats = await stat(join(fullPath, file));
-          aggregateSize += fileStats.size;
+          let fileSize: number;
+          try {
+            fileSize = (await stat(join(fullPath, file))).size;
+          } catch (error) {
+            logger.warn(
+              `Failed to stat MDX file: ${join(fullPath, file)}`,
+              error,
+            );
+            continue;
+          }
+          aggregateSize += fileSize;
           if (aggregateSize > MAX_DIRECTORY_CONTENT_SIZE) {
             truncated = true;
             break;

--- a/packages/mcp-docs-server/src/tools/docs.ts
+++ b/packages/mcp-docs-server/src/tools/docs.ts
@@ -1,7 +1,12 @@
 import { z } from "zod/v3";
 import { stat, lstat } from "node:fs/promises";
 import { join, extname } from "node:path";
-import { DOCS_PATH, MDX_EXTENSION, MAX_FILE_SIZE } from "../constants.js";
+import {
+  DOCS_PATH,
+  MDX_EXTENSION,
+  MAX_FILE_SIZE,
+  MAX_DIRECTORY_CONTENT_SIZE,
+} from "../constants.js";
 import { logger } from "../utils/logger.js";
 import {
   listDirContents,
@@ -30,6 +35,7 @@ interface DocResult {
   files?: string[];
   directories?: string[];
   suggestions?: string[];
+  hint?: string;
   error?: string;
 }
 
@@ -79,16 +85,24 @@ async function readDocumentation(docPath: string): Promise<DocResult> {
         const { directories, files } = await listDirContents(fullPath);
 
         const contents: Record<string, string> = {};
+        let aggregateSize = 0;
+        let truncated = false;
         for (const file of files) {
           const mdxContent = await readMDXFile(join(fullPath, file));
           if (mdxContent) {
+            const formatted = formatMDXContent(mdxContent);
+            aggregateSize += Buffer.byteLength(formatted, "utf-8");
+            if (aggregateSize > MAX_DIRECTORY_CONTENT_SIZE) {
+              truncated = true;
+              break;
+            }
             const fileName = file.replace(MDX_EXTENSION, "");
-            contents[fileName] = formatMDXContent(mdxContent);
+            contents[fileName] = formatted;
           }
         }
 
         const content =
-          Object.keys(contents).length > 0
+          !truncated && Object.keys(contents).length > 0
             ? JSON.stringify(contents, null, 2)
             : undefined;
         return {
@@ -98,6 +112,9 @@ async function readDocumentation(docPath: string): Promise<DocResult> {
           directories,
           files: files.map((f) => f.replace(MDX_EXTENSION, "")),
           ...(content !== undefined && { content }),
+          ...(truncated && {
+            hint: `Directory content exceeds ${MAX_DIRECTORY_CONTENT_SIZE} bytes and was omitted; request individual files by path to retrieve their content.`,
+          }),
         };
       }
     }

--- a/packages/mcp-docs-server/src/tools/docs.ts
+++ b/packages/mcp-docs-server/src/tools/docs.ts
@@ -88,16 +88,16 @@ async function readDocumentation(docPath: string): Promise<DocResult> {
         let aggregateSize = 0;
         let truncated = false;
         for (const file of files) {
+          const fileStats = await stat(join(fullPath, file));
+          aggregateSize += fileStats.size;
+          if (aggregateSize > MAX_DIRECTORY_CONTENT_SIZE) {
+            truncated = true;
+            break;
+          }
           const mdxContent = await readMDXFile(join(fullPath, file));
           if (mdxContent) {
-            const formatted = formatMDXContent(mdxContent);
-            aggregateSize += Buffer.byteLength(formatted, "utf-8");
-            if (aggregateSize > MAX_DIRECTORY_CONTENT_SIZE) {
-              truncated = true;
-              break;
-            }
-            const fileName = file.replace(MDX_EXTENSION, "");
-            contents[fileName] = formatted;
+            contents[file.replace(MDX_EXTENSION, "")] =
+              formatMDXContent(mdxContent);
           }
         }
 

--- a/packages/mcp-docs-server/src/tools/tests/directory-size-cap.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/directory-size-cap.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../utils/mdx.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../utils/mdx.js")>()),
+  readMDXFile: vi.fn(async () => ({
+    content: "x".repeat(600 * 1024),
+    frontmatter: {},
+  })),
+  formatMDXContent: (mdx: { content: string }) => mdx.content,
+}));
+
+import { docsTools } from "../docs.js";
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0]!.text);
+}
+
+describe("assistantUIDocs directory aggregate size cap", () => {
+  it("omits inlined content and returns a hint when a directory exceeds the cap", async () => {
+    const result = await docsTools.execute({
+      paths: ["(reference)/api-reference/primitives"],
+    });
+    const parsed = parse(result);
+
+    expect(parsed.type).toBe("directory");
+    expect(parsed.files.length).toBeGreaterThan(1);
+    expect(parsed.content).toBeUndefined();
+    expect(parsed.hint).toContain("exceeds");
+  });
+});

--- a/packages/mcp-docs-server/src/tools/tests/directory-size-cap.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/directory-size-cap.test.ts
@@ -1,5 +1,25 @@
 import { describe, it, expect, vi } from "vitest";
 
+vi.mock("../../utils/paths.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../utils/paths.js")>()),
+  listDirContents: vi.fn(async () => ({
+    directories: [],
+    files: ["first.mdx", "second.mdx"],
+  })),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    stat: vi.fn(async (path: string) => ({
+      isFile: () => path.endsWith(".mdx"),
+      isDirectory: () => !path.endsWith(".mdx"),
+      size: 600 * 1024,
+    })),
+  };
+});
+
 vi.mock("../../utils/mdx.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../utils/mdx.js")>()),
   readMDXFile: vi.fn(async () => ({
@@ -23,7 +43,7 @@ describe("assistantUIDocs directory aggregate size cap", () => {
     const parsed = parse(result);
 
     expect(parsed.type).toBe("directory");
-    expect(parsed.files.length).toBeGreaterThan(1);
+    expect(parsed.files).toEqual(["first", "second"]);
     expect(parsed.content).toBeUndefined();
     expect(parsed.hint).toContain("exceeds");
   });


### PR DESCRIPTION
## What
`assistantUIDocs` caps per-file size (`MAX_FILE_SIZE`) but, when reading a directory, inlines every file's content into one response with no aggregate limit. This adds an aggregate ceiling: once the combined inlined content exceeds `MAX_DIRECTORY_CONTENT_SIZE` (1 MB), the response drops the inlined `content` and returns the directory listing only, with a hint to fetch individual files.

## Why
A directory with many or large files could otherwise produce an unbounded MCP response and blow the client's context window. The root `/` listing already returns list-only; this closes the same gap for sub-directories. Behavior is unchanged for directories under the cap.

## How
- Add `MAX_DIRECTORY_CONTENT_SIZE` to constants.
- In the directory branch of `readDocumentation`, accumulate byte size while inlining; once it exceeds the cap, stop, omit `content`, and add a `hint`.
- Add a test that trips the cap with oversized mocked content against a real docs directory.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

