### PR TITLE
feat(ui): render follow-up suggestions in thread

### DIFF
--- a/apps/docs/content/docs/ui/follow-up-suggestions.mdx
+++ b/apps/docs/content/docs/ui/follow-up-suggestions.mdx
@@ -23,7 +23,7 @@ import { FollowUpSuggestionsSample } from "@/components/docs/samples/follow-up-s
 
 <InstallCommand shadcn={["follow-up-suggestions"]} />
 
-This adds a `/components/assistant-ui/follow-up-suggestions.tsx` file to your project.
+This adds a `/components/assistant-ui/follow-up-suggestions.tsx` file to your project. The default `thread` component already renders `ThreadFollowupSuggestions`, so installing it standalone is only needed when you build your own thread layout.
 
   </Step>
   <Step>
@@ -72,7 +72,7 @@ const ThreadViewportFooter = () => {
 
 ## Behavior
 
-The component only renders when the thread is not empty and not currently running. Each suggestion uses `ThreadPrimitive.Suggestion`, replaces the composer text with the prompt, and sends it immediately.
+The component only renders when the thread is not empty, not currently running, and has at least one suggestion. Each suggestion uses `ThreadPrimitive.Suggestion`, replaces the composer text with the prompt, and sends it immediately.
 
 ## Related Components
 

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -68,6 +68,7 @@ export const registry: RegistryItem[] = [
     registryDependencies: [
       "button",
       "https://r.assistant-ui.com/attachment.json",
+      "https://r.assistant-ui.com/follow-up-suggestions.json",
       "https://r.assistant-ui.com/markdown-text.json",
       "https://r.assistant-ui.com/reasoning.json",
       "https://r.assistant-ui.com/tooltip-icon-button.json",

--- a/packages/ui/src/components/assistant-ui/follow-up-suggestions.tsx
+++ b/packages/ui/src/components/assistant-ui/follow-up-suggestions.tsx
@@ -14,7 +14,7 @@ export const ThreadFollowupSuggestions: FC = () => {
       }
     >
       <div className="aui-thread-followup-suggestions flex min-h-8 items-center justify-center gap-2">
-        {suggestions?.map((suggestion, idx) => (
+        {suggestions.map((suggestion, idx) => (
           <ThreadPrimitive.Suggestion
             key={idx}
             className="aui-thread-followup-suggestion bg-background hover:bg-muted/80 rounded-full border px-3 py-1 text-sm transition-colors ease-in"

--- a/packages/ui/src/components/assistant-ui/follow-up-suggestions.tsx
+++ b/packages/ui/src/components/assistant-ui/follow-up-suggestions.tsx
@@ -6,7 +6,13 @@ import type { FC } from "react";
 export const ThreadFollowupSuggestions: FC = () => {
   const suggestions = useAuiState((s) => s.thread.suggestions);
   return (
-    <AuiIf condition={(s) => !s.thread.isEmpty && !s.thread.isRunning}>
+    <AuiIf
+      condition={(s) =>
+        !s.thread.isEmpty &&
+        !s.thread.isRunning &&
+        s.thread.suggestions.length > 0
+      }
+    >
       <div className="aui-thread-followup-suggestions flex min-h-8 items-center justify-center gap-2">
         {suggestions?.map((suggestion, idx) => (
           <ThreadPrimitive.Suggestion

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -5,6 +5,7 @@ import {
   ComposerAttachments,
   UserMessageAttachments,
 } from "@/components/assistant-ui/attachment";
+import { ThreadFollowupSuggestions } from "@/components/assistant-ui/follow-up-suggestions";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import {
   Reasoning,
@@ -151,6 +152,7 @@ const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
             )}
           >
             <ThreadScrollToBottom />
+            <ThreadFollowupSuggestions />
             <Composer />
             <AuiIf condition={(s) => isNewChatView(s) && s.composer.isEmpty}>
               <ThreadSuggestions />


### PR DESCRIPTION
## What

Wires `ThreadFollowupSuggestions` into the thread viewport footer (above the composer), so runtimes that populate `thread.suggestions` get follow-up chips after each assistant turn.

## Why

The `follow-up-suggestions` component existed in the kit and registry but nothing rendered it in the default thread.

## How

- `thread.tsx` renders `<ThreadFollowupSuggestions />` in `ViewportFooter`.
- The component's own `AuiIf` guard now also requires `s.thread.suggestions.length > 0`, so it no longer renders an empty `min-h-8` spacer div when there are no suggestions (previously it only checked `!isEmpty && !isRunning`).
- The `thread` registry item now lists `follow-up-suggestions.json` in `registryDependencies` — without it, `shadcn add thread` would install a `thread.tsx` with an unresolvable `@/components/assistant-ui/follow-up-suggestions` import. Verified the rebuilt `dist/thread.json` carries the dependency.

`templates/minimal/thread.tsx` is an intentional slim override (`OVERRIDES` in `scripts/sync-templates.sh`) and is unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

