### PR TITLE
Centralize assistant message construction

### DIFF
--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -11,6 +11,7 @@ import {
   fromThreadMessageLike,
   type ThreadMessageLike,
 } from "../../runtime/utils/thread-message-like";
+import { createThreadAssistantMessage } from "../../runtime/utils/create-thread-assistant-message";
 import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
 import type { ToolExecutionStatus } from "../../runtimes/tool-invocations/ToolInvocationTracker";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
@@ -322,20 +323,10 @@ const chunkExternalMessages = <T>(
 function createErrorAssistantMessage(
   error: ReadonlyJSONValue,
 ): ThreadAssistantMessage {
-  const msg: ThreadAssistantMessage = {
+  const msg = createThreadAssistantMessage({
     id: generateErrorMessageId(),
-    role: "assistant",
-    content: [],
     status: { type: "incomplete", reason: "error", error },
-    createdAt: new Date(),
-    metadata: {
-      unstable_state: null,
-      unstable_annotations: [],
-      unstable_data: [],
-      custom: {},
-      steps: [],
-    },
-  };
+  });
   bindExternalStoreMessage(msg, []);
   return msg;
 }

--- a/packages/core/src/runtime/utils/create-thread-assistant-message.test.ts
+++ b/packages/core/src/runtime/utils/create-thread-assistant-message.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { createThreadAssistantMessage } from "./create-thread-assistant-message";
+
+describe("createThreadAssistantMessage", () => {
+  it("fills assistant message defaults", () => {
+    const createdAt = new Date("2026-01-01T00:00:00.000Z");
+
+    expect(createThreadAssistantMessage({ id: "msg-1", createdAt })).toEqual({
+      id: "msg-1",
+      role: "assistant",
+      content: [],
+      status: { type: "running" },
+      createdAt,
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+    });
+  });
+
+  it("preserves provided fields while filling missing metadata defaults", () => {
+    const createdAt = new Date("2026-01-02T00:00:00.000Z");
+    const timing = {
+      streamStartTime: 100,
+      totalChunks: 2,
+      toolCallCount: 1,
+    };
+
+    expect(
+      createThreadAssistantMessage({
+        id: "msg-2",
+        createdAt,
+        content: [{ type: "text", text: "hello" }],
+        status: { type: "complete", reason: "stop" },
+        metadata: {
+          unstable_state: { step: "done" },
+          unstable_annotations: ["annotation"],
+          unstable_data: [{ value: 1 }],
+          steps: [{ messageId: "step-1" }],
+          timing,
+          submittedFeedback: { type: "positive" },
+          isOptimistic: true,
+          custom: { source: "test" },
+        },
+      }),
+    ).toEqual({
+      id: "msg-2",
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+      status: { type: "complete", reason: "stop" },
+      createdAt,
+      metadata: {
+        unstable_state: { step: "done" },
+        unstable_annotations: ["annotation"],
+        unstable_data: [{ value: 1 }],
+        steps: [{ messageId: "step-1" }],
+        timing,
+        submittedFeedback: { type: "positive" },
+        isOptimistic: true,
+        custom: { source: "test" },
+      },
+    });
+  });
+});

--- a/packages/core/src/runtime/utils/create-thread-assistant-message.ts
+++ b/packages/core/src/runtime/utils/create-thread-assistant-message.ts
@@ -1,0 +1,42 @@
+import type {
+  MessageStatus,
+  ThreadAssistantMessage,
+  ThreadAssistantMessagePart,
+} from "../../types/message";
+import { generateId } from "../../utils/id";
+
+type AssistantMetadata = ThreadAssistantMessage["metadata"];
+
+export type CreateThreadAssistantMessageOptions = {
+  readonly id?: string | undefined;
+  readonly createdAt?: Date | undefined;
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: Partial<AssistantMetadata> | undefined;
+};
+
+export const createThreadAssistantMessage = ({
+  id = generateId(),
+  createdAt = new Date(),
+  content = [],
+  status = { type: "running" },
+  metadata,
+}: CreateThreadAssistantMessageOptions = {}): ThreadAssistantMessage => ({
+  id,
+  role: "assistant",
+  content,
+  status,
+  createdAt,
+  metadata: {
+    unstable_state: metadata?.unstable_state ?? null,
+    unstable_annotations: metadata?.unstable_annotations ?? [],
+    unstable_data: metadata?.unstable_data ?? [],
+    steps: metadata?.steps ?? [],
+    custom: metadata?.custom ?? {},
+    ...(metadata?.timing !== undefined && { timing: metadata.timing }),
+    ...(metadata?.submittedFeedback !== undefined && {
+      submittedFeedback: metadata.submittedFeedback,
+    }),
+    ...(metadata?.isOptimistic === true && { isOptimistic: true }),
+  },
+});

--- a/packages/core/src/runtime/utils/thread-message-like.ts
+++ b/packages/core/src/runtime/utils/thread-message-like.ts
@@ -1,5 +1,6 @@
 import { parsePartialJsonObject } from "assistant-stream/utils";
 import { generateId } from "../../utils/id";
+import { createThreadAssistantMessage } from "./create-thread-assistant-message";
 import type {
   ReasoningMessagePart,
   SourceMessagePart,
@@ -8,7 +9,6 @@ import type {
   ImageMessagePart,
   ThreadMessage,
   ThreadAssistantMessagePart,
-  ThreadAssistantMessage,
   ThreadUserMessagePart,
   ThreadUserMessage,
   ThreadSystemMessage,
@@ -152,9 +152,8 @@ export const fromThreadMessageLike = (
 
   switch (role) {
     case "assistant":
-      return {
+      return createThreadAssistantMessage({
         ...common,
-        role,
         content: content
           .map((part): ThreadAssistantMessagePart | null => {
             const type = part.type;
@@ -214,19 +213,8 @@ export const fromThreadMessageLike = (
           })
           .filter((c) => !!c),
         status: status ?? fallbackStatus,
-        metadata: {
-          unstable_state: metadata?.unstable_state ?? null,
-          unstable_annotations: metadata?.unstable_annotations ?? [],
-          unstable_data: metadata?.unstable_data ?? [],
-          custom: metadata?.custom ?? {},
-          steps: metadata?.steps ?? [],
-          ...(metadata?.timing && { timing: metadata.timing }),
-          ...(metadata?.submittedFeedback && {
-            submittedFeedback: metadata.submittedFeedback,
-          }),
-          ...(metadata?.isOptimistic && { isOptimistic: true }),
-        },
-      } satisfies ThreadAssistantMessage;
+        metadata,
+      });
 
     case "user":
       return {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -1,4 +1,5 @@
 import { fromThreadMessageLike } from "../../runtime/utils/thread-message-like";
+import { createThreadAssistantMessage } from "../../runtime/utils/create-thread-assistant-message";
 import { generateId } from "../../utils/id";
 import type {
   ChatModelAdapter,
@@ -322,21 +323,11 @@ export class LocalThreadRuntimeCore
     this.ensureInitialized();
 
     // add assistant message
-    const id = generateId();
-    const message: ThreadAssistantMessage = {
-      id,
-      role: "assistant",
-      status: { type: "running" },
-      content: [],
+    const message = createThreadAssistantMessage({
       metadata: {
         unstable_state: this.state,
-        unstable_annotations: [],
-        unstable_data: [],
-        steps: [],
-        custom: {},
       },
-      createdAt: new Date(),
-    };
+    });
 
     return this._runLoop(parentId, message, runConfig, runCallback);
   }

--- a/packages/core/src/tests/thread-message-like.test.ts
+++ b/packages/core/src/tests/thread-message-like.test.ts
@@ -112,6 +112,29 @@ describe("fromThreadMessageLike", () => {
   });
 
   describe("reasoning and image robustness", () => {
+    it("fills assistant defaults around the fallback status", () => {
+      const result = fromThreadMessageLike(
+        { role: "assistant", content: [{ type: "text", text: "hello" }] },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result).toMatchObject({
+        id: fallbackId,
+        role: "assistant",
+        content: [{ type: "text", text: "hello" }],
+        status: fallbackStatus,
+        metadata: {
+          unstable_state: null,
+          unstable_annotations: [],
+          unstable_data: [],
+          steps: [],
+          custom: {},
+        },
+      });
+      expect(result.createdAt).toBeInstanceOf(Date);
+    });
+
     it("drops a reasoning part whose text is undefined", () => {
       const result = fromThreadMessageLike(
         {


### PR DESCRIPTION
## Summary

Centralizes construction of full `ThreadAssistantMessage` objects behind a shared internal helper.

This keeps `role: "assistant"` visible where it is the message discriminator or external wire shape, while removing duplicated default object construction for core assistant messages.

## Changes

- Add `createThreadAssistantMessage` as an internal core runtime utility.
- Use the helper in `fromThreadMessageLike`, local runtime assistant run initialization, and external converter error-message creation.
- Add focused tests for helper defaults and metadata preservation.
- Extend `fromThreadMessageLike` coverage to assert assistant defaults still match the previous behavior.

## Why

Several core paths manually constructed assistant messages with the same defaults for `status`, `content`, `createdAt`, and metadata arrays. Keeping those defaults in one place makes future changes less error-prone without changing public APIs or provider message formats.

## Validation

- `pnpm --filter @assistant-ui/core test`
- `pnpm --filter @assistant-ui/core build`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm api-surface:check`
- `pnpm lint`

Note: `pnpm lint` completed successfully with pre-existing React hooks warnings in unrelated files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

