### PR TITLE
fix: validate generative ui imports

### DIFF
--- a/.changeset/validate-generative-ui-imports.md
+++ b/.changeset/validate-generative-ui-imports.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-generative-compiler": patch
+---
+
+fix: validate JSONGenerativeUI constructor imports

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -369,6 +369,37 @@ export default defineToolkit({ present: ui.notARealMethod() });`;
     );
   });
 
+  it("allows an aliased JSONGenerativeUI import", () => {
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import { JSONGenerativeUI as GenUI } from "@assistant-ui/react-generative-ui";
+const ui = new GenUI({ library: {} });
+export default defineToolkit({ present: ui.present() });`;
+
+    expect(compileGenerative(src, { target: "server" }).code).toContain(
+      "ui.present()",
+    );
+    expect(compileGenerative(src, { target: "client" }).code).toContain(
+      "ui.present()",
+    );
+  });
+
+  it("does not trust a local class named JSONGenerativeUI", () => {
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+class JSONGenerativeUI {
+  present() {
+    return makeTool();
+  }
+}
+const ui = new JSONGenerativeUI();
+export default defineToolkit({ present: ui.present() });`;
+
+    expect(() => compileGenerative(src, { target: "server" })).toThrow(
+      /tool "present" cannot be `ui\.present\(\)`/,
+    );
+  });
+
   it("rejects a method call on an unknown (non-JSONGenerativeUI) object", () => {
     const src = `"use generative";
 import { defineToolkit } from "@assistant-ui/react";

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -37,6 +37,8 @@ const DISTRIBUTION_PACKAGES = [
   "@assistant-ui/react-native",
   "@assistant-ui/react-ink",
 ] as const;
+/** Package that exports the generative UI runtime split by export condition. */
+const GENERATIVE_UI_PACKAGE = "@assistant-ui/react-generative-ui";
 /**
  * The class whose instances expose split-by-condition tools (`present()`,
  * `promptUser()`). A toolkit entry that calls a method on one of these passes
@@ -600,6 +602,7 @@ function unwrapToCall(node: t.Node, name: string): t.CallExpression | null {
  */
 function collectGenerativeInstances(ast: t.File): Set<string> {
   const names = new Set<string>();
+  const generativeFactories = collectGenerativeFactoryImports(ast);
   for (const statement of ast.program.body) {
     if (!t.isVariableDeclaration(statement)) continue;
     for (const declaration of statement.declarations) {
@@ -607,9 +610,32 @@ function collectGenerativeInstances(ast: t.File): Set<string> {
       if (
         t.isIdentifier(id) &&
         t.isNewExpression(init) &&
-        t.isIdentifier(init.callee, { name: GENERATIVE_FACTORY })
+        t.isIdentifier(init.callee) &&
+        generativeFactories.has(init.callee.name)
       ) {
         names.add(id.name);
+      }
+    }
+  }
+  return names;
+}
+
+function collectGenerativeFactoryImports(ast: t.File): Set<string> {
+  const names = new Set<string>();
+  for (const statement of ast.program.body) {
+    if (
+      !t.isImportDeclaration(statement) ||
+      statement.source.value !== GENERATIVE_UI_PACKAGE
+    ) {
+      continue;
+    }
+
+    for (const specifier of statement.specifiers) {
+      if (
+        t.isImportSpecifier(specifier) &&
+        t.isIdentifier(specifier.imported, { name: GENERATIVE_FACTORY })
+      ) {
+        names.add(specifier.local.name);
       }
     }
   }


### PR DESCRIPTION
## Summary

Validate that `JSONGenerativeUI` instances come from the real `@assistant-ui/react-generative-ui` import before allowing `ui.present()` / `ui.promptUser()` to pass through the generative compiler.

## Why

The compiler previously recognized `new JSONGenerativeUI(...)` by identifier spelling. That meant aliases like `import { JSONGenerativeUI as GenUI } ...` were rejected, while a local class or unrelated binding named `JSONGenerativeUI` could be trusted as if it came from the package.

## Changes

- Collect local import names for `JSONGenerativeUI` from `@assistant-ui/react-generative-ui`.
- Use that collected import set when recognizing module-scope `JSONGenerativeUI` instances.
- Add regression tests for aliased imports and local classes named `JSONGenerativeUI`.
- Add a patch changeset for `@assistant-ui/x-generative-compiler`.

## Validation

- `git diff --check`
- `/Users/mac/oss/assistant-ui/node_modules/.bin/oxfmt --check packages/x-generative-compiler/src/compile.ts packages/x-generative-compiler/src/compile.test.ts`
- `/Users/mac/oss/assistant-ui/node_modules/.bin/oxlint packages/x-generative-compiler/src/compile.ts packages/x-generative-compiler/src/compile.test.ts`
- `/Users/mac/oss/assistant-ui/packages/x-generative-compiler/node_modules/.bin/vitest run src/compile.test.ts` from `packages/x-generative-compiler` in the sibling worktree: 78 tests passed

## Merge compatibility

I simulated merging `origin/fix/exported-generative-ui-instance` (#4629) into this branch with `git merge --no-commit --no-ff`; `compile.ts` and `compile.test.ts` auto-merged cleanly, then I aborted the simulation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

