### PR TITLE
fix: align react-generative-ui lockfile range

### DIFF
--- a/.changeset/mean-cycles-drum.md
+++ b/.changeset/mean-cycles-drum.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: align assistant-stream dependency range with lockfile

--- a/packages/react-generative-ui/package.json
+++ b/packages/react-generative-ui/package.json
@@ -39,7 +39,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "assistant-stream": "^0.3.23"
+    "assistant-stream": "^0.3.24"
   },
   "peerDependencies": {
     "@assistant-ui/react": "^0.14.14",


### PR DESCRIPTION
## Summary
- align @assistant-ui/react-generative-ui's assistant-stream dependency range with pnpm-lock.yaml
- add a patch changeset for the published package change

## Test
- pnpm install --frozen-lockfile

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

