### PR TITLE
Track Xulux chat turn outcomes

### DIFF
--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -304,6 +304,8 @@ export async function POST(req: Request): Promise<Response> {
         typeof payload?.error === "string"
           ? payload.error
           : "This request could not run because a usage limit was reached.";
+      const userMessageId = getLatestUserMessageId(messages);
+      const code = typeof payload?.code === "string" ? payload.code : undefined;
       return createXuluxDiagnosticMessageResponse({
         messages,
         text: userVisibleMessage,
@@ -312,10 +314,10 @@ export async function POST(req: Request): Promise<Response> {
           requestId,
           sessionId: sessionId.trim(),
           distinctId,
-          userMessageId: getLatestUserMessageId(messages),
           statusCode: budget.denied.status,
-          code: typeof payload?.code === "string" ? payload.code : undefined,
           userVisibleMessage,
+          ...(userMessageId ? { userMessageId } : {}),
+          ...(code ? { code } : {}),
         }),
       });
     }
@@ -425,6 +427,7 @@ export async function POST(req: Request): Promise<Response> {
           return { modelId: part.response.modelId };
         }
         if (part.type === "finish") {
+          const userMessageId = getLatestUserMessageId(messages);
           return {
             usage: part.totalUsage,
             custom: {
@@ -434,7 +437,7 @@ export async function POST(req: Request): Promise<Response> {
                   requestId,
                   sessionId: sessionId.trim(),
                   distinctId,
-                  userMessageId: getLatestUserMessageId(messages),
+                  ...(userMessageId ? { userMessageId } : {}),
                 }),
               },
             },

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -16,6 +16,11 @@ import {
 } from "ai";
 import type { UIMessage } from "ai";
 import { beginTurn, finishTurn } from "@/lib/xulux/usage-budget";
+import {
+  createXuluxDiagnosticMessageResponse,
+  createXuluxTurnOutcome,
+  getLatestUserMessageId,
+} from "@/lib/xulux/turn-outcome";
 import { createXuluxChatTools } from "./tools";
 
 type XuluxReasoningEffort =
@@ -257,6 +262,7 @@ Use inline code (\`backticks\`) for:
 `;
 
 export async function POST(req: Request): Promise<Response> {
+  const requestId = crypto.randomUUID();
   if (!isAiPlaygroundEnabled) {
     return NextResponse.json({ error: "Not found." }, { status: 404 });
   }
@@ -289,7 +295,30 @@ export async function POST(req: Request): Promise<Response> {
 
     const distinctId = getDistinctId(req);
     const budget = await beginTurn(sessionId.trim(), distinctId);
-    if (budget.denied) return budget.denied;
+    if (budget.denied) {
+      const payload = await budget.denied
+        .clone()
+        .json()
+        .catch(() => null);
+      const userVisibleMessage =
+        typeof payload?.error === "string"
+          ? payload.error
+          : "This request could not run because a usage limit was reached.";
+      return createXuluxDiagnosticMessageResponse({
+        messages,
+        text: userVisibleMessage,
+        outcome: createXuluxTurnOutcome({
+          type: "budget_denied",
+          requestId,
+          sessionId: sessionId.trim(),
+          distinctId,
+          userMessageId: getLatestUserMessageId(messages),
+          statusCode: budget.denied.status,
+          code: typeof payload?.code === "string" ? payload.code : undefined,
+          userVisibleMessage,
+        }),
+      });
+    }
     const budgetDate = budget.budgetDate;
 
     const isFirstUserTurn =
@@ -396,7 +425,20 @@ export async function POST(req: Request): Promise<Response> {
           return { modelId: part.response.modelId };
         }
         if (part.type === "finish") {
-          return { custom: { usage: part.totalUsage } };
+          return {
+            usage: part.totalUsage,
+            custom: {
+              xulux: {
+                outcome: createXuluxTurnOutcome({
+                  type: "assistant_response_completed",
+                  requestId,
+                  sessionId: sessionId.trim(),
+                  distinctId,
+                  userMessageId: getLatestUserMessageId(messages),
+                }),
+              },
+            },
+          };
         }
         return undefined;
       },

--- a/apps/docs/lib/xulux/turn-outcome.ts
+++ b/apps/docs/lib/xulux/turn-outcome.ts
@@ -1,0 +1,83 @@
+import {
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+} from "ai";
+import type { UIMessage } from "ai";
+
+export type XuluxTurnOutcomeType =
+  | "assistant_response_completed"
+  | "budget_denied";
+
+export type XuluxTurnOutcomeSeverity = "info" | "warning" | "error";
+
+export type XuluxTurnOutcome = {
+  type: XuluxTurnOutcomeType;
+  status: "completed";
+  severity: XuluxTurnOutcomeSeverity;
+  requestId: string;
+  capturedAt: string;
+  sessionId?: string;
+  distinctId?: string;
+  userMessageId?: string;
+  code?: string;
+  statusCode?: number;
+  userVisibleMessage?: string;
+  technicalSummary?: string;
+};
+
+type CreateXuluxTurnOutcomeOptions = Omit<
+  XuluxTurnOutcome,
+  "capturedAt" | "severity" | "status"
+> & {
+  capturedAt?: string;
+};
+
+export function createXuluxTurnOutcome({
+  capturedAt = new Date().toISOString(),
+  ...options
+}: CreateXuluxTurnOutcomeOptions): XuluxTurnOutcome {
+  return {
+    ...options,
+    status: "completed",
+    severity:
+      options.type === "assistant_response_completed" ? "info" : "warning",
+    capturedAt,
+  };
+}
+
+export function getLatestUserMessageId(messages: readonly UIMessage[]): string {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role === "user" && typeof message.id === "string") {
+      return message.id;
+    }
+  }
+  return "";
+}
+
+export function createXuluxDiagnosticMessageResponse({
+  messages,
+  text,
+  outcome,
+}: {
+  messages: UIMessage[];
+  text: string;
+  outcome: XuluxTurnOutcome;
+}): Response {
+  const textPartId = `text_${outcome.requestId}`;
+  const stream = createUIMessageStream<UIMessage>({
+    originalMessages: messages,
+    execute: ({ writer }) => {
+      writer.write({
+        type: "start",
+        messageMetadata: { custom: { xulux: { outcome } } },
+      });
+      writer.write({ type: "text-start", id: textPartId });
+      writer.write({ type: "text-delta", id: textPartId, delta: text });
+      writer.write({ type: "text-end", id: textPartId });
+      writer.write({ type: "finish", finishReason: "stop" });
+    },
+  });
+
+  return createUIMessageStreamResponse({ stream });
+}

--- a/apps/docs/lib/xulux/turn-outcome.ts
+++ b/apps/docs/lib/xulux/turn-outcome.ts
@@ -42,14 +42,16 @@ export function createXuluxTurnOutcome({
   };
 }
 
-export function getLatestUserMessageId(messages: readonly UIMessage[]): string {
+export function getLatestUserMessageId(
+  messages: readonly UIMessage[],
+): string | undefined {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
     if (message?.role === "user" && typeof message.id === "string") {
       return message.id;
     }
   }
-  return "";
+  return undefined;
 }
 
 export function createXuluxDiagnosticMessageResponse({

--- a/apps/docs/lib/xulux/turn-outcome.ts
+++ b/apps/docs/lib/xulux/turn-outcome.ts
@@ -1,7 +1,4 @@
-import {
-  createUIMessageStream,
-  createUIMessageStreamResponse,
-} from "ai";
+import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import type { UIMessage } from "ai";
 
 export type XuluxTurnOutcomeType =


### PR DESCRIPTION
﻿Closes #4602.

## Summary

This PR adds persisted Xulux chat turn outcome metadata for Cloud trace review.

- Stores successful model response usage at top-level `metadata.usage`.
- Adds `metadata.custom.xulux.outcome` for successful Xulux assistant responses.
- Converts Xulux budget-denied turns into a small Assistant UI message stream so the denial reason is visible and persisted in Cloud thread messages.
- Adds a focused Xulux helper for creating turn outcome metadata and diagnostic UI message responses.

## Validation

- Passed: `oxlint apps/docs/app/api/xulux/chat/route.ts apps/docs/lib/xulux/turn-outcome.ts`
- Passed: `git diff --cached --check` before commit
- Note: full docs typecheck was not run cleanly in the temporary worktree because the worktree did not have a full pnpm install. Earlier local `@assistant-ui/docs` typecheck in the main checkout still fails on existing unrelated docs/demo type errors and Node version warning (`node v22`, repo wants `>=24`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

