### PR TITLE
fix: stabilize react api surface snapshot

### DIFF
--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -4424,8 +4424,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: PendingAttachmentStatus;
-    file: File;
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4438,8 +4438,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
+    status: PendingAttachmentStatus;
+    file: File;
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4453,8 +4453,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: PendingAttachmentStatus;
-    file: File;
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4467,8 +4467,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
+    status: PendingAttachmentStatus;
+    file: File;
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4482,8 +4482,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: PendingAttachmentStatus;
-    file: File;
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4496,8 +4496,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
+    status: PendingAttachmentStatus;
+    file: File;
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4510,8 +4510,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: PendingAttachmentStatus;
-    file: File;
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4524,8 +4524,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
+    status: PendingAttachmentStatus;
+    file: File;
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4541,8 +4541,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: PendingAttachmentStatus;
-    file: File;
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4555,8 +4555,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
+    status: PendingAttachmentStatus;
+    file: File;
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4572,8 +4572,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: PendingAttachmentStatus;
-    file: File;
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4586,8 +4586,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
+    status: PendingAttachmentStatus;
+    file: File;
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4603,8 +4603,8 @@ declare const useThreadComposerAttachment: {
       file?: File;
       content?: ThreadUserMessagePart[];
     } & {
-      status: PendingAttachmentStatus;
-      file: File;
+      status: CompleteAttachmentStatus;
+      content: ThreadUserMessagePart[];
     } & {
       readonly source: "thread-composer";
     } & {
@@ -4617,8 +4617,8 @@ declare const useThreadComposerAttachment: {
       file?: File;
       content?: ThreadUserMessagePart[];
     } & {
-      status: CompleteAttachmentStatus;
-      content: ThreadUserMessagePart[];
+      status: PendingAttachmentStatus;
+      file: File;
     } & {
       readonly source: "thread-composer";
     } & {
@@ -4635,8 +4635,8 @@ declare const useThreadComposerAttachment: {
       file?: File;
       content?: ThreadUserMessagePart[];
     } & {
-      status: PendingAttachmentStatus;
-      file: File;
+      status: CompleteAttachmentStatus;
+      content: ThreadUserMessagePart[];
     } & {
       readonly source: "thread-composer";
     } & {
@@ -4649,8 +4649,8 @@ declare const useThreadComposerAttachment: {
       file?: File;
       content?: ThreadUserMessagePart[];
     } & {
-      status: CompleteAttachmentStatus;
-      content: ThreadUserMessagePart[];
+      status: PendingAttachmentStatus;
+      file: File;
     } & {
       readonly source: "thread-composer";
     } & {
@@ -4664,8 +4664,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: PendingAttachmentStatus;
-    file: File;
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4678,8 +4678,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
+    status: PendingAttachmentStatus;
+    file: File;
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4695,8 +4695,8 @@ declare const useThreadComposerAttachment: {
       file?: File;
       content?: ThreadUserMessagePart[];
     } & {
-      status: PendingAttachmentStatus;
-      file: File;
+      status: CompleteAttachmentStatus;
+      content: ThreadUserMessagePart[];
     } & {
       readonly source: "thread-composer";
     } & {
@@ -4709,8 +4709,8 @@ declare const useThreadComposerAttachment: {
       file?: File;
       content?: ThreadUserMessagePart[];
     } & {
-      status: CompleteAttachmentStatus;
-      content: ThreadUserMessagePart[];
+      status: PendingAttachmentStatus;
+      file: File;
     } & {
       readonly source: "thread-composer";
     } & {
@@ -4727,8 +4727,8 @@ declare const useThreadComposerAttachment: {
       file?: File;
       content?: ThreadUserMessagePart[];
     } & {
-      status: PendingAttachmentStatus;
-      file: File;
+      status: CompleteAttachmentStatus;
+      content: ThreadUserMessagePart[];
     } & {
       readonly source: "thread-composer";
     } & {
@@ -4741,8 +4741,8 @@ declare const useThreadComposerAttachment: {
       file?: File;
       content?: ThreadUserMessagePart[];
     } & {
-      status: CompleteAttachmentStatus;
-      content: ThreadUserMessagePart[];
+      status: PendingAttachmentStatus;
+      file: File;
     } & {
       readonly source: "thread-composer";
     } & {
@@ -4756,8 +4756,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: PendingAttachmentStatus;
-    file: File;
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
   } & {
     readonly source: "thread-composer";
   } & {
@@ -4770,8 +4770,8 @@ declare const useThreadComposerAttachment: {
     file?: File;
     content?: ThreadUserMessagePart[];
   } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
+    status: PendingAttachmentStatus;
+    file: File;
   } & {
     readonly source: "thread-composer";
   } & {
@@ -6641,7 +6641,7 @@ declare const MessagePartPrimitiveText: import("react").ForwardRefExoticComponen
   asChild?: boolean;
 }, "ref"> & {
   render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLSpanElement>, "ref">, "children" | "asChild"> & {
+} & import("react").RefAttributes<HTMLSpanElement>, "ref">, "asChild" | "children"> & {
   smooth?: boolean | SmoothOptions;
   component?: ElementType;
 } & import("react").RefAttributes<HTMLSpanElement>>;

--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -274,13 +274,46 @@ const KNOWN_DECLARATION_FIXUPS = [
     pattern: /__ASSISTANT_UI_DEVTOOLS_HOOK__\?: DevToolsHook;/g,
     replacement: "__ASSISTANT_UI_DEVTOOLS_HOOK__?: any;",
   },
+  {
+    pattern:
+      /(declare const MessagePartPrimitiveText:[\s\S]*?import\("react"\)\.RefAttributes<HTMLSpanElement>, "ref">, )"children" \| "asChild"/g,
+    replacement: '$1"asChild" | "children"',
+  },
 ];
 
+function normalizeThreadComposerAttachmentUnions(content) {
+  // The declaration bundler emits this expanded discriminated union in OS-dependent order.
+  const marker = "declare const useThreadComposerAttachment: {";
+  const start = content.indexOf(marker);
+  if (start === -1) return content;
+  const end = content.indexOf("\n};", start);
+  if (end === -1) return content;
+
+  const section = content.slice(start, end);
+  const normalizedSection = section.replace(
+    /(\(\{\n\s+id: string;\n\s+type: "image" \| "document" \| "file" \| \(string & \{\}\);\n\s+name: string;\n\s+contentType\?: string \| undefined;\n\s+file\?: File;\n\s+content\?: ThreadUserMessagePart\[\];\n\s+\} & \{\n\s+status: PendingAttachmentStatus;\n\s+file: File;\n\s+\} & \{\n\s+readonly source: "thread-composer";\n\s+\} & \{\n\s+source: "thread-composer";\n\s+\}\)) \| (\(\{\n\s+id: string;\n\s+type: "image" \| "document" \| "file" \| \(string & \{\}\);\n\s+name: string;\n\s+contentType\?: string \| undefined;\n\s+file\?: File;\n\s+content\?: ThreadUserMessagePart\[\];\n\s+\} & \{\n\s+status: CompleteAttachmentStatus;\n\s+content: ThreadUserMessagePart\[\];\n\s+\} & \{\n\s+readonly source: "thread-composer";\n\s+\} & \{\n\s+source: "thread-composer";\n\s+\}\))/g,
+    "$2 | $1",
+  );
+  if (
+    normalizedSection === section &&
+    !/status: CompleteAttachmentStatus;\n\s+content: ThreadUserMessagePart\[\];[\s\S]*?\}\) \| \(\{[\s\S]*?status: PendingAttachmentStatus;\n\s+file: File;/.test(
+      section,
+    )
+  ) {
+    throw new Error(
+      "normalizeThreadComposerAttachmentUnions matched no known union pairs; update the pattern.",
+    );
+  }
+
+  return `${content.slice(0, start)}${normalizedSection}${content.slice(end)}`;
+}
+
 function applyKnownDeclarationFixups(content) {
-  return KNOWN_DECLARATION_FIXUPS.reduce(
+  const fixed = KNOWN_DECLARATION_FIXUPS.reduce(
     (output, fixup) => output.replace(fixup.pattern, fixup.replacement),
     content,
   );
+  return normalizeThreadComposerAttachmentUnions(fixed);
 }
 
 function typeMemberName(member, sourceFile) {


### PR DESCRIPTION
## Summary

Fixes the failing API Surface workflow on `main` by normalizing nondeterministic generated declaration ordering that differs between local macOS generation and the Ubuntu CI runner.

## Details

- Adds a targeted API-surface declaration fixup for the `children`/`asChild` union order in `MessagePartPrimitiveText`.
- Normalizes expanded `useThreadComposerAttachment` attachment union ordering inside the generated `@assistant-ui/react` surface.
- Updates the checked-in `@assistant-ui/react` API surface snapshot to the CI-generated order.

## Verification

- `pnpm exec oxfmt --check scripts/generate-api-surface.mjs api-surface/assistant-ui__react.ts`
- `pnpm install --frozen-lockfile`
- `pnpm api-surface:build`
- `pnpm api-surface:check`
- `node scripts/generate-api-surface.mjs`
- `pnpm api-surface:check`