### PR TITLE
fix(cli): mcp install config error

### DIFF
--- a/.changeset/cli-mcp-config-error.md
+++ b/.changeset/cli-mcp-config-error.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: clarify MCP install config parse errors

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -135,6 +135,18 @@ function deepMerge(target: any, source: any): any {
   return result;
 }
 
+class McpConfigParseError extends Error {
+  constructor(targetName: string, configPath: string, flag: string) {
+    super(
+      `Invalid ${targetName} MCP config JSON at ${configPath}. Fix the JSON syntax, then run: assistant-ui mcp ${flag}`,
+    );
+    this.name = "McpConfigParseError";
+  }
+}
+
+const getTargetFlag = (target: Exclude<MCPTarget, "claude-code">) =>
+  `--${target}`;
+
 async function installForTarget(target: MCPTarget): Promise<void> {
   if (target === "claude-code") {
     logger.info("Installing MCP server for Claude Code...");
@@ -204,12 +216,15 @@ async function installForTarget(target: MCPTarget): Promise<void> {
     const content = fs.readFileSync(configPath, "utf-8");
     try {
       existingConfig = JSON.parse(content);
-    } catch (e) {
-      logger.error(`Could not parse existing config at ${configPath}`);
-      logger.error(
-        "Please fix the JSON syntax error before running this command.",
+    } catch {
+      const flag = getTargetFlag(target);
+      logger.error(`Could not parse ${targetConfig.name} MCP config.`);
+      logger.info(`Config path: ${configPath}`);
+      logger.info(
+        `Fix the JSON syntax in that file, then run: assistant-ui mcp ${flag}`,
       );
-      throw e;
+      logger.info("No changes were written.");
+      throw new McpConfigParseError(targetConfig.name, configPath, flag);
     }
   }
 

--- a/packages/cli/test/commands/mcp.test.ts
+++ b/packages/cli/test/commands/mcp.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mcp } from "../../src/commands/mcp";
+
+describe("mcp command", () => {
+  let cwd: string;
+  let tempDir: string;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    cwd = process.cwd();
+    tempDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "assistant-ui-mcp-")),
+    );
+    process.chdir(tempDir);
+
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(cwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    exitSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
+  it("prints recovery details for invalid existing config JSON", async () => {
+    const configPath = path.join(tempDir, ".cursor", "mcp.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, "{ invalid json", "utf-8");
+
+    await expect(
+      mcp.parseAsync(["node", "mcp", "--cursor"], { from: "node" }),
+    ).rejects.toThrow("process.exit");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    const output = [
+      ...consoleErrorSpy.mock.calls.flat(),
+      ...consoleLogSpy.mock.calls.flat(),
+    ].join("\n");
+
+    expect(output).toContain("Could not parse Cursor MCP config.");
+    expect(output).toContain(`Config path: ${configPath}`);
+    expect(output).toContain(
+      "Fix the JSON syntax in that file, then run: assistant-ui mcp --cursor",
+    );
+    expect(output).toContain("No changes were written.");
+    expect(output).not.toContain("SyntaxError");
+  });
+});


### PR DESCRIPTION
## Summary
- replace raw JSON parse rethrow with a named MCP config parse error
- print the target app, config path, rerun command, and that no changes were written
- add CLI coverage for invalid existing Cursor MCP config JSON

## Why
When `assistant-ui mcp` finds an existing malformed IDE config, users need to know which app config failed and what to do next. The previous path logged a generic parse message and rethrew the raw parser error, which can make the CLI output feel scarier than the actual recovery step.

## Testing
- `pnpm --filter assistant-ui test -- test/commands/mcp.test.ts`
- `pnpm --filter assistant-ui build`
- `pnpm lint`
- `pnpm --filter assistant-ui test`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

