### PR TITLE
fix(react-data-stream): include current message on request

### DIFF
--- a/.changeset/fix-data-stream-tool.md
+++ b/.changeset/fix-data-stream-tool.md
@@ -1,0 +1,4 @@
+---
+"@assistant-ui/react-data-stream": patch
+---
+fix: include current assistant message in toLanguageModelMessages to properly send frontend tool results

--- a/packages/react-data-stream/src/useDataStreamRuntime.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.ts
@@ -102,9 +102,10 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
       credentials: this.options.credentials ?? "same-origin",
       body: JSON.stringify({
         system: context.system,
-        messages: toLanguageModelMessages(messages, {
-          unstable_includeId: this.options.sendExtraMessageFields,
-        }) as DataStreamRuntimeRequestOptions["messages"],
+        messages: toLanguageModelMessages(
+          [...messages, unstable_getMessage()],
+          { unstable_includeId: this.options.sendExtraMessageFields },
+        ) as DataStreamRuntimeRequestOptions["messages"],
         tools: toToolsJSONSchema(
           context.tools ?? {},
         ) as unknown as DataStreamRuntimeRequestOptions["tools"],


### PR DESCRIPTION
The current message is needed when using multi steps tool calls, otherwise the frontend is always sending only the user message but never the tool result (which is part of the assistant message)

#4739 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

