### PR TITLE
feat(react-ink): add stageable DiffView (hunk include/exclude)

### DIFF
--- a/.changeset/stageable-diff-view.md
+++ b/.changeset/stageable-diff-view.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+feat: add stageable DiffView (hunk include/exclude)

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -2973,6 +2973,20 @@ type SpeechSynthesisAdapter = {
   speak: (text: string) => SpeechSynthesisAdapter.Utterance;
 };
 
+declare const StageableDiffView: (_param48: StageableDiffViewProps) => import("react").JSX.Element;
+
+type StageableDiffViewProps = DiffViewProps & {
+  onStageChange?: ((staged: StagedSelection) => void) | undefined;
+  isActive?: boolean | undefined;
+};
+
+type StagedSelection = {
+  stagedHunks: ReadonlyArray<{
+    fileIndex: number;
+    hunkIndex: number;
+  }>;
+};
+
 type StartRunConfig = {
   parentId: string | null;
   sourceId: string | null;
@@ -2988,7 +3002,7 @@ declare namespace StatusBarPrimitiveLatency {
 }
 
 declare const StatusBarPrimitiveLatency: {
-  (_param48: StatusBarPrimitiveLatency.Props): import("react").JSX.Element | null;
+  (_param49: StatusBarPrimitiveLatency.Props): import("react").JSX.Element | null;
   displayName: string;
 };
 
@@ -3001,7 +3015,7 @@ declare namespace StatusBarPrimitiveMessageCount {
 }
 
 declare const StatusBarPrimitiveMessageCount: {
-  (_param49: StatusBarPrimitiveMessageCount.Props): import("react").JSX.Element | null;
+  (_param50: StatusBarPrimitiveMessageCount.Props): import("react").JSX.Element | null;
   displayName: string;
 };
 
@@ -3014,7 +3028,7 @@ declare namespace StatusBarPrimitiveModelName {
 }
 
 declare const StatusBarPrimitiveModelName: {
-  (_param50: StatusBarPrimitiveModelName.Props): import("react").JSX.Element;
+  (_param51: StatusBarPrimitiveModelName.Props): import("react").JSX.Element;
   displayName: string;
 };
 
@@ -3027,7 +3041,7 @@ declare namespace StatusBarPrimitiveRoot {
 }
 
 declare const StatusBarPrimitiveRoot: {
-  (_param51: StatusBarPrimitiveRoot.Props): import("react").JSX.Element;
+  (_param52: StatusBarPrimitiveRoot.Props): import("react").JSX.Element;
   displayName: string;
 };
 
@@ -3040,7 +3054,7 @@ declare namespace StatusBarPrimitiveStatus {
 }
 
 declare const StatusBarPrimitiveStatus: {
-  (_param52: StatusBarPrimitiveStatus.Props): import("react").JSX.Element;
+  (_param53: StatusBarPrimitiveStatus.Props): import("react").JSX.Element;
   displayName: string;
 };
 
@@ -3053,7 +3067,7 @@ declare namespace StatusBarPrimitiveTokenCount {
 }
 
 declare const StatusBarPrimitiveTokenCount: {
-  (_param53: StatusBarPrimitiveTokenCount.Props): import("react").JSX.Element | null;
+  (_param54: StatusBarPrimitiveTokenCount.Props): import("react").JSX.Element | null;
   displayName: string;
 };
 
@@ -3097,7 +3111,7 @@ type SuggestionConfig = string | {
   prompt: string;
 };
 
-declare const SuggestionDescription: (_param54: SuggestionDescriptionProps) => import("react").JSX.Element;
+declare const SuggestionDescription: (_param55: SuggestionDescriptionProps) => import("react").JSX.Element;
 
 type SuggestionDescriptionProps = ComponentProps<typeof Text> & {
   children?: ReactNode;
@@ -3109,13 +3123,13 @@ type SuggestionState = {
   prompt: string;
 };
 
-declare const SuggestionTitle: (_param55: SuggestionTitleProps) => import("react").JSX.Element;
+declare const SuggestionTitle: (_param56: SuggestionTitleProps) => import("react").JSX.Element;
 
 type SuggestionTitleProps = ComponentProps<typeof Text> & {
   children?: ReactNode;
 };
 
-declare const SuggestionTrigger: (_param56: SuggestionTriggerProps) => import("react").JSX.Element;
+declare const SuggestionTrigger: (_param57: SuggestionTriggerProps) => import("react").JSX.Element;
 
 type SuggestionTriggerProps = Omit<PressableProps, "onPress"> & {
   children: ReactNode;
@@ -3133,7 +3147,7 @@ type SuggestionsComponentConfig = {
 
 declare const TOOL_RESPONSE_SYMBOL: unique symbol;
 
-declare const TextInput: (_param57: TextInputProps) => import("react").JSX.Element;
+declare const TextInput: (_param58: TextInputProps) => import("react").JSX.Element;
 
 type TextInputProps = ComponentProps<typeof Box> & {
   value: string;
@@ -3221,7 +3235,7 @@ type ThreadComposerState = BaseComposerState & {
   readonly type: "thread";
 };
 
-declare const ThreadEmpty: (_param58: ThreadEmptyProps) => import("react").JSX.Element | null;
+declare const ThreadEmpty: (_param59: ThreadEmptyProps) => import("react").JSX.Element | null;
 
 type ThreadEmptyProps = {
   children: ReactNode;
@@ -3238,7 +3252,7 @@ type ThreadHistoryAdapter = {
   withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
 };
 
-declare const ThreadIf: (_param59: ThreadIfProps) => import("react").JSX.Element | null;
+declare const ThreadIf: (_param60: ThreadIfProps) => import("react").JSX.Element | null;
 
 type ThreadIfProps = {
   children: ReactNode;
@@ -3246,7 +3260,7 @@ type ThreadIfProps = {
   running?: boolean | undefined;
 };
 
-declare const ThreadListItemArchive: (_param60: ThreadListItemArchiveProps) => import("react").JSX.Element;
+declare const ThreadListItemArchive: (_param61: ThreadListItemArchiveProps) => import("react").JSX.Element;
 
 type ThreadListItemArchiveProps = Omit<PressableProps, "onPress"> & {
   children: ReactNode;
@@ -3268,7 +3282,7 @@ type ThreadListItemCoreState = {
   readonly runtime?: ThreadRuntimeCore | undefined;
 };
 
-declare const ThreadListItemDelete: (_param61: ThreadListItemDeleteProps) => import("react").JSX.Element;
+declare const ThreadListItemDelete: (_param62: ThreadListItemDeleteProps) => import("react").JSX.Element;
 
 type ThreadListItemDeleteProps = Omit<PressableProps, "onPress"> & {
   children: ReactNode;
@@ -3291,7 +3305,7 @@ declare namespace ThreadListItemPrimitiveTitle {
 
 declare const ThreadListItemPrimitiveTitle: FC<ThreadListItemPrimitiveTitle.Props>;
 
-declare const ThreadListItemRoot: (_param62: ThreadListItemRootProps) => import("react").JSX.Element;
+declare const ThreadListItemRoot: (_param63: ThreadListItemRootProps) => import("react").JSX.Element;
 
 type ThreadListItemRootProps = ComponentProps<typeof Box> & {
   children: ReactNode;
@@ -3392,19 +3406,19 @@ type ThreadListItemStateBinding = SubscribableWithState<ThreadListItemState$1, T
 
 type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
-declare const ThreadListItemTrigger: (_param63: ThreadListItemTriggerProps) => import("react").JSX.Element;
+declare const ThreadListItemTrigger: (_param64: ThreadListItemTriggerProps) => import("react").JSX.Element;
 
 type ThreadListItemTriggerProps = Omit<PressableProps, "onPress"> & {
   children: ReactNode;
 };
 
-declare const ThreadListItemUnarchive: (_param64: ThreadListItemUnarchiveProps) => import("react").JSX.Element;
+declare const ThreadListItemUnarchive: (_param65: ThreadListItemUnarchiveProps) => import("react").JSX.Element;
 
 type ThreadListItemUnarchiveProps = Omit<PressableProps, "onPress"> & {
   children: ReactNode;
 };
 
-declare const ThreadListItems: (_param65: ThreadListItemsProps) => import("react").JSX.Element;
+declare const ThreadListItems: (_param66: ThreadListItemsProps) => import("react").JSX.Element;
 
 type ThreadListItemsProps = {
   renderItem: (props: {
@@ -3413,13 +3427,13 @@ type ThreadListItemsProps = {
   }) => ReactElement;
 };
 
-declare const ThreadListNew: (_param66: ThreadListNewProps) => import("react").JSX.Element;
+declare const ThreadListNew: (_param67: ThreadListNewProps) => import("react").JSX.Element;
 
 type ThreadListNewProps = Omit<PressableProps, "onPress"> & {
   children: ReactNode;
 };
 
-declare const ThreadListRoot: (_param67: ThreadListRootProps) => import("react").JSX.Element;
+declare const ThreadListRoot: (_param68: ThreadListRootProps) => import("react").JSX.Element;
 
 type ThreadListRootProps = ComponentProps<typeof Box> & {
   children: ReactNode;
@@ -3631,7 +3645,7 @@ declare namespace ThreadPrimitiveUnstable_MessageById {
 
 declare const ThreadPrimitiveUnstable_MessageById: FC<ThreadPrimitiveUnstable_MessageById.Props>;
 
-declare const ThreadRoot: (_param68: ThreadRootProps) => import("react").JSX.Element;
+declare const ThreadRoot: (_param69: ThreadRootProps) => import("react").JSX.Element;
 
 type ThreadRootProps = ComponentProps<typeof Box> & {
   children: ReactNode;
@@ -3900,7 +3914,7 @@ type ThreadStep = {
   } | undefined;
 };
 
-declare const ThreadSuggestion: (_param69: ThreadSuggestionProps) => import("react").JSX.Element;
+declare const ThreadSuggestion: (_param70: ThreadSuggestionProps) => import("react").JSX.Element;
 
 type ThreadSuggestion$1 = {
   prompt: string;
@@ -4108,7 +4122,7 @@ type ToolExecutionContext = {
   human: (payload: unknown) => Promise<unknown>;
 };
 
-declare const ToolFallback: (_param70: ToolFallbackProps) => import("react").JSX.Element;
+declare const ToolFallback: (_param71: ToolFallbackProps) => import("react").JSX.Element;
 
 type ToolFallbackBaseProps = Omit<ToolCallMessagePartProps, "addResult" | "respondToApproval" | "resume"> & Partial<Pick<ToolCallMessagePartProps, "addResult" | "respondToApproval" | "resume">>;
 
@@ -4497,7 +4511,7 @@ declare const hitlTool: typeof humanTool;
 declare function humanTool(): never;
 
 declare namespace entry_root_exports {
-  export { actionBar_d_exports as ActionBarPrimitive, AppendMessage, AssistantClient, AssistantContextConfig, AssistantDataUI, AssistantDataUIProps, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantInteractableProps, AssistantRuntime, AssistantRuntimeProvider, AssistantState, AssistantTool, AssistantToolProps, AssistantToolUI, AssistantToolUIProps, Attachment, AttachmentAdapter, attachment_d_exports as AttachmentPrimitive, AttachmentRuntime, AttachmentState, AuiIf, AuiProvider, branchPicker_d_exports as BranchPickerPrimitive, ChainOfThoughtByIndicesProvider, ChainOfThoughtClient, ChainOfThoughtPartByIndexProvider, chainOfThought_d_exports as ChainOfThoughtPrimitive, ChatModelAdapter, ChatModelRunOptions, ChatModelRunResult, ChecklistItemData, ChecklistItemStatus, checklist_d_exports as ChecklistPrimitive, CompleteAttachment, ComposerAttachmentByIndexProvider, composer_d_exports as ComposerPrimitive, ComposerRuntime, ComposerState, CompositeAttachmentAdapter, CreateAttachment, CreateFileStorageAdapterOptions, DataMessagePart, DataMessagePartComponent, DataMessagePartProps, DataRenderers, diff_d_exports as DiffPrimitive, DiffView, DiffViewProps, EditComposerRuntime, EmptyMessagePartComponent, EmptyMessagePartProps, index_d_exports$2 as ErrorPrimitive, FeedbackAdapter, FileMessagePart, FileMessagePartComponent, FileMessagePartProps, ImageMessagePart, ImageMessagePartComponent, ImageMessagePartProps, InMemoryThreadListAdapter, Interactables, LanguageModelConfig, LanguageModelV1CallSettings, LiveChecklist, LiveChecklistProps, index_d_exports$1 as LoadingPrimitive, LocalRuntimeOptions, McpToolkitDefinition, McpToolkitEntry, McpToolkitToolConfig, MessageAttachmentByIndexProvider, MessageByIndexProvider, messagePart_d_exports as MessagePartPrimitive, message_d_exports as MessagePrimitive, MessageRole, MessageRuntime, MessageState, MessageStatus, ModelContext$1 as ModelContext, ModelContext as ModelContextClient, ModelContextProvider, ModelContextRegistry, ModelContextRegistryInstructionHandle, ModelContextRegistryProviderHandle, ModelContextRegistryToolHandle, NotificationConfig, NotificationEvent, NotificationHandler, OSCVariant, PartByIndexProvider, PendingAttachment, ProviderToolConfig, queueItem_d_exports as QueueItemPrimitive, QueueItemState, RealtimeVoiceAdapter, ReasoningGroupComponent, ReasoningGroupProps, ReasoningMessagePart, ReasoningMessagePartComponent, ReasoningMessagePartProps, RemoteThreadListAdapter, RemoteThreadListOptions, RunConfig, RuntimeAdapterProvider, RuntimeAdapters, RuntimeCapabilities, SimpleImageAttachmentAdapter, SimpleTextAttachmentAdapter, SourceMessagePart, SourceMessagePartComponent, SourceMessagePartProps, statusBar_d_exports as StatusBarPrimitive, SuggestionAdapter, SuggestionByIndexProvider, SuggestionConfig, suggestion_d_exports as SuggestionPrimitive, Suggestions, TextInput, TextInputProps, TextMessagePart, TextMessagePartComponent, TextMessagePartProps, TextMessagePartProvider, ThreadAssistantMessage, ThreadAssistantMessagePart, ThreadComposerRuntime, ThreadHistoryAdapter, ThreadListItemByIndexProvider, threadListItem_d_exports as ThreadListItemPrimitive, ThreadListItemRuntime, ThreadListItemRuntimeProvider, ThreadListItemState, threadList_d_exports as ThreadListPrimitive, ThreadListRuntime, ThreadMessage, ThreadMessageLike, thread_d_exports as ThreadPrimitive, ThreadRuntime, ThreadState$1 as ThreadState, ThreadSystemMessage, ThreadUserMessage, ThreadUserMessagePart, ThreadsState, TitleGenerationAdapter, Tool, ToolArgsStatus, ToolCallMessagePart, ToolCallMessagePartComponent, ToolCallMessagePartProps, toolCall_d_exports as ToolCallPrimitive, ToolCallText, ToolDefinition, ToolModelContentPart, Toolkit, ToolkitDefinition, ToolkitDefinitionEntry, Tools, Unstable_AudioMessagePart, Unstable_AudioMessagePartComponent, Unstable_AudioMessagePartProps, Unstable_InferInteractableState, Unstable_InteractableConfig, Unstable_InteractableDefinition, Unstable_InteractablePersistedState, Unstable_InteractablePersistenceAdapter, Unstable_InteractablePersistenceStatus, Unstable_InteractableRegistration, Unstable_InteractableSnapshotEntry, Unstable_InteractableStateSchema, Unstable_InteractableToolConfig, Unstable_InteractableToolRenderProps, Unstable_InteractableVersion, Unstable_InteractableVersionInfo, Unstable_InteractablesClientSchema, Unstable_InteractablesConfig, Unstable_InteractablesMethods, Unstable_InteractablesState, Unsubscribe$1 as Unsubscribe, UseToolCallChecklistOptions, VoiceSessionControls, VoiceSessionHelpers, createFileStorageAdapter, createSimpleTitleAdapter, createVoiceSession, defineMcpToolkit, defineToolkit, fromThreadMessageLike, generateId, hitl, hitlTool, humanTool, makeAssistantDataUI, makeAssistantTool, makeAssistantToolUI, mergeModelContexts, providerTool, ringBell, sendOSCNotification, stubTool, tool, unstable_Interactables, unstable_formatInteractableSnapshot, unstable_getInteractableSnapshots, unstable_getInteractableVersions, unstable_interactableTool, unstable_useInteractable, unstable_useInteractableState, unstable_useInteractableVersions, unstable_useThreadMessageIds, useAssistantContext, useAssistantDataUI, useAssistantInstructions, useAssistantInteractable, useAssistantTool, useAssistantToolUI, useAui, useAuiEvent, useAuiState, useAuiToolOverrides, useInlineRender, useInteractableState, useLocalRuntime, useNotification, useRemoteThreadListRuntime, useRuntimeAdapters, useToolArgsStatus, useToolCallChecklist, useVoiceControls, useVoiceState, useVoiceVolume };
+  export { actionBar_d_exports as ActionBarPrimitive, AppendMessage, AssistantClient, AssistantContextConfig, AssistantDataUI, AssistantDataUIProps, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantInteractableProps, AssistantRuntime, AssistantRuntimeProvider, AssistantState, AssistantTool, AssistantToolProps, AssistantToolUI, AssistantToolUIProps, Attachment, AttachmentAdapter, attachment_d_exports as AttachmentPrimitive, AttachmentRuntime, AttachmentState, AuiIf, AuiProvider, branchPicker_d_exports as BranchPickerPrimitive, ChainOfThoughtByIndicesProvider, ChainOfThoughtClient, ChainOfThoughtPartByIndexProvider, chainOfThought_d_exports as ChainOfThoughtPrimitive, ChatModelAdapter, ChatModelRunOptions, ChatModelRunResult, ChecklistItemData, ChecklistItemStatus, checklist_d_exports as ChecklistPrimitive, CompleteAttachment, ComposerAttachmentByIndexProvider, composer_d_exports as ComposerPrimitive, ComposerRuntime, ComposerState, CompositeAttachmentAdapter, CreateAttachment, CreateFileStorageAdapterOptions, DataMessagePart, DataMessagePartComponent, DataMessagePartProps, DataRenderers, diff_d_exports as DiffPrimitive, DiffView, DiffViewProps, EditComposerRuntime, EmptyMessagePartComponent, EmptyMessagePartProps, index_d_exports$2 as ErrorPrimitive, FeedbackAdapter, FileMessagePart, FileMessagePartComponent, FileMessagePartProps, ImageMessagePart, ImageMessagePartComponent, ImageMessagePartProps, InMemoryThreadListAdapter, Interactables, LanguageModelConfig, LanguageModelV1CallSettings, LiveChecklist, LiveChecklistProps, index_d_exports$1 as LoadingPrimitive, LocalRuntimeOptions, McpToolkitDefinition, McpToolkitEntry, McpToolkitToolConfig, MessageAttachmentByIndexProvider, MessageByIndexProvider, messagePart_d_exports as MessagePartPrimitive, message_d_exports as MessagePrimitive, MessageRole, MessageRuntime, MessageState, MessageStatus, ModelContext$1 as ModelContext, ModelContext as ModelContextClient, ModelContextProvider, ModelContextRegistry, ModelContextRegistryInstructionHandle, ModelContextRegistryProviderHandle, ModelContextRegistryToolHandle, NotificationConfig, NotificationEvent, NotificationHandler, OSCVariant, PartByIndexProvider, PendingAttachment, ProviderToolConfig, queueItem_d_exports as QueueItemPrimitive, QueueItemState, RealtimeVoiceAdapter, ReasoningGroupComponent, ReasoningGroupProps, ReasoningMessagePart, ReasoningMessagePartComponent, ReasoningMessagePartProps, RemoteThreadListAdapter, RemoteThreadListOptions, RunConfig, RuntimeAdapterProvider, RuntimeAdapters, RuntimeCapabilities, SimpleImageAttachmentAdapter, SimpleTextAttachmentAdapter, SourceMessagePart, SourceMessagePartComponent, SourceMessagePartProps, StageableDiffView, StageableDiffViewProps, StagedSelection, statusBar_d_exports as StatusBarPrimitive, SuggestionAdapter, SuggestionByIndexProvider, SuggestionConfig, suggestion_d_exports as SuggestionPrimitive, Suggestions, TextInput, TextInputProps, TextMessagePart, TextMessagePartComponent, TextMessagePartProps, TextMessagePartProvider, ThreadAssistantMessage, ThreadAssistantMessagePart, ThreadComposerRuntime, ThreadHistoryAdapter, ThreadListItemByIndexProvider, threadListItem_d_exports as ThreadListItemPrimitive, ThreadListItemRuntime, ThreadListItemRuntimeProvider, ThreadListItemState, threadList_d_exports as ThreadListPrimitive, ThreadListRuntime, ThreadMessage, ThreadMessageLike, thread_d_exports as ThreadPrimitive, ThreadRuntime, ThreadState$1 as ThreadState, ThreadSystemMessage, ThreadUserMessage, ThreadUserMessagePart, ThreadsState, TitleGenerationAdapter, Tool, ToolArgsStatus, ToolCallMessagePart, ToolCallMessagePartComponent, ToolCallMessagePartProps, toolCall_d_exports as ToolCallPrimitive, ToolCallText, ToolDefinition, ToolModelContentPart, Toolkit, ToolkitDefinition, ToolkitDefinitionEntry, Tools, Unstable_AudioMessagePart, Unstable_AudioMessagePartComponent, Unstable_AudioMessagePartProps, Unstable_InferInteractableState, Unstable_InteractableConfig, Unstable_InteractableDefinition, Unstable_InteractablePersistedState, Unstable_InteractablePersistenceAdapter, Unstable_InteractablePersistenceStatus, Unstable_InteractableRegistration, Unstable_InteractableSnapshotEntry, Unstable_InteractableStateSchema, Unstable_InteractableToolConfig, Unstable_InteractableToolRenderProps, Unstable_InteractableVersion, Unstable_InteractableVersionInfo, Unstable_InteractablesClientSchema, Unstable_InteractablesConfig, Unstable_InteractablesMethods, Unstable_InteractablesState, Unsubscribe$1 as Unsubscribe, UseToolCallChecklistOptions, VoiceSessionControls, VoiceSessionHelpers, createFileStorageAdapter, createSimpleTitleAdapter, createVoiceSession, defineMcpToolkit, defineToolkit, fromThreadMessageLike, generateId, hitl, hitlTool, humanTool, makeAssistantDataUI, makeAssistantTool, makeAssistantToolUI, mergeModelContexts, providerTool, ringBell, sendOSCNotification, stubTool, tool, unstable_Interactables, unstable_formatInteractableSnapshot, unstable_getInteractableSnapshots, unstable_getInteractableVersions, unstable_interactableTool, unstable_useInteractable, unstable_useInteractableState, unstable_useInteractableVersions, unstable_useThreadMessageIds, useAssistantContext, useAssistantDataUI, useAssistantInstructions, useAssistantInteractable, useAssistantTool, useAssistantToolUI, useAui, useAuiEvent, useAuiState, useAuiToolOverrides, useInlineRender, useInteractableState, useLocalRuntime, useNotification, useRemoteThreadListRuntime, useRuntimeAdapters, useToolArgsStatus, useToolCallChecklist, useVoiceControls, useVoiceState, useVoiceVolume };
 }
 
 declare namespace index_d_exports$1 {
@@ -4656,7 +4670,7 @@ declare const useInteractableState: <TState>(id: string, fallback: TState) => [
   }
 ];
 
-declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param71?: LocalRuntimeOptions) => AssistantRuntime;
+declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param72?: LocalRuntimeOptions) => AssistantRuntime;
 
 declare const useNotification: (config?: NotificationConfig) => void;
 

--- a/apps/docs/content/docs/ink/primitives.mdx
+++ b/apps/docs/content/docs/ink/primitives.mdx
@@ -1004,7 +1004,11 @@ A built-in component for rendering tool calls with expandable/collapsible output
 ## Diff
 
 ```tsx
-import { DiffPrimitive, DiffView } from "@assistant-ui/react-ink";
+import {
+  DiffPrimitive,
+  DiffView,
+  StageableDiffView,
+} from "@assistant-ui/react-ink";
 ```
 
 Components for rendering code diffs in the terminal.
@@ -1040,6 +1044,38 @@ When a replacement is rendered as an equal-length adjacent `-`/`+` run, `DiffVie
 | `showLineNumbers` | `boolean` | Whether to show line numbers (default: true) |
 | `contextLines` | `number` | Number of context lines to show around changes |
 | `maxLines` | `number` | Maximum number of lines to display |
+
+### StageableDiffView
+
+Interactive variant of `DiffView` that lets the user include or exclude individual hunks before approving a change. Takes the same `patch` / `oldFile` / `newFile` inputs, renders a per-hunk `[x]` / `[ ]` gutter marker on each hunk's first change line, dims unstaged hunks, and highlights the focused hunk. All hunks start staged. It reports the staged subset through `onStageChange`, which a consumer feeds to its own apply step.
+
+```tsx
+<StageableDiffView
+  patch={unifiedDiffString}
+  onStageChange={(staged) => {
+    // staged.stagedHunks: [{ fileIndex, hunkIndex }, ...]
+    setStaged(staged);
+  }}
+/>
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `onStageChange` | `(staged: StagedSelection) => void` | Called with the staged hunk subset whenever the selection changes |
+| `isActive` | `boolean` | Gates the keymap so a parent screen can own focus (default: `true`) |
+| `...DiffViewProps` | `DiffViewProps` | Same `patch` / `oldFile` / `newFile` / `showLineNumbers` / `contextLines` / `maxLines` inputs as `DiffView` |
+
+Keymap (active only while focused and `isActive`):
+
+| Key | Action |
+|-----|--------|
+| `j` / `Down` | Move focus to the next hunk |
+| `k` / `Up` | Move focus to the previous hunk |
+| `Space` | Toggle the focused hunk in or out |
+| `a` | Stage all hunks |
+| `n` | Stage no hunks |
+
+`StagedSelection` is `{ stagedHunks: ReadonlyArray<{ fileIndex: number; hunkIndex: number }> }`, sorted by file then hunk. Unlike `DiffView`, the staged view does not yet layer intra-line word highlighting onto its rows.
 
 ### Root
 

--- a/packages/react-ink/src/index.ts
+++ b/packages/react-ink/src/index.ts
@@ -150,6 +150,11 @@ export * as LoadingPrimitive from "./primitives/loading";
 export * as StatusBarPrimitive from "./primitives/statusBar";
 export { DiffView, type DiffViewProps } from "./primitives/diff/DiffView";
 export {
+  StageableDiffView,
+  type StageableDiffViewProps,
+} from "./primitives/diff/StageableDiffView";
+export type { StagedSelection } from "./primitives/diff/diff-stage";
+export {
   TextInput,
   type TextInputProps,
 } from "./primitives/textInput/TextInput";

--- a/packages/react-ink/src/primitives/diff/DiffView.tsx
+++ b/packages/react-ink/src/primitives/diff/DiffView.tsx
@@ -3,18 +3,13 @@ import { Box, Text } from "ink";
 import { DiffContent } from "./DiffContent";
 import { useDiffContext } from "./DiffContext";
 import { DiffRoot } from "./DiffRoot";
-import { computeDiff, parsePatch } from "./diff-utils";
+import { getDiffFiles } from "./diff-utils";
 import {
   buildIntraLineSegments,
   buildLinePairMap,
   type StyledDiffSegment,
 } from "./intra-line-utils";
-import type {
-  DiffFileInput,
-  FoldedRegion,
-  ParsedFile,
-  ParsedLine,
-} from "./types";
+import type { DiffFileInput, FoldedRegion, ParsedLine } from "./types";
 
 export type DiffViewProps = Omit<ComponentProps<typeof Box>, "children"> & {
   patch?: string | undefined;
@@ -183,39 +178,6 @@ const DiffViewInner = ({
   );
 };
 
-const getDiffViewFiles = ({
-  patch,
-  oldFile,
-  newFile,
-}: {
-  patch?: string | undefined;
-  oldFile?: DiffFileInput | undefined;
-  newFile?: DiffFileInput | undefined;
-}): ParsedFile[] => {
-  if (patch) {
-    return parsePatch(patch);
-  }
-
-  if (!oldFile || !newFile) {
-    return [];
-  }
-
-  const { lines, additions, deletions } = computeDiff(
-    oldFile.content,
-    newFile.content,
-  );
-
-  return [
-    {
-      oldName: oldFile.name,
-      newName: newFile.name,
-      lines,
-      additions,
-      deletions,
-    },
-  ];
-};
-
 export const DiffView = ({
   patch,
   oldFile,
@@ -232,7 +194,7 @@ export const DiffView = ({
 
   const files = useMemo(
     () =>
-      getDiffViewFiles({
+      getDiffFiles({
         patch,
         oldFile:
           oldContent !== undefined

--- a/packages/react-ink/src/primitives/diff/StageableDiffView.test.tsx
+++ b/packages/react-ink/src/primitives/diff/StageableDiffView.test.tsx
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "ink-testing-library";
+
+type InputHandler = (
+  input: string,
+  key: { downArrow?: boolean; upArrow?: boolean },
+) => void;
+
+let inputHandler: InputHandler | undefined;
+
+vi.mock("ink", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ink")>();
+  return {
+    ...actual,
+    useFocus: () => ({ isFocused: true }),
+    useInput: (handler: InputHandler, options?: { isActive?: boolean }) => {
+      if (options?.isActive !== false) inputHandler = handler;
+    },
+  };
+});
+
+import { StageableDiffView } from "./StageableDiffView";
+import type { StagedSelection } from "./diff-stage";
+
+const MULTI_HUNK_PATCH = `diff --git a/f.txt b/f.txt
+--- a/f.txt
++++ b/f.txt
+@@ -1,3 +1,3 @@
+ a
+-b
++B
+ c
+@@ -10,3 +10,3 @@
+ x
+-y
++Y
+ z
+`;
+
+const flush = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const countMatches = (frame: string, needle: string) =>
+  frame.split(needle).length - 1;
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  inputHandler = undefined;
+});
+
+describe("StageableDiffView", () => {
+  it("stages every hunk by default", async () => {
+    const { lastFrame } = render(
+      <StageableDiffView patch={MULTI_HUNK_PATCH} />,
+    );
+    await flush();
+
+    const frame = lastFrame() ?? "";
+    expect(countMatches(frame, "[x]")).toBe(2);
+    expect(frame).not.toContain("[ ]");
+  });
+
+  it("toggles the focused hunk on space and reports the staged subset", async () => {
+    const onStageChange = vi.fn<(staged: StagedSelection) => void>();
+    const { lastFrame } = render(
+      <StageableDiffView
+        patch={MULTI_HUNK_PATCH}
+        onStageChange={onStageChange}
+      />,
+    );
+    await flush();
+
+    inputHandler?.(" ", {});
+    await flush();
+
+    expect(lastFrame()).toContain("[ ]");
+    expect(onStageChange).toHaveBeenLastCalledWith({
+      stagedHunks: [{ fileIndex: 0, hunkIndex: 1 }],
+    });
+  });
+
+  it("moves focus with j before toggling", async () => {
+    const onStageChange = vi.fn<(staged: StagedSelection) => void>();
+    render(
+      <StageableDiffView
+        patch={MULTI_HUNK_PATCH}
+        onStageChange={onStageChange}
+      />,
+    );
+    await flush();
+
+    inputHandler?.("j", {});
+    await flush();
+    inputHandler?.(" ", {});
+    await flush();
+
+    expect(onStageChange).toHaveBeenLastCalledWith({
+      stagedHunks: [{ fileIndex: 0, hunkIndex: 0 }],
+    });
+  });
+
+  it("stages none and all via n and a", async () => {
+    const onStageChange = vi.fn<(staged: StagedSelection) => void>();
+    const { lastFrame } = render(
+      <StageableDiffView
+        patch={MULTI_HUNK_PATCH}
+        onStageChange={onStageChange}
+      />,
+    );
+    await flush();
+
+    inputHandler?.("n", {});
+    await flush();
+    expect(countMatches(lastFrame() ?? "", "[ ]")).toBe(2);
+    expect(onStageChange).toHaveBeenLastCalledWith({ stagedHunks: [] });
+
+    inputHandler?.("a", {});
+    await flush();
+    expect(countMatches(lastFrame() ?? "", "[x]")).toBe(2);
+    expect(onStageChange).toHaveBeenLastCalledWith({
+      stagedHunks: [
+        { fileIndex: 0, hunkIndex: 0 },
+        { fileIndex: 0, hunkIndex: 1 },
+      ],
+    });
+  });
+
+  it("does not capture keys when isActive is false", async () => {
+    render(<StageableDiffView patch={MULTI_HUNK_PATCH} isActive={false} />);
+    await flush();
+
+    expect(inputHandler).toBeUndefined();
+  });
+});

--- a/packages/react-ink/src/primitives/diff/StageableDiffView.tsx
+++ b/packages/react-ink/src/primitives/diff/StageableDiffView.tsx
@@ -1,0 +1,207 @@
+import { useMemo, useReducer, useRef } from "react";
+import { Box, Text, useFocus, useInput } from "ink";
+
+import { DiffContent } from "./DiffContent";
+import { DiffRoot } from "./DiffRoot";
+import { getDiffFiles } from "./diff-utils";
+import {
+  createStageState,
+  getDiffHunks,
+  stageKey,
+  stageReducer,
+  toStagedSelection,
+  type StageAction,
+  type StagedSelection,
+} from "./diff-stage";
+import type { DiffViewProps } from "./DiffView";
+import type { ParsedFile, ParsedLine } from "./types";
+
+export type StageableDiffViewProps = DiffViewProps & {
+  onStageChange?: ((staged: StagedSelection) => void) | undefined;
+  isActive?: boolean | undefined;
+};
+
+const INDICATOR: Record<ParsedLine["type"], string> = {
+  add: "+",
+  del: "-",
+  normal: " ",
+};
+
+const firstChangeLinesOf = (file: ParsedFile) => {
+  const seen = new Set<number>();
+  const markers = new Set<ParsedLine>();
+  for (const line of file.lines) {
+    if (
+      line.type !== "normal" &&
+      line.hunkIndex !== undefined &&
+      !seen.has(line.hunkIndex)
+    ) {
+      seen.add(line.hunkIndex);
+      markers.add(line);
+    }
+  }
+  return markers;
+};
+
+const StageLine = ({
+  line,
+  showMarker,
+  staged,
+  focused,
+  showLineNumbers,
+}: {
+  line: ParsedLine;
+  showMarker: boolean;
+  staged: boolean;
+  focused: boolean;
+  showLineNumbers: boolean;
+}) => {
+  const lineNum = line.type === "add" ? line.newLineNumber : line.oldLineNumber;
+  const numStr = lineNum !== undefined ? String(lineNum).padStart(4) : "    ";
+  const gutter = showMarker ? (staged ? "[x]" : "[ ]") : "   ";
+  const body = `${INDICATOR[line.type]} ${line.content}`;
+  const color = staged
+    ? line.type === "add"
+      ? "green"
+      : line.type === "del"
+        ? "red"
+        : undefined
+    : undefined;
+
+  return (
+    <Box>
+      <Text inverse={focused} color={focused ? "cyan" : undefined}>
+        {gutter}
+      </Text>
+      <Text> </Text>
+      {showLineNumbers && <Text dimColor>{`${numStr} `}</Text>}
+      <Text color={color} dimColor={!staged}>
+        {body}
+      </Text>
+    </Box>
+  );
+};
+
+export const StageableDiffView = ({
+  patch,
+  oldFile,
+  newFile,
+  showLineNumbers,
+  contextLines,
+  maxLines,
+  onStageChange,
+  isActive = true,
+  ...boxProps
+}: StageableDiffViewProps) => {
+  const oldContent = oldFile?.content;
+  const oldName = oldFile?.name;
+  const newContent = newFile?.content;
+  const newName = newFile?.name;
+
+  const files = useMemo(
+    () =>
+      getDiffFiles({
+        patch,
+        oldFile:
+          oldContent !== undefined
+            ? { content: oldContent, name: oldName }
+            : undefined,
+        newFile:
+          newContent !== undefined
+            ? { content: newContent, name: newName }
+            : undefined,
+      }),
+    [patch, oldContent, oldName, newContent, newName],
+  );
+
+  const hunks = useMemo(() => getDiffHunks(files), [files]);
+  const hunkKeys = useMemo(() => hunks.map((h) => h.key), [hunks]);
+
+  const [state, dispatch] = useReducer(
+    stageReducer,
+    hunkKeys,
+    createStageState,
+  );
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const { isFocused } = useFocus({ isActive });
+
+  // run the reducer eagerly so onStageChange fires synchronously with the keypress
+  const apply = (action: StageAction) => {
+    const current = stateRef.current;
+    const next = stageReducer(current, action);
+    stateRef.current = next;
+    dispatch(action);
+    if (next.staged !== current.staged) {
+      onStageChange?.(toStagedSelection(next.staged));
+    }
+  };
+
+  useInput(
+    (input, key) => {
+      if (key.downArrow || input === "j") {
+        apply({ type: "move-focus", delta: 1, hunkCount: hunks.length });
+        return;
+      }
+      if (key.upArrow || input === "k") {
+        apply({ type: "move-focus", delta: -1, hunkCount: hunks.length });
+        return;
+      }
+      if (input === " ") {
+        const focusedKey = hunks[stateRef.current.focusedIndex]?.key;
+        if (focusedKey) apply({ type: "toggle", key: focusedKey });
+        return;
+      }
+      if (input === "a") {
+        apply({ type: "stage-all", keys: hunkKeys });
+        return;
+      }
+      if (input === "n") {
+        apply({ type: "stage-none" });
+      }
+    },
+    { isActive: isFocused && isActive },
+  );
+
+  const focusedKey = hunks[state.focusedIndex]?.key;
+
+  return (
+    <DiffRoot files={files} {...boxProps}>
+      {files.length === 0 ? (
+        <Text dimColor>No diff content</Text>
+      ) : (
+        files.map((file, fileIndex) => {
+          const markers = firstChangeLinesOf(file);
+          const displayName = file.newName ?? file.oldName;
+
+          return (
+            <Box key={fileIndex} flexDirection="column">
+              <Text bold>{displayName}</Text>
+              <DiffContent
+                fileIndex={fileIndex}
+                contextLines={contextLines}
+                maxLines={maxLines}
+                renderLine={({ line }) => {
+                  const key =
+                    line.hunkIndex !== undefined
+                      ? stageKey(fileIndex, line.hunkIndex)
+                      : undefined;
+                  return (
+                    <StageLine
+                      line={line}
+                      showMarker={markers.has(line)}
+                      staged={key !== undefined && state.staged.has(key)}
+                      focused={key !== undefined && key === focusedKey}
+                      showLineNumbers={showLineNumbers ?? true}
+                    />
+                  );
+                }}
+              />
+            </Box>
+          );
+        })
+      )}
+    </DiffRoot>
+  );
+};

--- a/packages/react-ink/src/primitives/diff/diff-stage.test.ts
+++ b/packages/react-ink/src/primitives/diff/diff-stage.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  createStageState,
+  getDiffHunks,
+  stageKey,
+  stageReducer,
+  toStagedSelection,
+} from "./diff-stage";
+import type { ParsedFile } from "./types";
+
+const fileWithHunks = (hunkIndices: number[]): ParsedFile => ({
+  oldName: "f.txt",
+  newName: "f.txt",
+  additions: 0,
+  deletions: 0,
+  lines: hunkIndices.map((hunkIndex) => ({
+    type: "add" as const,
+    content: "x",
+    hunkIndex,
+  })),
+});
+
+describe("getDiffHunks", () => {
+  it("enumerates hunks per file from the max hunkIndex", () => {
+    const hunks = getDiffHunks([fileWithHunks([0, 0, 1]), fileWithHunks([0])]);
+    expect(hunks).toEqual([
+      { fileIndex: 0, hunkIndex: 0, key: "0:0" },
+      { fileIndex: 0, hunkIndex: 1, key: "0:1" },
+      { fileIndex: 1, hunkIndex: 0, key: "1:0" },
+    ]);
+  });
+
+  it("emits no hunks for a file with no change lines", () => {
+    const file: ParsedFile = {
+      oldName: "f.txt",
+      newName: "f.txt",
+      additions: 0,
+      deletions: 0,
+      lines: [{ type: "normal", content: "a" }],
+    };
+    expect(getDiffHunks([file])).toEqual([]);
+  });
+});
+
+describe("stageReducer", () => {
+  const keys = ["0:0", "0:1"];
+
+  it("defaults to all hunks staged", () => {
+    const state = createStageState(keys);
+    expect([...state.staged]).toEqual(keys);
+    expect(state.focusedIndex).toBe(0);
+  });
+
+  it("toggles a hunk out and back in", () => {
+    let state = createStageState(keys);
+    state = stageReducer(state, { type: "toggle", key: "0:0" });
+    expect(state.staged.has("0:0")).toBe(false);
+    state = stageReducer(state, { type: "toggle", key: "0:0" });
+    expect(state.staged.has("0:0")).toBe(true);
+  });
+
+  it("stages all and none", () => {
+    let state = createStageState(keys);
+    state = stageReducer(state, { type: "stage-none" });
+    expect(state.staged.size).toBe(0);
+    state = stageReducer(state, { type: "stage-all", keys });
+    expect([...state.staged]).toEqual(keys);
+  });
+
+  it("clamps focus movement to bounds", () => {
+    let state = createStageState(keys);
+    state = stageReducer(state, {
+      type: "move-focus",
+      delta: -1,
+      hunkCount: 2,
+    });
+    expect(state.focusedIndex).toBe(0);
+    state = stageReducer(state, { type: "move-focus", delta: 1, hunkCount: 2 });
+    expect(state.focusedIndex).toBe(1);
+    state = stageReducer(state, { type: "move-focus", delta: 1, hunkCount: 2 });
+    expect(state.focusedIndex).toBe(1);
+  });
+
+  it("ignores focus movement when there are no hunks", () => {
+    const state = createStageState([]);
+    const next = stageReducer(state, {
+      type: "move-focus",
+      delta: 1,
+      hunkCount: 0,
+    });
+    expect(next).toBe(state);
+  });
+});
+
+describe("toStagedSelection", () => {
+  it("parses and sorts staged keys", () => {
+    const selection = toStagedSelection(new Set(["1:0", "0:1", "0:0"]));
+    expect(selection.stagedHunks).toEqual([
+      { fileIndex: 0, hunkIndex: 0 },
+      { fileIndex: 0, hunkIndex: 1 },
+      { fileIndex: 1, hunkIndex: 0 },
+    ]);
+  });
+
+  it("builds keys with stageKey", () => {
+    expect(stageKey(2, 3)).toBe("2:3");
+  });
+});

--- a/packages/react-ink/src/primitives/diff/diff-stage.ts
+++ b/packages/react-ink/src/primitives/diff/diff-stage.ts
@@ -1,0 +1,91 @@
+import type { ParsedFile } from "./types";
+
+export type StagedSelection = {
+  stagedHunks: ReadonlyArray<{ fileIndex: number; hunkIndex: number }>;
+};
+
+export type DiffHunkRef = {
+  fileIndex: number;
+  hunkIndex: number;
+  key: string;
+};
+
+export type StageState = {
+  staged: ReadonlySet<string>;
+  focusedIndex: number;
+};
+
+export type StageAction =
+  | { type: "toggle"; key: string }
+  | { type: "stage-all"; keys: readonly string[] }
+  | { type: "stage-none" }
+  | { type: "move-focus"; delta: number; hunkCount: number };
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+export const stageKey = (fileIndex: number, hunkIndex: number) =>
+  `${fileIndex}:${hunkIndex}`;
+
+export const getDiffHunks = (files: ParsedFile[]): DiffHunkRef[] => {
+  const hunks: DiffHunkRef[] = [];
+  files.forEach((file, fileIndex) => {
+    const maxHunk = file.lines.reduce(
+      (max, line) => Math.max(max, line.hunkIndex ?? -1),
+      -1,
+    );
+    for (let hunkIndex = 0; hunkIndex <= maxHunk; hunkIndex++) {
+      hunks.push({ fileIndex, hunkIndex, key: stageKey(fileIndex, hunkIndex) });
+    }
+  });
+  return hunks;
+};
+
+export const createStageState = (keys: readonly string[]): StageState => ({
+  staged: new Set(keys),
+  focusedIndex: 0,
+});
+
+export const stageReducer = (
+  state: StageState,
+  action: StageAction,
+): StageState => {
+  switch (action.type) {
+    case "toggle": {
+      const staged = new Set(state.staged);
+      if (staged.has(action.key)) staged.delete(action.key);
+      else staged.add(action.key);
+      return { ...state, staged };
+    }
+
+    case "stage-all":
+      return { ...state, staged: new Set(action.keys) };
+
+    case "stage-none":
+      return { ...state, staged: new Set() };
+
+    case "move-focus": {
+      if (action.hunkCount === 0) return state;
+      const next = clamp(
+        state.focusedIndex + action.delta,
+        0,
+        action.hunkCount - 1,
+      );
+      return next === state.focusedIndex
+        ? state
+        : { ...state, focusedIndex: next };
+    }
+  }
+};
+
+export const toStagedSelection = (
+  staged: ReadonlySet<string>,
+): StagedSelection => {
+  const stagedHunks = [...staged]
+    .map((key) => {
+      const [fileIndex, hunkIndex] = key.split(":");
+      return { fileIndex: Number(fileIndex), hunkIndex: Number(hunkIndex) };
+    })
+    .sort((a, b) => a.fileIndex - b.fileIndex || a.hunkIndex - b.hunkIndex);
+  return { stagedHunks };
+};

--- a/packages/react-ink/src/primitives/diff/diff-utils.ts
+++ b/packages/react-ink/src/primitives/diff/diff-utils.ts
@@ -3,6 +3,7 @@ import parseDiff from "parse-diff";
 import type {
   ParsedLine,
   ParsedFile,
+  DiffFileInput,
   DisplayLine,
   FoldedRegion,
 } from "./types";
@@ -135,6 +136,39 @@ function assignComputedHunkIndices(lines: ParsedLine[]) {
       line.hunkIndex = hunkIndex;
     }
   }
+}
+
+export function getDiffFiles({
+  patch,
+  oldFile,
+  newFile,
+}: {
+  patch?: string | undefined;
+  oldFile?: DiffFileInput | undefined;
+  newFile?: DiffFileInput | undefined;
+}): ParsedFile[] {
+  if (patch) {
+    return parsePatch(patch);
+  }
+
+  if (!oldFile || !newFile) {
+    return [];
+  }
+
+  const { lines, additions, deletions } = computeDiff(
+    oldFile.content,
+    newFile.content,
+  );
+
+  return [
+    {
+      oldName: oldFile.name,
+      newName: newFile.name,
+      lines,
+      additions,
+      deletions,
+    },
+  ];
 }
 
 export function foldContext(


### PR DESCRIPTION
## What

Adds `StageableDiffView`: an interactive `DiffView` variant for including/excluding individual hunks before approving a change, reporting the staged subset via `onStageChange`. Read-only `DiffView` is unchanged.

## Why

- "Approve this diff, but drop that hunk" is the richest terminal edit interaction, and no primitive offered it.
- First selection state and first keyboard interaction in the diff layer. Builds on the `hunkIndex` boundaries from #4660 (merged).

## How

- State is a pure reducer (`diff-stage.ts`): a `Set` of staged `"{fileIndex}:{hunkIndex}"` keys plus a focused-hunk cursor; actions `toggle` / `stage-all` / `stage-none` / `move-focus`; `toStagedSelection` projection.
- Kept as an internal `useReducer`, not an exported provider. Public surface is just `StageableDiffView` + `StageableDiffViewProps` + `StagedSelection`.
- Renders via the public `DiffRoot` / `DiffContent` with a custom `renderLine`: `[x]` / `[ ]` gutter marker on each hunk's first change line, dims unstaged hunks, highlights the focused hunk.
- Keymap mirrors the `Pressable` `isActive` convention (gated on `isFocused && isActive`): `j`/`k` + arrows move focus, `space` toggles, `a`/`n` all/none.
- `onStageChange` fires synchronously via an eager reducer run (same pattern as `ComposerInput`/`TextInput`), so it does not depend on effect-flush timing.
- Moves the private `getDiffViewFiles` to `diff-utils` as shared `getDiffFiles` (pure relocation, no behavior change); `DiffView` now imports it.

## Tests

- `diff-stage.test.ts`: default all-staged, toggle out/in, stage all/none, focus clamping, no-op move with zero hunks, sorted `toStagedSelection`.
- `StageableDiffView.test.tsx` (`ink-testing-library`): default markers, `space` toggles + emits subset, `j` then `space` toggles hunk 2, `n`/`a` payloads, `isActive={false}` registers no handler.

## Out of scope

- `materializeStaged` (patch reconstruction): follow-up, once agent-inbox needs it.
- In-hunk / intra-line staging, hunk splitting, separate file-level toggle (whole-hunk only).
- v1 limitation: staged rows use plain green/red/dim styling, not the intra-line word highlighting `DiffView` adds (leaves `DiffView`'s renderer untouched; shareable later).
- Staged state does not reset if the `patch` prop is swapped on a mounted component; remount with `key` for a new diff (acceptable for approval flows, follow-up if needed).
