### PR TITLE
fix: preserve image media type

### DIFF
--- a/.changeset/ai-sdk-image-media-type.md
+++ b/.changeset/ai-sdk-image-media-type.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: preserve image media types when creating AI SDK messages

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
@@ -11,6 +11,85 @@ const baseMessage = {
 } as const;
 
 describe("toCreateMessage", () => {
+  it("preserves the media type from image data URLs", () => {
+    const message = {
+      ...baseMessage,
+      content: [
+        {
+          type: "image",
+          image: "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+          filename: "photo.jpg",
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    const result = toCreateMessage(message);
+
+    expect(result.parts).toEqual([
+      {
+        type: "file",
+        url: "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+        filename: "photo.jpg",
+        mediaType: "image/jpeg",
+      },
+    ]);
+  });
+
+  it("uses attachment contentType for image attachments", () => {
+    const message = {
+      ...baseMessage,
+      content: [],
+      attachments: [
+        {
+          id: "some-id",
+          type: "image",
+          name: "photo.webp",
+          contentType: "image/webp",
+          status: { type: "complete" },
+          content: [
+            {
+              type: "image",
+              image: "https://cdn.example.com/photo",
+            },
+          ],
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    const result = toCreateMessage(message);
+
+    expect(result.parts).toEqual([
+      {
+        type: "file",
+        url: "https://cdn.example.com/photo",
+        filename: "photo.webp",
+        mediaType: "image/webp",
+      },
+    ]);
+  });
+
+  it("falls back to image/png for images without a known media type", () => {
+    const message = {
+      ...baseMessage,
+      content: [
+        {
+          type: "image",
+          image: "https://cdn.example.com/photo",
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    const result = toCreateMessage(message);
+
+    expect(result.parts).toEqual([
+      {
+        type: "file",
+        url: "https://cdn.example.com/photo",
+        mediaType: "image/png",
+      },
+    ]);
+  });
+
   it("converts a data part in message content into a data-<name> part", () => {
     const message = {
       ...baseMessage,

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
@@ -7,15 +7,38 @@ import type {
   UITools,
 } from "ai";
 
+type InputPart = AppendMessage["content"][number] & {
+  readonly contentType?: string | undefined;
+  readonly filename?: string | undefined;
+};
+
+const getDataUrlMediaType = (url: string) => {
+  const match = /^data:([^;,]+)(?:[;,])/.exec(url);
+  return match?.[1];
+};
+
+const getImageMediaType = (part: {
+  readonly contentType?: string | undefined;
+  readonly image: string;
+}) => {
+  if (part.contentType?.startsWith("image/")) return part.contentType;
+
+  const dataUrlMediaType = getDataUrlMediaType(part.image);
+  if (dataUrlMediaType?.startsWith("image/")) return dataUrlMediaType;
+
+  return "image/png";
+};
+
 export const toCreateMessage = <UI_MESSAGE extends UIMessage = UIMessage>(
   message: AppendMessage,
 ): CreateUIMessage<UI_MESSAGE> => {
-  const inputParts = [
+  const inputParts: InputPart[] = [
     ...message.content.filter((c) => c.type !== "file"),
     ...(message.attachments?.flatMap((a) =>
       a.content.map((c) => ({
         ...c,
         filename: a.name,
+        contentType: a.contentType,
       })),
     ) ?? []),
   ];
@@ -32,7 +55,7 @@ export const toCreateMessage = <UI_MESSAGE extends UIMessage = UIMessage>(
           type: "file",
           url: part.image,
           ...(part.filename && { filename: part.filename }),
-          mediaType: "image/png",
+          mediaType: getImageMediaType(part),
         };
       case "file":
         return {


### PR DESCRIPTION
## Summary
- preserve image MIME types when `toCreateMessage()` converts assistant-ui image parts into AI SDK file parts
- use attachment `contentType` when available, infer `data:` URL MIME types, and keep the existing `image/png` fallback for unknown image URLs
- add regression coverage for JPEG data URLs, WebP attachments, and the fallback path

## Why
When testing image inputs locally, non-PNG images such as JPEG/WebP could be sent to the AI SDK with `mediaType: "image/png"`. Providers use that field to interpret the file, so the model could receive mislabeled image input.

## Verification
- `pnpm --filter @assistant-ui/react-ai-sdk test -- src/ui/utils/toCreateMessage.test.ts`
- `pnpm --filter @assistant-ui/react-ai-sdk test -- src/ui/utils/toCreateMessage.test.ts src/ui/use-chat/useAISDKRuntime.test.ts`
- `pnpm --filter @assistant-ui/react-ai-sdk build`
- `pnpm lint`

Note: `pnpm --filter @assistant-ui/react-ai-sdk exec tsc --noEmit` currently fails on existing MCP toolkit test typings around the recently merged `tools` field in `generativeTools.test.ts`; the touched package build succeeds.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

