### PR TITLE
fix: ignore malformed mcp custom servers

### DIFF
--- a/.changeset/mcp-custom-server-storage.md
+++ b/.changeset/mcp-custom-server-storage.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: ignore malformed persisted MCP custom servers

--- a/packages/react-mcp/package.json
+++ b/packages/react-mcp/package.json
@@ -27,7 +27,9 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "aui-build"
+    "build": "aui-build",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@assistant-ui/core": "workspace:*",
@@ -49,7 +51,8 @@
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
     "@types/react": "^19.2.17",
-    "react": "^19.2.7"
+    "react": "^19.2.7",
+    "vitest": "^4.1.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeCustomServerRecords } from "./McpLocalStorage";
+
+const validRecord = {
+  id: "docs",
+  name: "Docs",
+  url: "https://docs.example.com/mcp",
+  auth: { type: "none" },
+  createdAt: 1,
+} as const;
+
+describe("normalizeCustomServerRecords", () => {
+  it("returns an empty list when the persisted value is not an array", () => {
+    expect(normalizeCustomServerRecords({ bad: true })).toEqual([]);
+    expect(normalizeCustomServerRecords(null)).toEqual([]);
+  });
+
+  it("filters malformed custom server entries", () => {
+    expect(
+      normalizeCustomServerRecords([
+        validRecord,
+        null,
+        { ...validRecord, id: "" },
+        { ...validRecord, id: "docs__search" },
+        { ...validRecord, name: 123 },
+        { ...validRecord, url: null },
+        { ...validRecord, createdAt: Number.NaN },
+        { ...validRecord, auth: { type: "bearer", token: 123 } },
+      ]),
+    ).toEqual([validRecord]);
+  });
+
+  it("accepts persisted bearer and oauth auth configs", () => {
+    expect(
+      normalizeCustomServerRecords([
+        {
+          ...validRecord,
+          id: "private-docs",
+          auth: { type: "bearer", token: "token" },
+        },
+        {
+          ...validRecord,
+          id: "oauth-docs",
+          auth: {
+            type: "oauth",
+            scopes: ["docs.read"],
+            authorizationEndpoint: "https://docs.example.com/oauth/authorize",
+            tokenEndpoint: "https://docs.example.com/oauth/token",
+          },
+        },
+      ]),
+    ).toHaveLength(2);
+  });
+});

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
@@ -23,9 +23,12 @@ describe("normalizeCustomServerRecords", () => {
         null,
         { ...validRecord, id: "" },
         { ...validRecord, id: "docs__search" },
+        { ...validRecord, name: "" },
+        { ...validRecord, url: " " },
         { ...validRecord, name: 123 },
         { ...validRecord, url: null },
         { ...validRecord, createdAt: Number.NaN },
+        { ...validRecord, auth: { type: "bearer", token: "" } },
         { ...validRecord, auth: { type: "bearer", token: 123 } },
       ]),
     ).toEqual([validRecord]);

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
@@ -29,6 +29,14 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const isOptionalString = (value: unknown): value is string | undefined =>
   value === undefined || typeof value === "string";
 
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
+const isOptionalNonEmptyString = (
+  value: unknown,
+): value is string | undefined =>
+  value === undefined || isNonEmptyString(value);
+
 const isOptionalStringArray = (value: unknown): value is string[] | undefined =>
   value === undefined ||
   (Array.isArray(value) && value.every((item) => typeof item === "string"));
@@ -49,7 +57,7 @@ const isMCPAuthConfig = (auth: unknown): auth is MCPAuthConfig => {
     case "none":
       return true;
     case "bearer":
-      return isOptionalString(auth.token);
+      return isOptionalNonEmptyString(auth.token);
     case "oauth":
       return (
         isOptionalStringArray(auth.scopes) &&
@@ -72,8 +80,8 @@ const isCustomServerRecord = (
     return false;
   }
   return (
-    typeof value.name === "string" &&
-    typeof value.url === "string" &&
+    isNonEmptyString(value.name) &&
+    isNonEmptyString(value.url) &&
     Number.isFinite(value.createdAt) &&
     isMCPAuthConfig(value.auth)
   );

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
@@ -1,6 +1,7 @@
 import { resource } from "@assistant-ui/tap";
-import type { MCPCustomServerRecord } from "../../mcp-scope";
+import type { MCPAuthConfig, MCPCustomServerRecord } from "../../mcp-scope";
 import type { MCPPersistedAuthState } from "../../auth/types";
+import { assertValidServerId } from "../../utils/serverId";
 import type { MCPStorage } from "./types";
 
 export type McpLocalStorageOptions = {
@@ -21,6 +22,69 @@ function resolveStorage(opts: McpLocalStorageOptions): Storage | null {
   }
   return null;
 }
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isOptionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === "string";
+
+const isOptionalStringArray = (value: unknown): value is string[] | undefined =>
+  value === undefined ||
+  (Array.isArray(value) && value.every((item) => typeof item === "string"));
+
+const isValidServerId = (id: string): boolean => {
+  try {
+    assertValidServerId(id);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const isMCPAuthConfig = (auth: unknown): auth is MCPAuthConfig => {
+  if (!isRecord(auth)) return false;
+
+  switch (auth.type) {
+    case "none":
+      return true;
+    case "bearer":
+      return isOptionalString(auth.token);
+    case "oauth":
+      return (
+        isOptionalStringArray(auth.scopes) &&
+        isOptionalString(auth.authorizationEndpoint) &&
+        isOptionalString(auth.tokenEndpoint) &&
+        isOptionalString(auth.registrationEndpoint) &&
+        isOptionalString(auth.clientId) &&
+        isOptionalString(auth.clientSecret)
+      );
+    default:
+      return false;
+  }
+};
+
+const isCustomServerRecord = (
+  value: unknown,
+): value is MCPCustomServerRecord => {
+  if (!isRecord(value)) return false;
+  if (typeof value.id !== "string" || !isValidServerId(value.id)) {
+    return false;
+  }
+  return (
+    typeof value.name === "string" &&
+    typeof value.url === "string" &&
+    Number.isFinite(value.createdAt) &&
+    isMCPAuthConfig(value.auth)
+  );
+};
+
+export const normalizeCustomServerRecords = (
+  value: unknown,
+): MCPCustomServerRecord[] => {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isCustomServerRecord);
+};
 
 const useMcpLocalStorage = (opts: McpLocalStorageOptions = {}): MCPStorage => {
   const prefix = opts.keyPrefix ?? "aui-mcp";
@@ -59,7 +123,7 @@ const useMcpLocalStorage = (opts: McpLocalStorageOptions = {}): MCPStorage => {
 
   return {
     loadCustomServers: async () =>
-      read<MCPCustomServerRecord[]>(customServersKey, []),
+      normalizeCustomServerRecords(read<unknown>(customServersKey, [])),
     saveCustomServers: async (records) => {
       write(customServersKey, records);
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4208,6 +4208,9 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/react-native:
     dependencies:


### PR DESCRIPTION
## Summary

- validate persisted MCP custom server records before hydrating them from `McpLocalStorage`
- ignore non-array or malformed storage values instead of letting invalid localStorage become runtime server state
- add focused `react-mcp` storage tests and wire the package into `vitest`

## Why

During local MCP development, `aui-mcp:custom-servers` can drift from the expected shape after testing schema changes, manually editing localStorage in DevTools, or carrying stale data from an older build. Previously the storage reader cast parsed JSON directly to `MCPCustomServerRecord[]`, so valid JSON with the wrong shape could hydrate into `McpManagerResource` and later crash on array operations or mount a server with invalid `id`, `url`, or `auth` data.

This keeps the manager recoverable by treating localStorage as untrusted runtime data and only returning records that match the current custom-server shape.

## Testing

- `pnpm --filter @assistant-ui/react-mcp test`
- `pnpm --filter @assistant-ui/react-mcp build`
- `pnpm --filter @assistant-ui/react-mcp exec tsc --noEmit`
- `pnpm lint` — passes; reports existing hook warnings in `packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts` and `packages/store/src/useAui.ts`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

