### PR TITLE
fix: avoid false positives in use-generative directive in compiler

### DIFF
--- a/.changeset/tighten-generative-directive-detection.md
+++ b/.changeset/tighten-generative-directive-detection.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-generative-compiler": patch
+---
+
+fix: avoid false positives when detecting use-generative directives

--- a/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.test.ts
+++ b/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { createTapRoot, useResource } from "@assistant-ui/tap";
+import { createTapRoot, flushTapSync, useResource } from "@assistant-ui/tap";
 import type {
   Unstable_TriggerCategory,
   Unstable_TriggerItem,
@@ -22,8 +22,6 @@ const makeKeyEvent = (key: string, shiftKey = false) => ({
   shiftKey,
   preventDefault: vi.fn(),
 });
-
-const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 const render = (
   overrides: Partial<Parameters<typeof TriggerKeyboardResource>[0]> = {},
@@ -106,55 +104,53 @@ describe("TriggerKeyboardResource", () => {
     expect(props.selectItem).not.toHaveBeenCalled();
   });
 
-  it("moves the highlight forward on ArrowDown", async () => {
+  it("moves the highlight forward on ArrowDown", () => {
     const { sub } = render();
 
-    const consumed = sub.getValue().handleKeyDown(makeKeyEvent("ArrowDown"));
-    await tick();
+    const consumed = flushTapSync(() =>
+      sub.getValue().handleKeyDown(makeKeyEvent("ArrowDown")),
+    );
 
     expect(consumed).toBe(true);
     expect(sub.getValue().highlightedIndex).toBe(1);
   });
 
-  it("wraps the highlight to the top on ArrowDown past the last entry", async () => {
+  it("wraps the highlight to the top on ArrowDown past the last entry", () => {
     const { sub } = render();
     const handle = sub.getValue().handleKeyDown;
 
-    handle(makeKeyEvent("ArrowDown"));
-    handle(makeKeyEvent("ArrowDown"));
-    handle(makeKeyEvent("ArrowDown"));
-    await tick();
+    flushTapSync(() => {
+      handle(makeKeyEvent("ArrowDown"));
+      handle(makeKeyEvent("ArrowDown"));
+      handle(makeKeyEvent("ArrowDown"));
+    });
 
     expect(sub.getValue().highlightedIndex).toBe(0);
   });
 
-  it("moves the highlight backward on ArrowUp", async () => {
+  it("moves the highlight backward on ArrowUp", () => {
     const { sub } = render();
     const handle = sub.getValue().handleKeyDown;
 
-    handle(makeKeyEvent("ArrowDown"));
-    await tick();
-    handle(makeKeyEvent("ArrowUp"));
-    await tick();
+    flushTapSync(() => handle(makeKeyEvent("ArrowDown")));
+    flushTapSync(() => handle(makeKeyEvent("ArrowUp")));
 
     expect(sub.getValue().highlightedIndex).toBe(0);
   });
 
-  it("wraps the highlight to the bottom on ArrowUp from the first entry", async () => {
+  it("wraps the highlight to the bottom on ArrowUp from the first entry", () => {
     const { sub } = render();
 
-    sub.getValue().handleKeyDown(makeKeyEvent("ArrowUp"));
-    await tick();
+    flushTapSync(() => sub.getValue().handleKeyDown(makeKeyEvent("ArrowUp")));
 
     expect(sub.getValue().highlightedIndex).toBe(2);
   });
 
-  it("keeps the highlight at 0 on ArrowDown when navigableList is empty", async () => {
+  it("keeps the highlight at 0 on ArrowDown when navigableList is empty", () => {
     const { sub } = render({ navigableList: [] });
     const e = makeKeyEvent("ArrowDown");
 
-    const consumed = sub.getValue().handleKeyDown(e);
-    await tick();
+    const consumed = flushTapSync(() => sub.getValue().handleKeyDown(e));
 
     expect(consumed).toBe(true);
     expect(e.preventDefault).toHaveBeenCalled();

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -1444,11 +1444,27 @@ export default defineToolkit({
       isGenerativeModule(`"use generative" + suffix;\nexport default {};`),
     ).toBe(false);
     expect(
+      isGenerativeModule(`"use generative"\n+ suffix;\nexport default {};`),
+    ).toBe(false);
+    expect(
       isGenerativeModule(`"use generative".toString();\nexport default {};`),
+    ).toBe(false);
+    expect(
+      isGenerativeModule(`"use generative"\n.toString();\nexport default {};`),
+    ).toBe(false);
+    expect(
+      isGenerativeModule(
+        `"use generative" // comment\n+ suffix;\nexport default {};`,
+      ),
     ).toBe(false);
     expect(
       isGenerativeModule(
         `"use generative" /* no line break */ + suffix;\nexport default {};`,
+      ),
+    ).toBe(false);
+    expect(
+      isGenerativeModule(
+        `"use generative" /* first line\nsecond line */ + suffix;\nexport default {};`,
       ),
     ).toBe(false);
   });

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -1430,6 +1430,26 @@ export default defineToolkit({
       true,
     );
     expect(isGenerativeModule(`// a comment\n"use generative";\n`)).toBe(true);
+    expect(isGenerativeModule(`"use generative"\nexport default {};`)).toBe(
+      true,
+    );
+    expect(
+      isGenerativeModule(`"use generative" // comment\nexport default {};`),
+    ).toBe(true);
+    expect(
+      isGenerativeModule(`"use generative" /* comment */;\nexport default {};`),
+    ).toBe(true);
     expect(isGenerativeModule(`export default {};`)).toBe(false);
+    expect(
+      isGenerativeModule(`"use generative" + suffix;\nexport default {};`),
+    ).toBe(false);
+    expect(
+      isGenerativeModule(`"use generative".toString();\nexport default {};`),
+    ).toBe(false);
+    expect(
+      isGenerativeModule(
+        `"use generative" /* no line break */ + suffix;\nexport default {};`,
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -112,9 +112,59 @@ export function isGenerativeModule(code: string): boolean {
       break;
     }
   }
-  return (
-    code.startsWith(`"${DIRECTIVE}"`, i) || code.startsWith(`'${DIRECTIVE}'`, i)
-  );
+
+  const quote = code[i];
+  if (quote !== '"' && quote !== "'") return false;
+
+  const directiveStart = i + 1;
+  if (!code.startsWith(DIRECTIVE, directiveStart)) return false;
+
+  const directiveEnd = directiveStart + DIRECTIVE.length;
+  if (code[directiveEnd] !== quote) return false;
+
+  return hasDirectiveTerminator(code, directiveEnd + 1);
+}
+
+function hasDirectiveTerminator(code: string, start: number): boolean {
+  let i = start;
+  for (;;) {
+    if (i >= code.length) return true;
+
+    const char = code.charCodeAt(i);
+    if (char === 59 || isLineTerminator(char)) return true;
+
+    if (code.startsWith("//", i)) return true;
+
+    if (code.startsWith("/*", i)) {
+      const end = code.indexOf("*/", i + 2);
+      if (end === -1) return false;
+      if (containsLineTerminator(code, i + 2, end)) return true;
+      i = end + 2;
+      continue;
+    }
+
+    if (/\s/.test(code[i]!)) {
+      i++;
+      continue;
+    }
+
+    return false;
+  }
+}
+
+function containsLineTerminator(
+  code: string,
+  start: number,
+  end: number,
+): boolean {
+  for (let i = start; i < end; i++) {
+    if (isLineTerminator(code.charCodeAt(i))) return true;
+  }
+  return false;
+}
+
+function isLineTerminator(char: number): boolean {
+  return char === 10 || char === 13 || char === 0x2028 || char === 0x2029;
 }
 
 /**

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -127,18 +127,30 @@ export function isGenerativeModule(code: string): boolean {
 
 function hasDirectiveTerminator(code: string, start: number): boolean {
   let i = start;
+  let sawLineTerminator = false;
   for (;;) {
     if (i >= code.length) return true;
 
     const char = code.charCodeAt(i);
-    if (char === 59 || isLineTerminator(char)) return true;
+    if (isSemicolon(char)) return true;
+    if (isLineTerminator(char)) {
+      sawLineTerminator = true;
+      i++;
+      continue;
+    }
 
-    if (code.startsWith("//", i)) return true;
+    if (code.startsWith("//", i)) {
+      const lineEnd = nextLineTerminatorIndex(code, i + 2);
+      if (lineEnd === -1) return true;
+      sawLineTerminator = true;
+      i = lineEnd + 1;
+      continue;
+    }
 
     if (code.startsWith("/*", i)) {
       const end = code.indexOf("*/", i + 2);
       if (end === -1) return false;
-      if (containsLineTerminator(code, i + 2, end)) return true;
+      sawLineTerminator ||= containsLineTerminator(code, i + 2, end);
       i = end + 2;
       continue;
     }
@@ -148,8 +160,15 @@ function hasDirectiveTerminator(code: string, start: number): boolean {
       continue;
     }
 
-    return false;
+    return sawLineTerminator && !startsExpressionContinuation(code, i);
   }
+}
+
+function nextLineTerminatorIndex(code: string, start: number): number {
+  for (let i = start; i < code.length; i++) {
+    if (isLineTerminator(code.charCodeAt(i))) return i;
+  }
+  return -1;
 }
 
 function containsLineTerminator(
@@ -161,6 +180,52 @@ function containsLineTerminator(
     if (isLineTerminator(code.charCodeAt(i))) return true;
   }
   return false;
+}
+
+function startsExpressionContinuation(code: string, start: number): boolean {
+  switch (code[start]) {
+    case ".":
+    case "+":
+    case "-":
+    case "*":
+    case "/":
+    case "%":
+    case "<":
+    case ">":
+    case "=":
+    case "!":
+    case "&":
+    case "|":
+    case "^":
+    case "?":
+    case ":":
+    case ",":
+    case "[":
+    case "(":
+    case "`":
+      return true;
+  }
+
+  return (
+    startsKeywordContinuation(code, start, "as") ||
+    startsKeywordContinuation(code, start, "in") ||
+    startsKeywordContinuation(code, start, "instanceof") ||
+    startsKeywordContinuation(code, start, "satisfies")
+  );
+}
+
+function startsKeywordContinuation(
+  code: string,
+  start: number,
+  keyword: string,
+): boolean {
+  if (!code.startsWith(keyword, start)) return false;
+  const next = code[start + keyword.length];
+  return next === undefined || !/[\p{ID_Continue}$]/u.test(next);
+}
+
+function isSemicolon(char: number): boolean {
+  return char === 59;
 }
 
 function isLineTerminator(char: number): boolean {


### PR DESCRIPTION
## Summary

Tightens `isGenerativeModule()` so the fast loader gate only accepts a complete `"use generative"` directive statement instead of any source that merely starts with that string.

## False-positive example

Before this fix, this source made `isGenerativeModule()` return `true` even though it is not a directive prologue:

```ts
"use generative" + suffix; // while suffix being any random thing
```

That meant the Next, Vite, or Metro loader could send the file into `compileGenerative()`, which then parsed the AST correctly and failed with `missing "use generative" directive`. After this fix, the fast detector returns `false` for that expression, so non-generative files stay out of the compiler path.

Valid directive forms still pass, including semicolonless directives:

```ts
"use generative"
export default defineToolkit({ ... });
```

Expression continuations now stay out of the compiler gate:

```ts
"use generative" + suffix;
"use generative".toString();
```

## Why

`isGenerativeModule()` is used by the Next, Vite, and Metro integrations as a cheap pre-check before invoking `compileGenerative()`. Previously it returned true for string literals that were part of larger expressions, which could send non-generative modules into the compiler and produce a confusing `missing "use generative" directive` error.

## Validation

- `pnpm --filter @assistant-ui/x-generative-compiler exec vitest run src/compile.test.ts`
- `pnpm --filter @assistant-ui/x-generative-compiler build`
- Manual smoke test against the built compiler for valid semicolon / semicolonless directives and invalid `+ suffix` / `.toString()` expressions
- `pnpm exec oxlint packages/x-generative-compiler/src/compile.ts packages/x-generative-compiler/src/compile.test.ts`
- `pnpm exec oxfmt --check packages/x-generative-compiler/src/compile.ts packages/x-generative-compiler/src/compile.test.ts .changeset/tighten-generative-directive-detection.md`
- `pnpm lint`