### PR TITLE
feat(docs): improve Xulux handoff actions and templates

### DIFF
--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -149,14 +149,20 @@ assistant-ui is a React library for building AI chat interfaces. It provides:
 When users send a casual greeting (hey, hi, hello):
 1. Welcome them to assistant-ui with emoji 👋
 2. Briefly explain what assistant-ui helps them do (build AI chat interfaces in React)
-3. Ask what they're working on or offer 2-3 common starter projects
+3. Ask what they're working on or offer 2-3 common starter projects using an \`ask-question\` block.
 
 Example tone:
 "Hey! 👋 Welcome to assistant-ui!
 
 I'm here to help you build AI chat interfaces with React. Whether you're just getting started, connecting to an AI backend, or customizing components — I've got you covered.
 
-What are you working on?"
+What are you working on?
+\`\`\`
+\`\`\`ask-question
+{"question":"Which direction should I take?","options":[{"label":"Build a new app","prompt":"Build a new app using assistant-ui.","preferred":true},{"label":"Read docs first","prompt":"Read the relevant assistant-ui docs first, then suggest the implementation path."}]}
+\`\`\`
+\`\`\`
+"
 
 Do NOT dump all documentation categories. Keep it conversational.
 </greetings>
@@ -218,18 +224,6 @@ Case 1: User wants to build an app:
 \`\`\`
 - Also include the same prompt as a fenced code block with language \`text\` in your response.
 
-6. **Clarifying choices:** If you cannot proceed because the user needs to choose between a few concrete next actions, ask the question and include a fenced code block with language \`suggestion-options\`. This renders clickable auto-send options:
-\`\`\`
-\`\`\`suggestion-options
-{"question":"Which direction should I take?","options":[{"label":"Customize current preview","prompt":"Customize the current preview for this request."},{"label":"Read docs first","prompt":"Read the relevant assistant-ui docs first, then suggest the implementation path."}]}
-\`\`\`
-\`\`\`
-  - Only use \`question\` and \`options\` at the top level.
-  - Each option MUST have only \`label\` and \`prompt\`.
-  - \`label\` should be short button text.
-  - \`prompt\` should be the full user message to auto-send when clicked.
-  - Do not use suggestions when you can confidently proceed with tools or a direct answer.
-
 Case 2: User ask questions about assistant-ui:
 - Use listDocs → readDoc to find relevant information.
 - Use inspectSourceMap / readSourceMapFile to explore source code.
@@ -251,6 +245,7 @@ Case 2: User ask questions about assistant-ui:
 - You assume wrong CLI flags; use the help command to understand how to use the CLI.
 - You confuse assistant-ui components at \`@/components/assistant-ui/*\` to be exported from \`@assistant-ui/react\`. They are shadcn-based components—read the Components doc/subdocs for details on available components and installation (use assistant-ui CLI or shadcn). If customization is needed, customize the generated components.
 - You some time guess for fabricate urls, always use the urls from the tool results.
+- You sometimes ask plain-text clarifying questions when the user needs to choose between concrete next actions. Instead, render an \`ask-question\` block.
 </common_pitfalls_to_avoid>
 
 <answering>
@@ -261,6 +256,19 @@ Case 2: User ask questions about assistant-ui:
 - When linking, copy the exact URL from tool results: [Page Title](/docs/exact-path-from-tool)
 - Prefer not linking over linking to a potentially non-existent page
 - Admit uncertainty rather than guessing
+- If you cannot proceed because the user needs to choose between a few concrete next actions, ask the question and include a fenced code block with language \`ask-question\`. This renders clickable auto-send options:
+\`\`\`
+\`\`\`ask-question
+{"question":"Which direction should I take?","options":[{"label":"Customize current preview","prompt":"Customize the current preview for this request.","preferred":true},{"label":"Read docs first","prompt":"Read the relevant assistant-ui docs first, then suggest the implementation path."}]}
+\`\`\`
+\`\`\`
+  - Only use \`question\` and \`options\` at the top level.
+  - Each option MUST have \`label\` and \`prompt\`, and may include \`preferred: true\`.
+  - Set \`preferred: true\` on exactly one option when there is a recommended path.
+  - Put the preferred option first in the JSON options array.
+  - \`label\` should be short button text.
+  - \`prompt\` should be the full user message to auto-send when clicked.
+  - Do not use suggestions when you can confidently proceed with tools or a direct answer.
 </answering>
 
 <formatting>

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -218,6 +218,18 @@ Case 1: User wants to build an app:
 \`\`\`
 - Also include the same prompt as a fenced code block with language \`text\` in your response.
 
+6. **Clarifying choices:** If you cannot proceed because the user needs to choose between a few concrete next actions, ask the question and include a fenced code block with language \`suggestion-options\`. This renders clickable auto-send options:
+\`\`\`
+\`\`\`suggestion-options
+{"question":"Which direction should I take?","options":[{"label":"Customize current preview","prompt":"Customize the current preview for this request."},{"label":"Read docs first","prompt":"Read the relevant assistant-ui docs first, then suggest the implementation path."}]}
+\`\`\`
+\`\`\`
+  - Only use \`question\` and \`options\` at the top level.
+  - Each option MUST have only \`label\` and \`prompt\`.
+  - \`label\` should be short button text.
+  - \`prompt\` should be the full user message to auto-send when clicked.
+  - Do not use suggestions when you can confidently proceed with tools or a direct answer.
+
 Case 2: User ask questions about assistant-ui:
 - Use listDocs → readDoc to find relevant information.
 - Use inspectSourceMap / readSourceMapFile to explore source code.

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -216,7 +216,7 @@ Case 1: User wants to build an app:
 {"title":"<short app name>","prompt":"<full step-by-step build guide from the docs you read — no fake download link>"}
 \`\`\`
 \`\`\`
-- Also include the same prompt as a blockquote in your response.
+- Also include the same prompt as a fenced code block with language \`text\` in your response.
 
 Case 2: User ask questions about assistant-ui:
 - Use listDocs → readDoc to find relevant information.

--- a/apps/docs/app/api/xulux/chat/tools/template-tools.ts
+++ b/apps/docs/app/api/xulux/chat/tools/template-tools.ts
@@ -1476,13 +1476,13 @@ export function createTemplateTools() {
                 withVersion(data.downloadUrl ?? "/api/download", versionId),
               ),
               title: entry.title,
-              ...(entry.previewFrame
-                ? { previewFrame: entry.previewFrame }
-                : {}),
               customized: true,
               config,
               summary: `Opened ${entry.title} with custom configuration.`,
               validationWarnings: data.validationWarnings ?? [],
+              ...(entry.previewFrame
+                ? { previewFrame: entry.previewFrame }
+                : {}),
             };
           } catch (err) {
             return {

--- a/apps/docs/app/api/xulux/chat/tools/template-tools.ts
+++ b/apps/docs/app/api/xulux/chat/tools/template-tools.ts
@@ -1,6 +1,7 @@
 import { getXuluxHostedTemplatesCatalog } from "@/lib/xulux/templates-catalog";
 import type { XuluxTemplate } from "@/components/xulux/templates/types";
 import { getDemoDownloadManifest } from "@/lib/xulux/demo-downloads/manifest";
+import { fetchSandboxResource } from "@/lib/xulux/fetch-sandbox";
 import { tool, zodSchema } from "ai";
 import z from "zod";
 
@@ -37,7 +38,7 @@ function hasConfig(config: Record<string, unknown> | undefined): boolean {
 }
 
 function isFixedDemo(entry: XuluxTemplate): boolean {
-  return entry.kind === "example" && !!getDemoDownloadManifest(entry.id);
+  return entry.kind === "example";
 }
 
 async function fetchTemplateContract(entry: XuluxTemplate, versionId?: string) {
@@ -45,7 +46,7 @@ async function fetchTemplateContract(entry: XuluxTemplate, versionId?: string) {
   try {
     const url = new URL("/api/template/contract", entry.sandboxBaseUrl);
     if (versionId) url.searchParams.set("v", versionId);
-    const res = await fetch(url, { cache: "no-store" });
+    const res = await fetchSandboxResource(url.toString());
     if (!res.ok) return null;
     return (await res.json()) as Record<string, unknown>;
   } catch {
@@ -67,6 +68,27 @@ type TemplateListMeta = {
 };
 
 const TEMPLATE_LIST_META: Record<string, TemplateListMeta> = {
+  "base-assistant-ui": {
+    name: "Configurable Base Assistant UI",
+    summary:
+      "A hosted configurable version of the assistant-ui Base demo with the same full-page chat shell, thread list, composer, model picker, mic input, suggestions, slash commands, and no-key demo flows.",
+    assistantPlacement: "full-page chat shell",
+    features: [
+      "assistant-ui Base demo layout with sidebar thread list and centered composer",
+      "Composer actions including attachments, model picker, send, and mic input",
+      "LocalStorage thread persistence with Assistant Cloud fallback when configured in source",
+      "Controlled suggestion groups and slash commands",
+      "Deterministic demo flows when no model key is present",
+      "Hosted preview sessions and downloadable materialized starter app",
+    ],
+    customizable: [
+      "brandTheme: preset plus accent, background, surface, and text hex overrides",
+      "assistant: appName, welcome headline/body, composer placeholder, new-thread/new-chat labels",
+      "assistant.suggestionGroups: controlled icon ids and prompt options with optional flowId",
+      "assistant.slashCommands: controlled icon ids",
+      "assistant.tools and assistant.demoFlows for no-key mock behavior",
+    ],
+  },
   "webpage-assistant": {
     name: "Webpage with Assistant",
     summary:
@@ -109,7 +131,23 @@ const TEMPLATE_LIST_META: Record<string, TemplateListMeta> = {
 
 function fixedDemoListMeta(entry: XuluxTemplate): TemplateListMeta | undefined {
   const demo = getDemoDownloadManifest(entry.id);
-  if (!demo) return undefined;
+  if (!demo) {
+    if (entry.id === "expo-react-native") {
+      return {
+        name: entry.title,
+        summary: entry.description,
+        assistantPlacement: "hosted Expo web preview",
+        features: [
+          "Expo / React Native mobile chat UI",
+          "Drawer navigation and thread management",
+          "Streaming assistant responses through assistant-ui runtime",
+          "Native mobile UI primitives, with hosted web preview for inspection",
+        ],
+        customizable: [],
+      };
+    }
+    return undefined;
+  }
 
   return {
     name: demo.name,
@@ -121,6 +159,181 @@ function fixedDemoListMeta(entry: XuluxTemplate): TemplateListMeta | undefined {
 }
 
 const CONFIG_ROOTS_SCHEMAS: Record<string, Record<string, unknown>> = {
+  "base-assistant-ui": {
+    brandTheme: {
+      description:
+        "Controls the Base chat visual theme. Use a preset first, then optional 6-digit hex overrides for key surfaces.",
+      schema: {
+        preset: {
+          type: "string",
+          enum: [
+            "assistantDark",
+            "assistantLight",
+            "neutralDark",
+            "neutralLight",
+          ],
+          default: "assistantDark",
+          optional: true,
+        },
+        accent: {
+          type: "string",
+          optional: true,
+          description: "6-digit hex color such as #14b8a6.",
+        },
+        background: {
+          type: "string",
+          optional: true,
+          description: "6-digit hex color for the main background.",
+        },
+        surface: {
+          type: "string",
+          optional: true,
+          description: "6-digit hex color for sidebar and composer surfaces.",
+        },
+        text: {
+          type: "string",
+          optional: true,
+          description: "6-digit hex color for primary foreground text.",
+        },
+      },
+    },
+    assistant: {
+      description:
+        "Controls visible Base chat labels, welcome copy, suggestions, slash commands, generic tools, and deterministic no-key demo flows. Omit fields you do not want to change.",
+      schema: {
+        appName: {
+          type: "string",
+          default: "assistant-ui",
+          description: "Visible app name in the sidebar.",
+        },
+        welcome: {
+          headline: {
+            type: "string",
+            default: "How can I help you today?",
+          },
+          body: {
+            type: "string",
+            optional: true,
+            description: "Optional supporting welcome text.",
+          },
+        },
+        labels: {
+          type: "object",
+          optional: true,
+          fields: {
+            composerPlaceholder: {
+              type: "string",
+              default: "Send a message... (@ to mention, / for commands)",
+            },
+            newThread: { type: "string", default: "New Thread" },
+            newChat: { type: "string", default: "New Chat" },
+          },
+        },
+        suggestionGroups: {
+          type: "array",
+          description:
+            "Suggestion buttons shown under the composer. Use only supported icon ids.",
+          item: {
+            id: { type: "string" },
+            label: { type: "string" },
+            icon: {
+              type: "string",
+              optional: true,
+              enum: [
+                "weather",
+                "code",
+                "write",
+                "analyze",
+                "brainstorm",
+                "search",
+                "document",
+                "help",
+              ],
+            },
+            options: {
+              type: "array",
+              item: {
+                label: { type: "string" },
+                prompt: { type: "string" },
+                flowId: {
+                  type: "string",
+                  optional: true,
+                  description:
+                    "When present, should match a key in assistant.demoFlows.",
+                },
+              },
+            },
+          },
+        },
+        slashCommands: {
+          type: "array",
+          optional: true,
+          description:
+            "Slash-command menu entries. Use only supported icon ids.",
+          item: {
+            id: { type: "string" },
+            description: { type: "string" },
+            icon: {
+              type: "string",
+              optional: true,
+              enum: ["FileText", "Languages", "Globe", "HelpCircle"],
+            },
+          },
+        },
+        tools: {
+          type: "array",
+          optional: true,
+          description:
+            "Generic demo tools available to no-key demo flows. Custom ids are supported and render as generic tool cards.",
+          item: {
+            id: { type: "string" },
+            displayName: { type: "string" },
+            aiDescription: { type: "string" },
+            rendererType: {
+              type: "string",
+              enum: ["generic"],
+              default: "generic",
+              optional: true,
+            },
+          },
+        },
+        demoFlows: {
+          type: "object",
+          optional: true,
+          description:
+            "Keyed by flow id. A suggestion option can trigger a flow through options[].flowId. Each step can call one configured generic tool.",
+          valueSchema: {
+            title: { type: "string", optional: true },
+            triggerPhrases: {
+              type: "array",
+              optional: true,
+              items: "string",
+            },
+            steps: {
+              type: "array",
+              item: {
+                id: { type: "string" },
+                assistantText: { type: "string" },
+                toolId: {
+                  type: "string",
+                  description: "Must match an id in assistant.tools.",
+                },
+                input: { type: "object" },
+                output: { type: "object" },
+              },
+            },
+            finalResponse: { type: "string" },
+          },
+        },
+        demoModeNotice: {
+          type: "string",
+          optional: true,
+          description:
+            "Short notice shown when deterministic demo mode is used.",
+        },
+      },
+    },
+  },
   "webpage-assistant": {
     hostUi: {
       description:
@@ -655,6 +868,89 @@ const TOOLS_META: Record<
     }>;
   }
 > = {
+  "base-assistant-ui": {
+    builtIn: [
+      {
+        id: "getWeather",
+        description: "Demo weather lookup tool used by the default Base flow.",
+        renderer: "generic",
+        input: {
+          city: { type: "string", required: true },
+          units: {
+            type: "string",
+            required: false,
+            enum: ["fahrenheit", "celsius"],
+          },
+        },
+        outputShape: {
+          city: "string",
+          summary: "string",
+          temperature: "string",
+          wind: "string",
+        },
+      },
+      {
+        id: "inspectCode",
+        description: "Demo code helper tool used by the default Base flow.",
+        renderer: "generic",
+        input: {
+          language: { type: "string", required: true },
+          topic: { type: "string", required: true },
+        },
+        outputShape: {
+          language: "string",
+          notes: ["string"],
+        },
+      },
+      {
+        id: "draftContent",
+        description: "Demo writing helper tool used by the default Base flow.",
+        renderer: "generic",
+        input: {
+          format: { type: "string", required: true },
+          tone: { type: "string", required: false },
+        },
+        outputShape: {
+          outline: ["string"],
+        },
+      },
+      {
+        id: "compareItems",
+        description: "Demo analysis helper tool used by the default Base flow.",
+        renderer: "generic",
+        input: {
+          criteria: { type: "array", required: true, items: "string" },
+        },
+        outputShape: {
+          columns: ["string"],
+          rows: "number",
+        },
+      },
+      {
+        id: "brainstormIdeas",
+        description:
+          "Demo brainstorming helper tool used by the default Base flow.",
+        renderer: "generic",
+        input: {
+          count: { type: "number", required: true },
+          grouping: { type: "string", required: false },
+        },
+        outputShape: {
+          themes: ["string"],
+          count: "number",
+        },
+      },
+    ],
+    customToolSupported: true,
+    renderers: [
+      {
+        type: "generic",
+        description:
+          "Fallback assistant-ui tool card rendering configured tool input and output as structured data.",
+        requiredOutputShape: "any JSON-serializable value",
+      },
+    ],
+  },
   "webpage-assistant": {
     builtIn: [
       {
@@ -885,6 +1181,15 @@ const TOOLS_META: Record<
 };
 
 const RULES: Record<string, string[]> = {
+  "base-assistant-ui": [
+    "Top-level config should use only assistant and brandTheme.",
+    "brandTheme color overrides must be 6-digit hex colors such as #14b8a6.",
+    "assistant.suggestionGroups[].icon must be one of weather, code, write, analyze, brainstorm, search, document, or help.",
+    "assistant.slashCommands[].icon must be one of FileText, Languages, Globe, or HelpCircle.",
+    "assistant.suggestionGroups[].options[].flowId should match a key in assistant.demoFlows.",
+    "assistant.demoFlows.*.steps[].toolId must match an id in assistant.tools.",
+    "Configured tools render with the generic renderer unless source code is changed to add a specialized renderer.",
+  ],
   "webpage-assistant": [
     "hostUi.root.props.defaultPageId must be one of the ids in root.props.pages.",
     "hostUi.root.props.navGroups[].pageIds must reference ids that exist in pages.",
@@ -987,15 +1292,18 @@ export function createTemplateTools() {
 
         if (isFixedDemo(entry)) {
           const demo = getDemoDownloadManifest(entry.id);
+          const meta = fixedDemoListMeta(entry);
           return {
             id: tid,
-            name: demo?.name ?? entry.title,
+            name: demo?.name ?? meta?.name ?? entry.title,
             selectedVersionId: null,
-            summary: demo?.description ?? entry.description,
-            assistantPlacement: "full-page demo route",
-            features: demo?.features ?? [],
+            summary: demo?.description ?? meta?.summary ?? entry.description,
+            assistantPlacement:
+              meta?.assistantPlacement ?? "full-page demo route",
+            features: demo?.features ?? meta?.features ?? [],
             customizable: [],
             previewUrl: entry.previewUrl,
+            previewFrame: entry.previewFrame,
             downloadUrl: entry.downloadUrl,
             sourcePath: demo?.entry ?? entry.sourcePath,
             tools: {
@@ -1010,8 +1318,9 @@ export function createTemplateTools() {
                 "If the user needs domain-specific content or behavior changes, choose a configurable hosted template or produce a custom implementation brief instead.",
               ],
             },
-            fixedDemoNote:
-              "This is a fixed assistant-ui demo. It supports preview and download, but not template config.",
+            fixedDemoNote: entry.downloadUrl
+              ? "This is a fixed assistant-ui demo. It supports preview and download, but not template config."
+              : "This is a fixed assistant-ui demo. It supports preview, but download is not wired for this platform yet.",
           };
         }
 
@@ -1107,8 +1416,8 @@ export function createTemplateTools() {
             templateId: tid,
             versionId: null,
             previewUrl: entry.previewUrl ?? `/demos/${entry.id}`,
-            downloadUrl:
-              entry.downloadUrl ?? `/api/xulux/demo-download?slug=${entry.id}`,
+            downloadUrl: entry.downloadUrl,
+            previewFrame: entry.previewFrame,
             title: entry.title,
             summary: `Opened ${entry.title} as a fixed demo.`,
           };
@@ -1126,7 +1435,7 @@ export function createTemplateTools() {
           try {
             const sessionUrl = new URL("/api/preview/session", baseUrl);
             if (versionId) sessionUrl.searchParams.set("v", versionId);
-            const res = await fetch(sessionUrl, {
+            const res = await fetchSandboxResource(sessionUrl.toString(), {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify(config),
@@ -1167,6 +1476,11 @@ export function createTemplateTools() {
                 withVersion(data.downloadUrl ?? "/api/download", versionId),
               ),
               title: entry.title,
+              ...(entry.previewFrame
+                ? { previewFrame: entry.previewFrame }
+                : {}),
+              customized: true,
+              config,
               summary: `Opened ${entry.title} with custom configuration.`,
               validationWarnings: data.validationWarnings ?? [],
             };
@@ -1184,6 +1498,7 @@ export function createTemplateTools() {
           versionId: versionId ?? entry.versionId,
           previewUrl: entry.previewUrl ?? baseUrl,
           downloadUrl: entry.downloadUrl ?? `${baseUrl}/api/download`,
+          ...(entry.previewFrame ? { previewFrame: entry.previewFrame } : {}),
           title: entry.title,
           summary: `Opened ${entry.title}.`,
         };

--- a/apps/docs/components/xulux/canvas/XuluxCanvas.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxCanvas.tsx
@@ -17,8 +17,10 @@ import {
   useXuluxAnalytics,
 } from "@/lib/xulux/analytics-context";
 import { cn } from "@/lib/utils";
+import type { XuluxPreviewFrame as XuluxPreviewFrameConfig } from "../templates/types";
 import { XuluxCanvasTabBar, type CanvasTab } from "./XuluxCanvasTabBar";
 import { XuluxFileBrowser } from "./XuluxFileBrowser";
+import { XuluxPreviewFrame } from "./XuluxPreviewFrame";
 import { useVirtualArchive } from "./useVirtualArchive";
 
 function toAbsoluteUrl(url: string | null): string | null {
@@ -54,6 +56,7 @@ export function XuluxCanvas({
   source,
   error,
   downloadUrl,
+  previewFrame,
   templateId,
   versionId,
   sourceUrl,
@@ -65,6 +68,7 @@ export function XuluxCanvas({
   source: "template" | "agent_template" | "refresh" | null;
   error: string | null;
   downloadUrl?: string;
+  previewFrame?: XuluxPreviewFrameConfig;
   templateId?: string;
   versionId?: string;
   sourceUrl?: string;
@@ -308,16 +312,18 @@ export function XuluxCanvas({
                   </div>
                 </div>
               )}
-              <iframe
-                key={iframeKey}
-                title={title ?? "Xulux preview"}
-                src={resolvedPreviewUrl}
-                onLoad={() => {
-                  previewLoadedForUrlRef.current = iframeKey;
-                  setIsPreviewLoading(false);
-                }}
-                className="h-full w-full border-0 bg-white"
-              />
+              <XuluxPreviewFrame frame={previewFrame}>
+                <iframe
+                  key={iframeKey}
+                  title={title ?? "Xulux preview"}
+                  src={resolvedPreviewUrl}
+                  onLoad={() => {
+                    previewLoadedForUrlRef.current = iframeKey;
+                    setIsPreviewLoading(false);
+                  }}
+                  className="h-full w-full border-0 bg-white"
+                />
+              </XuluxPreviewFrame>
             </>
           ) : (
             <div className="flex h-full items-center justify-center p-6 text-center">

--- a/apps/docs/components/xulux/canvas/XuluxPreviewFrame.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxPreviewFrame.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import type { CSSProperties, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import type { XuluxPreviewFrame as XuluxPreviewFrameConfig } from "../templates/types";
+
+type Props = {
+  frame?: XuluxPreviewFrameConfig | undefined;
+  children: ReactNode;
+  className?: string | undefined;
+};
+
+export function XuluxPreviewFrame({ frame, children, className }: Props) {
+  if (!frame) {
+    return <div className={cn("h-full w-full", className)}>{children}</div>;
+  }
+
+  if (frame.kind === "terminal") {
+    const width = frame.width ?? 800;
+    const height = frame.height ?? 480;
+    const terminalStyle = {
+      width: `min(${width}px, calc(100cqw - 2rem))`,
+      height: `min(${height}px, calc(100cqh - 2rem))`,
+    } satisfies CSSProperties;
+
+    return (
+      <div
+        className={cn(
+          "relative flex h-full w-full items-center justify-center overflow-hidden bg-[#09090b] p-4",
+          className,
+        )}
+        style={{ containerType: "size" }}
+      >
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_65%_45%_at_50%_38%,rgba(16,185,129,0.12)_0%,transparent_72%)]" />
+        <div
+          className="relative flex min-h-0 overflow-hidden rounded-xl border border-white/10 bg-[#1a1a1a] shadow-[0_25px_80px_-24px_rgba(0,0,0,0.85),0_0_60px_rgba(16,185,129,0.08)]"
+          style={terminalStyle}
+        >
+          <div className="flex min-h-0 w-full flex-col">
+            <div className="flex h-10 shrink-0 items-center gap-2 border-b border-white/[0.06] px-4">
+              <div className="flex gap-1.5">
+                <div className="size-3 rounded-full bg-[#ff5f57]" />
+                <div className="size-3 rounded-full bg-[#febc2e]" />
+                <div className="size-3 rounded-full bg-[#28c840]" />
+              </div>
+              <div className="min-w-0 flex-1 truncate text-center font-mono text-[13px] text-white/50">
+                {frame.title ?? "terminal"}
+              </div>
+              <div className="w-[54px]" aria-hidden />
+            </div>
+            <div className="min-h-0 flex-1 overflow-hidden bg-black">
+              {children}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const width = frame.width ?? 320;
+  const aspectRatio = frame.aspectRatio ?? "9 / 19.5";
+  const phoneStyle = {
+    width: `min(${width}px, calc(100cqw - 2rem), calc((100cqh - 2rem) * 9 / 19.5))`,
+    aspectRatio,
+  } satisfies CSSProperties;
+
+  return (
+    <div
+      className={cn(
+        "relative flex h-full w-full items-center justify-center overflow-hidden bg-[#09090b] p-4",
+        className,
+      )}
+      style={{ containerType: "size" }}
+    >
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_50%_50%_at_50%_40%,rgba(139,92,246,0.10)_0%,transparent_70%)]" />
+      <div
+        className="relative rounded-[2.5rem] bg-[#1a1a1a] p-3 shadow-[0_0_0_1px_rgba(255,255,255,0.10),0_25px_50px_-12px_rgba(0,0,0,0.5),0_0_80px_rgba(139,92,246,0.08)]"
+        style={phoneStyle}
+      >
+        <div className="pointer-events-none absolute inset-[-2px] rounded-[2.75rem] border border-white/10" />
+        <div className="absolute top-3 left-1/2 z-10 h-7 w-[37.5%] -translate-x-1/2 rounded-b-2xl bg-[#1a1a1a]" />
+        <div className="relative h-full w-full overflow-hidden rounded-[2rem] bg-black">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/components/xulux/canvas/XuluxPreviewFrame.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxPreviewFrame.tsx
@@ -10,6 +10,19 @@ type Props = {
   className?: string | undefined;
 };
 
+function aspectRatioWidthFactor(aspectRatio: string): number | null {
+  const match = /^\s*(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)\s*$/.exec(
+    aspectRatio,
+  );
+  if (!match) return null;
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || height <= 0) {
+    return null;
+  }
+  return width / height;
+}
+
 export function XuluxPreviewFrame({ frame, children, className }: Props) {
   if (!frame) {
     return <div className={cn("h-full w-full", className)}>{children}</div>;
@@ -59,8 +72,11 @@ export function XuluxPreviewFrame({ frame, children, className }: Props) {
 
   const width = frame.width ?? 320;
   const aspectRatio = frame.aspectRatio ?? "9 / 19.5";
+  const widthFactor = aspectRatioWidthFactor(aspectRatio);
   const phoneStyle = {
-    width: `min(${width}px, calc(100cqw - 2rem), calc((100cqh - 2rem) * 9 / 19.5))`,
+    width: `min(${width}px, calc(100cqw - 2rem)${
+      widthFactor ? `, calc((100cqh - 2rem) * ${widthFactor})` : ""
+    })`,
     aspectRatio,
   } satisfies CSSProperties;
 

--- a/apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useRef } from "react";
-import { useAuiState, type ToolCallMessagePart } from "@assistant-ui/react";
 import type { XuluxPreviewFrame } from "../templates/types";
+import { useAuiState, type ToolCallMessagePart } from "@assistant-ui/react";
 
 type OpenTemplatePreviewResult =
   | {

--- a/apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef } from "react";
 import { useAuiState, type ToolCallMessagePart } from "@assistant-ui/react";
+import type { XuluxPreviewFrame } from "../templates/types";
 
 type OpenTemplatePreviewResult =
   | {
@@ -9,7 +10,8 @@ type OpenTemplatePreviewResult =
       templateId: string;
       versionId?: string;
       previewUrl: string;
-      downloadUrl: string;
+      downloadUrl?: string;
+      previewFrame?: XuluxPreviewFrame;
       title: string;
       summary?: string;
     }
@@ -20,7 +22,8 @@ type OpenTemplatePreviewResult =
 
 type TemplatePreviewReady = {
   previewUrl: string;
-  downloadUrl: string;
+  downloadUrl?: string;
+  previewFrame?: XuluxPreviewFrame;
   templateId: string;
   versionId?: string;
   title: string;
@@ -79,7 +82,8 @@ export function XuluxTemplatePreviewObserver({
     if (payload.success) {
       onTemplatePreviewReady({
         previewUrl: payload.previewUrl,
-        downloadUrl: payload.downloadUrl,
+        ...(payload.downloadUrl ? { downloadUrl: payload.downloadUrl } : {}),
+        ...(payload.previewFrame ? { previewFrame: payload.previewFrame } : {}),
         templateId: payload.templateId,
         ...(payload.versionId !== undefined
           ? { versionId: payload.versionId }

--- a/apps/docs/components/xulux/chat/OpenInCard.tsx
+++ b/apps/docs/components/xulux/chat/OpenInCard.tsx
@@ -2,6 +2,7 @@
 
 import type { SyntaxHighlighterProps } from "@assistant-ui/react-streamdown";
 import { CheckIcon, CopyIcon, DownloadIcon } from "lucide-react";
+import { HoverCard } from "radix-ui";
 import { useCopyToClipboard } from "@assistant-ui/ui/hooks/use-copy-to-clipboard";
 import { analytics } from "@/lib/analytics";
 import {
@@ -131,9 +132,18 @@ function ChatGPTLogo() {
   );
 }
 
+function VSCodeLogo() {
+  return (
+    <svg viewBox="0 0 24 24" className="size-3.5 fill-current" aria-hidden>
+      <path d="M16.2 2.5 7.4 10.6 3.2 7.4 1.5 8.2v7.6l1.7.8 4.2-3.2 8.8 8.1 5.3-2.2V4.7l-5.3-2.2ZM4 10.5l2 1.5-2 1.5v-3Zm4.2 1.5 7-5.3v10.6l-7-5.3Zm10.3 5.4-1.5.6V6l1.5.6v10.8Z" />
+    </svg>
+  );
+}
+
 const PLATFORM_LOGOS = [
   { id: "claude", Logo: ClaudeLogo },
   { id: "codex", Logo: CodexLogo },
+  { id: "vscode", Logo: VSCodeLogo },
   { id: "cursor", Logo: CursorLogo },
   { id: "conductor", Logo: ConductorLogo },
   { id: "chatgpt", Logo: ChatGPTLogo },
@@ -178,7 +188,7 @@ export function OpenInCard({
       </div>
 
       {/* Row 2: actions */}
-      <div className="flex items-center gap-2.5">
+      <div className="flex flex-wrap items-center gap-2.5">
         {hasDownload && (
           <>
             <a
@@ -198,26 +208,49 @@ export function OpenInCard({
             <span className="text-muted-foreground/70 text-xs">or</span>
           </>
         )}
-        <button
-          type="button"
-          onClick={() => {
-            copyToClipboard(prompt);
-            analytics.xulux.converted(
-              withXuluxContext(analyticsCtx, {
-                action: "copy_prompt",
-                surface: "open_in_card",
-              }),
-            );
-          }}
-          className="bg-foreground text-background hover:bg-foreground/90 inline-flex h-8 items-center gap-1.5 rounded-md px-3.5 text-xs font-medium transition-colors"
-        >
-          {isCopied ? (
-            <CheckIcon className="size-3.5" />
-          ) : (
-            <CopyIcon className="size-3.5" />
-          )}
-          {isCopied ? "Copied!" : "Copy prompt"}
-        </button>
+        <HoverCard.Root openDelay={150} closeDelay={150}>
+          <HoverCard.Trigger asChild>
+            <button
+              type="button"
+              onClick={() => {
+                copyToClipboard(prompt);
+                analytics.xulux.converted(
+                  withXuluxContext(analyticsCtx, {
+                    action: "copy_prompt",
+                    surface: "open_in_card",
+                  }),
+                );
+              }}
+              className="bg-foreground text-background hover:bg-foreground/90 inline-flex h-8 items-center gap-1.5 rounded-md px-3.5 text-xs font-medium transition-colors"
+              aria-describedby="xulux-open-in-prompt-preview"
+            >
+              {isCopied ? (
+                <CheckIcon className="size-3.5" />
+              ) : (
+                <CopyIcon className="size-3.5" />
+              )}
+              {isCopied ? "Copied!" : "Copy prompt"}
+            </button>
+          </HoverCard.Trigger>
+          <HoverCard.Portal>
+            <HoverCard.Content
+              id="xulux-open-in-prompt-preview"
+              role="tooltip"
+              side="bottom"
+              align="start"
+              sideOffset={8}
+              collisionPadding={12}
+              className="border-border bg-popover text-popover-foreground z-[2147483647] w-[min(24rem,calc(100vw-2rem))] rounded-lg border p-3 text-xs shadow-lg"
+            >
+              <div className="text-muted-foreground mb-2 font-medium">
+                Prompt preview
+              </div>
+              <pre className="max-h-56 overflow-auto font-mono leading-normal break-words whitespace-pre-wrap">
+                {prompt}
+              </pre>
+            </HoverCard.Content>
+          </HoverCard.Portal>
+        </HoverCard.Root>
       </div>
     </div>
   );

--- a/apps/docs/components/xulux/chat/OpenInCard.tsx
+++ b/apps/docs/components/xulux/chat/OpenInCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import type { SyntaxHighlighterProps } from "@assistant-ui/react-streamdown";
 import { CheckIcon, CopyIcon, DownloadIcon } from "lucide-react";
 import { HoverCard } from "radix-ui";
@@ -165,6 +166,7 @@ export function OpenInCard({
     ? downloadUrl
     : undefined;
   const hasDownload = Boolean(validDownloadUrl);
+  const promptPreviewId = useId();
 
   return (
     <div className="border-border bg-muted/30 my-4 rounded-lg border px-4 py-3 text-sm shadow-sm">
@@ -222,7 +224,7 @@ export function OpenInCard({
                 );
               }}
               className="bg-foreground text-background hover:bg-foreground/90 inline-flex h-8 items-center gap-1.5 rounded-md px-3.5 text-xs font-medium transition-colors"
-              aria-describedby="xulux-open-in-prompt-preview"
+              aria-describedby={promptPreviewId}
             >
               {isCopied ? (
                 <CheckIcon className="size-3.5" />
@@ -234,7 +236,7 @@ export function OpenInCard({
           </HoverCard.Trigger>
           <HoverCard.Portal>
             <HoverCard.Content
-              id="xulux-open-in-prompt-preview"
+              id={promptPreviewId}
               role="tooltip"
               side="bottom"
               align="start"

--- a/apps/docs/components/xulux/chat/XuluxAskQuestion.tsx
+++ b/apps/docs/components/xulux/chat/XuluxAskQuestion.tsx
@@ -1,21 +1,22 @@
 "use client";
 
 import type { SyntaxHighlighterProps } from "@assistant-ui/react-streamdown";
-import { ThreadPrimitive } from "@assistant-ui/react";
+import { ThreadPrimitive, useAuiState } from "@assistant-ui/react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
 
-type XuluxSuggestionOption = {
+type XuluxAskQuestionOption = {
   label: string;
   prompt: string;
+  preferred?: boolean;
 };
 
-type XuluxSuggestionOptionsData = {
+type XuluxAskQuestionData = {
   question?: string;
-  options: XuluxSuggestionOption[];
+  options: XuluxAskQuestionOption[];
 };
 
-function parseSuggestionOptions(
-  code: string,
-): XuluxSuggestionOptionsData | null {
+function parseAskQuestion(code: string): XuluxAskQuestionData | null {
   let value: unknown;
   try {
     value = JSON.parse(code);
@@ -31,7 +32,7 @@ function parseSuggestionOptions(
   const rawOptions = record.options;
   if (!Array.isArray(rawOptions)) return null;
 
-  const options = rawOptions.flatMap((rawOption): XuluxSuggestionOption[] => {
+  const options = rawOptions.flatMap((rawOption): XuluxAskQuestionOption[] => {
     if (!rawOption || typeof rawOption !== "object") return [];
     if (Array.isArray(rawOption)) return [];
 
@@ -44,23 +45,29 @@ function parseSuggestionOptions(
     const prompt = option.prompt.trim();
     if (!label || !prompt) return [];
 
-    return [{ label, prompt }];
+    return [{ label, prompt, preferred: option.preferred === true }];
   });
 
   if (options.length === 0) return null;
+  const sortedOptions = [...options].sort((a, b) => {
+    if (a.preferred === b.preferred) return 0;
+    return a.preferred ? -1 : 1;
+  });
 
   const question =
     typeof record.question === "string" ? record.question.trim() : "";
 
   return {
     ...(question ? { question } : {}),
-    options,
+    options: sortedOptions,
   };
 }
 
-export function XuluxSuggestionOptions({ code }: SyntaxHighlighterProps) {
-  const data = parseSuggestionOptions(code);
-  if (!data) return null;
+export function XuluxAskQuestion({ code }: SyntaxHighlighterProps) {
+  const [hasSelected, setHasSelected] = useState(false);
+  const isLastMessage = useAuiState((s) => s.message.isLast);
+  const data = parseAskQuestion(code);
+  if (!data || hasSelected || !isLastMessage) return null;
 
   return (
     <div className="border-border/60 bg-muted/20 my-3 rounded-lg border p-3">
@@ -75,9 +82,20 @@ export function XuluxSuggestionOptions({ code }: SyntaxHighlighterProps) {
             key={`${option.label}:${index}`}
             prompt={option.prompt}
             send
-            className="border-border bg-background hover:bg-muted text-foreground inline-flex min-h-8 max-w-full items-center rounded-md border px-3 py-1.5 text-left text-xs leading-snug transition-colors"
+            onClick={() => setHasSelected(true)}
+            className={cn(
+              "inline-flex min-h-8 max-w-full items-center gap-1.5 rounded-md border px-3 py-1.5 text-left text-xs leading-snug transition-colors",
+              option.preferred
+                ? "border-primary/50 bg-primary text-primary-foreground hover:bg-primary/90"
+                : "border-border bg-background hover:bg-muted text-foreground",
+            )}
           >
             {option.label}
+            {option.preferred ? (
+              <span className="text-primary-foreground/80 text-[10px] font-medium">
+                Recommended
+              </span>
+            ) : null}
           </ThreadPrimitive.Suggestion>
         ))}
       </div>

--- a/apps/docs/components/xulux/chat/XuluxMarkdownText.tsx
+++ b/apps/docs/components/xulux/chat/XuluxMarkdownText.tsx
@@ -33,6 +33,9 @@ const XuluxMarkdownTextImpl = () => {
           SyntaxHighlighter: OpenInSyntaxHighlighter,
           CodeHeader: () => null,
         },
+        text: {
+          SyntaxHighlighter: PlainTextSyntaxHighlighter,
+        },
       }}
     />
   );
@@ -76,7 +79,7 @@ const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({ code, language }) => {
       showLanguage={false}
       showLineNumbers
       defaultColor={false}
-      className="[&_pre]:border-border/50 [&_pre]:bg-muted/30 [&_pre]:scrollbar-none [&_pre]:overflow-x-auto [&_pre]:rounded-t-none [&_pre]:rounded-b-lg [&_pre]:border [&_pre]:border-t-0 [&_pre]:py-3 [&_pre]:pr-3 [&_pre]:pl-1 [&_pre]:text-xs [&_pre]:leading-relaxed"
+      className="[&_pre]:border-border/50 [&_pre]:bg-muted/30 [&_pre]:m-0 [&_pre]:scrollbar-none [&_pre]:overflow-x-auto [&_pre]:rounded-t-none [&_pre]:rounded-b-lg [&_pre]:border [&_pre]:border-t-0 [&_pre]:py-3 [&_pre]:pr-3 [&_pre]:pl-1 [&_pre]:text-xs [&_pre]:leading-relaxed"
       style={
         {
           "--line-numbers-foreground": "var(--color-muted-foreground)",
@@ -88,6 +91,14 @@ const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({ code, language }) => {
     >
       {code.trim()}
     </ShikiHighlighter>
+  );
+};
+
+const PlainTextSyntaxHighlighter: FC<SyntaxHighlighterProps> = ({ code }) => {
+  return (
+    <pre className="border-border/50 bg-muted/30 !mt-0 max-w-full overflow-x-hidden rounded-t-none rounded-b-lg border border-t-0 px-3 py-2 text-xs leading-normal whitespace-pre-wrap">
+      <code className="break-words whitespace-pre-wrap">{code.trim()}</code>
+    </pre>
   );
 };
 

--- a/apps/docs/components/xulux/chat/XuluxMarkdownText.tsx
+++ b/apps/docs/components/xulux/chat/XuluxMarkdownText.tsx
@@ -11,7 +11,7 @@ import {
 } from "@assistant-ui/react-streamdown";
 import { type CodeHeaderProps } from "@assistant-ui/react-markdown";
 import { OpenInSyntaxHighlighter } from "@/components/xulux/chat/OpenInCard";
-import { XuluxSuggestionOptions } from "@/components/xulux/chat/XuluxSuggestionOptions";
+import { XuluxAskQuestion } from "@/components/xulux/chat/XuluxAskQuestion";
 import {
   type ComponentPropsWithoutRef,
   type CSSProperties,
@@ -34,8 +34,8 @@ const XuluxMarkdownTextImpl = () => {
           SyntaxHighlighter: OpenInSyntaxHighlighter,
           CodeHeader: () => null,
         },
-        "suggestion-options": {
-          SyntaxHighlighter: XuluxSuggestionOptions,
+        "ask-question": {
+          SyntaxHighlighter: XuluxAskQuestion,
           CodeHeader: () => null,
         },
         text: {

--- a/apps/docs/components/xulux/chat/XuluxMarkdownText.tsx
+++ b/apps/docs/components/xulux/chat/XuluxMarkdownText.tsx
@@ -11,6 +11,7 @@ import {
 } from "@assistant-ui/react-streamdown";
 import { type CodeHeaderProps } from "@assistant-ui/react-markdown";
 import { OpenInSyntaxHighlighter } from "@/components/xulux/chat/OpenInCard";
+import { XuluxSuggestionOptions } from "@/components/xulux/chat/XuluxSuggestionOptions";
 import {
   type ComponentPropsWithoutRef,
   type CSSProperties,
@@ -31,6 +32,10 @@ const XuluxMarkdownTextImpl = () => {
       componentsByLanguage={{
         "open-in": {
           SyntaxHighlighter: OpenInSyntaxHighlighter,
+          CodeHeader: () => null,
+        },
+        "suggestion-options": {
+          SyntaxHighlighter: XuluxSuggestionOptions,
           CodeHeader: () => null,
         },
         text: {

--- a/apps/docs/components/xulux/chat/XuluxSuggestionOptions.tsx
+++ b/apps/docs/components/xulux/chat/XuluxSuggestionOptions.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import type { SyntaxHighlighterProps } from "@assistant-ui/react-streamdown";
+import { ThreadPrimitive } from "@assistant-ui/react";
+
+type XuluxSuggestionOption = {
+  label: string;
+  prompt: string;
+};
+
+type XuluxSuggestionOptionsData = {
+  question?: string;
+  options: XuluxSuggestionOption[];
+};
+
+function parseSuggestionOptions(
+  code: string,
+): XuluxSuggestionOptionsData | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(code);
+  } catch {
+    return null;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const rawOptions = record.options;
+  if (!Array.isArray(rawOptions)) return null;
+
+  const options = rawOptions.flatMap((rawOption): XuluxSuggestionOption[] => {
+    if (!rawOption || typeof rawOption !== "object") return [];
+    if (Array.isArray(rawOption)) return [];
+
+    const option = rawOption as Record<string, unknown>;
+    if (typeof option.label !== "string" || typeof option.prompt !== "string") {
+      return [];
+    }
+
+    const label = option.label.trim();
+    const prompt = option.prompt.trim();
+    if (!label || !prompt) return [];
+
+    return [{ label, prompt }];
+  });
+
+  if (options.length === 0) return null;
+
+  const question =
+    typeof record.question === "string" ? record.question.trim() : "";
+
+  return {
+    ...(question ? { question } : {}),
+    options,
+  };
+}
+
+export function XuluxSuggestionOptions({ code }: SyntaxHighlighterProps) {
+  const data = parseSuggestionOptions(code);
+  if (!data) return null;
+
+  return (
+    <div className="border-border/60 bg-muted/20 my-3 rounded-lg border p-3">
+      {data.question ? (
+        <div className="text-muted-foreground mb-2 text-xs font-medium">
+          {data.question}
+        </div>
+      ) : null}
+      <div className="flex flex-wrap gap-2">
+        {data.options.map((option, index) => (
+          <ThreadPrimitive.Suggestion
+            key={`${option.label}:${index}`}
+            prompt={option.prompt}
+            send
+            className="border-border bg-background hover:bg-muted text-foreground inline-flex min-h-8 max-w-full items-center rounded-md border px-3 py-1.5 text-left text-xs leading-snug transition-colors"
+          >
+            {option.label}
+          </ThreadPrimitive.Suggestion>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/components/xulux/landing/TemplateDetailModal.tsx
+++ b/apps/docs/components/xulux/landing/TemplateDetailModal.tsx
@@ -22,6 +22,8 @@ import {
   useXuluxAnalytics,
   withXuluxContext,
 } from "@/lib/xulux/analytics-context";
+import { cn } from "@/lib/utils";
+import { XuluxPreviewFrame } from "../canvas/XuluxPreviewFrame";
 import type { XuluxTemplate } from "../templates/types";
 import { Thumbnail } from "./Thumbnail";
 
@@ -111,18 +113,22 @@ export function TemplateDetailModal({
                     </div>
                   </div>
                 )}
-                <iframe
-                  key={current.id}
-                  src={current.previewUrl}
-                  className="absolute inset-0 z-10 h-full w-full border-0"
-                  sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-                  title={`${current.title} preview`}
-                  onLoad={() => setIframeLoaded(true)}
-                  style={{
-                    opacity: iframeLoaded ? 1 : 0,
-                    transition: "opacity 200ms",
-                  }}
-                />
+                <XuluxPreviewFrame
+                  frame={current.previewFrame}
+                  className={cn(
+                    "absolute inset-0 z-10 transition-opacity duration-200",
+                    iframeLoaded ? "opacity-100" : "opacity-0",
+                  )}
+                >
+                  <iframe
+                    key={current.id}
+                    src={current.previewUrl}
+                    className="h-full w-full border-0"
+                    sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+                    title={`${current.title} preview`}
+                    onLoad={() => setIframeLoaded(true)}
+                  />
+                </XuluxPreviewFrame>
                 <a
                   href={current.previewUrl}
                   target="_blank"

--- a/apps/docs/components/xulux/runtime/types.ts
+++ b/apps/docs/components/xulux/runtime/types.ts
@@ -1,4 +1,5 @@
 import type { SelectedTemplateContext } from "../XuluxApp";
+import type { XuluxPreviewFrame } from "../templates/types";
 
 export type XuluxThreadStatus = "idle" | "running" | "interrupted";
 
@@ -8,6 +9,7 @@ export type XuluxCanvasSnapshot = {
   source: "template" | "agent_template" | "refresh" | null;
   error: string | null;
   downloadUrl?: string;
+  previewFrame?: XuluxPreviewFrame;
   templateId?: string;
   versionId?: string;
   title?: string;

--- a/apps/docs/components/xulux/shell/XuluxShell.tsx
+++ b/apps/docs/components/xulux/shell/XuluxShell.tsx
@@ -34,7 +34,7 @@ import {
 } from "@/lib/xulux/analytics-context";
 import { XuluxThread } from "../chat/XuluxThread";
 import { XuluxTemplateProvider } from "../chat/XuluxTemplateContext";
-import type { XuluxTemplate } from "../templates/types";
+import type { XuluxPreviewFrame, XuluxTemplate } from "../templates/types";
 import type { SelectedTemplateContext } from "../XuluxApp";
 import { XuluxCanvas } from "../canvas/XuluxCanvas";
 import { XuluxCanvasObserver } from "../canvas/XuluxCanvasObserver";
@@ -59,6 +59,7 @@ type CanvasState = {
   source: "template" | "agent_template" | "refresh" | null;
   error: string | null;
   downloadUrl?: string;
+  previewFrame?: XuluxPreviewFrame;
   templateId?: string;
   versionId?: string;
   title?: string;
@@ -158,6 +159,9 @@ export function XuluxShell({
         source: template.previewUrl ? "template" : null,
         error: null,
         ...(template.downloadUrl ? { downloadUrl: template.downloadUrl } : {}),
+        ...(template.previewFrame
+          ? { previewFrame: template.previewFrame }
+          : {}),
         templateId: getXuluxTemplateAnalyticsId(template),
         ...(template.versionId ? { versionId: template.versionId } : {}),
         title: template.title,
@@ -315,7 +319,12 @@ export function XuluxShell({
               url: preview.previewUrl,
               source: "agent_template",
               error: null,
-              downloadUrl: preview.downloadUrl,
+              ...(preview.downloadUrl
+                ? { downloadUrl: preview.downloadUrl }
+                : {}),
+              ...(preview.previewFrame
+                ? { previewFrame: preview.previewFrame }
+                : {}),
               templateId: preview.templateId,
               ...(preview.versionId !== undefined
                 ? { versionId: preview.versionId }
@@ -360,6 +369,9 @@ export function XuluxShell({
                     ? { downloadUrl: canvas.downloadUrl }
                     : {})}
                   {...(canvas.versionId ? { versionId: canvas.versionId } : {})}
+                  {...(canvas.previewFrame
+                    ? { previewFrame: canvas.previewFrame }
+                    : {})}
                   {...(sourceUrl ? { sourceUrl } : {})}
                   {...(canvasTitle ? { title: canvasTitle } : {})}
                 />
@@ -408,6 +420,9 @@ export function XuluxShell({
                     ? { downloadUrl: canvas.downloadUrl }
                     : {})}
                   {...(canvas.versionId ? { versionId: canvas.versionId } : {})}
+                  {...(canvas.previewFrame
+                    ? { previewFrame: canvas.previewFrame }
+                    : {})}
                   {...(sourceUrl ? { sourceUrl } : {})}
                   {...(canvasTitle ? { title: canvasTitle } : {})}
                 />
@@ -475,6 +490,7 @@ function toCanvasSnapshot(
     source: canvas.source,
     error: canvas.error,
     ...(canvas.downloadUrl ? { downloadUrl: canvas.downloadUrl } : {}),
+    ...(canvas.previewFrame ? { previewFrame: canvas.previewFrame } : {}),
     ...(canvas.templateId ? { templateId: canvas.templateId } : {}),
     ...(canvas.versionId ? { versionId: canvas.versionId } : {}),
     ...(title ? { title } : {}),
@@ -493,6 +509,7 @@ function fromCanvasSnapshot(
     source: snapshot.source,
     error: snapshot.error,
     ...(snapshot.downloadUrl ? { downloadUrl: snapshot.downloadUrl } : {}),
+    ...(snapshot.previewFrame ? { previewFrame: snapshot.previewFrame } : {}),
     ...(snapshot.templateId ? { templateId: snapshot.templateId } : {}),
     ...(snapshot.versionId ? { versionId: snapshot.versionId } : {}),
     ...(snapshot.title ? { title: snapshot.title } : {}),

--- a/apps/docs/components/xulux/templates/types.ts
+++ b/apps/docs/components/xulux/templates/types.ts
@@ -4,6 +4,20 @@ export type XuluxTemplateCategory = {
   description?: string | undefined;
 };
 
+export type XuluxPreviewFrame =
+  | {
+      kind: "phone";
+      width?: number | undefined;
+      aspectRatio?: string | undefined;
+      chrome?: "ios-dark" | undefined;
+    }
+  | {
+      kind: "terminal";
+      title?: string | undefined;
+      width?: number | undefined;
+      height?: number | undefined;
+    };
+
 export type XuluxTemplate = {
   id: string;
   templateId?: string | undefined;
@@ -18,6 +32,7 @@ export type XuluxTemplate = {
   kind: "template" | "example";
   previewStatus: "live" | "stale" | "missing";
   previewUrl?: string | undefined;
+  previewFrame?: XuluxPreviewFrame | undefined;
   downloadUrl?: string | undefined;
   sandboxBaseUrl?: string | undefined;
   screenshotUrl?: string | undefined;

--- a/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
+++ b/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
@@ -9,6 +9,7 @@ import {
 import {
   DEMO_DEPENDENCIES,
   DEMO_DEV_DEPENDENCIES,
+  dependencyVersionsFromPackage,
   dependencyVersions,
 } from "./package-versions";
 import { createZip, type ZipFileMap } from "./zip";
@@ -29,6 +30,10 @@ export function createDemoFileMap(slug: string, snapshot: SourceSnapshot) {
   const manifest = getDemoDownloadManifest(slug);
   if (!manifest) {
     throw new Error(`Unsupported demo slug: ${slug}`);
+  }
+
+  if (manifest.target === "node-cli") {
+    return createNodeCliDemoFileMap(manifest, snapshot);
   }
 
   const demoSource = assertSnapshotFile(snapshot, manifest.entry);
@@ -86,7 +91,11 @@ function assertSnapshotFile(snapshot: SourceSnapshot, snapshotKey: string) {
 
 function targetPathForSourceFile(sourceFile: string) {
   if (sourceFile.startsWith("packages/ui/src/")) {
-    return sourceFile.replace(/^packages\/ui\/src\//, "");
+    return sourceFile
+      .replace(/^packages\/ui\/src\//, "")
+      .replace(/^components\/ui\//, "components/ui/")
+      .replace(/^components\/assistant-ui\//, "components/assistant-ui/")
+      .replace(/^lib\//, "lib/");
   }
 
   if (sourceFile.startsWith("apps/docs/")) {
@@ -94,6 +103,81 @@ function targetPathForSourceFile(sourceFile: string) {
   }
 
   throw new Error(`Unsupported demo source path: ${sourceFile}`);
+}
+
+const REACT_INK_SOURCE_FILES = [
+  "examples/with-react-ink/src/app.tsx",
+  "examples/with-react-ink/src/components/thread.tsx",
+  "examples/with-react-ink/src/dev.ts",
+  "examples/with-react-ink/src/index.tsx",
+  "examples/with-react-ink/src/scripted-adapter.ts",
+  "examples/with-react-ink/src/tools.tsx",
+] as const;
+
+function createNodeCliDemoFileMap(
+  manifest: DemoDownloadManifest,
+  snapshot: SourceSnapshot,
+) {
+  if (manifest.slug !== "react-ink") {
+    throw new Error(`Unsupported node-cli demo slug: ${manifest.slug}`);
+  }
+
+  const files: ZipFileMap = {
+    "package.json": nodeCliPackageJson(manifest, snapshot),
+    "tsconfig.json": assertSnapshotFile(
+      snapshot,
+      "examples/with-react-ink/tsconfig.json",
+    ),
+    "README.md": nodeCliReadme(manifest),
+  };
+
+  for (const sourceFile of REACT_INK_SOURCE_FILES) {
+    files[sourceFile.replace(/^examples\/with-react-ink\//, "")] =
+      assertSnapshotFile(snapshot, sourceFile);
+  }
+
+  return files;
+}
+
+function nodeCliPackageJson(
+  manifest: DemoDownloadManifest,
+  snapshot: SourceSnapshot,
+) {
+  const packagePath = "examples/with-react-ink/package.json";
+  const dependencies = dependencyVersionsFromPackage(snapshot, packagePath, [
+    "@assistant-ui/react-ink",
+    "@assistant-ui/react-ink-markdown",
+    "ink",
+    "react",
+  ]);
+  const devDependencies = dependencyVersionsFromPackage(snapshot, packagePath, [
+    "@types/react",
+    "esbuild",
+    "tsx",
+    "typescript",
+  ]);
+
+  return `${JSON.stringify(
+    {
+      name: `xulux-${manifest.slug}-demo`,
+      version: "0.1.0",
+      private: true,
+      type: "module",
+      scripts: {
+        dev: "node --import tsx/esm src/dev.ts",
+        build: "tsc",
+        start: "node dist/index.js",
+      },
+      dependencies,
+      devDependencies,
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function nodeCliReadme(manifest: DemoDownloadManifest) {
+  return `# Xulux ${manifest.name}\n\n${manifest.description}\n\nThis is a Node.js terminal app. It renders a Claude Code or Codex CLI-style assistant UI with React Ink and assistant-ui terminal primitives.\n\n## Run\n\n\`\`\`bash\nnpm install\nnpm run dev\n\`\`\`\n\n## Build\n\n\`\`\`bash\nnpm run build\nnpm start\n\`\`\`\n\nSource demo: \`${manifest.sourcePath ?? "examples/with-react-ink"}\`\n`;
 }
 
 function packageJson(manifest: DemoDownloadManifest, snapshot: SourceSnapshot) {
@@ -175,7 +259,7 @@ function runtimeProviderTsx() {
 }
 
 function chatRouteTs() {
-  return `import { openai } from "@ai-sdk/openai";\nimport {\n  convertToModelMessages,\n  createUIMessageStream,\n  createUIMessageStreamResponse,\n  streamText,\n} from "ai";\n\nexport const maxDuration = 30;\n\nexport async function POST(req: Request) {\n  const { messages } = await req.json();\n\n  if (!process.env.OPENAI_API_KEY) {\n    const stream = createUIMessageStream({\n      originalMessages: messages,\n      execute: async ({ writer }) => {\n        await writer.write({\n          type: "text-delta",\n          id: "fallback-text",\n          delta:\n            "This starter is running without OPENAI_API_KEY. Add one to .env.local to enable live AI responses.",\n        });\n      },\n    });\n\n    return createUIMessageStreamResponse({ stream });\n  }\n\n  const result = streamText({\n    model: openai("gpt-4.1-mini"),\n    messages: await convertToModelMessages(messages),\n  });\n\n  return result.toUIMessageStreamResponse();\n}\n`;
+  return `import { openai } from "@ai-sdk/openai";\nimport {\n  convertToModelMessages,\n  createUIMessageStream,\n  createUIMessageStreamResponse,\n  streamText,\n} from "ai";\n\nexport const maxDuration = 30;\n\nexport async function POST(req: Request) {\n  const { messages } = await req.json();\n\n  if (!process.env.OPENAI_API_KEY) {\n    const stream = createUIMessageStream({\n      originalMessages: messages,\n      execute: async ({ writer }) => {\n        const messageId = \`msg-\${crypto.randomUUID()}\`;\n        const textId = "fallback-text";\n\n        writer.write({ type: "start", messageId });\n        writer.write({ type: "start-step" });\n        writer.write({ type: "text-start", id: textId });\n        writer.write({\n          type: "text-delta",\n          id: textId,\n          delta:\n            "This starter is running without OPENAI_API_KEY. Add one to .env.local to enable live AI responses.",\n        });\n        writer.write({ type: "text-end", id: textId });\n        writer.write({ type: "finish-step" });\n        writer.write({ type: "finish" });\n      },\n    });\n\n    return createUIMessageStreamResponse({ stream });\n  }\n\n  const result = streamText({\n    model: openai("gpt-4.1-mini"),\n    messages: await convertToModelMessages(messages),\n  });\n\n  return result.toUIMessageStreamResponse();\n}\n`;
 }
 
 function markdownTextShim() {

--- a/apps/docs/lib/xulux/demo-downloads/manifest.ts
+++ b/apps/docs/lib/xulux/demo-downloads/manifest.ts
@@ -11,7 +11,17 @@ export type DemoDownloadSlug =
   | "claude"
   | "grok"
   | "gemini"
-  | "perplexity";
+  | "perplexity"
+  | "react-ink";
+
+export type DemoDownloadTarget = "web" | "node-cli";
+
+export type DemoDownloadPreviewFrame = {
+  kind: "terminal";
+  title?: string;
+  width?: number;
+  height?: number;
+};
 
 export type DemoDownloadManifest = {
   slug: DemoDownloadSlug;
@@ -23,6 +33,16 @@ export type DemoDownloadManifest = {
   componentName: string;
   tags: string[];
   gradient: string;
+  target?: DemoDownloadTarget;
+  previewUrl?: string;
+  previewFrame?: DemoDownloadPreviewFrame;
+  docsUrl?: string;
+  sourcePath?: string;
+  tech?: {
+    framework: string;
+    runtime: string;
+    frontendPattern: string;
+  };
   featured?: boolean;
   extraSourceFiles?: string[];
 };
@@ -170,6 +190,38 @@ export const DEMO_DOWNLOAD_MANIFESTS: Record<
     gradient: "from-teal-500/35 via-cyan-300/25 to-zinc-200/20",
     featured: true,
     extraSourceFiles: [...COMMON_EXTRA_SOURCE_FILES],
+  },
+  "react-ink": {
+    slug: "react-ink",
+    name: "React Ink Terminal Assistant",
+    tagline: "A terminal AI assistant built with assistant-ui and Ink.",
+    description:
+      "A Claude Code or Codex CLI-style terminal assistant built with assistant-ui React Ink primitives, including streaming chat, tool calls, status output, and terminal-native diff rendering.",
+    features: [
+      "Terminal chat UI built with @assistant-ui/react-ink",
+      "Scripted coding-agent flow with reasoning, tool calls, tests, and summary",
+      "Terminal-native diff rendering for apply_patch output",
+    ],
+    entry: "examples/with-react-ink/src/app.tsx",
+    componentName: "ReactInk",
+    tags: ["assistant-ui", "React Ink", "terminal", "CLI", "tools"],
+    gradient: "from-emerald-500/35 via-cyan-400/25 to-zinc-300/20",
+    target: "node-cli",
+    previewUrl: "https://assistant-ui-ink.vercel.app",
+    previewFrame: {
+      kind: "terminal",
+      title: "assistant-ui ink",
+      width: 800,
+      height: 480,
+    },
+    docsUrl: "/docs/ink",
+    sourcePath: "examples/with-react-ink",
+    tech: {
+      framework: "Node.js",
+      runtime: "React Ink",
+      frontendPattern: "Terminal assistant",
+    },
+    featured: true,
   },
 };
 

--- a/apps/docs/lib/xulux/demo-downloads/package-versions.ts
+++ b/apps/docs/lib/xulux/demo-downloads/package-versions.ts
@@ -63,7 +63,7 @@ export function dependencyVersionsFromPackage(
         pkg.dependencies?.[name] ??
         pkg.devDependencies?.[name] ??
         pkg.peerDependencies?.[name];
-      if (typeof version === "string" && version && version !== "workspace:*") {
+      if (isInstallableVersion(version)) {
         return [name, version];
       }
       return [name, dependencyVersion(snapshot, name)];
@@ -86,11 +86,19 @@ function dependencyVersion(snapshot: Snapshot, name: string) {
     docsPkg.devDependencies?.[name] ??
     docsPkg.peerDependencies?.[name];
 
-  if (typeof version === "string" && version && version !== "workspace:*") {
+  if (isInstallableVersion(version)) {
     return version;
   }
 
   throw new Error(`No installable version found for ${name}.`);
+}
+
+function isInstallableVersion(version: unknown): version is string {
+  return (
+    typeof version === "string" &&
+    version.length > 0 &&
+    !version.startsWith("workspace:")
+  );
 }
 
 function packageJsonFromSnapshot(snapshot: Snapshot, snapshotKey: string) {

--- a/apps/docs/lib/xulux/demo-downloads/package-versions.ts
+++ b/apps/docs/lib/xulux/demo-downloads/package-versions.ts
@@ -3,6 +3,9 @@ type Snapshot = Record<string, string>;
 const WORKSPACE_PACKAGE_JSON: Record<string, string> = {
   "@assistant-ui/react": "packages/react/package.json",
   "@assistant-ui/react-ai-sdk": "packages/react-ai-sdk/package.json",
+  "@assistant-ui/react-ink": "packages/react-ink/package.json",
+  "@assistant-ui/react-ink-markdown":
+    "packages/react-ink-markdown/package.json",
   "@assistant-ui/react-lexical": "packages/react-lexical/package.json",
   "@assistant-ui/react-markdown": "packages/react-markdown/package.json",
 };
@@ -45,6 +48,26 @@ export function dependencyVersions(
 ) {
   return Object.fromEntries(
     names.map((name) => [name, dependencyVersion(snapshot, name)]),
+  );
+}
+
+export function dependencyVersionsFromPackage(
+  snapshot: Snapshot,
+  packagePath: string,
+  names: readonly string[],
+) {
+  const pkg = packageJsonFromSnapshot(snapshot, packagePath);
+  return Object.fromEntries(
+    names.map((name) => {
+      const version =
+        pkg.dependencies?.[name] ??
+        pkg.devDependencies?.[name] ??
+        pkg.peerDependencies?.[name];
+      if (typeof version === "string" && version && version !== "workspace:*") {
+        return [name, version];
+      }
+      return [name, dependencyVersion(snapshot, name)];
+    }),
   );
 }
 

--- a/apps/docs/lib/xulux/fetch-sandbox.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.ts
@@ -1,8 +1,12 @@
+import { setDefaultResultOrder } from "node:dns";
+
 const SANDBOX_FETCH_HEADERS = {
   Accept: "application/zip, application/octet-stream, */*",
-  // Blaxel preview hosts intermittently reset Node's default fetch without a UA.
+  // Blaxel preview hosts intermittently reset Node's default fetch path.
   "User-Agent": "curl/8.7.1",
 };
+
+setDefaultResultOrder("ipv4first");
 
 const MAX_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 300;

--- a/apps/docs/lib/xulux/fetch-sandbox.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.ts
@@ -1,12 +1,8 @@
-import { setDefaultResultOrder } from "node:dns";
-
 const SANDBOX_FETCH_HEADERS = {
   Accept: "application/zip, application/octet-stream, */*",
   // Blaxel preview hosts intermittently reset Node's default fetch path.
   "User-Agent": "curl/8.7.1",
 };
-
-setDefaultResultOrder("ipv4first");
 
 const MAX_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 300;
@@ -35,7 +31,7 @@ function mergeHeaders(headers?: HeadersInit): Headers {
 }
 
 export async function fetchSandboxResource(
-  url: URL,
+  url: string | URL,
   init?: RequestInit,
 ): Promise<Response> {
   let lastError: unknown;

--- a/apps/docs/lib/xulux/templates-catalog.ts
+++ b/apps/docs/lib/xulux/templates-catalog.ts
@@ -11,9 +11,18 @@ import {
 const DOCS_BASE_URL = "https://0d9e27d14127c0eeadfc34b424cc7ed0.preview.bl.run";
 const SUPPORT_BASE_URL =
   "https://8fd186ab9f30417b876d717f734067a9.preview.bl.run";
+const BASE_ASSISTANT_UI_URL =
+  "https://71e34324f44b97fed5523a6a9857f14b.preview.bl.run";
+const REACT_NATIVE_PREVIEW_URL = "https://assistant-ui-expo.vercel.app/";
 
 const CATEGORIES: XuluxTemplateCategory[] = [
   DEMO_DOWNLOAD_CATEGORY,
+  {
+    id: "base",
+    name: "Base Chat Templates",
+    description:
+      "assistant-ui Base chat templates with thread history, composer, suggestions, and AI SDK runtime.",
+  },
   {
     id: "docs",
     name: "Docs and Knowledge",
@@ -307,27 +316,139 @@ function demoCards(): XuluxTemplate[] {
     gradient: demo.gradient,
     kind: "example",
     previewStatus: "live",
-    previewUrl: `/demos/${demo.slug}`,
+    previewUrl: demo.previewUrl ?? `/demos/${demo.slug}`,
+    ...(demo.previewFrame ? { previewFrame: demo.previewFrame } : {}),
     downloadUrl: `/api/xulux/demo-download?slug=${demo.slug}`,
-    sourcePath: demo.entry,
-    docsUrl: `/demos/${demo.slug}`,
+    sourcePath: demo.sourcePath ?? demo.entry,
+    docsUrl: demo.docsUrl ?? `/demos/${demo.slug}`,
     featured: demo.featured,
-    tech: {
+    tech: demo.tech ?? {
       framework: "Next.js",
       runtime: "assistant-ui + AI SDK",
       frontendPattern: "Fixed demo",
     },
-    env: [
-      {
-        name: "OPENAI_API_KEY",
-        required: false,
-        secret: true,
-        description:
-          "Optional. Enables live AI responses in the downloaded starter app.",
-      },
-    ],
+    env:
+      demo.target === "node-cli"
+        ? []
+        : [
+            {
+              name: "OPENAI_API_KEY",
+              required: false,
+              secret: true,
+              description:
+                "Optional. Enables live AI responses in the downloaded starter app.",
+            },
+          ],
     canStart: true,
   }));
+}
+
+function baseAssistantCards(): XuluxTemplate[] {
+  return [
+    {
+      id: "base-assistant-ui",
+      templateId: "base-assistant-ui",
+      title: "Configurable Base Assistant UI",
+      description:
+        "The assistant-ui Base demo as a hosted configurable chat template with threads, composer, mic input, suggestions, slash commands, local/cloud persistence fallback, and no-key demo flows.",
+      categoryId: "base",
+      categoryName: "Base Chat Templates",
+      tags: ["assistant-ui", "Base", "Chat", "AI SDK", "Customizable"],
+      prompt:
+        "Spin up the configurable assistant-ui Base chat app with thread history, suggestions, slash commands, model picker, mic input, and AI SDK runtime.",
+      gradient: "from-teal-500/40 via-cyan-500/30 to-zinc-400/20",
+      kind: "template",
+      previewStatus: "live",
+      previewUrl: BASE_ASSISTANT_UI_URL,
+      downloadUrl: joinUrl(BASE_ASSISTANT_UI_URL, "/api/download"),
+      sandboxBaseUrl: BASE_ASSISTANT_UI_URL,
+      sourcePath:
+        "docsAgentVersion/xuluxVersion2Agent/generated-templates/base-assistant-ui",
+      docsUrl: "/demos/base",
+      featured: true,
+      intent: {
+        goodFor: [
+          "General chat assistants",
+          "assistant-ui Base starters",
+          "Configurable no-key demos",
+        ],
+        notFor: ["Docs article shells", "Support dashboard workflows"],
+        exampleUserRequests: [
+          "Build me a branded assistant-ui Base chat app.",
+          "Customize the welcome message, suggestions, theme, and demo flows.",
+          "Create a downloadable starter from the Base assistant template.",
+        ],
+      },
+      customization: {
+        safeFieldsSummary: [
+          "brandTheme preset plus accent, background, surface, and text hex overrides",
+          "assistant appName, welcome headline/body, composer and thread labels",
+          "assistant suggestionGroups and slashCommands with controlled icon ids",
+          "assistant tools and demoFlows for deterministic no-key mock behavior",
+        ],
+        supportedRenderers: ["generic"],
+        sourceEditFiles: [
+          "lib/base/defaults.ts",
+          "lib/base/preview-schema.ts",
+          "lib/base/template-contract.ts",
+          "lib/base/runtime-config.ts",
+          "lib/base/download-materializer.ts",
+        ],
+      },
+      tech: {
+        framework: "Next.js",
+        runtime: "assistant-ui + AI SDK",
+        frontendPattern: "Base demo shell",
+      },
+      env: [],
+      canStart: true,
+    },
+  ];
+}
+
+function platformPreviewCards(): XuluxTemplate[] {
+  return [
+    {
+      id: "expo-react-native",
+      title: "Expo React Native Assistant",
+      description:
+        "A mobile AI chat app built with Expo and assistant-ui React Native primitives, with drawer navigation, thread management, streaming responses, and native mobile UI.",
+      categoryId: DEMO_DOWNLOAD_CATEGORY.id,
+      categoryName: DEMO_DOWNLOAD_CATEGORY.name,
+      tags: ["assistant-ui", "React Native", "Expo", "mobile", "chat"],
+      prompt:
+        "Open the Expo React Native assistant demo and give me setup notes.",
+      gradient: "from-sky-500/35 via-blue-400/25 to-zinc-300/20",
+      kind: "example",
+      previewStatus: "live",
+      previewUrl: REACT_NATIVE_PREVIEW_URL,
+      previewFrame: {
+        kind: "phone",
+        width: 320,
+        aspectRatio: "9 / 19.5",
+        chrome: "ios-dark",
+      },
+      sourcePath: "examples/with-expo",
+      docsUrl: "/docs/react-native",
+      featured: true,
+      intent: {
+        goodFor: ["Mobile chat apps", "Expo starters", "React Native UI"],
+        notFor: ["Terminal assistants", "Browser-only chat skins"],
+        exampleUserRequests: [
+          "Build me a React Native assistant app.",
+          "Show me the Expo mobile chat starter.",
+          "I want an assistant-ui app for iOS and Android.",
+        ],
+      },
+      tech: {
+        framework: "Expo",
+        runtime: "React Native",
+        frontendPattern: "Mobile chat with drawer navigation",
+      },
+      env: [],
+      canStart: true,
+    },
+  ];
 }
 
 export function getXuluxHostedTemplatesCatalog(): XuluxTemplateCatalog {
@@ -335,6 +456,8 @@ export function getXuluxHostedTemplatesCatalog(): XuluxTemplateCatalog {
     categories: CATEGORIES,
     templates: [
       ...demoCards(),
+      ...platformPreviewCards(),
+      ...baseAssistantCards(),
       ...docsVersionCards(),
       ...supportVersionCards(),
     ],


### PR DESCRIPTION
## Summary

This PR reduces friction in the Xulux chat handoff flow and expands the template catalog for app requests that the current experience could not satisfy.

- renders copied starter prompts as normal fenced `text` blocks so users can see and copy the exact prompt
- polishes the open-in prompt card around prompt visibility and copy behavior
- replaces plain-text clarifying questions with an `ask-question` block that renders clickable user actions
- adds preview-frame plumbing for templates that need framed/phone/terminal presentation metadata
- adds a configurable Base Assistant UI template with theme, labels, suggestions, slash commands, generic tools, and no-key demo flows
- adds React Ink terminal assistant download/preview metadata
- adds Expo React Native assistant preview metadata
- teaches the Xulux template tools about those new customization and platform surfaces

## User problems

Users could not clearly see what prompt was being copied, and when the agent already knew a small set of valid next actions it still asked users to type an answer manually. Users also asked how to open generated work in VS Code, which should be handled through clearer handoff actions instead of extra back-and-forth.

Users also asked for custom assistant apps, Codex/Claude Code-style terminal apps, and mobile-style apps. The existing catalog could not represent those requests well, and even the simple Base app did not expose a clear customization surface to the agent.

Fixes #4641.
Fixes #4640.

## Validation

- `node_modules\\.bin\\oxlint.cmd apps/docs/app/api/xulux/chat/route.ts apps/docs/components/xulux/canvas/XuluxCanvas.tsx apps/docs/components/xulux/canvas/XuluxPreviewFrame.tsx apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx apps/docs/components/xulux/chat/XuluxAskQuestion.tsx apps/docs/components/xulux/chat/XuluxMarkdownText.tsx apps/docs/components/xulux/landing/TemplateDetailModal.tsx apps/docs/components/xulux/runtime/types.ts apps/docs/components/xulux/shell/XuluxShell.tsx apps/docs/components/xulux/templates/types.ts`
- `node_modules\\.bin\\oxfmt.cmd --check apps/docs/app/api/xulux/chat/route.ts apps/docs/components/xulux/canvas/XuluxCanvas.tsx apps/docs/components/xulux/canvas/XuluxPreviewFrame.tsx apps/docs/components/xulux/canvas/XuluxTemplatePreviewObserver.tsx apps/docs/components/xulux/chat/XuluxAskQuestion.tsx apps/docs/components/xulux/chat/XuluxMarkdownText.tsx apps/docs/components/xulux/landing/TemplateDetailModal.tsx apps/docs/components/xulux/runtime/types.ts apps/docs/components/xulux/shell/XuluxShell.tsx apps/docs/components/xulux/templates/types.ts`
- `node_modules\\.bin\\oxlint.cmd apps/docs/app/api/xulux/chat/tools/template-tools.ts apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts apps/docs/lib/xulux/demo-downloads/manifest.ts apps/docs/lib/xulux/demo-downloads/package-versions.ts apps/docs/lib/xulux/fetch-sandbox.ts apps/docs/lib/xulux/templates-catalog.ts`
- `node_modules\\.bin\\oxfmt.cmd --check apps/docs/app/api/xulux/chat/tools/template-tools.ts apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts apps/docs/lib/xulux/demo-downloads/manifest.ts apps/docs/lib/xulux/demo-downloads/package-versions.ts apps/docs/lib/xulux/fetch-sandbox.ts apps/docs/lib/xulux/templates-catalog.ts`

Note: local git hooks were skipped while replaying commits because this Windows setup still fails in `react-devtools` on `spawnSync tailwindcss ENOENT`; no local Tailwind workaround is included here.