### PR TITLE
docs: generative ui actions registry

### DIFF
--- a/apps/docs/content/docs/tools/generative-ui.mdx
+++ b/apps/docs/content/docs/tools/generative-ui.mdx
@@ -166,6 +166,43 @@ type GenerativeUISpec = {
 The spec is plain JSON — easy for any agent to emit, and easy to validate
 on the server before delivery.
 
+## Actions with `JSONGenerativeUI`
+
+When you expose a component library through `new JSONGenerativeUI(...)`, pass an
+action registry to let interactive nodes call back into your app. This path uses
+the flat `{ "$type": ... }` node shape; the model puts an `$action` object on
+the node, and its `type` is matched against your registered handlers.
+
+```tsx
+import {
+  JSONGenerativeUI,
+  createActionRegistry,
+  defaultGenerativeUILibrary,
+} from "@assistant-ui/react-generative-ui";
+
+const actions = createActionRegistry({
+  purchase: async ({ payload }) => {
+    await checkout(payload);
+  },
+});
+
+const generative = new JSONGenerativeUI({
+  library: defaultGenerativeUILibrary,
+  actions,
+});
+```
+
+```json
+{
+  "$type": "Button",
+  "label": "Buy",
+  "$action": { "type": "purchase", "sku": "pro-plan" }
+}
+```
+
+`Select`, `Input`, and `DatePicker` add the user's value as `$input` when they
+fire the action. Unknown action types are ignored and warn in development.
+
 ## Streaming
 
 When a message contains native `generative-ui` parts whose `spec` updates


### PR DESCRIPTION
## Summary

Documents the generative UI action registry added in #4625.

- Adds a concise `ActionRegistry` / `$action` section to the Generative UI JSON spec docs
- Shows `createActionRegistry(...)` wired into `new JSONGenerativeUI(...)`
- Notes `$input` behavior for interactive controls and unknown-action dev warnings

## Validation

- `pnpm --filter @assistant-ui/docs postinstall`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

