### PR TITLE
fix(api-surface): stabilize string literal union member order

### DIFF
--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -46,7 +46,7 @@ declare function createSamplingCollector(): {
 };
 
 type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "jwt" | "api-key";
+  readonly strategy: "anon" | "api-key" | "jwt";
   getAuthHeaders(): Promise<Record<string, string> | false>;
   readAuthHeaders(headers: Headers): void;
 };
@@ -116,7 +116,7 @@ type ObjectStreamOperation = {
 };
 
 type PartInit = {
-  readonly type: "text" | "reasoning";
+  readonly type: "reasoning" | "text";
   readonly parentId?: string;
 } | {
   readonly type: "tool-call";
@@ -165,7 +165,7 @@ type AssistantStreamChunk = {
   readonly messageId: string;
 } | {
   readonly type: "step-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -173,7 +173,7 @@ type AssistantStreamChunk = {
   readonly isContinued: boolean;
 } | {
   readonly type: "message-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -217,7 +217,7 @@ type ReportToolCall = {
   tool_call_id: string;
   tool_args?: string;
   tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
+  tool_source?: "backend" | "frontend" | "mcp";
   start_ms?: number;
   end_ms?: number;
   sampling_calls?: SamplingCallData[];
@@ -225,7 +225,7 @@ type ReportToolCall = {
 
 type AssistantCloudRunReport = {
   thread_id: string;
-  status: "completed" | "incomplete" | "error";
+  status: "completed" | "error" | "incomplete";
   total_steps?: number;
   tool_calls?: ReportToolCall[];
   steps?: {

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -12,9 +12,9 @@ import Deque from "denque";
 
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
-type ResumableStreamRole = "producer" | "consumer";
+type ResumableStreamRole = "consumer" | "producer";
 
-type ResumableStreamStatus = "streaming" | "done" | "error" | "missing";
+type ResumableStreamStatus = "done" | "error" | "missing" | "streaming";
 
 type ResumableStreamEntry = {
   readonly cursor: string;
@@ -394,12 +394,12 @@ interface RedisCommander<Context extends ClientContext = {
   argetBuffer(key: RedisKey, index: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
   argetrange(key: RedisKey, start: number | string, end: number | string, callback?: Callback<(string | null)[]>): Result<(string | null)[], Context>;
   argetrangeBuffer(key: RedisKey, start: number | string, end: number | string, callback?: Callback<(Buffer | null)[]>): Result<(Buffer | null)[], Context>;
-  argrep(key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, callback: Callback<number[]>): Result<number[], Context>;
+  argrep(key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'GLOB' | 'MATCH' | 'RE', value: RedisValue, callback: Callback<number[]>): Result<number[], Context>;
   argrep(...args: [
     key: RedisKey,
     start: number | string,
     end: number | string,
-    predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE',
+    predicate: 'EXACT' | 'GLOB' | 'MATCH' | 'RE',
     value: RedisValue,
     ...args: RedisValue[],
     callback: Callback<number[] | Array<[
@@ -414,19 +414,19 @@ interface RedisCommander<Context extends ClientContext = {
     key: RedisKey,
     start: number | string,
     end: number | string,
-    predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE',
+    predicate: 'EXACT' | 'GLOB' | 'MATCH' | 'RE',
     value: RedisValue,
     ...args: T
   ]): Result<'WITHVALUES' extends T[number] ? Array<[
     index: number,
     value: string
   ]> : number[], Context>;
-  argrepBuffer(key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, callback: Callback<number[]>): Result<number[], Context>;
+  argrepBuffer(key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'GLOB' | 'MATCH' | 'RE', value: RedisValue, callback: Callback<number[]>): Result<number[], Context>;
   argrepBuffer(...args: [
     key: RedisKey,
     start: number | string,
     end: number | string,
-    predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE',
+    predicate: 'EXACT' | 'GLOB' | 'MATCH' | 'RE',
     value: RedisValue,
     ...args: RedisValue[],
     callback: Callback<number[] | Array<[
@@ -441,7 +441,7 @@ interface RedisCommander<Context extends ClientContext = {
     key: RedisKey,
     start: number | string,
     end: number | string,
-    predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE',
+    predicate: 'EXACT' | 'GLOB' | 'MATCH' | 'RE',
     value: RedisValue,
     ...args: T
   ]): Result<'WITHVALUES' extends T[number] ? Array<[
@@ -10585,7 +10585,7 @@ interface SentinelConnectionOptions {
   failoverDetector?: boolean | undefined;
 }
 
-declare type TcpOptions = Pick<TcpNetConnectOpts, "port" | "host" | "family">;
+declare type TcpOptions = Pick<TcpNetConnectOpts, "family" | "host" | "port">;
 
 declare type IpcOptions = Pick<IpcNetConnectOpts, "path">;
 
@@ -10640,7 +10640,7 @@ declare type RedisOptions = CommonRedisOptions & SentinelConnectionOptions & Sta
 
 declare type NodeKey = string;
 
-declare type NodeRole = "master" | "slave" | "all";
+declare type NodeRole = "all" | "master" | "slave";
 
 declare type DNSResolveSrvFunction = (hostname: string, callback: (err: NodeJS.ErrnoException | null | undefined, records?: SrvRecord[]) => void) => void;
 
@@ -10674,7 +10674,7 @@ interface ClusterOptions extends CommanderOptions {
   slotsRefreshInterval?: number | undefined;
   shardedSubscribers?: boolean | undefined;
   clusterNodeRetryStrategy?: ClusterNodeRetryStrategy;
-  redisOptions?: Omit<RedisOptions, "port" | "host" | "path" | "sentinels" | "retryStrategy" | "enableOfflineQueue" | "readOnly"> | undefined;
+  redisOptions?: Omit<RedisOptions, "enableOfflineQueue" | "host" | "path" | "port" | "readOnly" | "retryStrategy" | "sentinels"> | undefined;
   lazyConnect?: boolean | undefined;
   useSRVRecords?: boolean | undefined;
   resolveSrv?: DNSResolveSrvFunction | undefined;
@@ -10694,7 +10694,7 @@ declare type ClusterNode = string | number | {
   port?: number | undefined;
 };
 
-declare type ClusterStatus = "end" | "close" | "wait" | "connecting" | "connect" | "ready" | "reconnecting" | "disconnecting";
+declare type ClusterStatus = "close" | "connect" | "connecting" | "disconnecting" | "end" | "ready" | "reconnecting" | "wait";
 
 declare class Cluster extends Commander {
   options: ClusterOptions;
@@ -10809,7 +10809,7 @@ interface BatchOperationContext {
   serverPort: number | undefined;
 }
 
-declare type RedisStatus = "wait" | "reconnecting" | "connecting" | "connect" | "ready" | "close" | "end";
+declare type RedisStatus = "close" | "connect" | "connecting" | "end" | "ready" | "reconnecting" | "wait";
 
 declare class Redis extends Commander implements DataHandledable {
   static Cluster: typeof Cluster;
@@ -10845,7 +10845,7 @@ declare class Redis extends Commander implements DataHandledable {
   disconnect(reconnect?: boolean): void;
   end(): void;
   duplicate(override?: Partial<RedisOptions>): Redis;
-  get mode(): "normal" | "subscriber" | "monitor";
+  get mode(): "monitor" | "normal" | "subscriber";
   monitor(callback?: Callback<Redis>): Promise<Redis>;
   sendCommand(command: Command, stream?: WriteableStream): unknown;
   private getBlockingTimeoutInMs;
@@ -10975,7 +10975,7 @@ type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
 declare function asAsyncIterableStream<T>(source: ReadableStream<T>): AsyncIterableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -11155,7 +11155,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -11225,7 +11225,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -11270,7 +11270,7 @@ type ObjectStreamChunk = {
 };
 
 type PartInit = {
-  readonly type: "text" | "reasoning";
+  readonly type: "reasoning" | "text";
   readonly parentId?: string;
 } | {
   readonly type: "tool-call";
@@ -11319,7 +11319,7 @@ type AssistantStreamChunk = {
   readonly messageId: string;
 } | {
   readonly type: "step-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -11327,7 +11327,7 @@ type AssistantStreamChunk = {
   readonly isContinued: boolean;
 } | {
   readonly type: "message-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -11378,7 +11378,7 @@ type TextStatus = {
   reason: "stop" | "unknown";
 } | {
   type: "incomplete";
-  reason: "cancelled" | "length" | "content-filter" | "other";
+  reason: "cancelled" | "content-filter" | "length" | "other";
 };
 
 type TextPart = {
@@ -11406,7 +11406,7 @@ type ToolCallStatus = {
   reason: "stop" | "unknown";
 } | {
   type: "incomplete";
-  reason: "cancelled" | "length" | "content-filter" | "other";
+  reason: "cancelled" | "content-filter" | "length" | "other";
 };
 
 type ToolCallTiming = {
@@ -11430,7 +11430,7 @@ type ToolCallPartBase = {
 };
 
 type ToolCallPartWithoutResult = ToolCallPartBase & {
-  state: "partial-call" | "call";
+  state: "call" | "partial-call";
   result?: undefined;
   modelContent?: undefined;
 };
@@ -11481,7 +11481,7 @@ type AssistantMessageStepMetadata = {
 } | {
   state: "finished";
   messageId: string;
-  finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   usage?: AssistantMessageStepUsage;
   isContinued: boolean;
 };
@@ -11496,7 +11496,7 @@ type AssistantMessageStatus = {
   reason: "stop" | "unknown";
 } | {
   type: "incomplete";
-  reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   error?: ReadonlyJSONValue;
 };
 
@@ -11579,7 +11579,7 @@ type CreateResumeAssistantStreamResponseOptions = {
 
 declare function createResumeAssistantStreamResponse(options: CreateResumeAssistantStreamResponseOptions): Promise<Response>;
 
-type ResumableStreamErrorCode = "missing" | "exists" | "finalized" | "invalid-id";
+type ResumableStreamErrorCode = "exists" | "finalized" | "invalid-id" | "missing";
 
 declare class ResumableStreamError extends Error {
   readonly code: ResumableStreamErrorCode;
@@ -11637,7 +11637,7 @@ declare class AssistantTransformStream<I> extends TransformStream<I, AssistantSt
 }
 
 type AssistantMetaStreamChunk = (AssistantStreamChunk & {
-  type: "text-delta" | "part-finish";
+  type: "part-finish" | "text-delta";
   meta: PartInit;
 }) | (AssistantStreamChunk & {
   type: "result" | "tool-call-args-text-finish";
@@ -11645,7 +11645,7 @@ type AssistantMetaStreamChunk = (AssistantStreamChunk & {
     type: "tool-call";
   };
 }) | (AssistantStreamChunk & {
-  type: Exclude<AssistantStreamChunk["type"], "text-delta" | "result" | "tool-call-args-text-finish" | "part-finish">;
+  type: Exclude<AssistantStreamChunk["type"], "part-finish" | "result" | "text-delta" | "tool-call-args-text-finish">;
 });
 
 declare class AssistantMetaTransformStream extends TransformStream<AssistantStreamChunk, AssistantMetaStreamChunk> {
@@ -11748,7 +11748,7 @@ type AttachmentLike = {
 };
 
 type ThreadMessageLike = {
-  role: "system" | "user" | "assistant";
+  role: "assistant" | "system" | "user";
   content: readonly MessagePartLike[];
   attachments?: readonly AttachmentLike[];
 };
@@ -11804,7 +11804,7 @@ declare class DataStreamDecoder extends PipeableTransformStream<Uint8Array<Array
   constructor();
 }
 
-type FinishReason = "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+type FinishReason = "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
 
 type Usage = {
   inputTokens: number;

--- a/api-surface/assistant-ui__cloud-ai-sdk.ts
+++ b/api-surface/assistant-ui__cloud-ai-sdk.ts
@@ -12,7 +12,7 @@ type SamplingCallData = {
 };
 
 type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "jwt" | "api-key";
+  readonly strategy: "anon" | "api-key" | "jwt";
   getAuthHeaders(): Promise<Record<string, string> | false>;
   readAuthHeaders(headers: Headers): void;
 };
@@ -82,7 +82,7 @@ type ObjectStreamOperation = {
 };
 
 type PartInit = {
-  readonly type: "text" | "reasoning";
+  readonly type: "reasoning" | "text";
   readonly parentId?: string;
 } | {
   readonly type: "tool-call";
@@ -131,7 +131,7 @@ type AssistantStreamChunk = {
   readonly messageId: string;
 } | {
   readonly type: "step-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -139,7 +139,7 @@ type AssistantStreamChunk = {
   readonly isContinued: boolean;
 } | {
   readonly type: "message-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -183,7 +183,7 @@ type ReportToolCall = {
   tool_call_id: string;
   tool_args?: string;
   tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
+  tool_source?: "backend" | "frontend" | "mcp";
   start_ms?: number;
   end_ms?: number;
   sampling_calls?: SamplingCallData[];
@@ -191,7 +191,7 @@ type ReportToolCall = {
 
 type AssistantCloudRunReport = {
   thread_id: string;
-  status: "completed" | "incomplete" | "error";
+  status: "completed" | "error" | "incomplete";
   total_steps?: number;
   tool_calls?: ReportToolCall[];
   steps?: {
@@ -376,7 +376,7 @@ declare class AssistantCloud {
   constructor(config: AssistantCloudConfig);
 }
 
-type ThreadStatus = "regular" | "archived";
+type ThreadStatus = "archived" | "regular";
 
 type CloudThread = {
   id: string;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -59,7 +59,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -239,7 +239,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -309,7 +309,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -349,7 +349,7 @@ type ObjectStreamOperation = {
 };
 
 type PartInit = {
-  readonly type: "text" | "reasoning";
+  readonly type: "reasoning" | "text";
   readonly parentId?: string;
 } | {
   readonly type: "tool-call";
@@ -398,7 +398,7 @@ type AssistantStreamChunk = {
   readonly messageId: string;
 } | {
   readonly type: "step-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -406,7 +406,7 @@ type AssistantStreamChunk = {
   readonly isContinued: boolean;
 } | {
   readonly type: "message-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -529,7 +529,7 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 declare const MCP_APP_URI_SCHEME = "ui://";
@@ -540,7 +540,7 @@ type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -605,7 +605,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -618,13 +618,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -692,7 +692,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -708,7 +708,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -739,7 +739,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -779,7 +779,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -929,10 +929,10 @@ declare const getThreadMessageText: (message: ThreadMessage | AppendMessage) => 
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -948,10 +948,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -1011,15 +1011,15 @@ declare class WebSpeechDictationAdapter implements DictationAdapter {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -1050,7 +1050,7 @@ type VoiceSessionControls = {
 
 type VoiceSessionHelpers = {
   setStatus: (status: RealtimeVoiceAdapter.Status) => void;
-  end: (reason: "finished" | "cancelled" | "error", error?: unknown) => void;
+  end: (reason: "cancelled" | "error" | "finished", error?: unknown) => void;
   emitTranscript: (item: RealtimeVoiceAdapter.TranscriptItem) => void;
   emitMode: (mode: RealtimeVoiceAdapter.Mode) => void;
   emitVolume: (volume: number) => void;
@@ -1174,7 +1174,7 @@ type QuoteInfo = {
   readonly messageId: string;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -1440,7 +1440,7 @@ type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
 type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
 
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "source" | "query"> : never;
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
 
 type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
 
@@ -1578,7 +1578,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -1600,7 +1600,7 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
   readonly composerSource: "edit";
 });
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemCoreState = {
   readonly id: string;
@@ -1747,7 +1747,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   private _text;
   get text(): string;
   private _role;
-  get role(): "system" | "user" | "assistant";
+  get role(): "assistant" | "system" | "user";
   private _runConfig;
   get runConfig(): RunConfig;
   private _quote;
@@ -1838,7 +1838,7 @@ declare class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -1975,7 +1975,7 @@ declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSou
   subscribe(callback: () => void): Unsubscribe$1;
 }
 
-declare abstract class ComposerAttachmentRuntime<Source extends "thread-composer" | "edit-composer"> extends AttachmentRuntimeImpl<Source> {
+declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
   private _composerApi;
   constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
   remove(): Promise<void>;
@@ -2069,7 +2069,7 @@ declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
   abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
 }
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -2091,7 +2091,7 @@ declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements T
   getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
 }
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -2745,10 +2745,10 @@ type ExternalThreadQueueAdapter = {
   }) => void;
   steer: (queueItemId: string) => void;
   remove: (queueItemId: string) => void;
-  clear: (reason: "edit" | "reload" | "cancel-run") => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
 };
 
-type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
   status: TState;
   id: string;
   remoteId?: string | undefined;
@@ -3076,7 +3076,7 @@ type RemoteThreadInitializeResponse = {
 };
 
 type RemoteThreadMetadata = {
-  readonly status: "regular" | "archived";
+  readonly status: "archived" | "regular";
   readonly remoteId: string;
   readonly externalId?: string | undefined;
   readonly title?: string | undefined;
@@ -3127,7 +3127,7 @@ type RemoteThreadData = {
   readonly initializeTask: Promise<RemoteThreadInitializeResponse>;
   readonly remoteId: undefined;
   readonly externalId: undefined;
-  readonly status: "regular" | "archived";
+  readonly status: "archived" | "regular";
   readonly title?: string | undefined;
   readonly custom: undefined;
 } | {
@@ -3135,7 +3135,7 @@ type RemoteThreadData = {
   readonly initializeTask: Promise<RemoteThreadInitializeResponse>;
   readonly remoteId: string;
   readonly externalId: string | undefined;
-  readonly status: "regular" | "archived";
+  readonly status: "archived" | "regular";
   readonly title?: string | undefined;
   readonly lastMessageAt?: Date | undefined;
   readonly custom?: Record<string, unknown> | undefined;
@@ -3160,7 +3160,7 @@ type RemoteThreadState = {
 
 declare const getThreadData: (state: RemoteThreadState, threadIdOrRemoteId: string) => RemoteThreadData | undefined;
 
-declare const updateStatusReducer: (state: RemoteThreadState, threadIdOrRemoteId: string, newStatus: "regular" | "archived" | "deleted") => RemoteThreadState;
+declare const updateStatusReducer: (state: RemoteThreadState, threadIdOrRemoteId: string, newStatus: "archived" | "deleted" | "regular") => RemoteThreadState;
 
 declare namespace entry_internal_exports {
   export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, RuntimeExtras, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, createRuntimeExtras, createThreadMappingId, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, isAutoStatus, isErrorMessageId, resolveToolApprovalResponse, shouldContinue, symbolInnerMessage, updateStatusReducer };
@@ -3233,7 +3233,7 @@ type AttachmentMethods = {
 };
 
 type AttachmentMeta = {
-  source: "message" | "composer";
+  source: "composer" | "message";
   query: {
     type: "index";
     index: number;
@@ -3262,7 +3262,7 @@ type ComposerState = {
   readonly canSend: boolean;
   readonly attachmentAccept: string;
   readonly isEmpty: boolean;
-  readonly type: "thread" | "edit";
+  readonly type: "edit" | "thread";
   readonly dictation: DictationState | undefined;
   readonly quote: QuoteInfo | undefined;
   readonly queue: readonly QueueItemState[];
@@ -3294,7 +3294,7 @@ type ComposerMethods = {
 };
 
 type ComposerMeta = {
-  source: "thread" | "message";
+  source: "message" | "thread";
   query: Record<string, never>;
 };
 
@@ -3379,10 +3379,10 @@ type MessageMethods = {
   speak(): void;
   stopSpeaking(): void;
   submitFeedback(feedback: {
-    type: "positive" | "negative";
+    type: "negative" | "positive";
   }): void;
   switchToBranch(options: {
-    position?: "previous" | "next";
+    position?: "next" | "previous";
     branchId?: string;
   }): void;
   getCopyText(): string;
@@ -3985,7 +3985,7 @@ type OverrideOptionalField<T, TKey extends keyof T, TValue> = undefined extends 
 
 type OverrideToolDeclarationCallbacks<T extends {
   streamCall?: unknown;
-}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "type" | "execute" | "toModelOutput" | "experimental_onSchemaValidationError" | "streamCall"> & {
+}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "execute" | "experimental_onSchemaValidationError" | "streamCall" | "toModelOutput" | "type"> & {
   type?: never;
 } & ("execute" extends keyof T ? OverrideOptionalField<T, "execute", ToolExecute<NoInfer<TArgs>, TResult>> : {}) & ("toModelOutput" extends keyof T ? OverrideOptionalField<T, "toModelOutput", ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>> : {}) & ("experimental_onSchemaValidationError" extends keyof T ? OverrideOptionalField<T, "experimental_onSchemaValidationError", (args: unknown, context: ToolExecuteContext) => NoInfer<TResult> | Promise<NoInfer<TResult>>> : {}) & OverrideOptionalField<T, "streamCall", ToolStreamCall<TArgs, unknown>>;
 
@@ -4032,7 +4032,7 @@ declare const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult
 type AssistantToolUIProps<TArgs, TResult> = {
   toolName: string;
   render: ToolCallMessagePartComponent<TArgs, TResult>;
-  display?: "standalone" | "inline";
+  display?: "inline" | "standalone";
 };
 
 declare const useAssistantToolUI: (tool: AssistantToolUIProps<any, any> | null) => void;
@@ -4096,7 +4096,7 @@ type ProviderToolDefinition<TArgs extends Record<string, unknown>> = Extract<Too
   type: "provider";
 }>;
 
-type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "providerId" | "args" | "parameters" | "providerOptions" | "supportsDeferredResults">;
+type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "args" | "parameters" | "providerId" | "providerOptions" | "supportsDeferredResults">;
 
 declare function providerTool(_config: ProviderToolConfig): never;
 
@@ -4223,10 +4223,10 @@ declare const unstable_interactableTool: <TSchema extends Unstable_InteractableS
   success: true;
 }>;
 
-type PropFieldStatus = "streaming" | "complete";
+type PropFieldStatus = "complete" | "streaming";
 
 type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unknown>> = {
-  status: "running" | "complete" | "incomplete" | "requires-action";
+  status: "complete" | "incomplete" | "requires-action" | "running";
   propStatus: Partial<Record<keyof TArgs, PropFieldStatus>>;
 };
 
@@ -4313,7 +4313,7 @@ declare const useRuntimeAdapters: () => RuntimeAdapters | null;
 
 declare const useExternalStoreRuntime: <T>(store: ExternalStoreAdapter<T>) => AssistantRuntime;
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "unstable_capabilities" | "suggestions">;
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
 
 declare const pickExternalStoreSharedOptions: (options: ExternalStoreSharedOptions) => ExternalStoreSharedOptions;
 
@@ -4648,7 +4648,7 @@ type SamplingCallData = {
 };
 
 type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "jwt" | "api-key";
+  readonly strategy: "anon" | "api-key" | "jwt";
   getAuthHeaders(): Promise<Record<string, string> | false>;
   readAuthHeaders(headers: Headers): void;
 };
@@ -4700,7 +4700,7 @@ type ReportToolCall = {
   tool_call_id: string;
   tool_args?: string;
   tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
+  tool_source?: "backend" | "frontend" | "mcp";
   start_ms?: number;
   end_ms?: number;
   sampling_calls?: SamplingCallData[];
@@ -4708,7 +4708,7 @@ type ReportToolCall = {
 
 type AssistantCloudRunReport = {
   thread_id: string;
-  status: "completed" | "incomplete" | "error";
+  status: "completed" | "error" | "incomplete";
   total_steps?: number;
   tool_calls?: ReportToolCall[];
   steps?: {
@@ -5094,7 +5094,7 @@ declare namespace MessagePrimitiveGroupedParts {
   type IndicatorPart = {
     readonly type: "indicator";
   };
-  type IndicatorMode = "never" | "empty" | "no-text" | "always";
+  type IndicatorMode = "always" | "empty" | "never" | "no-text";
   type RenderInfo<TKey extends `group-${string}` = `group-${string}`> = {
     readonly part: GroupPart<TKey> | EnrichedPartState | IndicatorPart;
     readonly children: ReactNode;
@@ -5522,7 +5522,7 @@ declare const splitLocalRuntimeOptions: <T extends LocalRuntimeOptions>(options:
     unstable_humanToolNames: string[] | undefined;
     unstable_enableMessageQueue: boolean | undefined;
   };
-  otherOptions: Omit<T, "adapters" | "maxSteps" | "unstable_humanToolNames" | "unstable_enableMessageQueue" | "cloud" | "initialMessages">;
+  otherOptions: Omit<T, "adapters" | "cloud" | "initialMessages" | "maxSteps" | "unstable_enableMessageQueue" | "unstable_humanToolNames">;
 };
 
 declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param20?: LocalRuntimeOptions) => AssistantRuntime;

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -59,7 +59,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -239,7 +239,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -298,7 +298,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -415,14 +415,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -487,7 +487,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -500,13 +500,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -574,7 +574,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -590,7 +590,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -626,7 +626,7 @@ type AttachmentAdapter = {
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -637,10 +637,10 @@ type Unsubscribe = () => void;
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -656,10 +656,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -702,15 +702,15 @@ declare global {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -794,7 +794,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -834,7 +834,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -870,7 +870,7 @@ type QueueItemState = {
   readonly prompt: string;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -1026,7 +1026,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -1048,7 +1048,7 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
   readonly composerSource: "edit";
 });
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemState = {
   readonly isMain: boolean;
@@ -1138,7 +1138,7 @@ type ComposerRuntime = {
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -1149,7 +1149,7 @@ type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentBy
   };
 };
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -1343,10 +1343,10 @@ type ExternalThreadQueueAdapter = {
   }) => void;
   steer: (queueItemId: string) => void;
   remove: (queueItemId: string) => void;
-  clear: (reason: "edit" | "reload" | "cancel-run") => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
 };
 
-type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
   status: TState;
   id: string;
   remoteId?: string | undefined;
@@ -1432,7 +1432,7 @@ type AssistantRuntime = {
   registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
 };
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "unstable_capabilities" | "suggestions">;
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
 
 type ConvertEveMessagesOptions = {
   readonly isRunning?: boolean | undefined;

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -6,7 +6,7 @@ type A2AClientOptions = {
   tenant?: string | undefined;
   headers?: Record<string, string> | (() => Record<string, string> | Promise<Record<string, string>>) | undefined;
   extensions?: string[] | undefined;
-  fetchOptions?: Omit<RequestInit, "headers" | "body" | "method" | "signal"> | undefined;
+  fetchOptions?: Omit<RequestInit, "body" | "headers" | "method" | "signal"> | undefined;
 };
 
 declare class A2AError extends Error {
@@ -101,7 +101,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -281,7 +281,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -340,7 +340,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -457,14 +457,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -529,7 +529,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -542,13 +542,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -616,7 +616,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -632,7 +632,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -668,7 +668,7 @@ type AttachmentAdapter = {
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -679,10 +679,10 @@ type Unsubscribe = () => void;
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -698,10 +698,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -744,15 +744,15 @@ declare global {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -836,7 +836,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -876,7 +876,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -918,7 +918,7 @@ type QueueItemState = {
   readonly prompt: string;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -1123,7 +1123,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -1145,7 +1145,7 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
   readonly composerSource: "edit";
 });
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemState = {
   readonly isMain: boolean;
@@ -1235,7 +1235,7 @@ type ComposerRuntime = {
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -1246,7 +1246,7 @@ type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentBy
   };
 };
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -1440,10 +1440,10 @@ type ExternalThreadQueueAdapter = {
   }) => void;
   steer: (queueItemId: string) => void;
   remove: (queueItemId: string) => void;
-  clear: (reason: "edit" | "reload" | "cancel-run") => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
 };
 
-type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
   status: TState;
   id: string;
   remoteId?: string | undefined;
@@ -1529,11 +1529,11 @@ type AssistantRuntime = {
   registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
 };
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "unstable_capabilities" | "suggestions">;
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
 
 declare const A2A_PROTOCOL_VERSION = "1.0";
 
-type A2ARole = "unspecified" | "user" | "agent";
+type A2ARole = "agent" | "unspecified" | "user";
 
 type A2APart = {
   text?: string | undefined;
@@ -1556,7 +1556,7 @@ type A2AMessage = {
   referenceTaskIds?: string[] | undefined;
 };
 
-type A2ATaskState = "unspecified" | "submitted" | "working" | "completed" | "failed" | "canceled" | "input_required" | "rejected" | "auth_required";
+type A2ATaskState = "auth_required" | "canceled" | "completed" | "failed" | "input_required" | "rejected" | "submitted" | "unspecified" | "working";
 
 type A2ATaskStatus = {
   state: A2ATaskState;

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -62,7 +62,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -242,7 +242,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -301,7 +301,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -418,14 +418,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -490,7 +490,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -503,13 +503,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -577,7 +577,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -593,7 +593,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -629,7 +629,7 @@ type AttachmentAdapter = {
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -640,10 +640,10 @@ type Unsubscribe = () => void;
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -659,10 +659,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -705,15 +705,15 @@ declare global {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -797,7 +797,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -837,7 +837,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -879,7 +879,7 @@ type QueueItemState = {
   readonly prompt: string;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -1084,7 +1084,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -1106,7 +1106,7 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
   readonly composerSource: "edit";
 });
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemState = {
   readonly isMain: boolean;
@@ -1196,7 +1196,7 @@ type ComposerRuntime = {
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -1207,7 +1207,7 @@ type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentBy
   };
 };
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -1401,10 +1401,10 @@ type ExternalThreadQueueAdapter = {
   }) => void;
   steer: (queueItemId: string) => void;
   remove: (queueItemId: string) => void;
-  clear: (reason: "edit" | "reload" | "cancel-run") => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
 };
 
-type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
   status: TState;
   id: string;
   remoteId?: string | undefined;
@@ -1490,7 +1490,7 @@ type AssistantRuntime = {
   registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
 };
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "unstable_capabilities" | "suggestions">;
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
 
 type SwitchToThreadResult = {
   messages: readonly ThreadMessage[];
@@ -1535,7 +1535,7 @@ type AgUiInterrupt = {
 
 type AgUiResumeEntry = {
   interruptId: string;
-  status: "resolved" | "cancelled";
+  status: "cancelled" | "resolved";
   payload?: unknown;
 };
 

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -18,7 +18,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -198,7 +198,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -257,7 +257,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -295,7 +295,7 @@ type ObjectStreamOperation = {
 };
 
 type PartInit = {
-  readonly type: "text" | "reasoning";
+  readonly type: "reasoning" | "text";
   readonly parentId?: string;
 } | {
   readonly type: "tool-call";
@@ -344,7 +344,7 @@ type AssistantStreamChunk = {
   readonly messageId: string;
 } | {
   readonly type: "step-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -352,7 +352,7 @@ type AssistantStreamChunk = {
   readonly isContinued: boolean;
 } | {
   readonly type: "message-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -557,14 +557,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -629,7 +629,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -642,13 +642,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -716,7 +716,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -732,7 +732,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -804,7 +804,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -828,10 +828,10 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -847,10 +847,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -901,7 +901,7 @@ type QueueItemState = {
   readonly prompt: string;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -933,15 +933,15 @@ type SendOptions = {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -994,7 +994,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -1034,7 +1034,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -1135,7 +1135,7 @@ type ResumeRunConfig = StartRunConfig & {
   stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 };
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemState = {
   readonly isMain: boolean;
@@ -1225,7 +1225,7 @@ type ComposerRuntime = {
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -1236,7 +1236,7 @@ type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentBy
   };
 };
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -1541,7 +1541,7 @@ type ThreadHistoryAdapter = {
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -1565,10 +1565,10 @@ type ExternalThreadQueueAdapter = {
   }) => void;
   steer: (queueItemId: string) => void;
   remove: (queueItemId: string) => void;
-  clear: (reason: "edit" | "reload" | "cancel-run") => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
 };
 
-type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
   status: TState;
   id: string;
   remoteId?: string | undefined;
@@ -1648,7 +1648,7 @@ type ExternalStoreAdapterBase<T> = {
 
 type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "unstable_capabilities" | "suggestions">;
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
 
 type JoinStrategy = "concat-content" | "none";
 
@@ -1662,7 +1662,7 @@ type SamplingCallData = {
 };
 
 type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "jwt" | "api-key";
+  readonly strategy: "anon" | "api-key" | "jwt";
   getAuthHeaders(): Promise<Record<string, string> | false>;
   readAuthHeaders(headers: Headers): void;
 };
@@ -1714,7 +1714,7 @@ type ReportToolCall = {
   tool_call_id: string;
   tool_args?: string;
   tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
+  tool_source?: "backend" | "frontend" | "mcp";
   start_ms?: number;
   end_ms?: number;
   sampling_calls?: SamplingCallData[];
@@ -1722,7 +1722,7 @@ type ReportToolCall = {
 
 type AssistantCloudRunReport = {
   thread_id: string;
-  status: "completed" | "incomplete" | "error";
+  status: "completed" | "error" | "incomplete";
   total_steps?: number;
   tool_calls?: ReportToolCall[];
   steps?: {

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -57,7 +57,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -237,7 +237,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -296,7 +296,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -334,7 +334,7 @@ type ObjectStreamOperation = {
 };
 
 type PartInit = {
-  readonly type: "text" | "reasoning";
+  readonly type: "reasoning" | "text";
   readonly parentId?: string;
 } | {
   readonly type: "tool-call";
@@ -383,7 +383,7 @@ type AssistantStreamChunk = {
   readonly messageId: string;
 } | {
   readonly type: "step-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -391,7 +391,7 @@ type AssistantStreamChunk = {
   readonly isContinued: boolean;
 } | {
   readonly type: "message-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -514,14 +514,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -586,7 +586,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -599,13 +599,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -673,7 +673,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -689,7 +689,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -725,7 +725,7 @@ type AttachmentAdapter = {
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -736,10 +736,10 @@ type Unsubscribe = () => void;
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -755,10 +755,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -801,15 +801,15 @@ declare global {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -897,7 +897,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -937,7 +937,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -979,7 +979,7 @@ type QueueItemState = {
   readonly prompt: string;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -1155,7 +1155,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -1177,7 +1177,7 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
   readonly composerSource: "edit";
 });
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemState = {
   readonly isMain: boolean;
@@ -1267,7 +1267,7 @@ type ComposerRuntime = {
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -1278,7 +1278,7 @@ type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentBy
   };
 };
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -1501,7 +1501,7 @@ type SamplingCallData = {
 };
 
 type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "jwt" | "api-key";
+  readonly strategy: "anon" | "api-key" | "jwt";
   getAuthHeaders(): Promise<Record<string, string> | false>;
   readAuthHeaders(headers: Headers): void;
 };
@@ -1553,7 +1553,7 @@ type ReportToolCall = {
   tool_call_id: string;
   tool_args?: string;
   tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
+  tool_source?: "backend" | "frontend" | "mcp";
   start_ms?: number;
   end_ms?: number;
   sampling_calls?: SamplingCallData[];
@@ -1561,7 +1561,7 @@ type ReportToolCall = {
 
 type AssistantCloudRunReport = {
   thread_id: string;
-  status: "completed" | "incomplete" | "error";
+  status: "completed" | "error" | "incomplete";
   total_steps?: number;
   tool_calls?: ReportToolCall[];
   steps?: {
@@ -1754,7 +1754,7 @@ type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
 
 type HeadersValue = Record<string, string> | Headers;
 
-type DataStreamProtocol = "ui-message-stream" | "data-stream";
+type DataStreamProtocol = "data-stream" | "ui-message-stream";
 
 type UseDataStreamRuntimeOptions = {
   api: string;

--- a/api-surface/assistant-ui__react-devtools.ts
+++ b/api-surface/assistant-ui__react-devtools.ts
@@ -58,7 +58,7 @@ interface DevToolsTabContext {
   apiId: number;
   data: ApiInfo;
   clearEvents: (apiId: number) => void;
-  theme: "light" | "dark";
+  theme: "dark" | "light";
   selection: string | null;
   setSelection: (nodeId: string | null) => void;
   switchToThread?: ((threadId: string) => void | Promise<void>) | undefined;
@@ -78,7 +78,7 @@ declare const builtinPlugins: DevToolsPanelPlugin[];
 
 interface DevToolsModalProps {
   plugins?: DevToolsPanelPlugin[];
-  theme?: "light" | "dark" | "system";
+  theme?: "dark" | "light" | "system";
   client?: DevToolsClient;
 }
 
@@ -90,7 +90,7 @@ declare const inProcessClient: DevToolsClient;
 
 interface DevToolsPanelProps {
   plugins?: DevToolsPanelPlugin[] | undefined;
-  theme?: "light" | "dark";
+  theme?: "dark" | "light";
   onClose?: (() => void) | undefined;
   client?: DevToolsClient | undefined;
 }
@@ -98,7 +98,7 @@ interface DevToolsPanelProps {
 declare const DevToolsPanel: (_param0: DevToolsPanelProps) => import("react").JSX.Element;
 
 interface ShadowRootProps {
-  theme: "light" | "dark";
+  theme: "dark" | "light";
   className?: string;
   style?: CSSProperties;
   children: ReactNode;
@@ -144,7 +144,7 @@ type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
 type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
 
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "source" | "query"> : never;
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
 
 type Unsubscribe = () => void;
 
@@ -211,7 +211,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -391,7 +391,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -450,7 +450,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -133,7 +133,7 @@ type GenerativeUINode$1 = GenerativeUIElement | string | number | boolean | null
 
 type GenerativeUIAction = Action;
 
-type GenerativeUIStatus = "streaming" | "done";
+type GenerativeUIStatus = "done" | "streaming";
 
 type GenerativeUIRenderContext = {
   status: GenerativeUIStatus;
@@ -169,7 +169,7 @@ type GenerativeUIComponent<P = any> = {
 
 type GenerativeUILibrary = Record<string, GenerativeUIComponent>;
 
-type JSONSchema7TypeName$1 = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName$1 = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type$1 = string | number | boolean | JSONSchema7Object$1 | JSONSchema7Array$1 | null;
 
@@ -282,7 +282,7 @@ type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
 type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
 
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "source" | "query"> : never;
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
 
 type Unsubscribe = () => void;
 
@@ -367,7 +367,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -547,7 +547,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -606,7 +606,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -723,14 +723,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -795,7 +795,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -808,13 +808,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -882,7 +882,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -898,7 +898,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -100,7 +100,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -280,7 +280,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -339,7 +339,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -377,7 +377,7 @@ type ObjectStreamOperation = {
 };
 
 type PartInit = {
-  readonly type: "text" | "reasoning";
+  readonly type: "reasoning" | "text";
   readonly parentId?: string;
 } | {
   readonly type: "tool-call";
@@ -426,7 +426,7 @@ type AssistantStreamChunk = {
   readonly messageId: string;
 } | {
   readonly type: "step-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -434,7 +434,7 @@ type AssistantStreamChunk = {
   readonly isContinued: boolean;
 } | {
   readonly type: "message-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -557,14 +557,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -629,7 +629,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -642,13 +642,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -716,7 +716,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -732,7 +732,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -768,7 +768,7 @@ type AttachmentAdapter = {
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -779,10 +779,10 @@ type Unsubscribe = () => void;
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -798,10 +798,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -844,15 +844,15 @@ declare global {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -936,7 +936,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -976,7 +976,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -1012,7 +1012,7 @@ type QueueItemState = {
   readonly prompt: string;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -1168,7 +1168,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -1190,7 +1190,7 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
   readonly composerSource: "edit";
 });
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemState = {
   readonly isMain: boolean;
@@ -1280,7 +1280,7 @@ type ComposerRuntime = {
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -1291,7 +1291,7 @@ type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentBy
   };
 };
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -1485,10 +1485,10 @@ type ExternalThreadQueueAdapter = {
   }) => void;
   steer: (queueItemId: string) => void;
   remove: (queueItemId: string) => void;
-  clear: (reason: "edit" | "reload" | "cancel-run") => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
 };
 
-type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
   status: TState;
   id: string;
   remoteId?: string | undefined;
@@ -1580,7 +1580,7 @@ type RemoteThreadInitializeResponse = {
 };
 
 type RemoteThreadMetadata = {
-  readonly status: "regular" | "archived";
+  readonly status: "archived" | "regular";
   readonly remoteId: string;
   readonly externalId?: string | undefined;
   readonly title?: string | undefined;
@@ -1610,7 +1610,7 @@ type RemoteThreadListAdapter = {
   unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
 };
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "unstable_capabilities" | "suggestions">;
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
 
 type AdkEventPart = {
   text?: string;
@@ -2032,7 +2032,7 @@ type SamplingCallData = {
 };
 
 type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "jwt" | "api-key";
+  readonly strategy: "anon" | "api-key" | "jwt";
   getAuthHeaders(): Promise<Record<string, string> | false>;
   readAuthHeaders(headers: Headers): void;
 };
@@ -2084,7 +2084,7 @@ type ReportToolCall = {
   tool_call_id: string;
   tool_args?: string;
   tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
+  tool_source?: "backend" | "frontend" | "mcp";
   start_ms?: number;
   end_ms?: number;
   sampling_calls?: SamplingCallData[];
@@ -2092,7 +2092,7 @@ type ReportToolCall = {
 
 type AssistantCloudRunReport = {
   thread_id: string;
-  status: "completed" | "incomplete" | "error";
+  status: "completed" | "error" | "incomplete";
   total_steps?: number;
   tool_calls?: ReportToolCall[];
   steps?: {

--- a/api-surface/assistant-ui__react-hook-form.ts
+++ b/api-surface/assistant-ui__react-hook-form.ts
@@ -170,14 +170,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -242,7 +242,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -255,13 +255,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -329,7 +329,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -345,7 +345,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;

--- a/api-surface/assistant-ui__react-ink-markdown.ts
+++ b/api-surface/assistant-ui__react-ink-markdown.ts
@@ -10,7 +10,7 @@ type MarkdownTextProps = {
   codeGutter?: boolean;
   codeWrap?: boolean;
   hyperlinks?: boolean;
-  tableBorder?: "unicode" | "ascii" | "none";
+  tableBorder?: "ascii" | "none" | "unicode";
   tablePadding?: number;
   tableDense?: boolean;
   quotePrefix?: string;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -61,7 +61,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -241,7 +241,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -311,7 +311,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -351,7 +351,7 @@ type ObjectStreamOperation = {
 };
 
 type PartInit = {
-  readonly type: "text" | "reasoning";
+  readonly type: "reasoning" | "text";
   readonly parentId?: string;
 } | {
   readonly type: "tool-call";
@@ -400,7 +400,7 @@ type AssistantStreamChunk = {
   readonly messageId: string;
 } | {
   readonly type: "step-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -408,7 +408,7 @@ type AssistantStreamChunk = {
   readonly isContinued: boolean;
 } | {
   readonly type: "message-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -531,14 +531,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -603,7 +603,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -616,13 +616,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -690,7 +690,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -706,7 +706,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -771,7 +771,7 @@ declare class CompositeAttachmentAdapter implements AttachmentAdapter {
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -782,10 +782,10 @@ type Unsubscribe$1 = () => void;
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -801,10 +801,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -847,15 +847,15 @@ declare global {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -886,7 +886,7 @@ type VoiceSessionControls = {
 
 type VoiceSessionHelpers = {
   setStatus: (status: RealtimeVoiceAdapter.Status) => void;
-  end: (reason: "finished" | "cancelled" | "error", error?: unknown) => void;
+  end: (reason: "cancelled" | "error" | "finished", error?: unknown) => void;
   emitTranscript: (item: RealtimeVoiceAdapter.TranscriptItem) => void;
   emitMode: (mode: RealtimeVoiceAdapter.Mode) => void;
   emitVolume: (volume: number) => void;
@@ -979,7 +979,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -1019,7 +1019,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -1089,7 +1089,7 @@ type QueueItemState = {
   readonly prompt: string;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -1449,7 +1449,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -1471,7 +1471,7 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
   readonly composerSource: "edit";
 });
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemCoreState = {
   readonly id: string;
@@ -1621,7 +1621,7 @@ declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSou
   subscribe(callback: () => void): Unsubscribe$1;
 }
 
-declare abstract class ComposerAttachmentRuntime<Source extends "thread-composer" | "edit-composer"> extends AttachmentRuntimeImpl<Source> {
+declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
   private _composerApi;
   constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
   remove(): Promise<void>;
@@ -1715,7 +1715,7 @@ declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
   abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
 }
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -1737,7 +1737,7 @@ declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements T
   getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
 }
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -2206,7 +2206,7 @@ type RemoteThreadInitializeResponse = {
 };
 
 type RemoteThreadMetadata = {
-  readonly status: "regular" | "archived";
+  readonly status: "archived" | "regular";
   readonly remoteId: string;
   readonly externalId?: string | undefined;
   readonly title?: string | undefined;
@@ -2315,7 +2315,7 @@ type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
 type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
 
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "source" | "query"> : never;
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
 
 type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
 
@@ -2452,7 +2452,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   private _text;
   get text(): string;
   private _role;
-  get role(): "system" | "user" | "assistant";
+  get role(): "assistant" | "system" | "user";
   private _runConfig;
   get runConfig(): RunConfig;
   private _quote;
@@ -2728,7 +2728,7 @@ type OverrideOptionalField<T, TKey extends keyof T, TValue> = undefined extends 
 
 type OverrideToolDeclarationCallbacks<T extends {
   streamCall?: unknown;
-}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "type" | "execute" | "toModelOutput" | "experimental_onSchemaValidationError" | "streamCall"> & {
+}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "execute" | "experimental_onSchemaValidationError" | "streamCall" | "toModelOutput" | "type"> & {
   type?: never;
 } & ("execute" extends keyof T ? OverrideOptionalField<T, "execute", ToolExecute<NoInfer<TArgs>, TResult>> : {}) & ("toModelOutput" extends keyof T ? OverrideOptionalField<T, "toModelOutput", ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>> : {}) & ("experimental_onSchemaValidationError" extends keyof T ? OverrideOptionalField<T, "experimental_onSchemaValidationError", (args: unknown, context: ToolExecuteContext) => NoInfer<TResult> | Promise<NoInfer<TResult>>> : {}) & OverrideOptionalField<T, "streamCall", ToolStreamCall<TArgs, unknown>>;
 
@@ -2775,7 +2775,7 @@ declare const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult
 type AssistantToolUIProps<TArgs, TResult> = {
   toolName: string;
   render: ToolCallMessagePartComponent<TArgs, TResult>;
-  display?: "standalone" | "inline";
+  display?: "inline" | "standalone";
 };
 
 declare const useAssistantToolUI: (tool: AssistantToolUIProps<any, any> | null) => void;
@@ -2829,7 +2829,7 @@ type ProviderToolDefinition<TArgs extends Record<string, unknown>> = Extract<Too
   type: "provider";
 }>;
 
-type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "providerId" | "args" | "parameters" | "providerOptions" | "supportsDeferredResults">;
+type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "args" | "parameters" | "providerId" | "providerOptions" | "supportsDeferredResults">;
 
 type McpToolkitDefinition = Record<string, McpServerConfig>;
 
@@ -2931,10 +2931,10 @@ declare const unstable_interactableTool: <TSchema extends Unstable_InteractableS
   success: true;
 }>;
 
-type PropFieldStatus = "streaming" | "complete";
+type PropFieldStatus = "complete" | "streaming";
 
 type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unknown>> = {
-  status: "running" | "complete" | "incomplete" | "requires-action";
+  status: "complete" | "incomplete" | "requires-action" | "running";
   propStatus: Partial<Record<keyof TArgs, PropFieldStatus>>;
 };
 
@@ -3017,7 +3017,7 @@ type SamplingCallData = {
 };
 
 type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "jwt" | "api-key";
+  readonly strategy: "anon" | "api-key" | "jwt";
   getAuthHeaders(): Promise<Record<string, string> | false>;
   readAuthHeaders(headers: Headers): void;
 };
@@ -3069,7 +3069,7 @@ type ReportToolCall = {
   tool_call_id: string;
   tool_args?: string;
   tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
+  tool_source?: "backend" | "frontend" | "mcp";
   start_ms?: number;
   end_ms?: number;
   sampling_calls?: SamplingCallData[];
@@ -3077,7 +3077,7 @@ type ReportToolCall = {
 
 type AssistantCloudRunReport = {
   thread_id: string;
-  status: "completed" | "incomplete" | "error";
+  status: "completed" | "error" | "incomplete";
   total_steps?: number;
   tool_calls?: ReportToolCall[];
   steps?: {
@@ -3274,7 +3274,7 @@ type ComposerState = {
   readonly canSend: boolean;
   readonly attachmentAccept: string;
   readonly isEmpty: boolean;
-  readonly type: "thread" | "edit";
+  readonly type: "edit" | "thread";
   readonly dictation: DictationState | undefined;
   readonly quote: QuoteInfo | undefined;
   readonly queue: readonly QueueItemState[];
@@ -3650,7 +3650,7 @@ type CreateFileStorageAdapterOptions = {
 
 declare const createFileStorageAdapter: (options: CreateFileStorageAdapterOptions) => RemoteThreadListAdapter;
 
-type OSCVariant = "osc9" | "osc99" | "osc777";
+type OSCVariant = "osc777" | "osc9" | "osc99";
 
 declare const ringBell: () => void;
 
@@ -3963,7 +3963,7 @@ declare namespace threadList_d_exports {
   export { ThreadListItems as Items, ThreadListItemsProps as ItemsProps, ThreadListNew as New, ThreadListNewProps as NewProps, ThreadListRoot as Root, ThreadListRootProps as RootProps };
 }
 
-type ActionBarCopyProps = Omit<PressableProps, "onPress" | "children"> & UseActionBarCopyOptions & {
+type ActionBarCopyProps = Omit<PressableProps, "children" | "onPress"> & UseActionBarCopyOptions & {
   children: ReactNode | ((props: {
     isCopied: boolean;
   }) => ReactNode);
@@ -3983,7 +3983,7 @@ type ActionBarReloadProps = Omit<PressableProps, "onPress"> & {
 
 declare const ActionBarReload: (_param31: ActionBarReloadProps) => import("react").JSX.Element;
 
-type ActionBarFeedbackPositiveProps = Omit<PressableProps, "onPress" | "children"> & {
+type ActionBarFeedbackPositiveProps = Omit<PressableProps, "children" | "onPress"> & {
   children: ReactNode | ((props: {
     isSubmitted: boolean;
   }) => ReactNode);
@@ -3991,7 +3991,7 @@ type ActionBarFeedbackPositiveProps = Omit<PressableProps, "onPress" | "children
 
 declare const ActionBarFeedbackPositive: (_param32: ActionBarFeedbackPositiveProps) => import("react").JSX.Element;
 
-type ActionBarFeedbackNegativeProps = Omit<PressableProps, "onPress" | "children"> & {
+type ActionBarFeedbackNegativeProps = Omit<PressableProps, "children" | "onPress"> & {
   children: ReactNode | ((props: {
     isSubmitted: boolean;
   }) => ReactNode);
@@ -4131,9 +4131,9 @@ declare namespace suggestion_d_exports {
   export { SuggestionDescription as Description, SuggestionDescriptionProps as DescriptionProps, SuggestionTitle as Title, SuggestionTitleProps as TitleProps, SuggestionTrigger as Trigger, SuggestionTriggerProps as TriggerProps };
 }
 
-type ToolCallStatus = "running" | "complete" | "error" | "requires-action";
+type ToolCallStatus = "complete" | "error" | "requires-action" | "running";
 
-type ToolFallbackBaseProps = Omit<ToolCallMessagePartProps, "addResult" | "resume" | "respondToApproval"> & Partial<Pick<ToolCallMessagePartProps, "addResult" | "resume" | "respondToApproval">>;
+type ToolFallbackBaseProps = Omit<ToolCallMessagePartProps, "addResult" | "respondToApproval" | "resume"> & Partial<Pick<ToolCallMessagePartProps, "addResult" | "respondToApproval" | "resume">>;
 
 type ToolFallbackProps = ToolFallbackBaseProps & {
   expanded?: boolean;
@@ -4483,7 +4483,7 @@ declare const StatusBarPrimitiveLatency: {
   displayName: string;
 };
 
-type StatusType = "idle" | "running" | "error" | "cancelled";
+type StatusType = "cancelled" | "error" | "idle" | "running";
 
 type StatusBarPrimitiveStatusProps = Omit<ComponentProps<typeof Text>, "children"> & {
   format?: (status: StatusType) => string;
@@ -4513,7 +4513,7 @@ type DiffViewProps = Omit<ComponentProps<typeof Box>, "children"> & {
 
 declare const DiffView: (_param66: DiffViewProps) => import("react").JSX.Element;
 
-type ChecklistItemStatus = "pending" | "running" | "complete" | "error";
+type ChecklistItemStatus = "complete" | "error" | "pending" | "running";
 
 type ChecklistItemData = {
   id: string;

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -59,7 +59,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -239,7 +239,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -298,7 +298,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -336,7 +336,7 @@ type ObjectStreamOperation = {
 };
 
 type PartInit = {
-  readonly type: "text" | "reasoning";
+  readonly type: "reasoning" | "text";
   readonly parentId?: string;
 } | {
   readonly type: "tool-call";
@@ -385,7 +385,7 @@ type AssistantStreamChunk = {
   readonly messageId: string;
 } | {
   readonly type: "step-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -393,7 +393,7 @@ type AssistantStreamChunk = {
   readonly isContinued: boolean;
 } | {
   readonly type: "message-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -516,14 +516,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -588,7 +588,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -601,13 +601,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -675,7 +675,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -691,7 +691,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -727,7 +727,7 @@ type AttachmentAdapter = {
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -738,10 +738,10 @@ type Unsubscribe = () => void;
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -757,10 +757,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -803,15 +803,15 @@ declare global {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -895,7 +895,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -935,7 +935,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -971,7 +971,7 @@ type QueueItemState = {
   readonly prompt: string;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -1127,7 +1127,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -1149,7 +1149,7 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
   readonly composerSource: "edit";
 });
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemState = {
   readonly isMain: boolean;
@@ -1239,7 +1239,7 @@ type ComposerRuntime = {
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -1250,7 +1250,7 @@ type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentBy
   };
 };
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -1444,10 +1444,10 @@ type ExternalThreadQueueAdapter = {
   }) => void;
   steer: (queueItemId: string) => void;
   remove: (queueItemId: string) => void;
-  clear: (reason: "edit" | "reload" | "cancel-run") => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
 };
 
-type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
   status: TState;
   id: string;
   remoteId?: string | undefined;
@@ -1539,7 +1539,7 @@ type RemoteThreadInitializeResponse = {
 };
 
 type RemoteThreadMetadata = {
-  readonly status: "regular" | "archived";
+  readonly status: "archived" | "regular";
   readonly remoteId: string;
   readonly externalId?: string | undefined;
   readonly title?: string | undefined;
@@ -1569,7 +1569,7 @@ type RemoteThreadListAdapter = {
   unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
 };
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "unstable_capabilities" | "suggestions">;
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
 
 type SamplingCallData = {
   model_id?: string;
@@ -1581,7 +1581,7 @@ type SamplingCallData = {
 };
 
 type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "jwt" | "api-key";
+  readonly strategy: "anon" | "api-key" | "jwt";
   getAuthHeaders(): Promise<Record<string, string> | false>;
   readAuthHeaders(headers: Headers): void;
 };
@@ -1633,7 +1633,7 @@ type ReportToolCall = {
   tool_call_id: string;
   tool_args?: string;
   tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
+  tool_source?: "backend" | "frontend" | "mcp";
   start_ms?: number;
   end_ms?: number;
   sampling_calls?: SamplingCallData[];
@@ -1641,7 +1641,7 @@ type ReportToolCall = {
 
 type AssistantCloudRunReport = {
   thread_id: string;
-  status: "completed" | "incomplete" | "error";
+  status: "completed" | "error" | "incomplete";
   total_steps?: number;
   tool_calls?: ReportToolCall[];
   steps?: {
@@ -1856,7 +1856,7 @@ type LangChainContentBlock = {
     filename?: string;
   };
 } | {
-  type: "tool_use" | "input_json_delta";
+  type: "input_json_delta" | "tool_use";
 };
 
 type LangChainToolCall = {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -14,7 +14,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -194,7 +194,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -253,7 +253,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -291,7 +291,7 @@ type ObjectStreamOperation = {
 };
 
 type PartInit = {
-  readonly type: "text" | "reasoning";
+  readonly type: "reasoning" | "text";
   readonly parentId?: string;
 } | {
   readonly type: "tool-call";
@@ -340,7 +340,7 @@ type AssistantStreamChunk = {
   readonly messageId: string;
 } | {
   readonly type: "step-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -348,7 +348,7 @@ type AssistantStreamChunk = {
   readonly isContinued: boolean;
 } | {
   readonly type: "message-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -516,14 +516,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -588,7 +588,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -601,13 +601,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -675,7 +675,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -691,7 +691,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -727,7 +727,7 @@ type AttachmentAdapter = {
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -738,10 +738,10 @@ type Unsubscribe = () => void;
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -757,10 +757,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -803,15 +803,15 @@ declare global {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -895,7 +895,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -935,7 +935,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -971,7 +971,7 @@ type QueueItemState = {
   readonly prompt: string;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -1127,7 +1127,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -1149,7 +1149,7 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
   readonly composerSource: "edit";
 });
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemState = {
   readonly isMain: boolean;
@@ -1239,7 +1239,7 @@ type ComposerRuntime = {
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -1250,7 +1250,7 @@ type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentBy
   };
 };
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -1444,10 +1444,10 @@ type ExternalThreadQueueAdapter = {
   }) => void;
   steer: (queueItemId: string) => void;
   remove: (queueItemId: string) => void;
-  clear: (reason: "edit" | "reload" | "cancel-run") => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
 };
 
-type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
   status: TState;
   id: string;
   remoteId?: string | undefined;
@@ -1539,7 +1539,7 @@ type RemoteThreadInitializeResponse = {
 };
 
 type RemoteThreadMetadata = {
-  readonly status: "regular" | "archived";
+  readonly status: "archived" | "regular";
   readonly remoteId: string;
   readonly externalId?: string | undefined;
   readonly title?: string | undefined;
@@ -1569,7 +1569,7 @@ type RemoteThreadListAdapter = {
   unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
 };
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "unstable_capabilities" | "suggestions">;
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
 
 type DataMessagePartProps<T = any> = MessagePartState & DataMessagePart<T>;
 
@@ -1617,7 +1617,7 @@ type SamplingCallData = {
 };
 
 type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "jwt" | "api-key";
+  readonly strategy: "anon" | "api-key" | "jwt";
   getAuthHeaders(): Promise<Record<string, string> | false>;
   readAuthHeaders(headers: Headers): void;
 };
@@ -1669,7 +1669,7 @@ type ReportToolCall = {
   tool_call_id: string;
   tool_args?: string;
   tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
+  tool_source?: "backend" | "frontend" | "mcp";
   start_ms?: number;
   end_ms?: number;
   sampling_calls?: SamplingCallData[];
@@ -1677,7 +1677,7 @@ type ReportToolCall = {
 
 type AssistantCloudRunReport = {
   thread_id: string;
-  status: "completed" | "incomplete" | "error";
+  status: "completed" | "error" | "incomplete";
   total_steps?: number;
   tool_calls?: ReportToolCall[];
   steps?: {
@@ -1907,7 +1907,7 @@ type MessageContentReasoning = {
 };
 
 type MessageContentToolUse = {
-  type: "tool_use" | "input_json_delta";
+  type: "input_json_delta" | "tool_use";
 };
 
 type MessageContentComputerCall = {
@@ -1969,7 +1969,7 @@ type LangChainMessage = {
   tool_call_id: string;
   name: string;
   artifact?: any;
-  status: "success" | "error";
+  status: "error" | "success";
 } | {
   id?: string;
   type: "ai";

--- a/api-surface/assistant-ui__react-markdown.ts
+++ b/api-surface/assistant-ui__react-markdown.ts
@@ -167,7 +167,7 @@ type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
 type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
 
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "source" | "query"> : never;
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
 
 type Unsubscribe = () => void;
 
@@ -276,9 +276,9 @@ type SmoothOptions = {
 
 type PrimitiveDivProps = ComponentPropsWithoutRef<typeof Primitive.div>;
 
-type MarkdownTextPrimitiveProps = Omit<Options, "components" | "children"> & {
+type MarkdownTextPrimitiveProps = Omit<Options, "children" | "components"> & {
   className?: string | undefined;
-  containerProps?: Omit<PrimitiveDivProps, "children" | "asChild"> | undefined;
+  containerProps?: Omit<PrimitiveDivProps, "asChild" | "children"> | undefined;
   containerComponent?: ElementType | undefined;
   components?: (NonNullable<Options["components"]> & {
     SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps> | undefined;

--- a/api-surface/assistant-ui__react-mcp.ts
+++ b/api-surface/assistant-ui__react-mcp.ts
@@ -37,7 +37,7 @@ type MCPCustomServerRecord = {
 
 type MCPServerKind = "connector" | "custom";
 
-type MCPConnectionState = "disconnected" | "authRequired" | "authPending" | "connecting" | "connected" | "error";
+type MCPConnectionState = "authPending" | "authRequired" | "connected" | "connecting" | "disconnected" | "error";
 
 type MCPToolInfo = {
   name: string;
@@ -163,7 +163,7 @@ type UseMcpOAuthCallbackOptions = {
 };
 
 type UseMcpOAuthCallbackResult = {
-  status: "idle" | "running" | "done" | "error";
+  status: "done" | "error" | "idle" | "running";
   serverId: string | null;
   error: Error | null;
 };
@@ -336,7 +336,7 @@ declare const McpServerPrimitiveError: import("react").ForwardRefExoticComponent
 
 declare namespace McpServerPrimitiveIcon {
   type Element = ComponentRef<typeof Primitive.img>;
-  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.img>, "src" | "alt"> & {
+  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.img>, "alt" | "src"> & {
     src?: string;
     alt?: string;
   };
@@ -429,21 +429,21 @@ declare const McpAddFormPrimitiveRoot: import("react").ForwardRefExoticComponent
 
 declare namespace McpAddFormPrimitiveNameField {
   type Element = ComponentRef<typeof Primitive.input>;
-  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.input>, "value" | "onChange" | "type">;
+  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.input>, "onChange" | "type" | "value">;
 }
 
 declare const McpAddFormPrimitiveNameField: import("react").ForwardRefExoticComponent<McpAddFormPrimitiveNameField.Props & import("react").RefAttributes<HTMLInputElement>>;
 
 declare namespace McpAddFormPrimitiveUrlField {
   type Element = ComponentRef<typeof Primitive.input>;
-  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.input>, "value" | "onChange" | "type">;
+  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.input>, "onChange" | "type" | "value">;
 }
 
 declare const McpAddFormPrimitiveUrlField: import("react").ForwardRefExoticComponent<McpAddFormPrimitiveUrlField.Props & import("react").RefAttributes<HTMLInputElement>>;
 
 declare namespace McpAddFormPrimitiveAuthSelect {
   type Element = ComponentRef<typeof Primitive.select>;
-  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.select>, "value" | "onChange">;
+  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.select>, "onChange" | "value">;
 }
 
 declare const McpAddFormPrimitiveAuthSelect: import("react").ForwardRefExoticComponent<McpAddFormPrimitiveAuthSelect.Props & import("react").RefAttributes<HTMLSelectElement>>;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -59,7 +59,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -239,7 +239,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -309,7 +309,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -349,7 +349,7 @@ type ObjectStreamOperation = {
 };
 
 type PartInit = {
-  readonly type: "text" | "reasoning";
+  readonly type: "reasoning" | "text";
   readonly parentId?: string;
 } | {
   readonly type: "tool-call";
@@ -398,7 +398,7 @@ type AssistantStreamChunk = {
   readonly messageId: string;
 } | {
   readonly type: "step-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -406,7 +406,7 @@ type AssistantStreamChunk = {
   readonly isContinued: boolean;
 } | {
   readonly type: "message-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -529,14 +529,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -601,7 +601,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -614,13 +614,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -688,7 +688,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -704,7 +704,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -769,7 +769,7 @@ declare class CompositeAttachmentAdapter implements AttachmentAdapter {
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -780,10 +780,10 @@ type Unsubscribe$1 = () => void;
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -799,10 +799,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -845,15 +845,15 @@ declare global {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -884,7 +884,7 @@ type VoiceSessionControls = {
 
 type VoiceSessionHelpers = {
   setStatus: (status: RealtimeVoiceAdapter.Status) => void;
-  end: (reason: "finished" | "cancelled" | "error", error?: unknown) => void;
+  end: (reason: "cancelled" | "error" | "finished", error?: unknown) => void;
   emitTranscript: (item: RealtimeVoiceAdapter.TranscriptItem) => void;
   emitMode: (mode: RealtimeVoiceAdapter.Mode) => void;
   emitVolume: (volume: number) => void;
@@ -977,7 +977,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -1017,7 +1017,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -1087,7 +1087,7 @@ type QueueItemState = {
   readonly prompt: string;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -1447,7 +1447,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -1469,7 +1469,7 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
   readonly composerSource: "edit";
 });
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemCoreState = {
   readonly id: string;
@@ -1619,7 +1619,7 @@ declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSou
   subscribe(callback: () => void): Unsubscribe$1;
 }
 
-declare abstract class ComposerAttachmentRuntime<Source extends "thread-composer" | "edit-composer"> extends AttachmentRuntimeImpl<Source> {
+declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
   private _composerApi;
   constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
   remove(): Promise<void>;
@@ -1713,7 +1713,7 @@ declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
   abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
 }
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -1735,7 +1735,7 @@ declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements T
   getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
 }
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -2204,7 +2204,7 @@ type RemoteThreadInitializeResponse = {
 };
 
 type RemoteThreadMetadata = {
-  readonly status: "regular" | "archived";
+  readonly status: "archived" | "regular";
   readonly remoteId: string;
   readonly externalId?: string | undefined;
   readonly title?: string | undefined;
@@ -2313,7 +2313,7 @@ type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
 type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
 
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "source" | "query"> : never;
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
 
 type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
 
@@ -2450,7 +2450,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   private _text;
   get text(): string;
   private _role;
-  get role(): "system" | "user" | "assistant";
+  get role(): "assistant" | "system" | "user";
   private _runConfig;
   get runConfig(): RunConfig;
   private _quote;
@@ -2731,7 +2731,7 @@ type OverrideOptionalField<T, TKey extends keyof T, TValue> = undefined extends 
 
 type OverrideToolDeclarationCallbacks<T extends {
   streamCall?: unknown;
-}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "type" | "execute" | "toModelOutput" | "experimental_onSchemaValidationError" | "streamCall"> & {
+}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "execute" | "experimental_onSchemaValidationError" | "streamCall" | "toModelOutput" | "type"> & {
   type?: never;
 } & ("execute" extends keyof T ? OverrideOptionalField<T, "execute", ToolExecute<NoInfer<TArgs>, TResult>> : {}) & ("toModelOutput" extends keyof T ? OverrideOptionalField<T, "toModelOutput", ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>> : {}) & ("experimental_onSchemaValidationError" extends keyof T ? OverrideOptionalField<T, "experimental_onSchemaValidationError", (args: unknown, context: ToolExecuteContext) => NoInfer<TResult> | Promise<NoInfer<TResult>>> : {}) & OverrideOptionalField<T, "streamCall", ToolStreamCall<TArgs, unknown>>;
 
@@ -2778,7 +2778,7 @@ declare const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult
 type AssistantToolUIProps<TArgs, TResult> = {
   toolName: string;
   render: ToolCallMessagePartComponent<TArgs, TResult>;
-  display?: "standalone" | "inline";
+  display?: "inline" | "standalone";
 };
 
 declare const useAssistantToolUI: (tool: AssistantToolUIProps<any, any> | null) => void;
@@ -2842,7 +2842,7 @@ type ProviderToolDefinition<TArgs extends Record<string, unknown>> = Extract<Too
   type: "provider";
 }>;
 
-type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "providerId" | "args" | "parameters" | "providerOptions" | "supportsDeferredResults">;
+type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "args" | "parameters" | "providerId" | "providerOptions" | "supportsDeferredResults">;
 
 declare function providerTool(_config: ProviderToolConfig): never;
 
@@ -2946,10 +2946,10 @@ declare const unstable_interactableTool: <TSchema extends Unstable_InteractableS
   success: true;
 }>;
 
-type PropFieldStatus = "streaming" | "complete";
+type PropFieldStatus = "complete" | "streaming";
 
 type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unknown>> = {
-  status: "running" | "complete" | "incomplete" | "requires-action";
+  status: "complete" | "incomplete" | "requires-action" | "running";
   propStatus: Partial<Record<keyof TArgs, PropFieldStatus>>;
 };
 
@@ -3032,7 +3032,7 @@ type SamplingCallData = {
 };
 
 type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "jwt" | "api-key";
+  readonly strategy: "anon" | "api-key" | "jwt";
   getAuthHeaders(): Promise<Record<string, string> | false>;
   readAuthHeaders(headers: Headers): void;
 };
@@ -3084,7 +3084,7 @@ type ReportToolCall = {
   tool_call_id: string;
   tool_args?: string;
   tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
+  tool_source?: "backend" | "frontend" | "mcp";
   start_ms?: number;
   end_ms?: number;
   sampling_calls?: SamplingCallData[];
@@ -3092,7 +3092,7 @@ type ReportToolCall = {
 
 type AssistantCloudRunReport = {
   thread_id: string;
-  status: "completed" | "incomplete" | "error";
+  status: "completed" | "error" | "incomplete";
   total_steps?: number;
   tool_calls?: ReportToolCall[];
   steps?: {
@@ -3289,7 +3289,7 @@ type ComposerState = {
   readonly canSend: boolean;
   readonly attachmentAccept: string;
   readonly isEmpty: boolean;
-  readonly type: "thread" | "edit";
+  readonly type: "edit" | "thread";
   readonly dictation: DictationState | undefined;
   readonly quote: QuoteInfo | undefined;
   readonly queue: readonly QueueItemState[];
@@ -3450,7 +3450,7 @@ declare namespace MessagePrimitiveGroupedParts {
   type IndicatorPart = {
     readonly type: "indicator";
   };
-  type IndicatorMode = "never" | "empty" | "no-text" | "always";
+  type IndicatorMode = "always" | "empty" | "never" | "no-text";
   type RenderInfo<TKey extends `group-${string}` = `group-${string}`> = {
     readonly part: GroupPart<TKey> | EnrichedPartState | IndicatorPart;
     readonly children: ReactNode;
@@ -3679,7 +3679,7 @@ type MessagesContent = {
   components?: never;
 };
 
-type ThreadMessagesProps = Omit<FlatListProps<ThreadMessage>, "data" | "renderItem" | "children"> & MessagesContent;
+type ThreadMessagesProps = Omit<FlatListProps<ThreadMessage>, "children" | "data" | "renderItem"> & MessagesContent;
 
 declare const ThreadMessages: {
   (_param10: ThreadMessagesProps): import("react").JSX.Element;
@@ -3723,7 +3723,7 @@ declare const ComposerAttachmentByIndex: import("react").FC<ComposerPrimitiveAtt
 
 declare const ComposerAttachments: import("react").FC<ComposerPrimitiveAttachments.Props>;
 
-type ComposerInputProps = Omit<TextInputProps, "value" | "onChangeText"> & {
+type ComposerInputProps = Omit<TextInputProps, "onChangeText" | "value"> & {
   submitMode?: "enter" | "none";
 };
 
@@ -3855,7 +3855,7 @@ declare namespace threadList_d_exports {
   export { ThreadListItems as Items, ThreadListItemsProps as ItemsProps, ThreadListNew as New, ThreadListNewProps as NewProps, ThreadListRoot as Root, ThreadListRootProps as RootProps };
 }
 
-type ActionBarCopyProps = Omit<PressableProps, "onPress" | "children"> & UseActionBarCopyOptions & {
+type ActionBarCopyProps = Omit<PressableProps, "children" | "onPress"> & UseActionBarCopyOptions & {
   children: ReactNode | ((props: {
     isCopied: boolean;
   }) => ReactNode);
@@ -3875,7 +3875,7 @@ type ActionBarReloadProps = Omit<PressableProps, "onPress"> & {
 
 declare const ActionBarReload: (_param27: ActionBarReloadProps) => import("react").JSX.Element;
 
-type ActionBarFeedbackPositiveProps = Omit<PressableProps, "onPress" | "children"> & {
+type ActionBarFeedbackPositiveProps = Omit<PressableProps, "children" | "onPress"> & {
   children: ReactNode | ((props: {
     isSubmitted: boolean;
   }) => ReactNode);
@@ -3883,7 +3883,7 @@ type ActionBarFeedbackPositiveProps = Omit<PressableProps, "onPress" | "children
 
 declare const ActionBarFeedbackPositive: (_param28: ActionBarFeedbackPositiveProps) => import("react").JSX.Element;
 
-type ActionBarFeedbackNegativeProps = Omit<PressableProps, "onPress" | "children"> & {
+type ActionBarFeedbackNegativeProps = Omit<PressableProps, "children" | "onPress"> & {
   children: ReactNode | ((props: {
     isSubmitted: boolean;
   }) => ReactNode);

--- a/api-surface/assistant-ui__react-o11y.ts
+++ b/api-surface/assistant-ui__react-o11y.ts
@@ -11,7 +11,7 @@ type SpanItemState = {
   parentSpanId: string | null;
   name: string;
   type: string;
-  status: "running" | "completed" | "failed" | "skipped";
+  status: "completed" | "failed" | "running" | "skipped";
   startedAt: number;
   endedAt: number | null;
   latencyMs: number | null;
@@ -219,7 +219,7 @@ type SpanData = {
   parentSpanId: string | null;
   name: string;
   type: string;
-  status: "running" | "completed" | "failed" | "skipped";
+  status: "completed" | "failed" | "running" | "skipped";
   startedAt: number;
   endedAt: number | null;
   latencyMs: number | null;

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -40,7 +40,7 @@ type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
 type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
 
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "source" | "query"> : never;
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
 
 type Unsubscribe$1 = () => void;
 
@@ -152,7 +152,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -332,7 +332,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -391,7 +391,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -508,14 +508,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -580,7 +580,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -593,13 +593,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -667,7 +667,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -683,7 +683,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -719,7 +719,7 @@ type AttachmentAdapter = {
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -730,10 +730,10 @@ type Unsubscribe = () => void;
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -749,10 +749,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -795,15 +795,15 @@ declare global {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -887,7 +887,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -927,7 +927,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -963,7 +963,7 @@ type QueueItemState = {
   readonly prompt: string;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -1119,7 +1119,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -1141,7 +1141,7 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
   readonly composerSource: "edit";
 });
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemState = {
   readonly isMain: boolean;
@@ -1231,7 +1231,7 @@ type ComposerRuntime = {
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -1242,7 +1242,7 @@ type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentBy
   };
 };
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -1436,10 +1436,10 @@ type ExternalThreadQueueAdapter = {
   }) => void;
   steer: (queueItemId: string) => void;
   remove: (queueItemId: string) => void;
-  clear: (reason: "edit" | "reload" | "cancel-run") => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
 };
 
-type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
   status: TState;
   id: string;
   remoteId?: string | undefined;
@@ -1525,7 +1525,7 @@ type AssistantRuntime = {
   registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
 };
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "unstable_capabilities" | "suggestions">;
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
 
 interface EventLog {
   time: Date;
@@ -1555,7 +1555,7 @@ type MessageWithParts = {
   parts: Part[];
 };
 
-type OpenCodePermissionResponse = "once" | "always" | "reject";
+type OpenCodePermissionResponse = "always" | "once" | "reject";
 
 type OpenCodePermissionRequest = {
   id: string;
@@ -1585,7 +1585,7 @@ type PendingUserMessage = {
   runConfig: unknown;
   contentText: string;
   parts: readonly ThreadUserMessagePart[];
-  status: "pending" | "failed";
+  status: "failed" | "pending";
   error?: unknown;
 };
 

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -51,7 +51,7 @@ interface PiUsage {
   };
 }
 
-type PiStopReason = "stop" | "length" | "toolUse" | "error" | "aborted";
+type PiStopReason = "aborted" | "error" | "length" | "stop" | "toolUse";
 
 interface PiUserMessage {
   role: "user";
@@ -177,7 +177,7 @@ type PiAssistantMessageDelta = {
   partial: PiAssistantMessage;
 } | {
   type: "done";
-  reason: "stop" | "length" | "toolUse";
+  reason: "length" | "stop" | "toolUse";
   message: PiAssistantMessage;
 } | {
   type: "error";
@@ -191,7 +191,7 @@ interface PiContextUsage {
   percent: number | null;
 }
 
-type PiThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+type PiThinkingLevel = "high" | "low" | "medium" | "minimal" | "off" | "xhigh";
 
 type PiModelInfo = {
   provider: string;
@@ -207,7 +207,7 @@ type PiRuntimeReadiness = {
     provider: string;
     modelId: string;
   };
-  source: "env" | "session" | "pi-default";
+  source: "env" | "pi-default" | "session";
 } | {
   state: "missing-model";
   message: string;
@@ -224,7 +224,7 @@ type PiRuntimeReadiness = {
   message: string;
 };
 
-type PiThreadStatus = "idle" | "running" | "failed";
+type PiThreadStatus = "failed" | "idle" | "running";
 
 type PiQueuedMessage = {
   id: string;
@@ -261,7 +261,7 @@ type PiSendMessageInput = {
   streamingBehavior?: "followUp" | "steer";
 };
 
-type PiHostUiRequestKind = "confirm" | "select" | "input" | "editor";
+type PiHostUiRequestKind = "confirm" | "editor" | "input" | "select";
 
 type PiHostUiRequest = {
   id: string;
@@ -349,7 +349,7 @@ type PiClientEventBody = {
   followUp: readonly string[];
 } | {
   type: "compaction_start";
-  reason: "manual" | "threshold" | "overflow";
+  reason: "manual" | "overflow" | "threshold";
 } | {
   type: "compaction_end";
   aborted: boolean;
@@ -566,22 +566,22 @@ interface PiHttpClientOptions {
 
 declare const createPiHttpClient: (options?: PiHttpClientOptions) => PiClient;
 
-type PiQueueMode = "steer" | "followUp";
+type PiQueueMode = "followUp" | "steer";
 
 declare const piQueueItemId: (mode: PiQueueMode, index: number) => string;
 
 declare const isPiSteerQueueItemId: (id: string) => boolean;
 
-type PiRunStatus = "idle" | "running" | "failed";
+type PiRunStatus = "failed" | "idle" | "running";
 
-type PiLoadState = "pending" | "loading" | "loaded";
+type PiLoadState = "loaded" | "loading" | "pending";
 
 interface PiToolExecutionState {
   toolCallId: string;
   toolName?: string;
   args?: unknown;
   partialResult?: unknown;
-  status: "running" | "complete" | "error";
+  status: "complete" | "error" | "running";
 }
 
 interface PiThreadState {
@@ -598,7 +598,7 @@ interface PiThreadState {
   contextUsage: PiContextUsage | undefined;
   compaction: {
     active: boolean;
-    reason?: "manual" | "threshold" | "overflow";
+    reason?: "manual" | "overflow" | "threshold";
   };
   retry: {
     active: boolean;
@@ -653,7 +653,7 @@ type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
 type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
 
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "source" | "query"> : never;
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
 
 type Unsubscribe$1 = () => void;
 
@@ -765,7 +765,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -945,7 +945,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -1004,7 +1004,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -1121,14 +1121,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -1193,7 +1193,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -1206,13 +1206,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -1280,7 +1280,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -1296,7 +1296,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -1332,7 +1332,7 @@ type AttachmentAdapter = {
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -1343,10 +1343,10 @@ type Unsubscribe = () => void;
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -1362,10 +1362,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -1408,15 +1408,15 @@ declare global {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -1500,7 +1500,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -1540,7 +1540,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -1576,7 +1576,7 @@ type QueueItemState = {
   readonly prompt: string;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -1732,7 +1732,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -1754,7 +1754,7 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
   readonly composerSource: "edit";
 });
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemState = {
   readonly isMain: boolean;
@@ -1844,7 +1844,7 @@ type ComposerRuntime = {
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -1855,7 +1855,7 @@ type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentBy
   };
 };
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -2049,10 +2049,10 @@ type ExternalThreadQueueAdapter = {
   }) => void;
   steer: (queueItemId: string) => void;
   remove: (queueItemId: string) => void;
-  clear: (reason: "edit" | "reload" | "cancel-run") => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
 };
 
-type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
   status: TState;
   id: string;
   remoteId?: string | undefined;
@@ -2138,7 +2138,7 @@ type AssistantRuntime = {
   registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
 };
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "unstable_capabilities" | "suggestions">;
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
 
 interface EventLog {
   time: Date;

--- a/api-surface/assistant-ui__react-streamdown.ts
+++ b/api-surface/assistant-ui__react-streamdown.ts
@@ -153,7 +153,7 @@ type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
 type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
 
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "source" | "query"> : never;
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
 
 type Unsubscribe = () => void;
 
@@ -367,7 +367,7 @@ type BlockProps = {
   remarkRehypeOptions?: RemarkRehypeOptions;
 };
 
-type StreamdownTextPrimitiveProps = Omit<StreamdownProps$2, "children" | "components" | "plugins" | "caret" | "controls" | "linkSafety" | "remend" | "mermaid" | "BlockComponent" | "parseMarkdownIntoBlocksFn"> & {
+type StreamdownTextPrimitiveProps = Omit<StreamdownProps$2, "BlockComponent" | "caret" | "children" | "components" | "controls" | "linkSafety" | "mermaid" | "parseMarkdownIntoBlocksFn" | "plugins" | "remend"> & {
   components?: StreamdownTextComponents | undefined;
   componentsByLanguage?: ComponentsByLanguage | undefined;
   plugins?: PluginConfig | undefined;
@@ -394,7 +394,7 @@ declare const DEFAULT_SHIKI_THEME: [
   BundledTheme
 ];
 
-declare const StreamdownTextPrimitive: import("react").ForwardRefExoticComponent<Omit<StreamdownProps, "children" | "components" | "plugins" | "caret" | "controls" | "linkSafety" | "remend" | "mermaid" | "BlockComponent" | "parseMarkdownIntoBlocksFn"> & {
+declare const StreamdownTextPrimitive: import("react").ForwardRefExoticComponent<Omit<StreamdownProps, "BlockComponent" | "caret" | "children" | "components" | "controls" | "linkSafety" | "mermaid" | "parseMarkdownIntoBlocksFn" | "plugins" | "remend"> & {
   components?: StreamdownTextComponents | undefined;
   componentsByLanguage?: ComponentsByLanguage | undefined;
   plugins?: PluginConfig | undefined;

--- a/api-surface/assistant-ui__react-syntax-highlighter.ts
+++ b/api-surface/assistant-ui__react-syntax-highlighter.ts
@@ -157,7 +157,7 @@ type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
 type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
 
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "source" | "query"> : never;
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
 
 type Unsubscribe = () => void;
 
@@ -257,23 +257,23 @@ declare global {
   }
 }
 
-declare const makeSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "language" | "children">) => import("react").FC<SyntaxHighlighterProps>;
+declare const makeSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
 
-declare const makePrismSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "language" | "children">) => import("react").FC<SyntaxHighlighterProps>;
+declare const makePrismSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
 
-declare const makePrismAsyncSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "language" | "children">) => import("react").FC<SyntaxHighlighterProps>;
+declare const makePrismAsyncSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
 
 declare namespace entry_full_exports {
   export { makePrismAsyncSyntaxHighlighter, makePrismSyntaxHighlighter, makeSyntaxHighlighter };
 }
 
-declare const makePrismAsyncLightSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "language" | "children">) => import("react").FC<SyntaxHighlighterProps>;
+declare const makePrismAsyncLightSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
 
-declare const makePrismLightSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "language" | "children">) => import("react").FC<SyntaxHighlighterProps>;
+declare const makePrismLightSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
 
-declare const makeLightSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "language" | "children">) => import("react").FC<SyntaxHighlighterProps>;
+declare const makeLightSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
 
-declare const makeLightAsyncSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "language" | "children">) => import("react").FC<SyntaxHighlighterProps>;
+declare const makeLightAsyncSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
 
 declare namespace entry_root_exports {
   export { makeLightAsyncSyntaxHighlighter, makeLightSyntaxHighlighter, makePrismAsyncLightSyntaxHighlighter, makePrismLightSyntaxHighlighter };

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -70,7 +70,7 @@ type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
 type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
 
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "source" | "query"> : never;
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
 
 type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
 
@@ -238,7 +238,7 @@ type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
 type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
@@ -418,7 +418,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type ToolDisplay = "standalone" | "inline";
+type ToolDisplay = "inline" | "standalone";
 
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
@@ -488,7 +488,7 @@ type McpServerConfig = {
   type: "http" | "sse";
   url: string;
   headers?: Record<string, string>;
-  redirect?: "follow" | "error";
+  redirect?: "error" | "follow";
 } | {
   type: "stdio";
   command: string;
@@ -528,7 +528,7 @@ type ObjectStreamOperation = {
 };
 
 type PartInit = {
-  readonly type: "text" | "reasoning";
+  readonly type: "reasoning" | "text";
   readonly parentId?: string;
 } | {
   readonly type: "tool-call";
@@ -577,7 +577,7 @@ type AssistantStreamChunk = {
   readonly messageId: string;
 } | {
   readonly type: "step-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -585,7 +585,7 @@ type AssistantStreamChunk = {
   readonly isContinued: boolean;
 } | {
   readonly type: "message-finish";
-  readonly finishReason: "stop" | "length" | "content-filter" | "tool-calls" | "error" | "other" | "unknown";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
   readonly usage: {
     readonly inputTokens: number;
     readonly outputTokens: number;
@@ -708,14 +708,14 @@ type GenerativeUIMessagePart = {
 type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
-  readonly visibility?: readonly ("model" | "app")[];
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type ToolCallMessagePartMcpMetadata = {
   readonly app?: McpAppMetadata;
 };
 
-type ToolApprovalOptionKind = "allow-once" | "allow-always" | "reject-once" | "reject-always";
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -780,7 +780,7 @@ type MessagePartStatus = {
   readonly type: "complete";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
 
@@ -793,13 +793,13 @@ type MessageStatus = {
   readonly type: "running";
 } | {
   readonly type: "requires-action";
-  readonly reason: "tool-calls" | "interrupt";
+  readonly reason: "interrupt" | "tool-calls";
 } | {
   readonly type: "complete";
   readonly reason: "stop" | "unknown";
 } | {
   readonly type: "incomplete";
-  readonly reason: "cancelled" | "tool-calls" | "length" | "content-filter" | "other" | "error";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
   readonly error?: ReadonlyJSONValue;
 };
 
@@ -867,7 +867,7 @@ type ThreadAssistantMessage = MessageCommonProps & {
     readonly unstable_data: readonly ReadonlyJSONValue[];
     readonly steps: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -883,7 +883,7 @@ type BaseThreadMessage = {
     readonly unstable_data?: readonly ReadonlyJSONValue[];
     readonly steps?: readonly ThreadStep[];
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly timing?: MessageTiming;
     readonly isOptimistic?: boolean;
@@ -978,7 +978,7 @@ declare const unstable_defaultDirectiveFormatter: Unstable_DirectiveFormatter;
 
 type FeedbackAdapterFeedback = {
   message: ThreadMessage;
-  type: "positive" | "negative";
+  type: "negative" | "positive";
 };
 
 type FeedbackAdapter = {
@@ -989,10 +989,10 @@ type Unsubscribe = () => void;
 
 declare namespace SpeechSynthesisAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Utterance = {
@@ -1008,10 +1008,10 @@ type SpeechSynthesisAdapter = {
 
 declare namespace DictationAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "stopped" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "stopped";
   };
   type Result = {
     transcript: string;
@@ -1071,15 +1071,15 @@ declare class WebSpeechDictationAdapter implements DictationAdapter {
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
-    type: "starting" | "running";
+    type: "running" | "starting";
   } | {
     type: "ended";
-    reason: "finished" | "cancelled" | "error";
+    reason: "cancelled" | "error" | "finished";
     error?: unknown;
   };
   type Mode = "listening" | "speaking";
   type TranscriptItem = {
-    role: "user" | "assistant";
+    role: "assistant" | "user";
     text: string;
     isFinal?: boolean;
   };
@@ -1110,7 +1110,7 @@ type VoiceSessionControls = {
 
 type VoiceSessionHelpers = {
   setStatus: (status: RealtimeVoiceAdapter.Status) => void;
-  end: (reason: "finished" | "cancelled" | "error", error?: unknown) => void;
+  end: (reason: "cancelled" | "error" | "finished", error?: unknown) => void;
   emitTranscript: (item: RealtimeVoiceAdapter.TranscriptItem) => void;
   emitMode: (mode: RealtimeVoiceAdapter.Mode) => void;
   emitVolume: (volume: number) => void;
@@ -1208,7 +1208,7 @@ type DataPrefixedPart = {
 };
 
 type ThreadMessageLike = {
-  readonly role: "assistant" | "user" | "system";
+  readonly role: "assistant" | "system" | "user";
   readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
     readonly type: "tool-call";
     readonly toolCallId?: string;
@@ -1248,7 +1248,7 @@ type ThreadMessageLike = {
     readonly steps?: readonly ThreadStep[] | undefined;
     readonly timing?: MessageTiming | undefined;
     readonly submittedFeedback?: {
-      readonly type: "positive" | "negative";
+      readonly type: "negative" | "positive";
     };
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
@@ -1324,7 +1324,7 @@ type QueueItemMethods = {
   remove(): void;
 };
 
-type AttachmentAddErrorReason = "no-adapter" | "not-accepted" | "adapter-error";
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
 
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
@@ -1768,7 +1768,7 @@ type MessagePartRuntimePath = MessageRuntimePath & {
 };
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "message" | "edit-composer";
+  readonly attachmentSource: "edit-composer" | "message";
 }) | (ThreadRuntimePath & {
   readonly attachmentSource: "thread-composer";
 })) & {
@@ -1790,7 +1790,7 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
   readonly composerSource: "edit";
 });
 
-type ThreadListItemStatus = "archived" | "regular" | "new" | "deleted";
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemCoreState = {
   readonly id: string;
@@ -1940,7 +1940,7 @@ declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSou
   subscribe(callback: () => void): Unsubscribe;
 }
 
-declare abstract class ComposerAttachmentRuntime<Source extends "thread-composer" | "edit-composer"> extends AttachmentRuntimeImpl<Source> {
+declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
   private _composerApi;
   constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
   remove(): Promise<void>;
@@ -2034,7 +2034,7 @@ declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
   abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
 }
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -2056,7 +2056,7 @@ declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements T
   getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
 }
 
-type EditComposerRuntime = Omit<ComposerRuntime, "getState" | "getAttachmentByIndex"> & {
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -2516,10 +2516,10 @@ type ExternalThreadQueueAdapter = {
   }) => void;
   steer: (queueItemId: string) => void;
   remove: (queueItemId: string) => void;
-  clear: (reason: "edit" | "reload" | "cancel-run") => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
 };
 
-type ExternalStoreThreadData<TState extends "regular" | "archived"> = {
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
   status: TState;
   id: string;
   remoteId?: string | undefined;
@@ -2621,7 +2621,7 @@ type RemoteThreadInitializeResponse = {
 };
 
 type RemoteThreadMetadata = {
-  readonly status: "regular" | "archived";
+  readonly status: "archived" | "regular";
   readonly remoteId: string;
   readonly externalId?: string | undefined;
   readonly title?: string | undefined;
@@ -2660,7 +2660,7 @@ type RemoteThreadListOptions = {
   allowNesting?: boolean | undefined;
 };
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "unstable_capabilities" | "suggestions">;
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
 
 declare const pickExternalStoreSharedOptions: (options: ExternalStoreSharedOptions) => ExternalStoreSharedOptions;
 
@@ -2772,7 +2772,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   private _text;
   get text(): string;
   private _role;
-  get role(): "system" | "user" | "assistant";
+  get role(): "assistant" | "system" | "user";
   private _runConfig;
   get runConfig(): RunConfig;
   private _quote;
@@ -3065,7 +3065,7 @@ type OverrideOptionalField<T, TKey extends keyof T, TValue> = undefined extends 
 
 type OverrideToolDeclarationCallbacks<T extends {
   streamCall?: unknown;
-}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "type" | "execute" | "toModelOutput" | "experimental_onSchemaValidationError" | "streamCall"> & {
+}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "execute" | "experimental_onSchemaValidationError" | "streamCall" | "toModelOutput" | "type"> & {
   type?: never;
 } & ("execute" extends keyof T ? OverrideOptionalField<T, "execute", ToolExecute<NoInfer<TArgs>, TResult>> : {}) & ("toModelOutput" extends keyof T ? OverrideOptionalField<T, "toModelOutput", ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>> : {}) & ("experimental_onSchemaValidationError" extends keyof T ? OverrideOptionalField<T, "experimental_onSchemaValidationError", (args: unknown, context: ToolExecuteContext) => NoInfer<TResult> | Promise<NoInfer<TResult>>> : {}) & OverrideOptionalField<T, "streamCall", ToolStreamCall<TArgs, unknown>>;
 
@@ -3112,7 +3112,7 @@ declare const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult
 type AssistantToolUIProps<TArgs, TResult> = {
   toolName: string;
   render: ToolCallMessagePartComponent<TArgs, TResult>;
-  display?: "standalone" | "inline";
+  display?: "inline" | "standalone";
 };
 
 declare const useAssistantToolUI: (tool: AssistantToolUIProps<any, any> | null) => void;
@@ -3176,7 +3176,7 @@ type ProviderToolDefinition<TArgs extends Record<string, unknown>> = Extract<Too
   type: "provider";
 }>;
 
-type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "providerId" | "args" | "parameters" | "providerOptions" | "supportsDeferredResults">;
+type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "args" | "parameters" | "providerId" | "providerOptions" | "supportsDeferredResults">;
 
 declare function providerTool(_config: ProviderToolConfig): never;
 
@@ -3280,10 +3280,10 @@ declare const unstable_interactableTool: <TSchema extends Unstable_InteractableS
   success: true;
 }>;
 
-type PropFieldStatus = "streaming" | "complete";
+type PropFieldStatus = "complete" | "streaming";
 
 type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unknown>> = {
-  status: "running" | "complete" | "incomplete" | "requires-action";
+  status: "complete" | "incomplete" | "requires-action" | "running";
   propStatus: Partial<Record<keyof TArgs, PropFieldStatus>>;
 };
 
@@ -3422,7 +3422,7 @@ type SamplingCallData = {
 };
 
 type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "jwt" | "api-key";
+  readonly strategy: "anon" | "api-key" | "jwt";
   getAuthHeaders(): Promise<Record<string, string> | false>;
   readAuthHeaders(headers: Headers): void;
 };
@@ -3474,7 +3474,7 @@ type ReportToolCall = {
   tool_call_id: string;
   tool_args?: string;
   tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
+  tool_source?: "backend" | "frontend" | "mcp";
   start_ms?: number;
   end_ms?: number;
   sampling_calls?: SamplingCallData[];
@@ -3482,7 +3482,7 @@ type ReportToolCall = {
 
 type AssistantCloudRunReport = {
   thread_id: string;
-  status: "completed" | "incomplete" | "error";
+  status: "completed" | "error" | "incomplete";
   total_steps?: number;
   tool_calls?: ReportToolCall[];
   steps?: {
@@ -3705,7 +3705,7 @@ type ComposerState = {
   readonly canSend: boolean;
   readonly attachmentAccept: string;
   readonly isEmpty: boolean;
-  readonly type: "thread" | "edit";
+  readonly type: "edit" | "thread";
   readonly dictation: DictationState | undefined;
   readonly quote: QuoteInfo | undefined;
   readonly queue: readonly QueueItemState[];
@@ -3880,7 +3880,7 @@ declare namespace MessagePrimitiveGroupedParts {
   type IndicatorPart = {
     readonly type: "indicator";
   };
-  type IndicatorMode = "never" | "empty" | "no-text" | "always";
+  type IndicatorMode = "always" | "empty" | "never" | "no-text";
   type RenderInfo<TKey extends `group-${string}` = `group-${string}`> = {
     readonly part: GroupPart<TKey> | EnrichedPartState | IndicatorPart;
     readonly children: ReactNode;
@@ -4176,7 +4176,7 @@ declare const splitLocalRuntimeOptions: <T extends LocalRuntimeOptions>(options:
     unstable_humanToolNames: string[] | undefined;
     unstable_enableMessageQueue: boolean | undefined;
   };
-  otherOptions: Omit<T, "adapters" | "maxSteps" | "unstable_humanToolNames" | "unstable_enableMessageQueue" | "cloud" | "initialMessages">;
+  otherOptions: Omit<T, "adapters" | "cloud" | "initialMessages" | "maxSteps" | "unstable_enableMessageQueue" | "unstable_humanToolNames">;
 };
 
 declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param10?: LocalRuntimeOptions) => AssistantRuntime;
@@ -4232,7 +4232,7 @@ type ThreadViewportState = {
   readonly onScrollToBottom: (callback: (_param11: {
     behavior: ScrollBehavior;
   }) => void) => Unsubscribe;
-  readonly turnAnchor: "top" | "bottom";
+  readonly turnAnchor: "bottom" | "top";
   readonly topAnchorMessageClamp: {
     readonly tallerThan: string;
     readonly visibleHeight: string;
@@ -4276,7 +4276,7 @@ type ThreadViewportStoreOptions = {
   } | undefined;
 };
 
-type ReadonlyStore<T> = Omit<StoreApi<T>, "setState" | "destroy">;
+type ReadonlyStore<T> = Omit<StoreApi<T>, "destroy" | "setState">;
 
 declare const useThreadViewport: {
   (): ThreadViewportState;
@@ -4365,53 +4365,53 @@ declare function useMessageAttachmentRuntime(options?: {
 
 declare const useAttachment: {
   (): AttachmentState & {
-    source: "message" | "thread-composer" | "edit-composer";
+    source: "edit-composer" | "message" | "thread-composer";
   };
   <TSelected>(selector: (state: AttachmentState & {
-    source: "message" | "thread-composer" | "edit-composer";
+    source: "edit-composer" | "message" | "thread-composer";
   }) => TSelected): TSelected;
   <TSelected>(selector: ((state: AttachmentState & {
-    source: "message" | "thread-composer" | "edit-composer";
+    source: "edit-composer" | "message" | "thread-composer";
   }) => TSelected) | undefined): (AttachmentState & {
-    source: "message" | "thread-composer" | "edit-composer";
+    source: "edit-composer" | "message" | "thread-composer";
   }) | TSelected;
   (options: {
     optional?: false | undefined;
   }): AttachmentState & {
-    source: "message" | "thread-composer" | "edit-composer";
+    source: "edit-composer" | "message" | "thread-composer";
   };
   (options: {
     optional?: boolean | undefined;
   }): (AttachmentState & {
-    source: "message" | "thread-composer" | "edit-composer";
+    source: "edit-composer" | "message" | "thread-composer";
   }) | null;
   <TSelected>(options: {
     optional?: false | undefined;
     selector: (state: AttachmentState & {
-      source: "message" | "thread-composer" | "edit-composer";
+      source: "edit-composer" | "message" | "thread-composer";
     }) => TSelected;
   }): TSelected;
   <TSelected>(options: {
     optional?: false | undefined;
     selector: ((state: AttachmentState & {
-      source: "message" | "thread-composer" | "edit-composer";
+      source: "edit-composer" | "message" | "thread-composer";
     }) => TSelected) | undefined;
   }): (AttachmentState & {
-    source: "message" | "thread-composer" | "edit-composer";
+    source: "edit-composer" | "message" | "thread-composer";
   }) | TSelected;
   <TSelected>(options: {
     optional?: boolean | undefined;
     selector: (state: AttachmentState & {
-      source: "message" | "thread-composer" | "edit-composer";
+      source: "edit-composer" | "message" | "thread-composer";
     }) => TSelected;
   }): TSelected | null;
   <TSelected>(options: {
     optional?: boolean | undefined;
     selector: ((state: AttachmentState & {
-      source: "message" | "thread-composer" | "edit-composer";
+      source: "edit-composer" | "message" | "thread-composer";
     }) => TSelected) | undefined;
   }): (AttachmentState & {
-    source: "message" | "thread-composer" | "edit-composer";
+    source: "edit-composer" | "message" | "thread-composer";
   }) | TSelected | null;
 };
 
@@ -5697,7 +5697,7 @@ type QueuedCommand = AssistantTransportCommand;
 
 type HeadersValue = Record<string, string> | Headers;
 
-type AssistantTransportProtocol = "data-stream" | "assistant-transport";
+type AssistantTransportProtocol = "assistant-transport" | "data-stream";
 
 type SendCommandsRequestBody = {
   commands: QueuedCommand[];
@@ -6631,7 +6631,7 @@ declare const useSmooth: (state: MessagePartState & (TextMessagePart | Reasoning
 
 declare namespace MessagePartPrimitiveText {
   type Element = ComponentRef<typeof Primitive$1.span>;
-  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive$1.span>, "children" | "asChild"> & {
+  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive$1.span>, "asChild" | "children"> & {
     smooth?: boolean | SmoothOptions;
     component?: ElementType;
   };
@@ -7211,7 +7211,7 @@ declare const useSmoothStatus: {
     readonly type: "complete";
   } | {
     readonly type: "incomplete";
-    readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+    readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
     readonly error?: unknown;
   } | {
     readonly type: "requires-action";
@@ -7223,7 +7223,7 @@ declare const useSmoothStatus: {
     readonly type: "complete";
   } | {
     readonly type: "incomplete";
-    readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+    readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
     readonly error?: unknown;
   } | {
     readonly type: "requires-action";
@@ -7237,7 +7237,7 @@ declare const useSmoothStatus: {
     readonly type: "complete";
   } | {
     readonly type: "incomplete";
-    readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+    readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
     readonly error?: unknown;
   } | {
     readonly type: "requires-action";
@@ -7251,7 +7251,7 @@ declare const useSmoothStatus: {
       readonly type: "complete";
     } | {
       readonly type: "incomplete";
-      readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+      readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
       readonly error?: unknown;
     } | {
       readonly type: "requires-action";
@@ -7265,7 +7265,7 @@ declare const useSmoothStatus: {
     readonly type: "complete";
   } | {
     readonly type: "incomplete";
-    readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+    readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
     readonly error?: unknown;
   } | {
     readonly type: "requires-action";
@@ -7279,7 +7279,7 @@ declare const useSmoothStatus: {
     readonly type: "complete";
   } | {
     readonly type: "incomplete";
-    readonly reason: "cancelled" | "length" | "content-filter" | "other" | "error";
+    readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
     readonly error?: unknown;
   } | {
     readonly type: "requires-action";
@@ -7435,7 +7435,7 @@ type Unstable_TriggerPopoverAriaProps = TriggerPopoverAriaProps;
 
 declare function unstable_useTriggerPopoverAriaProps(): Unstable_TriggerPopoverAriaProps;
 
-type SandboxOption = "allow-same-origin" | "allow-scripts" | "allow-forms" | "allow-popups" | "allow-modals" | "allow-downloads" | "allow-popups-to-escape-sandbox";
+type SandboxOption = "allow-downloads" | "allow-forms" | "allow-modals" | "allow-popups" | "allow-popups-to-escape-sandbox" | "allow-same-origin" | "allow-scripts";
 
 type SandboxHostConfig = {
   sandbox?: SandboxOption[];
@@ -7471,10 +7471,10 @@ type McpAppResource = {
   meta?: McpAppResourceMeta;
 };
 
-type McpAppDisplayMode = "inline" | "fullscreen" | "pip";
+type McpAppDisplayMode = "fullscreen" | "inline" | "pip";
 
 type McpAppHostContext = {
-  theme?: "light" | "dark";
+  theme?: "dark" | "light";
   displayMode?: McpAppDisplayMode;
   availableDisplayModes?: McpAppDisplayMode[];
   [k: string]: unknown;

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -55,7 +55,7 @@ type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
 type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
 
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "source" | "query"> : never;
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
 
 type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
 

--- a/api-surface/assistant-ui__x-generative-compiler.ts
+++ b/api-surface/assistant-ui__x-generative-compiler.ts
@@ -2,7 +2,7 @@ declare const DIRECTIVE = "use generative";
 
 type Target = "client" | "server";
 
-type ToolType = "frontend" | "backend" | "human" | "provider";
+type ToolType = "backend" | "frontend" | "human" | "provider";
 
 interface CompileOptions {
   target: Target;

--- a/api-surface/heat-graph.ts
+++ b/api-surface/heat-graph.ts
@@ -35,7 +35,7 @@ type DayLabel = {
   row: number;
 };
 
-type WeekStart = "sunday" | "monday";
+type WeekStart = "monday" | "sunday";
 
 type HeatGraphState = {
   cells: CellData[];

--- a/api-surface/safe-content-frame.ts
+++ b/api-surface/safe-content-frame.ts
@@ -10,7 +10,7 @@ declare namespace entry_root_exports {
   export { RenderedFrame, SafeContentFrame, SafeContentFrameOptions, SandboxOption };
 }
 
-type SandboxOption = "allow-same-origin" | "allow-scripts" | "allow-forms" | "allow-popups" | "allow-modals" | "allow-downloads" | "allow-popups-to-escape-sandbox";
+type SandboxOption = "allow-downloads" | "allow-forms" | "allow-modals" | "allow-popups" | "allow-popups-to-escape-sandbox" | "allow-same-origin" | "allow-scripts";
 
 interface SafeContentFrameOptions {
   useShadowDom?: boolean;

--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -477,6 +477,33 @@ function normalizeAttachmentUnionType(node, sourceFile, factory) {
   return factory.updateUnionTypeNode(node, types);
 }
 
+function stringLiteralUnionMemberValue(type) {
+  const unwrapped = unwrapParenthesizedType(type);
+  if (
+    ts.isLiteralTypeNode(unwrapped) &&
+    ts.isStringLiteral(unwrapped.literal)
+  ) {
+    return unwrapped.literal.text;
+  }
+  return undefined;
+}
+
+function normalizeStringLiteralUnionType(node, factory) {
+  const memberValues = node.types.map(stringLiteralUnionMemberValue);
+  if (memberValues.some((value) => value === undefined)) return node;
+  if (memberValues.length < 2) return node;
+
+  const sortedIndices = memberValues
+    .map((value, index) => ({ value, index }))
+    .toSorted((a, b) => compareStrings(a.value, b.value) || a.index - b.index);
+  if (sortedIndices.every(({ index }, sortedIndex) => index === sortedIndex)) {
+    return node;
+  }
+
+  const types = sortedIndices.map(({ index }) => node.types[index]);
+  return factory.updateUnionTypeNode(node, types);
+}
+
 function normalizeBundledDeclaration(content) {
   const stripped = content
     .replaceAll("\r\n", "\n")
@@ -496,9 +523,13 @@ function normalizeBundledDeclaration(content) {
       let bindingParameterIndex = 0;
       const visit = (node) => {
         if (ts.isUnionTypeNode(node)) {
-          return normalizeAttachmentUnionType(
+          const attachmentNormalized = normalizeAttachmentUnionType(
             ts.visitEachChild(node, visit, context),
             sourceFile,
+            context.factory,
+          );
+          return normalizeStringLiteralUnionType(
+            attachmentNormalized,
             context.factory,
           );
         }


### PR DESCRIPTION
## Summary

- the api-surface generator relied on the typescript compiler's internal union resolution order for string literal unions, which is not stable across runs
- this caused autofix to repeatedly "fix" and then revert the same snapshots on prs that never touched the affected packages (e.g. the back-and-forth on `get role(): "system" | "user" | "assistant"` vs `"user" | "system" | "assistant"` in #4612)
- added `normalizeStringLiteralUnionType`, which sorts any union whose members are all string literals by their literal value, with the existing index order as a tiebreaker

## Why

autofix runs `pnpm api-surface` on every pr and commits any diff. because string literal union order was non-deterministic, autofix kept producing a "fix" commit that reordered members, then a second "fix" commit on the next run that reverted them (#4612 has two such opposing commits from autofix). prs that don't touch `packages/*` should never produce api-surface diffs.

## How

`normalizeStringLiteralUnionType` runs in the transform pipeline right after `normalizeAttachmentUnionType`. it only touches unions where every member is a string literal, leaving the intersection-type attachment unions (which carry semantic ordering handled by `normalizeAttachmentUnionType`) and any non-string-literal union untouched. string literal unions are set-equivalent, so reordering is safe and has no effect on the published type surface.

the regenerated snapshots are now idempotent: running `pnpm api-surface` twice produces zero diff.

## Test plan

- [ ] `pnpm api-surface` produces no further diff on this branch
- [ ] running `pnpm api-surface` a second time yields zero changes (idempotency)
- [ ] `pnpm lint` passes on `scripts/generate-api-surface.mjs`
- [ ] ci `Build Changed Packages` / `Check API surface` is green

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

