### PR TITLE
feat(thread-list): make more composable

### DIFF
--- a/apps/docs/components/examples/base.tsx
+++ b/apps/docs/components/examples/base.tsx
@@ -167,6 +167,7 @@ const Sidebar: FC<{ collapsed?: boolean }> = ({ collapsed }) => {
         </Tooltip>
         <ThreadListItems
           aria-hidden={collapsed}
+          inert={collapsed}
           className={cn(
             "transition-[opacity,transform] duration-150",
             collapsed

--- a/apps/docs/components/examples/base.tsx
+++ b/apps/docs/components/examples/base.tsx
@@ -90,6 +90,11 @@ import {
 import Image from "next/image";
 import { useState, type FC, type ReactNode } from "react";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { ModelSelector } from "@/components/assistant-ui/model-selector";
 import { docsModelOptions } from "@/components/docs/assistant/docs-model-options";
 import { DEFAULT_MODEL_ID } from "@/constants/model";
@@ -141,18 +146,25 @@ const Sidebar: FC<{ collapsed?: boolean }> = ({ collapsed }) => {
           collapsed ? "w-12 px-2 pt-1" : "w-65 p-3",
         )}
       >
-        <ThreadListNew
-          className={cn(
-            "overflow-hidden transition-all duration-200",
-            collapsed
-              ? "w-8 gap-0 px-2 has-[>svg]:px-2"
-              : "w-full gap-2 px-2.5 has-[>svg]:px-2.5",
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <ThreadListNew
+              className={cn(
+                "overflow-hidden transition-all duration-200",
+                collapsed
+                  ? "w-8 gap-0 px-2 has-[>svg]:px-2"
+                  : "w-full gap-2 px-2.5 has-[>svg]:px-2.5",
+              )}
+              labelClassName={cn(
+                "overflow-hidden transition-all duration-200",
+                collapsed ? "max-w-0 opacity-0" : "max-w-24 opacity-100",
+              )}
+            />
+          </TooltipTrigger>
+          {collapsed && (
+            <TooltipContent side="right">New Thread</TooltipContent>
           )}
-          labelClassName={cn(
-            "overflow-hidden transition-all duration-200",
-            collapsed ? "max-w-0 opacity-0" : "max-w-24 opacity-100",
-          )}
-        />
+        </Tooltip>
         <ThreadListItems
           aria-hidden={collapsed}
           className={cn(

--- a/apps/docs/components/examples/base.tsx
+++ b/apps/docs/components/examples/base.tsx
@@ -14,7 +14,12 @@ import {
   ToolGroupRoot,
   ToolGroupTrigger,
 } from "@/components/assistant-ui/tool-group";
-import { ThreadList } from "@/components/assistant-ui/thread-list";
+import {
+  ThreadList,
+  ThreadListItems,
+  ThreadListNew,
+  ThreadListRoot,
+} from "@/components/assistant-ui/thread-list";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import {
   Reasoning,
@@ -43,7 +48,6 @@ import {
   ErrorPrimitive,
   groupPartByType,
   MessagePrimitive,
-  ThreadListPrimitive,
   ThreadPrimitive,
   unstable_useMentionAdapter,
   unstable_useSlashCommandAdapter,
@@ -73,7 +77,6 @@ import {
   PanelLeftIcon,
   PencilIcon,
   PencilLineIcon,
-  PlusIcon,
   RefreshCwIcon,
   ShareIcon,
   SlashIcon,
@@ -132,23 +135,34 @@ const Sidebar: FC<{ collapsed?: boolean }> = ({ collapsed }) => {
           assistant-ui
         </span>
       </div>
-      {collapsed ? (
-        <ThreadListPrimitive.New asChild>
-          <TooltipIconButton
-            tooltip="New thread"
-            side="right"
-            variant="ghost"
-            size="icon"
-            className="mt-1 ml-2 size-8"
-          >
-            <PlusIcon className="size-4" />
-          </TooltipIconButton>
-        </ThreadListPrimitive.New>
-      ) : (
-        <div className="relative w-65 flex-1 overflow-y-auto p-3">
-          <ThreadList />
-        </div>
-      )}
+      <ThreadListRoot
+        className={cn(
+          "relative flex-1 overflow-y-auto transition-[padding,width] duration-200",
+          collapsed ? "w-12 px-2 pt-1" : "w-65 p-3",
+        )}
+      >
+        <ThreadListNew
+          className={cn(
+            "overflow-hidden transition-all duration-200",
+            collapsed
+              ? "w-8 gap-0 px-2 has-[>svg]:px-2"
+              : "w-full gap-2 px-2.5 has-[>svg]:px-2.5",
+          )}
+          labelClassName={cn(
+            "overflow-hidden transition-all duration-200",
+            collapsed ? "max-w-0 opacity-0" : "max-w-24 opacity-100",
+          )}
+        />
+        <ThreadListItems
+          aria-hidden={collapsed}
+          className={cn(
+            "transition-[opacity,transform] duration-150",
+            collapsed
+              ? "pointer-events-none opacity-0 delay-50"
+              : "translate-x-0 opacity-100",
+          )}
+        />
+      </ThreadListRoot>
     </aside>
   );
 };

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -192,8 +192,8 @@
   *::-webkit-scrollbar-corner {
     background: transparent;
   }
-}
 
-:focus-visible {
-  box-shadow: none;
+  :focus-visible {
+    box-shadow: none;
+  }
 }

--- a/packages/ui/src/components/assistant-ui/thread-list.tsx
+++ b/packages/ui/src/components/assistant-ui/thread-list.tsx
@@ -17,6 +17,7 @@ import {
   TrashIcon,
 } from "lucide-react";
 import {
+  forwardRef,
   Fragment,
   useMemo,
   type ComponentPropsWithoutRef,
@@ -138,12 +139,14 @@ const ThreadListItemGroups: FC = () => {
   ));
 };
 
-export const ThreadListNew: FC<
+export const ThreadListNew = forwardRef<
+  HTMLButtonElement,
   ComponentPropsWithoutRef<typeof Button> & { labelClassName?: string }
-> = ({ className, labelClassName, children, ...props }) => {
+>(({ className, labelClassName, children, ...props }, ref) => {
   return (
     <ThreadListPrimitive.New asChild>
       <Button
+        ref={ref}
         variant="ghost"
         data-slot="aui_thread-list-new"
         className={cn(
@@ -169,7 +172,9 @@ export const ThreadListNew: FC<
       </Button>
     </ThreadListPrimitive.New>
   );
-};
+});
+
+ThreadListNew.displayName = "ThreadListNew";
 
 const ThreadListSkeleton: FC = () => {
   return (

--- a/packages/ui/src/components/assistant-ui/thread-list.tsx
+++ b/packages/ui/src/components/assistant-ui/thread-list.tsx
@@ -205,7 +205,7 @@ export const ThreadListItem: FC = () => {
     >
       <ThreadListItemPrimitive.Trigger
         data-slot="aui_thread-list-item-trigger"
-        className="flex h-full min-w-0 flex-1 items-center px-2.5 text-start text-sm group-hover:pe-9 group-has-data-[state=open]:pe-9 group-data-active:pe-9"
+        className="flex h-full min-w-0 flex-1 items-center px-2.5 text-start text-sm group-hover:pe-9 group-has-data-[state=open]:pe-9 group-has-[:focus-visible]:pe-9 group-data-active:pe-9"
       >
         <span
           data-slot="aui_thread-list-item-title"

--- a/packages/ui/src/components/assistant-ui/thread-list.tsx
+++ b/packages/ui/src/components/assistant-ui/thread-list.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 import {
   AuiIf,
   ThreadListItemMorePrimitive,
@@ -15,19 +16,51 @@ import {
   PlusIcon,
   TrashIcon,
 } from "lucide-react";
-import { Fragment, useMemo, type FC } from "react";
+import {
+  Fragment,
+  useMemo,
+  type ComponentPropsWithoutRef,
+  type FC,
+} from "react";
 
 export const ThreadList: FC = () => {
   return (
-    <ThreadListPrimitive.Root className="aui-root aui-thread-list-root flex flex-col gap-0.5">
+    <ThreadListRoot>
       <ThreadListNew />
+      <ThreadListItems />
+    </ThreadListRoot>
+  );
+};
+
+export const ThreadListRoot: FC<
+  ComponentPropsWithoutRef<typeof ThreadListPrimitive.Root>
+> = ({ className, ...props }) => {
+  return (
+    <ThreadListPrimitive.Root
+      data-slot="aui_thread-list-root"
+      className={cn("flex flex-col gap-0.5", className)}
+      {...props}
+    />
+  );
+};
+
+export const ThreadListItems: FC<ComponentPropsWithoutRef<"div">> = ({
+  className,
+  ...props
+}) => {
+  return (
+    <div
+      data-slot="aui_thread-list-items"
+      className={cn("flex flex-col gap-0.5", className)}
+      {...props}
+    >
       <AuiIf condition={(s) => s.threads.isLoading}>
         <ThreadListSkeleton />
       </AuiIf>
       <AuiIf condition={(s) => !s.threads.isLoading}>
-        <ThreadListItems />
+        <ThreadListItemGroups />
       </AuiIf>
-    </ThreadListPrimitive.Root>
+    </div>
   );
 };
 
@@ -44,7 +77,7 @@ const dateGroupLabel = (
 
 type ThreadListGroup = { label: string; indices: number[] };
 
-const ThreadListItems: FC = () => {
+const ThreadListItemGroups: FC = () => {
   const threadIds = useAuiState((s) => s.threads.threadIds);
   const threadItems = useAuiState((s) => s.threads.threadItems);
 
@@ -88,7 +121,10 @@ const ThreadListItems: FC = () => {
 
   return groups.map((group) => (
     <Fragment key={group.label}>
-      <div className="aui-thread-list-group-label text-muted-foreground px-2.5 pt-3 pb-1 text-xs font-medium">
+      <div
+        data-slot="aui_thread-list-group-label"
+        className="text-muted-foreground px-2.5 pt-3 pb-1 text-xs font-medium"
+      >
         {group.label}
       </div>
       {group.indices.map((index) => (
@@ -102,15 +138,34 @@ const ThreadListItems: FC = () => {
   ));
 };
 
-const ThreadListNew: FC = () => {
+export const ThreadListNew: FC<
+  ComponentPropsWithoutRef<typeof Button> & { labelClassName?: string }
+> = ({ className, labelClassName, children, ...props }) => {
   return (
     <ThreadListPrimitive.New asChild>
       <Button
         variant="ghost"
-        className="aui-thread-list-new hover:bg-muted data-active:bg-muted h-8 justify-start gap-2 rounded-md px-2.5 text-sm font-normal"
+        data-slot="aui_thread-list-new"
+        className={cn(
+          "hover:bg-muted data-active:bg-muted h-8 justify-start gap-2 rounded-md px-2.5 text-sm font-normal",
+          className,
+        )}
+        {...props}
       >
-        <PlusIcon className="size-4" />
-        New Thread
+        {children ?? (
+          <>
+            <PlusIcon
+              data-slot="aui_thread-list-new-icon"
+              className="size-4 shrink-0"
+            />
+            <span
+              data-slot="aui_thread-list-new-label"
+              className={cn("whitespace-nowrap", labelClassName)}
+            >
+              New Thread
+            </span>
+          </>
+        )}
       </Button>
     </ThreadListPrimitive.New>
   );
@@ -124,20 +179,33 @@ const ThreadListSkeleton: FC = () => {
           key={i}
           role="status"
           aria-label="Loading threads"
-          className="aui-thread-list-skeleton-wrapper flex h-8 items-center px-2.5"
+          data-slot="aui_thread-list-skeleton-wrapper"
+          className="flex h-8 items-center px-2.5"
         >
-          <Skeleton className="aui-thread-list-skeleton h-3.5 w-full" />
+          <Skeleton
+            data-slot="aui_thread-list-skeleton"
+            className="h-3.5 w-full"
+          />
         </div>
       ))}
     </div>
   );
 };
 
-const ThreadListItem: FC = () => {
+export const ThreadListItem: FC = () => {
   return (
-    <ThreadListItemPrimitive.Root className="aui-thread-list-item group hover:bg-muted focus-visible:bg-muted data-active:bg-muted relative flex h-8 items-center rounded-md transition-colors focus-visible:outline-none">
-      <ThreadListItemPrimitive.Trigger className="aui-thread-list-item-trigger flex h-full min-w-0 flex-1 items-center px-2.5 text-start text-sm group-hover:pe-9 group-has-data-[state=open]:pe-9 group-data-active:pe-9">
-        <span className="aui-thread-list-item-title min-w-0 flex-1 truncate">
+    <ThreadListItemPrimitive.Root
+      data-slot="aui_thread-list-item"
+      className="group hover:bg-muted focus-visible:bg-muted data-active:bg-muted relative flex h-8 items-center rounded-md transition-colors focus-visible:outline-none"
+    >
+      <ThreadListItemPrimitive.Trigger
+        data-slot="aui_thread-list-item-trigger"
+        className="flex h-full min-w-0 flex-1 items-center px-2.5 text-start text-sm group-hover:pe-9 group-has-data-[state=open]:pe-9 group-data-active:pe-9"
+      >
+        <span
+          data-slot="aui_thread-list-item-title"
+          className="min-w-0 flex-1 truncate"
+        >
           <ThreadListItemPrimitive.Title fallback="New Chat" />
         </span>
       </ThreadListItemPrimitive.Trigger>
@@ -153,7 +221,8 @@ const ThreadListItemMore: FC = () => {
         <Button
           variant="ghost"
           size="icon"
-          className="aui-thread-list-item-more data-[state=open]:bg-accent absolute end-1.5 top-1/2 size-6 -translate-y-1/2 p-0 opacity-0 group-hover:opacity-100 group-data-active:opacity-100 data-[state=open]:opacity-100"
+          data-slot="aui_thread-list-item-more"
+          className="data-[state=open]:bg-accent absolute end-1.5 top-1/2 size-6 -translate-y-1/2 p-0 opacity-0 group-hover:opacity-100 group-data-active:opacity-100 data-[state=open]:opacity-100"
         >
           <MoreHorizontalIcon className="size-3.5" />
           <span className="sr-only">More options</span>
@@ -163,16 +232,23 @@ const ThreadListItemMore: FC = () => {
         side="right"
         align="start"
         sideOffset={6}
-        className="aui-thread-list-item-more-content bg-popover/95 text-popover-foreground data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-xl border p-1.5 shadow-lg backdrop-blur-sm"
+        data-slot="aui_thread-list-item-more-content"
+        className="bg-popover/95 text-popover-foreground data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-xl border p-1.5 shadow-lg backdrop-blur-sm"
       >
         <ThreadListItemPrimitive.Archive asChild>
-          <ThreadListItemMorePrimitive.Item className="aui-thread-list-item-more-item hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground flex cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm outline-none select-none">
+          <ThreadListItemMorePrimitive.Item
+            data-slot="aui_thread-list-item-more-item"
+            className="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground flex cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm outline-none select-none"
+          >
             <ArchiveIcon className="size-4" />
             Archive
           </ThreadListItemMorePrimitive.Item>
         </ThreadListItemPrimitive.Archive>
         <ThreadListItemPrimitive.Delete asChild>
-          <ThreadListItemMorePrimitive.Item className="aui-thread-list-item-more-item text-destructive hover:bg-destructive/10 hover:text-destructive focus:bg-destructive/10 focus:text-destructive flex cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm outline-none select-none">
+          <ThreadListItemMorePrimitive.Item
+            data-slot="aui_thread-list-item-more-item"
+            className="text-destructive hover:bg-destructive/10 hover:text-destructive focus:bg-destructive/10 focus:text-destructive flex cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm outline-none select-none"
+          >
             <TrashIcon className="size-4" />
             Delete
           </ThreadListItemMorePrimitive.Item>

--- a/packages/ui/src/components/assistant-ui/thread-list.tsx
+++ b/packages/ui/src/components/assistant-ui/thread-list.tsx
@@ -201,11 +201,11 @@ export const ThreadListItem: FC = () => {
   return (
     <ThreadListItemPrimitive.Root
       data-slot="aui_thread-list-item"
-      className="group hover:bg-muted focus-visible:bg-muted data-active:bg-muted relative flex h-8 items-center rounded-md transition-colors focus-visible:outline-none"
+      className="group hover:bg-muted focus-visible:bg-muted data-active:bg-muted has-focus-visible:bg-muted has-data-[state=open]:bg-muted relative flex h-8 items-center rounded-md transition-colors focus-visible:outline-none"
     >
       <ThreadListItemPrimitive.Trigger
         data-slot="aui_thread-list-item-trigger"
-        className="flex h-full min-w-0 flex-1 items-center px-2.5 text-start text-sm group-hover:pe-9 group-has-data-[state=open]:pe-9 group-has-[:focus-visible]:pe-9 group-data-active:pe-9"
+        className="focus-visible:ring-ring/50 flex h-full min-w-0 flex-1 items-center rounded-md px-2.5 text-start text-sm outline-none group-hover:pe-9 group-has-focus-visible:pe-9 group-has-data-[state=open]:pe-9 group-data-active:pe-9 focus-visible:ring-[3px]"
       >
         <span
           data-slot="aui_thread-list-item-title"
@@ -227,7 +227,7 @@ const ThreadListItemMore: FC = () => {
           variant="ghost"
           size="icon"
           data-slot="aui_thread-list-item-more"
-          className="data-[state=open]:bg-accent absolute end-1.5 top-1/2 size-6 -translate-y-1/2 p-0 opacity-0 group-hover:opacity-100 group-data-active:opacity-100 data-[state=open]:opacity-100"
+          className="data-[state=open]:bg-accent absolute end-1.5 top-1/2 size-6 -translate-y-1/2 p-0 opacity-0 group-hover:opacity-100 group-has-focus-visible:opacity-100 group-data-active:opacity-100 data-[state=open]:opacity-100"
         >
           <MoreHorizontalIcon className="size-3.5" />
           <span className="sr-only">More options</span>
@@ -238,7 +238,7 @@ const ThreadListItemMore: FC = () => {
         align="start"
         sideOffset={6}
         data-slot="aui_thread-list-item-more-content"
-        className="bg-popover/95 text-popover-foreground data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-xl border p-1.5 shadow-lg backdrop-blur-sm"
+        className="bg-popover/95 text-popover-foreground data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-xl border p-1.5 shadow-lg backdrop-blur-sm"
       >
         <ThreadListItemPrimitive.Archive asChild>
           <ThreadListItemMorePrimitive.Item


### PR DESCRIPTION
this pr makes `thread-list.tsx` more composable by splitting the `ThreadList` into composable building blocks and exporting them, alongside the unchanged, default `ThreadList` component.

this updated thread-list allows the demo on our website (base.tsx) to smoothly transition the new thread button and icon when collapsing/expanding the sidebar

original `ThreadList` export is unchanged.

### usage in base.tsx:
```tsx
<ThreadListRoot
  className={cn(
    "relative flex-1 overflow-y-auto transition-[padding,width] duration-200",
    collapsed ? "w-12 px-2 pt-1" : "w-65 p-3",
  )}
>
  <ThreadListNew
    className={cn(
      "overflow-hidden transition-all duration-200",
      collapsed
        ? "w-8 gap-0 px-2 has-[>svg]:px-2"
        : "w-full gap-2 px-2.5 has-[>svg]:px-2.5",
    )}
    labelClassName={cn(
      "overflow-hidden transition-all duration-200",
      collapsed ? "max-w-0 opacity-0" : "max-w-24 opacity-100",
    )}
  />
  <ThreadListItems
    aria-hidden={collapsed}
    className={cn(
      "transition-[opacity,transform] duration-150",
      collapsed
        ? "pointer-events-none opacity-0 delay-50"
        : "translate-x-0 opacity-100",
    )}
  />
</ThreadListRoot>

```

### notes
- this deletes all aui-* prefixed classNames in the thread-list.tsx file. this is part of an ongoing migration from aui-* classNames to aui_* data-slot attrs.
- docs global.css had set focus-visible to box-shadow none, this rule was moved inside of `@layer base` to allow focus rings to work
- fixes truncation and focus behavior on threadlistitem in general

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

