### PR TITLE
feat(docs): open Ask AI panel beside the page instead of under the navbar

### DIFF
--- a/apps/docs/components/docs/layout/docs-header.tsx
+++ b/apps/docs/components/docs/layout/docs-header.tsx
@@ -20,6 +20,7 @@ import { MoreDropdown } from "@/components/shared/more-dropdown";
 import { NavItems } from "@/components/shared/nav-items";
 import { useDocsSidebar } from "@/components/docs/contexts/sidebar";
 import { useAssistantPanel } from "@/components/docs/assistant/context";
+import { getPanelWidth } from "@/components/docs/layout/docs-layout";
 import { ThemeToggle } from "@/components/shared/theme-toggle";
 import { analytics } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
@@ -140,6 +141,7 @@ export function DocsHeader({
     toggle: toggleSidebar,
   } = useDocsSidebar();
   const [navMenuOpen, setNavMenuOpen] = useState(false);
+  const { open, width, isResizing } = useAssistantPanel();
 
   const sectionFilter = (item: (typeof NAV_ITEMS)[number]) =>
     item.type !== "link" || item.href !== sectionHref;
@@ -163,7 +165,17 @@ export function DocsHeader({
   };
 
   return (
-    <header className="sticky top-0 z-50 w-full">
+    <header
+      className={cn(
+        "sticky top-0 z-50 md:mr-(--chat-panel-width)",
+        !isResizing && "transition-[margin] duration-300 ease-out",
+      )}
+      style={
+        {
+          "--chat-panel-width": getPanelWidth(open, width),
+        } as React.CSSProperties
+      }
+    >
       <div className="from-background pointer-events-none absolute inset-x-0 top-0 h-14 bg-linear-to-b to-transparent mask-[linear-gradient(to_bottom,black_75%,transparent)] backdrop-blur-xl" />
       <div className="relative flex h-12 w-full items-center px-4">
         <div className="flex min-w-0 flex-1 items-center">

--- a/apps/docs/components/docs/layout/docs-layout.tsx
+++ b/apps/docs/components/docs/layout/docs-layout.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
 
 export const COLLAPSED_WIDTH = "12px";
 
-function getPanelWidth(open: boolean, width: number): string {
+export function getPanelWidth(open: boolean, width: number): string {
   return open ? `${width}px` : COLLAPSED_WIDTH;
 }
 
@@ -42,7 +42,7 @@ export function DocsAssistantPanel(): ReactNode {
   return (
     <div
       className={cn(
-        "fixed top-12 right-0 bottom-0 hidden w-(--panel-width) md:block",
+        "fixed top-0 right-0 bottom-0 z-50 hidden w-(--panel-width) md:block",
         !isResizing && "transition-[width] duration-300 ease-out",
       )}
       style={


### PR DESCRIPTION
## What

Open the Ask AI panel as a full-height column on the right edge of the page, and shift the **navbar** along with the content when it opens — so the whole page slides over, instead of the panel opening tucked *under* the sticky navbar.

## Why

The panel was anchored at `top-12` (below the navbar) and only the docs content made room for it; the navbar stayed full-width and overlapped the panel. This makes it a proper side column that the entire page (navbar + content) accommodates.

## How

- `DocsAssistantPanel`: `top-12` → `top-0` + `z-50` (full-height column).
- Export `getPanelWidth` so the navbar can reuse the same width value.
- `DocsHeader` reads `useAssistantPanel()` and shifts with `md:mr-(--chat-panel-width)` (drops `w-full`), reusing the exact mechanism `DocsContent` already uses.

Animation timing is intentionally unchanged here (still 300ms `ease-out`) — it's sped up in the next PR.

---

## Merge order (4-PR stack)

Merge strictly in this order — each PR is based on the previous branch:

1. **#4633 — side panel + page shift  ← this PR, merge _first_**
2. #4634 — trigger restyle + faster animation
3. #4635 — homepage chat + ⌘I
4. #4636 — panel header + conversation starters

No changeset — `@assistant-ui/docs` is private.
