### PR TITLE
feat(mcp-docs-server): expose docs and examples as MCP resources

### DIFF
--- a/.changeset/mcp-docs-server-resources.md
+++ b/.changeset/mcp-docs-server-resources.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/mcp-docs-server": patch
+---
+
+feat: expose docs and examples as MCP resources

--- a/packages/mcp-docs-server/README.md
+++ b/packages/mcp-docs-server/README.md
@@ -1,6 +1,6 @@
 # `@assistant-ui/mcp-docs-server`
 
-Model Context Protocol (MCP) server that gives AI assistants direct access to assistant-ui's documentation and example projects. Exposes `assistantUIDocs` (retrieve documentation by path) and `assistantUIExamples` (access complete example projects).
+Model Context Protocol (MCP) server that gives AI assistants direct access to assistant-ui's documentation and example projects. Exposes `assistantUIDocs` (retrieve documentation by path) and `assistantUIExamples` (access complete example projects), and serves the same docs and examples as readable MCP **resources** (`aui-docs:///{path}`, `aui-example:///{name}`).
 
 > [!NOTE]
 > Detailed installation, troubleshooting, and advanced usage at [assistant-ui.com/docs/llm#mcp](https://www.assistant-ui.com/docs/llm#mcp).

--- a/packages/mcp-docs-server/src/index.ts
+++ b/packages/mcp-docs-server/src/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { docsTools } from "./tools/docs.js";
 import { examplesTools } from "./tools/examples.js";
+import { registerResources } from "./tools/resources.js";
 import { logger } from "./utils/logger.js";
 import { PACKAGE_DIR } from "./constants.js";
 
@@ -37,6 +38,8 @@ server.registerTool(
   },
   examplesTools.execute,
 );
+
+registerResources(server);
 
 export async function runServer() {
   try {

--- a/packages/mcp-docs-server/src/tools/examples.ts
+++ b/packages/mcp-docs-server/src/tools/examples.ts
@@ -15,7 +15,7 @@ const examplesInputSchema = z.object({
     ),
 });
 
-async function listCodeExamples(): Promise<string[]> {
+export async function listCodeExamples(): Promise<string[]> {
   try {
     const files = await readdir(CODE_EXAMPLES_PATH);
     return files
@@ -28,7 +28,9 @@ async function listCodeExamples(): Promise<string[]> {
   }
 }
 
-async function readCodeExample(exampleName: string): Promise<string | null> {
+export async function readCodeExample(
+  exampleName: string,
+): Promise<string | null> {
   try {
     const sanitized = sanitizePath(exampleName);
     const filePath = join(CODE_EXAMPLES_PATH, `${sanitized}.md`);

--- a/packages/mcp-docs-server/src/tools/resources.ts
+++ b/packages/mcp-docs-server/src/tools/resources.ts
@@ -1,0 +1,105 @@
+import {
+  McpServer,
+  ResourceTemplate,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import { join } from "node:path";
+import { DOCS_PATH, MDX_EXTENSION } from "../constants.js";
+import { getAvailablePaths, pathExists } from "../utils/paths.js";
+import { readMDXFileSafe, formatMDXContent } from "../utils/mdx.js";
+import { sanitizePath } from "../utils/security.js";
+import { listCodeExamples, readCodeExample } from "./examples.js";
+import { logger } from "../utils/logger.js";
+
+const MARKDOWN_MIME_TYPE = "text/markdown";
+const DOCS_SCHEME = "aui-docs";
+const EXAMPLE_SCHEME = "aui-example";
+
+function templateVarToPath(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return value.join("/");
+  return value ?? "";
+}
+
+interface MarkdownResourceConfig {
+  name: string;
+  scheme: string;
+  variable: string;
+  title: string;
+  description: string;
+  list: () => Promise<string[]>;
+  read: (key: string) => Promise<string | null>;
+}
+
+function registerMarkdownResource(
+  server: McpServer,
+  config: MarkdownResourceConfig,
+): void {
+  const { name, scheme, variable, title, description, list, read } = config;
+  server.registerResource(
+    name,
+    new ResourceTemplate(`${scheme}:///{+${variable}}`, {
+      list: async () => ({
+        resources: (await list()).map((key) => ({
+          uri: `${scheme}:///${key}`,
+          name: key,
+          mimeType: MARKDOWN_MIME_TYPE,
+        })),
+      }),
+    }),
+    { title, description, mimeType: MARKDOWN_MIME_TYPE },
+    async (uri, variables) => {
+      const key = templateVarToPath(variables[variable]);
+      const text = await read(key);
+      if (text === null) {
+        throw new Error(`Resource not found: ${scheme}:///${key}`);
+      }
+      return {
+        contents: [{ uri: uri.href, mimeType: MARKDOWN_MIME_TYPE, text }],
+      };
+    },
+  );
+}
+
+async function listDocPaths(): Promise<string[]> {
+  const paths = await getAvailablePaths();
+  const docPaths: string[] = [];
+  for (const path of paths) {
+    if (await pathExists(join(DOCS_PATH, `${path}${MDX_EXTENSION}`))) {
+      docPaths.push(path);
+    }
+  }
+  return docPaths;
+}
+
+async function readDocResource(path: string): Promise<string | null> {
+  const sanitized = sanitizePath(path);
+  const mdx = await readMDXFileSafe(
+    join(DOCS_PATH, `${sanitized}${MDX_EXTENSION}`),
+  );
+  return mdx ? formatMDXContent(mdx) : null;
+}
+
+export function registerResources(server: McpServer): void {
+  registerMarkdownResource(server, {
+    name: "assistant-ui-docs",
+    scheme: DOCS_SCHEME,
+    variable: "path",
+    title: "assistant-ui Documentation",
+    description:
+      "Individual assistant-ui documentation pages, readable as markdown by path.",
+    list: listDocPaths,
+    read: readDocResource,
+  });
+
+  registerMarkdownResource(server, {
+    name: "assistant-ui-examples",
+    scheme: EXAMPLE_SCHEME,
+    variable: "name",
+    title: "assistant-ui Examples",
+    description:
+      "Complete assistant-ui example projects, readable as markdown.",
+    list: listCodeExamples,
+    read: readCodeExample,
+  });
+
+  logger.debug("Registered docs and examples resources");
+}

--- a/packages/mcp-docs-server/src/tools/resources.ts
+++ b/packages/mcp-docs-server/src/tools/resources.ts
@@ -4,7 +4,7 @@ import {
 } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { join } from "node:path";
 import { DOCS_PATH, MDX_EXTENSION } from "../constants.js";
-import { getAvailablePaths, pathExists } from "../utils/paths.js";
+import { getAvailableDocFiles } from "../utils/paths.js";
 import { readMDXFileSafe, formatMDXContent } from "../utils/mdx.js";
 import { sanitizePath } from "../utils/security.js";
 import { listCodeExamples, readCodeExample } from "./examples.js";
@@ -25,6 +25,7 @@ interface MarkdownResourceConfig {
   variable: string;
   title: string;
   description: string;
+  notFoundLabel: string;
   list: () => Promise<string[]>;
   read: (key: string) => Promise<string | null>;
 }
@@ -33,7 +34,16 @@ function registerMarkdownResource(
   server: McpServer,
   config: MarkdownResourceConfig,
 ): void {
-  const { name, scheme, variable, title, description, list, read } = config;
+  const {
+    name,
+    scheme,
+    variable,
+    title,
+    description,
+    notFoundLabel,
+    list,
+    read,
+  } = config;
   server.registerResource(
     name,
     new ResourceTemplate(`${scheme}:///{+${variable}}`, {
@@ -50,24 +60,13 @@ function registerMarkdownResource(
       const key = templateVarToPath(variables[variable]);
       const text = await read(key);
       if (text === null) {
-        throw new Error(`Resource not found: ${scheme}:///${key}`);
+        throw new Error(`${notFoundLabel} not found: ${key}`);
       }
       return {
         contents: [{ uri: uri.href, mimeType: MARKDOWN_MIME_TYPE, text }],
       };
     },
   );
-}
-
-async function listDocPaths(): Promise<string[]> {
-  const paths = await getAvailablePaths();
-  const docPaths: string[] = [];
-  for (const path of paths) {
-    if (await pathExists(join(DOCS_PATH, `${path}${MDX_EXTENSION}`))) {
-      docPaths.push(path);
-    }
-  }
-  return docPaths;
 }
 
 async function readDocResource(path: string): Promise<string | null> {
@@ -86,7 +85,8 @@ export function registerResources(server: McpServer): void {
     title: "assistant-ui Documentation",
     description:
       "Individual assistant-ui documentation pages, readable as markdown by path.",
-    list: listDocPaths,
+    notFoundLabel: "Documentation",
+    list: getAvailableDocFiles,
     read: readDocResource,
   });
 
@@ -97,6 +97,7 @@ export function registerResources(server: McpServer): void {
     title: "assistant-ui Examples",
     description:
       "Complete assistant-ui example projects, readable as markdown.",
+    notFoundLabel: "Example",
     list: listCodeExamples,
     read: readCodeExample,
   });

--- a/packages/mcp-docs-server/src/tools/tests/resources.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/resources.test.ts
@@ -40,6 +40,25 @@ describe("MCP resources", () => {
     expect(read.contents[0].text.length).toBeGreaterThan(0);
   });
 
+  it("reads a slash-containing documentation resource", async () => {
+    const list = await handler("resources/list")(
+      { method: "resources/list", params: {} },
+      {},
+    );
+    const prefix = "aui-docs:///";
+    const nested = list.resources.find(
+      (r: any) =>
+        r.uri.startsWith(prefix) && r.uri.slice(prefix.length).includes("/"),
+    );
+    expect(nested).toBeDefined();
+    const read = await handler("resources/read")(
+      { method: "resources/read", params: { uri: nested.uri } },
+      {},
+    );
+    expect(read.contents[0].mimeType).toBe("text/markdown");
+    expect(read.contents[0].text.length).toBeGreaterThan(0);
+  });
+
   it("errors on an unknown documentation resource", async () => {
     await expect(
       handler("resources/read")(

--- a/packages/mcp-docs-server/src/tools/tests/resources.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/resources.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { server } from "../../index.js";
+
+function handler(method: string) {
+  const handlers = (server as any).server._requestHandlers;
+  const h = handlers.get(method);
+  if (!h) throw new Error(`No handler for ${method}`);
+  return h;
+}
+
+describe("MCP resources", () => {
+  it("lists docs and example resources", async () => {
+    const result = await handler("resources/list")(
+      { method: "resources/list", params: {} },
+      {},
+    );
+    expect(result.resources.length).toBeGreaterThan(0);
+    expect(
+      result.resources.some((r: any) => r.uri.startsWith("aui-docs:///")),
+    ).toBe(true);
+    expect(
+      result.resources.some((r: any) => r.uri.startsWith("aui-example:///")),
+    ).toBe(true);
+  });
+
+  it("reads a documentation resource as markdown", async () => {
+    const list = await handler("resources/list")(
+      { method: "resources/list", params: {} },
+      {},
+    );
+    const doc = list.resources.find((r: any) =>
+      r.uri.startsWith("aui-docs:///"),
+    );
+    const read = await handler("resources/read")(
+      { method: "resources/read", params: { uri: doc.uri } },
+      {},
+    );
+    expect(read.contents[0].mimeType).toBe("text/markdown");
+    expect(typeof read.contents[0].text).toBe("string");
+    expect(read.contents[0].text.length).toBeGreaterThan(0);
+  });
+
+  it("errors on an unknown documentation resource", async () => {
+    await expect(
+      handler("resources/read")(
+        {
+          method: "resources/read",
+          params: { uri: "aui-docs:///definitely-not-a-real-doc" },
+        },
+        {},
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("reads an example resource as markdown", async () => {
+    const list = await handler("resources/list")(
+      { method: "resources/list", params: {} },
+      {},
+    );
+    const example = list.resources.find((r: any) =>
+      r.uri.startsWith("aui-example:///"),
+    );
+    const read = await handler("resources/read")(
+      { method: "resources/read", params: { uri: example.uri } },
+      {},
+    );
+    expect(read.contents[0].mimeType).toBe("text/markdown");
+    expect(typeof read.contents[0].text).toBe("string");
+    expect(read.contents[0].text.length).toBeGreaterThan(0);
+  });
+
+  it("errors on an unknown example resource", async () => {
+    await expect(
+      handler("resources/read")(
+        {
+          method: "resources/read",
+          params: { uri: "aui-example:///definitely-not-a-real-example" },
+        },
+        {},
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/mcp-docs-server/src/utils/mdx.ts
+++ b/packages/mcp-docs-server/src/utils/mdx.ts
@@ -1,5 +1,6 @@
-import { readFile } from "node:fs/promises";
+import { readFile, lstat } from "node:fs/promises";
 import matter from "gray-matter";
+import { MAX_FILE_SIZE } from "../constants.js";
 import { logger } from "./logger.js";
 
 interface MDXContent {
@@ -30,6 +31,25 @@ export async function readMDXFile(
     logger.error(`Failed to read MDX file: ${filePath}`, error);
     return null;
   }
+}
+
+export async function readMDXFileSafe(
+  filePath: string,
+): Promise<MDXContent | null> {
+  try {
+    const stats = await lstat(filePath);
+    if (stats.isSymbolicLink()) {
+      logger.warn(`Attempted to read symlink: ${filePath}`);
+      return null;
+    }
+    if (stats.size > MAX_FILE_SIZE) {
+      logger.warn(`File size exceeds limit: ${filePath} (${stats.size} bytes)`);
+      return null;
+    }
+  } catch {
+    return null;
+  }
+  return readMDXFile(filePath);
 }
 
 export function formatMDXContent(mdxContent: MDXContent): string {

--- a/packages/mcp-docs-server/src/utils/paths.ts
+++ b/packages/mcp-docs-server/src/utils/paths.ts
@@ -66,6 +66,28 @@ export async function getAvailablePaths(): Promise<string[]> {
   return paths.sort();
 }
 
+export async function getAvailableDocFiles(): Promise<string[]> {
+  const files: string[] = [];
+
+  async function scanDirectory(dir: string, prefix = ""): Promise<void> {
+    const { directories, files: dirFiles } = await listDirContents(dir);
+
+    for (const file of dirFiles) {
+      if (extname(file) !== MDX_EXTENSION) continue;
+      const name = file.replace(MDX_EXTENSION, "");
+      files.push(prefix ? `${prefix}/${name}` : name);
+    }
+
+    for (const subdir of directories) {
+      const newPrefix = prefix ? `${prefix}/${subdir}` : subdir;
+      await scanDirectory(join(dir, subdir), newPrefix);
+    }
+  }
+
+  await scanDirectory(DOCS_PATH);
+  return files.sort();
+}
+
 export function findNearestPaths(
   requestedPath: string,
   availablePaths: string[],


### PR DESCRIPTION
## What

Expose the bundled assistant-ui documentation and example projects as MCP **resources**, in addition to the existing tools. Adds two resource templates, `aui-docs:///{path}` (a doc page) and `aui-example:///{name}` (an example project), each with list + read support, served from the bundled content.

## Why

Resources are the idiomatic MCP surface for client-readable, listable context: an editor or agent can enumerate every doc/example and read one by URI without invoking a tool, then attach or cache it. This is the offline equivalent of the docs site's hosted MCP resources, served from the package's bundled docs.

## How

- `tools/resources.ts`: register two `ResourceTemplate`s. `list` enumerates docs (from the bundled doc paths) and examples; the read callbacks reuse the existing MDX reader / example reader and the existing path sanitizer. URIs use a `{+path}` reserved expansion so doc paths with slashes round-trip.
- Export the two example-reading helpers for reuse; wire `registerResources(server)` into `index.ts` (this advertises the `resources` capability).
- Tests drive `resources/list` and `resources/read` against the bundled content; README updated to mention the resources capability.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

