### PR TITLE
fix(cli): register with-resumable-stream example for scaffolding

### DIFF
--- a/.changeset/cli-resumable-stream-example.md
+++ b/.changeset/cli-resumable-stream-example.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+cli: register the `with-resumable-stream` example so `npx assistant-ui create -e with-resumable-stream` resolves instead of failing with "Unknown example".

--- a/api-surface/assistant-ui.ts
+++ b/api-surface/assistant-ui.ts
@@ -79,7 +79,7 @@ export const cliSurface: CliSurfaceSnapshot = {
         },
         {
           "flags": "-e, --example <example>",
-          "description": "create from an example (with-ag-ui, with-google-adk, with-ai-sdk-v6, with-eve, with-artifacts, with-assistant-transport, with-chain-of-thought, with-cloud, with-custom-thread-list, with-elevenlabs-conversational, with-elevenlabs-scribe, with-livekit, with-expo, with-interactables, with-external-store, with-ffmpeg, with-langgraph, with-react-hook-form, with-react-ink, with-react-router, with-tanstack)",
+          "description": "create from an example (with-ag-ui, with-google-adk, with-ai-sdk-v6, with-eve, with-artifacts, with-assistant-transport, with-chain-of-thought, with-cloud, with-custom-thread-list, with-elevenlabs-conversational, with-elevenlabs-scribe, with-livekit, with-expo, with-interactables, with-external-store, with-ffmpeg, with-langgraph, with-react-hook-form, with-react-ink, with-react-router, with-tanstack, with-resumable-stream)",
           "required": true
         },
         {

--- a/api-surface/create-assistant-ui.ts
+++ b/api-surface/create-assistant-ui.ts
@@ -19,7 +19,7 @@ export const cliSurface: CliSurfaceSnapshot = {
     },
     {
       "flags": "-e, --example <example>",
-      "description": "create from an example (with-ag-ui, with-google-adk, with-ai-sdk-v6, with-eve, with-artifacts, with-assistant-transport, with-chain-of-thought, with-cloud, with-custom-thread-list, with-elevenlabs-conversational, with-elevenlabs-scribe, with-livekit, with-expo, with-interactables, with-external-store, with-ffmpeg, with-langgraph, with-react-hook-form, with-react-ink, with-react-router, with-tanstack)",
+      "description": "create from an example (with-ag-ui, with-google-adk, with-ai-sdk-v6, with-eve, with-artifacts, with-assistant-transport, with-chain-of-thought, with-cloud, with-custom-thread-list, with-elevenlabs-conversational, with-elevenlabs-scribe, with-livekit, with-expo, with-interactables, with-external-store, with-ffmpeg, with-langgraph, with-react-hook-form, with-react-ink, with-react-router, with-tanstack, with-resumable-stream)",
       "required": true
     },
     {

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -255,6 +255,14 @@ export const PROJECT_METADATA: ProjectMetadata[] = [
     path: "examples/with-tanstack",
     hasLocalComponents: false,
   },
+  {
+    name: "with-resumable-stream",
+    label: "Resumable Stream",
+    description: "Resumable LLM stream that survives reload mid-response",
+    category: "example",
+    path: "examples/with-resumable-stream",
+    hasLocalComponents: false,
+  },
 ];
 
 // Examples that exist in the monorepo but are intentionally excluded from the CLI:


### PR DESCRIPTION
## Summary

The docs advertise `npx assistant-ui create my-app -e with-resumable-stream`, but `PROJECT_METADATA` in `packages/cli/src/commands/create.ts` has no entry for it, so the command exits with "Unknown example". This adds the missing entry so the example can be scaffolded.

## Why

`examples/with-resumable-stream` exists and is documented, and it is not in the "intentionally excluded" list in `create.ts`, so it should be scaffoldable. It runs out of the box: an in-memory store fallback (no Redis) and a built-in mock model (no `OPENAI_API_KEY`). It uses `workspace:*` deps and aliases `@/components/assistant-ui/*` to the shared `packages/ui` source with no local component copies, the same shape as `with-cloud`, so the entry uses `hasLocalComponents: false`.

## Scope

Only the metadata entry plus a changeset. The doc row already exists, so no docs change is needed here. The other examples missing from the cli.mdx table are handled separately.

## Testing

`pnpm --filter assistant-ui build` and `pnpm --filter assistant-ui test` pass (195 tests). `resolveProject({ example: "with-resumable-stream" })` now returns the entry instead of logging "Unknown example".


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

