### PR TITLE
ci(claude-review): fail the job when Claude execution errors

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -122,6 +122,19 @@ jobs:
           claude_args: ${{ env.CLAUDE_ARGS }}
           additional_permissions: ${{ env.ADDITIONAL_PERMISSIONS }}
 
+      # The action reports success even when the Claude execution errors out
+      # (e.g. expired OAuth token or exhausted usage limit), leaving PRs with a
+      # green check and no review. Fail loudly and surface the error text,
+      # which the action redacts from its own logs.
+      - name: Fail on Claude execution error
+        if: always()
+        run: |
+          FILE='${{ steps.review.outputs.execution_file }}'
+          [ -f "$FILE" ] || exit 0
+          jq -e 'last(.[] | select(.type == "result")) | .is_error == true' "$FILE" >/dev/null || exit 0
+          echo "::error::Claude review failed: $(jq -r 'last(.[] | select(.type == "result")) | .result // "no error text"' "$FILE" | tr '\n' ' ' | head -c 500)"
+          exit 1
+
       # Fable's cybersecurity classifier can silently swap the session to Opus
       # mid-run; the model's own context still claims Fable, so the transcript
       # is the only reliable signal of the downgrade.


### PR DESCRIPTION
## What

Add a guard step to the Claude Code Review workflow that fails the job and prints the error text when the Claude execution errors out.

## Why

Every claude-review run since 2026-07-03 11:36 UTC has silently produced no review: the execution dies on the first API call (`is_error: true`, 1 turn, ~450ms, $0 cost), but the job still reports a green check because the action derives success from `resultMessage.subtype === "success"` and ignores `is_error`. The sticky comment just says "Claude finished in 0s", so PRs lost their review summary without anyone noticing.

## How

After the Review step, parse the action's `execution_file` output (a JSON array of SDK messages): if the last `result` message has `is_error: true`, emit the error text as a `::error::` annotation (truncated to 500 chars) and exit 1. Runs where the file is missing or the result is clean are untouched.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

