### PR TITLE
fix(react-ai-sdk): make default attachment adapter work without FileReader

### DIFF
--- a/.changeset/react-ai-sdk-attachment-no-filereader.md
+++ b/.changeset/react-ai-sdk-attachment-no-filereader.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: make the default attachment adapter work without FileReader (Node, react-ink, SSR)

--- a/packages/react-ai-sdk/src/ui/utils/vercelAttachmentAdapter.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/vercelAttachmentAdapter.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { vercelAttachmentAdapter } from "./vercelAttachmentAdapter";
+
+const originalFileReader = globalThis.FileReader;
+const originalBuffer = globalThis.Buffer;
+
+afterEach(() => {
+  globalThis.FileReader = originalFileReader;
+  globalThis.Buffer = originalBuffer;
+});
+
+const makeAttachment = (file: File) => ({
+  id: "1",
+  type: "file" as const,
+  name: file.name,
+  file,
+  contentType: file.type,
+  content: [],
+  status: {
+    type: "requires-action" as const,
+    reason: "composer-send" as const,
+  },
+});
+
+const sendFile = async (file: File) => {
+  const result = await vercelAttachmentAdapter.send(makeAttachment(file));
+  const part = result.content[0];
+  if (part?.type !== "file") throw new Error("expected file content part");
+  return part.data;
+};
+
+describe("vercelAttachmentAdapter", () => {
+  it("uses FileReader when available (browser/RN path unchanged)", async () => {
+    class FakeFileReader {
+      result: string | null = null;
+      onload: (() => void) | null = null;
+      onerror: ((error: unknown) => void) | null = null;
+      readAsDataURL(file: File) {
+        file
+          .arrayBuffer()
+          .then((buf) => {
+            const base64 = Buffer.from(buf).toString("base64");
+            this.result = `data:${file.type};base64,${base64}`;
+            this.onload?.();
+          })
+          .catch((error) => this.onerror?.(error));
+      }
+    }
+    globalThis.FileReader = FakeFileReader as unknown as typeof FileReader;
+
+    const file = new File(["hello"], "a.txt", { type: "text/plain" });
+    expect(await sendFile(file)).toBe(
+      `data:text/plain;base64,${Buffer.from("hello").toString("base64")}`,
+    );
+  });
+
+  it("falls back to Buffer when FileReader is absent (Node/react-ink)", async () => {
+    globalThis.FileReader = undefined as unknown as typeof FileReader;
+
+    const file = new File(["hello"], "a.txt", { type: "text/plain" });
+    expect(await sendFile(file)).toBe(
+      `data:text/plain;base64,${Buffer.from("hello").toString("base64")}`,
+    );
+  });
+
+  it("defaults to application/octet-stream when the file has no type", async () => {
+    globalThis.FileReader = undefined as unknown as typeof FileReader;
+
+    const file = new File(["hello"], "a.bin", { type: "" });
+    expect(await sendFile(file)).toBe(
+      `data:application/octet-stream;base64,${Buffer.from("hello").toString("base64")}`,
+    );
+  });
+
+  it("falls back to chunked btoa when neither FileReader nor Buffer exist", async () => {
+    globalThis.FileReader = undefined as unknown as typeof FileReader;
+    globalThis.Buffer = undefined as unknown as typeof Buffer;
+
+    const file = new File(["hello"], "a.txt", { type: "text/plain" });
+    const data = await sendFile(file);
+    expect(data).toBe(
+      `data:text/plain;base64,${originalBuffer.from("hello").toString("base64")}`,
+    );
+  });
+
+  it("encodes large inputs without RangeError on the btoa path", async () => {
+    globalThis.FileReader = undefined as unknown as typeof FileReader;
+    globalThis.Buffer = undefined as unknown as typeof Buffer;
+
+    const bytes = new Uint8Array(100_000);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = i % 256;
+    const file = new File([bytes], "big.bin", {
+      type: "application/octet-stream",
+    });
+
+    const data = await sendFile(file);
+    const expected = originalBuffer.from(bytes).toString("base64");
+    expect(data).toBe(`data:application/octet-stream;base64,${expected}`);
+  });
+});

--- a/packages/react-ai-sdk/src/ui/utils/vercelAttachmentAdapter.ts
+++ b/packages/react-ai-sdk/src/ui/utils/vercelAttachmentAdapter.ts
@@ -1,15 +1,34 @@
 import type { AttachmentAdapter } from "@assistant-ui/core";
 import { generateId } from "ai";
 
-const getFileDataURL = (file: File) =>
-  new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
+const bytesToBase64 = (bytes: Uint8Array): string => {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+};
 
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = (error) => reject(error);
+const getFileDataURL = async (file: File): Promise<string> => {
+  if (typeof FileReader !== "undefined") {
+    return new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
 
-    reader.readAsDataURL(file);
-  });
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = (error) => reject(error);
+
+      reader.readAsDataURL(file);
+    });
+  }
+
+  const buffer = await file.arrayBuffer();
+  const base64 =
+    typeof Buffer !== "undefined"
+      ? Buffer.from(buffer).toString("base64")
+      : bytesToBase64(new Uint8Array(buffer));
+  return `data:${file.type || "application/octet-stream"};base64,${base64}`;
+};
 
 export const vercelAttachmentAdapter: AttachmentAdapter = {
   accept: "*",


### PR DESCRIPTION
## What

Make the default attachment adapter (`vercelAttachmentAdapter`) build its data URL without depending on `FileReader`, so it works in Node, react-ink, and SSR.

## Why

`getFileDataURL` used `new FileReader()`, a browser-only API that is undefined in Node / react-ink / SSR, so sending an attachment there threw `ReferenceError`. This adapter is the default attachments adapter wired unconditionally in `useAISDKRuntime`, including the React Native entry, so the browser dependency leaked into non-browser runtimes. AGENTS.md calls for keeping browser-only APIs out of code paths that run in Node, react-ink, or React Native.

## How

Feature-detect `FileReader` and keep it as the primary path, so browser and React Native are byte-identical (they both provide `FileReader`). When it is absent, build the data URL from `await file.arrayBuffer()`: use Node's `Buffer` when present, otherwise a Buffer-free chunked `btoa` encoder. The chunking (`0x8000`-byte windows into `String.fromCharCode`) avoids the `RangeError` a naive spread hits on multi-MB attachments. Going Buffer-free for the last tier means the fix holds on edge SSR runtimes (Workers, Vercel Edge) that have neither `FileReader` nor `Buffer`, not just Node, while `btoa` is a universal global.

```ts
const bytesToBase64 = (bytes: Uint8Array): string => {
  let binary = "";
  const chunkSize = 0x8000;
  for (let i = 0; i < bytes.length; i += chunkSize) {
    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
  }
  return btoa(binary);
};

const getFileDataURL = async (file: File): Promise<string> => {
  if (typeof FileReader !== "undefined") {
    return new Promise<string>((resolve, reject) => {
      const reader = new FileReader();
      reader.onload = () => resolve(reader.result as string);
      reader.onerror = (error) => reject(error);
      reader.readAsDataURL(file);
    });
  }

  const buffer = await file.arrayBuffer();
  const base64 =
    typeof Buffer !== "undefined"
      ? Buffer.from(buffer).toString("base64")
      : bytesToBase64(new Uint8Array(buffer));
  return `data:${file.type || "application/octet-stream"};base64,${base64}`;
};
```

When the file has no MIME type the fallback emits `data:application/octet-stream;base64,...`. `FileReader` emits `data:;base64,...` in that rare case, so the tiers diverge on the empty-MIME edge; the concrete media type is the more useful contract for downstream providers, and the test asserts it so the divergence is intentional.

## Tests

Added `vercelAttachmentAdapter.test.ts` driving each tier by stubbing `globalThis.FileReader` / `globalThis.Buffer` (restored after each test): the `FileReader` happy path, the `Buffer` fallback, the `btoa` fallback, the `application/octet-stream` default for an empty MIME type, and a 100k-byte regression proving the chunked encoder does not throw `RangeError`. Each asserts `send` returns the correct `data:<mime>;base64,...` URL.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

