### PR TITLE
feat(ui): add caret color and enterKeyHint to composer input

### DIFF
--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -234,9 +234,10 @@ const Composer: FC = () => {
           <ComposerAttachments />
           <ComposerPrimitive.Input
             placeholder="Send a message..."
-            className="aui-composer-input placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
+            className="aui-composer-input caret-primary placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
             rows={1}
             autoFocus
+            enterKeyHint="send"
             aria-label="Message input"
           />
           <ComposerAction />


### PR DESCRIPTION
## What

Two small composer input polish changes: the text caret uses the primary color (`caret-primary`), and the textarea sets `enterKeyHint="send"` so mobile virtual keyboards show a Send action key.

## Why

The default black caret is visually disconnected from the themed composer, and mobile keyboards showed a generic return key even though plain Enter submits the message.

## How

Both are attribute-level changes on `ComposerPrimitive.Input` in `thread.tsx`. `templates/minimal/thread.tsx` is an intentional slim override (`OVERRIDES` in `scripts/sync-templates.sh`) and is unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

