### PR TITLE
fix: preserve direct file parts

### DIFF
--- a/.changeset/ai-sdk-direct-file-parts.md
+++ b/.changeset/ai-sdk-direct-file-parts.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: preserve direct file parts in AI SDK message creation

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
@@ -11,6 +11,64 @@ const baseMessage = {
 } as const;
 
 describe("toCreateMessage", () => {
+  it("converts a direct file part in message content", () => {
+    const message = {
+      ...baseMessage,
+      content: [
+        {
+          type: "file",
+          data: "data:application/pdf;base64,JVBERi0xLjQ=",
+          mimeType: "application/pdf",
+          filename: "invoice.pdf",
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    const result = toCreateMessage(message);
+
+    expect(result.parts).toEqual([
+      {
+        type: "file",
+        url: "data:application/pdf;base64,JVBERi0xLjQ=",
+        mediaType: "application/pdf",
+        filename: "invoice.pdf",
+      },
+    ]);
+  });
+
+  it("preserves text and direct file parts together", () => {
+    const message = {
+      ...baseMessage,
+      content: [
+        {
+          type: "text",
+          text: "Summarize this invoice and list the due date.",
+        },
+        {
+          type: "file",
+          data: "data:application/pdf;base64,JVBERi0xLjQ=",
+          mimeType: "application/pdf",
+          filename: "invoice.pdf",
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    const result = toCreateMessage(message);
+
+    expect(result.parts).toEqual([
+      {
+        type: "text",
+        text: "Summarize this invoice and list the due date.",
+      },
+      {
+        type: "file",
+        url: "data:application/pdf;base64,JVBERi0xLjQ=",
+        mediaType: "application/pdf",
+        filename: "invoice.pdf",
+      },
+    ]);
+  });
+
   it("preserves the media type from image data URLs", () => {
     const message = {
       ...baseMessage,
@@ -128,6 +186,40 @@ describe("toCreateMessage", () => {
 
     expect(result.parts).toEqual([
       { type: "data-some-content-name", data: { field: 1 } },
+    ]);
+  });
+
+  it("keeps converting attachment file content", () => {
+    const message = {
+      ...baseMessage,
+      content: [],
+      attachments: [
+        {
+          id: "some-id",
+          type: "document",
+          name: "invoice.pdf",
+          contentType: "application/pdf",
+          status: { type: "complete" },
+          content: [
+            {
+              type: "file",
+              data: "data:application/pdf;base64,JVBERi0xLjQ=",
+              mimeType: "application/pdf",
+            },
+          ],
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    const result = toCreateMessage(message);
+
+    expect(result.parts).toEqual([
+      {
+        type: "file",
+        url: "data:application/pdf;base64,JVBERi0xLjQ=",
+        mediaType: "application/pdf",
+        filename: "invoice.pdf",
+      },
     ]);
   });
 });

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
@@ -33,7 +33,7 @@ export const toCreateMessage = <UI_MESSAGE extends UIMessage = UIMessage>(
   message: AppendMessage,
 ): CreateUIMessage<UI_MESSAGE> => {
   const inputParts: InputPart[] = [
-    ...message.content.filter((c) => c.type !== "file"),
+    ...message.content,
     ...(message.attachments?.flatMap((a) =>
       a.content.map((c) => ({
         ...c,


### PR DESCRIPTION
## Summary
- preserve direct `file` parts passed through message `content` when creating AI SDK messages
- keep attachment-derived file conversion unchanged
- add regression tests for direct files, text+file content, and attachment files

## Why
Apps can append messages programmatically with text plus a file, for example `thread.append({ content: [{ type: "text", text: "Summarize this invoice" }, { type: "file", ... }] })`. Previously `toCreateMessage()` filtered direct file parts before the converter switch, so the AI SDK message could receive the text without the file.

## Testing
- `pnpm --filter @assistant-ui/react-ai-sdk test -- src/ui/utils/toCreateMessage.test.ts`
- `pnpm --filter @assistant-ui/react-ai-sdk build`
- `pnpm lint`
- `pnpm --filter @assistant-ui/react-ai-sdk test`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

