### PR TITLE
fix(model-selector): accessibility and keyboard nav

### DIFF
--- a/apps/docs/components/docs/samples/model-selector.tsx
+++ b/apps/docs/components/docs/samples/model-selector.tsx
@@ -17,6 +17,7 @@ import { DEFAULT_MODEL_ID, getContextWindow } from "@/constants/model";
 import { docsModelOptions } from "@/components/docs/assistant/docs-model-options";
 import { SampleFrame } from "@/components/docs/samples/sample-frame";
 import { cn } from "@/lib/utils";
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui";
 
 const PROVIDER_NAMES: Record<string, string> = {
   openai: "OpenAI",
@@ -90,18 +91,6 @@ function ComposedRow() {
     new Set(),
   );
 
-  const toggleProvider = (provider: string) => {
-    setProviderFilter((prev) => {
-      const next = new Set(prev);
-      if (next.has(provider)) {
-        next.delete(provider);
-      } else {
-        next.add(provider);
-      }
-      return next;
-    });
-  };
-
   // An empty filter means no filtering — all providers are shown.
   const visibleGroups = [...modelsByProvider].filter(
     ([provider]) => providerFilter.size === 0 || providerFilter.has(provider),
@@ -122,35 +111,44 @@ function ComposedRow() {
         <ModelSelectorTrigger />
         <ModelSelectorContent>
           <ModelSelectorSearch />
-          <div
+          <ToggleGroupPrimitive.Root
+            type="multiple"
+            orientation="horizontal"
+            value={[...providerFilter]}
+            onValueChange={(next) => setProviderFilter(new Set(next))}
+            aria-label="Filter by provider"
             className="flex flex-wrap gap-1 border-b px-3 py-2"
-            // Keep cmdk's root handler from claiming Enter so the focused
-            // chip toggles instead of selecting the highlighted model.
             onKeyDown={(e) => {
-              if (e.key === "Enter") e.stopPropagation();
+              // Keep cmdk's root handler from claiming Enter (the focused
+              // chip toggles instead of selecting the highlighted model) and
+              // Home/End (the roving focus group jumps chips, not the list).
+              if (e.key === "Enter" || e.key === "Home" || e.key === "End") {
+                e.stopPropagation();
+              }
+              // Vertical arrows hand focus back to the model list, matching
+              // the packaged Thinking row.
+              if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+                e.currentTarget
+                  .closest("[cmdk-root]")
+                  ?.querySelector<HTMLInputElement>("[cmdk-input]")
+                  ?.focus();
+              }
             }}
           >
-            {[...modelsByProvider.keys()].map((provider) => {
-              const isActive = providerFilter.has(provider);
-              return (
-                <button
-                  key={provider}
-                  type="button"
-                  aria-pressed={isActive}
-                  data-state={isActive ? "on" : "off"}
-                  onClick={() => toggleProvider(provider)}
-                  className={cn(
-                    "rounded-full border px-2 py-0.5 text-xs transition-colors",
-                    isActive
-                      ? "bg-accent text-accent-foreground border-transparent"
-                      : "text-muted-foreground hover:text-foreground",
-                  )}
-                >
-                  {provider}
-                </button>
-              );
-            })}
-          </div>
+            {[...modelsByProvider.keys()].map((provider) => (
+              <ToggleGroupPrimitive.Item
+                key={provider}
+                value={provider}
+                className={cn(
+                  "rounded-full border px-2 py-0.5 text-xs transition-colors",
+                  "text-muted-foreground hover:text-foreground",
+                  "data-[state=on]:bg-accent data-[state=on]:text-accent-foreground data-[state=on]:border-transparent",
+                )}
+              >
+                {provider}
+              </ToggleGroupPrimitive.Item>
+            ))}
+          </ToggleGroupPrimitive.Root>
           <ModelSelectorList>
             <ModelSelectorEmpty />
             {visibleGroups.map(([provider, providerModels]) => (

--- a/apps/docs/content/docs/ui/model-selector.mdx
+++ b/apps/docs/content/docs/ui/model-selector.mdx
@@ -149,7 +149,7 @@ Search is opt-in. Pass `searchable` to the default component:
 <ModelSelector models={models} searchable />
 ```
 
-Or compose `ModelSelector.Search` into a custom layout. Matching runs against each model's `id`, `name`, and `keywords`; add the provider name to `keywords` so typing "openai" finds its models.
+The same prop works on `ModelSelector.Content` when it renders its default children. Or compose `ModelSelector.Search` into a custom layout. Matching runs against each model's `id`, `name`, and `keywords`; add the provider name to `keywords` so typing "openai" finds its models.
 
 ## Composition
 

--- a/apps/docs/content/docs/ui/model-selector.mdx
+++ b/apps/docs/content/docs/ui/model-selector.mdx
@@ -204,6 +204,7 @@ import {
 | `ModelSelector.Value` | Selected model name, icon, and active effort |
 | `ModelSelector.Content` | Popover content wrapping a Command |
 | `ModelSelector.Search` | Search input that filters the list |
+| `ModelSelector.FocusAnchor` | Visually hidden input that anchors keyboard navigation when there is no search box |
 | `ModelSelector.List` | List of model items (renders all models by default) |
 | `ModelSelector.Empty` | Empty state shown when search has no matches |
 | `ModelSelector.Group` | Labeled group of items (e.g. by provider) |
@@ -212,6 +213,8 @@ import {
 | `ModelSelector.Effort` | Thinking level row for the selected model |
 
 `ModelSelector.List` is a Command list, so filtering and keyboard navigation work across groups automatically. Custom sorting is plain code: order the models before rendering items.
+
+Keyboard navigation needs a focused input to drive it. When content is unfiltered (`searchable={false}` on `ModelSelector.Content`, or the default children), `ModelSelector.Content` renders a visually hidden `ModelSelector.FocusAnchor` automatically, so custom layouts without a search box stay keyboard-operable. In a custom layout that renders neither `ModelSelector.Search` nor `searchable={false}`, place `ModelSelector.FocusAnchor` yourself to keep the list reachable from the keyboard.
 
 <Callout type="warn">
   `ModelSelector.Content` wraps a Command whose root keydown handler claims
@@ -261,7 +264,7 @@ The picker is fully operable from the keyboard, including when search is disable
 | <Kbd>Escape</Kbd> | Close the popover and return focus to the trigger |
 | <Kbd>Tab</Kbd> | Move from the model list to the Thinking row |
 | <Kbd>ArrowLeft</Kbd> / <Kbd>ArrowRight</Kbd> | Move between reasoning effort levels (Thinking row) |
-| <Kbd>Home</Kbd> / <Kbd>End</Kbd> | Jump to the first / last effort level |
+| <Kbd>Home</Kbd> / <Kbd>End</Kbd> | Jump to the first / last model (list) or effort level (Thinking row) |
 
 When `searchable` is set, typing filters the list; otherwise the keys above drive selection directly.
 
@@ -271,7 +274,7 @@ The picker implements the WAI-ARIA combobox pattern over Popover + Command.
 
 - The trigger is `role="combobox"` with `aria-haspopup="listbox"`; Radix Popover manages `aria-expanded` and `aria-controls`.
 - The model list is a Command (cmdk) listbox: each item is `role="option"` with `aria-selected`, and the active item is tracked with `aria-activedescendant`.
-- Keyboard navigation works without a visible search box: a visually hidden input anchors cmdk's focus so the list stays reachable. Pass `searchable` to surface that input.
+- Keyboard navigation works without a visible search box: `ModelSelector.Content` renders a visually hidden input (`ModelSelector.FocusAnchor`) that anchors cmdk's focus so the list stays reachable. Pass `searchable` to surface a real search input instead.
 - The Thinking row (`ModelSelector.Effort`) is a `role="radiogroup"` of `role="radio"` toggles with roving tabindex, so it is a single tab stop and <Kbd>ArrowLeft</Kbd> / <Kbd>ArrowRight</Kbd> move focus and select in one step.
 
 ## How It Works

--- a/apps/docs/content/docs/ui/model-selector.mdx
+++ b/apps/docs/content/docs/ui/model-selector.mdx
@@ -219,8 +219,9 @@ import {
   through the list. Interactive elements composed inside it (filter chips,
   custom effort controls) should stop propagation for the keys they handle in
   their own `onKeyDown` so the focused control responds instead.
-  `ModelSelector.Effort` already does this for <Kbd>Enter</Kbd> and its arrow
-  keys.
+  `ModelSelector.Effort` does this for <Kbd>Home</Kbd> / <Kbd>End</Kbd> (which
+  cmdk would otherwise use to jump to the first / last model) and lets its
+  radiogroup own the arrow keys.
 </Callout>
 
 ## Variants

--- a/apps/docs/content/docs/ui/model-selector.mdx
+++ b/apps/docs/content/docs/ui/model-selector.mdx
@@ -215,10 +215,12 @@ import {
 
 <Callout type="warn">
   `ModelSelector.Content` wraps a Command whose root keydown handler claims
-  <kbd>Enter</kbd> to select the highlighted model. Interactive elements
-  composed inside it (filter chips, custom effort controls) should stop
-  propagation for Enter in their own `onKeyDown` so the focused control
-  activates instead. `ModelSelector.Effort` already does this.
+  <Kbd>Enter</Kbd> to select the highlighted model and the arrow keys to move
+  through the list. Interactive elements composed inside it (filter chips,
+  custom effort controls) should stop propagation for the keys they handle in
+  their own `onKeyDown` so the focused control responds instead.
+  `ModelSelector.Effort` already does this for <Kbd>Enter</Kbd> and its arrow
+  keys.
 </Callout>
 
 ## Variants
@@ -246,6 +248,30 @@ Use the `size` prop to control the trigger dimensions.
 <ModelSelector size="default" /> // Standard (h-9)
 <ModelSelector size="lg" />      // Large (h-10)
 ```
+
+## Keyboard Navigation
+
+The picker is fully operable from the keyboard, including when search is disabled.
+
+| Key | Action |
+| --- | --- |
+| <Kbd>ArrowDown</Kbd> / <Kbd>ArrowUp</Kbd> | Open the popover from the focused trigger; move between models once open |
+| <Kbd>Enter</Kbd> | Select the highlighted model and close |
+| <Kbd>Escape</Kbd> | Close the popover and return focus to the trigger |
+| <Kbd>Tab</Kbd> | Move from the model list to the Thinking row |
+| <Kbd>ArrowLeft</Kbd> / <Kbd>ArrowRight</Kbd> | Move between reasoning effort levels (Thinking row) |
+| <Kbd>Home</Kbd> / <Kbd>End</Kbd> | Jump to the first / last effort level |
+
+When `searchable` is set, typing filters the list; otherwise the keys above drive selection directly.
+
+## Accessibility
+
+The picker implements the WAI-ARIA combobox pattern over Popover + Command.
+
+- The trigger is `role="combobox"` with `aria-haspopup="listbox"`; Radix Popover manages `aria-expanded` and `aria-controls`.
+- The model list is a Command (cmdk) listbox: each item is `role="option"` with `aria-selected`, and the active item is tracked with `aria-activedescendant`.
+- Keyboard navigation works without a visible search box: a visually hidden input anchors cmdk's focus so the list stays reachable. Pass `searchable` to surface that input.
+- The Thinking row (`ModelSelector.Effort`) is a `role="radiogroup"` of `role="radio"` toggles with roving tabindex, so it is a single tab stop and <Kbd>ArrowLeft</Kbd> / <Kbd>ArrowRight</Kbd> move focus and select in one step.
 
 ## How It Works
 

--- a/apps/docs/content/docs/ui/model-selector.mdx
+++ b/apps/docs/content/docs/ui/model-selector.mdx
@@ -223,8 +223,11 @@ Keyboard navigation needs a focused input to drive it. When content is unfiltere
   custom effort controls) should stop propagation for the keys they handle in
   their own `onKeyDown` so the focused control responds instead.
   `ModelSelector.Effort` does this for <Kbd>Home</Kbd> / <Kbd>End</Kbd> (which
-  cmdk would otherwise use to jump to the first / last model) and lets its
-  radiogroup own the arrow keys.
+  cmdk would otherwise use to jump to the first / last model), lets its
+  radiogroup own <Kbd>ArrowLeft</Kbd> / <Kbd>ArrowRight</Kbd>, and hands
+  <Kbd>ArrowUp</Kbd> / <Kbd>ArrowDown</Kbd> back to the model list by
+  refocusing cmdk's input, so the highlight only moves while a following
+  <Kbd>Enter</Kbd> can act on it.
 </Callout>
 
 ## Variants
@@ -259,7 +262,7 @@ The picker is fully operable from the keyboard, including when search is disable
 
 | Key | Action |
 | --- | --- |
-| <Kbd>ArrowDown</Kbd> / <Kbd>ArrowUp</Kbd> | Open the popover from the focused trigger; move between models once open |
+| <Kbd>ArrowDown</Kbd> / <Kbd>ArrowUp</Kbd> | Open the popover from the focused trigger; move between models once open, returning focus to the list from the Thinking row |
 | <Kbd>Enter</Kbd> | Select the highlighted model and close |
 | <Kbd>Escape</Kbd> | Close the popover and return focus to the trigger |
 | <Kbd>Tab</Kbd> | Move from the model list to the Thinking row |
@@ -275,7 +278,7 @@ The picker implements the WAI-ARIA combobox pattern over Popover + Command.
 - The trigger is `role="combobox"` with `aria-haspopup="listbox"`; Radix Popover manages `aria-expanded` and `aria-controls`.
 - The model list is a Command (cmdk) listbox: each item is `role="option"` with `aria-selected`, and the active item is tracked with `aria-activedescendant`.
 - Keyboard navigation works without a visible search box: `ModelSelector.Content` renders a visually hidden input (`ModelSelector.FocusAnchor`) that anchors cmdk's focus so the list stays reachable. Pass `searchable` to surface a real search input instead.
-- The Thinking row (`ModelSelector.Effort`) is a `role="radiogroup"` of `role="radio"` toggles with roving tabindex, so it is a single tab stop and <Kbd>ArrowLeft</Kbd> / <Kbd>ArrowRight</Kbd> move focus and select in one step.
+- The Thinking row (`ModelSelector.Effort`) is a `role="radiogroup"` of `role="radio"` toggles with roving tabindex, so it is a single tab stop and <Kbd>ArrowLeft</Kbd> / <Kbd>ArrowRight</Kbd> move focus and select in one step. <Kbd>ArrowUp</Kbd> / <Kbd>ArrowDown</Kbd> return focus to the model list.
 
 ## How It Works
 

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -493,6 +493,7 @@ export const registry: RegistryItem[] = [
       "@assistant-ui/react",
       "lucide-react",
       "class-variance-authority",
+      "radix-ui",
     ],
     registryDependencies: ["command", "popover"],
   },

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -10,7 +10,6 @@ import {
   createContext,
   useContext,
   type ComponentPropsWithoutRef,
-  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
@@ -31,6 +30,7 @@ import {
   CommandList,
   CommandSeparator,
 } from "@/components/ui/command";
+import { RadioGroup } from "radix-ui";
 
 export type ModelSelectorEffortOption = {
   id: string;
@@ -232,7 +232,6 @@ function ModelSelectorRoot({
 
   return (
     <ModelSelectorContext.Provider value={contextValue}>
-      {/* `?? false` narrows away undefined for exactOptionalPropertyTypes consumers. */}
       <Popover open={open ?? false} onOpenChange={setOpen}>
         {children}
       </Popover>
@@ -273,15 +272,28 @@ function ModelSelectorTrigger({
   variant,
   size,
   children,
+  onKeyDown,
   ...props
 }: ModelSelectorTriggerProps) {
+  const { setOpen } = useModelSelectorContext();
+
   return (
     <PopoverTrigger
       data-slot="model-selector-trigger"
       data-variant={variant ?? "outline"}
       data-size={size ?? "default"}
       role="combobox"
+      aria-haspopup="listbox"
       className={cn(modelSelectorTriggerVariants({ variant, size }), className)}
+      onKeyDown={(e) => {
+        // ARIA combobox: arrows open the listbox from a focused trigger.
+        // Popover leaves this to the consumer.
+        if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+          e.preventDefault();
+          setOpen(true);
+        }
+        onKeyDown?.(e);
+      }}
       {...props}
     >
       {children ?? <ModelSelectorValue />}
@@ -344,16 +356,30 @@ function ModelSelectorValue({
 
 export type ModelSelectorContentProps = ComponentPropsWithoutRef<
   typeof PopoverContent
->;
+> & {
+  searchable?: boolean;
+};
+
+// cmdk drives arrow/Enter navigation from a focused input, exposing the active
+// row via aria-activedescendant. Hide input when not searchable to serve as anchor.
+function ModelSelectorFocusAnchor() {
+  return (
+    <div className="sr-only">
+      <CommandInput aria-label="Search models" />
+    </div>
+  );
+}
 
 function ModelSelectorContent({
   className,
   align = "start",
   sideOffset = 6,
+  searchable,
   children,
   ...props
 }: ModelSelectorContentProps) {
   const { value } = useModelSelectorContext();
+  const unfiltered = searchable === false || children === undefined;
 
   return (
     <PopoverContent
@@ -366,14 +392,14 @@ function ModelSelectorContent({
       )}
       {...props}
     >
-      {/* Seeding cmdk with the selected id makes it the active item, which
-          cmdk scrolls into view when the popover opens. */}
       <Command
         className="bg-transparent"
+        {...(unfiltered ? { shouldFilter: false } : {})}
         {...(value !== undefined ? { defaultValue: value } : {})}
       >
         {children ?? (
           <>
+            <ModelSelectorFocusAnchor />
             <ModelSelectorList />
             <ModelSelectorEffort />
           </>
@@ -536,29 +562,28 @@ function ModelSelectorEffort({
         "flex items-center justify-between gap-3 border-t px-3 py-2",
         className,
       )}
-      onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
-        // cmdk's root keydown handler claims Enter to select the highlighted
-        // model; stop it from seeing Enter so the focused toggle activates.
-        if (e.key === "Enter") e.stopPropagation();
+      onKeyDown={(e) => {
+        // cmdk's Command root claims Home/End to jump the model list; stop
+        // them here so only the radiogroup reacts.
+        if (e.key === "Home" || e.key === "End") e.stopPropagation();
         onKeyDown?.(e);
       }}
       {...props}
     >
       <span className="text-muted-foreground text-xs">{label}</span>
-      <div
-        role="group"
+      <RadioGroup.Root
+        value={effort ?? ""}
+        onValueChange={setEffort}
+        orientation="horizontal"
         aria-label={typeof label === "string" ? label : "Reasoning effort"}
         className="flex items-center gap-0.5"
       >
         {efforts.map((option) => {
           const isActive = option.id === effort;
           return (
-            <button
+            <RadioGroup.Item
               key={option.id}
-              type="button"
-              aria-pressed={isActive}
-              data-state={isActive ? "on" : "off"}
-              onClick={() => setEffort(option.id)}
+              value={option.id}
               className={cn(
                 "focus-visible:ring-ring/50 rounded-md px-2 py-1 text-xs transition-colors outline-none focus-visible:ring-2",
                 isActive
@@ -567,10 +592,10 @@ function ModelSelectorEffort({
               )}
             >
               {option.name}
-            </button>
+            </RadioGroup.Item>
           );
         })}
-      </div>
+      </RadioGroup.Root>
     </div>
   );
 }
@@ -621,8 +646,11 @@ const ModelSelectorImpl = ({
         size={size}
         className={className}
       />
-      <ModelSelectorContent className={contentClassName}>
-        {searchable && <ModelSelectorSearch />}
+      <ModelSelectorContent
+        className={contentClassName}
+        searchable={searchable ?? false}
+      >
+        {searchable ? <ModelSelectorSearch /> : <ModelSelectorFocusAnchor />}
         <ModelSelectorList />
         <ModelSelectorEffort />
       </ModelSelectorContent>

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -30,7 +30,7 @@ import {
   CommandList,
   CommandSeparator,
 } from "@/components/ui/command";
-import { RadioGroup } from "radix-ui";
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
 
 export type ModelSelectorEffortOption = {
   id: string;
@@ -576,11 +576,21 @@ function ModelSelectorEffort({
         // cmdk's Command root claims Home/End to jump the model list; stop
         // them here so only the radiogroup reacts.
         if (e.key === "Home" || e.key === "End") e.stopPropagation();
+        // Vertical arrows refocus cmdk's input before the event bubbles to
+        // the Command root: the same keypress then moves the list highlight,
+        // and Enter selects again (cmdk's Enter is inert while a radio has
+        // focus, so the highlight would otherwise move with no way to act).
+        if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+          e.currentTarget
+            .closest("[cmdk-root]")
+            ?.querySelector<HTMLInputElement>("[cmdk-input]")
+            ?.focus();
+        }
       }}
       {...props}
     >
       <span className="text-muted-foreground text-xs">{label}</span>
-      <RadioGroup.Root
+      <RadioGroupPrimitive.Root
         value={effort ?? ""}
         onValueChange={setEffort}
         orientation="horizontal"
@@ -588,7 +598,7 @@ function ModelSelectorEffort({
         className="flex items-center gap-0.5"
       >
         {efforts.map((option) => (
-          <RadioGroup.Item
+          <RadioGroupPrimitive.Item
             key={option.id}
             value={option.id}
             className={cn(
@@ -597,9 +607,9 @@ function ModelSelectorEffort({
             )}
           >
             {option.name}
-          </RadioGroup.Item>
+          </RadioGroupPrimitive.Item>
         ))}
-      </RadioGroup.Root>
+      </RadioGroupPrimitive.Root>
     </div>
   );
 }

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -286,13 +286,14 @@ function ModelSelectorTrigger({
       aria-haspopup="listbox"
       className={cn(modelSelectorTriggerVariants({ variant, size }), className)}
       onKeyDown={(e) => {
+        onKeyDown?.(e);
+        if (e.defaultPrevented) return;
         // ARIA combobox: arrows open the listbox from a focused trigger.
         // Popover leaves this to the consumer.
         if (e.key === "ArrowDown" || e.key === "ArrowUp") {
           e.preventDefault();
           setOpen(true);
         }
-        onKeyDown?.(e);
       }}
       {...props}
     >
@@ -384,7 +385,8 @@ function ModelSelectorContent({
   ...props
 }: ModelSelectorContentProps) {
   const { value } = useModelSelectorContext();
-  const unfiltered = searchable === false || children === undefined;
+  const unfiltered =
+    searchable === false || (!searchable && children === undefined);
 
   return (
     <PopoverContent
@@ -405,6 +407,7 @@ function ModelSelectorContent({
         {unfiltered && <ModelSelectorFocusAnchor />}
         {children ?? (
           <>
+            {searchable && <ModelSelectorSearch />}
             <ModelSelectorList />
             <ModelSelectorEffort />
           </>
@@ -568,10 +571,11 @@ function ModelSelectorEffort({
         className,
       )}
       onKeyDown={(e) => {
+        onKeyDown?.(e);
+        if (e.defaultPrevented) return;
         // cmdk's Command root claims Home/End to jump the model list; stop
         // them here so only the radiogroup reacts.
         if (e.key === "Home" || e.key === "End") e.stopPropagation();
-        onKeyDown?.(e);
       }}
       {...props}
     >
@@ -649,11 +653,7 @@ const ModelSelectorImpl = ({
       <ModelSelectorContent
         className={contentClassName}
         searchable={searchable ?? false}
-      >
-        {searchable && <ModelSelectorSearch />}
-        <ModelSelectorList />
-        <ModelSelectorEffort />
-      </ModelSelectorContent>
+      />
     </ModelSelectorRoot>
   );
 };

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -362,8 +362,11 @@ export type ModelSelectorContentProps = ComponentPropsWithoutRef<
   searchable?: boolean;
 };
 
-// cmdk drives arrow/Enter navigation from a focused input, exposing the active
-// row via aria-activedescendant. Hide input when not searchable to serve as anchor.
+/**
+ * Hidden input that anchors cmdk's keyboard navigation, keeping the list
+ * keyboard-operable without a visible search box. ModelSelectorContent renders
+ * one automatically when unfiltered.
+ */
 function ModelSelectorFocusAnchor() {
   return (
     <div className="sr-only">
@@ -396,12 +399,12 @@ function ModelSelectorContent({
     >
       <Command
         className="bg-transparent"
-        {...(unfiltered ? { shouldFilter: false } : {})}
+        shouldFilter={!unfiltered}
         {...(value !== undefined ? { defaultValue: value } : {})}
       >
+        {unfiltered && <ModelSelectorFocusAnchor />}
         {children ?? (
           <>
-            <ModelSelectorFocusAnchor />
             <ModelSelectorList />
             <ModelSelectorEffort />
           </>
@@ -580,23 +583,18 @@ function ModelSelectorEffort({
         aria-label={typeof label === "string" ? label : "Reasoning effort"}
         className="flex items-center gap-0.5"
       >
-        {efforts.map((option) => {
-          const isActive = option.id === effort;
-          return (
-            <RadioGroup.Item
-              key={option.id}
-              value={option.id}
-              className={cn(
-                "focus-visible:ring-ring/50 rounded-md px-2 py-1 text-xs transition-colors outline-none focus-visible:ring-2",
-                isActive
-                  ? "bg-accent text-accent-foreground font-medium"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              {option.name}
-            </RadioGroup.Item>
-          );
-        })}
+        {efforts.map((option) => (
+          <RadioGroup.Item
+            key={option.id}
+            value={option.id}
+            className={cn(
+              "focus-visible:ring-ring/50 text-muted-foreground hover:text-foreground rounded-md px-2 py-1 text-xs transition-colors outline-none focus-visible:ring-2",
+              "data-[state=checked]:bg-accent data-[state=checked]:text-accent-foreground data-[state=checked]:font-medium",
+            )}
+          >
+            {option.name}
+          </RadioGroup.Item>
+        ))}
       </RadioGroup.Root>
     </div>
   );
@@ -652,7 +650,7 @@ const ModelSelectorImpl = ({
         className={contentClassName}
         searchable={searchable ?? false}
       >
-        {searchable ? <ModelSelectorSearch /> : <ModelSelectorFocusAnchor />}
+        {searchable && <ModelSelectorSearch />}
         <ModelSelectorList />
         <ModelSelectorEffort />
       </ModelSelectorContent>
@@ -667,6 +665,7 @@ type ModelSelectorComponent = typeof ModelSelectorImpl & {
   Value: typeof ModelSelectorValue;
   Content: typeof ModelSelectorContent;
   Search: typeof ModelSelectorSearch;
+  FocusAnchor: typeof ModelSelectorFocusAnchor;
   List: typeof ModelSelectorList;
   Empty: typeof ModelSelectorEmpty;
   Group: typeof ModelSelectorGroup;
@@ -685,6 +684,7 @@ ModelSelector.Trigger = ModelSelectorTrigger;
 ModelSelector.Value = ModelSelectorValue;
 ModelSelector.Content = ModelSelectorContent;
 ModelSelector.Search = ModelSelectorSearch;
+ModelSelector.FocusAnchor = ModelSelectorFocusAnchor;
 ModelSelector.List = ModelSelectorList;
 ModelSelector.Empty = ModelSelectorEmpty;
 ModelSelector.Group = ModelSelectorGroup;
@@ -699,6 +699,7 @@ export {
   ModelSelectorValue,
   ModelSelectorContent,
   ModelSelectorSearch,
+  ModelSelectorFocusAnchor,
   ModelSelectorList,
   ModelSelectorEmpty,
   ModelSelectorGroup,

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -348,7 +348,9 @@ function ModelSelectorValue({
       {selectedModel.icon && <ModelIcon>{selectedModel.icon}</ModelIcon>}
       <span className="truncate font-medium">{selectedModel.name}</span>
       {effortName && (
-        <span className="text-muted-foreground text-center min-w-7.5 truncate">{effortName}</span>
+        <span className="text-muted-foreground min-w-7.5 truncate text-center">
+          {effortName}
+        </span>
       )}
     </span>
   );

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -365,7 +365,7 @@ export type ModelSelectorContentProps = ComponentPropsWithoutRef<
 function ModelSelectorFocusAnchor() {
   return (
     <div className="sr-only">
-      <CommandInput aria-label="Search models" />
+      <CommandInput readOnly aria-label="Model" />
     </div>
   );
 }

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -39,7 +39,7 @@ export type ModelSelectorEffortOption = {
 
 export const DEFAULT_EFFORT_OPTIONS: readonly ModelSelectorEffortOption[] = [
   { id: "low", name: "Low" },
-  { id: "medium", name: "Medium" },
+  { id: "medium", name: "Med" },
   { id: "high", name: "High" },
 ];
 
@@ -348,7 +348,7 @@ function ModelSelectorValue({
       {selectedModel.icon && <ModelIcon>{selectedModel.icon}</ModelIcon>}
       <span className="truncate font-medium">{selectedModel.name}</span>
       {effortName && (
-        <span className="text-muted-foreground truncate">{effortName}</span>
+        <span className="text-muted-foreground text-center min-w-7.5 truncate">{effortName}</span>
       )}
     </span>
   );


### PR DESCRIPTION
fixes inconsistent keyboard nav behavior and improves accessibility. also resolves the triggers layout shift when switching effort levels by renaming medium label to med, and setting min-w-[30px]

- Effort row as a radiogroup: the Thinking toggle is now a Radix `RadioGroup` (`role="radiogroup"`/`radio`, roving tabindex, arrow + Home/End nav, RTL-aware, select-on-navigate), replacing a hand-rolled keydown handler.
- Trigger as a combobox: `role="combobox"` + `aria-haspopup="listbox"`, and ArrowUp/ArrowDown open the popover from the focused trigger.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

