### PR TITLE
fix: contain Ask AI drawer scrolling

### DIFF
--- a/apps/docs/components/docs/assistant/panel.tsx
+++ b/apps/docs/components/docs/assistant/panel.tsx
@@ -7,7 +7,40 @@ import { COLLAPSED_WIDTH } from "@/components/docs/layout/docs-layout";
 import { cn } from "@/lib/utils";
 import { analytics } from "@/lib/analytics";
 import { PanelRightCloseIcon } from "lucide-react";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
+
+function canScrollVertically(element: HTMLElement, deltaY: number): boolean {
+  if (element.scrollHeight <= element.clientHeight) return false;
+  if (deltaY < 0) return element.scrollTop > 0;
+  return element.scrollTop + element.clientHeight < element.scrollHeight - 1;
+}
+
+function hasScrollableAncestor(
+  target: EventTarget | null,
+  boundary: HTMLElement,
+  deltaY: number,
+): boolean {
+  if (!(target instanceof Node)) return false;
+
+  let element = target instanceof HTMLElement ? target : target.parentElement;
+
+  while (element && boundary.contains(element)) {
+    const overflowY = window.getComputedStyle(element).overflowY;
+    if (
+      (overflowY === "auto" ||
+        overflowY === "scroll" ||
+        overflowY === "overlay") &&
+      canScrollVertically(element, deltaY)
+    ) {
+      return true;
+    }
+
+    if (element === boundary) break;
+    element = element.parentElement;
+  }
+
+  return false;
+}
 
 function ResizeHandle() {
   const { width, setWidth, setIsResizing, isResizing } = useAssistantPanel();
@@ -78,6 +111,29 @@ export function AssistantPanelToggle(): React.ReactNode {
 
 export function AssistantPanelContent(): React.ReactNode {
   const { open, toggle } = useAssistantPanel();
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!open || !content) return;
+
+    const handleWheel = (event: WheelEvent) => {
+      if (event.deltaY === 0 || event.ctrlKey) return;
+      if (!hasScrollableAncestor(event.target, content, event.deltaY)) {
+        event.preventDefault();
+      }
+    };
+
+    content.addEventListener("wheel", handleWheel, {
+      capture: true,
+      passive: false,
+    });
+    return () => {
+      content.removeEventListener("wheel", handleWheel, {
+        capture: true,
+      });
+    };
+  }, [open]);
 
   const handleTriggerClick = () => {
     analytics.assistant.panelToggled({ open: !open, source: "trigger" });
@@ -86,6 +142,7 @@ export function AssistantPanelContent(): React.ReactNode {
 
   return (
     <div
+      ref={contentRef}
       className={cn(
         "bg-background before:bg-border relative h-full w-(--panel-content-width) before:absolute before:inset-y-0 before:left-0 before:w-px before:transition-opacity before:duration-300",
         open ? "before:opacity-100" : "before:opacity-0",

--- a/apps/docs/components/docs/assistant/thread.tsx
+++ b/apps/docs/components/docs/assistant/thread.tsx
@@ -68,7 +68,7 @@ export function AssistantThread({
   return (
     <ThreadPrimitive.Root className="bg-background flex h-full flex-col">
       <PendingMessageHandler />
-      <ThreadPrimitive.Viewport className="flex flex-1 scrollbar-none flex-col overflow-y-auto px-3 pt-3">
+      <ThreadPrimitive.Viewport className="flex flex-1 scrollbar-none flex-col overflow-y-auto overscroll-contain px-3 pt-3">
         <AuiIf condition={(s) => s.thread.isEmpty}>{welcome}</AuiIf>
 
         <div className="px-1.5" data-slot="thread-messages">


### PR DESCRIPTION
## Summary

Fix the docs Ask AI drawer so wheel scrolling inside the open drawer does not continue into the docs page behind it.

## Why

The drawer's thread viewport was scrollable, but extra wheel input at the viewport boundaries, or wheel input over non-scrollable drawer areas, could continue to the page. That made the docs content move while the pointer was still inside the Ask AI panel.

## What changed

- Added a panel-scoped native `wheel` listener registered with `passive: false` while the drawer is open.
- The listener lets scrollable descendants consume wheel input when they can scroll, and prevents the leftover wheel event from chaining to the document when the drawer cannot consume it.
- Added `overscroll-contain` to the assistant thread viewport for native scroll chaining containment.

## Validation

- `PATH="/Users/mac/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm exec oxfmt apps/docs/components/docs/assistant/panel.tsx apps/docs/components/docs/assistant/thread.tsx`
- `PATH="/Users/mac/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm exec oxlint apps/docs/components/docs/assistant/panel.tsx apps/docs/components/docs/assistant/thread.tsx`
- `git diff --check`
- Browser verification on `http://localhost:3000/docs`: with the docs page at `scrollY=700`, wheel input inside the empty Ask AI drawer left the page at `700`; after submitting a long test message, wheel input moved the drawer viewport from `1152.5` to `352.5` while the page stayed at `700`.

## Notes

The docs dev server reported Turbopack cache writes failing with `ENOSPC` because the local volume is 99% full, but the route served and the browser verification completed. Local assistant API calls also reported missing Assistant Cloud auth / `OPENAI_API_KEY`, which is expected in this environment and unrelated to the scroll behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

