### PR TITLE
fix: preserve package imports in aui-build

### DIFF
--- a/.changeset/soft-cameras-resolve.md
+++ b/.changeset/soft-cameras-resolve.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-buildutils": patch
+---
+
+fix: preserve package imports as external build specifiers

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -34,10 +34,7 @@ const dependsOnTap = ["dependencies", "peerDependencies"].some(
 );
 const isTapPackage = pkg.name === "@assistant-ui/tap";
 const remapReactToShim = dependsOnTap || isTapPackage;
-const packageImportExternals =
-  typeof pkg.imports === "object" && pkg.imports !== null
-    ? Object.keys(pkg.imports)
-    : [];
+const packageImportExternals = Object.keys(pkg.imports ?? {});
 
 await build({
   entry: [

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -34,6 +34,10 @@ const dependsOnTap = ["dependencies", "peerDependencies"].some(
 );
 const isTapPackage = pkg.name === "@assistant-ui/tap";
 const remapReactToShim = dependsOnTap || isTapPackage;
+const packageImportExternals =
+  typeof pkg.imports === "object" && pkg.imports !== null
+    ? Object.keys(pkg.imports)
+    : [];
 
 await build({
   entry: [
@@ -56,7 +60,10 @@ await build({
     : {}),
   platform: "neutral",
   unbundle: true,
-  deps: { neverBundle: /^node:/, skipNodeModulesBundle: true },
+  deps: {
+    neverBundle: [/^node:/, ...packageImportExternals],
+    skipNodeModulesBundle: true,
+  },
   // Skip declaration files in dev for faster reloads.
   dts: isDev ? false : { sourcemap: true },
   sourcemap: true,


### PR DESCRIPTION
## Summary
- Treat package.json `imports` keys as external specifiers in `aui-build`
- Preserve conditional package imports like `#mcp-stdio` in emitted unbundled output
- Add a patch changeset for `@assistant-ui/x-buildutils`

## Validation
- `pnpm lint`
- `pnpm --filter @assistant-ui/react-ai-sdk build`
- `pnpm exec turbo build --concurrency=1`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

