### PR TITLE
chore(style): add view transition theme toggle

### DIFF
--- a/apps/docs/components/shared/theme-toggle.tsx
+++ b/apps/docs/components/shared/theme-toggle.tsx
@@ -4,6 +4,12 @@ import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { Moon, Sun } from "lucide-react";
 
+type DocumentWithViewTransition = Document & {
+  startViewTransition?: (updateCallback: () => void) => void;
+};
+
+type Theme = "dark" | "light";
+
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
@@ -11,7 +17,23 @@ export function ThemeToggle() {
   useEffect(() => setMounted(true), []);
 
   const toggleTheme = () => {
-    setTheme(resolvedTheme === "dark" ? "light" : "dark");
+    if (!mounted) return;
+
+    const nextTheme: Theme = resolvedTheme === "dark" ? "light" : "dark";
+
+    const updateTheme = () => {
+      setTheme(nextTheme);
+    };
+
+    const startViewTransition = (document as DocumentWithViewTransition)
+      .startViewTransition;
+
+    if (!startViewTransition) {
+      runFallbackTransition(nextTheme, updateTheme);
+      return;
+    }
+
+    startViewTransition.call(document, updateTheme);
   };
 
   return (
@@ -19,7 +41,11 @@ export function ThemeToggle() {
       type="button"
       onClick={toggleTheme}
       className="text-muted-foreground hover:text-foreground flex size-8 items-center justify-center transition-colors"
-      aria-label="Toggle theme"
+      aria-label={
+        mounted && resolvedTheme === "dark"
+          ? "Switch to light theme"
+          : "Switch to dark theme"
+      }
     >
       {mounted ? (
         resolvedTheme === "dark" ? (
@@ -33,3 +59,21 @@ export function ThemeToggle() {
     </button>
   );
 }
+
+const runFallbackTransition = (nextTheme: Theme, updateTheme: () => void) => {
+  if (document.querySelector("[data-theme-toggle-fallback]")) return;
+
+  const ripple = document.createElement("div");
+  ripple.dataset.themeToggleFallback = "true";
+  ripple.className = "theme-toggle-fallback-ripple";
+  ripple.style.setProperty(
+    "--theme-toggle-fallback-background",
+    nextTheme === "dark" ? "oklch(0.145 0 0)" : "oklch(1 0 0)",
+  );
+
+  document.body.appendChild(ripple);
+  window.setTimeout(updateTheme, 420);
+  ripple.addEventListener("animationend", () => ripple.remove(), {
+    once: true,
+  });
+};

--- a/apps/docs/components/shared/theme-toggle.tsx
+++ b/apps/docs/components/shared/theme-toggle.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import type { MutableRefObject } from "react";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Moon, Sun } from "lucide-react";
 
 type DocumentWithViewTransition = Document & {
@@ -10,30 +11,45 @@ type DocumentWithViewTransition = Document & {
 
 type Theme = "dark" | "light";
 
+const FALLBACK_REVEAL_DELAY_MS = 420;
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
+  const themeRef = useRef<Theme>("light");
+  const fallbackTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    themeRef.current = resolvedTheme === "dark" ? "dark" : "light";
+  }, [resolvedTheme]);
+
+  useEffect(() => {
+    return () => clearFallbackTransition(fallbackTimeoutRef);
+  }, []);
 
   const toggleTheme = () => {
     if (!mounted) return;
 
-    const nextTheme: Theme = resolvedTheme === "dark" ? "light" : "dark";
+    const nextTheme: Theme = themeRef.current === "dark" ? "light" : "dark";
+    themeRef.current = nextTheme;
 
     const updateTheme = () => {
       setTheme(nextTheme);
     };
 
-    const startViewTransition = (document as DocumentWithViewTransition)
-      .startViewTransition;
-
-    if (!startViewTransition) {
-      runFallbackTransition(nextTheme, updateTheme);
+    if (window.matchMedia(REDUCED_MOTION_QUERY).matches) {
+      clearFallbackTransition(fallbackTimeoutRef);
+      updateTheme();
       return;
     }
 
-    startViewTransition.call(document, updateTheme);
+    const doc = document as DocumentWithViewTransition;
+
+    if (doc.startViewTransition) doc.startViewTransition(updateTheme);
+    else runFallbackTransition(nextTheme, updateTheme, fallbackTimeoutRef);
   };
 
   return (
@@ -60,8 +76,25 @@ export function ThemeToggle() {
   );
 }
 
-const runFallbackTransition = (nextTheme: Theme, updateTheme: () => void) => {
-  if (document.querySelector("[data-theme-toggle-fallback]")) return;
+const clearFallbackTransition = (
+  fallbackTimeoutRef: MutableRefObject<number | null>,
+) => {
+  if (fallbackTimeoutRef.current !== null) {
+    window.clearTimeout(fallbackTimeoutRef.current);
+    fallbackTimeoutRef.current = null;
+  }
+
+  document
+    .querySelectorAll("[data-theme-toggle-fallback]")
+    .forEach((element) => element.remove());
+};
+
+const runFallbackTransition = (
+  nextTheme: Theme,
+  updateTheme: () => void,
+  fallbackTimeoutRef: MutableRefObject<number | null>,
+) => {
+  clearFallbackTransition(fallbackTimeoutRef);
 
   const ripple = document.createElement("div");
   ripple.dataset.themeToggleFallback = "true";
@@ -72,7 +105,10 @@ const runFallbackTransition = (nextTheme: Theme, updateTheme: () => void) => {
   );
 
   document.body.appendChild(ripple);
-  window.setTimeout(updateTheme, 420);
+  fallbackTimeoutRef.current = window.setTimeout(() => {
+    fallbackTimeoutRef.current = null;
+    updateTheme();
+  }, FALLBACK_REVEAL_DELAY_MS);
   ripple.addEventListener("animationend", () => ripple.remove(), {
     once: true,
   });

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -70,6 +70,24 @@
 
 :root {
   --radius: 0.625rem;
+  --expo-out: linear(
+    0 0%,
+    0.1684 2.66%,
+    0.3165 5.49%,
+    0.446 8.52%,
+    0.5581 11.78%,
+    0.6535 15.29%,
+    0.7341 19.11%,
+    0.8011 23.3%,
+    0.8557 27.93%,
+    0.8962 32.68%,
+    0.9283 38.01%,
+    0.9529 44.08%,
+    0.9711 51.14%,
+    0.9833 59.06%,
+    0.9915 68.74%,
+    1 100%
+  );
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -147,6 +165,46 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+
+  ::view-transition-group(root) {
+    animation-timing-function: var(--expo-out);
+  }
+
+  ::view-transition-new(root) {
+    mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="0" cy="0" r="18" fill="white" filter="url(%23blur)"/></svg>')
+      top left / 0 no-repeat;
+    mask-origin: content-box;
+    animation: theme-toggle-scale 1s;
+    animation-fill-mode: both;
+    transform-origin: top left;
+  }
+
+  ::view-transition-old(root),
+  .dark::view-transition-old(root) {
+    animation: theme-toggle-scale 1s;
+    animation-fill-mode: both;
+    transform-origin: top left;
+    z-index: -1;
+  }
+
+  @keyframes theme-toggle-scale {
+    to {
+      mask-size: 350vmax;
+    }
+  }
+
+  .theme-toggle-fallback-ripple {
+    background: var(--theme-toggle-fallback-background);
+    inset: 0;
+    mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="0" cy="0" r="18" fill="white" filter="url(%23blur)"/></svg>')
+      top left / 0 no-repeat;
+    mask-origin: content-box;
+    pointer-events: none;
+    position: fixed;
+    transform-origin: top left;
+    z-index: 2147483647;
+    animation: theme-toggle-scale 1s var(--expo-out) both;
   }
 
   @supports not selector(::-webkit-scrollbar) {

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -178,12 +178,14 @@
     mask-origin: content-box;
     animation: theme-toggle-scale 1s;
     animation-fill-mode: both;
+    animation-timing-function: var(--expo-out);
     transform-origin: top left;
   }
 
   ::view-transition-old(root) {
     animation: theme-toggle-scale 1s;
     animation-fill-mode: both;
+    animation-timing-function: var(--expo-out);
     transform-origin: top left;
     z-index: -1;
   }

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -70,6 +70,8 @@
 
 :root {
   --radius: 0.625rem;
+  --theme-toggle-mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="0" cy="0" r="18" fill="white" filter="url(%23blur)"/></svg>')
+    top left / 0 no-repeat;
   --expo-out: linear(
     0 0%,
     0.1684 2.66%,
@@ -172,16 +174,14 @@
   }
 
   ::view-transition-new(root) {
-    mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="0" cy="0" r="18" fill="white" filter="url(%23blur)"/></svg>')
-      top left / 0 no-repeat;
+    mask: var(--theme-toggle-mask);
     mask-origin: content-box;
     animation: theme-toggle-scale 1s;
     animation-fill-mode: both;
     transform-origin: top left;
   }
 
-  ::view-transition-old(root),
-  .dark::view-transition-old(root) {
+  ::view-transition-old(root) {
     animation: theme-toggle-scale 1s;
     animation-fill-mode: both;
     transform-origin: top left;
@@ -197,14 +197,22 @@
   .theme-toggle-fallback-ripple {
     background: var(--theme-toggle-fallback-background);
     inset: 0;
-    mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="0" cy="0" r="18" fill="white" filter="url(%23blur)"/></svg>')
-      top left / 0 no-repeat;
+    mask: var(--theme-toggle-mask);
     mask-origin: content-box;
     pointer-events: none;
     position: fixed;
     transform-origin: top left;
     z-index: 2147483647;
     animation: theme-toggle-scale 1s var(--expo-out) both;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    ::view-transition-new(root),
+    ::view-transition-old(root),
+    .theme-toggle-fallback-ripple {
+      animation: none;
+      mask: none;
+    }
   }
 
   @supports not selector(::-webkit-scrollbar) {


### PR DESCRIPTION
## Summary

Adds circle-blur top-left theme transition to the existing docs theme toggle.

## Details

- Wraps the existing `next-themes` toggle with `document.startViewTransition` when the browser supports it.
- Adds the circle-blur top-left view-transition CSS in the docs global stylesheet.
- Adds a matching fallback ripple so browsers without View Transitions, including the in-app preview browser, still show a visible top-left blur effect.

## Validation

- `pnpm exec oxfmt --check apps/docs/components/shared/theme-toggle.tsx apps/docs/styles/globals.css`
- `pnpm exec oxlint apps/docs/components/shared/theme-toggle.tsx`
- `pnpm --filter docs exec tsc --noEmit`
- Ran the docs dev server and previewed `/docs` locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

