### PR TITLE
feat(ui): client-side search for the thread list

### DIFF
--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -177,6 +177,7 @@ export const registry: RegistryItem[] = [
     ],
     registryDependencies: [
       "button",
+      "input",
       "skeleton",
       "https://r.assistant-ui.com/tooltip-icon-button.json",
     ],

--- a/packages/ui/src/components/assistant-ui/thread-list.tsx
+++ b/packages/ui/src/components/assistant-ui/thread-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import {
@@ -14,24 +15,61 @@ import {
   ArchiveIcon,
   MoreHorizontalIcon,
   PlusIcon,
+  SearchIcon,
   TrashIcon,
 } from "lucide-react";
 import {
   forwardRef,
   Fragment,
   useMemo,
+  useState,
   type ComponentPropsWithoutRef,
   type FC,
 } from "react";
 
 export const ThreadList: FC = () => {
+  const [search, setSearch] = useState("");
+  const hasThreads = useAuiState((s) => s.threads.threadIds.length > 0);
+
   return (
     <ThreadListRoot>
       <ThreadListNew />
-      <ThreadListItems />
+      {hasThreads && (
+        <ThreadListSearch value={search} onValueChange={setSearch} />
+      )}
+      <ThreadListItems searchQuery={hasThreads ? search : ""} />
     </ThreadListRoot>
   );
 };
+
+export const ThreadListSearch = forwardRef<
+  HTMLInputElement,
+  Omit<ComponentPropsWithoutRef<typeof Input>, "value" | "onChange"> & {
+    value: string;
+    onValueChange: (value: string) => void;
+  }
+>(({ className, value, onValueChange, ...props }, ref) => {
+  return (
+    <div data-slot="aui_thread-list-search" className="relative px-0.5 py-1">
+      <SearchIcon
+        data-slot="aui_thread-list-search-icon"
+        className="text-muted-foreground pointer-events-none absolute start-3 top-1/2 size-4 -translate-y-1/2"
+      />
+      <Input
+        ref={ref}
+        type="search"
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+        aria-label="Search threads"
+        placeholder="Search threads"
+        className={cn("h-8 ps-8 text-sm", className)}
+        {...props}
+      />
+    </div>
+  );
+});
+
+ThreadListSearch.displayName = "ThreadListSearch";
 
 export const ThreadListRoot: FC<
   ComponentPropsWithoutRef<typeof ThreadListPrimitive.Root>
@@ -45,10 +83,9 @@ export const ThreadListRoot: FC<
   );
 };
 
-export const ThreadListItems: FC<ComponentPropsWithoutRef<"div">> = ({
-  className,
-  ...props
-}) => {
+export const ThreadListItems: FC<
+  ComponentPropsWithoutRef<"div"> & { searchQuery?: string }
+> = ({ className, searchQuery = "", ...props }) => {
   return (
     <div
       data-slot="aui_thread-list-items"
@@ -59,7 +96,7 @@ export const ThreadListItems: FC<ComponentPropsWithoutRef<"div">> = ({
         <ThreadListSkeleton />
       </AuiIf>
       <AuiIf condition={(s) => !s.threads.isLoading}>
-        <ThreadListItemGroups />
+        <ThreadListItemGroups searchQuery={searchQuery} />
       </AuiIf>
     </div>
   );
@@ -78,14 +115,30 @@ const dateGroupLabel = (
 
 type ThreadListGroup = { label: string; indices: number[] };
 
-const ThreadListItemGroups: FC = () => {
+const ThreadListItemGroups: FC<{ searchQuery?: string }> = ({
+  searchQuery = "",
+}) => {
   const threadIds = useAuiState((s) => s.threads.threadIds);
   const threadItems = useAuiState((s) => s.threads.threadItems);
 
-  const groups = useMemo<ThreadListGroup[] | null>(() => {
+  const query = searchQuery.trim().toLowerCase();
+
+  const { filteredIndices, groups } = useMemo(() => {
     const itemsById = new Map(threadItems.map((item) => [item.id, item]));
     const dates = threadIds.map((id) => itemsById.get(id)?.lastMessageAt);
-    if (!dates.some(Boolean)) return null;
+    const filteredIndices = threadIds
+      .map((id, index) => ({ id, index }))
+      .filter(
+        ({ id }) =>
+          !query ||
+          (itemsById.get(id)?.title || "New Chat")
+            .toLowerCase()
+            .includes(query),
+      )
+      .map(({ index }) => index);
+    if (!filteredIndices.some((index) => dates[index])) {
+      return { filteredIndices, groups: null };
+    }
 
     const now = new Date();
     const startOfToday = new Date(
@@ -95,12 +148,10 @@ const ThreadListItemGroups: FC = () => {
     ).getTime();
     const time = (index: number) =>
       dates[index]?.getTime() ?? Number.MAX_SAFE_INTEGER;
-    const indices = threadIds
-      .map((_, index) => index)
-      .sort((a, b) => time(b) - time(a));
+    const sorted = [...filteredIndices].sort((a, b) => time(b) - time(a));
 
     const result: ThreadListGroup[] = [];
-    for (const index of indices) {
+    for (const index of sorted) {
       const label = dateGroupLabel(dates[index], startOfToday);
       const lastGroup = result[result.length - 1];
       if (lastGroup?.label === label) {
@@ -109,15 +160,28 @@ const ThreadListItemGroups: FC = () => {
         result.push({ label, indices: [index] });
       }
     }
-    return result;
-  }, [threadIds, threadItems]);
+    return { filteredIndices, groups: result };
+  }, [threadIds, threadItems, query]);
+
+  if (query && filteredIndices.length === 0) {
+    return (
+      <div
+        data-slot="aui_thread-list-empty"
+        className="text-muted-foreground px-2.5 py-4 text-sm"
+      >
+        No threads found
+      </div>
+    );
+  }
 
   if (!groups) {
-    return (
-      <ThreadListPrimitive.Items>
-        {() => <ThreadListItem />}
-      </ThreadListPrimitive.Items>
-    );
+    return filteredIndices.map((index) => (
+      <ThreadListPrimitive.ItemByIndex
+        key={threadIds[index]}
+        index={index}
+        components={{ ThreadListItem }}
+      />
+    ));
   }
 
   return groups.map((group) => (


### PR DESCRIPTION
Adds a search box to the thread-list registry component that filters loaded threads by title

## What

- Search input below "New Thread", shown once there is at least one thread.
- Filters by title, case-insensitive, and regroups matches by date.
- "No threads found" empty state when nothing matches.

## Scope

Registry component only. No runtime, core, adapter, or cloud API changes. Reuses the existing `useMemo` in `ThreadListItemGroups` that already derives and groups `s.threads.threadIds`. Searches only threads already loaded in the store.

## Follow-up

This is the client-side, loaded-threads-only tier. Searching across unloaded/paginated threads needs a `RemoteThreadListAdapter.search?()` plus a cloud/backend change, which is public-API surface deferred to a separate design discussion.
## Changes

- `thread-list.tsx`: new `ThreadListSearch` (controlled `<Input type="search">`); `ThreadList` owns the query state; `ThreadListItemGroups` filters + empty state.
- `registry.ts`: add `input` to the `thread-list` item's `registryDependencies`.

## Notes

- No changeset (`@assistant-ui/ui` and `@assistant-ui/shadcn-registry` are private).
- No template-sync impact (minimal does not ship `thread-list.tsx`).
- Backwards compatible: default render is unchanged with no query; `ThreadListItems` gains one optional `searchQuery` prop.
- Verified: `with-cloud` builds under strictest; `pnpm lint` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

