### PR TITLE
fix: re-export platform context providers

### DIFF
--- a/.changeset/platform-provider-barrel-exports.md
+++ b/.changeset/platform-provider-barrel-exports.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-ink": patch
+"@assistant-ui/react-native": patch
+---
+
+fix: re-export documented context providers from platform barrels

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -166,8 +166,11 @@ export {
 // Re-export shared providers from core/react
 export {
   ThreadListItemByIndexProvider,
+  ThreadListItemRuntimeProvider,
   ChainOfThoughtByIndicesProvider,
   MessageByIndexProvider,
+  MessageAttachmentByIndexProvider,
+  ComposerAttachmentByIndexProvider,
   PartByIndexProvider,
   TextMessagePartProvider,
   ChainOfThoughtPartByIndexProvider,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -137,8 +137,11 @@ export { unstable_useThreadMessageIds } from "@assistant-ui/core/react";
 // Re-export shared providers from core/react
 export {
   ThreadListItemByIndexProvider,
+  ThreadListItemRuntimeProvider,
   ChainOfThoughtByIndicesProvider,
   MessageByIndexProvider,
+  MessageAttachmentByIndexProvider,
+  ComposerAttachmentByIndexProvider,
   PartByIndexProvider,
   TextMessagePartProvider,
   ChainOfThoughtPartByIndexProvider,


### PR DESCRIPTION
## Summary

Re-export the documented low-level context providers from the `@assistant-ui/react-ink` and `@assistant-ui/react-native` package roots:

- `ThreadListItemRuntimeProvider`
- `MessageAttachmentByIndexProvider`
- `ComposerAttachmentByIndexProvider`

## Why

The Ink hooks docs page documents these providers as root imports from `@assistant-ui/react-ink` in the Context Providers section:

- Source: `apps/docs/content/docs/ink/hooks.mdx`
- Public docs page: https://www.assistant-ui.com/docs/ink/hooks
- Referenced sections: `ThreadListItemRuntimeProvider`, `MessageAttachmentByIndexProvider`, and `ComposerAttachmentByIndexProvider`

Following those documented imports currently fails after a proper package build because the provider implementations exist internally, but the platform root barrels do not expose them.

Example error before this change:

```text
Module '"@assistant-ui/react-ink"' has no exported member 'ThreadListItemRuntimeProvider'.
Module '"@assistant-ui/react-ink"' has no exported member 'MessageAttachmentByIndexProvider'.
Module '"@assistant-ui/react-ink"' has no exported member 'ComposerAttachmentByIndexProvider'.
```

## Affected Usage

This does not affect basic primitive usage where the built-in primitive components set up context internally. It affects advanced/custom primitive composition that follows the docs and manually scopes lower-level contexts, for example:

```tsx
import {
  AttachmentPrimitive,
  MessageAttachmentByIndexProvider,
  ThreadListItemPrimitive,
  ThreadListItemRuntimeProvider,
} from "@assistant-ui/react-ink";

<ThreadListItemRuntimeProvider runtime={threadListItemRuntime}>
  <ThreadListItemPrimitive.Root />
</ThreadListItemRuntimeProvider>;

<MessageAttachmentByIndexProvider index={0}>
  <AttachmentPrimitive.Name />
</MessageAttachmentByIndexProvider>;
```

React Native has the same platform barrel gap for the matching provider files, so this keeps the platform packages consistent and lets advanced/custom primitive composition import these helpers from the distribution package instead of reaching into `@assistant-ui/core/react`.

## Validation

- `pnpm exec turbo build --filter=@assistant-ui/react-ink --filter=@assistant-ui/react-native`
- Focused TypeScript import check against rebuilt `packages/react-ink/dist/index` and `packages/react-native/dist/index` for the three providers

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->