### PR TITLE
fix: validate duplicate mcp server ids

### DIFF
--- a/.changeset/dirty-bikes-promise.md
+++ b/.changeset/dirty-bikes-promise.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: validate duplicate MCP server ids in the React MCP manager

--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -80,6 +80,7 @@ Defaults and useful options:
 - `oauthRedirectUri` — `${window.location.origin}/mcp/callback`
 - `autoConnect` — `true` (connect on mount when usable auth is persisted)
 - `connectionTimeout` — optional timeout in milliseconds. Set it on the manager as a default or on a connector/custom server to bound the MCP readiness flow (`connect()` plus `listTools()`) with a clear error.
+- Connector `id` values must be unique. The id is used for server lookup, OAuth routing, and model-visible tool names such as `linear__search`.
 
 </Step>
 <Step>

--- a/packages/react-mcp/src/resources/McpManagerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.test.ts
@@ -1,0 +1,40 @@
+import { createTapRoot, useResource } from "@assistant-ui/tap";
+import { describe, expect, it } from "vitest";
+import { defineConnector } from "../connector";
+import type { MCPConnector } from "../mcp-scope";
+import { assertUniqueServerIds } from "../utils/serverId";
+import { McpManagerResource } from "./McpManagerResource";
+import { McpMemoryStorage } from "./storage/McpMemoryStorage";
+
+const connector = (id: string, name = id): MCPConnector =>
+  defineConnector({
+    id,
+    name,
+    url: `https://example.com/${id}/mcp`,
+    auth: { type: "none" },
+  });
+
+const mount = (connectors: MCPConnector[]) =>
+  createTapRoot(function Root() {
+    return useResource(
+      McpManagerResource({
+        connectors,
+        storage: McpMemoryStorage(),
+        autoConnect: false,
+      }),
+    );
+  });
+
+describe("McpManagerResource server ids", () => {
+  it("throws when connectors reuse an id", () => {
+    expect(() =>
+      mount([connector("docs", "Docs"), connector("docs", "Internal Docs")]),
+    ).toThrow(
+      'McpManagerResource received duplicate MCP server id "docs". Server ids must be unique because they are used for lookups, OAuth routing, and tool name prefixes.',
+    );
+  });
+
+  it("allows distinct ids", () => {
+    expect(() => assertUniqueServerIds(["docs", "linear"])).not.toThrow();
+  });
+});

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -11,6 +11,7 @@ import type { Tool } from "assistant-stream";
 import { McpServerResource } from "./McpServerResource";
 import { McpLocalStorage } from "./storage/McpLocalStorage";
 import type { MCPStorageElement } from "./storage/types";
+import { assertUniqueServerIds } from "../utils/serverId";
 import type {
   MCPAuthConfig,
   MCPConnector,
@@ -104,6 +105,11 @@ const useMcpManagerResource = (
   }, [customServers]);
 
   const serverElements = useMemo(() => {
+    assertUniqueServerIds([
+      ...connectors.map((c) => c.id),
+      ...customServers.map((s) => s.id),
+    ]);
+
     const connectorElements = connectors.map((c) =>
       withKey(
         c.id,

--- a/packages/react-mcp/src/utils/serverId.ts
+++ b/packages/react-mcp/src/utils/serverId.ts
@@ -17,3 +17,15 @@ export function assertValidServerId(id: string): void {
     );
   }
 }
+
+export function assertUniqueServerIds(ids: Iterable<string>): void {
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (seen.has(id)) {
+      throw new Error(
+        `McpManagerResource received duplicate MCP server id "${id}". Server ids must be unique because they are used for lookups, OAuth routing, and tool name prefixes.`,
+      );
+    }
+    seen.add(id);
+  }
+}


### PR DESCRIPTION
## Summary

Validate the complete React MCP server id set before `McpManagerResource` creates keyed server resources.

## Why

React MCP uses each server id in several places: resource lookup via `aui.mcp().server({ id })`, OAuth routing, and model-visible tool prefixes like `docs__search`. If an app accidentally defines two connectors with the same id, one server can shadow the other and tool execution/debugging becomes ambiguous.

Example bad config:

```tsx
const connectors = [
  defineConnector({ id: "docs", name: "Public Docs", url, auth }),
  defineConnector({ id: "docs", name: "Internal Docs", url, auth }),
];
```

This PR fails early with a clear duplicate-id error instead of letting the duplicate ids reach keyed resources and tool registration.

## Changes

- Add duplicate MCP server id validation alongside the existing server id shape validation.
- Run the validation in `McpManagerResource` across connector and custom server ids before building keyed resources.
- Add tests covering duplicate connector ids and the allowed distinct-id path.
- Add a short docs note that connector ids must be unique because they drive lookup, OAuth routing, and tool names.
- Add a patch changeset for `@assistant-ui/react-mcp`.

## Checks

- `pnpm --filter @assistant-ui/react-mcp test`
- `pnpm lint`
- `pnpm --filter @assistant-ui/react-mcp build`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

