### PR TITLE
docs: clarify frontend tool auto resume

### DIFF
--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -216,13 +216,19 @@ The callback reads `?state=...&code=...` from the URL, derives the target server
 
 ```tsx
 "use client";
+import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 
 export function Chat() {
-  const runtime = useChatRuntime({ api: "/api/chat" });
+  const runtime = useChatRuntime({
+    api: "/api/chat",
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+  });
   /* … */
 }
 ```
+
+`sendAutomaticallyWhen` sends completed frontend tool results back to the server so the model can continue after a tool call.
 
 Tool names are prefixed `serverId__toolName` to avoid collisions across connected servers. The toolkit re-registers whenever a server connects / disconnects or its tool list changes.
 


### PR DESCRIPTION
## Summary

Clarify the user-managed MCP runtime example so connected frontend tools send their completed results back to the server automatically.

## Why

MCP tools registered by `McpManagerResource` run as frontend tools. Without `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls`, the browser can add the tool result locally but the model does not receive the follow-up request to continue. This is the confusion reported in #4688.

## Changes

- Add `lastAssistantMessageIsCompleteWithToolCalls` to the `useChatRuntime` example.
- Add one short sentence explaining that `sendAutomaticallyWhen` lets the model continue after frontend tool calls.

## Checks

- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

