### PR TITLE
fix(core): restore composer text and attachments when send upload fails

### DIFF
--- a/.changeset/composer-send-restore-on-upload-failure.md
+++ b/.changeset/composer-send-restore-on-upload-failure.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: restore composer text and attachments when an attachment upload fails during send

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -195,16 +195,30 @@ export abstract class BaseComposerRuntimeCore
           )
         : [];
 
+    const originalAttachments = this.attachments;
     const text = this.text;
     const quote = this._quote;
     this._quote = undefined;
     this._emptyTextAndAttachments();
 
+    let resolvedAttachments: Awaited<typeof attachments>;
+    try {
+      resolvedAttachments = await attachments;
+    } catch (e) {
+      if (this.isEmpty && this._quote === undefined) {
+        this._attachments = originalAttachments;
+        this._text = text;
+        this._quote = quote;
+        this._notifySubscribers();
+      }
+      throw e;
+    }
+
     const message: Omit<AppendMessage, "parentId" | "sourceId"> = {
       createdAt: new Date(),
       role: this.role,
       content: text ? [{ type: "text", text }] : [],
-      attachments: await attachments,
+      attachments: resolvedAttachments,
       runConfig: this.runConfig,
       metadata: { custom: { ...(quote ? { quote } : {}) } },
     };

--- a/packages/core/src/tests/base-composer-runtime-core-send.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-send.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { DefaultThreadComposerRuntimeCore } from "../runtime/base/default-thread-composer-runtime-core";
+import type { AttachmentAdapter } from "../adapters/attachment";
+import type { ThreadRuntimeCore } from "../runtime/interfaces/thread-runtime-core";
+import type { PendingAttachment } from "../types/attachment";
+
+const makeAdapter = (
+  overrides: Partial<AttachmentAdapter> = {},
+): AttachmentAdapter => ({
+  accept: "*",
+  add: async ({ file }: { file: File }): Promise<PendingAttachment> => ({
+    id: "att-1",
+    type: "image",
+    name: file.name,
+    contentType: file.type,
+    file,
+    status: { type: "requires-action", reason: "composer-send" },
+  }),
+  remove: async () => {},
+  send: async (a) => ({ ...a, status: { type: "complete" }, content: [] }),
+  ...overrides,
+});
+
+const makeComposer = (adapter?: AttachmentAdapter) => {
+  const append = vi.fn();
+  const runtime = {
+    append,
+    cancelRun: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
+    capabilities: { cancel: false },
+    messages: [],
+    getModelContext: () => ({ unstable_composerMetadata: undefined }),
+    adapters: adapter ? { attachments: adapter } : undefined,
+  } as unknown as Omit<ThreadRuntimeCore, "composer"> & {
+    adapters?: { attachments?: AttachmentAdapter };
+  };
+  const composer = new DefaultThreadComposerRuntimeCore(runtime);
+  return { composer, append };
+};
+
+const textFile = () => new File(["content"], "f.txt", { type: "text/plain" });
+
+describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
+  it("restores text, attachments, and quote when an upload fails", async () => {
+    const adapter = makeAdapter({
+      send: async () => {
+        throw new Error("upload failed");
+      },
+    });
+    const { composer, append } = makeComposer(adapter);
+
+    composer.setText("hello");
+    await composer.addAttachment(textFile());
+    composer.setQuote({ text: "quoted", messageId: "m-1" });
+    const originalAttachments = composer.attachments;
+
+    await expect(composer.send()).rejects.toThrow("upload failed");
+
+    expect(composer.text).toBe("hello");
+    expect(composer.attachments).toEqual(originalAttachments);
+    expect(composer.attachments).toHaveLength(1);
+    expect(composer.quote).toEqual({ text: "quoted", messageId: "m-1" });
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it("does not clobber text the user typed while the upload was in flight", async () => {
+    let rejectSend!: (e: Error) => void;
+    const adapter = makeAdapter({
+      send: () =>
+        new Promise((_resolve, reject) => {
+          rejectSend = reject;
+        }),
+    });
+    const { composer, append } = makeComposer(adapter);
+
+    composer.setText("hello");
+    await composer.addAttachment(textFile());
+
+    const sendPromise = composer.send();
+    composer.setText("new draft");
+    rejectSend(new Error("upload failed"));
+
+    await expect(sendPromise).rejects.toThrow("upload failed");
+
+    expect(composer.text).toBe("new draft");
+    expect(composer.attachments).toHaveLength(0);
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it("does not clobber a quote the user set while the upload was in flight", async () => {
+    let rejectSend!: (e: Error) => void;
+    const adapter = makeAdapter({
+      send: () =>
+        new Promise((_resolve, reject) => {
+          rejectSend = reject;
+        }),
+    });
+    const { composer, append } = makeComposer(adapter);
+
+    composer.setText("hello");
+    await composer.addAttachment(textFile());
+
+    const sendPromise = composer.send();
+    composer.setQuote({ text: "new quote", messageId: "m-2" });
+    rejectSend(new Error("upload failed"));
+
+    await expect(sendPromise).rejects.toThrow("upload failed");
+
+    expect(composer.quote).toEqual({ text: "new quote", messageId: "m-2" });
+    expect(composer.text).toBe("");
+    expect(composer.attachments).toHaveLength(0);
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it("sends and clears the composer on a successful upload", async () => {
+    const { composer, append } = makeComposer(makeAdapter());
+
+    composer.setText("hello");
+    await composer.addAttachment(textFile());
+
+    await composer.send();
+
+    expect(composer.isEmpty).toBe(true);
+    expect(composer.attachments).toHaveLength(0);
+    expect(append).toHaveBeenCalledTimes(1);
+    const message = append.mock.calls[0]![0];
+    expect(message.content).toEqual([{ type: "text", text: "hello" }]);
+    expect(message.attachments).toHaveLength(1);
+    expect(message.attachments[0].status).toEqual({ type: "complete" });
+  });
+
+  it("sends a text-only message with no attachment adapter", async () => {
+    const { composer, append } = makeComposer();
+
+    composer.setText("hello");
+
+    await composer.send();
+
+    expect(composer.isEmpty).toBe(true);
+    expect(append).toHaveBeenCalledTimes(1);
+    expect(append.mock.calls[0]![0].content).toEqual([
+      { type: "text", text: "hello" },
+    ]);
+  });
+});


### PR DESCRIPTION

## What

`send()` now restores the composer (text, attachments, quote) if an attachment upload fails, instead of leaving it permanently empty.

## Why

`send()` clears the composer synchronously, then awaits the uploads. If an upload rejects, the composer is already empty and the rejection escapes unhandled (`useComposerSend` calls `send()` fire-and-forget). One transient upload failure silently destroys the user's message.

The early clear is intentional (responsiveness), so the fix is restore-on-failure, not delaying the clear. This matches `ExternalStoreThreadRuntimeCore.cancelRun()`, which already restores composer text the same way.

## How

- Capture text/attachments/quote before the clear; wrap the upload `await` in try/catch.
- On failure, restore them only when the composer is still empty (`this.isEmpty`), then re-throw.
- The `isEmpty` guard avoids clobbering anything the user typed while the upload was in flight.
- Fix lives on the base `send()`, so thread and edit composers are both covered. No new event or API.

## Tests

New colocated `base-composer-runtime-core-send.test.ts`:
- failure restores text, attachments, and quote (and does not append)
- failure does not clobber text typed during the upload
- successful upload sends and clears
- text-only send with no adapter still works

The failure-restore case fails without the fix and passes with it.

## Scope

One file (`base-composer-runtime-core.ts`, `send()` only) plus its test and a `@assistant-ui/core` patch changeset. Out of scope: surfacing the rejection in `useComposerSend`, and any new composer error event.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

