### PR TITLE
feat: add onResumeError hook callback for `useChatRuntime`

### DIFF
--- a/.changeset/chat-runtime-resume-error-hook.md
+++ b/.changeset/chat-runtime-resume-error-hook.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+feat: expose chat runtime resume errors

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -1926,6 +1926,7 @@ type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatI
   adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
   toCreateMessage?: CustomToCreateMessageFunction;
   onResume?: AISDKRuntimeAdapter["onResume"];
+  onResumeError?: ((error: unknown) => void) | undefined;
   joinStrategy?: AISDKRuntimeAdapter["joinStrategy"];
   onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
 };

--- a/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
@@ -358,6 +358,12 @@ export function Chat() {
       description:
         "Custom transport implementation. Defaults to AssistantChatTransport which sends requests to '/api/chat'.",
     },
+    {
+      name: "onResumeError",
+      type: "(error: unknown) => void",
+      description:
+        "Optional callback when useChatRuntime finds a pending resumable stream id but the automatic reconnect fails. Use it for a toast, telemetry, or retry UI; the stale stream id is still cleared.",
+    },
   ]}
 />
 

--- a/apps/docs/content/docs/guides/resumable-streams.mdx
+++ b/apps/docs/content/docs/guides/resumable-streams.mdx
@@ -112,7 +112,12 @@ export default function Page() {
       }),
     [],
   );
-  const runtime = useChatRuntime({ transport });
+  const runtime = useChatRuntime({
+    transport,
+    onResumeError: (error) => {
+      console.error("Could not resume the previous response", error);
+    },
+  });
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
@@ -121,6 +126,8 @@ export default function Page() {
   );
 }
 ```
+
+`onResumeError` runs when the client finds a stored stream id but the reconnect attempt fails. Use it to show a toast, report telemetry, or mark the thread as needing retry; assistant-ui still clears the stale stream id after the callback runs.
 
 `createResumableSessionStorage` returns a `ResumableClientStorage` backed by `window.sessionStorage`. Pass `{ key }` to namespace per route or per chat surface, or supply your own implementation of the three methods (`getStreamId`, `setStreamId`, `clear`). If you are running on a transport that already wraps `fetch` or `prepareReconnectToStreamRequest`, the `resumable` option composes with your existing handlers.
 

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const runtime = {};
+  return {
+    runtime,
+    useChat: vi.fn(),
+    useAISDKRuntime: vi.fn(() => runtime),
+    useCloudThreadListAdapter: vi.fn(() => null),
+    useRemoteThreadListRuntime: vi.fn(
+      ({ runtimeHook }: { runtimeHook: () => unknown }) => runtimeHook(),
+    ),
+    useAui: vi.fn(() => ({
+      threadListItem: Object.assign(() => ({}), { source: undefined }),
+    })),
+    useAuiState: vi.fn(() => "thread-id"),
+  };
+});
+
+vi.mock("@ai-sdk/react", () => ({
+  useChat: mocks.useChat,
+}));
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/core/react")>()),
+  useCloudThreadListAdapter: mocks.useCloudThreadListAdapter,
+  useRemoteThreadListRuntime: mocks.useRemoteThreadListRuntime,
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: mocks.useAui,
+  useAuiState: mocks.useAuiState,
+}));
+
+vi.mock("./useAISDKRuntime", () => ({
+  useAISDKRuntime: mocks.useAISDKRuntime,
+}));
+
+import { useChatRuntime } from "./useChatRuntime";
+
+describe("useChatRuntime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls onResumeError when automatic resumable stream resume fails", async () => {
+    const error = new Error("resume failed");
+    const resumeStream = vi.fn().mockRejectedValue(error);
+    const clear = vi.fn();
+    const onResumeError = vi.fn();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mocks.useChat.mockReturnValue({
+      resumeStream,
+    });
+
+    const transport = {
+      getResumableAdapter: () => ({
+        storage: {
+          getStreamId: () => "stream-1",
+          setStreamId: vi.fn(),
+          clear,
+        },
+        resumeApi: "/api/chat/resume",
+      }),
+    };
+
+    renderHook(() =>
+      useChatRuntime({
+        transport: transport as never,
+        onResumeError,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onResumeError).toHaveBeenCalledWith(error);
+    });
+    expect(resumeStream).toHaveBeenCalledTimes(1);
+    expect(clear).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      "[assistant-ui] resumable: resume failed; clearing stored stream id",
+      error,
+    );
+    warn.mockRestore();
+  });
+});

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.test.ts
@@ -80,10 +80,59 @@ describe("useChatRuntime", () => {
     });
     expect(resumeStream).toHaveBeenCalledTimes(1);
     expect(clear).toHaveBeenCalledTimes(1);
+    expect(onResumeError.mock.invocationCallOrder[0]).toBeLessThan(
+      clear.mock.invocationCallOrder[0]!,
+    );
     expect(warn).toHaveBeenCalledWith(
       "[assistant-ui] resumable: resume failed; clearing stored stream id",
       error,
     );
     warn.mockRestore();
+  });
+
+  it("clears resumable stream storage when onResumeError throws", async () => {
+    const error = new Error("resume failed");
+    const callbackError = new Error("callback failed");
+    const resumeStream = vi.fn().mockRejectedValue(error);
+    const clear = vi.fn();
+    const onResumeError = vi.fn(() => {
+      throw callbackError;
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.useChat.mockReturnValue({
+      resumeStream,
+    });
+
+    const transport = {
+      getResumableAdapter: () => ({
+        storage: {
+          getStreamId: () => "stream-1",
+          setStreamId: vi.fn(),
+          clear,
+        },
+        resumeApi: "/api/chat/resume",
+      }),
+    };
+
+    renderHook(() =>
+      useChatRuntime({
+        transport: transport as never,
+        onResumeError,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(clear).toHaveBeenCalledTimes(1);
+    });
+    expect(onResumeError).toHaveBeenCalledWith(error);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] resumable: onResumeError callback failed",
+      callbackError,
+    );
+    warn.mockRestore();
+    consoleError.mockRestore();
   });
 });

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -29,6 +29,13 @@ export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
       adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
       toCreateMessage?: CustomToCreateMessageFunction;
       onResume?: AISDKRuntimeAdapter["onResume"];
+      /**
+       * Called when `useChatRuntime` automatically attempts to resume a pending
+       * resumable stream on mount and that reconnect fails. Use this to surface
+       * a toast, report telemetry, or mark the thread as needing a retry. The
+       * stored stream id is still cleared after the callback runs.
+       */
+      onResumeError?: ((error: unknown) => void) | undefined;
       joinStrategy?: AISDKRuntimeAdapter["joinStrategy"];
       onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
     };
@@ -80,6 +87,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     unstable_capabilities: _unstable_capabilities,
     suggestions: _suggestions,
     onResume,
+    onResumeError,
     joinStrategy,
     ...chatOptions
   } = options ?? {};
@@ -129,9 +137,13 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         "[assistant-ui] resumable: resume failed; clearing stored stream id",
         err,
       );
-      adapter.storage.clear();
+      try {
+        onResumeError?.(err);
+      } finally {
+        adapter.storage.clear();
+      }
     });
-  }, [transport, chat]);
+  }, [transport, chat, onResumeError]);
 
   return runtime;
 };

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -125,6 +125,10 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   }
 
   const resumeFiredRef = useRef(false);
+  const onResumeErrorRef = useRef(onResumeError);
+  useEffect(() => {
+    onResumeErrorRef.current = onResumeError;
+  });
   useEffect(() => {
     if (resumeFiredRef.current) return;
     const adapter = getResumableAdapter(transport);
@@ -138,12 +142,17 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         err,
       );
       try {
-        onResumeError?.(err);
+        onResumeErrorRef.current?.(err);
+      } catch (callbackError) {
+        console.error(
+          "[assistant-ui] resumable: onResumeError callback failed",
+          callbackError,
+        );
       } finally {
         adapter.storage.clear();
       }
     });
-  }, [transport, chat, onResumeError]);
+  }, [transport, chat]);
 
   return runtime;
 };


### PR DESCRIPTION
## What

Adds an optional `onResumeError(error)` callback to `useChatRuntime`. It fires when the runtime finds a stored resumable stream id on mount, attempts `chat.resumeStream()`, and that automatic reconnect fails.

The existing behavior stays in place: assistant-ui still logs the resume failure and clears the stale stored stream id. The callback runs before the clear, so apps can still inspect their resumable storage if they need to.

## Why

Today a failed resumable reconnect is only visible in the console. Production apps often need to surface that failure or observe it elsewhere, for example:

- show a toast like “Could not reconnect to the previous response”
- send the error to Sentry, Datadog, PostHog, or another telemetry pipeline
- mark the current thread as needing retry after a reload or mobile reconnect

## How

- Adds `onResumeError?: (error: unknown) => void` to `UseChatRuntimeOptions`.
- Invokes it from the existing automatic resume failure path.
- Keeps stale stream id cleanup in a `finally` so cleanup still happens if the app callback throws.
- Documents the option in the resumable streams guide and the `useChatRuntime` options table.
- Adds a focused test covering the callback, existing warning, and storage clear behavior.

## Validation

- `pnpm exec oxlint packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.test.ts`
- `pnpm --filter @assistant-ui/react-ai-sdk test`
- `pnpm --filter @assistant-ui/react-ai-sdk exec tsc --noEmit`
- `pnpm --filter @assistant-ui/docs generate:type-docs`
- `git diff --check`

## Changeset

Patch changeset included for `@assistant-ui/react-ai-sdk`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

