### PR TITLE
refactor(react-ai-sdk): use addToolOutput instead of deprecated addToolResult

### DIFF
--- a/.changeset/react-ai-sdk-add-tool-output.md
+++ b/.changeset/react-ai-sdk-add-tool-output.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+refactor: use addToolOutput instead of the deprecated addToolResult for tool results

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
@@ -203,6 +203,52 @@ describe("useAISDKRuntime", () => {
     ).resolves.toBeDefined();
   });
 
+  it("forwards a successful tool result through addToolOutput, not the deprecated addToolResult", async () => {
+    const chat = createChatHelpers([
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-weather",
+            toolCallId: "tc-1",
+            state: "input-available",
+            input: { city: "NYC" },
+          },
+        ],
+      },
+    ]);
+
+    const { result } = renderHook(() => useAISDKRuntime(chat));
+
+    await waitFor(() => {
+      expect(result.current.thread.getState().messages.length).toBeGreaterThan(
+        0,
+      );
+    });
+
+    act(() => {
+      result.current.thread
+        .getMessageById("a1")
+        .getMessagePartByToolCallId("tc-1")
+        .addToolResult({ temp: 72 });
+    });
+
+    await waitFor(() => {
+      expect(chat.addToolOutput).toHaveBeenCalledTimes(1);
+    });
+
+    expect(chat.addToolOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool: "weather",
+        toolCallId: "tc-1",
+        output: { temp: 72 },
+        options: { metadata: undefined },
+      }),
+    );
+    expect(chat.addToolResult).not.toHaveBeenCalled();
+  });
+
   it("appends a new user message without sending when startRun is false", async () => {
     const chat = createChatHelpers([
       { id: "u1", role: "user", parts: [{ type: "text", text: "earlier" }] },

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -362,7 +362,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
           modelContent !== undefined
             ? wrapModelContentEnvelope(result, modelContent)
             : result;
-        chatHelpers.addToolResult({
+        chatHelpers.addToolOutput({
           tool: toolName,
           toolCallId,
           output,


### PR DESCRIPTION
## What

Switch the success branch of `onAddToolResult` from the deprecated `addToolResult` to `addToolOutput` in `useAISDKRuntime`.

## Why

The AI SDK marks `addToolResult` as `@deprecated Use addToolOutput`. The error branch of the same callback already uses `addToolOutput` (`{ state: "output-error", … }`), so the success branch calling `addToolResult` was the only remaining use of the deprecated method, and an inconsistency between the two branches.

## How

`addToolOutput`'s success variant takes the same shape and defaults `state` to `output-available`, so the call moves over with identical arguments and no behavior change: a successful tool result still lands as `output-available` with the same output payload and run-config options.

## Tests

Adds a success-path test that drives the real runtime: it seeds an assistant message with a tool call in `input-available`, dispatches the result through the public part API, and asserts `addToolOutput` is invoked with the expected `{ tool, toolCallId, output }` and run-config options, while the deprecated `addToolResult` is not called.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

