### PR TITLE
feat(mcp-docs-server): return structuredContent from the tools

### DIFF
--- a/.changeset/mcp-docs-structured-content.md
+++ b/.changeset/mcp-docs-structured-content.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/mcp-docs-server": patch
+---
+
+feat: return structuredContent from the docs, examples, and search tools

--- a/packages/mcp-docs-server/src/utils/mcp-format.ts
+++ b/packages/mcp-docs-server/src/utils/mcp-format.ts
@@ -1,12 +1,14 @@
 export function formatMCPResponse(data: any): {
   content: Array<{ type: "text"; text: string }>;
+  structuredContent?: Record<string, unknown>;
 } {
+  const text = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+  const isStructured =
+    typeof data === "object" && data !== null && !Array.isArray(data);
   return {
-    content: [
-      {
-        type: "text",
-        text: typeof data === "string" ? data : JSON.stringify(data, null, 2),
-      },
-    ],
+    content: [{ type: "text", text }],
+    ...(isStructured && {
+      structuredContent: data as Record<string, unknown>,
+    }),
   };
 }

--- a/packages/mcp-docs-server/src/utils/tests/mcp-format.test.ts
+++ b/packages/mcp-docs-server/src/utils/tests/mcp-format.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { formatMCPResponse } from "../mcp-format.js";
+
+describe("formatMCPResponse", () => {
+  it("attaches structuredContent for object data, mirroring the text block", () => {
+    const data = { found: true, path: "getting-started", type: "file" };
+    const res = formatMCPResponse(data);
+    expect(res.content[0]!.text).toBe(JSON.stringify(data, null, 2));
+    expect(res.structuredContent).toEqual(data);
+  });
+
+  it("omits structuredContent for string data", () => {
+    const res = formatMCPResponse("plain text");
+    expect(res.content[0]!.text).toBe("plain text");
+    expect(res.structuredContent).toBeUndefined();
+  });
+
+  it("omits structuredContent for array data", () => {
+    const res = formatMCPResponse([1, 2, 3] as any);
+    expect(res.structuredContent).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Tool results now include `structuredContent`, the same data the tools already serialize into their text block but as a real JSON object, for `assistantUIDocs`, `assistantUIExamples`, and `assistantUISearch`.

## Why

Each tool returned its result only as stringified JSON inside a text block, so a client wanting structured data had to re-parse the text. MCP's `structuredContent` lets clients consume the object directly. All tools route through one response helper, so this is a single additive change.

## How

`formatMCPResponse` now attaches `structuredContent` when the data is a plain object (strings and arrays keep the text-only result). No output schema is declared: the SDK passes `structuredContent` through without validation, which keeps this fully additive and avoids constraining the tools' union-shaped returns. The existing text block is unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

