### PR TITLE
feat: support mcp connection timeouts

### DIFF
--- a/.changeset/nice-pears-invite.md
+++ b/.changeset/nice-pears-invite.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+feat: support MCP connection timeouts

--- a/api-surface/assistant-ui__react-mcp.ts
+++ b/api-surface/assistant-ui__react-mcp.ts
@@ -25,6 +25,7 @@ type MCPConnector = {
   url: string;
   icon?: string | undefined;
   auth: MCPAuthConfig;
+  connectionTimeoutMs?: number | undefined;
 };
 
 type MCPCustomServerRecord = {
@@ -32,6 +33,7 @@ type MCPCustomServerRecord = {
   name: string;
   url: string;
   auth: MCPAuthConfig;
+  connectionTimeoutMs?: number | undefined;
   createdAt: number;
 };
 
@@ -99,6 +101,7 @@ type MCPManagerMethods = {
     name: string;
     url: string;
     auth: MCPAuthConfig;
+    connectionTimeoutMs?: number | undefined;
   }) => Promise<string>;
   removeServer: (id: string) => Promise<void>;
 };
@@ -217,6 +220,7 @@ type McpManagerResourceProps = {
   storage?: MCPStorageElement | undefined;
   oauthRedirectUri?: string | undefined;
   autoConnect?: boolean | undefined;
+  connectionTimeoutMs?: number | undefined;
 };
 
 declare const McpManagerResource: Resource<ClientOutput<"mcp">, [
@@ -233,6 +237,7 @@ type McpServerResourceProps = {
   storage: MCPStorage;
   redirectUri: string;
   autoConnect: boolean;
+  connectionTimeoutMs?: number | undefined;
   onRemove: () => Promise<void>;
 };
 

--- a/api-surface/assistant-ui__react-mcp.ts
+++ b/api-surface/assistant-ui__react-mcp.ts
@@ -25,7 +25,7 @@ type MCPConnector = {
   url: string;
   icon?: string | undefined;
   auth: MCPAuthConfig;
-  connectionTimeoutMs?: number | undefined;
+  connectionTimeout?: number | undefined;
 };
 
 type MCPCustomServerRecord = {
@@ -33,7 +33,7 @@ type MCPCustomServerRecord = {
   name: string;
   url: string;
   auth: MCPAuthConfig;
-  connectionTimeoutMs?: number | undefined;
+  connectionTimeout?: number | undefined;
   createdAt: number;
 };
 
@@ -101,7 +101,7 @@ type MCPManagerMethods = {
     name: string;
     url: string;
     auth: MCPAuthConfig;
-    connectionTimeoutMs?: number | undefined;
+    connectionTimeout?: number | undefined;
   }) => Promise<string>;
   removeServer: (id: string) => Promise<void>;
 };
@@ -220,7 +220,7 @@ type McpManagerResourceProps = {
   storage?: MCPStorageElement | undefined;
   oauthRedirectUri?: string | undefined;
   autoConnect?: boolean | undefined;
-  connectionTimeoutMs?: number | undefined;
+  connectionTimeout?: number | undefined;
 };
 
 declare const McpManagerResource: Resource<ClientOutput<"mcp">, [
@@ -237,7 +237,7 @@ type McpServerResourceProps = {
   storage: MCPStorage;
   redirectUri: string;
   autoConnect: boolean;
-  connectionTimeoutMs?: number | undefined;
+  connectionTimeout?: number | undefined;
   onRemove: () => Promise<void>;
 };
 

--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -59,7 +59,7 @@ const connectors = [
     name: "Weather",
     url: "https://mcp.example.com/weather",
     auth: { type: "none" },
-    connectionTimeoutMs: 10_000,
+    connectionTimeout: 10_000,
   }),
 ];
 
@@ -67,7 +67,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   const aui = useAui({
     mcp: McpManagerResource({
       connectors,
-      connectionTimeoutMs: 15_000,
+      connectionTimeout: 15_000,
     }),
   });
   return <AuiProvider value={aui}>{children}</AuiProvider>;
@@ -79,7 +79,7 @@ Defaults and useful options:
 - `storage` — `McpLocalStorage()` (override for production; see [Storage](#storage))
 - `oauthRedirectUri` — `${window.location.origin}/mcp/callback`
 - `autoConnect` — `true` (connect on mount when usable auth is persisted)
-- `connectionTimeoutMs` — optional. Set it on the manager as a default or on a connector/custom server to bound the MCP readiness flow (`connect()` plus `listTools()`) with a clear error.
+- `connectionTimeout` — optional timeout in milliseconds. Set it on the manager as a default or on a connector/custom server to bound the MCP readiness flow (`connect()` plus `listTools()`) with a clear error.
 
 </Step>
 <Step>

--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -59,20 +59,27 @@ const connectors = [
     name: "Weather",
     url: "https://mcp.example.com/weather",
     auth: { type: "none" },
+    connectionTimeoutMs: 10_000,
   }),
 ];
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  const aui = useAui({ mcp: McpManagerResource({ connectors }) });
+  const aui = useAui({
+    mcp: McpManagerResource({
+      connectors,
+      connectionTimeoutMs: 15_000,
+    }),
+  });
   return <AuiProvider value={aui}>{children}</AuiProvider>;
 }
 ```
 
-Defaults baked in:
+Defaults and useful options:
 
 - `storage` — `McpLocalStorage()` (override for production; see [Storage](#storage))
 - `oauthRedirectUri` — `${window.location.origin}/mcp/callback`
 - `autoConnect` — `true` (connect on mount when usable auth is persisted)
+- `connectionTimeoutMs` — optional. Set it on the manager as a default or on a connector/custom server to bound the MCP readiness flow (`connect()` plus `listTools()`) with a clear error.
 
 </Step>
 <Step>

--- a/packages/react-mcp/SPEC.md
+++ b/packages/react-mcp/SPEC.md
@@ -85,6 +85,7 @@ type MCPConnector = {
   url: string;
   icon?: string;
   auth: MCPAuthConfig;
+  connectionTimeoutMs?: number;
 };
 defineConnector(c: MCPConnector): MCPConnector;
 ```
@@ -97,6 +98,7 @@ type MCPCustomServerRecord = {
   name: string;
   url: string;
   auth: MCPAuthConfig;
+  connectionTimeoutMs?: number;
   createdAt: number;
 };
 ```
@@ -144,7 +146,7 @@ declare module "@assistant-ui/store" {
 type MCPManagerMethods = {
   getState: () => MCPManagerState;
   server: (lookup: { id: string }) => MCPServerMethods;
-  addCustomServer: (input: { name: string; url: string; auth: MCPAuthConfig }) => Promise<string>;
+  addCustomServer: (input: { name: string; url: string; auth: MCPAuthConfig; connectionTimeoutMs?: number }) => Promise<string>;
   removeServer: (id: string) => Promise<void>;
 };
 
@@ -204,6 +206,7 @@ function App() {
       // optional:
       // storage: McpCustomStorage({ ... }),
       // autoConnect: false,
+      // connectionTimeoutMs: 10_000,
       // oauthRedirectUri: "https://app.example.com/mcp/callback",
     }),
   });
@@ -216,6 +219,7 @@ Defaults baked in:
 - `storage` → `McpLocalStorage()`
 - `oauthRedirectUri` → `${window.location.origin}/mcp/callback`
 - `autoConnect` → `true`
+- `connectionTimeoutMs` → disabled by default; set on the manager as a default or on a server entry to bound the MCP readiness flow (`connect()` plus `listTools()`).
 
 ## 4. Auth
 

--- a/packages/react-mcp/SPEC.md
+++ b/packages/react-mcp/SPEC.md
@@ -85,7 +85,7 @@ type MCPConnector = {
   url: string;
   icon?: string;
   auth: MCPAuthConfig;
-  connectionTimeoutMs?: number;
+  connectionTimeout?: number;
 };
 defineConnector(c: MCPConnector): MCPConnector;
 ```
@@ -98,7 +98,7 @@ type MCPCustomServerRecord = {
   name: string;
   url: string;
   auth: MCPAuthConfig;
-  connectionTimeoutMs?: number;
+  connectionTimeout?: number;
   createdAt: number;
 };
 ```
@@ -146,7 +146,7 @@ declare module "@assistant-ui/store" {
 type MCPManagerMethods = {
   getState: () => MCPManagerState;
   server: (lookup: { id: string }) => MCPServerMethods;
-  addCustomServer: (input: { name: string; url: string; auth: MCPAuthConfig; connectionTimeoutMs?: number }) => Promise<string>;
+  addCustomServer: (input: { name: string; url: string; auth: MCPAuthConfig; connectionTimeout?: number }) => Promise<string>;
   removeServer: (id: string) => Promise<void>;
 };
 
@@ -206,7 +206,7 @@ function App() {
       // optional:
       // storage: McpCustomStorage({ ... }),
       // autoConnect: false,
-      // connectionTimeoutMs: 10_000,
+      // connectionTimeout: 10_000,
       // oauthRedirectUri: "https://app.example.com/mcp/callback",
     }),
   });
@@ -219,7 +219,7 @@ Defaults baked in:
 - `storage` → `McpLocalStorage()`
 - `oauthRedirectUri` → `${window.location.origin}/mcp/callback`
 - `autoConnect` → `true`
-- `connectionTimeoutMs` → disabled by default; set on the manager as a default or on a server entry to bound the MCP readiness flow (`connect()` plus `listTools()`).
+- `connectionTimeout` → optional timeout in milliseconds; disabled by default. Set it on the manager as a default or on a server entry to bound the MCP readiness flow (`connect()` plus `listTools()`).
 
 ## 4. Auth
 

--- a/packages/react-mcp/package.json
+++ b/packages/react-mcp/package.json
@@ -27,7 +27,9 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "aui-build"
+    "build": "aui-build",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@assistant-ui/core": "workspace:*",
@@ -49,7 +51,8 @@
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
     "@types/react": "^19.2.17",
-    "react": "^19.2.7"
+    "react": "^19.2.7",
+    "vitest": "^4.1.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/react-mcp/src/mcp-scope.ts
+++ b/packages/react-mcp/src/mcp-scope.ts
@@ -19,6 +19,7 @@ export type MCPConnector = {
   url: string;
   icon?: string | undefined;
   auth: MCPAuthConfig;
+  connectionTimeoutMs?: number | undefined;
 };
 
 export type MCPCustomServerRecord = {
@@ -26,6 +27,7 @@ export type MCPCustomServerRecord = {
   name: string;
   url: string;
   auth: MCPAuthConfig;
+  connectionTimeoutMs?: number | undefined;
   createdAt: number;
 };
 
@@ -93,6 +95,7 @@ export type MCPManagerMethods = {
     name: string;
     url: string;
     auth: MCPAuthConfig;
+    connectionTimeoutMs?: number | undefined;
   }) => Promise<string>;
   removeServer: (id: string) => Promise<void>;
 };

--- a/packages/react-mcp/src/mcp-scope.ts
+++ b/packages/react-mcp/src/mcp-scope.ts
@@ -19,7 +19,7 @@ export type MCPConnector = {
   url: string;
   icon?: string | undefined;
   auth: MCPAuthConfig;
-  connectionTimeoutMs?: number | undefined;
+  connectionTimeout?: number | undefined;
 };
 
 export type MCPCustomServerRecord = {
@@ -27,7 +27,7 @@ export type MCPCustomServerRecord = {
   name: string;
   url: string;
   auth: MCPAuthConfig;
-  connectionTimeoutMs?: number | undefined;
+  connectionTimeout?: number | undefined;
   createdAt: number;
 };
 
@@ -95,7 +95,7 @@ export type MCPManagerMethods = {
     name: string;
     url: string;
     auth: MCPAuthConfig;
-    connectionTimeoutMs?: number | undefined;
+    connectionTimeout?: number | undefined;
   }) => Promise<string>;
   removeServer: (id: string) => Promise<void>;
 };

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -25,6 +25,8 @@ export type McpManagerResourceProps = {
   oauthRedirectUri?: string | undefined;
   /** Connect on mount when usable auth exists. Default true. */
   autoConnect?: boolean | undefined;
+  /** Optional timeout for connect/listTools calls. Disabled by default. */
+  connectionTimeoutMs?: number | undefined;
 };
 
 function defaultRedirectUri(): string {
@@ -42,6 +44,7 @@ const useMcpManagerResource = (
   const connectors = props.connectors ?? NO_CONNECTORS;
   const autoConnect = props.autoConnect ?? true;
   const redirectUri = props.oauthRedirectUri ?? defaultRedirectUri();
+  const connectionTimeoutMs = props.connectionTimeoutMs;
 
   const storageElement = props.storage ?? McpLocalStorage();
   const storage = useResource(storageElement);
@@ -114,6 +117,7 @@ const useMcpManagerResource = (
           storage,
           redirectUri,
           autoConnect,
+          connectionTimeoutMs: c.connectionTimeoutMs ?? connectionTimeoutMs,
           onRemove: async () => {
             // connectors cannot be removed
           },
@@ -132,6 +136,7 @@ const useMcpManagerResource = (
           storage,
           redirectUri,
           autoConnect,
+          connectionTimeoutMs: s.connectionTimeoutMs ?? connectionTimeoutMs,
           onRemove: async () => {
             setCustomServers((prev) => prev.filter((x) => x.id !== s.id));
           },
@@ -139,7 +144,14 @@ const useMcpManagerResource = (
       ),
     );
     return [...connectorElements, ...customElements];
-  }, [connectors, customServers, storage, redirectUri, autoConnect]);
+  }, [
+    connectors,
+    customServers,
+    storage,
+    redirectUri,
+    autoConnect,
+    connectionTimeoutMs,
+  ]);
 
   const lookup = useClientLookup(serverElements);
 
@@ -208,7 +220,7 @@ const useMcpManagerResource = (
     },
     connector: ({ index }) => serverByKind("connector", index),
     customServer: ({ index }) => serverByKind("custom", index),
-    addCustomServer: async ({ name, url, auth }) => {
+    addCustomServer: async ({ name, url, auth, connectionTimeoutMs }) => {
       const record: MCPCustomServerRecord = {
         id:
           typeof crypto !== "undefined" && "randomUUID" in crypto
@@ -217,6 +229,7 @@ const useMcpManagerResource = (
         name,
         url,
         auth: auth as MCPAuthConfig,
+        connectionTimeoutMs,
         createdAt: Date.now(),
       };
       setCustomServers((prev) => [...prev, record]);

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -25,8 +25,8 @@ export type McpManagerResourceProps = {
   oauthRedirectUri?: string | undefined;
   /** Connect on mount when usable auth exists. Default true. */
   autoConnect?: boolean | undefined;
-  /** Optional timeout for connect/listTools calls. Disabled by default. */
-  connectionTimeoutMs?: number | undefined;
+  /** Optional timeout in milliseconds for connect/listTools calls. Disabled by default. */
+  connectionTimeout?: number | undefined;
 };
 
 function defaultRedirectUri(): string {
@@ -44,7 +44,7 @@ const useMcpManagerResource = (
   const connectors = props.connectors ?? NO_CONNECTORS;
   const autoConnect = props.autoConnect ?? true;
   const redirectUri = props.oauthRedirectUri ?? defaultRedirectUri();
-  const connectionTimeoutMs = props.connectionTimeoutMs;
+  const connectionTimeout = props.connectionTimeout;
 
   const storageElement = props.storage ?? McpLocalStorage();
   const storage = useResource(storageElement);
@@ -117,7 +117,7 @@ const useMcpManagerResource = (
           storage,
           redirectUri,
           autoConnect,
-          connectionTimeoutMs: c.connectionTimeoutMs ?? connectionTimeoutMs,
+          connectionTimeout: c.connectionTimeout ?? connectionTimeout,
           onRemove: async () => {
             // connectors cannot be removed
           },
@@ -136,7 +136,7 @@ const useMcpManagerResource = (
           storage,
           redirectUri,
           autoConnect,
-          connectionTimeoutMs: s.connectionTimeoutMs ?? connectionTimeoutMs,
+          connectionTimeout: s.connectionTimeout ?? connectionTimeout,
           onRemove: async () => {
             setCustomServers((prev) => prev.filter((x) => x.id !== s.id));
           },
@@ -150,7 +150,7 @@ const useMcpManagerResource = (
     storage,
     redirectUri,
     autoConnect,
-    connectionTimeoutMs,
+    connectionTimeout,
   ]);
 
   const lookup = useClientLookup(serverElements);
@@ -220,7 +220,7 @@ const useMcpManagerResource = (
     },
     connector: ({ index }) => serverByKind("connector", index),
     customServer: ({ index }) => serverByKind("custom", index),
-    addCustomServer: async ({ name, url, auth, connectionTimeoutMs }) => {
+    addCustomServer: async ({ name, url, auth, connectionTimeout }) => {
       const record: MCPCustomServerRecord = {
         id:
           typeof crypto !== "undefined" && "randomUUID" in crypto
@@ -229,7 +229,7 @@ const useMcpManagerResource = (
         name,
         url,
         auth: auth as MCPAuthConfig,
-        connectionTimeoutMs,
+        connectionTimeout,
         createdAt: Date.now(),
       };
       setCustomServers((prev) => [...prev, record]);

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -77,11 +77,9 @@ const createStorage = (): MCPStorage => ({
   clearAuthState: vi.fn(async () => {}),
 });
 
-const mount = (props?: { connectionTimeoutMs?: number | undefined }) => {
-  const connectionTimeoutMs =
-    props && "connectionTimeoutMs" in props
-      ? props.connectionTimeoutMs
-      : 10_000;
+const mount = (props?: { connectionTimeout?: number | undefined }) => {
+  const connectionTimeout =
+    props && "connectionTimeout" in props ? props.connectionTimeout : 10_000;
 
   return createTapRoot(function Root() {
     return useResource(
@@ -94,14 +92,14 @@ const mount = (props?: { connectionTimeoutMs?: number | undefined }) => {
         storage: createStorage(),
         redirectUri: "https://example.com/callback",
         autoConnect: false,
-        connectionTimeoutMs,
+        connectionTimeout,
         onRemove: vi.fn(async () => {}),
       }),
     );
   });
 };
 
-describe("McpServerResource connectionTimeoutMs", () => {
+describe("McpServerResource connectionTimeout", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mocks.clients.length = 0;
@@ -200,9 +198,9 @@ describe("McpServerResource connectionTimeoutMs", () => {
     }
   });
 
-  it("keeps waiting when connectionTimeoutMs is undefined", async () => {
+  it("keeps waiting when connectionTimeout is undefined", async () => {
     mocks.connectResults.push(() => never());
-    const root = mount({ connectionTimeoutMs: undefined });
+    const root = mount({ connectionTimeout: undefined });
 
     try {
       void root.getValue().connect();

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -1,0 +1,223 @@
+import { createTapRoot, useResource } from "@assistant-ui/tap";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MCPStorage } from "./storage/types";
+
+const mocks = vi.hoisted(() => {
+  const clients: any[] = [];
+  const transports: any[] = [];
+  const connectResults: Array<() => Promise<void>> = [];
+  const listToolsResults: Array<
+    () => Promise<{
+      tools: Array<{
+        name: string;
+        description?: string;
+        inputSchema: unknown;
+      }>;
+    }>
+  > = [];
+
+  const Client = vi.fn().mockImplementation(function Client(this: any) {
+    const index = clients.length;
+    this.connect = vi.fn(() => connectResults[index]?.() ?? Promise.resolve());
+    this.listTools = vi.fn(
+      () => listToolsResults[index]?.() ?? Promise.resolve({ tools: [] }),
+    );
+    this.callTool = vi.fn();
+    this.readResource = vi.fn();
+    clients.push(this);
+  });
+
+  const StreamableHTTPClientTransport = vi
+    .fn()
+    .mockImplementation(function StreamableHTTPClientTransport(this: any) {
+      this.close = vi.fn(() => Promise.resolve());
+      this.finishAuth = vi.fn(() => Promise.resolve());
+      transports.push(this);
+    });
+
+  return {
+    Client,
+    StreamableHTTPClientTransport,
+    clients,
+    transports,
+    connectResults,
+    listToolsResults,
+  };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: mocks.Client,
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: mocks.StreamableHTTPClientTransport,
+}));
+
+const { McpServerResource } = await import("./McpServerResource");
+
+const never = <T>() => new Promise<T>(() => {});
+
+const tick = async () => {
+  await Promise.resolve();
+};
+
+const waitFor = async (predicate: () => boolean) => {
+  for (let i = 0; i < 20; i++) {
+    if (predicate()) return;
+    await tick();
+  }
+  expect(predicate()).toBe(true);
+};
+
+const createStorage = (): MCPStorage => ({
+  loadCustomServers: vi.fn(async () => []),
+  saveCustomServers: vi.fn(async () => {}),
+  loadAuthState: vi.fn(async () => null),
+  saveAuthState: vi.fn(async () => {}),
+  clearAuthState: vi.fn(async () => {}),
+});
+
+const mount = (props?: { connectionTimeoutMs?: number | undefined }) => {
+  const connectionTimeoutMs =
+    props && "connectionTimeoutMs" in props
+      ? props.connectionTimeoutMs
+      : 10_000;
+
+  return createTapRoot(function Root() {
+    return useResource(
+      McpServerResource({
+        id: "docs",
+        kind: "connector",
+        name: "Docs",
+        url: "https://example.com/mcp",
+        auth: { type: "none" },
+        storage: createStorage(),
+        redirectUri: "https://example.com/callback",
+        autoConnect: false,
+        connectionTimeoutMs,
+        onRemove: vi.fn(async () => {}),
+      }),
+    );
+  });
+};
+
+describe("McpServerResource connectionTimeoutMs", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.clients.length = 0;
+    mocks.transports.length = 0;
+    mocks.connectResults.length = 0;
+    mocks.listToolsResults.length = 0;
+    mocks.Client.mockClear();
+    mocks.StreamableHTTPClientTransport.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fails the connection when client.connect hangs", async () => {
+    mocks.connectResults.push(() => never());
+    const root = mount();
+
+    try {
+      const connectPromise = root.getValue().connect();
+      await waitFor(() => mocks.clients[0]?.connect.mock.calls.length === 1);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await connectPromise;
+
+      expect(root.getValue().getState()).toMatchObject({
+        connectionState: "error",
+        tools: [],
+        lastError: {
+          message:
+            'MCP server "docs" timed out while connecting after 10000ms.',
+        },
+      });
+      expect(mocks.transports[0].close).toHaveBeenCalledTimes(1);
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("fails the connection when client.listTools hangs", async () => {
+    mocks.listToolsResults.push(() => never());
+    const root = mount();
+
+    try {
+      const connectPromise = root.getValue().connect();
+      await waitFor(() => mocks.clients[0]?.listTools.mock.calls.length === 1);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await connectPromise;
+
+      expect(root.getValue().getState()).toMatchObject({
+        connectionState: "error",
+        tools: [],
+        lastError: {
+          message:
+            'MCP server "docs" timed out while listing tools after 10000ms.',
+        },
+      });
+      expect(mocks.transports[0].close).toHaveBeenCalledTimes(1);
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("uses one timeout budget for connect and listTools", async () => {
+    mocks.connectResults.push(
+      () => new Promise<void>((resolve) => setTimeout(resolve, 9_000)),
+    );
+    mocks.listToolsResults.push(() => never());
+    const root = mount();
+
+    try {
+      const connectPromise = root.getValue().connect();
+      await waitFor(() => mocks.clients[0]?.connect.mock.calls.length === 1);
+
+      await vi.advanceTimersByTimeAsync(9_000);
+      await waitFor(() => mocks.clients[0]?.listTools.mock.calls.length === 1);
+      await vi.advanceTimersByTimeAsync(999);
+      await tick();
+      expect(root.getValue().getState().connectionState).toBe("connecting");
+
+      await vi.advanceTimersByTimeAsync(1);
+      await connectPromise;
+
+      expect(root.getValue().getState()).toMatchObject({
+        connectionState: "error",
+        tools: [],
+        lastError: {
+          message:
+            'MCP server "docs" timed out while listing tools after 10000ms.',
+        },
+      });
+      expect(mocks.transports[0].close).toHaveBeenCalledTimes(1);
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("keeps waiting when connectionTimeoutMs is undefined", async () => {
+    mocks.connectResults.push(() => never());
+    const root = mount({ connectionTimeoutMs: undefined });
+
+    try {
+      void root.getValue().connect();
+      await waitFor(() => mocks.clients[0]?.connect.mock.calls.length === 1);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await tick();
+
+      expect(root.getValue().getState()).toMatchObject({
+        connectionState: "connecting",
+        tools: [],
+        lastError: null,
+      });
+      expect(mocks.transports[0].close).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+    }
+  });
+});

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -30,6 +30,7 @@ export type McpServerResourceProps = {
   storage: MCPStorage;
   redirectUri: string;
   autoConnect: boolean;
+  connectionTimeoutMs?: number | undefined;
   onRemove: () => Promise<void>;
 };
 
@@ -45,6 +46,35 @@ const useMcpServerResource = (
 
   const clientRef = useRef<Client | null>(null);
   const transportRef = useRef<StreamableHTTPClientTransport | null>(null);
+
+  const withConnectionTimeout = useEffectEvent(
+    async <T>(
+      promise: Promise<T>,
+      phase: "connecting" | "listing tools",
+      startedAt: number,
+    ): Promise<T> => {
+      const timeoutMs = props.connectionTimeoutMs;
+      if (timeoutMs === undefined) return await promise;
+      const remainingMs = timeoutMs - (Date.now() - startedAt);
+      const timeoutError = () =>
+        new Error(
+          `MCP server "${props.id}" timed out while ${phase} after ${timeoutMs}ms.`,
+        );
+      if (remainingMs <= 0) throw timeoutError();
+
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          promise,
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(() => reject(timeoutError()), remainingMs);
+          }),
+        ]);
+      } finally {
+        if (timeout !== undefined) clearTimeout(timeout);
+      }
+    },
+  );
 
   const buildTransport = useEffectEvent(
     async (): Promise<StreamableHTTPClientTransport> => {
@@ -80,16 +110,25 @@ const useMcpServerResource = (
         name: "assistant-ui-mcp",
         version: "0.0.0",
       });
+      const startedAt = Date.now();
       // SDK's StreamableHTTPClientTransport.sessionId is `string | undefined`
       // but Transport.sessionId is declared `string?` — under
       // exactOptionalPropertyTypes the SDK's own classes don't satisfy its
       // Transport interface. Cast to bridge the gap.
-      await client.connect(transport as unknown as Transport);
+      await withConnectionTimeout(
+        client.connect(transport as unknown as Transport),
+        "connecting",
+        startedAt,
+      );
       // Defer ref assignment until listTools() also succeeds — otherwise a
       // post-connect failure leaves stale refs that `callTool()` would
       // happily walk into, producing confusing SDK errors instead of
       // "not connected".
-      const list = await client.listTools();
+      const list = await withConnectionTimeout(
+        client.listTools(),
+        "listing tools",
+        startedAt,
+      );
       clientRef.current = client;
       transportRef.current = transport;
       setTools(

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -30,7 +30,7 @@ export type McpServerResourceProps = {
   storage: MCPStorage;
   redirectUri: string;
   autoConnect: boolean;
-  connectionTimeoutMs?: number | undefined;
+  connectionTimeout?: number | undefined;
   onRemove: () => Promise<void>;
 };
 
@@ -53,7 +53,7 @@ const useMcpServerResource = (
       phase: "connecting" | "listing tools",
       startedAt: number,
     ): Promise<T> => {
-      const timeoutMs = props.connectionTimeoutMs;
+      const timeoutMs = props.connectionTimeout;
       if (timeoutMs === undefined) return await promise;
       const remainingMs = timeoutMs - (Date.now() - startedAt);
       const timeoutError = () =>

--- a/packages/react-mcp/vitest.config.ts
+++ b/packages/react-mcp/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4208,6 +4208,9 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/react-native:
     dependencies:


### PR DESCRIPTION
## Summary
- add `connectionTimeout` to user-managed MCP manager/server config
- fail hanging MCP `connect()` and `listTools()` calls with a clear timeout error
- add react-mcp Vitest coverage, package test config, docs, API surface, and a patch changeset

## Use case
When testing local MCP servers or connecting to flaky remote servers, the SDK can hang during `connect()` or `listTools()`. Without a timeout the UI can stay in `connecting` forever. Apps can now set `connectionTimeout: 10_000` on the manager as a default or on a specific connector/custom server, and users get an actionable error like `MCP server "docs" timed out while connecting after 10000ms.`

## Testing
- `pnpm --filter @assistant-ui/react-mcp test`
- `pnpm --filter @assistant-ui/react-mcp exec tsc --noEmit`
- `pnpm --filter @assistant-ui/react-mcp build`
- `pnpm run api-surface:check -- --skip-build --filter="...[HEAD]"`
- `pnpm exec oxlint packages/react-mcp/src/resources/McpServerResource.ts packages/react-mcp/src/resources/McpManagerResource.ts packages/react-mcp/src/mcp-scope.ts packages/react-mcp/src/resources/McpServerResource.test.ts packages/react-mcp/vitest.config.ts`
- `pnpm exec oxfmt --check ...`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->