### PR TITLE
perf(docs): 4x faster docs dev server

### DIFF
--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -4,6 +4,13 @@ import { DEMOS } from "@/lib/demos";
 import { GALLERY_TEMPLATES } from "@/lib/gallery-templates";
 import { BASE_URL, PRODUCTS } from "@/lib/constants";
 
+type SitemapLastModified = MetadataRoute.Sitemap[number]["lastModified"];
+
+const getLastModified = (data: unknown): SitemapLastModified =>
+  typeof data === "object" && data !== null && "lastModified" in data
+    ? (data as { lastModified?: SitemapLastModified }).lastModified
+    : undefined;
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticPages: MetadataRoute.Sitemap = [
     { url: BASE_URL, changeFrequency: "weekly", priority: 1 },
@@ -41,21 +48,21 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const docsPages: MetadataRoute.Sitemap = source.getPages().map((page) => ({
     url: `${BASE_URL}${page.url}`,
-    lastModified: page.data.lastModified,
+    lastModified: getLastModified(page.data),
     changeFrequency: "weekly",
     priority: 0.9,
   }));
 
   const tapDocsPages: MetadataRoute.Sitemap = getTapDocsPages().map((page) => ({
     url: `${BASE_URL}${page.url}`,
-    lastModified: page.data.lastModified,
+    lastModified: getLastModified(page.data),
     changeFrequency: "weekly",
     priority: 0.7,
   }));
 
   const blogPages: MetadataRoute.Sitemap = blog.getPages().map((page) => ({
     url: `${BASE_URL}${page.url}`,
-    lastModified: page.data.lastModified,
+    lastModified: getLastModified(page.data),
     changeFrequency: "monthly",
     priority: 0.7,
   }));
@@ -64,7 +71,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     .getPages()
     .map((page) => ({
       url: `${BASE_URL}${page.url}`,
-      lastModified: page.data.lastModified,
+      lastModified: getLastModified(page.data),
       changeFrequency: "monthly",
       priority: 0.6,
     }));
@@ -85,7 +92,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const careerPages: MetadataRoute.Sitemap = careers.getPages().map((page) => ({
     url: `${BASE_URL}${page.url}`,
-    lastModified: page.data.lastModified,
+    lastModified: getLastModified(page.data),
     changeFrequency: "monthly",
     priority: 0.5,
   }));

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -55,6 +55,11 @@ const config: NextConfig = {
   transpilePackages: ["@assistant-ui/ui", "shiki"],
   serverExternalPackages: ["just-bash"],
   skipTrailingSlashRedirect: true,
+  ...(isDev && {
+    experimental: {
+      turbopackSourceMaps: false,
+    },
+  }),
   headers: async () => [
     {
       source: "/(.*)",

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -8,7 +8,6 @@ import {
 import { rehypeCodeDefaultOptions } from "fumadocs-core/mdx-plugins";
 import { transformerMetaHighlight } from "@shikijs/transformers";
 import { z } from "zod";
-import lastModified from "fumadocs-mdx/plugins/last-modified";
 import type { ShikiTransformer } from "shiki";
 import { remarkMermaid } from "./lib/remark-mermaid";
 
@@ -101,8 +100,13 @@ export const careers = defineCollections({
   }),
 });
 
+const isDev = process.env.NODE_ENV === "development";
+const plugins = isDev
+  ? []
+  : [(await import("fumadocs-mdx/plugins/last-modified")).default()];
+
 export default defineConfig({
-  plugins: [lastModified()],
+  plugins,
   mdxOptions: {
     remarkPlugins: [remarkMermaid],
     rehypeCodeOptions: {


### PR DESCRIPTION
experimental: I had pi-autoresearch (gpt-5.5) investigate improving docs dev server speed, it ran a little over 300 experiments and found a couple safe optimizations for a significant speed improvement.

- disable Turbopack dev source maps: ~50 seconds saved
- skip Fumadocs lastModified plugin in dev: ~30 seconds saved 

time saved is based on measuring dev server cold start, then navigate to any mdx docs page

this is a draft PR for now, two reasons:
- disabling source maps in dev makes debugging more difficult (easy to override if needed)
- MDX edits still sometimes don’t hot-reload (refreshing/restarting dev server is much faster though)
 
test these changes locally and let me know if you encounter any issues.
planning on using the same approach to improve the entire monorepo build as well.

agent drafted PR summary with metrics:

## Summary

Improves the `apps/docs` dev server cold start and first docs navigation workflow by **~81.6s** in the benchmark:

- Before: **107.6s** median
- After: **26.0s** median
- Improvement: **75.9% lower total time** / **4.14× faster**

## Measurements

Workflow: delete `apps/docs/.next`, start `next dev`, load `/`, navigate to a representative docs page, then measure an MDX edit reload.

| Variant | Runs | Dev server ready | Home load | Docs navigation after home | Total workflow | MDX edit reload |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Before these changes | 5 | 0.50s median, 0.37–0.71s range | 9.27s median, 8.02–18.11s range | 98.19s median, 97.07–101.72s range | 107.61s median, 105.14–119.88s range | 2.05s median, 0.68–2.19s range |
| After these changes | 5 | 0.49s median, 0.49–0.49s range | 7.91s median, 7.73–13.02s range | 17.34s median, 15.28–23.76s range | 25.97s median, 23.24–32.41s range | 1.17s median, 1.12–1.31s range |

## Estimated contribution

Practical estimates, the bottlenecks interact, so direct ablations are not perfectly additive.

| Change | Total workflow saved | Docs navigation saved | Home load saved | MDX edit reload saved |
| --- | ---: | ---: | ---: | ---: |
| Disable Turbopack dev source maps | ~52s | ~51s | ~0.3s | ~0.7s |
| Skip Fumadocs `lastModified` in local dev | ~30s | ~30s | ~1.0s | ~0.2s |
| **Total measured improvement** | **~81.6s** | **~80.9s** | **~1.4s** | **~0.9s** |

## DX notes

- `lastModified` is skipped only for local development. Preview and production still compute it.
- Disabling dev source maps is the main DX tradeoff: much faster docs startup/navigation, but weaker local source map debugging fidelity.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.HLQ9EOtRyP75BwQEQGnvAevL6SjM5pLoXB6uhiXlHT39zxjhgqNJdMF6UT8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->