### PR TITLE
fix: skip malformed generative ui action types

### DIFF
--- a/.changeset/malformed-action-type.md
+++ b/.changeset/malformed-action-type.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: skip malformed generative UI action types

--- a/packages/react-generative-ui/src/actionRegistry.test.ts
+++ b/packages/react-generative-ui/src/actionRegistry.test.ts
@@ -43,6 +43,24 @@ describe("createActionRegistry", () => {
     }
   });
 
+  it("dispatch is a no-op for malformed non-string action types", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const handler = vi.fn();
+      const registry = createActionRegistry({ purchase: handler });
+
+      expect(registry.dispatch({ type: 123 } as never)).toBeUndefined();
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        "[@assistant-ui/react-generative-ui] Skipping malformed action; `$action.type` must be a string. Received number. Update the emitted `$action` payload.",
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("has reports whether a handler is registered", () => {
     const registry = createActionRegistry({ a: () => undefined });
     expect(registry.has("a")).toBe(true);

--- a/packages/react-generative-ui/src/actionRegistry.ts
+++ b/packages/react-generative-ui/src/actionRegistry.ts
@@ -41,6 +41,19 @@ export function createActionRegistry(
   const map = new Map(Object.entries(handlers));
   return {
     dispatch(action) {
+      if (typeof action?.type !== "string") {
+        if (process.env["NODE_ENV"] !== "production") {
+          // eslint-disable-next-line no-console
+          console.warn(
+            "[@assistant-ui/react-generative-ui] Skipping malformed action; " +
+              "`$action.type` must be a string. " +
+              `Received ${formatReceivedType(action?.type)}. Update the emitted ` +
+              "`$action` payload.",
+          );
+        }
+        return undefined;
+      }
+
       const handler = map.get(action.type);
       if (!handler) {
         if (process.env["NODE_ENV"] !== "production") {
@@ -74,4 +87,10 @@ function formatRegisteredActions(actionTypes: string[]) {
   return `Registered actions: ${actionTypes
     .map((type) => `"${type}"`)
     .join(", ")}.`;
+}
+
+function formatReceivedType(value: unknown) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
 }


### PR DESCRIPTION
## Summary

- guard ActionRegistry dispatch when `$action.type` is not a string
- emit a clear malformed-action warning instead of the unknown-action warning for invalid payload shape
- add regression coverage for `$action: { type: 123 }` plus a patch changeset

## Why

While testing locally with backend/model-generated generative UI action payloads, malformed output can include a non-string action type, for example:

```ts
$action: { type: 123 }
```

Before this change, ActionRegistry treated that payload like an unknown action name and reported a misleading missing-handler warning. A non-string `type` is malformed action data, so dispatch now skips it with a warning that points at the payload shape.

## Testing

- `pnpm --filter @assistant-ui/react-generative-ui test`
- `pnpm --filter @assistant-ui/react-generative-ui build`
- `pnpm exec oxfmt --check packages/react-generative-ui/src/actionRegistry.ts packages/react-generative-ui/src/actionRegistry.test.ts .changeset/malformed-action-type.md`
- `git diff --check`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

