### PR TITLE
feat(react-ag-ui): steer-away cancels pending client-side tool calls

### DIFF
--- a/.changeset/steer-away-tool-calls.md
+++ b/.changeset/steer-away-tool-calls.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: steer-away cancels pending client-side tool calls

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -137,7 +137,9 @@ await runtime.unstable_submitInterruptResponses(
 
 ### Steering away from an interrupt
 
-When the user ignores the interrupt UI and just sends a new message, use the `useAgUiSteerAway` hook. Every open interrupt defaults to `status: "cancelled"`, the new message is appended, and the run resumes with `resume: ResumeEntry[]` on the wire. With no pending interrupts it behaves like a normal append.
+When the user ignores the interrupt UI and just sends a new message, use the `useAgUiSteerAway` hook. Every open interrupt defaults to `status: "cancelled"`, the new message is appended, and the run resumes with `resume: ResumeEntry[]` on the wire.
+
+The same hook also steers away from pending client-side tool calls. When the head assistant message is in `requires-action` with `reason: "tool-calls"` (frontend tools awaiting a result) and the user sends a new message, every unresolved tool call is cancelled with an error result, the message is completed, and a single fresh run starts with those cancellations in its history. Passing `responses` in this case throws, since responses only address interrupts. With nothing pending, `steerAway` behaves like a normal append.
 
 ```tsx
 const steerAway = useAgUiSteerAway();

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -36,6 +36,11 @@ const optimisticPrefix = "__optimistic__";
 const generateOptimisticId = () => `${optimisticPrefix}${generateId()}`;
 const isOptimisticId = (id: string) => id.startsWith(optimisticPrefix);
 
+const isResolvedToolCall = (
+  part: ThreadAssistantMessage["content"][number],
+): boolean =>
+  part.type === "tool-call" && "result" in part && part.result !== undefined;
+
 const symbolResumeShim = Symbol("agui-resume-shim");
 
 type RunConfig = NonNullable<AppendMessage["runConfig"]>;
@@ -255,20 +260,28 @@ export class AgUiThreadRuntimeCore {
     );
   }
 
-  getPendingInterrupts(): {
-    messageId: string;
-    interrupts: readonly AgUiInterrupt[];
-  } | null {
+  private findRequiresActionAssistant(
+    reason: "interrupt" | "tool-calls",
+  ): ThreadAssistantMessage | null {
     const assistant = this.messages.findLast((m) => m.role === "assistant") as
       | ThreadAssistantMessage
       | undefined;
     if (
       !assistant ||
       assistant.status?.type !== "requires-action" ||
-      assistant.status.reason !== "interrupt"
+      assistant.status.reason !== reason
     ) {
       return null;
     }
+    return assistant;
+  }
+
+  getPendingInterrupts(): {
+    messageId: string;
+    interrupts: readonly AgUiInterrupt[];
+  } | null {
+    const assistant = this.findRequiresActionAssistant("interrupt");
+    if (!assistant) return null;
     const stored = (
       assistant.metadata.custom[AG_UI_METADATA_NAMESPACE] as
         | AgUiCustomMetadata
@@ -276,6 +289,22 @@ export class AgUiThreadRuntimeCore {
     )?.interrupts;
     if (!stored?.length) return null;
     return { messageId: assistant.id, interrupts: stored };
+  }
+
+  getPendingToolCalls(): {
+    messageId: string;
+    toolCallIds: string[];
+  } | null {
+    const assistant = this.findRequiresActionAssistant("tool-calls");
+    if (!assistant) return null;
+    const toolCallIds: string[] = [];
+    for (const part of assistant.content) {
+      if (part.type !== "tool-call") continue;
+      if (isResolvedToolCall(part)) continue;
+      toolCallIds.push(part.toolCallId);
+    }
+    if (toolCallIds.length === 0) return null;
+    return { messageId: assistant.id, toolCallIds };
   }
 
   async submitInterruptResponses(
@@ -359,6 +388,23 @@ export class AgUiThreadRuntimeCore {
   ): Promise<void> {
     const pending = this.getPendingInterrupts();
     if (!pending) {
+      const pendingTools = this.getPendingToolCalls();
+      if (pendingTools) {
+        if (responses?.length) {
+          throw new Error(
+            "[agui] steerAway: responses are only valid for pending interrupts",
+          );
+        }
+        if (this.isRunningFlag) {
+          throw new Error("[agui] steerAway: a run is already in progress");
+        }
+        this.cancelUnresolvedToolCalls(pendingTools.messageId);
+        this.maybeCompleteAfterToolResults(pendingTools.messageId);
+        const normalized = this.toAppendMessage(message);
+        const threadMessageId = this.appendEntry(normalized);
+        await this.startRun(threadMessageId, normalized.runConfig);
+        return;
+      }
       if (responses?.length) {
         throw new Error(
           "[agui] steerAway: no pending interrupts on this thread",
@@ -484,13 +530,31 @@ export class AgUiThreadRuntimeCore {
       for (const part of message.content) {
         if (part.type !== "tool-call" || part.toolCallId !== toolCallId)
           continue;
-        if (!("result" in part) || part.result === undefined) {
+        if (!isResolvedToolCall(part)) {
           return message.id;
         }
         fallbackMessageId ??= message.id;
       }
     }
     return fallbackMessageId;
+  }
+
+  private cancelUnresolvedToolCalls(messageId: string): void {
+    this.messages = this.messages.map((message) => {
+      if (message.id !== messageId || message.role !== "assistant")
+        return message;
+      const assistant = message as ThreadAssistantMessage;
+      const content = assistant.content.map((part) => {
+        if (part.type !== "tool-call" || isResolvedToolCall(part)) return part;
+        return {
+          ...part,
+          result: { error: "Tool call cancelled by user" },
+          isError: true,
+        };
+      });
+      return { ...assistant, content };
+    });
+    this.notifyUpdate();
   }
 
   addToolResult(options: AddToolResultOptions): void {
@@ -547,9 +611,7 @@ export class AgUiThreadRuntimeCore {
       return false;
     }
     const allResolved = assistant.content.every(
-      (part) =>
-        part.type !== "tool-call" ||
-        ("result" in part && part.result !== undefined),
+      (part) => part.type !== "tool-call" || isResolvedToolCall(part),
     );
     if (!allResolved) return false;
 
@@ -952,11 +1014,7 @@ export class AgUiThreadRuntimeCore {
   ): ThreadAssistantMessage["content"] {
     const resolved = new Map<string, ToolCallMessagePart>();
     for (const part of previous) {
-      if (
-        part.type === "tool-call" &&
-        "result" in part &&
-        part.result !== undefined
-      ) {
+      if (part.type === "tool-call" && isResolvedToolCall(part)) {
         resolved.set(part.toolCallId, part);
       }
     }
@@ -964,8 +1022,7 @@ export class AgUiThreadRuntimeCore {
 
     let changed = false;
     const merged = next.map((part) => {
-      if (part.type !== "tool-call") return part;
-      if ("result" in part && part.result !== undefined) return part;
+      if (part.type !== "tool-call" || isResolvedToolCall(part)) return part;
       const prior = resolved.get(part.toolCallId);
       if (!prior) return part;
       changed = true;

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1729,6 +1729,253 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(runCount).toBe(1);
   });
 
+  it("steerAway cancels a pending client-side tool call and starts one fresh run", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "call-1",
+            toolCallName: "tool_a",
+          },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onTextMessageContentEvent?.({
+        event: { type: "TEXT_MESSAGE_CONTENT", delta: "Done." },
+      });
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(core.getPendingToolCalls()?.toolCallIds).toEqual(["call-1"]);
+
+    await core.steerAway("changed my mind");
+
+    expect(runCount).toBe(2);
+
+    const assistant = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    expect(assistant.status).toMatchObject({ type: "complete" });
+    const call1 = assistant.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "call-1",
+    ) as any;
+    expect(call1.result).toEqual({ error: "Tool call cancelled by user" });
+    expect(call1.isError).toBe(true);
+
+    const run2Messages = runInputs[1]?.messages ?? [];
+    const toolMsg = run2Messages.find(
+      (m: any) => m.role === "tool" && m.toolCallId === "call-1",
+    );
+    expect(toolMsg?.content).toContain("Tool call cancelled by user");
+    expect(
+      run2Messages.some(
+        (m: any) => m.role === "user" && m.content === "changed my mind",
+      ),
+    ).toBe(true);
+  });
+
+  it("steerAway cancels every pending client-side tool call", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      if (runCount === 1) {
+        for (const id of ["call-1", "call-2"]) {
+          subscriber.onToolCallStartEvent?.({
+            event: {
+              type: "TOOL_CALL_START",
+              toolCallId: id,
+              toolCallName: "tool_a",
+            },
+          });
+          subscriber.onToolCallEndEvent?.({
+            event: { type: "TOOL_CALL_END", toolCallId: id },
+          });
+        }
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(core.getPendingToolCalls()?.toolCallIds).toEqual([
+      "call-1",
+      "call-2",
+    ]);
+
+    await core.steerAway("stop");
+
+    expect(runCount).toBe(2);
+    const run2Messages = runInputs[1]?.messages ?? [];
+    const toolMsgs = run2Messages.filter((m: any) => m.role === "tool");
+    expect(toolMsgs.map((m: any) => m.toolCallId).sort()).toEqual([
+      "call-1",
+      "call-2",
+    ]);
+  });
+
+  it("steerAway cancels only unresolved tool calls and preserves resolved ones", async () => {
+    let core: AgUiThreadRuntimeCore;
+    const runInputs: any[] = [];
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      if (runCount === 1) {
+        for (const id of ["call-1", "call-2"]) {
+          subscriber.onToolCallStartEvent?.({
+            event: {
+              type: "TOOL_CALL_START",
+              toolCallId: id,
+              toolCallName: "tool_a",
+            },
+          });
+          subscriber.onToolCallEndEvent?.({
+            event: { type: "TOOL_CALL_END", toolCallId: id },
+          });
+        }
+        const assistantMsg = core
+          .getMessages()
+          .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+        core.addToolResult({
+          messageId: assistantMsg.id,
+          toolCallId: "call-1",
+          toolName: "tool_a",
+          result: "ra",
+          isError: false,
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(core.getPendingToolCalls()?.toolCallIds).toEqual(["call-2"]);
+
+    await core.steerAway("never mind");
+
+    const assistant = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    const call1 = assistant.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "call-1",
+    ) as any;
+    const call2 = assistant.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "call-2",
+    ) as any;
+    expect(call1.result).toBe("ra");
+    expect(call2.result).toEqual({ error: "Tool call cancelled by user" });
+    expect(call2.isError).toBe(true);
+  });
+
+  it("steerAway rejects responses when only tool calls are pending", async () => {
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runCount++;
+      subscriber.onToolCallStartEvent?.({
+        event: {
+          type: "TOOL_CALL_START",
+          toolCallId: "call-1",
+          toolCallName: "tool_a",
+        },
+      });
+      subscriber.onToolCallEndEvent?.({
+        event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+
+    await expect(
+      core.steerAway("x", [{ interruptId: "call-1", status: "cancelled" }]),
+    ).rejects.toThrow("responses are only valid for pending interrupts");
+    expect(runCount).toBe(1);
+  });
+
+  it("steerAway throws when a run is still in progress", async () => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    let runCount = 0;
+    const runAgent = vi.fn(async (_input: any, subscriber: any) => {
+      runCount++;
+      subscriber.onToolCallStartEvent?.({
+        event: {
+          type: "TOOL_CALL_START",
+          toolCallId: "call-1",
+          toolCallName: "tool_a",
+        },
+      });
+      subscriber.onToolCallEndEvent?.({
+        event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+      });
+      subscriber.onRunFinalized?.();
+      await gate;
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    const appendPromise = core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(core.getPendingToolCalls()?.toolCallIds).toEqual(["call-1"]);
+    expect(core.isRunning()).toBe(true);
+
+    await expect(core.steerAway("x")).rejects.toThrow(
+      "a run is already in progress",
+    );
+
+    release();
+    await appendPromise;
+    expect(runCount).toBe(1);
+  });
+
   it("attaches a TOOL_CALL_RESULT for a prior run's tool call to its owning message", async () => {
     let runCount = 0;
     const runAgent = vi.fn(async (input: any, subscriber: any) => {


### PR DESCRIPTION
Closes #4673

## Summary

Extends `useAgUiSteerAway` to cancel pending client-side (frontend) tool calls, not just AG-UI interrupts.

## Problem

- `steerAway` only handled `requires-action` / `reason: "interrupt"`.
- With `reason: "tool-calls"` pending, it fell through to a plain append.
- The prior tool calls stayed unresolved and the agent never got a result for them.

## Change

When the user sends a new message while client-side tool calls are pending, `steerAway` now:

- Auto-cancels every unresolved tool call on the head assistant message.
- Completes that message and appends the new user message.
- Starts a single fresh run; cancels reach the agent as `tool` messages in run history (no separate resume run, matching the interrupt path).

## Details

- Cancel shape `{ result: { error: "Tool call cancelled by user" }, isError: true }`, mirroring core's tool-approval-denied convention.
- Resolved tool calls keep their real results; only unresolved ones are cancelled.
- Throws if `responses` is passed (interrupt-shaped, meaningless here) or if a run is in progress, for parity with the interrupt branch.

## Tests

- Single and multiple pending tool calls.
- Partial resolution (preserve resolved, cancel unresolved).
- `responses` rejection and in-progress guard.
- Existing no-pending regression.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

