### PR TITLE
fix: generative ui action warnings

### DIFF
--- a/.changeset/fuzzy-action-warnings.md
+++ b/.changeset/fuzzy-action-warnings.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: clarify unknown generative UI action warnings

--- a/packages/react-generative-ui/src/actionRegistry.test.ts
+++ b/packages/react-generative-ui/src/actionRegistry.test.ts
@@ -29,10 +29,15 @@ describe("createActionRegistry", () => {
   it("dispatch is a no-op (returns undefined) for an unknown action type", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
-      const registry = createActionRegistry({ known: () => undefined });
+      const registry = createActionRegistry({
+        purchase: () => undefined,
+        refund: () => undefined,
+      });
       expect(registry.dispatch({ type: "unknown" })).toBeUndefined();
       expect(warn).toHaveBeenCalledTimes(1);
-      expect(warn.mock.calls[0]![0]).toContain('"unknown"');
+      expect(warn).toHaveBeenCalledWith(
+        '[@assistant-ui/react-generative-ui] Action "unknown" has no registered handler. Registered actions: "purchase", "refund". Register it with createActionRegistry(...) or update the emitted `$action.type`.',
+      );
     } finally {
       warn.mockRestore();
     }
@@ -53,6 +58,9 @@ describe("emptyActionRegistry", () => {
         emptyActionRegistry.dispatch({ type: "anything" }),
       ).toBeUndefined();
       expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        '[@assistant-ui/react-generative-ui] Action "anything" has no registered handler. No actions are registered. Register it with createActionRegistry(...) or update the emitted `$action.type`.',
+      );
     } finally {
       warn.mockRestore();
     }

--- a/packages/react-generative-ui/src/actionRegistry.ts
+++ b/packages/react-generative-ui/src/actionRegistry.ts
@@ -44,11 +44,13 @@ export function createActionRegistry(
       const handler = map.get(action.type);
       if (!handler) {
         if (process.env["NODE_ENV"] !== "production") {
+          const actionTypes = [...map.keys()];
           // eslint-disable-next-line no-console
           console.warn(
-            `[@assistant-ui/react-generative-ui] No handler registered for ` +
-              `action type "${action.type}". Available: ` +
-              `${[...map.keys()].join(", ") || "(none)"}.`,
+            `[@assistant-ui/react-generative-ui] Action "${action.type}" has ` +
+              `no registered handler. ${formatRegisteredActions(actionTypes)} ` +
+              "Register it with createActionRegistry(...) or update the emitted " +
+              "`$action.type`.",
           );
         }
         return undefined;
@@ -65,3 +67,11 @@ export function createActionRegistry(
  * `undefined` and logs a warning in dev for unknown types, so a model-emitted
  * action with no handler degrades to "does nothing" rather than throwing. */
 export const emptyActionRegistry: ActionRegistry = createActionRegistry({});
+
+function formatRegisteredActions(actionTypes: string[]) {
+  if (actionTypes.length === 0) return "No actions are registered.";
+
+  return `Registered actions: ${actionTypes
+    .map((type) => `"${type}"`)
+    .join(", ")}.`;
+}


### PR DESCRIPTION
## Summary

- Make unknown `$action.type` warnings name the missing action directly.
- Show the registered action types, or say when no actions are registered.
- Add focused tests for both registered-action and empty-registry warnings, plus a patch changeset.

## Why

When a generative UI component fires an action that the host app did not register, the old warning said a handler was missing but did not give a clear fix path. The new warning keeps the non-throwing behavior while making it easier to spot a typo, a missing `createActionRegistry(...)` entry, or a model-emitted `$action.type` mismatch.

## Validation

- `pnpm --filter @assistant-ui/react-generative-ui test`
- `pnpm --filter @assistant-ui/react-generative-ui build`
- `pnpm exec oxfmt --check packages/react-generative-ui/src/actionRegistry.ts packages/react-generative-ui/src/actionRegistry.test.ts .changeset/fuzzy-action-warnings.md`
- `git diff --check`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

