### PR TITLE
fix: support exported generative ui instances

### DIFF
--- a/.changeset/exported-json-generative-ui.md
+++ b/.changeset/exported-json-generative-ui.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-generative-compiler": patch
+---
+
+fix: support exported module-scope JSONGenerativeUI instances

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -358,6 +358,21 @@ export default defineToolkit({
     expect(code).not.toContain("defineGenerativeComponents");
   });
 
+  it("allows an exported module-scope JSONGenerativeUI instance", () => {
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import { JSONGenerativeUI } from "@assistant-ui/react-generative-ui";
+export const ui = new JSONGenerativeUI({ library: {} });
+export default defineToolkit({ present: ui.present() });`;
+
+    expect(compileGenerative(src, { target: "server" }).code).toContain(
+      "ui.present()",
+    );
+    expect(compileGenerative(src, { target: "client" }).code).toContain(
+      "ui.present()",
+    );
+  });
+
   it("rejects an unknown method on a JSONGenerativeUI instance", () => {
     const src = `"use generative";
 import { defineToolkit } from "@assistant-ui/react";

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -601,8 +601,14 @@ function unwrapToCall(node: t.Node, name: string): t.CallExpression | null {
 function collectGenerativeInstances(ast: t.File): Set<string> {
   const names = new Set<string>();
   for (const statement of ast.program.body) {
-    if (!t.isVariableDeclaration(statement)) continue;
-    for (const declaration of statement.declarations) {
+    const variableDeclaration = t.isVariableDeclaration(statement)
+      ? statement
+      : t.isExportNamedDeclaration(statement) &&
+          t.isVariableDeclaration(statement.declaration)
+        ? statement.declaration
+        : null;
+    if (!variableDeclaration) continue;
+    for (const declaration of variableDeclaration.declarations) {
       const { id, init } = declaration;
       if (
         t.isIdentifier(id) &&


### PR DESCRIPTION
## Summary

Support `export const ui = new JSONGenerativeUI(...)` as a compiler-visible module-scope generative UI instance.

## Why

The compiler already allows toolkit entries like `present: ui.present()` when `ui` is declared as a module-scope `const`. The exported form is the same user-facing pattern, but Babel represents it as an `ExportNamedDeclaration` wrapping a variable declaration, so the collector did not record the instance name.

## Changes

- Teach `collectGenerativeInstances` to unwrap exported variable declarations.
- Add a regression test covering `export const ui = new JSONGenerativeUI(...)` for both server and client compiler targets.
- Add a patch changeset for `@assistant-ui/x-generative-compiler`.

## Validation

- `pnpm --filter @assistant-ui/x-generative-compiler test -- compile.test.ts`
- `pnpm exec oxfmt --check packages/x-generative-compiler/src/compile.ts packages/x-generative-compiler/src/compile.test.ts`
- `pnpm exec oxlint packages/x-generative-compiler/src/compile.ts packages/x-generative-compiler/src/compile.test.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

