### PR TITLE
perf(mcp-docs-server): cache docs and examples file listings

### DIFF
--- a/.changeset/cache-doc-listings.md
+++ b/.changeset/cache-doc-listings.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/mcp-docs-server": patch
+---
+
+perf: cache the docs and examples file listings

--- a/packages/mcp-docs-server/src/tools/examples.ts
+++ b/packages/mcp-docs-server/src/tools/examples.ts
@@ -2,6 +2,7 @@ import { z } from "zod/v3";
 import { readFile, readdir, lstat } from "node:fs/promises";
 import { join, extname } from "node:path";
 import { CODE_EXAMPLES_PATH, MAX_FILE_SIZE } from "../constants.js";
+import { cacheListing } from "../utils/cache.js";
 import { logger } from "../utils/logger.js";
 import { formatMCPResponse } from "../utils/mcp-format.js";
 import { sanitizePath } from "../utils/security.js";
@@ -15,17 +16,21 @@ const examplesInputSchema = z.object({
     ),
 });
 
-export async function listCodeExamples(): Promise<string[]> {
-  try {
-    const files = await readdir(CODE_EXAMPLES_PATH);
-    return files
-      .filter((file) => extname(file) === ".md")
-      .map((file) => file.replace(".md", ""))
-      .sort();
-  } catch (error) {
+const loadCodeExamples = cacheListing(scanCodeExamples);
+
+export function listCodeExamples(): Promise<string[]> {
+  return loadCodeExamples().catch((error) => {
     logger.error("Failed to list code examples", error);
     return [];
-  }
+  });
+}
+
+async function scanCodeExamples(): Promise<string[]> {
+  const files = await readdir(CODE_EXAMPLES_PATH);
+  return files
+    .filter((file) => extname(file) === ".md")
+    .map((file) => file.replace(".md", ""))
+    .sort();
 }
 
 export async function readCodeExample(

--- a/packages/mcp-docs-server/src/tools/tests/listings-cache.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/listings-cache.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { getAvailableDocFiles } from "../../utils/paths.js";
+import { listCodeExamples } from "../examples.js";
+
+describe("listing caches", () => {
+  it("caches the doc file listing (same instance on repeat calls)", async () => {
+    const first = await getAvailableDocFiles();
+    const second = await getAvailableDocFiles();
+    expect(second).toBe(first);
+    expect(first.length).toBeGreaterThan(0);
+  });
+
+  it("caches the example listing (same instance on repeat calls)", async () => {
+    const first = await listCodeExamples();
+    const second = await listCodeExamples();
+    expect(second).toBe(first);
+    expect(first.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/mcp-docs-server/src/utils/cache.ts
+++ b/packages/mcp-docs-server/src/utils/cache.ts
@@ -4,10 +4,16 @@ export function cacheListing(
   let cache: Promise<string[]> | null = null;
   return () => {
     if (!cache) {
-      cache = scan().catch((error) => {
-        cache = null;
-        throw error;
-      });
+      cache = scan().then(
+        (result) => {
+          if (result.length === 0) cache = null;
+          return result;
+        },
+        (error) => {
+          cache = null;
+          throw error;
+        },
+      );
     }
     return cache;
   };

--- a/packages/mcp-docs-server/src/utils/cache.ts
+++ b/packages/mcp-docs-server/src/utils/cache.ts
@@ -1,0 +1,14 @@
+export function cacheListing(
+  scan: () => Promise<string[]>,
+): () => Promise<string[]> {
+  let cache: Promise<string[]> | null = null;
+  return () => {
+    if (!cache) {
+      cache = scan().catch((error) => {
+        cache = null;
+        throw error;
+      });
+    }
+    return cache;
+  };
+}

--- a/packages/mcp-docs-server/src/utils/paths.ts
+++ b/packages/mcp-docs-server/src/utils/paths.ts
@@ -1,6 +1,7 @@
 import { readdir, stat } from "node:fs/promises";
 import { join, extname } from "node:path";
 import { DOCS_PATH, MDX_EXTENSION, MD_EXTENSION } from "../constants.js";
+import { cacheListing } from "./cache.js";
 import { logger } from "./logger.js";
 
 const SIMILARITY_THRESHOLDS = {
@@ -66,7 +67,9 @@ export async function getAvailablePaths(): Promise<string[]> {
   return paths.sort();
 }
 
-export async function getAvailableDocFiles(): Promise<string[]> {
+export const getAvailableDocFiles = cacheListing(scanDocFiles);
+
+async function scanDocFiles(): Promise<string[]> {
   const files: string[] = [];
 
   async function scanDirectory(dir: string, prefix = ""): Promise<void> {

--- a/packages/mcp-docs-server/src/utils/tests/cache.test.ts
+++ b/packages/mcp-docs-server/src/utils/tests/cache.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { cacheListing } from "../cache.js";
+
+describe("cacheListing", () => {
+  it("scans once and reuses the result", async () => {
+    let calls = 0;
+    const listing = cacheListing(async () => {
+      calls++;
+      return ["a", "b"];
+    });
+    const first = await listing();
+    const second = await listing();
+    expect(second).toBe(first);
+    expect(calls).toBe(1);
+  });
+
+  it("shares one in-flight scan across concurrent callers", async () => {
+    let calls = 0;
+    const listing = cacheListing(async () => {
+      calls++;
+      return ["a"];
+    });
+    const [first, second] = await Promise.all([listing(), listing()]);
+    expect(second).toBe(first);
+    expect(calls).toBe(1);
+  });
+
+  it("re-scans after a failed scan", async () => {
+    let calls = 0;
+    const listing = cacheListing(async () => {
+      calls++;
+      if (calls === 1) throw new Error("boom");
+      return ["a"];
+    });
+    await expect(listing()).rejects.toThrow("boom");
+    expect(await listing()).toEqual(["a"]);
+    expect(calls).toBe(2);
+  });
+
+  it("does not cache an empty listing", async () => {
+    let calls = 0;
+    const listing = cacheListing(async () => {
+      calls++;
+      return calls === 1 ? [] : ["a"];
+    });
+    expect(await listing()).toEqual([]);
+    expect(await listing()).toEqual(["a"]);
+    expect(await listing()).toEqual(["a"]);
+    expect(calls).toBe(2);
+  });
+});


### PR DESCRIPTION
## What
Memoize `getAvailableDocFiles` (docs tree walk) and `listCodeExamples` (examples dir read) so each scans the filesystem once per process instead of on every call.

## Why
Both are invoked on every `resources/list` and on every resource-completion keystroke, re-walking the bundled docs/examples each time. The bundled content is fixed at publish time and never changes at runtime, so the listing can be cached. (Raised as a perf note on the resource-completions PR.)

## How
Wrap each lister in a lazy cached promise, resetting the cache if a scan fails so a transient error is not cached. Return values and error behavior are unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

