### PR TITLE
chore: cap concurrency in root build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "docs:dev": "turbo run dev --filter=@assistant-ui/docs",
     "ci:version": "changeset version && pnpm install --no-frozen-lockfile",
     "ci:publish": "turbo build --filter=\"./packages/*\" && changeset publish",
-    "build": "turbo build",
+    "build": "turbo build --concurrency=4",
     "api-surface": "pnpm api-surface:build && node scripts/generate-api-surface.mjs",
     "api-surface:build": "pnpm exec turbo build --filter='./packages/*' --force",
     "api-surface:check": "node scripts/check-api-surface.mjs",


### PR DESCRIPTION
## What

Caps the root `build` script at `--concurrency=4` so `pnpm build` no longer oversubscribes memory and CPU.

## Why

The unfiltered root graph is 93 tasks including 40 Next.js app builds. At turbo's default concurrency of 10, ten heavyweight `next build` tasks run at once (each ~2GB RSS plus its own worker pool), exhaust RAM on typical contributor machines, and drive them into swap and hard hangs.

## Impact

- `--concurrency` only bounds how many tasks run simultaneously. It does not change the task graph or any build output.
- Cached tasks stay near-free, so warm builds are unaffected. Only cold full builds trade some wall-clock for staying usable.
- No CI impact: no workflow invokes the root `build` script; every CI build calls `pnpm turbo build --filter=...` directly, which does not read this script's flags.
- Root `package.json` is `private: true`, so no changeset is required.

## Why 4, not a percentage

The binding constraint is memory per concurrent Next build, not core count. This value is the shared default every contributor inherits, so a fixed low number bounds peak memory on the weakest machine, while anyone with more headroom can override on the fly (`pnpm build -- --concurrency=8`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

