### PR TITLE
fix(core): fail CloudFileAttachmentAdapter uploads that return an HTTP error status

### DIFF
--- a/.changeset/cloud-attachment-upload-status.md
+++ b/.changeset/cloud-attachment-upload-status.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): CloudFileAttachmentAdapter now fails uploads that return an HTTP error status instead of attaching a dead link

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AssistantCloud } from "assistant-cloud";
+import type { PendingAttachment } from "../../../types/attachment";
+import { CloudFileAttachmentAdapter } from "./CloudFileAttachmentAdapter";
+
+const makeCloud = () =>
+  ({
+    files: {
+      generatePresignedUploadUrl: vi.fn().mockResolvedValue({
+        signedUrl: "https://storage.example/upload",
+        publicUrl: "https://cdn.example/file.png",
+      }),
+    },
+  }) as unknown as AssistantCloud;
+
+const makeFile = () =>
+  new File([new Uint8Array([1, 2, 3])], "pixel.png", { type: "image/png" });
+
+const drain = async (adapter: CloudFileAttachmentAdapter) => {
+  const yields: PendingAttachment[] = [];
+  for await (const value of adapter.add({ file: makeFile() })) {
+    yields.push(value);
+  }
+  return yields;
+};
+
+describe("CloudFileAttachmentAdapter", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("marks the attachment ready when the upload succeeds", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+    const adapter = new CloudFileAttachmentAdapter(makeCloud());
+
+    const yields = await drain(adapter);
+
+    expect(yields.at(0)?.status).toEqual({
+      type: "running",
+      reason: "uploading",
+      progress: 0,
+    });
+    expect(yields.at(-1)?.status).toEqual({
+      type: "requires-action",
+      reason: "composer-send",
+    });
+
+    const complete = await adapter.send(yields.at(-1)!);
+    expect(complete.status).toEqual({ type: "complete" });
+    expect(complete.content).toEqual([
+      {
+        type: "image",
+        image: "https://cdn.example/file.png",
+        filename: "pixel.png",
+      },
+    ]);
+  });
+
+  it("marks the attachment incomplete when the upload returns an HTTP error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+      }),
+    );
+    const adapter = new CloudFileAttachmentAdapter(makeCloud());
+
+    const yields = await drain(adapter);
+
+    expect(yields.at(-1)?.status).toEqual({
+      type: "incomplete",
+      reason: "error",
+    });
+    await expect(adapter.send(yields.at(-1)!)).rejects.toThrow(
+      "Attachment not uploaded",
+    );
+  });
+
+  it("marks the attachment incomplete when the upload throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("network down")),
+    );
+    const adapter = new CloudFileAttachmentAdapter(makeCloud());
+
+    const yields = await drain(adapter);
+
+    expect(yields.at(-1)?.status).toEqual({
+      type: "incomplete",
+      reason: "error",
+    });
+    await expect(adapter.send(yields.at(-1)!)).rejects.toThrow(
+      "Attachment not uploaded",
+    );
+  });
+});

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
@@ -44,7 +44,7 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
         await this.cloud.files.generatePresignedUploadUrl({
           filename: file.name,
         });
-      await fetch(signedUrl, {
+      const res = await fetch(signedUrl, {
         method: "PUT",
         body: file,
         headers: {
@@ -52,6 +52,11 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
         },
         mode: "cors",
       });
+      if (!res.ok) {
+        throw new Error(
+          `Failed to upload file: ${res.status} ${res.statusText}`,
+        );
+      }
       this.uploadedUrls.set(id, publicUrl);
       attachment = {
         ...attachment,


### PR DESCRIPTION
## What

`CloudFileAttachmentAdapter.add()` PUTs the file to the presigned URL but never checks the response status. It now throws when `!res.ok`, routing HTTP failures into the existing catch that yields `{ type: "incomplete", reason: "error" }`.

## Why

Before this change, a 403 or 500 from storage resolved the `fetch` promise normally, so execution fell through and the attachment was marked `requires-action` (ready). `send()` then attached the `publicUrl` of a file that was never stored, so the model received a dead link. The failure was silent: the UI showed the attachment as ready and the message sent successfully. The existing catch only handled network-level throws, not HTTP error statuses.

## How

Capture the fetch response and throw `Failed to upload file: ${status} ${statusText}` when `!res.ok`, before `uploadedUrls.set(...)` runs. This mirrors the existing `if (!response.ok) throw` pattern already used in `AssistantCloudAPI.ts`, and reuses the one incomplete/error path so HTTP failures behave identically to the network-throw path that already existed. No new event or interface change.

Added a colocated `CloudFileAttachmentAdapter.test.ts` (greenfield, none existed) covering three cases: a successful upload yields `requires-action` and `send()` returns the public URL; an HTTP 403 yields `incomplete/error` and `send()` rejects with "Attachment not uploaded" (proving no dead link can escape); and a network throw is unchanged.

## Scope

One file plus its test. The two `AssistantCloudAuthStrategy` fetches and `AssistantCloudAPI` already check `response.ok`; only this raw PUT to the presigned URL bypassed the check.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

