### PR TITLE
fix(turbo-cache): exclude generated output contents from build inputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,16 +7,16 @@
       "dependsOn": ["^build"],
       "inputs": [
         "**/*.*",
-        "!.next",
-        "!.turbo",
-        "!dist",
-        "!build",
-        "!generated",
-        "!.output",
-        "!.source"
+        "!.next/**",
+        "!.turbo/**",
+        "!dist/**",
+        "!build/**",
+        "!generated/**",
+        "!.output/**",
+        "!.source/**"
       ],
       "outputs": [
-        "dist",
+        "dist/**",
         ".next/**",
         "!.next/cache/**",
         "!.next/dev/**",


### PR DESCRIPTION
## Summary

Fixes a Turbo input glob issue that was breaking build cache hits after generated output files were written.

The previous patterns like `!dist`, `!build`, `!generated`, and `!.source` did not reliably exclude files created inside those directories from the next task hash. After a build/dev run produced outputs, Turbo could treat those generated files as changed inputs and miss cache on the next run.

This updates the globs to directory-content patterns:

- `!dist/**`
- `!build/**`
- `!generated/**`
- `!.source/**`
- etc.

It also changes the `dist` output declaration to `dist/**`.

## Validation


Tested full monorepo build and docs build, both showed significant speed improvements as a result of fixed caching.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

