### PR TITLE
fix: skip malformed generative ui component nodes

### DIFF
--- a/.changeset/malformed-generative-ui-component.md
+++ b/.changeset/malformed-generative-ui-component.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: skip malformed generative UI component nodes

--- a/packages/core/src/react/primitives/generativeUI/GenerativeUI.tsx
+++ b/packages/core/src/react/primitives/generativeUI/GenerativeUI.tsx
@@ -51,7 +51,11 @@ const renderNode = (
 
   if (typeof node === "string") return node;
 
-  if (!isObjectNode(node) || !("component" in node)) {
+  if (
+    !isObjectNode(node) ||
+    !("component" in node) ||
+    typeof node.component !== "string"
+  ) {
     if (
       typeof process !== "undefined" &&
       process.env?.NODE_ENV !== "production"

--- a/packages/react/src/tests/generative-ui.test.tsx
+++ b/packages/react/src/tests/generative-ui.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
   GenerativeUIRender,
@@ -111,6 +111,26 @@ describe("MessagePrimitive.GenerativeUI (same-realm renderer)", () => {
       />,
     );
     expect(out2).toContain("<h3>loading</h3>");
+  });
+
+  it("skips malformed nodes with non-string component names", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const malformedNode = { component: 123, props: { title: "bad" } };
+    const spec = { root: malformedNode } as unknown as GenerativeUISpec;
+
+    try {
+      const out = renderToStaticMarkup(
+        <GenerativeUIRender spec={spec} components={{ Card }} />,
+      );
+
+      expect(out).toBe("");
+      expect(warn).toHaveBeenCalledWith(
+        "[generative-ui] Skipping malformed node at 0:",
+        malformedNode,
+      );
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("respects user-provided keys", () => {


### PR DESCRIPTION
## Summary

- Treat generative-ui spec nodes with a non-string `component` value as malformed input.
- Keep valid string component names that miss the allowlist throwing `GenerativeUIRenderError`.
- Add regression coverage for malformed backend/model output such as `component: 123`, plus a patch changeset for `@assistant-ui/core`.

## Why

While testing backend-generated generative-ui specs, it is possible to receive malformed model output where `component` exists but is not a string. That shape is not a valid component name, so it should follow the existing malformed-node path instead of being treated as an allowlist violation.

This preserves the security behavior for real component names like `"NotAllowed"`, while making invalid JSON shapes render nothing with the existing dev warning.

## Validation

- `pnpm --filter @assistant-ui/core build`
- `pnpm --filter @assistant-ui/react exec vitest run src/tests/generative-ui.test.tsx`
- `pnpm exec oxfmt --check packages/core/src/react/primitives/generativeUI/GenerativeUI.tsx packages/react/src/tests/generative-ui.test.tsx .changeset/malformed-generative-ui-component.md`
- `git diff --check`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

