### PR TITLE
docs: add react native markdown rendering docs

### DIFF
--- a/apps/docs/content/docs/react-native/primitives.mdx
+++ b/apps/docs/content/docs/react-native/primitives.mdx
@@ -362,6 +362,29 @@ Renders message content parts using render-prop functions instead of the compone
 | `renderFile` | `(props: { part, index }) => ReactElement` | Renderer for file parts |
 | `renderData` | `(props: { part, index }) => ReactElement` | Fallback renderer for data parts not handled by registered data UIs |
 
+#### Rendering Markdown
+
+`MessagePrimitive.Content` renders text parts with React Native's `<Text>` by default, so markdown syntax is displayed as plain text. To render markdown, install a React Native markdown renderer and pass it through `renderText`:
+
+<InstallCommand npm={["react-native-markdown-display"]} />
+
+```tsx
+import Markdown from "react-native-markdown-display";
+import { MessagePrimitive } from "@assistant-ui/react-native";
+
+const AssistantMessage = () => {
+  return (
+    <MessagePrimitive.Root>
+      <MessagePrimitive.Content
+        renderText={({ part }) => (
+          <Markdown>{part.text}</Markdown>
+        )}
+      />
+    </MessagePrimitive.Root>
+  );
+};
+```
+
 ### MessagePrimitive.Parts
 
 Renders message content parts via a `components` prop. Tool call and data parts automatically render registered toolkit renderers and data UIs (via `useAssistantDataUI`), falling back to components provided here. A default `Text` component using React Native's `<Text>` is provided out of the box.


### PR DESCRIPTION
## Summary

Documents how to render markdown in React Native message text by passing a custom markdown renderer to `MessagePrimitive.Content` via `renderText`.

## Why

React Native message text currently defaults to React Native's `<Text>`, so markdown syntax is displayed as plain text unless apps provide their own renderer. This gives users a direct copy-paste path using a React Native markdown package without adding a new dependency to assistant-ui itself.

Fixes #4680.

## Testing

- `git diff --check`
- Checked the `MessagePrimitive.Content` API against `packages/react-native/src/primitives/message/MessageContent.tsx`

Note: full `pnpm lint` was not completed locally because this clean worktree had to reinstall dependencies and the registry repeatedly stalled. The changed file is MDX-only, and the repo formatter/linter does not target this MDX path directly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

