### PR TITLE
fix(core): log the swallowed CloudFileAttachmentAdapter upload error

### DIFF
--- a/.changeset/cloud-attachment-upload-error-log.md
+++ b/.changeset/cloud-attachment-upload-error-log.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): log the swallowed CloudFileAttachmentAdapter upload error instead of discarding it

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
@@ -27,6 +27,7 @@ const drain = async (adapter: CloudFileAttachmentAdapter) => {
 describe("CloudFileAttachmentAdapter", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("marks the attachment ready when the upload succeeds", async () => {
@@ -57,6 +58,7 @@ describe("CloudFileAttachmentAdapter", () => {
   });
 
   it("marks the attachment incomplete when the upload returns an HTTP error", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -73,16 +75,21 @@ describe("CloudFileAttachmentAdapter", () => {
       type: "incomplete",
       reason: "error",
     });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[assistant-ui] Failed to upload attachment:",
+      expect.objectContaining({
+        message: "Failed to upload file: 403 Forbidden",
+      }),
+    );
     await expect(adapter.send(yields.at(-1)!)).rejects.toThrow(
       "Attachment not uploaded",
     );
   });
 
   it("marks the attachment incomplete when the upload throws", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockRejectedValue(new Error("network down")),
-    );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const uploadError = new Error("network down");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(uploadError));
     const adapter = new CloudFileAttachmentAdapter(makeCloud());
 
     const yields = await drain(adapter);
@@ -91,6 +98,10 @@ describe("CloudFileAttachmentAdapter", () => {
       type: "incomplete",
       reason: "error",
     });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[assistant-ui] Failed to upload attachment:",
+      uploadError,
+    );
     await expect(adapter.send(yields.at(-1)!)).rejects.toThrow(
       "Attachment not uploaded",
     );

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
@@ -63,7 +63,8 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
         status: { type: "requires-action", reason: "composer-send" },
       };
       yield attachment;
-    } catch {
+    } catch (error) {
+      console.error("[assistant-ui] Failed to upload attachment:", error);
       attachment = {
         ...attachment,
         status: { type: "incomplete", reason: "error" },


### PR DESCRIPTION
Follow-up to #4714.
### Summary
`CloudFileAttachmentAdapter.add()` caught upload failures with a bare `catch {}`, discarding the error. The console showed nothing, and the `attachmentAddError` event could only report a generic message.

This binds the error and logs it via `console.error`, matching the existing `[assistant-ui] …:` idiom. The yielded status is unchanged: only a log line is added on the already-failing path.

### Tests

The two failure-path tests now assert `console.error` is called with the thrown error.

Changeset: `@assistant-ui/core` patch.
