### PR TITLE
chore(examples): thin hover-reveal scrollbars in global styles

### DIFF
--- a/examples/waterfall/app/globals.css
+++ b/examples/waterfall/app/globals.css
@@ -35,7 +35,8 @@ body {
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/waterfall/app/globals.css
+++ b/examples/waterfall/app/globals.css
@@ -33,3 +33,37 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/waterfall/app/globals.css
+++ b/examples/waterfall/app/globals.css
@@ -41,7 +41,11 @@ body {
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -57,11 +61,19 @@ body {
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-a2a/app/globals.css
+++ b/examples/with-a2a/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-a2a/app/globals.css
+++ b/examples/with-a2a/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-a2a/app/globals.css
+++ b/examples/with-a2a/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-ag-ui/app/globals.css
+++ b/examples/with-ag-ui/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-ag-ui/app/globals.css
+++ b/examples/with-ag-ui/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-ag-ui/app/globals.css
+++ b/examples/with-ag-ui/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-ai-sdk-v6/app/globals.css
+++ b/examples/with-ai-sdk-v6/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-ai-sdk-v6/app/globals.css
+++ b/examples/with-ai-sdk-v6/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-ai-sdk-v6/app/globals.css
+++ b/examples/with-ai-sdk-v6/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-artifacts/app/globals.css
+++ b/examples/with-artifacts/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-artifacts/app/globals.css
+++ b/examples/with-artifacts/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-artifacts/app/globals.css
+++ b/examples/with-artifacts/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-assistant-transport/app/globals.css
+++ b/examples/with-assistant-transport/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-assistant-transport/app/globals.css
+++ b/examples/with-assistant-transport/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-assistant-transport/app/globals.css
+++ b/examples/with-assistant-transport/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-browser-extension/app.css
+++ b/examples/with-browser-extension/app.css
@@ -69,7 +69,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -85,11 +89,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-browser-extension/app.css
+++ b/examples/with-browser-extension/app.css
@@ -63,7 +63,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-browser-extension/app.css
+++ b/examples/with-browser-extension/app.css
@@ -61,3 +61,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-chain-of-thought/app/globals.css
+++ b/examples/with-chain-of-thought/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-chain-of-thought/app/globals.css
+++ b/examples/with-chain-of-thought/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-chain-of-thought/app/globals.css
+++ b/examples/with-chain-of-thought/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-cloud-standalone/app/globals.css
+++ b/examples/with-cloud-standalone/app/globals.css
@@ -107,7 +107,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-cloud-standalone/app/globals.css
+++ b/examples/with-cloud-standalone/app/globals.css
@@ -105,3 +105,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-cloud-standalone/app/globals.css
+++ b/examples/with-cloud-standalone/app/globals.css
@@ -113,7 +113,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -129,11 +133,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-cloud/app/globals.css
+++ b/examples/with-cloud/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-cloud/app/globals.css
+++ b/examples/with-cloud/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-cloud/app/globals.css
+++ b/examples/with-cloud/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-custom-thread-list/app/globals.css
+++ b/examples/with-custom-thread-list/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-custom-thread-list/app/globals.css
+++ b/examples/with-custom-thread-list/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-custom-thread-list/app/globals.css
+++ b/examples/with-custom-thread-list/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-elevenlabs-conversational/app/globals.css
+++ b/examples/with-elevenlabs-conversational/app/globals.css
@@ -60,3 +60,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-elevenlabs-conversational/app/globals.css
+++ b/examples/with-elevenlabs-conversational/app/globals.css
@@ -62,7 +62,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-elevenlabs-conversational/app/globals.css
+++ b/examples/with-elevenlabs-conversational/app/globals.css
@@ -68,7 +68,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -84,11 +88,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-elevenlabs-scribe/app/globals.css
+++ b/examples/with-elevenlabs-scribe/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-elevenlabs-scribe/app/globals.css
+++ b/examples/with-elevenlabs-scribe/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-elevenlabs-scribe/app/globals.css
+++ b/examples/with-elevenlabs-scribe/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-eve/app/globals.css
+++ b/examples/with-eve/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-eve/app/globals.css
+++ b/examples/with-eve/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-eve/app/globals.css
+++ b/examples/with-eve/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-external-store/app/globals.css
+++ b/examples/with-external-store/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-external-store/app/globals.css
+++ b/examples/with-external-store/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-external-store/app/globals.css
+++ b/examples/with-external-store/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-ffmpeg/app/globals.css
+++ b/examples/with-ffmpeg/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-ffmpeg/app/globals.css
+++ b/examples/with-ffmpeg/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-ffmpeg/app/globals.css
+++ b/examples/with-ffmpeg/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-generative-ui/app/globals.css
+++ b/examples/with-generative-ui/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-generative-ui/app/globals.css
+++ b/examples/with-generative-ui/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-generative-ui/app/globals.css
+++ b/examples/with-generative-ui/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-google-adk/app/globals.css
+++ b/examples/with-google-adk/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-google-adk/app/globals.css
+++ b/examples/with-google-adk/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-google-adk/app/globals.css
+++ b/examples/with-google-adk/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-heat-graph/app/globals.css
+++ b/examples/with-heat-graph/app/globals.css
@@ -19,7 +19,8 @@ body {
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-heat-graph/app/globals.css
+++ b/examples/with-heat-graph/app/globals.css
@@ -17,3 +17,37 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, currentColor 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, currentColor 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, currentColor 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-image-generation/app/globals.css
+++ b/examples/with-image-generation/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-image-generation/app/globals.css
+++ b/examples/with-image-generation/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-image-generation/app/globals.css
+++ b/examples/with-image-generation/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-interactables/app/globals.css
+++ b/examples/with-interactables/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-interactables/app/globals.css
+++ b/examples/with-interactables/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-interactables/app/globals.css
+++ b/examples/with-interactables/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-langchain/app/globals.css
+++ b/examples/with-langchain/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-langchain/app/globals.css
+++ b/examples/with-langchain/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-langchain/app/globals.css
+++ b/examples/with-langchain/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-langgraph/app/globals.css
+++ b/examples/with-langgraph/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-langgraph/app/globals.css
+++ b/examples/with-langgraph/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-langgraph/app/globals.css
+++ b/examples/with-langgraph/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-livekit/app/globals.css
+++ b/examples/with-livekit/app/globals.css
@@ -60,3 +60,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-livekit/app/globals.css
+++ b/examples/with-livekit/app/globals.css
@@ -62,7 +62,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-livekit/app/globals.css
+++ b/examples/with-livekit/app/globals.css
@@ -68,7 +68,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -84,11 +88,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-mcp/app/app/globals.css
+++ b/examples/with-mcp/app/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-mcp/app/app/globals.css
+++ b/examples/with-mcp/app/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-mcp/app/app/globals.css
+++ b/examples/with-mcp/app/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-opencode/app/globals.css
+++ b/examples/with-opencode/app/globals.css
@@ -142,7 +142,11 @@ body.dark,
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -158,11 +162,19 @@ body.dark,
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-opencode/app/globals.css
+++ b/examples/with-opencode/app/globals.css
@@ -134,3 +134,37 @@ body.dark,
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-opencode/app/globals.css
+++ b/examples/with-opencode/app/globals.css
@@ -136,7 +136,8 @@ body.dark,
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-pi/app/globals.css
+++ b/examples/with-pi/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-pi/app/globals.css
+++ b/examples/with-pi/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-pi/app/globals.css
+++ b/examples/with-pi/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-react-hook-form/app/globals.css
+++ b/examples/with-react-hook-form/app/globals.css
@@ -130,7 +130,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -146,11 +150,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-react-hook-form/app/globals.css
+++ b/examples/with-react-hook-form/app/globals.css
@@ -124,7 +124,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-react-hook-form/app/globals.css
+++ b/examples/with-react-hook-form/app/globals.css
@@ -122,3 +122,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-react-router/app/app.css
+++ b/examples/with-react-router/app/app.css
@@ -137,7 +137,8 @@ body {
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-react-router/app/app.css
+++ b/examples/with-react-router/app/app.css
@@ -143,7 +143,11 @@ body {
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -159,11 +163,19 @@ body {
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-react-router/app/app.css
+++ b/examples/with-react-router/app/app.css
@@ -135,3 +135,37 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-resumable-stream/app/globals.css
+++ b/examples/with-resumable-stream/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-resumable-stream/app/globals.css
+++ b/examples/with-resumable-stream/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-resumable-stream/app/globals.css
+++ b/examples/with-resumable-stream/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-store/app/globals.css
+++ b/examples/with-store/app/globals.css
@@ -26,7 +26,8 @@ body {
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-store/app/globals.css
+++ b/examples/with-store/app/globals.css
@@ -24,3 +24,37 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, currentColor 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, currentColor 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, currentColor 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-tanstack/src/styles.css
+++ b/examples/with-tanstack/src/styles.css
@@ -259,7 +259,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -275,11 +279,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-tanstack/src/styles.css
+++ b/examples/with-tanstack/src/styles.css
@@ -253,7 +253,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-tanstack/src/styles.css
+++ b/examples/with-tanstack/src/styles.css
@@ -251,3 +251,37 @@
 .ease-out {
   animation-timing-function: ease-out;
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-tap-runtime/app/globals.css
+++ b/examples/with-tap-runtime/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-tap-runtime/app/globals.css
+++ b/examples/with-tap-runtime/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-tap-runtime/app/globals.css
+++ b/examples/with-tap-runtime/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/examples/with-virtualized-thread/app/globals.css
+++ b/examples/with-virtualized-thread/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/examples/with-virtualized-thread/app/globals.css
+++ b/examples/with-virtualized-thread/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/examples/with-virtualized-thread/app/globals.css
+++ b/examples/with-virtualized-thread/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/templates/cloud-clerk/app/globals.css
+++ b/templates/cloud-clerk/app/globals.css
@@ -143,7 +143,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/templates/cloud-clerk/app/globals.css
+++ b/templates/cloud-clerk/app/globals.css
@@ -141,3 +141,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/templates/cloud-clerk/app/globals.css
+++ b/templates/cloud-clerk/app/globals.css
@@ -149,7 +149,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -165,11 +169,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/templates/cloud/app/globals.css
+++ b/templates/cloud/app/globals.css
@@ -143,7 +143,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/templates/cloud/app/globals.css
+++ b/templates/cloud/app/globals.css
@@ -141,3 +141,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/templates/cloud/app/globals.css
+++ b/templates/cloud/app/globals.css
@@ -149,7 +149,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -165,11 +169,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/templates/default/app/globals.css
+++ b/templates/default/app/globals.css
@@ -143,7 +143,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/templates/default/app/globals.css
+++ b/templates/default/app/globals.css
@@ -141,3 +141,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/templates/default/app/globals.css
+++ b/templates/default/app/globals.css
@@ -149,7 +149,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -165,11 +169,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/templates/eve/app/globals.css
+++ b/templates/eve/app/globals.css
@@ -122,7 +122,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/templates/eve/app/globals.css
+++ b/templates/eve/app/globals.css
@@ -120,3 +120,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/templates/eve/app/globals.css
+++ b/templates/eve/app/globals.css
@@ -128,7 +128,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -144,11 +148,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/templates/langchain/app/globals.css
+++ b/templates/langchain/app/globals.css
@@ -133,7 +133,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/templates/langchain/app/globals.css
+++ b/templates/langchain/app/globals.css
@@ -139,7 +139,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -155,11 +159,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/templates/langchain/app/globals.css
+++ b/templates/langchain/app/globals.css
@@ -131,3 +131,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/templates/mcp/app/globals.css
+++ b/templates/mcp/app/globals.css
@@ -143,7 +143,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/templates/mcp/app/globals.css
+++ b/templates/mcp/app/globals.css
@@ -141,3 +141,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/templates/mcp/app/globals.css
+++ b/templates/mcp/app/globals.css
@@ -149,7 +149,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -165,11 +169,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/templates/minimal/app/globals.css
+++ b/templates/minimal/app/globals.css
@@ -117,7 +117,8 @@
 }
 
 @layer base {
-  @supports not selector(::-webkit-scrollbar) {
+  /* Firefox only: standard scrollbar-* props would disable ::-webkit-scrollbar styling in Chromium */
+  @supports (-moz-appearance: none) {
     * {
       scrollbar-width: thin;
       scrollbar-color: transparent transparent;

--- a/templates/minimal/app/globals.css
+++ b/templates/minimal/app/globals.css
@@ -123,7 +123,11 @@
       scrollbar-color: transparent transparent;
     }
     *:hover {
-      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+      scrollbar-color: color-mix(
+          in srgb,
+          var(--muted-foreground) 35%,
+          transparent
+        )
         transparent;
     }
   }
@@ -139,11 +143,19 @@
     border-radius: 9999px;
   }
   *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 30%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-thumb:hover,
   *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--muted-foreground) 50%,
+      transparent
+    );
   }
   *::-webkit-scrollbar-corner {
     background: transparent;

--- a/templates/minimal/app/globals.css
+++ b/templates/minimal/app/globals.css
@@ -115,3 +115,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: color-mix(in srgb, var(--muted-foreground) 35%, transparent)
+        transparent;
+    }
+  }
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted-foreground) 30%, transparent);
+  }
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}


### PR DESCRIPTION
Ports the docs scrollbar treatment (#4331) to all web example and template stylesheets: 6px hover-revealed WebKit scrollbars plus a `scrollbar-width: thin` fallback for Firefox, using each app's `--muted-foreground` token. Examples previously shipped default OS scrollbars; this aligns them with assistant-ui.com. Terminal/native examples (with-expo, with-react-ink, with-react-ink-web) excluded. Two examples (with-store, with-heat-graph) use stock Next starter CSS without shadcn tokens, so their blocks substitute `currentColor` for `var(--muted-foreground)`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

