### PR TITLE
fix: retain model-provided keys during rendering

### DIFF
--- a/.changeset/generative-ui-stable-keys.md
+++ b/.changeset/generative-ui-stable-keys.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: honor stable generative UI item keys

--- a/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
+++ b/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
+import { isValidElement, type ReactElement } from "react";
 import { parsePartialJsonObject } from "assistant-stream/utils";
 import { z } from "zod";
 import { renderGenerativeUI } from "./renderGenerativeUI";
@@ -63,6 +64,26 @@ describe("renderGenerativeUI", () => {
     expect(html).toBe(
       '<section data-title="Hello"><p>first</p><p data-tone="muted">second</p></section>',
     );
+  });
+
+  it("uses stable $key for array items and keeps the positional fallback", () => {
+    const out = renderGenerativeUI(
+      [
+        { $type: "Text", $key: "task-1", children: "first" },
+        { $type: "Text", children: "second" },
+        "plain",
+      ],
+      library,
+    );
+
+    expect(Array.isArray(out)).toBe(true);
+    const elements = out as ReactElement[];
+    expect(elements.every(isValidElement)).toBe(true);
+    expect(elements.map((element) => element.key)).toEqual([
+      "task-1",
+      "1:Text",
+      "2:#text",
+    ]);
   });
 
   it("passes a component's own `type` prop through without collision", () => {

--- a/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
+++ b/packages/react-generative-ui/src/renderGenerativeUI.test.tsx
@@ -69,9 +69,10 @@ describe("renderGenerativeUI", () => {
   it("uses stable $key for array items and keeps the positional fallback", () => {
     const out = renderGenerativeUI(
       [
-        { $type: "Text", $key: "task-1", children: "first" },
+        { $type: "Text", $key: "1:Text", children: "first" },
         { $type: "Text", children: "second" },
         "plain",
+        { $type: "Text", $key: { id: "bad" }, children: "bad key" },
       ],
       library,
     );
@@ -80,9 +81,10 @@ describe("renderGenerativeUI", () => {
     const elements = out as ReactElement[];
     expect(elements.every(isValidElement)).toBe(true);
     expect(elements.map((element) => element.key)).toEqual([
-      "task-1",
+      "model:1:Text",
       "1:Text",
       "2:#text",
+      "3:Text",
     ]);
   });
 

--- a/packages/react-generative-ui/src/renderGenerativeUI.tsx
+++ b/packages/react-generative-ui/src/renderGenerativeUI.tsx
@@ -43,13 +43,12 @@ function renderNode(
   if (node == null || typeof node === "boolean") return null;
   if (typeof node === "string" || typeof node === "number") return node;
   if (Array.isArray(node)) {
-    // The wire format has no per-node id, so the key is positional. Pairing the
-    // index with the node's kind means that when the model splices or reorders
-    // `children` and the kind at an index changes, the key changes and React
-    // remounts instead of handing a streaming node's hook state to a different
-    // component.
+    // Use a model-provided stable key when present. Otherwise, keep the
+    // positional fallback: pairing the index with the node's kind means that
+    // when the kind at an index changes, React remounts instead of handing a
+    // streaming node's hook state to a different component.
     return node.map((child, index) => (
-      <Fragment key={`${index}:${nodeKind(child)}`}>
+      <Fragment key={nodeKey(child, index)}>
         {renderNode(child, library, context)}
       </Fragment>
     ));
@@ -116,6 +115,13 @@ function nodeKind(node: NormalizedUINode): string {
   if (Array.isArray(node)) return "#array";
   return isElement(node) ? node.type : "";
 }
+
+function nodeKey(node: NormalizedUINode, index: number): string | number {
+  return isElement(node) && node.key !== undefined
+    ? node.key
+    : `${index}:${nodeKind(node)}`;
+}
+
 function reportUnknownComponent(type: string, available: string[]): void {
   if (process.env["NODE_ENV"] !== "production") {
     // eslint-disable-next-line no-console

--- a/packages/react-generative-ui/src/renderGenerativeUI.tsx
+++ b/packages/react-generative-ui/src/renderGenerativeUI.tsx
@@ -116,9 +116,10 @@ function nodeKind(node: NormalizedUINode): string {
   return isElement(node) ? node.type : "";
 }
 
-function nodeKey(node: NormalizedUINode, index: number): string | number {
-  return isElement(node) && node.key !== undefined
-    ? node.key
+function nodeKey(node: NormalizedUINode, index: number): string {
+  return isElement(node) &&
+    (typeof node.key === "string" || typeof node.key === "number")
+    ? `model:${node.key}`
     : `${index}:${nodeKind(node)}`;
 }
 


### PR DESCRIPTION
## Summary

- use normalized `$key` values as React Fragment keys when rendering generative UI arrays
- keep the existing `index:type` fallback for unkeyed elements and primitive children
- add regression coverage for both the stable-key path and fallback behavior
- add a patch changeset for `@assistant-ui/react-generative-ui`

## Why

The generative UI IR already preserves model-provided stable keys as `element.key`, but the React renderer always keyed array items by position and node kind. That meant generated UI could emit stable identities like `$key: "task-1"`, yet React would still reconcile the item by array index.

This matters when model-generated lists reorder or stream updates over time: a stable key should let React keep state with the actual generated item instead of the position it happened to occupy.

## Root cause

`normalizeUINode` carried `$key` into the normalized element, but `renderNode` ignored that field while mapping arrays and always used `${index}:${nodeKind(child)}`.

## Behavior compatibility

Unkeyed nodes keep the previous fallback key format. The new test asserts both `$key` usage and fallback keys (`1:Text`, `2:#text`) so existing behavior stays covered.

## Testing

- `pnpm --filter @assistant-ui/react-generative-ui test`
- `pnpm --filter @assistant-ui/react-generative-ui build`
- `pnpm exec oxfmt --check packages/react-generative-ui/src/renderGenerativeUI.tsx packages/react-generative-ui/src/renderGenerativeUI.test.tsx .changeset/generative-ui-stable-keys.md`
- `git diff --check`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

