### PR TITLE
docs(cli): list all supported examples in the create table

### DIFF
--- a/apps/docs/content/docs/(docs)/cli.mdx
+++ b/apps/docs/content/docs/(docs)/cli.mdx
@@ -70,15 +70,19 @@ Use `--example` to create a project from one of the monorepo examples with full 
 | `with-eve` | Eve agent integration | `npx assistant-ui create my-app -e with-eve` |
 | `with-artifacts` | HTML artifact rendering with live preview | `npx assistant-ui create my-app -e with-artifacts` |
 | `with-langgraph` | LangGraph agent with custom tools | `npx assistant-ui create my-app -e with-langgraph` |
+| `with-google-adk` | Google ADK agent integration | `npx assistant-ui create my-app -e with-google-adk` |
 | `with-cloud` | Assistant Cloud persistence | `npx assistant-ui create my-app -e with-cloud` |
 | `with-ag-ui` | [AG-UI protocol](/docs/runtimes/ag-ui/overview) integration | `npx assistant-ui create my-app -e with-ag-ui` |
 | `with-assistant-transport` | Custom backend via Assistant Transport | `npx assistant-ui create my-app -e with-assistant-transport` |
 | `with-resumable-stream` | Resumable LLM stream that survives reload mid-response | `npx assistant-ui create my-app -e with-resumable-stream` |
 | `with-chain-of-thought` | Chain-of-thought reasoning, tool calls, and source citations | `npx assistant-ui create my-app -e with-chain-of-thought` |
 | `with-external-store` | External message store | `npx assistant-ui create my-app -e with-external-store` |
+| `with-interactables` | AI-driven interactive UI components | `npx assistant-ui create my-app -e with-interactables` |
 | `with-custom-thread-list` | Custom thread list UI | `npx assistant-ui create my-app -e with-custom-thread-list` |
 | `with-react-hook-form` | React Hook Form integration | `npx assistant-ui create my-app -e with-react-hook-form` |
 | `with-ffmpeg` | FFmpeg video processing tool | `npx assistant-ui create my-app -e with-ffmpeg` |
+| `with-elevenlabs-conversational` | Realtime voice with ElevenLabs | `npx assistant-ui create my-app -e with-elevenlabs-conversational` |
+| `with-livekit` | Realtime voice with LiveKit | `npx assistant-ui create my-app -e with-livekit` |
 | `with-elevenlabs-scribe` | ElevenLabs voice transcription | `npx assistant-ui create my-app -e with-elevenlabs-scribe` |
 | `with-expo` | Expo / React Native | `npx assistant-ui create my-app -e with-expo` |
 | `with-react-ink` | Terminal UI chat | `npx assistant-ui create my-app -e with-react-ink` |


### PR DESCRIPTION

## Summary

The examples table in `cli.mdx` omits four examples the CLI already supports, so `create -e <name>` works for them but they are undiscoverable from the docs. This adds their rows.

## Rows added

- `with-google-adk`
- `with-elevenlabs-conversational`
- `with-livekit`
- `with-interactables`

Each is already in `PROJECT_METADATA` in `packages/cli/src/commands/create.ts`, so the commands work today. Descriptions mirror the metadata entries.

## Scope

Docs only, no code change. Rows are inserted next to related entries without reordering the table.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

