### PR TITLE
fix(docs): validate pruned Xulux chat messages

### DIFF
--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -394,11 +394,16 @@ export async function POST(req: Request): Promise<Response> {
       activePreviewContext,
     } = body;
 
-    const inputError = validateDocChatInput(messages);
-    if (inputError) return inputError;
+    if (!Array.isArray(messages)) {
+      return new Response("Invalid messages format", { status: 400 });
+    }
 
     const uiMessages = messages as UIMessage[];
     const prunedMessages = await prepareMessages(uiMessages);
+
+    const inputError = validateDocChatInput(prunedMessages);
+    if (inputError) return inputError;
+
     const normalizedPreviewContext =
       normalizeActivePreviewContext(activePreviewContext);
     const userMessageId = getLatestUserMessageId(uiMessages);

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -109,6 +109,7 @@ type JsonValue =
 type JsonObject = { [key: string]: JsonValue };
 
 const MAX_ACTIVE_PREVIEW_CONFIG_CHARS = 8_000;
+const MAX_RAW_MESSAGES_CHARS = 1_000_000;
 
 async function prepareMessages(messages: readonly UIMessage[]) {
   const modelMessages = await convertToModelMessages(
@@ -397,12 +398,12 @@ export async function POST(req: Request): Promise<Response> {
     if (!Array.isArray(messages)) {
       return new Response("Invalid messages format", { status: 400 });
     }
+    if (JSON.stringify(messages).length > MAX_RAW_MESSAGES_CHARS) {
+      return new Response("Input too long", { status: 400 });
+    }
 
     const uiMessages = messages as UIMessage[];
     const prunedMessages = await prepareMessages(uiMessages);
-
-    const inputError = validateDocChatInput(prunedMessages);
-    if (inputError) return inputError;
 
     const normalizedPreviewContext =
       normalizeActivePreviewContext(activePreviewContext);
@@ -465,6 +466,9 @@ export async function POST(req: Request): Promise<Response> {
         );
       }
     }
+
+    const inputError = validateDocChatInput(prunedMessages);
+    if (inputError) return inputError;
 
     const evalRunId = req.headers.get("x-agent-eval-run-id");
     const localTraceUrl = req.headers.get("x-agent-eval-trace-url");

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -416,6 +416,31 @@ export async function POST(req: Request): Promise<Response> {
       );
     }
 
+    const isFirstUserTurn =
+      prunedMessages.filter((m) => m.role === "user").length === 1 &&
+      !prunedMessages.some((m) => m.role === "assistant");
+    if (isFirstUserTurn) {
+      const templateContext = formatSelectedTemplateContext(selectedTemplate);
+      const firstUser = prunedMessages.find((m) => m.role === "user");
+      if (templateContext && firstUser) {
+        appendHiddenText(firstUser, templateContext);
+      }
+    }
+    if (normalizedPreviewContext) {
+      const latestUser = [...prunedMessages]
+        .reverse()
+        .find((m) => m.role === "user");
+      if (latestUser) {
+        appendHiddenText(
+          latestUser,
+          formatActivePreviewContext(normalizedPreviewContext),
+        );
+      }
+    }
+
+    const inputError = validateDocChatInput(prunedMessages);
+    if (inputError) return inputError;
+
     const distinctId = getDistinctId(req);
     const budget = await beginTurn(sessionId.trim(), distinctId);
     if (budget.denied) {
@@ -444,31 +469,6 @@ export async function POST(req: Request): Promise<Response> {
       });
     }
     const budgetDate = budget.budgetDate;
-
-    const isFirstUserTurn =
-      prunedMessages.filter((m) => m.role === "user").length === 1 &&
-      !prunedMessages.some((m) => m.role === "assistant");
-    if (isFirstUserTurn) {
-      const templateContext = formatSelectedTemplateContext(selectedTemplate);
-      const firstUser = prunedMessages.find((m) => m.role === "user");
-      if (templateContext && firstUser) {
-        appendHiddenText(firstUser, templateContext);
-      }
-    }
-    if (normalizedPreviewContext) {
-      const latestUser = [...prunedMessages]
-        .reverse()
-        .find((m) => m.role === "user");
-      if (latestUser) {
-        appendHiddenText(
-          latestUser,
-          formatActivePreviewContext(normalizedPreviewContext),
-        );
-      }
-    }
-
-    const inputError = validateDocChatInput(prunedMessages);
-    if (inputError) return inputError;
 
     const evalRunId = req.headers.get("x-agent-eval-run-id");
     const localTraceUrl = req.headers.get("x-agent-eval-trace-url");


### PR DESCRIPTION
## Summary

Fixes #4734.

The Xulux chat route was validating raw AI SDK UI messages before pruning. Raw UI messages can include large assistant tool outputs for history/rendering, even though those tool calls are removed by `prepareMessages()` before the model call.

This PR keeps the raw request shape check, then validates the pruned/model-ready messages.

## Testing

- `pnpm --config.verify-deps-before-run=false exec oxfmt --check apps/docs/app/api/xulux/chat/route.ts`
- `pnpm --config.verify-deps-before-run=false exec oxlint apps/docs/app/api/xulux/chat/route.ts`
- Local reproduction with a saved Xulux thread: raw UI history max message size was 28,557 chars and failed the 24,000 char single-message limit; after `convertToModelMessages()` + `pruneMessages()`, max message size was 2,103 chars and passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

