### PR TITLE
fix: redirect docs overview roots

### DIFF
--- a/apps/docs/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/(docs)/docs/[[...slug]]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { DocsPage, DocsBody } from "fumadocs-ui/page";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { createOgMetadata } from "@/lib/og";
 import { getMDXComponents } from "@/mdx-components";
 import { source } from "@/lib/source";
@@ -30,9 +30,13 @@ export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
 }) {
   const params = await props.params;
-  const page = source.getPage(params.slug ?? []);
+  const slug = params.slug ?? [];
+  const page = source.getPage(slug);
 
   if (page == null) {
+    const overviewPage = source.getPage([...slug, "overview"]);
+    if (overviewPage) redirect(overviewPage.url);
+
     notFound();
   }
 

--- a/apps/docs/content/docs/(docs)/cli.mdx
+++ b/apps/docs/content/docs/(docs)/cli.mdx
@@ -71,7 +71,7 @@ Use `--example` to create a project from one of the monorepo examples with full 
 | `with-artifacts` | HTML artifact rendering with live preview | `npx assistant-ui create my-app -e with-artifacts` |
 | `with-langgraph` | LangGraph agent with custom tools | `npx assistant-ui create my-app -e with-langgraph` |
 | `with-cloud` | Assistant Cloud persistence | `npx assistant-ui create my-app -e with-cloud` |
-| `with-ag-ui` | [AG-UI protocol](/docs/runtimes/ag-ui) integration | `npx assistant-ui create my-app -e with-ag-ui` |
+| `with-ag-ui` | [AG-UI protocol](/docs/runtimes/ag-ui/overview) integration | `npx assistant-ui create my-app -e with-ag-ui` |
 | `with-assistant-transport` | Custom backend via Assistant Transport | `npx assistant-ui create my-app -e with-assistant-transport` |
 | `with-resumable-stream` | Resumable LLM stream that survives reload mid-response | `npx assistant-ui create my-app -e with-resumable-stream` |
 | `with-chain-of-thought` | Chain-of-thought reasoning, tool calls, and source citations | `npx assistant-ui create my-app -e with-chain-of-thought` |

--- a/apps/docs/content/docs/cloud/langgraph.mdx
+++ b/apps/docs/content/docs/cloud/langgraph.mdx
@@ -547,6 +547,6 @@ For other authentication providers or custom implementations, see the [Cloud Aut
 
 ## Next Steps
 
-- Learn about [LangGraph runtime setup](/docs/runtimes/langgraph) for your application
+- Learn about [LangGraph runtime setup](/docs/runtimes/langgraph/overview) for your application
 - Explore [ThreadListRuntime](/docs/api-reference/runtimes/thread-list-runtime) for advanced thread management
 - Check out the [LangGraph example](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-langgraph) on GitHub

--- a/apps/docs/content/docs/integrations/frameworks/ai-sdk.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/ai-sdk.mdx
@@ -5,7 +5,7 @@ description: Wire the Vercel AI SDK into a React chat UI with assistant-ui — u
 
 import { VercelIcon } from "@/components/icons/vercel";
 
-[Vercel AI SDK](https://ai-sdk.dev/) is the most common framework people pair with assistant-ui. The full setup, attachments, persistence, tool-call patterns, and version notes are documented under [runtimes/ai-sdk](/docs/runtimes/ai-sdk); this page is the entry point in the integrations tree for discoverability and architecture context.
+[Vercel AI SDK](https://ai-sdk.dev/) is the most common framework people pair with assistant-ui. The full setup, attachments, persistence, tool-call patterns, and version notes are documented under [runtimes/ai-sdk](/docs/runtimes/ai-sdk/overview); this page is the entry point in the integrations tree for discoverability and architecture context.
 
 <Callout type="info">
 If you arrived here looking to wire up your first chat: jump to [AI SDK v6 quickstart](/docs/runtimes/ai-sdk/v6). This page is a high-level pointer.
@@ -58,7 +58,7 @@ AI SDK is the default choice for new projects on Next.js, Remix, or any framewor
 - You will compose with a framework like [Mastra](/docs/integrations/frameworks/mastra/overview), an [observability tool](/docs/integrations/observability/helicone), an [LLM gateway](/docs/integrations/gateways), or [tools through MCP](/docs/tools/mcp), all of which assume an AI SDK route.
 - You want first-party `frontendTools`, attachments, multi-step tool calls, token-usage metadata, and persisted history via `withFormat`.
 
-If you need streaming agent state (subgraph events, generative UI messages), look at [LangGraph](/docs/runtimes/langgraph) instead. If you have a different protocol-shaped backend (A2A, AG-UI, OpenCode), see [pick a runtime](/docs/runtimes/pick-a-runtime).
+If you need streaming agent state (subgraph events, generative UI messages), look at [LangGraph](/docs/runtimes/langgraph/overview) instead. If you have a different protocol-shaped backend (A2A, AG-UI, OpenCode), see [pick a runtime](/docs/runtimes/pick-a-runtime).
 
 ## Related
 
@@ -67,7 +67,7 @@ If you need streaming agent state (subgraph events, generative UI messages), loo
     icon={<VercelIcon width={20} height={20} />}
     title="AI SDK runtime overview"
     description="The full runtime documentation and version selector."
-    href="/docs/runtimes/ai-sdk"
+    href="/docs/runtimes/ai-sdk/overview"
   />
   <Card
     title="Pick a runtime"

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -158,7 +158,7 @@ Upload chat attachments to object storage instead of inlining as data URLs.
 assistant-ui doesn't ship a guide for every tool, but most fit one of two patterns:
 
 - **Routes through your AI SDK handler** (agent frameworks, observability proxies, gateways): adapt the [Mastra full-stack](/docs/integrations/frameworks/mastra/full-stack) or [Helicone proxy](/docs/integrations/observability/helicone) pattern using the service's own SDK.
-- **Replaces the runtime entirely** (custom backends): see [custom backend](/docs/runtimes/custom).
+- **Replaces the runtime entirely** (custom backends): see [custom backend](/docs/runtimes/custom/overview).
 
 If you build something useful, [open an issue](https://github.com/assistant-ui/assistant-ui/issues) or post in [Discord](https://discord.gg/S9dwgCNEFs); the docs are open to contributions.
 

--- a/apps/docs/content/docs/integrations/observability/langsmith.mdx
+++ b/apps/docs/content/docs/integrations/observability/langsmith.mdx
@@ -9,7 +9,7 @@ import { VercelIcon } from "@/components/icons/vercel";
 
 [LangSmith](https://www.langchain.com/langsmith) is LangChain's observability and eval platform. If you are already in the LangChain or LangGraph ecosystem, LangSmith is the natural pairing: traces, datasets, prompt versioning, and LLM-as-judge evals share state with the rest of the LangChain stack.
 
-This page covers the **AI SDK** path. If you use [`@assistant-ui/react-langgraph`](/docs/runtimes/langgraph), tracing flows through LangGraph Cloud automatically; you only need this guide when your route handler talks to AI SDK directly.
+This page covers the **AI SDK** path. If you use [`@assistant-ui/react-langgraph`](/docs/runtimes/langgraph/overview), tracing flows through LangGraph Cloud automatically; you only need this guide when your route handler talks to AI SDK directly.
 
 ## How it works
 
@@ -134,7 +134,7 @@ Send a message. The trace should appear in your LangSmith project within seconds
     icon={<LangGraphIcon width={20} height={20} className="text-[#1C3C3C] dark:text-[#5b9595]" />}
     title="LangGraph runtime"
     description="If your backend is LangGraph, tracing flows through LangGraph Cloud automatically."
-    href="/docs/runtimes/langgraph"
+    href="/docs/runtimes/langgraph/overview"
   />
   <Card
     icon={<LangfuseIcon width={20} height={20} />}

--- a/apps/docs/content/docs/migrations/react-langgraph-v0-7.mdx
+++ b/apps/docs/content/docs/migrations/react-langgraph-v0-7.mdx
@@ -323,6 +323,6 @@ export function Provider({ children }) {
 ## Need Help?
 
 If you encounter issues during migration:
-1. Check the updated [LangGraph documentation](/docs/runtimes/langgraph)
+1. Check the updated [LangGraph documentation](/docs/runtimes/langgraph/overview)
 2. Review the [example implementation](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-langgraph)
 3. Report issues on [GitHub](https://github.com/assistant-ui/assistant-ui/issues)

--- a/apps/docs/content/docs/runtimes/a2a/quickstart.mdx
+++ b/apps/docs/content/docs/runtimes/a2a/quickstart.mdx
@@ -3,7 +3,7 @@ title: Quickstart
 description: Minimal runtime and Thread setup against an A2A server.
 ---
 
-Three steps to a working chat against an A2A server. Assumes you have already installed the package and have an A2A v1.0 server reachable; if not, start at [overview](/docs/runtimes/a2a).
+Three steps to a working chat against an A2A server. Assumes you have already installed the package and have an A2A v1.0 server reachable; if not, start at [overview](/docs/runtimes/a2a/overview).
 
 <Steps>
 <Step>

--- a/apps/docs/content/docs/runtimes/ag-ui/quickstart.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/quickstart.mdx
@@ -3,7 +3,7 @@ title: Quickstart
 description: Minimal HttpAgent + useAgUiRuntime setup against an AG-UI server.
 ---
 
-Three steps to a working chat against an AG-UI agent. Assumes you have already installed the package and have an AG-UI server reachable; if not, start at [overview](/docs/runtimes/ag-ui).
+Three steps to a working chat against an AG-UI agent. Assumes you have already installed the package and have an AG-UI server reachable; if not, start at [overview](/docs/runtimes/ag-ui/overview).
 
 <Steps>
 <Step>

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -201,7 +201,7 @@ The runtime parses the AG-UI event stream and maps each event type to assistant-
     icon={<AguiIcon width={20} height={20} />}
     title="AG-UI overview"
     description="What AG-UI is and when to pick it."
-    href="/docs/runtimes/ag-ui"
+    href="/docs/runtimes/ag-ui/overview"
   />
   <Card
     title="Quickstart"

--- a/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
@@ -3,7 +3,7 @@ title: AI SDK v6
 description: Integrate Vercel AI SDK v6 with assistant-ui for streaming chat.
 ---
 
-Current-version integration. Requires `ai@^6` and `@ai-sdk/react@^3`. For older versions see the [overview](/docs/runtimes/ai-sdk).
+Current-version integration. Requires `ai@^6` and `@ai-sdk/react@^3`. For older versions see the [overview](/docs/runtimes/ai-sdk/overview).
 
 ## Quickstart
 

--- a/apps/docs/content/docs/runtimes/google-adk/quickstart.mdx
+++ b/apps/docs/content/docs/runtimes/google-adk/quickstart.mdx
@@ -3,7 +3,7 @@ title: Quickstart
 description: Minimal API route and client setup with createAdkApiRoute.
 ---
 
-Four steps to a working ADK chat. Assumes you have already installed the package and have ADK ready on the server side; if not, start at [overview](/docs/runtimes/google-adk).
+Four steps to a working ADK chat. Assumes you have already installed the package and have ADK ready on the server side; if not, start at [overview](/docs/runtimes/google-adk/overview).
 
 <Steps>
 <Step>

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -5,7 +5,7 @@ description: Use LangChain's useStream hook with a React chat UI through assista
 
 import { LangGraphIcon } from "@/components/icons/langgraph";
 
-`@assistant-ui/react-langchain` wraps [`useStream`](https://docs.langchain.com/oss/javascript/langgraph-sdk/react-stream) from `@langchain/react` and exposes it as an assistant-ui runtime. It targets the same backend as [`@assistant-ui/react-langgraph`](/docs/runtimes/langgraph) (LangGraph Cloud) but at a higher level, delegating stream plumbing to the upstream hook.
+`@assistant-ui/react-langchain` wraps [`useStream`](https://docs.langchain.com/oss/javascript/langgraph-sdk/react-stream) from `@langchain/react` and exposes it as an assistant-ui runtime. It targets the same backend as [`@assistant-ui/react-langgraph`](/docs/runtimes/langgraph/overview) (LangGraph Cloud) but at a higher level, delegating stream plumbing to the upstream hook.
 
 ## When to use it
 
@@ -891,7 +891,7 @@ Regenerate works without configuration. Clicking regenerate resolves the server 
     icon={<LangGraphIcon width={20} height={20} className="text-[#1C3C3C] dark:text-[#5b9595]" />}
     title="LangGraph"
     description="The original LangGraph adapter, built on the raw SDK."
-    href="/docs/runtimes/langgraph"
+    href="/docs/runtimes/langgraph/overview"
   />
   <Card
     title="ExternalStoreRuntime"

--- a/apps/docs/content/docs/runtimes/opencode/hooks.mdx
+++ b/apps/docs/content/docs/runtimes/opencode/hooks.mdx
@@ -175,7 +175,7 @@ These are only needed for advanced cases; most apps should use `useOpenCodeRunti
     icon={<OpenCodeIcon width={20} height={20} />}
     title="OpenCode overview"
     description="What OpenCode is and when to pick it."
-    href="/docs/runtimes/opencode"
+    href="/docs/runtimes/opencode/overview"
   />
   <Card
     title="Quickstart"

--- a/apps/docs/content/tap-docs/store/api-reference.mdx
+++ b/apps/docs/content/tap-docs/store/api-reference.mdx
@@ -91,7 +91,7 @@ Sets up a lazy item accessor for list rendering. The `getItem` function defers r
 | `getItemState` | `(aui: AssistantClient) => T` |
 | `children` | `(getItem: () => T) => ReactNode` |
 
-See [Rendering Lists](/tap-docs/store/rendering-lists) for the full pattern.
+See [Rendering Lists](/tap/docs/store/rendering-lists) for the full pattern.
 
 ---
 


### PR DESCRIPTION
## What changed

- Redirect missing docs section-root pages to their matching `/overview` page when one exists.
- Updated internal docs links that pointed at section roots such as `/docs/runtimes/ai-sdk`, `/docs/runtimes/langgraph`, and `/docs/api-reference` so they point directly at canonical `/overview` URLs.
- Fixed one Tap docs link typo from `/tap-docs/...` to `/tap/docs/...`.

## Why

Some assistant-ui docs links were landing on 404 pages because several docs sections use `overview.mdx` as their first page instead of `index.mdx`. For example, `/docs/runtimes/ai-sdk` did not resolve, while `/docs/runtimes/ai-sdk/overview` did.

Related Discord thread: https://discord.com/channels/1251324227668283443/1268446361192497164/threads/1514238622272979055

## Validation

- `git diff --check`
- `pnpm exec oxlint 'apps/docs/app/(docs)/docs/[[...slug]]/page.tsx'`
- `pnpm --filter @assistant-ui/docs exec tsc --noEmit`
- Local docs server checks confirmed representative roots return `307` to `/overview`: `/docs/runtimes/ai-sdk`, `/docs/runtimes/langgraph`, `/docs/runtimes/ag-ui`, `/docs/api-reference`, and `/docs/integrations/frameworks/mastra`.
- Browser smoke check with system Chrome confirmed `/docs/runtimes/ai-sdk` lands on `/docs/runtimes/ai-sdk/overview` and renders content. Local dev still shows the existing Assistant Cloud auth overlay without Cloud env, unrelated to this routing change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

