### PR TITLE
fix: clarify mcp oauth callback errors

### DIFF
--- a/.changeset/mcp-oauth-callback-errors.md
+++ b/.changeset/mcp-oauth-callback-errors.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: clarify MCP OAuth callback failures

--- a/packages/react-mcp/src/hooks/useMcpOAuthCallback.test.ts
+++ b/packages/react-mcp/src/hooks/useMcpOAuthCallback.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { createMcpOAuthCallbackError } from "./useMcpOAuthCallback";
+
+describe("createMcpOAuthCallbackError", () => {
+  it("adds MCP OAuth callback context without a server id", () => {
+    expect(
+      createMcpOAuthCallbackError(new Error('missing "state" parameter'), null)
+        .message,
+    ).toBe('MCP OAuth callback failed: missing "state" parameter');
+  });
+
+  it("adds MCP OAuth callback context with a server id", () => {
+    expect(
+      createMcpOAuthCallbackError(new Error("invalid_grant"), "github").message,
+    ).toBe('MCP OAuth callback for server "github" failed: invalid_grant');
+  });
+});

--- a/packages/react-mcp/src/hooks/useMcpOAuthCallback.test.ts
+++ b/packages/react-mcp/src/hooks/useMcpOAuthCallback.test.ts
@@ -3,15 +3,22 @@ import { createMcpOAuthCallbackError } from "./useMcpOAuthCallback";
 
 describe("createMcpOAuthCallbackError", () => {
   it("adds MCP OAuth callback context without a server id", () => {
-    expect(
-      createMcpOAuthCallbackError(new Error('missing "state" parameter'), null)
-        .message,
-    ).toBe('MCP OAuth callback failed: missing "state" parameter');
+    const cause = new Error('missing "state" parameter');
+    const error = createMcpOAuthCallbackError(cause, null);
+
+    expect(error.message).toBe(
+      'MCP OAuth callback failed: missing "state" parameter',
+    );
+    expect(error.cause).toBe(cause);
   });
 
   it("adds MCP OAuth callback context with a server id", () => {
-    expect(
-      createMcpOAuthCallbackError(new Error("invalid_grant"), "github").message,
-    ).toBe('MCP OAuth callback for server "github" failed: invalid_grant');
+    const cause = new Error("invalid_grant");
+    const error = createMcpOAuthCallbackError(cause, "github");
+
+    expect(error.message).toBe(
+      'MCP OAuth callback for server "github" failed: invalid_grant',
+    );
+    expect(error.cause).toBe(cause);
   });
 });

--- a/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
+++ b/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
@@ -2,6 +2,19 @@ import { type FC, type ReactNode, useEffect, useRef, useState } from "react";
 import { useAui } from "@assistant-ui/store";
 import { decodeServerIdFromState } from "../auth/createOAuthProvider";
 
+export const createMcpOAuthCallbackError = (
+  err: unknown,
+  serverId: string | null,
+): Error => {
+  const message = err instanceof Error ? err.message : String(err);
+  if (serverId) {
+    return new Error(
+      `MCP OAuth callback for server "${serverId}" failed: ${message}`,
+    );
+  }
+  return new Error(`MCP OAuth callback failed: ${message}`);
+};
+
 export type UseMcpOAuthCallbackOptions = {
   /** Defaults to `window.location.href`. */
   url?: string;
@@ -39,27 +52,28 @@ export function useMcpOAuthCallback(
     startedRef.current = url;
 
     (async () => {
+      let serverId: string | null = null;
       try {
         const parsed = new URL(url);
         const state = parsed.searchParams.get("state");
+        if (state) serverId = decodeServerIdFromState(state);
         const error = parsed.searchParams.get("error");
         if (error) {
           throw new Error(
             parsed.searchParams.get("error_description") ?? error,
           );
         }
-        if (!state) throw new Error("missing state parameter in callback URL");
-        const serverId = decodeServerIdFromState(state);
+        if (!state) throw new Error('missing "state" parameter');
         if (!serverId) {
-          throw new Error("callback state does not match an MCP server");
+          throw new Error("state was not created by assistant-ui MCP");
         }
         setResult({ status: "running", serverId, error: null });
         await aui.mcp().server({ id: serverId }).completeAuth(url);
         setResult({ status: "done", serverId, error: null });
         optsRef.current.onComplete?.(serverId);
       } catch (err) {
-        const e = err instanceof Error ? err : new Error(String(err));
-        setResult((prev) => ({ ...prev, status: "error", error: e }));
+        const e = createMcpOAuthCallbackError(err, serverId);
+        setResult({ status: "error", serverId, error: e });
         optsRef.current.onError?.(e);
       }
     })();

--- a/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
+++ b/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
@@ -10,9 +10,10 @@ export const createMcpOAuthCallbackError = (
   if (serverId) {
     return new Error(
       `MCP OAuth callback for server "${serverId}" failed: ${message}`,
+      { cause: err },
     );
   }
-  return new Error(`MCP OAuth callback failed: ${message}`);
+  return new Error(`MCP OAuth callback failed: ${message}`, { cause: err });
 };
 
 export type UseMcpOAuthCallbackOptions = {

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -1,5 +1,6 @@
 import { createTapRoot, useResource } from "@assistant-ui/tap";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MCPAuthConfig } from "../mcp-scope";
 import type { MCPStorage } from "./storage/types";
 
 const mocks = vi.hoisted(() => {
@@ -15,6 +16,7 @@ const mocks = vi.hoisted(() => {
       }>;
     }>
   > = [];
+  const finishAuthResults: Array<() => Promise<void>> = [];
 
   const Client = vi.fn().mockImplementation(function Client(this: any) {
     const index = clients.length;
@@ -30,8 +32,11 @@ const mocks = vi.hoisted(() => {
   const StreamableHTTPClientTransport = vi
     .fn()
     .mockImplementation(function StreamableHTTPClientTransport(this: any) {
+      const index = transports.length;
       this.close = vi.fn(() => Promise.resolve());
-      this.finishAuth = vi.fn(() => Promise.resolve());
+      this.finishAuth = vi.fn(
+        () => finishAuthResults[index]?.() ?? Promise.resolve(),
+      );
       transports.push(this);
     });
 
@@ -42,6 +47,7 @@ const mocks = vi.hoisted(() => {
     transports,
     connectResults,
     listToolsResults,
+    finishAuthResults,
   };
 });
 
@@ -61,6 +67,18 @@ const tick = async () => {
   await Promise.resolve();
 };
 
+const flushMacrotask = async () => {
+  await new Promise<void>((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => {
+      channel.port1.close();
+      channel.port2.close();
+      resolve();
+    };
+    channel.port2.postMessage(null);
+  });
+};
+
 const waitFor = async (predicate: () => boolean) => {
   for (let i = 0; i < 20; i++) {
     if (predicate()) return;
@@ -77,7 +95,20 @@ const createStorage = (): MCPStorage => ({
   clearAuthState: vi.fn(async () => {}),
 });
 
-const mount = (props?: { connectionTimeout?: number | undefined }) => {
+const resetMocks = () => {
+  mocks.clients.length = 0;
+  mocks.transports.length = 0;
+  mocks.connectResults.length = 0;
+  mocks.listToolsResults.length = 0;
+  mocks.finishAuthResults.length = 0;
+  mocks.Client.mockClear();
+  mocks.StreamableHTTPClientTransport.mockClear();
+};
+
+const mount = (props?: {
+  auth?: MCPAuthConfig | undefined;
+  connectionTimeout?: number | undefined;
+}) => {
   const connectionTimeout =
     props && "connectionTimeout" in props ? props.connectionTimeout : 10_000;
 
@@ -88,7 +119,7 @@ const mount = (props?: { connectionTimeout?: number | undefined }) => {
         kind: "connector",
         name: "Docs",
         url: "https://example.com/mcp",
-        auth: { type: "none" },
+        auth: props?.auth ?? { type: "none" },
         storage: createStorage(),
         redirectUri: "https://example.com/callback",
         autoConnect: false,
@@ -102,12 +133,7 @@ const mount = (props?: { connectionTimeout?: number | undefined }) => {
 describe("McpServerResource connectionTimeout", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    mocks.clients.length = 0;
-    mocks.transports.length = 0;
-    mocks.connectResults.length = 0;
-    mocks.listToolsResults.length = 0;
-    mocks.Client.mockClear();
-    mocks.StreamableHTTPClientTransport.mockClear();
+    resetMocks();
   });
 
   afterEach(() => {
@@ -214,6 +240,55 @@ describe("McpServerResource connectionTimeout", () => {
         lastError: null,
       });
       expect(mocks.transports[0].close).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+    }
+  });
+});
+
+describe("McpServerResource completeAuth", () => {
+  beforeEach(resetMocks);
+
+  it("rejects when the callback URL has no authorization code", async () => {
+    const root = mount();
+
+    try {
+      await expect(
+        root.getValue().completeAuth("https://example.com/callback?state=abc"),
+      ).rejects.toThrow("missing authorization code in callback URL");
+      await flushMacrotask();
+
+      expect(root.getValue().getState()).toMatchObject({
+        connectionState: "error",
+        lastError: {
+          message: "missing authorization code in callback URL",
+        },
+      });
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("rejects after storing finishAuth failures on the server state", async () => {
+    mocks.finishAuthResults.push(() =>
+      Promise.reject(new Error("invalid_grant")),
+    );
+    const root = mount({ auth: { type: "oauth" } });
+
+    try {
+      await expect(
+        root.getValue().completeAuth("https://example.com/callback?code=abc"),
+      ).rejects.toThrow("invalid_grant");
+      await flushMacrotask();
+
+      expect(root.getValue().getState()).toMatchObject({
+        connectionState: "error",
+        lastError: {
+          message: "invalid_grant",
+        },
+      });
+      expect(mocks.transports[0].finishAuth).toHaveBeenCalledWith("abc");
+      expect(mocks.transports[0].close).toHaveBeenCalledTimes(1);
     } finally {
       root.unmount();
     }

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -221,10 +221,12 @@ const useMcpServerResource = (
       await finalizeConnect(transport);
     } catch (err) {
       await closeTransport();
+      const error = err instanceof Error ? err : new Error(String(err));
       setLastError({
-        message: err instanceof Error ? err.message : String(err),
+        message: error.message,
       });
       setConnectionState("error");
+      throw error;
     }
   });
 


### PR DESCRIPTION
## Summary

Clarifies MCP OAuth callback failures so callback pages receive actionable errors with MCP/server context. This also makes `completeAuth` reject after it stores the server error state, so `McpOAuthCallback` no longer calls `onComplete` when finishing OAuth actually failed.

## Why

While testing MCP OAuth locally, a stale callback or failed token/code exchange can move the MCP server into `error`, but the callback component can still treat the flow as complete. Apps commonly redirect from `onComplete`, so that false-success path can hide the real auth failure from users.

## Changes

- Wrap callback errors as `MCP OAuth callback failed: ...` or `MCP OAuth callback for server "id" failed: ...` when the server id is known.
- Rethrow `completeAuth` failures after preserving `lastError` and `connectionState: "error"` on the MCP server.
- Add focused tests for callback error formatting and `completeAuth` rejection/state preservation.

## Checks

- `pnpm --filter @assistant-ui/react-mcp test`
- `pnpm --filter @assistant-ui/react-mcp build`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

