### PR TITLE
fix: improve providerTool duplicate config error via keys

### DIFF
--- a/.changeset/provider-tool-config-errors.md
+++ b/.changeset/provider-tool-config-errors.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-generative-compiler": patch
+---
+
+fix: name duplicate providerTool config keys in compiler errors

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -1401,17 +1401,34 @@ export default defineToolkit({
 import { defineToolkit, providerTool } from "@assistant-ui/react";
 export default defineToolkit({
   web_search: {
-    render: () => null,
+    providerId: "openai.web_search_preview",
     execute: providerTool({
       providerId: "openai.web_search_preview",
       args: {},
-      render: "duplicate",
     }),
   },
 });`;
 
     expect(() => compileGenerative(src, { target: "server" })).toThrow(
-      /cannot duplicate tool properties/,
+      /`providerTool\(\.\.\.\)` config for "web_search" duplicates "providerId"/,
+    );
+  });
+
+  it("rejects duplicate providerTool config properties with the duplicated key", () => {
+    const src = `"use generative";
+import { defineToolkit, providerTool } from "@assistant-ui/react";
+export default defineToolkit({
+  web_search: {
+    execute: providerTool({
+      providerId: "openai.web_search_preview",
+      providerId: "openai.web_search_preview_2",
+      args: {},
+    }),
+  },
+});`;
+
+    expect(() => compileGenerative(src, { target: "server" })).toThrow(
+      /`providerTool\(\.\.\.\)` config for "web_search" duplicates "providerId"/,
     );
   });
 

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -1286,7 +1286,10 @@ function compileToolkit(
     }
 
     if (type === "provider" && execute) {
-      applyProviderToolConfig(value, execute, filename);
+      const toolName = t.isObjectProperty(entry)
+        ? memberName(entry.key, entry.computed)
+        : undefined;
+      applyProviderToolConfig(value, execute, toolName, filename);
     }
 
     if (isExternal) {
@@ -1328,6 +1331,7 @@ function compileToolkit(
 function applyProviderToolConfig(
   object: t.ObjectExpression,
   execute: t.ObjectProperty | t.ObjectMethod,
+  toolName: string | undefined,
   filename: string | undefined,
 ): void {
   if (
@@ -1375,8 +1379,9 @@ function applyProviderToolConfig(
       );
     }
     if (existingNames.has(name) || configNames.has(name)) {
+      const toolLabel = toolName ? ` for "${toolName}"` : "";
       throw new GenerativeCompileError(
-        "`providerTool(...)` config cannot duplicate tool properties",
+        `\`providerTool(...)\` config${toolLabel} duplicates "${name}"`,
         filename,
       );
     }


### PR DESCRIPTION
## Summary

Improves the compiler diagnostic for duplicate `providerTool(...)` config keys. Instead of the broad `config cannot duplicate tool properties` message, the error now includes the affected toolkit entry and duplicated key, for example:

```txt
`providerTool(...)` config for "web_search" duplicates "providerId"
```

## Why

`providerTool({ ... })` config is merged onto the surrounding tool object during compilation. When a config key duplicates either an existing tool property or another config key, users need to know which tool and which key caused the rejection.

## Changes

- Pass the static toolkit entry name into the provider-tool config validation path.
- Include the duplicated config key in the `GenerativeCompileError` message.
- Cover both duplicate existing tool properties and duplicate config properties in `compile.test.ts`.
- Add a patch changeset for `@assistant-ui/x-generative-compiler`.

## Validation

- `PATH=/Users/mac/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm --filter @assistant-ui/x-generative-compiler exec vitest run src/compile.test.ts`
- `PATH=/Users/mac/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm --filter @assistant-ui/x-generative-compiler build`
- `PATH=/Users/mac/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec oxlint packages/x-generative-compiler/src/compile.ts packages/x-generative-compiler/src/compile.test.ts`
- `PATH=/Users/mac/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec oxfmt --check packages/x-generative-compiler/src/compile.ts packages/x-generative-compiler/src/compile.test.ts .changeset/provider-tool-config-errors.md`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

