### PR TITLE
feat: support ai sdk mcp connection timeouts

### DIFF
--- a/.changeset/server-mcp-connection-timeout.md
+++ b/.changeset/server-mcp-connection-timeout.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+"assistant-stream": patch
+---
+
+feat: support server-side MCP connection timeouts

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -11226,12 +11226,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -310,12 +310,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -299,12 +299,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -341,12 +341,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -302,12 +302,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -258,12 +258,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -297,12 +297,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react-devtools.ts
+++ b/api-surface/assistant-ui__react-devtools.ts
@@ -451,12 +451,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -628,12 +628,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -340,12 +340,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -312,12 +312,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -299,12 +299,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -254,12 +254,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -310,12 +310,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -392,12 +392,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1005,12 +1005,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -489,12 +489,14 @@ type McpServerConfig = {
   url: string;
   headers?: Record<string, string>;
   redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
   type: "stdio";
   command: string;
   args?: readonly string[];
   env?: Record<string, string>;
   cwd?: string;
+  connectionTimeout?: number | undefined;
 };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/apps/docs/content/docs/tools/mcp.mdx
+++ b/apps/docs/content/docs/tools/mcp.mdx
@@ -93,6 +93,7 @@ export default defineToolkit({
     github: {
       type: "http",
       url: "https://mcp.example.com/mcp",
+      connectionTimeout: 10_000,
     },
   }),
 });
@@ -100,6 +101,10 @@ export default defineToolkit({
 
 Use `AISDKToolkit` in the route. It opens the MCP clients, merges their tools
 with the rest of your toolkit, and closes them when you call `close()`:
+
+`connectionTimeout` is optional and measured in milliseconds. Set it to fail
+the server-side MCP readiness flow (`createMCPClient()` plus `tools()`) before
+a bad URL or hanging local process can stall the route.
 
 ```ts title="app/api/chat/route.ts"
 import { AISDKToolkit } from "@assistant-ui/react-ai-sdk";

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -348,6 +348,8 @@ export type McpServerConfig =
       url: string;
       headers?: Record<string, string>;
       redirect?: "follow" | "error";
+      /** Optional timeout in milliseconds for client creation and tool listing. */
+      connectionTimeout?: number | undefined;
     }
   | {
       /** Start and connect to a local MCP server over stdio. */
@@ -356,6 +358,8 @@ export type McpServerConfig =
       args?: readonly string[];
       env?: Record<string, string>;
       cwd?: string;
+      /** Optional timeout in milliseconds for client creation and tool listing. */
+      connectionTimeout?: number | undefined;
     };
 
 type McpTool = ToolBase<Record<string, unknown>, unknown> & {

--- a/packages/react-ai-sdk/src/generativeTools.test.ts
+++ b/packages/react-ai-sdk/src/generativeTools.test.ts
@@ -19,6 +19,8 @@ vi.mock("@ai-sdk/mcp/mcp-stdio", () => ({
   })),
 }));
 
+const never = <T>() => new Promise<T>(() => {});
+
 describe("AISDKToolkit.tools()", () => {
   it("merges frontend tools with toolkit tools", async () => {
     const toolSet = await new AISDKToolkit({
@@ -241,6 +243,83 @@ describe("AISDKToolkit", () => {
     await expect(toolkit.tools()).rejects.toThrow(error);
     await expect(toolkit.tools()).resolves.toHaveProperty("echo");
     expect(mocks.createMCPClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("times out MCP client creation", async () => {
+    vi.useFakeTimers();
+    mocks.createMCPClient.mockReturnValue(never());
+
+    const toolkit = new AISDKToolkit({
+      toolkit: {
+        docs: {
+          type: "mcp",
+          server: {
+            type: "http",
+            url: "http://localhost:3001/mcp",
+            connectionTimeout: 10_000,
+          },
+        },
+      },
+    });
+
+    try {
+      const toolsPromise = toolkit.tools();
+      const expectedRejection = expect(toolsPromise).rejects.toThrow(
+        'MCP toolkit entry "docs" timed out while connecting after 10000ms.',
+      );
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expectedRejection;
+
+      mocks.createMCPClient.mockResolvedValueOnce({
+        tools: vi.fn().mockResolvedValue({ echo: { inputSchema: {} } }),
+        close: mocks.close,
+      });
+      await expect(toolkit.tools()).resolves.toHaveProperty("echo");
+      expect(mocks.createMCPClient).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out MCP tool listing", async () => {
+    vi.useFakeTimers();
+    const close = vi.fn().mockResolvedValue(undefined);
+    mocks.createMCPClient.mockResolvedValue({
+      tools: vi.fn(() => never()),
+      close,
+    });
+
+    const toolkit = new AISDKToolkit({
+      toolkit: {
+        docs: {
+          type: "mcp",
+          server: {
+            type: "http",
+            url: "http://localhost:3001/mcp",
+            connectionTimeout: 10_000,
+          },
+        },
+      },
+    });
+
+    try {
+      const toolsPromise = toolkit.tools();
+      const expectedRejection = expect(toolsPromise).rejects.toThrow(
+        'MCP toolkit entry "docs" timed out while listing tools after 10000ms.',
+      );
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expectedRejection;
+      expect(close).toHaveBeenCalledTimes(1);
+
+      mocks.createMCPClient.mockResolvedValueOnce({
+        tools: vi.fn().mockResolvedValue({ echo: { inputSchema: {} } }),
+        close: mocks.close,
+      });
+      await expect(toolkit.tools()).resolves.toHaveProperty("echo");
+      expect(mocks.createMCPClient).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rejects duplicate MCP tool names", async () => {

--- a/packages/react-ai-sdk/src/generativeTools.ts
+++ b/packages/react-ai-sdk/src/generativeTools.ts
@@ -28,6 +28,48 @@ const humanNotSupported = (): never => {
 // AI SDK leaves `abortSignal` optional; assistant-ui's execute requires one.
 const neverAbort = new AbortController().signal;
 
+type MCPConnectionTimeoutPhase = "connecting" | "listing tools";
+
+class MCPConnectionTimeoutError extends Error {}
+
+const createMcpConnectionTimeoutError = (
+  name: string,
+  phase: MCPConnectionTimeoutPhase,
+  timeoutMs: number,
+) =>
+  new MCPConnectionTimeoutError(
+    `MCP toolkit entry "${name}" timed out while ${phase} after ${timeoutMs}ms.`,
+  );
+
+const withMcpConnectionTimeout = async <T>(
+  promise: Promise<T>,
+  options: {
+    name: string;
+    config: McpServerConfig;
+    phase: MCPConnectionTimeoutPhase;
+    startedAt: number;
+  },
+): Promise<T> => {
+  const timeoutMs = options.config.connectionTimeout;
+  if (timeoutMs === undefined) return await promise;
+  const remainingMs = timeoutMs - (Date.now() - options.startedAt);
+  const timeoutError = () =>
+    createMcpConnectionTimeoutError(options.name, options.phase, timeoutMs);
+  if (remainingMs <= 0) throw timeoutError();
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(timeoutError()), remainingMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+};
+
 const parametersToInputSchema = (parameters: Tool["parameters"] | undefined) =>
   jsonSchema(parameters ? toJSONSchema(parameters) : EMPTY_SCHEMA);
 
@@ -169,8 +211,23 @@ export class AISDKToolkit {
           isMcpToolkitTool(entry[1]),
         )
         .map(async ([name, tool]) => {
-          const client = await this.#mcpClient(name, tool.server);
-          return [name, await client.tools()] as const;
+          const startedAt = Date.now();
+          const client = await this.#mcpClient(name, tool.server, startedAt);
+          try {
+            const tools = await withMcpConnectionTimeout(client.tools(), {
+              name,
+              config: tool.server,
+              phase: "listing tools",
+              startedAt,
+            });
+            return [name, tools] as const;
+          } catch (error) {
+            if (error instanceof MCPConnectionTimeoutError) {
+              this.#mcpClients.delete(name);
+              void client.close().catch(() => {});
+            }
+            throw error;
+          }
         }),
     );
 
@@ -191,11 +248,23 @@ export class AISDKToolkit {
     return { tools, sources: toolSources };
   }
 
-  #mcpClient(name: string, config: McpServerConfig): Promise<MCPClient> {
+  #mcpClient(
+    name: string,
+    config: McpServerConfig,
+    startedAt: number,
+  ): Promise<MCPClient> {
     const existing = this.#mcpClients.get(name);
     if (existing) return existing;
     let next: Promise<MCPClient>;
-    next = createMCPClient(toMCPClientConfig(config)).catch((error) => {
+    next = withMcpConnectionTimeout(
+      createMCPClient(toMCPClientConfig(config)),
+      {
+        name,
+        config,
+        phase: "connecting",
+        startedAt,
+      },
+    ).catch((error) => {
       if (this.#mcpClients.get(name) === next) {
         this.#mcpClients.delete(name);
       }


### PR DESCRIPTION
## Summary
- add `connectionTimeout` to server-side MCP toolkit entries
- fail hanging `createMCPClient()` and `client.tools()` calls with a clear toolkit-entry error
- add AISDKToolkit tests, docs, API surface updates, and a patch changeset

## Use case
When testing MCP-backed API routes locally, a bad URL, hanging local MCP process, or flaky remote server can leave `await aiToolkit.tools()` pending before `streamText()` starts. Apps can now set `connectionTimeout: 10_000` on a `defineMcpToolkit` entry and get an actionable error like `MCP toolkit entry "docs" timed out while connecting after 10000ms.`

## Follow-up
This is the server-side counterpart to #4684. That PR adds `connectionTimeout` for user-managed React MCP connections; this PR adds the same option for API routes that use `AISDKToolkit`.

## Testing
- `pnpm --filter @assistant-ui/react-ai-sdk test -- generativeTools.test.ts`
- `pnpm oxfmt --check packages/react-ai-sdk/src/generativeTools.ts packages/react-ai-sdk/src/generativeTools.test.ts packages/assistant-stream/src/core/tool/tool-types.ts apps/docs/content/docs/tools/mcp.mdx .changeset/server-mcp-connection-timeout.md`
- `pnpm --filter assistant-stream build`
- `pnpm --filter @assistant-ui/react-ai-sdk build`
- `node scripts/generate-api-surface.mjs --skip-build --filter=assistant-stream --filter=@assistant-ui/react-ai-sdk`
- `pnpm api-surface:check -- --skip-build --filter=assistant-stream --filter=@assistant-ui/react-ai-sdk`
- `pnpm exec oxlint packages/react-ai-sdk/src/generativeTools.ts packages/react-ai-sdk/src/generativeTools.test.ts packages/assistant-stream/src/core/tool/tool-types.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

