### PR TITLE
fix(cli): skip shadcn registry install when --skip-install is passed

### DIFF
--- a/.changeset/cli-skip-install-shadcn-gate.md
+++ b/.changeset/cli-skip-install-shadcn-gate.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix(cli): skip shadcn registry install when --skip-install is passed

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -232,7 +232,12 @@ export async function transformProject(
     await installDependencies(projectDir, pm);
   }
 
-  if (!opts.hasLocalComponents && shadcnUI && assistantUI) {
+  if (
+    !opts.skipInstall &&
+    !opts.hasLocalComponents &&
+    shadcnUI &&
+    assistantUI
+  ) {
     const allShadcn = shadcnUI.includes("utils")
       ? shadcnUI
       : [...shadcnUI, "utils"];

--- a/packages/cli/test/lib/create-project.test.ts
+++ b/packages/cli/test/lib/create-project.test.ts
@@ -400,7 +400,11 @@ describe("transformProject — hasLocalComponents: false", () => {
         'import { Thread } from "@/components/assistant-ui/thread.tsx";\nimport { Button } from "@/components/ui/button.tsx";\nexport default function Page() { return <Thread />; }\n',
       );
 
-      await run();
+      await transformProject(testDir, {
+        ...defaultOpts,
+        skipInstall: false,
+        hasLocalComponents: false,
+      });
 
       const addCalls = (spawn as Mock).mock.calls.filter(
         ([cmd, args]: [string, string[]]) =>
@@ -415,6 +419,21 @@ describe("transformProject — hasLocalComponents: false", () => {
       expect(args).toContain("@assistant-ui/thread");
       expect(args).not.toContain("button.tsx");
       expect(args).not.toContain("@assistant-ui/thread.tsx");
+    });
+
+    it("skips shadcn when skipInstall is true even without local components", async () => {
+      writeFile(
+        "app/page.tsx",
+        'import { Thread } from "@/components/assistant-ui/thread.tsx";\nimport { Button } from "@/components/ui/button.tsx";\nexport default function Page() { return <Thread />; }\n',
+      );
+
+      await run();
+
+      const shadcnCalls = (spawn as Mock).mock.calls.filter(
+        ([cmd, args]: [string, string[]]) =>
+          cmd === TEST_DLX_CMD && args.includes("shadcn@latest"),
+      );
+      expect(shadcnCalls).toHaveLength(0);
     });
   });
 });
@@ -439,7 +458,13 @@ describe("transformProject — install behavior", () => {
 
 describe("installShadcnRegistry behavior", () => {
   it("resolves with a warning when shadcn exits non-zero", async () => {
-    // Override spawn mock to emit non-zero exit
+    // First spawn call is `pm install` (skipInstall: false); let it succeed.
+    (spawn as Mock).mockImplementationOnce(() => {
+      const ee = new EventEmitter();
+      setTimeout(() => ee.emit("close", 0), 0);
+      return ee;
+    });
+    // Second spawn call is `shadcn add`; emit non-zero exit.
     (spawn as Mock).mockImplementationOnce(() => {
       const ee = new EventEmitter();
       setTimeout(() => ee.emit("close", 1), 0);
@@ -455,6 +480,7 @@ describe("installShadcnRegistry behavior", () => {
     // Should NOT throw — warn-and-continue behavior
     await transformProject(testDir, {
       ...defaultOpts,
+      skipInstall: false,
       hasLocalComponents: false,
     });
   });


### PR DESCRIPTION
## summary

- `transformProject` ran `installShadcnRegistry` unconditionally for `hasLocalComponents:false` templates, so `--skip-install` still triggered a networked `shadcn add` for the six registry templates (`default`, `cloud`, `cloud-clerk`, `langchain`, `mcp`, `eve`).
- gate the shadcn install behind `!opts.skipInstall`, matching the existing guard on `installDependencies`, so `--skip-install` now skips every install path.
- fixes the root cause without copying components into the default template, preserving the registry-resolve model from #4054.

## test plan

### already verified

- [x] `pnpm --filter assistant-ui exec vitest run test/lib/create-project.test.ts test/commands/create.test.ts` -> 58/58 green
- [x] `pnpm exec oxlint <changed files>` -> clean
- [x] `pnpm exec oxfmt --check <changed files>` -> clean

### reviewer should verify

- [ ] `npx assistant-ui create my-app --template cloud --skip-install` scaffolds without invoking `shadcn add`, and `components/assistant-ui/*` are absent until a real install runs.

## notes

- the two pre-existing tests that asserted on the shadcn path used `skipInstall:true` and only passed because the gate was missing; they now use `skipInstall:false` so they exercise the install path for real, plus a new regression test pins `shadcnCalls.toHaveLength(0)` when `skipInstall` is true.
- supersedes the install-path slice of #4511; that PR's `packages/ui` attachment and tooltip provider fixes are independent and worth salvaging separately.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

