### PR TITLE
fix(cli): doctor detects duplicate assistant-ui packages under pnpm

### DIFF
--- a/.changeset/doctor-pnpm-duplicates.md
+++ b/.changeset/doctor-pnpm-duplicates.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix(cli): doctor now detects duplicate assistant-ui packages in pnpm node_modules layouts

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -106,13 +106,90 @@ function walkNodeModulesAt(
   }
 }
 
+// pnpm keeps every real package dir in the `.pnpm` virtual store as
+// `node_modules/.pnpm/<pkg>@<ver>[_<peerhash>]/node_modules/<pkg>` and never
+// nests a package's deps inside its own dir, so the hoisted-layout walk above
+// only ever reaches the project's direct deps. The store dir name encodes the
+// package, so filtering by a tracked prefix keeps this pass O(tracked entries).
+const TRACKED_PNPM_ENTRY_PREFIXES = [
+  "@assistant-ui+",
+  "assistant-ui@",
+  "assistant-stream@",
+  "assistant-cloud@",
+];
+
+function isTrackedPnpmEntry(dirName: string): boolean {
+  return TRACKED_PNPM_ENTRY_PREFIXES.some((p) => dirName.startsWith(p));
+}
+
+function processTrackedPackagesIn(
+  nm: string,
+  results: DiscoveredPackage[],
+  visited: ProcessedDir,
+): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(nm, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) continue;
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+
+    if (entry.name.startsWith("@")) {
+      const scopeDir = path.join(nm, entry.name);
+      let scoped: fs.Dirent[];
+      try {
+        scoped = fs.readdirSync(scopeDir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const s of scoped) {
+        if (!s.isDirectory() && !s.isSymbolicLink()) continue;
+        if (!isTrackedPackage(`${entry.name}/${s.name}`)) continue;
+        processPackageDir(path.join(scopeDir, s.name), results, visited);
+      }
+    } else if (isTrackedPackage(entry.name)) {
+      processPackageDir(path.join(nm, entry.name), results, visited);
+    }
+  }
+}
+
+function walkPnpmStore(
+  cwd: string,
+  results: DiscoveredPackage[],
+  visited: ProcessedDir,
+): void {
+  const storeDir = path.join(cwd, "node_modules", ".pnpm");
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(storeDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    if (!isTrackedPnpmEntry(entry.name)) continue;
+    processTrackedPackagesIn(
+      path.join(storeDir, entry.name, "node_modules"),
+      results,
+      visited,
+    );
+  }
+}
+
 // Discover every installation of an assistant-ui-family package reachable
 // from `cwd`. Recurses into nested node_modules so transitive copies
-// (the real source of duplicate-version bugs) are not missed.
+// (the real source of duplicate-version bugs) are not missed, and scans the
+// pnpm `.pnpm` virtual store, which the hoisted walk cannot reach.
 export function discoverInstalledPackages(cwd: string): DiscoveredPackage[] {
   const results: DiscoveredPackage[] = [];
   const visited: ProcessedDir = { set: new Set() };
   walkNodeModulesAt(cwd, results, visited);
+  walkPnpmStore(cwd, results, visited);
   return results;
 }
 

--- a/packages/cli/test/commands/doctor.test.ts
+++ b/packages/cli/test/commands/doctor.test.ts
@@ -146,6 +146,108 @@ describe("doctor — package discovery", () => {
   });
 });
 
+describe("doctor — pnpm store discovery", () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "aui-doctor-pnpm-"));
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({
+        name: "fixture",
+        version: "1.0.0",
+        dependencies: { "@assistant-ui/react": "0.14.5" },
+      }),
+    );
+
+    // Direct dependency hoisted into the top-level node_modules.
+    writePackage(root, {
+      name: "@assistant-ui/react",
+      version: "0.14.5",
+      installPath: "node_modules/@assistant-ui/react",
+    });
+
+    // Two peer-closure-split copies of @assistant-ui/core, each in its own
+    // .pnpm virtual-store entry — the exact duplication class from #4101.
+    writePackage(root, {
+      name: "@assistant-ui/core",
+      version: "0.2.5",
+      installPath:
+        "node_modules/.pnpm/@assistant-ui+core@0.2.5_react@18.3.1/node_modules/@assistant-ui/core",
+    });
+    writePackage(root, {
+      name: "@assistant-ui/core",
+      version: "0.2.2",
+      installPath:
+        "node_modules/.pnpm/@assistant-ui+core@0.2.2_react@19.0.0/node_modules/@assistant-ui/core",
+    });
+
+    // Unscoped tracked package living in the store.
+    writePackage(root, {
+      name: "assistant-stream",
+      version: "0.3.14",
+      installPath:
+        "node_modules/.pnpm/assistant-stream@0.3.14/node_modules/assistant-stream",
+    });
+
+    // Unrelated package in the store must be ignored.
+    writePackage(root, {
+      name: "lodash",
+      version: "4.17.21",
+      installPath: "node_modules/.pnpm/lodash@4.17.21/node_modules/lodash",
+    });
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("collects assistant-ui copies from the .pnpm virtual store", () => {
+    const found = discoverInstalledPackages(root);
+    const summary = found
+      .map((p) => `${p.name}@${p.version}`)
+      .sort()
+      .join(",");
+
+    expect(summary).toContain("@assistant-ui/core@0.2.2");
+    expect(summary).toContain("@assistant-ui/core@0.2.5");
+    expect(summary).toContain("@assistant-ui/react@0.14.5");
+    expect(summary).toContain("assistant-stream@0.3.14");
+    expect(summary).not.toContain("lodash");
+  });
+
+  it("flags the peer-split @assistant-ui/core copies as duplicated", () => {
+    const dups = findDuplicates(discoverInstalledPackages(root));
+    expect(dups).toHaveLength(1);
+    expect(dups[0]!.name).toBe("@assistant-ui/core");
+    const versions = dups[0]!.installations.map((i) => i.version).sort();
+    expect(versions).toEqual(["0.2.2", "0.2.5"]);
+  });
+});
+
+describe("doctor — no pnpm store", () => {
+  it("returns nothing extra and does not throw when .pnpm is absent", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "aui-doctor-npm-"));
+    try {
+      fs.writeFileSync(
+        path.join(root, "package.json"),
+        JSON.stringify({ name: "fixture", version: "1.0.0" }),
+      );
+      writePackage(root, {
+        name: "@assistant-ui/react",
+        version: "0.14.5",
+        installPath: "node_modules/@assistant-ui/react",
+      });
+      const found = discoverInstalledPackages(root);
+      expect(found.map((p) => `${p.name}@${p.version}`)).toEqual([
+        "@assistant-ui/react@0.14.5",
+      ]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("findOutdated", () => {
   it("flags packages whose installed version is older than the latest", () => {
     const installed: DiscoveredPackage[] = [


### PR DESCRIPTION
## Problem

`assistant-ui doctor` misses duplicate versions on pnpm. It walks nested `node_modules` (the npm/yarn layout), but under pnpm:

- it skips dot-prefixed entries, so it never enters `node_modules/.pnpm/`
- packages live at `node_modules/.pnpm/<pkg>@<ver>[_<peerhash>]/node_modules/<pkg>`, with no nested `node_modules` inside a package to descend into

So on pnpm it only sees direct deps and prints "No duplicate versions detected", even for the peer-closure-split case it exists to catch. Doctor's own output links #4101, which was exactly that (duplicate `@assistant-ui/core`), so it can't detect its own motivating bug on the package manager most contributors use.

## Fix

- Add a second discovery pass over `node_modules/.pnpm`, sharing the existing visited set so nothing is double-counted.
- Keep only entries prefixed `@assistant-ui+`, `assistant-ui@`, `assistant-stream@`, `assistant-cloud@`. This keeps the pass O(tracked entries) and preserves the existing perf guard.
- Reuse `processPackageDir` for each kept entry, so name/version come from `package.json` and dedup stays by realpath, identical to the npm path. No parsing of the mangled `.pnpm` dir name.

## Tests

- New `pnpm store discovery` block: two peer-split `@assistant-ui/core` copies flagged as duplicate; unrelated `lodash` ignored.
- Guard test: absent `.pnpm` is a no-op.
- Existing npm-layout tests untouched.

Patch changeset for `assistant-ui`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

