### PR TITLE
feat(docs): keep Xulux active preview context across turns

### DIFF
--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -285,6 +285,7 @@ Case 2: User ask questions about assistant-ui:
 - When customizing, review both the visible UI and the assistant behavior together. A good match requires the screen, assistant identity, prompts, tool descriptions, and mock/demo responses to all reflect the same user request.
 - Use 'getTemplateDetails' and especially 'exampleConfig' to understand what the template actually represents in practice: what the UI looks like, how the assistant behaves, what the tools do, and what the demo/mock flows are modeling.
 - After reading that full template shape, decide whether the user’s request can be represented within it with supported customization. If not, do not force the template.
+- When a user message contains <xulux_active_preview_context>, treat it as the current open preview state. Use it to understand follow-up requests, and call template tools if you need schema or template details before customizing or opening a template.
 </template_customization_guide>
 
 <common_pitfalls_to_avoid>

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -47,11 +47,17 @@ function isReasoningEffort(value: unknown): value is XuluxReasoningEffort {
   );
 }
 
-function resolveXuluxModel(config: XuluxRequestConfig | undefined) {
+function resolveXuluxModel(config: unknown) {
+  const requestConfig =
+    config && typeof config === "object" && !Array.isArray(config)
+      ? (config as XuluxRequestConfig)
+      : undefined;
   const modelName =
-    typeof config?.modelName === "string" ? config.modelName.trim() : "";
-  const reasoningEffort = isReasoningEffort(config?.reasoningEffort)
-    ? config.reasoningEffort
+    typeof requestConfig?.modelName === "string"
+      ? requestConfig.modelName.trim()
+      : "";
+  const reasoningEffort = isReasoningEffort(requestConfig?.reasoningEffort)
+    ? requestConfig.reasoningEffort
     : undefined;
 
   if (modelName === "gpt-5.4" && reasoningEffort) {
@@ -90,8 +96,19 @@ type ActivePreviewRequestContext = {
   templateId: string;
   versionId?: string | null;
   customized: boolean;
-  config?: Record<string, unknown>;
+  config?: JsonObject;
 };
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+type JsonObject = { [key: string]: JsonValue };
+
+const MAX_ACTIVE_PREVIEW_CONFIG_CHARS = 8_000;
 
 async function prepareMessages(messages: readonly UIMessage[]) {
   const modelMessages = await convertToModelMessages(
@@ -102,6 +119,17 @@ async function prepareMessages(messages: readonly UIMessage[]) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeJsonObject(value: unknown): JsonObject | undefined {
+  if (!isRecord(value)) return undefined;
+  try {
+    const json = JSON.stringify(value);
+    if (json.length > MAX_ACTIVE_PREVIEW_CONFIG_CHARS) return undefined;
+    return JSON.parse(json) as JsonObject;
+  } catch {
+    return undefined;
+  }
 }
 
 function normalizeActivePreviewContext(
@@ -119,6 +147,7 @@ function normalizeActivePreviewContext(
   ) {
     return null;
   }
+  const config = normalizeJsonObject(value.config);
   return {
     source,
     templateId,
@@ -126,7 +155,7 @@ function normalizeActivePreviewContext(
       ? { versionId }
       : {}),
     customized,
-    ...(isRecord(value.config) ? { config: value.config } : {}),
+    ...(config ? { config } : {}),
   };
 }
 
@@ -139,42 +168,42 @@ function appendHiddenText(message: { content: unknown }, text: string) {
 }
 
 function formatActivePreviewContext(context: ActivePreviewRequestContext) {
+  const json = JSON.stringify(context).replaceAll("<", "\\u003c");
   return [
     "<xulux_active_preview_context>",
     "Treat this as the currently open preview state.",
-    JSON.stringify(context),
+    json,
     "</xulux_active_preview_context>",
   ].join("\n");
 }
 
 function formatSelectedTemplateContext(
-  selectedTemplate: SelectedTemplateRequestContext | null | undefined,
+  selectedTemplate: unknown,
 ): string | null {
   if (!selectedTemplate || typeof selectedTemplate !== "object") return null;
-  const id =
-    typeof selectedTemplate.id === "string" ? selectedTemplate.id : null;
-  const title =
-    typeof selectedTemplate.title === "string" ? selectedTemplate.title : null;
+  const template = selectedTemplate as SelectedTemplateRequestContext;
+  const id = typeof template.id === "string" ? template.id : null;
+  const title = typeof template.title === "string" ? template.title : null;
   if (!id || !title) return null;
 
   const lines = [
     "<selected_template_context>",
-    `The user selected this ${selectedTemplate.kind === "example" ? "example" : "template"} before sending their message.`,
+    `The user selected this ${template.kind === "example" ? "example" : "template"} before sending their message.`,
     `id: ${id}`,
     `title: ${title}`,
   ];
 
-  if (typeof selectedTemplate.description === "string") {
-    lines.push(`description: ${selectedTemplate.description}`);
+  if (typeof template.description === "string") {
+    lines.push(`description: ${template.description}`);
   }
-  if (typeof selectedTemplate.prompt === "string") {
-    lines.push(`catalog_prompt: ${selectedTemplate.prompt}`);
+  if (typeof template.prompt === "string") {
+    lines.push(`catalog_prompt: ${template.prompt}`);
   }
-  if (typeof selectedTemplate.sourcePath === "string") {
-    lines.push(`sourcePath: ${selectedTemplate.sourcePath}`);
+  if (typeof template.sourcePath === "string") {
+    lines.push(`sourcePath: ${template.sourcePath}`);
   }
-  if (typeof selectedTemplate.downloadUrl === "string") {
-    lines.push(`downloadUrl: ${selectedTemplate.downloadUrl}`);
+  if (typeof template.downloadUrl === "string") {
+    lines.push(`downloadUrl: ${template.downloadUrl}`);
   }
 
   lines.push(
@@ -345,13 +374,14 @@ export async function POST(req: Request): Promise<Response> {
       activePreviewContext,
     } = body;
 
-    const prunedMessages = await prepareMessages(messages);
+    const inputError = validateDocChatInput(messages);
+    if (inputError) return inputError;
+
+    const uiMessages = messages as UIMessage[];
+    const prunedMessages = await prepareMessages(uiMessages);
     const normalizedPreviewContext =
       normalizeActivePreviewContext(activePreviewContext);
-    const userMessageId = getLatestUserMessageId(messages);
-
-    const inputError = validateDocChatInput(prunedMessages);
-    if (inputError) return inputError;
+    const userMessageId = getLatestUserMessageId(uiMessages);
 
     if (typeof sessionId !== "string" || sessionId.trim().length === 0) {
       return NextResponse.json(
@@ -373,7 +403,7 @@ export async function POST(req: Request): Promise<Response> {
           : "This request could not run because a usage limit was reached.";
       const code = typeof payload?.code === "string" ? payload.code : undefined;
       return createXuluxDiagnosticMessageResponse({
-        messages,
+        messages: uiMessages,
         text: userVisibleMessage,
         outcome: createXuluxTurnOutcome({
           type: "budget_denied",
@@ -417,7 +447,9 @@ export async function POST(req: Request): Promise<Response> {
     const baseModel = modelConfig.model;
     const prismTracer = createPrismTracer({ evalRunId, localTraceUrl });
     const xuluxTools = createXuluxChatTools({
-      clientTools,
+      clientTools: clientTools as Parameters<
+        typeof createXuluxChatTools
+      >[0]["clientTools"],
       routeUrl: req.url,
     });
     const toolManifest =
@@ -491,7 +523,7 @@ export async function POST(req: Request): Promise<Response> {
     });
 
     return result.toUIMessageStreamResponse({
-      originalMessages: messages,
+      originalMessages: uiMessages,
       messageMetadata: ({ part }) => {
         if (part.type === "finish-step") {
           return { modelId: part.response.modelId };

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -85,11 +85,66 @@ type SelectedTemplateRequestContext = {
   downloadUrl?: unknown;
 };
 
+type ActivePreviewRequestContext = {
+  source: "template_modal" | "agent_tool";
+  templateId: string;
+  versionId?: string | null;
+  customized: boolean;
+  config?: Record<string, unknown>;
+};
+
 async function prepareMessages(messages: readonly UIMessage[]) {
   const modelMessages = await convertToModelMessages(
     injectQuoteContext([...messages]),
   );
   return pruneMessages({ messages: modelMessages, ...PRUNE_OPTIONS });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeActivePreviewContext(
+  value: unknown,
+): ActivePreviewRequestContext | null {
+  if (!isRecord(value)) return null;
+  const source = value.source;
+  const templateId = value.templateId;
+  const versionId = value.versionId;
+  const customized = value.customized;
+  if (
+    (source !== "template_modal" && source !== "agent_tool") ||
+    typeof templateId !== "string" ||
+    typeof customized !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    source,
+    templateId,
+    ...(typeof versionId === "string" || versionId === null
+      ? { versionId }
+      : {}),
+    customized,
+    ...(isRecord(value.config) ? { config: value.config } : {}),
+  };
+}
+
+function appendHiddenText(message: { content: unknown }, text: string) {
+  if (typeof message.content === "string") {
+    message.content = `${message.content}\n\n${text}`;
+  } else if (Array.isArray(message.content)) {
+    message.content = [...message.content, { type: "text", text }];
+  }
+}
+
+function formatActivePreviewContext(context: ActivePreviewRequestContext) {
+  return [
+    "<xulux_active_preview_context>",
+    "Treat this as the currently open preview state.",
+    JSON.stringify(context),
+    "</xulux_active_preview_context>",
+  ].join("\n");
 }
 
 function formatSelectedTemplateContext(
@@ -279,9 +334,13 @@ export async function POST(req: Request): Promise<Response> {
       config,
       sessionId,
       selectedTemplate,
+      activePreviewContext,
     } = body;
 
     const prunedMessages = await prepareMessages(messages);
+    const normalizedPreviewContext =
+      normalizeActivePreviewContext(activePreviewContext);
+    const userMessageId = getLatestUserMessageId(messages);
 
     const inputError = validateDocChatInput(prunedMessages);
     if (inputError) return inputError;
@@ -304,7 +363,6 @@ export async function POST(req: Request): Promise<Response> {
         typeof payload?.error === "string"
           ? payload.error
           : "This request could not run because a usage limit was reached.";
-      const userMessageId = getLatestUserMessageId(messages);
       const code = typeof payload?.code === "string" ? payload.code : undefined;
       return createXuluxDiagnosticMessageResponse({
         messages,
@@ -330,14 +388,18 @@ export async function POST(req: Request): Promise<Response> {
       const templateContext = formatSelectedTemplateContext(selectedTemplate);
       const firstUser = prunedMessages.find((m) => m.role === "user");
       if (templateContext && firstUser) {
-        if (typeof firstUser.content === "string") {
-          firstUser.content = `${firstUser.content}\n\n${templateContext}`;
-        } else if (Array.isArray(firstUser.content)) {
-          firstUser.content = [
-            ...firstUser.content,
-            { type: "text", text: templateContext },
-          ];
-        }
+        appendHiddenText(firstUser, templateContext);
+      }
+    }
+    if (normalizedPreviewContext) {
+      const latestUser = [...prunedMessages]
+        .reverse()
+        .find((m) => m.role === "user");
+      if (latestUser) {
+        appendHiddenText(
+          latestUser,
+          formatActivePreviewContext(normalizedPreviewContext),
+        );
       }
     }
 
@@ -427,10 +489,10 @@ export async function POST(req: Request): Promise<Response> {
           return { modelId: part.response.modelId };
         }
         if (part.type === "finish") {
-          const userMessageId = getLatestUserMessageId(messages);
           return {
             usage: part.totalUsage,
             custom: {
+              usage: part.totalUsage,
               xulux: {
                 outcome: createXuluxTurnOutcome({
                   type: "assistant_response_completed",
@@ -439,6 +501,16 @@ export async function POST(req: Request): Promise<Response> {
                   distinctId,
                   ...(userMessageId ? { userMessageId } : {}),
                 }),
+                ...(normalizedPreviewContext
+                  ? {
+                      activePreviewContext: {
+                        value: normalizedPreviewContext,
+                        ...(userMessageId
+                          ? { injectedIntoUserMessageId: userMessageId }
+                          : {}),
+                      },
+                    }
+                  : {}),
               },
             },
           };

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -326,7 +326,14 @@ export async function POST(req: Request): Promise<Response> {
     const rateLimitResponse = await checkRateLimit(req);
     if (rateLimitResponse) return rateLimitResponse;
 
-    const body = await req.json();
+    const body = await req.json().catch(() => null);
+    if (!isRecord(body)) {
+      return NextResponse.json(
+        { error: "Invalid JSON request body." },
+        { status: 400 },
+      );
+    }
+
     const {
       messages,
       tools: clientTools,

--- a/apps/docs/app/api/xulux/chat/tools/template-tools.ts
+++ b/apps/docs/app/api/xulux/chat/tools/template-tools.ts
@@ -1110,6 +1110,7 @@ export function createTemplateTools() {
             downloadUrl:
               entry.downloadUrl ?? `/api/xulux/demo-download?slug=${entry.id}`,
             title: entry.title,
+            customized: false,
             summary: `Opened ${entry.title} as a fixed demo.`,
           };
         }
@@ -1167,6 +1168,8 @@ export function createTemplateTools() {
                 withVersion(data.downloadUrl ?? "/api/download", versionId),
               ),
               title: entry.title,
+              customized: true,
+              config,
               summary: `Opened ${entry.title} with custom configuration.`,
               validationWarnings: data.validationWarnings ?? [],
             };
@@ -1185,6 +1188,7 @@ export function createTemplateTools() {
           previewUrl: entry.previewUrl ?? baseUrl,
           downloadUrl: entry.downloadUrl ?? `${baseUrl}/api/download`,
           title: entry.title,
+          customized: false,
           summary: `Opened ${entry.title}.`,
         };
       },

--- a/apps/docs/components/xulux/XuluxApp.tsx
+++ b/apps/docs/components/xulux/XuluxApp.tsx
@@ -21,6 +21,7 @@ import {
   XuluxUsageBudgetProvider,
   type XuluxLimitBlock,
 } from "./chat/XuluxUsageLimitBanner";
+import type { XuluxActivePreviewContext } from "./runtime/types";
 
 export type SelectedTemplateContext = Pick<
   XuluxTemplate,
@@ -41,21 +42,26 @@ export function XuluxApp() {
   const [sessionId, setSessionId] = useState(() => crypto.randomUUID());
   const [selectedTemplateContext, setSelectedTemplateContext] =
     useState<SelectedTemplateContext | null>(null);
+  const [activePreviewContext, setActivePreviewContext] =
+    useState<XuluxActivePreviewContext | null>(null);
 
   const resetSession = () => {
     setSelectedTemplateContext(null);
+    setActivePreviewContext(null);
   };
 
   return (
     <XuluxRuntimeProvider
       sessionId={sessionId}
       selectedTemplateContext={selectedTemplateContext}
+      activePreviewContext={activePreviewContext}
     >
       <AssistantPanelProvider>
         <XuluxShell
           sessionId={sessionId}
           onSetSessionId={setSessionId}
           onSetSelectedTemplateContext={setSelectedTemplateContext}
+          onSetActivePreviewContext={setActivePreviewContext}
           onResetSession={resetSession}
         />
       </AssistantPanelProvider>
@@ -66,10 +72,12 @@ export function XuluxApp() {
 function XuluxRuntimeProvider({
   sessionId,
   selectedTemplateContext,
+  activePreviewContext,
   children,
 }: {
   sessionId: string;
   selectedTemplateContext: SelectedTemplateContext | null;
+  activePreviewContext: XuluxActivePreviewContext | null;
   children: ReactNode;
 }) {
   const cloudBaseUrl =
@@ -84,6 +92,7 @@ function XuluxRuntimeProvider({
     <XuluxRuntimeProviderInner
       sessionId={sessionId}
       selectedTemplateContext={selectedTemplateContext}
+      activePreviewContext={activePreviewContext}
       cloudBaseUrl={cloudBaseUrl}
     >
       {children}
@@ -110,11 +119,13 @@ function XuluxMissingCloudConfig() {
 function XuluxRuntimeProviderInner({
   sessionId,
   selectedTemplateContext,
+  activePreviewContext,
   cloudBaseUrl,
   children,
 }: {
   sessionId: string;
   selectedTemplateContext: SelectedTemplateContext | null;
+  activePreviewContext: XuluxActivePreviewContext | null;
   cloudBaseUrl: string;
   children: ReactNode;
 }) {
@@ -122,6 +133,8 @@ function XuluxRuntimeProviderInner({
   sessionIdRef.current = sessionId;
   const selectedTemplateContextRef = useRef(selectedTemplateContext);
   selectedTemplateContextRef.current = selectedTemplateContext;
+  const activePreviewContextRef = useRef(activePreviewContext);
+  activePreviewContextRef.current = activePreviewContext;
   const [limitBlock, setLimitBlock] = useState<XuluxLimitBlock | null>(null);
 
   useEffect(() => {
@@ -165,6 +178,9 @@ function XuluxRuntimeProviderInner({
           },
           get selectedTemplate() {
             return selectedTemplateContextRef.current;
+          },
+          get activePreviewContext() {
+            return activePreviewContextRef.current;
           },
         },
         fetch: async (input, init) => {

--- a/apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx
@@ -12,6 +12,8 @@ type OpenTemplatePreviewResult =
       downloadUrl: string;
       title: string;
       summary?: string;
+      customized?: boolean;
+      config?: Record<string, unknown>;
     }
   | {
       success: false;
@@ -24,6 +26,8 @@ type TemplatePreviewReady = {
   templateId: string;
   versionId?: string;
   title: string;
+  customized: boolean;
+  config?: Record<string, unknown>;
 };
 
 function isOpenTemplatePreviewCall(part: unknown): part is ToolCallMessagePart {
@@ -85,6 +89,8 @@ export function XuluxTemplatePreviewObserver({
           ? { versionId: payload.versionId }
           : {}),
         title: payload.title,
+        customized: payload.customized ?? false,
+        ...(payload.config ? { config: payload.config } : {}),
       });
     } else {
       onCanvasError(payload.error);

--- a/apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef } from "react";
 import { useAuiState, type ToolCallMessagePart } from "@assistant-ui/react";
+import type { XuluxJsonObject } from "../runtime/types";
 
 type OpenTemplatePreviewResult =
   | {
@@ -13,7 +14,7 @@ type OpenTemplatePreviewResult =
       title: string;
       summary?: string;
       customized?: boolean;
-      config?: Record<string, unknown>;
+      config?: XuluxJsonObject;
     }
   | {
       success: false;
@@ -27,7 +28,7 @@ type TemplatePreviewReady = {
   versionId?: string;
   title: string;
   customized: boolean;
-  config?: Record<string, unknown>;
+  config?: XuluxJsonObject;
 };
 
 function isOpenTemplatePreviewCall(part: unknown): part is ToolCallMessagePart {

--- a/apps/docs/components/xulux/runtime/types.ts
+++ b/apps/docs/components/xulux/runtime/types.ts
@@ -13,6 +13,14 @@ export type XuluxCanvasSnapshot = {
   title?: string;
 };
 
+export type XuluxActivePreviewContext = {
+  source: "template_modal" | "agent_tool";
+  templateId: string;
+  versionId?: string | null;
+  customized: boolean;
+  config?: Record<string, unknown>;
+};
+
 export type XuluxThreadCustom = {
   xuluxStatus: XuluxThreadStatus;
   sessionId: string;
@@ -20,6 +28,7 @@ export type XuluxThreadCustom = {
   pendingUserMessage?: string | null;
   selectedTemplate?: SelectedTemplateContext | null;
   canvas?: XuluxCanvasSnapshot;
+  activePreviewContext?: XuluxActivePreviewContext | null;
 };
 
 export type XuluxStoredThread = {

--- a/apps/docs/components/xulux/runtime/types.ts
+++ b/apps/docs/components/xulux/runtime/types.ts
@@ -13,12 +13,21 @@ export type XuluxCanvasSnapshot = {
   title?: string;
 };
 
+export type XuluxJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | XuluxJsonValue[]
+  | { [key: string]: XuluxJsonValue };
+export type XuluxJsonObject = { [key: string]: XuluxJsonValue };
+
 export type XuluxActivePreviewContext = {
   source: "template_modal" | "agent_tool";
   templateId: string;
   versionId?: string | null;
   customized: boolean;
-  config?: Record<string, unknown>;
+  config?: XuluxJsonObject;
 };
 
 export type XuluxThreadCustom = {

--- a/apps/docs/components/xulux/runtime/xulux-local-storage.ts
+++ b/apps/docs/components/xulux/runtime/xulux-local-storage.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useSyncExternalStore } from "react";
 import type {
+  XuluxActivePreviewContext,
   XuluxCanvasSnapshot,
   XuluxStoredThread,
   XuluxThreadCustom,
@@ -191,6 +192,7 @@ export function updateXuluxThreadContext(
   context: {
     selectedTemplate?: SelectedTemplateContext | null;
     canvas?: XuluxCanvasSnapshot;
+    activePreviewContext?: XuluxActivePreviewContext | null;
   },
 ) {
   updateXuluxThreadCustom(remoteId, context);

--- a/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
+++ b/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
@@ -104,6 +104,8 @@ export function createXuluxLocalThreadListAdapter({
       );
     }
 
+    const latestSessionStub = findXuluxSessionStub(sessionId) ?? sessionStub;
+
     // Drop pre-init local stubs (remoteId was sessionId) now that we have a cloud id.
     const threadsWithoutStub = readXuluxThreads().filter(
       (thread) =>
@@ -118,38 +120,43 @@ export function createXuluxLocalThreadListAdapter({
     upsertThread(cloudThreadId, (existing) => ({
       remoteId: cloudThreadId,
       externalId: sessionId,
-      status: existing?.status ?? sessionStub?.status ?? "regular",
+      status: existing?.status ?? latestSessionStub?.status ?? "regular",
       ...(existing?.title !== undefined
         ? { title: existing.title }
-        : sessionStub?.title !== undefined
-          ? { title: sessionStub.title }
+        : latestSessionStub?.title !== undefined
+          ? { title: latestSessionStub.title }
           : {}),
       custom: {
         xuluxStatus:
           existing?.custom.xuluxStatus ??
-          sessionStub?.custom.xuluxStatus ??
+          latestSessionStub?.custom.xuluxStatus ??
           "idle",
         sessionId,
         updatedAt: now,
         ...(existing?.custom.pendingUserMessage !== undefined
           ? { pendingUserMessage: existing.custom.pendingUserMessage }
-          : sessionStub?.custom.pendingUserMessage !== undefined
-            ? { pendingUserMessage: sessionStub.custom.pendingUserMessage }
+          : latestSessionStub?.custom.pendingUserMessage !== undefined
+            ? {
+                pendingUserMessage: latestSessionStub.custom.pendingUserMessage,
+              }
             : {}),
         ...(existing?.custom.selectedTemplate !== undefined
           ? { selectedTemplate: existing.custom.selectedTemplate }
-          : sessionStub?.custom.selectedTemplate !== undefined
-            ? { selectedTemplate: sessionStub.custom.selectedTemplate }
+          : latestSessionStub?.custom.selectedTemplate !== undefined
+            ? { selectedTemplate: latestSessionStub.custom.selectedTemplate }
             : {}),
         ...(existing?.custom.canvas !== undefined
           ? { canvas: existing.custom.canvas }
-          : sessionStub?.custom.canvas !== undefined
-            ? { canvas: sessionStub.custom.canvas }
+          : latestSessionStub?.custom.canvas !== undefined
+            ? { canvas: latestSessionStub.custom.canvas }
             : {}),
         ...(existing?.custom.activePreviewContext !== undefined
           ? { activePreviewContext: existing.custom.activePreviewContext }
-          : sessionStub?.custom.activePreviewContext !== undefined
-            ? { activePreviewContext: sessionStub.custom.activePreviewContext }
+          : latestSessionStub?.custom.activePreviewContext !== undefined
+            ? {
+                activePreviewContext:
+                  latestSessionStub.custom.activePreviewContext,
+              }
             : {}),
       } satisfies XuluxThreadCustom,
     }));

--- a/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
+++ b/apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx
@@ -146,6 +146,11 @@ export function createXuluxLocalThreadListAdapter({
           : sessionStub?.custom.canvas !== undefined
             ? { canvas: sessionStub.custom.canvas }
             : {}),
+        ...(existing?.custom.activePreviewContext !== undefined
+          ? { activePreviewContext: existing.custom.activePreviewContext }
+          : sessionStub?.custom.activePreviewContext !== undefined
+            ? { activePreviewContext: sessionStub.custom.activePreviewContext }
+            : {}),
       } satisfies XuluxThreadCustom,
     }));
 

--- a/apps/docs/components/xulux/shell/XuluxShell.tsx
+++ b/apps/docs/components/xulux/shell/XuluxShell.tsx
@@ -48,7 +48,11 @@ import {
   updateXuluxThreadStatus,
   useXuluxStoredThreads,
 } from "../runtime/xulux-local-storage";
-import type { XuluxCanvasSnapshot, XuluxStoredThread } from "../runtime/types";
+import type {
+  XuluxActivePreviewContext,
+  XuluxCanvasSnapshot,
+  XuluxStoredThread,
+} from "../runtime/types";
 
 const ASSISTANT_UI_REPO_URL = "https://github.com/assistant-ui/assistant-ui";
 
@@ -73,12 +77,16 @@ export function XuluxShell({
   sessionId,
   onSetSessionId,
   onSetSelectedTemplateContext,
+  onSetActivePreviewContext,
   onResetSession,
 }: {
   sessionId: string;
   onSetSessionId: (sessionId: string) => void;
   onSetSelectedTemplateContext: (
     template: SelectedTemplateContext | null,
+  ) => void;
+  onSetActivePreviewContext: (
+    context: XuluxActivePreviewContext | null,
   ) => void;
   onResetSession: () => void;
 }) {
@@ -93,6 +101,8 @@ export function XuluxShell({
     useState<XuluxTemplate | null>(null);
   const [selectedTemplateContext, setSelectedTemplateContext] =
     useState<SelectedTemplateContext | null>(null);
+  const [activePreviewContext, setActivePreviewContext] =
+    useState<XuluxActivePreviewContext | null>(null);
   const [templatesOpen, setTemplatesOpen] = useState(false);
   const [canvas, setCanvas] = useState<CanvasState>({
     status: "empty",
@@ -130,7 +140,9 @@ export function XuluxShell({
       updateXuluxPendingUserMessage(currentRemoteId ?? sessionId, prompt);
       setSelectedTemplate(null);
       setSelectedTemplateContext(null);
+      setActivePreviewContext(null);
       onSetSelectedTemplateContext(null);
+      onSetActivePreviewContext(null);
       setCanvas({ status: "empty", url: null, source: null, error: null });
       setViewMode("chat");
       setTemplatesOpen(false);
@@ -140,6 +152,7 @@ export function XuluxShell({
       analyticsCtx,
       askAI,
       currentRemoteId,
+      onSetActivePreviewContext,
       onSetSelectedTemplateContext,
       sessionId,
     ],
@@ -149,9 +162,12 @@ export function XuluxShell({
     (template: XuluxTemplate) => {
       const context = toSelectedTemplateContext(template);
       void aui.threads().switchToNewThread();
+      const previewContext = toTemplateModalPreviewContext(template);
       setSelectedTemplate(template);
       setSelectedTemplateContext(context);
+      setActivePreviewContext(previewContext);
       onSetSelectedTemplateContext(context);
+      onSetActivePreviewContext(previewContext);
       setCanvas({
         status: template.previewUrl ? "ready" : "empty",
         url: template.previewUrl ?? null,
@@ -165,7 +181,7 @@ export function XuluxShell({
       setTemplatesOpen(false);
       setViewMode(template.previewUrl ? "preview" : "chat");
     },
-    [aui, onSetSelectedTemplateContext],
+    [aui, onSetActivePreviewContext, onSetSelectedTemplateContext],
   );
 
   const handleNewChat = useCallback(() => {
@@ -173,26 +189,31 @@ export function XuluxShell({
     onSetSessionId(nextSessionId);
     setSelectedTemplate(null);
     setSelectedTemplateContext(null);
+    setActivePreviewContext(null);
     setCanvas({ status: "empty", url: null, source: null, error: null });
+    onSetActivePreviewContext(null);
     previewTrackedRef.current = null;
     setTemplatesOpen(false);
     setViewMode("landing");
     onResetSession();
     void aui.threads().switchToNewThread();
-  }, [aui, onResetSession, onSetSessionId]);
+  }, [aui, onResetSession, onSetActivePreviewContext, onSetSessionId]);
 
   const handleRestoreThread = useCallback(
     (thread: XuluxStoredThread) => {
       const restoredTemplate = thread.custom.selectedTemplate ?? null;
+      const restoredPreviewContext = thread.custom.activePreviewContext ?? null;
       onSetSessionId(thread.custom.sessionId);
       setSelectedTemplate(null);
       setSelectedTemplateContext(restoredTemplate);
+      setActivePreviewContext(restoredPreviewContext);
       onSetSelectedTemplateContext(restoredTemplate);
+      onSetActivePreviewContext(restoredPreviewContext);
       setCanvas(fromCanvasSnapshot(thread.custom.canvas));
       setTemplatesOpen(false);
       setViewMode(thread.custom.canvas?.url ? "preview" : "chat");
     },
-    [onSetSelectedTemplateContext, onSetSessionId],
+    [onSetActivePreviewContext, onSetSelectedTemplateContext, onSetSessionId],
   );
 
   const activeStoredThread =
@@ -255,12 +276,19 @@ export function XuluxShell({
     if (!currentRemoteId) return;
     updateXuluxThreadContext(currentRemoteId, {
       selectedTemplate: selectedTemplateContext,
+      activePreviewContext,
       canvas: toCanvasSnapshot(
         canvas,
         selectedTemplate?.title ?? selectedTemplateContext?.title,
       ),
     });
-  }, [canvas, currentRemoteId, selectedTemplate, selectedTemplateContext]);
+  }, [
+    activePreviewContext,
+    canvas,
+    currentRemoteId,
+    selectedTemplate,
+    selectedTemplateContext,
+  ]);
 
   useEffect(() => {
     if (canvas.status !== "ready" || !canvas.url || !canvas.source) return;
@@ -322,6 +350,9 @@ export function XuluxShell({
                 : {}),
               title: preview.title,
             });
+            const previewContext = toAgentPreviewContext(preview);
+            setActivePreviewContext(previewContext);
+            onSetActivePreviewContext(previewContext);
             setViewMode("preview");
           }}
           onCanvasError={(error) => {
@@ -454,6 +485,33 @@ function toSelectedTemplateContext(
     ...(template.versionId ? { versionId: template.versionId } : {}),
     ...(template.previewUrl ? { previewUrl: template.previewUrl } : {}),
     ...(template.downloadUrl ? { downloadUrl: template.downloadUrl } : {}),
+  };
+}
+
+function toTemplateModalPreviewContext(
+  template: XuluxTemplate,
+): XuluxActivePreviewContext | null {
+  if (!template.previewUrl) return null;
+  return {
+    source: "template_modal",
+    templateId: template.templateId ?? template.id,
+    versionId: template.versionId ?? null,
+    customized: false,
+  };
+}
+
+function toAgentPreviewContext(preview: {
+  templateId: string;
+  versionId?: string;
+  customized: boolean;
+  config?: Record<string, unknown>;
+}): XuluxActivePreviewContext {
+  return {
+    source: "agent_tool",
+    templateId: preview.templateId,
+    versionId: preview.versionId ?? null,
+    customized: preview.customized,
+    ...(preview.config ? { config: preview.config } : {}),
   };
 }
 

--- a/apps/docs/components/xulux/shell/XuluxShell.tsx
+++ b/apps/docs/components/xulux/shell/XuluxShell.tsx
@@ -51,6 +51,7 @@ import {
 import type {
   XuluxActivePreviewContext,
   XuluxCanvasSnapshot,
+  XuluxJsonObject,
   XuluxStoredThread,
 } from "../runtime/types";
 
@@ -504,7 +505,7 @@ function toAgentPreviewContext(preview: {
   templateId: string;
   versionId?: string;
   customized: boolean;
-  config?: Record<string, unknown>;
+  config?: XuluxJsonObject;
 }): XuluxActivePreviewContext {
   return {
     source: "agent_tool",


### PR DESCRIPTION
## Summary

This PR keeps the latest Xulux preview context available to the agent on follow-up turns.

- sends the active preview context with the latest user message, including whether it came from the template modal or an agent tool call
- stores the injected preview context in stream message metadata so we can inspect what was sent
- preserves selected-template context for the first turn and adds a prompt guardrail for follow-up turns
- handles malformed JSON chat requests with a 400 response instead of throwing

## User problem

The Xulux agent could forget or fail to know what app/template was currently open, so follow-up requests like customization or refinement could be answered without awareness of the active preview.

Fixes #4639.

## Validation

- `node_modules\\.bin\\oxlint.cmd apps/docs/app/api/xulux/chat/route.ts apps/docs/app/api/xulux/chat/tools/template-tools.ts apps/docs/components/xulux/XuluxApp.tsx apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx apps/docs/components/xulux/runtime/types.ts apps/docs/components/xulux/runtime/xulux-local-storage.ts apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx apps/docs/components/xulux/shell/XuluxShell.tsx`
- `node_modules\\.bin\\oxfmt.cmd --check apps/docs/app/api/xulux/chat/route.ts apps/docs/app/api/xulux/chat/tools/template-tools.ts apps/docs/components/xulux/XuluxApp.tsx apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx apps/docs/components/xulux/runtime/types.ts apps/docs/components/xulux/runtime/xulux-local-storage.ts apps/docs/components/xulux/runtime/xulux-thread-list-adapter.tsx apps/docs/components/xulux/shell/XuluxShell.tsx`

Note: local git hooks were skipped for the cherry-pick commit because this Windows setup still fails in `react-devtools` on `spawnSync tailwindcss ENOENT`; no local Tailwind workaround is included here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

