### PR TITLE
refactor(with-mcp): migrate test server to registerTool with read-only annotations

### DIFF
--- a/examples/with-mcp/server/server.ts
+++ b/examples/with-mcp/server/server.ts
@@ -165,18 +165,27 @@ const provider: OAuthServerProvider = {
 
 function buildMcpServer(): McpServer {
   const server = new McpServer({ name: "aui-mcp-test", version: "0.0.1" });
-  server.tool(
+  server.registerTool(
     "echo",
-    "Echo back the provided text.",
-    { text: z.string().describe("Text to echo back") },
+    {
+      title: "Echo",
+      description: "Echo back the provided text.",
+      inputSchema: { text: z.string().describe("Text to echo back") },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
     async ({ text }) => ({
       content: [{ type: "text" as const, text: `echo: ${text}` }],
     }),
   );
-  server.tool(
+  server.registerTool(
     "fingerprint",
-    "Return a deterministic fingerprint of a string (sha256 hex).",
-    { input: z.string() },
+    {
+      title: "Fingerprint",
+      description:
+        "Return a deterministic fingerprint of a string (sha256 hex).",
+      inputSchema: { input: z.string() },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
     async ({ input }) => ({
       content: [
         {


### PR DESCRIPTION
 Follow-up to #4574, which migrated the `mcp-docs-server` package. This applies the same `registerTool` change to the `with-mcp` example.

## What

Migrate the `with-mcp` example's standalone test MCP server from the deprecated `server.tool()` registration API to `server.registerTool()`, and advertise both demo tools as read-only.

## Why

`@modelcontextprotocol/sdk` marks `server.tool()` `@deprecated` in favor of `registerTool()`. PR #4574 already migrated the `mcp-docs-server` package; this applies the same change to the example so the reference code clients copy from uses the current API. Both `echo` and `fingerprint` are pure deterministic reads, so they now advertise `readOnlyHint: true` and `openWorldHint: false`.

## How

- `server/server.ts`: replace the two `server.tool(...)` calls in `buildMcpServer` with `server.registerTool(name, { title, description, inputSchema, annotations }, cb)`. The same input schemas and callbacks are reused, so tool names, input schemas, and response shapes are unchanged. Additive metadata only, no contract change.
- No changeset: `with-mcp` is a private example package.

## Notes

The file's top doc comment still reads "One MCP tool, `echo`", which predates the second `fingerprint` tool and is inaccurate. Left untouched to keep this diff scoped to the registration change; can fold the comment fix in here or as a separate cleanup if preferred.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

