### PR TITLE
fix(react-ai-sdk): make default attachment adapter work without FileReader via shared core helper

### DIFF
--- a/.changeset/share-attachment-data-url.md
+++ b/.changeset/share-attachment-data-url.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: make the default attachment adapter work without FileReader (Node, react-ink, SSR) by sharing a single getFileDataURL from @assistant-ui/core/internal, whose base64 fallback chunks large inputs and works on runtimes without Buffer

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -733,6 +733,46 @@ type AppendMessage = Omit<ThreadMessage, "id"> & {
   steer?: boolean | undefined;
 };
 
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
+
+declare class SimpleImageAttachmentAdapter implements AttachmentAdapter {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(): Promise<void>;
+}
+
+declare const getFileDataURL: (file: File) => Promise<string>;
+
+declare class SimpleTextAttachmentAdapter implements AttachmentAdapter {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(): Promise<void>;
+}
+
+declare class CompositeAttachmentAdapter implements AttachmentAdapter {
+  private _adapters;
+  accept: string;
+  constructor(adapters: AttachmentAdapter[]);
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void, any>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(attachment: Attachment): Promise<void>;
+}
+
 type DataPrefixedPart = {
   readonly type: `data-${string}`;
   readonly data: any;
@@ -1688,44 +1728,6 @@ declare abstract class BaseAssistantRuntimeCore implements AssistantRuntimeCore 
   abstract get threads(): ThreadListRuntimeCore;
   registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
   getModelContextProvider(): ModelContextProvider;
-}
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-declare class SimpleImageAttachmentAdapter implements AttachmentAdapter {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(): Promise<void>;
-}
-
-declare class SimpleTextAttachmentAdapter implements AttachmentAdapter {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(): Promise<void>;
-}
-
-declare class CompositeAttachmentAdapter implements AttachmentAdapter {
-  private _adapters;
-  accept: string;
-  constructor(adapters: AttachmentAdapter[]);
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void, any>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(attachment: Attachment): Promise<void>;
 }
 
 declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implements ComposerRuntimeCore {
@@ -3163,7 +3165,7 @@ declare const getThreadData: (state: RemoteThreadState, threadIdOrRemoteId: stri
 declare const updateStatusReducer: (state: RemoteThreadState, threadIdOrRemoteId: string, newStatus: "archived" | "deleted" | "regular") => RemoteThreadState;
 
 declare namespace entry_internal_exports {
-  export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, RuntimeExtras, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, createRuntimeExtras, createThreadMappingId, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, isAutoStatus, isErrorMessageId, resolveToolApprovalResponse, shouldContinue, symbolInnerMessage, updateStatusReducer };
+  export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, RuntimeExtras, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, createRuntimeExtras, createThreadMappingId, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, isAutoStatus, isErrorMessageId, resolveToolApprovalResponse, shouldContinue, symbolInnerMessage, updateStatusReducer };
 }
 
 type ThreadListItemState = {

--- a/packages/core/src/adapters/attachment.test.ts
+++ b/packages/core/src/adapters/attachment.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getFileDataURL, SimpleImageAttachmentAdapter } from "./attachment";
+
+const originalFileReader = globalThis.FileReader;
+const originalBuffer = globalThis.Buffer;
+
+afterEach(() => {
+  globalThis.FileReader = originalFileReader;
+  globalThis.Buffer = originalBuffer;
+});
+
+describe("getFileDataURL", () => {
+  it("uses FileReader when available", async () => {
+    class FakeFileReader {
+      result: string | null = null;
+      onload: (() => void) | null = null;
+      onerror: ((error: unknown) => void) | null = null;
+      readAsDataURL(file: File) {
+        file
+          .arrayBuffer()
+          .then((buf) => {
+            this.result = `data:${file.type};base64,${originalBuffer.from(buf).toString("base64")}`;
+            this.onload?.();
+          })
+          .catch((error) => this.onerror?.(error));
+      }
+    }
+    globalThis.FileReader = FakeFileReader as unknown as typeof FileReader;
+
+    const file = new File(["hello"], "a.txt", { type: "text/plain" });
+    expect(await getFileDataURL(file)).toBe(
+      `data:text/plain;base64,${originalBuffer.from("hello").toString("base64")}`,
+    );
+  });
+
+  it("falls back to Buffer when FileReader is absent", async () => {
+    globalThis.FileReader = undefined as unknown as typeof FileReader;
+
+    const file = new File(["hello"], "a.txt", { type: "text/plain" });
+    expect(await getFileDataURL(file)).toBe(
+      `data:text/plain;base64,${originalBuffer.from("hello").toString("base64")}`,
+    );
+  });
+
+  it("defaults to application/octet-stream when the file has no type", async () => {
+    globalThis.FileReader = undefined as unknown as typeof FileReader;
+
+    const file = new File(["hello"], "a.bin", { type: "" });
+    expect(await getFileDataURL(file)).toBe(
+      `data:application/octet-stream;base64,${originalBuffer.from("hello").toString("base64")}`,
+    );
+  });
+
+  it("falls back to chunked btoa when neither FileReader nor Buffer exist", async () => {
+    globalThis.FileReader = undefined as unknown as typeof FileReader;
+    globalThis.Buffer = undefined as unknown as typeof Buffer;
+
+    const file = new File(["hello"], "a.txt", { type: "text/plain" });
+    expect(await getFileDataURL(file)).toBe(
+      `data:text/plain;base64,${originalBuffer.from("hello").toString("base64")}`,
+    );
+  });
+
+  it("encodes large inputs without RangeError on the btoa path", async () => {
+    globalThis.FileReader = undefined as unknown as typeof FileReader;
+    globalThis.Buffer = undefined as unknown as typeof Buffer;
+
+    const bytes = new Uint8Array(100_000);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = i % 256;
+    const file = new File([bytes], "big.bin", {
+      type: "application/octet-stream",
+    });
+
+    expect(await getFileDataURL(file)).toBe(
+      `data:application/octet-stream;base64,${originalBuffer.from(bytes).toString("base64")}`,
+    );
+  });
+});
+
+describe("SimpleImageAttachmentAdapter", () => {
+  it("sends an image as a data URL", async () => {
+    globalThis.FileReader = undefined as unknown as typeof FileReader;
+
+    const file = new File(["img"], "a.png", { type: "image/png" });
+    const adapter = new SimpleImageAttachmentAdapter();
+    const result = await adapter.send(await adapter.add({ file }));
+    const part = result.content[0];
+    if (part?.type !== "image") throw new Error("expected image content part");
+    expect(part.image).toBe(
+      `data:image/png;base64,${originalBuffer.from("img").toString("base64")}`,
+    );
+  });
+});

--- a/packages/core/src/adapters/attachment.ts
+++ b/packages/core/src/adapters/attachment.ts
@@ -49,21 +49,31 @@ export class SimpleImageAttachmentAdapter implements AttachmentAdapter {
   }
 }
 
-const bytesToBase64 = (bytes: Uint8Array): string =>
-  (
+const bytesToBase64 = (bytes: Uint8Array): string => {
+  const nodeBuffer = (
     globalThis as {
-      Buffer: {
+      Buffer?: {
         from(bytes: Uint8Array): { toString(encoding: string): string };
       };
     }
-  ).Buffer.from(bytes).toString("base64");
+  ).Buffer;
+  if (nodeBuffer) {
+    return nodeBuffer.from(bytes).toString("base64");
+  }
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+};
 
 // React Native's Blob polyfill has FileReader but not file.text()/arrayBuffer(); Node has
 // the reverse. Prefer FileReader when present, falling back to the Blob methods otherwise.
-const getFileDataURL = async (file: File): Promise<string> => {
+export const getFileDataURL = async (file: File): Promise<string> => {
   if (typeof FileReader === "undefined") {
     const buffer = await file.arrayBuffer();
-    return `data:${file.type};base64,${bytesToBase64(new Uint8Array(buffer))}`;
+    return `data:${file.type || "application/octet-stream"};base64,${bytesToBase64(new Uint8Array(buffer))}`;
   }
   return new Promise<string>((resolve, reject) => {
     const reader = new FileReader();

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -37,6 +37,10 @@ export { resolveToolApprovalResponse } from "./runtime/utils/resolveToolApproval
 // Composite context provider
 export { CompositeContextProvider } from "./utils/composite-context-provider";
 
+// Shared attachment data-URL encoder, reused by framework adapters so the
+// FileReader fallback lives in one place.
+export { getFileDataURL } from "./adapters/attachment";
+
 // Runtime extras helper for external-store adapters. Internal because the
 // tap-native runtime path replaces the `thread.extras` side-channel it wraps.
 export {

--- a/packages/react-ai-sdk/src/ui/utils/vercelAttachmentAdapter.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/vercelAttachmentAdapter.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { vercelAttachmentAdapter } from "./vercelAttachmentAdapter";
+
+const originalFileReader = globalThis.FileReader;
+
+afterEach(() => {
+  globalThis.FileReader = originalFileReader;
+});
+
+describe("vercelAttachmentAdapter", () => {
+  it("sends a file as a data URL via the shared core encoder", async () => {
+    globalThis.FileReader = undefined as unknown as typeof FileReader;
+
+    const file = new File(["hello"], "a.txt", { type: "text/plain" });
+    const result = await vercelAttachmentAdapter.send({
+      id: "1",
+      type: "file",
+      name: file.name,
+      file,
+      contentType: file.type,
+      content: [],
+      status: { type: "requires-action", reason: "composer-send" },
+    });
+
+    const part = result.content[0];
+    if (part?.type !== "file") throw new Error("expected file content part");
+    expect(part.data).toBe(
+      `data:text/plain;base64,${Buffer.from("hello").toString("base64")}`,
+    );
+  });
+});

--- a/packages/react-ai-sdk/src/ui/utils/vercelAttachmentAdapter.ts
+++ b/packages/react-ai-sdk/src/ui/utils/vercelAttachmentAdapter.ts
@@ -1,15 +1,6 @@
 import type { AttachmentAdapter } from "@assistant-ui/core";
+import { getFileDataURL } from "@assistant-ui/core/internal";
 import { generateId } from "ai";
-
-const getFileDataURL = (file: File) =>
-  new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = (error) => reject(error);
-
-    reader.readAsDataURL(file);
-  });
 
 export const vercelAttachmentAdapter: AttachmentAdapter = {
   accept: "*",


### PR DESCRIPTION
Supersedes #4649. That PR fixed the same `FileReader` bug by patching react-ai-sdk's own copy of the encoder; this one instead reuses core's existing helper and deletes the duplicate, so it fixes the bug and removes the duplication in one change.

## What

`vercelAttachmentAdapter` built its data URL with `new FileReader()`, a browser-only API that is undefined in Node / react-ink / SSR, so sending an attachment there threw `ReferenceError`. It's the default attachments adapter wired unconditionally in `useAISDKRuntime` (including the React Native entry), so the browser dependency leaked into non-browser runtimes.

## How

`@assistant-ui/core` already solved this in `adapters/attachment.ts` (`getFileDataURL`, used by `SimpleImageAttachmentAdapter`), so rather than fix a second copy this exports that helper from `@assistant-ui/core/internal` and has `vercelAttachmentAdapter` consume it.

The shared fallback is hardened so every adapter benefits: it prefers `Buffer` when present and otherwise base64-encodes in `0x8000`-byte windows through `btoa` (a universal global). That fixes core's own gaps, its old fallback assumed `Buffer` exists and threw on bufferless edge runtimes (Workers, Vercel Edge), and an empty MIME type now defaults to `application/octet-stream`. The `FileReader` path stays primary, so browser and React Native stay byte-identical.

## Tests

`core/src/adapters/attachment.test.ts` covers each tier (FileReader, Buffer, chunked `btoa`), the octet-stream default, a 100k-byte regression for the chunked path, and a `SimpleImageAttachmentAdapter.send` case. react-ai-sdk gets a delegation test asserting `send` returns the correct data URL through the shared encoder.

`patch` changeset for both `@assistant-ui/core` and `@assistant-ui/react-ai-sdk`. The empty-MIME default is a small, deliberate behavior change to core.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

