### PR TITLE
feat: add mcp tool name collision validation

### DIFF
--- a/.changeset/react-ai-sdk-mcp-tool-collisions.md
+++ b/.changeset/react-ai-sdk-mcp-tool-collisions.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: detect MCP tool name collisions with toolkit tools

--- a/packages/react-ai-sdk/src/generativeTools.test.ts
+++ b/packages/react-ai-sdk/src/generativeTools.test.ts
@@ -272,6 +272,87 @@ describe("AISDKToolkit", () => {
     );
   });
 
+  it("rejects MCP tool names that collide with toolkit tools", async () => {
+    mocks.tools.mockResolvedValue({ search: { inputSchema: {} } });
+    mocks.createMCPClient.mockResolvedValue({
+      tools: mocks.tools,
+      close: mocks.close,
+    });
+
+    const toolkit = new AISDKToolkit({
+      toolkit: {
+        docs: {
+          type: "mcp",
+          server: { type: "http", url: "http://localhost:3001/mcp" },
+        },
+        search: {
+          type: "backend",
+          parameters: { type: "object", properties: {} },
+          execute: async () => "local search",
+        } as never,
+      },
+    });
+
+    await expect(toolkit.tools()).rejects.toThrow(
+      'MCP tool "search" from "docs" conflicts with toolkit tool "search"',
+    );
+  });
+
+  it("rejects MCP tool names that collide with provider tools", async () => {
+    mocks.tools.mockResolvedValue({ web_search: { inputSchema: {} } });
+    mocks.createMCPClient.mockResolvedValue({
+      tools: mocks.tools,
+      close: mocks.close,
+    });
+
+    const toolkit = new AISDKToolkit({
+      toolkit: {
+        docs: {
+          type: "mcp",
+          server: { type: "http", url: "http://localhost:3001/mcp" },
+        },
+        web_search: {
+          type: "provider",
+          providerId: "openai.web_search_preview",
+          args: { searchContextSize: "low" },
+        },
+      },
+    });
+
+    await expect(toolkit.tools()).rejects.toThrow(
+      'MCP tool "web_search" from "docs" conflicts with provider tool "web_search"',
+    );
+  });
+
+  it("rejects MCP tool names that collide with uploaded frontend tools", async () => {
+    mocks.tools.mockResolvedValue({ clientTool: { inputSchema: {} } });
+    mocks.createMCPClient.mockResolvedValue({
+      tools: mocks.tools,
+      close: mocks.close,
+    });
+
+    const toolkit = new AISDKToolkit({
+      toolkit: {
+        docs: {
+          type: "mcp",
+          server: { type: "http", url: "http://localhost:3001/mcp" },
+        },
+      },
+    });
+
+    await expect(
+      toolkit.tools({
+        frontend: {
+          clientTool: {
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      'MCP tool "clientTool" from "docs" conflicts with frontend tool "clientTool"',
+    );
+  });
+
   it("includes provider tools alongside MCP tools", async () => {
     mocks.tools.mockResolvedValue({ echo: { inputSchema: {} } });
     mocks.createMCPClient.mockResolvedValue({

--- a/packages/react-ai-sdk/src/generativeTools.ts
+++ b/packages/react-ai-sdk/src/generativeTools.ts
@@ -114,11 +114,24 @@ export class AISDKToolkit {
   }
 
   async tools(options: AISDKToolkitToolsOptions = {}): Promise<ToolSet> {
+    const frontendToolSet = options.frontend
+      ? frontendTools(options.frontend)
+      : {};
+    const mcpToolSet = await this.#mcpTools();
+    const providerToolSet = toProviderToolSet(this.#toolkit);
+    const serverToolSet = toServerToolSet(this.#toolkit as ToolkitDefinition);
+
+    assertNoMcpToolNameCollisions(mcpToolSet, [
+      { source: "frontend", tools: frontendToolSet },
+      { source: "provider", tools: providerToolSet },
+      { source: "toolkit", tools: serverToolSet },
+    ]);
+
     return {
-      ...(options.frontend ? frontendTools(options.frontend) : {}),
-      ...(await this.#mcpTools()),
-      ...toProviderToolSet(this.#toolkit),
-      ...toServerToolSet(this.#toolkit as ToolkitDefinition),
+      ...frontendToolSet,
+      ...mcpToolSet.tools,
+      ...providerToolSet,
+      ...serverToolSet,
     };
   }
 
@@ -149,7 +162,7 @@ export class AISDKToolkit {
     }
   }
 
-  async #mcpTools(): Promise<ToolSet> {
+  async #mcpTools(): Promise<McpToolSet> {
     const toolSets = await Promise.all(
       Object.entries(this.#toolkit)
         .filter((entry): entry is [string, McpToolkitTool] =>
@@ -175,7 +188,7 @@ export class AISDKToolkit {
         tools[toolName] = tool;
       }
     }
-    return tools;
+    return { tools, sources: toolSources };
   }
 
   #mcpClient(name: string, config: McpServerConfig): Promise<MCPClient> {
@@ -220,6 +233,25 @@ type ToolkitTool = Toolkit[string];
 type McpToolkitTool = ToolkitTool & {
   type: "mcp";
   server: McpServerConfig;
+};
+
+type McpToolSet = {
+  tools: ToolSet;
+  sources: Map<string, string>;
+};
+
+const assertNoMcpToolNameCollisions = (
+  mcp: McpToolSet,
+  toolSets: readonly { source: string; tools: ToolSet }[],
+): void => {
+  for (const [toolName, serverName] of mcp.sources) {
+    for (const { source, tools } of toolSets) {
+      if (!Object.prototype.hasOwnProperty.call(tools, toolName)) continue;
+      throw new Error(
+        `MCP tool "${toolName}" from "${serverName}" conflicts with ${source} tool "${toolName}". Rename one of the tools so each model-visible tool name is unique.`,
+      );
+    }
+  }
 };
 
 const isMcpToolkitTool = (tool: ToolkitTool): tool is McpToolkitTool =>


### PR DESCRIPTION
## Summary

Detect mixed MCP tool name collisions in `AISDKToolkit.tools()` before returning the final AI SDK `ToolSet`.

MCP-vs-MCP duplicate names already threw a clear error, but MCP tools could still collide with uploaded frontend tools, provider tools, or local toolkit tools. Because the final tool set is assembled with object spreads, one side of the collision could silently overwrite the other.

## What Changed

- Keep MCP tool source metadata after loading server tools.
- Throw a clear error when an MCP tool name conflicts with a frontend, provider, or toolkit tool name.
- Add regression coverage for MCP collisions with toolkit, provider, and uploaded frontend tools.
- Add a patch changeset for `@assistant-ui/react-ai-sdk`.

## Validation

- `pnpm --filter @assistant-ui/react-ai-sdk test -- generativeTools.test.ts`
- `pnpm exec oxlint packages/react-ai-sdk/src/generativeTools.ts packages/react-ai-sdk/src/generativeTools.test.ts`
- `pnpm --filter @assistant-ui/react-ai-sdk build`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

