### PR TITLE
feat(mcp-docs-server): add argument completions for docs/examples resources

### DIFF
--- a/.changeset/mcp-resource-completions.md
+++ b/.changeset/mcp-resource-completions.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/mcp-docs-server": patch
+---
+
+feat: add argument completions for the docs and examples resources

--- a/packages/mcp-docs-server/src/tools/resources.ts
+++ b/packages/mcp-docs-server/src/tools/resources.ts
@@ -54,6 +54,14 @@ function registerMarkdownResource(
           mimeType: MARKDOWN_MIME_TYPE,
         })),
       }),
+      complete: {
+        [variable]: async (value) => {
+          const needle = value.toLowerCase();
+          return (await list()).filter((key) =>
+            key.toLowerCase().includes(needle),
+          );
+        },
+      },
     }),
     { title, description, mimeType: MARKDOWN_MIME_TYPE },
     async (uri, variables) => {

--- a/packages/mcp-docs-server/src/tools/tests/completions.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/completions.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { server } from "../../index.js";
+
+function handler(method: string) {
+  const handlers = (server as any).server._requestHandlers;
+  const h = handlers.get(method);
+  if (!h) throw new Error(`No handler for ${method}`);
+  return h;
+}
+
+async function complete(uri: string, name: string, value: string) {
+  return handler("completion/complete")(
+    {
+      method: "completion/complete",
+      params: { ref: { type: "ref/resource", uri }, argument: { name, value } },
+    },
+    {},
+  );
+}
+
+describe("resource argument completions", () => {
+  it("suggests doc paths matching the partial value", async () => {
+    const res = await complete("aui-docs:///{+path}", "path", "api");
+    expect(res.completion.values.length).toBeGreaterThan(0);
+    expect(
+      res.completion.values.every((v: string) =>
+        v.toLowerCase().includes("api"),
+      ),
+    ).toBe(true);
+  });
+
+  it("suggests example names matching the partial value", async () => {
+    const res = await complete("aui-example:///{+name}", "name", "with");
+    expect(res.completion.values.length).toBeGreaterThan(0);
+    expect(
+      res.completion.values.every((v: string) =>
+        v.toLowerCase().includes("with"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns no values for a nonsense partial", async () => {
+    const res = await complete("aui-docs:///{+path}", "path", "zzzqqxnope");
+    expect(res.completion.values).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What
Add MCP argument completions to the documentation and example **resource templates**: as a client types the `{path}` (docs) or `{name}` (example) URI variable, the server suggests matching entries from the bundled content.

## Why
The resource templates (`aui-docs:///{path}`, `aui-example:///{name}`) had no completer, so `completion/complete` returned nothing. This makes the resources discoverable: an editor can autocomplete which doc or example to read, fully offline. (MCP completions apply to resource templates and prompts; this is the resource-template case.)

## How
Add a `complete` map to the shared `registerMarkdownResource` resource-template factory, keyed by each resource's URI variable and reusing its existing `list` helper (doc file paths / example names) filtered by the partial value. One change covers both the docs and examples resources. The SDK already wires the completion handler when a template is registered and caps results at 100.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

