### PR TITLE
fix(react-ai-sdk): guard converters against missing parts and mediaType

### DIFF
--- a/.changeset/react-ai-sdk-converter-guards.md
+++ b/.changeset/react-ai-sdk-converter-guards.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: guard converters against missing parts and mediaType on non-spec payloads

--- a/packages/react-ai-sdk/src/injectInteractableContext.test.ts
+++ b/packages/react-ai-sdk/src/injectInteractableContext.test.ts
@@ -106,6 +106,25 @@ describe("unstable_injectInteractableContext", () => {
     expect(unstable_injectInteractableContext(input)[0]).toBe(input[0]);
   });
 
+  it("does not throw when a user message has no parts", () => {
+    const input = [
+      {
+        id: "m1",
+        role: "user",
+        metadata: {
+          custom: {
+            interactables: [{ name: "note", id: "n1", state: { v: 1 } }],
+          },
+        },
+      } as unknown as UIMessage,
+    ];
+    const run = () => unstable_injectInteractableContext(input);
+    expect(run).not.toThrow();
+    expect(textOf(run()[0]!.parts[0])).toBe(
+      '[Current state of "note" (id: "n1"): {"v":1}]\n\n',
+    );
+  });
+
   it("is idempotent on its own (does not double-inject)", () => {
     const once = unstable_injectInteractableContext([
       userMsg([{ name: "note", id: "n1", state: { v: 1 } }]),

--- a/packages/react-ai-sdk/src/injectInteractableContext.ts
+++ b/packages/react-ai-sdk/src/injectInteractableContext.ts
@@ -50,7 +50,7 @@ export function unstable_injectInteractableContext(
     const text = `${items.map(format).join("\n")}\n\n`;
 
     const alreadyInjected =
-      msg.parts[0]?.type === "text" && msg.parts[0].text === text;
+      msg.parts?.[0]?.type === "text" && msg.parts[0].text === text;
     if (alreadyInjected) return msg;
 
     return {

--- a/packages/react-ai-sdk/src/injectQuoteContext.test.ts
+++ b/packages/react-ai-sdk/src/injectQuoteContext.test.ts
@@ -1,0 +1,33 @@
+import type { UIMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { injectQuoteContext } from "./injectQuoteContext";
+
+const textOf = (part: unknown) => (part as { text?: string }).text;
+
+describe("injectQuoteContext", () => {
+  it("prepends the quote as a markdown blockquote", () => {
+    const out = injectQuoteContext([
+      {
+        id: "m1",
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+        metadata: { custom: { quote: { text: "quoted" } } },
+      } as unknown as UIMessage,
+    ]);
+    expect(textOf(out[0]!.parts[0])).toBe("> quoted\n\n");
+    expect(textOf(out[0]!.parts[1])).toBe("hello");
+  });
+
+  it("does not throw when a user message has no parts", () => {
+    const input = [
+      {
+        id: "m1",
+        role: "user",
+        metadata: { custom: { quote: { text: "quoted" } } },
+      } as unknown as UIMessage,
+    ];
+    const run = () => injectQuoteContext(input);
+    expect(run).not.toThrow();
+    expect(textOf(run()[0]!.parts[0])).toBe("> quoted\n\n");
+  });
+});

--- a/packages/react-ai-sdk/src/injectQuoteContext.ts
+++ b/packages/react-ai-sdk/src/injectQuoteContext.ts
@@ -47,7 +47,7 @@ export function injectQuoteContext(messages: UIMessage[]): UIMessage[] {
       .join("\n");
 
     const alreadyInjected =
-      msg.parts[0]?.type === "text" &&
+      msg.parts?.[0]?.type === "text" &&
       msg.parts[0].text === `${blockquote}\n\n`;
     if (alreadyInjected) return msg;
 

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
@@ -69,6 +69,32 @@ describe("AISDKMessageConverter", () => {
     expect(converted[0]?.attachments?.[1]?.type).toBe("file");
   });
 
+  it("degrades a user file part missing mediaType instead of throwing", () => {
+    const convert = () =>
+      AISDKMessageConverter.toThreadMessages([
+        {
+          id: "u1",
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              url: "https://cdn/file.bin",
+              filename: "file.bin",
+            },
+          ],
+        } as any,
+      ]);
+
+    expect(convert).not.toThrow();
+    const attachment = convert()[0]?.attachments?.[0];
+    expect(attachment?.type).toBe("file");
+    expect(attachment?.contentType).toBe("unknown/unknown");
+    expect(attachment?.content[0]).toMatchObject({
+      type: "file",
+      mimeType: "unknown/unknown",
+    });
+  });
+
   it("converts source-document parts into document sources", () => {
     const converted = AISDKMessageConverter.toThreadMessages([
       {

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -377,7 +377,7 @@ export const AISDKMessageConverter = unstable_createMessageConverter(
           attachments: message.parts
             ?.filter((p) => p.type === "file")
             .map((part, idx) => {
-              const mediaType = part.mediaType || "unknown/unknown";
+              const mediaType = part.mediaType ?? "unknown/unknown";
               const isImage = mediaType.startsWith("image/");
               return {
                 id: idx.toString(),

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -376,27 +376,31 @@ export const AISDKMessageConverter = unstable_createMessageConverter(
           content,
           attachments: message.parts
             ?.filter((p) => p.type === "file")
-            .map((part, idx) => ({
-              id: idx.toString(),
-              type: part.mediaType.startsWith("image/") ? "image" : "file",
-              name: part.filename ?? "file",
-              content: [
-                part.mediaType.startsWith("image/")
-                  ? {
-                      type: "image",
-                      image: part.url,
-                      filename: part.filename!,
-                    }
-                  : {
-                      type: "file",
-                      filename: part.filename!,
-                      data: part.url,
-                      mimeType: part.mediaType,
-                    },
-              ],
-              contentType: part.mediaType ?? "unknown/unknown",
-              status: { type: "complete" as const },
-            })),
+            .map((part, idx) => {
+              const mediaType = part.mediaType || "unknown/unknown";
+              const isImage = mediaType.startsWith("image/");
+              return {
+                id: idx.toString(),
+                type: isImage ? "image" : "file",
+                name: part.filename ?? "file",
+                content: [
+                  isImage
+                    ? {
+                        type: "image",
+                        image: part.url,
+                        filename: part.filename!,
+                      }
+                    : {
+                        type: "file",
+                        filename: part.filename!,
+                        data: part.url,
+                        mimeType: mediaType,
+                      },
+                ],
+                contentType: mediaType,
+                status: { type: "complete" as const },
+              };
+            }),
           metadata: message.metadata as MessageMetadata,
         };
 


### PR DESCRIPTION
## What

Make the react-ai-sdk converters survive non-spec message payloads instead of throwing, by fixing two spots where the same field is already defended a few lines away but not at the point of use. These converters run on untrusted `req.json()` data, so a missing field should degrade, not crash. Hardens the AI SDK converters so a provider response that's missing some fields doesn't crash the whole thing.

## The two inconsistencies

- **`injectQuoteContext.ts` / `injectInteractableContext.ts`** read `msg.parts[0]?.type` to detect an already-injected prefix, then immediately spread `...(msg.parts ?? [])`. The spread shows missing `parts` is expected, but the read above it throws on `msg.parts[0]` when `parts` is absent. Changed to `msg.parts?.[0]?.type`.
- **`convertMessage.ts`** user-attachment mapping calls `part.mediaType.startsWith("image/")` while setting `contentType: part.mediaType ?? "unknown/unknown"` on the same object. A `file` part without `mediaType` throws on `.startsWith` even though the field is treated as optional below. The fallback is now computed once and reused for the image check, the inner `mimeType`, and `contentType`, so a degraded file reports `"unknown/unknown"` consistently rather than `""` in one place and `"unknown/unknown"` in another.

```ts
.map((part, idx) => {
  const mediaType = part.mediaType || "unknown/unknown";
  const isImage = mediaType.startsWith("image/");
  return {
    id: idx.toString(),
    type: isImage ? "image" : "file",
    name: part.filename ?? "file",
    content: [
      isImage
        ? { type: "image", image: part.url, filename: part.filename! }
        : { type: "file", filename: part.filename!, data: part.url, mimeType: mediaType },
    ],
    contentType: mediaType,
    status: { type: "complete" as const },
  };
});
```

## Why it is safe

No behavior change on spec-compliant messages: `mediaType` and `parts` are present in normal AI SDK output, so the guarded paths produce identical results. The change only affects malformed or partial payloads, which previously threw.

## Scope

Only the two throwing dereferences are touched. The `part.filename!` assertions stay as-is (`!` is type-only, it does not throw, and rewriting it would widen the diff). A third candidate, `toolOutputConversion.ts`'s `part.mediaType.startsWith`, is deliberately left alone: `mediaType` is a required `string` on the `file` variant of `ToolModelContentPart`, so a guard there would be the redundant defense AGENTS.md warns against.

## Tests

Added cases driving each converter with the offending shape and asserting no throw plus the expected degraded output:

- `injectInteractableContext.test.ts` — a user message with `parts` omitted still prepends the snapshot text.
- `injectQuoteContext.test.ts` (new file) — a quoted user message with `parts` omitted still prepends the blockquote, plus a happy-path case.
- `convertMessage.test.ts` — a user `file` part with no `mediaType` degrades to `type: "file"` with `contentType` and `mimeType` both `"unknown/unknown"`.

## Note

Independent of the AI SDK v7 work in #4646; this lands first and the v7 branches rebase onto the hardened converter region.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

