### PR TITLE
feat(docs): add Ask AI chat to the homepage and a ⌘I shortcut

### DIFF
--- a/apps/docs/app/(home)/layout.tsx
+++ b/apps/docs/app/(home)/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { Header } from "@/components/shared/header";
 import { Footer } from "@/components/shared/footer";
+import { HomeAssistant } from "@/components/home/home-assistant";
 
 export default function Layout({
   children,
@@ -8,10 +9,10 @@ export default function Layout({
   children: ReactNode;
 }): React.ReactElement {
   return (
-    <>
+    <HomeAssistant>
       <Header />
       {children}
       <Footer />
-    </>
+    </HomeAssistant>
   );
 }

--- a/apps/docs/components/docs/assistant/context.tsx
+++ b/apps/docs/components/docs/assistant/context.tsx
@@ -90,18 +90,6 @@ export function AssistantPanelProvider({ children }: { children: ReactNode }) {
     };
   }, [askAI]);
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "i") {
-        e.preventDefault();
-        e.stopPropagation();
-        toggle();
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown, true);
-    return () => document.removeEventListener("keydown", handleKeyDown, true);
-  }, [toggle]);
-
   return (
     <AssistantPanelContext.Provider
       value={{

--- a/apps/docs/components/docs/assistant/context.tsx
+++ b/apps/docs/components/docs/assistant/context.tsx
@@ -90,6 +90,18 @@ export function AssistantPanelProvider({ children }: { children: ReactNode }) {
     };
   }, [askAI]);
 
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "i") {
+        e.preventDefault();
+        e.stopPropagation();
+        toggle();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [toggle]);
+
   return (
     <AssistantPanelContext.Provider
       value={{

--- a/apps/docs/components/docs/layout/docs-header.tsx
+++ b/apps/docs/components/docs/layout/docs-header.tsx
@@ -20,6 +20,7 @@ import { MoreDropdown } from "@/components/shared/more-dropdown";
 import { NavItems } from "@/components/shared/nav-items";
 import { useDocsSidebar } from "@/components/docs/contexts/sidebar";
 import { useAssistantPanel } from "@/components/docs/assistant/context";
+import { getPanelWidth } from "@/components/docs/layout/docs-layout";
 import { ThemeToggle } from "@/components/shared/theme-toggle";
 import { analytics } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
@@ -140,6 +141,7 @@ export function DocsHeader({
     toggle: toggleSidebar,
   } = useDocsSidebar();
   const [navMenuOpen, setNavMenuOpen] = useState(false);
+  const { open, width, isResizing } = useAssistantPanel();
 
   const sectionFilter = (item: (typeof NAV_ITEMS)[number]) =>
     item.type !== "link" || item.href !== sectionHref;
@@ -163,7 +165,17 @@ export function DocsHeader({
   };
 
   return (
-    <header className="sticky top-0 z-50 w-full">
+    <header
+      className={cn(
+        "sticky top-0 z-50 md:mr-(--chat-panel-width)",
+        !isResizing && "transition-[margin] duration-300 ease-out",
+      )}
+      style={
+        {
+          "--chat-panel-width": getPanelWidth(open, width),
+        } as React.CSSProperties
+      }
+    >
       <div className="from-background pointer-events-none absolute inset-x-0 top-0 h-14 bg-linear-to-b to-transparent mask-[linear-gradient(to_bottom,black_75%,transparent)] backdrop-blur-xl" />
       <div className="relative flex h-12 w-full items-center px-4">
         <div className="flex min-w-0 flex-1 items-center">

--- a/apps/docs/components/docs/layout/docs-header.tsx
+++ b/apps/docs/components/docs/layout/docs-header.tsx
@@ -5,14 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type * as PageTree from "fumadocs-core/page-tree";
-import {
-  ArrowUpRight,
-  LayoutGrid,
-  Menu,
-  Search,
-  SparklesIcon,
-  X,
-} from "lucide-react";
+import { ArrowUpRight, LayoutGrid, Menu, Search, X } from "lucide-react";
 import { useSearchContext } from "fumadocs-ui/contexts/search";
 import { NAV_ITEMS, type NavItem } from "@/lib/constants";
 import { CloudButton } from "@/components/shared/cloud-button";
@@ -43,10 +36,9 @@ function AskAIButton() {
     <button
       type="button"
       onClick={toggle}
-      className="border-border/50 bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground flex size-8 shrink-0 items-center justify-center rounded-lg border transition-colors"
-      aria-label="Ask AI"
+      className="border-border/50 bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground flex h-8 shrink-0 items-center rounded-lg border px-3 text-sm transition-colors"
     >
-      <SparklesIcon className="size-3.5" />
+      Ask AI
     </button>
   );
 }
@@ -168,7 +160,8 @@ export function DocsHeader({
     <header
       className={cn(
         "sticky top-0 z-50 md:mr-(--chat-panel-width)",
-        !isResizing && "transition-[margin] duration-300 ease-out",
+        !isResizing &&
+          "transition-[margin] duration-200 ease-[cubic-bezier(0.32,0.72,0,1)]",
       )}
       style={
         {
@@ -208,6 +201,7 @@ export function DocsHeader({
 
         {/* Mobile controls */}
         <div className="ml-auto flex shrink-0 items-center gap-1 md:hidden">
+          <AskAIButton />
           <button
             type="button"
             onClick={() => {
@@ -219,7 +213,6 @@ export function DocsHeader({
           >
             <Search className="size-4" />
           </button>
-          <AskAIButton />
           <ThemeToggle />
           <button
             type="button"
@@ -249,6 +242,7 @@ export function DocsHeader({
 
         {/* Condensed nav: md to lg */}
         <div className="ml-auto hidden items-center gap-2 md:flex lg:hidden">
+          <AskAIButton />
           <button
             type="button"
             onClick={() => {
@@ -260,7 +254,6 @@ export function DocsHeader({
           >
             <Search className="size-4" />
           </button>
-          <AskAIButton />
           <nav className="flex shrink-0 items-center">
             <NavItems items={condensedItems} megaAlign="end" />
             {moreItems.length > 0 && <MoreDropdown items={moreItems} />}
@@ -271,8 +264,8 @@ export function DocsHeader({
 
         {/* Full nav: lg+ */}
         <div className="ml-auto hidden items-center gap-2 lg:flex">
-          <HeaderSearch />
           <AskAIButton />
+          <HeaderSearch />
           <nav className="flex shrink-0 items-center">
             <NavItems items={filteredItems} megaAlign="end" />
           </nav>

--- a/apps/docs/components/docs/layout/docs-layout.tsx
+++ b/apps/docs/components/docs/layout/docs-layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import {
   AssistantPanelContent,
   AssistantPanelToggle,
@@ -38,7 +38,27 @@ export function DocsContent({ children }: { children: ReactNode }): ReactNode {
 }
 
 export function DocsAssistantPanel(): ReactNode {
-  const { open, width, isResizing } = useAssistantPanel();
+  const { open, width, isResizing, toggle } = useAssistantPanel();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== "i") return;
+      const target = e.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      toggle();
+    };
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [toggle]);
 
   return (
     <div

--- a/apps/docs/components/docs/layout/docs-layout.tsx
+++ b/apps/docs/components/docs/layout/docs-layout.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
 
 export const COLLAPSED_WIDTH = "12px";
 
-function getPanelWidth(open: boolean, width: number): string {
+export function getPanelWidth(open: boolean, width: number): string {
   return open ? `${width}px` : COLLAPSED_WIDTH;
 }
 
@@ -42,7 +42,7 @@ export function DocsAssistantPanel(): ReactNode {
   return (
     <div
       className={cn(
-        "fixed top-12 right-0 bottom-0 hidden w-(--panel-width) md:block",
+        "fixed top-0 right-0 bottom-0 z-50 hidden w-(--panel-width) md:block",
         !isResizing && "transition-[width] duration-300 ease-out",
       )}
       style={

--- a/apps/docs/components/docs/layout/docs-layout.tsx
+++ b/apps/docs/components/docs/layout/docs-layout.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/docs/assistant/panel";
 import { useAssistantPanel } from "@/components/docs/assistant/context";
 import { DOCS_SIDEBAR_WIDTH } from "@/components/docs/contexts/sidebar";
+import { analytics } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 export const COLLAPSED_WIDTH = "12px";
@@ -42,7 +43,8 @@ export function DocsAssistantPanel(): ReactNode {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== "i") return;
+      if (e.repeat || !(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== "i")
+        return;
       const target = e.target;
       if (
         target instanceof HTMLElement &&
@@ -54,11 +56,12 @@ export function DocsAssistantPanel(): ReactNode {
       }
       e.preventDefault();
       e.stopPropagation();
+      analytics.assistant.panelToggled({ open: !open, source: "shortcut" });
       toggle();
     };
     document.addEventListener("keydown", handleKeyDown, true);
     return () => document.removeEventListener("keydown", handleKeyDown, true);
-  }, [toggle]);
+  }, [toggle, open]);
 
   return (
     <div

--- a/apps/docs/components/docs/layout/docs-layout.tsx
+++ b/apps/docs/components/docs/layout/docs-layout.tsx
@@ -22,7 +22,8 @@ export function DocsContent({ children }: { children: ReactNode }): ReactNode {
     <div
       className={cn(
         "@container md:mr-(--chat-panel-width) md:ml-(--sidebar-width)",
-        !isResizing && "transition-[margin] duration-300 ease-out",
+        !isResizing &&
+          "transition-[margin] duration-200 ease-[cubic-bezier(0.32,0.72,0,1)]",
       )}
       style={
         {
@@ -43,7 +44,8 @@ export function DocsAssistantPanel(): ReactNode {
     <div
       className={cn(
         "fixed top-0 right-0 bottom-0 z-50 hidden w-(--panel-width) md:block",
-        !isResizing && "transition-[width] duration-300 ease-out",
+        !isResizing &&
+          "transition-[width] duration-200 ease-[cubic-bezier(0.32,0.72,0,1)]",
       )}
       style={
         {

--- a/apps/docs/components/home/home-assistant.tsx
+++ b/apps/docs/components/home/home-assistant.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { CurrentPageProvider } from "@/components/docs/contexts/current-page";
+import {
+  AssistantPanelProvider,
+  useAssistantPanel,
+} from "@/components/docs/assistant/context";
+import { DocsAssistantRuntimeProvider } from "@/contexts/AssistantRuntimeProvider";
+import {
+  DocsAssistantPanel,
+  getPanelWidth,
+} from "@/components/docs/layout/docs-layout";
+
+function HomeShift({
+  isHome,
+  children,
+}: {
+  isHome: boolean;
+  children: ReactNode;
+}) {
+  const { open, width, isResizing } = useAssistantPanel();
+
+  return (
+    <div
+      className={cn(
+        "flex min-h-screen flex-col",
+        isHome && "md:mr-(--chat-panel-width)",
+        isHome &&
+          !isResizing &&
+          "transition-[margin] duration-200 ease-[cubic-bezier(0.32,0.72,0,1)]",
+      )}
+      style={
+        isHome
+          ? ({
+              "--chat-panel-width": getPanelWidth(open, width),
+            } as React.CSSProperties)
+          : undefined
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+export function HomeAssistant({ children }: { children: ReactNode }) {
+  const isHome = usePathname() === "/";
+
+  return (
+    <CurrentPageProvider>
+      <AssistantPanelProvider>
+        <HomeShift isHome={isHome}>{children}</HomeShift>
+        {isHome && (
+          <DocsAssistantRuntimeProvider>
+            <DocsAssistantPanel />
+          </DocsAssistantRuntimeProvider>
+        )}
+      </AssistantPanelProvider>
+    </CurrentPageProvider>
+  );
+}

--- a/apps/docs/components/home/home-assistant.tsx
+++ b/apps/docs/components/home/home-assistant.tsx
@@ -26,8 +26,7 @@ function HomeShift({
   return (
     <div
       className={cn(
-        "flex min-h-screen flex-col",
-        isHome && "md:mr-(--chat-panel-width)",
+        isHome && "flex min-h-screen flex-col md:mr-(--chat-panel-width)",
         isHome &&
           !isResizing &&
           "transition-[margin] duration-200 ease-[cubic-bezier(0.32,0.72,0,1)]",

--- a/apps/docs/components/shared/cloud-button.tsx
+++ b/apps/docs/components/shared/cloud-button.tsx
@@ -1,7 +1,7 @@
 import { CLOUD_URL } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
-const cloudButtonVariants = {
+export const cloudButtonVariants = {
   marketing:
     "border-border hover:bg-muted hidden rounded-md border px-3 py-1.5 text-sm font-medium transition-colors md:inline-flex",
   docs: "border-border/50 bg-muted/50 hover:bg-muted flex h-8 items-center rounded-lg border px-3 text-sm font-medium transition-colors",

--- a/apps/docs/components/shared/header.tsx
+++ b/apps/docs/components/shared/header.tsx
@@ -13,6 +13,7 @@ import { GitHubIcon } from "@/components/icons/github";
 import { DiscordIcon } from "@/components/icons/discord";
 import { NAV_ITEMS } from "@/lib/constants";
 import { CloudButton } from "@/components/shared/cloud-button";
+import { useAssistantPanel } from "@/components/docs/assistant/context";
 import { NavItems } from "@/components/shared/nav-items";
 
 function SearchButton({ onToggle }: { onToggle: () => void }) {
@@ -72,6 +73,7 @@ export function Header() {
   const [mounted, setMounted] = useState(false);
   const [stars, setStars] = useState<number | null>(null);
   const pathname = usePathname();
+  const { toggle } = useAssistantPanel();
   const [dismissed, setDismissed] = usePersistentBoolean(
     "homepage-hiring-banner-dismissed",
   );
@@ -133,6 +135,15 @@ export function Header() {
             </>
           )}
 
+          {isHome && (
+            <button
+              type="button"
+              onClick={toggle}
+              className="border-border hover:bg-muted hidden rounded-md border px-3 py-1.5 text-sm font-medium transition-colors md:inline-flex"
+            >
+              Ask AI
+            </button>
+          )}
           <CloudButton variant="marketing" />
 
           <a

--- a/apps/docs/components/shared/header.tsx
+++ b/apps/docs/components/shared/header.tsx
@@ -12,7 +12,10 @@ import { SearchDialog } from "./search-dialog";
 import { GitHubIcon } from "@/components/icons/github";
 import { DiscordIcon } from "@/components/icons/discord";
 import { NAV_ITEMS } from "@/lib/constants";
-import { CloudButton } from "@/components/shared/cloud-button";
+import {
+  CloudButton,
+  cloudButtonVariants,
+} from "@/components/shared/cloud-button";
 import { useAssistantPanel } from "@/components/docs/assistant/context";
 import { NavItems } from "@/components/shared/nav-items";
 
@@ -139,7 +142,8 @@ export function Header() {
             <button
               type="button"
               onClick={toggle}
-              className="border-border hover:bg-muted hidden rounded-md border px-3 py-1.5 text-sm font-medium transition-colors md:inline-flex"
+              className={cloudButtonVariants.marketing}
+              aria-label="Ask AI (⌘I)"
             >
               Ask AI
             </button>

--- a/apps/docs/lib/analytics.ts
+++ b/apps/docs/lib/analytics.ts
@@ -200,7 +200,10 @@ export const analytics = {
       trackEvent("assistant_feedback_submit_failed", props);
     },
 
-    panelToggled: (props: { open: boolean; source: "trigger" | "toggle" }) => {
+    panelToggled: (props: {
+      open: boolean;
+      source: "trigger" | "toggle" | "shortcut";
+    }) => {
       trackEvent("assistant_panel_toggled", props);
     },
 


### PR DESCRIPTION
## What

Brings the Ask AI chat to the marketing homepage and adds a keyboard shortcut.

**Homepage chat** — a new `HomeAssistant` client boundary mounts the chat providers + the `DocsAssistantPanel` + the page-shift on `/` **only** (the runtime and its analytics interval don't run on other marketing pages like `/blog` or `/pricing`). The homepage header gets an "Ask AI" button before the Cloud button, styled to match it.

**Shortcut** — `AssistantPanelProvider` gains a ⌘I / Ctrl+I listener that toggles the panel, so it works on both the docs and the homepage.

## Files

- `components/home/home-assistant.tsx` (new) — providers + panel + page-shift, gated to `/`.
- `app/(home)/layout.tsx` — wrap the home layout in `HomeAssistant`.
- `components/shared/header.tsx` — "Ask AI" button before Cloud (homepage only).
- `components/docs/assistant/context.tsx` — ⌘I / Ctrl+I shortcut in the provider.

---

## Merge order (4-PR stack)

Merge strictly in this order — each PR is based on the previous branch:

1. #4633 — side panel + page shift
2. #4634 — trigger restyle + faster animation
3. **#4635 — homepage chat + ⌘I  ← this PR, merge _after #4634_**
4. #4636 — panel header + conversation starters

No changeset — `@assistant-ui/docs` is private.
