### PR TITLE
ci: clarify template sync only targets minimal template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Keep provider-driven choices flexible: core-primitive choice, thin wrapper vs ac
 
 Every publishable package builds with `aui-build` (`@assistant-ui/x-buildutils`). Do not add a per-package build config or use tsup, unbuild, swc, or the tsc CLI. Exports maps are ESM-only and types-first (`"types"` before `"default"`), with `type: module` and `sideEffects: false`.
 
-`packages/ui/src/components/assistant-ui` is the canonical UI source. `templates/*` hold byte-equal copies verified by `pnpm sync-templates`; `examples/*` alias to it through tsconfig and must not carry copies. Declare intentional divergence in the `OVERRIDES` array in `scripts/sync-templates.sh`.
+`packages/ui/src/components/assistant-ui` is the canonical UI source. Templates and examples alias it through tsconfig (`@/components/*`, `@/hooks/*`, `@/lib/utils`) and carry no byte-equal copies of it — except `minimal`, which ships its own (examples may still hold intentional forks). `pnpm sync-templates` keeps minimal's copies byte-equal with the source; declare intentional divergence in the `OVERRIDES` array in `scripts/sync-templates.sh`.
 
 Run `pnpm check:resource-memo` when bumping `@babel/core`, `babel-plugin-react-compiler`, or `react-compiler`; a green build does not prove the compiler toolchain is intact. A package the published dist imports at runtime belongs in `dependencies`, not `devDependencies`, so the bundler externalizes it (a devDep gets inlined and drags unresolvable transitive imports into consumer builds). A registry item must be self-contained: enumerate every `@/components/*` import and CSS `@import` as `registryDependencies`, so `shadcn add` never lands a file with an unresolvable import.
 

--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
-# Verifies that shared assistant-ui components in templates/* are byte-equal
-# with the canonical source in packages/ui/src/components/assistant-ui, and
-# that examples/* don't carry redundant byte-equal copies (examples resolve
-# `@/components/assistant-ui/*` to packages/ui via tsconfig paths, so an
-# identical local copy is dead weight that silently drifts).
+# Templates and examples alias packages/ui via tsconfig and carry no copies,
+# except `minimal`, which ships its own. This keeps minimal's copies byte-equal
+# with packages/ui/src/components/assistant-ui (minus the OVERRIDES divergences)
+# and flags any redundant byte-equal copy under examples/*.
 #
 # Usage:
 #   bash scripts/sync-templates.sh            # check (CI mode), exits 1 on drift
-#   bash scripts/sync-templates.sh --write    # copy source -> templates to fix drift
+#   bash scripts/sync-templates.sh --write    # copy source -> minimal to fix drift
 #
 # To allow an intentional divergence (e.g. minimal/thread.tsx is a slim variant),
 # add `<tpl>/<file>` to the OVERRIDES array below with a comment explaining why.
@@ -21,7 +20,8 @@ SOURCE_DIR="$ROOT_DIR/packages/ui/src/components/assistant-ui"
 TEMPLATES_ROOT="$ROOT_DIR/templates"
 EXAMPLES_ROOT="$ROOT_DIR/examples"
 
-TEMPLATES=(default minimal cloud cloud-clerk langgraph mcp)
+# Only minimal carries copies; every other template aliases packages/ui.
+TEMPLATES=(minimal)
 
 OVERRIDES=(
     # minimal intentionally ships a slim thread.tsx without GroupedParts /

--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -9,8 +9,8 @@
 #   bash scripts/sync-templates.sh            # check (CI mode), exits 1 on drift
 #   bash scripts/sync-templates.sh --write    # copy source -> minimal to fix drift
 #
-# To allow an intentional divergence (e.g. minimal/thread.tsx is a slim variant),
-# add `<tpl>/<file>` to the OVERRIDES array below with a comment explaining why.
+# To allow an intentional divergence (e.g. thread.tsx is a slim variant),
+# add `<file>` to the OVERRIDES array below with a comment explaining why.
 
 set -e
 
@@ -21,15 +21,15 @@ TEMPLATES_ROOT="$ROOT_DIR/templates"
 EXAMPLES_ROOT="$ROOT_DIR/examples"
 
 # Only minimal carries copies; every other template aliases packages/ui.
-TEMPLATES=(minimal)
+MINIMAL_DIR="$TEMPLATES_ROOT/minimal/components/assistant-ui"
 
 OVERRIDES=(
     # minimal intentionally ships a slim thread.tsx without GroupedParts /
     # reasoning / tool-group, since it doesn't bundle those companion files.
-    "minimal/thread.tsx"
+    "thread.tsx"
     # minimal ships without react-shiki, so its markdown-text.tsx omits the
     # SyntaxHighlighter wiring.
-    "minimal/markdown-text.tsx"
+    "markdown-text.tsx"
 )
 
 MODE="${1:-check}"
@@ -44,31 +44,28 @@ annotate() {
 
 drift=()
 
-for tpl in "${TEMPLATES[@]}"; do
-    tpl_dir="$TEMPLATES_ROOT/$tpl/components/assistant-ui"
-    [[ -d "$tpl_dir" ]] || continue
-
-    while IFS= read -r -d '' tpl_file; do
-        file="$(basename "$tpl_file")"
+if [[ -d "$MINIMAL_DIR" ]]; then
+    while IFS= read -r -d '' min_file; do
+        file="$(basename "$min_file")"
         src_file="$SOURCE_DIR/$file"
 
-        # template-specific file with no packages/ui counterpart, leave alone
+        # minimal-specific file with no packages/ui counterpart, leave alone
         [[ -f "$src_file" ]] || continue
 
         is_override=0
         for o in "${OVERRIDES[@]}"; do
-            if [[ "$tpl/$file" == "$o" ]]; then
+            if [[ "$file" == "$o" ]]; then
                 is_override=1
                 break
             fi
         done
         [[ "$is_override" -eq 1 ]] && continue
 
-        if ! cmp -s "$src_file" "$tpl_file"; then
-            drift+=("$tpl/$file")
+        if ! cmp -s "$src_file" "$min_file"; then
+            drift+=("$file")
         fi
-    done < <(find "$tpl_dir" -maxdepth 1 -type f \( -name "*.tsx" -o -name "*.ts" \) -print0)
-done
+    done < <(find "$MINIMAL_DIR" -maxdepth 1 -type f \( -name "*.tsx" -o -name "*.ts" \) -print0)
+fi
 
 # Examples must NOT hold byte-equal copies of packages/ui components: their
 # tsconfig already aliases `@/components/assistant-ui/*` to packages/ui, so a
@@ -93,11 +90,9 @@ if [[ ${#drift[@]} -eq 0 && ${#redundant[@]} -eq 0 ]]; then
 fi
 
 if [[ "$MODE" == "--write" ]]; then
-    for d in "${drift[@]}"; do
-        tpl="${d%%/*}"
-        file="${d##*/}"
-        cp "$SOURCE_DIR/$file" "$TEMPLATES_ROOT/$tpl/components/assistant-ui/$file"
-        echo "synced $d"
+    for file in "${drift[@]}"; do
+        cp "$SOURCE_DIR/$file" "$MINIMAL_DIR/$file"
+        echo "synced minimal/$file"
     done
     for r in "${redundant[@]}"; do
         rm "$ROOT_DIR/$r"
@@ -109,10 +104,10 @@ if [[ "$MODE" == "--write" ]]; then
 fi
 
 if [[ ${#drift[@]} -gt 0 ]]; then
-    echo "✗ drift detected in ${#drift[@]} template file(s) vs packages/ui:"
-    for d in "${drift[@]}"; do
-        echo "    templates/$d"
-        annotate "templates/$d/components/assistant-ui/${d##*/}" "out of sync with packages/ui/src/components/assistant-ui/${d##*/}; run 'pnpm sync-templates --write' or add an OVERRIDES entry"
+    echo "✗ drift detected in ${#drift[@]} minimal file(s) vs packages/ui:"
+    for file in "${drift[@]}"; do
+        echo "    templates/minimal/components/assistant-ui/$file"
+        annotate "templates/minimal/components/assistant-ui/$file" "out of sync with packages/ui/src/components/assistant-ui/$file; run 'pnpm sync-templates --write' or add an OVERRIDES entry"
     done
 fi
 
@@ -126,5 +121,5 @@ fi
 
 echo ""
 echo "to fix, run:    pnpm sync-templates --write"
-echo "if a template divergence is intentional, add '<tpl>/<file>' to OVERRIDES in scripts/sync-templates.sh"
+echo "if a minimal divergence is intentional, add '<file>' to OVERRIDES in scripts/sync-templates.sh"
 exit 1


### PR DESCRIPTION
other templates use aliased imports directly from packages/ui

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

