### PR TITLE
fix: improve duplicate generative ui prop warnings

### DIFF
--- a/.changeset/clear-prop-schema-warnings.md
+++ b/.changeset/clear-prop-schema-warnings.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: name duplicate prop owners in generative UI schema warnings

--- a/packages/react-generative-ui/src/buildPresentParameters.ts
+++ b/packages/react-generative-ui/src/buildPresentParameters.ts
@@ -29,6 +29,7 @@ export function buildPresentParameters(
   // first component's schema wins — props are an advisory hint here, not a
   // strict per-component contract.
   const props: Record<string, JSONSchema7Definition> = {};
+  const propOwners = new Map<string, string[]>();
   for (const name of names) {
     const propsSchema = toJSONSchema(library[name]!.properties);
     if (propsSchema.type !== "object") {
@@ -41,14 +42,20 @@ export function buildPresentParameters(
       if (key === TYPE_KEY || key === "children") continue;
       if (!(key in props)) {
         props[key] = schema;
-      } else if (process.env["NODE_ENV"] !== "production") {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[@assistant-ui/react-generative-ui] Prop "${key}" is declared by more ` +
-            "than one component; the first component's schema is kept and the rest " +
-            "are ignored. Rename or align the type to avoid an ambiguous schema.",
-        );
       }
+      propOwners.set(key, [...(propOwners.get(key) ?? []), name]);
+    }
+  }
+
+  if (process.env["NODE_ENV"] !== "production") {
+    for (const [key, owners] of propOwners) {
+      if (owners.length < 2) continue;
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[@assistant-ui/react-generative-ui] Prop "${key}" is declared by ` +
+          `${formatComponentList(owners)}; keeping "${owners[0]}"'s schema. ` +
+          "Rename or align the prop type to avoid an ambiguous schema.",
+      );
     }
   }
 
@@ -87,4 +94,13 @@ export function buildPresentParameters(
     ...node,
     $defs: { node, children },
   };
+}
+
+function formatComponentList(names: string[]) {
+  if (names.length <= 2) return names.map((name) => `"${name}"`).join(" and ");
+
+  return `${names
+    .slice(0, -1)
+    .map((name) => `"${name}"`)
+    .join(", ")}, and "${names[names.length - 1]}"`;
 }

--- a/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
+++ b/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
@@ -226,6 +226,36 @@ describe("buildPresentParameters", () => {
     expect(schema.required).toEqual(["$type"]);
   });
 
+  it("names every component that declares the same prop in the dev warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      buildPresentParameters({
+        Select: {
+          description: "Selects an option.",
+          properties: z.object({ value: z.string() }),
+          render: () => null,
+        },
+        DatePicker: {
+          description: "Picks a date.",
+          properties: z.object({ value: z.string() }),
+          render: () => null,
+        },
+        Combobox: {
+          description: "Chooses from filtered options.",
+          properties: z.object({ value: z.string() }),
+          render: () => null,
+        },
+      });
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        '[@assistant-ui/react-generative-ui] Prop "value" is declared by "Select", "DatePicker", and "Combobox"; keeping "Select"\'s schema. Rename or align the prop type to avoid an ambiguous schema.',
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("throws when a component's properties is not an object schema", () => {
     expect(() =>
       buildPresentParameters({


### PR DESCRIPTION
## Summary

- Track which generative UI components declare each flattened prop schema.
- Emit one dev warning per duplicate prop that names all component owners and the schema owner being kept.
- Add regression coverage for three components declaring the same prop plus a patch changeset.

## Why

`buildPresentParameters` flattens component prop schemas into one tool parameter schema, so the first component schema wins when multiple components declare the same prop. The previous warning explained that a duplicate existed, but not which components caused it, making the warning hard to act on in larger libraries.

## Validation

- `pnpm --filter @assistant-ui/react-generative-ui test`
- `pnpm --filter @assistant-ui/react-generative-ui build`
- `pnpm exec oxfmt --check packages/react-generative-ui/src/buildPresentParameters.ts packages/react-generative-ui/src/renderGenerativeUI.test.tsx .changeset/clear-prop-schema-warnings.md`
- `git diff --check`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

