### PR TITLE
fix(assistant-stream): accept ai sdk tool input chunks

### DIFF
--- a/.changeset/fifty-worlds-fall.md
+++ b/.changeset/fifty-worlds-fall.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix(assistant-stream): accept ai sdk tool input chunks

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -11850,8 +11850,20 @@ type UIMessageStreamChunk = {
   toolCallId: string;
   toolName: string;
 } | {
+  type: "tool-input-start";
+  toolCallId: string;
+  toolName: string;
+} | {
   type: "tool-call-delta";
   argsText: string;
+} | {
+  type: "tool-input-delta";
+  toolCallId?: string;
+  inputTextDelta: string;
+} | {
+  type: "tool-input-available";
+  toolCallId: string;
+  input: ReadonlyJSONValue;
 } | {
   type: "tool-call-end";
 } | {
@@ -11860,6 +11872,10 @@ type UIMessageStreamChunk = {
   result: ReadonlyJSONValue;
   isError?: boolean;
   messages?: ReadonlyJSONValue;
+} | {
+  type: "tool-output-available";
+  toolCallId: string;
+  output: ReadonlyJSONValue;
 } | {
   type: "start-step";
   messageId?: string;

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -89,6 +89,69 @@ describe("UIMessageStreamDecoder", () => {
     expect(partStarts.some((p) => p.part.type === "reasoning")).toBe(true);
   });
 
+  it("should decode AI SDK v6 tool input/output aliases", async () => {
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({ type: "text-start", id: "text_1" }),
+      JSON.stringify({ type: "text-delta", textDelta: "Hello" }),
+      JSON.stringify({ type: "text-end" }),
+      JSON.stringify({
+        type: "tool-input-start",
+        toolCallId: "call_abc",
+        toolName: "weather",
+      }),
+      JSON.stringify({
+        type: "tool-input-delta",
+        toolCallId: "call_abc",
+        inputTextDelta: '{"city":"NY',
+      }),
+      JSON.stringify({
+        type: "tool-input-delta",
+        toolCallId: "call_abc",
+        inputTextDelta: 'C"}',
+      }),
+      JSON.stringify({
+        type: "tool-output-available",
+        toolCallId: "call_abc",
+        output: { temp: 72 },
+      }),
+      JSON.stringify({
+        type: "finish",
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    const chunks = await collectChunks(decodedStream);
+
+    const toolCallStart = chunks.find(
+      (c): c is AssistantStreamChunk & { type: "part-start" } =>
+        c.type === "part-start" && c.part.type === "tool-call",
+    );
+    expect(toolCallStart).toBeDefined();
+    if (toolCallStart?.part.type === "tool-call") {
+      expect(toolCallStart.part.toolCallId).toBe("call_abc");
+      expect(toolCallStart.part.toolName).toBe("weather");
+    }
+
+    const toolArgChunks = chunks.filter(
+      (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+        c.type === "text-delta",
+    );
+    expect(toolArgChunks.some((c) => c.textDelta.includes('{"city"'))).toBe(
+      true,
+    );
+
+    const result = chunks.find(
+      (c): c is AssistantStreamChunk & { type: "result" } =>
+        c.type === "result",
+    );
+    expect(result?.result).toEqual({ temp: 72 });
+  });
+
   it("should decode tool calls", async () => {
     const events = [
       JSON.stringify({ type: "start", messageId: "msg_123" }),

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -89,34 +89,42 @@ describe("UIMessageStreamDecoder", () => {
     expect(partStarts.some((p) => p.part.type === "reasoning")).toBe(true);
   });
 
-  it("should clean up tool input arg tracking when input becomes available", async () => {
+  it("should clean up tool input arg tracking after the tool result arrives", async () => {
     const deleteSpy = vi.spyOn(Map.prototype, "delete");
-    const events = [
-      JSON.stringify({ type: "start", messageId: "msg_123" }),
-      JSON.stringify({
-        type: "tool-input-start",
-        toolCallId: "call_cleanup",
-        toolName: "weather",
-      }),
-      JSON.stringify({
-        type: "tool-input-available",
-        toolCallId: "call_cleanup",
-        input: { city: "NYC" },
-      }),
-      JSON.stringify({
-        type: "finish",
-        finishReason: "stop",
-        usage: { inputTokens: 10, outputTokens: 5 },
-      }),
-      "[DONE]",
-    ];
+    try {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_cleanup",
+          toolName: "weather",
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_cleanup",
+          input: { city: "NYC" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_cleanup",
+          output: { temp: 72 },
+        }),
+        JSON.stringify({
+          type: "finish",
+          finishReason: "stop",
+          usage: { inputTokens: 10, outputTokens: 5 },
+        }),
+        "[DONE]",
+      ];
 
-    const stream = createUIMessageStream(events);
-    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
-    await collectChunks(decodedStream);
+      const stream = createUIMessageStream(events);
+      const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+      await collectChunks(decodedStream);
 
-    expect(deleteSpy).toHaveBeenCalledWith("call_cleanup");
-    deleteSpy.mockRestore();
+      expect(deleteSpy).toHaveBeenCalledWith("call_cleanup");
+    } finally {
+      deleteSpy.mockRestore();
+    }
   });
 
   it("should decode AI SDK v6 tool input/output aliases", async () => {

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -89,6 +89,36 @@ describe("UIMessageStreamDecoder", () => {
     expect(partStarts.some((p) => p.part.type === "reasoning")).toBe(true);
   });
 
+  it("should clean up tool input arg tracking when input becomes available", async () => {
+    const deleteSpy = vi.spyOn(Map.prototype, "delete");
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({
+        type: "tool-input-start",
+        toolCallId: "call_cleanup",
+        toolName: "weather",
+      }),
+      JSON.stringify({
+        type: "tool-input-available",
+        toolCallId: "call_cleanup",
+        input: { city: "NYC" },
+      }),
+      JSON.stringify({
+        type: "finish",
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    await collectChunks(decodedStream);
+
+    expect(deleteSpy).toHaveBeenCalledWith("call_cleanup");
+    deleteSpy.mockRestore();
+  });
+
   it("should decode AI SDK v6 tool input/output aliases", async () => {
     const events = [
       JSON.stringify({ type: "start", messageId: "msg_123" }),

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -229,7 +229,6 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                 toolCallController.argsText.append(JSON.stringify(chunk.input));
               }
               toolCallController.argsText.close();
-              toolCallHasArgsText.delete(chunk.toolCallId);
               if (activeToolCallId === chunk.toolCallId) {
                 activeToolCallArgsText = undefined;
                 activeToolCallId = undefined;
@@ -239,9 +238,6 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
 
             case "tool-call-end":
               activeToolCallArgsText?.close();
-              if (activeToolCallId) {
-                toolCallHasArgsText.delete(activeToolCallId);
-              }
               activeToolCallArgsText = undefined;
               activeToolCallId = undefined;
               break;
@@ -267,6 +263,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                   ? { messages: chunk.messages }
                   : {}),
               });
+              toolCallHasArgsText.delete(chunk.toolCallId);
               break;
             }
 

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -229,6 +229,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                 toolCallController.argsText.append(JSON.stringify(chunk.input));
               }
               toolCallController.argsText.close();
+              toolCallHasArgsText.delete(chunk.toolCallId);
               if (activeToolCallId === chunk.toolCallId) {
                 activeToolCallArgsText = undefined;
                 activeToolCallId = undefined;
@@ -238,6 +239,9 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
 
             case "tool-call-end":
               activeToolCallArgsText?.close();
+              if (activeToolCallId) {
+                toolCallHasArgsText.delete(activeToolCallId);
+              }
               activeToolCallArgsText = undefined;
               activeToolCallId = undefined;
               break;

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -101,6 +101,8 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
   constructor(options: UIMessageStreamDecoderOptions = {}) {
     super((readable) => {
       const toolCallControllers = new Map<string, ToolCallStreamController>();
+      const toolCallHasArgsText = new Map<string, boolean>();
+      let activeToolCallId: string | undefined;
       let activeToolCallArgsText: TextStreamController | undefined;
       let currentMessageId: string | undefined;
       let receivedDone = false;
@@ -175,9 +177,11 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               });
               break;
 
-            case "tool-call-start": {
+            case "tool-call-start":
+            case "tool-input-start": {
               activeToolCallArgsText?.close();
               activeToolCallArgsText = undefined;
+              activeToolCallId = undefined;
 
               if (toolCallControllers.has(chunk.toolCallId)) {
                 throw new Error(
@@ -190,20 +194,56 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                 toolName: chunk.toolName,
               });
               toolCallControllers.set(chunk.toolCallId, toolCallController);
+              toolCallHasArgsText.set(chunk.toolCallId, false);
               activeToolCallArgsText = toolCallController.argsText;
+              activeToolCallId = chunk.toolCallId;
               break;
             }
 
             case "tool-call-delta":
+              if (activeToolCallId) {
+                toolCallHasArgsText.set(activeToolCallId, true);
+              }
               activeToolCallArgsText?.append(chunk.argsText);
               break;
+
+            case "tool-input-delta": {
+              const targetToolCallId = chunk.toolCallId ?? activeToolCallId;
+              if (targetToolCallId) {
+                toolCallHasArgsText.set(targetToolCallId, true);
+              }
+              activeToolCallArgsText?.append(chunk.inputTextDelta);
+              break;
+            }
+
+            case "tool-input-available": {
+              const toolCallController = toolCallControllers.get(
+                chunk.toolCallId,
+              );
+              if (!toolCallController) {
+                throw new Error(
+                  `Encountered tool input with unknown id: ${chunk.toolCallId}`,
+                );
+              }
+              if (!toolCallHasArgsText.get(chunk.toolCallId)) {
+                toolCallController.argsText.append(JSON.stringify(chunk.input));
+              }
+              toolCallController.argsText.close();
+              if (activeToolCallId === chunk.toolCallId) {
+                activeToolCallArgsText = undefined;
+                activeToolCallId = undefined;
+              }
+              break;
+            }
 
             case "tool-call-end":
               activeToolCallArgsText?.close();
               activeToolCallArgsText = undefined;
+              activeToolCallId = undefined;
               break;
 
-            case "tool-result": {
+            case "tool-result":
+            case "tool-output-available": {
               const toolCallController = toolCallControllers.get(
                 chunk.toolCallId,
               );
@@ -213,9 +253,13 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                 );
               }
               toolCallController.setResponse({
-                result: chunk.result,
-                isError: chunk.isError ?? false,
-                ...(chunk.messages !== undefined
+                result:
+                  chunk.type === "tool-result" ? chunk.result : chunk.output,
+                isError:
+                  chunk.type === "tool-result"
+                    ? (chunk.isError ?? false)
+                    : false,
+                ...(chunk.type === "tool-result" && chunk.messages !== undefined
                   ? { messages: chunk.messages }
                   : {}),
               });

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-types.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-types.ts
@@ -33,7 +33,18 @@ export type UIMessageStreamChunk =
       toolCallId: string;
       toolName: string;
     }
+  | {
+      type: "tool-input-start";
+      toolCallId: string;
+      toolName: string;
+    }
   | { type: "tool-call-delta"; argsText: string }
+  | { type: "tool-input-delta"; toolCallId?: string; inputTextDelta: string }
+  | {
+      type: "tool-input-available";
+      toolCallId: string;
+      input: ReadonlyJSONValue;
+    }
   | { type: "tool-call-end" }
   | {
       type: "tool-result";
@@ -41,6 +52,11 @@ export type UIMessageStreamChunk =
       result: ReadonlyJSONValue;
       isError?: boolean;
       messages?: ReadonlyJSONValue;
+    }
+  | {
+      type: "tool-output-available";
+      toolCallId: string;
+      output: ReadonlyJSONValue;
     }
   | { type: "start-step"; messageId?: string }
   | {


### PR DESCRIPTION
Follow-up to #4676.

## Summary
- accept AI SDK v6 `tool-input-*` and `tool-output-available` chunk names in `UIMessageStreamDecoder`
- keep backward compatibility with the existing assistant-ui tool chunk names
- add a decoder regression test that covers streamed tool input and emitted tool output using the AI SDK v6 wire format

## Testing
- `pnpm install --ignore-scripts --frozen-lockfile --filter assistant-stream...`
- `pnpm --filter assistant-stream test -- packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

