### PR TITLE
fix(react-native): show composer scrollbar at max height

### DIFF
--- a/.changeset/fuzzy-olives-see.md
+++ b/.changeset/fuzzy-olives-see.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-native": patch
+---
+
+fix(react-native): show composer scrollbar at max height

--- a/packages/react-native/src/primitives/composer/ComposerInput.test.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerInput.test.tsx
@@ -49,21 +49,28 @@ vi.mock("react-native", async (importOriginal) => {
 
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
-const setNativeValue = (input: HTMLInputElement, value: string) => {
-  const setter = Object.getOwnPropertyDescriptor(
-    HTMLInputElement.prototype,
-    "value",
-  )?.set;
+const setNativeValue = (
+  input: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+) => {
+  const prototype =
+    input instanceof HTMLTextAreaElement
+      ? HTMLTextAreaElement.prototype
+      : HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
   setter?.call(input, value);
 };
 
-const fireInput = (input: HTMLInputElement, value: string) => {
+const fireInput = (
+  input: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+) => {
   setNativeValue(input, value);
   input.dispatchEvent(new InputEvent("input", { bubbles: true }));
 };
 
 const fireKeyDown = (
-  input: HTMLInputElement,
+  input: HTMLInputElement | HTMLTextAreaElement,
   opts: {
     key?: string;
     shiftKey?: boolean;
@@ -114,7 +121,9 @@ describe("ComposerInput", () => {
     await act(async () => {
       root.render(<ComposerInput {...props} />);
     });
-    const input = container.querySelector("input") as HTMLInputElement;
+    const input = container.querySelector("textarea, input") as
+      | HTMLInputElement
+      | HTMLTextAreaElement;
     expect(input).not.toBeNull();
     return input;
   };
@@ -205,6 +214,29 @@ describe("ComposerInput", () => {
 
       expect(h.sendSpy).not.toHaveBeenCalled();
       expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("shows a scrollbar when multiline content exceeds the maximum height", async () => {
+      h.composerState.text = "line 1";
+      const input = await mount({
+        multiline: true,
+        style: { maxHeight: 40 },
+      });
+      expect(input.tagName).toBe("TEXTAREA");
+
+      Object.defineProperty(input, "scrollHeight", {
+        configurable: true,
+        value: 120,
+      });
+
+      h.composerState.text = "line 1\nline 2\nline 3";
+      await act(async () => {
+        root.render(<ComposerInput multiline style={{ maxHeight: 40 }} />);
+      });
+
+      expect(input.style.height).toBe("40px");
+      expect(input.style.overflowY).toBe("auto");
+      expect(input.style.overflowX).toBe("hidden");
     });
 
     it("forwards keydown events to a consumer onKeyPress handler", async () => {

--- a/packages/react-native/src/primitives/composer/ComposerInput.test.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerInput.test.tsx
@@ -239,6 +239,72 @@ describe("ComposerInput", () => {
       expect(input.style.overflowX).toBe("hidden");
     });
 
+    it("shrinks back below max height after content is deleted", async () => {
+      h.composerState.text = "line 1";
+      const input = await mount({
+        multiline: true,
+        style: { maxHeight: 40 },
+      });
+      expect(input.tagName).toBe("TEXTAREA");
+
+      let scrollHeight = 120;
+      Object.defineProperty(input, "scrollHeight", {
+        configurable: true,
+        get: () => scrollHeight,
+      });
+
+      h.composerState.text = "line 1\nline 2\nline 3";
+      await act(async () => {
+        root.render(<ComposerInput multiline style={{ maxHeight: 40 }} />);
+      });
+
+      expect(input.style.height).toBe("40px");
+      expect(input.style.overflowY).toBe("auto");
+
+      scrollHeight = 24;
+      h.composerState.text = "line 1";
+      await act(async () => {
+        root.render(<ComposerInput multiline style={{ maxHeight: 40 }} />);
+      });
+
+      expect(input.style.height).toBe("24px");
+      expect(input.style.overflowY).toBe("hidden");
+    });
+
+    it("prefers computed maxHeight over raw CSS unit parsing", async () => {
+      h.composerState.text = "line 1";
+      const computedStyleSpy = vi
+        .spyOn(globalThis, "getComputedStyle")
+        .mockImplementation((() => ({
+          maxHeight: "64px",
+        })) as typeof getComputedStyle);
+
+      try {
+        const input = await mount({
+          multiline: true,
+          style: { maxHeight: "4rem" as never },
+        });
+        expect(input.tagName).toBe("TEXTAREA");
+
+        Object.defineProperty(input, "scrollHeight", {
+          configurable: true,
+          value: 80,
+        });
+
+        h.composerState.text = "line 1\nline 2\nline 3";
+        await act(async () => {
+          root.render(
+            <ComposerInput multiline style={{ maxHeight: "4rem" as never }} />,
+          );
+        });
+
+        expect(input.style.height).toBe("64px");
+        expect(input.style.overflowY).toBe("auto");
+      } finally {
+        computedStyleSpy.mockRestore();
+      }
+    });
+
     it("forwards keydown events to a consumer onKeyPress handler", async () => {
       const onKeyPress = vi.fn();
       const input = await mount({ onKeyPress });

--- a/packages/react-native/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerInput.tsx
@@ -22,6 +22,17 @@ export type ComposerInputProps = Omit<
   submitMode?: "enter" | "none";
 };
 
+const getWebTextareaMaxHeight = (el: HTMLTextAreaElement) => {
+  const inlineMaxHeight = Number.parseFloat(el.style.maxHeight);
+  if (Number.isFinite(inlineMaxHeight)) return inlineMaxHeight;
+
+  const computedMaxHeight = globalThis.getComputedStyle?.(el).maxHeight;
+  const parsedComputedMaxHeight = Number.parseFloat(computedMaxHeight ?? "");
+  return Number.isFinite(parsedComputedMaxHeight)
+    ? parsedComputedMaxHeight
+    : null;
+};
+
 const adjustWebTextareaHeight = (ref: React.RefObject<TextInput | null>) => {
   if (Platform.OS !== "web") return;
   // On web, the TextInput ref IS the DOM element
@@ -29,9 +40,19 @@ const adjustWebTextareaHeight = (ref: React.RefObject<TextInput | null>) => {
   if (!el) return;
   // Ensure rows=1 so scrollHeight reflects actual content
   if (el.rows !== 1) el.rows = 1;
-  el.style.overflow = "hidden";
+
+  const maxHeight = getWebTextareaMaxHeight(el);
+  const needsScrollbar = maxHeight !== null && el.scrollHeight > maxHeight;
+  const nextHeight = needsScrollbar
+    ? maxHeight
+    : maxHeight === null
+      ? el.scrollHeight
+      : Math.min(el.scrollHeight, maxHeight);
+
+  el.style.overflowX = "hidden";
+  el.style.overflowY = needsScrollbar ? "auto" : "hidden";
   el.style.height = "auto";
-  el.style.height = `${el.scrollHeight}px`;
+  el.style.height = `${nextHeight}px`;
 };
 
 export const ComposerInput = ({

--- a/packages/react-native/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerInput.tsx
@@ -23,14 +23,12 @@ export type ComposerInputProps = Omit<
 };
 
 const getWebTextareaMaxHeight = (el: HTMLTextAreaElement) => {
-  const inlineMaxHeight = Number.parseFloat(el.style.maxHeight);
-  if (Number.isFinite(inlineMaxHeight)) return inlineMaxHeight;
-
   const computedMaxHeight = globalThis.getComputedStyle?.(el).maxHeight;
   const parsedComputedMaxHeight = Number.parseFloat(computedMaxHeight ?? "");
-  return Number.isFinite(parsedComputedMaxHeight)
-    ? parsedComputedMaxHeight
-    : null;
+  if (Number.isFinite(parsedComputedMaxHeight)) return parsedComputedMaxHeight;
+
+  const inlineMaxHeight = Number.parseFloat(el.style.maxHeight);
+  return Number.isFinite(inlineMaxHeight) ? inlineMaxHeight : null;
 };
 
 const adjustWebTextareaHeight = (ref: React.RefObject<TextInput | null>) => {
@@ -41,17 +39,17 @@ const adjustWebTextareaHeight = (ref: React.RefObject<TextInput | null>) => {
   // Ensure rows=1 so scrollHeight reflects actual content
   if (el.rows !== 1) el.rows = 1;
 
-  const maxHeight = getWebTextareaMaxHeight(el);
-  const needsScrollbar = maxHeight !== null && el.scrollHeight > maxHeight;
-  const nextHeight = needsScrollbar
-    ? maxHeight
-    : maxHeight === null
-      ? el.scrollHeight
-      : Math.min(el.scrollHeight, maxHeight);
-
   el.style.overflowX = "hidden";
-  el.style.overflowY = needsScrollbar ? "auto" : "hidden";
+  el.style.overflowY = "hidden";
   el.style.height = "auto";
+
+  const scrollHeight = el.scrollHeight;
+  const maxHeight = getWebTextareaMaxHeight(el);
+  const needsScrollbar = maxHeight !== null && scrollHeight > maxHeight;
+  const nextHeight =
+    maxHeight === null ? scrollHeight : Math.min(scrollHeight, maxHeight);
+
+  el.style.overflowY = needsScrollbar ? "auto" : "hidden";
   el.style.height = `${nextHeight}px`;
 };
 


### PR DESCRIPTION
## Summary
- keep the web composer auto-resize behavior for small multiline inputs
- cap the rendered height at `maxHeight` once content grows past it
- switch vertical overflow to `auto` in that overflow state so users can scroll the full draft
- add focused coverage for the multiline + maxHeight scrollbar case

Closes #4686

## Testing
- `packages/react-native/node_modules/.bin/vitest run src/primitives/composer/ComposerInput.test.tsx`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

