### PR TITLE
fix: bound test:types parallelism to avoid memory exhaustion

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format:fix": "pnpm exec oxfmt",
     "sync-templates": "bash scripts/sync-templates.sh",
     "test": "turbo test && pnpm test:types",
-    "test:types": "pnpm -r --parallel exec sh -c '! test -f tsconfig.json || tsc --noEmit'",
+    "test:types": "pnpm -r --workspace-concurrency=4 --no-bail exec sh -c '! test -f tsconfig.json || tsc --noEmit'",
     "prepare": "husky && pnpm --filter @assistant-ui/react-devtools run build:css",
     "deps:check": "npx taze major -f -r",
     "deps:update": "npx taze major -f -w -r && cd examples/with-expo && npx expo install --fix && cd ../.. && find . -name node_modules -prune -exec rm -rf {} + && rm -f pnpm-lock.yaml && pnpm install && pnpm dedupe && bash scripts/generate-deps-changeset.sh"


### PR DESCRIPTION
## What

Change the root `test:types` script from pnpm's unbounded `--parallel` to a bounded `--workspace-concurrency=4 --no-bail`.

```diff
-    "test:types": "pnpm -r --parallel exec sh -c '! test -f tsconfig.json || tsc --noEmit'",
+    "test:types": "pnpm -r --workspace-concurrency=4 --no-bail exec sh -c '! test -f tsconfig.json || tsc --noEmit'",
```

One line in root `package.json`. No other files.

## Why

pnpm's `--parallel` completely disregards `--workspace-concurrency` and topological order, launching the command in every matching workspace at once. 90 of the 94 workspaces carry a `tsconfig.json`, so `pnpm test:types` (and therefore `pnpm test`, which runs `turbo test && pnpm test:types`) spawns ~90 simultaneous `tsc --noEmit` processes, each 0.5 to 1.5 GB RSS. On a typical machine this exhausts memory, hits swap, and hangs the box. It is the same hang-class problem as the unbounded root `build` script.

Capping to 4 concurrent typechecks bounds peak memory while still typechecking every workspace.

## Why `--no-bail` and not just dropping `--parallel`

`--parallel` has a second, non-obvious effect: it disables pnpm's default bail-on-first-failure, so a red repo reports every failing workspace in one run. Simply dropping `--parallel` (or replacing it with a bare `--workspace-concurrency=4`) re-enables bail, which quietly degrades the signal from "report every type error" to "report the first few, then stop."

Measured on this checkout with a deliberately-failing command across `./packages/*`:

- `--parallel`: ran all 46 packages (no bail).
- default / `--workspace-concurrency=4`: ran only ~5 before bailing.
- `--workspace-concurrency=4 --no-bail`: ran all 45 tsconfig-bearing packages, capped to 4 at a time, and preserved the non-zero exit code on failure.

`--no-bail` keeps the current report-all contract while bounding concurrency. The 2 packages without a `tsconfig.json` are still correctly skipped by the `! test -f tsconfig.json` guard.

## Impact

- Peak concurrency for `test:types` drops from ~90 to 4; the machine no longer hangs.
- No behavior change to the check itself: all 90 tsconfig workspaces still typecheck, all failures are still reported (`--no-bail`), and the exit code is preserved.
- `tsc --noEmit` produces no artifacts, so there is no output/artifact change of any kind.
- Console output changes from fully-interleaved prefixed streaming to bounded prefixed output. Cosmetic only.

## Mechanics

- CI impact: none. No workflow invokes `test:types` or `pnpm test` (verified: `grep -rn 'test:types' .github/` is empty; CI runs `turbo test` directly with its own filters). This is purely local-facing.
- Concurrency value `4` matches the memory-bound reasoning used for the root build cap, keeping the two hang-class fixes consistent; the binding constraint is memory, not core count.
- No output change: bounds how many typechecks run at once, not which run or what is reported.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

