### PR TITLE
perf(turbo): restore git-aware build cache inputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,16 +5,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": [
-        "**/*.*",
-        "!.next/**",
-        "!.turbo/**",
-        "!dist/**",
-        "!build/**",
-        "!generated/**",
-        "!.output/**",
-        "!.source/**"
-      ],
+      "inputs": ["$TURBO_DEFAULT$"],
       "outputs": [
         "dist/**",
         ".next/**",

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,12 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.test.{ts,tsx}",
+        "!**/*.spec.{ts,tsx}",
+        "!**/__tests__/**"
+      ],
       "outputs": [
         "dist/**",
         ".next/**",


### PR DESCRIPTION
## What

`turbo.json` `build.inputs`, in two commits:

```diff
- "inputs": ["**/*.*", "!.next/**", "!.turbo/**", "!dist/**", "!build/**", "!generated/**", "!.output/**", "!.source/**"]
+ "inputs": ["$TURBO_DEFAULT$", "!**/*.test.{ts,tsx}", "!**/__tests__/**"]
```

## Why

The old glob is the biggest lever on the warm-repo cache-miss rate (76 of 93 tasks missing). Two separate bugs:

- **Gitignored files bust the cache.** A custom `inputs` array opts out of git-aware hashing, and custom globs ignore `.gitignore`. So `.env`, `.DS_Store`, editor junk, and `*-debug.log` inside a package dir feed the key though they cannot affect output. The `!...` entries just hand-roll a subset of what gitignore already covers.
- **Colocated test edits bust every dependent.** Tests are tracked, so they hash into the build key. 363 test files in `packages/` follow the colocated convention; editing one rebuilds that package and its whole dependent subtree, though the build never reads test code.

## Impact

- Warm `turbo build` (local and CI) stops missing on gitignored-file churn and test-only edits.
- No behavior or output change: `inputs` feeds only the cache key, never the build command or artifacts.

## Mechanics

- **`$TURBO_DEFAULT$`**: turbo v2 default hashing (files git is aware of per package, gitignored excluded). Repo pins `turbo ^2.9.18`; exists since turbo 2.0. Dropped `!` dirs were all gitignored, so already auto-excluded.
- **Test exclusions** mirror what `aui-build` already drops from its build entry (`packages/x-buildutils/src/index.ts:41-43`: `!src/**/*.test.{ts,tsx}` + `!src/**/__tests__/**`). That is the proof build output does not read test code; grep finds zero production imports of test code.
- **`__tests__/**` scope is safe**: no `__tests__` dir under `examples/`, `templates/`, or `apps/`, so it only affects aui-build packages. Vitest setup files are `src/tests/setup.ts`, not matched, still hashed.
- **Tests still rerun**: the `test` task has no `inputs`, still hashes its own `*.test.*`, and `dependsOn: ["^build"]`.
- **CI**: none. CI runs `pnpm turbo build --filter=...`; no workflow reads `build.inputs`.
- **Changeset**: not required (`turbo.json` tooling; root package is `private: true`).

## Validation (dry-run, no full builds)

- Task graph unchanged: `turbo build --dry=json | jq '.tasks|length'` is 93 before and after.
- Gitignored fix: a gitignored `.env` + `.DS_Store` leave tap's build hash identical on the new config; the same `.env` changed it on the old config.
- Test-exclusion fix: editing a `.test.ts` and a `__tests__/test-utils.ts` leave tap's build hash identical, while the `test` task hash changes (tests rerun).
- `oxfmt --check turbo.json` passes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

