### PR TITLE
docs(cli): rename langgraph template to langchain in package READMEs

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -58,7 +58,7 @@ npx assistant-ui info
 
 ## Templates
 
-`create` scaffolds from named templates: `default` (AI SDK), `minimal`, `cloud`, `cloud-clerk`, `langgraph`, `mcp`, `eve`. Pass `-t <name>`, pass `--example <name>` for examples such as `with-ai-sdk-v6`, use `--native` for Expo / React Native, use `--ink` for React Ink, or pass `--preset <url>` to scaffold from an `assistant-ui.com` playground link.
+`create` scaffolds from named templates: `default` (AI SDK), `minimal`, `cloud`, `cloud-clerk`, `langchain`, `mcp`, `eve`. Pass `-t <name>`, pass `--example <name>` for examples such as `with-ai-sdk-v6`, use `--native` for Expo / React Native, use `--ink` for React Ink, or pass `--preset <url>` to scaffold from an `assistant-ui.com` playground link.
 
 ## Documentation
 

--- a/packages/create-assistant-ui/README.md
+++ b/packages/create-assistant-ui/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/create-assistant-ui)](https://www.npmjs.com/package/create-assistant-ui)
 [![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
 
-Scaffold a new assistant-ui project from a chosen template (default AI SDK, minimal, cloud, langgraph, MCP, Eve, and more).
+Scaffold a new assistant-ui project from a chosen template (default AI SDK, minimal, cloud, langchain, MCP, Eve, and more).
 
 ## Usage
 
@@ -25,7 +25,7 @@ This wraps the `assistant-ui create` command from the [`assistant-ui` CLI](https
 | `minimal`      | Smallest possible Next.js + assistant-ui setup.            |
 | `cloud`        | Default template plus Assistant Cloud thread persistence.  |
 | `cloud-clerk`  | Cloud template with Clerk authentication.                  |
-| `langgraph`    | Next.js + LangGraph agent backend.                         |
+| `langchain`    | Next.js + LangGraph agent via the react-langchain adapter. |
 | `mcp`          | Next.js + an MCP server integration.                       |
 | `eve`          | Next.js + Eve agent backend.                               |
 


### PR DESCRIPTION
## What

Update `packages/cli/README.md` and `packages/create-assistant-ui/README.md` to reference the `langchain` starter template instead of the old `langgraph` name.

## How

Swapped `langgraph` for `langchain` in the CLI README templates prose and the create-assistant-ui README intro sentence, and renamed the create-assistant-ui table row to `langchain` with the description "Next.js + LangGraph agent via the react-langchain adapter." (accurate to `create.ts`, consistent with the table's "Next.js + ..." row style, column alignment preserved).

No changeset

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

