### PR TITLE
test(api-surface): cover generator union normalizers

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -134,6 +134,9 @@ jobs:
             pnpm run api-surface:check -- --skip-build --filter="...[HEAD^1]"
           fi
 
+      - name: Test API surface generator
+        run: pnpm run api-surface:test
+
   test:
     name: Test Changed Packages
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "api-surface": "pnpm api-surface:build && node scripts/generate-api-surface.mjs",
     "api-surface:build": "pnpm exec turbo build --filter='./packages/*' --force",
     "api-surface:check": "node scripts/check-api-surface.mjs",
+    "api-surface:test": "node --test scripts/generate-api-surface.test.mjs",
     "lint": "pnpm exec oxlint && pnpm exec oxfmt --check",
     "check:resource-memo": "node packages/x-buildutils/check-resource-memoization.mjs",
     "lint:fix": "pnpm exec oxlint --fix && pnpm exec oxfmt",

--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -504,7 +504,7 @@ function normalizeStringLiteralUnionType(node, factory) {
   return factory.updateUnionTypeNode(node, types);
 }
 
-function normalizeBundledDeclaration(content) {
+export function normalizeBundledDeclaration(content) {
   const stripped = content
     .replaceAll("\r\n", "\n")
     .replace(/ ?\/\/# sourceMappingURL=.*$/gm, "")
@@ -817,4 +817,6 @@ async function main() {
   }
 }
 
-await main();
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/generate-api-surface.test.mjs
+++ b/scripts/generate-api-surface.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeBundledDeclaration } from "./generate-api-surface.mjs";
+
+const attachmentUnion = (first, second) =>
+  `type X = (${first}) | (${second});\n`;
+
+const completeMember = (source) =>
+  `{ status: CompleteAttachmentStatus; content: ThreadUserMessagePart[] } & { source: "${source}" }`;
+
+const pendingMember = (source) =>
+  `{ status: PendingAttachmentStatus; file: File } & { source: "${source}" }`;
+
+const statusOrder = (output) => [
+  output.indexOf("CompleteAttachmentStatus"),
+  output.indexOf("PendingAttachmentStatus"),
+];
+
+test("attachment union normalizes thread-composer members to Complete-first", () => {
+  const pendingFirst = normalizeBundledDeclaration(
+    attachmentUnion(
+      pendingMember("thread-composer"),
+      completeMember("thread-composer"),
+    ),
+  );
+  const completeFirst = normalizeBundledDeclaration(
+    attachmentUnion(
+      completeMember("thread-composer"),
+      pendingMember("thread-composer"),
+    ),
+  );
+
+  const [complete, pending] = statusOrder(pendingFirst);
+  assert.ok(complete >= 0 && pending >= 0);
+  assert.ok(complete < pending);
+  assert.equal(pendingFirst, completeFirst);
+});
+
+test("attachment union normalizes edit-composer members to Complete-first", () => {
+  const [complete, pending] = statusOrder(
+    normalizeBundledDeclaration(
+      attachmentUnion(
+        pendingMember("edit-composer"),
+        completeMember("edit-composer"),
+      ),
+    ),
+  );
+  assert.ok(complete < pending);
+});
+
+test("string literal unions are sorted into a canonical order", () => {
+  const output = normalizeBundledDeclaration(
+    `type Role = "user" | "system" | "assistant";\n`,
+  );
+  assert.match(output, /"assistant"\s*\|\s*"system"\s*\|\s*"user"/);
+});
+
+test("normalization is idempotent", () => {
+  const once = normalizeBundledDeclaration(
+    attachmentUnion(
+      pendingMember("thread-composer"),
+      completeMember("thread-composer"),
+    ),
+  );
+  assert.equal(normalizeBundledDeclaration(once), once);
+});
+
+test("an unrecognized composer attachment union shape throws", () => {
+  const bad = attachmentUnion(
+    `{ status: CompleteAttachmentStatus } & { source: "thread-composer" }`,
+    `{ status: PendingAttachmentStatus } & { source: "thread-composer" }`,
+  );
+  assert.throws(() => normalizeBundledDeclaration(bad), /unsupported shape/);
+});


### PR DESCRIPTION
## Summary

Adds unit coverage for the api-surface generator's determinism normalizers, which keep the committed snapshots stable across environments but had no tests of their own.

## Why

The generator now relies on three normalizers to produce deterministic output: the composer attachment union normalizer (#4601), the string-literal union normalizer (#4623), and the Primitive member sort. Until now these were guarded only by the CI snapshot diff added in #4619, which catches drift after the fact but never asserts that the normalizers actually canonicalize scrambled input. A regression in the sort logic could silently bake a non-canonical order into a freshly committed baseline.

## What

A `node --test` suite that drives the real transform pipeline through `normalizeBundledDeclaration`:

- both the thread-composer and edit-composer attachment unions normalize to Complete-first regardless of input member order
- string-literal unions sort into a canonical order
- normalization is idempotent
- an unrecognized composer attachment union shape throws

## How

To make the script importable without running generation, `normalizeBundledDeclaration` is exported and the top-level `main()` call is guarded behind `import.meta.main` (Node is pinned to >=24, which supports it). The suite runs via a new `api-surface:test` script in the Build Changed Packages job, which already path-filters on `scripts/generate-api-surface.mjs`.

## Notes

Tooling and CI only. No published package changes, so no changeset. Uses Node's built-in test runner, so no new dependency. `scripts/` sits outside every workspace package, so `turbo test` does not pick it up; the suite is wired into the one CI job already triggered by generator changes.

## Verification

- `pnpm run api-surface:test` passes (5 tests)
- importing the module for tests does not trigger generation, confirming the `import.meta.main` guard
- `pnpm exec oxlint` and `pnpm exec oxfmt --check` clean on the touched files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

