### PR TITLE
feat(react-ink): render the upload failure message in AttachmentStatus

### DIFF
--- a/.changeset/ink-attachment-error-message.md
+++ b/.changeset/ink-attachment-error-message.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+feat: render the upload failure message in AttachmentStatus

--- a/packages/react-ink/src/primitives/attachment/AttachmentStatus.tsx
+++ b/packages/react-ink/src/primitives/attachment/AttachmentStatus.tsx
@@ -36,7 +36,10 @@ export const AttachmentStatus: FC<AttachmentStatusProps> = ({
   if (status.type === "incomplete") {
     const { text, defaultColor } =
       status.reason === "error"
-        ? { text: "x error", defaultColor: "red" }
+        ? {
+            text: status.message ? `x error: ${status.message}` : "x error",
+            defaultColor: "red",
+          }
         : { text: "|| paused", defaultColor: "yellow" };
     return (
       <Text {...textProps} color={textProps.color ?? defaultColor}>

--- a/packages/react-ink/src/tests/AttachmentPrimitive.test.tsx
+++ b/packages/react-ink/src/tests/AttachmentPrimitive.test.tsx
@@ -190,6 +190,22 @@ describe("AttachmentPrimitive.Status", () => {
     expect(frame).toContain("error");
   });
 
+  it("renders the failure message when the error status carries one", () => {
+    setAttachmentState({
+      id: "a1",
+      type: "file",
+      name: "broken.bin",
+      status: {
+        type: "incomplete",
+        reason: "error",
+        message: "Failed to upload file: 403 Forbidden",
+      },
+    });
+    const { lastFrame } = render(<AttachmentStatus />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("x error: Failed to upload file: 403 Forbidden");
+  });
+
   it("renders a paused marker for incomplete/upload-paused", () => {
     setAttachmentState({
       id: "a1",


### PR DESCRIPTION
## What

Parity follow-up to #4728. The core `PendingAttachmentStatus` incomplete arm now carries `message?: string` and the web ui kit shows it in the attachment tooltip; react-ink's `AttachmentStatus` still rendered a bare `x error`.

## How

- `x error: <message>` when the error status carries a message, bare `x error` otherwise
- no new prop; Ink `Text` handles wrapping and callers keep full pass-through control
- paused arm unchanged (nothing populates a message for it)

## Tests

- new: error status with message renders `x error: <message>`
- existing bare-error test keeps covering the fallback


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

