### PR TITLE
feat(ui): show upload and error status on attachment tiles

### DIFF
--- a/packages/ui/src/components/assistant-ui/attachment.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { type PropsWithChildren, useEffect, useState, type FC } from "react";
-import { XIcon, PlusIcon, FileText } from "lucide-react";
+import {
+  XIcon,
+  PlusIcon,
+  FileText,
+  Loader2Icon,
+  AlertCircleIcon,
+} from "lucide-react";
 import {
   AttachmentPrimitive,
   ComposerPrimitive,
@@ -142,6 +148,10 @@ const AttachmentUI: FC = () => {
     }
   });
 
+  const status = useAuiState((s) => s.attachment.status);
+  const isUploading = status.type === "running";
+  const isError = status.type === "incomplete" && status.reason === "error";
+
   return (
     <Tooltip>
       <AttachmentPrimitive.Root
@@ -155,12 +165,33 @@ const AttachmentUI: FC = () => {
         <AttachmentPreviewDialog>
           <TooltipTrigger asChild>
             <div
-              className="aui-attachment-tile bg-muted size-14 cursor-pointer overflow-hidden rounded-[calc(var(--composer-radius)-var(--composer-padding))] border transition-opacity hover:opacity-75"
+              className={cn(
+                "aui-attachment-tile bg-muted relative size-14 cursor-pointer overflow-hidden rounded-[calc(var(--composer-radius)-var(--composer-padding))] border transition-opacity hover:opacity-75",
+                isError && "border-destructive",
+              )}
               role="button"
               tabIndex={0}
-              aria-label={`${typeLabel} attachment`}
+              aria-label={`${typeLabel} attachment${
+                isError ? ", upload failed" : isUploading ? ", uploading" : ""
+              }`}
             >
               <AttachmentThumb />
+              {isUploading && (
+                <div
+                  aria-hidden="true"
+                  className="aui-attachment-tile-uploading bg-background/60 absolute inset-0 flex items-center justify-center backdrop-blur-[1px]"
+                >
+                  <Loader2Icon className="text-muted-foreground size-5 animate-spin" />
+                </div>
+              )}
+              {isError && (
+                <div
+                  aria-hidden="true"
+                  className="aui-attachment-tile-error bg-destructive/10 absolute inset-0 flex items-center justify-center"
+                >
+                  <AlertCircleIcon className="text-destructive size-5" />
+                </div>
+              )}
             </div>
           </TooltipTrigger>
         </AttachmentPreviewDialog>

--- a/packages/ui/src/components/assistant-ui/attachment.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.tsx
@@ -148,9 +148,16 @@ const AttachmentUI: FC = () => {
     }
   });
 
-  const status = useAuiState((s) => s.attachment.status);
-  const isUploading = status.type === "running";
-  const isError = status.type === "incomplete" && status.reason === "error";
+  const uploadState = useAuiState((s) =>
+    s.attachment.status.type === "running"
+      ? "uploading"
+      : s.attachment.status.type === "incomplete" &&
+          s.attachment.status.reason === "error"
+        ? "error"
+        : undefined,
+  );
+  const isUploading = uploadState === "uploading";
+  const isError = uploadState === "error";
 
   return (
     <Tooltip>

--- a/templates/minimal/components/assistant-ui/attachment.tsx
+++ b/templates/minimal/components/assistant-ui/attachment.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { type PropsWithChildren, useEffect, useState, type FC } from "react";
-import { XIcon, PlusIcon, FileText } from "lucide-react";
+import {
+  XIcon,
+  PlusIcon,
+  FileText,
+  Loader2Icon,
+  AlertCircleIcon,
+} from "lucide-react";
 import {
   AttachmentPrimitive,
   ComposerPrimitive,
@@ -142,6 +148,10 @@ const AttachmentUI: FC = () => {
     }
   });
 
+  const status = useAuiState((s) => s.attachment.status);
+  const isUploading = status.type === "running";
+  const isError = status.type === "incomplete" && status.reason === "error";
+
   return (
     <Tooltip>
       <AttachmentPrimitive.Root
@@ -155,12 +165,33 @@ const AttachmentUI: FC = () => {
         <AttachmentPreviewDialog>
           <TooltipTrigger asChild>
             <div
-              className="aui-attachment-tile bg-muted size-14 cursor-pointer overflow-hidden rounded-[calc(var(--composer-radius)-var(--composer-padding))] border transition-opacity hover:opacity-75"
+              className={cn(
+                "aui-attachment-tile bg-muted relative size-14 cursor-pointer overflow-hidden rounded-[calc(var(--composer-radius)-var(--composer-padding))] border transition-opacity hover:opacity-75",
+                isError && "border-destructive",
+              )}
               role="button"
               tabIndex={0}
-              aria-label={`${typeLabel} attachment`}
+              aria-label={`${typeLabel} attachment${
+                isError ? ", upload failed" : isUploading ? ", uploading" : ""
+              }`}
             >
               <AttachmentThumb />
+              {isUploading && (
+                <div
+                  aria-hidden="true"
+                  className="aui-attachment-tile-uploading bg-background/60 absolute inset-0 flex items-center justify-center backdrop-blur-[1px]"
+                >
+                  <Loader2Icon className="text-muted-foreground size-5 animate-spin" />
+                </div>
+              )}
+              {isError && (
+                <div
+                  aria-hidden="true"
+                  className="aui-attachment-tile-error bg-destructive/10 absolute inset-0 flex items-center justify-center"
+                >
+                  <AlertCircleIcon className="text-destructive size-5" />
+                </div>
+              )}
             </div>
           </TooltipTrigger>
         </AttachmentPreviewDialog>

--- a/templates/minimal/components/assistant-ui/attachment.tsx
+++ b/templates/minimal/components/assistant-ui/attachment.tsx
@@ -148,9 +148,16 @@ const AttachmentUI: FC = () => {
     }
   });
 
-  const status = useAuiState((s) => s.attachment.status);
-  const isUploading = status.type === "running";
-  const isError = status.type === "incomplete" && status.reason === "error";
+  const uploadState = useAuiState((s) =>
+    s.attachment.status.type === "running"
+      ? "uploading"
+      : s.attachment.status.type === "incomplete" &&
+          s.attachment.status.reason === "error"
+        ? "error"
+        : undefined,
+  );
+  const isUploading = uploadState === "uploading";
+  const isError = uploadState === "error";
 
   return (
     <Tooltip>


### PR DESCRIPTION
## What

Composer attachment tiles now surface upload state: a spinner overlay while the attachment adapter reports `status.type === "running"`, and a destructive border plus alert overlay when it reports `{ type: "incomplete", reason: "error" }`. The tile's `aria-label` announces the same state ("uploading" / "upload failed"), and the overlays are `aria-hidden` so screen readers don't double-announce.

## Why

With async attachment adapters (e.g. `CloudFileAttachmentAdapter`), a tile looks identical whether the upload is in flight, failed, or complete — users can send a message believing a failed attachment went through.

## How

`AttachmentUI` reads `s.attachment.status` via `useAuiState` and derives `isUploading`/`isError`; overlays render inside the existing tile div. The `templates/minimal` copy is kept byte-equal (`pnpm sync-templates` passes).

Note: `{ type: "incomplete", reason: "upload-paused" }` intentionally renders no overlay — no built-in adapter emits it today.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

