### PR TITLE
feat(ui): use Radix ScrollArea for reasoning panel

### DIFF
--- a/apps/docs/content/docs/ui/reasoning.mdx
+++ b/apps/docs/content/docs/ui/reasoning.mdx
@@ -97,7 +97,7 @@ The component consists of two parts:
 
 Consecutive reasoning parts are grouped by `MessagePrimitive.GroupedParts`. Use the composable API below to control the grouped layout.
 
-> When using the composable API, `ReasoningText` is a plain container. Add `<MarkdownText />` for markdown rendering.
+> When using the composable API, `ReasoningText` renders a Radix ScrollArea with a built-in auto-hiding scrollbar — content taller than `max-h-64` scrolls and pins to the bottom while streaming. Add `<MarkdownText />` for markdown rendering. To customize scroll behavior, target the `reasoning-text-viewport` slot (the scrolling element, which carries the max height) or the `reasoning-scrollbar` / `reasoning-scrollbar-thumb` slots.
 
 ## Variants
 
@@ -160,7 +160,7 @@ All sub-components are exported for custom layouts:
 | `ReasoningRoot`      | Collapsible container with scroll lock     |
 | `ReasoningTrigger`   | Button with icon, label, and shimmer       |
 | `ReasoningContent`   | Animated collapsible content wrapper       |
-| `ReasoningText`      | Text wrapper with slide/fade animation     |
+| `ReasoningText`      | Scroll area with slide/fade animation      |
 | `ReasoningFade`      | Gradient fade overlay at bottom            |
 
 ```tsx

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -124,6 +124,7 @@ export const registry: RegistryItem[] = [
     ],
     registryDependencies: [
       "collapsible",
+      "scroll-area",
       "https://r.assistant-ui.com/markdown-text.json",
     ],
     dependencies: [

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -124,7 +124,6 @@ export const registry: RegistryItem[] = [
     ],
     registryDependencies: [
       "collapsible",
-      "scroll-area",
       "https://r.assistant-ui.com/markdown-text.json",
     ],
     dependencies: [

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -131,6 +131,7 @@ export const registry: RegistryItem[] = [
       "lucide-react",
       "class-variance-authority",
       "tw-shimmer",
+      "radix-ui",
     ],
     css: {
       '@import "tw-shimmer"': {},

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -25,7 +25,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { ScrollBar } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 
 const ANIMATION_DURATION = 200;
@@ -300,7 +299,16 @@ function ReasoningText({
           {children}
         </div>
       </ScrollAreaPrimitive.Viewport>
-      <ScrollBar />
+      <ScrollAreaPrimitive.ScrollAreaScrollbar
+        data-slot="reasoning-scrollbar"
+        orientation="vertical"
+        className="aui-reasoning-scrollbar flex h-full w-2.5 touch-none border-s border-s-transparent p-px transition-colors select-none"
+      >
+        <ScrollAreaPrimitive.ScrollAreaThumb
+          data-slot="reasoning-scrollbar-thumb"
+          className="aui-reasoning-scrollbar-thumb bg-border relative flex-1 rounded-full"
+        />
+      </ScrollAreaPrimitive.ScrollAreaScrollbar>
     </ScrollAreaPrimitive.Root>
   );
 }

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -12,6 +12,7 @@ import {
 } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { BrainIcon, ChevronDownIcon } from "lucide-react";
+import { ScrollArea as ScrollAreaPrimitive } from "radix-ui";
 import {
   useScrollLock,
   useAuiState,
@@ -249,7 +250,7 @@ function ReasoningText({
   className,
   children,
   ...props
-}: React.ComponentProps<"div">) {
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
   const isPreview = useContext(ReasoningPreviewContext);
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -269,11 +270,10 @@ function ReasoningText({
   }, [isPreview]);
 
   return (
-    <div
-      ref={scrollRef}
+    <ScrollAreaPrimitive.Root
       data-slot="reasoning-text"
       className={cn(
-        "aui-reasoning-text relative z-0 max-h-64 overflow-y-auto ps-6 pt-2 pb-2 leading-relaxed text-pretty",
+        "aui-reasoning-text relative z-0",
         "transform-gpu transition-[transform,opacity] ease-[cubic-bezier(0.32,0.72,0,1)]",
         "motion-reduce:animate-none",
         "group-data-[state=open]/collapsible-content:animate-in",
@@ -290,10 +290,26 @@ function ReasoningText({
       )}
       {...props}
     >
-      <div ref={contentRef} className="aui-reasoning-text-content space-y-4">
-        {children}
-      </div>
-    </div>
+      <ScrollAreaPrimitive.Viewport
+        ref={scrollRef}
+        data-slot="reasoning-text-viewport"
+        className="aui-reasoning-text-viewport max-h-64 w-full ps-6 pt-2 pb-2 leading-relaxed text-pretty outline-none"
+      >
+        <div ref={contentRef} className="aui-reasoning-text-content space-y-4">
+          {children}
+        </div>
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollAreaPrimitive.ScrollAreaScrollbar
+        data-slot="scroll-area-scrollbar"
+        orientation="vertical"
+        className="flex h-full w-2.5 touch-none border-s border-s-transparent p-px transition-colors select-none"
+      >
+        <ScrollAreaPrimitive.ScrollAreaThumb
+          data-slot="scroll-area-thumb"
+          className="bg-border relative flex-1 rounded-full"
+        />
+      </ScrollAreaPrimitive.ScrollAreaScrollbar>
+    </ScrollAreaPrimitive.Root>
   );
 }
 

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -294,7 +294,7 @@ function ReasoningText({
       <ScrollAreaPrimitive.Viewport
         ref={scrollRef}
         data-slot="reasoning-text-viewport"
-        className="aui-reasoning-text-viewport max-h-64 w-full ps-6 pt-2 pb-2 leading-relaxed text-pretty outline-none"
+        className="aui-reasoning-text-viewport focus-visible:ring-ring/50 max-h-64 w-full ps-6 pt-2 pb-2 leading-relaxed text-pretty transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >
         <div ref={contentRef} className="aui-reasoning-text-content space-y-4">
           {children}

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -25,6 +25,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { ScrollBar } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 
 const ANIMATION_DURATION = 200;
@@ -136,7 +137,7 @@ function ReasoningFade({
       <div
         data-slot="reasoning-fade"
         className={cn(
-          "aui-reasoning-fade pointer-events-none absolute inset-x-0 top-0 z-10 h-8",
+          "aui-reasoning-fade pointer-events-none absolute start-0 end-2.5 top-0 z-10 h-8",
           "bg-[linear-gradient(to_bottom,var(--color-background),transparent)]",
           "group-data-[variant=muted]/reasoning-root:bg-[linear-gradient(to_bottom,hsl(var(--muted)/0.5),transparent)]",
           "fade-in-0 animate-in",
@@ -152,7 +153,7 @@ function ReasoningFade({
     <div
       data-slot="reasoning-fade"
       className={cn(
-        "aui-reasoning-fade pointer-events-none absolute inset-x-0 bottom-0 z-10 h-8",
+        "aui-reasoning-fade pointer-events-none absolute start-0 end-2.5 bottom-0 z-10 h-8",
         "bg-[linear-gradient(to_top,var(--color-background),transparent)]",
         "group-data-[variant=muted]/reasoning-root:bg-[linear-gradient(to_top,hsl(var(--muted)/0.5),transparent)]",
         "fade-in-0 animate-in",
@@ -299,16 +300,7 @@ function ReasoningText({
           {children}
         </div>
       </ScrollAreaPrimitive.Viewport>
-      <ScrollAreaPrimitive.ScrollAreaScrollbar
-        data-slot="scroll-area-scrollbar"
-        orientation="vertical"
-        className="flex h-full w-2.5 touch-none border-s border-s-transparent p-px transition-colors select-none"
-      >
-        <ScrollAreaPrimitive.ScrollAreaThumb
-          data-slot="scroll-area-thumb"
-          className="bg-border relative flex-1 rounded-full"
-        />
-      </ScrollAreaPrimitive.ScrollAreaScrollbar>
+      <ScrollBar />
     </ScrollAreaPrimitive.Root>
   );
 }


### PR DESCRIPTION
Replaces the reasoning preview's native `overflow-y-auto` div with radix-ui ScrollArea primitives, giving it the shadcn-style auto-hiding overlay scrollbar. Pin-to-bottom streaming behavior is preserved (the ResizeObserver effect now targets the Radix viewport, which is the scrolling element). max-h moves onto the viewport because Radix viewports don't scroll when only the root is max-height-constrained. Scrollbar markup/classes mirror components/ui/scroll-area.tsx. The reasoning registry item gains the `radix-ui` npm dependency; no registryDependencies change since no `@/components/ui` import is added.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

