### PR TITLE
fix: restrict Xulux download proxy

### DIFF
--- a/apps/docs/app/api/xulux/download-proxy/route.ts
+++ b/apps/docs/app/api/xulux/download-proxy/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
 import { fetchSandboxResource } from "@/lib/xulux/fetch-sandbox";
+import { resolveSandboxDownloadUrl } from "@/lib/xulux/sandbox-download-url";
+import { getXuluxHostedTemplatesCatalog } from "@/lib/xulux/templates-catalog";
 
 export const runtime = "nodejs";
 
@@ -45,37 +47,33 @@ export async function GET(req: Request) {
   }
 
   const { searchParams } = new URL(req.url);
-  const targetUrl = searchParams.get("url");
+  const templateId = searchParams.get("templateId");
+  const versionId = searchParams.get("versionId") ?? undefined;
+  const downloadSearch = searchParams.get("downloadSearch") ?? undefined;
 
-  if (!targetUrl) {
+  if (!templateId) {
     return NextResponse.json(
-      { error: "Missing `url` query parameter." },
+      { error: "Missing `templateId` query parameter." },
       { status: 400 },
     );
   }
 
-  let parsed: URL;
-  try {
-    parsed = new URL(targetUrl);
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid `url` parameter." },
-      { status: 400 },
-    );
-  }
+  const upstreamUrl = resolveSandboxDownloadUrl({
+    templates: getXuluxHostedTemplatesCatalog().templates,
+    templateId,
+    versionId,
+    downloadSearch,
+  });
 
-  const allowed =
-    parsed.hostname.endsWith(".bl.run") ||
-    parsed.hostname.endsWith(".blaxel.ai");
-  if (!allowed) {
+  if (!upstreamUrl) {
     return NextResponse.json(
-      { error: "URL host not allowed." },
+      { error: "Template download URL not allowed." },
       { status: 403 },
     );
   }
 
   try {
-    const upstream = await fetchSandboxResource(targetUrl, {
+    const upstream = await fetchSandboxResource(upstreamUrl, {
       redirect: "manual",
     });
 

--- a/apps/docs/components/xulux/canvas/XuluxCanvas.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxCanvas.tsx
@@ -55,6 +55,7 @@ export function XuluxCanvas({
   error,
   downloadUrl,
   templateId,
+  versionId,
   sourceUrl,
   title,
 }: {
@@ -65,6 +66,7 @@ export function XuluxCanvas({
   error: string | null;
   downloadUrl?: string;
   templateId?: string;
+  versionId?: string;
   sourceUrl?: string;
   title?: string;
 }) {
@@ -86,7 +88,7 @@ export function XuluxCanvas({
     : "empty";
 
   const archiveUrl = canDownloadTemplate ? downloadUrl : undefined;
-  const archiveState = useVirtualArchive(archiveUrl);
+  const archiveState = useVirtualArchive(archiveUrl, templateId, versionId);
 
   useEffect(() => {
     if (!resolvedPreviewUrl) {

--- a/apps/docs/components/xulux/canvas/useVirtualArchive.ts
+++ b/apps/docs/components/xulux/canvas/useVirtualArchive.ts
@@ -12,47 +12,65 @@ export type ArchiveState =
   | { status: "ready"; archive: VirtualArchive }
   | { status: "error"; error: string };
 
-function resolveDownloadFetchUrl(downloadUrl: string): string {
+function resolveDownloadFetchUrl(
+  downloadUrl: string,
+  templateId: string | undefined,
+  versionId: string | undefined,
+): string {
   if (downloadUrl.startsWith("/")) return downloadUrl;
-  return `/api/xulux/download-proxy?url=${encodeURIComponent(downloadUrl)}`;
+
+  if (!templateId) {
+    throw new Error("Template id is required to download hosted archives.");
+  }
+
+  const parsed = new URL(downloadUrl);
+  const params = new URLSearchParams({ templateId });
+  if (versionId) params.set("versionId", versionId);
+  if (parsed.search) params.set("downloadSearch", parsed.search);
+  return `/api/xulux/download-proxy?${params.toString()}`;
 }
 
 export function useVirtualArchive(
   downloadUrl: string | undefined,
+  templateId?: string,
+  versionId?: string,
 ): ArchiveState {
   const [state, setState] = useState<ArchiveState>({ status: "idle" });
   const abortRef = useRef<AbortController | null>(null);
   const cachedUrlRef = useRef<string | null>(null);
   const cachedArchiveRef = useRef<VirtualArchive | null>(null);
 
-  const load = useCallback(async (url: string) => {
-    if (cachedUrlRef.current === url && cachedArchiveRef.current) {
-      setState({ status: "ready", archive: cachedArchiveRef.current });
-      return;
-    }
+  const load = useCallback(
+    async (url: string) => {
+      if (cachedUrlRef.current === url && cachedArchiveRef.current) {
+        setState({ status: "ready", archive: cachedArchiveRef.current });
+        return;
+      }
 
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
 
-    setState({ status: "loading" });
-    try {
-      const fetchUrl = resolveDownloadFetchUrl(url);
-      const res = await fetch(fetchUrl, { signal: controller.signal });
-      if (!res.ok) throw new Error(`Download failed: ${res.status}`);
-      const buffer = await res.arrayBuffer();
-      const archive = createVirtualArchive(new Uint8Array(buffer));
-      cachedUrlRef.current = url;
-      cachedArchiveRef.current = archive;
-      setState({ status: "ready", archive });
-    } catch (err) {
-      if (controller.signal.aborted) return;
-      setState({
-        status: "error",
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }, []);
+      setState({ status: "loading" });
+      try {
+        const fetchUrl = resolveDownloadFetchUrl(url, templateId, versionId);
+        const res = await fetch(fetchUrl, { signal: controller.signal });
+        if (!res.ok) throw new Error(`Download failed: ${res.status}`);
+        const buffer = await res.arrayBuffer();
+        const archive = createVirtualArchive(new Uint8Array(buffer));
+        cachedUrlRef.current = url;
+        cachedArchiveRef.current = archive;
+        setState({ status: "ready", archive });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setState({
+          status: "error",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [templateId, versionId],
+  );
 
   useEffect(() => {
     if (!downloadUrl) {

--- a/apps/docs/components/xulux/canvas/useVirtualArchive.ts
+++ b/apps/docs/components/xulux/canvas/useVirtualArchive.ts
@@ -37,32 +37,38 @@ export function useVirtualArchive(
 ): ArchiveState {
   const [state, setState] = useState<ArchiveState>({ status: "idle" });
   const abortRef = useRef<AbortController | null>(null);
-  const cachedUrlRef = useRef<string | null>(null);
+  const cachedFetchUrlRef = useRef<string | null>(null);
   const cachedArchiveRef = useRef<VirtualArchive | null>(null);
 
   const load = useCallback(
     async (url: string) => {
-      if (cachedUrlRef.current === url && cachedArchiveRef.current) {
-        setState({ status: "ready", archive: cachedArchiveRef.current });
-        return;
-      }
+      let controller: AbortController | null = null;
 
-      abortRef.current?.abort();
-      const controller = new AbortController();
-      abortRef.current = controller;
-
-      setState({ status: "loading" });
       try {
         const fetchUrl = resolveDownloadFetchUrl(url, templateId, versionId);
+
+        if (
+          cachedFetchUrlRef.current === fetchUrl &&
+          cachedArchiveRef.current
+        ) {
+          setState({ status: "ready", archive: cachedArchiveRef.current });
+          return;
+        }
+
+        abortRef.current?.abort();
+        controller = new AbortController();
+        abortRef.current = controller;
+
+        setState({ status: "loading" });
         const res = await fetch(fetchUrl, { signal: controller.signal });
         if (!res.ok) throw new Error(`Download failed: ${res.status}`);
         const buffer = await res.arrayBuffer();
         const archive = createVirtualArchive(new Uint8Array(buffer));
-        cachedUrlRef.current = url;
+        cachedFetchUrlRef.current = fetchUrl;
         cachedArchiveRef.current = archive;
         setState({ status: "ready", archive });
       } catch (err) {
-        if (controller.signal.aborted) return;
+        if (controller?.signal.aborted) return;
         setState({
           status: "error",
           error: err instanceof Error ? err.message : String(err),

--- a/apps/docs/components/xulux/shell/XuluxShell.tsx
+++ b/apps/docs/components/xulux/shell/XuluxShell.tsx
@@ -359,6 +359,7 @@ export function XuluxShell({
                   {...(canvas.downloadUrl
                     ? { downloadUrl: canvas.downloadUrl }
                     : {})}
+                  {...(canvas.versionId ? { versionId: canvas.versionId } : {})}
                   {...(sourceUrl ? { sourceUrl } : {})}
                   {...(canvasTitle ? { title: canvasTitle } : {})}
                 />
@@ -406,6 +407,7 @@ export function XuluxShell({
                   {...(canvas.downloadUrl
                     ? { downloadUrl: canvas.downloadUrl }
                     : {})}
+                  {...(canvas.versionId ? { versionId: canvas.versionId } : {})}
                   {...(sourceUrl ? { sourceUrl } : {})}
                   {...(canvasTitle ? { title: canvasTitle } : {})}
                 />

--- a/apps/docs/lib/xulux/fetch-sandbox.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.ts
@@ -31,7 +31,7 @@ function mergeHeaders(headers?: HeadersInit): Headers {
 }
 
 export async function fetchSandboxResource(
-  url: string,
+  url: URL,
   init?: RequestInit,
 ): Promise<Response> {
   let lastError: unknown;

--- a/apps/docs/lib/xulux/sandbox-download-url.test.ts
+++ b/apps/docs/lib/xulux/sandbox-download-url.test.ts
@@ -51,6 +51,19 @@ it("preserves query parameters from a matching sandbox download URL", () => {
   );
 });
 
+it("adds the selected version when dynamic download params omit it", () => {
+  const url = resolveSandboxDownloadUrl({
+    templates: [template],
+    templateId: "webpage-assistant",
+    versionId: "product-docs",
+    downloadSearch: "?session=abc",
+  });
+
+  expect(url?.href).toBe(
+    "https://0d9e27d14127c0eeadfc34b424cc7ed0.preview.bl.run/api/download?session=abc&v=product-docs",
+  );
+});
+
 it("rejects unsafe query parameter names", () => {
   const url = resolveSandboxDownloadUrl({
     templates: [template],

--- a/apps/docs/lib/xulux/sandbox-download-url.test.ts
+++ b/apps/docs/lib/xulux/sandbox-download-url.test.ts
@@ -1,0 +1,74 @@
+import { expect, it } from "vitest";
+import { resolveSandboxDownloadUrl } from "./sandbox-download-url";
+import type { XuluxTemplate } from "@/components/xulux/templates/types";
+
+const template: XuluxTemplate = {
+  id: "webpage-assistant-product-docs",
+  templateId: "webpage-assistant",
+  versionId: "product-docs",
+  title: "Product Docs Assistant",
+  description: "A docs assistant.",
+  categoryId: "docs",
+  categoryName: "Docs",
+  tags: [],
+  prompt: "Open it.",
+  gradient: "",
+  kind: "template",
+  previewStatus: "live",
+  sandboxBaseUrl: "https://0d9e27d14127c0eeadfc34b424cc7ed0.preview.bl.run",
+  tech: {
+    framework: "Next.js",
+    runtime: "assistant-ui + AI SDK",
+    frontendPattern: "Docs assistant",
+  },
+  env: [],
+  canStart: true,
+};
+
+it("builds a download URL from a catalog sandbox host", () => {
+  const url = resolveSandboxDownloadUrl({
+    templates: [template],
+    templateId: "webpage-assistant",
+    versionId: "product-docs",
+    downloadSearch: undefined,
+  });
+
+  expect(url?.href).toBe(
+    "https://0d9e27d14127c0eeadfc34b424cc7ed0.preview.bl.run/api/download?v=product-docs",
+  );
+});
+
+it("preserves query parameters from a matching sandbox download URL", () => {
+  const url = resolveSandboxDownloadUrl({
+    templates: [template],
+    templateId: "webpage-assistant",
+    versionId: "product-docs",
+    downloadSearch: "?session=abc&v=custom",
+  });
+
+  expect(url?.href).toBe(
+    "https://0d9e27d14127c0eeadfc34b424cc7ed0.preview.bl.run/api/download?session=abc&v=custom",
+  );
+});
+
+it("rejects unsafe query parameter names", () => {
+  const url = resolveSandboxDownloadUrl({
+    templates: [template],
+    templateId: "webpage-assistant",
+    versionId: "product-docs",
+    downloadSearch: "?../secret=abc",
+  });
+
+  expect(url).toBeNull();
+});
+
+it("rejects non-sandbox catalog hosts", () => {
+  const url = resolveSandboxDownloadUrl({
+    templates: [{ ...template, sandboxBaseUrl: "https://example.com" }],
+    templateId: "webpage-assistant",
+    versionId: "product-docs",
+    downloadSearch: "?session=abc",
+  });
+
+  expect(url).toBeNull();
+});

--- a/apps/docs/lib/xulux/sandbox-download-url.ts
+++ b/apps/docs/lib/xulux/sandbox-download-url.ts
@@ -6,7 +6,7 @@ const MAX_DOWNLOAD_SEARCH_LENGTH = 2048;
 const MAX_DOWNLOAD_SEARCH_VALUE_LENGTH = 512;
 const DOWNLOAD_SEARCH_KEY_PATTERN = /^[a-zA-Z0-9._-]{1,64}$/;
 
-function templateId(template: XuluxTemplate): string {
+function getTemplateId(template: XuluxTemplate): string {
   return template.templateId ?? template.id;
 }
 
@@ -24,12 +24,12 @@ function findTemplate(
   if (versionId) {
     const version = templates.find(
       (template) =>
-        templateId(template) === id && template.versionId === versionId,
+        getTemplateId(template) === id && template.versionId === versionId,
     );
     if (version) return version;
   }
 
-  return templates.find((template) => templateId(template) === id);
+  return templates.find((template) => getTemplateId(template) === id);
 }
 
 export function resolveSandboxDownloadUrl({

--- a/apps/docs/lib/xulux/sandbox-download-url.ts
+++ b/apps/docs/lib/xulux/sandbox-download-url.ts
@@ -1,0 +1,77 @@
+import type { XuluxTemplate } from "@/components/xulux/templates/types";
+
+const ALLOWED_SANDBOX_HOST_SUFFIXES = [".bl.run", ".blaxel.ai"] as const;
+const SANDBOX_DOWNLOAD_PATHNAME = "/api/download";
+const MAX_DOWNLOAD_SEARCH_LENGTH = 2048;
+const MAX_DOWNLOAD_SEARCH_VALUE_LENGTH = 512;
+const DOWNLOAD_SEARCH_KEY_PATTERN = /^[a-zA-Z0-9._-]{1,64}$/;
+
+function templateId(template: XuluxTemplate): string {
+  return template.templateId ?? template.id;
+}
+
+function isAllowedSandboxHost(hostname: string): boolean {
+  return ALLOWED_SANDBOX_HOST_SUFFIXES.some((suffix) =>
+    hostname.endsWith(suffix),
+  );
+}
+
+function findTemplate(
+  templates: readonly XuluxTemplate[],
+  id: string,
+  versionId: string | undefined,
+): XuluxTemplate | undefined {
+  if (versionId) {
+    const version = templates.find(
+      (template) =>
+        templateId(template) === id && template.versionId === versionId,
+    );
+    if (version) return version;
+  }
+
+  return templates.find((template) => templateId(template) === id);
+}
+
+export function resolveSandboxDownloadUrl({
+  templates,
+  templateId,
+  versionId,
+  downloadSearch,
+}: {
+  templates: readonly XuluxTemplate[];
+  templateId: string;
+  versionId: string | undefined;
+  downloadSearch: string | undefined;
+}): URL | null {
+  const template = findTemplate(templates, templateId, versionId);
+  if (!template?.sandboxBaseUrl) return null;
+
+  let baseUrl: URL;
+  try {
+    baseUrl = new URL(template.sandboxBaseUrl);
+  } catch {
+    return null;
+  }
+
+  if (baseUrl.protocol !== "https:") return null;
+  if (!isAllowedSandboxHost(baseUrl.hostname)) return null;
+
+  const resolved = new URL(SANDBOX_DOWNLOAD_PATHNAME, baseUrl);
+
+  if (downloadSearch) {
+    if (downloadSearch.length > MAX_DOWNLOAD_SEARCH_LENGTH) return null;
+
+    const sourceParams = new URLSearchParams(downloadSearch);
+    for (const [key, value] of sourceParams) {
+      if (!DOWNLOAD_SEARCH_KEY_PATTERN.test(key)) return null;
+      if (value.length > MAX_DOWNLOAD_SEARCH_VALUE_LENGTH) return null;
+      resolved.searchParams.append(key, value);
+    }
+  }
+
+  if (versionId && !resolved.searchParams.has("v")) {
+    resolved.searchParams.set("v", versionId);
+  }
+
+  return resolved;
+}


### PR DESCRIPTION
## Summary

Fixes the CodeQL SSRF alert for the Xulux download proxy by removing the caller-controlled upstream URL from the proxy contract. The proxy now resolves the sandbox origin from the server-side template catalog, always fetches `/api/download`, and only carries validated download query parameters.

Also updates the canvas archive loader to pass template context to the proxy and adds focused resolver tests.

## Dynamic download query

`downloadSearch` is still needed because customized hosted preview sessions can return session-specific download query values that are not derivable from the static template catalog. The server keeps the host and path fixed from trusted catalog data and only applies bounded, validated query parameters.

## Validation

- `pnpm lint`
- `pnpm build`
- `node_modules/.pnpm/node_modules/.bin/vitest run apps/docs/lib/xulux/sandbox-download-url.test.ts`
- `apps/docs/node_modules/.bin/tsc --noEmit`

## Notes

No changeset: this only changes the private docs app.