### PR TITLE
docs: update mcp apps client example

### DIFF
--- a/apps/docs/content/docs/tools/mcp-apps.mdx
+++ b/apps/docs/content/docs/tools/mcp-apps.mdx
@@ -24,6 +24,12 @@ Capability presence is determined at mount time by which handlers you provide. U
 
 The renderer talks to a backend route you expose — the MCP client lives server-side so credentials and transport stay out of the browser. The route receives `{ method, params }` POSTs and dispatches to your MCP client.
 
+### Install the MCP client
+
+Install the AI SDK MCP client package used by the route handler:
+
+<InstallCommand npm={["@ai-sdk/mcp"]} />
+
 ### Client
 
 Compose `McpAppRenderer({...})` into your `Tools` resource. Provide `host.url` pointing at your route. Any tool-call part carrying `mcp.app` metadata renders the MCP App widget automatically.

--- a/apps/docs/content/docs/tools/mcp-apps.mdx
+++ b/apps/docs/content/docs/tools/mcp-apps.mdx
@@ -73,6 +73,9 @@ let clientPromise: ReturnType<typeof createMCPClient> | undefined;
 const getClient = () => {
   clientPromise ??= createMCPClient({
     transport: { type: "sse", url: process.env.MCP_SERVER_URL! },
+  }).catch((error) => {
+    clientPromise = undefined;
+    throw error;
   });
   return clientPromise;
 };

--- a/apps/docs/content/docs/tools/mcp-apps.mdx
+++ b/apps/docs/content/docs/tools/mcp-apps.mdx
@@ -61,11 +61,11 @@ The route accepts `POST` requests with `{ method, params }` JSON bodies. Dispatc
 
 ```ts
 // app/api/mcp-apps/route.ts
-import { experimental_createMCPClient } from "ai";
+import { createMCPClient } from "@ai-sdk/mcp";
 
-let clientPromise: ReturnType<typeof experimental_createMCPClient> | undefined;
+let clientPromise: ReturnType<typeof createMCPClient> | undefined;
 const getClient = () => {
-  clientPromise ??= experimental_createMCPClient({
+  clientPromise ??= createMCPClient({
     transport: { type: "sse", url: process.env.MCP_SERVER_URL! },
   });
   return clientPromise;


### PR DESCRIPTION
## Summary
- add an `@ai-sdk/mcp` install step to the MCP Apps quick start
- update the MCP Apps route example to import `createMCPClient` from `@ai-sdk/mcp`
- remove the stale `experimental_createMCPClient` usage from the snippet

## Why
The main MCP docs already show the current `@ai-sdk/mcp` client API. This keeps the MCP Apps copy/paste path aligned so users install the right package and do not start from the older experimental import.

## Testing
- `pnpm --filter @assistant-ui/docs postinstall`

Note: I previously tried `pnpm --filter @assistant-ui/docs build`, but the local machine ran out of disk space while Turbopack was writing `.next` artifacts (`ENOSPC`). The MDX generation step passed before that failure, and CI build passed on the prior version of this PR.