### PR TITLE
fix: add mcp app host error context

### DIFF
--- a/.changeset/mcp-app-host-error-context.md
+++ b/.changeset/mcp-app-host-error-context.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: add MCP App host request error context

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.test.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.test.ts
@@ -1,0 +1,81 @@
+import { createTapRoot, useResource } from "@assistant-ui/tap";
+import { describe, expect, it, vi } from "vitest";
+import { McpAppsRemoteHost } from "./McpAppsRemoteHost";
+
+const mount = (fetch: typeof globalThis.fetch) =>
+  createTapRoot(function Root() {
+    return useResource(
+      McpAppsRemoteHost({
+        url: "/api/mcp-apps",
+        fetch,
+      }),
+    );
+  });
+
+describe("McpAppsRemoteHost", () => {
+  it("posts the requested method and params to the host route", async () => {
+    const fetch = vi.fn(async () =>
+      Response.json({ content: [{ type: "text", text: "ok" }] }),
+    ) as unknown as typeof globalThis.fetch;
+    const root = mount(fetch);
+
+    try {
+      await expect(
+        root.getValue().callTool({
+          name: "search",
+          arguments: { query: "docs" },
+        }),
+      ).resolves.toEqual({ content: [{ type: "text", text: "ok" }] });
+
+      expect(fetch).toHaveBeenCalledWith("/api/mcp-apps", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          method: "tools/call",
+          params: { name: "search", arguments: { query: "docs" } },
+        }),
+      });
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("includes method, url, status, and text body in host request errors", async () => {
+    const fetch = vi.fn(
+      async () =>
+        new Response("Missing tool name", {
+          status: 500,
+          statusText: "Internal Server Error",
+        }),
+    ) as unknown as typeof globalThis.fetch;
+    const root = mount(fetch);
+
+    try {
+      await expect(
+        root.getValue().callTool({ name: "search" }),
+      ).rejects.toThrow(
+        'MCP App host request "tools/call" to "/api/mcp-apps" failed with 500 Internal Server Error: Missing tool name',
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("uses JSON error messages from failed host responses", async () => {
+    const fetch = vi.fn(async () =>
+      Response.json(
+        { error: { message: "resources/list is not supported" } },
+        { status: 400, statusText: "Bad Request" },
+      ),
+    ) as unknown as typeof globalThis.fetch;
+    const root = mount(fetch);
+
+    try {
+      await expect(root.getValue().listResources()).rejects.toThrow(
+        'MCP App host request "resources/list" to "/api/mcp-apps" failed with 400 Bad Request: resources/list is not supported',
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+});

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
@@ -6,6 +6,39 @@ import type {
   McpAppsRemoteHostOptions,
 } from "./types";
 
+const truncateBody = (body: string) =>
+  body.length > 500 ? `${body.slice(0, 500)}...` : body;
+
+const extractErrorBody = (body: string): string | undefined => {
+  const trimmed = body.trim();
+  if (!trimmed) return undefined;
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (parsed && typeof parsed === "object") {
+      const record = parsed as Record<string, unknown>;
+      if (typeof record.message === "string") return record.message;
+      if (typeof record.error === "string") return record.error;
+      if (record.error && typeof record.error === "object") {
+        const error = record.error as Record<string, unknown>;
+        if (typeof error.message === "string") return error.message;
+      }
+    }
+  } catch {
+    return truncateBody(trimmed);
+  }
+
+  return truncateBody(trimmed);
+};
+
+const readErrorBody = async (res: Response): Promise<string | undefined> => {
+  try {
+    return extractErrorBody(await res.text());
+  } catch {
+    return undefined;
+  }
+};
+
 async function postToHost(
   options: McpAppsRemoteHostOptions,
   method: string,
@@ -22,7 +55,13 @@ async function postToHost(
     body: JSON.stringify({ method, params }),
   });
   if (!res.ok) {
-    throw new Error(`MCP App host request failed: ${res.status}`);
+    const status = res.statusText
+      ? `${res.status} ${res.statusText}`
+      : `${res.status}`;
+    const body = await readErrorBody(res);
+    throw new Error(
+      `MCP App host request "${method}" to "${options.url}" failed with ${status}${body ? `: ${body}` : ""}`,
+    );
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary

Adds context to failed `McpAppsRemoteHost` requests so developers can see which MCP Apps method failed, which route was called, the HTTP status, and any useful response error body.

## Why

When testing MCP Apps locally, a route can fail because a tool is missing, a resource handler is not wired, or the route returns a JSON-RPC style error. Previously the frontend only threw `MCP App host request failed: 500`, which made the real backend failure hard to find.

## Changes

- Include method, host URL, status, and status text in failed host request errors.
- Read common error response shapes such as plain text, `{ message }`, `{ error: string }`, and `{ error: { message } }`.
- Add tests covering successful host POSTs and contextual failed-request messages.

## Checks

- `pnpm --filter @assistant-ui/react test`
- `pnpm --filter @assistant-ui/react build`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

